### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/benchmarks/functional_autograd_benchmark/torchvision_models.py
+++ b/benchmarks/functional_autograd_benchmark/torchvision_models.py
@@ -247,7 +247,7 @@ class IntermediateLayerGetter(nn.ModuleDict):
     Additionally, it is only able to query submodules that are directly
     assigned to the model. So if `model` is passed, `model.feature1` can
     be returned, but not `model.feature1.layer2`.
-    Arguments:
+    Args:
         model (nn.Module): model on which we will extract the features
         return_layers (Dict[name, new_name]): a dict containing the names
             of the modules for which the activations will be returned as
@@ -324,7 +324,7 @@ class _SimpleSegmentationModel(nn.Module):
 class FCN(_SimpleSegmentationModel):
     """
     Implements a Fully-Convolutional Network for semantic segmentation.
-    Arguments:
+    Args:
         backbone (nn.Module): the network used to compute the features for the model.
             The backbone should return an OrderedDict[Tensor], with the key being
             "out" for the last feature map used, and "aux" if an auxiliary classifier
@@ -509,7 +509,7 @@ def box_area(boxes):
     """
     Computes the area of a set of bounding boxes, which are specified by its
     (x1, y1, x2, y2) coordinates.
-    Arguments:
+    Args:
         boxes (Tensor[N, 4]): boxes for which the area will be computed. They
             are expected to be in (x1, y1, x2, y2) format
     Returns:

--- a/caffe2/python/data_parallel_model.py
+++ b/caffe2/python/data_parallel_model.py
@@ -1056,7 +1056,7 @@ def _AllReduce(devices, model, net, param, use_nccl=False, control_input=None):
         """Create a Sum op for 2 or more blobs on different devices.
         Saves the result on the first device.
 
-        Arguments:
+        Args:
         dev_indices -- a list of device indices, which can be translated into
                        CUDA identifiers with model._devices
         """

--- a/caffe2/python/layers/merge_id_lists.py
+++ b/caffe2/python/layers/merge_id_lists.py
@@ -16,7 +16,7 @@ import numpy as np
 class MergeIdLists(ModelLayer):
     """Merge multiple ID_LISTs into a single ID_LIST
 
-    Arguments:
+    Args:
         model: A layer model instance
         input_record: Tuple (Struct) of ID_LIST features to be
         merged

--- a/caffe2/python/net_builder.py
+++ b/caffe2/python/net_builder.py
@@ -13,7 +13,7 @@ from caffe2.python.control_ops_util import add_if_op, add_while_op
 class NetBuilder(context.Managed):
     """
     Scope-driven mechanism for building nets, loops and conditional blocks.
-    Arguments:
+    Args:
       name: NetBuilder's name
       initial_scope: list of blobs that are available for reading/writing
     Example:

--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -755,7 +755,7 @@ but intuitively the interface they provide looks like this::
       ONNX outputs whose values correspond to the original PyTorch return values
       of the autograd Function (or None if an output is not supported by ONNX).
 
-      Arguments:
+      Args:
         g (Graph): graph to write the ONNX representation into
         inputs (Value...): list of values representing the variables which contain
             the inputs for this function
@@ -782,7 +782,7 @@ but intuitively the interface they provide looks like this::
         The set of operators and the inputs/attributes they take
         is documented at https://github.com/onnx/onnx/blob/master/docs/Operators.md
 
-        Arguments:
+        Args:
             opname (string): The ONNX operator name, e.g., `Abs` or `Add`.
             args (Value...): The inputs to the operator; usually provided
                 as arguments to the `symbolic` definition.

--- a/test/onnx/pytorch_helper.py
+++ b/test/onnx/pytorch_helper.py
@@ -23,7 +23,7 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
     """
     Embed an ONNX-exportable PyTorch Model into a Caffe2 model being built.
 
-    Arguments:
+    Args:
         helper (caffe2.python.core.ModelHelder): the model helper where
             this imported network should be inserted
         model (torch.nn.Module): the model to be exported

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -246,7 +246,7 @@ def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode
     For reproducibility, we recommend explicitly setting PyTorch's seed before
     invoking this function.
 
-    Arguments:
+    Args:
         model (torch.nn.Module): the model to be exported and verified
         args (tuple of arguments): the inputs to
             the model, e.g., such that ``model(*args)`` is a valid

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -617,7 +617,7 @@ def find_test_index(test, selected_tests, find_last_index=False):
     If :attr:`test`='torch' and :attr:`find_last_index`=False, result should be **2**.
     If :attr:`test`='torch' and :attr:`find_last_index`=True, result should be **4**.
 
-    Arguments:
+    Args:
         test (str): Name of test to lookup
         selected_tests (list): List of tests
         find_last_index (bool, optional): should we lookup the index of first or last

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -891,7 +891,7 @@ class TensorOptionsArguments:
         return [self.dtype, self.layout, self.device, self.pin_memory]
 
 @dataclass(frozen=True)
-class Args:
+class Arguments:
     # pre_self_positional is usually empty, but is notably non-empty
     # for where.self, where the condition argument comes before the
     # self argument

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -891,7 +891,7 @@ class TensorOptionsArguments:
         return [self.dtype, self.layout, self.device, self.pin_memory]
 
 @dataclass(frozen=True)
-class Arguments:
+class Args:
     # pre_self_positional is usually empty, but is notably non-empty
     # for where.self, where the condition argument comes before the
     # self argument

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -32,7 +32,7 @@ USE_NINJA = (not check_negative_env_flag('USE_NINJA') and
 def convert_cmake_value_to_python_value(cmake_value, cmake_type):
     r"""Convert a CMake value in a string form to a Python value.
 
-    Arguments:
+    Args:
       cmake_value (string): The CMake value in a string form (e.g., "ON", "OFF", "1").
       cmake_type (string): The CMake type of :attr:`cmake_value`.
 
@@ -56,7 +56,7 @@ def convert_cmake_value_to_python_value(cmake_value, cmake_type):
 def get_cmake_cache_variables_from_file(cmake_cache_file):
     r"""Gets values in CMakeCache.txt into a dictionary.
 
-    Arguments:
+    Args:
       cmake_cache_file: A CMakeCache.txt file object.
     Returns:
       dict: A ``dict`` containing the value of cached CMake variables.

--- a/tools/setup_helpers/env.py
+++ b/tools/setup_helpers/env.py
@@ -43,7 +43,7 @@ class BuildType(object):
     is ``None``, then the build type will be inferred from ``CMakeCache.txt``. If ``CMakeCache.txt`` does not exist,
     os.environ['CMAKE_BUILD_TYPE'] will be used.
 
-    Arguments:
+    Args:
       cmake_build_type_env (str): The value of os.environ['CMAKE_BUILD_TYPE']. If None, the actual build type will be
         inferred.
 

--- a/torch/_classes.py
+++ b/torch/_classes.py
@@ -40,7 +40,7 @@ class _Classes(types.ModuleType):
         ``torch.classes.loaded_libraries`` attribute, a set that may be inspected
         for the paths of all libraries loaded using this function.
 
-        Arguments:
+        Args:
             path (str): A path to a shared library to load.
         """
         torch.ops.load_library(path)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -254,7 +254,7 @@ def get_type_hint_captures(fn):
     for the literal annotations on 'fn'. These are not considered to be closed-over by fn
     and must be obtained separately (e.g. using this function).
 
-    Arguments:
+    Args:
         fn: A callable.
     Returns:
         A Dict[str, Any] containing a mapping from the literal annotations used on

--- a/torch/_lobpcg.py
+++ b/torch/_lobpcg.py
@@ -76,7 +76,7 @@ def _polynomial_value(poly, x, zero_power, transition):
     """
     A generic method for computing poly(x) using the Horner's rule.
 
-    Arguments:
+    Args:
       poly (Tensor): the (possibly batched) 1D Tensor representing
                      polynomial coefficients such that
                      poly[..., i] = (a_{i_0}, ..., a{i_n} (==1)), and
@@ -384,7 +384,7 @@ def lobpcg(A: Tensor,
       we do the following symmetrization map: `A -> (A + A.t()) / 2`.
       The map is performed only when the `A` requires gradients.
 
-    Arguments:
+    Args:
 
       A (Tensor): the input tensor of size :math:`(*, m, m)`
 
@@ -925,7 +925,7 @@ class LOBPCG(object):
           matrix product `D M` with element-wise product `M *
           d`. Also, creating the diagonal matrix `D` is avoided.
 
-        Arguments:
+        Args:
         S (Tensor): the matrix basis for the search subspace, size is
                     :math:`(m, n)`.
 
@@ -957,7 +957,7 @@ class LOBPCG(object):
                   modification of the corresponding algorithm
                   introduced in [StathopolousWu2002].
 
-        Arguments:
+        Args:
 
           U (Tensor) : initial approximation, size is (m, n)
           drop (bool) : when True, drop columns that
@@ -1023,7 +1023,7 @@ class LOBPCG(object):
         .. note:: If all U columns are B-collinear to V then the
                   returned tensor U will be empty.
 
-        Arguments:
+        Args:
 
           U (Tensor) : initial approximation, size is (m, n)
           V (Tensor) : B-orthogonal external basis, size is (m, k)

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -37,7 +37,7 @@ def get_approximate_basis(A,        # type: Tensor
     .. note:: To obtain repeatable results, reset the seed for the
               pseudorandom number generator
 
-    Arguments::
+    Args::
         A (Tensor): the input tensor of size :math:`(*, m, n)`
 
         q (int): the dimension of subspace spanned by :math:`Q`
@@ -103,7 +103,7 @@ def svd_lowrank(A, q=6, niter=2, M=None):
               will be useful for huge sparse matrices that
               ``torch.svd`` cannot handle.
 
-    Arguments::
+    Args::
         A (Tensor): the input tensor of size :math:`(*, m, n)`
 
         q (int, optional): a slightly overestimated rank of A.
@@ -211,7 +211,7 @@ def pca_lowrank(A, q=None, center=True, niter=2):
     .. note:: To obtain repeatable results, reset the seed for the
               pseudorandom number generator
 
-    Arguments:
+    Args:
 
         A (Tensor): the input tensor of size :math:`(*, m, n)`
 

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -94,7 +94,7 @@ class _Ops(types.ModuleType):
         ``torch.ops.loaded_libraries`` attribute, a set that may be inspected
         for the paths of all libraries loaded using this function.
 
-        Arguments:
+        Args:
             path (str): A path to a shared library to load.
         """
         path = torch._utils_internal.resolve_library_path(path)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3727,7 +3727,7 @@ Tests if each element of :attr:`input` is infinite
     Complex values are infinite when their real or imaginary part is
     infinite.
 
-    Arguments:
+    Args:
         {input}
 
     Returns:
