### PR TITLE
Change watchdog timeout logging from INFO to ERROR.

### DIFF
--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -525,7 +525,7 @@ void ProcessGroupNCCL::abortTimedOutCollectives(std::unordered_set<std::string>&
                                           " ran for ",
                                           timeElapsed.count(),
                                           " milliseconds before timing out.");
-      LOG(INFO) << exceptionMsg;
+      LOG(ERROR) << exceptionMsg;
       std::exception_ptr exception_ptr = std::make_exception_ptr(
           std::runtime_error(exceptionMsg));
       work.setException(exception_ptr);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50455 Change watchdog timeout logging from INFO to ERROR.**

Certain systems only print logging messages for ERROR/WARN and the
error message that the watchdog is timing out a particular operation is pretty
important.

As a result, changing its level to ERROR instead of INFO.

Differential Revision: [D25894795](https://our.internmc.facebook.com/intern/diff/D25894795/)