### PR TITLE
[PyTorch] Make SROpFunctor a raw function pointer

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -7,7 +7,7 @@ namespace torch {
 namespace jit {
 
 using SROperator = std::function<void(ProcessedNode*)>;
-using SROpFunctor = std::function<SROperator(Node* n)>;
+using SROpFunctor = SROperator(*)(Node* n);
 struct SROperatorFunctor {
   virtual SROperator Generate(Node*) {
     std::function<void(ProcessedNode*)> out;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50395 [PyTorch] Make SROpFunctor a raw function pointer**

There's no need for these to be `std::function`.

Differential Revision: [D25874187](https://our.internmc.facebook.com/intern/diff/D25874187/)