### PR TITLE
[TensorExpr] Use wider type for scalars

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1716,7 +1716,7 @@ void TensorExprKernel::bindInput(const torch::jit::Value* input) {
       break;
     }
     case TypeKind::FloatType: {
-      VarHandle v("v" + input->debugName(), kFloat);
+      VarHandle v("v" + input->debugName(), kDouble);
       kernelArgs_.emplace_back(v);
       scalars_.emplace(input->unique(), v);
       break;
@@ -1728,7 +1728,7 @@ void TensorExprKernel::bindInput(const torch::jit::Value* input) {
       break;
     }
     case TypeKind::IntType: {
-      VarHandle v("v" + input->debugName(), kInt);
+      VarHandle v("v" + input->debugName(), kLong);
       kernelArgs_.emplace_back(v);
       scalars_.emplace(input->unique(), v);
       break;
@@ -2196,9 +2196,9 @@ std::vector<CodeGen::CallArg> TensorExprKernel::prepareRunArgs(
   for (size_t i = 0, e = inputs.size(); i < e; i++) {
     auto const& input = inputs[i];
     if (input.isInt()) {
-      runArgs.emplace_back((int32_t)input.toInt());
+      runArgs.emplace_back(input.toInt());
     } else if (input.isDouble()) {
-      runArgs.emplace_back((float)input.toDouble());
+      runArgs.emplace_back(input.toDouble());
     } else if (input.isTensor()) {
       runArgs.emplace_back(input.toTensor().data_ptr());
     }

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -405,7 +405,9 @@ class JitTestCase(JitCommonTestCase):
                     inputs_requires_grad=False,
                     capture_output=False,
                     frames_up=1,
-                    profiling=ProfilingMode.PROFILING):
+                    profiling=ProfilingMode.PROFILING,
+                    atol=None,
+                    rtol=None):
         with torch.jit.optimized_execution(optimize):
             with enable_profiling_mode_for_profiling_tests():
                 if isinstance(script, str):
@@ -455,7 +457,7 @@ class JitTestCase(JitCommonTestCase):
                         python_outputs = python_fn(*inputs)
                     if not IS_WINDOWS:
                         self.assertExpected(script_stdout[0], subname='stdout')
-                    self.assertEqual(python_outputs, opt_script_outputs)
+                    self.assertEqual(python_outputs, opt_script_outputs, atol=atol, rtol=rtol)
                 else:
                     # profiling run
                     script_outputs = scripted_fn(*recording_inputs)
@@ -464,8 +466,8 @@ class JitTestCase(JitCommonTestCase):
                     if TEST_BAILOUTS:
                         self.checkBailouts(scripted_fn, inputs, opt_script_outputs)
                     python_outputs = python_fn(*inputs)
-                self.assertEqual(python_outputs, script_outputs)
-                self.assertEqual(script_outputs, opt_script_outputs)
+                self.assertEqual(python_outputs, script_outputs, atol=atol, rtol=rtol)
+                self.assertEqual(script_outputs, opt_script_outputs, atol=atol, rtol=rtol)
                 return scripted_fn
 
     def checkTrace(self, func, reference_tensors, input_tensors=None,


### PR DESCRIPTION
Summary: Scalars have to be double / 64-bit integers to match eager semantics.

Test Plan:
python test/test_jit_fuser_te.py -k TestTEFuser.test_clamp