### PR TITLE
Minor Fix: Double ";" typo in transformerlayer.h

### DIFF
--- a/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
+++ b/torch/csrc/api/include/torch/nn/modules/transformerlayer.h
@@ -70,7 +70,7 @@ class TORCH_API TransformerEncoderLayerImpl : public Cloneable<TransformerEncode
     /// pre feedforward, normalization layer
     LayerNorm norm1 = nullptr;
     /// post feedfastward, normalization layer
-    LayerNorm norm2 = nullptr;;
+    LayerNorm norm2 = nullptr;
 
     /// pre feedfastward, dropout layer
     Dropout dropout1 = nullptr;


### PR DESCRIPTION
Fix double ";" typo in transformerlayer.h
