### PR TITLE
Fix compiler warnings pertaining to uniform_int()

### DIFF
--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -70,7 +70,7 @@ C10_HOST_DEVICE inline typename std::enable_if<!(std::is_floating_point<T>::valu
 
 /**
  * An overloaded transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`,
- * added to fix compiler warnings reported in GitHub issue 46391. T is either float or double.
+ * added to fix compiler warnings reported in GitHub issue 46391. T is either float or double in this version.
  */
 template<typename T, typename V>
 C10_HOST_DEVICE inline typename std::enable_if<std::is_floating_point<T>::value, T>::type uniform_int(V val) {

--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -54,11 +54,9 @@ template <typename T, typename V>
 C10_HOST_DEVICE inline T uniform_int(V val) {
   if (std::is_same<T, bool>::value) {
     return static_cast<bool>(val & 1);
-  } else if (std::is_same<T, double>::value) {
-    return static_cast<T>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<T>::digits) + 1));
   } else if (std::is_same<T, int64_t>::value) {
     return static_cast<T>(val % (static_cast<uint64_t>(std::numeric_limits<T>::max()) + 1));
-  } else if (std::is_floating_point<T>::value || std::is_same<T, at::Half>::value || std::is_same<T, at::BFloat16>::value) {
+  } else if (std::is_same<T, at::Half>::value || std::is_same<T, at::BFloat16>::value) {
     return static_cast<T>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<T>::digits) + 1));
   } else if (std::is_integral<T>::value) {
     return static_cast<T>(val % (static_cast<uint64_t>(std::numeric_limits<T>::max()) + 1));
@@ -66,6 +64,46 @@ C10_HOST_DEVICE inline T uniform_int(V val) {
     assert(false);
     return 0;
   }
+}
+
+/**
+ * An overloaded transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`,
+ * added to fix compiler warnings reported in GitHub issue 46391.
+ * Here, <T, V> is <float, uint32_t>
+ */
+template <>
+C10_HOST_DEVICE inline float uniform_int(uint32_t val) {
+  return static_cast<float>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<float>::digits) + 1));
+}
+
+/**
+ * An overloaded transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`,
+ * added to fix compiler warnings reported in GitHub issue 46391.
+ * Here, <T, V> is <float, uint64_t>
+ */
+template <>
+C10_HOST_DEVICE inline float uniform_int(uint64_t val) {
+  return static_cast<float>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<float>::digits) + 1));
+}
+
+/**
+ * An overloaded transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`,
+ * added to fix compiler warnings reported in GitHub issue 46391.
+ * Here, <T, V> is <double, uint32_t>
+ */
+template <>
+C10_HOST_DEVICE inline double uniform_int(uint32_t val) {
+  return static_cast<double>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<double>::digits) + 1));
+}
+
+/**
+ * An overloaded transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`,
+ * added to fix compiler warnings reported in GitHub issue 46391.
+ * Here, <T, V> is <double, uint64_t>
+ */
+template <>
+C10_HOST_DEVICE inline double uniform_int(uint64_t val) {
+  return static_cast<double>(val % static_cast<uint64_t>((1ULL << std::numeric_limits<double>::digits) + 1));
 }
 
 template <typename T, typename V>

--- a/aten/src/ATen/core/TransformationHelper.h
+++ b/aten/src/ATen/core/TransformationHelper.h
@@ -47,7 +47,6 @@ C10_HOST_DEVICE inline T uniform_int_full_range(V val) {
   return static_cast<T>(static_cast<int64_t>(val));
 }
 
-
 /**
  * A transformation function for `torch.Tensor.random_()`, when used without specifying `from` and `to`.
  * In order to prevent compiler warnings reported in GitHub issue 46391, T can't be float or double


### PR DESCRIPTION
**PROBLEM DESCRIPTION:**
GitHub issue 46391 suggests that compiler warnings pertaining to _floating-point value does not fit in required integral type_ might cause some confusion.

These compiler-warnings arise during compilation of the templated function `uniform_int()`. The warnings are misleading because they arise from the way the compiler compiles templated functions, but the if-else statements in the function obviate the possibilities that the warnings describe. So, the purpose of a fix would only be to fix the compiler warnings, and not to fix any sort of a bug.


**FIX DESCRIPTION:**
[EDITED, after inputs from @malfet]: In the function `uniform_int()`, the if-else conditions pertaining to types `double` & `float` can be removed, and then an overloaded specialized function can be added for floating-point types. The current version of the function can be specialized to not have its return type as a floating point type.

An unrelated observation is that the if-else condition pertaining to the type `double` (line 57 in the original code) was redundant, as line 61 in the original code covered it (`std::is_floating_point<T>::value` would also have been true for the type `double`).

Fixes #46391
