### PR TITLE
[CUDA graphs] [JIT] Capture-safe RNG in nvfuser

### DIFF
--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -1,3 +1,4 @@
+#include <ATen/CUDAGeneratorImpl.h>
 #include <torch/csrc/jit/codegen/cuda/codegen.h>
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
@@ -86,7 +87,7 @@ class CudaKernelGenerator : private OptInConstDispatch {
 
     // Kernels generating random numbers take extra (seed, offset) arguments
     if (kernel_summary.is_stochastic) {
-      code_ << ", unsigned long long seed, unsigned long long offset";
+      code_ << ", at::PhiloxCudaState philox_args";
     }
 
     code_ << ") ";
@@ -99,7 +100,8 @@ class CudaKernelGenerator : private OptInConstDispatch {
     // Random number generator (optional)
     if (kernel_summary.is_stochastic) {
       indent() << "const int idx = blockIdx.x*blockDim.x + threadIdx.x;\n";
-      indent() << "Philox rnd(seed, idx, offset);\n";
+      indent() << "auto seeds = at::cuda::philox::unpack(philox_args)\n";
+      indent() << "Philox rnd(std::get<0>(seeds), idx, std::get<1>(seeds));\n";
     }
 
     // Do we have any dynamic shared memory buffers?

--- a/torch/csrc/jit/codegen/cuda/executor.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor.cpp
@@ -34,6 +34,9 @@ std::string FusionExecutor::getStructuredCode(const std::string& kernel) {
   code += std::string("namespace ") + FusionExecutor::kernelNamespace() +
       " {\n" + executor_utils::kernelPreamble() + kernel + "}\n";
 
+  // How to define PhiloxCudaState for nvrtc, first option:
+  // code += "#include <ATen/CUDAGeneratorImpl.h># here?
+
   const char* debug_env = std::getenv("PYTORCH_CUDA_FUSER_DEBUG");
   if (debug_env && atoi(debug_env)) {
     std::cout << "\n==== codegen output for kernel: " << kernelName()

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -74,6 +74,10 @@ void KernelArgumentHolder::push(const uint64_t& val) {
   arguments_.push_back(std::make_unique<ULongArg>(val));
 }
 
+void KernelArgumentHolder::push(const at::PhiloxCudaState& val) {
+  arguments_.push_back(std::make_unique<PhiloxCudaStateArg>(val));
+}
+
 // Create buffer, flatten arguments into it, align by 8 Bytes, return pointers
 // in the buffer
 void** KernelArgumentHolder::getBuffer() {
@@ -107,17 +111,16 @@ void KernelArgumentHolder::push(const std::vector<at::Tensor>& tensors) {
 }
 
 void KernelArgumentHolder::appendPhiloxRNGSeed(uint64_t rand_offset) {
-  std::pair<uint64_t, uint64_t> philox_engine_inputs;
+  at::PhiloxCudaState philox_engine_inputs;
   auto gen = at::cuda::detail::getDefaultCUDAGenerator();
   {
     // See Note [Acquire lock when using random generators]
     std::lock_guard<std::mutex> lock(gen.mutex());
     philox_engine_inputs =
-        at::check_generator<at::CUDAGeneratorImpl>(gen)->philox_engine_inputs(
+        at::check_generator<at::CUDAGeneratorImpl>(gen)->philox_cuda_state(
             rand_offset);
   }
-  push(philox_engine_inputs.first);
-  push(philox_engine_inputs.second);
+  push(philox_engine_inputs);
 }
 
 } // namespace cuda

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <ATen/CUDAGeneratorImpl.h>
 #include <c10/util/Exception.h>
 #include <torch/csrc/jit/ir/ir.h>
 
@@ -51,6 +52,14 @@ struct TensorArgCodegen<T, 0> {
 struct ArgAbstract {
   virtual ~ArgAbstract() {}
   virtual void* arg() = 0;
+};
+
+struct PhiloxCudaStateArg : public ArgAbstract {
+  at::PhiloxCudaState val_;
+  PhiloxCudaStateArg(at::PhiloxCudaState _val) : val_(_val){};
+  void* arg() {
+    return &val_;
+  }
 };
 
 struct ULongArg : public ArgAbstract {
@@ -155,6 +164,8 @@ class KernelArgumentHolder {
   void push(const IValue& val);
 
   void push(const uint64_t& val);
+
+  void push(const at::PhiloxCudaState& val);
 
   // Create buffer, flatten arguments into it, align by 8 Bytes, return pointers
   // in the buffer

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -39,6 +39,11 @@ std::string kernelPreamble() {
   ss << nvfuser_resources::block_reduction_cu;
   ss << nvfuser_resources::grid_reduction_cu;
   ss << nvfuser_resources::broadcast_cu;
+  // How to define PhiloxCudaState for nvtrc, another option:
+  // ss << nvfuser_resources::philox_cu
+  // with some corresponding file in torch/include/nvfuser_resources?
+  // If so, should that file contain a full definition of PhiloxCudaState somehow,
+  // or just "#include <ATen/CUDAGeneratorImpl.h>">?
 
   return ss.str();
 }


### PR DESCRIPTION
Update:  @csarofeen says he prefers nvfuser changes to move through his fork before moving into mainline.  Closing to submit nvfuser changes to his fork and the non-nvfuser (CUDAGeneratorImpl) changes as a separate PR.

**************

Eager mode RNG kernels needed some minor changes to interact safely with cuda graphs.  This PR extends those changes to the kernels generated by nvfuser.

One thing I'm unclear on is the best way to let NVRTC know the definition of PhiloxCudaState (defined in [ATen/CUDAGeneratorImpl.h](https://github.com/pytorch/pytorch/blob/74c055b24065d0202aecdf4bc837d3698d1639e1/aten/src/ATen/CUDAGeneratorImpl.h#L89)).  I suggested two options in comments ([1](https://github.com/pytorch/pytorch/compare/master...mcarilli:graphable_jit_rng?expand=1#diff-6f1e7ce30c1600288756ba97ab7b4324993d2959452d874f0d15e79a16e1f850R38), [2](https://github.com/pytorch/pytorch/compare/master...mcarilli:graphable_jit_rng?expand=1#diff-5e44e2a0e9a686349e4152cd3f1255ae55c3c208b22112f194144d8c6612f61aR42-R46)) but im not sure.

Another thing I'm unclear on is the best way to test these diffs.

Unrelated to graphs, this PR also fixes what I'm fairly sure is a subtle bug with custom "Philox" class usage in jitted kernels.  `Philox` [constructors in kernels](https://github.com/pytorch/pytorch/blob/68a6e4637903dba279c60daae5cff24e191ff9b4/torch/csrc/jit/codegen/cuda/codegen.cpp#L102) take the cuda rng generator's current offset.  The Philox constructor then carries out [`offset/4`](https://github.com/pytorch/pytorch/blob/74c055b24065d0202aecdf4bc837d3698d1639e1/torch/csrc/jit/codegen/cuda/runtime/random_numbers.cu#L13) (a uint64_t division) to compute its internal offset in its virtual Philox bitstream of 128-bit chunks.  In other words, it assumes the incoming offset is a multiple of 4.  But (in current code) that's not guaranteed.  For example, the increments used by [these eager kernels](https://github.com/pytorch/pytorch/blob/74c055b24065d0202aecdf4bc837d3698d1639e1/aten/src/ATen/native/cuda/Distributions.cu#L171-L216) could easily make offset not divisible by 4.  I figured the easiest fix** was to round all incoming increments up to the nearest multiple of 4 in CUDAGeneratorImpl itself.

** Another option would be to round the current offset up to the next multiple of 4 at the jit point of use.  But that would be a jit-specific offset jump, so jit rng kernels wouldn't have a prayer of being bitwise accurate with eager rng kernels that used non-multiple-of-4 offsets.  Restricting the offset to multiples of 4 for everyone at least gives jit rng the chance to match eager rng.  (Of course, there are still many other ways the numerics could diverge, like if a jit kernel launches a different number of threads than an eager kernel, or assigns threads to data elements differently.)