### PR TITLE
Skip  test_variant_consistency_jit_addr_cpu_bfloat16

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -945,7 +945,7 @@ op_db: List[OpInfo] = [
            test_inplace_grad=False,
            skips=(
                SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.float16, torch.cfloat, torch.cdouble]),
+                        dtypes=[torch.float16, torch.cfloat, torch.cdouble, torch.bfloat16]),
                # Reference: https://github.com/pytorch/pytorch/issues/50747
                SkipInfo('TestCommon', 'test_variant_consistency_eager',
                         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16)),),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50836 Skip test_variant_consistency_eager_addr_cpu_bfloat16**

Fixes the broken master

Differential Revision: [D25981125](https://our.internmc.facebook.com/intern/diff/D25981125)