### PR TITLE
Fix #42271

### DIFF
--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -60,7 +60,7 @@ void THCTensor_(maskedCopy)(THCState* state,
              "mask and tensor must have the same number of elements");
 
   // Determine our output size
-  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
+  int64_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
 
   // The number of `1` elements present in the mask must be <= the
   // number of elements available in `src`
@@ -126,7 +126,7 @@ void THCTensor_(maskedCopyBool)(THCState* state,
              "mask and tensor must have the same number of elements");
 
   // Determine our output size
-  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
+  int64_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
 
   // The number of `1` elements present in the mask must be <= the
   // number of elements available in `src`

--- a/aten/src/THC/generic/THCTensorMasked.cu
+++ b/aten/src/THC/generic/THCTensorMasked.cu
@@ -60,7 +60,7 @@ void THCTensor_(maskedCopy)(THCState* state,
              "mask and tensor must have the same number of elements");
 
   // Determine our output size
-  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<ptrdiff_t>();
+  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
 
   // The number of `1` elements present in the mask must be <= the
   // number of elements available in `src`
@@ -126,7 +126,7 @@ void THCTensor_(maskedCopyBool)(THCState* state,
              "mask and tensor must have the same number of elements");
 
   // Determine our output size
-  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<ptrdiff_t>();
+  ptrdiff_t totalElements = THTensor_wrap(mask).sum().item<int64_t>();
 
   // The number of `1` elements present in the mask must be <= the
   // number of elements available in `src`


### PR DESCRIPTION
This pull fix #42271 by manually specifying template data type of `tensor<template>.item()` in `aten/src/THC/generic/THCTensorMasked.cu`.

Changes in submodules are not expected since I have pulled the latest submodules from the Pytorch master branch.
