### PR TITLE
Independent constraint

### DIFF
--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -7,6 +7,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA
 
 CONSTRAINTS = [
     (constraints.real,),
+    (constraints.real_vector,),
     (constraints.positive,),
     (constraints.greater_than, [-10., -2, 0, 2, 10]),
     (constraints.greater_than, 0),

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3915,7 +3915,9 @@ class TestConstraints(TestCase):
                 constraint = dist.support
                 message = '{} example {}/{} sample = {}'.format(
                     Dist.__name__, i + 1, len(params), value)
-                self.assertTrue(constraint.check(value).all(), msg=message)
+                ok = constraint.check(value).all()
+                assert ok.shape == dist.batch_shape
+                self.assertTrue(ok.all(), msg=message)
 
 
 class TestNumericalStability(TestCase):

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3915,7 +3915,7 @@ class TestConstraints(TestCase):
                 constraint = dist.support
                 message = '{} example {}/{} sample = {}'.format(
                     Dist.__name__, i + 1, len(params), value)
-                ok = constraint.check(value).all()
+                ok = constraint.check(value)
                 assert ok.shape == dist.batch_shape
                 self.assertTrue(ok.all(), msg=message)
 

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3913,11 +3913,11 @@ class TestConstraints(TestCase):
                 dist = Dist(**param)
                 value = dist.sample()
                 constraint = dist.support
-                self.assertEqual(constraint.event_dim, len(dist.event_shape))
                 message = '{} example {}/{} sample = {}'.format(
                     Dist.__name__, i + 1, len(params), value)
+                self.assertEqual(constraint.event_dim, len(dist.event_shape), msg=message)
                 ok = constraint.check(value)
-                self.assertEqual(ok.shape, dist.batch_shape)
+                self.assertEqual(ok.shape, dist.batch_shape, msg=message)
                 self.assertTrue(ok.all(), msg=message)
 
 

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3913,10 +3913,11 @@ class TestConstraints(TestCase):
                 dist = Dist(**param)
                 value = dist.sample()
                 constraint = dist.support
+                self.assertEqual(constraint.event_dim, len(dist.event_shape))
                 message = '{} example {}/{} sample = {}'.format(
                     Dist.__name__, i + 1, len(params), value)
                 ok = constraint.check(value)
-                assert ok.shape == dist.batch_shape
+                self.assertEqual(ok.shape, dist.batch_shape)
                 self.assertTrue(ok.all(), msg=message)
 
 

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -67,7 +67,7 @@ class Binomial(Distribution):
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
-    @constraints.dependent_property
+    @constraints.dependent_property(is_discrete=True)
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -76,7 +76,7 @@ class Categorical(Distribution):
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
-    @constraints.dependent_property
+    @constraints.dependent_property(is_discrete=True)
     def support(self):
         return constraints.integer_interval(0, self._num_events - 1)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -38,7 +38,7 @@ class Categorical(Distribution):
         logits (Tensor): event log-odds
     """
     arg_constraints = {'probs': constraints.simplex,
-                       'logits': constraints.real}
+                       'logits': constraints.real_vector}
     has_enumerate_support = True
 
     def __init__(self, probs=None, logits=None, validate_args=None):

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -153,11 +153,19 @@ transform_to = ConstraintRegistry()
 ################################################################################
 
 @biject_to.register(constraints.real)
-@biject_to.register(constraints.real_vector)
 @transform_to.register(constraints.real)
-@transform_to.register(constraints.real_vector)
 def _transform_to_real(constraint):
     return transforms.identity_transform
+
+
+@biject_to.register(constraints.independent)
+def _biject_to_independent(constraint):
+    return biject_to(constraint.base_constraint)
+
+
+@transform_to.register(constraints.independent)
+def _transform_to_independent(constraint):
+    return transform_to(constraint.base_constraint)
 
 
 @biject_to.register(constraints.positive)

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -131,7 +131,7 @@ class _DependentProperty(property, _Dependent):
         """
         Support for syntax to customize static attributes::
 
-            @constraints.dependent_dependent(is_discrete=True, event_dim=1)
+            @constraints.dependent_property(is_discrete=True, event_dim=1)
             def support(self):
                 ...
         """

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -68,7 +68,8 @@ class Independent(Distribution):
 
     @constraints.dependent_property
     def support(self):
-        return self.base_dist.support
+        return constraints.independent(self.base_dist.support,
+                                       self.reinterpreted_batch_ndims)
 
     @property
     def mean(self):

--- a/torch/distributions/lowrank_multivariate_normal.py
+++ b/torch/distributions/lowrank_multivariate_normal.py
@@ -73,10 +73,10 @@ class LowRankMultivariateNormal(Distribution):
 
             capacitance = I + cov_factor.T @ inv(cov_diag) @ cov_factor
     """
-    arg_constraints = {"loc": constraints.real,
-                       "cov_factor": constraints.real,
-                       "cov_diag": constraints.positive}
-    support = constraints.real
+    arg_constraints = {"loc": constraints.real_vector,
+                       "cov_factor": constraints.independent(constraints.real, 2),
+                       "cov_diag": constraints.independent(constraints.positive, 1)}
+    support = constraints.real_vector
     has_rsample = True
 
     def __init__(self, loc, cov_factor, cov_diag, validate_args=None):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -70,9 +70,10 @@ class Multinomial(Distribution):
     def _new(self, *args, **kwargs):
         return self._categorical._new(*args, **kwargs)
 
-    @constraints.dependent_property
+    @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
-        return constraints.integer_interval(0, self.total_count)
+        return constraints.independent(
+            constraints.integer_interval(0, self.total_count), 1)
 
     @property
     def logits(self):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -38,7 +38,7 @@ class Multinomial(Distribution):
         logits (Tensor): event log probabilities
     """
     arg_constraints = {'probs': constraints.simplex,
-                       'logits': constraints.real}
+                       'logits': constraints.real_vector}
     total_count: int
 
     @property

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -72,8 +72,11 @@ class Multinomial(Distribution):
 
     @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
+        total_count = self.total_count
+        if hasattr(total_count, "unsqueeze"):
+            total_count = total_count.unsqueeze(-1)
         return constraints.independent(
-            constraints.integer_interval(0, self.total_count), 1)
+            constraints.integer_interval(0, total_count), 1)
 
     @property
     def logits(self):

--- a/torch/distributions/multinomial.py
+++ b/torch/distributions/multinomial.py
@@ -72,11 +72,7 @@ class Multinomial(Distribution):
 
     @constraints.dependent_property(is_discrete=True, event_dim=1)
     def support(self):
-        total_count = self.total_count
-        if hasattr(total_count, "unsqueeze"):
-            total_count = total_count.unsqueeze(-1)
-        return constraints.independent(
-            constraints.integer_interval(0, total_count), 1)
+        return constraints.multinomial(self.total_count)
 
     @property
     def logits(self):

--- a/torch/distributions/multivariate_normal.py
+++ b/torch/distributions/multivariate_normal.py
@@ -113,7 +113,7 @@ class MultivariateNormal(Distribution):
                        'covariance_matrix': constraints.positive_definite,
                        'precision_matrix': constraints.positive_definite,
                        'scale_tril': constraints.lower_cholesky}
-    support = constraints.real
+    support = constraints.real_vector
     has_rsample = True
 
     def __init__(self, loc, covariance_matrix=None, precision_matrix=None, scale_tril=None, validate_args=None):

--- a/torch/distributions/one_hot_categorical.py
+++ b/torch/distributions/one_hot_categorical.py
@@ -28,7 +28,7 @@ class OneHotCategorical(Distribution):
         logits (Tensor): event log probabilities
     """
     arg_constraints = {'probs': constraints.simplex,
-                       'logits': constraints.real}
+                       'logits': constraints.real_vector}
     support = constraints.one_hot
     has_enumerate_support = True
 

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -22,7 +22,8 @@ class Uniform(Distribution):
         high (float or Tensor): upper range (exclusive).
     """
     # TODO allow (loc,scale) parameterization to allow independent constraints.
-    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
+    arg_constraints = {'low': constraints.dependent(is_discrete=False, event_dim=0),
+                       'high': constraints.dependent(is_discrete=False, event_dim=0)}
     has_rsample = True
 
     @property

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -22,8 +22,7 @@ class Uniform(Distribution):
         high (float or Tensor): upper range (exclusive).
     """
     # TODO allow (loc,scale) parameterization to allow independent constraints.
-    arg_constraints = {'low': constraints.dependent(is_discrete=False, event_dim=0),
-                       'high': constraints.dependent(is_discrete=False, event_dim=0)}
+    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
     has_rsample = True
 
     @property


### PR DESCRIPTION
Addresses #50496 

This fixes a number of inconsistencies in torch.distributions.constraints as used for parameters and supports of probability distributions.
- Adds a `constraints.independent` and replaces `real_vector` with `independent(real, 1)`. (this pattern has long been used in Pyro)
- Adds an `.event_dim` attribute to all constraints.
- Tests that `constraint.check(data)` has the correct shape. (Previously the shapes were incorrect).
- Adds machinery to set static `.is_discrete` and `.event_dim` for `constraints.dependent`.
- Fixes constraints for a number of distributions.

## Tested
- added a new check to the constraints tests
- added a new check for `.event_dim`

cc @fehiepsi @feynmanliang @stefanwebb