### PR TITLE
Fix TransformedDistribution shaping logic

### DIFF
--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -68,7 +68,7 @@ def test_biject_to(constraint_fn, args, is_cuda):
     assert torch.allclose(x, x2), "Error in biject_to({}) inverse".format(constraint)
 
     j = t.log_abs_det_jacobian(x, y)
-    assert j.shape == x.shape[:x.dim() - t.input_event_dim]
+    assert j.shape == x.shape[:x.dim() - t.domain.event_dim]
 
 
 @pytest.mark.parametrize('constraint_fn, args', [(c[0], c[1:]) for c in CONSTRAINTS])

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3848,6 +3848,16 @@ class TestKL(TestCase):
                     'Actual {}'.format(kl.shape),
                 ]))
 
+    def test_kl_transformed(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/34859
+        scale = torch.ones(2, 3)
+        loc = torch.zeros(2, 3)
+        normal = Normal(loc=loc, scale=scale)
+        diag_normal = Independent(normal, reinterpreted_batch_ndims=1)
+        trans_dist = TransformedDistribution(diag_normal, AffineTransform(loc=0., scale=2.))
+        self.assertEqual(kl_divergence(diag_normal, diag_normal).shape, (2,))
+        self.assertEqual(kl_divergence(trans_dist, trans_dist).shape, (2,))
+
     def test_entropy_monte_carlo(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]
         for Dist, params in EXAMPLES:

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -878,6 +878,22 @@ class TestDistributions(TestCase):
                 self.assertIn(Dist, distributions_with_examples,
                               "Please add {} to the EXAMPLES list in test_distributions.py".format(Dist.__name__))
 
+    def test_support_attributes(self):
+        for Dist, params in EXAMPLES:
+            for param in params:
+                d = Dist(**param)
+                event_dim = len(d.event_shape)
+                self.assertEqual(d.support.event_dim, event_dim)
+                try:
+                    self.assertEqual(Dist.support.event_dim, event_dim)
+                except NotImplementedError:
+                    pass
+                is_discrete = d.support.is_discrete
+                try:
+                    self.assertEqual(Dist.support.is_discrete, is_discrete)
+                except NotImplementedError:
+                    pass
+
     def test_distribution_expand(self):
         shapes = [torch.Size(), torch.Size((2,)), torch.Size((2, 1))]
         for Dist, params in EXAMPLES:
@@ -1620,8 +1636,8 @@ class TestDistributions(TestCase):
         self.assertEqual(LogisticNormal(mean, std).sample((7,)).size(), (7, 5, 6))
         self.assertEqual(LogisticNormal(mean_1d, std_1d).sample((1,)).size(), (1, 2))
         self.assertEqual(LogisticNormal(mean_1d, std_1d).sample().size(), (2,))
-        self.assertEqual(LogisticNormal(0.2, .6).sample((1,)).size(), (2,))
-        self.assertEqual(LogisticNormal(-0.7, 50.0).sample((1,)).size(), (2,))
+        self.assertEqual(LogisticNormal(0.2, .6).sample().size(), (2,))
+        self.assertEqual(LogisticNormal(-0.7, 50.0).sample().size(), (2,))
 
         # sample check for extreme value of mean, std
         set_rng_seed(1)

--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -6,8 +6,8 @@ import torch
 from torch.autograd.functional import jacobian
 from torch.distributions import Dirichlet, Normal, TransformedDistribution, constraints
 from torch.distributions.transforms import (AbsTransform, AffineTransform, ComposeTransform,
-                                            CorrCholeskyTransform, ExpTransform,
-                                            LowerCholeskyTransform, PowerTransform,
+                                            CorrCholeskyTransform, ExpTransform, IndependentTransform,
+                                            LowerCholeskyTransform, PowerTransform, ReshapeTransform,
                                             SigmoidTransform, TanhTransform, SoftmaxTransform,
                                             StickBreakingTransform, identity_transform, Transform,
                                             _InverseTransform)
@@ -57,6 +57,7 @@ def get_transforms(cache_size):
                             torch.randn(4, 5),
                             cache_size=cache_size),
         ]),
