### PR TITLE
[JIT] Print better error when class attribute IValue conversion fails

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -1405,7 +1405,7 @@ class TestClassType(JitTestCase):
         to an IValue that has an attribute of the wrong type.
         """
         @torch.jit.script
-        class ValHolder(object):
+        class ValHolder(object):  # noqa: B903
             def __init__(self, val):
                 self.val = val
 
@@ -1422,5 +1422,5 @@ class TestClassType(JitTestCase):
                     mod = self.mod2
                 return mod.val
 
-        with self.assertRaisesRegex(RuntimeError, "Could not cast attribute val to type Tensor"):
+        with self.assertRaisesRegex(RuntimeError, "Could not cast attribute 'val' to type Tensor"):
             torch.jit.script(Mod())

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -157,8 +157,16 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
               attrName));
         }
 
-        const auto& contained = py::getattr(obj, attrName.c_str());
-        userObj->setSlot(slot, toIValue(contained, attrType));
+        try {
+          const auto& contained = py::getattr(obj, attrName.c_str());
+          userObj->setSlot(slot, toIValue(contained, attrType));
+        } catch (std::exception& e) {
+          throw py::cast_error(c10::str(
+              "Could not cast attribute ",
+              attrName,
+              " to type ",
+              attrType->repr_str()));
+        }
       }
       return userObj;
     }

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -162,10 +162,12 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
           userObj->setSlot(slot, toIValue(contained, attrType));
         } catch (std::exception& e) {
           throw py::cast_error(c10::str(
-              "Could not cast attribute ",
+              "Could not cast attribute '",
               attrName,
-              " to type ",
-              attrType->repr_str()));
+              "' to type ",
+              attrType->repr_str(),
+              ": ",
+              e.what()));
         }
       }
       return userObj;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50255 [JIT] Print better error when class attribute IValue conversion fails**

**Summary**
TorchScript classes are copied attribute-by-attribute from a py::object into
a `jit::Object` in `toIValue`, which is called when copying objects from
Python into TorchScript. However, if an attribute of the class cannot be
converted, the error thrown is a standard pybind error that is hard to
act on.

This commit adds code to `toIValue` to convert each attribute to an
`IValue` inside a try-catch block, throwing a `cast_error` containing
the name of the attribute and the target type if the conversion fails.

**Test Plan**
This commit adds a unit test to `test_class_type.py`
based on the code in the issue that commit fixes.

**Fixes**
This commit fixes #46341.

Differential Revision: [D25854183](https://our.internmc.facebook.com/intern/diff/D25854183)