### PR TITLE
Use separate mypy caches for TestTypeHints cases

### DIFF
--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -149,7 +149,7 @@ class TestTypeHints(TestCase):
             except OSError:
                 raise unittest.SkipTest('cannot symlink') from None
             (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy-doc_cache',
+                '--cache-dir=.mypy_cache/doc',
                 '--follow-imports', 'silent',
                 '--check-untyped-defs',
                 '--no-strict-optional',  # needed because of torch.lu_unpack, see gh-36584
@@ -170,7 +170,7 @@ class TestTypeHints(TestCase):
         for example in examples:
             example_path = os.path.join(examples_folder, example)
             (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy-examples_cache',
+                '--cache-dir=.mypy_cache/examples',
                 '--follow-imports', 'silent',
                 '--check-untyped-defs',
                 example_path,
@@ -208,6 +208,7 @@ class TestTypeHints(TestCase):
         # process!
         with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
+                '--cache-dir=.mypy_cache/normal',
                 '--check-untyped-defs',
                 '--follow-imports', 'silent',
             ])
@@ -228,7 +229,7 @@ class TestTypeHints(TestCase):
 
         with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy-strict_cache',
+                '--cache-dir=.mypy_cache/strict',
                 '--config', mypy_inifile,
             ])
 

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -149,6 +149,7 @@ class TestTypeHints(TestCase):
             except OSError:
                 raise unittest.SkipTest('cannot symlink') from None
             (stdout, stderr, result) = mypy.api.run([
+                '--cache-dir=.mypy-doc_cache',
                 '--follow-imports', 'silent',
                 '--check-untyped-defs',
                 '--no-strict-optional',  # needed because of torch.lu_unpack, see gh-36584
@@ -169,6 +170,7 @@ class TestTypeHints(TestCase):
         for example in examples:
             example_path = os.path.join(examples_folder, example)
             (stdout, stderr, result) = mypy.api.run([
+                '--cache-dir=.mypy-examples_cache',
                 '--follow-imports', 'silent',
                 '--check-untyped-defs',
                 example_path,
@@ -226,6 +228,7 @@ class TestTypeHints(TestCase):
 
         with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
+                '--cache-dir=.mypy-strict_cache',
                 '--config', mypy_inifile,
             ])
 


### PR DESCRIPTION
Addresses one of the speed points in #50513 by making the `TestTypeHints` suite much faster when run incrementally. Also fixes an issue (at least on 5834438090a1b3206347e30968e48f44251a53a1) where running that suite repeatedly results in a failure every other run (see the test plan below).

**Test plan:**

First clear your [`mypy` cache](https://mypy.readthedocs.io/en/stable/command_line.html#incremental-mode):
```
$ rm -r .mypy_cache
```
Then run this twice:
```
$ python test/test_type_hints.py
```

- *Before:*
  ```
  ....
  ----------------------------------------------------------------------
  Ran 4 tests in 212.340s

  OK
  ```
  ```
  .F..
  ======================================================================
  FAIL: test_run_mypy (__main__.TestTypeHints)
  Runs mypy over all files specified in mypy.ini
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "test/test_type_hints.py", line 214, in test_run_mypy
      self.fail(f"mypy failed: {stdout} {stderr}")
  AssertionError: mypy failed: torch/quantization/fx/quantize.py:138: error: "Tensor" not callable  [operator]
  Found 1 error in 1 file (checked 1189 source files)
   

  ----------------------------------------------------------------------
  Ran 4 tests in 199.331s

  FAILED (failures=1)
  ```
- *After:*
  ```
  ....
  ----------------------------------------------------------------------
  Ran 4 tests in 212.815s

  OK
  ```
  ```
  ....
  ----------------------------------------------------------------------
  Ran 4 tests in 5.491s

  OK
  ```