@@ -3812,7 +3812,7 @@ Returns a new tensor with boolean elements representing if each element is `fini
 Real values are finite when they are not NaN, negative infinity, or infinity.
 Complex values are finite when both their real and imaginary parts are finite.
 
-    Arguments:
+    Args:
         {input}
 
     Returns:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -248,7 +248,7 @@ def _flatten_dense_tensors(tensors):
     buffer. Element-wise operation on this buffer will be equivalent to
     operating individually.
 
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): dense tensors to flatten.
 
     Returns:
@@ -264,7 +264,7 @@ def _flatten_sparse_tensors(tensors):
     """Flatten sparse tensors into two contiguous 1D buffers, one of indices and
     one of values. Assume tensors are of same sparse type.
 
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): sparse tensors to flatten.
 
     Returns:
@@ -280,7 +280,7 @@ def _unflatten_dense_tensors(flat, tensors):
     """View a flat buffer using the sizes of tensors. Assume that tensors are of
     same dense type, and that flat is given by _flatten_dense_tensors.
 
-    Arguments:
+    Args:
         flat (Tensor): flattened dense tensors to unflatten.
         tensors (Iterable[Tensor]): dense tensors whose sizes will be used to
           unflatten flat.
@@ -303,7 +303,7 @@ def _unflatten_sparse_tensors(flat, tensors):
     tensors. Assume that tensors are of same sparse type, and that flat is given
     by _flatten_sparse_tensors.
 
-    Arguments:
+    Args:
         flat (tuple(Tensor, Tensor)): flattened indices and values of sparse
           tensors to unflatten.
         tensors (Iterable[Tensor]): sparse tensors whose sizes will be used to
@@ -327,7 +327,7 @@ def _reorder_tensors_as(tensors, ordered_tensors):
     types, e.g., from _take_tensors. Reorder them to be of same order as
     ordered_tensors.
 
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): tensors to be reordered. They should be of
           the same order as ordered_tensors within their own types.
         ordered_tensors (Iterable[Tensor]): tensors whose order will be the

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -101,7 +101,7 @@ def backward(
         in a user-specified CUDA stream context, see
         :ref:`Stream semantics of backward passes<bwd-cuda-stream-semantics>`.
 
-    Arguments:
+    Args:
         tensors (sequence of Tensor): Tensors of which the derivative will be
             computed.
         grad_tensors (sequence of (Tensor or None)): The "vector" in the Jacobian-vector
@@ -173,7 +173,7 @@ def grad(
         in a user-specified CUDA stream context, see
         :ref:`Stream semantics of backward passes<bwd-cuda-stream-semantics>`.
 
-    Arguments:
+    Args:
         outputs (sequence of Tensor): outputs of the differentiated function.
         inputs (sequence of Tensor): Inputs w.r.t. which the gradient will be
             returned (and not accumulated into ``.grad``).

--- a/torch/autograd/anomaly_mode.py
+++ b/torch/autograd/anomaly_mode.py
@@ -89,7 +89,7 @@ class set_detect_anomaly(object):
 
     See ``detect_anomaly`` above for details of the anomaly detection behaviour.
 
-    Arguments:
+    Args:
         mode (bool): Flag whether to enable anomaly detection (``True``),
                      or disable (``False``).
 

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -172,7 +172,7 @@ class set_grad_enabled(object):
     This context manager is thread local; it will not affect computation
     in other threads.
 
-    Arguments:
+    Args:
         mode (bool): Flag whether to enable grad (``True``), or disable
                      (``False``). This can be used to conditionally enable
                      gradients.

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -172,7 +172,7 @@ class EventList(list):
     def table(self, sort_by=None, row_limit=100, max_src_column_width=75, header=None, top_level_events_only=False):
         """Prints an EventList as a nicely formatted table.
 
-        Arguments:
+        Args:
             sort_by (str, optional): Attribute used to sort entries. By default
                 they are printed in the same order as they were registered.
                 Valid keys include: ``cpu_time``, ``cuda_time``, ``cpu_time_total``,
@@ -203,7 +203,7 @@ class EventList(list):
 
         The checkpoint can be later loaded and inspected under ``chrome://tracing`` URL.
 
-        Arguments:
+        Args:
             path (str): Path where the trace will be written.
         """
         import os
@@ -288,7 +288,7 @@ class EventList(list):
     def key_averages(self, group_by_input_shapes=False, group_by_stack_n=0):
         """Averages all function events over their keys.
 
-        Arguments:
+        Args:
             group_by_input_shapes: group entries by
             (event name, input shapes) rather than just event name.
             This is useful to see which input shapes contribute to the runtime
@@ -345,7 +345,7 @@ class profile(object):
     only report runtime of PyTorch functions.
     Note: profiler is thread local and is automatically propagated into the async tasks
 
-    Arguments:
+    Args:
         enabled (bool, optional): Setting this to False makes this context manager a no-op.
             Default: ``True``.
 
@@ -574,7 +574,7 @@ class record_function(ContextDecorator):
     Python code (or function) when running autograd profiler. It is
     useful when tracing the code profile.
 
-    Arguments:
+    Args:
         name (str): Label assigned to the block of code.
         node_id (int): ID of node, for distributed profiling. Unset in
         non-distributed cases.
@@ -628,7 +628,7 @@ class record_function(ContextDecorator):
         once to attach the callback onto the future, and will throw if called multiple
         times.
 
-        Arguments:
+        Args:
             fut: (torch._C.Future): future for which to schedule
             callback for.
 
@@ -666,7 +666,7 @@ class emit_nvtx(object):
         This context manager should not be called recursively, i.e. at most one
         instance should be enabled at any given time.
 
-    Arguments:
+    Args:
         enabled (bool, optional, default=True): Setting ``enabled=False`` makes this context manager a no-op.
             Default: ``True``.
         record_shapes (bool, optional, default=False): If ``record_shapes=True``, the nvtx range wrapping
@@ -761,7 +761,7 @@ class emit_nvtx(object):
 def load_nvprof(path):
     """Opens an nvprof trace file and parses autograd annotations.
 
-    Arguments:
+    Args:
         path (str): path to nvprof trace
     """
     return EventList(parse_nvprof_trace(path))

--- a/torch/contrib/_tensorboard_vis.py
+++ b/torch/contrib/_tensorboard_vis.py
@@ -52,7 +52,7 @@ def visualize(graph, name_prefix='', pb_graph=None, executors_it=None):
 def visualize_graph_executor(state, name_prefix, pb_graph, inline_graph):
     """Appends the state of a given GraphExecutor to the graph protobuf.
 
-    Arguments:
+    Args:
         state (GraphExecutor or GraphExecutorState): GraphExecutor to display.
         name_prefix (str): Name prefix of the containing subgraph.
         pb_graph (GraphDef): graph to append to.

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -245,7 +245,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
                   to the local node and returns it. If the current node is the
                   owner, returns a reference to the local value.
 
-                  Arguments:
+                  Args:
                       timeout (float, optional): Timeout for ``to_here``. If
                           the call does not complete within this timeframe, an
                           exception indicating so will be raised. If this
@@ -437,7 +437,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
                   the node calling this API has to be the owner of the RRef.
                   The value of the RRef is expected to be a scalar Tensor.
 
-                Arguments:
+                Args:
                     dist_autograd_ctx_id (int, optional): The distributed
                         autograd context id for which we should retrieve the
                         gradients (default: -1).
@@ -464,7 +464,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
           The backend options class for ``ProcessGroupAgent``, which is derived
           from ``RpcBackendOptions``.
 
-          Arguments:
+          Args:
               num_send_recv_threads (int, optional): The number of threads in
                   the thread-pool used by ``ProcessGroupAgent`` (default: 4).
               rpc_timeout (float, optional): The default timeout, in seconds,
@@ -782,7 +782,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
     Set whether GIL wait times should be enabled or not. This incurs a slight
     overhead cost. Default is disabled for performance reasons.
 
-    Arguments:
+    Args:
         flag (bool): True to set GIL profiling, False to disable.
       )");
 
@@ -801,7 +801,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
           :meth:`~torch.distributed.rpc.rpc_sync` and
           :meth:`~torch.distributed.rpc.rpc_async`.
 
-          Arguments:
+          Args:
             rpcTimeoutSeconds (float): Timeout value in seconds.
       )");
 

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -210,7 +210,7 @@ def check_error(res: int) -> None:
 class device(object):
     r"""Context-manager that changes the selected device.
 
-    Arguments:
+    Args:
         device (torch.device or int): device index to select. It's a no-op if
             this argument is a negative integer or ``None``.
     """
@@ -239,7 +239,7 @@ class device_of(device):
     You can use both tensors and storages as arguments. If a given object is
     not allocated on a GPU, this is a no-op.
 
-    Arguments:
+    Args:
         obj (Tensor or Storage): object allocated on the selected device.
     """
 
@@ -254,7 +254,7 @@ def set_device(device: _device_t) -> None:
     Usage of this function is discouraged in favor of :any:`device`. In most
     cases it's better to use ``CUDA_VISIBLE_DEVICES`` environmental variable.
 
-    Arguments:
+    Args:
         device (torch.device or int): selected device. This function is a no-op
             if this argument is negative.
     """
@@ -266,7 +266,7 @@ def set_device(device: _device_t) -> None:
 def get_device_name(device: Optional[_device_t] = None) -> str:
     r"""Gets the name of a device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): device for which to return the
             name. This function is a no-op if this argument is a negative
             integer. It uses the current device, given by :func:`~torch.cuda.current_device`,
@@ -278,7 +278,7 @@ def get_device_name(device: Optional[_device_t] = None) -> str:
 def get_device_capability(device: Optional[_device_t] = None) -> Tuple[int, int]:
     r"""Gets the cuda capability of a device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): device for which to return the
             device capability. This function is a no-op if this argument is
             a negative integer. It uses the current device, given by
@@ -307,7 +307,7 @@ def stream(stream):
     All CUDA kernels queued within its context will be enqueued on a selected
     stream.
 
-    Arguments:
+    Args:
         stream (Stream): selected stream. This manager is a no-op if it's
             ``None``.
 
@@ -370,7 +370,7 @@ def current_device() -> int:
 def synchronize(device: _device_t = None) -> None:
     r"""Waits for all kernels in all streams on a CUDA device to complete.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): device for which to synchronize.
             It uses the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -396,7 +396,7 @@ def ipc_collect():
 def current_stream(device: Optional[_device_t] = None) -> Stream:
     r"""Returns the currently selected :class:`Stream` for a given device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             the currently selected :class:`Stream` for the current device, given
             by :func:`~torch.cuda.current_device`, if :attr:`device` is ``None``
@@ -410,7 +410,7 @@ def current_stream(device: Optional[_device_t] = None) -> Stream:
 def default_stream(device: Optional[_device_t] = None) -> Stream:
     r"""Returns the default :class:`Stream` for a given device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             the default :class:`Stream` for the current device, given by
             :func:`~torch.cuda.current_device`, if :attr:`device` is ``None``

--- a/torch/cuda/amp/autocast_mode.py
+++ b/torch/cuda/amp/autocast_mode.py
@@ -109,7 +109,7 @@ class autocast(object):
     :class:`torch.nn.parallel.DistributedDataParallel` when used with more than one GPU per process
     (see :ref:`Working with Multiple GPUs<amp-multigpu>`).
 
-    Arguments:
+    Args:
         enabled(bool, optional, default=True):  Whether autocasting should be enabled in the region.
     """
     def __init__(self, enabled=True):
@@ -176,7 +176,7 @@ def custom_fwd(fwd=None, **kwargs):
     Helper decorator for ``forward`` methods of custom autograd functions (subclasses of
     :class:`torch.autograd.Function`).  See the :ref:`example page<amp-custom-examples>` for more detail.
 
-    Arguments:
+    Args:
         cast_inputs (:class:`torch.dtype` or None, optional, default=None):  If not ``None``,
             when ``forward`` runs in an autocast-enabled region, casts incoming
             floating-point CUDA Tensors to the target dtype (non-floating-point Tensors are not affected),

--- a/torch/cuda/amp/grad_scaler.py
+++ b/torch/cuda/amp/grad_scaler.py
@@ -94,7 +94,7 @@ class GradScaler(object):
     value calibrates.  ``scaler.step`` will skip the underlying ``optimizer.step()`` for these
     iterations.  After that, step skipping should occur rarely (once every few hundred or thousand iterations).
 
-    Arguments:
+    Args:
         init_scale (float, optional, default=2.**16):  Initial scale factor.
         growth_factor (float, optional, default=2.0):  Factor by which the scale is multiplied during
             :meth:`update` if no inf/NaN gradients occur for ``growth_interval`` consecutive iterations.
@@ -150,7 +150,7 @@ class GradScaler(object):
         Returns scaled outputs.  If this instance of :class:`GradScaler` is not enabled, outputs are returned
         unmodified.
 
-        Arguments:
+        Args:
             outputs (Tensor or iterable of Tensors):  Outputs to scale.
         """
         if not self._enabled:
@@ -245,7 +245,7 @@ class GradScaler(object):
             scaler.step(optimizer)
             scaler.update()
 
-        Arguments:
+        Args:
             optimizer (torch.optim.Optimizer):  Optimizer that owns the gradients to be unscaled.
 
         .. note::
@@ -292,7 +292,7 @@ class GradScaler(object):
 
         Returns the return value of ``optimizer.step(*args, **kwargs)``.
 
-        Arguments:
+        Args:
             optimizer (torch.optim.Optimizer):  Optimizer that applies the gradients.
             args:  Any arguments.
             kwargs:  Any keyword arguments.
@@ -346,7 +346,7 @@ class GradScaler(object):
 
         Passing ``new_scale`` sets the scale directly.
 
-        Arguments:
+        Args:
             new_scale (float or :class:`torch.cuda.FloatTensor`, optional, default=None):  New scale factor.
 
         .. warning::
@@ -415,7 +415,7 @@ class GradScaler(object):
 
     def set_growth_factor(self, new_factor):
         r"""
-        Arguments:
+        Args:
             new_scale (float):  Value to use as the new scale growth factor.
         """
         self._growth_factor = new_factor
@@ -428,7 +428,7 @@ class GradScaler(object):
 
     def set_backoff_factor(self, new_factor):
         r"""
-        Arguments:
+        Args:
             new_scale (float):  Value to use as the new scale backoff factor.
         """
         self._backoff_factor = new_factor
@@ -441,7 +441,7 @@ class GradScaler(object):
 
     def set_growth_interval(self, new_interval):
         r"""
-        Arguments:
+        Args:
             new_interval (int):  Value to use as the new growth interval.
         """
         self._growth_interval = new_interval
@@ -484,7 +484,7 @@ class GradScaler(object):
         r"""
         Loads the scaler state.  If this instance is disabled, :meth:`load_state_dict` is a no-op.
 
-        Arguments:
+        Args:
            state_dict(dict): scaler state.  Should be an object returned from a call to :meth:`state_dict`.
         """
         if not self._enabled:

--- a/torch/cuda/memory.py
+++ b/torch/cuda/memory.py
@@ -29,7 +29,7 @@ def caching_allocator_alloc(size, device: Union[Device, int] = None, stream=None
     frameworks. Allocated memory is released through
     :func:`~torch.cuda.caching_allocator_delete`.
 
-    Arguments:
+    Args:
         size (int): number of bytes to be allocated.
         device (torch.device or int, optional): selected device. If it is
             ``None`` the default CUDA device is used.
@@ -62,7 +62,7 @@ def caching_allocator_delete(mem_ptr):
     is freed here. The associated device and stream are tracked inside
     the allocator.
 
-    Arguments:
+    Args:
         mem_ptr (int): memory address to be freed by the allocator.
 
     .. note::
@@ -79,7 +79,7 @@ def set_per_process_memory_fraction(fraction, device: Union[Device, int] = None)
     If trying to allocate more than the allowed value in a process, will raise an out of
     memory error in allocator.
 
-    Arguments:
+    Args:
         fraction(float): Range: 0~1. Allowed memory equals total_memory * fraction.
         device (torch.device or int, optional): selected device. If it is
             ``None`` the default CUDA device is used.
@@ -164,7 +164,7 @@ def memory_stats(device: Union[Device, int] = None) -> Dict[str, Any]:
       result in a cache flush and retry.
     - ``"num_ooms"``: number of out-of-memory errors thrown.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistics for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -204,7 +204,7 @@ def reset_accumulated_memory_stats(device: Union[Device, int] = None) -> None:
     the `"allocated"` and `"freed"` keys in each individual stat dict, as well as
     `"num_alloc_retries"` and `"num_ooms"`.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -223,7 +223,7 @@ def reset_peak_memory_stats(device: Union[Device, int] = None) -> None:
     See :func:`~torch.cuda.memory_stats` for details. Peak stats correspond to the
     `"peak"` key in each individual stat dict.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -242,7 +242,7 @@ def reset_max_memory_allocated(device: Union[Device, int] = None) -> None:
 
     See :func:`~torch.cuda.max_memory_allocated` for details.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -268,7 +268,7 @@ def reset_max_memory_cached(device: Union[Device, int] = None) -> None:
 
     See :func:`~torch.cuda.max_memory_cached` for details.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -292,7 +292,7 @@ def memory_allocated(device: Union[Device, int] = None) -> int:
     r"""Returns the current GPU memory occupied by tensors in bytes for a given
     device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -316,7 +316,7 @@ def max_memory_allocated(device: Union[Device, int] = None) -> int:
     functions can measure the peak allocated memory usage of each iteration in a
     training loop.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -332,7 +332,7 @@ def memory_reserved(device: Union[Device, int] = None) -> int:
     r"""Returns the current GPU memory managed by the caching allocator in bytes
     for a given device.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -354,7 +354,7 @@ def max_memory_reserved(device: Union[Device, int] = None) -> int:
     can measure the peak cached memory amount of each iteration in a training
     loop.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             statistic for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -402,7 +402,7 @@ def memory_summary(device: Union[Device, int] = None, abbreviated: bool = False)
     This can be useful to display periodically during training, or when
     handling out-of-memory exceptions.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             printout for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).
@@ -503,7 +503,7 @@ def list_gpu_processes(device: Union[Device, int] = None) -> str:
     This can be useful to display periodically during training, or when
     handling out-of-memory exceptions.
 
-    Arguments:
+    Args:
         device (torch.device or int, optional): selected device. Returns
             printout for the current device, given by :func:`~torch.cuda.current_device`,
             if :attr:`device` is ``None`` (default).

--- a/torch/cuda/nvtx.py
+++ b/torch/cuda/nvtx.py
@@ -22,7 +22,7 @@ def range_push(msg):
     Pushes a range onto a stack of nested range span.  Returns zero-based
     depth of the range that is started.
 
-    Arguments:
+    Args:
         msg (string): ASCII message to associate with range
     """
     return _nvtx.rangePushA(msg)
@@ -40,7 +40,7 @@ def mark(msg):
     """
     Describe an instantaneous event that occurred at some point.
 
-    Arguments:
+    Args:
         msg (string): ASCII message to associate with the event.
     """
     return _nvtx.markA(msg)
@@ -53,7 +53,7 @@ def range(msg, *args, **kwargs):
     of its scope, and pops it at the end. If extra arguments are given,
     they are passed as arguments to msg.format().
 
-    Arguments:
+    Args:
         msg (string): message to associate with the range
     """
     range_push(msg.format(*args, **kwargs))

--- a/torch/cuda/streams.py
+++ b/torch/cuda/streams.py
@@ -17,7 +17,7 @@ class Stream(torch._C._CudaStreamBase):
     device, independent from other streams.  See :ref:`cuda-semantics` for
     details.
 
-    Arguments:
+    Args:
         device(torch.device or int, optional): a device on which to allocate
             the stream. If :attr:`device` is ``None`` (default) or a negative
             integer, this will use the current device.
@@ -36,7 +36,7 @@ class Stream(torch._C._CudaStreamBase):
     def wait_event(self, event):
         r"""Makes all future work submitted to the stream wait for an event.
 
-        Arguments:
+        Args:
             event (Event): an event to wait for.
 
         .. note:: This is a wrapper around ``cudaStreamWaitEvent()``: see
@@ -56,7 +56,7 @@ class Stream(torch._C._CudaStreamBase):
         All future work submitted to this stream will wait until all kernels
         submitted to a given stream at the time of call complete.
 
-        Arguments:
+        Args:
             stream (Stream): a stream to synchronize.
 
         .. note:: This function returns without waiting for currently enqueued
@@ -67,7 +67,7 @@ class Stream(torch._C._CudaStreamBase):
     def record_event(self, event=None):
         r"""Records an event.
 
-        Arguments:
+        Args:
             event (Event, optional): event to record. If not given, a new one
                 will be allocated.
 
@@ -123,7 +123,7 @@ class Event(torch._C._CudaEventBase):
     same device may record the event. However, streams on any device can wait on
     the event.
 
-    Arguments:
+    Args:
         enable_timing (bool, optional): indicates if the event should measure time
             (default: ``False``)
         blocking (bool, optional): if ``True``, :meth:`wait` will be blocking (default: ``False``)

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -111,7 +111,7 @@ def powerSGD_hook(
     one left multiplication and one right multiplication.
     For warm start, can take one such step at a time, and alternate between them.
 
-    Arguments:
+    Args:
         state (PowerSGDState): State information to configure the compression rate and support error feedback, warm start, etc.
         bucket (dist._GradBucket): Bucket that stores a 1D flattened gradient tensor that batches multiple per-variable tensors.
             Note that since DDP comm hook only supports single process single device mode at this time,
@@ -348,7 +348,7 @@ def batched_powerSGD_hook(
     one left multiplication and one right multiplication.
     For warm start, can take one such step at a time, and alternate between them.
 
-    Arguments:
+    Args:
         state (PowerSGDState): State information to configure the compression rate and support error feedback, warm start, etc.
         bucket (dist._GradBucket): Bucket that stores a 1D flattened gradient tensor that batches multiple per-variable tensors.
             Note that since DDP comm hook only supports single process single device mode at this time,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -114,7 +114,7 @@ class Backend(object):
 
         This class method is used by 3rd party cpp extension to register new backend.
 
-        Arguments:
+        Args:
             name (str): Backend name matching with the one in `init_process_group()`.
             func (function): Function handler that instantiates the backend.
                              The function should be implemented in the backend cpp extension
@@ -356,7 +356,7 @@ def get_backend(group=None):
     """
     Returns the backend of the given process group.
 
-    Arguments:
+    Args:
         group (ProcessGroup, optional): The process group to work on. The
             default is the general main process group. If another specific group
             is specified, the calling process must be part of :attr:`group`.
@@ -396,7 +396,7 @@ def init_process_group(backend,
     If neither is specified, ``init_method`` is assumed to be "env://".
 
 
-    Arguments:
+    Args:
         backend (str or Backend): The backend to use. Depending on
             build-time configurations, valid values include ``mpi``, ``gloo``,
             and ``nccl``. This field should be given as a lowercase string
@@ -611,7 +611,7 @@ def destroy_process_group(group=None):
     """
     Destroy a given process group, and deinitialize the distributed package
 
-    Arguments:
+    Args:
         group (ProcessGroup, optional): The process group to be destroyed, if
                                         group.WORLD is given, all process
                                         groups including the default one will
@@ -665,7 +665,7 @@ def get_rank(group=None):
     process group. They are always consecutive integers ranging from 0 to
     ``world_size``.
 
-    Arguments:
+    Args:
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
 
@@ -688,7 +688,7 @@ def get_world_size(group=None):
     """
     Returns the number of processes in the current process group
 
-    Arguments:
+    Args:
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
 
@@ -710,7 +710,7 @@ def isend(tensor,
     """
     Sends a tensor asynchronously.
 
-    Arguments:
+    Args:
         tensor (Tensor): Tensor to send.
         dst (int): Destination rank.
         group (ProcessGroup, optional): The process group to work on. If None,
@@ -741,7 +741,7 @@ def irecv(tensor,
     """
     Receives a tensor asynchronously.
 
-    Arguments:
+    Args:
         tensor (Tensor): Tensor to fill with received data.
         src (int, optional): Source rank. Will receive from any
             process if unspecified.
@@ -780,7 +780,7 @@ def send(tensor,
     """
     Sends a tensor synchronously.
 
-    Arguments:
+    Args:
         tensor (Tensor): Tensor to send.
         dst (int): Destination rank.
         group (ProcessGroup, optional): The process group to work on. If None,
@@ -807,7 +807,7 @@ def recv(tensor,
     """
     Receives a tensor synchronously.
 
-    Arguments:
+    Args:
         tensor (Tensor): Tensor to fill with received data.
         src (int, optional): Source rank. Will receive from any
             process if unspecified.
@@ -854,7 +854,7 @@ class P2POp(object):
     Process Group group, and tag. Instances of this class will be passed to
     ``batch_isend_irecv`` for point-to-point communications.
 
-    Arguments:
+    Args:
         op (callable): A function to send data to or receive data from a peer process.
             The type of ``op`` is either ``torch.distributed.isend`` or
             ``torch.distributed.irecv``.
@@ -895,7 +895,7 @@ def batch_isend_irecv(p2p_op_list):
     Process each of the operations in p2p_op_list and return the corresponding
     requests. NCCL and Gloo backend are currently supported.
 
-    Arguments:
+    Args:
         p2p_op_list: A list of point-to-point operations(type of each operator is
             ``torch.distributed.P2POp``). The order of the isend/irecv in the list
             matters and it needs to match with corresponding isend/irecv on the
@@ -955,7 +955,7 @@ def broadcast_multigpu(tensor_list,
     Only nccl and gloo backend are currently supported
     tensors should only be GPU tensors
 
-    Arguments:
+    Args:
         tensor_list (List[Tensor]): Tensors that participate in the collective
             operation. If ``src`` is the rank, then the specified ``src_tensor``
             element of ``tensor_list`` (``tensor_list[src_tensor]``) will be
@@ -1005,7 +1005,7 @@ def broadcast(tensor,
     ``tensor`` must have the same number of elements in all processes
     participating in the collective.
 
-    Arguments:
+    Args:
         tensor (Tensor): Data to be sent if ``src`` is the rank of current
             process, and tensor to be used to save received data otherwise.
         src (int): Source rank.
@@ -1058,7 +1058,7 @@ def all_reduce_multigpu(tensor_list,
     Only nccl and gloo backend is currently supported
     tensors should only be GPU tensors
 
-    Arguments:
+    Args:
         tensor list (List[Tensor]): List of input and output tensors of
             the collective. The function operates in-place and requires that
             each tensor to be a GPU tensor on different GPUs.
@@ -1107,7 +1107,7 @@ def all_reduce(tensor,
 
     Complex tensors are supported.
 
-    Arguments:
+    Args:
         tensor (Tensor): Input and output of the collective. The function
             operates in-place.
         op (optional): One of the values from
@@ -1189,7 +1189,7 @@ def all_reduce_coalesced(tensors,
 
     Complex tensors are supported.
 
-    Arguments:
+    Args:
         tensors (List[Tensor]): Input and output of the collective. The function
             operates in-place.
         op (Optional[ReduceOp]): One of the values from
@@ -1243,7 +1243,7 @@ def reduce_multigpu(tensor_list,
     Only nccl backend is currently supported
     tensors should only be GPU tensors
 
-    Arguments:
+    Args:
         tensor_list (List[Tensor]): Input and output GPU tensors of the
             collective. The function operates in-place.
             You also need to make sure that ``len(tensor_list)`` is the same for
@@ -1295,7 +1295,7 @@ def reduce(tensor,
 
     Only the process with rank ``dst`` is going to receive the final result.
 
-    Arguments:
+    Args:
         tensor (Tensor): Input and output of the collective. The function
             operates in-place.
         dst (int): Destination rank
@@ -1346,7 +1346,7 @@ def all_gather_multigpu(output_tensor_lists,
 
     Complex tensors are supported.
 
-    Arguments:
+    Args:
         output_tensor_lists (List[List[Tensor]]): Output lists. It should
             contain correctly-sized tensors on each GPU to be used for output
             of the collective, e.g. ``output_tensor_lists[i]`` contains the
@@ -1417,7 +1417,7 @@ def all_gather_object(object_list, obj, group=None):
     :func:`all_gather`, but Python objects can be passed in. Note that the object
     must be picklable in order to be gathered.
 
-    Arguments:
+    Args:
         object_list (list[Any]): Output list. It should be correctly sized as the
             size of the group for this collective and will contain the output.
         object (Any): Pickable Python object to be broadcast from current process.
@@ -1505,7 +1505,7 @@ def gather_object(obj, object_gather_list=None, dst=0, group=None):
     Similar to :func:`gather`, but Python objects can be passed in. Note that the
     object must be picklable in order to be gathered.
 
-    Arguments:
+    Args:
         obj (Any): Input object. Must be picklable.
         object_gather_list (list[Any]): Output list. On the ``dst`` rank, it
             should be correctly sized as the size of the group for this
@@ -1606,7 +1606,7 @@ def broadcast_object_list(object_list, src, group=None):
     Note that all objects in ``object_list`` must be picklable in order to be
     broadcasted.
 
-    Arguments:
+    Args:
         object_list (List[Any]): List of input objects to broadcast.
             Each object must be picklable. Only objects on the ``src`` rank will
             be broadcast, but each rank must provide lists of equal sizes.
@@ -1701,7 +1701,7 @@ def scatter_object_list(
     ``scatter_object_output_list``. Note that all objects in
     ``scatter_object_input_list`` must be picklable in order to be scattered.
 
-    Arguments:
+    Args:
         scatter_object_output_list (List[Any]): Non-empty list whose first
             element will store the object scattered to this rank.
         scatter_object_input_list (List[Any]): List of input objects to scatter.
@@ -1799,7 +1799,7 @@ def all_gather(tensor_list,
 
     Complex tensors are supported.
 
-    Arguments:
+    Args:
         tensor_list (list[Tensor]): Output list. It should contain
             correctly-sized tensors to be used for output of the collective.
         tensor (Tensor): Tensor to be broadcast from current process.
@@ -1869,7 +1869,7 @@ def all_gather_coalesced(output_tensor_lists,
 
     Complex tensors are supported.
 
-    Arguments:
+    Args:
         output_tensor_lists (list[list[Tensor]]): Output list. It should contain
             correctly-sized tensors to be used for output of the collective.
         input_tensor_list (list[Tensor]): Tensors to be broadcast from
@@ -1954,7 +1954,7 @@ def gather(tensor,
     """
     Gathers a list of tensors in a single process.
 
-    Arguments:
+    Args:
         tensor (Tensor): Input tensor.
         gather_list (list[Tensor], optional): List of appropriately-sized
             tensors to use for gathered data (default is None, must be specified
@@ -2013,7 +2013,7 @@ def scatter(tensor,
     Each process will receive exactly one tensor and store its data in the
     ``tensor`` argument.
 
-    Arguments:
+    Args:
         tensor (Tensor): Output tensor.
         scatter_list (list[Tensor]): List of tensors to scatter (default is
             None, must be specified on the source rank)
@@ -2081,7 +2081,7 @@ def reduce_scatter_multigpu(output_tensor_list,
     Each tensor in ``output_tensor_list`` should reside on a separate GPU, as
     should each list of tensors in ``input_tensor_lists``.
 
-    Arguments:
+    Args:
         output_tensor_list (List[Tensor]): Output tensors (on different GPUs)
             to receive the result of the operation.
 
@@ -2149,7 +2149,7 @@ def reduce_scatter(output,
     """
     Reduces, then scatters a list of tensors to all processes in a group.
 
-    Arguments:
+    Args:
         output (Tensor): Output tensor.
         input_list (list[Tensor]): List of tensors to reduce and scatter.
         group (ProcessGroup, optional): The process group to work on. If None,
@@ -2192,7 +2192,7 @@ def all_to_all_single(output,
     to all processes in a group. Then concatenate the received tensors from all
     the processes in the group and return single output tensor.
 
-    Arguments:
+    Args:
         output (Tensor): Gathered cancatenated output tensor.
         input (Tensor): Input tensor to scatter.
         output_split_sizes: (list[Int], optional): Output split sizes for dim 0
@@ -2285,7 +2285,7 @@ def all_to_all(output_tensor_list,
     Each process scatters list of input tensors to all processes in a group and
     return gathered list of tensors in output list.
 
-    Arguments:
+    Args:
         output_tensor_list (list[Tensor]): List of tensors to be gathered one
             per rank.
         input_tensor_list (list[Tensor]): List of tensors to scatter one per rank.
@@ -2378,7 +2378,7 @@ def barrier(group=GroupMember.WORLD,
     This collective blocks processes until the whole group enters this function,
     if async_op is False, or if async work handle is called on wait().
 
-    Arguments:
+    Args:
         group (ProcessGroup, optional): The process group to work on. If None,
             the default process group will be used.
         async_op (bool, optional): Whether this op should be an async op
@@ -2422,7 +2422,7 @@ def new_group(ranks=None, timeout=default_pg_timeout, backend=None):
         ia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html#using
         -multiple-nccl-communicators-concurrently>`_ for more details.
 
