### PR TITLE
Make `_s_where` warning much more useful

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -272,7 +272,24 @@ std::vector<Tensor> where(const Tensor& condition) {
 }
 
 Tensor _s_where(const Tensor& condition, const Tensor& self, const Tensor& other) {
-  TORCH_CHECK(self.dtype() == other.dtype(), "expected scalar type ", self.dtype(), " but found ", other.dtype());
+  if(self.dtype() != other.dtype()){
+    if(other.dtype() == ScalarType::Undefined){
+      TORCH_CHECK(false,
+        "expected scalar type ", self.dtype(), " but found ", other.dtype(), "\n"
+        "Reasons this might happen:\n",
+        "  1. You have the code `Tensor tens; tens.data_ptr<int>();` - Tensor type was not ever defined.\n"
+        "  2. Something else"
+      );
+    } else {
+      TORCH_CHECK(false,
+        "expected scalar type ", self.dtype(), " but found ", other.dtype(), "\n"
+        "Reasons this might happen:\n",
+        "  1. You have the code `Tensor tens = at::zeros(2, at::ScalarType::Int); tens.data_ptr<float>();` - Data types don't match.\n"
+        "  2. Something else"
+      );
+    }
+  }
+
   Tensor ret = at::empty(self.sizes(), self.options());
   auto iter = at::TensorIteratorConfig()
     .check_all_same_dtype(false)


### PR DESCRIPTION
Summary: It took me several hours to figure out why/how the error being modified arose. This is because the LOC the error traces back to is not necessarily the lines where the problem occurs. This error message should prevent others from suffering similarly.

Test Plan: Sandcastle tests

Differential Revision: D25908738

