### PR TITLE
[ONNX] Add logical_and, logical_or, logical_xor torch op support in pytorch exporter

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3210,6 +3210,36 @@ class TestONNXRuntime(unittest.TestCase):
             self.run_test(model, x_float)
             self.run_test(model, x_int)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_logical_and(self):
+        class AndModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.logical_or(x, y)
+
+        x = torch.torch.BoolTensor(5, 5)
+        y = torch.torch.BoolTensor(5, 5)
+        self.run_test(AndModel(), input=(x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_logical_or(self):
+        class OrModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.logical_or(x, y)
+
+        x = torch.torch.BoolTensor(5, 5)
+        y = torch.torch.BoolTensor(5, 5)
+        self.run_test(OrModel(), input=(x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_logical_xor(self):
+        class XorModel(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.logical_xor(x, y)
+
+        x = torch.torch.BoolTensor(5, 5)
+        y = torch.torch.BoolTensor(5, 5)
+        self.run_test(XorModel(), input=(x, y))
+
     def test_gt(self):
         class GreaterModel(torch.nn.Module):
             def forward(self, input, other):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3214,7 +3214,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_logical_and(self):
         class AndModel(torch.nn.Module):
             def forward(self, x, y):
-                return torch.logical_or(x, y)
+                return torch.logical_and(x, y)
 
         x = torch.torch.BoolTensor(5, 5)
         y = torch.torch.BoolTensor(5, 5)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3216,8 +3216,8 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_and(x, y)
 
-        x = torch.torch.BoolTensor(5, 5)
-        y = torch.torch.BoolTensor(5, 5)
+        x = torch.randint(0, 2, (5, 5), dtype=bool)
+        y = torch.randint(0, 2, (5, 5), dtype=bool)
         self.run_test(AndModel(), input=(x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -3226,8 +3226,8 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_or(x, y)
 
-        x = torch.torch.BoolTensor(5, 5)
-        y = torch.torch.BoolTensor(5, 5)
+        x = torch.randint(0, 2, (5, 5), dtype=bool)
+        y = torch.randint(0, 2, (5, 5), dtype=bool)
         self.run_test(OrModel(), input=(x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -3236,8 +3236,8 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_xor(x, y)
 
-        x = torch.torch.BoolTensor(5, 5)
-        y = torch.torch.BoolTensor(5, 5)
+        x = torch.randint(0, 2, (5, 5), dtype=bool)
+        y = torch.randint(0, 2, (5, 5), dtype=bool)
         self.run_test(XorModel(), input=(x, y))
 
     def test_gt(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3216,8 +3216,20 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_and(x, y)
 
-        x = torch.randint(0, 2, (5, 5), dtype=bool)
-        y = torch.randint(0, 2, (5, 5), dtype=bool)
+        x = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        y = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        self.run_test(AndModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.int32)
+        y = torch.randint(10, (5, 5), dtype=torch.int32)
+        self.run_test(AndModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.double)
+        y = torch.randint(10, (5, 5), dtype=torch.double)
+        self.run_test(AndModel(), input=(x, y))
+
+        x = torch.randint(10, (2, 3, 5), dtype=torch.float32)
+        y = torch.randint(10, (2, 3, 5), dtype=torch.long)
         self.run_test(AndModel(), input=(x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -3226,8 +3238,20 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_or(x, y)
 
-        x = torch.randint(0, 2, (5, 5), dtype=bool)
-        y = torch.randint(0, 2, (5, 5), dtype=bool)
+        x = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        y = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        self.run_test(OrModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.int32)
+        y = torch.randint(10, (5, 5), dtype=torch.int32)
+        self.run_test(OrModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.double)
+        y = torch.randint(10, (5, 5), dtype=torch.double)
+        self.run_test(OrModel(), input=(x, y))
+
+        x = torch.randint(10, (2, 3, 5), dtype=torch.float32)
+        y = torch.randint(10, (2, 3, 5), dtype=torch.long)
         self.run_test(OrModel(), input=(x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -3236,8 +3260,20 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x, y):
                 return torch.logical_xor(x, y)
 
-        x = torch.randint(0, 2, (5, 5), dtype=bool)
-        y = torch.randint(0, 2, (5, 5), dtype=bool)
+        x = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        y = torch.randint(0, 2, (5, 5), dtype=torch.bool)
+        self.run_test(XorModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.int32)
+        y = torch.randint(10, (5, 5), dtype=torch.int32)
+        self.run_test(XorModel(), input=(x, y))
+
+        x = torch.randint(10, (5, 5), dtype=torch.double)
+        y = torch.randint(10, (5, 5), dtype=torch.double)
+        self.run_test(XorModel(), input=(x, y))
+
+        x = torch.randint(10, (2, 3, 5), dtype=torch.float32)
+        y = torch.randint(10, (2, 3, 5), dtype=torch.long)
         self.run_test(XorModel(), input=(x, y))
 
     def test_gt(self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1119,7 +1119,7 @@ def logical_or(g, input, other):
 def logical_xor(g, input, other):
     return g.op('Xor', input, other)
 
-    
+
 def __rshift_(g, self, other):
     # make sure to cast other to self's type
     # (when self is long, make sure that other is not float)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1105,6 +1105,21 @@ def __or_(g, input, other):
     return g.op('Or', input, other)
 
 
+@wrap_logical_op_with_cast_to_and_from('Bool')
+def logical_and(g, input, other):
+    return g.op('And', input, other)
+
+
+@wrap_logical_op_with_cast_to_and_from('Bool')
+def logical_or(g, input, other):
+    return g.op('Or', input, other)
+
+
+@wrap_logical_op_with_cast_to_and_from('Bool')
+def logical_xor(g, input, other):
+    return g.op('Xor', input, other)
+
+    
 def __rshift_(g, self, other):
     # make sure to cast other to self's type
     # (when self is long, make sure that other is not float)


### PR DESCRIPTION
Fixes #{}
Add logical_and, logical_or, logical_xor torch op support in pytorch exporter.