### PR TITLE
[TensorExpr] Hook Fuser Pass to JIT opt-limit utility.

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/jit_opt_limit.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
@@ -975,6 +976,13 @@ class TensorExprFuser {
 
     REQ(tensorexpr::isSupported(node));
     REQ(typesAreSupported(node));
+
+    // A hook to optimizations limitter to allow bisecting the pass
+    auto allowed = JIT_OPT_LIMIT();
+    if (!allowed) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50519 [Do not commit] Re-introduce bug to test pass bisection mechanism.
* **#50518 [TensorExpr] Hook Fuser Pass to JIT opt-limit utility.**

That new feature allows to bisect the pass easily by hard-stopping it
after a given number of hits.

Differential Revision: [D25908597](https://our.internmc.facebook.com/intern/diff/D25908597)