### PR TITLE
Fix PyTorch NEON compilation with gcc-7

### DIFF
--- a/aten/src/ATen/cpu/vec256/missing_vld1_neon.h
+++ b/aten/src/ATen/cpu/vec256/missing_vld1_neon.h
@@ -5,7 +5,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_u8_x2 (const uint8_t *__a)
 {
   uint8x8x2_t ret;
-  asm ("ld1 {%S0.8b - %T0.8b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8b - %T0.8b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -14,7 +14,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_s8_x2 (const int8_t *__a)
 {
   int8x8x2_t ret;
-  asm ("ld1 {%S0.8b - %T0.8b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8b - %T0.8b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -23,7 +23,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_u16_x2 (const uint16_t *__a)
 {
   uint16x4x2_t ret;
-  asm ("ld1 {%S0.4h - %T0.4h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4h - %T0.4h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -32,7 +32,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_s16_x2 (const int16_t *__a)
 {
   int16x4x2_t ret;
-  asm ("ld1 {%S0.4h - %T0.4h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4h - %T0.4h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -41,7 +41,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_u32_x2 (const uint32_t *__a)
 {
   uint32x2x2_t ret;
-  asm ("ld1 {%S0.2s - %T0.2s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2s - %T0.2s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -50,7 +50,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_s32_x2 (const int32_t *__a)
 {
   int32x2x2_t ret;
-  asm ("ld1 {%S0.2s - %T0.2s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2s - %T0.2s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -59,7 +59,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_u64_x2 (const uint64_t *__a)
 {
   uint64x1x2_t ret;
-  asm ("ld1 {%S0.1d - %T0.1d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.1d - %T0.1d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -69,7 +69,7 @@ vld1_s64_x2 (const int64_t *__a)
 {
   int64x1x2_t ret;
   __builtin_aarch64_simd_oi __o;
-  asm ("ld1 {%S0.1d - %T0.1d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.1d - %T0.1d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -78,7 +78,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_f16_x2 (const float16_t *__a)
 {
   float16x4x2_t ret;
-  asm ("ld1 {%S0.4h - %T0.4h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4h - %T0.4h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -87,7 +87,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_f32_x2 (const float32_t *__a)
 {
   float32x2x2_t ret;
-  asm ("ld1 {%S0.2s - %T0.2s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2s - %T0.2s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -96,7 +96,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_f64_x2 (const float64_t *__a)
 {
   float64x1x2_t ret;
-  asm ("ld1 {%S0.1d - %T0.1d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.1d - %T0.1d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -105,7 +105,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_p8_x2 (const poly8_t *__a)
 {
   poly8x8x2_t ret;
-  asm ("ld1 {%S0.8b - %T0.8b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8b - %T0.8b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -114,7 +114,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_p16_x2 (const poly16_t *__a)
 {
   poly16x4x2_t ret;
-  asm ("ld1 {%S0.4h - %T0.4h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4h - %T0.4h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -123,7 +123,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1_p64_x2 (const poly64_t *__a)
 {
   poly64x1x2_t ret;
-  asm ("ld1 {%S0.1d - %T0.1d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.1d - %T0.1d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -132,7 +132,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_u8_x2 (const uint8_t *__a)
 {
   uint8x16x2_t ret;
-  asm ("ld1 {%S0.16b - %T0.16b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.16b - %T0.16b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -141,7 +141,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_s8_x2 (const int8_t *__a)
 {
   int8x16x2_t ret;
-  asm ("ld1 {%S0.16b - %T0.16b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.16b - %T0.16b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -150,7 +150,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_u16_x2 (const uint16_t *__a)
 {
   uint16x8x2_t ret;
-  asm ("ld1 {%S0.8h - %T0.8h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8h - %T0.8h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -159,7 +159,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_s16_x2 (const int16_t *__a)
 {
   int16x8x2_t ret;
-  asm ("ld1 {%S0.8h - %T0.8h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8h - %T0.8h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -168,7 +168,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_u32_x2 (const uint32_t *__a)
 {
   uint32x4x2_t ret;
-  asm ("ld1 {%S0.4s - %T0.4s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4s - %T0.4s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -177,7 +177,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_s32_x2 (const int32_t *__a)
 {
   int32x4x2_t ret;
-  asm ("ld1 {%S0.4s - %T0.4s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4s - %T0.4s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -186,7 +186,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_u64_x2 (const uint64_t *__a)
 {
   uint64x2x2_t ret;
-  asm ("ld1 {%S0.2d - %T0.2d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2d - %T0.2d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -195,7 +195,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_s64_x2 (const int64_t *__a)
 {
   int64x2x2_t ret;
-  asm ("ld1 {%S0.2d - %T0.2d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2d - %T0.2d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -204,7 +204,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_f16_x2 (const float16_t *__a)
 {
   float16x8x2_t ret;
-  asm ("ld1 {%S0.8h - %T0.8h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8h - %T0.8h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -213,7 +213,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_f32_x2 (const float32_t *__a)
 {
   float32x4x2_t ret;
-  asm ("ld1 {%S0.4s - %T0.4s}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.4s - %T0.4s}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -222,7 +222,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_f64_x2 (const float64_t *__a)
 {
   float64x2x2_t ret;
-  asm ("ld1 {%S0.2d - %T0.2d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2d - %T0.2d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -231,7 +231,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_p8_x2 (const poly8_t *__a)
 {
   poly8x16x2_t ret;
-  asm ("ld1 {%S0.16b - %T0.16b}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.16b - %T0.16b}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -240,7 +240,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_p16_x2 (const poly16_t *__a)
 {
   poly16x8x2_t ret;
-  asm ("ld1 {%S0.8h - %T0.8h}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.8h - %T0.8h}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -249,7 +249,7 @@ __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vld1q_p64_x2 (const poly64_t *__a)
 {
   poly64x2x2_t ret;
-  asm ("ld1 {%S0.2d - %T0.2d}, [%1]" : "=w" (ret) : "r"(__a) :);
+  asm volatile("ld1 {%S0.2d - %T0.2d}, %1" : "=w" (ret) : "Q"(*__a));
   return ret;
 }
 
@@ -259,194 +259,194 @@ __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_s64_x2 (int64_t * __a, int64x1x2_t val)
 {
-  asm ("st1 {%S0.1d - %T0.1d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.1d - %T1.1d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_u64_x2 (uint64_t * __a, uint64x1x2_t val)
 {
-  asm ("st1 {%S0.1d - %T0.1d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.1d - %T1.1d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_f64_x2 (float64_t * __a, float64x1x2_t val)
 {
-  asm ("st1 {%S0.1d - %T0.1d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.1d - %T1.1d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_s8_x2 (int8_t * __a, int8x8x2_t val)
 {
-  asm ("st1 {%S0.8b - %T0.8b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8b - %T1.8b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_p8_x2 (poly8_t * __a, poly8x8x2_t val)
 {
-  asm ("st1 {%S0.8b - %T0.8b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8b - %T1.8b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_s16_x2 (int16_t * __a, int16x4x2_t val)
 {
-  asm ("st1 {%S0.4h - %T0.4h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4h - %T1.4h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_p16_x2 (poly16_t * __a, poly16x4x2_t val)
 {
-  asm ("st1 {%S0.4h - %T0.4h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4h - %T1.4h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_s32_x2 (int32_t * __a, int32x2x2_t val)
 {
-  asm ("st1 {%S0.2s - %T0.2s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2s - %T1.2s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_u8_x2 (uint8_t * __a, uint8x8x2_t val)
 {
-  asm ("st1 {%S0.8b - %T0.8b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8b - %T1.8b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_u16_x2 (uint16_t * __a, uint16x4x2_t val)
 {
-  asm ("st1 {%S0.4h - %T0.4h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4h - %T1.4h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_u32_x2 (uint32_t * __a, uint32x2x2_t val)
 {
-  asm ("st1 {%S0.2s - %T0.2s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2s - %T1.2s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_f16_x2 (float16_t * __a, float16x4x2_t val)
 {
-  asm ("st1 {%S0.4h - %T0.4h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4h - %T1.4h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_f32_x2 (float32_t * __a, float32x2x2_t val)
 {
-  asm ("st1 {%S0.2s - %T0.2s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2s - %T1.2s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1_p64_x2 (poly64_t * __a, poly64x1x2_t val)
 {
-  asm ("st1 {%S0.1d - %T0.1d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.1d - %T1.1d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_s8_x2 (int8_t * __a, int8x16x2_t val)
 {
-  asm ("st1 {%S0.16b - %T0.16b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.16b - %T1.16b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_p8_x2 (poly8_t * __a, poly8x16x2_t val)
 {
-  asm ("st1 {%S0.16b - %T0.16b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.16b - %T1.16b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_s16_x2 (int16_t * __a, int16x8x2_t val)
 {
-  asm ("st1 {%S0.8h - %T0.8h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8h - %T1.8h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_p16_x2 (poly16_t * __a, poly16x8x2_t val)
 {
-  asm ("st1 {%S0.8h - %T0.8h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8h - %T1.8h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_s32_x2 (int32_t * __a, int32x4x2_t val)
 {
-  asm ("st1 {%S0.4s - %T0.4s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4s - %T1.4s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_s64_x2 (int64_t * __a, int64x2x2_t val)
 {
-  asm ("st1 {%S0.2d - %T0.2d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2d - %T1.2d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_u8_x2 (uint8_t * __a, uint8x16x2_t val)
 {
-  asm ("st1 {%S0.16b - %T0.16b}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.16b - %T1.16b}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_u16_x2 (uint16_t * __a, uint16x8x2_t val)
 {
-  asm ("st1 {%S0.8h - %T0.8h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8h - %T1.8h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_u32_x2 (uint32_t * __a, uint32x4x2_t val)
 {
-  asm ("st1 {%S0.4s - %T0.4s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4s - %T1.4s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_u64_x2 (uint64_t * __a, uint64x2x2_t val)
 {
-  asm ("st1 {%S0.2d - %T0.2d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2d - %T1.2d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_f16_x2 (float16_t * __a, float16x8x2_t val)
 {
-  asm ("st1 {%S0.8h - %T0.8h}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.8h - %T1.8h}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_f32_x2 (float32_t * __a, float32x4x2_t val)
 {
-  asm ("st1 {%S0.4s - %T0.4s}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.4s - %T1.4s}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_f64_x2 (float64_t * __a, float64x2x2_t val)
 {
-  asm ("st1 {%S0.2d - %T0.2d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2d - %T1.2d}, %0" : "=Q" (*__a) : "w" (val));
 }
 
 __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_p64_x2 (poly64_t * __a, poly64x2x2_t val)
 {
-  asm ("st1 {%S0.2d - %T0.2d}, [%1]" :: "w" (val), "r"(__a) :);
+  asm volatile("st1 {%S1.2d - %T1.2d}, %0" : "=Q" (*__a) : "w" (val));
 }

--- a/aten/src/ATen/cpu/vec256/missing_vst1_neon.h
+++ b/aten/src/ATen/cpu/vec256/missing_vst1_neon.h
@@ -4,5 +4,5 @@ __extension__ extern __inline void
 __attribute__ ((__always_inline__, __gnu_inline__, __artificial__))
 vst1q_f32_x2 (float32_t * __a, float32x4x2_t val)
 {
-  asm ("st1 {%S1.4s - %T1.4s}, [%2]" : "=m" (*__a) : "w" (val), "r"(__a) : "memory");
+  asm volatile("st1 {%S1.4s - %T1.4s}, %0" : "=Q" (*__a) : "w" (val));
 }

--- a/aten/src/ATen/cpu/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec256/vec256_float_neon.h
@@ -25,8 +25,6 @@ namespace {
 //    https://bugs.llvm.org/show_bug.cgi?id=45824
 // Most likely we will do aarch32 support with inline asm.
 #if defined(__aarch64__)
-// See https://github.com/pytorch/pytorch/issues/47098
-#if defined(__clang__) || (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ > 3))
 
 #ifdef __BIG_ENDIAN__
 #error "Big endian is not supported."
@@ -696,7 +694,6 @@ Vec256<float> inline fmadd(const Vec256<float>& a, const Vec256<float>& b, const
   return Vec256<float>(r0, r1);
 }
 
-#endif /* defined(__clang__) || (__GNUC__ > 8 || (__GNUC__ == 8 && __GNUC_MINOR__ > 3)) */
 #endif /* defined(aarch64) */
 
 }}}


### PR DESCRIPTION
Apply @sebpop patch to correctly inform optimizing compiler about side-effect of missing neon restrictions
Allow vec256_float_neon to be used even if compiled by gcc-7
Fixes https://github.com/pytorch/pytorch/issues/47098