### PR TITLE
[PyTorch] Remove CAFFE2_FB_LIMITED_MOBILE_CAPABILITY

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -253,7 +253,7 @@ auto ConvParams::use_nnpack(const at::Tensor& input, const at::Tensor& weight) c
          input.ndimension() == 4 && // must be in NCHW format
          weight.ndimension() == 4 &&
          (weight.size(2) < 17) && (weight.size(3) < 17) // NNPACK only supports kernels up to 16x16
-#if !defined(C10_MOBILE) && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#if !defined(C10_MOBILE)
          && input.size(0) >= 16 // ensure large enough batch size to ensure perf, tuneable
 #endif
      ;

--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -5,18 +5,8 @@
 namespace c10 {
 namespace impl {
 
-/// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
-/// thread_local is not supported.
-#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
-
 // NB: POD, zero initialized!
 thread_local PODLocalDispatchKeySet raw_local_dispatch_key_set;
-
-#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
-
-PODLocalDispatchKeySet raw_local_dispatch_key_set;
-
-#endif
 
 #ifdef _MSC_VER
 LocalDispatchKeySet tls_local_dispatch_key_set() {

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -56,13 +56,7 @@ struct C10_API LocalDispatchKeySet {
 #ifdef _MSC_VER
 C10_API LocalDispatchKeySet tls_local_dispatch_key_set();
 #else // _MSC_VER
-/// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
-/// thread_local is not supported.
-#ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
   extern C10_API thread_local PODLocalDispatchKeySet raw_local_dispatch_key_set;
-#else // defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
-  extern C10_API PODLocalDispatchKeySet raw_local_dispatch_key_set;
-#endif
 
 inline C10_API LocalDispatchKeySet tls_local_dispatch_key_set() {
   // Don't let people fiddle with the thread_local directly just

--- a/caffe2/operators/conv_transpose_op_mobile_test.cc
+++ b/caffe2/operators/conv_transpose_op_mobile_test.cc
@@ -168,7 +168,7 @@ int randInt(int a, int b) {
 }
 
 // TODO(#14383029) cblas_sgemm not yet implemented on limited mobile cases.
-#if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
+#if (defined(__ARM_NEON__) || defined(__ARM_NEON))
 TEST(ConvTransposeMobile, Test) {
   for (int i = 0; i < 10; ++i) {
     int n = randInt(1, 3);

--- a/caffe2/share/contrib/depthwise/depthwise3x3_conv_op_test.cc
+++ b/caffe2/share/contrib/depthwise/depthwise3x3_conv_op_test.cc
@@ -202,16 +202,11 @@ void runConv(
 
 constexpr size_t kIters = 20;
 
-// TODO(#14383029) cblas_sgemm not yet implemented on limited mobile cases.
-#if !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
-
 TEST(DEPTHWISE3x3, Conv) {
   for (int i = 0; i < kIters; ++i) {
     int channel = 2;
     runConv(3, 3, 1, 1, channel, channel, channel, randInt(1, 2));
   }
 }
-
-#endif
 
 } // namespace caffe2

--- a/caffe2/share/contrib/nnpack/nnpack_test.cc
+++ b/caffe2/share/contrib/nnpack/nnpack_test.cc
@@ -238,9 +238,6 @@ void runConv(
 
 constexpr size_t kIters = 20;
 
-// TODO(#14383029) cblas_sgemm not yet implemented on limited mobile cases.
-#if !defined(CAFFE2_FB_LIMITED_MOBILE_CAPABILITY)
-
 TEST(NNPACK, Conv_3x3s1) {
   for (int i = 0; i < kIters; ++i) {
     runConv(3, 3, 1, 1);
@@ -383,7 +380,5 @@ TEST(NNPACK, Conv_HxWsHxW) {
     runConv(kernelH, kernelW, strideH, strideW);
   }
 }
-
-#endif
 
 } // namespace caffe2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50385 [PyTorch] Remove CAFFE2_FB_LIMITED_MOBILE_CAPABILITY**

We no longer use this flag internally, and it's not referenced externally either, so let's clean up.

Differential Revision: [D25852220](https://our.internmc.facebook.com/intern/diff/D25852220/)