### PR TITLE
Check CUDA kernel launches in caffe2/caffe2/utils/math

### DIFF
--- a/caffe2/utils/math/broadcast.cu
+++ b/caffe2/utils/math/broadcast.cu
@@ -83,6 +83,7 @@ __global__ void AffineChannelNHWCCUDAKernel<float>(
     AffineChannelNCHWCUDAKernel<T>                                           \
         <<<N * C * M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(  \
             C, M, HxW, X, scale, bias, Y);                                   \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                          \
   }                                                                          \
   template <>                                                                \
   CAFFE2_CUDA_EXPORT void AffineChannel<T, CUDAContext, StorageOrder::NHWC>( \
@@ -100,6 +101,7 @@ __global__ void AffineChannelNHWCCUDAKernel<float>(
            CAFFE_CUDA_NUM_THREADS,                                           \
            0,                                                                \
            context->cuda_stream()>>>(C, X, scale, bias, Y);                  \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                          \
   }
 CAFFE2_SPECIALIZED_CUDA_AFFINE_CHANNEL(float)
 #undef CAFFE2_SPECIALIZED_CUDA_AFFINE_CHANNEL

--- a/caffe2/utils/math/elementwise.cu
+++ b/caffe2/utils/math/elementwise.cu
@@ -417,6 +417,7 @@ DELEGATE_CUDA_POWX(float, powf)
       SinCosCUDAKernel<T>                                             \
           <<<K, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>( \
               N, X, S, C);                                            \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                 \
     }                                                                 \
   }
 CAFFE2_SPECIALIZED_CUDA_SINCOS(float)
@@ -443,6 +444,7 @@ CAFFE2_SPECIALIZED_CUDA_SINCOS(double)
       ScaleCUDAKernel<T, T>                                                  \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, alpha, X, Y);                                               \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }                                                                          \
   template <>                                                                \
@@ -464,6 +466,7 @@ CAFFE2_SPECIALIZED_CUDA_SINCOS(double)
       ScaleCUDAKernel<T, T>                                                  \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, alpha, X, Y);                                               \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }
 DELEGATE_CUDA_SCALE(float, cublasSscal)
@@ -501,6 +504,7 @@ DELEGATE_CUDA_SCALE(double, cublasDscal)
       ScaleCUDAKernel<TAlpha, TData>                                         \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, alpha, X, Y);                                               \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }                                                                          \
   template <>                                                                \
@@ -530,6 +534,7 @@ DELEGATE_CUDA_SCALE(double, cublasDscal)
       ScaleCUDAKernel<TAlpha, TData>                                         \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, alpha, X, Y);                                               \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }
 DELEGATE_CUDA_SCALE_EX(float, double, CUDA_R_32F, CUDA_R_64F, CUDA_R_64F)
@@ -551,6 +556,7 @@ DELEGATE_CUDA_SCALE_EX(float, at::Half, CUDA_R_32F, CUDA_R_16F, CUDA_R_32F)
       ScaleCUDAKernel<TAlpha, TData>                                         \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, alpha, X, Y);                                               \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }                                                                          \
   template <>                                                                \
@@ -565,6 +571,7 @@ DELEGATE_CUDA_SCALE_EX(float, at::Half, CUDA_R_32F, CUDA_R_16F, CUDA_R_32F)
       ScaleCUDAKernel<TAlpha, TData>                                         \
           <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
               N, *alpha, X, Y);                                              \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
     }                                                                        \
   }
 CAFFE2_SPECIALIZED_CUDA_SCALE(std::int32_t, std::int32_t)
@@ -852,6 +859,7 @@ DELEGATE_CUDA_AXPY_EX(float, at::Half, CUDA_R_32F, CUDA_R_16F, CUDA_R_32F)
     AxpyCUDAKernel<TAlpha, TData>                                          \
         <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
             N, alpha, X, Y);                                               \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
   }                                                                        \
   template <>                                                              \
   CAFFE2_CUDA_EXPORT void Axpy<TAlpha, TData, CUDAContext>(                \
@@ -864,6 +872,7 @@ DELEGATE_CUDA_AXPY_EX(float, at::Half, CUDA_R_32F, CUDA_R_16F, CUDA_R_32F)
     AxpyCUDAKernel<TAlpha, TData>                                          \
         <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
             N, alpha, X, Y);                                               \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
   }
 CAFFE2_SPECIALIZED_CUDA_AXPY(float, double)
 CAFFE2_SPECIALIZED_CUDA_AXPY(float, at::Half)
@@ -884,6 +893,7 @@ CAFFE2_SPECIALIZED_CUDA_AXPY(float, at::Half)
     AxpbyCUDAKernel<TAlpha, TData>                                         \
         <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
             N, alpha, X, beta, Y);                                         \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
   }                                                                        \
   template <>                                                              \
   CAFFE2_CUDA_EXPORT void Axpby<TAlpha, TData, CUDAContext>(               \
@@ -897,6 +907,7 @@ CAFFE2_SPECIALIZED_CUDA_AXPY(float, at::Half)
     AxpbyCUDAKernel<TAlpha, TData>                                         \
         <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(        \
             N, alpha, X, beta, Y);                                         \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                        \
   }
 CAFFE2_SPECIALIZED_CUDA_AXPBY(float, float)
 CAFFE2_SPECIALIZED_CUDA_AXPBY(float, double)

