### PR TITLE
Make test_multiprocessing_spawn.py compatible with pytest

### DIFF
--- a/test/test_multiprocessing_spawn.py
+++ b/test/test_multiprocessing_spawn.py
@@ -10,65 +10,65 @@ from torch.testing._internal.common_utils import (TestCase, run_tests, IS_WINDOW
 import torch.multiprocessing as mp
 
 
-def test_success_func(i):
+def _test_success_func(i):
     pass
 
 
-def test_success_single_arg_func(i, arg):
+def _test_success_single_arg_func(i, arg):
     if arg:
         arg.put(i)
 
 
-def test_exception_single_func(i, arg):
+def _test_exception_single_func(i, arg):
     if i == arg:
         raise ValueError("legitimate exception from process %d" % i)
     time.sleep(1.0)
 
 
-def test_exception_all_func(i):
+def _test_exception_all_func(i):
     time.sleep(random.random() / 10)
     raise ValueError("legitimate exception from process %d" % i)
 
 
-def test_terminate_signal_func(i):
+def _test_terminate_signal_func(i):
     if i == 0:
         os.kill(os.getpid(), signal.SIGABRT)
     time.sleep(1.0)
 
 
-def test_terminate_exit_func(i, arg):
+def _test_terminate_exit_func(i, arg):
     if i == 0:
         sys.exit(arg)
     time.sleep(1.0)
 
 
-def test_success_first_then_exception_func(i, arg):
+def _test_success_first_then_exception_func(i, arg):
     if i == 0:
         return
     time.sleep(0.1)
     raise ValueError("legitimate exception")
 
 
-def test_nested_child_body(i, ready_queue, nested_child_sleep):
+def _test_nested_child_body(i, ready_queue, nested_child_sleep):
     ready_queue.put(None)
     time.sleep(nested_child_sleep)
 
 
-def test_infinite_task(i):
+def _test_infinite_task(i):
     while True:
         time.sleep(1)
 
 
-def test_process_exit(idx):
+def _test_process_exit(idx):
     sys.exit(12)
 
 
-def test_nested(i, pids_queue, nested_child_sleep, start_method):
+def _test_nested(i, pids_queue, nested_child_sleep, start_method):
     context = mp.get_context(start_method)
     nested_child_ready_queue = context.Queue()
     nprocs = 2
     mp_context = mp.start_processes(
-        fn=test_nested_child_body,
+        fn=_test_nested_child_body,
         args=(nested_child_ready_queue, nested_child_sleep),
         nprocs=nprocs,
         join=False,
@@ -89,10 +89,10 @@ class _TestMultiProcessing(object):
     start_method = None
 
     def test_success(self):
-        mp.start_processes(test_success_func, nprocs=2, start_method=self.start_method)
+        mp.start_processes(_test_success_func, nprocs=2, start_method=self.start_method)
 
     def test_success_non_blocking(self):
-        mp_context = mp.start_processes(test_success_func, nprocs=2, join=False, start_method=self.start_method)
+        mp_context = mp.start_processes(_test_success_func, nprocs=2, join=False, start_method=self.start_method)
 
         # After all processes (nproc=2) have joined it must return True
         mp_context.join(timeout=None)
@@ -102,7 +102,7 @@ class _TestMultiProcessing(object):
     def test_first_argument_index(self):
         context = mp.get_context(self.start_method)
         queue = context.SimpleQueue()
-        mp.start_processes(test_success_single_arg_func, args=(queue,), nprocs=2, start_method=self.start_method)
+        mp.start_processes(_test_success_single_arg_func, args=(queue,), nprocs=2, start_method=self.start_method)
         self.assertEqual([0, 1], sorted([queue.get(), queue.get()]))
 
     def test_exception_single(self):
@@ -112,14 +112,14 @@ class _TestMultiProcessing(object):
                 Exception,
                 "\nValueError: legitimate exception from process %d$" % i,
             ):
-                mp.start_processes(test_exception_single_func, args=(i,), nprocs=nprocs, start_method=self.start_method)
+                mp.start_processes(_test_exception_single_func, args=(i,), nprocs=nprocs, start_method=self.start_method)
 
     def test_exception_all(self):
         with self.assertRaisesRegex(
             Exception,
             "\nValueError: legitimate exception from process (0|1)$",
         ):
-            mp.start_processes(test_exception_all_func, nprocs=2, start_method=self.start_method)
+            mp.start_processes(_test_exception_all_func, nprocs=2, start_method=self.start_method)
 
     def test_terminate_signal(self):
         # SIGABRT is aliased with SIGIOT
@@ -134,7 +134,7 @@ class _TestMultiProcessing(object):
             message = "process 0 terminated with exit code 22"
 
         with self.assertRaisesRegex(Exception, message):
-            mp.start_processes(test_terminate_signal_func, nprocs=2, start_method=self.start_method)
+            mp.start_processes(_test_terminate_signal_func, nprocs=2, start_method=self.start_method)
 
     def test_terminate_exit(self):
         exitcode = 123
@@ -142,7 +142,7 @@ class _TestMultiProcessing(object):
             Exception,
             "process 0 terminated with exit code %d" % exitcode,
         ):
