### PR TITLE
[PyTorch] Make TensorImpl::empty_tensor_restride non-virtual

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1423,7 +1423,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * WARNING: This function doesn't rearrange data and assumes tensor is a memory
    * contiguous
    */
-  virtual void empty_tensor_restride(MemoryFormat memory_format) {
+  void empty_tensor_restride(MemoryFormat memory_format) {
     #ifdef DEBUG
         TORCH_INTERNAL_ASSERT(compute_numel() == numel_,
         "If you are seeing this error, that means empty_tensor_restride was "


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50301 [PyTorch] Make TensorImpl::empty_tensor_restride non-virtual**

I'm not sure why this is virtual. We don't seem to override it anywhere, and GitHub code search doesn't turn up anything either.

Differential Revision: [D25856434](https://our.internmc.facebook.com/intern/diff/D25856434/)