### PR TITLE
tools: Move sha check to else statement

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -13,8 +13,6 @@ def get_sha():
 def get_torch_version(sha=None):
     pytorch_root = Path(__file__).parent.parent
     version = open('version.txt', 'r').read().strip()
-    if sha is None:
-        sha = get_sha()
 
     if os.getenv('PYTORCH_BUILD_VERSION'):
         assert os.getenv('PYTORCH_BUILD_NUMBER') is not None
@@ -23,6 +21,8 @@ def get_torch_version(sha=None):
         if build_number > 1:
             version += '.post' + str(build_number)
     elif sha != 'Unknown':
+        if sha is None:
+            sha = get_sha()
         version += '+' + sha[:7]
     return version
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50773 tools: Move sha check to else statement**

Summary: Moves the sha check for version generation to the else clause
since it was causing issues for users building pytorch when the .git
directory was not present and PYTORCH_BUILD_VERSION was already set

Test Plan: CI

Closes https://github.com/pytorch/pytorch/issues/50730
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D25963486](https://our.internmc.facebook.com/intern/diff/D25963486)