### PR TITLE
[FX] Fix tracing __getitem__ on a buffer

### DIFF
--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -309,8 +309,8 @@ class Tracer(TracerBase):
         try:
             # Seems to be a mypy limitation: https://github.com/python/mypy/issues/2427
             torch.nn.Module.__getattr__ = module_getattr_wrapper  # type: ignore
-            torch.nn.Module.__call__ = module_call_wrapper
-            torch.Tensor.__getitem__ = _create_wrapped_method(torch.Tensor, "__getitem__")
+            torch.nn.Module.__call__ = module_call_wrapper  # type: ignore
+            torch.Tensor.__getitem__ = _create_wrapped_method(torch.Tensor, "__getitem__")  # type: ignore
 
             _patch_wrapped_functions(orig_fns)
 
@@ -318,9 +318,9 @@ class Tracer(TracerBase):
                              type_expr=fn.__annotations__.get('return', None))
         finally:
             _unpatch_wrapped_functions(orig_fns)
-            torch.nn.Module.__call__ = orig_call
             torch.nn.Module.__getattr__ = orig_getattr  # type: ignore
-            torch.Tensor.__getitem__ = orig_tensor_getitem
+            torch.nn.Module.__call__ = orig_call  # type: ignore
+            torch.Tensor.__getitem__ = orig_tensor_getitem  # type: ignore
         return self.graph
 
 # List of pairs of (global dict, function name) functions


### PR DESCRIPTION
This fixes a failed trace of [PositionalEmbedding from BERT](https://github.com/pytorch/benchmark/blob/6f79061bd145eeaa9b4a75847939901fd245ddf9/torchbenchmark/models/BERT_pytorch/bert_pytorch/model/embedding/position.py#L24), which failed to trace with the error `TypeError: slice indices must be integers or None or have an __index__ method` (a Proxy() is getting passed into `Tensor.__getitem__`).

After this PR, the following part of PositionalEmbedding:
```
def forward(self, x):
    return self.pe[:, :x.size(1)]
```
`symbolic_trace()`s to the following:
```
def forward(self, x):
    size = x.size(1);  x = None
    pe = self.pe
    getitem = pe.__getitem__((slice(None, None, None), slice(None, size, None)));  pe = size = None
    return getitem
```