### PR TITLE
[FX] Make torch.fx.len scriptable

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1157,6 +1157,14 @@ class TestFX(JitTestCase):
         m = M()
         self.checkGraphModule(m, ())
 
+    def test_script_fx_len(self):
+        def len(x):
+            return torch.fx.len(x)
+
+        symtraced = symbolic_trace(len)
+        scripted = torch.jit.script(symtraced)
+        self.assertEqual(scripted(torch.rand(3)), 3)
+
     def test_namedtuple_return_qualname(self):
         class NamedTupReturn(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49811 [FX] Make torch.fx.len scriptable**

Closes https://github.com/pytorch/pytorch/issues/49804. Usages of `torch.fx.len` were previously not scriptable. This makes them scriptable.

Note that I didn't directly just add a `(torch.fx.len, 'aten::len')` pair to `torch.jit._builtins._builtin_ops` because `torch.fx` is not always available at `jit` init time, particularly in FBCode where we have `fx` in its own target

Differential Revision: [D25695701](https://our.internmc.facebook.com/intern/diff/D25695701)