### PR TITLE
Fix adam docstring (L2 implementation)

### DIFF
--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -7,7 +7,7 @@ class Adam(Optimizer):
     r"""Implements Adam algorithm.
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
-    The implementation of the L2 penalty is based on the original alogirthm.
+    The implementation of the L2 penalty is based on the original algorithm.
 
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -7,8 +7,7 @@ class Adam(Optimizer):
     r"""Implements Adam algorithm.
 
     It has been proposed in `Adam: A Method for Stochastic Optimization`_.
-    The implementation of the L2 penalty follows changes proposed in
-    `Decoupled Weight Decay Regularization`_.
+    The implementation of the L2 penalty is based on the original alogirthm.
 
     Args:
         params (iterable): iterable of parameters to optimize or dicts defining
@@ -25,8 +24,6 @@ class Adam(Optimizer):
 
     .. _Adam\: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980
-    .. _Decoupled Weight Decay Regularization:
-        https://arxiv.org/abs/1711.05101
     .. _On the Convergence of Adam and Beyond:
         https://openreview.net/forum?id=ryQu7f-RZ
     """


### PR DESCRIPTION
Fixes #48793. 

Corrects `torch.optim.Adam` docstring with regards to L2-penalty implementation.