### PR TITLE
[ROCm] warn unsupported PYTORCH_CUDA_FUSER_DISABLE_FMA

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -303,7 +303,12 @@ NvrtcFunction nvrtcCompile(
   const char* disable_fma = getenv("PYTORCH_CUDA_FUSER_DISABLE_FMA");
   // int disable_fma_flag = disable_fma ? atoi(disable_fma) : 0;
   if (disable_fma && atoi(disable_fma)) {
+#ifdef __HIP_PLATFORM_HCC__
+    TORCH_WARN_ONCE(
+        "PYTORCH_CUDA_FUSER_DISABLE_FMA is not supported on ROCm, ignoring");
+#else
     args.push_back("--fmad=false");
+#endif
   }
 
   const char* ptxas_opt_level = getenv("PYTORCH_CUDA_FUSER_JIT_OPT_LEVEL");


### PR DESCRIPTION
nvcc's `--fmad=false` is not valid for the HIP compiler.  Upcoming ROCm releases will start treating unrecognized compiler flags as an error.