-            mp.start_processes(test_terminate_exit_func, args=(exitcode,), nprocs=2, start_method=self.start_method)
+            mp.start_processes(_test_terminate_exit_func, args=(exitcode,), nprocs=2, start_method=self.start_method)
 
     def test_success_first_then_exception(self):
         exitcode = 123
@@ -150,18 +150,18 @@ class _TestMultiProcessing(object):
             Exception,
             "ValueError: legitimate exception",
         ):
-            mp.start_processes(test_success_first_then_exception_func, args=(exitcode,), nprocs=2, start_method=self.start_method)
+            mp.start_processes(_test_success_first_then_exception_func, args=(exitcode,), nprocs=2, start_method=self.start_method)
 
     @unittest.skipIf(
         sys.platform != "linux",
         "Only runs on Linux; requires prctl(2)",
     )
-    def test_nested(self):
+    def _test_nested(self):
         context = mp.get_context(self.start_method)
         pids_queue = context.Queue()
         nested_child_sleep = 20.0
         mp_context = mp.start_processes(
-            fn=test_nested,
+            fn=_test_nested,
             args=(pids_queue, nested_child_sleep, self.start_method),
             nprocs=1,
             join=False,
@@ -195,18 +195,18 @@ class SpawnTest(TestCase, _TestMultiProcessing):
 
     def test_exception_raises(self):
         with self.assertRaises(mp.ProcessRaisedException):
-            mp.spawn(test_success_first_then_exception_func, args=(), nprocs=1)
+            mp.spawn(_test_success_first_then_exception_func, args=(), nprocs=1)
 
     def test_signal_raises(self):
-        context = mp.spawn(test_infinite_task, args=(), nprocs=1, join=False)
+        context = mp.spawn(_test_infinite_task, args=(), nprocs=1, join=False)
         for pid in context.pids():
             os.kill(pid, signal.SIGTERM)
         with self.assertRaises(mp.ProcessExitedException):
             context.join()
 
-    def test_process_exited(self):
+    def _test_process_exited(self):
         with self.assertRaises(mp.ProcessExitedException) as e:
-            mp.spawn(test_process_exit, args=(), nprocs=1)
+            mp.spawn(_test_process_exit, args=(), nprocs=1)
             self.assertEqual(12, e.exit_code)
 
 


### PR DESCRIPTION
This file is currently failing with

```
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 13
  def test_success_func(i):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:13
________________________________________________________________________________________________________________ ERROR at setup of test_success_single_arg_func ________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 17
  def test_success_single_arg_func(i, arg):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:17
_________________________________________________________________________________________________________________ ERROR at setup of test_exception_single_func _________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 22
  def test_exception_single_func(i, arg):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:22
__________________________________________________________________________________________________________________ ERROR at setup of test_exception_all_func ___________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 28
  def test_exception_all_func(i):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:28
_________________________________________________________________________________________________________________ ERROR at setup of test_terminate_signal_func _________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 33
  def test_terminate_signal_func(i):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:33
__________________________________________________________________________________________________________________ ERROR at setup of test_terminate_exit_func __________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 39
  def test_terminate_exit_func(i, arg):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:39
___________________________________________________________________________________________________________ ERROR at setup of test_success_first_then_exception_func ___________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 45
  def test_success_first_then_exception_func(i, arg):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:45
___________________________________________________________________________________________________________________ ERROR at setup of test_nested_child_body ___________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 52
  def test_nested_child_body(i, ready_queue, nested_child_sleep):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:52
_____________________________________________________________________________________________________________________ ERROR at setup of test_infinite_task _____________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 57
  def test_infinite_task(i):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:57
_____________________________________________________________________________________________________________________ ERROR at setup of test_process_exit ______________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 62
  def test_process_exit(idx):
E       fixture 'idx' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py:62
________________________________________________________________________________________________________________________ ERROR at setup of test_nested _________________________________________________________________________________________________________________________
file /home/gaoxiang/pytorch-tf32/test/test_multiprocessing_spawn.py, line 66
  def test_nested(i, pids_queue, nested_child_sleep, start_method):
E       fixture 'i' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, include_metadata_in_junit_xml, json_metadata, metadata, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```
when running with pytest. This is because pytest considers anything starting with `test_` as a test, so I renamed it to `_test_...` to prevent this from happening.