### PR TITLE
[static runtime] move memonger to new ownership model

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -149,10 +149,10 @@ BENCHMARK(BM_leaky_relu_const)->RangeMultiplier(8)->Ranges({{1, 20}});
 
 static void BM_long_static_memory_optimization(benchmark::State& state) {
   auto mod = getLongScriptModel();
-  torch::jit::InferenceModuleOptions opts;
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntimeOptions opts;
   opts.optimize_memory = state.range(1);
-  auto g = torch::jit::PrepareForStaticRuntime(mod, opts);
-  torch::jit::StaticRuntime runtime(g);
+  torch::jit::StaticRuntime runtime(g, opts);
 
   const auto N = state.range(0);
   auto a = torch::randn({N, N});

--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -37,6 +37,39 @@ const auto reshape_script_2 = R"JIT(
       return b.reshape(shape)
 )JIT";
 
+const auto reshape_script_3 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = a.reshape(shape)
+      c = a.reshape(shape)
+      d = c + c
+      e = d + d
+      f = e * e
+      g = f * f
+      return b.reshape(shape), g
+)JIT";
+
+const auto reshape_script_4 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      k = inp + inp
+      a = k + k
+      b = a.reshape(shape)
+      c = a.flatten().reshape(shape)
+      return b + c
+)JIT";
+
+const auto reshape_script_5 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = a.reshape(shape)
+      c = a.reshape(shape)
+      d = c + c
+      e = d + d
+      f = e * e
+      g = f * f
+      return g
+)JIT";
+
 const auto flatten_script_1 = R"JIT(
   def forward(self, a: Tensor, start_dim: int, end_dim: int):
       b = torch.flatten(a, start_dim, end_dim)

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -117,6 +117,9 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
 
   testStaticRuntime(reshape_script_1, args);
   testStaticRuntime(reshape_script_2, args);
