### PR TITLE
Save memory by using a random permutation generator for sampler indices

### DIFF
--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -129,7 +129,7 @@ class TestDatasetRandomSplit(TestCase):
     def test_splits_reproducibility(self):
         self.assertEqual(
             [list(x) for x in random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(1))],
-            [[5, 6, 1], [2, 0, 8, 9, 3, 7, 4]],
+            [[3, 8, 7], [9, 5, 2, 4, 0, 6, 1]],
         )
         self.assertEqual(
             random_split(range(100), [60, 40], generator=torch.Generator().manual_seed(42)),

--- a/test/test_index_utils.py
+++ b/test/test_index_utils.py
@@ -1,0 +1,105 @@
+from bitarray import bitarray
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.utils.data._utils.index_utils import Range, Permutation
+
+
+class TestRange(TestCase):
+
+    def test_slicing(self):
+        self.assertEqual(list(Range(10)[0:20:2]),
+                         [0, 2, 4, 6, 8, 0, 2, 4, 6, 8])
+
+        self.assertEqual(list(Range(20)[0:20:2][0:10:2]),
+                         [0, 4, 8, 12, 16])
+
+    def test_size_0(self):
+        self.assertEqual(list(Range(0)), [])
+
+    def test_size_0_stop_nonzero(self):
+        with self.assertRaises(ValueError):
+            self.assertEqual(list(Range(0, stop=10)), [])
+
+    def test_size_1(self):
+        self.assertEqual(list(Range(1)), [0])
+        self.assertEqual(list(Range(1, stop=3)), [0, 0, 0])
+
+
+class TestPermutation(TestCase):
+
+    def test_slicing(self):
+        self.assertEqual(list(Permutation(10, 42, stop=20)[::2]),
+                         [7, 4, 9, 8, 0, 7, 4, 9, 8, 0])
+
+        self.assertEqual(list(Permutation(10, 42, stop=20)[::2][0:10:2]),
+                         [7, 9, 0, 4, 8])
+
+    def test_size_0(self):
+        self._test_exhaustiveness(0, 0)
+
+    def test_size_1(self):
+        self._test_exhaustiveness(1, 0)
+
+    def test_small_values(self):
+        for i in range(100):
+            for s in range(i):
+                self._test_exhaustiveness(i, s)
+
+    def test_large_value(self):
+        size = 195036
+        seed = 42
+        seq = Permutation(size, seed)
+
+        visited = bitarray(size)
+        visited.setall(False)
+        for i in range(len(seq)):
+            value = seq[i]
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert visited.all()
+
+        visited.setall(False)
+        for value in seq:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert visited.all()
+
+        visited.setall(False)
+        for value in seq[:size // 2]:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert len(seq[:size // 2]) == size // 2
+        for value in seq[size // 2:]:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert visited.all()
+
+        visited.setall(False)
+        for value in seq[0:size:2]:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert len(seq[0:size:2]) == size // 2
+        for value in seq[1:size:2]:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert visited.all()
+
+    def _test_exhaustiveness(self, size, seed):
+        seq = Permutation(size, seed)
+        visited = bitarray(size)
+        visited.setall(False)
+        for value in seq:
+            if visited[value]:
+                raise Exception
+            visited[value] = True
+        assert visited.all()
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/utils/data/_utils/index_utils.py
+++ b/torch/utils/data/_utils/index_utils.py
@@ -1,0 +1,150 @@
+from math import sqrt, floor
+
+
+class Range:
+    size: int
+
+    # for slicing
+    start: int
+    stop: int
+    step: int
+
+    # for iterating
+    index: int
+
+    def __init__(self, size: int, start: int = None, stop: int = None, step: int = None):
+        self.size = size
+        self.start = start if start is not None else 0
+        self.stop = stop if stop is not None else size
+        self.step = step if step is not None else 1
+        if not (0 <= self.start <= self.stop):
+            raise ValueError('not (0 <= start <= stop)')
+        if self.stop > self.size:
+            pass  # Allow wrap-around
+        if self.step <= 0:
+            raise ValueError('step <= 0')
+        if (size == 0) != (len(self) == 0):
+            raise ValueError('if size==0 then stop-start must also be 0')
+
+    def __len__(self):
+        if self.start == self.stop:
+            return 0
+        return (self.stop - self.start - 1) // self.step + 1
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            sl = slice(index.start if index.start is not None else 0,
+                       index.stop if index.stop is not None else len(self),
+                       index.step if index.step is not None else 1)
+            if not (0 <= sl.start and sl.start <= sl.stop and 0 < sl.step):
+                raise IndexError
+            return self._slice(sl)
+
+        if not 0 <= index < len(self):
+            raise IndexError
+
+        abs_index = (self.start + index * self.step) % self.size
+
+        return self._get(abs_index)
+
+    def __iter__(self):
+        self.index = 0
+        return self
+
+    def __next__(self):
+        if self.index == len(self):
+            raise StopIteration
+        next = self[self.index]
+        self.index = self.index + 1
+        return next
+
+    def _get(self, index):
+        return index
+
+    def _slice(self, sl):
+        return Range(self.size,
+                     self.start + sl.start * self.step,
+                     self.start + sl.stop * self.step,
+                     self.step * sl.step)
+
+
+# We can use a faster primehood test, but there is no readily available implementation.
+# But even this brute-force test is reasonably fast, O(sqrt(n))
+def _is_prime(n):
+    if n == 2:
+        return True
+    if n == 1 or n % 2 == 0:
+        return False
+
+    for d in range(3, floor(sqrt(n)) + 1, 2):  # can use isqrt in Python 3.8
+        if n % d == 0:
+            return False
+
+    return True
+
+
+class Permutation(Range):
+    """
+    Generates a random permutation of integers from 0 up to size.
+    Inspired by https://preshing.com/20121224/how-to-generate-a-sequence-of-unique-random-integers/
+    """
+
+    prime: int
+    seed: int
+
+    def __init__(self, size: int, seed: int, start: int = None, stop: int = None, step: int = None, _prime: int = None):
+        super().__init__(size, start, stop, step)
+        self.prime = self._get_prime(size) if _prime is None else _prime
+        self.seed = seed % self.prime
+
+    def _get(self, index):
+        x = self._map(index)
+
+        while x >= self.size:
+            # If we map to a number greater than size, then the cycle of successive mappings must eventually result
+            # in a number less than size. Proof: The cycle of successive mappings traces a path
+            # that either always stays in the set n>=size or it enters and leaves it,
+            # else the 1:1 mapping would be violated (two numbers would map to the same number).
+            # Moreover, `set(range(size)) - set(map(n) for n in range(size) if map(n) < size)`
+            # equals the `set(map(n) for n in range(size, prime) if map(n) < size)`
+            # because the total mapping is exhaustive.
+            # Which means we'll arrive at a number that wasn't mapped to by any other valid index.
+            # This will take at most `prime-size` steps, and `prime-size` is on the order of log(size), so fast.
+            # But usually we just need to remap once.
+            x = self._map(x)
+
+        return x
+
+    def _slice(self, sl):
+        return Permutation(self.size,
+                           self.seed,
+                           self.start + sl.start * self.step,
+                           self.start + sl.stop * self.step,
+                           self.step * sl.step,
+                           self.prime)
+
+    @staticmethod
+    def _get_prime(size):
+        """
+        Returns the prime number >= size which has the form (4n-1)
+        """
+        n = size + (3 - size % 4)
+        while not _is_prime(n):
+            # We expect to find a prime after O(log(size)) iterations
+            # Using a brute-force primehood test, total complexity is O(log(size)*sqrt(size)), which is pretty good.
+            n = n + 4
+        return n
+
+    def _map(self, index):
+        a = self._permute_qpr(index)
+        b = (a + self.seed) % self.prime
+        c = self._permute_qpr(b)
+        return c
+
+    def _permute_qpr(self, x):
+        residue = pow(x, 2, self.prime)
+
+        if x * 2 < self.prime:
+            return residue
+        else:
+            return self.prime - residue

--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -5,6 +5,7 @@ import torch
 from . import Sampler, Dataset
 import torch.distributed as dist
 
+from ._utils import index_utils
 
 T_co = TypeVar('T_co', covariant=True)
 
@@ -76,43 +77,31 @@ class DistributedSampler(Sampler[T_co]):
         self.rank = rank
         self.epoch = 0
         self.drop_last = drop_last
+        # `type:ignore` is required because Dataset cannot provide a default __len__
+        # see NOTE in pytorch/torch/utils/data/sampler.py
+        self.dataset_size = len(self.dataset)  # type: ignore
         # If the dataset length is evenly divisible by # of replicas, then there
         # is no need to drop any data, since the dataset will be split equally.
-        if self.drop_last and len(self.dataset) % self.num_replicas != 0:  # type: ignore
+        if self.drop_last and self.dataset_size % self.num_replicas != 0:
             # Split to nearest available length that is evenly divisible.
             # This is to ensure each rank receives the same amount of data when
             # using this Sampler.
-            self.num_samples = math.ceil(
-                # `type:ignore` is required because Dataset cannot provide a default __len__
-                # see NOTE in pytorch/torch/utils/data/sampler.py
-                (len(self.dataset) - self.num_replicas) / self.num_replicas  # type: ignore
-            )
+            self.num_samples = math.ceil((self.dataset_size - self.num_replicas) / self.num_replicas)
         else:
-            self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)  # type: ignore
+            self.num_samples = math.ceil(self.dataset_size / self.num_replicas)
         self.total_size = self.num_samples * self.num_replicas
         self.shuffle = shuffle
         self.seed = seed
 
     def __iter__(self) -> Iterator[T_co]:
-        if self.shuffle:
+        if not self.shuffle:
+            indices = index_utils.Range(self.dataset_size, stop=self.total_size)
+        else:
             # deterministically shuffle based on epoch and seed
             g = torch.Generator()
             g.manual_seed(self.seed + self.epoch)
-            indices = torch.randperm(len(self.dataset), generator=g).tolist()  # type: ignore
-        else:
-            indices = list(range(len(self.dataset)))  # type: ignore
-
-        if not self.drop_last:
-            # add extra samples to make it evenly divisible
-            padding_size = self.total_size - len(indices)
-            if padding_size <= len(indices):
-                indices += indices[:padding_size]
-            else:
-                indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
-        else:
-            # remove tail of data to make it evenly divisible.
-            indices = indices[:self.total_size]
-        assert len(indices) == self.total_size
+            seed = int(torch.randint(high=self.dataset_size, size=(1,), dtype=torch.int64, generator=g).item())
+            indices = index_utils.Permutation(self.dataset_size, seed, stop=self.total_size)
 
         # subsample
         indices = indices[self.rank:self.total_size:self.num_replicas]


### PR DESCRIPTION
Fixes #50201

Inspired by https://preshing.com/20121224/how-to-generate-a-sequence-of-unique-random-integers/

The Permutation class passes TestU01 Rabbit and Alphabit tests.