### PR TITLE
[quant] Backend string for the quantized types

### DIFF
--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -21,6 +21,7 @@ static const char* backend_to_string(const at::Backend& backend) {
     case at::Backend::CUDA: return "torch.cuda";
     case at::Backend::SparseCPU: return "torch.sparse";
     case at::Backend::SparseCUDA: return "torch.cuda.sparse";
+    case at::Backend::QuantizedCPU: return "torch.quantized";
     default: AT_ERROR("Unimplemented backend ", backend);
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#49965 [quant] Backend string for the quantized types**

Without this checking the type of the quantized tensor using `type` would throw an error.

After this PR running the `type(qx)`, where `qx` is a quantized tensor would show something like `torch.quantized.QUInt8`.

Test Plan: Not needed -- this is just a string description for the quantized tensors

Differential Revision: [D25731594](https://our.internmc.facebook.com/intern/diff/D25731594)