### PR TITLE
Exclude test/generated_type_hints_smoketest.py from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,4 +13,21 @@ ignore =
     # these ignores are from flake8-comprehensions; please fix!
     C400,C401,C402,C403,C404,C405,C407,C411,C413,C414,C415
 per-file-ignores = __init__.py: F401 torch/utils/cpp_extension.py: B950
-exclude = docs/src,docs/cpp/src,venv,third_party,caffe2,scripts,docs/caffe2,torch/lib/include,torch/lib/tmp_install,build,torch/include,*.pyi,.git,build,build_test_custom_build,build_code_analyzer
+exclude =
+    docs/src,
+    docs/cpp/src,
+    venv,
+    third_party,
+    caffe2,
+    scripts,
+    docs/caffe2,
+    torch/lib/include,
+    torch/lib/tmp_install,
+    build,
+    torch/include,
+    *.pyi,
+    .git,
+    build,
+    build_test_custom_build,
+    build_code_analyzer,
+    test/generated_type_hints_smoketest.py


### PR DESCRIPTION
Similar to #48201, this PR excludes a file that is auto-generated by [`test/test_type_hints.py`](https://github.com/pytorch/pytorch/blob/5834438090a1b3206347e30968e48f44251a53a1/test/test_type_hints.py#L109-L111), which doesn't happen to be run before the Flake8 check is done in CI. Also, because the `exclude` list in `.flake8` has gotten fairly long, this PR splits it across multiple lines.

**Test plan:**

Run this in your shell:

```sh
python test/test_type_hints.py TestTypeHints.test_doc_examples
flake8
```

- _Before:_ `flake8` prints [these 169 false positives](https://pastebin.com/qPJY24g8) and returns exit code 1
- _After:_ `flake8` prints no output and returns exit code 0