### PR TITLE
Add CUDA RPC stress tests

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -5294,9 +5294,11 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
 
         rpc.shutdown()
 
+    @skip_if_lt_x_gpu(2)
     def test_stress_cuda_light(self):
         self._test_stress_cuda([2, 2])
 
+    @skip_if_lt_x_gpu(2)
     def test_stress_cuda_heavy(self):
         self._test_stress_cuda([10000, 10000])
 

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -5270,7 +5270,7 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
         dst = worker_name((self.rank + 1) % self.world_size)
         options.set_device_map(dst, {0: 1})
 
-        n = 1
+        n = 10
         xs = [torch.ones(sizes, device="cuda:0") for _ in range(n)]
 
         rpc.init_rpc(
@@ -5300,7 +5300,7 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
 
     @skip_if_lt_x_gpu(2)
     def test_stress_cuda_heavy(self):
-        self._test_stress_cuda([10000, 10000])
+        self._test_stress_cuda([5000, 5000])
 
     @dist_init
     def test_rref_get_type_timeout(self):

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -5247,6 +5247,60 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
             {"cuda:0": "cuda:1", "cuda:1": "cuda:0"}
         )
 
+    @staticmethod
+    def _cuda_identity(x):
+        return x
+
+    def _cuda_stress_run(self, n, dst, xs):
+        futs = []
+        for i in range(n):
+            futs.append(rpc.rpc_async(
+                dst,
+                TensorPipeAgentRpcTest._cuda_identity,
+                args=(xs[i],)
+            ))
+
+        for fut in futs:
+            fut.wait()
+
+        for d in range(torch.cuda.device_count()):
+            torch.cuda.synchronize(d)
+
+    def _test_stress_cuda(self, sizes):
+        options = self.rpc_backend_options
+        dst = worker_name((self.rank + 1) % self.world_size)
+        options.set_device_map(dst, {0: 1})
+
+        n = 1
+        xs = [torch.ones(sizes, device="cuda:0") for _ in range(n)]
+
+        rpc.init_rpc(
+            name=worker_name(self.rank),
+            backend=self.rpc_backend,
+            rank=self.rank,
+            world_size=self.world_size,
+            rpc_backend_options=options,
+        )
+
+        if self.rank == 0:
+            # warmup
+            self._cuda_stress_run(n, dst, xs)
+
+            # testing
+            for _ in range(5):
+                tik = time.time()
+                self._cuda_stress_run(n, dst, xs)
+                tok = time.time()
+                print(f"rank{self.rank}: {tok - tik}")
+
+        rpc.shutdown()
+
+    def test_stress_cuda_light(self):
+        self._test_stress_cuda([2, 2])
+
+    def test_stress_cuda_heavy(self):
+        self._test_stress_cuda([10000, 10000])
+
     @dist_init
     def test_rref_get_type_timeout(self):
         # Test where we try to get the type of a RRef from an owner, but RRef


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50949 Fix CUDA RPC Stream Synchronization
* **#50788 Add CUDA RPC stress tests**
* #50676 Let TensorPipe detect peer access

Differential Revision: [D25967414](https://our.internmc.facebook.com/intern/diff/D25967414)