### PR TITLE
Fix Error with torch.flip() for cuda tensors when dims=()

### DIFF
--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -11,8 +11,8 @@ namespace native {
 
 static inline void flip_check_errors(int64_t total_dims, int64_t flip_dims_size, IntArrayRef dims) {
   // Return if flip_dims_size = 0
-  if(flip_dims_size==0){
-	  return;
+  if (flip_dims_size==0){
+    return;
   }	  
   // check if number of axis in dim is valid
   if (flip_dims_size < 0 || flip_dims_size > total_dims) {

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -10,8 +10,12 @@ namespace at {
 namespace native {
 
 static inline void flip_check_errors(int64_t total_dims, int64_t flip_dims_size, IntArrayRef dims) {
+  // Return if flip_dims_size = 0
+  if(flip_dims_size==0){
+	  return;
+  }	  
   // check if number of axis in dim is valid
-  if (flip_dims_size <= 0 || flip_dims_size > total_dims) {
+  if (flip_dims_size < 0 || flip_dims_size > total_dims) {
     TORCH_CHECK_INDEX(false, "flip dims size out of range, got flip dims size=", flip_dims_size);
   }
 

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -10,7 +10,7 @@ namespace at {
 namespace native {
 
 static inline void flip_check_errors(int64_t total_dims, int64_t flip_dims_size, IntArrayRef dims) {
-  if (flip_dims_size==0){
+  if (flip_dims_size==0) {
     return;
   } 
   // check if number of axis in dim is valid

--- a/aten/src/ATen/native/TensorTransformations.h
+++ b/aten/src/ATen/native/TensorTransformations.h
@@ -10,10 +10,9 @@ namespace at {
 namespace native {
 
 static inline void flip_check_errors(int64_t total_dims, int64_t flip_dims_size, IntArrayRef dims) {
-  // Return if flip_dims_size = 0
   if (flip_dims_size==0){
     return;
-  }	  
+  } 
   // check if number of axis in dim is valid
   if (flip_dims_size < 0 || flip_dims_size > total_dims) {
     TORCH_CHECK_INDEX(false, "flip dims size out of range, got flip dims size=", flip_dims_size);

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -395,13 +395,7 @@ class TestShapeOps(TestCase):
 
         # case: dims=()
         a = torch.randn(3, 2, 1, device=device)
-        if device == 'cpu':
-            self.assertEqual(a.flip(dims=()), a)
-        else:
-            # Reference: https://github.com/pytorch/pytorch/issues/49982
-            with self.assertRaisesRegex(IndexError,
-                                        "flip dims size out of range, got flip dims size=0"):
-                a.flip(dims=())
+        self.assertEqual(a.flip(dims=()), a)
 
     def _rand_shape(self, dim, min_size, max_size):
         shape = []

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -645,9 +645,7 @@ def sample_inputs_flip(op_info, device, dtype, requires_grad):
         make_tensor((S, 0, M), device, dtype, low=None, high=None, requires_grad=requires_grad)
     )
 
-    dims = ((0, 1, 2), (0,), (0, 2), (-1,))
-
-    dims = dims + ((),)  # type: ignore
+    dims = ((0, 1, 2), (0,), (0, 2), (-1,), ())
 
     samples = [SampleInput(tensor, kwargs={'dims': dim}) for tensor, dim in product(tensors, dims)]
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -647,10 +647,7 @@ def sample_inputs_flip(op_info, device, dtype, requires_grad):
 
     dims = ((0, 1, 2), (0,), (0, 2), (-1,))
 
-    # On CUDA, `dims=()` errors out with IndexError
-    # Reference: https://github.com/pytorch/pytorch/issues/49982
-    if device == 'cpu':
-        dims = dims + ((),)  # type: ignore
+    dims = dims + ((),)  # type: ignore
 
     samples = [SampleInput(tensor, kwargs={'dims': dim}) for tensor, dim in product(tensors, dims)]
 


### PR DESCRIPTION
Fixes #49982

The method flip_check_errors was being called in cuda file which had a condition to throw an exception for when dims size is <=0 changed that to <0 and added seperate condition for when equal to zero to return from the method... the return was needed because after this point the method was performing check expecting a non-zero size dims ... 

Also removed the comment/condition written to point to the issue 

@mruberry @kshitij12345 please review this once