### PR TITLE
Fix some JIT tests on python 3.9.1

### DIFF
--- a/test/jit/test_class_type.py
+++ b/test/jit/test_class_type.py
@@ -21,6 +21,51 @@ if __name__ == '__main__':
                        "\tpython test/test_jit.py TESTNAME\n\n"
                        "instead.")
 
+
+class Foo:
+    pass
+
+
+class Bar:
+    pass
+
+
+class MyClass:
+    pass
+
+
+class OneTwo:
+    pass
+
+
+class OneTwoThree:
+    pass
+
+
+class OneTwoWrong:
+    pass
+
+
+class NotMember:
+    pass
+
+
+class NotMember2:
+    pass
+
+
+class FooTest:
+    pass
+
+
+class ClassWithClassMethod:
+    pass
+
+
+class ClassWithStaticMethod:
+    pass
+
+
 class TestClassType(JitTestCase):
     def test_get_with_method(self):
         class FooTest(object):

--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -16,6 +16,34 @@ if __name__ == '__main__':
                        "\tpython test/test_jit.py TESTNAME\n\n"
                        "instead.")
 
+
+class IntEnum:
+    pass
+
+
+class FloatEnum:
+    pass
+
+
+class StringEnum:
+    pass
+
+
+class TensorEnum:
+    pass
+
+
+class Color:
+    pass
+
+
+class Foo:
+    pass
+
+
+class Bar:
+    pass
+
 class TestEnum(JitTestCase):
     def test_enum_value_types(self):
         global IntEnum

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -19,6 +19,23 @@ if __name__ == '__main__':
                        "\tpython test/test_jit.py TESTNAME\n\n"
                        "instead.")
 
+
+class OneTwoModule:
+    pass
+
+
+class OneTwoClass:
+    pass
+
+
+class TensorToAny:
+    pass
+
+
+class AnyToAny:
+    pass
+
+
 class OrigModule(nn.Module):
     def __init__(self):
         super(OrigModule, self).__init__()

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -19,6 +19,10 @@ if __name__ == "__main__":
     )
 
 
+class Context:
+    pass
+
+
 class TestWith(JitTestCase):
     """
     A suite of tests for with statements.


### PR DESCRIPTION
Python 3.9.1 can no longer get the source code if you define a class inside a method using

```python
def f():
    global SomeClass
    class SomeClass:
        pass
```
we should now do
```python
class SomeClass:
    pass
def f():
    global SomeClass
    class SomeClass:
        pass
```
This is causing test failures like:
```
FAILED test/test_jit_legacy.py::TestClassType::test_cast_overloads - OSError: Can't get source for <class 'jit.test_class_type.Foo'>. TorchScript requires source access in order to carry out compilation, make sure original .py files are available.
FAILED test/test_jit_legacy.py::TestClassType::test_class_sorting - OSError: Can't get source for <class 'jit.test_class_type.Foo'>. TorchScript requires source access in order to carry out compilation, make sure original .py files are available.
FAILED test/test_jit_legacy.py::TestClassType::test_class_specialization - OSError: Can't get source for <class 'jit.test_class_type.Foo'>. TorchScript requires source access in order to carry out compilation, make sure original .py files are available.
FAILED test/test_jit_legacy.py::TestClassType::test_class_type_as_param - OSError: Can't get source for <class 'jit.test_class_type.FooTest'>. TorchScript requires source access in order to carry out compilation, make sure original .py files are available.
FAILED test/test_jit_legacy.py::TestClassType::test_classmethod - OSError: Can't get source for <class 'jit.test_class_type.ClassWithClassMethod'>. TorchScript requires source access in order to carry out compilation, make sure original .py files are available.

```