### PR TITLE
[static runtime] Remove register concept by giving ownership to the nodes

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -369,34 +369,60 @@ StaticRuntime::StaticRuntime(
   TORCH_CHECK(
       module_ != nullptr,
       "std::shared_ptr<InferenceModule> module_ cannot be nullptr")
-  // initialize registers
-  reg_.resize(module_->value_to_reg.size());
 
   Graph* graph = module_->graph.get();
-  const auto& value_to_reg = module_->value_to_reg;
+  std::unordered_map<Value*, IValue*> val_to_ival;
+
+  // NB: create an unchanging std::vector<IValue> we can reference
+  for (auto input : graph->inputs()) {
+    inputs_.emplace_back();
+  }
+  for (auto i = 0; i < graph->inputs().size(); ++i) {
+    Value* input = graph->inputs()[i];
+    val_to_ival[input] = &(inputs_[i]);
+  }
 
   // fill workspace_ with constants and create ProcessedNodes
   // NB: before optimizing the order of execution, ensure that the
   // memory optimization pass (LivenessMap + AssignRegisters) is
   // aware of the new order!
+
+  // Fill constants first, so we have a std::vector<IValue> we can reference
+  // later
+  for (Node* node : graph->nodes()) {
+    if (node->kind() != prim::Constant) {
+      continue;
+    }
+    auto* v = node->output();
+    TORCH_CHECK(v->type()->kind() != FunctionType::Kind);
+    constants_.emplace_back(toIValue(v).value());
+  }
+  {
+    int i = 0;
+    for (Node* node : graph->nodes()) {
+      if (node->kind() != prim::Constant) {
+        continue;
+      }
+      auto* v = node->output();
+      val_to_ival[v] = &(constants_[i++]);
+    }
+  }
   for (Node* node : graph->nodes()) {
     if (node->kind() == prim::Constant) {
-      TORCH_CHECK(node->output()->type()->kind() != FunctionType::Kind);
-      reg_[value_to_reg.at(node->output())] = toIValue(node->output()).value();
-    } else {
-      std::vector<size_t> input_regs, output_regs;
-      for (Value* input : node->inputs()) {
-        input_regs.push_back(value_to_reg.at(input));
-      }
-      for (Value* output : node->outputs()) {
-        output_regs.push_back(value_to_reg.at(output));
-      }
-      nodes_.emplace_back(
-          node,
-          std::move(input_regs),
-          std::move(output_regs),
-          opts.enable_out_variant);
+      continue;
     }
+    std::vector<const IValue*> inputs;
+    for (Value* input : node->inputs()) {
+      inputs.emplace_back(val_to_ival.at(input));
+    }
+    nodes_.emplace_back(
+        ProcessedNode(node, std::move(inputs), opts.enable_out_variant));
+    for (auto i = 0; i < node->outputs().size(); ++i) {
+      val_to_ival[node->outputs()[i]] = &nodes_.back().Output(i);
+    }
+  }
+  for (auto output : graph->outputs()) {
+    outputs_.emplace_back(val_to_ival.at(output));
   }
 }
 
@@ -460,28 +486,28 @@ c10::IValue StaticRuntime::run(
   // NB: before optimizing the order of execution, ensure that the
   // memory optimization pass (LivenessMap + AssignRegisters) is
   // aware of the new order!
-  for (const auto& n : nodes_) {
-    n.run(reg_);
+  for (auto& n : nodes_) {
+    n.run();
   }
 
   if (opts_.cleanup_activations) {
     if (!planner_) {
-      planner_ = std::make_unique<MemoryPlanner>(this);
+      std::unordered_map<Value*, std::vector<Value*>> shared;
+      planner_ = std::make_unique<MemoryPlanner>(this, shared);
     }
     planner_->deallocate();
-    deallocate_registers(module_->internals);
   }
 
   // no need to keep references of outputs in static runtime anymore
   if (num_outputs() > 1) {
     std::vector<c10::IValue> outputs;
     outputs.reserve(num_outputs());
-    for (const auto& reg : module_->output_regs) {
-      outputs.emplace_back(reg_[reg]);
+    for (auto i = 0; i < num_outputs(); ++i) {
+      outputs.emplace_back(Output(i));
     }
     return c10::ivalue::Tuple::create(outputs);
   }
-  return std::move(reg_[module_->output_regs[0]]);
+  return Output(0);
 }
 
 void StaticRuntime::benchmark(
@@ -594,16 +620,16 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     }
     for (size_t j = 0; j < nodes_.size(); j++) {
       timer.Start();
-      nodes_[j].run(reg_);
+      nodes_[j].run();
       float millis = timer.MilliSeconds();
       results.time_per_node[j] += millis;
     }
     if (opts_.cleanup_activations) {
       if (!planner_) {
-        planner_ = std::make_unique<MemoryPlanner>(this);
+        std::unordered_map<Value*, std::vector<Value*>> shared;
+        planner_ = std::make_unique<MemoryPlanner>(this, shared);
       }
       planner_->deallocate();
-      deallocate_registers(module_->internals);
     }
   }
 
@@ -623,64 +649,79 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   return results;
 }
 
