### PR TITLE
cleaned up ModuleAttributeError

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -675,7 +675,6 @@ class TestScriptPy3(JitTestCase):
         mod = ModuleWithProperties(3)
         scripted_mod = torch.jit.script(mod)
 
-        # raises wrong AttributeError
         with self.assertRaisesRegex(AttributeError, "has no attribute"):
             scripted_mod.ignored_attr
 

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -675,7 +675,8 @@ class TestScriptPy3(JitTestCase):
         mod = ModuleWithProperties(3)
         scripted_mod = torch.jit.script(mod)
 
-        with self.assertRaisesRegex(torch.nn.modules.module.ModuleAttributeError, "has no attribute"):
+        # raises wrong AttributeError
+        with self.assertRaisesRegex(AttributeError, "has no attribute"):
             scripted_mod.ignored_attr
 
     def test_ignoring_module_attributes(self):

--- a/test/test_mobile_optimizer.py
+++ b/test/test_mobile_optimizer.py
@@ -8,7 +8,6 @@ from torch.utils.mobile_optimizer import *
 from torch.nn import functional as F
 from torch._C import MobileOptimizerType
 from torch.testing._internal.common_quantized import override_quantized_engine
-from torch.nn.modules.module import ModuleAttributeError
 
 FileCheck = torch._C.FileCheck
 
@@ -299,7 +298,7 @@ class TestOptimizer(unittest.TestCase):
         )
 
         # We expect an exception here
-        with self.assertRaises(ModuleAttributeError):
+        with self.assertRaises(AttributeError):
             module_optim_bi_not_preserved.run_on_bundled_input(0)
 
         # Add bundled inputs methods to the module

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1211,6 +1211,7 @@ class TestNN(NNTestCase):
         with self.assertRaises(KeyError):
             m.add_module('attribute_name', nn.Module())
 
+    @unittest.expectedFailure
     def test_getattr_with_property(self):
         class Model(nn.Module):
             @property
@@ -1219,8 +1220,9 @@ class TestNN(NNTestCase):
 
         model = Model()
 
-        # raises wrong AttributeError 
-        with self.assertRaisesRegex(AttributeError, "has no attribute"):
+        with self.assertRaisesRegex(
+                AttributeError,
+                r"'Model' object has no attribute 'something_that_doesnt_exist'"):
             model.some_property
 
     def test_Sequential_getitem(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1213,30 +1213,15 @@ class TestNN(NNTestCase):
 
     def test_getattr_with_property(self):
         class Model(nn.Module):
-            def __init__(self):
-                super(Model, self).__init__()
-                self.linear = nn.Linear(4, 5)
-
-            def forward(self, input):
-                return self.linear(input)
-
             @property
             def some_property(self):
                 return self.something_that_doesnt_exist
 
         model = Model()
-        with self.assertRaises(nn.modules.module.ModuleAttributeError) as mae:
-            check = model.shouldnt_exist
-            self.assertIn("shouldnt_exist", mae)
 
-        # Before using nn.modules.ModuleAttributeError, if an AttributeError
-        # was raised in a property. The AttributeError was raised on the
-        # property itself. This checks that some_property is not in the
-        # expection.
-        with self.assertRaises(nn.modules.module.ModuleAttributeError) as mae:
-            check = model.some_property
-            self.assertIn("something_that_doesnt_exist", mae)
-            self.assertNotIn("some_propery", mae)
+        # raises wrong AttributeError 
+        with self.assertRaisesRegex(AttributeError, "has no attribute"):
+            model.some_property
 
     def test_Sequential_getitem(self):
         l1 = nn.Linear(10, 20)

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -26,14 +26,6 @@ class _IncompatibleKeys(namedtuple('IncompatibleKeys', ['missing_keys', 'unexpec
     __str__ = __repr__
 
 
-class ModuleAttributeError(AttributeError):
-    """ When `__getattr__` raises AttributeError inside a property,
-    AttributeError is raised with the property name instead of the
-    attribute that initially raised AttributeError, making the error
-    message uninformative. Using `ModuleAttributeError` instead
-    fixes this issue."""
-
-
 def _addindent(s_, numSpaces):
     s = s_.split('\n')
     # don't do anything for single-line stuff
@@ -934,7 +926,7 @@ class Module:
             modules = self.__dict__['_modules']
             if name in modules:
                 return modules[name]
-        raise ModuleAttributeError("'{}' object has no attribute '{}'".format(
+        raise AttributeError("'{}' object has no attribute '{}'".format(
             type(self).__name__, name))
 
     def __setattr__(self, name: str, value: Union[Tensor, 'Module']) -> None:


### PR DESCRIPTION
Fixes #49726
Just cleaned up the unnecessary `ModuleAttributeError`

BC-breaking note:
`ModuleAttributeError` was added in the previous unsuccessful [PR](https://github.com/pytorch/pytorch/pull/49879) and removed here. If a user catches `ModuleAttributeError` specifically, this will no longer work. They should catch `AttributeError` instead.