### PR TITLE
Fix torch.cdist backward issue by modifying gridDim

### DIFF
--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -342,8 +342,8 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   // const int grid_y = int(sqrt(float(grid_temp - 1))) + 1;
   // const int grid_z = (grid_temp + grid_y - 1) / grid_y;
 
-  const int grid_y = grid_temp / 65536 ? 65535 : grid_temp;
-  const int grid_z = (grid_temp + 65535) / 65536;
+  const int grid_z = grid_temp / 65536 ? 65535 : grid_temp;
+  const int grid_y = (grid_temp + 65535) / 65536;
 
   const dim3 grid(grid_x, grid_y, grid_z);
   const dim3 block(block_x, block_y);

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -132,7 +132,7 @@ __global__ static void pdist_kernel_cuda_impl(scalar_t * result, const scalar_t 
 template <typename scalar_t, typename F>
 __global__ static void cdist_backward_kernel_cuda_impl(scalar_t * buffer, const scalar_t * grad, const scalar_t * x1, const scalar_t * x2, const scalar_t * dist, int64_t gs,
                                                        const scalar_t p, const int64_t r1, const int64_t r2, const int64_t m, const int64_t count, const int64_t r_size, const int64_t l1_size, const int64_t l2_size) {
-  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  const int y = (blockIdx.y * gridDim.z + blockIdx.z) * blockDim.y + threadIdx.y;
   const int init = blockIdx.x * blockDim.x + threadIdx.x;
   if (y >= count || init >= m) {
     return;
@@ -335,12 +335,19 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const int block_x = 64;
   const int block_y = 16;
   const int grid_x = (m + block_x * 8 - 1) / (block_x * 8);
-  const int grid_y = (dist.numel() + block_y - 1) / block_y;
-
-  const dim3 grid(grid_x, grid_y);
-  const dim3 block(block_x, block_y);
 
   const int64_t count = dist.numel();
+  const int64_t grid_temp = (count + block_y - 1) / block_y;
+
+  // const int grid_y = int(sqrt(float(grid_temp - 1))) + 1;
+  // const int grid_z = (grid_temp + grid_y - 1) / grid_y;
+
+  const int grid_y = grid_temp / 65536 ? 65535 : grid_temp;
+  const int grid_z = (grid_temp + 65535) / 65536;
+
+  const dim3 grid(grid_x, grid_y, grid_z);
+  const dim3 block(block_x, block_y);
+
   const int64_t r_size = r1 * r2;
   const int64_t l1_size = r1 * m;
   const int64_t l2_size = r2 * m;

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -342,9 +342,6 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const int grid_y = int(std::sqrt(float(grid_temp - 1))) + 1;
   const int grid_z = (grid_temp + grid_y - 1) / grid_y;
 
-  // const int grid_z = grid_temp / 65536 ? 65535 : grid_temp;
-  // const int grid_y = (grid_temp + 65535) / 65536;
-
   const dim3 grid(grid_x, grid_y, grid_z);
   const dim3 block(block_x, block_y);
 

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -339,11 +339,11 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const int64_t count = dist.numel();
   const int64_t grid_temp = (count + block_y - 1) / block_y;
 
-  // const int grid_y = int(sqrt(float(grid_temp - 1))) + 1;
-  // const int grid_z = (grid_temp + grid_y - 1) / grid_y;
+  const int grid_y = int(std::sqrt(float(grid_temp - 1))) + 1;
+  const int grid_z = (grid_temp + grid_y - 1) / grid_y;
 
-  const int grid_z = grid_temp / 65536 ? 65535 : grid_temp;
-  const int grid_y = (grid_temp + 65535) / 65536;
+  // const int grid_z = grid_temp / 65536 ? 65535 : grid_temp;
+  // const int grid_y = (grid_temp + 65535) / 65536;
 
   const dim3 grid(grid_x, grid_y, grid_z);
   const dim3 block(block_x, block_y);

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -340,7 +340,7 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const int64_t grid_temp = (count + block_y - 1) / block_y;
 
   const int grid_y = (grid_temp - 1) / 65535 + 1;
-  const int grid_z = (grid_temp + grid_y - 1) / grid_y + 1;
+  const int grid_z = (grid_temp - 1) / grid_y + 1;
 
   const dim3 grid(grid_x, grid_y, grid_z);
   const dim3 block(block_x, block_y);

--- a/aten/src/ATen/native/cuda/DistanceKernel.cu
+++ b/aten/src/ATen/native/cuda/DistanceKernel.cu
@@ -339,8 +339,8 @@ void cdist_backward_kernel_impl(Tensor& result, const Tensor& grad, const Tensor
   const int64_t count = dist.numel();
   const int64_t grid_temp = (count + block_y - 1) / block_y;
 
-  const int grid_y = int(std::sqrt(float(grid_temp - 1))) + 1;
-  const int grid_z = (grid_temp + grid_y - 1) / grid_y;
+  const int grid_y = (grid_temp - 1) / 65535 + 1;
+  const int grid_z = (grid_temp + grid_y - 1) / grid_y + 1;
 
   const dim3 grid(grid_x, grid_y, grid_z);
   const dim3 block(block_x, block_y);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3878,6 +3878,29 @@ class TestTorchDeviceType(TestCase):
                             expected = self._brute_cdist(x, y, p=p)
                             self.assertEqual(expected, actual)
 
+    @onlyCUDA
+    def test_cdist_cuda_backward(self, device):
+        for l1 in [1, 511, 512, 1024]:
+            for l2 in [1, 511, 512, 1024]:
+                for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
+                    x1 = torch.randn(4, l1, 32, device=device, requires_grad=True)
+                    x2 = x1.clone().detach_().requires_grad_()
+                    y1 = torch.randn(4, l2, 32, device=device, requires_grad=True)
+                    y2 = y1.clone().detach_().requires_grad_()
+                    if p == 2:
+                        for cm in ['use_mm_for_euclid_dist', 'donot_use_mm_for_euclid_dist']:
+                            z1 = torch.cdist(x1, y1, p=2, compute_mode=cm).mean()
+                            z2 = self._brute_cdist(x2, y2, p=2).mean()
+                            z1.backward()
+                            z2.backward()
+                            self.assertEqual(x1.grad, x2.grad, rtol=0, atol=0.001)
+                            self.assertEqual(y1.grad, y2.grad, rtol=0, atol=0.001)
+                    else:
+                        z1 = torch.cdist(x1, y1, p=p).mean()
+                        z2 = self._brute_cdist(x2, y2, p=p).mean()
+                        self.assertEqual(x1.grad, x2.grad, rtol=0, atol=0.001)
+                        self.assertEqual(y1.grad, y2.grad, rtol=0, atol=0.001)
+
     @tf32_on_and_off(0.005)
     def test_cdist_large(self, device):
         for cm in ['use_mm_for_euclid_dist_if_necessary', 'use_mm_for_euclid_dist', 'donot_use_mm_for_euclid_dist']:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3880,8 +3880,8 @@ class TestTorchDeviceType(TestCase):
 
     @onlyCUDA
     def test_cdist_cuda_backward(self, device):
-        for l1 in [1, 511, 512, 1024]:
-            for l2 in [1, 511, 512, 1024]:
+        for l1 in [1, 511, 513]:
+            for l2 in [1, 511, 513]:
                 for p in [0, 1, 2, 3, 1.5, 2.5, float('inf')]:
                     x1 = torch.randn(4, l1, 32, device=device, requires_grad=True)
                     x2 = x1.clone().detach_().requires_grad_()


### PR DESCRIPTION
Fixes #49928

This fixes the torch.cdist.backward issue raised by CUDA dimension. However I think there are more space to improve.

As I commit in line 342~343, using the squared root (or +1) can reduce the number of blocks significantly. However it seems that my implementation conflicts with predefine sqrt function.

Any ideas? I'm a little new at C++ programming ... 🤦‍♂️


