### PR TITLE
BLD: create a LICENSE_BUNDLED.txt file from third_party licenses

### DIFF
--- a/test/test_license.py
+++ b/test/test_license.py
@@ -1,0 +1,30 @@
+import io
+import unittest
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+try:
+    from third_party.build_bundled import create_bundled
+except ImportError:
+    create_bundled = None
+
+license_file = 'third_party/LICENSES_BUNDLED.txt'
+
+class TestLicense(TestCase):
+
+    @unittest.skipIf(not create_bundled, "can only be run in a source tree")
+    def test_license_in_wheel(self):
+        current = io.StringIO()
+        create_bundled('third_party', current)
+        with open(license_file) as fid:
+            src_tree = fid.read()
+        if not src_tree == current.getvalue():
+            raise AssertionError(
+                f'the contents of "{license_file}" do not '
+                'match the current state of the third_party files. Use '
+                '"python third_party/build_bundled.py" to regenerate it')
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/third_party/LICENSES_BUNDLED.txt
+++ b/third_party/LICENSES_BUNDLED.txt
@@ -1,0 +1,264 @@
+The Pytorch repository and source distributions bundle several libraries that are 
+compatibly licensed.  We list these here.
+
+Name: FP16
+License: MIT
+Files: third_party/FP16
+  For details, see third_party/FP16/LICENSE
+
+Name: FXdiv
+License: MIT
+Files: third_party/FXdiv
+  For details, see third_party/FXdiv/LICENSE
+
+Name: NNPACK
+License: BSD-2-Clause
+Files: third_party/NNPACK
+  For details, see third_party/NNPACK/LICENSE
+
+Name: QNNPACK
+License: BSD-3-Clause
+Files: third_party/QNNPACK
+  For details, see third_party/QNNPACK/LICENSE
+
+Name: XNNPACK
+License: BSD-3-Clause
+Files: third_party/XNNPACK
+  For details, see third_party/XNNPACK/LICENSE
+
+Name: benchmark
+License: Apache-2.0
+Files: third_party/benchmark,
+     third_party/protobuf/third_party/benchmark,
+     third_party/onnx-tensorrt/third_party/onnx/third_party/benchmark,
+     third_party/onnx/third_party/benchmark
+  For details, see third_party/benchmark/LICENSE,
+     third_party/protobuf/third_party/benchmark/LICENSE,
+     third_party/onnx-tensorrt/third_party/onnx/third_party/benchmark/LICENSE,
+     third_party/onnx/third_party/benchmark/LICENSE
+
+Name: clog
+License: BSD-2-Clause
+Files: third_party/cpuinfo/deps/clog,
+     third_party/fbgemm/third_party/cpuinfo/deps/clog,
+     third_party/QNNPACK/deps/clog
+  For details, see third_party/cpuinfo/deps/clog/LICENSE,
+     third_party/fbgemm/third_party/cpuinfo/deps/clog/LICENSE,
+     third_party/QNNPACK/deps/clog/LICENSE
+
+Name: cpuinfo
+License: BSD-2-Clause
+Files: third_party/cpuinfo,
+     third_party/fbgemm/third_party/cpuinfo
+  For details, see third_party/cpuinfo/LICENSE,
+     third_party/fbgemm/third_party/cpuinfo/LICENSE
+
+Name: eigen
+License: BSD-3-Clause
+Files: third_party/eigen
+  For details, see third_party/eigen/COPYING.BSD
+
+Name: enum
+License: BSD-3-Clause
+Files: third_party/python-enum/enum
+  For details, see third_party/python-enum/enum/LICENSE
+
+Name: fbgemm
+License: BSD-3-Clause
+Files: third_party/fbgemm
+  For details, see third_party/fbgemm/LICENSE
+
+Name: fmt
+License: MIT with exception
+Files: third_party/kineto/libkineto/third_party/fmt,
+     third_party/fmt
+  For details, see third_party/kineto/libkineto/third_party/fmt/LICENSE.rst,
+     third_party/fmt/LICENSE.rst
+
+Name: foxi
+License: MIT
+Files: third_party/foxi
+  For details, see third_party/foxi/LICENSE
+
+Name: gemmlowp
+License: Apache-2.0
+Files: third_party/gemmlowp/gemmlowp
+  For details, see third_party/gemmlowp/gemmlowp/LICENSE
+
+Name: generator
+License: Apache-2.0
+Files: third_party/kineto/libkineto/third_party/googletest/googlemock/scripts/generator,
+     third_party/googletest/googlemock/scripts/generator,
+     third_party/fbgemm/third_party/googletest/googlemock/scripts/generator,
+     third_party/protobuf/third_party/googletest/googlemock/scripts/generator,
+     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator
+  For details, see third_party/kineto/libkineto/third_party/googletest/googlemock/scripts/generator/LICENSE,
+     third_party/googletest/googlemock/scripts/generator/LICENSE,
+     third_party/fbgemm/third_party/googletest/googlemock/scripts/generator/LICENSE,
+     third_party/protobuf/third_party/googletest/googlemock/scripts/generator/LICENSE,
+     third_party/tensorpipe/third_party/googletest/googlemock/scripts/generator/LICENSE
+
+Name: gloo
+License: BSD-3-Clause
+Files: third_party/gloo
+  For details, see third_party/gloo/LICENSE
+
+Name: googlemock
+License: BSD-3-Clause
+Files: third_party/kineto/libkineto/third_party/googletest/googlemock,
+     third_party/googletest/googlemock,
+     third_party/fbgemm/third_party/googletest/googlemock,
+     third_party/protobuf/third_party/googletest/googlemock,
+     third_party/tensorpipe/third_party/googletest/googlemock
+  For details, see third_party/kineto/libkineto/third_party/googletest/googlemock/LICENSE,
+     third_party/googletest/googlemock/LICENSE,
+     third_party/fbgemm/third_party/googletest/googlemock/LICENSE,
+     third_party/protobuf/third_party/googletest/googlemock/LICENSE,
+     third_party/tensorpipe/third_party/googletest/googlemock/LICENSE
+
+Name: googletest
+License: BSD-3-Clause
+Files: third_party/kineto/libkineto/third_party/googletest,
+     third_party/kineto/libkineto/third_party/googletest/googletest,
+     third_party/googletest,
+     third_party/googletest/googletest,
+     third_party/fbgemm/third_party/googletest,
+     third_party/fbgemm/third_party/googletest/googletest,
+     third_party/protobuf/third_party/googletest,
+     third_party/protobuf/third_party/googletest/googletest,
+     third_party/tensorpipe/third_party/googletest,
+     third_party/tensorpipe/third_party/googletest/googletest
+  For details, see third_party/kineto/libkineto/third_party/googletest/LICENSE,
+     third_party/kineto/libkineto/third_party/googletest/googletest/LICENSE,
+     third_party/googletest/LICENSE,
+     third_party/googletest/googletest/LICENSE,
+     third_party/fbgemm/third_party/googletest/LICENSE,
+     third_party/fbgemm/third_party/googletest/googletest/LICENSE,
+     third_party/protobuf/third_party/googletest/LICENSE,
+     third_party/protobuf/third_party/googletest/googletest/LICENSE,
+     third_party/tensorpipe/third_party/googletest/LICENSE,
+     third_party/tensorpipe/third_party/googletest/googletest/LICENSE
+
+Name: gtest
+License: BSD-3-Clause
+Files: third_party/ideep/mkl-dnn/tests/gtests/gtest
+  For details, see third_party/ideep/mkl-dnn/tests/gtests/gtest/LICENSE
+
+Name: ideep
+License: MIT
+Files: third_party/ideep
+  For details, see third_party/ideep/LICENSE
+
+Name: ios-cmake
+License: BSD-3-Clause
+Files: third_party/ios-cmake
+  For details, see third_party/ios-cmake/LICENSE
+
+Name: kineto
+License: BSD-3-Clause
+Files: third_party/kineto
+  For details, see third_party/kineto/LICENSE
+
+Name: libkineto
+License: BSD-3-Clause
+Files: third_party/kineto/libkineto
+  For details, see third_party/kineto/libkineto/LICENSE
+
+Name: libnop
+License: Apache-2.0
+Files: third_party/tensorpipe/third_party/libnop
+  For details, see third_party/tensorpipe/third_party/libnop/LICENSE
+
+Name: libuv
+License: MIT
+Files: third_party/tensorpipe/third_party/libuv
+  For details, see third_party/tensorpipe/third_party/libuv/LICENSE
+
+Name: miniz-2.0.8
+License: MIT
+Files: third_party/miniz-2.0.8
+  For details, see third_party/miniz-2.0.8/LICENSE
+
+Name: mkl-dnn
+License: Apache-2.0
+Files: third_party/ideep/mkl-dnn
+  For details, see third_party/ideep/mkl-dnn/LICENSE
+
+Name: nccl
+License: BSD-3-Clause
+Files: third_party/nccl/nccl
+  For details, see third_party/nccl/nccl/LICENSE.txt
+
+Name: neon2sse
+License: BSD-Source-Code
+Files: third_party/neon2sse
+  For details, see third_party/neon2sse/LICENSE
+
+Name: onnx
+License: MIT
+Files: third_party/onnx-tensorrt/third_party/onnx,
+     third_party/onnx
+  For details, see third_party/onnx-tensorrt/third_party/onnx/LICENSE,
+     third_party/onnx/LICENSE
+
+Name: onnx-tensorrt
+License: MIT
+Files: third_party/onnx-tensorrt
+  For details, see third_party/onnx-tensorrt/LICENSE
+
+Name: protobuf
+License: BSD-3-Clause
+Files: third_party/protobuf
+  For details, see third_party/protobuf/LICENSE
+
+Name: psimd
+License: MIT
+Files: third_party/psimd
+  For details, see third_party/psimd/LICENSE
+
+Name: pthreadpool
+License: BSD-2-Clause
+Files: third_party/pthreadpool
+  For details, see third_party/pthreadpool/LICENSE
+
+Name: pybind11
+License: BSD-3-Clause
+Files: third_party/pybind11,
+     third_party/onnx-tensorrt/third_party/onnx/third_party/pybind11,
+     third_party/onnx/third_party/pybind11,
+     third_party/tensorpipe/third_party/pybind11
+  For details, see third_party/pybind11/LICENSE,
+     third_party/onnx-tensorrt/third_party/onnx/third_party/pybind11/LICENSE,
+     third_party/onnx/third_party/pybind11/LICENSE,
+     third_party/tensorpipe/third_party/pybind11/LICENSE
+
+Name: python-peachpy
+License: BSD-2-Clause
+Files: third_party/python-peachpy
+  For details, see third_party/python-peachpy/LICENSE.rst
+
+Name: python-six
+License: MIT
+Files: third_party/python-six
+  For details, see third_party/python-six/LICENSE
+
+Name: sleef
+License: BSL-1.0
+Files: third_party/sleef
+  For details, see third_party/sleef/LICENSE.txt
+
+Name: tbb
+License: Apache-2.0
+Files: third_party/tbb
+  For details, see third_party/tbb/LICENSE
+
+Name: tensorpipe
+License: BSD-3-Clause
+Files: third_party/tensorpipe
+  For details, see third_party/tensorpipe/LICENSE.txt
+
+Name: zstd
+License: BSD-3-Clause
+Files: third_party/zstd
+  For details, see third_party/zstd/LICENSE
+

