### PR TITLE
Raise warning during validation when arg_constraints not defined

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -28,6 +28,7 @@ import unittest
 from collections import namedtuple
 from itertools import product
 from random import shuffle
+import warnings
 
 import torch
 
@@ -4474,6 +4475,27 @@ class TestValidation(TestCase):
                 except AssertionError as e:
                     fail_string = 'ValueError not raised for {} example {}/{}'
                     raise AssertionError(fail_string.format(Dist.__name__, i + 1, len(params))) from e
+
+    def test_warning_unimplemented_constraints(self):
+        class Delta(Distribution):
+            def __init__(self, validate_args=True):
+                super().__init__(validate_args=validate_args)
+
+            def sample(self, sample_shape=torch.Size()):
+                return torch.tensor(0.).expand(sample_shape)
+
+            def log_prob(self, value):
+                if self._validate_args:
+                    self._validate_sample(value)
+                value[value != 0.] = -float('inf')
+                value[value == 0.] = 0.
+                return value
+
+        with self.assertWarns(UserWarning):
+            d = Delta()
+        sample = d.sample((2,))
+        with self.assertWarns(UserWarning):
+            d.log_prob(sample)
 
     def tearDown(self):
         super(TestValidation, self).tearDown()

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -28,7 +28,6 @@ import unittest
 from collections import namedtuple
 from itertools import product
 from random import shuffle
-import warnings
 
 import torch
 

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -270,8 +270,8 @@ class Distribution(object):
             if not self.support.check(value).all():
                 raise ValueError('The value argument must be within the support')
         except NotImplementedError:
-            warnings.warn(f'The class {self.__class__} does not define `support` ' +
-                           'to enable sample validation. Please set `validate_args=False` ' +
+            warnings.warn(f'{self.__class__} does not define `support` to enable ' +
+                           'sample validation. Please set `validate_args=False` ' +
                            'to turn off validation.')
 
     def _get_checked_instance(self, cls, _instance=None):

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -271,8 +271,8 @@ class Distribution(object):
                 raise ValueError('The value argument must be within the support')
         except NotImplementedError:
             warnings.warn(f'{self.__class__} does not define `support` to enable ' +
-                          'sample validation. Please set `validate_args=False` ' +
-                          'to turn off validation.')
+                          'sample validation. Please initialize the distribution with ' +
+                          '`validate_args=False` to turn off validation.')
 
     def _get_checked_instance(self, cls, _instance=None):
         if _instance is None and type(self).__init__ != cls.__init__:

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -266,13 +266,15 @@ class Distribution(object):
                 raise ValueError('Value is not broadcastable with batch_shape+event_shape: {} vs {}.'.
                                  format(actual_shape, expected_shape))
         try:
-            assert self.support is not None
-            if not self.support.check(value).all():
-                raise ValueError('The value argument must be within the support')
+            support = self.support
         except NotImplementedError:
             warnings.warn(f'{self.__class__} does not define `support` to enable ' +
                           'sample validation. Please initialize the distribution with ' +
                           '`validate_args=False` to turn off validation.')
+            return
+        assert support is not None
+        if not support.check(value).all():
+            raise ValueError('The value argument must be within the support')
 
     def _get_checked_instance(self, cls, _instance=None):
         if _instance is None and type(self).__init__ != cls.__init__:

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -42,8 +42,8 @@ class Distribution(object):
             except NotImplementedError:
                 arg_constraints = {}
                 warnings.warn(f'{self.__class__} does not define `arg_constraints`. ' +
-                               'Please set `arg_constraints = {}` or initialize the distribution ' +
-                               'with `validate_args=False` to turn off validation.')
+                              'Please set `arg_constraints = {}` or initialize the distribution ' +
+                              'with `validate_args=False` to turn off validation.')
             for param, constraint in arg_constraints.items():
                 if constraints.is_dependent(constraint):
                     continue  # skip constraints that cannot be checked
@@ -271,8 +271,8 @@ class Distribution(object):
                 raise ValueError('The value argument must be within the support')
         except NotImplementedError:
             warnings.warn(f'{self.__class__} does not define `support` to enable ' +
-                           'sample validation. Please set `validate_args=False` ' +
-                           'to turn off validation.')
+                          'sample validation. Please set `validate_args=False` ' +
+                          'to turn off validation.')
 
     def _get_checked_instance(self, cls, _instance=None):
         if _instance is None and type(self).__init__ != cls.__init__:


### PR DESCRIPTION
After we merged https://github.com/pytorch/pytorch/pull/48743, we noticed that some existing code that subclasses `torch.Distribution` started throwing `NotImplemenedError` since the constraints required for validation checks were not implemented.

```sh
File "torch/distributions/distribution.py", line 40, in __init__
  for param, constraint in self.arg_constraints.items():
File "torch/distributions/distribution.py", line 92, in arg_constraints
  raise NotImplementedError
```

This PR throws a UserWarning for such cases instead and gives a better warning message.

cc. @balandat