### PR TITLE
[PyTorch] Use expectRef() when calling listConstruct

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -148,7 +148,7 @@ bool InterpreterState::run(Stack& stack) {
       case RET:
         return false;
       case LIST_CONSTRUCT: {
-        auto type = code_->types_[inst.X]->expect<at::ListType>();
+        const auto& type = code_->types_[inst.X]->expectRef<at::ListType>();
         listConstruct(stack, type, inst.N);
         ++pc;
       } break;

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -45,7 +45,7 @@ c10::optional<std::vector<IValue>> runNodeIfInputsAreConstant(
     } break;
     case prim::ListConstruct: {
       listConstruct(
-          stack, n->output()->type()->expect<ListType>(), n->inputs().size());
+          stack, n->output()->type()->expectRef<ListType>(), n->inputs().size());
     } break;
     case prim::DictConstruct: {
       dictConstruct(

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1495,7 +1495,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             ++frame.pc;
           } break;
           case LIST_CONSTRUCT: {
-            auto type = frame.function->type_table_[inst.X]->expect<ListType>();
+            const auto& type = frame.function->type_table_[inst.X]->expectRef<ListType>();
             listConstruct(stack, type, inst.N);
             ++frame.pc;
           } break;

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -361,7 +361,7 @@ getNativeOperation(Node* n) {
       // run op
       listConstruct(
           stack,
-          p_node->get_node()->output()->type()->expect<ListType>(),
+          p_node->get_node()->output()->type()->expectRef<ListType>(),
           p_node->input_regs().size());
       // put output back
       p_node->Output(0, reg) = std::move(stack[0]);

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -206,14 +206,14 @@ void namedTupleConstruct(
 
 void listConstruct(
     Stack& stack,
-    const at::ListTypePtr& type,
+    const at::ListType& type,
     size_t num_inputs) {
   // Structuring the implementation this way allows NRVO to avoid
   // move-constructing vals on its way onto the stack. Moving a List
   // isn't free.
   auto makeList =
-      [](Stack& stack, const at::ListTypePtr& type, size_t num_inputs) {
-        c10::List<IValue> vals(type->getElementType());
+      [](Stack& stack, const at::ListType& type, size_t num_inputs) {
+        c10::List<IValue> vals(type.getElementType());
         vals.reserve(num_inputs);
         for (size_t i = stack.size() - num_inputs; i < stack.size(); ++i) {
           vals.emplace_back(std::move(stack[i]));

--- a/torch/csrc/jit/runtime/vararg_functions.h
+++ b/torch/csrc/jit/runtime/vararg_functions.h
@@ -25,7 +25,7 @@ void namedTupleConstruct(
 
 void listConstruct(
     Stack& stack,
-    const at::ListTypePtr& list_type,
+    const at::ListType& list_type,
     size_t num_inputs);
 
 void dictConstruct(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50062 [PyTorch] Use expectRef() when calling listConstruct**
* #50061 [PyTorch][jit] Add Type::{castRaw,expectRef}

Avoids creating an extra shared_ptr.

Differential Revision: [D25766631](https://our.internmc.facebook.com/intern/diff/D25766631/)