### PR TITLE
Update MultiHeadAttention docstring

### DIFF
--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -847,9 +847,9 @@ class MultiheadAttention(Module):
                        value sequences at dim=1.
         kdim: total number of features in key. Default: None.
         vdim: total number of features in value. Default: None.
-
-        Note: if kdim and vdim are None, they will be set to embed_dim such that
-              query, key, and value have the same number of features.
+            Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+            to :attr:`embed_dim` such that query, key, and value have the same
+            number of features.
 
     Examples::
 

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -847,9 +847,10 @@ class MultiheadAttention(Module):
                        value sequences at dim=1.
         kdim: total number of features in key. Default: None.
         vdim: total number of features in value. Default: None.
-            Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
-            to :attr:`embed_dim` such that query, key, and value have the same
-            number of features.
+
+    Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+    to :attr:`embed_dim` such that query, key, and value have the same
+    number of features.
 
     Examples::
 


### PR DESCRIPTION
Fixes MultiHeadAttention docstring.

Currently, https://pytorch.org/docs/stable/generated/torch.nn.MultiheadAttention.html#torch.nn.MultiheadAttention
is 

<img width="648" alt="Screen Shot 2020-12-29 at 21 06 43" src="https://user-images.githubusercontent.com/2459423/103311124-cd10cc00-4a19-11eb-89c9-0ee261364963.png">


and with the fix will be

<img width="648" alt="Screen Shot 2020-12-29 at 22 41 35" src="https://user-images.githubusercontent.com/2459423/103315838-0dc31200-4a27-11eb-82e2-ca8f13d713a1.png">

