### PR TITLE
[FX] Fix NoneType annotation in generated code

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -815,6 +815,9 @@ class TestFX(JitTestCase):
 
         self.assertTrue(neg not in relu.users)
 
+    def test_nonetype_annotation(self):
+        eb = torch.nn.EmbeddingBag(3, 4)
+        symbolic_trace(eb)
 
     def test_construct_root_dict(self):
         graph : torch.fx.Graph = torch.fx.Graph()

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -8,7 +8,7 @@ import keyword
 import re
 
 def _shadows_builtin_name(name: str) -> bool:
-    return name in builtins.__dict__ or name in keyword.kwlist or name in {'inf', 'nan'}
+    return name in builtins.__dict__ or name in keyword.kwlist or name in {'inf', 'nan', 'NoneType'}
 
 def _is_magic(x: str) -> bool:
     return x.startswith('__') and x.endswith('__')

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -36,7 +36,8 @@ def patched_getline(*args, **kwargs):
 linecache.getlines = patched_getline
 
 def _forward_from_src(src : str):
-    gbls: Dict[str, Any] = {'inf': math.inf, 'nan': math.nan}
+    # If you add more globals here, remember to add their names to fx.graph._shadows_builtin_name!
+    gbls: Dict[str, Any] = {'inf': math.inf, 'nan': math.nan, 'NoneType' : type(None)}
     exec_with_source(src, gbls)
     return gbls['forward']
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50777 [FX] Fix NoneType annotation in generated code**

Previously, when trying to symbolically trace some `Module`s that had--for example--`Union[Tensor, NoneType]` as a parameter, execution would fail because the `repr` for `NoneType` doesn't map to any name in Python (`NoneType` is only directly exposed on the `types` namespace in Python 3.10+). This change makes it so that `NoneType` is available in the global namespace and ensures that we do not have any collisions with that name.

Old error:

```
  File "<eval_with_key_0>", line 3, in <module>
    def forward(self, input : torch.Tensor, offsets : typing.Union[torch.Tensor, NoneType] = None, per_sample_weights : typing.Union[torch.Tensor, NoneType] = None) -> torch.Tensor:
NameError: name 'NoneType' is not defined
```

Differential Revision: [D25966026](https://our.internmc.facebook.com/intern/diff/D25966026)