### PR TITLE
enable half for some things, so that "fast path" for multinomial

### DIFF
--- a/aten/src/ATen/native/Distributions.cpp
+++ b/aten/src/ATen/native/Distributions.cpp
@@ -496,9 +496,7 @@ Tensor& multinomial_out(
   // Fast-path for no replacement.
   // Reference:
   // https://github.com/pytorch/pytorch/issues/11931#issuecomment-625882503
-  // Half is not supported on CPU.
-  if (!with_replacement &&
-      !(self.device().is_cpu() && self.scalar_type() == ScalarType::Half)) {
+  if (!with_replacement) {
     // Sanity checks on `self`.
     auto is_valid = ((self.max() < INFINITY) & (self.min() >= 0)).item();
     TORCH_CHECK(

--- a/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceAllOpsKernel.cpp
@@ -74,12 +74,22 @@ static void min_all_kernel_impl(Tensor& result, const Tensor& input) {
     reduce_all_impl<int64_t>(result, input, upper_bound<int64_t>(),
       [=](int64_t a, int64_t b) -> int64_t { return min_impl(a, b); });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(input.scalar_type(), "min_all", [&] {
-      using Vec = vec256::Vec256<scalar_t>;
-      reduce_all_impl_vec<scalar_t>(result, input, upper_bound<scalar_t>(),
-        [=] (scalar_t a , scalar_t b) -> scalar_t { return min_impl(a, b); },
-        [=](Vec a, Vec b) -> Vec { return minimum(a, b); });
-    });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        input.scalar_type(),
+        "min_all",
+        [&] {
+          using Vec = vec256::Vec256<scalar_t>;
+          reduce_all_impl_vec<scalar_t>(
+              result,
+              input,
+              upper_bound<scalar_t>(),
+              [=](scalar_t a, scalar_t b) -> scalar_t {
+                return min_impl(a, b);
+              },
+              [=](Vec a, Vec b) -> Vec { return minimum(a, b); });
+        });
   }
 }
 
@@ -99,12 +109,22 @@ static void max_all_kernel_impl(Tensor& result, const Tensor& input) {
     reduce_all_impl<int64_t>(result, input, lower_bound<int64_t>(),
       [=](int64_t a, int64_t b) -> int64_t { return max_impl(a, b); });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(input.scalar_type(), "max_all", [&] {
-      using Vec = vec256::Vec256<scalar_t>;
-      reduce_all_impl_vec<scalar_t>(result, input, lower_bound<scalar_t>(),
-        [=] (scalar_t a , scalar_t b) -> scalar_t { return max_impl(a, b); },
-        [=](Vec a, Vec b) -> Vec { return maximum(a, b); });
-    });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        input.scalar_type(),
+        "max_all",
+        [&] {
+          using Vec = vec256::Vec256<scalar_t>;
+          reduce_all_impl_vec<scalar_t>(
+              result,
+              input,
+              lower_bound<scalar_t>(),
+              [=](scalar_t a, scalar_t b) -> scalar_t {
+                return max_impl(a, b);
+              },
+              [=](Vec a, Vec b) -> Vec { return maximum(a, b); });
+        });
   }
 }
 
