### PR TITLE
Add note about TCP init in RPC tests to contributing doc.

### DIFF
--- a/torch/distributed/CONTRIBUTING.md
+++ b/torch/distributed/CONTRIBUTING.md
@@ -89,6 +89,7 @@ python test/distributed/rpc/test_process_group_agent.py
 # Run a specific test method.
 pytest -k test_self_add test/distributed/rpc/test_process_group_agent.py
 
+```
+
 Note that the RPC framework is by default only tested with filesystem [initialization](https://pytorch.org/docs/stable/distributed.html#initialization). To run tests with TCP initialization, set the
 environment variable `RPC_INIT_WITH_TCP=1` before running your test command.
-```

--- a/torch/distributed/CONTRIBUTING.md
+++ b/torch/distributed/CONTRIBUTING.md
@@ -88,7 +88,6 @@ python test/distributed/rpc/test_process_group_agent.py
 
 # Run a specific test method.
 pytest -k test_self_add test/distributed/rpc/test_process_group_agent.py
-
 ```
 
 Note that the RPC framework is by default only tested with filesystem [initialization](https://pytorch.org/docs/stable/distributed.html#initialization). To run tests with TCP initialization, set the

--- a/torch/distributed/CONTRIBUTING.md
+++ b/torch/distributed/CONTRIBUTING.md
@@ -88,4 +88,7 @@ python test/distributed/rpc/test_process_group_agent.py
 
 # Run a specific test method.
 pytest -k test_self_add test/distributed/rpc/test_process_group_agent.py
+
+Note that the RPC framework is by default only tested with filesystem [initialization](https://pytorch.org/docs/stable/distributed.html#initialization). To run tests with TCP initialization, set the
+environment variable `RPC_INIT_WITH_TCP=1` before running your test command.
 ```


### PR DESCRIPTION
We added this option in https://github.com/pytorch/pytorch/pull/48248, but it would be good to document it somewhere as well, hence adding it to this contributing doc.