### PR TITLE
[ONNX] Fix param names

### DIFF
--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -567,7 +567,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
       if (it != node->inputs().end()) {
         int index = std::distance(node->inputs().begin(), it);
 
-				std::string input_name = input->debugName();
+	std::string input_name = input->debugName();
         std::cerr
             << "Warning: ONNX Preprocess - Removing mutation on block inputs. "
             << "This changes graph semantics." << std::endl;

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -567,7 +567,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
       if (it != node->inputs().end()) {
         int index = std::distance(node->inputs().begin(), it);
 
-	std::string input_name = input->debugName();
+        std::string input_name = input->debugName();
         std::cerr
             << "Warning: ONNX Preprocess - Removing mutation on block inputs. "
             << "This changes graph semantics." << std::endl;

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -567,6 +567,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
       if (it != node->inputs().end()) {
         int index = std::distance(node->inputs().begin(), it);
 
+				std::string input_name = input->debugName();
         std::cerr
             << "Warning: ONNX Preprocess - Removing mutation on block inputs. "
             << "This changes graph semantics." << std::endl;
@@ -579,6 +580,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
           newNode->insertBefore(node);
           node->replaceInput(index, newNode->output());
           input->replaceAllUsesAfterNodeWith(node, newNode->output());
+          input->setDebugName(input_name);
         } else {
           // Create an aten::clone to clone the tensor in graph inputs
           auto newNode = node->owningGraph()->create(aten::clone, 1);
@@ -593,6 +595,7 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
           noneNode->insertBefore(newNode);
           node->replaceInput(index, newNode->output());
           input->replaceAllUsesAfterNodeWith(node, newNode->output());
+          input->setDebugName(input_name);
         }
       }
     }


### PR DESCRIPTION
Preserve name of parameters for ONNX.

Looks like newNode->addInput(input) API for a graph input is inserting a new clone of the node to graph inputs, which results in appending a '.1' to the name of the input (parameter). This PR is reverting the input name to the original name.