### PR TITLE
Add check to ensure CUDA event is created when synchronizing

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -350,15 +350,14 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
   for (size_t i = 0; i < devices_.size(); ++i) {
     auto currentStream = at::cuda::getCurrentCUDAStream(devices_[i].index());
     // Block the current stream on the NCCL stream
-    auto cudaEvent = (*cudaEvents_)[i];
     // Check to ensure event is created. Otherwise, this block() call will be a
     // no-op which can cause silent correctness issues as there will be no
     // stream synchronization.
     TORCH_CHECK(
-      cudaEvent.isCreated(),
+      (*cudaEvents_)[i].isCreated(),
       c10::str("Invalid CUDA event on device ", devices_[i].index())
     );
-    cudaEvent.block(currentStream);
+    (*cudaEvents_)[i].block(currentStream);
   }
 }
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -355,7 +355,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
     // stream synchronization.
     TORCH_CHECK(
       (*cudaEvents_)[i].isCreated(),
-      c10::str("Invalid CUDA event on device ", devices_[i].index())
+      c10::str("Invalid CUDA event on device ", i)
     );
     (*cudaEvents_)[i].block(currentStream);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50445 Add check to ensure CUDA event is created when synchronizing**

We have been seeing some silent correctness issues that only surface
later (i.e. after a device synchronize), and one potential source of this could be issues in stream
synchronization.

As per https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/cuda/CUDAEvent.h#L123, `cudaStreamWaitEvent` is only called if the event has been successfully created. It should indeed be created in the `WorkNCCL` constructor: https://github.com/pytorch/pytorch/blob/master/torch/lib/c10d/ProcessGroupNCCL.cpp#L251, but just adding this check to catch any synchronization issues that may occur and raise a better error message.

Differential Revision: [D25889723](https://our.internmc.facebook.com/intern/diff/D25889723/)