### PR TITLE
[BE] Fix the broken test caffe2/caffe2/python:lazy_dyndep_test - test_allcompare

### DIFF
--- a/caffe2/python/lazy_dyndep_test.py
+++ b/caffe2/python/lazy_dyndep_test.py
@@ -60,7 +60,7 @@ class TestLazyDynDepAllCompare(hu.HypothesisTestCase):
     @given(
         d=st.integers(1, 5), n=st.integers(2, 11), num_procs=st.integers(1, 8)
     )
-    @settings(deadline=10000)
+    @settings(deadline=None)
     def test_allcompare(self, d, n, num_procs):
         dims = []
         for _ in range(d):


### PR DESCRIPTION
Summary: set no deadline for test_alklcompare

Test Plan: buck test mode/dev //caffe2/caffe2/python:lazy_dyndep_test -- --exact 'caffe2/caffe2/python:lazy_dyndep_test - test_allcompare (caffe2.caffe2.python.lazy_dyndep_test.TestLazyDynDepAllCompare)' --run-disabled

Reviewed By: hl475

Differential Revision: D25947800

