### PR TITLE
enable CPU tests back

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -302,7 +302,7 @@ class TestDistBackend(MultiProcessTestCase):
         self.rank = rank
         self.file_name = file_name
 
-        if torch.cuda.device_count() < int(self.world_size):
+        if torch.cuda.is_available() and torch.cuda.device_count() < int(self.world_size):
             sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
         try:
             timeout = timedelta(seconds=60)


### PR DESCRIPTION
Summary:
Right now CPU tests are skipped because it always failed in checking 'torch.cuda.device_count() < int(self.world_size)',
enable CPU tests back by checking device count only when cuda is available

Test Plan: unit tests, CPU tests are not skipped with this diff

Differential Revision: D25901980

