### PR TITLE
[WIP] Add tests for insertion of named tensor into other

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3072,8 +3072,10 @@ from_numpy(ndarray) -> Tensor
 Creates a :class:`Tensor` from a :class:`numpy.ndarray`.
 
 The returned tensor and :attr:`ndarray` share the same memory. Modifications to
-the tensor will be reflected in the :attr:`ndarray` and vice versa. The returned
-tensor is not resizable.
+the tensor will be reflected in the :attr:`ndarray` and vice versa. 
+If the underlying :attr:`ndarray` is memory mapped and read only, changing the
+tensor is not allowed.
+The returned tensor is not resizable.
 
 It currently accepts :attr:`ndarray` with dtypes of ``numpy.float64``,
 ``numpy.float32``, ``numpy.float16``, ``numpy.complex64``, ``numpy.complex128``,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3073,8 +3073,8 @@ Creates a :class:`Tensor` from a :class:`numpy.ndarray`.
 
 The returned tensor and :attr:`ndarray` share the same memory. Modifications to
 the tensor will be reflected in the :attr:`ndarray` and vice versa. 
-If the underlying :attr:`ndarray` is memory mapped and read only, changing the
-tensor is not allowed.
+Writing to a tensor created from a read-only NumPy array is not supported and 
+will result in undefined behavior.
 The returned tensor is not resizable.
 
 It currently accepts :attr:`ndarray` with dtypes of ``numpy.float64``,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3071,19 +3071,17 @@ from_numpy(ndarray) -> Tensor
 
 Creates a :class:`Tensor` from a :class:`numpy.ndarray`.
 
-The returned tensor and :attr:`ndarray` share the same memory. Modifications to
-the tensor will be reflected in the :attr:`ndarray` and vice versa. 
-The returned tensor is not resizable.
-
 It currently accepts :attr:`ndarray` with dtypes of ``numpy.float64``,
 ``numpy.float32``, ``numpy.float16``, ``numpy.complex64``, ``numpy.complex128``,
 ``numpy.int64``, ``numpy.int32``, ``numpy.int16``, ``numpy.int8``, ``numpy.uint8``,
 and ``numpy.bool``.
 
 .. warning::
+    The returned tensor and :attr:`ndarray` share the same memory. Modifications to
+    the tensor will be reflected in the :attr:`ndarray` and vice versa. 
     Writing to a tensor created from a read-only NumPy array is not supported and 
     will result in undefined behavior.
-
+    The returned tensor is not resizable.
 Example::
 
     >>> a = numpy.array([1, 2, 3])

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3073,14 +3073,16 @@ Creates a :class:`Tensor` from a :class:`numpy.ndarray`.
 
 The returned tensor and :attr:`ndarray` share the same memory. Modifications to
 the tensor will be reflected in the :attr:`ndarray` and vice versa. 
-Writing to a tensor created from a read-only NumPy array is not supported and 
-will result in undefined behavior.
 The returned tensor is not resizable.
 
 It currently accepts :attr:`ndarray` with dtypes of ``numpy.float64``,
 ``numpy.float32``, ``numpy.float16``, ``numpy.complex64``, ``numpy.complex128``,
 ``numpy.int64``, ``numpy.int32``, ``numpy.int16``, ``numpy.int8``, ``numpy.uint8``,
 and ``numpy.bool``.
+
+.. warning::
+    Writing to a tensor created from a read-only NumPy array is not supported and 
+    will result in undefined behavior.
 
 Example::
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3071,17 +3071,18 @@ from_numpy(ndarray) -> Tensor
 
 Creates a :class:`Tensor` from a :class:`numpy.ndarray`.
 
+The returned tensor and :attr:`ndarray` share the same memory. Modifications to
+the tensor will be reflected in the :attr:`ndarray` and vice versa. The returned
+tensor is not resizable.
+
 It currently accepts :attr:`ndarray` with dtypes of ``numpy.float64``,
 ``numpy.float32``, ``numpy.float16``, ``numpy.complex64``, ``numpy.complex128``,
 ``numpy.int64``, ``numpy.int32``, ``numpy.int16``, ``numpy.int8``, ``numpy.uint8``,
 and ``numpy.bool``.
 
-.. warning::
-    The returned tensor and :attr:`ndarray` share the same memory. Modifications to
-    the tensor will be reflected in the :attr:`ndarray` and vice versa. 
+.. warning::     
     Writing to a tensor created from a read-only NumPy array is not supported and 
     will result in undefined behavior.
-    The returned tensor is not resizable.
 Example::
 
     >>> a = numpy.array([1, 2, 3])

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -136,9 +136,9 @@ at::Tensor tensor_from_numpy(PyObject* obj, bool warn_if_not_writeable/*=true*/)
   if (!PyArray_ISWRITEABLE(array) && warn_if_not_writeable) {
     TORCH_WARN_ONCE(
       "The given NumPy array is not writeable, and PyTorch does "
-      "not support non-writeable tensors. This means that writing to the "
-      "underlying (supposedly non-writeable) NumPy array using the tensor will "
-      "probably result in a crash of the program. You may want to copy the "
+      "not support non-writeable tensors. Writing to this tensor is not "
+      "supported and will result in undefined behavior. "
+      " You may want to copy the "
       "array to protect its data or make it writeable before converting it to " 
       "a tensor. "
       "This type of warning will be suppressed for the rest of this program.");

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -136,11 +136,12 @@ at::Tensor tensor_from_numpy(PyObject* obj, bool warn_if_not_writeable/*=true*/)
   if (!PyArray_ISWRITEABLE(array) && warn_if_not_writeable) {
     TORCH_WARN_ONCE(
       "The given NumPy array is not writeable, and PyTorch does "
-      "not support non-writeable tensors. This means you can write to the "
-      "underlying (supposedly non-writeable) NumPy array using the tensor. "
-      "You may want to copy the array to protect its data or make it writeable "
-      "before converting it to a tensor. This type of warning will be "
-      "suppressed for the rest of this program.");
+      "not support non-writeable tensors. This means that writing to the "
+      "underlying (supposedly non-writeable) NumPy array using the tensor will "
+      "probably result in a crash of the program. You may want to copy the "
+      "array to protect its data or make it writeable before converting it to " 
+      "a tensor. "
+      "This type of warning will be suppressed for the rest of this program.");
 
   }
 

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -138,7 +138,7 @@ at::Tensor tensor_from_numpy(PyObject* obj, bool warn_if_not_writeable/*=true*/)
       "The given NumPy array is not writeable, and PyTorch does "
       "not support non-writeable tensors. Writing to this tensor is not "
       "supported and will result in undefined behavior. "
-      " You may want to copy the "
+      "You may want to copy the "
       "array to protect its data or make it writeable before converting it to " 
       "a tensor. "
       "This type of warning will be suppressed for the rest of this program.");


### PR DESCRIPTION
**Got replaced by** #50205

Inserting a named tensor into another named tensor did not work in the 1.7.x build, but works in the current build, although there is no PR explicitly addressing this. This PR fixes 49427 by ensuring that support for this functionality cannot be dropped unknowingly, as there are unit tests now.