+        ReshapeTransform((4, 5), (2, 5, 2)),
     ]
     transforms += [t.inv for t in transforms]
     return transforms
@@ -92,7 +93,16 @@ def transform_id(x):
 
 def generate_data(transform):
     torch.manual_seed(1)
+    while isinstance(transform, IndependentTransform):
+        transform = transform.base_transform
+    if isinstance(transform, ReshapeTransform):
+        return torch.randn(transform.in_shape)
+    if isinstance(transform.inv, ReshapeTransform):
+        return torch.randn(transform.inv.out_shape)
     domain = transform.domain
+    while (isinstance(domain, constraints.independent) and
+           domain.reinterpreted_batch_ndims == 0):
+        domain = domain.base_constraint
     codomain = transform.codomain
     x = torch.empty(4, 5)
     if domain is constraints.lower_cholesky or codomain is constraints.lower_cholesky:
@@ -170,8 +180,10 @@ def test_forward_inverse(transform, test_cached):
         y = transform(x)
     except NotImplementedError:
         pytest.skip('Not implemented.')
+    assert y.shape == transform.forward_shape(x.shape)
     if test_cached:
         x2 = transform.inv(y)  # should be implemented at least by caching
+        x2.shape == transform.inverse_shape(y.shape)
     else:
         try:
             x2 = transform.inv(y.clone())  # bypass cache
@@ -316,25 +328,29 @@ def test_jacobian(transform):
     except NotImplementedError:
         pytest.skip('Not implemented.')
     # Test shape
-    target_shape = x.shape[:x.dim() - transform.input_event_dim]
+    target_shape = x.shape[:x.dim() - transform.domain.event_dim]
     assert actual.shape == target_shape
 
     # Expand if required
     transform = reshape_transform(transform, x.shape)
     ndims = len(x.shape)
-    event_dim = ndims - transform.input_event_dim
+    event_dim = ndims - transform.domain.event_dim
     x_ = x.view((-1,) + x.shape[event_dim:])
     n = x_.shape[0]
     # Reshape to squash batch dims to a single batch dim
     transform = reshape_transform(transform, x_.shape)
 
-    # 1. Transforms with 0 off-diagonal elements
-    if transform.input_event_dim == 0:
+    # 1. Transforms with unit jacobian
+    if isinstance(transform, ReshapeTransform) or isinstance(transform.inv, ReshapeTransform):
+        expected = x.new_zeros(x.shape[x.dim() - transform.domain.event_dim])
+        expected = x.new_zeros(x.shape[x.dim() - transform.domain.event_dim])
+    # 2. Transforms with 0 off-diagonal elements
+    elif transform.domain.event_dim == 0:
         jac = jacobian(transform, x_)
         # assert off-diagonal elements are zero
         assert torch.allclose(jac, jac.diagonal().diag_embed())
         expected = jac.diagonal().abs().log().reshape(x.shape)
-    # 2. Transforms with non-0 off-diagonal elements
+    # 3. Transforms with non-0 off-diagonal elements
     else:
         if isinstance(transform, CorrCholeskyTransform):
             jac = jacobian(lambda x: tril_matrix_to_vec(transform(x), diag=-1), x_)
@@ -359,6 +375,40 @@ def test_jacobian(transform):
         expected = torch.slogdet(jac).logabsdet
 
     assert torch.allclose(actual, expected, atol=1e-5)