--- a/caffe2/utils/math/reduce.cu
+++ b/caffe2/utils/math/reduce.cu
@@ -156,6 +156,7 @@ void ReduceTensorCUDAImpl(
   ReduceTensorCUDAKernel<T, Reducer, D>
       <<<outer_size, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
           inner_size, X_strides, Y_dims, reducer, init, alpha, X, Y);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename T, class Reducer>
@@ -188,12 +189,14 @@ void ReduceTensorCUDA(
     RowwiseReduceCUDAKernel<T, Reducer>
         <<<rows, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
             cols, reducer, init, alpha, X, Y);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return;
   }
   if (utils::IsColwiseReduce(ndim, X_dims, Y_dims, &rows, &cols)) {
     ColwiseReduceCUDAKernel<T, Reducer>
         <<<cols, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
             rows, cols, reducer, init, alpha, X, Y);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return;
   }
   int M;
@@ -393,6 +396,7 @@ void MomentsCUDAImpl(
   MomentsCUDAKernel<T, D>
       <<<outer_size, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
           inner_size, X_strides, Y_dims, X, mean, var);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <typename T>
@@ -430,12 +434,14 @@ void MomentsCUDA(
     RowwiseMomentsCUDAKernel<T>
         <<<rows, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
             cols, X, mean, var);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return;
   }
   if (utils::IsColwiseReduce(ndim, X_dims, Y_dims, &rows, &cols)) {
     ColwiseMomentsCUDAKernel<T>
         <<<cols, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
             rows, cols, X, mean, var);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return;
   }
   int M;

--- a/caffe2/utils/math/reduce.cuh
+++ b/caffe2/utils/math/reduce.cuh
@@ -21,12 +21,16 @@ using BlockReduce2D = cub::
     if (size >= 128) {                                                        \
       Func<T, 1, 128>                                                         \
           <<<grid_dim, dim3(1, 128), 0, cuda_stream>>>(__VA_ARGS__);          \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
     } else if (size >= 64) {                                                  \
       Func<T, 2, 64><<<grid_dim, dim3(2, 64), 0, cuda_stream>>>(__VA_ARGS__); \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
     } else if (size >= 32) {                                                  \
       Func<T, 4, 32><<<grid_dim, dim3(4, 32), 0, cuda_stream>>>(__VA_ARGS__); \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
     } else {                                                                  \
       Func<T, 8, 16><<<grid_dim, dim3(8, 16), 0, cuda_stream>>>(__VA_ARGS__); \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                         \
     }                                                                         \
   } while (false)
 
@@ -36,15 +40,19 @@ using BlockReduce2D = cub::
     if (size >= 128) {                                               \
       Func<T1, T2, 1, 128>                                           \
           <<<grid_dim, dim3(1, 128), 0, cuda_stream>>>(__VA_ARGS__); \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                \
     } else if (size >= 64) {                                         \
       Func<T1, T2, 2, 64>                                            \
           <<<grid_dim, dim3(2, 64), 0, cuda_stream>>>(__VA_ARGS__);  \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                \
     } else if (size >= 32) {                                         \
       Func<T1, T2, 4, 32>                                            \
           <<<grid_dim, dim3(4, 32), 0, cuda_stream>>>(__VA_ARGS__);  \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                \
     } else {                                                         \
       Func<T1, T2, 8, 16>                                            \
           <<<grid_dim, dim3(8, 16), 0, cuda_stream>>>(__VA_ARGS__);  \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                                \
     }                                                                \
   } while (false)
 

--- a/caffe2/utils/math/transpose.cu
+++ b/caffe2/utils/math/transpose.cu
@@ -68,6 +68,7 @@ void BatchTranspose2DCUDAImpl(
   BatchTranspose2DCUDAKernel<TIndex, TData>
       <<<N * dh * dw, dim3(kTileDim, kBlockRows), 0, context->cuda_stream()>>>(
           N, H, W, dh, dw, X, Y);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 #define DELEGATE_TRANSPOSE_2D_CUDA_IMPL(TIndex, TData, CuBLASFunc) \
@@ -106,6 +107,7 @@ void BatchTranspose2DCUDAImpl(
              dim3(kTileDim, kBlockRows),                           \
              0,                                                    \
              context->cuda_stream()>>>(N, H, W, dh, dw, X, Y);     \
+      C10_CUDA_KERNEL_LAUNCH_CHECK();                              \
     }                                                              \
   }
 DELEGATE_TRANSPOSE_2D_CUDA_IMPL(std::int32_t, float, cublasSgeam)
@@ -157,6 +159,7 @@ void TransposeCUDAImpl(
   TransposeCUDAKernel<TIndex, TData, D>
       <<<M, CAFFE_CUDA_NUM_THREADS, 0, context->cuda_stream()>>>(
           size, X_strides, Y_dims, X, Y);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Added `C10_CUDA_KERNEL_LAUNCH_CHECK();` after all kernel launches in caffe2/caffe2/utils/math

Test Plan:
```
buck build //caffe2/caffe2
```

{F356531214}

files in caffe2/caffe2/utils/math no longer show up when running
```
python3 caffe2/torch/testing/check_kernel_launches.py
```

Differential Revision: D25773299