@@ -193,22 +213,26 @@ static void _aminmax_all_kernel_impl(Tensor& min_result, Tensor& max_result,
       }
     );
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(input.scalar_type(), "_aminmax_all_all", [&] {
-      using Vec = vec256::Vec256<scalar_t>;
-      using scalar_t_pair = std::pair<scalar_t, scalar_t>;
-      reduce_all_impl_vec_two_outputs<scalar_t>(
-        min_result,
-        max_result,
-        input,
-        scalar_t_pair(upper_bound<scalar_t>(), lower_bound<scalar_t>()),
-        [=] (scalar_t_pair a , scalar_t_pair b) -> scalar_t_pair {
-          return scalar_t_pair(
-            min_impl(a.first, b.first), max_impl(a.second, b.second));
-        },
-        [=](Vec a, Vec b) -> Vec { return minimum(a, b); },
-        [=](Vec a, Vec b) -> Vec { return maximum(a, b); }
-      );
-    });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        input.scalar_type(),
+        "_aminmax_all_all",
+        [&] {
+          using Vec = vec256::Vec256<scalar_t>;
+          using scalar_t_pair = std::pair<scalar_t, scalar_t>;
+          reduce_all_impl_vec_two_outputs<scalar_t>(
+              min_result,
+              max_result,
+              input,
+              scalar_t_pair(upper_bound<scalar_t>(), lower_bound<scalar_t>()),
+              [=](scalar_t_pair a, scalar_t_pair b) -> scalar_t_pair {
+                return scalar_t_pair(
+                    min_impl(a.first, b.first), max_impl(a.second, b.second));
+              },
+              [=](Vec a, Vec b) -> Vec { return minimum(a, b); },
+              [=](Vec a, Vec b) -> Vec { return maximum(a, b); });
+        });
   }
 }
 

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -135,11 +135,13 @@ static void topk_kernel(
     int64_t dim,
     bool largest,
     bool sorted) {
-  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "topk_cpu", [&] {
-    dim_apply(
-        {self, values, indices},
-        dim,
-        [&](int64_t i, TensorList tl) {
+  AT_DISPATCH_ALL_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      self.scalar_type(),
+      "topk_cpu",
+      [&] {
+        dim_apply({self, values, indices}, dim, [&](int64_t i, TensorList tl) {
           auto tmp_values = tl[0].accessor<scalar_t, 1>();
           auto mode_values = tl[1].accessor<scalar_t, 1>();
           auto mode_indices = tl[2].accessor<int64_t, 1>();
@@ -198,7 +200,7 @@ static void topk_kernel(
             mode_indices[j] = queue[j].second;
           }
         });
-  });
+      });
 }
 
 } // anonymous namespace

