### PR TITLE
[PyTorch][jit] Add Type::{castRaw,expectRef}

### DIFF
--- a/aten/src/ATen/core/jit_type_base.h
+++ b/aten/src/ATen/core/jit_type_base.h
@@ -152,6 +152,20 @@ struct TORCH_API Type : std::enable_shared_from_this<Type> {
     return nullptr;
   }
   template <typename T>
+  T* castRaw() {
+    if (T::Kind == kind()) {
+      return static_cast<T*>(this);
+    }
+    return nullptr;
+  }
+  template <typename T>
+  const T* castRaw() const {
+    if (T::Kind == kind()) {
+      return static_cast<T*>(this);
+    }
+    return nullptr;
+  }
+  template <typename T>
   std::shared_ptr<T> expect() {
     auto r = cast<T>();
     AT_ASSERT(r);
@@ -162,6 +176,18 @@ struct TORCH_API Type : std::enable_shared_from_this<Type> {
     auto r = cast<const T>();
     AT_ASSERT(r);
     return r;
+  }
+  template <typename T>
+  T& expectRef() {
+    auto* r = castRaw<T>();
+    AT_ASSERT(r);
+    return *r;
+  }
+  template <typename T>
+  const T& expectRef() const {
+    auto* r = castRaw<const T>();
+    AT_ASSERT(r);
+    return *r;
   }
   virtual ~Type() = default;
   virtual bool hasFreeVariables() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50062 [PyTorch] Use expectRef() when calling listConstruct
* **#50061 [PyTorch][jit] Add Type::{castRaw,expectRef}**

These are more efficient than creating an extra `shared_ptr`
when you just want to access the casted value.

Differential Revision: [D25766630](https://our.internmc.facebook.com/intern/diff/D25766630/)