### PR TITLE
[PyTorch] RFC: should we pass TensorOptions by value?

### DIFF
--- a/tools/autograd/gen_variable_factories.py
+++ b/tools/autograd/gen_variable_factories.py
@@ -72,12 +72,7 @@ def process_function(f: NativeFunction) -> Optional[str]:
 
     return f"""\
 inline at::Tensor {name}({', '.join(formals)}) {{
-  at::Tensor tensor = ([&]() {{
-    at::AutoNonVariableTypeMode non_var_type_mode(true);
-    return at::{name}({', '.join(exprs)});
-  }})();
-  at::Tensor result =
-    autograd::make_variable(std::move(tensor), /*requires_grad=*/{requires_grad});
-  return result;
+  at::AutoNonVariableTypeMode non_var_type_mode(true);
+  return autograd::make_variable(at::{name}({', '.join(exprs)}), /*requires_grad=*/{requires_grad});
 }}
 """

--- a/tools/codegen/api/cpp.py
+++ b/tools/codegen/api/cpp.py
@@ -268,7 +268,7 @@ def argument(
             elif a.dtype.default == "long":
                 default = 'at::kLong'  # TODO: this is wrong
             return [Binding(
-                ctype=ConstRefCType(BaseCType('TensorOptions', 'options')),
+                ctype=BaseCType('TensorOptions', 'options'),
                 name='options',
                 default=default,
                 argument=a,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50847 [PyTorch] RFC: should we pass TensorOptions by value?**

`TensorOptions` does not have a non-trivial copy, move, or
destroy operation and is small enough to fit in a register, so it
seems like we should pass it by value.

This diff is RFC status because of the problems with measurement
detailed in the test plan.

Differential Revision: [D25983863](https://our.internmc.facebook.com/intern/diff/D25983863/)