### PR TITLE
Reapply D25856891: [te] Benchmark comparing fused overhead to unfused

### DIFF
--- a/benchmarks/cpp/tensorexpr/CMakeLists.txt
+++ b/benchmarks/cpp/tensorexpr/CMakeLists.txt
@@ -1,2 +1,9 @@
-add_executable(tensorexpr_bench bench_gemm.cpp bench_compile.cpp main.cpp)
+add_executable(
+  tensorexpr_bench
+  bench_approx.cpp
+  bench_compile.cpp
+  bench_fuser_overhead.cpp
+  bench_gemm.cpp
+  main.cpp)
+
 target_link_libraries(tensorexpr_bench PRIVATE torch_library benchmark)

--- a/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
@@ -1,0 +1,57 @@
+#include <benchmark/benchmark.h>
+#include <torch/csrc/jit/codegen/fuser/interface.h>
+#include <torch/torch.h>
+
+using namespace torch::jit;
+
+static const std::string two_adds = R"JIT(
+def two_adds(self, x: Tensor, y: Tensor, z: Tensor) -> Tensor:
+    return x + y + z
+)JIT";
+
+static void FusedOverhead(benchmark::State& state) {
+  torch::NoGradGuard ng;
+  torch::AutoNonVariableTypeMode nv;
+  overrideCanFuseOnCPU(true);
+
+  Module m("m");
+  m.define(two_adds);
+
+  auto x = torch::ones({1});
+  auto y = torch::ones({1});
+  auto z = torch::ones({1});
+
+  // Warmup.
+  for (int i = 0; i < 8; i++) {
+    m.run_method("two_adds", x, y, z);
+  }
+
+  for (auto _ : state) {
+    m.run_method("two_adds", x, y, z);
+  }
+}
+
+static void UnfusedOverhead(benchmark::State& state) {
+  torch::NoGradGuard ng;
+  torch::AutoNonVariableTypeMode nv;
+  overrideCanFuseOnCPU(false);
+
+  Module m("m");
+  m.define(two_adds);
+
+  auto x = torch::ones({1});
+  auto y = torch::ones({1});
+  auto z = torch::ones({1});
+
+  // Warmup.
+  for (int i = 0; i < 8; i++) {
+    m.run_method("two_adds", x, y, z);
+  }
+
+  for (auto _ : state) {
+    m.run_method("two_adds", x, y, z);
+  }
+}
+
+BENCHMARK(FusedOverhead);
+BENCHMARK(UnfusedOverhead);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50543 Reapply D25856891: [te] Benchmark comparing fused overhead to unfused**

Original commit changeset: 2d2f07f79986

Was part of a stack that got reverted.  This is just a benchmark.

Differential Revision: [D25912439](https://our.internmc.facebook.com/intern/diff/D25912439/)