### PR TITLE
Modernize for-loops

### DIFF
--- a/aten/src/ATen/VmapTransforms.cpp
+++ b/aten/src/ATen/VmapTransforms.cpp
@@ -280,8 +280,8 @@ Tensor VmapPhysicalToLogicalMap::apply(const Tensor& physical_tensor) const {
 }
 
 void VmapPhysicalToLogicalMap::applyInplace(std::vector<Tensor>& physical_tensors) const {
-  for (int64_t idx = 0; idx < physical_tensors.size(); ++idx) {
-    physical_tensors[idx] = apply(physical_tensors[idx]);
+  for (auto & physical_tensor : physical_tensors) {
+    physical_tensor = apply(physical_tensor);
   }
 }
 

--- a/aten/src/ATen/core/List_test.cpp
+++ b/aten/src/ATen/core/List_test.cpp
@@ -225,11 +225,11 @@ TEST(ListTest_IValueBasedList, whenIterating_thenFindsElements) {
   List<string> list({"3", "5"});
   bool found_first = false;
   bool found_second = false;
-  for (List<string>::iterator iter = list.begin(); iter != list.end(); ++iter) {
-    if (static_cast<string>(*iter) == "3") {
+  for (const auto && iter : list) {
+    if (static_cast<string>(iter) == "3") {
       EXPECT_FALSE(found_first);
       found_first = true;
-    } else if (static_cast<string>(*iter) == "5") {
+    } else if (static_cast<string>(iter) == "5") {
       EXPECT_FALSE(found_second);
       found_second = true;
     } else {
@@ -755,11 +755,11 @@ TEST(ListTest_NonIValueBasedList, whenIterating_thenFindsElements) {
   List<int64_t> list({3, 5});
   bool found_first = false;
   bool found_second = false;
-  for (List<int64_t>::iterator iter = list.begin(); iter != list.end(); ++iter) {
-    if (static_cast<int64_t>(*iter) == 3) {
+  for (const auto && iter : list) {
+    if (static_cast<int64_t>(iter) == 3) {
       EXPECT_FALSE(found_first);
       found_first = true;
-    } else if (static_cast<int64_t>(*iter) == 5) {
+    } else if (static_cast<int64_t>(iter) == 5) {
       EXPECT_FALSE(found_second);
       found_second = true;
     } else {

--- a/aten/src/ATen/core/dispatch/OperatorEntry.cpp
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.cpp
@@ -51,10 +51,10 @@ const AnnotatedKernel OperatorEntry::ambiguousAutogradOtherKernel_ = AnnotatedKe
 
 void OperatorEntry::registerSchema(FunctionSchema&& schema, std::string&& debug) {
   TORCH_INTERNAL_ASSERT(!schema_.has_value());
-  for (auto i = kernels_.begin(); i != kernels_.end(); ++i) {
-    for (auto j = i->second.begin(); j != i->second.end(); ++j) {
-      if (j->inferred_function_schema != nullptr) {
-        checkSchema(name_, schema, debug, *j->inferred_function_schema, j->debug);
+  for (const auto& kernel : kernels_) {
+    for (const auto &j : kernel.second) {
+      if (j.inferred_function_schema != nullptr) {
+        checkSchema(name_, schema, debug, *j.inferred_function_schema, j.debug);
       }
     }
   }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -1609,9 +1609,9 @@ void ClassType::checkNotExist(const std::string& name, const std::string& what) 
   }
 
   // Check no overlap with existing attributes
-  for (size_t i = 0; i < attributes_.size(); ++i) {
+  for (const auto & attribute : attributes_) {
     TORCH_CHECK(
-        name != attributes_[i].getName(),
+        name != attribute.getName(),
         "attempting to add ",
         what,
         " '",
@@ -1619,7 +1619,7 @@ void ClassType::checkNotExist(const std::string& name, const std::string& what) 
         "' to ",
         repr_str(),
         " but an attribute field of the same name already exists with type ",
-        attributes_[i].getType()->repr_str());
+        attribute.getType()->repr_str());
   }
 }
 

--- a/aten/src/ATen/native/Linear.cpp
+++ b/aten/src/ATen/native/Linear.cpp
@@ -252,7 +252,7 @@ Tensor einsum(std::string equation, TensorList operands) {
   // shape out_dims + sum_dims. For this, we create a mapping of label
   // to index into the permuted shape.
   std::vector<int64_t> label_perm_index(TOTAL_LABELS, -1);
-  
+
   // Current index in the permuted shape
   int64_t perm_index = 0;
 
@@ -332,7 +332,7 @@ Tensor einsum(std::string equation, TensorList operands) {
 
   // Here we unsqueeze missing dimensions to make all operands have the same
   // number of dimensions. We take diagonals for repeated labels within the
-  // same operand. Finally we permute the operands to align dimensions as 
+  // same operand. Finally we permute the operands to align dimensions as
   // per the perm_out_index we computed above.
   std::vector<Tensor> permuted_operands;
   for (auto i = decltype(num_ops){0}; i < num_ops; ++i) {
@@ -609,12 +609,8 @@ Tensor tensordot(const Tensor& input1, const Tensor& input2, IntArrayRef dims1, 
       rsizes.emplace_back(t1.size(i));
     }
   }
-  for (size_t i = 0; i < dims1.size(); i++) {
-    p1.emplace_back(dims1[i]);
-  }
-  for (size_t i = 0; i < dims2.size(); i++) {
-    p2.emplace_back(dims2[i]);
-  }
+  p1.insert(p1.end(), dims1.begin(), dims1.end());
+  p2.insert(p1.end(), dims2.begin(), dims2.end());
   for (int64_t i = 0; i < input2.dim(); i++) {
     if (! cdims2[i]) {
       p2.emplace_back(i);

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -201,8 +201,8 @@ AdvancedIndex::AdvancedIndex(const Tensor& src, TensorList indices_list)
   // simplify the CUDA kernel.
   if (indices.size() >= 2 && this->src.device().type() == kCUDA) {
     if (!all_strides_match(indices)) {
-      for (size_t i = 0; i < indices.size(); i++) {
-        indices[i] = indices[i].contiguous();
+      for (auto & indice : indices) {
+        indice = indice.contiguous();
       }
     }
   }
@@ -229,9 +229,9 @@ static AdvancedIndex make_info(Tensor self, const torch::List<c10::optional<at::
     std::tie(self, indices) = transposeToFront(self, indices);
   }
   // Ensure indices are on the same device as self
-  for (size_t i = 0; i < indices.size(); i++) {
-    if (indices[i].defined() && indices[i].device() != self.device()) {
-      indices[i] = indices[i].to(self.device());
+  for (auto & indice : indices) {
+    if (indice.defined() && indice.device() != self.device()) {
+      indice = indice.to(self.device());
     }
   }
   return AdvancedIndex(self, indices);

--- a/aten/src/ATen/native/TensorIteratorReduce.cpp
+++ b/aten/src/ATen/native/TensorIteratorReduce.cpp
@@ -136,8 +136,8 @@ void TensorIteratorBase::foreach_reduced_elt(loop_subiter_t loop, bool paralleli
     auto non_reduced_shape = shape.slice(reduce_dims, shape.size() - reduce_dims);
 
     int64_t non_reduced_numel = 1;
-    for (int i = 0; i < non_reduced_shape.size(); ++i) {
-      non_reduced_numel *= non_reduced_shape[i];
+    for (const auto i : non_reduced_shape) {
+      non_reduced_numel *= i;
     }
     DimCounter dims {non_reduced_shape, {0, non_reduced_numel}};
     while (!dims.is_done()) {

--- a/aten/src/ATen/native/cudnn/LossCTC.cpp
+++ b/aten/src/ATen/native/cudnn/LossCTC.cpp
@@ -54,8 +54,8 @@ bool _use_cudnn_ctc_loss(
     // we don't know that input_lengths and target_lengths have the same size
     // (they should, but we didn't check yet)
     int64_t max_input_length = log_probs.size(0);
-    for (size_t b = 0; b < input_lengths.size(); b++) {
-      use_cudnn &= (input_lengths[b] == max_input_length);
+    for (const auto input_length : input_lengths) {
+      use_cudnn &= ((input_length == max_input_length) ? 1 : 0);
     }
     for (size_t b = 0; b < target_lengths.size(); b++) {
       // target length < 256 is documented, but we see illegal memory accesses

--- a/aten/src/ATen/native/quantized/QTensor.cpp
+++ b/aten/src/ATen/native/quantized/QTensor.cpp
@@ -50,8 +50,8 @@ Tensor dequantize_quant(const Tensor& self) {
 
 std::vector<Tensor> dequantize_tensors_quantized_cpu(TensorList tensors) {
   std::vector<Tensor> dequantized_tensors;
-  for (auto i = 0; i < tensors.size(); ++i) {
-    dequantized_tensors.push_back(tensors[i].dequantize());
+  for (const auto & tensor : tensors) {
+    dequantized_tensors.push_back(tensor.dequantize());
   }
   return dequantized_tensors;
 }

--- a/aten/src/ATen/test/scalar_tensor_test.cpp
+++ b/aten/src/ATen/test/scalar_tensor_test.cpp
@@ -151,28 +151,28 @@ void test(DeprecatedTypeProperties &T) {
         t.fill_(t.sum(0)), ASSERT_GT(t.dim(), 1), ASSERT_LE(t.dim(), 1));
   }
 
-  for (auto lhs_it = sizes.begin(); lhs_it != sizes.end(); ++lhs_it) {
-    for (auto rhs_it = sizes.begin(); rhs_it != sizes.end(); ++rhs_it) {
+  for (const auto& lhs_size: sizes) {
+    for (const auto& rhs_size : sizes) {
       // is_same_size should only match if they are the same shape
       {
-        auto lhs = ones(*lhs_it, T);
-        auto rhs = ones(*rhs_it, T);
-        if (*lhs_it != *rhs_it) {
+        auto lhs = ones(lhs_size, T);
+        auto rhs = ones(rhs_size, T);
+        if (lhs_size != rhs_size) {
           ASSERT_FALSE(lhs.is_same_size(rhs));
           ASSERT_FALSE(rhs.is_same_size(lhs));
         }
       }
       // forced size functions (resize_, resize_as, set_)
       {// resize_
-       {auto lhs = ones(*lhs_it, T);
-      auto rhs = ones(*rhs_it, T);
-      lhs.resize_(*rhs_it);
+       {auto lhs = ones(lhs_size, T);
+      auto rhs = ones(rhs_size, T);
+      lhs.resize_(rhs_size);
       require_equal_size_dim(lhs, rhs);
     }
     // resize_as_
     {
-      auto lhs = ones(*lhs_it, T);
-      auto rhs = ones(*rhs_it, T);
+      auto lhs = ones(lhs_size, T);
+      auto rhs = ones(rhs_size, T);
       lhs.resize_as_(rhs);
       require_equal_size_dim(lhs, rhs);
     }
@@ -180,15 +180,15 @@ void test(DeprecatedTypeProperties &T) {
     {
       {
         // with tensor
-        auto lhs = ones(*lhs_it, T);
-        auto rhs = ones(*rhs_it, T);
+        auto lhs = ones(lhs_size, T);
+        auto rhs = ones(rhs_size, T);
         lhs.set_(rhs);
         require_equal_size_dim(lhs, rhs);
       }
       {
         // with storage
-        auto lhs = ones(*lhs_it, T);
-        auto rhs = ones(*rhs_it, T);
+        auto lhs = ones(lhs_size, T);
+        auto rhs = ones(rhs_size, T);
         lhs.set_(rhs.storage());
         // should not be dim 0 because an empty storage is dim 1; all other
         // storages aren't scalars
@@ -196,8 +196,8 @@ void test(DeprecatedTypeProperties &T) {
       }
       {
         // with storage, offset, sizes, strides
-        auto lhs = ones(*lhs_it, T);
-        auto rhs = ones(*rhs_it, T);
+        auto lhs = ones(lhs_size, T);
+        auto rhs = ones(rhs_size, T);
         lhs.set_(rhs.storage(), rhs.storage_offset(), rhs.sizes(), rhs.strides());
         require_equal_size_dim(lhs, rhs);
       }
@@ -206,9 +206,8 @@ void test(DeprecatedTypeProperties &T) {
 
   // view
   {
-    auto lhs = ones(*lhs_it, T);
-    auto rhs = ones(*rhs_it, T);
-    auto rhs_size = *rhs_it;
+    auto lhs = ones(lhs_size, T);
+    auto rhs = ones(rhs_size, T);
     TRY_CATCH_ELSE(auto result = lhs.view(rhs_size),
                    ASSERT_NE(lhs.numel(), rhs.numel()),
                    ASSERT_EQ(lhs.numel(), rhs.numel());
@@ -217,8 +216,8 @@ void test(DeprecatedTypeProperties &T) {
 
   // take
   {
-    auto lhs = ones(*lhs_it, T);
-    auto rhs = zeros(*rhs_it, T).toType(ScalarType::Long);
+    auto lhs = ones(lhs_size, T);
+    auto rhs = zeros(rhs_size, T).toType(ScalarType::Long);
     TRY_CATCH_ELSE(auto result = lhs.take(rhs), ASSERT_EQ(lhs.numel(), 0);
                    ASSERT_NE(rhs.numel(), 0),
                    require_equal_size_dim(result, rhs));
@@ -226,8 +225,8 @@ void test(DeprecatedTypeProperties &T) {
 
   // ger
   {
-    auto lhs = ones(*lhs_it, T);
-    auto rhs = ones(*rhs_it, T);
+    auto lhs = ones(lhs_size, T);
+    auto rhs = ones(rhs_size, T);
     TRY_CATCH_ELSE(auto result = lhs.ger(rhs),
                    ASSERT_TRUE(
                        (lhs.numel() == 0 || rhs.numel() == 0 ||
@@ -242,10 +241,8 @@ void test(DeprecatedTypeProperties &T) {
 
   // expand
   {
-    auto lhs = ones(*lhs_it, T);
-    auto lhs_size = *lhs_it;
-    auto rhs = ones(*rhs_it, T);
-    auto rhs_size = *rhs_it;
+    auto lhs = ones(lhs_size, T);
+    auto rhs = ones(rhs_size, T);
     bool should_pass = should_expand(lhs_size, rhs_size);
     TRY_CATCH_ELSE(auto result = lhs.expand(rhs_size),
                    ASSERT_FALSE(should_pass),
@@ -260,7 +257,7 @@ void test(DeprecatedTypeProperties &T) {
       TRY_CATCH_ELSE(lhs.add_(rhs),
                      ASSERT_FALSE(should_pass_inplace),
                      ASSERT_TRUE(should_pass_inplace);
-                     require_equal_size_dim(lhs, ones(*lhs_it, T)););
+                     require_equal_size_dim(lhs, ones(lhs_size, T)););
     }
   }
 }


### PR DESCRIPTION
Summary:
Modernize for-loops throughout caffe2/ subdirs to use ranged-loops where possible (all `.cpp` files were examined).

```
find caffe2/ -iname "*.cpp" > /home/rbarnes/files
buck run mode/opt foundation/clangr:clangr_local -- -j 10 --file=/home/rbarnes/files --multi --apply-replacements=true tidy '--checks=-*,modernize-loop-convert'
```

Differential Revision: D25969148

