### PR TITLE
Fix bug in hipify if include_dirs is not specified in setup.py

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -883,12 +883,10 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     if IS_HIP_EXTENSION:
         build_dir = os.getcwd()
-        if not include_dirs:
-            include_dirs = ['*']
         hipify_result = hipify_python.hipify(
             project_directory=build_dir,
             output_directory=build_dir,
-            includes=[os.path.join(os.path.relpath(include_dir, build_dir), '*') for include_dir in include_dirs],
+            includes=[os.path.join(os.path.relpath(include_dir, build_dir), '*') for include_dir in include_dirs] if include_dirs else ['*'],
             extra_files=[os.path.abspath(s) for s in sources],
             show_detailed=True,
             is_pytorch_extension=True,


### PR DESCRIPTION
Bugs:
1) would introduce -I* in compile commands 
2) wouldn't hipify source code directly in build_dir, only one level down or more