--- a/third_party/LICENSES_BUNDLED.txt
+++ b/third_party/LICENSES_BUNDLED.txt
@@ -159,11 +159,6 @@ License: BSD-3-Clause
 Files: third_party/kineto
   For details, see third_party/kineto/LICENSE
 
-Name: libkineto
-License: BSD-3-Clause
-Files: third_party/kineto/libkineto
-  For details, see third_party/kineto/libkineto/LICENSE
-
 Name: libnop
 License: Apache-2.0
 Files: third_party/tensorpipe/third_party/libnop

--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 
 

--- a/third_party/build_bundled.py
+++ b/third_party/build_bundled.py
@@ -1,0 +1,158 @@
+import os
+
+
+mydir = os.path.dirname(__file__)
+licenses = {'LICENSE', 'LICENSE.txt', 'LICENSE.rst', 'COPYING.BSD'}
+
+
+def collect_license(current):
+    collected = {}
+    for root, dirs, files in os.walk(current):
+        license = list(licenses & set(files))
+        if license:
+            name = root.split('/')[-1]
+            license_file = os.path.join(root, license[0])
+            try:
+                ident = identify_license(license_file)
+            except ValueError:
+                raise ValueError('could not identify license file '
+                                 f'for {root}') from None
+            val = {
+                'Name': name,
+                'Files': [root],
+                'License': ident,
+                'License_file': [license_file],
+            }
+            if name in collected:
+                # Only add it if the license is different
+                if collected[name]['License'] == ident:
+                    collected[name]['Files'].append(root)
+                    collected[name]['License_file'].append(license_file)
+                else:
+                    collected[name + f' ({root})'] = val
+            else:
+                collected[name] = val
+    return collected
+
+
+def create_bundled(d, outstream):
+    """Write the information to an open outstream"""
+    collected = collect_license(d)
+    sorted_keys = sorted(collected.keys())
+    outstream.write('The Pytorch repository and source distributions bundle '
+                    'several libraries that are \n')
+    outstream.write('compatibly licensed.  We list these here.\n\n')
+    for k in sorted_keys:
+        c = collected[k]
+        files = ',\n     '.join(c['Files'])
+        license_file = ',\n     '.join(c['License_file'])
+        outstream.write(f"Name: {c['Name']}\n")
+        outstream.write(f"License: {c['License']}\n")
+        outstream.write(f"Files: {files}\n")
+        outstream.write('  For details, see ')
+        outstream.write(license_file)
+        outstream.write('\n\n') 
+
+
+def identify_license(f, exception=''):
+    """
+    Read f and try to identify the license type
+    This is __very__ rough and probably not legally binding, it is specific for
+    this repo.
+    """
+    def squeeze(t):
+        """Remove 'n and ' ', normalize quotes
+        """
+        t = t.replace('\n', '').replace(' ', '')
+        t = t.replace('``', '"').replace("''", '"')
+        return t
+
+    with open(f) as fid:
+        txt = fid.read()
+        if not exception and 'exception' in txt:
+            license = identify_license(f, 'exception')
+            return license + ' with exception'
+        txt = squeeze(txt)
+        if 'ApacheLicense' in txt:
+            # Hmm, do we need to check the text?
+            return 'Apache-2.0'
+        elif 'MITLicense' in txt:
+            # Hmm, do we need to check the text?
+            return 'MIT'
+        elif 'BSD-3-ClauseLicense' in txt:
+            # Hmm, do we need to check the text?
+            return 'BSD-3-Clause'
+        elif 'BSD3-ClauseLicense' in txt:
+            # Hmm, do we need to check the text?
+            return 'BSD-3-Clause'
+        elif 'BoostSoftwareLicense-Version1.0' in txt:
+            # Hmm, do we need to check the text?
+            return 'BSL-1.0'
+        elif all([squeeze(m) in txt.lower() for m in bsd3_txt]):
+            return 'BSD-3-Clause'
+        elif all([squeeze(m) in txt.lower() for m in bsd3_v1_txt]):
+            return 'BSD-3-Clause'
+        elif all([squeeze(m) in txt.lower() for m in bsd2_txt]):
+            return 'BSD-2-Clause'
+        elif all([squeeze(m) in txt.lower() for m in bsd3_src_txt]):
+            return 'BSD-Source-Code'
+        elif all([squeeze(m) in txt.lower() for m in mit_txt]):
+            return 'MIT'
+        else:
+            raise ValueError('unknown license')
+
+mit_txt = ['permission is hereby granted, free of charge, to any person '
+           'obtaining a copy of this software and associated documentation '
+           'files (the "software"), to deal in the software without '
+           'restriction, including without limitation the rights to use, copy, '
+           'modify, merge, publish, distribute, sublicense, and/or sell copies '
+           'of the software, and to permit persons to whom the software is '
+           'furnished to do so, subject to the following conditions:',
+
+           'the above copyright notice and this permission notice shall be '
+           'included in all copies or substantial portions of the software.',
+
+           'the software is provided "as is", without warranty of any kind, '
+           'express or implied, including but not limited to the warranties of '
+           'merchantability, fitness for a particular purpose and '
+           'noninfringement. in no event shall the authors or copyright holders '
+           'be liable for any claim, damages or other liability, whether in an '
+           'action of contract, tort or otherwise, arising from, out of or in '
+           'connection with the software or the use or other dealings in the '
+           'software.'
+           ]
+
+bsd3_txt = ['redistribution and use in source and binary forms, with or without '
+            'modification, are permitted provided that the following conditions '
+            'are met:',
+
+            'redistributions of source code',
+
+            'redistributions in binary form',
+
+            'neither the name',
+
+            'this software is provided by the copyright holders and '
+            'contributors "as is" and any express or implied warranties, '
+            'including, but not limited to, the implied warranties of '
+            'merchantability and fitness for a particular purpose are disclaimed.',
+            ]
+
+# BSD2 is BSD3 without the "neither the name..." clause
+bsd2_txt = bsd3_txt[:3] + bsd3_txt[4:]
+
+# This BSD3 variant leaves "and contributors" out of the last clause of BSD-3,
+# which is still valid BSD-3
+v1 = bsd3_txt[4].replace('and contributors', '')
+bsd3_v1_txt = bsd3_txt[:3] + [v1]
+
+# This source variant of BSD-3 leaves the "redistributions in binary form" out
+# which is https://spdx.org/licenses/BSD-Source-Code.html
+bsd3_src_txt = bsd3_txt[:2] + bsd3_txt[4:]
+
+
+if __name__ == '__main__':
+    third_party = os.path.join(mydir)
+    fname = os.path.join(third_party, 'LICENSES_BUNDLED.txt')
+    with open(fname, 'w') as fid:
+        create_bundled(third_party, fid)


### PR DESCRIPTION
Fixes #50695.

Rather than maintain a LICENSE_BUNDLED.txt by hand, this build it out of the subrepos. 

I ~copied and adapted the sdist handling from Numpy~ added a separate file, so the LICENSE.txt file of the repo remains in pristine condition and the GitHub website still recognizes it. If we modify the file, the website will no longer recognize the license.

This is not enough, since the license in the ~wheel~ wheel and sdist is not modified. Numpy has a [separate step](https://github.com/MacPython/numpy-wheels/blob/master/patch_code.sh) when preparing the wheel to concatenate the licenses. I am not sure where/if the [conda-forge numpy-feedstock](https://github.com/conda-forge/numpy-feedstock/) also fixes up the license.

~Should~ I ~commit~ commited the artifact to the repo and ~add~ added a test that reproducing the file is consistent.

Edit: now the file is part of the repo.

Edit: rework the mention of sdist. After this is merged another PR is needed to make the sdist and wheel ship the proper merged license.