### PR TITLE
Add code owners for TensorPipe submodule

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,8 +12,9 @@
 /torch/autograd/ @albanD
 
 # Tensorpipe RPC Agent.
-/torch/csrc/distributed/rpc/tensorpipe_agent.cpp @jiayisuse @osalpekar @lw @beauby
-/torch/csrc/distributed/rpc/tensorpipe_agent.h @jiayisuse @osalpekar @lw @beauby
+/torch/csrc/distributed/rpc/tensorpipe_agent.cpp @lw @beauby
+/torch/csrc/distributed/rpc/tensorpipe_agent.h @lw @beauby
+/third_party/tensorpipe @lw @beauby
 
 # Distributed package
 # This list is mostly if you'd like to be tagged as reviewer, feel free to add


### PR DESCRIPTION
Summary: This is in order to be tagged as reviewers and thus be notified when an automatic submodule update PR is sent out by the bot.

Test Plan: I am not sure how submodules play with code owners. The only strategy I see is to land this and try. There should be no dire consequences for landing this.

Differential Revision: D25846635

