### PR TITLE
Native stack for contiguous inputs

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -12,6 +12,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/TypeProperties.h>
 #include <ATen/native/cpu/CatKernel.h>
+#include <ATen/native/cpu/StackKernel.h>
 #include <ATen/quantized/QTensorImpl.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
@@ -24,6 +25,7 @@ namespace at {
 namespace native {
 
 DEFINE_DISPATCH(cat_serial_stub);
+DEFINE_DISPATCH(stack_serial_stub);
 
 Tensor _reshape_from_tensor(const Tensor& self, const Tensor& shape_tensor) {
   TORCH_CHECK(shape_tensor.dim() == 1);
@@ -1322,6 +1324,101 @@ static inline std::vector<Tensor> get_stack_inputs(TensorList tensors, int64_t d
   return inputs;
 }
 
+// Checks to see whether native stack can be invoked under these conditions:
+// - result and input tensors are contiguous
+// - only one thread is used
+// - no type promotion has to occur
+// - tensors dtype is Double or Float
+bool inline can_use_native_serial_stack(Tensor& result, TensorList tensors, int64_t dim) {
+  TORCH_CHECK(tensors.size() > 0, "expected a non-empty list of Tensors");
+
+  const Tensor& firstTensor = tensors[0];
+  // stack dimension should be in range [0,firstTensor.dim())
+  // dim == firstTensor.dim() is a valid input, but it is handled by default code path
+  // that uses unsqueeze
+  if (dim >= firstTensor.dim()) return false;
+  // Native stack doesn't apply any tensor is skipped.
+  if (should_skip(firstTensor)) return false;
+  // there should be no type promotion
+  if (result.dtype() != firstTensor.dtype()) return false;
+
+  // Inputs cannot alias the output tensor
+  for (size_t i = 0; i < tensors.size(); i++) {
+    auto lap = at::get_overlap_status(result, tensors[i]);
+    TORCH_CHECK(lap != at::MemOverlapStatus::PARTIAL &&
+        lap != at::MemOverlapStatus::FULL, 0,
+        "unsupported operation: the input tensors cannot refer to any of the "
+        "output memory locations. Found overlap in input tensor ", i);
+  }
+
+  auto first_tensor_mem_format = firstTensor.suggest_memory_format();
+  ScalarType dtype = firstTensor.scalar_type();
+
+  if (!result.is_contiguous(first_tensor_mem_format)) {
+    return false;
+  }
+
+  // fast path only works for Double and Float
+  if (dtype != ScalarType::Double && dtype != ScalarType::Float) {
+    return false;
+  }
+
+  // check remainder of inputs
+  auto const &first_tensor_shape = firstTensor.sizes();
+  for (size_t i = 1; i < tensors.size(); i++) {
+    auto const &tensor = tensors[i];
+    TORCH_CHECK(tensors[i].sizes() == firstTensor.sizes(),
+      "stack expects each tensor to be equal size, but got ", first_tensor_shape,
+      " at entry 0 and ", tensor.sizes(), " at entry ", i);
+
+    // every tensor must be contiguous
+    // tensor sizes and strides must be the same
+    // there should be no type promotion
+    if (!tensor.is_contiguous(first_tensor_mem_format) ||
+      tensor.strides() != firstTensor.strides() ||
+      tensor.dtype() != dtype) {
+      return false;
+    }
+  }
+
+  // fast native stack should only be used when it is not worth using multiple threads
+  // or there is only one thread. Note that we aren't checking result.numel() here because
+  // it may not have been resized and we want to defer that cost till later.
+  int64_t numel_in_stack = firstTensor.numel() * tensors.size();
+  return numel_in_stack < at::internal::GRAIN_SIZE && at::get_num_threads() == 1;
+}
+
+bool inline maybe_native_stack(Tensor& result, TensorList tensors, int64_t dim) {
+  if (can_use_native_serial_stack(result, tensors, dim)) {
+    // compute the size of the result
+    auto result_sizes = tensors[0].sizes().vec();
+    result_sizes.insert(result_sizes.begin() + dim, tensors.size());
+
+    // skip resizing if size of result is same as expected
+    if (result.sizes() != result_sizes) {
+      result.resize_(result_sizes);
+    }
+    stack_serial_stub(kCPU, result, tensors, dim);
+    return true;
+  }
+  return false;
+}
+
+Tensor _stack(TensorList tensors, int64_t dim) {
+  dim = maybe_wrap_dim(dim, tensors[0].dim() + 1);
+  ScalarType high_type = result_type(tensors);
+  Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
+  return at::native::_stack_out(get_stack_inputs(tensors, dim), dim, result);
+}
+
+Tensor _stack_cpu(TensorList tensors, int64_t dim) {
+  dim = maybe_wrap_dim(dim, tensors[0].dim() + 1);
+  ScalarType high_type = result_type(tensors);
+  Tensor result = at::empty({0}, tensors[0].options().dtype(high_type));
+  return at::native::_stack_out_cpu(tensors, dim, result);
+}
+
+// TODO(msubkhankulov): refactor to use _stack
 Tensor stack(TensorList tensors, int64_t dim) {
   TORCH_CHECK(tensors.size() > 0,
            "stack expects a non-empty TensorList");
@@ -1329,6 +1426,21 @@ Tensor stack(TensorList tensors, int64_t dim) {
   return at::cat(get_stack_inputs(tensors, dim), dim);
 }
 
+// CPU specific implementation
+Tensor& _stack_out_cpu(TensorList tensors, int64_t dim, Tensor& result) {
+  if (maybe_native_stack(result, tensors, dim)) {
+    return result;
+  } else {
+    return at::cat_out(result, get_stack_inputs(tensors, dim), dim);
+  }
+}
+
+// default backend
+Tensor& _stack_out(TensorList tensors, int64_t dim, Tensor& result) {
+  return at::cat_out(result, tensors, dim);
+}
+
+// TODO(msubkhankulov): refactor to use _stack_out
 Tensor& stack_out(Tensor& result, TensorList tensors, int64_t dim) {
   TORCH_CHECK(tensors.size() > 0,
            "stack expects a non-empty TensorList");

--- a/aten/src/ATen/native/cpu/StackKernel.cpp
+++ b/aten/src/ATen/native/cpu/StackKernel.cpp
@@ -1,0 +1,73 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <ATen/ATen.h>
+
+#include <ATen/Dispatch.h>
+#include <ATen/cpu/vec256/functional.h>
+#include <ATen/cpu/vec256/vec256.h>
+#include <ATen/native/cpu/StackKernel.h>
+
+namespace at {
+namespace native {
+
+namespace {
+
+struct InputMeta {
+  void* data_ptr;
+  int64_t inner_size;
+
+  InputMeta(const Tensor& t, int64_t dim, int64_t inner)
+      : data_ptr(t.data_ptr()), inner_size(t.sizes()[dim] * inner) {}
+};
+
+template <typename scalar_t>
+void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      dim >= 0 && dim <= result.dim(),
+      "dim out of range in stack_serial_kernel_impl");
+  int64_t outer =
+      result.numel() / (result.sizes()[dim] * result.strides()[dim]);
+  scalar_t* result_data = result.data_ptr<scalar_t>();
+  int64_t ninputs = tensors.size();
+  std::vector<InputMeta> inputs;
+  inputs.reserve(ninputs);
+  for (auto const& tensor : tensors) {
+    inputs.emplace_back(tensor, dim, tensor.strides()[dim]);
+  }
+
+  using Vec = vec256::Vec256<scalar_t>;
+  scalar_t* result_ptr = result_data;
+  for (int64_t i = 0; i < outer; ++i) {
+    for (int64_t j = 0; j < ninputs; j++) {
+      int64_t local_inner = inputs[j].inner_size;
+      scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
+
+      if (local_inner < Vec::size()) {
+#if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
+#pragma unroll
+#endif
+        for (int64_t k = 0; k < local_inner; k++) {
+          result_ptr[k] = input_ptr[k];
+        }
+      } else {
+        vec256::map(
+            [](Vec x) { return x; }, result_ptr, input_ptr, local_inner);
+      }
+      result_ptr += local_inner;
+    }
+  }
+}
+
+void stack_serial_kernel(Tensor& result, TensorList tensors, int64_t dim) {
+  AT_DISPATCH_FLOATING_TYPES(
+      result.scalar_type(), "stack_serial_kernel", [&]() {
+        stack_serial_kernel_impl<scalar_t>(result, tensors, dim);
+      });
+}
+
+} // anonymous namespace
+
+REGISTER_DISPATCH(stack_serial_stub, &stack_serial_kernel);
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cpu/StackKernel.h
+++ b/aten/src/ATen/native/cpu/StackKernel.h
@@ -1,0 +1,12 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#pragma once
+
+#include <ATen/ATen.h>
+#include <ATen/native/DispatchStub.h>
+
+namespace at { namespace native {
+
+using stack_serial_fn = void(*)(Tensor &, TensorList, int64_t);
+DECLARE_DISPATCH(stack_serial_fn, stack_serial_stub);
+
+}}  // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3545,6 +3545,16 @@
   dispatch:
     DefaultBackend: stack_out
 
+- func: _stack(Tensor[] tensors, int dim=0) -> Tensor
+  dispatch: # match the backends supported by _cat
+    CPU: _stack_cpu
+    DefaultBackend: _stack
+
+- func: _stack.out(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)
+  dispatch: # match the backends supported by _cat_out
+    CPU: _stack_out_cpu
+    DefaultBackend: _stack_out
+
 - func: hstack(Tensor[] tensors) -> Tensor
 
 - func: hstack.out(Tensor[] tensors, *, Tensor(a!) out) -> Tensor(a!)

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -42,25 +42,63 @@ void TestChunk(TensorOptions T, Tensor& t) {
   ASSERT_EQUAL(at::cat(chunkMethod, 0), t);
 }
 
-void TestStack(TensorOptions T, Tensor& t) {
-  auto x = rand({2, 3, 4});
-  auto y = rand({2, 3, 4});
-  auto z = rand({2, 3, 4});
-  for (int64_t dim = 0; dim < 4; ++dim) {
-    auto res = at::stack({x, y, z}, dim);
-    auto res_neg = at::stack({x, y, z}, dim - 4);
-    std::vector<int64_t> expected_size;
-    expected_size.insert(
-        expected_size.end(), x.sizes().begin(), x.sizes().begin() + dim);
-    expected_size.insert(expected_size.end(), 3);
-    expected_size.insert(
-        expected_size.end(), x.sizes().begin() + dim, x.sizes().end());
+typedef Tensor StackFunc (TensorList, int64_t);
 
-    ASSERT_EQUAL(res, res_neg);
-    ASSERT_TRUE(res.sizes().equals(expected_size));
-    ASSERT_EQUAL(res.select(dim, 0), x);
-    ASSERT_EQUAL(res.select(dim, 1), y);
-    ASSERT_EQUAL(res.select(dim, 2), z);
+// helper function for TestStack
+void _test_stack(TensorList inputs, int64_t dim, StackFunc stack_func) {
+  auto const &x = inputs[0];
+
+  auto res = stack_func(inputs, dim);
+  auto res_neg = stack_func(inputs, dim - x.dim() - 1);
+  std::vector<int64_t> expected_size;
+  expected_size.insert(
+      expected_size.end(), x.sizes().begin(), x.sizes().begin() + dim);
+  expected_size.insert(expected_size.end(), inputs.size());
+  expected_size.insert(
+      expected_size.end(), x.sizes().begin() + dim, x.sizes().end());
+
+  ASSERT_EQUAL(res, res_neg);
+  ASSERT_TRUE(res.sizes().equals(expected_size));
+
+  int d = 0;
+  for (auto& t : inputs) {
+    ASSERT_EQUAL(res.select(dim, d), t);
+    d++;
+  }
+}
+
+void TestStack(TensorOptions T, Tensor& t) {
+  { // at::stack
+    auto x = rand({2, 3, 4});
+    auto y = rand({2, 3, 4});
+    auto z = rand({2, 3, 4});
+
+    auto inputs = {x, y, z};
+    for (int64_t dim = 0; dim < 4; ++dim) {
+      _test_stack(inputs, dim, at::stack);
+    }
+  }
+
+  { // at::native::_stack
+    auto x = rand({2, 3, 4});
+    auto y = rand({2, 3, 4});
+    auto z = rand({2, 3, 4});
+
+    auto inputs = {x, y, z};
+    for (int64_t dim = 0; dim < 4; ++dim) {
+      _test_stack(inputs, dim, at::native::_stack);
+    }
+  }
+
+  { // at::native::_stack_cpu
+    auto x = rand({2, 3, 4});
+    auto y = rand({2, 3, 4});
+    auto z = rand({2, 3, 4});
+
+    auto inputs = {x, y, z};
+    for (int64_t dim = 0; dim < 4; ++dim) {
+      _test_stack(inputs, dim, at::native::_stack_cpu);
+    }
   }
 }
 

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -284,25 +284,9 @@ SROperator aten_stack(Node* n) {
     if (p_node->Output(0).isNone()) {
       p_node->Output(0) = create_empty_from(inputs[0]);
     }
-#ifndef NDEBUG
-    at::IntArrayRef entry_shape = inputs[0].sizes();
-    for (auto i = 1; i < inputs.size(); i++) {
-      TORCH_CHECK(
-          inputs[i].sizes() == entry_shape,
-          "stack expects each tensor to be equal size, but got ",
-          entry_shape,
-          " at entry 0 and ",
-          inputs[i].sizes(),
-          " at entry ",
-          i);
-    }
-#endif
-    for (auto i = 0; i < inputs.size(); i++) {
-      inputs[i] = inputs[i].unsqueeze(dim);
-    }
     auto& out_t = p_node->Output(0).toTensor();
     fastResizeToZero(out_t);
-    at::native::_cat_out_cpu(out_t, inputs, dim);
+    at::native::_stack_out_cpu(inputs, dim, out_t);
   };
 }
 


### PR DESCRIPTION
Summary:
- Avoid calling unsqueeze on every input tensor by copying data directly
- Op benchmark shows significant improvement: -40%
- Model benchmark shows small improvement: -0.5% (b=20), -0.2% (b=1)

TODO:
- Add this implementation as fast path for serial, contiguous, type promotion free case just as cat_out_cpu does
- Handle `dim == tensors[0].dim()`

Test Plan:
# Test
```
buck test //caffe2/aten:native_test
```

# Op Benchmark

```
buck build mode/opt //caffe2/benchmarks/operator_benchmark/pt:stack_test --show-output
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 buck-out/gen/caffe2/benchmarks/operator_benchmark/pt/stack_test.par --tag_filter=static_runtime
```

Baseline (us): 6.750
Native stack (us): 3.943

# Adindexer model benchmark

```
for i in {1..10}; do caffe2=0 batch=20 ./scripts/bwasti/static_runtime/run.sh 2>&1 | grep "run finished"; done
```

## Baseline
```
Batch 20
Milliseconds per iter: 0.513718. Iters per second: 1946.6
Milliseconds per iter: 0.52093. Iters per second: 1919.65
Milliseconds per iter: 0.524066. Iters per second: 1908.16
Milliseconds per iter: 0.47121. Iters per second: 2122.2
Milliseconds per iter: 0.522638. Iters per second: 1913.37
Milliseconds per iter: 0.517213. Iters per second: 1933.44
Milliseconds per iter: 0.518727. Iters per second: 1927.79
Milliseconds per iter: 0.520067. Iters per second: 1922.83
Milliseconds per iter: 0.514205. Iters per second: 1944.75
Milliseconds per iter: 0.512909. Iters per second: 1949.66
Batch 1
Milliseconds per iter: 0.0813898. Iters per second: 12286.5
Milliseconds per iter: 0.0822777. Iters per second: 12154
Milliseconds per iter: 0.075089. Iters per second: 13317.5
Milliseconds per iter: 0.0741665. Iters per second: 13483.2
Milliseconds per iter: 0.0804374. Iters per second: 12432
Milliseconds per iter: 0.07466. Iters per second: 13394.1
Milliseconds per iter: 0.0809198. Iters per second: 12357.9
Milliseconds per iter: 0.0810188. Iters per second: 12342.8
Milliseconds per iter: 0.0807718. Iters per second: 12380.6
Milliseconds per iter: 0.0774743. Iters per second: 12907.5
```

## Native stack (this change)
```
Batch 20
Milliseconds per iter: 0.517055. Iters per second: 1934.03
Milliseconds per iter: 0.521079. Iters per second: 1919.1
Milliseconds per iter: 0.516038. Iters per second: 1937.84
Milliseconds per iter: 0.519455. Iters per second: 1925.1
Milliseconds per iter: 0.517468. Iters per second: 1932.49
Milliseconds per iter: 0.51819. Iters per second: 1929.79
Milliseconds per iter: 0.514044. Iters per second: 1945.36
Milliseconds per iter: 0.513014. Iters per second: 1949.26
Milliseconds per iter: 0.517211. Iters per second: 1933.45
Milliseconds per iter: 0.515545. Iters per second: 1939.7
Batch 1
Milliseconds per iter: 0.0823644. Iters per second: 12141.2
Milliseconds per iter: 0.0828163. Iters per second: 12074.9
Milliseconds per iter: 0.0818834. Iters per second: 12212.5
Milliseconds per iter: 0.0809143. Iters per second: 12358.8
Milliseconds per iter: 0.0744324. Iters per second: 13435
Milliseconds per iter: 0.0812736. Iters per second: 12304.1
Milliseconds per iter: 0.0740112. Iters per second: 13511.5
Milliseconds per iter: 0.0744604. Iters per second: 13430
Milliseconds per iter: 0.074748. Iters per second: 13378.3
Milliseconds per iter: 0.0774134. Iters per second: 12917.7
```

Differential Revision: D25988638