+
+
+@pytest.mark.parametrize("event_dims",
+                         [(0,), (1,), (2, 3), (0, 1, 2), (1, 2, 0), (2, 0, 1)],
+                         ids=str)
+def test_compose_affine(event_dims):
+    transforms = [AffineTransform(torch.zeros((1,) * e), 1, event_dim=e) for e in event_dims]
+    transform = ComposeTransform(transforms)
+    assert transform.codomain.event_dim == max(event_dims)
+    assert transform.domain.event_dim == max(event_dims)
+
+    dist = TransformedDistribution(Normal(0, 1), transform.parts)
+    assert dist.support.event_dim == max(event_dims)
+
+    dist = TransformedDistribution(Dirichlet(torch.ones(5)), transforms)
+    assert dist.support.event_dim == max(1, max(event_dims))
+
+
+@pytest.mark.parametrize("batch_shape", [(), (6,), (5, 4)], ids=str)
+def test_compose_reshape(batch_shape):
+    transforms = [ReshapeTransform((), ()),
+                  ReshapeTransform((2,), (1, 2)),
+                  ReshapeTransform((3, 1, 2), (6,)),
+                  ReshapeTransform((6,), (2, 3))]
+    transform = ComposeTransform(transforms)
+    assert transform.codomain.event_dim == 2
+    assert transform.domain.event_dim == 2
+    data = torch.randn(batch_shape + (3, 2))
+    assert transform(data).shape == batch_shape + (2, 3)
+
+    dist = TransformedDistribution(Normal(data, 1), transforms)
+    assert dist.batch_shape == batch_shape
+    assert dist.event_shape == (2, 3)
+    assert dist.support.event_dim == 2
 
 
 if __name__ == '__main__':

--- a/test/distributions/test_transforms.py
+++ b/test/distributions/test_transforms.py
@@ -22,6 +22,8 @@ def get_transforms(cache_size):
                        cache_size=cache_size),
         PowerTransform(exponent=torch.tensor(5.).normal_(),
                        cache_size=cache_size),
+        PowerTransform(exponent=torch.tensor(5.).normal_(),
+                       cache_size=cache_size),
         SigmoidTransform(cache_size=cache_size),
         TanhTransform(cache_size=cache_size),
         AffineTransform(0, 1, cache_size=cache_size),
@@ -58,6 +60,11 @@ def get_transforms(cache_size):
                             cache_size=cache_size),
         ]),
         ReshapeTransform((4, 5), (2, 5, 2)),
+        IndependentTransform(
+            AffineTransform(torch.randn(5),
+                            torch.randn(5),
+                            cache_size=cache_size),
+            1),
     ]
     transforms += [t.inv for t in transforms]
     return transforms
@@ -101,7 +108,7 @@ def generate_data(transform):
         return torch.randn(transform.inv.out_shape)
     domain = transform.domain
     while (isinstance(domain, constraints.independent) and
-           domain.reinterpreted_batch_ndims == 0):
+           domain is not constraints.real_vector):
         domain = domain.base_constraint
     codomain = transform.codomain
     x = torch.empty(4, 5)

--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -67,7 +67,7 @@ class Binomial(Distribution):
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
-    @constraints.dependent_property(is_discrete=True)
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, self.total_count)
 

--- a/torch/distributions/categorical.py
+++ b/torch/distributions/categorical.py
@@ -76,7 +76,7 @@ class Categorical(Distribution):
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
 
-    @constraints.dependent_property(is_discrete=True)
+    @constraints.dependent_property(is_discrete=True, event_dim=0)
     def support(self):
         return constraints.integer_interval(0, self._num_events - 1)
 

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -160,12 +160,16 @@ def _transform_to_real(constraint):
 
 @biject_to.register(constraints.independent)
 def _biject_to_independent(constraint):
-    return biject_to(constraint.base_constraint)
+    base_transform = biject_to(constraint.base_constraint)
+    return transforms.IndependentTransform(
+        base_transform, constraint.reinterpreted_batch_ndims)
 
 
 @transform_to.register(constraints.independent)
 def _transform_to_independent(constraint):
