### PR TITLE
caffe2 test.sh pip might not need sudo if pip is root

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -84,7 +84,8 @@ fi
 # CircleCI docker images could install conda as jenkins user, or use the OS's python package.
 PIP=$(which pip)
 PIP_USER=$(stat --format '%U' $PIP)
-if [[ "$PIP_USER" = root ]]; then
+CURRENT_USER=$(id -u -n)
+if [[ "$PIP_USER" = root && "$CURRENT_USER" != root ]]; then
   MAYBE_SUDO=sudo
 fi
 


### PR DESCRIPTION
Update logic in MAYBE_SUDO check. Assumption was incorrect that if pip
was installed as user then sudo is needed. pip could be installed as
root and run as root. Assumption was initially pip was root and user was
non root.
