### PR TITLE
Fix warnings in "ForeachUtils.h"

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -25,7 +25,7 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
 
   auto expected_dtype = tensors1[0].dtype();
 
-  for (int i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
@@ -41,7 +41,7 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, Te
 
   auto expected_dtype = tensors1[0].dtype();
 
-  for (int i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
@@ -146,7 +146,7 @@ bool can_use_fast_route(TensorList tensors1, TensorList tensors2) {
   return false;
 #else
   auto expected_device = tensors1[0].device();
-  for (int64_t i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     if (!has_same_attributes(expected_device, {tensors1[i], tensors2[i]})) {
       return false;
     }
@@ -161,7 +161,7 @@ bool can_use_fast_route(TensorList tensors1, TensorList tensors2, Scalar scalar)
   return false;
 #else
   auto expected_device = tensors1[0].device();
-  for (int64_t i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     if (!has_same_attributes(expected_device, {tensors1[i], tensors2[i]})) {
       return false;
     }
@@ -180,7 +180,7 @@ bool can_use_fast_route(TensorList tensors1, TensorList tensors2, TensorList ten
   return false;
 #else
   auto expected_device = tensors1[0].device();
-  for (int64_t i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     if (!has_same_attributes(expected_device, {tensors1[i], tensors2[i], tensors3[i]})) {
       return false;
     }
@@ -195,7 +195,7 @@ bool can_use_fast_route(TensorList tensors1, TensorList tensors2, TensorList ten
   return false;
 #else
   auto expected_device = tensors1[0].device();
-  for (int64_t i = 0; i < tensors1.size(); i++) {
+  for (size_t i = 0; i < tensors1.size(); i++) {
     if (!has_same_attributes(expected_device, {tensors1[i], tensors2[i], tensors3[i]})) {
       return false;
     }


### PR DESCRIPTION
Summary:
Compiling currently raises the warnings:
```
Jan 13 16:46:28 In file included from ../aten/src/ATen/native/ForeachOpsKernels.cpp:2:
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:28:21: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:44:21: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:149:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:164:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:183:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:198:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
```
This diff fixes that

Differential Revision: D25901713