-    return transform_to(constraint.base_constraint)
+    base_transform = transform_to(constraint.base_constraint)
+    return transforms.IndependentTransform(
+        base_transform, constraint.reinterpreted_batch_ndims)
 
 
 @biject_to.register(constraints.positive)

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -71,7 +71,7 @@ class Constraint(object):
         event_dim (int): Number of rightmost dimensions that together define
             an event. The :meth:`check` method will remove this many dimensions
             when computing validity.
-        """
+    """
     is_discrete = False  # Default to continuous.
     event_dim = 0  # Default to univariate.
 

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -64,13 +64,20 @@ class Constraint(object):
 
     A constraint object represents a region over which a variable is valid,
     e.g. within which a variable can be optimized.
-    """
+
+    Attributes:
+        is_discrete (bool): Whether constrained space is discrete.
+            Defaults to False.
+        event_dim (int): Number of rightmost dimensions that together define
+            an event. The :meth:`check` method will remove this many dimensions
+            when computing validity.
+        """
     is_discrete = False  # Default to continuous.
     event_dim = 0  # Default to univariate.
 
     def check(self, value):
         """
-        Returns a byte tensor of `sample_shape + batch_shape` indicating
+        Returns a byte tensor of ``sample_shape + batch_shape`` indicating
         whether each event in value satisfies this constraint.
         """
         raise NotImplementedError
@@ -83,22 +90,42 @@ class _Dependent(Constraint):
     """
     Placeholder for variables whose support depends on other variables.
     These variables obey no simple coordinate-wise constraints.
+
+    Args:
+        is_discrete (bool): Optional value of ``.is_discrete`` in case this
+            can be computed statically. If not provided, access to the
+            ``.is_discrete`` attribute will raise a NotImplementedError.
+        event_dim (int): Optional value of ``.event_dim`` in case this
+            can be computed statically. If not provided, access to the
+            ``.event_dim`` attribute will raise a NotImplementedError.
     """
-    def __init__(self, *, is_discrete=False, event_dim=0):
-        self.is_discrete = is_discrete
-        self.event_dim = event_dim
+    def __init__(self, *, is_discrete=NotImplemented, event_dim=NotImplemented):
+        self._is_discrete = is_discrete
+        self._event_dim = event_dim
         super().__init__()
 
-    def __call__(self, *, is_discrete=None, event_dim=None):
+    @property
+    def is_discrete(self):
+        if self._is_discrete is NotImplemented:
+            raise NotImplementedError(".is_discrete cannot be determined statically")
+        return self._is_discrete
+
+    @property
+    def event_dim(self):
+        if self._event_dim is NotImplemented:
+            raise NotImplementedError(".event_dim cannot be determined statically")
+        return self._event_dim
+
+    def __call__(self, *, is_discrete=NotImplemented, event_dim=NotImplemented):
         """
         Support for syntax to customize static attributes::
 
             constraints.dependent(is_discrete=True, event_dim=1)
         """
-        if is_discrete is None:
-            is_discrete = self.is_discrete
-        if event_dim is None:
-            event_dim = self.event_dim
+        if is_discrete is NotImplemented:
+            is_discrete = self._is_discrete
+        if event_dim is NotImplemented:
+            event_dim = self._event_dim
         return _Dependent(is_discrete=is_discrete, event_dim=event_dim)
 
     def check(self, x):
@@ -120,14 +147,23 @@ class _DependentProperty(property, _Dependent):
             def __init__(self, low, high):
                 self.low = low
                 self.high = high
-            @constraints.dependent_property
+            @constraints.dependent_property(is_discrete=False, event_dim=0)
             def support(self):
                 return constraints.interval(self.low, self.high)
+
+    Args:
+        fn (callable): The function to be decorated.
+        is_discrete (bool): Optional value of ``.is_discrete`` in case this
+            can be computed statically. If not provided, access to the
+            ``.is_discrete`` attribute will raise a NotImplementedError.
+        event_dim (int): Optional value of ``.event_dim`` in case this
+            can be computed statically. If not provided, access to the
+            ``.event_dim`` attribute will raise a NotImplementedError.
     """
-    def __init__(self, fn=None, *, is_discrete=False, event_dim=0):
-        self.is_discrete = is_discrete
-        self.event_dim = event_dim
+    def __init__(self, fn=None, *, is_discrete=NotImplemented, event_dim=NotImplemented):
         super().__init__(fn)
+        self._is_discrete = is_discrete
+        self._event_dim = event_dim
 
     def __call__(self, fn):
         """
