### PR TITLE
Improve upon CUDA NVCC flags

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -486,6 +486,7 @@ if(MSVC)
   list(APPEND CUDA_NVCC_FLAGS "--no-host-device-move-forward")
 else()
   list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
+  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "--std=c++14")
   list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-fPIC")
 endif()
 


### PR DESCRIPTION
Seems like the CUDA NVCC flags `-std=c++14` sometimes not recognize correctly. Setting additional `-Xcompiler --std=c++14`