### PR TITLE
Remove gtest_prod.h from TP agent.

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -2,7 +2,6 @@
 
 #ifdef USE_TENSORPIPE
 
-#include <gtest/gtest_prod.h>
 #include <atomic>
 #include <thread>
 
@@ -221,11 +220,11 @@ class TensorPipeAgent : public RpcAgent {
   static std::string guessUvAddress(
       tensorpipe::transport::uv::Context& uvContext);
 
- private:
-  FRIEND_TEST(TestE2ETensorPipe, TestTrainingLoop);
+  // For testing purposes.
   size_t timeoutMapSize();
   size_t numPendingResponses();
 
+ private:
   // Removes the given messageId with the given expirationTime from the
   // timeoutMap_.
   void removeFromTimeoutMap(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50766 Remove gtest_prod.h from TP agent.**

This header breaks certain builds since it causes PyTorch to depend
on gtest.

Differential Revision: [D25960810](https://our.internmc.facebook.com/intern/diff/D25960810/)