-    Arguments:
+    Args:
         ranks (list[int]): List of ranks of group members. If ``None``, will be
             set to all ranks. Default is ``None``.
         timeout (timedelta, optional): Timeout for operations executed against

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -100,7 +100,7 @@ class _RemoteModule(nn.Module):
         ``def forward(input: Tensor) -> Tensor:`` and
         ``def forward_async(input: Tensor) -> Future[Tensor]:``.
 
-        Arguments:
+        Args:
             remote_device (str): Device on the destination worker where we‘d like to place this module.
                 The format should be "<workername>/<device>", where the device field can be parsed as torch.device type.
                 E.g., "trainer0/cpu", "trainer0", "ps0/cuda:0".
@@ -339,7 +339,7 @@ class RemoteModule(_RemoteModule):
         ``def forward(input: Tensor) -> Tensor:`` and
         ``def forward_async(input: Tensor) -> Future[Tensor]:``.
 
-    Arguments:
+    Args:
         remote_device (str): Device on the destination worker where we‘d like to place this module.
             The format should be "<workername>/<device>", where the device field can be parsed as torch.device type.
             E.g., "trainer0/cpu", "trainer0", "ps0/cuda:0".

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -95,7 +95,7 @@ def _retrieve_device(module: nn.Module) -> torch.device:
     """Validates all parameters in the Module have the same device and returns
     the appropriate device.
 
-    Arguments:
+    Args:
         An ``nn.Module`` to process.
 
     Returns:
@@ -152,7 +152,7 @@ class Pipe(Module):
     into an :class:`nn.Sequential <torch.nn.Sequential>` module defining the
     desired order of execution.
 
-    Arguments:
+    Args:
         module (:class:`nn.Sequential <torch.nn.Sequential>`):
             sequential module to be parallelized using pipelining. Each module
             in the sequence has to have all of its parameters on a single
@@ -339,7 +339,7 @@ class Pipe(Module):
         size is less than ``chunks``, the number of micro-batches is equal to
         the batch size.
 
-        Arguments:
+        Args:
             input (torch.Tensor or sequence of :class:`~torch.Tensor`): input mini-batch
 
         Returns:

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -31,7 +31,7 @@ def register_rendezvous_handler(scheme, handler):
     Pick a unique name and use the URL scheme to identify it when
     calling the `rendezvous()` function.
 
-    Arguments:
+    Args:
         scheme (str): URL scheme to identify your rendezvous handler.
         handler (function): Handler that is invoked when the
             `rendezvous()` function is called with a URL that uses

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -85,7 +85,7 @@ if is_available():
         and distributed autograd, which immediately makes the current
         process ready to send and receive RPCs.
 
-        Arguments:
+        Args:
             backend (BackendType, optional): The type of RPC backend
                 implementation. Supported values include
                 ``BackendType.TENSORPIPE`` (the default) and

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -273,7 +273,7 @@ def shutdown(graceful=True):
         :meth:`~torch.distributed.rpc.rpc_async`, ``future.wait()`` should not
         be called after ``shutdown()``.
 
-    Arguments:
+    Args:
         graceful (bool): Whether to do a graceful shutdown or not. If True,
                          this will 1) wait until there is no pending system
                          messages for ``UserRRefs`` and delete them; 2) block
@@ -337,7 +337,7 @@ def get_worker_info(worker_name=None):
     Use this :class:`~torch.distributed.rpc.WorkerInfo` to avoid passing an
     expensive string on every invocation.
 
-    Arguments:
+    Args:
         worker_name (str): the string name of a worker. If ``None``, return the
                            the id of the current worker. (default ``None``)
 
@@ -446,7 +446,7 @@ def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     :class:`~torch.distributed.rpc.RRef` is only destructed when globally there
     are no living references to it.
 
-    Arguments:
+    Args:
         to (str or WorkerInfo or int): name/rank/``WorkerInfo`` of the destination worker.
         func (callable): a callable function, such as Python callables, builtin
                          operators (e.g. :meth:`~torch.add`) and annotated
@@ -703,7 +703,7 @@ def rpc_sync(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     messages are sent and received in parallel to execution of Python code. This
     method is thread-safe.
 
-    Arguments:
+    Args:
         to (str or WorkerInfo or int): name/rank/``WorkerInfo`` of the destination worker.
         func (callable): a callable function, such as Python callables, builtin
                          operators (e.g. :meth:`~torch.add`) and annotated
@@ -782,7 +782,7 @@ def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     method is thread-safe. This method will immediately return a
     :class:`~torch.futures.Future` that can be awaited on.
 
-    Arguments:
+    Args:
         to (str or WorkerInfo or int): name/rank/``WorkerInfo`` of the destination worker.
         func (callable): a callable function, such as Python callables, builtin
                          operators (e.g. :meth:`~torch.add`) and annotated

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -38,7 +38,7 @@ def backend_registered(backend_name):
     """
     Checks if backend_name is registered as an RPC backend.
 
