### PR TITLE
Fix fft slow tests

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -482,9 +482,10 @@ class SpectralFuncInfo(OpInfo):
                  skips=None,
                  decorators=None,
                  **kwargs):
+        skips = skips if skips is not None else []
+
         # gradgrad is quite slow
         if not TEST_WITH_SLOW:
-            skips = skips if skips is not None else []
             skips.append(SkipInfo('TestGradients', 'test_fn_gradgrad'))
 
         decorators = decorators if decorators is not None else []


### PR DESCRIPTION
The failure is:
```
______________________________________________________________________________________________________ TestCommonCUDA.test_variant_consistency_jit_fft_rfft_cuda_float64 _______________________________________________________________________________________________________
../.local/lib/python3.9/site-packages/torch/testing/_internal/common_utils.py:889: in wrapper
    method(*args, **kwargs)
../.local/lib/python3.9/site-packages/torch/testing/_internal/common_utils.py:889: in wrapper
    method(*args, **kwargs)
../.local/lib/python3.9/site-packages/torch/testing/_internal/common_device_type.py:267: in instantiated_test
    if op is not None and op.should_skip(generic_cls.__name__, name,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch.testing._internal.common_methods_invocations.SpectralFuncInfo object at 0x7f7375f9b550>, cls_name = 'TestCommon', test_name = 'test_variant_consistency_jit', device_type = 'cuda', dtype = torch.float64

    def should_skip(self, cls_name, test_name, device_type, dtype):
>       for si in self.skips:
E       TypeError: 'NoneType' object is not iterable

../.local/lib/python3.9/site-packages/torch/testing/_internal/common_methods_invocations.py:186: TypeError

```