### PR TITLE
Make generate_square_subsequent_mask static

### DIFF
--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -126,7 +126,8 @@ class Transformer(Module):
                               memory_key_padding_mask=memory_key_padding_mask)
         return output
 
-    def generate_square_subsequent_mask(self, sz: int) -> Tensor:
+    @staticmethod
+    def generate_square_subsequent_mask(sz: int) -> Tensor:
         r"""Generate a square mask for the sequence. The masked positions are filled with float('-inf').
             Unmasked positions are filled with float(0.0).
         """


### PR DESCRIPTION
This method is useful when just using the transformer layers, so it would be nice to be able to access it without having to create a transformer instance. Otherwise call sites are encouraged to copy paste it instead, which is what the transformer tutorial does (https://pytorch.org/tutorials/beginner/transformer_tutorial.html)
