### PR TITLE
prefer "const auto&" for latests gcc

### DIFF
--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -389,7 +389,7 @@ void initJITBindings(PyObject* module) {
             ArgumentSpecCreator arg_spec_creator(*graph);
             Stack stack;
             stack.reserve(inputs.size()); // captures?
-            for (auto& obj : inputs) {
+            for (const auto& obj : inputs) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             ArgumentSpec spec = arg_spec_creator.create(with_grad, stack);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1065,7 +1065,7 @@ void initJitScriptBindings(PyObject* module) {
              const std::string& method_name,
              const py::tuple& input_tuple) {
             Stack stack;
-            for (auto& input : input_tuple) {
+            for (const auto& input : input_tuple) {
               stack.push_back(toTypeInferredIValue(input));
             }
             return m.get_method(method_name)(stack);
@@ -1076,7 +1076,7 @@ void initJitScriptBindings(PyObject* module) {
           "forward",
           [](mobile::Module& m, const py::tuple& input_tuple) {
             Stack stack;
-            for (auto& input : input_tuple) {
+            for (const auto& input : input_tuple) {
               stack.push_back(toTypeInferredIValue(input));
             }
             return m.get_method("forward")(stack);


### PR DESCRIPTION
gcc (Debian 10.2.1-3) 10.2.1 20201224
ex
../torch/csrc/jit/python/init.cpp:356:30: error: cannot bind non-const lvalue reference of type ‘pybind11::detail::accessor<pybind11::detail::accessor_policies::sequence_item>&’ to an rvalue of type ‘pybind11::detail::generic_iterator<pybind11::detail::iterator_policies::sequence_slow_readwrite>::reference’ {aka ‘pybind11::detail::accessor<pybind11::detail::accessor_policies::sequence_item>’}
  356 |             for (auto& obj : inputs) {
      |                              ^~~~~~

Fixes #{issue number}