--- a/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
+++ b/aten/src/ATen/native/cpu/TensorCompareKernel.cpp
@@ -81,29 +81,41 @@ static void min_kernel_impl(
   TORCH_CHECK(result.scalar_type() == self.scalar_type() && indice.scalar_type() == kLong,
     "Expect dtype ", self.scalar_type(), "and torch.long, but got ", result.scalar_type(), "and", indice.scalar_type());
 
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "min_cpu", [&] {
-    compare_base_kernel<scalar_t>(result, indice, self, wrap_dim, keepdim, [&] (
-      scalar_t* result_data, int64_t* indice_data,
-      const scalar_t* self_data, auto self_dim_stride) {
-        using value_t = typename c10::scalar_value_type<scalar_t>::type;
-        value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
-        scalar_t min_number = self_data[0];
-        int64_t index = 0;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
-          scalar_t value = self_data[i * self_dim_stride];
-          if (!(zabs_(value) >= zabs_(min_number))) {
-            min_number = value;
-            index = i;
-            if (_isnan<scalar_t>(value)) {
-              break;
-            }
-          }
-        }
-        *result_data = min_number;
-        *indice_data = index;
-      }
-    );
-  });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      ScalarType::Bool,
+      self.scalar_type(),
+      "min_cpu",
+      [&] {
+        compare_base_kernel<scalar_t>(
+            result,
+            indice,
+            self,
+            wrap_dim,
+            keepdim,
+            [&](scalar_t* result_data,
+                int64_t* indice_data,
+                const scalar_t* self_data,
+                auto self_dim_stride) {
+              using value_t = typename c10::scalar_value_type<scalar_t>::type;
+              value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
+              scalar_t min_number = self_data[0];
+              int64_t index = 0;
+              for (int64_t i = 0; i < self_dim_size; ++i) {
+                scalar_t value = self_data[i * self_dim_stride];
+                if (!(zabs_(value) >= zabs_(min_number))) {
+                  min_number = value;
+                  index = i;
+                  if (_isnan<scalar_t>(value)) {
+                    break;
+                  }
+                }
+              }
+              *result_data = min_number;
+              *indice_data = index;
+            });
+      });
 }
 
 static void max_kernel_impl(
@@ -118,29 +130,41 @@ static void max_kernel_impl(
   TORCH_CHECK(result.scalar_type() == self.scalar_type() && indice.scalar_type() == kLong,
     "Expect dtype ", self.scalar_type(), "and torch.long, but got ", result.scalar_type(), "and", indice.scalar_type());
 
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(ScalarType::Bool, self.scalar_type(), "max_cpu", [&] {
-    compare_base_kernel<scalar_t>(result, indice, self, wrap_dim, keepdim, [&] (
-      scalar_t* result_data, int64_t* indice_data,
-      const scalar_t* self_data, auto self_dim_stride) {
-        using value_t = typename c10::scalar_value_type<scalar_t>::type;
-        value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
-        scalar_t max_number = self_data[0];
-        int64_t index = 0;
-        for (int64_t i = 0; i < self_dim_size; ++i) {
-          scalar_t value = self_data[i * self_dim_stride];
-          if (!(zabs_(value) <= zabs_(max_number))) {
-            max_number = value;
-            index = i;
-            if (_isnan<scalar_t>(value)) {
-              break;
-            }
-          }
-        }
-        *result_data = max_number;
-        *indice_data = index;
-      }
-    );
-  });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      ScalarType::Bool,
+      self.scalar_type(),
+      "max_cpu",
+      [&] {
+        compare_base_kernel<scalar_t>(
+            result,
+            indice,
+            self,
+            wrap_dim,
+            keepdim,
+            [&](scalar_t* result_data,
+                int64_t* indice_data,
+                const scalar_t* self_data,
+                auto self_dim_stride) {
+              using value_t = typename c10::scalar_value_type<scalar_t>::type;
+              value_t (*zabs_)(scalar_t) = zabs<scalar_t, value_t>;
+              scalar_t max_number = self_data[0];
+              int64_t index = 0;
+              for (int64_t i = 0; i < self_dim_size; ++i) {
+                scalar_t value = self_data[i * self_dim_stride];
+                if (!(zabs_(value) <= zabs_(max_number))) {
+                  max_number = value;
+                  index = i;
+                  if (_isnan<scalar_t>(value)) {
+                    break;
+                  }
+                }
+              }
+              *result_data = max_number;
+              *indice_data = index;
+            });
+      });
 }
 
 static void _aminmax_kernel_impl(
@@ -156,30 +180,42 @@ static void _aminmax_kernel_impl(
     "Expect min and max dtype ", self.scalar_type(),
     " but got ", min_result.scalar_type(), " and ", max_result.scalar_type());
 
-  AT_DISPATCH_ALL_TYPES_AND(ScalarType::Bool, self.scalar_type(), "_aminmax_cpu", [&] {
-    compare_base_kernel<scalar_t, scalar_t>(min_result, max_result, self, wrap_dim, keepdim, [&] (
-      scalar_t* min_result_data, scalar_t* max_result_data,
-      const scalar_t* self_data, auto self_dim_stride) {
-        scalar_t min_number = self_data[0];
-        scalar_t max_number = self_data[0];
-        for (int64_t i = 0; i < self_dim_size; ++i) {
-          scalar_t value = self_data[i * self_dim_stride];
-          // note: comparison is written this way to handle NaN correctly
-          if (!(value >= min_number)) {
-            min_number = value;
-            if (_isnan<scalar_t>(value)) {
-              max_number = value;
-              break;
-            }
-          } else if (!(value <= max_number)) {
-            max_number = value;
-          }
-        }
-        *min_result_data = min_number;
-        *max_result_data = max_number;
-      }
-    );
-  });
+  AT_DISPATCH_ALL_TYPES_AND3(
+      ScalarType::Half,
+      ScalarType::BFloat16,
+      ScalarType::Bool,
+      self.scalar_type(),
+      "_aminmax_cpu",
+      [&] {
+        compare_base_kernel<scalar_t, scalar_t>(
+            min_result,
+            max_result,
+            self,
+            wrap_dim,
+            keepdim,
+            [&](scalar_t* min_result_data,
+                scalar_t* max_result_data,
+                const scalar_t* self_data,
+                auto self_dim_stride) {
+              scalar_t min_number = self_data[0];
+              scalar_t max_number = self_data[0];
+              for (int64_t i = 0; i < self_dim_size; ++i) {
+                scalar_t value = self_data[i * self_dim_stride];
+                // note: comparison is written this way to handle NaN correctly
+                if (!(value >= min_number)) {
+                  min_number = value;
+                  if (_isnan<scalar_t>(value)) {
+                    max_number = value;
+                    break;
+                  }
+                } else if (!(value <= max_number)) {
+                  max_number = value;
+                }
+              }
+              *min_result_data = min_number;
+              *max_result_data = max_number;
+            });
+      });
 }
 
 static void where_kernel_impl(TensorIterator &iter, ScalarType condition_type) {

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -499,8 +499,7 @@ class TestReductions(TestCase):
         self.assertTrue(x.all())
         self.assertFalse(x.any())
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.half, torch.float, torch.double)
     def test_max_with_inf(self, device, dtype):
         a = torch.tensor([[-inf, -inf, inf, 3], [inf, inf, -inf, -1]], dtype=dtype, device=device)
         self.assertTrue(torch.all(torch.max(a, dim=1).values == inf).item())
