### PR TITLE
Adding missing decorator for test_device_map_gpu_mixed_self_4

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4844,6 +4844,7 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
             dst=worker_name(self.rank)
         )
 
+    @skip_if_no_peer_access
     @skip_if_lt_x_gpu(2)
     def test_device_map_gpu_mixed_self_4(self):
         self._test_device_maps_gpu(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50732 Adding missing decorator for test_device_map_gpu_mixed_self_4**

closes #50731

Differential Revision: [D25954041](https://our.internmc.facebook.com/intern/diff/D25954041)