### PR TITLE
add a specialized check for gradients (RequiresGradCheck) to speed up runtime assumptions check 

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -103,6 +103,7 @@ namespace c10 {
   _(prim, Guard)                     \
   _(prim, BailOut)                   \
   _(prim, TypeCheck)                 \
+  _(prim, RequiresGradCheck)         \
   _(prim, FallbackGraph)             \
   _(prim, FusedConcat)               \
   _(prim, ConstantChunk)             \

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -31,7 +31,8 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
     def assertGraphSize(self, graph, size):
         nodes = list(filter(lambda n: (n.kind() != "prim::BailOut" and
                                        n.kind() != "prim::BailoutTemplate" and
-                                       n.kind() != "prim::TypeCheck"),
+                                       n.kind() != "prim::TypeCheck" and
+                                       n.kind() != "prim::RequiresGradCheck"),
                             graph.nodes()))
         self.assertEqual(len(list(nodes)), size)
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -270,7 +270,7 @@ def get_grad_executor(plan_state, diff_graph_idx=None, skip_check=False):
             nodes = list(filter(lambda n : n.kind() != "prim::BailOut" and n.kind() != "prim::BailoutTemplate", nodes))
             if len(nodes) == 1 or (len(nodes) == 2 and nodes[1].kind() == "prim::TupleConstruct"):
                 pass