@@ -508,8 +507,7 @@ class TestReductions(TestCase):
         self.assertTrue(torch.max(a).item() == inf)
         self.assertTrue(torch.amax(a).item() == inf)
 
-    @dtypesIfCUDA(torch.half, torch.float, torch.double)
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.half, torch.float, torch.double)
     def test_min_with_inf(self, device, dtype):
         a = torch.tensor([[-inf, -inf, inf, 3], [inf, inf, -inf, -1]], dtype=dtype, device=device)
         self.assertTrue(torch.all(torch.min(a, dim=1).values == (-inf)).item())
@@ -566,32 +564,32 @@ class TestReductions(TestCase):
                         self.assertEqual(i, index)
                 self.assertEqual(torchfn(x), nan)
 
-    @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
+    @dtypesIfCPU(torch.half, torch.float, torch.double, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
     def test_max(self, device, dtype):
         self._test_minmax_helper(torch.max, np.amax, device, dtype)
 
-    @dtypesIfCPU(torch.float, torch.double, torch.long, torch.bool)
+    @dtypesIfCPU(torch.half, torch.float, torch.double, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
     def test_min(self, device, dtype):
         self._test_minmax_helper(torch.min, np.amin, device, dtype)
 
-    @dtypesIfCPU(torch.float, torch.double, torch.int, torch.long, torch.bool)
+    @dtypesIfCPU(torch.half, torch.float, torch.double, torch.int, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.int, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
     def test_amin(self, device, dtype):
         self._test_minmax_helper(torch.amin, np.amin, device, dtype)
 
-    @dtypesIfCPU(torch.float, torch.double, torch.int, torch.long, torch.bool)
+    @dtypesIfCPU(torch.half, torch.float, torch.double, torch.int, torch.long, torch.bool)
     @dtypesIfCUDA(torch.half, torch.float, torch.int, torch.long, torch.bool)
     @dtypes(torch.float, torch.double)
     def test_amax(self, device, dtype):
         self._test_minmax_helper(torch.amax, np.amax, device, dtype)
 
     @onlyOnCPUAndCUDA
-    @dtypesIfCPU(torch.float, torch.double)
+    @dtypesIfCPU(torch.half, torch.float, torch.double)
     @dtypesIfCUDA(torch.half, torch.float)
     def test_aminmax(self, device, dtype):
 

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -9,7 +9,7 @@ from torch.testing._internal.common_utils import \
     (TestCase, run_tests, make_tensor)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, onlyOnCPUAndCUDA,
-     skipCUDAIfRocm, onlyCUDA, dtypesIfCUDA)
+     skipCUDAIfRocm, onlyCUDA)
 
 # TODO: remove this
 SIZE = 100
@@ -433,8 +433,7 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(sort_topk, topk[0])      # check values
         self.assertEqual(sort_topk, a[topk[1]])   # check indices
 
-    @dtypesIfCUDA(*torch.testing.get_all_fp_dtypes())
-    @dtypes(torch.float, torch.double)
+    @dtypes(*torch.testing.get_all_fp_dtypes())
     def test_topk_nonfinite(self, device, dtype):
         x = torch.tensor([float('nan'), float('inf'), 1e4, 0, -1e4, -float('inf')], device=device, dtype=dtype)
         val, idx = x.topk(4)
@@ -447,7 +446,8 @@ class TestSortAndSelect(TestCase):
         self.assertEqual(val, expect)
         self.assertEqual(idx, [5, 4, 3, 2])
 
-    def test_topk_4d(self, device):
+    @dtypes(*torch.testing.get_all_fp_dtypes())
+    def test_topk_4d(self, device, dtype):
         x = torch.ones(2, 3072, 2, 2, device=device)
         x[:, 1, :, :] *= 2.
         x[:, 10, :, :] *= 1.5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50059 disable multinomial for half
* **#50021 enable half for some things, so that "fast path" for multinomial**

without replacement can be used unconditionally

Next step is to drop the dead code.