### PR TITLE
[PyTorch] typeid: ensmallen scalarTypeItemSizes

### DIFF
--- a/c10/util/typeid.h
+++ b/c10/util/typeid.h
@@ -309,7 +309,7 @@ class _Uninitialized final {};
 //
 
 // item sizes for TypeMeta::itemsize() fast path
-static constexpr size_t scalarTypeItemSizes[NumScalarTypes] = {
+static constexpr uint8_t scalarTypeItemSizes[NumScalarTypes] = {
 #define SCALAR_TYPE_SIZE(T, name) sizeof(T),
   AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS(SCALAR_TYPE_SIZE)
 #undef SCALAR_TYPE_SIZE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50165 [PyTorch] typeid: ensmallen scalarTypeItemSizes**

There are currently 17 types, so this used to stretch across 3 cache lines and now it fits in one. All the types in question seem to be way under 255 bytes in size anyway.

Differential Revision: [D25813574](https://our.internmc.facebook.com/intern/diff/D25813574/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25813574/)!