### PR TITLE
Convert string => raw strings so char classes can be represented in Python regex

### DIFF
--- a/scripts/release_notes/commitlist.py
+++ b/scripts/release_notes/commitlist.py
@@ -97,7 +97,7 @@ class CommitList:
         if topic is not None:
             commits = [commit for commit in commits if commit.topic == topic]
         return commits
- 
+
     def update_to(self, new_version):
         last_hash = self.commits[-1].commit_hash
         new_commits = CommitList.get_commits_between(last_hash, new_version)
@@ -121,7 +121,7 @@ def update_existing(path, new_version):
 
 def to_markdown(commit_list, category):
     def cleanup_title(commit):
-        match = re.match('(.*) \(#\d+\)', commit.title)
+        match = re.match(r'(.*) \(#\d+\)', commit.title)
         if match is None:
             return commit.title
         return match.group(1)


### PR DESCRIPTION
Summary:
Convert regex strings that have character classes (e.g. \d, \s, \w, \b, etc) into raw strings so they won't be interpreted as escape characters.

References:
Python RegEx - https://www.w3schools.com/python/python_regex.asp
Python Escape Chars - https://www.w3schools.com/python/gloss_python_escape_characters.asp
Python Raw String - https://www.journaldev.com/23598/python-raw-string
Python RegEx Docs - https://docs.python.org/3/library/re.html
Python String Tester - https://www.w3schools.com/python/trypython.asp?filename=demo_string_escape
Python Regex Tester - https://regex101.com/

Test Plan: To find occurrences of regex strings with the above issue in VS Code, search using the regex \bre\.[a-z]+\(['"], and under 'files to include', use /data/users/your_username/fbsource/fbcode/caffe2.

Differential Revision: D25813302

