### PR TITLE
Refactor `torch.Generator` bindings to use pybind11

### DIFF
--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -114,14 +114,6 @@ struct TORCH_API Generator {
 
   Device device() const { return impl_->device(); }
 
-  inline void set_pyobj(PyObject* pyobj) const noexcept {
-    impl_->set_pyobj(pyobj);
-  }
-
-  inline PyObject* pyobj() const noexcept {
-    return impl_->pyobj();
-  }
-
   template<typename T>
   T* get() const { return static_cast<T*>(impl_.get()); }
 

--- a/c10/core/GeneratorImpl.h
+++ b/c10/core/GeneratorImpl.h
@@ -12,7 +12,6 @@
 #include <c10/util/intrusive_ptr.h>
 #include <c10/core/Device.h>
 #include <c10/core/DispatchKeySet.h>
-#include <c10/util/python_stub.h>
 #include <c10/core/TensorImpl.h>
 
 /**
@@ -81,18 +80,9 @@ struct C10_API GeneratorImpl : public c10::intrusive_ptr_target {
 
   DispatchKeySet key_set() const { return key_set_; }
 
-  inline void set_pyobj(PyObject* pyobj) noexcept {
-    pyobj_ = pyobj;
-  }
-
-  inline PyObject* pyobj() const noexcept {
-    return pyobj_;
-  }
-
   protected:
     Device device_;
     DispatchKeySet key_set_;
-    PyObject* pyobj_ = nullptr;
 
     virtual GeneratorImpl* clone_impl() const = 0;
 };

--- a/test/cpp_extensions/rng_extension.cpp
+++ b/test/cpp_extensions/rng_extension.cpp
@@ -47,7 +47,7 @@ Generator createTestCPUGenerator(uint64_t value) {
   return at::make_generator<TestCPUGenerator>(value);
 }
 
-Generator identity(Generator g) {
+Generator& identity(Generator& g) {
   return g;
 }
 

--- a/test/cpp_extensions/rng_extension.cpp
+++ b/test/cpp_extensions/rng_extension.cpp
@@ -47,8 +47,12 @@ Generator createTestCPUGenerator(uint64_t value) {
   return at::make_generator<TestCPUGenerator>(value);
 }
 
-Generator& identity(Generator& g) {
-  return g;
+py::object identity(py::object gen_obj) {
+  TORCH_CHECK_TYPE(
+    py::isinstance<Generator&>(gen_obj),
+    "expected a torch.Generator, got ", Py_TYPE(gen_obj.ptr())->tp_name
+  );
+  return gen_obj;
 }
 
 size_t getInstanceCount() {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -133,7 +133,7 @@ class AbstractTestCases:
             with open(doc_file, "r") as f:
                 doc_strs = f.read()
 
-            for doc_str in re.findall(r'add_docstr\((.*?),.*?("""|\'\'\')(.*?)("""|\'\'\')\)', doc_strs, re.MULTILINE | re.DOTALL):
+            for doc_str in re.findall(r'^add_docstr\((.*?),.*?("""|\'\'\')(.*?)("""|\'\'\')\)', doc_strs, re.MULTILINE | re.DOTALL):
                 for common_args in [multi_dim_common, single_dim_common, factory_common_args, factory_like_common_args]:
                     for k, v in common_args.items():
                         self.assertNotIn(v, doc_str[2], 'The argument description "{}" in {} can be '
@@ -782,7 +782,7 @@ class AbstractTestCases:
                     expected_initial_seed, seed, actual_initial_seed)
                 self.assertEqual(expected_initial_seed, actual_initial_seed, msg=msg)
             for invalid_seed in [min_int64 - 1, max_uint64 + 1]:
-                with self.assertRaisesRegex(RuntimeError, r'Overflow when unpacking long'):
+                with self.assertRaisesRegex(TypeError, r'incompatible function arguments'):
                     torch.manual_seed(invalid_seed)
 
             torch.set_rng_state(rng_state)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3,7 +3,26 @@
 import re
 
 import torch._C
-from torch._C import _add_docstr as add_docstr
+from torch._C import _add_docstr
+
+
+def add_docstr(obj, doc):
+    cls = obj.__class__
+    # Pybind11 class
+    if cls.__name__ == "pybind11_type":
+        if obj.__doc__ is not None:
+            raise RuntimeError("pybind11 type '{}' already has a docstring".format(obj.__name__))
+        obj.__doc__ = doc
+        return obj
+    # Pybind11 property
+    elif cls is property:
+        # Pybind11 leaves an empty docstring for property
+        if obj.__doc__:
+            raise RuntimeError("pybind11 property already has a docstring")
+        obj.__doc__ = doc
+        return obj
+    else:
+        return _add_docstr(obj, doc)
 
 
 def parse_kwargs(desc):

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -1,272 +1,117 @@
 #include <torch/csrc/Generator.h>
+#include <torch/csrc/Device.h>
+#include <torch/csrc/utils/pybind.h>
 
-#include <structmember.h>
 #include <ATen/ATen.h>
 #include <ATen/CPUGeneratorImpl.h>
-
-#include <TH/TH.h>
-#include <torch/csrc/THP.h>
-#include <torch/csrc/Device.h>
-#include <torch/csrc/Exceptions.h>
-#include <torch/csrc/autograd/python_variable.h>
-#include <torch/csrc/autograd/generated/VariableType.h>
-#include <torch/csrc/utils/tensor_types.h>
-#include <torch/csrc/utils/python_arg_parser.h>
-#include <torch/csrc/autograd/generated/variable_factories.h>
 
 #ifdef USE_CUDA
 #include <ATen/CUDAGeneratorImpl.h>
 #endif
 
+namespace torch {
 using namespace at;
-using namespace torch;
 
-PyObject *THPGeneratorClass = nullptr;
-
-PyObject * THPGenerator_initDefaultGenerator(at::Generator cdata)
-{
-  auto type = (PyTypeObject*)THPGeneratorClass;
-  auto self = THPObjectPtr{type->tp_alloc(type, 0)};
-  if (!self) throw python_error();
-  auto self_ = reinterpret_cast<THPGenerator*>(self.get());
-  self_->cdata = cdata;
-  return self.release();
-}
-
-static void THPGenerator_dealloc(PyObject* _self)
-{
-  auto self = reinterpret_cast<THPGenerator*>(_self);
-  if (self->cdata.defined()) {
-    self->cdata.set_pyobj(nullptr);
-    self->cdata.~Generator();
-  }
-  Py_TYPE(_self)->tp_free(_self);
-}
-
-static PyObject * THPGenerator_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
+static Generator pyCreateGenerator(const Device& device) {
   HANDLE_TH_ERRORS
-  static torch::PythonArgParser parser({
-    "Generator(Device device=None)"
-  });
-  torch::ParsedArgs<1> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  auto device = r.deviceWithDefault(0, at::Device(at::kCPU));
-
-  THPGeneratorPtr self((THPGenerator *)type->tp_alloc(type, 0));
+  if (device.type() == kCPU) {
+    return make_generator<CPUGeneratorImpl>();
 #ifdef USE_CUDA
-  if (device.type() == at::kCPU) {
-    self->cdata = make_generator<CPUGeneratorImpl>();
-  } else if (device.type() == at::kCUDA){
-    self->cdata = make_generator<CUDAGeneratorImpl>(device.index());
+  } else if (device.type() == kCUDA) {
+    return make_generator<CUDAGeneratorImpl>(device.index());
+#endif
   } else {
     AT_ERROR("Device type ", c10::DeviceTypeName(device.type()),
              " is not supported for torch.Generator() api.");
   }
-#else
-  TORCH_CHECK(device.type() == at::kCPU,
-              "Device type ", c10::DeviceTypeName(device.type()),
-              " is not supported for torch.Generator() api.");
-  self->cdata = make_generator<CPUGeneratorImpl>();
-#endif
-  return (PyObject*)self.release();
-  END_HANDLE_TH_ERRORS
+  END_HANDLE_TH_ERRORS_PYBIND
 }
 
-static PyObject * THPGenerator_getState(PyObject *_self, PyObject *noargs)
-{
-  using namespace torch::autograd;
+static Generator& pyManualSeed(Generator& gen, uint64_t seed) {
   HANDLE_TH_ERRORS
-  auto& gen = ((THPGenerator*)_self)->cdata;
-
   // See Note [Acquire lock when using random generators]
   std::lock_guard<std::mutex> lock(gen.mutex());
-  auto state_tensor = gen.get_state();
-
-  return THPVariable_Wrap(std::move(state_tensor));
-  END_HANDLE_TH_ERRORS
+  gen.set_current_seed(seed);
+  return gen;
+  END_HANDLE_TH_ERRORS_PYBIND
 }
 
-static PyObject * THPGenerator_setState(PyObject *_self, PyObject *_new_state)
-{
-  using namespace torch::autograd;
-  
-  HANDLE_TH_ERRORS
-  if (!THPVariable_Check(_new_state)) {
-    throw torch::TypeError("expected a torch.ByteTensor, but got %s", Py_TYPE(_new_state)->tp_name);
-  }
-  auto self = (THPGenerator*)_self;
-  auto& gen = self->cdata;
-  auto& new_state_tensor = ((THPVariable*)_new_state)->cdata;
-  
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(gen.mutex());
-  gen.set_state(new_state_tensor);
-  
-  Py_INCREF(self);
-  return (PyObject*)self;
-  END_HANDLE_TH_ERRORS
+void initGeneratorBindings(PyObject* module) {
+  py::options options;
+  options.disable_user_defined_docstrings();
+  options.disable_function_signatures();
+
+  py::class_<Generator>(module, "Generator")
+      // FIXME Refactor this after binding Device with pybind11
+      .def(py::init([]() { return pyCreateGenerator(Device(kCPU)); }))
+      .def(py::init(
+          [](std::string& dev_str) {
+            HANDLE_TH_ERRORS
+            return pyCreateGenerator(Device(dev_str));
+            END_HANDLE_TH_ERRORS_PYBIND
+          }),
+          py::arg("device"))
+      .def(py::init(
+          [](DeviceIndex index) {
+            HANDLE_TH_ERRORS
+            return pyCreateGenerator(Device(kCUDA, index));
+            END_HANDLE_TH_ERRORS_PYBIND
+          }),
+          py::arg("device"))
+      .def(py::init(
+          [](py::object obj) {
+            HANDLE_TH_ERRORS
+            auto obj_ptr = obj.ptr();
+            TORCH_CHECK_TYPE(
+              THPDevice_Check(obj_ptr),
+              "expect torch.device for creating Generator, got ",
+              Py_TYPE(obj_ptr)->tp_name
+            );
+            auto& device = ((THPDevice*)obj_ptr)->device;
+            return pyCreateGenerator(device);
+            END_HANDLE_TH_ERRORS_PYBIND
+          }),
+          py::arg("device"))
+      .def(
+          "get_state",
+          [](Generator& gen) {
+            HANDLE_TH_ERRORS
+            // See Note [Acquire lock when using random generators]
+            std::lock_guard<std::mutex> lock(gen.mutex());
+            return gen.state();
+            END_HANDLE_TH_ERRORS_PYBIND
+          })
+      .def("set_state",
+          [](Generator& gen, Tensor& new_state) -> Generator& {
+            HANDLE_TH_ERRORS
+            // See Note [Acquire lock when using random generators]
+            std::lock_guard<std::mutex> lock(gen.mutex());
+            gen.set_state(new_state);
+            return gen;
+            END_HANDLE_TH_ERRORS_PYBIND
+          },
+          py::arg("new_state"))
+      .def("manual_seed", &pyManualSeed, py::arg("seed"))
+      .def("manual_seed",
+          [](Generator& gen, int64_t seed) -> Generator& {
+            return pyManualSeed(gen, (uint64_t)seed);
+          },
+          py::arg("seed"))
+      .def("seed",
+          [](Generator& gen) {
+            HANDLE_TH_ERRORS
+            // See Note [Acquire lock when using random generators]
+            std::lock_guard<std::mutex> lock(gen.mutex());
+            return gen.seed();
+            END_HANDLE_TH_ERRORS_PYBIND
+          })
+      .def("initial_seed", [](Generator& gen) { return gen.current_seed(); })
+      // FIXME Refactor this after binding Device with pybind11
+      .def_property_readonly(
+          "device",
+          [](const Generator& gen) {
+              return py::handle((PyObject*)THPDevice_New(gen.device()));
+          });
 }
 
-static PyObject * THPGenerator_manualSeed(PyObject *_self, PyObject *seed)
-{
-  HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
-  auto generator = self->cdata;
-  THPUtils_assert(THPUtils_checkLong(seed), "manual_seed expected a long, "
-          "but got %s", THPUtils_typename(seed));
-  // See Note [Acquire lock when using random generators]
-  std::lock_guard<std::mutex> lock(generator.mutex());
-  uint64_t seed_unpacked;
-  try {
-    // First try to interpret as unsigned long
-    seed_unpacked = THPUtils_unpackUInt64(seed);
-  } catch(...) {
-    if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
-      // If an overflow happened, then the seed could be negative,
-      // so try to interpret it as signed long
-      PyErr_Clear();
-      int64_t seed_unpacked_signed = THPUtils_unpackLong(seed);
-      seed_unpacked = *(reinterpret_cast<uint64_t*>(&seed_unpacked_signed));
-    } else {
-      // If any other type of exception happened, rethrow it
-      throw;
-    }
-  }
-  generator.set_current_seed(seed_unpacked);
-  Py_INCREF(self);
-  return (PyObject*)self;
-  END_HANDLE_TH_ERRORS
-}
-
-static PyObject * THPGenerator_seed(PyObject *_self, PyObject *noargs)
-{
-  HANDLE_TH_ERRORS
-  // See Note [Acquire lock when using random generators]
-  auto self = (THPGenerator*)_self;
-  std::lock_guard<std::mutex> lock(self->cdata.mutex());
-  uint64_t seed_val = self->cdata.seed();
-  return THPUtils_packUInt64(seed_val);
-  END_HANDLE_TH_ERRORS
-}
-
-static PyObject * THPGenerator_initialSeed(PyObject *_self, PyObject *noargs)
-{
-  HANDLE_TH_ERRORS
-  auto self = (THPGenerator*)_self;
-  return THPUtils_packUInt64(self->cdata.current_seed());
-  END_HANDLE_TH_ERRORS
-}
-
-static PyObject * THPGenerator_get_device(THPGenerator *self, void *unused) {
-  HANDLE_TH_ERRORS
-  return THPDevice_New(self->cdata.device());
-  END_HANDLE_TH_ERRORS
-}
-
-static struct PyGetSetDef THPGenerator_properties[] = {
-  {"device", (getter)THPGenerator_get_device, nullptr, nullptr, nullptr},
-  {nullptr}
-};
-
-static PyMethodDef THPGenerator_methods[] = {
-  {"get_state",       THPGenerator_getState,       METH_NOARGS,  nullptr},
-  {"set_state",       THPGenerator_setState,       METH_O,       nullptr},
-  {"manual_seed",     THPGenerator_manualSeed,     METH_O,       nullptr},
-  {"seed",            THPGenerator_seed,           METH_NOARGS,  nullptr},
-  {"initial_seed",    THPGenerator_initialSeed,    METH_NOARGS,  nullptr},
-  {nullptr}
-};
-
-static struct PyMemberDef THPGenerator_members[] = {
-  {(char*)"_cdata", T_ULONGLONG, offsetof(THPGenerator, cdata), READONLY, nullptr},
-  {nullptr}
-};
-
-PyTypeObject THPGeneratorType = {
-  PyVarObject_HEAD_INIT(nullptr, 0)
-  "torch._C.Generator",                   /* tp_name */
-  sizeof(THPGenerator),                        /* tp_basicsize */
-  0,                                           /* tp_itemsize */
-  THPGenerator_dealloc,                        /* tp_dealloc */
-  0,                                           /* tp_vectorcall_offset */
-  nullptr,                                     /* tp_getattr */
-  nullptr,                                     /* tp_setattr */
-  nullptr,                                     /* tp_reserved */
-  nullptr,                                     /* tp_repr */
-  nullptr,                                     /* tp_as_number */
-  nullptr,                                     /* tp_as_sequence */
-  nullptr,                                     /* tp_as_mapping */
-  nullptr,                                     /* tp_hash  */
-  nullptr,                                     /* tp_call */
-  nullptr,                                     /* tp_str */
-  nullptr,                                     /* tp_getattro */
-  nullptr,                                     /* tp_setattro */
-  nullptr,                                     /* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,    /* tp_flags */
-  nullptr,                                     /* tp_doc */
-  nullptr,                                     /* tp_traverse */
-  nullptr,                                     /* tp_clear */
-  nullptr,                                     /* tp_richcompare */
-  0,                                           /* tp_weaklistoffset */
-  nullptr,                                     /* tp_iter */
-  nullptr,                                     /* tp_iternext */
-  THPGenerator_methods,                        /* tp_methods */
-  THPGenerator_members,                        /* tp_members */
-  THPGenerator_properties,                     /* tp_getset */
-  nullptr,                                     /* tp_base */
-  nullptr,                                     /* tp_dict */
-  nullptr,                                     /* tp_descr_get */
-  nullptr,                                     /* tp_descr_set */
-  0,                                           /* tp_dictoffset */
-  nullptr,                                     /* tp_init */
-  nullptr,                                     /* tp_alloc */
-  THPGenerator_pynew,                          /* tp_new */
-};
-
-bool THPGenerator_init(PyObject *module)
-{
-  THPGeneratorClass = (PyObject*)&THPGeneratorType;
-  if (PyType_Ready(&THPGeneratorType) < 0)
-    return false;
-  Py_INCREF(&THPGeneratorType);
-  PyModule_AddObject(module, "Generator", (PyObject *)&THPGeneratorType);
-  return true;
-}
-
-void set_pyobj(const Generator& self, PyObject* pyobj) {
-  TORCH_CHECK(self.defined(), "cannot call set_pyobj() on undefined generator");
-  self.set_pyobj(pyobj);
-}
-
-PyObject* pyobj(const Generator& self) {
-  TORCH_CHECK(self.defined(), "cannot call pyobj() on undefined generator");
-  return self.pyobj();
-}
-
-PyObject * THPGenerator_Wrap(Generator gen)
-{
-  if (!gen.defined()) {
-    Py_RETURN_NONE;
-  }
-
-  if (auto obj = pyobj(gen)) {
-    Py_INCREF(obj);
-    return obj;
-  }
-
-  return THPGenerator_NewWithVar((PyTypeObject *)THPGeneratorClass, std::move(gen));
-}
-
-// Creates a new Python object for a Generator. The Generator must not already
-// have a PyObject* associated with it.
-PyObject* THPGenerator_NewWithVar(PyTypeObject* type, Generator gen)
-{
-  PyObject* obj = type->tp_alloc(type, 0);
-  if (obj) {
-    auto g = (THPGenerator*) obj;
-    new (&g->cdata) Generator(std::move(gen));
-    set_pyobj(g->cdata, obj);
-  }
-  return obj;
-}
+} // namespace torch

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -30,12 +30,13 @@ inline Generator createGenerator(const Device& device) {
   END_HANDLE_TH_ERRORS_PYBIND
 }
 