@@ -137,7 +173,7 @@ class _DependentProperty(property, _Dependent):
             def support(self):
                 ...
         """
-        return _DependentProperty(fn, is_discrete=self.is_discrete, event_dim=self.event_dim)
+        return _DependentProperty(fn, is_discrete=self._is_discrete, event_dim=self._event_dim)
 
 
 class _IndependentConstraint(Constraint):
@@ -170,6 +206,10 @@ class _IndependentConstraint(Constraint):
         result = result.reshape(result.shape[:result.dim() - self.reinterpreted_batch_ndims] + (-1,))
         result = result.all(-1)
         return result
+
+    def __repr__(self):
+        return "{}({}, {})".format(self.__class__.__name__[1:], repr(self.base_constraint),
+                                   self.reinterpreted_batch_ndims)
 
 
 class _Boolean(Constraint):

--- a/torch/distributions/independent.py
+++ b/torch/distributions/independent.py
@@ -68,8 +68,10 @@ class Independent(Distribution):
 
     @constraints.dependent_property
     def support(self):
-        return constraints.independent(self.base_dist.support,
-                                       self.reinterpreted_batch_ndims)
+        result = self.base_dist.support
+        if self.reinterpreted_batch_ndims:
+            result = constraints.independent(result, self.reinterpreted_batch_ndims)
+        return result
 
     @property
     def mean(self):

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -437,10 +437,7 @@ def _kl_transformed_transformed(p, q):
         raise NotImplementedError
     if p.event_shape != q.event_shape:
         raise NotImplementedError
-    # extra_event_dim = len(p.event_shape) - len(p.base_dist.event_shape)
-    extra_event_dim = len(p.event_shape)
-    base_kl_divergence = kl_divergence(p.base_dist, q.base_dist)
-    return _sum_rightmost(base_kl_divergence, extra_event_dim)
+    return kl_divergence(p.base_dist, q.base_dist)
 
 
 @register_kl(Uniform, Uniform)

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -44,8 +44,8 @@ class LogisticNormal(TransformedDistribution):
 
     @property
     def loc(self):
-        return self.base_dist.loc
+        return self.base_dist.base_dist.loc
 
     @property
     def scale(self):
-        return self.base_dist.scale
+        return self.base_dist.base_dist.scale

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -1,4 +1,3 @@
-import torch
 from torch.distributions import constraints
 from torch.distributions.normal import Normal
 from torch.distributions.transformed_distribution import TransformedDistribution
@@ -33,11 +32,11 @@ class LogisticNormal(TransformedDistribution):
 
     def __init__(self, loc, scale, validate_args=None):
         base_dist = Normal(loc, scale)
+        if not base_dist.batch_shape:
+            base_dist = base_dist.expand([1])
         super(LogisticNormal, self).__init__(base_dist,
                                              StickBreakingTransform(),
                                              validate_args=validate_args)
-        # Adjust event shape since StickBreakingTransform adds 1 dimension
-        self._event_shape = torch.Size([s + 1 for s in self._event_shape])
 
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(LogisticNormal, _instance)

--- a/torch/distributions/pareto.py
+++ b/torch/distributions/pareto.py
@@ -45,7 +45,7 @@ class Pareto(TransformedDistribution):
         a = self.alpha.clamp(min=2)
         return self.scale.pow(2) * a / ((a - 1).pow(2) * (a - 2))
 
-    @constraints.dependent_property
+    @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self):
         return constraints.greater_than(self.scale)
 

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -30,8 +30,8 @@ class ExpRelaxedCategorical(Distribution):
     (Jang et al, 2017)
     """
     arg_constraints = {'probs': constraints.simplex,
-                       'logits': constraints.real}
-    support = constraints.real
+                       'logits': constraints.real_vector}
+    support = constraints.real_vector  # The true support is actually a submanifold of this.
     has_rsample = True
 
     def __init__(self, temperature, probs=None, logits=None, validate_args=None):
