### PR TITLE
Skip None submodule during JIT-tracing

### DIFF
--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -1846,6 +1846,20 @@ class TestTracer(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, r"Type 'Tuple\[int\]' cannot be traced"):
             torch.jit.trace(f, (1,))
 
+    def test_trace_skip_none_submodule(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.submod = torch.nn.Linear(3, 4)
+                self.submod = None
+
+            def forward(self, inputs):
+                return inputs
+
+        m = TestModule()
+        tm = torch.jit.trace(m, torch.tensor(1.))
+        self.assertFalse(hasattr(tm, "submod"))
+
 
 class TestMixTracingScripting(JitTestCase):
     def test_trace_script(self):

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1035,6 +1035,8 @@ class TracedModule(ScriptModule):
             )
 
         for name, submodule in orig._modules.items():
+            if submodule is None:
+                continue
             tmp_module._modules[name] = make_module(
                 submodule, TracedModule, _compilation_unit=None
             )


### PR DESCRIPTION
Summary:
Some PyTorch module can have None as submodule, which causes the following error in JIT-tracing:

Repro script:
```
import torch

class TestModule(torch.nn.Module):
  def __init__(self):
    super().__init__()
    self.submod = torch.nn.Linear(3, 4)
    self.submod = None

  def forward(self, inputs):
    return inputs

m = TestModule()
tm = torch.jit.trace(m, torch.tensor(1.))
```
Error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 742, in trace
    _module_class,
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 928, in trace_module
    module = make_module(mod, _module_class, _compilation_unit)
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 560, in make_module
    return _module_class(mod, _compilation_unit=_compilation_unit)
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 1039, in __init__
    submodule, TracedModule, _compilation_unit=None
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 560, in make_module
    return _module_class(mod, _compilation_unit=_compilation_unit)
  File "/data/miniconda3/envs/master_nightly/lib/python3.7/site-packages/torch/jit/_trace.py", line 988, in __init__
    assert isinstance(orig, torch.nn.Module)
AssertionError
```

This pull request changes the JIT-tracing logic to skip the None submodule when tracing.

Test Plan: Sandcastle

Differential Revision: D25670948

