### PR TITLE
[packaging] add support for BytesIO

### DIFF
--- a/test/test_package.py
+++ b/test/test_package.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import torch
 from sys import version_info
-from io import StringIO
+from io import StringIO, BytesIO
 import pickle
 
 try:
@@ -74,6 +74,22 @@ the_math = math
             he.save_module(module_a.__name__)
             he.save_module(package_a.__name__)
         hi = PackageImporter(filename)
+        module_a_i = hi.import_module('module_a')
+        self.assertEqual(module_a_i.result, 'module_a')
+        self.assertIsNot(module_a, module_a_i)
+        package_a_i = hi.import_module('package_a')
+        self.assertEqual(package_a_i.result, 'package_a')
+        self.assertIsNot(package_a_i, package_a)
+
+    def test_save_module_binary(self):
+        f = BytesIO()
+        with PackageExporter(f, verbose=False) as he:
+            import module_a
+            import package_a
+            he.save_module(module_a.__name__)
+            he.save_module(package_a.__name__)
+        f.seek(0)
+        hi = PackageImporter(f)
         module_a_i = hi.import_module('module_a')
         self.assertEqual(module_a_i.result, 'module_a')
         self.assertIsNot(module_a, module_a_i)

--- a/torch/package/exporter.py
+++ b/torch/package/exporter.py
@@ -8,8 +8,7 @@ from ._importlib import _normalize_path
 from ._mangling import is_mangled
 import types
 import importlib
-from os import PathLike
-from typing import List, Any, Callable, Dict, Tuple, Union, Iterable, BinaryIO, IO, Optional
+from typing import List, Any, Callable, Dict, Tuple, Union, Iterable, BinaryIO, Optional
 from distutils.sysconfig import get_python_lib
 from pathlib import Path
 import linecache
@@ -59,21 +58,21 @@ class PackageExporter:
     """
 
 
-    def __init__(self, f: Union[str, PathLike, BinaryIO, IO[bytes]], verbose: bool = True):
+    def __init__(self, f: Union[str, Path, BinaryIO], verbose: bool = True):
         """
         Create an exporter.
 
         Args:
-            f: a file-like object (has to implement write and flush) or a string or
-                os.PathLike object containing a file name.
+            f: The location to export to. Can be a  string/Path object containing a filename,
+                or a Binary I/O object.
             verbose: Print information about dependency resolution to stdout.
                 Useful for tracking down why certain files get included.
         """
-        if isinstance(f, (PathLike, str)):
+        if isinstance(f, (Path, str)):
             f = str(f)
-            self.buffer = None
+            self.buffer: Optional[BinaryIO] = None
         else:  # is a byte buffer
-            self.buffer: Optional[Union[BinaryIO, IO[bytes]]] = f
+            self.buffer = f
 
         self.zip_file = torch._C.PyTorchFileWriter(f)
         self.serialized_storages : Dict[str, Any] = {}

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Dict, Optional, Any, Union, BinaryIO, IO
+from typing import List, Callable, Dict, Optional, Any, Union, BinaryIO
 import builtins
 import importlib
 import linecache
@@ -8,7 +8,7 @@ import torch
 import _compat_pickle  # type: ignore
 import types
 import os.path
-from os import PathLike
+from pathlib import Path
 
 from ._importlib import _normalize_line_endings, _resolve_name, _sanity_check, _calc___package__, \
     _normalize_path
@@ -34,7 +34,7 @@ class PackageImporter:
     """
     modules : Dict[str, Optional[types.ModuleType]]
 