@@ -104,7 +104,7 @@ class RelaxedOneHotCategorical(TransformedDistribution):
         logits (Tensor): the log probability of each event.
     """
     arg_constraints = {'probs': constraints.simplex,
-                       'logits': constraints.real}
+                       'logits': constraints.real_vector}
     support = constraints.simplex
     has_rsample = True
 

--- a/torch/distributions/transformed_distribution.py
+++ b/torch/distributions/transformed_distribution.py
@@ -1,7 +1,8 @@
 import torch
 from torch.distributions import constraints
 from torch.distributions.distribution import Distribution
-from torch.distributions.transforms import Transform
+from torch.distributions.independent import Independent
+from torch.distributions.transforms import ComposeTransform, Transform
 from torch.distributions.utils import _sum_rightmost
 from typing import Dict
 
@@ -42,7 +43,6 @@ class TransformedDistribution(Distribution):
     arg_constraints: Dict[str, constraints.Constraint] = {}
 
     def __init__(self, base_distribution, transforms, validate_args=None):
-        self.base_dist = base_distribution
         if isinstance(transforms, Transform):
             self.transforms = [transforms, ]
         elif isinstance(transforms, list):
@@ -51,12 +51,27 @@ class TransformedDistribution(Distribution):
             self.transforms = transforms
         else:
             raise ValueError("transforms must be a Transform or list, but was {}".format(transforms))
-        shape = self.base_dist.batch_shape + self.base_dist.event_shape
-        event_dim = self.base_dist.support.event_dim
-        for t in self.transforms:
-            shape = t.forward_shape(shape)
-            event_dim += t.codomain.event_dim - t.domain.event_dim
-            event_dim = max(event_dim, t.codomain.event_dim)
+
+        # Reshape base_distribution according to transforms.
+        base_shape = base_distribution.batch_shape + base_distribution.event_shape
+        base_event_dim = len(base_distribution.event_shape)
+        transform = ComposeTransform(self.transforms)
+        domain_event_dim = transform.domain.event_dim
+        if len(base_shape) < domain_event_dim:
+            raise ValueError("base_distribution needs to have shape with size at least {}, but got {}."
+                             .format(domain_event_dim, base_shape))
+        shape = transform.forward_shape(base_shape)
+        expanded_base_shape = transform.inverse_shape(shape)
+        if base_shape != expanded_base_shape:
+            base_batch_shape = expanded_base_shape[:len(expanded_base_shape) - base_event_dim]
+            base_distribution = base_distribution.expand(base_batch_shape)
+        reinterpreted_batch_ndims = domain_event_dim - base_event_dim
+        if reinterpreted_batch_ndims > 0:
+            base_distribution = Independent(base_distribution, reinterpreted_batch_ndims)
+        self.base_dist = base_distribution
+
+        # Compute shapes.
+        event_dim = transform.codomain.event_dim + max(base_event_dim - domain_event_dim, 0)
         assert len(shape) >= event_dim
         cut = len(shape) - event_dim
         batch_shape = shape[:cut]
@@ -124,8 +139,9 @@ class TransformedDistribution(Distribution):
         y = value
         for transform in reversed(self.transforms):
             x = transform.inv(y)
+            event_dim += transform.domain.event_dim - transform.codomain.event_dim
             log_prob = log_prob - _sum_rightmost(transform.log_abs_det_jacobian(x, y),
-                                                 event_dim - transform.event_dim)
+                                                 event_dim - transform.domain.event_dim)
             y = x
 
         log_prob = log_prob + _sum_rightmost(self.base_dist.log_prob(y),

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -564,6 +564,12 @@ class PowerTransform(Transform):
     def log_abs_det_jacobian(self, x, y):
         return (self.exponent * y / x).abs().log()
 
+    def forward_shape(self, shape):
+        return torch.broadcast_shapes(shape, getattr(self.exponent, "shape", ()))
+
+    def inverse_shape(self, shape):
+        return torch.broadcast_shapes(shape, getattr(self.exponent, "shape", ()))
+
 
 def _clipped_sigmoid(x):
     finfo = torch.finfo(x.dtype)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -13,7 +13,6 @@ from torch.distributions.utils import (_sum_rightmost, broadcast_all,
                                        vec_to_tril_matrix)
 from torch.nn.functional import pad
 from torch.nn.functional import softplus
-from typing import List
 
 __all__ = [
     'AbsTransform',

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -3,6 +3,7 @@ import math
 import numbers
 import operator
 import weakref
+from typing import List
 
 import torch
 import torch.nn.functional as F
@@ -80,6 +81,7 @@ class Transform(object):
             increasing or decreasing.
     """
     bijective = False