-    Arguments:
+    Args:
         backend_name (str): string to identify the RPC backend.
     Returns:
         True if the backend has been registered with ``register_backend``, else
@@ -52,7 +52,7 @@ def register_backend(
 ):
     """Registers a new RPC backend.
 
-    Arguments:
+    Args:
         backend_name (str): backend string to identify the handler.
         construct_rpc_backend_options_handler (function):
             Handler that is invoked when

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -211,7 +211,7 @@ def _build_rpc_profiling_key(
     Builds the key that RPC calls are profiled with using the autograd profiler.
     This will be the name of the corresponding Event recorded in the profiler.
 
-    Arguments:
+    Args:
         exec_type (RPCExecMode): Type of RPC/RRef call
         func_name (str): Name of function being profiled.
         current_worker_name (str): Name of current worker.
@@ -236,7 +236,7 @@ def _start_record_function(exec_type, func_name, current_worker_name, dest_worke
     callbacks that start the profiling, though the user is responsible for
     running the appropriate callbacks when the function to be profiled finishes.
 
-    Arguments:
+    Args:
         exec_type (RPCExecMode): Type of RPC/RRef call
         func_name (str): Name of function being profiled.
         current_worker_name (str): Name of current worker.

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -12,7 +12,7 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
     :class:`~torch.distributed.rpc.TensorPipeAgent`, derived from
     :class:`~torch.distributed.rpc.RpcBackendOptions`.
 
-    Arguments:
+    Args:
         num_worker_threads (int, optional): The number of threads in the
             thread-pool used by
             :class:`~torch.distributed.rpc.TensorPipeAgent` to execute
@@ -58,7 +58,7 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
         function can be called multiple times to incrementally add
         device placement configurations.
 
-        Arguments:
+        Args:
             worker_name (str): Callee name.
             device_map (Dict of int, str, or torch.device): Device placement
                 mappings from this worker to the callee. This map must be

--- a/torch/distributed/rpc/server_process_global_profiler.py
+++ b/torch/distributed/rpc/server_process_global_profiler.py
@@ -22,7 +22,7 @@ class _server_process_global_profile(profile):
     only report runtime of PyTorch functions.
     Note: profiler is thread local and is automatically propagated into the async tasks
 
-    Arguments:
+    Args:
         enabled (bool, optional): Setting this to False makes this context manager a no-op.
             Default: ``True``.
 

--- a/torch/distributed/rpc/utils.py
+++ b/torch/distributed/rpc/utils.py
@@ -2,7 +2,7 @@ def _parse_remote_device(remote_device: str):
     r"""
     Parses the remote device.
 
