### PR TITLE
[Do not commit] Re-introduce bug to test pass bisection mechanism.

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -747,6 +747,11 @@ bool LoopNest::computeInline(Stmt* s) {
 }
 
 bool LoopNest::computeInline(const Buf* b) {
+  if (output_bufs_.count(b)) {
+    // Cannot inline producers of output Tensors
+    return false;
+  }
+
   // Find producers.
   Store* relevant_store{nullptr};
   auto stores = NodeFinder<Store>::find(root_stmt_);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50519 [Do not commit] Re-introduce bug to test pass bisection mechanism.**
* #50518 [TensorExpr] Hook Fuser Pass to JIT opt-limit utility.

Just to reproduce the bug and make sure that the bisection works.

Differential Revision: [D25908596](https://our.internmc.facebook.com/intern/diff/D25908596)