+    domain: constraints.Constraint
     codomain: constraints.Constraint
 
     def __init__(self, cache_size=0):
@@ -202,7 +204,7 @@ class _InverseTransform(Transform):
     Inverts a single :class:`Transform`.
     This class is private; please instead use the ``Transform.inv`` property.
     """
-    def __init__(self, transform):
+    def __init__(self, transform: Transform):
         super(_InverseTransform, self).__init__(cache_size=transform._cache_size)
         self._inv = transform
 
@@ -265,7 +267,7 @@ class ComposeTransform(Transform):
         cache_size (int): Size of cache. If zero, no caching is done. If one,
             the latest single value is cached. Only 0 and 1 are supported.
     """
-    def __init__(self, parts, cache_size=0):
+    def __init__(self, parts: List[Transform], cache_size=0):
         if cache_size:
             parts = [part.with_cache(cache_size) for part in parts]
         super(ComposeTransform, self).__init__(cache_size=cache_size)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -415,9 +415,13 @@ class IndependentTransform(Transform):
         return self.base_transform.sign
 
     def _call(self, x):
+        if x.dim() < self.domain.event_dim:
+            raise ValueError("Too few dimensions on input")
         return self.base_transform(x)
 
     def _inverse(self, y):
+        if y.dim() < self.codomain.event_dim:
+            raise ValueError("Too few dimensions on input")
         return self.base_transform.inv(y)
 
     def log_abs_det_jacobian(self, x, y):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -431,6 +431,12 @@ class IndependentTransform(Transform):
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.base_transform)}, {self.reinterpreted_batch_ndims})"
 
+    def forward_shape(shape):
+        return self.base_transform.forward_shape(shape)
+
+    def inverse_shape(shape):
+        return self.base_transform.inverse_shape(shape)
+
 
 class ReshapeTransform(Transform):
     """
@@ -787,7 +793,7 @@ class CorrCholeskyTransform(Transform):
     def forward_shape(self, shape):
         # Reshape from (..., N) to (..., D, D).
         if len(shape) < 1:
-            raise ValueError("Too few dimensions in input")
+            raise ValueError("Too few dimensions on input")
         N = shape[-1]
         D = round((0.25 + 2 * N) ** 0.5 + 0.5)
         if D * (D - 1) // 2 != N:
@@ -828,6 +834,16 @@ class SoftmaxTransform(Transform):
     def _inverse(self, y):
         probs = y
         return probs.log()
+
+    def forward_shape(self, shape):
+        if len(shape) < 1:
+            raise ValueError("Too few dimensions on input")
+        return shape
+
+    def inverse_shape(self, shape):
+        if len(shape) < 1:
+            raise ValueError("Too few dimensions on input")
+        return shape
 
 
 class StickBreakingTransform(Transform):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -205,7 +205,7 @@ class _InverseTransform(Transform):
     """
     def __init__(self, transform: Transform):
         super(_InverseTransform, self).__init__(cache_size=transform._cache_size)