-    Arguments:
+    Args:
         remote_device (str): Device on the destination worker where we‘d like to place this module.
             The format should be "<workername>/<device>", where the device field can be parsed as torch.device type.
             E.g., "trainer0/cpu", "trainer0", "ps0/cuda:0".

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -118,7 +118,7 @@ def split(tensor, split_size_or_sections, dim=0):
     into ``len(split_size_or_sections)`` chunks with sizes in :attr:`dim` according
     to :attr:`split_size_or_sections`.
 
-    Arguments:
+    Args:
         tensor (Tensor): tensor to split.
         split_size_or_sections (int) or (list(int)): size of a single chunk or
             list of sizes for each chunk
@@ -189,7 +189,7 @@ def lu_unpack(LU_data, LU_pivots, unpack_data=True, unpack_pivots=True):
 
     Returns a tuple of tensors as ``(the pivots, the L tensor, the U tensor)``.
 
-    Arguments:
+    Args:
         LU_data (Tensor): the packed LU factorization data
         LU_pivots (Tensor): the packed LU factorization pivots
         unpack_data (bool): flag indicating if the data should be unpacked
@@ -540,7 +540,7 @@ def stft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
       This function changed signature at version 0.4.1. Calling with the
       previous signature may cause error or return incorrect result.
 
-    Arguments:
+    Args:
         input (Tensor): the input tensor
         n_fft (int): size of Fourier transform
         hop_length (int, optional): the distance between neighboring sliding window
