### PR TITLE
Fix fastrnn benchmark regression introduced by 49946

### DIFF
--- a/benchmarks/fastrnns/cells.py
+++ b/benchmarks/fastrnns/cells.py
@@ -1,4 +1,6 @@
 import torch
+from typing import Tuple
+from torch import Tensor
 
 
 def milstm_cell(x, hx, cx, w_ih, w_hh, alpha, beta_i, beta_h, bias):

--- a/benchmarks/fastrnns/factory.py
+++ b/benchmarks/fastrnns/factory.py
@@ -1,6 +1,8 @@
 import torch
 
 from collections import namedtuple
+from typing import List, Tuple
+from torch import Tensor
 
 from .cells import lstm_cell, premul_lstm_cell, premul_lstm_cell_no_bias, flat_lstm_cell
 


### PR DESCRIPTION
Simply add missing `from typing import List, Tuple` and `from torch import Tensor`

Fixes regressions introduced by #49946 
