### PR TITLE
Migrate `torch.device` bindings to pybind11

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -23,17 +23,16 @@ T = TypeVar('T')
 
 # Defined in torch/csrc/Device.cpp
 class device:
-    type: str  # THPDevice_type
-    index: _int  # THPDevice_index
+    type: str
+    index: _int
 
-    # THPDevice_pynew
     @overload
     def __init__(self, device: Union[_device, _int, str]) -> None: ...
 
     @overload
     def __init__(self, type: str, index: _int) -> None: ...
 
-    def __reduce__(self) -> Tuple[Any, ...]: ...  # THPDevice_reduce
+    def __reduce__(self) -> Tuple[Any, ...]: ...
 
 # Defined in torch/csrc/Stream.cpp
 class Stream:

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-namespace torch {
+namespace torch { namespace python {
 using namespace at;
 
 namespace {
@@ -103,4 +103,4 @@ void initDeviceBindings(PyObject* module) {
           });
 }
 
-} // namespace torch
+}} // namespace torch::python

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -22,7 +22,7 @@ inline std::string deviceType(const Device& device) {
 
 } // namespace
 
-Device parseDevice(py::object device) {
+Device parseDevice(py::handle device) {
   if (py::isinstance<Device>(device)) {
     return device.cast<Device>();
   } else if (py::isinstance<py::str>(device)) {

--- a/torch/csrc/Device.cpp
+++ b/torch/csrc/Device.cpp
@@ -1,235 +1,106 @@
 #include <torch/csrc/Device.h>
-
 #include <torch/csrc/Exceptions.h>
-#include <torch/csrc/utils/object_ptr.h>
-#include <torch/csrc/utils/python_arg_parser.h>
-#include <torch/csrc/utils/python_strings.h>
-#include <torch/csrc/utils/python_numbers.h>
-#include <torch/csrc/utils/pybind.h>
 
-#include <ATen/Device.h>
-#include <c10/util/Exception.h>
-
-#include <cstring>
-#include <limits>
-#include <structmember.h>
 #include <sstream>
 
-PyObject *THPDevice_New(const at::Device& device)
-{
-  auto type = (PyTypeObject*)&THPDeviceType;
-  auto self = THPObjectPtr{type->tp_alloc(type, 0)};
-  if (!self) throw python_error();
-  auto self_ = reinterpret_cast<THPDevice*>(self.get());
-  self_->device = device;
-  return self.release();
+namespace torch {
+using namespace at;
+
+namespace {
+
+inline Device parseDeviceIndex(DeviceType type, DeviceIndex index) {
+  // -1 is allowed in ATen/C++, to mean the default device, but not in Python
+  TORCH_CHECK(index >= 0, "Device index must not be negative");
+  return Device(type, index);
 }
 
-PyObject *THPDevice_repr(THPDevice *self)
-{
+inline std::string deviceType(const Device& device) {
   std::ostringstream oss;
-  oss << "device(type=\'" << self->device.type() << "\'";
-  if (self->device.has_index()) {
-    // `self->device.index()` returns uint8_t which is treated as ascii while printing,
-    // hence casting it to uint16_t.
-    // https://stackoverflow.com/questions/19562103/uint8-t-cant-be-printed-with-cout
-    oss << ", index=" << static_cast<uint16_t>(self->device.index());
-  }
-  oss << ")";
-  return THPUtils_packString(oss.str().c_str());
+  oss << device.type();
+  return oss.str();
 }
 
-PyObject *THPDevice_str(THPDevice *self)
-{
-  std::ostringstream oss;
-  oss << self->device;
-  return THPUtils_packString(oss.str().c_str());
-}
+} // namespace
 
-PyObject *THPDevice_pynew(PyTypeObject *type, PyObject *args, PyObject *kwargs)
-{
-  HANDLE_TH_ERRORS
-  static torch::PythonArgParser parser({
-    "Device(Device device)",
-    "Device(std::string type, int64_t? index=-1)"
-  });
-  torch::ParsedArgs<2> parsed_args;
-  auto r = parser.parse(args, kwargs, parsed_args);
-  if (r.idx == 0) {
-    auto device = r.device(0);
-    return THPDevice_New(device);
-  } else if (r.idx == 1) {
-    auto as_device = r.device(0);  // this works, because device can take strings
-    auto device_type = r.string(0);
-    if (as_device.has_index()) {
-      throw std::runtime_error("type (string) must not include an index because index "
-                                "was passed explicitly: " + device_type);
-    }
-    int32_t device_index = -1;
-    if (!r.isNone(1)) {
-      device_index = r.toInt64(1);
-      // -1 is allowed in ATen/C++, to mean the default device, but not in
-      // Python.
-      TORCH_CHECK(device_index >= 0, "Device index must not be negative");
-    }
-    at::Device device(as_device.type(), device_index);
-    return THPDevice_New(device);
-  }
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject *THPDevice_type(THPDevice *self, PyObject *noargs)
-{
-  HANDLE_TH_ERRORS
-  std::ostringstream oss;
-  oss << self->device.type();
-  return THPUtils_packString(oss.str().c_str());
-  Py_RETURN_NONE;
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject *THPDevice_index(THPDevice *self, PyObject *noargs)
-{
-  HANDLE_TH_ERRORS
-  if (self->device.has_index()) {
-    return THPUtils_packInt64(self->device.index());
+Device parseDevice(py::object device) {
+  if (py::isinstance<Device>(device)) {
+    return device.cast<Device>();
+  } else if (py::isinstance<py::str>(device)) {
+    return Device(device.cast<std::string>());
+  } else if (py::isinstance<py::int_>(device)) {
+    return parseDeviceIndex(kCUDA, device.cast<DeviceIndex>());
   } else {
-    Py_RETURN_NONE;
-  }
-  END_HANDLE_TH_ERRORS
-}
-
-static Py_ssize_t THPDevice_hash(THPDevice *self)
-{
-  HANDLE_TH_ERRORS
-  return static_cast<Py_ssize_t>(std::hash<at::Device>{}(self->device) % std::numeric_limits<Py_ssize_t>::max());
-  END_HANDLE_TH_ERRORS_RET(-1)
-}
-
-PyObject *THPDevice_rc(PyObject *a, PyObject *b, int op) {
-  HANDLE_TH_ERRORS
-  if (!THPDevice_Check(a) || !THPDevice_Check(b)) {
-    // Py_RETURN_NOTIMPLEMENTED not in python 2.
-    Py_INCREF(Py_NotImplemented);
-    return Py_NotImplemented;
-  }
-  THPDevice *da = reinterpret_cast<THPDevice*>(a);
-  THPDevice *db = reinterpret_cast<THPDevice*>(b);
-
-  switch(op) {
-    case Py_EQ:
-      if (da->device == db->device) {
-        Py_RETURN_TRUE;
-      } else {
-        Py_RETURN_FALSE;
-      }
-    case Py_NE:
-      if (da->device == db->device) {
-        Py_RETURN_FALSE;
-      } else {
-        Py_RETURN_TRUE;
-      }
-    case Py_LT:
-    case Py_LE:
-    case Py_GT:
-    case Py_GE:
-      throw torch::TypeError("comparison not implemented");
-    default:
-      throw torch::TypeError("unexpected comparison op");
-  }
-  END_HANDLE_TH_ERRORS
-}
-
-PyObject *THPDevice_reduce(PyObject *_self, PyObject *noargs)
-{
-  HANDLE_TH_ERRORS
-  auto self = (THPDevice*)_self;
-  auto ret = THPObjectPtr{PyTuple_New(2)};
-  if (!ret) throw python_error();
-
-  py::object torch_module = py::module::import("torch");
-  py::object torch_device = torch_module.attr("device");
-  PyTuple_SET_ITEM(ret.get(), 0, torch_device.release().ptr());
-
-  THPObjectPtr args;
-  std::ostringstream oss;
-  oss << self->device.type();
-  if (self->device.has_index()) {
-    args = THPObjectPtr{Py_BuildValue("(si)", oss.str().c_str(), self->device.index())};
-  } else {
-    args = THPObjectPtr{Py_BuildValue("(s)", oss.str().c_str())};
-  }
-  if (!args) throw python_error();
-  PyTuple_SET_ITEM(ret.get(), 1, args.release());
-
-  return ret.release();
-  END_HANDLE_TH_ERRORS
-}
-
-typedef PyObject *(*getter)(PyObject *, void *);
-
-// NB: If you edit these properties/methods, update torch/_C/__init__.pyi.in
-
-static struct PyGetSetDef THPDevice_properties[] = {
-  {"type",       (getter)THPDevice_type, nullptr, nullptr, nullptr},
-  {"index",      (getter)THPDevice_index, nullptr, nullptr, nullptr},
-  {nullptr}
-};
-
-static PyMethodDef THPDevice_methods[] = {
-  {"__reduce__", THPDevice_reduce, METH_NOARGS, nullptr},
-  {nullptr}  /* Sentinel */
-};
-
-PyTypeObject THPDeviceType = {
-  PyVarObject_HEAD_INIT(nullptr, 0)
-  "torch.device",                        /* tp_name */
-  sizeof(THPDevice),                     /* tp_basicsize */
-  0,                                     /* tp_itemsize */
-  nullptr,                               /* tp_dealloc */
-  0,                                     /* tp_vectorcall_offset */
-  nullptr,                               /* tp_getattr */
-  nullptr,                               /* tp_setattr */
-  nullptr,                               /* tp_reserved */
-  (reprfunc)THPDevice_repr,              /* tp_repr */
-  nullptr,                               /* tp_as_number */
-  nullptr,                               /* tp_as_sequence */
-  nullptr,                               /* tp_as_mapping */
-  (hashfunc)THPDevice_hash,              /* tp_hash  */
-  nullptr,                               /* tp_call */
-  (reprfunc)THPDevice_str,               /* tp_str */
-  nullptr,                               /* tp_getattro */
-  nullptr,                               /* tp_setattro */
-  nullptr,                               /* tp_as_buffer */
-  Py_TPFLAGS_DEFAULT,                    /* tp_flags */
-  nullptr,                               /* tp_doc */
-  nullptr,                               /* tp_traverse */
-  nullptr,                               /* tp_clear */
-  (richcmpfunc)THPDevice_rc,             /* tp_richcompare */
-  0,                                     /* tp_weaklistoffset */
-  nullptr,                               /* tp_iter */
-  nullptr,                               /* tp_iternext */
-  THPDevice_methods,                     /* tp_methods */
-  nullptr,                               /* tp_members */
-  THPDevice_properties,                  /* tp_getset */
-  nullptr,                               /* tp_base */
-  nullptr,                               /* tp_dict */
-  nullptr,                               /* tp_descr_get */
-  nullptr,                               /* tp_descr_set */
-  0,                                     /* tp_dictoffset */
-  nullptr,                               /* tp_init */
-  nullptr,                               /* tp_alloc */
-  THPDevice_pynew,                       /* tp_new */
-};
-
-void THPDevice_init(PyObject *module)
-{
-  if (PyType_Ready(&THPDeviceType) < 0) {
-    throw python_error();
-  }
-  Py_INCREF(&THPDeviceType);
-  if (PyModule_AddObject(module, "device", (PyObject *)&THPDeviceType) != 0) {
-    throw python_error();
+    TORCH_CHECK_TYPE(
+      false, "device argument must be torch.device, str or int, not ",
+      py::type::of(device).attr("__name__").cast<std::string>()
+    );
   }
 }
+
+void initDeviceBindings(PyObject* module) {
+  py::options options;
+  options.disable_user_defined_docstrings();
+  options.disable_function_signatures();
+
+  // NB: If you edit these properties/methods, update torch/_C/__init__.pyi.in
+  py::class_<Device>(module, "device", py::is_final())
+      .def(py::init<const Device&>(), py::arg("device"))
+      .def(py::init(wrap_pybind_function(parseDevice)), py::arg("device"))
+      .def(py::init(
+          [](const std::string& type, DeviceIndex index) {
+            HANDLE_TH_ERRORS
+            auto check_device = Device(type);
+            TORCH_CHECK(
+              !check_device.has_index(),
+              "type (string) must not include an index because index was passed explicitly: ",
+              type
+            );
+            return parseDeviceIndex(check_device.type(), index);
+            END_HANDLE_TH_ERRORS_PYBIND
+          }),
+          py::arg("type"),
+          py::arg("index"))
+      .def(py::self == py::self)
+      .def(py::self != py::self)
+      .def(py::hash(py::self))
+      .def("__repr__",
+          [](const Device& device) {
+            std::ostringstream oss;
+            oss << "device(type=\'" << device.type() << "\'";
+            if (device.has_index()) {
+              // `device.index()` returns uint8_t which is treated as ascii while printing,
+              // hence casting it to uint16_t.
+              // https://stackoverflow.com/questions/19562103/uint8-t-cant-be-printed-with-cout
+              oss << ", index=" << static_cast<uint16_t>(device.index());
+            }
+            oss << ")";
+            return oss.str();
+          })
+      .def("__str__",
+          [](const Device& device) {
+            std::ostringstream oss;
+            oss << device;
+            return oss.str();
+          })
+      .def("__reduce__",
+          [](const Device& device) {
+            static auto device_cls = py::type::of<Device>();
+            auto type = deviceType(device);
+            auto args = device.has_index() ?
+              py::make_tuple(type, device.index()) :
+              py::make_tuple(type);
+            return py::make_tuple(device_cls, args);
+          })
+      .def_property_readonly("type", &deviceType)
+      .def_property_readonly(
+          "index",
+          [](const Device& device) -> c10::optional<DeviceIndex> {
+            if (device.has_index()) {
+              return device.index();
+            } else {
+              return c10::nullopt;
+            }
+          });
+}
+
+} // namespace torch

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -10,7 +10,7 @@ namespace torch { namespace python {
 /**
  * Utility for parsing Python device argument.
  */
-at::Device parseDevice(py::object device);
+at::Device parseDevice(py::handle device);
 
 void initDeviceBindings(PyObject* module);
 

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -1,22 +1,26 @@
 #pragma once
 
+#include <ATen/ATen.h>
 #include <torch/csrc/python_headers.h>
-#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/utils/pybind.h>
 
-#include <ATen/Device.h>
+namespace torch {
 
-// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
-struct TORCH_API THPDevice {
-  PyObject_HEAD
-  at::Device device;
-};
+/**
+ * Utility for parsing the device argument.
+ */
+at::Device parseDevice(py::object device);
 
-TORCH_API extern PyTypeObject THPDeviceType;
+void initDeviceBindings(PyObject* module);
 
+} // namespace torch
+
+// Legacy functions are still kept to ease transition to pybind11 bindings
+// FIXME Remove use of these functions and get rid of them
 inline bool THPDevice_Check(PyObject *obj) {
-  return Py_TYPE(obj) == &THPDeviceType;
+  return py::isinstance<at::Device>(obj);
 }
 
-PyObject * THPDevice_New(const at::Device& device);
-
-void THPDevice_init(PyObject *module);
+inline PyObject* THPDevice_New(const at::Device& device) {
+  return py::cast(device).release().ptr();
+}

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -1,19 +1,20 @@
 #pragma once
 
-#include <ATen/ATen.h>
 #include <torch/csrc/python_headers.h>
+
+#include <ATen/ATen.h>
 #include <torch/csrc/utils/pybind.h>
 
-namespace torch {
+namespace torch { namespace python {
 
 /**
- * Utility for parsing the device argument.
+ * Utility for parsing Python device argument.
  */
 at::Device parseDevice(py::object device);
 
 void initDeviceBindings(PyObject* module);
 
-} // namespace torch
+}} // namespace torch::python
 
 // Legacy functions are still kept to ease transition to pybind11 bindings
 // FIXME Remove use of these functions and get rid of them

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -730,7 +730,7 @@ PyObject* initModule() {
   THPLayout_init(module);
   THPMemoryFormat_init(module);
   THPQScheme_init(module);
-  torch::initDeviceBindings(module);
+  torch::python::initDeviceBindings(module);
   THPStream_init(module);
   ASSERT_TRUE(THPVariable_initModule(module));
   ASSERT_TRUE(THPFunction_initModule(module));

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -730,7 +730,7 @@ PyObject* initModule() {
   THPLayout_init(module);
   THPMemoryFormat_init(module);
   THPQScheme_init(module);
-  THPDevice_init(module);
+  torch::initDeviceBindings(module);
   THPStream_init(module);
   ASSERT_TRUE(THPVariable_initModule(module));
   ASSERT_TRUE(THPFunction_initModule(module));

--- a/torch/csrc/api/include/torch/python.h
+++ b/torch/csrc/api/include/torch/python.h
@@ -21,9 +21,8 @@ namespace torch {
 namespace python {
 namespace detail {
 inline Device py_object_to_device(py::object object) {
-  PyObject* obj = object.ptr();
-  if (THPDevice_Check(obj)) {
-    return reinterpret_cast<THPDevice*>(obj)->device;
+  if (py::isinstance<Device>(object)) {
+    return object.cast<Device>();
   }
   throw TypeError("Expected device");
 }
@@ -146,10 +145,8 @@ py::class_<ModuleType, Extra...> add_module_bindings(
       .def("named_children",
           [](ModuleType& module) { return module.named_children(); })
       .def("to", [](ModuleType& module, py::object object, bool non_blocking) {
-            if (THPDevice_Check(object.ptr())) {
-              module.to(
-                  reinterpret_cast<THPDevice*>(object.ptr())->device,
-                  non_blocking);
+            if (py::isinstance<Device>(object)) {
+              module.to(object.cast<Device>(), non_blocking);
             } else {
               module.to(detail::py_object_to_dtype(object), non_blocking);
             }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -69,10 +69,8 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
     }
     case TypeKind::StringType:
       return ConstantString::create(py::cast<std::string>(obj));
-    case TypeKind::DeviceObjType: {
-      auto device = reinterpret_cast<THPDevice*>(obj.ptr());
-      return device->device;
-    }
+    case TypeKind::DeviceObjType:
+      return py::cast<Device>(obj);
     case TypeKind::StreamObjType: {
       auto stream = reinterpret_cast<THPStream*>(obj.ptr());
       return static_cast<int64_t>(stream->cdata);

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -668,7 +668,7 @@ inline py::object toPyObject(IValue ivalue) {
       return std::move(t);
     }
   } else if (ivalue.isDevice()) {
-    return py::cast<py::object>(THPDevice_New(std::move(ivalue).toDevice()));
+    return py::cast(std::move(ivalue).toDevice());
   } else if (ivalue.isGenericDict()) {
     auto dict = std::move(ivalue).toGenericDict();
     py::dict py_dict;

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -925,9 +925,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
       return toSimple(g.insertConstant(py::cast<std::string>(obj), loc));
     } else if (obj.is(py::none())) {
       return toSimple(g.insertConstant(IValue(), loc));
-    } else if (THPDevice_Check(obj.ptr())) {
-      auto device = reinterpret_cast<THPDevice*>(obj.ptr());
-      return toSimple(g.insertConstant(device->device));
+    } else if (py::isinstance<Device>(obj)) {
+      return toSimple(g.insertConstant(py::cast<Device>(obj)));
     } else if (THPLayout_Check(obj.ptr())) {
       auto layout = reinterpret_cast<THPLayout*>(obj.ptr());
       const auto v = static_cast<int64_t>(layout->layout);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1405,9 +1405,8 @@ void initJitScriptBindings(PyObject* module) {
          const py::dict& extra_files) {
         c10::optional<at::Device> optional_device;
         if (!map_location.is(py::none())) {
-          AT_ASSERT(THPDevice_Check(map_location.ptr()));
-          optional_device =
-              reinterpret_cast<THPDevice*>(map_location.ptr())->device;
+          AT_ASSERT(py::isinstance<Device>(map_location));
+          optional_device = map_location.cast<Device>();
         }
         ExtraFilesMap extra_files_map = extra_files_from_python(extra_files);
         auto ret = import_ir_module(
@@ -1424,9 +1423,8 @@ void initJitScriptBindings(PyObject* module) {
         std::istringstream in(buffer);
         c10::optional<at::Device> optional_device;
         if (!map_location.is(py::none())) {
-          AT_ASSERT(THPDevice_Check(map_location.ptr()));
-          optional_device =
-              reinterpret_cast<THPDevice*>(map_location.ptr())->device;
+          AT_ASSERT(py::isinstance<Device>(map_location));
+          optional_device = map_location.cast<Device>();
         }
         ExtraFilesMap extra_files_map = extra_files_from_python(extra_files);
         auto ret = import_ir_module(
@@ -1439,9 +1437,8 @@ void initJitScriptBindings(PyObject* module) {
       [](const std::string& filename, py::object map_location) {
         c10::optional<at::Device> optional_device;
         if (!map_location.is(py::none())) {
-          AT_ASSERT(THPDevice_Check(map_location.ptr()));
-          optional_device =
-              reinterpret_cast<THPDevice*>(map_location.ptr())->device;
+          AT_ASSERT(py::isinstance<Device>(map_location));
+          optional_device = map_location.cast<Device>();
         }
         return _load_for_mobile(filename, optional_device);
       });
@@ -1451,9 +1448,8 @@ void initJitScriptBindings(PyObject* module) {
         std::istringstream in(buffer);
         c10::optional<at::Device> optional_device;
         if (!map_location.is(py::none())) {
-          AT_ASSERT(THPDevice_Check(map_location.ptr()));
-          optional_device =
-              reinterpret_cast<THPDevice*>(map_location.ptr())->device;
+          AT_ASSERT(py::isinstance<Device>(map_location));
+          optional_device = map_location.cast<Device>();
         }
         return _load_for_mobile(in, optional_device);
       });

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -5,6 +5,7 @@
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/operators.h>
 
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/autograd/python_variable.h>

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -489,7 +489,7 @@ inline at::Device PythonArgs::device(int i) {
     return at::Device(backendToDeviceType(dispatchKeyToBackend(torch::tensors::get_default_dispatch_key())));
   }
   // Original code does not mutate reference counts, so make a copy here
-  return torch::parseDevice(py::reinterpret_borrow<py::object>(args[i]));
+  return torch::python::parseDevice(py::reinterpret_borrow<py::object>(args[i]));
 }
 
 inline at::Device PythonArgs::deviceWithDefault(int i, const at::Device& default_device) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -489,7 +489,7 @@ inline at::Device PythonArgs::device(int i) {
     return at::Device(backendToDeviceType(dispatchKeyToBackend(torch::tensors::get_default_dispatch_key())));
   }
   // Original code does not mutate reference counts, so make a copy here
-  return torch::python::parseDevice(py::reinterpret_borrow<py::object>(args[i]));
+  return torch::python::parseDevice(args[i]);
 }
 
 inline at::Device PythonArgs::deviceWithDefault(int i, const at::Device& default_device) {


### PR DESCRIPTION
* `THPDevice_Check` and `THPDevice_new` stubs are still kept to ease the transition and reduce the number of files that needs to be changed.
* `torch::parseDevice` utility is introduced to parse Python `device` arguments. It accepts `torch.device`, `str` and `int`, just like `THPDevice_pynew`.