### PR TITLE
[FX] Fix using fx.wrap as a decorator

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -54,6 +54,11 @@ wrap(a_lifted_leaf2)
 
 wrap('len')
 
+
+@wrap
+def wrapped_via_decorator(a):
+    return a + 1
+
 class Pair(NamedTuple):
     x : torch.Tensor
     y : torch.Tensor
@@ -243,6 +248,16 @@ class TestFX(JitTestCase):
         m = symbolic_trace(to_trace)
         self.assertIn('a_lifted_leaf2', m.code)
         self.assertEqual(27, m(2))
+
+    def test_wrapped_via_decorator(self):
+        self.assertEqual(wrapped_via_decorator(0), 1)
+
+        def to_trace(y):
+            return wrapped_via_decorator(y)
+
+        m = symbolic_trace(to_trace)
+        self.assertIn('wrapped_via_decorator', m.code)
+        self.assertEqual(m(0), 1)
 
     def test_graph_edit_with_proxy(self):
         class M(torch.nn.Module):

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -460,6 +460,7 @@ def wrap(fn_or_name : Union[str, Callable]):
         raise NotImplementedError('wrap must be called at the top level of a module')
 
     _wrapped_fns_to_patch.append((f.f_globals, fn_name))
+    return fn_or_name
 
 def symbolic_trace(root : Union[torch.nn.Module, Callable]) -> GraphModule:
     """Symbolic tracing API


### PR DESCRIPTION
`torch.fx.wrap()` could not be used as a decorator as the docstring claimed because it returned None.

Test Plan: Added `test_wrapped_via_decorator` which used to fail with `'NoneType' object is not callable` and now passes
