### PR TITLE
[static runtime] remove ListConstructs (and Tuple)

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt.cc
+++ b/benchmarks/static_runtime/deep_wide_pt.cc
@@ -85,7 +85,6 @@ torch::jit::Module getDeepAndWideSciptModel(int num_features) {
   auto clstype = cu->get_class(c10::QualifiedName(base, "DeepAndWide"));
 
   torch::jit::Module mod(cu, clstype);
-
   mod.register_parameter("_mu", torch::randn({1, num_features}), false);
   mod.register_parameter("_sigma", torch::randn({1, num_features}), false);
   mod.register_parameter("_fc_w", torch::randn({1, num_features + 1}), false);

--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -149,10 +149,10 @@ BENCHMARK(BM_leaky_relu_const)->RangeMultiplier(8)->Ranges({{1, 20}});
 
 static void BM_long_static_memory_optimization(benchmark::State& state) {
   auto mod = getLongScriptModel();
-  torch::jit::InferenceModuleOptions opts;
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntimeOptions opts;
   opts.optimize_memory = state.range(1);
-  auto g = torch::jit::PrepareForStaticRuntime(mod, opts);
-  torch::jit::StaticRuntime runtime(g);
+  torch::jit::StaticRuntime runtime(g, opts);
 
   const auto N = state.range(0);
   auto a = torch::randn({N, N});

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -61,7 +61,8 @@ void testStaticRuntime(
 
   auto expect = module.forward(args);
 
-  StaticRuntime runtime(module);
+  auto gs = torch::jit::PrepareForStaticRuntime(module);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
   auto actual = runtime.run(args, {});
 
   if (expect.isTuple()) {
@@ -100,8 +101,8 @@ TEST(StaticRuntime, LongModel) {
 
   // run static runtime
   std::vector<at::Tensor> input_tensors({a, b, c});
-  auto g = torch::jit::PrepareForStaticRuntime(mod);
-  torch::jit::StaticRuntime runtime(g);
+  auto gs = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   EXPECT_TRUE(output_1.equal(output_2));
 }
@@ -118,8 +119,8 @@ TEST(StaticRuntime, TrivialModel) {
 
   // run static runtime
   std::vector<at::Tensor> input_tensors({a, b, c});
-  auto g = torch::jit::PrepareForStaticRuntime(mod);
-  torch::jit::StaticRuntime runtime(g);
+  auto gs = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   EXPECT_TRUE(output_1.equal(output_2));
 }
@@ -134,8 +135,8 @@ TEST(StaticRuntime, LeakyReLU) {
 
   // run static runtime
   std::vector<at::Tensor> input_tensors({inputs});
-  auto g = torch::jit::PrepareForStaticRuntime(mod);
-  torch::jit::StaticRuntime runtime(g);
+  auto gs = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   EXPECT_TRUE(output_1.equal(output_2));
 }
@@ -144,8 +145,8 @@ TEST(StaticRuntime, DeepWide) {
   const int embedding_size = 32;
   const int num_features = 50;
   torch::jit::Module mod = getDeepAndWideSciptModel();
-  auto g = torch::jit::PrepareForStaticRuntime(mod);
-  torch::jit::StaticRuntime runtime(g);
+  auto gs = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
 
   for (int batch_size : {1, 8, 32}) {
     for (int i = 0; i < 2; ++i) {
@@ -169,7 +170,8 @@ TEST(StaticRuntime, KWargsAPI_1) {
   const int embedding_size = 32;
   const int num_features = 50;
   auto module = getDeepAndWideSciptModel();
-  torch::jit::StaticRuntime runtime(module);
+  auto gs = torch::jit::PrepareForStaticRuntime(module);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
 
   for (int batch_size : {1, 8, 32}) {
     for (int i = 0; i < 2; ++i) {
@@ -192,8 +194,8 @@ TEST(StaticRuntime, KWargsAPI_2) {
   const int embedding_size = 32;
   const int num_features = 50;
   auto module = getDeepAndWideSciptModel();
-  auto g = torch::jit::PrepareForStaticRuntime(module);
-  torch::jit::StaticRuntime runtime(module);
+  auto gs = torch::jit::PrepareForStaticRuntime(module);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
 
   for (int batch_size : {1, 8, 32}) {
     for (int i = 0; i < 2; ++i) {
@@ -221,14 +223,15 @@ TEST(StaticRuntime, CleanUpMemory) {
   const int embedding_size = 32;
   const int num_features = 50;
   torch::jit::Module mod = getDeepAndWideSciptModel();
-  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  auto gs = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntime runtime(gs.first, gs.second);
 
   for (auto cleanup_memory : {true, false}) {
     for (auto enable_out_variant : {true, false}) {
       VLOG(1) << "cleanup_memory: " << cleanup_memory
               << ", enable_out_variant: " << enable_out_variant;
       torch::jit::StaticRuntimeOptions opts{cleanup_memory, enable_out_variant};
-      torch::jit::StaticRuntime runtime(g, opts);
+      torch::jit::StaticRuntime runtime(gs.first, gs.second, opts);
 
       for (int batch_size : {1, 8, 32}) {
         for (int i = 0; i < 2; ++i) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -369,34 +369,60 @@ StaticRuntime::StaticRuntime(
   TORCH_CHECK(
       module_ != nullptr,
       "std::shared_ptr<InferenceModule> module_ cannot be nullptr")
-  // initialize registers
-  reg_.resize(module_->value_to_reg.size());
 
   Graph* graph = module_->graph.get();
-  const auto& value_to_reg = module_->value_to_reg;
+  std::unordered_map<Value*, IValue*> val_to_ival;
+
+  // NB: create an unchanging std::vector<IValue> we can reference
+  for (auto input : graph->inputs()) {
+    inputs_.emplace_back();
+  }
+  for (auto i = 0; i < graph->inputs().size(); ++i) {
+    Value* input = graph->inputs().at(i);
+    val_to_ival[input] = &(inputs_[i]);
+  }
 
   // fill workspace_ with constants and create ProcessedNodes
   // NB: before optimizing the order of execution, ensure that the
   // memory optimization pass (LivenessMap + AssignRegisters) is
   // aware of the new order!
+
+  // Fill constants first, so we have a std::vector<IValue> we can reference
+  // later
+  for (Node* node : graph->nodes()) {
+    if (node->kind() != prim::Constant) {
+      continue;
+    }
+    auto* v = node->output();
+    TORCH_CHECK(v->type()->kind() != FunctionType::Kind);
+    constants_.emplace_back(toIValue(v).value());
+  }
+  {
+    int i = 0;
+    for (Node* node : graph->nodes()) {
+      if (node->kind() != prim::Constant) {
+        continue;
+      }
+      auto* v = node->output();
+      val_to_ival[v] = &(constants_[i++]);
+    }
+  }
   for (Node* node : graph->nodes()) {
     if (node->kind() == prim::Constant) {
-      TORCH_CHECK(node->output()->type()->kind() != FunctionType::Kind);
-      reg_[value_to_reg.at(node->output())] = toIValue(node->output()).value();
-    } else {
-      std::vector<size_t> input_regs, output_regs;
-      for (Value* input : node->inputs()) {
-        input_regs.push_back(value_to_reg.at(input));
-      }
-      for (Value* output : node->outputs()) {
-        output_regs.push_back(value_to_reg.at(output));
-      }
-      nodes_.emplace_back(
-          node,
-          std::move(input_regs),
-          std::move(output_regs),
-          opts.enable_out_variant);
+      continue;
     }
+    std::vector<const IValue*> inputs;
+    for (Value* input : node->inputs()) {
+      inputs.emplace_back(val_to_ival.at(input));
+    }
+    nodes_.emplace_back(
+        ProcessedNode(node, std::move(inputs), opts.enable_out_variant));
+    for (auto i = 0; i < node->outputs().size(); ++i) {
+      val_to_ival[node->outputs().at(i)] = &nodes_.back().outputs().at(i);
+    }
+  }
+  for (auto output : graph->outputs()) {
+    outputs_.emplace_back(val_to_ival.at(output));
   }
 }
 
@@ -460,28 +486,28 @@ c10::IValue StaticRuntime::run(
   // NB: before optimizing the order of execution, ensure that the
   // memory optimization pass (LivenessMap + AssignRegisters) is
   // aware of the new order!
-  for (const auto& n : nodes_) {
-    n.run(reg_);
+  for (auto& n : nodes_) {
+    n.run();
   }
 
   if (opts_.cleanup_activations) {
     if (!planner_) {
-      planner_ = std::make_unique<MemoryPlanner>(this);
+      std::unordered_map<Value*, std::vector<Value*>> shared;
+      planner_ = std::make_unique<MemoryPlanner>(this, shared);
     }
     planner_->deallocate();
-    deallocate_registers(module_->internals);
   }
 
   // no need to keep references of outputs in static runtime anymore
   if (num_outputs() > 1) {
     std::vector<c10::IValue> outputs;
     outputs.reserve(num_outputs());
-    for (const auto& reg : module_->output_regs) {
-      outputs.emplace_back(reg_[reg]);
+    for (auto i = 0; i < num_outputs(); ++i) {
+      outputs.emplace_back(Output(i));
     }
     return c10::ivalue::Tuple::create(outputs);
   }
-  return std::move(reg_[module_->output_regs[0]]);
+  return Output(0);
 }
 
 void StaticRuntime::benchmark(
@@ -594,16 +620,16 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     }
     for (size_t j = 0; j < nodes_.size(); j++) {
       timer.Start();
-      nodes_[j].run(reg_);
+      nodes_[j].run();
       float millis = timer.MilliSeconds();
       results.time_per_node[j] += millis;
     }
     if (opts_.cleanup_activations) {
       if (!planner_) {
-        planner_ = std::make_unique<MemoryPlanner>(this);
+        std::unordered_map<Value*, std::vector<Value*>> shared;
+        planner_ = std::make_unique<MemoryPlanner>(this, shared);
       }
       planner_->deallocate();
-      deallocate_registers(module_->internals);
     }
   }
 
@@ -623,64 +649,78 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   return results;
 }
 
-void StaticRuntime::deallocate_registers(const std::vector<size_t>& internals) {
-  // discard Tensor objects to reduce memory usage
-  // they will be re-created in the next iteration regardless
-  for (auto i : internals) {
-    if (reg_[i].isTensor()) {
-      // If the tensor has no storage, we can keep it around. We
-      // implement by moving out of the register (leaving behind an
-      // empty IValue for free!) and possibly moving back.
-      at::Tensor asTensor = std::move(reg_[i]).toTensor();
-      if (asTensor.storage().nbytes() == 0) {
-        reg_[i] = std::move(asTensor);
+MemoryPlanner::MemoryPlanner(
+    StaticRuntime* runtime,
+    std::unordered_map<Value*, std::vector<Value*>> should_share) {
+  // collect register indices of outputs of ops with out variant
+  std::unordered_set<IValue*> unmanaged_value_set;
+  for (ProcessedNode& node : runtime->get_nodes()) {
+    if (node.has_out_variant()) {
+      // Types are stored in the underlying TorchScript IR
+      for (Value* out : node.get_node()->outputs()) {
+        if (out->type()->cast<TensorType>()) {
+          managed_values_.insert(out);
+        }
       }
     } else {
-      reg_[i] = IValue();
-    }
-  }
-}
-
-MemoryPlanner::MemoryPlanner(StaticRuntime* runtime)
-    : reg_(runtime->get_registers()) {
-  // collect register indices of outputs of ops with out variant
-  for (const ProcessedNode& node : runtime->get_nodes()) {
-    if (node.has_out_variant()) {
-      for (auto out : node.output_regs()) {
-        reg_out_variant_.insert(out);
+      for (IValue& out : node.outputs()) {
+        unmanaged_value_set.insert(&out);
       }
     }
   }
 
   const InferenceModule* module = runtime->get_inference_module();
 
-  // remove model outputs from reg_out_variant_
-  for (size_t output : module->output_regs) {
-    reg_out_variant_.erase(output);
+  // remove model outputs from managed_values_
+  for (Value* output : module->graph->outputs()) {
+    managed_values_.erase(output);
+  }
+  for (IValue* output : runtime->outputs()) {
+    unmanaged_value_set.erase(output);
+  }
+  for (IValue* out : unmanaged_value_set) {
+    unmanaged_values_.emplace_back(out);
   }
 
-  // remove tensors in output List/Tuple from reg_out_variant_
+  // remove tensors in output List/Tuple from managed_values_
   for (Value* output : module->graph->outputs()) {
     Node* output_node = output->node();
     if (output_node->kind() == prim::TupleConstruct ||
         output_node->kind() == prim::ListConstruct) {
       for (Value* input : output_node->inputs()) {
-        reg_out_variant_.erase(module->value_to_reg.at(input));
+        managed_values_.erase(input);
       }
     }
   }
 
-  // debug only
-  for (auto reg : reg_out_variant_) {
-    VLOG(1) << "reg_out_variant_: %" << module->values[reg]->debugName();
+  // some Values should share storage, this map will
+  // keep track of the index into managed_storage_
+  std::unordered_map<Value*, size_t> shared;
+
+  // Snapshot of the current memory state
+  for (const auto& node : runtime->get_nodes()) {
+    for (auto i = 0; i < node.outputs().size(); ++i) {
+      const auto& ival = node.outputs().at(i);
+      const auto& val = node.get_node()->outputs().at(i);
+      if (managed_values_.count(val)) {
+        TORCH_CHECK(ival.isTensor());
+        auto* impl = ival.toTensor().storage().unsafeGetStorageImpl();
+        if (shared.count(val)) {
+          managed_storage_[shared.at(val)].second.emplace_back(impl);
+        } else {
+          auto p =
+              std::make_pair<size_t, std::vector<c10::StorageImpl*>>(0, {impl});
+          managed_storage_.emplace_back(std::move(p));
+          // first of a group, update the shared map with the index
+          if (should_share.count(val)) {
+            for (auto v : should_share.at(val)) {
+              shared[v] = managed_storage_.size() - 1;
+            }
+          }
+        }
+      }
+    }
   }
-
-  // dedup tensor storages (tensor views share the same tensor storage)
-  auto internal_storages_set = reg_to_storage_impls();
-  internal_storages_.assign(
-      internal_storages_set.begin(), internal_storages_set.end());
-
-  internal_blob_max_sizes_.resize(internal_storages_.size());
 }
 
 // Don't change the size if it is already aligned, otherwise increase the size
@@ -695,77 +735,64 @@ at::DataPtr MemoryPlanner::allocate_buffer(size_t size) {
   return allocator->allocate(size);
 }
 
-std::unordered_set<c10::StorageImpl*> MemoryPlanner::reg_to_storage_impls() {
-  std::unordered_set<c10::StorageImpl*> internal_storages_set;
-  for (auto i : reg_out_variant_) {
-    internal_storages_set.insert(
-        reg_[i].toTensor().storage().unsafeGetStorageImpl());
-  }
-  return internal_storages_set;
-}
-
 void MemoryPlanner::allocate() {
-  if (internal_blob_max_sizes_sum_ == 0) {
+  if (managed_bytes_ == 0) {
     return;
   }
 
-  buffer_ = allocate_buffer(internal_blob_max_sizes_sum_);
+  buffer_ = allocate_buffer(managed_bytes_);
 
   size_t offset = 0;
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
 
-  for (auto i = 0; i < internal_storages_.size(); i++) {
-    auto tensor_size = internal_blob_max_sizes_[i];
+  for (const auto& ms : managed_storage_) {
+    auto tensor_size = ms.first;
     if (tensor_size == 0) {
       continue;
     }
-    DCHECK_LE(offset + tensor_size, internal_blob_max_sizes_sum_);
+    const auto& impls = ms.second;
+    DCHECK_LE(offset + tensor_size, managed_bytes_);
     void* src = static_cast<void*>(start + offset);
 
-    c10::StorageImpl* impl = internal_storages_[i];
-    impl->set_data_ptr(at::DataPtr(src, src, nullptr, impl->device()));
-    impl->set_nbytes(tensor_size);
+    for (auto& impl : impls) {
+      impl->set_data_ptr(at::DataPtr(src, src, nullptr, impl->device()));
+      impl->set_nbytes(tensor_size);
+    }
 
     offset += tensor_size;
   }
-  DCHECK_EQ(offset, internal_blob_max_sizes_sum_);
-}
-
-void MemoryPlanner::verify_internal_storages() {
-  auto internal_storages_set = reg_to_storage_impls();
-  for (auto* storage_impl : internal_storages_) {
-    TORCH_CHECK(
-        internal_storages_set.count(storage_impl) > 0,
-        "Found internal_storage mismatch");
-  }
+  DCHECK_EQ(offset, managed_bytes_);
 }
 
 void MemoryPlanner::deallocate() {
-#ifndef NDEBUG
-  verify_internal_storages();
-#endif
-  internal_blob_max_sizes_sum_ = 0;
+  managed_bytes_ = 0;
+
   // free memory used by outputs of ops in out variants
   // but keep the TensorImpl and StorageImpl around
-  for (auto i = 0; i < internal_storages_.size(); i++) {
-    c10::StorageImpl* impl = internal_storages_[i];
-    size_t current_size = compute_aligned_tensor_size(impl->nbytes());
-    size_t& max_size = internal_blob_max_sizes_[i];
-    max_size = std::max(max_size, current_size);
-    internal_blob_max_sizes_sum_ += max_size;
-    impl->reset();
+  for (auto& ms : managed_storage_) {
+    const auto& impls = ms.second;
+    size_t max = 0;
+    for (auto& impl : impls) {
+      size_t current_size = compute_aligned_tensor_size(impl->nbytes());
+      impl->reset();
+      max = std::max(max, current_size);
+    }
+    ms.first = max;
+    managed_bytes_ += max;
+  }
+  for (auto& iv : unmanaged_values_) {
+    *iv = IValue();
   }
   buffer_ = {};
 }
 
 ProcessedNode::ProcessedNode(
     Node* node,
-    std::vector<size_t>&& input_regs,
-    std::vector<size_t>&& output_regs,
+    std::vector<const IValue*>&& inputs,
     bool enable_out_variants)
-    : node_(node),
-      input_regs_(std::move(input_regs)),
-      output_regs_(std::move(output_regs)) {
+    : node_(node), inputs_(std::move(inputs)) {
+  // TODO leverage type information
+  outputs_.resize(node->outputs().size());
   if (node->kind() != prim::ListConstruct &&
       node->kind() != prim::TupleConstruct &&
       node->kind() != prim::ListUnpack) {
@@ -775,7 +802,6 @@ ProcessedNode::ProcessedNode(
   }
   if (enable_out_variants && canRunOutOfPlace(node)) {
     fn_ = getOutOfPlaceOperation(node);
-
     std::ostringstream ss;
     node->print(ss, 0, nullptr, false);
     VLOG(1) << "Switch to out variant for node: " << ss.str();
@@ -791,17 +817,17 @@ ProcessedNode::ProcessedNode(
   }
 }
 
-void ProcessedNode::run(std::vector<IValue>& reg) const {
+void ProcessedNode::run() {
   if (fn_) {
-    fn_(this, reg);
+    fn_(this);
   } else if (native_fn_) {
-    native_fn_(this, reg);
+    native_fn_(this);
   } else {
     std::vector<IValue> stack;
     const size_t size = node_->inputs().size();
     stack.reserve(size);
     for (size_t i = 0; i < size; i++) {
-      stack.emplace_back(Input(i, reg));
+      stack.emplace_back(Input(i));
     }
 
     DCHECK(op_);
@@ -809,7 +835,7 @@ void ProcessedNode::run(std::vector<IValue>& reg) const {
 
     DCHECK_EQ(stack.size(), node_->outputs().size());
     for (auto i = 0; i < node_->outputs().size(); i++) {
-      Output(i, reg) = std::move(stack[i]);
+      Output(i) = std::move(stack[i]);
     }
   }
 }

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -68,12 +68,14 @@ void initStaticRuntimeBindings(PyObject* module) {
   m.def(
        "_jit_to_static_runtime",
        [](std::shared_ptr<torch::jit::Graph> g) {
-         return StaticRuntime(PrepareForStaticRuntime(g));
+         PrepareGraphForStaticRuntime(g);
+         return StaticRuntime(g);
        })
       .def(
           "_jit_to_static_runtime",
-          [](const torch::jit::Module& m) {
-            return StaticRuntime(PrepareForStaticRuntime(m));
+          [](const torch::jit::Module& module) {
+            auto gs = PrepareForStaticRuntime(module);
+            return StaticRuntime(gs.first, gs.second);
           })
       .def(
           "_fuse_to_static_runtime",

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -78,14 +78,14 @@ struct static_add final : public at::native::structured_add_out {
 };
 
 REGISTER_OPERATOR_FUNCTOR(aten::add, aten_add, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_t = p_node->Input(1, reg).toTensor();
-    auto in2_s = p_node->Input(2, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    auto in1_t = p_node->Input(1).toTensor();
+    auto in2_s = p_node->Input(2).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     static_add op{out_t};
     op.meta(in0_t, in1_t, in2_s);
     op.impl(in0_t, in1_t, in2_s, out_t);
@@ -93,56 +93,56 @@ REGISTER_OPERATOR_FUNCTOR(aten::add, aten_add, [](Node* n) -> SROperator {
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_t = p_node->Input(1, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    auto in1_t = p_node->Input(1).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::mul_out(out_t, in0_t, in1_t);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::addmm, aten_addmm, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_t = p_node->Input(1, reg).toTensor();
-    auto in2_t = p_node->Input(2, reg).toTensor();
-    auto in3_s = p_node->Input(3, reg).toScalar();
-    auto in4_s = p_node->Input(4, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    auto in1_t = p_node->Input(1).toTensor();
+    auto in2_t = p_node->Input(2).toTensor();
+    auto in3_s = p_node->Input(3).toScalar();
+    auto in4_s = p_node->Input(4).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::addmm_cpu_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::clamp, aten_clamp, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_s = p_node->Input(1, reg).toScalar();
-    auto in2_s = p_node->Input(2, reg).toScalar();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    auto in1_s = p_node->Input(1).toScalar();
+    auto in2_s = p_node->Input(2).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::clamp_out(out_t, in0_t, in1_s, in2_s);
   };
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::bmm, aten_bmm, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    auto in1_t = p_node->Input(1, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    auto in1_t = p_node->Input(1).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::bmm_out_cpu(out_t, in0_t, in1_t);
   };
@@ -152,42 +152,42 @@ REGISTER_OPERATOR_FUNCTOR(
     aten::nan_to_num,
     aten_nan_to_num,
     [](Node* n) -> SROperator {
-      return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-        auto input_size = p_node->input_regs().size();
-        auto in0_t = p_node->Input(0, reg).toTensor();
-        double in1_d = input_size > 1 ? p_node->Input(1, reg).toDouble() : 0;
-        double in2_d = input_size > 2 ? p_node->Input(2, reg).toDouble()
+      return [](ProcessedNode* p_node) {
+        auto input_size = p_node->inputs().size();
+        auto in0_t = p_node->Input(0).toTensor();
+        double in1_d = input_size > 1 ? p_node->Input(1).toDouble() : 0;
+        double in2_d = input_size > 2 ? p_node->Input(2).toDouble()
                                       : std::numeric_limits<double>::infinity();
         double in3_d = input_size > 3
-            ? p_node->Input(3, reg).toDouble()
+            ? p_node->Input(3).toDouble()
             : -std::numeric_limits<double>::infinity();
-        if (p_node->Output(0, reg).isNone()) {
-          p_node->Output(0, reg) = create_empty_from(in0_t);
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = create_empty_from(in0_t);
         }
-        auto out_t = p_node->Output(0, reg).toTensor();
+        auto out_t = p_node->Output(0).toTensor();
         out_t.resize_({0});
         at::native::nan_to_num_out(out_t, in0_t, in1_d, in2_d, in3_d);
       };
     });
 REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_tl = p_node->Input(0, reg).toTensorVector();
-    auto in1_i = p_node->Input(1, reg).toInt();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_tl[0]);
+  return [](ProcessedNode* p_node) {
+    auto in0_tl = p_node->Input(0).toTensorVector();
+    auto in1_i = p_node->Input(1).toInt();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_tl[0]);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::_cat_out_cpu(out_t, in0_tl, in1_i);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::tanh_out(out_t, in0_t);
   };
@@ -195,11 +195,11 @@ REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
 
 // Split out into a function to appease MSVC's pre-processor
 SROperator aten_stack(Node* n) {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto inputs = p_node->Input(0, reg).toTensorVector();
-    auto dim = p_node->Input(1, reg).toInt();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(inputs[0]);
+  return [](ProcessedNode* p_node) {
+    auto inputs = p_node->Input(0).toTensorVector();
+    auto dim = p_node->Input(1).toInt();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(inputs[0]);
     }
 #ifndef NDEBUG
     at::IntArrayRef entry_shape = inputs[0].sizes();
@@ -217,7 +217,7 @@ SROperator aten_stack(Node* n) {
     for (auto i = 0; i < inputs.size(); i++) {
       inputs[i] = inputs[i].unsqueeze(dim);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::_cat_out_cpu(out_t, inputs, dim);
   };
@@ -229,12 +229,12 @@ REGISTER_OPERATOR_FUNCTOR(
     aten::sigmoid,
     aten_sigmoid,
     [](Node* n) -> SROperator {
-      return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-        auto in0_t = p_node->Input(0, reg).toTensor();
-        if (p_node->Output(0, reg).isNone()) {
-          p_node->Output(0, reg) = create_empty_from(in0_t);
+      return [](ProcessedNode* p_node) {
+        auto in0_t = p_node->Input(0).toTensor();
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = create_empty_from(in0_t);
         }
-        auto out_t = p_node->Output(0, reg).toTensor();
+        auto out_t = p_node->Output(0).toTensor();
         out_t.resize_({0});
         at::native::sigmoid_out(out_t, in0_t);
       };
@@ -246,97 +246,94 @@ REGISTER_OPERATOR_FUNCTOR(
       auto in1 = toIValue(n->inputs()[1]);
       if (in1) {
         auto in1_s = in1->toScalar();
-        return [=](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-          auto in0_t = p_node->Input(0, reg).toTensor();
-          if (p_node->Output(0, reg).isNone()) {
-            p_node->Output(0, reg) = create_empty_from(in0_t);
+        return [=](ProcessedNode* p_node) {
+          auto in0_t = p_node->Input(0).toTensor();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(in0_t);
           }
-          auto out_t = p_node->Output(0, reg).toTensor();
+          auto out_t = p_node->Output(0).toTensor();
           at::native::leaky_relu_out(out_t, in0_t, in1_s);
         };
       } else {
-        return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-          auto in0_t = p_node->Input(0, reg).toTensor();
-          auto in1_s = p_node->Input(1, reg).toScalar();
-          if (p_node->Output(0, reg).isNone()) {
-            p_node->Output(0, reg) = create_empty_from(in0_t);
+        return [](ProcessedNode* p_node) {
+          auto in0_t = p_node->Input(0).toTensor();
+          auto in1_s = p_node->Input(1).toScalar();
+          if (p_node->Output(0).isNone()) {
+            p_node->Output(0) = create_empty_from(in0_t);
           }
-          auto out_t = p_node->Output(0, reg).toTensor();
+          auto out_t = p_node->Output(0).toTensor();
           at::native::leaky_relu_out(out_t, in0_t, in1_s);
         };
       }
     });
 REGISTER_OPERATOR_FUNCTOR(aten::relu, aten_relu, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::threshold_out(out_t, in0_t, 0, 0);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    double in1_d = p_node->input_regs().size() > 1
-        ? p_node->Input(1, reg).toDouble()
-        : -1.0;
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    double in1_d =
+        p_node->inputs().size() > 1 ? p_node->Input(1).toDouble() : -1.0;
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     out_t.resize_({0});
     at::native::logit_out(out_t, in0_t, in1_d);
   };
 });
 REGISTER_OPERATOR_FUNCTOR(aten::clone, aten_clone, [](Node* n) -> SROperator {
-  return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-    auto in0_t = p_node->Input(0, reg).toTensor();
-    if (p_node->Output(0, reg).isNone()) {
-      p_node->Output(0, reg) = create_empty_from(in0_t);
+  return [](ProcessedNode* p_node) {
+    auto in0_t = p_node->Input(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
     }
-    auto out_t = p_node->Output(0, reg).toTensor();
+    auto out_t = p_node->Output(0).toTensor();
     at::native::resize_as_(out_t, in0_t, c10::nullopt);
     at::native::copy_(out_t, in0_t, false);
   };
 });
 
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getOutOfPlaceOperation(Node* n) {
+std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n) {
   auto op_name = n->kind().toQualString();
   if (SROperatorRegistry()->Has(op_name)) {
     return SROperatorRegistry()->Create(op_name)->Generate(n);
   }
 
-  return [](const ProcessedNode*, std::vector<IValue>&) { TORCH_CHECK(0); };
+  return [](ProcessedNode*) { TORCH_CHECK(0); };
 }
 
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getNativeOperation(Node* n) {
+std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
   if (n->kind() == c10::Symbol::fromQualString("aten::transpose")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      p_node->Output(0, reg) = at::native::transpose(in0_t, in1_i, in2_i);
+    return [](ProcessedNode* p_node) {
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      p_node->Output(0) = at::native::transpose(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::flatten")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      p_node->Output(0, reg) = at::native::flatten(in0_t, in1_i, in2_i);
+    return [](ProcessedNode* p_node) {
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      p_node->Output(0) = at::native::flatten(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == prim::TupleConstruct) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
       auto* node = p_node->get_node();
@@ -347,77 +344,76 @@ getNativeOperation(Node* n) {
         tupleConstruct(stack, node->inputs().size());
       }
       // put output back
-      p_node->Output(0, reg) = std::move(stack[0]);
+      p_node->Output(0) = std::move(stack[0]);
     };
   } else if (n->kind() == prim::ListConstruct) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
       listConstruct(
           stack,
           p_node->get_node()->output()->type()->expect<ListType>(),
-          p_node->input_regs().size());
+          p_node->inputs().size());
       // put output back
-      p_node->Output(0, reg) = std::move(stack[0]);
+      p_node->Output(0) = std::move(stack[0]);
     };
   } else if (n->kind() == prim::ListUnpack) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
+    return [](ProcessedNode* p_node) {
       // prepare inputs
       std::vector<IValue> stack;
-      const size_t size = p_node->input_regs().size();
+      const size_t size = p_node->inputs().size();
       stack.reserve(size);
       for (size_t i = 0; i < size; i++) {
-        stack.emplace_back(p_node->Input(i, reg));
+        stack.emplace_back(p_node->Input(i));
       }
       // run op
-      size_t num_outputs = p_node->output_regs().size();
+      size_t num_outputs = p_node->outputs().size();
       listUnpack(stack, num_outputs);
       // put output back
       DCHECK_EQ(stack.size(), num_outputs);
       for (auto i = 0; i < num_outputs; i++) {
-        p_node->Output(i, reg) = std::move(stack[i]);
+        p_node->Output(i) = std::move(stack[i]);
       }
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::permute")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_iv = p_node->Input(1, reg).toIntVector();
-      p_node->Output(0, reg) = at::native::permute(in0_t, in1_iv);
+    return [](ProcessedNode* p_node) {
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_iv = p_node->Input(1).toIntVector();
+      p_node->Output(0) = at::native::permute(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::reshape")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_iv = p_node->Input(1, reg).toIntVector();
-      p_node->Output(0, reg) = at::native::reshape(in0_t, in1_iv);
+    return [](ProcessedNode* p_node) {
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_iv = p_node->Input(1).toIntVector();
+      p_node->Output(0) = at::native::reshape(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::slice")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toInt();
-      auto in2_i = p_node->Input(2, reg).toInt();
-      auto in3_i = p_node->Input(3, reg).toInt();
-      auto in4_i = p_node->Input(4, reg).toInt();
-      p_node->Output(0, reg) =
-          at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
+    return [](ProcessedNode* p_node) {
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toInt();
+      auto in2_i = p_node->Input(2).toInt();
+      auto in3_i = p_node->Input(3).toInt();
+      auto in4_i = p_node->Input(4).toInt();
+      p_node->Output(0) = at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::narrow")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      auto self = p_node->Input(0, reg).toTensor(); // self
-      auto dim = p_node->Input(1, reg).toInt(); // dim
+    return [](ProcessedNode* p_node) {
+      auto self = p_node->Input(0).toTensor(); // self
+      auto dim = p_node->Input(1).toInt(); // dim
       int64_t start = 0;
-      if (p_node->Input(2, reg).isScalar()) {
-        start = p_node->Input(2, reg).toInt();
+      if (p_node->Input(2).isScalar()) {
+        start = p_node->Input(2).toInt();
       } else {
-        auto t = p_node->Input(2, reg).toTensor();
+        auto t = p_node->Input(2).toTensor();
         start = t.item<int64_t>();
       }
-      auto length = p_node->Input(3, reg).toInt(); // length
+      auto length = p_node->Input(3).toInt(); // length
       TORCH_CHECK(
           self.dim() > 0, "narrow() cannot be applied to a 0-dim tensor.");
       auto cur_size = self.size(dim);
@@ -434,27 +430,26 @@ getNativeOperation(Node* n) {
           ") exceeds dimension size (",
           cur_size,
           ").");
-      p_node->Output(0, reg) =
+      p_node->Output(0) =
           at::native::slice(self, dim, start, start + length, 1);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::to")) {
-    return [](const ProcessedNode* p_node, std::vector<IValue>& reg) {
-      DCHECK(p_node->input_regs().size() == 5);
-      auto in0_t = p_node->Input(0, reg).toTensor();
-      auto in1_i = p_node->Input(1, reg).toScalarType();
-      auto in2_i = p_node->Input(2, reg).toBool();
-      auto in3_i = p_node->Input(3, reg).toBool();
-      if (p_node->Input(4, reg).isNone()) {
-        p_node->Output(0, reg) =
+    return [](ProcessedNode* p_node) {
+      DCHECK(p_node->inputs().size() == 5);
+      auto in0_t = p_node->Input(0).toTensor();
+      auto in1_i = p_node->Input(1).toScalarType();
+      auto in2_i = p_node->Input(2).toBool();
+      auto in3_i = p_node->Input(3).toBool();
+      if (p_node->Input(4).isNone()) {
+        p_node->Output(0) =
             at::native::to(in0_t, in1_i, in2_i, in3_i, c10::nullopt);
       } else {
-        auto in4_o = p_node->Input(4, reg).toMemoryFormat();
-        p_node->Output(0, reg) =
-            at::native::to(in0_t, in1_i, in2_i, in3_i, in4_o);
+        auto in4_o = p_node->Input(4).toMemoryFormat();
+        p_node->Output(0) = at::native::to(in0_t, in1_i, in2_i, in3_i, in4_o);
       }
     };
   }
-  return [](const ProcessedNode*, std::vector<IValue>&) { TORCH_CHECK(0); };
+  return [](ProcessedNode*) { TORCH_CHECK(0); };
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -6,12 +6,11 @@
 namespace torch {
 namespace jit {
 
-using SROperator =
-    std::function<void(const ProcessedNode*, std::vector<IValue>&)>;
+using SROperator = std::function<void(ProcessedNode*)>;
 using SROpFunctor = std::function<SROperator(Node* n)>;
 struct SROperatorFunctor {
   virtual SROperator Generate(Node*) {
-    std::function<void(const ProcessedNode*, std::vector<IValue>&)> out;
+    std::function<void(ProcessedNode*)> out;
     return out;
   }
   virtual bool CanReuseInput() {
@@ -52,40 +51,11 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
 bool canRunOutOfPlace(Node* n);
 bool canReuseInputs(Node* n);
 bool canReuseOutputs(Node* n);
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getOutOfPlaceOperation(Node* n);
+
+std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);
 
 bool canRunNatively(Node* n);
-std::function<void(const ProcessedNode*, std::vector<IValue>&)>
-getNativeOperation(Node* n);
-
-#define SUPPORTED_OPS(F) \
-  F(aten::__getitem__)   \
-  F(aten::add)           \
-  F(aten::addmm)         \
-  F(aten::bmm)           \
-  F(aten::cat)           \
-  F(aten::clamp)         \
-  F(aten::contiguous)    \
-  F(aten::div)           \
-  F(aten::flatten)       \
-  F(aten::index_put_)    \
-  F(aten::isnan)         \
-  F(aten::leaky_relu)    \
-  F(aten::matmul)        \
-  F(aten::mul)           \
-  F(aten::permute)       \
-  F(aten::relu)          \
-  F(aten::sigmoid)       \
-  F(aten::size)          \
-  F(aten::softmax)       \
-  F(aten::t)             \
-  F(aten::to)            \
-  F(aten::transpose)     \
-  F(aten::view)          \
-  F(prim::Constant)      \
-  F(prim::ListConstruct) \
-  F(prim::TupleConstruct)
+std::function<void(ProcessedNode*)> getNativeOperation(Node* n);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -40,6 +40,7 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
 }
 
 bool canRunOutOfPlace(Node* n);
+bool mustRunOutOfPlace(Node* n);
 bool canReuseInputs(Node* n);
 bool canReuseOutputs(Node* n);
 

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -26,23 +26,14 @@ C10_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 
 // TODO: reuse_inp reuse_out can be deprecated with further analysis
 // try to avoid this API.
-#define REGISTER_OPERATOR_FUNCTOR_OPT(name, id, reuse_inp, reuse_out, ...) \
-  struct SROperatorFunctor_##id : public SROperatorFunctor {               \
-    const SROpFunctor fn = __VA_ARGS__;                                    \
-    bool CanReuseInput() override {                                        \
-      return reuse_inp;                                                    \
-    }                                                                      \
-    bool CanReuseOutput() override {                                       \
-      return reuse_out;                                                    \
-    }                                                                      \
-    SROperator Generate(Node* n) override {                                \
-      return fn(n);                                                        \
-    }                                                                      \
-  };                                                                       \
+#define REGISTER_OPERATOR_FUNCTOR(name, id, ...)             \
+  struct SROperatorFunctor_##id : public SROperatorFunctor { \
+    const SROpFunctor fn = __VA_ARGS__;                      \
+    SROperator Generate(Node* n) override {                  \
+      return fn(n);                                          \
+    }                                                        \
+  };                                                         \
   C10_REGISTER_CLASS(SROperatorRegistry, name, SROperatorFunctor_##id);
-
-#define REGISTER_OPERATOR_FUNCTOR(name, id, ...) \
-  REGISTER_OPERATOR_FUNCTOR_OPT(name, id, true, true, __VA_ARGS__)
 
 inline at::Tensor create_empty_from(const at::Tensor& t) {
   return at::empty({0}, t.options());


### PR DESCRIPTION
Summary:
Removes ListConstruct from the graph and forces cat and stack to accept variable arguments

results on top of previous diff:
BS=1 P155702119 1.7% improvement (reduction of calls to listConstruct)
BS=20 P155703115 1.1% improvement (probably due to increased memonger opportunity)

results of full stack on top of master:
BS=1 P155712725 6.74% improvement
BS=20 P155711554  1.14% improvement

Test Plan: buck run mode/opt-clang caffe2/caffe2/fb/predictor:ptvsc2_predictor_bench

Differential Revision: D25285719

