### PR TITLE
[FX] Make graph target printouts more user-friendly

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -646,6 +646,20 @@ class TestFX(JitTestCase):
         with self.assertRaisesRegex(TraceError, 'Proxy object cannot be iterated.'):
             symbolic_trace(ud)
 
+    def test_pretty_print_targets(self):
+        # Test that Graph pretty-print prints friendly name for targets
+        # in `operator` and `builtins`
+
+        class SomeMod(torch.nn.Module):
+            def forward(self, x):
+                return torch.add(x.foo + x.bar, 3.0)
+
+        traced = symbolic_trace(SomeMod())
+        graph_str = str(traced.graph)
+        self.assertIn('builtins.getattr', graph_str)
+        self.assertIn('operator.add', graph_str)
+        self.assertIn('torch.add', graph_str)
+
     def test_script_tensor_constant(self):
         # TorchScript seems to ignore attributes that start with `__`.
         # We used to call anonymous Tensor values `__tensor_constant*`, but

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -735,6 +735,22 @@ def forward(self, {', '.join(free_vars)}){maybe_return_annotation[0]}:
             else:
                 return str(arg)
 
+        def pretty_print_target(target):
+            """
+            Make target printouts more user-friendly.
+            1) builtins will be printed as `builtins.xyz`
+            2) operators will be printed as `operator.xyz`
+            3) other callables will be printed with qualfied name, e.g. torch.add
+            """
+            if isinstance(target, str):
+                return target
+            if hasattr(target, '__module__'):
+                if target.__module__ == 'builtins':
+                    return f'builtins.{target.__name__}'
+                elif target.__module__ == '_operator':
+                    return f'operator.{target.__name__}'
+            return get_qualified_name(target)
+
         def format_node(n : Node) -> Optional[str]:
             if n.op == 'placeholder':
                 assert isinstance(n.target, str)
@@ -751,7 +767,7 @@ def forward(self, {', '.join(free_vars)}){maybe_return_annotation[0]}:
                 return f'return {n.args[0]}'
             else:
                 maybe_typename = f'{_type_repr(n.type)} ' if n.type is not None else ''
-                return f'%{n.name} : {maybe_typename}[#users={len(n.users)}] = {n.op}[target={n.target}](' \
+                return f'%{n.name} : {maybe_typename}[#users={len(n.users)}] = {n.op}[target={pretty_print_target(n.target)}](' \
                        f'args = {format_arg(n.args)}, kwargs = {format_arg(n.kwargs)})'
 
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -745,6 +745,12 @@ def forward(self, {', '.join(free_vars)}){maybe_return_annotation[0]}:
             if isinstance(target, str):
                 return target
             if hasattr(target, '__module__'):
+                if not hasattr(target, '__name__'):
+                    # Just to be defensive, if we don't have `__name__`, get the
+                    # qualname. Not sure if this happens for any members of `operator`
+                    # or `builtins`. This fallback path is not as good, since e.g.
+                    # things in `operator` have `_operator` as their __module__.
+                    return get_qualified_name(target)
                 if target.__module__ == 'builtins':
                     return f'builtins.{target.__name__}'
                 elif target.__module__ == '_operator':


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50296 [FX] Make graph target printouts more user-friendly**

This makes it so we don't see the useless `<builtin-function xyz at ...>` default Python repr in the graph printout anymore. This helps since it means that the targets people see in the graph are valid Python expressions referring to the actual call target, that they can then use in their own code

Diff of Resnet18 graph printout before/after this change:

