### PR TITLE
Clean up some type annotations in caffe2/contrib/aten/gen_op

### DIFF
--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -236,11 +236,11 @@ if __name__ == '__main__':
     decls = yaml.load(read(os.path.join(args.yaml_dir, 'Declarations.yaml')), Loader=Loader)
     factory_methods = find_factory_methods(decls)
     filtered = [expanded for o in decls for expanded in expand(o) if supports(expanded, factory_methods)]
-    top_env = {
+    top_env: Dict[str, List] = {
         'mappings': [],
         'implementations': [],
         'cases': [],
-    }  # type: Dict[str, List]
+    }
     seen: Set[str] = set()
     key = 0
     for o in filtered:


### PR DESCRIPTION
Summary: Upgrades type annotations from Python2 to Python3

Test Plan: Sandcastle tests

Differential Revision: D25717502

