### PR TITLE
Fix Docstring in onnx export function

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -175,7 +175,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             opset version. Right now, supported stable opset version is 9.
             The opset_version must be _onnx_master_opset or in _onnx_stable_opsets
             which are defined in torch/onnx/symbolic_helper.py
-        do_constant_folding (bool, default False): If True, the constant-folding
+        do_constant_folding (bool, default True): If True, the constant-folding
             optimization is applied to the model during export. Constant-folding
             optimization will replace some of the ops that have all constant
             inputs, with pre-computed constant nodes.


### PR DESCRIPTION
The default value for `do_constant_folding` in the onnx `export` function is True, but the Docstring is stating otherwise.