### PR TITLE
[JIT][WIP] Enable Python-language hooks for ScriptModule

### DIFF
--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -684,6 +684,8 @@ if _enabled:
         "forward",
         "register_buffer",
         "register_parameter",
+        "register_forward_pre_hook",
+        "register_forward_hook",
         "add_module",
         "_apply",
         "apply",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50776 [JIT][WIP] Enable Python-language hooks for ScriptModule**

**Summary**
This commit enables attachment of forward pre-hooks and forward hooks on
`RecursiveScriptModule`. This can be useful for observing internals of
an already-scripted model.

**Test Plan**
Code sample.
```
import torch

class HookedModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.a = 3

    def forward(self):
        return self.a


def pre_hook(model, input):
    print(model.a)
    model.a = 10


def post_hook(model, input, output):
    print(model.a)
    model.a = 20


a = HookedModule()
s_a = torch.jit.script(a)
s_a.register_forward_pre_hook(pre_hook)
s_a.register_forward_hook(post_hook)

s_a()
```

Output.
```
3
10
```