### PR TITLE
Fix warnings in "ForeachOpsKernels" with c10::irange

### DIFF
--- a/aten/src/ATen/native/ForeachOpsKernels.cpp
+++ b/aten/src/ATen/native/ForeachOpsKernels.cpp
@@ -1,5 +1,6 @@
 #include <ATen/ATen.h>
 #include <ATen/native/ForeachUtils.h>
+#include <c10/util/irange.h>
 
 namespace at { namespace native {
 
@@ -28,7 +29,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalar_kernel_slow(TensorList tensors,
 void foreach_tensor_##OP##_scalarlist_kernel_slow_(TensorList tensors, at::ArrayRef<double> scalars) {                  \
   check_foreach_api_restrictions(tensors, scalars);                                                                     \
                                                                                                                         \
-  for (size_t i = 0; i < tensors.size(); i++) {                                                                            \
+  for (const auto i : c10::irange(tensors.size())) {                                                                    \
       tensors[i].OP##_(scalars[i]);                                                                                     \
     }                                                                                                                   \
 }                                                                                                                       \
@@ -37,7 +38,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalarlist_kernel_slow(TensorList tens
   check_foreach_api_restrictions(tensors, scalars);                                                                     \
   std::vector<Tensor> result;                                                                                           \
   result.reserve(tensors.size());                                                                                       \
-  for (size_t i = 0; i < tensors.size(); i++) {                                                                            \
+  for (const auto i : c10::irange(tensors.size())) {                                                                    \
     result.emplace_back(tensors[i].OP(scalars[i]));                                                                     \
   }                                                                                                                     \
                                                                                                                         \
@@ -50,7 +51,7 @@ std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, 
                                                                                                           \
   std::vector<Tensor> result;                                                                             \
   result.reserve(tensors1.size());                                                                        \
-  for (size_t i = 0; i < tensors1.size(); i++) {                                                             \
+  for (const auto i : c10::irange(tensors1.size())) {                                                     \
     result.emplace_back(tensors1[i].OP(tensors2[i]));                                                     \
   }                                                                                                       \
                                                                                                           \
@@ -60,7 +61,7 @@ std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, 
 void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList tensors2) {                  \
   check_foreach_api_restrictions(tensors1, tensors2);                                                     \
                                                                                                           \
-  for (size_t i = 0; i < tensors1.size(); i++) {                                                             \
+  for (const auto i : c10::irange(tensors1.size())) {                                                     \
     tensors1[i].OP##_(tensors2[i]);                                                                       \
   }                                                                                                       \
 }
@@ -71,7 +72,7 @@ std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, 
                                                                                                                         \
   std::vector<Tensor> result;                                                                                           \
   result.reserve(tensors1.size());                                                                                      \
-  for (size_t i = 0; i < tensors1.size(); i++) {                                                                           \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                   \
     result.emplace_back(tensors1[i].OP(tensors2[i], alpha));                                                            \
   }                                                                                                                     \
                                                                                                                         \
@@ -81,7 +82,7 @@ std::vector<Tensor> foreach_tensor_##OP##_list_kernel_slow(TensorList tensors1, 
 void foreach_tensor_##OP##_list_kernel_slow_(TensorList tensors1, TensorList tensors2, Scalar alpha) {                  \
   check_foreach_api_restrictions(tensors1, tensors2);                                                                   \
                                                                                                                         \
-  for (size_t i = 0; i < tensors1.size(); i++) {                                                                           \
+  for (const auto i : c10::irange(tensors1.size())) {                                                                   \
     tensors1[i].OP##_(tensors2[i], alpha);                                                                              \
   }                                                                                                                     \
 }
@@ -112,7 +113,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalar_slow(TensorList input, TensorLi
   check_foreach_api_restrictions(input, tensors1, tensors2);                                                                         \
                                                                                                                                      \
   std::vector<Tensor> result;                                                                                                        \
-  for (size_t i = 0; i < input.size(); i++) {                                                                                           \
+  for(const auto i : c10::irange(input.size())) {                                                                                    \
     result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalar));                                                              \
   }                                                                                                                                  \
                                                                                                                                      \
@@ -122,7 +123,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalar_slow(TensorList input, TensorLi
 void foreach_tensor_##OP##_scalar_slow_(TensorList input, TensorList tensors1, TensorList tensors2, Scalar scalar) {                 \
   check_foreach_api_restrictions(input, tensors1, tensors2);                                                                         \
                                                                                                                                      \
-  for (size_t i = 0; i < input.size(); i++) {                                                                                           \
+  for(const auto i : c10::irange(input.size())) {                                                                                    \
     input[i].OP##_(tensors1[i], tensors2[i], scalar);                                                                                \
   }                                                                                                                                  \
 }                                                                                                                                    \
@@ -132,7 +133,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalarlist_slow(TensorList input, Tens
   check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                   \
                                                                                                                                                         \
   std::vector<Tensor> result;                                                                                                                           \
-  for (size_t i = 0; i < input.size(); i++) {                                                                                                              \
+  for(const auto i : c10::irange(input.size())) {                                                                                                       \
     result.emplace_back(input[i].OP(tensors1[i], tensors2[i], scalars[i]));                                                                             \
   }                                                                                                                                                     \
                                                                                                                                                         \
@@ -142,7 +143,7 @@ std::vector<Tensor> foreach_tensor_##OP##_scalarlist_slow(TensorList input, Tens
 void foreach_tensor_##OP##_scalarlist_slow_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<double> scalars) {                 \
   check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                   \
                                                                                                                                                         \
-  for (size_t i = 0; i < input.size(); i++) {                                                                                                              \
+  for(const auto i : c10::irange(input.size())) {                                                                                                       \
     input[i].OP##_(tensors1[i], tensors2[i], scalars[i]);                                                                                               \
   }                                                                                                                                                     \
 }                                                                                                                                                       \
@@ -204,7 +205,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_slow(TensorList tensors1, TensorList
                                                                                              \
   std::vector<Tensor> result;                                                                \
   result.reserve(tensors1.size());                                                           \
-  for (size_t i = 0; i < tensors1.size(); i++) {                                             \
+  for (const auto i : c10::irange(tensors1.size())) {                                        \
     result.emplace_back(at::NAME(tensors1[i], tensors2[i]));                                 \
   }                                                                                          \
                                                                                              \


### PR DESCRIPTION
Summary:
Compiling currently shows:
```
Jan 13 16:46:28 In file included from ../aten/src/ATen/native/ForeachOpsKernels.cpp:2:
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:28:21: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:44:21: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:149:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:164:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:183:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachUtils.h:198:25: warning: comparison of integers of different signs: 'int64_t' (aka 'long long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28   for (int64_t i = 0; i < tensors1.size(); i++) {
Jan 13 16:46:28                       ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:150:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST_ALPHA(add);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:74:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST_ALPHA'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:150:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST_ALPHA(add);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:84:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST_ALPHA'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:151:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST_ALPHA(sub);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:74:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST_ALPHA'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:151:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST_ALPHA(sub);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:84:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST_ALPHA'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:158:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(add);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:31:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:158:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(add);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:40:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:159:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(sub);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:31:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:159:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(sub);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:40:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:160:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(mul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:31:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:160:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(mul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:40:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:161:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(div);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:31:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:161:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_SCALARLIST(div);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:40:21: note: expanded from macro 'FOREACH_BINARY_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < tensors.size(); i++) {                                                                            \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:163:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST(mul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:53:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                             \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:163:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST(mul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:63:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                             \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:164:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST(div);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:53:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                             \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:164:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_BINARY_OP_LIST(div);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:63:21: note: expanded from macro 'FOREACH_BINARY_OP_LIST'
Jan 13 16:46:28   for (int i = 0; i < tensors1.size(); i++) {                                                             \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:195:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALAR(addcdiv);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:115:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALAR'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:195:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALAR(addcdiv);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:125:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALAR'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:196:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALAR(addcmul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:115:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALAR'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:196:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALAR(addcmul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:125:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALAR'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                           \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:198:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALARLIST(addcdiv);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:135:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                                              \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:198:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALARLIST(addcdiv);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:145:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                                              \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:199:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALARLIST(addcmul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:135:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {                                                                                                              \
Jan 13 16:46:28                   ~ ^ ~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:199:1: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
Jan 13 16:46:28 FOREACH_POINTWISE_OP_SCALARLIST(addcmul);
Jan 13 16:46:28 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Jan 13 16:46:28 ../aten/src/ATen/native/ForeachOpsKernels.cpp:145:21: note: expanded from macro 'FOREACH_POINTWISE_OP_SCALARLIST'
Jan 13 16:46:28   for (int i = 0; i < input.size(); i++) {
```
this diff fixes that

Test Plan: Sandcastle tests

Differential Revision: D25935046

