### PR TITLE
NOCOMMIT: validate in prod builds that SparseTensorImpl::dim needn't be overridden

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -70,6 +70,7 @@ void SparseTensorImpl::set_storage_offset(int64_t storage_offset) {
 }
 
 int64_t SparseTensorImpl::dim() const {
+  TORCH_INTERNAL_ASSERT(sparse_dim_ + dense_dim_ == TensorImpl::dim());
   return sparse_dim_ + dense_dim_;
 }
 bool SparseTensorImpl::has_storage() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50172 NOCOMMIT: validate in prod builds that SparseTensorImpl::dim needn't be overridden**
* #49766 [PyTorch] Devirtualize TensorImpl::numel() with macro

By request on D25686830

Differential Revision: [D25815636](https://our.internmc.facebook.com/intern/diff/D25815636/)