### PR TITLE
[quant][bug] Fixing the mapping getter to return a copy

### DIFF
--- a/torch/quantization/quantization_mappings.py
+++ b/torch/quantization/quantization_mappings.py
@@ -1,3 +1,5 @@
+import copy
+
 import torch
 from torch import nn
 
@@ -112,7 +114,7 @@ DEFAULT_MODULE_TO_ACT_POST_PROCESS : Dict[Callable, Callable] = {
 def get_default_static_quant_module_mappings() -> Dict[Callable, Any]:
     ''' Get module mapping for post training static quantization
     '''
-    return DEFAULT_STATIC_QUANT_MODULE_MAPPINGS
+    return copy.deepcopy(DEFAULT_STATIC_QUANT_MODULE_MAPPINGS)
 
 def get_static_quant_module_class(
         float_module_class: Callable,
@@ -127,7 +129,7 @@ def get_static_quant_module_class(
     assert static_quant_module_class is not None, \
         "Floating point module class {}".format(str(float_module_class)) + \
         " does not have a corresponding quantized module class"
-    return static_quant_module_class
+    return copy.deepcopy(static_quant_module_class)
 
 def get_dynamic_quant_module_class(
         float_module_class: Callable,
@@ -142,12 +144,12 @@ def get_dynamic_quant_module_class(
     assert dynamic_quant_module_class is not None, \
         "Floating point module class {}".format(str(float_module_class)) + \
         " does not have a corresponding quantized module class"
-    return dynamic_quant_module_class
+    return copy.deepcopy(dynamic_quant_module_class)
 
 def get_default_qat_module_mappings() -> Dict[Callable, Any]:
     ''' Get default module mapping for quantization aware training
     '''
-    return DEFAULT_QAT_MODULE_MAPPINGS
+    return copy.deepcopy(DEFAULT_QAT_MODULE_MAPPINGS)
 
 def get_default_dynamic_quant_module_mappings() -> Dict[Callable, Any]:
     ''' Get module mapping for post training dynamic quantization
@@ -164,7 +166,7 @@ def get_default_qconfig_propagation_list() -> Set[Callable]:
          set(DEFAULT_DYNAMIC_QUANT_MODULE_MAPPINGS.keys()) |
          _INCLUDE_QCONFIG_PROPAGATE_LIST)
     )
-    return QCONFIG_PROPAGATE_MODULE_CLASS_LIST
+    return copy.deepcopy(QCONFIG_PROPAGATE_MODULE_CLASS_LIST)
 
 def get_default_compare_output_module_list() -> Set[Callable]:
     ''' Get list of module class types that we will record output
@@ -179,7 +181,7 @@ def get_default_compare_output_module_list() -> Set[Callable]:
         | set(DEFAULT_DYNAMIC_QUANT_MODULE_MAPPINGS.keys())
         | _INCLUDE_QCONFIG_PROPAGATE_LIST
     )
-    return NUMERIC_SUITE_COMPARE_MODEL_OUTPUT_MODULE_LIST
+    return copy.deepcopy(NUMERIC_SUITE_COMPARE_MODEL_OUTPUT_MODULE_LIST)
 
 # TODO: merge with get_static_quant_module_class
 def get_quantized_operator(float_op: Union[Callable, str]) -> Callable:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50304 [quant][refactor] Minor refactor of some typos
* **#50297 [quant][bug] Fixing the mapping getter to return a copy**

Current implementation has a potential bug: if a user modifies the quantization mappings returned by the getters, the changes will propagate.
For example, the bug will manifest itself if the user does the following:

```
my_mapping = get_default_static_quant_module_mappings()
my_mapping[nn.Linear] = UserLinearImplementation
model_A = convert(model_A, mapping=my_mapping)

default_mapping = get_default_static_quant_module_mappings()
model_B = convert(model_B, mapping=default_mapping)
```

In that case the `model_B` will be quantized with with the modified mapping.

Differential Revision: [D25855753](https://our.internmc.facebook.com/intern/diff/D25855753)