@@ -617,7 +617,7 @@ def istft(input: Tensor, n_fft: int, hop_length: Optional[int] = None,
     [1] D. W. Griffin and J. S. Lim, "Signal estimation from modified short-time Fourier transform,"
     IEEE Trans. ASSP, vol.32, no.2, pp.236-243, Apr. 1984.
 
-    Arguments:
+    Args:
         input (Tensor): The input tensor. Expected to be output of :func:`~torch.stft`,
             can either be complex (``channel``, ``fft_size``, ``n_frame``), or real
             (``channel``, ``fft_size``, ``n_frame``, 2) where the ``channel``
@@ -685,7 +685,7 @@ def _unique_impl(input: Tensor, sorted: bool = True,
         Sorting could be slow, so if your input tensor is already sorted, it is recommended to use
         :func:`torch.unique_consecutive` which avoids the sorting.
 
-    Arguments:
+    Args:
         input (Tensor): the input tensor
         sorted (bool): Whether to sort the unique elements in ascending order
             before returning as output.
@@ -766,7 +766,7 @@ def _unique_consecutive_impl(input: Tensor, return_inverse: bool = False,
         only eliminates consecutive duplicate values. This semantics is similar to `std::unique`
         in C++.
 
-    Arguments:
+    Args:
         input (Tensor): the input tensor
         return_inverse (bool): Whether to also return the indices for where
             elements in the original input ended up in the returned unique list.
@@ -1021,7 +1021,7 @@ def cartesian_prod(*tensors):
     """Do cartesian product of the given sequence of tensors. The behavior is similar to
     python's `itertools.product`.
 
-    Arguments:
+    Args:
         *tensors: any number of 1 dimensional tensors.
 
     Returns:
@@ -1053,7 +1053,7 @@ def cartesian_prod(*tensors):
 def block_diag(*tensors):
     """Create a block diagonal matrix from provided tensors.
 
-    Arguments:
+    Args:
         *tensors: One or more tensors with 0, 1, or 2 dimensions.
 
     Returns:
@@ -1515,7 +1515,7 @@ def _lu_impl(A, pivot=True, get_infos=False, out=None):
         The LU factorization does have backward support,
         but only for square inputs of full rank.
 
-    Arguments:
+    Args:
         A (Tensor): the tensor to factor of size :math:`(*, m, n)`
         pivot (bool, optional): controls whether pivoting is done. Default: ``True``
         get_infos (bool, optional): if set to ``True``, returns an info IntTensor.

--- a/torch/futures/__init__.py
+++ b/torch/futures/__init__.py
@@ -51,7 +51,7 @@ class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
         this ``Future``. The callback function can use the ``Future.wait()`` API
         to get the value.
 
-        Arguments:
+        Args:
             callback(``Callable``): a ``Callable`` that takes this ``Future`` as
                                     the only argument.
 
@@ -97,7 +97,7 @@ class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
         use the same callback registration API under the hood, and thus the order of
         their callbacks will be maintained even if their calls are interleaved.
 
-        Arguments:
+        Args:
             callback(``None``): a ``Callable`` that takes in no arguments
 
         Example::
@@ -121,7 +121,7 @@ class Future(torch._C.Future, Generic[T], metaclass=_PyFutureMeta):
         completed and trigger all attached callbacks. Note that a ``Future``
         cannot be marked completed twice.
 
-        Arguments:
+        Args:
             result (object): the result object of this ``Future``.
 
         Example::
@@ -152,7 +152,7 @@ def collect_all(futures: List[Future]) -> Future[List[Future]]:
     combined :class:`~torch.futures.Future` that is completed when all of the
     sub-futures are completed.
 
-    Arguments:
+    Args:
         futures (list): a list of :class:`~torch.futures.Future` objects.
 
     Returns:
@@ -185,7 +185,7 @@ def wait_all(futures: List[Future]) -> List:
     Waits for all provided futures to be complete, and returns
     the list of completed values.
 
-    Arguments:
+    Args:
         futures (list): a list of :class:`~torch.futures.Future` object.
 
     Returns:

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -81,7 +81,7 @@ def script_if_tracing(fn):
     ``@torch.jit.script_if_tracing`` to substitute for
     ``torch.jit.script``.
 
-    Arguments:
+    Args:
         fn: A function to compile.
 
     Returns:
@@ -100,7 +100,7 @@ def isinstance(obj, target_type):
     ``Dict[str, List[torch.Tensor]]``, ``Optional[Tuple[int,str,int]]``. It can also 
     refine basic types such as bools and ints that are available in TorchScript.
 
-    Arguments:
+    Args:
         obj: object to refine the type of
         target_type: type to try to refine obj to 
     Returns:

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -31,7 +31,7 @@ def fork(func, *args, **kwargs):
         `fork` tasks will execute non-deterministicly. We recommend only spawning
         parallel fork tasks for pure functions that do not modify their inputs,
         module attributes, or global state.
-    Arguments:
+    Args:
         func (callable or torch.nn.Module):  A Python function or `torch.nn.Module`
             that will be invoked. If executed in TorchScript, it will execute asynchronously,
             otherwise it will not. Traced invocations of fork will be captured in the IR.
@@ -84,7 +84,7 @@ def wait(future):
     """
     Forces completion of a `torch.jit.Future[T]` asynchronous task, returning the
     result of the task. See :func:`~fork` for docs and examples.
-    Arguments:
+    Args:
         func (torch.jit.Future[T]): an asynchronous task reference, created through `torch.jit.fork`
     Returns:
         `T`: the return value of the the completed task

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -20,7 +20,7 @@ def freeze(mod, preserved_attrs: Optional[List[str]] = None):
 
     Freezing currently only accepts ScriptModules that are in eval mode.
 
-    Arguments:
+    Args:
         mod (:class:`ScriptModule`): a module to be frozen
 
         preserved_attrs (Optional[List[str]]): a list of attributes to preserve in addition to the forward method.

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -328,7 +328,7 @@ def get_module_concrete_type(nn_module, share_types=True):
     type is fetched from concrete_type_store. If it is False, a new concrete type
     is created without first searching concrete_type_store.
 
-    Arguments:
+    Args:
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
         share_types = Whether to share underlying JIT types between modules (if possible).
 
@@ -356,7 +356,7 @@ def create_script_module(nn_module, stubs_fn, share_types=True):
     """
     Creates a new ScriptModule from an nn.Module
 
-    Arguments:
+    Args:
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
         stubs_fn:  Lambda that takes an nn.Module and generates a list of ScriptMethodStubs to compile.
         share_types:  Whether to share underlying JIT types between modules (if possible).
@@ -373,7 +373,7 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
     """
     Convert an nn.Module to a RecursiveScriptModule.
 
-    Arguments:
+    Args:
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
         concrete_type:  The fully initialized ConcreteType of the module.
         stubs_fn:  Lambda that takes an nn.Module and generates a list of ScriptMethodStubs to compile.
@@ -645,7 +645,7 @@ def interface_script(mod_interface, nn_module):
     Makes a ScriptModule from an nn.Module, using the interface methods rule for
     determining which methods to compile.
 
-    Arguments:
+    Args:
         mod_interface: the interface type that the module have
         nn_module:  The original Python nn.Module that we are creating a ScriptModule for.
     """

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -379,7 +379,7 @@ if _enabled:
             object is properly finalized (and in the future we may take
             control of how the RecursiveScriptModule instance is created).
 
-            Arguments:
+            Args:
                 cpp_module:  The C++ Module that will hold the actual state of
                              this RecursiveScriptModule instance.
                 init_fn:  Lambda that initializes the RecursiveScriptModule passed to it.
@@ -409,7 +409,7 @@ if _enabled:
             """
             Re-construct an instance of RecursiveScriptModule using an instance of a C++ module.
 
-            Arguments:
+            Args:
                 cpp_module: The C++ module that this RecursiveScriptModule will be rebuilt around.
             """
             self.__init__(cpp_module)  # type: ignore
@@ -493,7 +493,7 @@ if _enabled:
             Add (or update) the bytecode session to the script model. The updated model is used
             in lite interpreter for mobile applications.
 
-            Arguments:
+            Args:
                 f: a string containing a file name.
                 _extra_files: Map from filename to contents which will be stored as part of 'f'.
 
@@ -754,7 +754,7 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
     ``torch.jit.script`` can be used as a function for modules and functions, and as a decorator
     ``@torch.jit.script`` for :ref:`torchscript-classes` and functions.
 
-    Arguments:
+    Args:
         obj (callable, class, or ``nn.Module``):  The ``nn.Module``, function, or class type to
                                                   compile.
 

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -33,7 +33,7 @@ def save(m, f, _extra_files=None):
         during loading.  This is different from :func:`torch.load`'s semantics
         and may change in the future.
 
-    Arguments:
+    Args:
         m: A :class:`ScriptModule` to save.
         f: A file-like object (has to implement write and flush) or a string
            containing a file name.
@@ -94,7 +94,7 @@ def load(f, map_location=None, _extra_files=None):
     because the run time system doesn't have certain devices), an exception is
     raised.
 
-    Arguments:
+    Args:
         f: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
         map_location (string or torch.device): A simplified version of

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -194,7 +194,7 @@ def verify(model, args, loss_fn=torch.sum, devices=None):
     parameters), so don't expect the model to come out exactly the same as what
     you passed in.
 
-    Arguments:
+    Args:
         model (compiled torch.nn.Module or function): the module/function to be
             verified.  The module/function definition MUST have been decorated with
             `@torch.jit.compile`.
@@ -626,7 +626,7 @@ def trace(
         invocations of the model. The tracer will try to emit warnings when
         doing something that may cause an incorrect trace to be produced.
 
-    Arguments:
+    Args:
         func (callable or torch.nn.Module):  A Python function or `torch.nn.Module`
             that will be run with `example_inputs`. `func` arguments and return
             values  must be tensors or (possibly nested) tuples that contain
@@ -830,7 +830,7 @@ def trace_module(
 
     See :func:`torch.jit.trace <torch.jit.trace>` for more information on tracing.
 
-    Arguments:
+    Args:
         mod (torch.nn.Module):  A ``torch.nn.Module`` containing methods whose names are
                                 specified in ``inputs``. The given methods will be compiled
                                 as a part of a single `ScriptModule`.
@@ -1075,7 +1075,7 @@ class TopLevelTracedModule(TracedModule):
         """
         Re-construct an instance of TopLevelTracedModule using an instance of a C++ module.
 
-        Arguments:
+        Args:
             cpp_module: The C++ module that this TopLevelTracedModule will be rebuilt around.
         """
         self.__dict__["_actual_script_module"]._reconstruct(cpp_module)
@@ -1115,7 +1115,7 @@ def _get_trace_graph(f, args=(), kwargs=None, strict=True, _force_outplace=False
     Tracing is guaranteed not to change the semantics of the function/module
     that is traced.
 
-    Arguments:
+    Args:
         f (torch.nn.Module or function): the function or module
             to be traced.
         args (tuple or Tensor): the positional arguments to pass to the

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -134,7 +134,7 @@ def get_class_properties(cls, self_name):
     """
     Get a list of Property objects representing the properties of a class.
 
-    Arguments:
+    Args:
         cls:  The class to get properties of.
         self_name: The name of the class that the properties should belong to.
     Returns:
@@ -188,7 +188,7 @@ def normalize_source_lines(sourcelines: List[str]) -> List[str]:
     all lines in the function body to a point at or greater than that
     level. This allows for comments and continued string literals that
     are at a lower indentation than the rest of the code.
-    Arguments:
+    Args:
         sourcelines: function source code, separated into lines by
                         the '\n' character
     Returns:
@@ -221,7 +221,7 @@ def get_jit_def(fn, def_name, self_name=None):
     """
     Build a JIT AST (TreeView) from the given function.
 
-    Arguments:
+    Args:
         fn: A function object to compile
         def_name: The name to give to the resulting AST object. This is not
             always the same as `fn.__name__`, for example:

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -10,7 +10,7 @@ def _load_for_lite_interpreter(f, map_location=None):
     Load a :class:`LiteScriptModule`
     saved with :func:`torch.jit._save_for_lite_interpreter`
 
-    Arguments:
+    Args:
         f: a file-like object (has to implement read, readline, tell, and seek),
             or a string containing a file name
         map_location: a string or torch.device used to dynamically remap

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -50,7 +50,7 @@ else:
 def set_sharing_strategy(new_strategy):
     """Sets the strategy for sharing CPU tensors.
 
-    Arguments:
+    Args:
         new_strategy (str): Name of the selected strategy. Should be one of
             the values returned by :func:`get_all_sharing_strategies()`.
     """

--- a/torch/multiprocessing/_atfork.py
+++ b/torch/multiprocessing/_atfork.py
@@ -23,7 +23,7 @@ def register_after_fork(func):
         ``multiprocessing`` module. In python >= 3.7 it also works with
         ``os.fork()``.
 
-    Arguments:
+    Args:
         func (function): Function taking no arguments to be called in the child after fork
 
     """

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -104,7 +104,7 @@ class ProcessContext:
         Returns ``True`` if all processes have been joined successfully,
         ``False`` if there are more processes that need to be joined.
 
-        Arguments:
+        Args:
             timeout (float): Wait this long before giving up on waiting.
         """
         # Ensure this function can be called even when we're done.
@@ -215,7 +215,7 @@ def spawn(fn, args=(), nprocs=1, join=True, daemon=False, start_method='spawn'):
     child process, it is forwarded and its traceback is included in
     the exception raised in the parent process.
 
-    Arguments:
+    Args:
         fn (function): Function is called as the entrypoint of the
             spawned process. This function must be defined at the top
             level of a module so it can be pickled and spawned. This

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1430,7 +1430,7 @@ def softmin(input, dim=None, _stacklevel=3, dtype=None):
 
     See :class:`~torch.nn.Softmin` for more details.
 
-    Arguments:
+    Args:
         input (Tensor): input
         dim (int): A dimension along which softmin will be computed (so every slice
             along dim will sum to 1).
@@ -1464,7 +1464,7 @@ def softmax(input, dim=None, _stacklevel=3, dtype=None):
 
     See :class:`~torch.nn.Softmax` for more details.
 
-    Arguments:
+    Args:
         input (Tensor): input
         dim (int): A dimension along which softmax will be computed.
         dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
@@ -1563,7 +1563,7 @@ def log_softmax(input, dim=None, _stacklevel=3, dtype=None):
 
     See :class:`~torch.nn.LogSoftmax` for more details.
 
-    Arguments:
+    Args:
         input (Tensor): input
         dim (int): A dimension along which log_softmax will be computed.
         dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1112,7 +1112,7 @@ class Softmin(Module):
           dimensions
         - Output: :math:`(*)`, same shape as the input
 
-    Arguments:
+    Args:
         dim (int): A dimension along which Softmin will be computed (so every slice
             along dim will sum to 1).
 
@@ -1166,7 +1166,7 @@ class Softmax(Module):
         a Tensor of the same dimension and shape as the input with
         values in the range [0, 1]
 
-    Arguments:
+    Args:
         dim (int): A dimension along which Softmax will be computed (so every slice
             along dim will sum to 1).
 
@@ -1240,7 +1240,7 @@ class LogSoftmax(Module):
           dimensions
         - Output: :math:`(*)`, same shape as the input
 
-    Arguments:
+    Args:
         dim (int): A dimension along which LogSoftmax will be computed.
 
     Returns:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -125,7 +125,7 @@ class ModuleList(Module):
     modules it contains are properly registered, and will be visible by all
     :class:`~torch.nn.Module` methods.
 
-    Arguments:
+    Args:
         modules (iterable, optional): an iterable of modules to add
 
     Example::
@@ -197,7 +197,7 @@ class ModuleList(Module):
     def insert(self, index: int, module: Module) -> None:
         r"""Insert a given module before a given index in the list.
 
-        Arguments:
+        Args:
             index (int): index to insert.
             module (nn.Module): module to insert
         """
@@ -208,7 +208,7 @@ class ModuleList(Module):
     def append(self: T, module: Module) -> T:
         r"""Appends a given module to the end of the list.
 
-        Arguments:
+        Args:
             module (nn.Module): module to append
         """
         self.add_module(str(len(self)), module)
@@ -217,7 +217,7 @@ class ModuleList(Module):
     def extend(self: T, modules: Iterable[Module]) -> T:
         r"""Appends modules from a Python iterable to the end of the list.
 
-        Arguments:
+        Args:
             modules (iterable): iterable of modules to append
         """
         if not isinstance(modules, container_abcs.Iterable):
@@ -252,7 +252,7 @@ class ModuleDict(Module):
     types (e.g., Python's plain ``dict`` before Python version 3.6) does not
     preserve the order of the merged mapping.
 
-    Arguments:
+    Args:
         modules (iterable, optional): a mapping (dictionary) of (string: module)
             or an iterable of key-value pairs of type (string, module)
 
@@ -311,7 +311,7 @@ class ModuleDict(Module):
     def pop(self, key: str) -> Module:
         r"""Remove key from the ModuleDict and return its module.
 
-        Arguments:
+        Args:
             key (string): key to pop from the ModuleDict
         """
         v = self[key]
@@ -344,7 +344,7 @@ class ModuleDict(Module):
             If :attr:`modules` is an ``OrderedDict``, a :class:`~torch.nn.ModuleDict`, or
             an iterable of key-value pairs, the order of new elements in it is preserved.
 
-        Arguments:
+        Args:
             modules (iterable): a mapping (dictionary) from string to :class:`~torch.nn.Module`,
                 or an iterable of key-value pairs of type (string, :class:`~torch.nn.Module`)
         """
@@ -379,7 +379,7 @@ class ParameterList(Module):
     list, but parameters it contains are properly registered, and will be
     visible by all :class:`~torch.nn.Module` methods.
 
-    Arguments:
+    Args:
         parameters (iterable, optional): an iterable of :class:`~torch.nn.Parameter` to add
 
     Example::
@@ -458,7 +458,7 @@ class ParameterList(Module):
     def append(self: T, parameter: 'Parameter') -> T:
         """Appends a given parameter at the end of the list.
 
-        Arguments:
+        Args:
             parameter (nn.Parameter): parameter to append
         """
         self.register_parameter(str(len(self)), parameter)
@@ -467,7 +467,7 @@ class ParameterList(Module):
     def extend(self: T, parameters: Iterable['Parameter']) -> T:
         """Appends parameters from a Python iterable to the end of the list.
 
-        Arguments:
+        Args:
             parameters (iterable): iterable of parameters to append
         """
         if not isinstance(parameters, container_abcs.Iterable):
@@ -518,7 +518,7 @@ class ParameterDict(Module):
     types (e.g., Python's plain ``dict``) does not preserve the order of the
     merged mapping.
 
-    Arguments:
+    Args:
         parameters (iterable, optional): a mapping (dictionary) of
             (string : :class:`~torch.nn.Parameter`) or an iterable of key-value pairs
             of type (string, :class:`~torch.nn.Parameter`)
@@ -581,7 +581,7 @@ class ParameterDict(Module):
     def pop(self, key: str) -> 'Parameter':
         r"""Remove key from the ParameterDict and return its parameter.
 
-        Arguments:
+        Args:
             key (string): key to pop from the ParameterDict
         """
         v = self[key]
@@ -611,7 +611,7 @@ class ParameterDict(Module):
             If :attr:`parameters` is an ``OrderedDict``, a :class:`~torch.nn.ParameterDict`, or
             an iterable of key-value pairs, the order of new elements in it is preserved.
 
-        Arguments:
+        Args:
             parameters (iterable): a mapping (dictionary) from string to
                 :class:`~torch.nn.Parameter`, or an iterable of
                 key-value pairs of type (string, :class:`~torch.nn.Parameter`)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -489,7 +489,7 @@ class Module:
         it should be called before constructing optimizer if the module will
         live on GPU while being optimized.
 
-        Arguments:
+        Args:
             device (int, optional): if specified, all parameters will be
                 copied to that device
 
@@ -509,7 +509,7 @@ class Module:
     def type(self: T, dst_type: Union[dtype, str]) -> T:
         r"""Casts all parameters and buffers to :attr:`dst_type`.
 
-        Arguments:
+        Args:
             dst_type (type or string): the desired type
 
         Returns:
@@ -1015,7 +1015,7 @@ class Module:
         In rare cases, subclasses can achieve class-specific behavior by
         overriding this method with custom logic.
 
-        Arguments:
+        Args:
             destination (dict): a dict where state will be stored
             prefix (str): the prefix for parameters and buffers used in this
                 module
@@ -1096,7 +1096,7 @@ class Module:
             :attr:`state_dict` to :meth:`~torch.nn.Module.load_state_dict`. So
             it can be modified.
 
-        Arguments:
+        Args:
             state_dict (dict): a dict containing parameters and
                 persistent buffers.
             prefix (str): the prefix for parameters and buffers used in this
@@ -1166,7 +1166,7 @@ class Module:
         the keys of :attr:`state_dict` must exactly match the keys returned
         by this module's :meth:`~torch.nn.Module.state_dict` function.
 
-        Arguments:
+        Args:
             state_dict (dict): a dict containing parameters and
                 persistent buffers.
             strict (bool, optional): whether to strictly enforce that the keys
@@ -1479,7 +1479,7 @@ class Module:
         r"""Sets gradients of all model parameters to zero. See similar function
         under :class:`torch.optim.Optimizer` for more context.
 
-        Arguments:
+        Args:
             set_to_none (bool): instead of setting to zero, set the grads to None.
                 See :meth:`torch.optim.Optimizer.zero_grad` for details.
         """

--- a/torch/nn/parallel/comm.py
+++ b/torch/nn/parallel/comm.py
@@ -8,7 +8,7 @@ from typing import List
 def broadcast(tensor, devices=None, *, out=None):
     r"""Broadcasts a tensor to specified GPU devices.
 
-    Arguments:
+    Args:
         tensor (Tensor): tensor to broadcast. Can be on CPU or GPU.
         devices (Iterable[torch.device, str or int], optional): an iterable of
           GPU devices, among which to broadcast.
@@ -43,7 +43,7 @@ def broadcast_coalesced(tensors, devices, buffer_size=10485760):
     Small tensors are first coalesced into a buffer to reduce the number
     of synchronizations.
 
-    Arguments:
+    Args:
         tensors (sequence): tensors to broadcast. Must be on the same device,
           either CPU or GPU.
         devices (Iterable[torch.device, str or int]): an iterable of GPU
@@ -64,7 +64,7 @@ def reduce_add(inputs, destination=None):
     All inputs should have matching shapes, dtype, and layout. The output tensor
     will be of the same shape, dtype, and layout.
 
-    Arguments:
+    Args:
         inputs (Iterable[Tensor]): an iterable of tensors to add.
         destination (int, optional): a device on which the output will be
             placed (default: current device).
@@ -110,7 +110,7 @@ def reduce_add_coalesced(inputs, destination=None, buffer_size=10485760):
     Small tensors are first coalesced into a buffer to reduce the number
     of synchronizations.
 
-    Arguments:
+    Args:
         inputs (Iterable[Iterable[Tensor]]): iterable of iterables that
             contain tensors from a single device.
         destination (int, optional): a device on which the output will be
@@ -152,7 +152,7 @@ def reduce_add_coalesced(inputs, destination=None, buffer_size=10485760):
 def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=None):
     """Scatters tensor across multiple GPUs.
 
-    Arguments:
+    Args:
         tensor (Tensor): tensor to scatter. Can be on CPU or GPU.
         devices (Iterable[torch.device, str or int], optional): an iterable of
           GPU devices, among which to scatter.
@@ -202,7 +202,7 @@ def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=
 def gather(tensors, dim=0, destination=None, *, out=None):
     r"""Gathers tensors from multiple GPU devices.
 
-    Arguments:
+    Args:
         tensors (Iterable[Tensor]): an iterable of tensors to gather.
           Tensor sizes in all dimensions other than :attr:`dim` have to match.
         dim (int, optional): a dimension along which the tensors will be

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -999,7 +999,7 @@ class DistributedDataParallel(Module):
         and gradient compression which involve different communication strategies for
         parameter syncs while running Distributed DataParallel training.
 
-        Arguments:
+        Args:
             state (object): state is passed to the hook and can be used to maintain
                             and update any state information that users would like to
                             maintain as part of the training process. Examples: error
@@ -1084,7 +1084,7 @@ class DistributedDataParallel(Module):
         The built-in hooks aim to provide efficient C++ implementations for certain hooks,
         which might not be as efficient if implemented in Python using a Python communication hook.
 
-        Arguments:
+        Args:
             comm_hook_type (dist.BuiltinCommHookType): type of communication hook, such as
             ALLREDUCE, FP16_COMPRESS, etc.
 

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -15,7 +15,7 @@ class Parameter(torch.Tensor):
     the model. If there was no such class as :class:`Parameter`, these
     temporaries would get registered too.
 
-    Arguments:
+    Args:
         data (Tensor): parameter tensor.
         requires_grad (bool, optional): if the parameter requires gradient. See
             :ref:`excluding-subgraphs` for more details. Default: `True`

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -12,7 +12,7 @@ def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: 
     The norm is computed over all gradients together, as if they were
     concatenated into a single vector. Gradients are modified in-place.
 
-    Arguments:
+    Args:
         parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a
             single Tensor that will have gradients normalized
         max_norm (float or int): max norm of the gradients
@@ -58,7 +58,7 @@ def clip_grad_value_(parameters: _tensor_or_tensors, clip_value: float) -> None:
 
     Gradients are modified in-place.
 
-    Arguments:
+    Args:
         parameters (Iterable[Tensor] or Tensor): an iterable of Tensors or a
             single Tensor that will have gradients normalized
         clip_value (float or int): maximum allowed value of the gradients.

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional
 def parameters_to_vector(parameters: Iterable[torch.Tensor]) -> torch.Tensor:
     r"""Convert parameters to one vector
 
-    Arguments:
+    Args:
         parameters (Iterable[Tensor]): an iterator of Tensors that are the
             parameters of a model.
 
@@ -27,7 +27,7 @@ def parameters_to_vector(parameters: Iterable[torch.Tensor]) -> torch.Tensor:
 def vector_to_parameters(vec: torch.Tensor, parameters: Iterable[torch.Tensor]) -> None:
     r"""Convert one vector to the parameters
 
-    Arguments:
+    Args:
         vec (Tensor): a single vector represents the parameters of a model.
         parameters (Iterable[Tensor]): an iterator of Tensors that are the
             parameters of a model.
@@ -60,7 +60,7 @@ def _check_param_device(param: torch.Tensor, old_param_device: Optional[int]) ->
     and single vector form is not supported for multiple allocations,
     e.g. parameters in different GPUs, or mixture of CPU/GPU.
 
-    Arguments:
+    Args:
         param ([Tensor]): a Tensor of a parameter of a model
         old_param_device (int): the device where the first parameter of a
                                 model is allocated.

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -213,7 +213,7 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
         them to compute the loss directly. A Tensor can be retrieved from
         a :class:`PackedSequence` object by accessing its ``.data`` attribute.
 
-    Arguments:
+    Args:
         input (Tensor): padded batch of variable length sequences.
         lengths (Tensor or list(int)): list of sequence lengths of each batch
             element (must be on the CPU if provided as a tensor).
@@ -279,7 +279,7 @@ def pad_packed_sequence(sequence, batch_first=False, padding_value=0.0, total_le
         See :ref:`this FAQ section <pack-rnn-unpack-with-data-parallelism>` for
         details.
 
-    Arguments:
+    Args:
         sequence (PackedSequence): batch to pad
         batch_first (bool, optional): if ``True``, the output will be in ``B x T x *``
             format.
@@ -343,7 +343,7 @@ def pad_sequence(sequences, batch_first=False, padding_value=0.0):
         where `T` is the length of the longest sequence. This function assumes
         trailing dimensions and type of all the Tensors in sequences are same.
 
-    Arguments:
+    Args:
         sequences (list[Tensor]): list of variable length sequences.
         batch_first (bool, optional): output will be in ``B x T x *`` if True, or in
             ``T x B x *`` otherwise
@@ -398,7 +398,7 @@ def pack_sequence(sequences, enforce_sorted=True):
         PackedSequence(data=tensor([ 1,  4,  6,  2,  5,  3]), batch_sizes=tensor([ 3,  2,  1]))
 
 
-    Arguments:
+    Args:
         sequences (list[Tensor]): A list of sequences of decreasing length.
         enforce_sorted (bool, optional): if ``True``, checks that the input
             contains sequences sorted by length in a decreasing order. If

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -40,7 +40,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
     once in order to get a trace of its execution to be exported;
     at the moment, it supports a limited set of dynamic models (e.g., RNNs.)
 
-    Arguments:
+    Args:
         model (torch.nn.Module): the model to be exported.
         args (tuple of arguments or torch.Tensor, a dictionary consisting of named arguments (optional)): 
             a dictionary to specify the input to the corresponding named parameter: 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -518,7 +518,7 @@ def unbind(g, self, dim=0, _outputs=None):
 
 
 # Generate paddings in ONNX order based on pad in pytorch.
-# Arguments:
+# Args:
 #     dim: the dimension of the tensor.
 #     pad: the paddings in pytorch.
 #          The order is dim_n_begin, dim_n_end, dim_n-1_begin, dim_n-1_end, ..., dim_m_begin, dim_m_end,

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -932,7 +932,7 @@ adaptive_max_pool3d = _adaptive_pool('adaptive_max_pool3d', "MaxPool", _triple, 
 
 
 # Generate paddings in ONNX order based on pad in pytorch.
-# Arguments:
+# Args:
 #     dim: the dimension of the tensor.
 #     pad: the paddings in pytorch.
 #          The order is dim_n_begin, dim_n_end, dim_n-1_begin, dim_n-1_end, ...

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -831,7 +831,7 @@ def _graph_op(g, opname, *raw_args, **kwargs):
 
     This function is monkey-patched onto Graph.
 
-    Arguments:
+    Args:
         opname (string): The ONNX operator name, e.g., `Abs` or `Add`.
         args (Node...): The inputs to the operator; usually provided
             as arguments to the `symbolic` definition.

--- a/torch/optim/_multi_tensor/adadelta.py
+++ b/torch/optim/_multi_tensor/adadelta.py
@@ -7,7 +7,7 @@ class Adadelta(Optimizer):
 
     It has been proposed in `ADADELTA: An Adaptive Learning Rate Method`__.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         rho (float, optional): coefficient used for computing a running average
@@ -38,7 +38,7 @@ class Adadelta(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/adam.py
+++ b/torch/optim/_multi_tensor/adam.py
@@ -10,7 +10,7 @@ class Adam(Optimizer):
     The implementation of the L2 penalty follows changes proposed in
     `Decoupled Weight Decay Regularization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -56,7 +56,7 @@ class Adam(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/adamax.py
+++ b/torch/optim/_multi_tensor/adamax.py
@@ -7,7 +7,7 @@ class Adamax(Optimizer):
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`__.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 2e-3)
@@ -40,7 +40,7 @@ class Adamax(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/adamw.py
+++ b/torch/optim/_multi_tensor/adamw.py
@@ -9,7 +9,7 @@ class AdamW(Optimizer):
     The original Adam algorithm was proposed in `Adam: A Method for Stochastic Optimization`_.
     The AdamW variant was proposed in `Decoupled Weight Decay Regularization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -55,7 +55,7 @@ class AdamW(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/asgd.py
+++ b/torch/optim/_multi_tensor/asgd.py
@@ -9,7 +9,7 @@ class ASGD(Optimizer):
     It has been proposed in `Acceleration of stochastic approximation by
     averaging`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -36,7 +36,7 @@ class ASGD(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/rmsprop.py
+++ b/torch/optim/_multi_tensor/rmsprop.py
@@ -17,7 +17,7 @@ class RMSprop(Optimizer):
     is the scheduled learning rate and :math:`v` is the weighted moving average
     of the squared gradient.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -56,7 +56,7 @@ class RMSprop(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/rprop.py
+++ b/torch/optim/_multi_tensor/rprop.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 class Rprop(Optimizer):
     """Implements the resilient backpropagation algorithm.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -29,7 +29,7 @@ class Rprop(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/_multi_tensor/sgd.py
+++ b/torch/optim/_multi_tensor/sgd.py
@@ -76,7 +76,7 @@ class SGD(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/adadelta.py
+++ b/torch/optim/adadelta.py
@@ -8,7 +8,7 @@ class Adadelta(Optimizer):
 
     It has been proposed in `ADADELTA: An Adaptive Learning Rate Method`__.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         rho (float, optional): coefficient used for computing a running average
@@ -39,7 +39,7 @@ class Adadelta(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/adagrad.py
+++ b/torch/optim/adagrad.py
@@ -9,7 +9,7 @@ class Adagrad(Optimizer):
     It has been proposed in `Adaptive Subgradient Methods for Online Learning
     and Stochastic Optimization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -54,7 +54,7 @@ class Adagrad(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -10,7 +10,7 @@ class Adam(Optimizer):
     The implementation of the L2 penalty follows changes proposed in
     `Decoupled Weight Decay Regularization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -56,7 +56,7 @@ class Adam(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -7,7 +7,7 @@ class Adamax(Optimizer):
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`__.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 2e-3)
@@ -40,7 +40,7 @@ class Adamax(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/adamw.py
+++ b/torch/optim/adamw.py
@@ -9,7 +9,7 @@ class AdamW(Optimizer):
     The original Adam algorithm was proposed in `Adam: A Method for Stochastic Optimization`_.
     The AdamW variant was proposed in `Decoupled Weight Decay Regularization`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -55,7 +55,7 @@ class AdamW(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/asgd.py
+++ b/torch/optim/asgd.py
@@ -9,7 +9,7 @@ class ASGD(Optimizer):
     It has been proposed in `Acceleration of stochastic approximation by
     averaging`_.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -36,7 +36,7 @@ class ASGD(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -197,7 +197,7 @@ class LBFGS(Optimizer):
         ``param_bytes * (history_size + 1)`` bytes). If it doesn't fit in memory
         try reducing the history size, or use a different algorithm.
 
-    Arguments:
+    Args:
         lr (float): learning rate (default: 1)
         max_iter (int): maximal number of iterations per optimization step
             (default: 20)
@@ -283,7 +283,7 @@ class LBFGS(Optimizer):
     def step(self, closure):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -87,7 +87,7 @@ class _LRScheduler(object):
     def load_state_dict(self, state_dict):
         """Loads the schedulers state.
 
-        Arguments:
+        Args:
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
@@ -227,7 +227,7 @@ class LambdaLR(_LRScheduler):
 
         When saving or loading the scheduler, please make sure to also save or load the state of the optimizer.
 
-        Arguments:
+        Args:
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
@@ -305,7 +305,7 @@ class MultiplicativeLR(_LRScheduler):
     def load_state_dict(self, state_dict):
         """Loads the schedulers state.
 
-        Arguments:
+        Args:
             state_dict (dict): scheduler state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -24,7 +24,7 @@ class Optimizer(object):
         ordering that is consistent between runs. Examples of objects that don't
         satisfy those properties are sets and iterators over values of dictionaries.
 
-    Arguments:
+    Args:
         params (iterable): an iterable of :class:`torch.Tensor` s or
             :class:`dict` s. Specifies what Tensors should be optimized.
         defaults: (dict): a dict containing default values of optimization
@@ -127,7 +127,7 @@ class Optimizer(object):
     def load_state_dict(self, state_dict):
         r"""Loads the optimizer state.
 
-        Arguments:
+        Args:
             state_dict (dict): optimizer state. Should be an object returned
                 from a call to :meth:`state_dict`.
         """
@@ -189,7 +189,7 @@ class Optimizer(object):
     def zero_grad(self, set_to_none: bool = False):
         r"""Sets the gradients of all optimized :class:`torch.Tensor` s to zero.
 
-        Arguments:
+        Args:
             set_to_none (bool): instead of setting to zero, set the grads to None.
                 This is will in general have lower memory footprint, and can modestly improve performance.
                 However, it changes certain behaviors. For example:
@@ -219,7 +219,7 @@ class Optimizer(object):
     def step(self, closure):
         r"""Performs a single optimization step (parameter update).
 
-        Arguments:
+        Args:
             closure (callable): A closure that reevaluates the model and
                 returns the loss. Optional for most optimizers.
 
@@ -235,7 +235,7 @@ class Optimizer(object):
         This can be useful when fine tuning a pre-trained network as frozen layers can be made
         trainable and added to the :class:`Optimizer` as training progresses.
 
-        Arguments:
+        Args:
             param_group (dict): Specifies what Tensors should be optimized along with group
             specific optimization options.
         """

--- a/torch/optim/rmsprop.py
+++ b/torch/optim/rmsprop.py
@@ -17,7 +17,7 @@ class RMSprop(Optimizer):
     is the scheduled learning rate and :math:`v` is the weighted moving average
     of the squared gradient.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -56,7 +56,7 @@ class RMSprop(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/rprop.py
+++ b/torch/optim/rprop.py
@@ -5,7 +5,7 @@ from .optimizer import Optimizer
 class Rprop(Optimizer):
     """Implements the resilient backpropagation algorithm.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-2)
@@ -29,7 +29,7 @@ class Rprop(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/sgd.py
+++ b/torch/optim/sgd.py
@@ -76,7 +76,7 @@ class SGD(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/sparse_adam.py
+++ b/torch/optim/sparse_adam.py
@@ -9,7 +9,7 @@ class SparseAdam(Optimizer):
     In this variant, only moments that show up in the gradient get updated, and
     only those portions of the gradient get applied to the parameters.
 
-    Arguments:
+    Args:
         params (iterable): iterable of parameters to optimize or dicts defining
             parameter groups
         lr (float, optional): learning rate (default: 1e-3)
@@ -54,7 +54,7 @@ class SparseAdam(Optimizer):
     def step(self, closure=None):
         """Performs a single optimization step.
 
-        Arguments:
+        Args:
             closure (callable, optional): A closure that reevaluates the model
                 and returns the loss.
         """

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -17,7 +17,7 @@ class AveragedModel(Module):
     on the device :attr:`device` and allows to compute running averages of the 
     parameters of the :attr:`model`.
 
-    Arguments:
+    Args:
         model (torch.nn.Module): model to use with SWA
         device (torch.device, optional): if provided, the averaged model will be
             stored on the :attr:`device` 
@@ -117,7 +117,7 @@ def update_bn(loader, model, device=None):
 
     It performs one pass over data in `loader` to estimate the activation
     statistics for BatchNorm layers in the model.
-    Arguments:
+    Args:
         loader (torch.utils.data.DataLoader): dataset loader to compute the
             activation statistics on. Each data batch should be either a
             tensor, or a list/tuple whose first element is a tensor
@@ -172,7 +172,7 @@ class SWALR(_LRScheduler):
     This learning rate scheduler is meant to be used with Stochastic Weight 
     Averaging (SWA) method (see `torch.optim.swa_utils.AveragedModel`).
 
-    Arguments:
+    Args:
         optimizer (torch.optim.Optimizer): wrapped optimizer
         swa_lrs (float or list): the learning rate value for all param groups
             together or separately for each group.

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -50,7 +50,7 @@ class profile(object):
     """
     Profiler context manager.
 
-    Arguments:
+    Args:
 
     - ``activities`` - list of activity groups (CPU, CUDA) to use in profiling;
     - ``schedule`` - callable that takes step (int) as a single parameter and returns
@@ -249,7 +249,7 @@ class profile(object):
         """
         Save stack traces in a file in a format suitable for visualization.
 
-        Arguments:
+        Args:
 
         - ``path`` - save stacks file to this location;
         - ``metric`` - metric to use: "self_cpu_time_total" or "self_cuda_time_total"

--- a/torch/quantization/fuse_modules.py
+++ b/torch/quantization/fuse_modules.py
@@ -93,7 +93,7 @@ def fuse_modules(model, modules_to_fuse, inplace=False, fuser_func=fuse_known_mo
     with the fused module, replacing the rest of the modules
     with identity.
 
-    Arguments:
+    Args:
         model: Model containing the modules to be fused
         modules_to_fuse: list of list of module names to fuse. Can also be a list
                          of strings if there is only a single list of modules to fuse.

--- a/torch/random.py
+++ b/torch/random.py
@@ -67,7 +67,7 @@ def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="device
     Forks the RNG, so that when you return, the RNG is reset
     to the state that it was previously in.
 
-    Arguments:
+    Args:
         devices (iterable of CUDA IDs): CUDA devices for which to fork
             the RNG.  CPU RNG state is always forked.  By default, :meth:`fork_rng` operates
             on all devices, but will emit a warning if your machine has a lot

--- a/torch/sparse/__init__.py
+++ b/torch/sparse/__init__.py
@@ -174,7 +174,7 @@ def softmax(input: Tensor, dim: int, dtype: Optional[DType] = None) -> Tensor:
     It is applied to all slices along `dim`, and will re-scale them so
     that the elements lie in the range `[0, 1]` and sum to 1.
 
-    Arguments:
+    Args:
         input (Tensor): input
         dim (int): A dimension along which softmax will be computed.
         dtype (:class:`torch.dtype`, optional): the desired data type
@@ -191,7 +191,7 @@ def log_softmax(input: Tensor, dim: int, dtype: Optional[DType] = None) -> Tenso
 
     See :class:`~torch.sparse.softmax` for more details.
 
-    Arguments:
+    Args:
         input (Tensor): input
         dim (int): A dimension along which softmax will be computed.
         dtype (:class:`torch.dtype`, optional): the desired data type

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -198,7 +198,7 @@ class Tensor(torch._C._TensorBase):
             in a user-specified CUDA stream context, see
             :ref:`Stream semantics of backward passes<bwd-cuda-stream-semantics>`.
 
-        Arguments:
+        Args:
             gradient (Tensor or None): Gradient w.r.t. the
                 tensor. If it is a tensor, it will be automatically converted
                 to a Tensor that does not require grad unless ``create_graph`` is True.
@@ -671,7 +671,7 @@ class Tensor(torch._C._TensorBase):
     def __contains__(self, element):
         r"""Check if `element` is present in tensor
 
-        Arguments:
+        Args:
             element (Tensor or scalar): element to be checked
                 for presence in current tensor"
         """
@@ -772,7 +772,7 @@ class Tensor(torch._C._TensorBase):
         Python 2 does not support Ellipsis but one may use a string literal
         instead (``'...'``).
 
-        Arguments:
+        Args:
             names (iterable of str): The desired names of the output tensor. May
                 contain up to one Ellipsis.
 
@@ -818,7 +818,7 @@ class Tensor(torch._C._TensorBase):
         Python 2 does not support Ellipsis but one may use a string literal
         instead (``'...'``).
 
-        Arguments:
+        Args:
             names (iterable of str): The desired dimension ordering of the
                 output tensor. May contain up to one Ellipsis that is expanded
                 to all unmentioned dim names of :attr:`self`.
@@ -855,7 +855,7 @@ class Tensor(torch._C._TensorBase):
           if :attr:`self` is a `NamedTensor`. The total number of elements in sizes must match the number
           of elements in the original dim being unflattened.
 
-        Arguments:
+        Args:
             dim (Union[int, str]): Dimension to unflatten
             sizes (Union[Tuple[int] or torch.Size, Tuple[Tuple[str, int]]]): New shape of the unflattened dimension
 

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -103,7 +103,7 @@ class Timer(object):
 
         `label`, `sub_label`, `description`, `env`, `num_threads`
 
-    Arguments:
+    Args:
         stmt: Code snippet to be run in a loop and timed.
 
         setup: Optional setup code. Used to define variables used in `stmt`

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -226,7 +226,7 @@ def check_compiler_ok_for_platform(compiler: str) -> bool:
     r'''
     Verifies that the compiler is the expected one for the current platform.
 
-    Arguments:
+    Args:
         compiler (str): The compiler executable to check.
 
     Returns:
@@ -261,7 +261,7 @@ def check_compiler_abi_compatibility(compiler) -> bool:
     r'''
     Verifies that the given compiler is ABI-compatible with PyTorch.
 
-    Arguments:
+    Args:
         compiler (str): The compiler executable name to check (e.g. ``g++``).
             Must be executable in a shell process.
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -55,7 +55,7 @@ class _InfiniteConstantSampler(Sampler):
     r"""Analogous to ``itertools.repeat(None, None)``.
     Used as sampler for :class:`~torch.utils.data.IterableDataset`.
 
-    Arguments:
+    Args:
         data_source (Dataset): dataset to sample from
     """
 
@@ -78,7 +78,7 @@ class DataLoader(Generic[T_co]):
 
     See :py:mod:`torch.utils.data` documentation page for more details.
 
-    Arguments:
+    Args:
         dataset (Dataset): dataset from which to load the data.
         batch_size (int, optional): how many samples per batch to load
             (default: ``1``).

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -158,7 +158,7 @@ class TensorDataset(Dataset[Tuple[Tensor, ...]]):
 
     Each sample will be retrieved by indexing tensors along the first dimension.
 
-    Arguments:
+    Args:
         *tensors (Tensor): tensors that have the same size of the first dimension.
     """
     tensors: Tuple[Tensor, ...]
@@ -179,7 +179,7 @@ class ConcatDataset(Dataset[T_co]):
 
     This class is useful to assemble different existing datasets.
 
-    Arguments:
+    Args:
         datasets (sequence): List of datasets to be concatenated
     """
     datasets: List[Dataset[T_co]]
@@ -232,7 +232,7 @@ class ChainDataset(IterableDataset):
     chainning operation is done on-the-fly, so concatenating large-scale
     datasets with this class will be efficient.
 
-    Arguments:
+    Args:
         datasets (iterable of IterableDataset): datasets to be chained together
     """
     def __init__(self, datasets: Iterable[Dataset]) -> None:
@@ -284,7 +284,7 @@ class BufferedShuffleDataset(IterableDataset[T_co]):
         ...     random.seed(...)
         >>> print(list(torch.utils.data.DataLoader(ds, ..., num_workers=n, worker_init_fn=init_fn)))
 
-    Arguments:
+    Args:
         dataset (IterableDataset): The original IterableDataset.
         buffer_size (int): The buffer size for shuffling.
     """
@@ -315,7 +315,7 @@ class Subset(Dataset[T_co]):
     r"""
     Subset of a dataset at specified indices.
 
-    Arguments:
+    Args:
         dataset (Dataset): The whole Dataset
         indices (sequence): Indices in the whole set selected for subset
     """
@@ -341,7 +341,7 @@ def random_split(dataset: Dataset[T], lengths: Sequence[int],
 
     >>> random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(42))
 
-    Arguments:
+    Args:
         dataset (Dataset): Dataset to be split
         lengths (sequence): lengths of splits to be produced
         generator (Generator): Generator used for the random permutation.

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -21,7 +21,7 @@ class DistributedSampler(Sampler[T_co]):
     .. note::
         Dataset is assumed to be of constant size.
 
-    Arguments:
+    Args:
         dataset: Dataset used for sampling.
         num_replicas (int, optional): Number of processes participating in
             distributed training. By default, :attr:`world_size` is retrieved from the
@@ -129,7 +129,7 @@ class DistributedSampler(Sampler[T_co]):
         use a different random ordering for each epoch. Otherwise, the next iteration of this
         sampler will yield the same ordering.
 
-        Arguments:
+        Args:
             epoch (int): Epoch number.
         """
         self.epoch = epoch

--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -55,7 +55,7 @@ class Sampler(Generic[T_co]):
 class SequentialSampler(Sampler[int]):
     r"""Samples elements sequentially, always in the same order.
 
-    Arguments:
+    Args:
         data_source (Dataset): dataset to sample from
     """
     data_source: Sized
@@ -74,7 +74,7 @@ class RandomSampler(Sampler[int]):
     r"""Samples elements randomly. If without replacement, then sample from a shuffled dataset.
     If with replacement, then user can specify :attr:`num_samples` to draw.
 
-    Arguments:
+    Args:
         data_source (Dataset): dataset to sample from
         replacement (bool): samples are drawn on-demand with replacement if ``True``, default=``False``
         num_samples (int): number of samples to draw, default=`len(dataset)`. This argument
@@ -131,7 +131,7 @@ class RandomSampler(Sampler[int]):
 class SubsetRandomSampler(Sampler[int]):
     r"""Samples elements randomly from a given list of indices, without replacement.
 
-    Arguments:
+    Args:
         indices (sequence): a sequence of indices
         generator (Generator): Generator used in sampling.
     """


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue when I was parsing/generating from the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings.

```sh
(pytorch#c348fae)$ for name in 'Args:' 'Arguments:'; do
    printf '%-10s %04d\n' "$name" "$(rg -IFtpy --count-matches "$name" | paste -s -d+ -- | bc)"; done
Args:      1095
Arguments: 0336
```

It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420

PPS: The trackbacks automatically appearing below are sending the same changes to other repositories in the [PyTorch](https://github.com/pytorch) organisation.