### PR TITLE
[aten] Optimizing reshape

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1794,7 +1794,7 @@ Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
     shape.push_back(self.size(i));
   }
 
-  return self.reshape(shape);
+  return native::reshape(self, shape);
 }
 
 Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim, Dimname out_dim) {


### PR DESCRIPTION
Summary: `aten::view` calls `infer_size` and `computeStride` again which are already done inside `reshape`. Skipping those two function calls and avoiding calling `aten::view` to avoid the dispatcher proves to be more efficient.

Test Plan:
Unit test:
```
buck test //caffe2/test:torch
```
Benchmark:
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 13 \
./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench \
--scripted_model=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge_v2/traced_precomputation.pt \
--pt_inputs=/home/hlu/ads/adindexer/adindexer_ctr_mobilefeed/pt/merge_v2/container_precomputation_bs20.pt \
--iters=10000 --warmup_iters=10000 --num_threads=1 --pt_enable_static_runtime=true \
--pt_cleanup_activations=true --pt_enable_out_variant=true --do_profile=true
```

Reduces the total time spent on reshape and flatten from 3.16% to 2.46% (net 0.7% reduction).
```
Before: PyTorch run finished. Milliseconds per iter: 0.0736055. Iters per second: 13585.9

    0.0013895 ms.    1.92361%. aten::reshape (2 nodes)
    0.000892179 ms.    1.23513%. aten::flatten (1 nodes)

After: PyTorch run finished. Milliseconds per iter: 0.0722102. Iters per second: 13848.5

    0.000978748 ms.    1.36668%. aten::reshape (2 nodes)
    0.000786076 ms.    1.09764%. aten::flatten (1 nodes)
```

Differential Revision: D25986759

