### PR TITLE
currently _load_from_bytes loads without the option to specify device…

### DIFF
--- a/torch/storage.py
+++ b/torch/storage.py
@@ -158,7 +158,10 @@ class _StorageBase(object):
 
 
 def _load_from_bytes(b):
-    return torch.load(io.BytesIO(b))
+    if torch.cuda.is_available():
+        return torch.load(io.BytesIO(b))
+    else:
+        return torch.load(io.BytesIO(b), map_location=torch.device('cpu'))
 
 
 _StorageBase.type = _type  # type: ignore[assignment]


### PR DESCRIPTION
… and is used in load from pickle for example. this change will check if cuda is present in the system then use regular load, otherwise with mapping to CPU device. example open issue that this can solve: https://github.com/pytorch/pytorch/issues/16797

Fixes #16797