-    def __init__(self, file_or_buffer: Union[str, torch._C.PyTorchFileReader, PathLike, BinaryIO, IO[bytes]],
+    def __init__(self, file_or_buffer: Union[str, torch._C.PyTorchFileReader, Path, BinaryIO],
                  module_allowed: Callable[[str], bool] = lambda module_name: True):
         """Open `file_or_buffer` for importing. This checks that the imported package only requires modules
         allowed by `module_allowed`
@@ -53,7 +53,7 @@ class PackageImporter:
         if isinstance(file_or_buffer, torch._C.PyTorchFileReader):
             self.filename = '<pytorch_file_reader>'
             self.zip_reader = file_or_buffer
-        elif isinstance(file_or_buffer, (PathLike, str)):
+        elif isinstance(file_or_buffer, (Path, str)):
             self.filename = str(file_or_buffer)
             if not os.path.isdir(self.filename):
                 self.zip_reader = torch._C.PyTorchFileReader(self.filename)

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,4 +1,4 @@
-from typing import List, Callable, Dict, Optional, Any, Union
+from typing import List, Callable, Dict, Optional, Any, Union, BinaryIO, IO
 import builtins
 import importlib
 import linecache
@@ -8,6 +8,7 @@ import torch
 import _compat_pickle  # type: ignore
 import types
 import os.path
+from os import PathLike
 
 from ._importlib import _normalize_line_endings, _resolve_name, _sanity_check, _calc___package__, \
     _normalize_path
@@ -33,14 +34,14 @@ class PackageImporter:
     """
     modules : Dict[str, Optional[types.ModuleType]]
 
-    def __init__(self, filename: Union[str, torch._C.PyTorchFileReader],
+    def __init__(self, file_or_buffer: Union[str, torch._C.PyTorchFileReader, PathLike, BinaryIO, IO[bytes]],
                  module_allowed: Callable[[str], bool] = lambda module_name: True):
-        """Open `filename` for importing. This checks that the imported package only requires modules
+        """Open `file_or_buffer` for importing. This checks that the imported package only requires modules
         allowed by `module_allowed`
 
         Args:
-            filename (str): archive to load. Can also be a directory of the unzipped files in the archive
-                for easy debugging and editing.
+            file_or_buffer: a file-like object (has to implement :meth:`read`, :meth:`readline`, :meth:`tell`, and :meth:`seek`),
+                or a string or os.PathLike object containing a file name.
             module_allowed (Callable[[str], bool], optional): A method to determine if a externally provided module
                 should be allowed. Can be used to ensure packages loaded do not depend on modules that the server
                 does not support. Defaults to allowing anything.
@@ -49,15 +50,18 @@ class PackageImporter:
             ImportError: If the package will use a disallowed module.
         """
         self.zip_reader : Any
-        if isinstance(filename, torch._C.PyTorchFileReader):
+        if isinstance(file_or_buffer, torch._C.PyTorchFileReader):
             self.filename = '<pytorch_file_reader>'
-            self.zip_reader = filename
-        else:
-            self.filename = filename
+            self.zip_reader = file_or_buffer
+        elif isinstance(file_or_buffer, (PathLike, str)):
+            self.filename = str(file_or_buffer)
             if not os.path.isdir(self.filename):
                 self.zip_reader = torch._C.PyTorchFileReader(self.filename)
             else:
                 self.zip_reader = MockZipReader(self.filename)
+        else:
+            self.filename = '<binary>'
+            self.zip_reader = torch._C.PyTorchFileReader(file_or_buffer)
 
         self.root = _PackageNode(None)
         self.modules = {}
@@ -65,7 +69,7 @@ class PackageImporter:
 
         for extern_module in self.extern_modules:
             if not module_allowed(extern_module):
-                raise ImportError(f"package '{filename}' needs the external module '{extern_module}' "
+                raise ImportError(f"package '{file_or_buffer}' needs the external module '{extern_module}' "
                                   f"but that module has been disallowed")
             self._add_extern(extern_module)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50838 [packaging] add support for BytesIO**

Similar to `torch.save` and `torch.jit.save`, accept a IO-like object
instead of just a file.

Differential Revision: [D25982719](https://our.internmc.facebook.com/intern/diff/D25982719)