-            elif len(nodes) == 2 and nodes[0].kind() == "prim::TypeCheck" and nodes[1].kind() == "prim::If":
+            elif len(nodes) == 2 and nodes[0].kind() == "prim::RequiresGradCheck" and nodes[1].kind() == "prim::If":
                 pass
             else:
                 raise RuntimeError("Can't get a grad_executor for a non-differentiable graph")

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -529,7 +529,8 @@ void AliasDb::analyzeImpl(Node* node) {
     case prim::profile:
       makePointerTo(node->output(), node->inputs().at(0));
       return;
-    case prim::TypeCheck: {
+    case prim::TypeCheck:
+    case prim::RequiresGradCheck: {
       auto num_inputs = node->inputs().size();
       for (size_t i = 0; i < num_inputs; i++) {
         makePointerTo(node->outputs().at(i), node->inputs().at(i));

--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -21,7 +21,8 @@ bool canRunWithAutograd(Node* node) {
   }
   return kind != prim::FusionGroup && kind != prim::CudaFusionGroup &&
       kind != prim::TypeCheck && kind != prim::TensorExprGroup &&
-      kind != prim::CudaFusionGuard && (kind.is_aten() || kind.is_prim());
+      kind != prim::RequiresGradCheck && kind != prim::CudaFusionGuard &&
+      (kind.is_aten() || kind.is_prim());
 }
 
 namespace {

--- a/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
+++ b/torch/csrc/jit/passes/inline_autodiff_subgraphs.cpp
@@ -21,8 +21,7 @@ bool canRunWithAutograd(Node* node) {
   }
   return kind != prim::FusionGroup && kind != prim::CudaFusionGroup &&
       kind != prim::TypeCheck && kind != prim::TensorExprGroup &&
-      kind != prim::RequiresGradCheck && kind != prim::CudaFusionGuard &&
-      (kind.is_aten() || kind.is_prim());
+      kind != prim::CudaFusionGuard && (kind.is_aten() || kind.is_prim());
 }
 
 namespace {

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -3,6 +3,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <memory>
+#include "ATen/core/interned_strings.h"
 
 namespace torch {
 namespace jit {
@@ -51,7 +52,8 @@ using tensor_type_converter_t =
 // expectation that the guarded_node's subgraph will then be optimized.
 TORCH_API void insertTypeGuard(
     Node* guarded_node,
-    tensor_type_converter_t type_converter);
+    tensor_type_converter_t type_converter,
+    c10::Symbol kind);
 
 TORCH_API bool usedOnlyInSize(Value* v);
 TORCH_API Value* broadcastSizes(at::ArrayRef<Value*> sizes, AliasDb* db);

--- a/torch/csrc/jit/passes/tensorexpr_fuser.h
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.h
@@ -3,7 +3,6 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <memory>
-#include "ATen/core/interned_strings.h"
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -7,7 +7,6 @@
 #include <queue>
 #include <utility>
 #include <vector>
-#include "ATen/core/interned_strings.h"
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -7,6 +7,7 @@
 #include <queue>
 #include <utility>
 #include <vector>
+#include "ATen/core/interned_strings.h"
 
 namespace torch {
 namespace jit {
@@ -249,6 +250,7 @@ bool printerHasSpecialCaseFor(Symbol sym) {
       prim::profile_optional, // used in interpreter only
       prim::profile_ivalue, // used in interpreter only
       prim::TypeCheck, // used in interpreter only
+      prim::RequiresGradCheck, // used in interpreter only
       prim::FallbackGraph, // converted into prim::CallFunction
 
   };
@@ -309,6 +311,7 @@ bool aliasAnalysisHasSpecialCaseFor(Symbol symbol) {
       prim::profile_optional,
       prim::profile_ivalue,
       prim::TypeCheck,
+      prim::RequiresGradCheck,
       prim::Print,
       prim::CallFunction,
       prim::CallMethod,

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -32,6 +32,7 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/update_differentiable_graph_requires_grad.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
+#include "ATen/core/interned_strings.h"
 
 C10_DEFINE_bool(
     torch_jit_enable_new_executor,
@@ -157,10 +158,13 @@ bool guardDifferentiableGraph(Node* dnode) {
     // will give us trouble when we get "alternating patterns" of gradients
     // of two inputs, but so it is. An alternative could be to look into
     // the individual requires_grad seen in the profiling record.
-    insertTypeGuard(dnode, [](const TensorTypePtr& t) {
-      return TensorType::get()->withRequiresGrad(
-          t->requiresGrad().value_or(true));
-    });
+    insertTypeGuard(
+        dnode,
+        [](const TensorTypePtr& t) {
+          return TensorType::get()->withRequiresGrad(
+              t->requiresGrad().value_or(true));
+        },
+        prim::RequiresGradCheck);
     return true;
   } else {
     // we inline the differentiable graph as a fallback

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -32,7 +32,6 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include <torch/csrc/jit/passes/update_differentiable_graph_requires_grad.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
-#include "ATen/core/interned_strings.h"
 
 C10_DEFINE_bool(
     torch_jit_enable_new_executor,

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -69,6 +69,10 @@ RegisterOperators reg(
          [](const Node* node) -> Operation {
            std::vector<bool> rg_props =
                fmap(node->tys(attr::types), [](const TypePtr& t) {
+                 // if an rg property changes we assume a tensor does require
+                 // gradients which is set in `guardDifferentiableGraph`
+                 TORCH_INTERNAL_ASSERT(
+                     t->cast<TensorType>()->requiresGrad().has_value());
                  return *t->cast<TensorType>()->requiresGrad();
                });
            return [rg_props](Stack* stack) {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -19,7 +19,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include "jit/jit_log.h"
 
 namespace torch {
 namespace jit {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -74,12 +74,10 @@ RegisterOperators reg(
                });
            return [rg_props](Stack* stack) {
              auto num_inputs = rg_props.size();
-             TORCH_INTERNAL_ASSERT(
-                 stack->size() >= num_inputs && num_inputs > 0);
              // Check every input's shape against profiled (expected) shape.
              for (size_t i = 0; i < num_inputs; i++) {
                auto& input = peek(stack, i, num_inputs);
-               auto t = input.toTensor();
+               const auto& t = input.toTensor();
                if (rg_props[i].has_value() &&
                    *rg_props[i] != t.requires_grad()) {
                  push(stack, false);

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -67,9 +67,9 @@ RegisterOperators reg(
      Operator(
          prim::RequiresGradCheck /* (...)  -> (..., bool) */,
          [](const Node* node) -> Operation {
-           std::vector<c10::optional<bool>> rg_props =
+           std::vector<bool> rg_props =
                fmap(node->tys(attr::types), [](const TypePtr& t) {
-                 return t->cast<TensorType>()->requiresGrad();
+                 return *t->cast<TensorType>()->requiresGrad();
                });
            return [rg_props](Stack* stack) {
              auto num_inputs = rg_props.size();
@@ -77,8 +77,7 @@ RegisterOperators reg(
              for (size_t i = 0; i < num_inputs; i++) {
                auto& input = peek(stack, i, num_inputs);
                const auto& t = input.toTensor();
-               if (rg_props[i].has_value() &&
-                   *rg_props[i] != t.requires_grad()) {
+               if (rg_props[i] != t.requires_grad()) {
                  push(stack, false);
                  return;
                }

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -146,14 +146,15 @@ class JitTestCase(JitCommonTestCase):
                 elif node.kind() == 'prim::DifferentiableGraph':
                     get_nodes_and_parents_recursively(node.g('Subgraph'), kind, acc)
                 elif node.kind() == 'prim::If' and (node.inputs().__next__().node().kind() == 'aten::all' or
-                                                    node.inputs().__next__().node().kind() == 'prim::TypeCheck'):
+                                                    node.inputs().__next__().node().kind() == 'prim::TypeCheck' or 
+                                                    node.inputs().__next__().node().kind() == 'prim::RequiresGradCheck'):
                     get_nodes_and_parents_recursively(node.blocks().__next__(), kind, acc)
                 else:
                     for inner_block in node.blocks():
                         get_nodes_and_parents_recursively(inner_block, kind, acc)
 
         allowed_nodes = {'prim::Constant', FUSION_GROUP, 'prim::BailoutTemplate',
-                         'prim::TupleConstruct', 'prim::If', 'prim::TypeCheck'} | set(except_for)
+                         'prim::TupleConstruct', 'prim::If', 'prim::TypeCheck', 'prim::RequiresGradCheck'} | set(except_for)
 
         fusion_groups : Dict[torch._C.Block, List[torch._C.Node]] = defaultdict(list)
         get_nodes_and_parents_recursively(graph, FUSION_GROUP, fusion_groups)


### PR DESCRIPTION
This change replaces general-case TypeChecks on DifferentiableGraphs addded in https://github.com/pytorch/pytorch/pull/49433 with specialized `RequiresGradCheck`s that only checks if the profiled `requires_gradients` properties match tensors' `requires_gard` at runtime. 
This change improves perf by 3-4% on fastrnns.