### PR TITLE
Faster strides check

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -102,8 +102,8 @@ namespace c10 {
   _(aten, backward)                  \
   _(prim, Guard)                     \
   _(prim, BailOut)                   \
-  _(prim, TypeCheck)                 \
   _(prim, RequiresGradCheck)         \
+  _(prim, CompleteTypeCheck)         \
   _(prim, FallbackGraph)             \
   _(prim, FusedConcat)               \
   _(prim, ConstantChunk)             \

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -581,8 +581,6 @@ struct TORCH_API TensorType : public Type {
 
   TensorTypePtr merge(const TensorType& other, bool merge_sizes = true) const;
 
-  bool matchTensor(const at::Tensor& t);
-
   // is all information about the type specified except for autograd?
   // This replaces the notion of a 'CompleteTensorType' that used to exist
   // in the type-hierarchy. Excluding require_grad and undefined allows
@@ -643,6 +641,11 @@ struct TORCH_API TensorType : public Type {
     return strides;
   }
 
+  static VaryingShape<Stride> computeStrideProps(
+    at::IntArrayRef sizes,
+    at::IntArrayRef strides,
+    bool tensor_contiguity = false);
+
  private:
   TensorType(
       c10::optional<at::ScalarType> scalar_type,
@@ -656,11 +659,6 @@ struct TORCH_API TensorType : public Type {
     return TensorTypePtr(new TensorType(
         scalar_type_, device_, sizes_, strides_, requires_grad_, undefined_));
   }
-
-  static VaryingShape<Stride> computeStrideProps(
-      at::IntArrayRef sizes,
-      at::IntArrayRef strides,
-      bool tensor_contiguity = false);
 
   c10::optional<at::ScalarType> scalar_type_;
   c10::optional<at::Device> device_;

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -599,37 +599,6 @@ TensorTypePtr TensorType::merge(const TensorType& other, bool merge_sizes) const
       undef);
 }
 
-template <typename T>
-bool is_null_or_equal(c10::optional<T> a, c10::IntArrayRef b) {
-  return !a.has_value() || a.value() == b;
-}
-
-bool TensorType::matchTensor(const at::Tensor& t) {
-  bool undef = undefined().value_or(!t.defined());
-  if (undef != !t.defined()) {
-    // When the followings are true, we consider it's not a match:
-    // - undefined().has_value() == true
-    // - undefined().value() != !t.defined()
-    return false;
-  } else if (!t.defined()) {
-    // When the followings are true, we consider it's a match:
-    // - t is not defined
-    // - undefined() == null or undefined().value() == true
-    return true;
-  }
-  // Here we know t.defined() == true and compare all other properties.
-  bool rg = at::GradMode::is_enabled() && t.requires_grad();
-  bool matched_strides = (!stride_properties().size()) ||
-      (!t.has_storage() && !stride_properties().isComplete()) ||
-      stride_properties() ==
-          computeStrideProps(t.sizes(), t.strides(), t.is_contiguous());
-  return scalarType().value_or(t.scalar_type()) == t.scalar_type()
-    && device().value_or(t.device()) == t.device()
-    && requiresGrad().value_or(rg) == rg
-    && matched_strides
-    && is_null_or_equal(sizes().concrete_sizes(), t.sizes());
-}
-
 bool TensorType::operator==(const c10::Type& rhs) const {
   if (rhs.kind() != kind()) {
     return false;

--- a/test/cpp/jit/test_interpreter.cpp
+++ b/test/cpp/jit/test_interpreter.cpp
@@ -23,7 +23,7 @@ class TypeCheckTest : public ::testing::Test {
         R"IR(
 graph(%a.1 : Tensor,
       %b.1 : Tensor):
-  %t0 : Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::TypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
+  %t0 : Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), %t1 : Float(3, 3, strides=[3, 1]), %type_matched : bool = prim::CompleteTypeCheck[types=[Float(2, 2, strides=[2, 1], device=cpu, requires_grad=1), Float(3, 3, strides=[3, 1])]](%a.1, %b.1)
   return (%t0, %t1, %type_matched)
   )IR",
         &*graph,
@@ -35,7 +35,7 @@ graph(%a.1 : Tensor,
 };
 
 TEST_F(TypeCheckTest, MatchingType) {
-  // TypeCheck yields to true! Shape, grad and device matches.
+  // CompleteTypeCheck yields to true! Shape, grad and device matches.
   auto a = at::zeros({2, 2}, at::kFloat);
   auto b = at::ones({3, 3}, at::kFloat);
   a.set_requires_grad(true);
@@ -97,7 +97,7 @@ TEST_F(TypeCheckTest, DeviceMismatch_CUDA) {
 //       R"IR(
 // graph(%a.1 : Tensor,
 //       %b.1 : Tensor):
-//   %type_matched : bool = prim::TypeCheck()
+//   %type_matched : bool = prim::CompleteTypeCheck()
 //   return (%type_matched)
 //   )IR",
 //       &*graph,
@@ -113,7 +113,7 @@ TEST_F(TypeCheckTest, DeviceMismatch_CUDA) {
 //       R"IR(
 // graph(%a.1 : Tensor,
 //       %b.1 : Tensor):
-//   %type_matched : bool = prim::TypeCheck(%a.1)
+//   %type_matched : bool = prim::CompleteTypeCheck(%a.1)
 //   return (%type_matched)
 //   )IR",
 //       &*graph,

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -117,8 +117,7 @@ class TestProfiler(JitTestCase):
 
         g = torch.jit.last_executed_optimized_graph()
         # Types should remain specialized for typecheck outputs & fusion outputs
-        FileCheck().check("Double(").check_same("prim::TypeCheck").check_same("\n").check("Double").check_same("TensorExpr").run(g)
-
+        FileCheck().check("Double(").check_same("prim::CompleteTypeCheck").check_same("\n").check("Double").check_same("TensorExpr").run(g)
         # other outputs should not be specialized
         FileCheck().check("Tensor = prim::If").run(g)
 
@@ -136,7 +135,7 @@ class TestProfiler(JitTestCase):
         foo(x, y)
         b = foo(x, y)
         g = torch.jit.last_executed_optimized_graph()
-        self.assertEqual(len(list(g.findAllNodes("prim::TypeCheck"))), 2)
+        self.assertEqual(len(list(g.findAllNodes("prim::CompleteTypeCheck"))), 2)
         FileCheck().check("TensorExpr").check("aten::add_").check("TensorExpr").run(g)
 
     def test_use_not_profiled(self):

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -599,7 +599,7 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::profile:
       makePointerTo(node->output(), node->inputs().at(0));
       return;
-    case prim::TypeCheck:
+    case prim::CompleteTypeCheck:
     case prim::RequiresGradCheck: {
       auto num_inputs = node->inputs().size();
       for (size_t i = 0; i < num_inputs; i++) {

--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -20,7 +20,7 @@ bool canRunWithAutograd(Node* node) {
     }
   }
   return kind != prim::FusionGroup && kind != prim::CudaFusionGroup &&
-      kind != prim::TypeCheck && kind != prim::TensorExprGroup &&
+      kind != prim::CompleteTypeCheck && kind != prim::TensorExprGroup &&
       kind != prim::CudaFusionGuard && (kind.is_aten() || kind.is_prim());
 }
 

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -315,10 +315,10 @@ void removeTensorTypeSpecialization(Value* v) {
     return;
   }
   // Constants & TensorExprGroup will always produce specialized tensor type,
-  // TypeCheck are inserted by this pass and only used by fusion groups that
-  // insert proper guards
+  // CompleteTypeCheck are inserted by this pass and only used by fusion groups
+  // that insert proper guards
   if (v->node()->kind() == prim::Constant ||
-      v->node()->kind() == prim::TypeCheck ||
+      v->node()->kind() == prim::CompleteTypeCheck ||
       v->node()->kind() == prim::TensorExprGroup) {
     return;
   }
@@ -1109,7 +1109,7 @@ class TensorExprFuser {
       insertTypeGuard(
           fusion_group,
           [](const TensorTypePtr& t) { return t; },
-          prim::TypeCheck);
+          prim::CompleteTypeCheck);
     }
   }
 

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -247,7 +247,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::Store, // used in interpreter only
       prim::profile, // used in interpreter only
       prim::profile_ivalue, // used in interpreter only
-      prim::TypeCheck, // used in interpreter only
+      prim::CompleteTypeCheck, // used in interpreter only
       prim::RequiresGradCheck, // used in interpreter only
       prim::FallbackGraph, // converted into prim::CallFunction
 
@@ -307,7 +307,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::SetAttr,
       prim::profile,
       prim::profile_ivalue,
-      prim::TypeCheck,
+      prim::CompleteTypeCheck,
       prim::RequiresGradCheck,
       prim::Print,
       prim::CallFunction,

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -82,10 +82,10 @@ RegisterOperators reg(
          },
          aliasAnalysisSpecialCase()),
      Operator(
-         prim::TypeCheck /* (...)  -> (..., bool) */,
+         prim::CompleteTypeCheck /* (...)  -> (..., bool) */,
          [](const Node* /* node */) -> Operation {
            return [](Stack* /* stack */) {
-             AT_ERROR("prim::TypeCheck not yet implemented"); // NOLINT
+             AT_ERROR("prim::CompleteTypeCheck not yet implemented"); // NOLINT
            };
          },
          aliasAnalysisSpecialCase()),

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -155,6 +155,10 @@ class JitTestCase(JitCommonTestCase):
 
         allowed_nodes = {'prim::Constant', FUSION_GROUP, 'prim::BailoutTemplate',
                          'prim::TupleConstruct', 'prim::If', 'prim::CompleteTypeCheck', 'prim::RequiresGradCheck'} | set(except_for)
+        fusion_groups : Dict[torch._C.Block, List[torch._C.Node]] = defaultdict(list)
+        get_nodes_and_parents_recursively(graph, FUSION_GROUP, fusion_groups)
+        self.assertTrue(len(fusion_groups) == 1, 'got {}'.format(graph))
+        (graph, fusion_nodes) = list(fusion_groups.items())[0]
         # the block contains one FUSION_GROUP and the rest of nodes are `allowed_nodes`
         self.assertTrue(len(fusion_nodes) == 1, 'got {}'.format(graph))
         self.assertTrue(all(node.kind() in allowed_nodes for node in graph.nodes()),

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -146,7 +146,7 @@ class JitTestCase(JitCommonTestCase):
                 elif node.kind() == 'prim::DifferentiableGraph':
                     get_nodes_and_parents_recursively(node.g('Subgraph'), kind, acc)
                 elif node.kind() == 'prim::If' and (node.inputs().__next__().node().kind() == 'aten::all' or
-                                                    node.inputs().__next__().node().kind() == 'prim::TypeCheck' or 
+                                                    node.inputs().__next__().node().kind() == 'prim::CompleteTypeCheck' or 
                                                     node.inputs().__next__().node().kind() == 'prim::RequiresGradCheck'):
                     get_nodes_and_parents_recursively(node.blocks().__next__(), kind, acc)
                 else:
@@ -154,12 +154,7 @@ class JitTestCase(JitCommonTestCase):
                         get_nodes_and_parents_recursively(inner_block, kind, acc)
 
         allowed_nodes = {'prim::Constant', FUSION_GROUP, 'prim::BailoutTemplate',
-                         'prim::TupleConstruct', 'prim::If', 'prim::TypeCheck', 'prim::RequiresGradCheck'} | set(except_for)
-
-        fusion_groups : Dict[torch._C.Block, List[torch._C.Node]] = defaultdict(list)
-        get_nodes_and_parents_recursively(graph, FUSION_GROUP, fusion_groups)
-        self.assertTrue(len(fusion_groups) == 1, 'got {}'.format(graph))
-        (graph, fusion_nodes) = list(fusion_groups.items())[0]
+                         'prim::TupleConstruct', 'prim::If', 'prim::CompleteTypeCheck', 'prim::RequiresGradCheck'} | set(except_for)
         # the block contains one FUSION_GROUP and the rest of nodes are `allowed_nodes`
         self.assertTrue(len(fusion_nodes) == 1, 'got {}'.format(graph))
         self.assertTrue(all(node.kind() in allowed_nodes for node in graph.nodes()),


### PR DESCRIPTION
This speeds up a TypeCheck by 5% on the following microbenchmark: https://gitlab.com/-/snippets/2058334
We make sure we don't compute strides unless absolutely necessary and arrange checks in the order they are most likely to fail.