### PR TITLE
[BE] Fix the broken test -- caffe2/caffe2/python:hypothesis_test - test_recurrent

### DIFF
--- a/caffe2/python/hypothesis_test.py
+++ b/caffe2/python/hypothesis_test.py
@@ -1,7 +1,3 @@
-
-
-
-
 import numpy as np
 import copy
 import time
@@ -346,6 +342,7 @@ class TestOperators(hu.HypothesisTestCase):
 
     @unittest.skipIf(not workspace.has_gpu_support,
                      "Skipping test due to no gpu present.")
+    @settings(deadline=None)
     @given(hidden_size=st.integers(min_value=1, max_value=3),
            num_layers=st.integers(min_value=1, max_value=3),
            bidirectional=st.booleans(),


### PR DESCRIPTION
Summary: GPU initialization sometimes is slow

Test Plan: buck test mode/opt //caffe2/caffe2/python:hypothesis_test -- --exact 'caffe2/caffe2/python:hypothesis_test - test_recurrent (caffe2.caffe2.python.hypothesis_test.TestOperators)' --run-disabled

Reviewed By: hl475

Differential Revision: D25939037

