### PR TITLE
Unused exception variables

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -80,7 +80,7 @@ def createResolutionCallbackFromEnv(lookup_base):
             value, len_parsed = parseNestedExpr(expr, module)
             assert len_parsed == len(expr), "whole expression was not parsed, falling back to c++ parser"
             return value
-        except Exception as e:
+        except Exception:
             """
             The python resolver fails in several cases in known unit tests, and is intended
             to fall back gracefully to the c++ resolver in general.  For example, python 2 style

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -295,7 +295,7 @@ def main():
                 print(f"Killing subprocess {process.pid}")
                 try:
                     process.kill()
-                except Exception as e:
+                except Exception:
                     pass
             if last_return_code is not None:
                 raise subprocess.CalledProcessError(returncode=last_return_code, cmd=cmd)

--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -381,7 +381,7 @@ try:
     # Combine the implementation class and the type class.
     class RRef(PyRRef, Generic[T]):
         pass
-except TypeError as exc:
+except TypeError:
     # TypeError: metaclass conflict: the metaclass of a derived class
     # must be a (non-strict) subclass of the metaclasses of all its bases
     # Mypy doesn't understand __class__ (mypy bug #4177)


### PR DESCRIPTION
These unused variables were identified by [pyflakes](https://pypi.org/project/pyflakes/). They can be safely removed to simplify the code.