```
@@ -8,14 +8,14 @@ graph(x):
     %layer1_0_relu : [#users=1] = call_module[target=layer1.0.relu](args = (%layer1_0_bn1,), kwargs = {})
     %layer1_0_conv2 : [#users=1] = call_module[target=layer1.0.conv2](args = (%layer1_0_relu,), kwargs = {})
     %layer1_0_bn2 : [#users=1] = call_module[target=layer1.0.bn2](args = (%layer1_0_conv2,), kwargs = {})
-    %add_1 : [#users=1] = call_function[target=<built-in function add>](args = (%layer1_0_bn2, %maxpool), kwargs = {})
+    %add_1 : [#users=1] = call_function[target=operator.add](args = (%layer1_0_bn2, %maxpool), kwargs = {})
     %layer1_0_relu_1 : [#users=2] = call_module[target=layer1.0.relu](args = (%add_1,), kwargs = {})
     %layer1_1_conv1 : [#users=1] = call_module[target=layer1.1.conv1](args = (%layer1_0_relu_1,), kwargs = {})
     %layer1_1_bn1 : [#users=1] = call_module[target=layer1.1.bn1](args = (%layer1_1_conv1,), kwargs = {})
     %layer1_1_relu : [#users=1] = call_module[target=layer1.1.relu](args = (%layer1_1_bn1,), kwargs = {})
     %layer1_1_conv2 : [#users=1] = call_module[target=layer1.1.conv2](args = (%layer1_1_relu,), kwargs = {})
     %layer1_1_bn2 : [#users=1] = call_module[target=layer1.1.bn2](args = (%layer1_1_conv2,), kwargs = {})
-    %add_2 : [#users=1] = call_function[target=<built-in function add>](args = (%layer1_1_bn2, %layer1_0_relu_1), kwargs = {})
+    %add_2 : [#users=1] = call_function[target=operator.add](args = (%layer1_1_bn2, %layer1_0_relu_1), kwargs = {})
     %layer1_1_relu_1 : [#users=2] = call_module[target=layer1.1.relu](args = (%add_2,), kwargs = {})
     %layer2_0_conv1 : [#users=1] = call_module[target=layer2.0.conv1](args = (%layer1_1_relu_1,), kwargs = {})
     %layer2_0_bn1 : [#users=1] = call_module[target=layer2.0.bn1](args = (%layer2_0_conv1,), kwargs = {})
@@ -24,14 +24,14 @@ graph(x):
     %layer2_0_bn2 : [#users=1] = call_module[target=layer2.0.bn2](args = (%layer2_0_conv2,), kwargs = {})
     %layer2_0_downsample_0 : [#users=1] = call_module[target=layer2.0.downsample.0](args = (%layer1_1_relu_1,), kwargs = {})
     %layer2_0_downsample_1 : [#users=1] = call_module[target=layer2.0.downsample.1](args = (%layer2_0_downsample_0,), kwargs = {})
-    %add_3 : [#users=1] = call_function[target=<built-in function add>](args = (%layer2_0_bn2, %layer2_0_downsample_1), kwargs = {})
+    %add_3 : [#users=1] = call_function[target=operator.add](args = (%layer2_0_bn2, %layer2_0_downsample_1), kwargs = {})
     %layer2_0_relu_1 : [#users=2] = call_module[target=layer2.0.relu](args = (%add_3,), kwargs = {})
     %layer2_1_conv1 : [#users=1] = call_module[target=layer2.1.conv1](args = (%layer2_0_relu_1,), kwargs = {})
     %layer2_1_bn1 : [#users=1] = call_module[target=layer2.1.bn1](args = (%layer2_1_conv1,), kwargs = {})
     %layer2_1_relu : [#users=1] = call_module[target=layer2.1.relu](args = (%layer2_1_bn1,), kwargs = {})
     %layer2_1_conv2 : [#users=1] = call_module[target=layer2.1.conv2](args = (%layer2_1_relu,), kwargs = {})
     %layer2_1_bn2 : [#users=1] = call_module[target=layer2.1.bn2](args = (%layer2_1_conv2,), kwargs = {})
-    %add_4 : [#users=1] = call_function[target=<built-in function add>](args = (%layer2_1_bn2, %layer2_0_relu_1), kwargs = {})
+    %add_4 : [#users=1] = call_function[target=operator.add](args = (%layer2_1_bn2, %layer2_0_relu_1), kwargs = {})
     %layer2_1_relu_1 : [#users=2] = call_module[target=layer2.1.relu](args = (%add_4,), kwargs = {})
     %layer3_0_conv1 : [#users=1] = call_module[target=layer3.0.conv1](args = (%layer2_1_relu_1,), kwargs = {})
     %layer3_0_bn1 : [#users=1] = call_module[target=layer3.0.bn1](args = (%layer3_0_conv1,), kwargs = {})
@@ -40,14 +40,14 @@ graph(x):
     %layer3_0_bn2 : [#users=1] = call_module[target=layer3.0.bn2](args = (%layer3_0_conv2,), kwargs = {})
     %layer3_0_downsample_0 : [#users=1] = call_module[target=layer3.0.downsample.0](args = (%layer2_1_relu_1,), kwargs = {})
     %layer3_0_downsample_1 : [#users=1] = call_module[target=layer3.0.downsample.1](args = (%layer3_0_downsample_0,), kwargs = {})
-    %add_5 : [#users=1] = call_function[target=<built-in function add>](args = (%layer3_0_bn2, %layer3_0_downsample_1), kwargs = {})
+    %add_5 : [#users=1] = call_function[target=operator.add](args = (%layer3_0_bn2, %layer3_0_downsample_1), kwargs = {})
     %layer3_0_relu_1 : [#users=2] = call_module[target=layer3.0.relu](args = (%add_5,), kwargs = {})
     %layer3_1_conv1 : [#users=1] = call_module[target=layer3.1.conv1](args = (%layer3_0_relu_1,), kwargs = {})
     %layer3_1_bn1 : [#users=1] = call_module[target=layer3.1.bn1](args = (%layer3_1_conv1,), kwargs = {})
     %layer3_1_relu : [#users=1] = call_module[target=layer3.1.relu](args = (%layer3_1_bn1,), kwargs = {})
     %layer3_1_conv2 : [#users=1] = call_module[target=layer3.1.conv2](args = (%layer3_1_relu,), kwargs = {})
     %layer3_1_bn2 : [#users=1] = call_module[target=layer3.1.bn2](args = (%layer3_1_conv2,), kwargs = {})
-    %add_6 : [#users=1] = call_function[target=<built-in function add>](args = (%layer3_1_bn2, %layer3_0_relu_1), kwargs = {})
+    %add_6 : [#users=1] = call_function[target=operator.add](args = (%layer3_1_bn2, %layer3_0_relu_1), kwargs = {})
     %layer3_1_relu_1 : [#users=2] = call_module[target=layer3.1.relu](args = (%add_6,), kwargs = {})
     %layer4_0_conv1 : [#users=1] = call_module[target=layer4.0.conv1](args = (%layer3_1_relu_1,), kwargs = {})
     %layer4_0_bn1 : [#users=1] = call_module[target=layer4.0.bn1](args = (%layer4_0_conv1,), kwargs = {})
@@ -56,16 +56,16 @@ graph(x):
     %layer4_0_bn2 : [#users=1] = call_module[target=layer4.0.bn2](args = (%layer4_0_conv2,), kwargs = {})
     %layer4_0_downsample_0 : [#users=1] = call_module[target=layer4.0.downsample.0](args = (%layer3_1_relu_1,), kwargs = {})
     %layer4_0_downsample_1 : [#users=1] = call_module[target=layer4.0.downsample.1](args = (%layer4_0_downsample_0,), kwargs = {})
-    %add_7 : [#users=1] = call_function[target=<built-in function add>](args = (%layer4_0_bn2, %layer4_0_downsample_1), kwargs = {})
+    %add_7 : [#users=1] = call_function[target=operator.add](args = (%layer4_0_bn2, %layer4_0_downsample_1), kwargs = {})
     %layer4_0_relu_1 : [#users=2] = call_module[target=layer4.0.relu](args = (%add_7,), kwargs = {})
     %layer4_1_conv1 : [#users=1] = call_module[target=layer4.1.conv1](args = (%layer4_0_relu_1,), kwargs = {})
     %layer4_1_bn1 : [#users=1] = call_module[target=layer4.1.bn1](args = (%layer4_1_conv1,), kwargs = {})
     %layer4_1_relu : [#users=1] = call_module[target=layer4.1.relu](args = (%layer4_1_bn1,), kwargs = {})
     %layer4_1_conv2 : [#users=1] = call_module[target=layer4.1.conv2](args = (%layer4_1_relu,), kwargs = {})
     %layer4_1_bn2 : [#users=1] = call_module[target=layer4.1.bn2](args = (%layer4_1_conv2,), kwargs = {})
-    %add_8 : [#users=1] = call_function[target=<built-in function add>](args = (%layer4_1_bn2, %layer4_0_relu_1), kwargs = {})
+    %add_8 : [#users=1] = call_function[target=operator.add](args = (%layer4_1_bn2, %layer4_0_relu_1), kwargs = {})
     %layer4_1_relu_1 : [#users=1] = call_module[target=layer4.1.relu](args = (%add_8,), kwargs = {})
     %avgpool : [#users=1] = call_module[target=avgpool](args = (%layer4_1_relu_1,), kwargs = {})
-    %flatten_1 : [#users=1] = call_function[target=<built-in method flatten of type object at 0x7fee0ab6b7e0>](args = (%avgpool, 1), kwargs = {})
+    %flatten_1 : [#users=1] = call_function[target=torch.flatten](args = (%avgpool, 1), kwargs = {})
     %fc : [#users=1] = call_module[target=fc](args = (%flatten_1,), kwargs = {})
     return fc
```

Differential Revision: [D25855288](https://our.internmc.facebook.com/intern/diff/D25855288)