### PR TITLE
[PyTorch] Add missing Dispatcher.h include in quantized_ops.cpp

### DIFF
--- a/test/mobile/op_deps/quantized_ops.cpp
+++ b/test/mobile/op_deps/quantized_ops.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include <c10/core/TensorOptions.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/core/op_registration/op_registration.h>
 
 // This file simulates some irregular op registration/invocation patterns for


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50646 [PyTorch] Add missing Dispatcher.h include in quantized_ops.cpp**

Master build broke (see https://app.circleci.com/pipelines/github/pytorch/pytorch/260715/workflows/948c9235-8844-4747-b40d-c14ed33f8dbb/jobs/10195595)

Differential Revision: [D25935300](https://our.internmc.facebook.com/intern/diff/D25935300/)