### PR TITLE
Consolidate mypy tests and args

### DIFF
--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -7,6 +7,7 @@
 [mypy]
 python_version = 3.6
 
+cache_dir = .mypy_cache/strict
 strict_optional = True
 show_column_numbers = True
 warn_no_return = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,12 @@
 # This is the PyTorch MyPy config file (note: don't change this line! -
 # test_run_mypy in test/test_type_hints.py uses this string)
 [mypy]
+cache_dir = .mypy_cache/normal
 warn_unused_configs = True
 warn_redundant_casts = True
 show_error_codes = True
 check_untyped_defs = True
+follow_imports = silent
 
 #
 # Note: test/ still has syntax errors so can't be added
@@ -17,6 +19,7 @@ check_untyped_defs = True
 files =
     torch,
     caffe2,
+    test/type_hint_tests,
     test/test_bundled_images.py,
     test/test_bundled_inputs.py,
     test/test_complex.py,

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -150,33 +150,11 @@ class TestTypeHints(TestCase):
                 raise unittest.SkipTest('cannot symlink') from None
             (stdout, stderr, result) = mypy.api.run([
                 '--cache-dir=.mypy_cache/doc',
-                '--follow-imports', 'silent',
-                '--check-untyped-defs',
                 '--no-strict-optional',  # needed because of torch.lu_unpack, see gh-36584
                 os.path.abspath(fn),
             ])
             if result != 0:
                 self.fail(f"mypy failed:\n{stdout}")
-
-    @unittest.skipIf(not HAVE_MYPY, "need mypy")
-    def test_type_hint_examples(self):
-        """
-        Runs mypy over all the test examples present in
-        `type_hint_tests` directory.
-        """
-        test_path = os.path.dirname(os.path.realpath(__file__))
-        examples_folder = os.path.join(test_path, "type_hint_tests")
-        examples = os.listdir(examples_folder)
-        for example in examples:
-            example_path = os.path.join(examples_folder, example)
-            (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy_cache/examples',
-                '--follow-imports', 'silent',
-                '--check-untyped-defs',
-                example_path,
-            ])
-            if result != 0:
-                self.fail(f"mypy failed for example {example}\n{stdout}")
 
     @unittest.skipIf(not HAVE_MYPY, "need mypy")
     def test_run_mypy(self):
@@ -207,11 +185,7 @@ class TestTypeHints(TestCase):
         # TODO: Would be better not to chdir here, this affects the entire
         # process!
         with set_cwd(repo_rootdir):
-            (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy_cache/normal',
-                '--check-untyped-defs',
-                '--follow-imports', 'silent',
-            ])
+            (stdout, stderr, result) = mypy.api.run([])
 
         if result != 0:
             self.fail(f"mypy failed: {stdout} {stderr}")
@@ -229,7 +203,6 @@ class TestTypeHints(TestCase):
 
         with set_cwd(repo_rootdir):
             (stdout, stderr, result) = mypy.api.run([
-                '--cache-dir=.mypy_cache/strict',
                 '--config', mypy_inifile,
             ])
 


### PR DESCRIPTION
This PR helps with #50513 by reducing the complexity of our `mypy` test suite and making it easier to reproduce on the command line. Previously, to reproduce how `mypy` was actually run on tracked source files (ignoring the doctest typechecking) in CI, you technically needed to run 9 different commands with various arguments:
```
$ mypy --cache-dir=.mypy_cache/normal --check-untyped-defs --follow-imports silent
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/module_list.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/namedtuple.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/opt_size.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/size.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/tensor_copy.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/torch_cuda_random.py
$ mypy --cache-dir=.mypy_cache/examples --follow-imports silent --check-untyped-defs test/type_hint_tests/torch_optim.py
$ mypy --cache-dir=.mypy_cache/strict --config mypy-strict.ini
```
Now you only have to run 2 much simpler commands:
```
$ mypy
$ mypy --config mypy-strict.ini
```
One reason this is useful is because it will make it easier to integrate PyTorch's `mypy` setup into editors (remaining work on this to be done in a followup PR).

Also, as shown in the test plan, this also reduces the time it takes to run `test/test_type_hints.py` incrementally, by reducing the number of times `mypy` is invoked while still checking the same set of files with the same configs.

(Because this PR merges `test_type_hint_examples` (added in #34595) into `test_run_mypy` (added in #36584), I've added some people involved in those PRs as reviewers, in case there's a specific reason they weren't combined in the first place.)

**Test plan:**

Run this twice (the first time is to warm the cache):
```
$ python test/test_type_hints.py -v
```

- *Before:*
  ```
  test_doc_examples (__main__.TestTypeHints)
  Run documentation examples through mypy. ... ok
  test_run_mypy (__main__.TestTypeHints)
  Runs mypy over all files specified in mypy.ini ... ok
  test_run_mypy_strict (__main__.TestTypeHints)
  Runs mypy over all files specified in mypy-strict.ini ... ok
  test_type_hint_examples (__main__.TestTypeHints)
  Runs mypy over all the test examples present in ... ok
  
  ----------------------------------------------------------------------
  Ran 4 tests in 5.090s
  
  OK
  ```
  You can also just run `mypy` to see how many files it checks:
  ```
  $ mypy --cache-dir=.mypy_cache/normal --check-untyped-defs --follow-imports silent
  Success: no issues found in 1192 source files
  ```
- *After:*
  ```
  test_doc_examples (__main__.TestTypeHints)
  Run documentation examples through mypy. ... ok
  test_run_mypy (__main__.TestTypeHints)
  Runs mypy over all files specified in mypy.ini ... ok
  test_run_mypy_strict (__main__.TestTypeHints)
  Runs mypy over all files specified in mypy-strict.ini ... ok
  
  ----------------------------------------------------------------------
  Ran 3 tests in 2.404s
  
  OK
  ```
  Now `mypy` checks 7 more files, which is the number in `test/type_hint_tests`:
  ```
  $ mypy
  Success: no issues found in 1199 source files
  ```