### PR TITLE
[PyTorch] Specialize `list_element_from` for `IValue` to avoid extra move/copy

### DIFF
--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -216,7 +216,7 @@ void listConstruct(
         c10::List<IValue> vals(type->getElementType());
         vals.reserve(num_inputs);
         for (size_t i = stack.size() - num_inputs; i < stack.size(); ++i) {
-          vals.emplace_back(std::move(stack[i]));
+          vals.push_back(std::move(stack[i]));
         }
         drop(stack, num_inputs);
         return vals;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50124 [PyTorch] Specialize `list_element_from` for `IValue` to avoid extra move/copy**

This patch makes `list_element_from` avoid extra `IValue`
move/copies for `List<IValue>` by just forwarding the reference
argument.

We take advantage of this in `listConstruct` by using `push_back`
(which hits the `ListElementFrom` path) instead of `

Differential Revision: [D25794277](https://our.internmc.facebook.com/intern/diff/D25794277/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25794277/)!