### PR TITLE
[pytorch] fix ConstRefCType usage in codegen/api/native.py

### DIFF
--- a/tools/codegen/api/native.py
+++ b/tools/codegen/api/native.py
@@ -34,7 +34,7 @@ def argumenttype_type(t: Type, *, mutable: bool, binds: ArgName) -> CType:
         else:
             return ConstRefCType(BaseCType('Tensor', binds))
     elif str(t) == 'Tensor?[]':
-        return BaseCType('const c10::List<c10::optional<Tensor>> &', binds)
+        return ConstRefCType(BaseCType("c10::List<c10::optional<Tensor>>", binds))
     return cpp.argumenttype_type(t, mutable=mutable, binds=binds)
 
 def returns_type(rs: Sequence[Return]) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50742 [pytorch] fix ConstRefCType usage in codegen/api/native.py**

Summary:
Fixed the other usage of `BaseCType('const ...&)` on #49138.

Checked byte-for-byte compatibility of the codegen output.

Differential Revision: [D25955565](https://our.internmc.facebook.com/intern/diff/D25955565)