### PR TITLE
Adding MyPy daemon status file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 .coverage
 coverage.xml
+.dmypy.json
 .gradle
 .hypothesis
 .mypy_cache


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50132 Adding MyPy daemon status file to gitignore**

When running mypy command using `dmypy run`, it creates a status file.
This PR adds the file to the ignore list.

Differential Revision: [D25834504](https://our.internmc.facebook.com/intern/diff/D25834504)