### PR TITLE
test, fix deepcopy of tensor with grad

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2895,6 +2895,17 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a.size(), deepcopy(a).size())
         self.assertEqual(a, deepcopy(a))
 
+    @dtypes(torch.float32)
+    @onlyCPU
+    def test_deepcopy_gradient(self, device, dtype):
+        from copy import deepcopy
+        a = torch.zeros(10)
+        a.grad = torch.ones(10)
+        self.assertEqual(a.grad, deepcopy(a).grad)
+        s = torch.zeros(10).to_sparse()
+        s.grad = torch.ones(10).to_sparse()
+        self.assertEqual(s.grad, deepcopy(s).grad)
+
     def check_internal_mem_overlap(self, inplace_op, num_inputs,
                                    dtype, device,
                                    expected_failure=False):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6994,6 +6994,9 @@ class TestTorch(AbstractTestCases._TestTorchMixin):
         s.grad = torch.ones(10).to_sparse()
         self.assertEqual(s.grad, deepcopy(s).grad)
 
+        # ensure sharing is not broken
+        c = deepcopy([a, a.grad])
+        self.assertTrue(c[0].grad is c[1])
 
 # TODO: this empy class is temporarily instantiated for XLA compatibility
 #   once XLA updates their test suite it should be removed

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2895,17 +2895,6 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a.size(), deepcopy(a).size())
         self.assertEqual(a, deepcopy(a))
 
-    @dtypes(torch.float32)
-    @onlyCPU
-    def test_deepcopy_gradient(self, device, dtype):
-        from copy import deepcopy
-        a = torch.zeros(10)
-        a.grad = torch.ones(10)
-        self.assertEqual(a.grad, deepcopy(a).grad)
-        s = torch.zeros(10).to_sparse()
-        s.grad = torch.ones(10).to_sparse()
-        self.assertEqual(s.grad, deepcopy(s).grad)
-
     def check_internal_mem_overlap(self, inplace_op, num_inputs,
                                    dtype, device,
                                    expected_failure=False):
@@ -6995,6 +6984,16 @@ class TestTensorDeviceOps(TestCase):
 
 class TestTorch(AbstractTestCases._TestTorchMixin):
     exact_dtype = True
+
+    def test_deepcopy_gradient(self):
+        from copy import deepcopy
+        a = torch.zeros(10)
+        a.grad = torch.ones(10)
+        self.assertEqual(a.grad, deepcopy(a).grad)
+        s = torch.zeros(10).to_sparse()
+        s.grad = torch.ones(10).to_sparse()
+        self.assertEqual(s.grad, deepcopy(s).grad)
+
 
 # TODO: this empy class is temporarily instantiated for XLA compatibility
 #   once XLA updates their test suite it should be removed

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from copy import deepcopy
 import functools
 from numbers import Number
 from typing import Any, Dict, Optional, Tuple, Union
@@ -79,7 +78,7 @@ class Tensor(torch._C._TensorBase):
                     new_tensor.set_(new_storage, self.storage_offset(), self.size(), self.stride())
                     new_tensor.requires_grad = self.requires_grad
             if self.grad is not None:
-                new_tensor.grad = deepcopy(self.grad)
+                new_tensor.grad = self.grad.__deepcopy__(memo)
             memo[id(self)] = new_tensor
             return new_tensor
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -77,6 +77,8 @@ class Tensor(torch._C._TensorBase):
                     new_tensor = self.new()
                     new_tensor.set_(new_storage, self.storage_offset(), self.size(), self.stride())
                     new_tensor.requires_grad = self.requires_grad
+            if self.grad is not None:
+                new_tensor.grad = self.grad.clone()
             memo[id(self)] = new_tensor
             return new_tensor
 

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from copy import deepcopy
 import functools
 from numbers import Number
 from typing import Any, Dict, Optional, Tuple, Union
@@ -78,7 +79,7 @@ class Tensor(torch._C._TensorBase):
                     new_tensor.set_(new_storage, self.storage_offset(), self.size(), self.stride())
                     new_tensor.requires_grad = self.requires_grad
             if self.grad is not None:
-                new_tensor.grad = self.grad.clone()
+                new_tensor.grad = deepcopy(self.grad)
             memo[id(self)] = new_tensor
             return new_tensor
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5192,6 +5192,9 @@ class NewModuleTest(InputVariableMixin, ModuleTest):  # type: ignore[misc]
             if input.grad is not None:
                 with torch.no_grad():
                     input.grad.zero_()
+            if input_ip.grad is not None:
+                with torch.no_grad():
+                    input_ip.grad.zero_()
             output.backward(grad)
             output_ip.backward(grad)
             test_case.assertEqual(input.grad, input_ip.grad)


### PR DESCRIPTION
Fixes #3307

Previously, `self.grad` was not ~cloned~ deepcopied to the returned tensor in `deepcopy`. Added a test and an implementation.