-        self._inv = transform
+        self._inv: Transform = transform
 
     @constraints.dependent_property(is_discrete=False)
     def domain(self):

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -784,7 +784,7 @@ class CorrCholeskyTransform(Transform):
         if len(shape) < 1:
             raise ValueError("Too few dimensions in input")
         N = shape[-1]
-        D = round((0.25 + 2 * N) ** 0.5 - 0.5)
+        D = round((0.25 + 2 * N) ** 0.5 + 0.5)
         if D * (D - 1) // 2 != N:
             raise ValueError("Input is not a flattend lower-diagonal number")
         return shape[:-1] + (D, D)

--- a/torch/distributions/transforms.py
+++ b/torch/distributions/transforms.py
@@ -784,7 +784,7 @@ class CorrCholeskyTransform(Transform):
         if len(shape) < 1:
             raise ValueError("Too few dimensions in input")
         N = shape[-1]
-        D = 1 + int(round((2 * N) ** 0.5))
+        D = round((0.25 + 2 * N) ** 0.5 - 0.5)
         if D * (D - 1) // 2 != N:
             raise ValueError("Input is not a flattend lower-diagonal number")
         return shape[:-1] + (D, D)

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -22,7 +22,8 @@ class Uniform(Distribution):
         high (float or Tensor): upper range (exclusive).
     """
     # TODO allow (loc,scale) parameterization to allow independent constraints.
-    arg_constraints = {'low': constraints.dependent, 'high': constraints.dependent}
+    arg_constraints = {'low': constraints.dependent(is_discrete=False, event_dim=0),
+                       'high': constraints.dependent(is_discrete=False, event_dim=0)}
     has_rsample = True
 
     @property
@@ -58,7 +59,7 @@ class Uniform(Distribution):
         new._validate_args = self._validate_args
         return new
 
-    @constraints.dependent_property
+    @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self):
         return constraints.interval(self.low, self.high)
 


### PR DESCRIPTION
Fixes #50496
Fixes #34859
Fixes #21596

This fixes many bugs involving `TransformedDistribution` and `ComposeTransform` when the component transforms changed their event shapes. Part of the fix is to introduce an `IndependentTransform` analogous to `distributions.Independent` and `constraints.independent`, and to introduce methods `Transform.forward_shape()` and `.inverse_shape()`. I have followed @fehiepsi's suggestion and replaced `.input_event_dim` -> `.domain.event_dim` and `.output_event_dim` -> `.codomain.event_dim`. This allows us to deprecate `.event_dim` as an attribute.

## Summary of changes

- Fixes `TransformDistribution` and `ComposeTransform` shape errors.
- Fixes a behavior bug in `LogisticNormal`.
- Fixes `kl_divergence(TransformedDistribution, TransformedDistribution)`
- Adds methods `Transform.forward_shape()`, `.inverse_shape()` which are required for correct shape computations in `TransformedDistribution` and `ComposeTransform`.
- Adds an `IndependentTransform`.
- Adds a `ReshapeTransform` which is invaluable in testing shape logic in `ComposeTransform` and `TransformedDistribution` and which will be used by @stefanwebb flowtorch.
- Fixes incorrect default values in `constraints.dependent.event_dim`.
- Documents the `.event_dim` and `.is_discrete` attributes.

## Changes planned for follow-up PRs

- Memoize `@constraints.dependent_property` as we do with `@lazy_property`, since we now consult those properties much more often.

## Tested
- [x] added a test for `Dist.support` vs `Dist(**params).support` to ensure static and dynamic attributes agree.
- [x] refactoring is covered by existing tests
- [x] add test cases for `ReshapedTransform`
- [x] add a test for `TransformedDistribution` on a wide grid of input shapes
- [x] added a regression test for #34859

cc @fehiepsi @feynmanliang @stefanwebb