### PR TITLE
Drop unused imports

### DIFF
--- a/caffe2/contrib/aten/aten_test.py
+++ b/caffe2/contrib/aten/aten_test.py
@@ -3,7 +3,7 @@
 
 
 
-from caffe2.python import core, dyndep
+from caffe2.python import core
 from hypothesis import given
 
 import caffe2.python.hypothesis_test_util as hu

--- a/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
+++ b/caffe2/contrib/fakelowp/test/test_batchnorm_nnpi_fp16.py
@@ -1,5 +1,4 @@
 import numpy as np
-import unittest
 
 import caffe2.python.fakelowp.init_shared_libs  # noqa
 from hypothesis import given, settings


### PR DESCRIPTION
Summary:
From
```
./python/libcst/libcst codemod remove_unused_imports.RemoveUnusedImportsWithGlean --no-format caffe2/
```

Test Plan: Standard sandcastle tests

Differential Revision: D25727358

