### PR TITLE
[not for land] temp fix for per-channel observers used by multiple layers

### DIFF
--- a/torch/quantization/fake_quantize.py
+++ b/torch/quantization/fake_quantize.py
@@ -137,7 +137,7 @@ class FakeQuantize(FakeQuantizeBase):
 
         if self.fake_quant_enabled[0] == 1:
             if self.is_per_channel:
-                X = torch.fake_quantize_per_channel_affine(X, self.scale, self.zero_point,
+                X = torch.fake_quantize_per_channel_affine(X, self.scale.clone().detach(), self.zero_point.clone().detach(),
                                                            self.ch_axis, self.quant_min, self.quant_max)
             else:
                 X = torch.fake_quantize_per_tensor_affine(X, float(self.scale),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50828 [not for land] temp fix for per-channel observers used by multiple layers**

Summary:

If a layer is used twice, the scale+zp from the first use need to be
passed to the fq backward.  This PR unbreaks this, for now, by cloning
scale + zp.

This is not for land, a better approach would be to stop
passing scale+zp to the backward altogether, we'll put up a separate PR
for that, but it will take more time.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D25978784](https://our.internmc.facebook.com/intern/diff/D25978784)