### PR TITLE
[wip] [Pipe] supporting None and non-Tensors in forward's input/output

### DIFF
--- a/torch/distributed/pipeline/sync/copy.py
+++ b/torch/distributed/pipeline/sync/copy.py
@@ -91,7 +91,7 @@ class Wait(torch.autograd.Function):
 
         wait_stream(next_stream, prev_stream)
 
-        return tuple(x.detach() for x in input)
+        return tuple(x.detach() if x is not None else x for x in input)
 
     @staticmethod
     def backward(ctx: Context, *grad_input: Tensor,) -> Tuple[Optional[Tensor], ...]:


### PR DESCRIPTION
I was trying to convert `transformers` [t5](https://github.com/huggingface/transformers/blob/357fb1c5d8b6a16f042f9b504f023d935086e8e5/src/transformers/models/t5/modeling_t5.py#L589) to use the new Pipe and I encountered a dozen of input args that some are Bools and some are optionally `None`, yet others tuples within tuples. You can see an example of the complex inputs it gets:

https://github.com/huggingface/transformers/blob/357fb1c5d8b6a16f042f9b504f023d935086e8e5/src/transformers/models/t5/modeling_t5.py#L600-L612

Currently `Pipe` only handles `input`/`output` which is either a single Tensor or a tuple of Tensors, so we can't use it as it stands now.

A user needs to be able to pass as a part of the `input` and `output` tuple:
1. `None` - in transformers these are passed to `forward` when the thing needs to be optionally generated by downstream layers, but is a Tensor at other times
2. Bools - these are flow control flags that the user's code needs to pass forward to the model. These aren't available during model's init.
3. tuples of Tensors within a tuple - there are several aggregators that append to a tuple, which is then returned as part of outputs - so again, some recursive introspection and `to()` is needed see below.

Bottom line, a whole bunch of variations of variables might be needed to be passed to and from the `forward` function in the pipe chain. As long as these structures can be traversed and switched `.to()` the right device and spliced where this is needed, any type of variable should be supported. Please, see below.

I made `microbatch.py` work with `None`s - this PR, but stumbled upon errors in C++ implementation:

```
TypeError: WaitBackward.forward: expected Tensor or tuple of Tensor (got NoneType) for return value 3
```

I'd love some help with this and also to figure out the Bools and other structures.

I'm very open to a different way of resolving this issue as well.

# Proposal

To summarize I propose to change the user-side `forward` in `Pipe` to support the following requirements:

```
def forward(self, input_to_slice, input_to_copy):
    [...]
    return input_to_slice, input_to_copy
```

where the `input_to_slice` tuple:
* may contain a single `Tensor` or a tuple of `(Tensor|None)`. `None` must be supported in `input`, since `None` is that only sometimes, and normal input data at other times. So micro-batch splice if it's `not None`, and pass `None` otherwise.
* first dimension of batch size len
* obvious how to switch `to()`

basically, what we have now plus supporting any number of `None`s in the tuple.

and then add an optional `input_to_copy` tuple, which:

* could be `None`
* may contain any nested tuples, lists, dicts, simple vars (but no objects, unless perhaps if they have `.to()` implemented)
* any variable in the tuple can be of any dimension - we are not slicing these
* will be switched `to()` by recursively traversing the structure. Here is a  [recursive_to](https://github.com/pytorch/pytorch/issues/49961#issuecomment-753441248) function that does the recursive traversal. may need to add support for objects which implement `.to()`

Each stage of the `Pipe` will receive:

* `self`
* a microbatch slice of  `input_to_slice` switched to the right device
* a full copy of `input_to_slice` switched to the right device

the `Pipe` will return:

* a reconstructed to full batch `input_to_slice` (updated to outputs)
* a full copy of `input_to_slice` (updated to outputs)

The names are just to make the proposal clear - surely they should be named something else should the proposal be accepted.

Thank you!

p.s. If I'm not mistaken pytorch `Pipe` is derived from/modelled after FairScale and there is also DeepSpeed's implementation, so let me know if I should work it out with one of the above first and then sync with pytorch?

tagging @blefaudeux from FairScale and @ShadenSmith from DeepSpeed - in case you have some insight - and since we need all 3 sets of APIs to agree I believe. If it's someone else at your org that is in charge of that domain please kindly tag them instead. thank you!

tagging @pritamdamania87 who originally suggested I use Pipe [here](https://github.com/pytorch/pytorch/issues/49961#issuecomment-754877078).