### PR TITLE
Remove workaround for TensorPipe failing to get device of CUDA ptr

### DIFF
--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -263,10 +263,6 @@ def _tensorpipe_init_backend_handler(store, name, rank, world_size, rpc_backend_
         # CUDA-related RPC request to this process before user code in this
         # process initializes its PyTorch CUDA states.
         torch.cuda.init()
-        # FIXME: this is needed for now because TensorPipe calls
-        # cudaPointerGetAttributes() on the default device.
-        # This error was also reported in https://github.com/pytorch/pytorch/issues/36594
-        torch.zeros([1], device="cuda:0")
 
     # The agent's join method is required to behave like a barrier and perform
     # collective operations, for which it relies on a process group, instead of


### PR DESCRIPTION
Due to what looked like a bug in CUDA, TensorPipe was sometimes failing to auto-detect the device of a CUDA pointer. A workaround, on the PyTorch side, was to always initialize a CUDA context on device 0. Now that TensorPipe has fixed that we can undo the workaround.