### PR TITLE
fixes indices computation for trilinear interpolate backwards

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -168,43 +168,43 @@ __global__ void upsample_trilinear3d_backward_out_frame(
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1, h1, w1 + w1p),
+      idx_3d(nc, depth1, height1, width1, t1, h1, w1 + w1p),
       i_numel,
       static_cast<scalar_t>(t0lambda * h0lambda * w1lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1, h1 + h1p, w1),
+      idx_3d(nc, depth1, height1, width1, t1, h1 + h1p, w1),
       i_numel,
       static_cast<scalar_t>(t0lambda * h1lambda * w0lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1, h1 + h1p, w1 + w1p),
+      idx_3d(nc, depth1, height1, width1, t1, h1 + h1p, w1 + w1p),
       i_numel,
       static_cast<scalar_t>(t0lambda * h1lambda * w1lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1, w1),
+      idx_3d(nc, depth1, height1, width1, t1 + t1p, h1, w1),
       i_numel,
       static_cast<scalar_t>(t1lambda * h0lambda * w0lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1, w1 + w1p),
+      idx_3d(nc, depth1, height1, width1, t1 + t1p, h1, w1 + w1p),
       i_numel,
       static_cast<scalar_t>(t1lambda * h0lambda * w1lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1 + h1p, w1),
+      idx_3d(nc, depth1, height1, width1, t1 + t1p, h1 + h1p, w1),
       i_numel,
       static_cast<scalar_t>(t1lambda * h1lambda * w0lambda * d2val),
       true);
     fastAtomicAdd(
       idata,
-      idx_3d(nc, depth1, width1, height1, t1 + t1p, h1 + h1p, w1 + w1p),
+      idx_3d(nc, depth1, height1, width1, t1 + t1p, h1 + h1p, w1 + w1p),
       i_numel,
       static_cast<scalar_t>(t1lambda * h1lambda * w1lambda * d2val),
       true);

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2988,7 +2988,7 @@ new_module_tests = [
                             .scale_factor(std::vector<double>({3., 3., 3.}))
                             .mode(torch::kTrilinear)
                             .align_corners(false)''',
-        input_size=(1, 2, 3, 4, 4),
+        input_size=(1, 2, 3, 4, 5),
         fullname='interpolate_trilinear_scale_3d',
         # See https://github.com/pytorch/pytorch/issues/5006
         precision=3e-4,


### PR DESCRIPTION
#48675 had some typos in indices computations so that results for trilinear interpolation where height is not equal to width were wrong. This PR fixes it. 
cc @xwang233 
