### PR TITLE
[FX] Make _update_args_kwargs more private

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1166,6 +1166,12 @@ class TestFX(JitTestCase):
         input = torch.rand(3, 4)
         self.assertEqual(traced(input), MyNamedTup(input, input))
 
+    def test_update_args_kwargs_yells_at_you(self):
+        symtraced = symbolic_trace(SimpleTest())
+        node = next(iter(symtraced.graph.nodes))
+        with self.assertRaisesRegex(AttributeError, '__update_args_kwargs'):
+            node.__update_args_kwargs((), {})
+
     def test_torchbind_class_attribute_in_fx(self):
         if TEST_WITH_ROCM or IS_SANDCASTLE or IS_WINDOWS or IS_MACOS:
             self.skipTest("torch.classes._TorchScriptTesting._StackString is registered, skipping")

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,6 +1,7 @@
 # Nodes represent a definition of a value in our graph of operators.
 from typing import TYPE_CHECKING, Union, Callable, Any, Tuple, List, Optional, Dict
 from .immutable_collections import immutable_dict, immutable_list
+from ._internal import _update_args_kwargs as _update_args_kwargs_DO_NOT_CALL
 import torch
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ class Node:
         # The public API for this is `all_input_nodes`, this private attribute
         # should not be accessed directly.
         self._input_nodes : Dict[Node, None] = {}
-        self._update_args_kwargs(map_arg(args, lambda x: x), map_arg(kwargs, lambda x: x))  # type: ignore
+        _update_args_kwargs_DO_NOT_CALL(self, map_arg(args, lambda x: x), map_arg(kwargs, lambda x: x))  # type: ignore
 
         # All of the nodes that use the value produced by this Node
         # Note one user may correspond to several uses, e.g. the node fo ``x + x``
@@ -159,7 +160,9 @@ class Node:
         depends on the node's opcode. See the ``fx.Graph`` docstring for more
         information.
         """
-        self._update_args_kwargs(map_arg(a, lambda x: x), self._kwargs)  # type: ignore
+        # DO NOT CALL `_update_args_kwargs_DO_NOT_CALL` directly. THe correct way to
+        # set `args` is via direct assignment, i.e. `node.args = new_args`
+        _update_args_kwargs_DO_NOT_CALL(self, map_arg(a, lambda x: x), self._kwargs)  # type: ignore
 
     @property
     def kwargs(self) -> Dict[str, Argument]:
@@ -180,7 +183,9 @@ class Node:
         depends on the node's opcode. See the ``fx.Graph`` docstring for more
         information.
         """
-        self._update_args_kwargs(self._args, map_arg(k, lambda x: x))  # type: ignore
+        # DO NOT CALL `_update_args_kwargs_DO_NOT_CALL` directly. THe correct way to
+        # set `args` is via direct assignment, i.e. `node.kwargs = new_kwargs`
+        _update_args_kwargs_DO_NOT_CALL(self, self._args, map_arg(k, lambda x: x))  # type: ignore
 
     @property
     def all_input_nodes(self) -> List['Node']:
@@ -195,23 +200,6 @@ class Node:
             ``Node``, in that order.
         """
         return list(self._input_nodes.keys())
-
-    def _update_args_kwargs(self, new_args : Tuple[Argument, ...], new_kwargs : Dict[str, Argument]):
-        """
-        This API is internal. Do *not* call it directly.
-        """
-        self._args = new_args
-        self._kwargs = new_kwargs
-
-        for old_use in self._input_nodes.keys():
-            old_use.users.pop(self)
-
-        self._input_nodes = {}
-        map_arg(self._args, lambda n: self._input_nodes.setdefault(n))
-        map_arg(self._kwargs, lambda n: self._input_nodes.setdefault(n))
-
-        for new_use in self._input_nodes.keys():
-            new_use.users.setdefault(self)
 
     def __repr__(self) -> str:
         return self.name
@@ -240,10 +228,27 @@ class Node:
             new_kwargs = map_arg(use_node.kwargs, maybe_replace_node)
             assert isinstance(new_args, tuple)
             assert isinstance(new_kwargs, dict)
-            use_node._update_args_kwargs(new_args, new_kwargs)
+            _update_args_kwargs_DO_NOT_CALL(use_node, new_args, new_kwargs)
 
         assert len(self.users) == 0
         return to_process
+
+def _update_args_kwargs_DO_NOT_CALL(self, new_args : Tuple['Argument', ...], new_kwargs : Dict[str, 'Argument']):
+    """
+    This API is internal. Do *not* call it directly.
+    """
+    self._args = new_args
+    self._kwargs = new_kwargs
+
+    for old_use in self._input_nodes.keys():
+        old_use.users.pop(self)
+
+    self._input_nodes = {}
+    map_arg(self._args, lambda n: self._input_nodes.setdefault(n))
+    map_arg(self._kwargs, lambda n: self._input_nodes.setdefault(n))
+
+    for new_use in self._input_nodes.keys():
+        new_use.users.setdefault(self)
 
 
 def map_arg(a: Argument, fn: Callable[[Node], Argument]) -> Argument:

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -1,7 +1,6 @@
 # Nodes represent a definition of a value in our graph of operators.
 from typing import TYPE_CHECKING, Union, Callable, Any, Tuple, List, Optional, Dict
 from .immutable_collections import immutable_dict, immutable_list
-from ._internal import _update_args_kwargs as _update_args_kwargs_DO_NOT_CALL
 import torch
 
 if TYPE_CHECKING:
@@ -249,7 +248,6 @@ def _update_args_kwargs_DO_NOT_CALL(self, new_args : Tuple['Argument', ...], new
 
     for new_use in self._input_nodes.keys():
         new_use.users.setdefault(self)
-
 
 def map_arg(a: Argument, fn: Callable[[Node], Argument]) -> Argument:
     """ Apply fn to each Node appearing arg. arg may be a list, tuple, slice, or dict with string keys. """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49745 [FX] Try to make it more clear that _update_args_kwargs should not be called**

A ton of people have been trying to call this directly. This PR makes the method a double-underscore method so that it can't be called directly outside the class https://www.tutorialspoint.com/What-does-double-underscore-prefix-do-in-Python-variables



Differential Revision: [D25682177](https://our.internmc.facebook.com/intern/diff/D25682177)