### PR TITLE
Drop unused imports

### DIFF
--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -2,10 +2,10 @@
 
 """
 
-from typing import Optional, Tuple
-
-import torch
 from torch import Tensor
+import torch
+
+from typing import Optional, Tuple
 
 
 def is_sparse(A):
@@ -29,8 +29,7 @@ def get_floating_dtype(A):
     return torch.float32
 
 
-def matmul(A, B):
-    # type: (Optional[Tensor], Tensor) -> Tensor
+def matmul(A: Optional[Tensor], B: Tensor) -> Tensor:
     """Multiply two matrices.
 
     If A is None, return B. A can be sparse or dense. B is always
@@ -66,15 +65,13 @@ def transjugate(A):
     return conjugate(transpose(A))
 
 
-def bform(X, A, Y):
-    # type: (Tensor, Optional[Tensor], Tensor) -> Tensor
+def bform(X: Tensor, A: Optional[Tensor], Y: Tensor) -> Tensor:
     """Return bilinear form of matrices: :math:`X^T A Y`.
     """
     return matmul(transpose(X), matmul(A, Y))
 
 
-def qform(A, S):
-    # type: (Optional[Tensor], Tensor) -> Tensor
+def qform(A: Optional[Tensor], S: Tensor):
     """Return quadratic form :math:`S^T A S`.
     """
     return bform(S, A, S)
@@ -91,8 +88,7 @@ def basis(A):
     return Q
 
 
-def symeig(A, largest=False, eigenvectors=True):
-    # type: (Tensor, Optional[bool], Optional[bool]) -> Tuple[Tensor, Tensor]
+def symeig(A: Tensor, largest: Optional[bool] = False, eigenvectors: Optional[bool] = True) -> Tuple[Tensor, Tensor]:
     """Return eigenpairs of A with specified ordering.
     """
     if largest is None:

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -3,20 +3,18 @@
 
 __all__ = ['svd_lowrank', 'pca_lowrank']
 
-from typing import Tuple, Optional
-
-import torch
 from torch import Tensor
+import torch
 from . import _linalg_utils as _utils
 from .overrides import has_torch_function, handle_torch_function
 
+from typing import Optional, Tuple
 
-def get_approximate_basis(A,        # type: Tensor
-                          q,        # type: int
-                          niter=2,  # type: Optional[int]
-                          M=None    # type: Optional[Tensor]
-                          ):
-    # type: (...) -> Tensor
+def get_approximate_basis(A: Tensor,
+                          q: int,
+                          niter: Optional[int] = 2,
+                          M: Optional[Tensor] = None
+                          ) -> Tensor:
     """Return tensor :math:`Q` with :math:`q` orthonormal columns such
     that :math:`Q Q^H A` approximates :math:`A`. If :math:`M` is
     specified, then :math:`Q` is such that :math:`Q Q^H (A - M)`
@@ -82,8 +80,8 @@ def get_approximate_basis(A,        # type: Tensor
     return Q
 
 
-def svd_lowrank(A, q=6, niter=2, M=None):
-    # type: (Tensor, Optional[int], Optional[int], Optional[Tensor]) -> Tuple[Tensor, Tensor, Tensor]
+def svd_lowrank(A: Tensor, q: Optional[int] = 6, niter: Optional[int] = 2,
+                M: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Return the singular value decomposition ``(U, S, V)`` of a matrix,
     batches of matrices, or a sparse matrix :math:`A` such that
     :math:`A \approx U diag(S) V^T`. In case :math:`M` is given, then
@@ -130,8 +128,8 @@ def svd_lowrank(A, q=6, niter=2, M=None):
     return _svd_lowrank(A, q=q, niter=niter, M=M)
 
 
-def _svd_lowrank(A, q=6, niter=2, M=None):
-    # type: (Tensor, Optional[int], Optional[int], Optional[Tensor]) -> Tuple[Tensor, Tensor, Tensor]
+def _svd_lowrank(A: Tensor, q: Optional[int] = 6, niter: Optional[int] = 2,
+                 M: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Tensor]:
     q = 6 if q is None else q
     m, n = A.shape[-2:]
     matmul = _utils.matmul
@@ -175,8 +173,8 @@ def _svd_lowrank(A, q=6, niter=2, M=None):
     return U, S, V
 
 
-def pca_lowrank(A, q=None, center=True, niter=2):
-    # type: (Tensor, Optional[int], bool, int) -> Tuple[Tensor, Tensor, Tensor]
+def pca_lowrank(A: Tensor, q: Optional[int] = None, center: bool = True,
+                niter: int = 2) -> Tuple[Tensor, Tensor, Tensor]:
     r"""Performs linear Principal Component Analysis (PCA) on a low-rank
     matrix, batches of such matrices, or sparse matrix.
 

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -1,12 +1,11 @@
+from torch import Tensor, _VF  # noqa: F401
+from torch.nn.utils.rnn import PackedSequence
 import torch
 
-from typing import Tuple, Optional, List
-
-from torch import Tensor, _VF  # noqa: F401
-
-from torch.nn.utils.rnn import PackedSequence
-
 import warnings
+
+from typing import List, Optional, Tuple
+
 
 class QuantizedLinear(torch.jit.ScriptModule):
     __constants__ = ['scale', 'zero_point']

--- a/torch/multiprocessing/pool.py
+++ b/torch/multiprocessing/pool.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import multiprocessing.pool
 import multiprocessing.util as util
 

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -1,5 +1,4 @@
 import io
-import multiprocessing
 import multiprocessing.queues
 from multiprocessing.reduction import ForkingPickler
 import pickle

--- a/torch/nn/_reduction.py
+++ b/torch/nn/_reduction.py
@@ -1,5 +1,5 @@
-import warnings
 from typing import Optional
+import warnings
 
 # NB: Keep this file in sync with enums in aten/src/ATen/core/Reduction.h
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -1,8 +1,8 @@
 import math
 import warnings
 
-import torch
 from torch import Tensor
+import torch
 
 
 # These no_grad_* functions are necessary as wrappers around the parts of these

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import torch
 from torch import Tensor

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -1,7 +1,8 @@
-from typing import List
 
 from torch._six import container_abcs
+
 from itertools import repeat
+from typing import List
 
 
 def _ntuple(n):

--- a/torch/nn/quantized/modules/functional_modules.py
+++ b/torch/nn/quantized/modules/functional_modules.py
@@ -4,7 +4,6 @@ import torch
 from torch import Tensor
 from torch._ops import ops
 
-
 class FloatFunctional(torch.nn.Module):
     r"""State collector class for float operations.
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -349,7 +349,6 @@ def _check_module_exists(name):
     our tests, e.g., setting multiprocessing start method when imported
     (see librosa/#747, torchvision/#544).
     """
-    import importlib
     import importlib.util
     spec = importlib.util.find_spec(name)
     return spec is not None

--- a/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
+++ b/torch/testing/_internal/distributed/rpc/jit/dist_autograd_test.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict
+from typing import Dict, Tuple
 
 import torch
 import torch.distributed.autograd as dist_autograd

--- a/torch/testing/_internal/test_module/future_div.py
+++ b/torch/testing/_internal/test_module/future_div.py
@@ -1,5 +1,4 @@
 from __future__ import division
-import torch  # noqa: F401
 
 
 def div_int_future():


### PR DESCRIPTION
Summary:
From
```
./python/libcst/libcst codemod remove_unused_imports.RemoveUnusedImportsWithGlean --no-format caffe2/
```

Test Plan: Standard sandcastle tests

Differential Revision: D25727352

