### PR TITLE
Drop unused imports from test

### DIFF
--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -11,7 +11,7 @@ from typing import Any
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from torch.testing._internal.jit_utils import JitTestCase, _inline_everything
-from typing import List, Tuple
+from typing import List
 from torch import Tensor
 
 class TestAsync(JitTestCase):

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1,13 +1,12 @@
 import os
 import sys
 import inspect
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Any
 from textwrap import dedent
 from collections import OrderedDict
 
 import torch
 from torch.testing import FileCheck
-from torch import Tensor
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))

--- a/test/jit/test_recursive_script.py
+++ b/test/jit/test_recursive_script.py
@@ -2,11 +2,10 @@ import os
 import sys
 import typing
 import typing_extensions
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional
 
 import torch
 import torch.nn as nn
-from torch import Tensor
 from torch.testing import FileCheck
 from collections import OrderedDict
 

--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -5,7 +5,6 @@ import sys
 import random
 import torch
 from itertools import product as product
-from torch import Tensor
 from torch.testing._internal.common_utils import TemporaryFileName
 from typing import NamedTuple, Optional
 

--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -82,6 +82,7 @@ import torch.testing._internal.hypothesis_utils as hu
 hu.assert_deadline_disabled()
 
 # Standard library
+from typing import Tuple
 import copy
 import io
 import unittest
@@ -1007,10 +1008,7 @@ class TestPostTrainingDynamic(QuantizationTestCase):
                     super(ScriptWrapperPackedLSTM, self).__init__()
                     self.cell = cell
 
-                def forward(self,
-                            x  # type: PackedSequence
-                            ):
-                    # type: (...) -> Tuple[PackedSequence, Tuple[torch.Tensor, torch.Tensor]]
+                def forward(self, x: PackedSequence) -> Tuple[PackedSequence, Tuple[torch.Tensor, torch.Tensor]]:
                     return self.cell(x)
 
             class ScriptWrapperPackedGRU(torch.nn.Module):
@@ -1018,10 +1016,7 @@ class TestPostTrainingDynamic(QuantizationTestCase):
                     super(ScriptWrapperPackedGRU, self).__init__()
                     self.cell = cell
 
-                def forward(self,
-                            x  # type: PackedSequence
-                            ):
-                    # type: (...) -> Tuple[PackedSequence, torch.Tensor]
+                def forward(self, x: PackedSequence) -> Tuple[PackedSequence, torch.Tensor]:
                     return self.cell(x)
 
             script_wrapper_map = {'LSTM': ScriptWrapperPackedLSTM,

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3845,7 +3845,6 @@ class TestLinalg(TestCase):
         """Compare torch and scipy.sparse.linalg implementations of lobpcg
         """
         import time
-        import scipy
         from torch.testing._internal.common_utils import random_sparse_pd_matrix
         from torch._linalg_utils import matmul as mm
         from scipy.sparse.linalg import lobpcg as scipy_lobpcg

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -1,16 +1,13 @@
 import unittest
 
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_utils import TEST_NUMBA, TEST_NUMPY
+from torch.testing._internal.common_utils import TEST_NUMPY
 from torch.testing._internal.common_cuda import TEST_NUMBA_CUDA, TEST_CUDA, TEST_MULTIGPU
 
 import torch
 
 if TEST_NUMPY:
     import numpy
-
-if TEST_NUMBA:
-    import numba
 
 if TEST_NUMBA_CUDA:
     import numba.cuda


### PR DESCRIPTION
Summary:
From
```
./python/libcst/libcst codemod remove_unused_imports.RemoveUnusedImportsWithGlean --no-format caffe2/
```

Test Plan: Standard sandcastle tests

Differential Revision: D25727350

