### PR TITLE
[PyTorch] Gate tls_local_dispatch_key_set inlining off for Android

### DIFF
--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -18,11 +18,11 @@ PODLocalDispatchKeySet raw_local_dispatch_key_set;
 
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(C10_ANDROID)
 LocalDispatchKeySet tls_local_dispatch_key_set() {
   return raw_local_dispatch_key_set;
 }
-#endif // _MSC_VER
+#endif // defined(_MSC_VER) || defined(C10_ANDROID)
 
 void _force_tls_local_dispatch_key_set(LocalDispatchKeySet key_set) {
   raw_local_dispatch_key_set = PODLocalDispatchKeySet {

--- a/c10/core/impl/LocalDispatchKeySet.h
+++ b/c10/core/impl/LocalDispatchKeySet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/core/DispatchKeySet.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Flags.h>
 
 // TLS management for DispatchKeySet (the "local" DispatchKeySet(s))
@@ -53,9 +54,10 @@ struct C10_API LocalDispatchKeySet {
 };
 
 // thread_local variables cannot be C10_API on Windows.
-#ifdef _MSC_VER
+// Inlining this seems to break AutoNonVariableTypeGuard on Android.
+#if defined(_MSC_VER) || defined(C10_ANDROID)
 C10_API LocalDispatchKeySet tls_local_dispatch_key_set();
-#else // _MSC_VER
+#else // defined(_MSC_VER) || defined(C10_ANDROID)
 /// In the CAFFE2_FB_LIMITED_MOBILE_CAPABILITY build setting,
 /// thread_local is not supported.
 #ifndef CAFFE2_FB_LIMITED_MOBILE_CAPABILITY
@@ -69,7 +71,7 @@ inline C10_API LocalDispatchKeySet tls_local_dispatch_key_set() {
   // because they include this header.
   return raw_local_dispatch_key_set;
 }
-#endif // _MSC_VER
+#endif // defined(_MSC_VER) || defined(C10_ANDROID)
 
 // Internal, use ThreadLocalStateGuard
 C10_API void _force_tls_local_dispatch_key_set(LocalDispatchKeySet key_set);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50450 [PyTorch] Gate tls_local_dispatch_key_set inlining off for Android**

See comment, seems to break things.

Differential Revision: [D25892759](https://our.internmc.facebook.com/intern/diff/D25892759/)