### PR TITLE
Caffe2 Concat operator benchmark

### DIFF
--- a/benchmarks/operator_benchmark/c2/concat_test.py
+++ b/benchmarks/operator_benchmark/c2/concat_test.py
@@ -1,0 +1,116 @@
+import operator_benchmark as op_bench
+import benchmark_caffe2 as op_bench_c2
+import random
+from benchmark_caffe2 import Caffe2BenchmarkBase # noqa
+from caffe2.python import core
+
+
+"""Microbenchmarks for Concat operator. Supports both Caffe2/PyTorch."""
+
+# Configs for C2 concat operator
+cat_configs_short = op_bench.config_list(
+    attr_names=['sizes', 'N', 'axis'],
+    attrs=[
+        [(1,    1,      1), 2, 0], # noqa
+        [(512,  512,    2), 2, 1], # noqa
+        [(128, 1024,    2), 2, 1], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype': ['float'],
+    },
+    tags=['short'],
+)
+
+cat_configs_long = op_bench.config_list(
+    attr_names=['sizes', 'N', 'axis'],
+    attrs=[
+        [(2**10,    2**10,      2), 2, 0], # noqa
+        [(2**10+1,  2**10-1,    2), 2, 1], # noqa
+        [(2**10,    2**10,      2), 2, 2], # noqa
+
+        [[ lambda: random.randint(2**6, 2**7),      2**7-17,    2**6+1], # noqa
+            5, 0],
+        [[ 2**6+2**5,   lambda: random.randint(2**6, 2**7),     2**6], # noqa
+            5, 1],
+        [[ 2**7,        2**6,       lambda: random.randint(2**6, 2**7)], # noqa
+            5, 2],
+
+        [[lambda: random.randint(2**5, 2**6),       2**5,       2**6], # noqa
+            50, 0],
+        [[2**5,         lambda: random.randint(2**5, 2**6),     2**6], # noqa
+            50, 1],
+        [[2**5+1,       2**6+1,         lambda: random.randint(2**5, 2**6)], # noqa
+            50, 2],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype': ['float'],
+    },
+    tags=['long'],
+)
+
+# There is a different codepath on CUDA for >4 dimensions
+cat_configs_multidim = op_bench.config_list(
+    attr_names=['sizes', 'N', 'axis', 'dtype'],
+    attrs=[
+        [(2**6,     2**5,   2**2,   2**4,   2**5), 2, 2], # noqa
+        [(2**4,     2**5,   2**2,   2**4,   2**5), 8, 2], # noqa
+        [(2**3+1,   2**5-1, 2**2+1, 2**4-1, 2**5+1), 17, 4], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype': ['float'],
+    },
+    tags=['multidim'],
+)
+
+cat_configs_manyinputs = op_bench.config_list(
+    attr_names=['sizes', 'N', 'axis', 'dtype'],
+    attrs=[
+        [[lambda: random.randint(1, 10000)], 100, 0],
+        [[lambda: random.randint(1, 1000)], 1000, 0],
+        [[lambda: random.randint(1, 500)], 2000, 0],
+        [[lambda: random.randint(1, 300)], 3000, 0],
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dtype': ['float'],
+    },
+    tags=['manyinputs'],
+)
+
+
+class ConcatBenchmark(op_bench_c2.Caffe2BenchmarkBase):
+    def init(self, sizes, N, axis, dtype, device):
+        random.seed(42)
+        self.inputs = []
+        self.args = {'axis': axis}
+        gen_sizes = []
+        for i in range(N):
+            gen_sizes.append([old_size() if callable(old_size) else old_size
+                             for old_size in sizes])
+
+        for s in gen_sizes:
+            self.inputs.append(self.tensor(s, dtype, device=device))
+
+        self.output = self.tensor(gen_sizes[0], dtype, device=device)
+        self.split_info = self.tensor(gen_sizes[0], "int")
+        self.set_module_name("concat")
+
+    def forward(self):
+        op = core.CreateOperator(
+            "Concat", self.inputs, [self.output, self.split_info], **self.args
+        )
+        return op
+
+
+op_bench_c2.generate_c2_test(cat_configs_short +
+                             cat_configs_long +
+                             cat_configs_multidim +
+                             cat_configs_manyinputs,
+                             ConcatBenchmark)
+
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary:
Port caffe2 operator benchmark from torch.cat to caffe2 concat to measure the difference in performance.

previous diff abandoned to rerun github CI tests. D25738076

Test Plan:
Tested on devbig by running both pt and c2 benchmarks. Compiled with mode/opt

Inputs:
```
size, number of inputs, cat dimension, device
----------------------------------------------------
(1, 1, 1), N: 2, dim: 0, device: cpu
(512, 512, 2), N: 2, dim: 1, device: cpu
(128, 1024, 2), N: 2, dim: 1, device: cpu
(1024, 1024, 2), N: 2, dim: 0, device: cpu
(1025, 1023, 2), N: 2, dim: 1, device: cpu
(1024, 1024, 2), N: 2, dim: 2, device: cpu
[<function <lambda> at 0x7f922718e8c0>, 111, 65], N: 5, dim: 0, device: cpu
[96, <function <lambda> at 0x7f9226dad710>, 64], N: 5, dim: 1, device: cpu
[128, 64, <function <lambda> at 0x7f91a3625ef0>], N: 5, dim: 2, device: cpu
[<function <lambda> at 0x7f91a3625f80>, 32, 64], N: 50, dim: 0, device: cpu
[32, <function <lambda> at 0x7f91a3621050>, 64], N: 50, dim: 1, device: cpu
[33, 65, <function <lambda> at 0x7f91a36210e0>], N: 50, dim: 2, device: cpu
(64, 32, 4, 16, 32), N: 2, dim: 2, device: cpu
(16, 32, 4, 16, 32), N: 8, dim: 2, device: cpu
(9, 31, 5, 15, 33), N: 17, dim: 4, device: cpu
[<function <lambda> at 0x7f91a3621170>], N: 100, dim: 0, device: cpu
[<function <lambda> at 0x7f91a3621200>], N: 1000, dim: 0, device: cpu
[<function <lambda> at 0x7f91a3621290>], N: 2000, dim: 0, device: cpu
[<function <lambda> at 0x7f91a3621320>], N: 3000, dim: 0, device: cpu
```

```
pytorch: MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 buck-out/gen/caffe2/benchmarks/operator_benchmark/pt/cat_test.par --tag_filter=all
caffe2: MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 buck-out/gen/caffe2/benchmarks/operator_benchmark/c2/concat_test.par --tag_filter=all
```
```
Metric: Forward Execution Time (us)

pytorch             | caffe2
--------------------------------
 4.066              | 0.312
 351.507            | 584.033
 184.649            | 292.157
 9482.895           | 6845.112
 9558.988           | 6847.511
 13730.016          | 14118.505
 6324.371           | 4840.883
 4613.497           | 3702.213
 7504.718           | 7889.751
 9882.978           | 7364.350
 10087.076          | 7483.178
 16849.556          | 18092.295
 19181.075          | 13363.742
 19296.508          | 13466.863
 34157.449          | 56320.073
 176.483            | 267.106
 322.247            | 352.782
 480.064            | 460.214
 607.381            | 476.908
```

Differential Revision: D25890595