-void StaticRuntime::deallocate_registers(const std::vector<size_t>& internals) {
-  // discard Tensor objects to reduce memory usage
-  // they will be re-created in the next iteration regardless
-  for (auto i : internals) {
-    if (reg_[i].isTensor()) {
-      // If the tensor has no storage, we can keep it around. We
-      // implement by moving out of the register (leaving behind an
-      // empty IValue for free!) and possibly moving back.
-      at::Tensor asTensor = std::move(reg_[i]).toTensor();
-      if (asTensor.storage().nbytes() == 0) {
-        reg_[i] = std::move(asTensor);
+MemoryPlanner::MemoryPlanner(
+    StaticRuntime* runtime,
+    std::unordered_map<Value*, std::vector<Value*>> should_share) {
+  // collect register indices of outputs of ops with out variant
+  std::unordered_set<Value*> managed_values;
+  std::unordered_set<IValue*> unmanaged_value_set;
+  for (ProcessedNode& pnode : runtime->get_nodes()) {
+    if (pnode.has_out_variant()) {
+      // Types are stored in the underlying TorchScript IR
+      for (Value* out : pnode.get_node()->outputs()) {
+        if (out->type()->cast<TensorType>()) {
+          managed_values.insert(out);
+        }
       }
     } else {
-      reg_[i] = IValue();
-    }
-  }
-}
-
-MemoryPlanner::MemoryPlanner(StaticRuntime* runtime)
-    : reg_(runtime->get_registers()) {
-  // collect register indices of outputs of ops with out variant
-  for (const ProcessedNode& node : runtime->get_nodes()) {
-    if (node.has_out_variant()) {
-      for (auto out : node.output_regs()) {
-        reg_out_variant_.insert(out);
+      for (auto i = 0; i < pnode.outputs().size(); ++i) {
+        unmanaged_value_set.insert(&pnode.Output(i));
       }
     }
   }
 
   const InferenceModule* module = runtime->get_inference_module();
 
-  // remove model outputs from reg_out_variant_
-  for (size_t output : module->output_regs) {
-    reg_out_variant_.erase(output);
+  // remove model outputs from managed_values
+  for (Value* output : module->graph->outputs()) {
+    managed_values.erase(output);
+  }
+  for (IValue* output : runtime->outputs()) {
+    unmanaged_value_set.erase(output);
+  }
+  for (IValue* out : unmanaged_value_set) {
+    unmanaged_values_.emplace_back(out);
   }
 
-  // remove tensors in output List/Tuple from reg_out_variant_
+  // remove tensors in output List/Tuple from managed_values
   for (Value* output : module->graph->outputs()) {
     Node* output_node = output->node();
     if (output_node->kind() == prim::TupleConstruct ||
         output_node->kind() == prim::ListConstruct) {
       for (Value* input : output_node->inputs()) {
-        reg_out_variant_.erase(module->value_to_reg.at(input));
+        managed_values.erase(input);
       }
     }
   }
 
-  // debug only
-  for (auto reg : reg_out_variant_) {
-    VLOG(1) << "reg_out_variant_: %" << module->values[reg]->debugName();
+  // some Values should share storage, this map will
+  // keep track of the index into managed_storage_
+  std::unordered_map<Value*, size_t> shared;
+
+  // Snapshot of the current memory state
+  for (const auto& pnode : runtime->get_nodes()) {
+    for (auto i = 0; i < pnode.outputs().size(); ++i) {
+      const auto& ival = pnode.outputs()[i];
+      const auto& val = pnode.get_node()->outputs()[i];
+      if (managed_values.count(val)) {
+        TORCH_CHECK(ival.isTensor());
+        auto* impl = ival.toTensor().storage().unsafeGetStorageImpl();
+        if (shared.count(val)) {
+          managed_storage_[shared.at(val)].second.emplace_back(impl);
+        } else {
+          auto p =
+              std::make_pair<size_t, std::vector<c10::StorageImpl*>>(0, {impl});
+          managed_storage_.emplace_back(std::move(p));
+          // first of a group, update the shared map with the index
+          if (should_share.count(val)) {
+            for (auto v : should_share.at(val)) {
+              shared[v] = managed_storage_.size() - 1;
+            }
+          }
+        }
+      }
+    }
   }
-
-  // dedup tensor storages (tensor views share the same tensor storage)
-  auto internal_storages_set = reg_to_storage_impls();
-  internal_storages_.assign(
-      internal_storages_set.begin(), internal_storages_set.end());
-
-  internal_blob_max_sizes_.resize(internal_storages_.size());
 }
 
 // Don't change the size if it is already aligned, otherwise increase the size
@@ -695,77 +736,64 @@ at::DataPtr MemoryPlanner::allocate_buffer(size_t size) {
   return allocator->allocate(size);
 }
 
-std::unordered_set<c10::StorageImpl*> MemoryPlanner::reg_to_storage_impls() {
-  std::unordered_set<c10::StorageImpl*> internal_storages_set;
-  for (auto i : reg_out_variant_) {
-    internal_storages_set.insert(
-        reg_[i].toTensor().storage().unsafeGetStorageImpl());
-  }
-  return internal_storages_set;
-}
-
 void MemoryPlanner::allocate() {
-  if (internal_blob_max_sizes_sum_ == 0) {
+  if (managed_bytes_ == 0) {
     return;
   }
 
-  buffer_ = allocate_buffer(internal_blob_max_sizes_sum_);
+  buffer_ = allocate_buffer(managed_bytes_);
 
   size_t offset = 0;
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
 
-  for (auto i = 0; i < internal_storages_.size(); i++) {
-    auto tensor_size = internal_blob_max_sizes_[i];
+  for (const auto& ms : managed_storage_) {
+    auto tensor_size = ms.first;
     if (tensor_size == 0) {
       continue;
     }
-    DCHECK_LE(offset + tensor_size, internal_blob_max_sizes_sum_);
+    const auto& impls = ms.second;
+    DCHECK_LE(offset + tensor_size, managed_bytes_);
     void* src = static_cast<void*>(start + offset);
 
-    c10::StorageImpl* impl = internal_storages_[i];
-    impl->set_data_ptr(at::DataPtr(src, src, nullptr, impl->device()));
-    impl->set_nbytes(tensor_size);
+    for (auto& impl : impls) {
+      impl->set_data_ptr(at::DataPtr(src, src, nullptr, impl->device()));
+      impl->set_nbytes(tensor_size);
+    }
 
     offset += tensor_size;
   }
-  DCHECK_EQ(offset, internal_blob_max_sizes_sum_);
-}
-
-void MemoryPlanner::verify_internal_storages() {
-  auto internal_storages_set = reg_to_storage_impls();
-  for (auto* storage_impl : internal_storages_) {
-    TORCH_CHECK(
-        internal_storages_set.count(storage_impl) > 0,
-        "Found internal_storage mismatch");
-  }
+  DCHECK_EQ(offset, managed_bytes_);
 }
 
 void MemoryPlanner::deallocate() {
-#ifndef NDEBUG
-  verify_internal_storages();
-#endif
-  internal_blob_max_sizes_sum_ = 0;
+  managed_bytes_ = 0;
+
   // free memory used by outputs of ops in out variants
   // but keep the TensorImpl and StorageImpl around
-  for (auto i = 0; i < internal_storages_.size(); i++) {
-    c10::StorageImpl* impl = internal_storages_[i];
-    size_t current_size = compute_aligned_tensor_size(impl->nbytes());
-    size_t& max_size = internal_blob_max_sizes_[i];
-    max_size = std::max(max_size, current_size);
-    internal_blob_max_sizes_sum_ += max_size;
-    impl->reset();
+  for (auto& ms : managed_storage_) {
+    const auto& impls = ms.second;
+    size_t max = 0;
+    for (auto& impl : impls) {
+      size_t current_size = compute_aligned_tensor_size(impl->nbytes());
+      impl->reset();
+      max = std::max(max, current_size);
+    }
+    ms.first = max;
+    managed_bytes_ += max;
+  }
+  for (auto& iv : unmanaged_values_) {
+    *iv = IValue();
   }
   buffer_ = {};
 }
 
 ProcessedNode::ProcessedNode(
     Node* node,
-    std::vector<size_t>&& input_regs,
-    std::vector<size_t>&& output_regs,
+    std::vector<const IValue*>&& inputs,
     bool enable_out_variants)
-    : node_(node),
-      input_regs_(std::move(input_regs)),
-      output_regs_(std::move(output_regs)) {
+    : node_(node), inputs_(std::move(inputs)) {
+  // TODO leverage type information
+  outputs_.resize(node->outputs().size());
   if (node->kind() != prim::ListConstruct &&
       node->kind() != prim::TupleConstruct &&
       node->kind() != prim::ListUnpack) {
@@ -775,7 +803,6 @@ ProcessedNode::ProcessedNode(
   }
   if (enable_out_variants && canRunOutOfPlace(node)) {
     fn_ = getOutOfPlaceOperation(node);
-
     std::ostringstream ss;
     node->print(ss, 0, nullptr, false);
     VLOG(1) << "Switch to out variant for node: " << ss.str();
@@ -791,17 +818,17 @@ ProcessedNode::ProcessedNode(
   }
 }
 
-void ProcessedNode::run(std::vector<IValue>& reg) const {
+void ProcessedNode::run() {
   if (fn_) {
-    fn_(this, reg);
+    fn_(this);
   } else if (native_fn_) {
-    native_fn_(this, reg);
+    native_fn_(this);
   } else {
     std::vector<IValue> stack;
     const size_t size = node_->inputs().size();
     stack.reserve(size);
     for (size_t i = 0; i < size; i++) {
-      stack.emplace_back(Input(i, reg));
+      stack.emplace_back(Input(i));
     }
 
     DCHECK(op_);
@@ -809,7 +836,7 @@ void ProcessedNode::run(std::vector<IValue>& reg) const {
 
     DCHECK_EQ(stack.size(), node_->outputs().size());
     for (auto i = 0; i < node_->outputs().size(); i++) {
-      Output(i, reg) = std::move(stack[i]);
+      Output(i) = std::move(stack[i]);
     }
   }
 }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -151,7 +151,11 @@ class TORCH_API StaticRuntime {
     return module_.get();
   }
 
-  const std::vector<ProcessedNode>& get_nodes() {
+  const std::vector<ProcessedNode>& get_nodes() const {
+    return nodes_;
+  }
+
+  std::vector<ProcessedNode>& get_nodes() {
     return nodes_;
   }
 
@@ -161,12 +165,19 @@ class TORCH_API StaticRuntime {
 
   size_t num_outputs() const;
 
+  inline const std::vector<IValue*>& outputs() const {
+    return outputs_;
+  }
+
  private:
   // Static runtime states
   std::shared_ptr<InferenceModule> module_;
   StaticRuntimeOptions opts_;
   // IValue table (including inputs, outputs, intermediates, and weights)
   std::vector<IValue> reg_;
+  std::vector<IValue> constants_;
+  std::vector<IValue> inputs_;
+  std::vector<IValue*> outputs_;
   // The nodes we need to run
   std::vector<ProcessedNode> nodes_;
 
@@ -174,28 +185,24 @@ class TORCH_API StaticRuntime {
   // Otherwise, the memory used by activations is cached inside the static
   // runtime.
   std::unique_ptr<MemoryPlanner> planner_;
-  // The memory planner does not take care of the IValues that are stored in the
-  // registers but don't participate in memory planning. They need to be cleaned
-  // up if cleanup_activations is enabled to avoid memory leak.
-  void deallocate_registers(const std::vector<size_t>& internals);
 
   // Input is readwrite
   IValue& Input(size_t i) {
-    DCHECK(i < module_->input_regs.size());
-    return reg_[module_->input_regs[i]];
+    DCHECK(i < inputs_.size());
+    return inputs_[i];
   }
 
   // Output is readonly. The writing process happens inside ProcessedNodes
   const IValue& Output(size_t i) const {
-    DCHECK(i < module_->output_regs.size());
-    return reg_[module_->output_regs[i]];
+    DCHECK(i < outputs_.size());
+    return *outputs_[i];
   }
 };
 
 /// There are three types of ops in a processed graph in Static Runtime:
 ///   1. op with _out variant
 ///   2. view producing op
-///   3. tensor producing op (could be replaced with 1 by adding the _out
+///   3. tensor producing op (could be replaced with type 1 by adding the _out
 ///      variant to Static Runtime)
 /// The memory planner only manages tensors that are outputs of type 1 ops,
 /// because type 2 ops don't incur memory allocation and for type 3, the output
@@ -209,8 +216,8 @@ class TORCH_API StaticRuntime {
 ///      iteration
 ///   2. in the next iteration, allocate the buffer for the max total usage and
 ///      compute the offset of each allocation with regard to the single memory
-///      buffer. In the first iteration, we rely on the default allocator for
-///      memory allocation.
+///      buffer, optionally reusing memory.  In the first iteration, we rely on
+///      the default allocator for memory allocation.
 ///   3. free the buffer at the end of each iteration
 /// Steps 1 and 3 are handled by `deallocate()`, and step 2 by `allocate()`.
 /// Only models with simple output types are supported, i.e. None, Tensor or
@@ -219,78 +226,74 @@ class TORCH_API StaticRuntime {
 
 class MemoryPlanner {
  public:
-  explicit MemoryPlanner(StaticRuntime* runtime);
+  explicit MemoryPlanner(
+      StaticRuntime* runtime,
+      std::unordered_map<Value*, std::vector<Value*>> should_share);
 
   void allocate();
   void deallocate();
   size_t total_managed() const {
-    return internal_blob_max_sizes_sum_;
+    return managed_bytes_;
   }
 
  private:
-  const std::vector<IValue>& reg_;
-  std::unordered_set<size_t> reg_out_variant_;
-  std::vector<c10::StorageImpl*> internal_storages_;
-  std::vector<size_t> internal_blob_max_sizes_;
-  size_t internal_blob_max_sizes_sum_{0};
+  std::vector<IValue*> unmanaged_values_;
+  // each pair contains the size (in bytes) of data to be allocated
+  // and a vector of StorageImpl's that should be backed by that same data
+  // Thus, if memonger is disabled, all vectors are of size 1.
+  std::vector<std::pair<size_t, std::vector<c10::StorageImpl*>>>
+      managed_storage_;
+  size_t managed_bytes_{0};
   at::DataPtr buffer_; // allocated each time we call Run()
 
   static size_t compute_aligned_tensor_size(size_t nbytes);
   static at::DataPtr allocate_buffer(size_t size);
-  std::unordered_set<c10::StorageImpl*> reg_to_storage_impls();
-  void verify_internal_storages();
 };
 
 class ProcessedNode {
  public:
   ProcessedNode(
       Node* n,
-      std::vector<size_t>&& input_regs,
-      std::vector<size_t>&& output_regs,
+      std::vector<const IValue*>&& inputs,
       bool enable_out_variant);
-  void run(std::vector<IValue>& reg) const;
+
+  void run();
 
   Node* get_node() const {
     return node_;
   }
 
   // Input is readonly
-  const IValue& Input(size_t i, std::vector<IValue>& reg) const {
-    DCHECK(i < input_regs_.size());
-    return reg[input_regs_[i]];
+  const IValue& Input(size_t i) const {
+    DCHECK(i < inputs_.size());
+    return *inputs_[i];
   }
 
   // Output is readwrite
-  IValue& Output(size_t i, std::vector<IValue>& reg) const {
-    DCHECK(i < output_regs_.size());
-    return reg[output_regs_[i]];
+  IValue& Output(size_t i) {
+    DCHECK(i < outputs_.size());
+    return outputs_[i];
+  }
+
+  const std::vector<IValue>& outputs() const {
+    return outputs_;
+  }
+
+  const std::vector<const IValue*>& inputs() const {
+    return inputs_;
   }
 
   bool has_out_variant() const {
     return static_cast<bool>(fn_);
   }
 
-  const std::vector<size_t>& input_regs() const {
-    return input_regs_;
-  }
-
-  const std::vector<size_t>& output_regs() const {
-    return output_regs_;
-  }
-
-  const TypePtr& get_output_type(size_t i) const {
-    DCHECK_LT(i, output_regs().size());
-    return node_->outputs()[i]->type();
-  }
-
  private:
   Node* node_;
   c10::optional<Operation> op_;
-  std::function<void(const ProcessedNode*, std::vector<IValue>&)> fn_;
-  std::function<void(const ProcessedNode*, std::vector<IValue>&)> native_fn_;
-
-  std::vector<size_t> input_regs_;
-  std::vector<size_t> output_regs_;
+  std::function<void(ProcessedNode*)> fn_;
+  std::function<void(ProcessedNode*)> native_fn_;
+  std::vector<const IValue*> inputs_; // unowned
+  std::vector<IValue> outputs_; // TODO make list for safety
 };
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -78,14 +78,14 @@ struct static_add final : public at::native::structured_add_out {
 };
 
 REGISTER_OPERATOR_FUNCTOR(aten::add, aten_add, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    auto& in1_t = p_node->Input(1, reg).toTensor();
-    auto in2_s = p_node->Input(2, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    auto& in1_t = p_node->Input(1).toTensor();
+    auto in2_s = p_node->Input(2).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     static_add op{out_t};
     op.meta(in0_t, in1_t, in2_s);
     op.impl(in0_t, in1_t, in2_s, out_t);
@@ -93,56 +93,56 @@ REGISTER_OPERATOR_FUNCTOR(aten::add, aten_add, [](Node* n) -> SROperator {
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    auto& in1_t = p_node->Input(1, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    auto& in1_t = p_node->Input(1).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::mul_out(out_t, in0_t, in1_t);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::addmm, aten_addmm, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    auto& in1_t = p_node->Input(1, reg).toTensor();
-    auto& in2_t = p_node->Input(2, reg).toTensor();
-    auto in3_s = p_node->Input(3, reg).toScalar();
-    auto in4_s = p_node->Input(4, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    auto& in1_t = p_node->Input(1).toTensor();
+    auto& in2_t = p_node->Input(2).toTensor();
+    auto in3_s = p_node->Input(3).toScalar();
+    auto in4_s = p_node->Input(4).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::addmm_cpu_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::clamp, aten_clamp, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_s = p_node->Input(1, reg).toScalar();
-    auto in2_s = p_node->Input(2, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    auto in1_s = p_node->Input(1).toScalar();
+    auto in2_s = p_node->Input(2).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::clamp_out(out_t, in0_t, in1_s, in2_s);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::bmm, aten_bmm, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    auto& in1_t = p_node->Input(1, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    auto& in1_t = p_node->Input(1).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::bmm_out_cpu(out_t, in0_t, in1_t);
   };
@@ -152,42 +152,42 @@ REGISTER_OPERATOR_FUNCTOR(
     aten::nan_to_num,
     aten_nan_to_num,
     [](Node* n) -> SROperator {
-      return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-        auto input_size = p_node->input_regs().size();
-        auto& in0_t = p_node->Input(0, reg).toTensor();
-        double in1_d = input_size > 1 ? p_node->Input(1, reg).toDouble() : 0;
-        double in2_d = input_size > 2 ? p_node->Input(2, reg).toDouble()
+      return [](ProcessedNode* p_node) {
+        auto input_size = p_node->inputs().size();
+        auto& in0_t = p_node->Input(0).toTensor();
+        double in1_d = input_size > 1 ? p_node->Input(1).toDouble() : 0;
+        double in2_d = input_size > 2 ? p_node->Input(2).toDouble()
                                       : std::numeric_limits<double>::infinity();
         double in3_d = input_size > 3
-            ? p_node->Input(3, reg).toDouble()
+            ? p_node->Input(3).toDouble()
             : -std::numeric_limits<double>::infinity();
-        if (p_node->Output(0, reg).isNone()) {
-          p_node->Output(0, reg) = create_empty_from(in0_t);
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = create_empty_from(in0_t);
         }
-        auto& out_t = p_node->Output(0, reg).toTensor();
+        auto& out_t = p_node->Output(0).toTensor();
         out_t.resize_({0});
         at::native::nan_to_num_out(out_t, in0_t, in1_d, in2_d, in3_d);
       };
     });
 REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_tl = p_node->Input(0, reg).toTensorVector();
-    auto in1_i = p_node->Input(1, reg).toInt();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_tl[0]);
+  return [](ProcessedNode* p_node) {
+    auto in0_tl = p_node->Input(0).toTensorVector();
+    auto in1_i = p_node->Input(1).toInt();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_tl[0]);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::_cat_out_cpu(out_t, in0_tl, in1_i);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::tanh_out(out_t, in0_t);
   };
@@ -195,11 +195,11 @@ REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
 
 // Split out into a function to appease MSVC's pre-processor
 SROperator aten_stack(Node* n) {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto inputs = p_node->Input(0, reg).toTensorVector();
-    auto dim = p_node->Input(1, reg).toInt();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(inputs[0]);
+  return [](ProcessedNode* p_node) {
+    auto inputs = p_node->Input(0).toTensorVector();
+    auto dim = p_node->Input(1).toInt();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(inputs[0]);
     }
 #ifndef NDEBUG
     at::IntArrayRef entry_shape = inputs[0].sizes();
@@ -217,7 +217,7 @@ SROperator aten_stack(Node* n) {
     for (auto i = 0; i < inputs.size(); i++) {
       inputs[i] = inputs[i].unsqueeze(dim);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::_cat_out_cpu(out_t, inputs, dim);
   };
@@ -229,12 +229,12 @@ REGISTER_OPERATOR_FUNCTOR(
     aten::sigmoid,
     aten_sigmoid,
     [](Node* n) -> SROperator {
-      return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-        auto& in0_t = p_node->Input(0, reg).toTensor();
-        if (p_node->Output(0, reg).isNone()) {
-          p_node->Output(0, reg) = create_empty_from(in0_t);
+      return [](ProcessedNode* p_node) {
+        auto& in0_t = p_node->Input(0).toTensor();
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = create_empty_from(in0_t);
         }
-        auto& out_t = p_node->Output(0, reg).toTensor();
+        auto& out_t = p_node->Output(0).toTensor();
         out_t.resize_({0});
         at::native::sigmoid_out(out_t, in0_t);
       };
@@ -246,97 +246,94 @@ REGISTER_OPERATOR_FUNCTOR(
       auto in1 = toIValue(n->inputs()[1]);
       if (in1) {
         auto in1_s = in1->toScalar();
-        return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-          auto& in0_t = p_node->Input(0, reg).toTensor();
-          if (p_node->Output(0, reg).isNone()) {
-            p_node->Output(0, reg) = create_empty_from(in0_t);
+        return [=](ProcessedNode* p_node) {
+          auto& in0_t = p_node->Input(0).toTensor();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(in0_t);
           }
-          auto& out_t = p_node->Output(0, reg).toTensor();
+          auto& out_t = p_node->Output(0).toTensor();
           at::native::leaky_relu_out(out_t, in0_t, in1_s);
         };
       } else {
-        return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-          auto& in0_t = p_node->Input(0, reg).toTensor();
-          auto in1_s = p_node->Input(1, reg).toScalar();
-          if (p_node->Output(0, reg).isNone()) {
-            p_node->Output(0, reg) = create_empty_from(in0_t);
+        return [](ProcessedNode* p_node) {
+          auto& in0_t = p_node->Input(0).toTensor();
+          auto in1_s = p_node->Input(1).toScalar();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(in0_t);
           }
-          auto& out_t = p_node->Output(0, reg).toTensor();
+          auto& out_t = p_node->Output(0).toTensor();
           at::native::leaky_relu_out(out_t, in0_t, in1_s);
         };
       }
     });
 REGISTER_OPERATOR_FUNCTOR(aten::relu, aten_relu, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::threshold_out(out_t, in0_t, 0, 0);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    double in1_d = p_node->input_regs().size() > 1
-        ? p_node->Input(1, reg).toDouble()
-        : -1.0;
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    double in1_d =
+        p_node->inputs().size() > 1 ? p_node->Input(1).toDouble() : -1.0;
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::logit_out(out_t, in0_t, in1_d);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::clone, aten_clone, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto& in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto& in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto& out_t = p_node->Output(0, reg).toTensor();
+    auto& out_t = p_node->Output(0).toTensor();
     at::native::resize_as_(out_t, in0_t, c10::nullopt);
     at::native::copy_(out_t, in0_t, false);
   };
 });
 
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getOutOfPlaceOperation(Node* n) {
+std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n) {
   auto op_name = n->kind().toQualString();
   if (SROperatorRegistry()->Has(op_name)) {
     return SROperatorRegistry()->Create(op_name)->Generate(n);
   }
 
-  return [](const ProcessedNode*, std::vector<IValue>&) { TORCH_CHECK(0); };
+  return [](ProcessedNode*) { TORCH_CHECK(0); };
 }
 
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getNativeOperation(Node* n) {
+std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
   if (n->kind() == c10::Symbol::fromQualString("aten::transpose")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      p_node->Output(0, reg) = at::native::transpose(in0_t, in1_i, in2_i);
+    return [](ProcessedNode* p_node) {
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      p_node->Output(0) = at::native::transpose(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::flatten")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      p_node->Output(0, reg) = at::native::flatten(in0_t, in1_i, in2_i);
+    return [](ProcessedNode* p_node) {
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      p_node->Output(0) = at::native::flatten(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == prim::TupleConstruct) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
       auto* node = p_node->get_node();
@@ -347,77 +344,76 @@ getNativeOperation(Node* n) {
         tupleConstruct(stack, node->inputs().size());
       }
       // put output back
-      p_node->Output(0, reg) = std::move(stack[0]);
+      p_node->Output(0) = std::move(stack[0]);
     };
   } else if (n->kind() == prim::ListConstruct) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
       listConstruct(
           stack,
           p_node->get_node()->output()->type()->expectRef<ListType>(),
-          p_node->input_regs().size());
+          p_node->inputs().size());
       // put output back
-      p_node->Output(0, reg) = std::move(stack[0]);
+      p_node->Output(0) = std::move(stack[0]);
     };
   } else if (n->kind() == prim::ListUnpack) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
-      size_t num_outputs = p_node->output_regs().size();
+      size_t num_outputs = p_node->outputs().size();
       listUnpack(stack, num_outputs);
       // put output back
       DCHECK_EQ(stack.size(), num_outputs);
       for (auto i = 0; i < num_outputs; i++) {
-        p_node->Output(i, reg) = std::move(stack[i]);
+        p_node->Output(i) = std::move(stack[i]);
       }
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::permute")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_iv = p_node->Input(1, reg).toIntVector();
-      p_node->Output(0, reg) = at::native::permute(in0_t, in1_iv);
+    return [](ProcessedNode* p_node) {
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_iv = p_node->Input(1).toIntVector();
+      p_node->Output(0) = at::native::permute(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::reshape")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_iv = p_node->Input(1, reg).toIntVector();
-      p_node->Output(0, reg) = at::native::reshape(in0_t, in1_iv);
+    return [](ProcessedNode* p_node) {
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_iv = p_node->Input(1).toIntVector();
+      p_node->Output(0) = at::native::reshape(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::slice")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      auto in3_i = p_node->Input(3, reg).toInt();
-      auto in4_i = p_node->Input(4, reg).toInt();
-      p_node->Output(0, reg) =
-          at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
+    return [](ProcessedNode* p_node) {
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      auto in3_i = p_node->Input(3).toInt();
+      auto in4_i = p_node->Input(4).toInt();
+      p_node->Output(0) = at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::narrow")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto& self = p_node->Input(0, reg).toTensor(); // self
-      auto dim = p_node->Input(1, reg).toInt(); // dim
+    return [](ProcessedNode* p_node) {
+      auto& self = p_node->Input(0).toTensor(); // self
+      auto dim = p_node->Input(1).toInt(); // dim
       int64_t start = 0;
-      if (p_node->Input(2, reg).isScalar()) {
-        start = p_node->Input(2, reg).toInt();
+      if (p_node->Input(2).isScalar()) {
+        start = p_node->Input(2).toInt();
       } else {
-        auto& t = p_node->Input(2, reg).toTensor();
+        auto& t = p_node->Input(2).toTensor();
         start = t.item<int64_t>();
       }
-      auto length = p_node->Input(3, reg).toInt(); // length
+      auto length = p_node->Input(3).toInt(); // length
       TORCH_CHECK(
           self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
       auto cur_size = self.size(dim);
@@ -434,27 +430,26 @@ getNativeOperation(Node* n) {
           ") exceeds dimension size (",
           cur_size,
           ").");
-      p_node->Output(0, reg) =
+      p_node->Output(0) =
           at::native::slice(self, dim, start, start + length, 1);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::to")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      DCHECK(p_node->input_regs().size() == 5);
-      auto& in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toScalarType();
-      auto in2_i = p_node->Input(2, reg).toBool();
-      auto in3_i = p_node->Input(3, reg).toBool();
-      if (p_node->Input(4, reg).isNone()) {
-        p_node->Output(0, reg) =
+    return [](ProcessedNode* p_node) {
+      DCHECK(p_node->inputs().size() == 5);
+      auto& in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toScalarType();
+      auto in2_i = p_node->Input(2).toBool();
+      auto in3_i = p_node->Input(3).toBool();
+      if (p_node->Input(4).isNone()) {
+        p_node->Output(0) =
             at::native::to(in0_t, in1_i, in2_i, in3_i, c10::nullopt);
       } else {
-        auto in4_o = p_node->Input(4, reg).toMemoryFormat();
-        p_node->Output(0, reg) =
-            at::native::to(in0_t, in1_i, in2_i, in3_i, in4_o);
+        auto in4_o = p_node->Input(4).toMemoryFormat();
+        p_node->Output(0) = at::native::to(in0_t, in1_i, in2_i, in3_i, in4_o);
       }
     };
   }
-  return [](const ProcessedNode*, std::vector<IValue>&) { TORCH_CHECK(0); };
+  return [](ProcessedNode*) { TORCH_CHECK(0); };
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -6,12 +6,11 @@
 namespace torch {
 namespace jit {
 
-using SROperator =
-    std::function<void(const ProcessedNode*, std::vector<IValue>&)>;
+using SROperator = std::function<void(ProcessedNode*)>;
 using SROpFunctor = std::function<SROperator(Node* n)>;
 struct SROperatorFunctor {
   virtual SROperator Generate(Node*) {
-    std::function<void(const ProcessedNode*, std::vector<IValue>&)> out;
+    std::function<void(ProcessedNode*)> out;
     return out;
   }
   virtual bool CanReuseInput() {
@@ -52,40 +51,11 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
 bool canRunOutOfPlace(Node* n);
 bool canReuseInputs(Node* n);
 bool canReuseOutputs(Node* n);
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getOutOfPlaceOperation(Node* n);
+
+std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);
 
 bool canRunNatively(Node* n);
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getNativeOperation(Node* n);
-
-#define SUPPORTED_OPS(F) \
-  F(aten::__getitem__)   \
-  F(aten::add)           \
-  F(aten::addmm)         \
-  F(aten::bmm)           \
-  F(aten::cat)           \
-  F(aten::clamp)         \
-  F(aten::contiguous)    \
-  F(aten::div)           \
-  F(aten::flatten)       \
-  F(aten::index_put_)    \
-  F(aten::isnan)         \
-  F(aten::leaky_relu)    \
-  F(aten::matmul)        \
-  F(aten::mul)           \
-  F(aten::permute)       \
-  F(aten::relu)          \
-  F(aten::sigmoid)       \
-  F(aten::size)          \
-  F(aten::softmax)       \
-  F(aten::t)             \
-  F(aten::to)            \
-  F(aten::transpose)     \
-  F(aten::view)          \
-  F(prim::Constant)      \
-  F(prim::ListConstruct) \
-  F(prim::TupleConstruct)
+std::function<void(ProcessedNode*)> getNativeOperation(Node* n);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
Every node will now own its outputs.
I don't expect any big improvements perf-wise from this diff, the only eliminated code is from deallocate_registers
Largely, this is to enable more optimizations going forward.

Test Plan:
buck test mode/dev //caffe2/benchmarks/static_runtime:static_runtime_cpptest
buck test //caffe2/test:static_runtime

Differential Revision: D25571181

