### PR TITLE
Make stft (temporarily) warn

### DIFF
--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -469,10 +469,13 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
   const bool return_complex = return_complexOpt.value_or(
       self.is_complex() || (window.defined() && window.is_complex()));
   if (!return_complex) {
-    TORCH_WARN_ONCE(return_complexOpt.has_value(),
+    if (!return_complexOpt.has_value()) {
+      TORCH_WARN_ONCE(
         "stft will soon require the return_complex parameter be given for real inputs, "
         "and will further require that return_complex=True in a future PyTorch release."
       );
+    }
+
 
     // TORCH_WARN_ONCE(
     //     "stft with return_complex=False is deprecated. In a future pytorch "

--- a/aten/src/ATen/native/SpectralOps.cpp
+++ b/aten/src/ATen/native/SpectralOps.cpp
@@ -469,18 +469,17 @@ Tensor stft(const Tensor& self, const int64_t n_fft, const optional<int64_t> hop
   const bool return_complex = return_complexOpt.value_or(
       self.is_complex() || (window.defined() && window.is_complex()));
   if (!return_complex) {
-    TORCH_CHECK(return_complexOpt.has_value(),
-        "stft requires the return_complex parameter be given for real inputs."
-        "You should pass return_complex=True to opt-in to complex dtype returns "
-        "(which will be required in a future pytorch release). "
+    TORCH_WARN_ONCE(return_complexOpt.has_value(),
+        "stft will soon require the return_complex parameter be given for real inputs, "
+        "and will further require that return_complex=True in a future PyTorch release."
       );
 
-    TORCH_WARN_ONCE(
-        "stft with return_complex=False is deprecated. In a future pytorch "
-        "release, stft will return complex tensors for all inputs, and "
-        "return_complex=False will raise an error.\n"
-        "Note: you can still call torch.view_as_real on the complex output to "
-        "recover the old return format.");
+    // TORCH_WARN_ONCE(
+    //     "stft with return_complex=False is deprecated. In a future pytorch "
+    //     "release, stft will return complex tensors for all inputs, and "
+    //     "return_complex=False will raise an error.\n"
+    //     "Note: you can still call torch.view_as_real on the complex output to "
+    //     "recover the old return format.");
   }
 
   if (!at::isFloatingType(self.scalar_type()) && !at::isComplexType(self.scalar_type())) {

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1066,12 +1066,12 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'complex'):
             x.stft(10, pad_mode='constant', onesided=True)
 
-    # TODO: re-enable this test
     # stft is currently warning that it requires return-complex while an upgrader is written
-    # def test_stft_requires_complex(self, device):
-    #     x = torch.rand(100)
-    #     with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
-    #         y = x.stft(10, pad_mode='constant')
+    def test_stft_requires_complex(self, device):
+        x = torch.rand(100)
+        y = x.stft(10, pad_mode='constant')
+        # with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
+        #     y = x.stft(10, pad_mode='constant')
 
     @skipCUDAIfRocm
     @skipCPUIfNoMkl

--- a/test/test_spectral_ops.py
+++ b/test/test_spectral_ops.py
@@ -1066,10 +1066,12 @@ class TestFFT(TestCase):
         with self.assertRaisesRegex(RuntimeError, 'complex'):
             x.stft(10, pad_mode='constant', onesided=True)
 
-    def test_stft_requires_complex(self, device):
-        x = torch.rand(100)
-        with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
-            y = x.stft(10, pad_mode='constant')
+    # TODO: re-enable this test
+    # stft is currently warning that it requires return-complex while an upgrader is written
+    # def test_stft_requires_complex(self, device):
+    #     x = torch.rand(100)
+    #     with self.assertRaisesRegex(RuntimeError, 'stft requires the return_complex parameter'):
+    #         y = x.stft(10, pad_mode='constant')
 
     @skipCUDAIfRocm
     @skipCPUIfNoMkl


### PR DESCRIPTION
When continuing the deprecation process for stft it was made to throw an error when `use_complex` was not explicitly set by the user. Unfortunately this PR missed a model relying on the historic stft functionality. Before re-enabling the error we'll need to write an upgrader for that model.

This PR turns the error back into a warning to allow that model to continue running as before. 