### PR TITLE
eager quant: assert model.training consistently with FX

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -220,6 +220,8 @@ def prepare(model, inplace=False, allow_list=None,
 
     """
     torch._C._log_api_usage_once("quantization_api.quantize.prepare")
+    assert not model.training, 'prepare only works for models in ' + \
+        'eval mode'
     if prepare_custom_config_dict is None:
         prepare_custom_config_dict = {}
     custom_module_class_mapping = prepare_custom_config_dict.get("float_to_observed_custom_module_class", {})
@@ -394,6 +396,8 @@ def prepare_qat(model, mapping=None, inplace=False):
                  is mutated
     """
     torch._C._log_api_usage_once("quantization_api.quantize.prepare_qat")
+    assert model.training, 'prepare_qat only works for models in  ' + \
+        'train mode'
     if mapping is None:
         mapping = get_default_qat_module_mappings()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49893 eager quant: assert model.training consistently with FX**

Summary:

Ensures that `quantize.{prepare|prepare_qat}` asserts the value
of the `model.training` flag in the same way as
`quantize_fx.{prepare_fx|prepare_qat_fx`.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25715737](https://our.internmc.facebook.com/intern/diff/D25715737)