+  testStaticRuntime(reshape_script_3, args);
+  testStaticRuntime(reshape_script_4, args);
+  testStaticRuntime(reshape_script_5, args);
 }
 
 TEST(StaticRuntime, IndividualOps_flatten) {

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -11,13 +11,10 @@
 namespace torch {
 namespace jit {
 
-struct TORCH_API InferenceModuleOptions {
-  bool optimize_memory{true}; // TODO remove when logic moves to runtime
-};
-
 struct TORCH_API StaticRuntimeOptions {
   bool cleanup_activations{true};
   bool enable_out_variant{true};
+  bool optimize_memory{true};
 };
 
 /// Static runime supports two execution modes.
@@ -63,15 +60,11 @@ struct TORCH_API StaticRuntimeOptions {
 // Group readonly data structures into InferenceModule
 struct TORCH_API InferenceModule {
  public:
-  explicit InferenceModule(const torch::jit::Module& m, InferenceModuleOptions);
-  explicit InferenceModule(
-      std::shared_ptr<torch::jit::Graph> g,
-      InferenceModuleOptions);
+  explicit InferenceModule(const torch::jit::Module& m);
+  explicit InferenceModule(std::shared_ptr<torch::jit::Graph> g);
   torch::jit::Module module;
   std::shared_ptr<torch::jit::Graph> graph;
   std::unique_ptr<c10::FunctionSchema> schema;
-
-  InferenceModuleOptions opts;
 
  private:
   void init();
@@ -81,15 +74,13 @@ TORCH_API void PrepareGraphForStaticRuntime(
     std::shared_ptr<torch::jit::Graph> g);
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    const torch::jit::Module& m,
-    InferenceModuleOptions opts = InferenceModuleOptions()) {
-  return std::make_shared<InferenceModule>(m, opts);
+    const torch::jit::Module& m) {
+  return std::make_shared<InferenceModule>(m);
 }
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g,
-    InferenceModuleOptions opts = InferenceModuleOptions()) {
-  return std::make_shared<InferenceModule>(g, opts);
+    const std::shared_ptr<torch::jit::Graph>& g) {
+  return std::make_shared<InferenceModule>(g);
 }
 
 class MemoryPlanner;
@@ -175,6 +166,10 @@ class TORCH_API StaticRuntime {
   std::vector<IValue*> outputs_;
   // The nodes we need to run
   std::vector<ProcessedNode> nodes_;
+  // Output of liveness analyis. A mapping from a value to the set of values
+  // with which it could potentially share memory.
+  std::unordered_map<const Value*, std::vector<const Value*>> shared_values_;
+  std::unordered_set<const Value*> external_values_;
 
   // Memory planning is only enabled if opts_.cleanup_activations is true.
   // Otherwise, the memory used by activations is cached inside the static
@@ -223,12 +218,18 @@ class MemoryPlanner {
  public:
   explicit MemoryPlanner(
       StaticRuntime* runtime,
-      std::unordered_map<Value*, std::vector<Value*>> should_share);
+      const std::unordered_map<const Value*, std::vector<const Value*>>&
+          should_share,
+      const std::unordered_set<const Value*>& external_values,
+      bool out_variants);
 
   void allocate();
   void deallocate();
   size_t total_managed() const {
     return managed_bytes_;
+  }
+  size_t total_reused_tensors() const {
+    return reused_tensors_;
   }
 
  private:
@@ -239,6 +240,7 @@ class MemoryPlanner {
   std::vector<std::pair<size_t, std::vector<c10::StorageImpl*>>>
       managed_storage_;
   size_t managed_bytes_{0};
+  size_t reused_tensors_{0};
   at::DataPtr buffer_; // allocated each time we call Run()
 
   static size_t compute_aligned_tensor_size(size_t nbytes);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -113,15 +113,10 @@ bool canRunOutOfPlace(Node* n) {
       SRViewOperatorRegistry()->Has(op_name);
 }
 
-// The inputs/outputs of view ops do not participate in memory reuse
+// Same as "canRunOutOfPlace" but excluds view operations
 bool canReuseInputsOutputs(Node* n) {
   auto op_name = std::string(n->kind().toQualString());
-  return !SRViewOperatorRegistry()->Has(op_name);
-}
-
-bool isViewOp(Node* n) {
-  auto op_name = std::string(n->kind().toQualString());
-  return SRViewOperatorRegistry()->Has(op_name);
+  return SROperatorRegistry()->Has(op_name);
 }
 
 bool canReuseInputs(Node* n) {
@@ -440,27 +435,30 @@ REGISTER_OPERATOR_FUNCTOR_OPT(
     });
 
 // The out variant takes precedence over native
-REGISTER_OPERATOR_FUNCTOR(aten::narrow, aten_narrow, [](Node* n) -> SROperator {
-  return [](ProcessedNode* p_node) {
-    auto& self = p_node->Input(0).toTensor(); // self
-    auto dim = p_node->Input(1).toInt(); // dim
-    int64_t start = 0;
-    if (p_node->Input(2).isScalar()) {
-      start = p_node->Input(2).toInt();
-    } else {
-      auto& t = p_node->Input(2).toTensor();
-      start = t.item<int64_t>();
-    }
-    auto length = p_node->Input(3).toInt(); // length
+REGISTER_OPERATOR_FUNCTOR(
+    aten::narrow_copy,
+    aten_narrow_copy,
+    [](Node* n) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        auto& self = p_node->Input(0).toTensor(); // self
+        auto dim = p_node->Input(1).toInt(); // dim
+        int64_t start = 0;
+        if (p_node->Input(2).isScalar()) {
+          start = p_node->Input(2).toInt();
+        } else {
+          auto& t = p_node->Input(2).toTensor();
+          start = t.item<int64_t>();
+        }
+        auto length = p_node->Input(3).toInt(); // length
 
-    if (p_node->Output(0).isNone()) {
-      p_node->Output(0) = create_empty_from(self);
-    }
-    auto& output = p_node->Output(0).toTensor();
-    fastResizeToZero(output);
-    at::native::narrow_copy_dense_cpu_out(self, dim, start, length, output);
-  };
-});
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = create_empty_from(self);
+        }
+        auto& output = p_node->Output(0).toTensor();
+        fastResizeToZero(output);
+        at::native::narrow_copy_dense_cpu_out(self, dim, start, length, output);
+      };
+    });
 REGISTER_OPERATOR_FUNCTOR(aten::index, aten_index, [](Node* n) -> SROperator {
   return [](ProcessedNode* p_node) {
     const auto& in0_t = p_node->Input(0).toTensor();
@@ -477,7 +475,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::index, aten_index, [](Node* n) -> SROperator {
 
 // Out variants for view ops are registered to a separate registry because
 // their outputs (views) can't participate in memory reuse.
-REGISTER_VIEW_OPERATOR_FUNCTOR(
+REGISTER_OPERATOR_FUNCTOR(
     aten::reshape,
     aten_reshape,
     [](Node* n) -> SROperator {
@@ -493,7 +491,7 @@ REGISTER_VIEW_OPERATOR_FUNCTOR(
       };
     });
 
-REGISTER_VIEW_OPERATOR_FUNCTOR(
+REGISTER_OPERATOR_FUNCTOR(
     aten::flatten,
     aten_flatten,
     [](Node* n) -> SROperator {

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/passes.h>
 
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 
 namespace torch {
@@ -154,6 +155,72 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
   ClipRangesGatherSigridHash(graph);
   ClipRangesGatherRangesSigridHash(graph);
 #endif
+}
+
+TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
+  m.def("static_runtime::pure_inputs() -> Tensor", []() -> at::Tensor {
+    return at::randn({1});
+  });
+  m.def(
+      "static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor",
+      [](at::Tensor self, ArrayRef<int64_t> dims) -> at::Tensor {
+        at::Tensor out = at::empty_like(self);
+        at::native::copy_(out, self);
+        return out.permute(dims);
+      });
+}
+
+void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
+  auto* fake_input =
+      graph->insert(Symbol::fromQualString("static_runtime::pure_inputs"), {});
+  fake_input->node()->moveBefore(*graph->nodes().begin());
+
+  std::vector<std::pair<Value*, Use>> old_inputs;
+  for (auto* input : graph->inputs()) {
+    for (const auto& use : input->uses()) {
+      old_inputs.emplace_back(std::make_pair(input, use));
+    }
+    input->replaceAllUsesWith(fake_input);
+  }
+
+  AliasDb db(graph);
+  for (const auto& p : old_inputs) {
+    p.second.user->replaceInput(p.second.offset, p.first);
+  }
+  fake_input->node()->destroy();
+
+  const std::map<c10::Symbol, c10::Symbol> supported = {
+      {c10::Symbol::fromQualString("aten::permute"),
+       c10::Symbol::fromQualString("static_runtime::permute_copy")},
+      {c10::Symbol::fromQualString("aten::narrow"),
+       c10::Symbol::fromQualString("aten::narrow_copy")}};
+  std::vector<std::pair<Node*, Node*>> replacement;
+  for (auto* n : graph->nodes()) {
+    if (!supported.count(n->kind())) {
+      continue;
+    }
+    DCHECK(n->outputs().size() == 1);
+    auto* out = n->output();
+    if (out->uses().size() > 1) {
+      continue;
+    }
+    if (db.mayContainAlias({out}, graph->outputs())) {
+      continue;
+    }
+    auto new_symbol = supported.at(n->kind());
+    auto* new_node = graph->create(new_symbol, n->outputs().size());
+    new_node->insertBefore(n);
+    for (auto* input : n->inputs()) {
+      new_node->addInput(input);
+    }
+    replacement.emplace_back(std::make_pair(n, new_node));
+  }
+  for (const auto& p : replacement) {
+    auto* old_node = p.first;
+    auto* new_node = p.second;
+    old_node->replaceAllUsesWith(new_node);
+    old_node->destroy();
+  }
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -4,6 +4,7 @@ namespace torch {
 namespace jit {
 
 void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph);
+void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
This works for the contrived example
```
[bwasti@devbig216.ftw3 ~/fbsource/fbcode] buck run mode/opt caffe2/benchmarks/static_runtime:deep_wide_pt_benchmark
Parsing buck files: finished in 0.6 sec
Building: finished in 9.9 sec (100%) 3637/3637 jobs, 0 updated
  Total time: 10.6 sec
Run on (80 X 2001 MHz CPU s)
2020-12-16 09:40:23
--------------------------------------------------------------------------------
Benchmark                                         Time           CPU Iterations
--------------------------------------------------------------------------------
BM_long_static_memory_optimization/2/0         9557 ns       9556 ns      58310
BM_long_static_memory_optimization/8/0         9048 ns       9048 ns      77194
BM_long_static_memory_optimization/32/0       11493 ns      11492 ns      60826
BM_long_static_memory_optimization/512/0    5722748 ns    5722422 ns        122
BM_long_static_memory_optimization/2/1         9007 ns       9006 ns      78032
BM_long_static_memory_optimization/8/1         9012 ns       9012 ns      77415
BM_long_static_memory_optimization/32/1       10639 ns      10638 ns      66973
BM_long_static_memory_optimization/512/1    1279752 ns    1279694 ns        546
```
but I'm not seeing similar speedups on real models yet.

Test Plan:
buck test //caffe2/test:static_runtime
buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest

Differential Revision: D25581156

