### PR TITLE
Graceful invalidation of Python Node/Value/Block when C++ object is deleted

### DIFF
--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -150,6 +150,19 @@ using ValueSet = std::unordered_set<const Value*>;
 
 struct OperatorSet;
 
+// This is a wrapper to allow invalidating the Python object
+// safely when the C++ object for a Node/Value/Block is deleted
+// like much of graph, it isn't safe for different threads to
+// access the same graph
+template <typename T>
+struct Wrap {
+  Wrap(T* p) : elem(p) {}
+  void clear() {
+    elem = nullptr;
+  }
+  T* elem;
+};
+
 struct Value {
   TH_DISALLOW_COPY_AND_ASSIGN(Value);
   Value(Node* node_, size_t offset_);
@@ -163,6 +176,8 @@ struct Value {
   use_list uses_;
   std::string unique_name_;
   TypePtr type_;
+  // a managing wrapper for Python to allow invalidation
+  std::shared_ptr<Wrap<Value>> wrap_;
 
  public:
   Value* setType(TypePtr type);
@@ -248,6 +263,19 @@ struct Value {
   TORCH_API void replaceAllUsesAfterNodeWith(const Node* node, Value* newValue);
 
   TORCH_API Value* copyMetadata(Value* from);
+
+  TORCH_API std::shared_ptr<Wrap<Value>> wrap() {
+    if (!wrap_) {
+      wrap_ = std::make_shared<Wrap<Value>>(this);
+    }
+    return wrap_;
+  }
+
+  virtual ~Value() {
+    if (wrap_) {
+      wrap_->clear();
+    }
+  }
 };
 
 struct TORCH_API Node {
@@ -277,6 +305,8 @@ struct TORCH_API Node {
   // change the schema. note: mutable because schema_ is effectively a cache
   mutable const Operator* op_;
   topo_position_t topo_position_ = 0;
+  // a managing wrapper for Python to allow invalidation
+  std::shared_ptr<Wrap<Node>> wrap_;
 
  protected:
   Node(Graph* graph_, NodeKind kind_); // defined after graph
@@ -290,6 +320,13 @@ struct TORCH_API Node {
   // pointer using an array to allow the same iterator class for forward and
   // reverse node lists This list represents a topological sort
   Node* next_in_graph[2] = {nullptr, nullptr};
+
+  std::shared_ptr<Wrap<Node>> wrap() {
+    if (!wrap_) {
+      wrap_ = std::make_shared<Wrap<Node>>(this);
+    }
+    return wrap_;
+  }
 
   Node*& next() {
     return next_in_graph[kNextDirection];
@@ -689,7 +726,11 @@ struct TORCH_API Node {
       bool print_scopes = true,
       bool print_body = true) const;
 
-  virtual ~Node() = default;
+  virtual ~Node() {
+    if (wrap_) {
+      wrap_->clear();
+    }
+  }
 
   // Methods for accessing attributes
   Node* copyAttributes(const Node& rhs) {
@@ -992,6 +1033,19 @@ struct Block {
   TORCH_API void cloneFrom(Block* src, std::function<Value*(Value*)> value_map);
   TORCH_API void remapTypes(const std::function<TypePtr(TypePtr)>& type_map);
 
+  TORCH_API std::shared_ptr<Wrap<Block>> wrap() {
+    if (!wrap_) {
+      wrap_ = std::make_shared<Wrap<Block>>(this);
+    }
+    return wrap_;
+  }
+
+  virtual ~Block() {
+    if (wrap_) {
+      wrap_->clear();
+    }
+  }
+
  private:
   void reIndexTopology();
 
@@ -1009,6 +1063,8 @@ struct Block {
   Node* const input_;
   Node* const
       owning_node_; // either the node that has this block or nullptr for root
+  // a managing wrapper for Python to allow invalidation
+  std::shared_ptr<Wrap<Block>> wrap_;
 };
 
 struct Graph {

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -156,11 +156,15 @@ struct OperatorSet;
 // access the same graph
 template <typename T>
 struct Wrap {
-  Wrap(T* p) : elem(p) {}
+  Wrap(T* p) : elem(p), clear_cb(nullptr) {}
   void clear() {
+    if (clear_cb) {
+      clear_cb(elem);
+    }
     elem = nullptr;
   }
   T* elem;
+  void (*clear_cb)(void*);
 };
 
 struct Value {

--- a/torch/csrc/jit/python/pybind.h
+++ b/torch/csrc/jit/python/pybind.h
@@ -34,9 +34,10 @@ class unwrapping_shared_ptr {
   std::shared_ptr<torch::jit::Wrap<T>> impl;
 
  public:
-  unwrapping_shared_ptr() = default;
-  unwrapping_shared_ptr(std::shared_ptr<T> p) : impl(p) {}
-  unwrapping_shared_ptr(T* p) : impl(p->wrap()) {}
+  unwrapping_shared_ptr() : impl({}){};
+  unwrapping_shared_ptr(T* p) : impl(p->wrap()) {
+    impl->clear_cb = &clear_registered_instances;
+  }
   T* get() const {
     if (!impl->elem) {
       throw std::logic_error("has been invalidated");

--- a/torch/csrc/jit/python/pybind.h
+++ b/torch/csrc/jit/python/pybind.h
@@ -30,6 +30,12 @@ namespace jit {
 // workaround offered in https://github.com/pybind/pybind11/issues/2751
 template <typename T>
 class unwrapping_shared_ptr {
+  static_assert(
+      std::is_same<T, torch::jit::Value>::value ||
+          std::is_same<T, torch::jit::Node>::value ||
+          std::is_same<T, torch::jit::Block>::value,
+      "unwrapping type only defined for Graph object types");
+
  private:
   std::shared_ptr<torch::jit::Wrap<T>> impl;
 

--- a/torch/csrc/jit/python/pybind.h
+++ b/torch/csrc/jit/python/pybind.h
@@ -50,12 +50,16 @@ class unwrapping_shared_ptr {
     }
     return impl->elem;
   }
+  // we need to disable the overloaded & for PyBind11 < 2.3 due.
+  // see https://github.com/pybind/pybind11/pull/1435
+#if (PYBIND11_VERSION_MAJOR > 2) || ((PYBIND11_VERSION_MAJOR == 2) && (PYBIND11_VERSION_MINOR >= 3))
   T** operator&() {
     if (!impl->elem) {
       throw std::logic_error("has been invalidated");
     }
     return &(impl->elem);
-  }
+    }
+#endif
 };
 
 } // namespace jit

--- a/torch/csrc/jit/python/pybind.h
+++ b/torch/csrc/jit/python/pybind.h
@@ -52,13 +52,14 @@ class unwrapping_shared_ptr {
   }
   // we need to disable the overloaded & for PyBind11 < 2.3 due.
   // see https://github.com/pybind/pybind11/pull/1435
-#if (PYBIND11_VERSION_MAJOR > 2) || ((PYBIND11_VERSION_MAJOR == 2) && (PYBIND11_VERSION_MINOR >= 3))
+#if (PYBIND11_VERSION_MAJOR > 2) || \
+    ((PYBIND11_VERSION_MAJOR == 2) && (PYBIND11_VERSION_MINOR >= 3))
   T** operator&() {
     if (!impl->elem) {
       throw std::logic_error("has been invalidated");
     }
     return &(impl->elem);
-    }
+  }
 #endif
 };
 

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -5,6 +5,20 @@
 namespace torch {
 namespace jit {
 
+// This is a hack to remove instances deleted in C++ from the PyBind cache
+// C++->Python. We need this because otherwise we may get the old Python object
+// if C++ creates a new object at the memory location of the deleted object.
+void clear_registered_instances(void* ptr) {
+  auto& registered_instances =
+      pybind11::detail::get_internals().registered_instances;
+  auto range = registered_instances.equal_range(ptr);
+  for (auto it = range.first; it != range.second; ++it) {
+    auto vh = it->second->get_value_and_holder();
+    vh.set_instance_registered(false);
+  }
+  registered_instances.erase(ptr);
+}
+
 IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
   switch (type->kind()) {
     case TypeKind::TensorType: {

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -54,6 +54,8 @@
 namespace torch {
 namespace jit {
 
+void clear_registered_instances(void* ptr);
+
 IValue toIValue(
     py::handle obj,
     const TypePtr& type,

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -396,7 +396,7 @@ void initPythonIRBindings(PyObject* module_) {
 #undef GS
 
 #define VS(name) def(#name, &Value ::name)
-  py::class_<Value, std::unique_ptr<Value, py::nodelete>>(m, "Value")
+  py::class_<Value, unwrapping_shared_ptr<Value>>(m, "Value")
       .def(
           "__repr__",
           [](Value& n) {
@@ -439,7 +439,7 @@ void initPythonIRBindings(PyObject* module_) {
       .def("type", [](Value& v) { return v.type(); });
 #undef VS
 
-  py::class_<Block, std::unique_ptr<Block, py::nodelete>>(m, "Block")
+  py::class_<Block, unwrapping_shared_ptr<Block>>(m, "Block")
       .def(
           "nodes",
           [](Block& b) {
@@ -484,7 +484,7 @@ void initPythonIRBindings(PyObject* module_) {
       });
 
 #define NS(name) def(#name, &Node ::name)
-  py::class_<Node, std::unique_ptr<Node, py::nodelete>>(m, "Node")
+  py::class_<Node, unwrapping_shared_ptr<Node>>(m, "Node")
       .def(
           "__repr__",
           [](Node& n) {


### PR DESCRIPTION
Previously we might have gotten segfaults and all, now it raises an exception.
Thread safety hasn't been an objective.

I have a followup to expand the Python interface for the API.

Fixes #49969.

@wanchaol