### PR TITLE
Drop unused imports from benchmarks

### DIFF
--- a/benchmarks/overrides_benchmark/pyspybench.py
+++ b/benchmarks/overrides_benchmark/pyspybench.py
@@ -1,6 +1,6 @@
-import torch
+from common import SubTensor  # noqa: F401
 import argparse
-from common import SubTensor, WithTorchFunction, SubWithTorchFunction  # noqa: F401
+import torch
 
 Tensor = torch.Tensor
 


### PR DESCRIPTION
Summary:
From
```
./python/libcst/libcst codemod remove_unused_imports.RemoveUnusedImportsWithGlean --no-format caffe2/
```

Test Plan: Standard sandcastle tests

Differential Revision: D25727355

