### PR TITLE
[ONNX] Improve error message for parse_arg in symbolic functions

### DIFF
--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -136,7 +136,7 @@ def parse_args(*arg_descriptors):
                 sig = inspect.signature(fn)
                 arg_names = list(sig.parameters.keys())[1:]
                 fn_name = fn.__name__
-            except:
+            except Exception:
                 arg_names = [None] * len(args)
                 fn_name = None
             args = [_parse_arg(arg, arg_desc, arg_name, fn_name)  # type: ignore

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -88,10 +88,10 @@ def _parse_arg(value, desc, arg_name=None, node_name=None):
             raise RuntimeError("ONNX symbolic doesn't know to interpret ListConstruct node")
 
     if arg_name is None or node_name is None:
-        raise RuntimeError("Expected node type: 'onnx::Constant', got: '{}'.".format(value.node().kind()))
+        raise RuntimeError("Expected node type 'onnx::Constant', got '{}'.".format(value.node().kind()))
     else:
-        raise RuntimeError("Expected node type: 'onnx::Constant' "
-                           "for argument '{}' of node '{}', got: '{}'.".format(arg_name, node_name, value.node().kind()))
+        raise RuntimeError("Expected node type 'onnx::Constant' "
+                           "for argument '{}' of node '{}', got '{}'.".format(arg_name, node_name, value.node().kind()))
 
 
 def _maybe_get_const(value, desc):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -1,6 +1,7 @@
 
 import torch
 import warnings
+import inspect
 from sys import maxsize as maxsize
 from typing import Set
 
@@ -50,7 +51,7 @@ from torch._C import OptionalType
 _sum = sum
 
 
-def _parse_arg(value, desc):
+def _parse_arg(value, desc, arg_name=None, node_name=None):
     if desc == 'none':
         return value
     if desc == 'v' or not _is_value(value):
@@ -86,7 +87,11 @@ def _parse_arg(value, desc):
         else:
             raise RuntimeError("ONNX symbolic doesn't know to interpret ListConstruct node")
 
-    raise RuntimeError("Unexpected node type: {}".format(value.node().kind()))
+    if arg_name is None or node_name is None:
+        raise RuntimeError("Expected node type: 'onnx::Constant', got: '{}'.".format(value.node().kind()))
+    else:
+        raise RuntimeError("Expected node type: 'onnx::Constant' "
+                           "for argument '{}' of node '{}', got: '{}'.".format(arg_name, node_name, value.node().kind()))
 
 
 def _maybe_get_const(value, desc):
@@ -127,7 +132,9 @@ def parse_args(*arg_descriptors):
         def wrapper(g, *args, **kwargs):
             # some args may be optional, so the length may be smaller
             assert len(arg_descriptors) >= len(args)
-            args = [_parse_arg(arg, arg_desc) for arg, arg_desc in zip(args, arg_descriptors)]  # type: ignore
+            sig = inspect.signature(fn)
+            arg_names = list(sig.parameters.keys())[1:]
+            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__) for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
             # only support _outputs in kwargs
             assert len(kwargs) <= 1
             if len(kwargs) == 1:

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -134,7 +134,8 @@ def parse_args(*arg_descriptors):
             assert len(arg_descriptors) >= len(args)
             sig = inspect.signature(fn)
             arg_names = list(sig.parameters.keys())[1:]
-            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__) for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
+            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__)
+                    for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
             # only support _outputs in kwargs
             assert len(kwargs) <= 1
             if len(kwargs) == 1:

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -132,9 +132,14 @@ def parse_args(*arg_descriptors):
         def wrapper(g, *args, **kwargs):
             # some args may be optional, so the length may be smaller
             assert len(arg_descriptors) >= len(args)
-            sig = inspect.signature(fn)
-            arg_names = list(sig.parameters.keys())[1:]
-            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__)  # type: ignore
+            try:
+                sig = inspect.signature(fn)
+                arg_names = list(sig.parameters.keys())[1:]
+                fn_name = fn.__name__
+            except:
+                arg_names = [None] * len(args)
+                fn_name = None
+            args = [_parse_arg(arg, arg_desc, arg_name, fn_name)  # type: ignore
                     for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
             # only support _outputs in kwargs
             assert len(kwargs) <= 1

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -137,8 +137,8 @@ def parse_args(*arg_descriptors):
                 arg_names = list(sig.parameters.keys())[1:]
                 fn_name = fn.__name__
             except Exception:
-                arg_names = [None] * len(args)
-                fn_name = None
+                arg_names = [None] * len(args)  # type: ignore
+                fn_name = None  # type: ignore
             args = [_parse_arg(arg, arg_desc, arg_name, fn_name)  # type: ignore
                     for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
             # only support _outputs in kwargs

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -134,7 +134,7 @@ def parse_args(*arg_descriptors):
             assert len(arg_descriptors) >= len(args)
             sig = inspect.signature(fn)
             arg_names = list(sig.parameters.keys())[1:]
-            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__)
+            args = [_parse_arg(arg, arg_desc, arg_name, fn.__name__)  # type: ignore
                     for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
             # only support _outputs in kwargs
             assert len(kwargs) <= 1


### PR DESCRIPTION
previous error message looks like this 
```
RuntimeError: Unexpected node type: onnx::Gather
```
now
```
RuntimeError: Expected node type 'onnx::Constant' for argument 'groups' of node 'conv1d', got 'onnx::Gather'.
```

Repro example:
```python
    @torch.jit.script
    def conv(x, w):
        return F.conv1d(x, w, groups=x.shape[0])

    class Net(nn.Module):
        def forward(self, x, w):
            return conv(x, w)

    model = Net()

    x = torch.randn(8, 8, 512)
    w = torch.randn(8, 1, 3)
    torch.onnx.export(model,
                        (x, w),
                        "file.onnx",
                        opset_version=12)
```