-inline Generator& manualSeed(Generator& gen, uint64_t seed) {
+inline py::object manualSeed(py::object gen_obj, uint64_t seed) {
   HANDLE_TH_ERRORS
+  Generator& gen = gen_obj.cast<Generator&>();
   // See Note [Acquire lock when using random generators]
   std::lock_guard<std::mutex> lock(gen.mutex());
   gen.set_current_seed(seed);
-  return gen;
+  return gen_obj;
   END_HANDLE_TH_ERRORS_PYBIND
 }
 
@@ -56,7 +57,7 @@ void initGeneratorBindings(PyObject* module) {
             return createGenerator(Device(dev_str));
             END_HANDLE_TH_ERRORS_PYBIND
           }),
-          py::arg("device"))
+          py::arg("device").noconvert())
       .def(py::init(
           [](DeviceIndex index) {
             HANDLE_TH_ERRORS
@@ -65,11 +66,11 @@ void initGeneratorBindings(PyObject* module) {
             return createGenerator(Device(kCUDA, index));
             END_HANDLE_TH_ERRORS_PYBIND
           }),
-          py::arg("device"))
+          py::arg("device").noconvert())
       .def(py::init(
-          [](py::object obj) {
+          [](py::handle dev_obj) {
             HANDLE_TH_ERRORS
-            auto obj_ptr = obj.ptr();
+            auto obj_ptr = dev_obj.ptr();
             TORCH_CHECK_TYPE(
               THPDevice_Check(obj_ptr),
               "expect torch.device for creating Generator, got ",
@@ -79,7 +80,7 @@ void initGeneratorBindings(PyObject* module) {
             return createGenerator(device);
             END_HANDLE_TH_ERRORS_PYBIND
           }),
-          py::arg("device"))
+          py::arg("device").noconvert())
       .def(
           "get_state",
           [](Generator& gen) {
@@ -90,21 +91,22 @@ void initGeneratorBindings(PyObject* module) {
             END_HANDLE_TH_ERRORS_PYBIND
           })
       .def("set_state",
-          [](Generator& gen, Tensor& new_state) -> Generator& {
+          [](py::object gen_obj, Tensor& new_state) {
             HANDLE_TH_ERRORS
+            Generator& gen = gen_obj.cast<Generator&>();
             // See Note [Acquire lock when using random generators]
             std::lock_guard<std::mutex> lock(gen.mutex());
             gen.set_state(new_state);
-            return gen;
+            return gen_obj;
             END_HANDLE_TH_ERRORS_PYBIND
           },
-          py::arg("new_state"))
-      .def("manual_seed", &manualSeed, py::arg("seed"))
+          py::arg().noconvert())
+      .def("manual_seed", &manualSeed, py::arg().noconvert())
       .def("manual_seed",
-          [](Generator& gen, int64_t seed) -> Generator& {
-            return manualSeed(gen, (uint64_t)seed);
+          [](py::object gen_obj, int64_t seed) {
+            return manualSeed(gen_obj, (uint64_t) seed);
           },
-          py::arg("seed"))
+          py::arg().noconvert())
       .def("seed",
           [](Generator& gen) {
             HANDLE_TH_ERRORS
@@ -113,12 +115,12 @@ void initGeneratorBindings(PyObject* module) {
             return gen.seed();
             END_HANDLE_TH_ERRORS_PYBIND
           })
-      .def("initial_seed", [](const Generator& gen) { return gen.current_seed(); })
+      .def("initial_seed", &Generator::current_seed)
       // FIXME Refactor this after binding Device with pybind11
       .def_property_readonly(
           "device",
-          [](const Generator& gen) {
-              return py::handle((PyObject*)THPDevice_New(gen.device()));
+          [](const Generator& gen) -> py::handle {
+              return (PyObject*) THPDevice_New(gen.device());
           });
 }
 

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -10,8 +10,7 @@
 #include <ATen/CUDAGeneratorImpl.h>
 #endif
 
-namespace torch {
-
+namespace torch { namespace python {
 using namespace at;
 
 namespace {
@@ -87,7 +86,7 @@ void initGeneratorBindings(PyObject* module) {
             HANDLE_TH_ERRORS
             // See Note [Acquire lock when using random generators]
             std::lock_guard<std::mutex> lock(gen.mutex());
-            return gen.state();
+            return gen.get_state();
             END_HANDLE_TH_ERRORS_PYBIND
           })
       .def("set_state",
@@ -123,4 +122,4 @@ void initGeneratorBindings(PyObject* module) {
           });
 }
 
-} // namespace torch
+}} // namespace torch::python

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -46,7 +46,7 @@ void initGeneratorBindings(PyObject* module) {
   options.disable_user_defined_docstrings();
   options.disable_function_signatures();
 
-  py::class_<Generator>(module, "Generator", py::is_final())
+  py::class_<Generator>(module, "Generator")
       // FIXME These constructors are temporary and will be replaced by a subsequent
       // PR that binds at::Device with pybind11
       .def(py::init([]() { return createGenerator(Device(kCPU)); }))
@@ -113,7 +113,7 @@ void initGeneratorBindings(PyObject* module) {
             return gen.seed();
             END_HANDLE_TH_ERRORS_PYBIND
           })
-      .def("initial_seed", [](Generator& gen) { return gen.current_seed(); })
+      .def("initial_seed", [](const Generator& gen) { return gen.current_seed(); })
       // FIXME Refactor this after binding Device with pybind11
       .def_property_readonly(
           "device",

--- a/torch/csrc/Generator.cpp
+++ b/torch/csrc/Generator.cpp
@@ -104,7 +104,7 @@ void initGeneratorBindings(PyObject* module) {
       .def("manual_seed", &manualSeed, py::arg().noconvert())
       .def("manual_seed",
           [](py::object gen_obj, int64_t seed) {
-            return manualSeed(gen_obj, (uint64_t) seed);
+            return manualSeed(std::move(gen_obj), (uint64_t) seed);
           },
           py::arg().noconvert())
       .def("seed",

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -1,29 +1,10 @@
 #pragma once
 
-#include <torch/csrc/python_headers.h>
 #include <ATen/ATen.h>
+#include <torch/csrc/python_headers.h>
 
-#include <torch/csrc/THP_export.h>
+namespace torch {
 
-struct THPGenerator {
-  PyObject_HEAD
-  at::Generator cdata;
-};
+void initGeneratorBindings(PyObject* module);
 
-// Creates a new Python object wrapping the default at::Generator. The reference is
-// borrowed. The caller should ensure that the at::Generator object lifetime
-// last at least as long as the Python wrapper.
-THP_API PyObject * THPGenerator_initDefaultGenerator(at::Generator cdata);
-
-#define THPGenerator_Check(obj) \
-  PyObject_IsInstance(obj, THPGeneratorClass)
-
-THP_API PyObject *THPGeneratorClass;
-
-bool THPGenerator_init(PyObject *module);
-
-THP_API PyObject * THPGenerator_Wrap(at::Generator gen);
-
-// Creates a new Python object for a Generator. The Generator must not already
-// have a PyObject* associated with it.
-PyObject* THPGenerator_NewWithVar(PyTypeObject* type, at::Generator gen);
+}

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -3,8 +3,8 @@
 #include <ATen/ATen.h>
 #include <torch/csrc/python_headers.h>
 
-namespace torch {
+namespace torch { namespace python {
 
 void initGeneratorBindings(PyObject* module);
 
-}
+}} // namespace torch::python

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -775,7 +775,7 @@ PyObject* initModule() {
      methods.data()
   };
   ASSERT_TRUE(module = PyModule_Create(&torchmodule));
-  torch::initGeneratorBindings(module);
+  torch::python::initGeneratorBindings(module);
   ASSERT_TRUE(THPException_init(module));
   THPSize_init(module);
   THPDtype_init(module);

--- a/torch/csrc/THP.h
+++ b/torch/csrc/THP.h
@@ -29,7 +29,6 @@
 #define THWTensor_(NAME) THTensor_(NAME)
 
 #include <torch/csrc/Exceptions.h>
-#include <torch/csrc/Generator.h>
 #include <torch/csrc/Module.h>
 #include <torch/csrc/Size.h>
 #include <torch/csrc/Storage.h>

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -20,7 +20,6 @@
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/cuda/python_comm.h>
-#include <torch/csrc/Generator.h>
 #include <torch/csrc/python_headers.h>
 
 #ifndef WIN32
@@ -511,10 +510,9 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
   auto num_gpus = c10::cuda::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));
   for(int i = 0; i < num_gpus; i++) {
-    auto gen = at::cuda::detail::getDefaultCUDAGenerator(i);
-    auto cast_gen = (THPGenerator*)THPGenerator_initDefaultGenerator(gen);
+    py::object cuda_generator = py::cast(at::cuda::detail::getDefaultCUDAGenerator(i));
     // This reference is meant to be given away, so no need to incref here.
-    PyTuple_SetItem(default_cuda_generators, i, (PyObject*)cast_gen);
+    PyTuple_SetItem(default_cuda_generators, i, cuda_generator.release().ptr());
   }
   set_module_attr("default_generators", default_cuda_generators);
   bindGetDeviceProperties(m);

--- a/torch/csrc/utils.cpp
+++ b/torch/csrc/utils.cpp
@@ -200,14 +200,6 @@ void THPUtils_invalidArguments(PyObject *given_args, PyObject *given_kwargs,
       given_args, given_kwargs, function_name, option_strings).c_str());
 }
 
-template<>
-void THPPointer<THPGenerator>::free() {
-  if (ptr)
-    Py_DECREF(ptr);
-}
-
-template class THPPointer<THPGenerator>;
-
 static bool backCompatBroadcastWarn = false;
 
 void setBackCompatBroadcastWarn(bool warn) {

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -141,8 +141,6 @@ int THPUtils_getCallable(PyObject *arg, PyObject **result);
 #define THPTensorPtr  TH_CONCAT_3(THP,Real,TensorPtr)
 #define THSPTensorPtr  TH_CONCAT_3(THSP,Real,TensorPtr)
 
-typedef THPPointer<THPGenerator> THPGeneratorPtr;
-
 template <typename T>
 struct THPUtils_typeTraits {};
 

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -10,7 +10,6 @@
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/utils/python_tuples.h>
 #include <torch/csrc/utils/python_numbers.h>
-#include <torch/csrc/Generator.h>
 
 #include <stdexcept>
 #include <utility>
@@ -42,26 +41,6 @@ struct type_caster<at::Tensor> {
   static handle
   cast(const at::Tensor& src, return_value_policy /* policy */, handle /* parent */) {
     return handle(THPVariable_Wrap(torch::autograd::Variable(src)));
-  }
-};
-
-template <>
-struct type_caster<at::Generator> {
- public:
-  PYBIND11_TYPE_CASTER(at::Generator, _("at::Generator"));
-
-  bool load(handle src, bool) {
-    PyObject* obj = src.ptr();
-    if (THPGenerator_Check(obj)) {
-      value = reinterpret_cast<THPGenerator*>(obj)->cdata;
-      return true;
-    }
-    return false;
-  }
-
-  static handle
-  cast(const at::Generator& src, return_value_policy /* policy */, handle /* parent */) {
-    return handle(THPGenerator_Wrap(src));
   }
 };
 

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -478,7 +478,7 @@ auto FunctionParameter::check(PyObject* obj, std::vector<py::handle> &overloaded
       return size > 0 && THPUtils_checkLong(obj);
     }
     case ParameterType::FLOAT_LIST: return is_float_or_complex_list(obj);
-    case ParameterType::GENERATOR: return THPGenerator_Check(obj);
+    case ParameterType::GENERATOR: return py::isinstance<at::Generator>(obj);
     case ParameterType::BOOL: return PyBool_Check(obj);
     case ParameterType::STORAGE: return isStorage(obj);
     case ParameterType::PYOBJECT: return true;

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -47,7 +47,6 @@
 #include <torch/csrc/Dtype.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
-#include <torch/csrc/Generator.h>
 #include <torch/csrc/MemoryFormat.h>
 #include <torch/csrc/QScheme.h>
 #include <torch/csrc/Layout.h>
@@ -652,7 +651,7 @@ inline bool PythonArgs::isNone(int i) {
 
 inline c10::optional<at::Generator> PythonArgs::generator(int i) {
   if (!args[i]) return c10::nullopt;
-  return reinterpret_cast<THPGenerator*>(args[i])->cdata;
+  return py::handle(args[i]).cast<at::Generator>();
 }
 
 inline at::Storage PythonArgs::storage(int i) {


### PR DESCRIPTION
Refactor `torch.Generator` bindings to use pybind11, as Python bindings with pybind11 do not need to deal with low-level Python APIs and reference counting, and thus the code is much cleaner. This is a preparation for implementing pickling support for `torch.Generator` (#43672). Depends on #49589.

## What is being refactored?

* Interfaces
  - `{c10::GeneratorImpl, at::Generator}::{pyobj, set_pyobj}` are removed, as they are no longer needed.
* PyTorch Bindings
  - Class `THPGenerator` and all `THPGenerator_*` functions are removed. `torch.Generator` now directly binds to `at::Generator` through pybind11 in `torch::initGeneratorBindings`.
  - Instance checks now use `py::isinstance<at::Generator>(...)` instead of `THPGenerator_Check`.
  - `py::cast` is used to convert between `at::Generator` and `torch.Generator`.
* Utilities
  - `at::Generator` pybind11 type caster is removed, as it is now directly bound to Python.
  - `THPModule_addDocStr` now handles `PyInstanceMethod` generated by pybind11 for class methods. Note that the implementation is extremely hacky and uses implementation details of pybind11.
  - A python `add_docstr` implementation is created and handles docstring addition for pybind11 types and properties. For any other objects, it simply forwards to `torch._C._add_docstr` (`THPModule_addDocStr`).
* Fixed docstring tests and an exception test when an invalid seed is provided to the Generator.

## Questions

~~As mentioned in issue #49797, this pull request introduces pybind11 to core PyTorch APIs and removes `THP*` functions. Thus, it needs to be clarified whether these APIs are considered implementation details or public APIs. Otherwise merging this pull request will break backward compatibility for certain C extensions.~~

It has been clarified that `THP*` functions are internal APIs and migrating them to pybind11 is OK as long as it does not cause performance issues.