### PR TITLE
[android] Fix YUV camera image to tensor

### DIFF
--- a/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
+++ b/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
@@ -65,7 +65,7 @@ static void imageYUV420CenterCropToFloatBuffer(
   const uint8_t* vData = (uint8_t*)jniEnv->GetDirectBufferAddress(vBuffer);
 
   float scale = cropWidthAfterRtn / tensorWidth;
-  int uvRowStride = uRowStride >> 1;
+  int uvRowStride = uRowStride;
   int cropXMult = 1;
   int cropYMult = 1;
   int cropXAdd = offsetX;
@@ -91,7 +91,7 @@ static void imageYUV420CenterCropToFloatBuffer(
   float normStdBm255 = 255 * normStdRGB[2];
 
   int xBeforeRtn, yBeforeRtn;
-  int yIdx, uvIdx, ui, vi, a0, ri, gi, bi;
+  int yi, yIdx, uvIdx, ui, vi, a0, ri, gi, bi;
   int channelSize = tensorWidth * tensorHeight;
   int wr = outOffset;
   int wg = wr + channelSize;
@@ -101,13 +101,17 @@ static void imageYUV420CenterCropToFloatBuffer(
       xBeforeRtn = cropXAdd + cropXMult * (int)(x * scale);
       yBeforeRtn = cropYAdd + cropYMult * (int)(y * scale);
       yIdx = yBeforeRtn * yRowStride + xBeforeRtn * yPixelStride;
-      uvIdx = (yBeforeRtn >> 1) * uvRowStride + xBeforeRtn * uvPixelStride;
+      uvIdx = (yBeforeRtn >> 1) * uvRowStride + (xBeforeRtn >> 1) * uvPixelStride;
       ui = uData[uvIdx];
       vi = vData[uvIdx];
-      a0 = 1192 * (yData[yIdx] - 16);
-      ri = (a0 + 1634 * (vi - 128)) >> 10;
-      gi = (a0 - 832 * (vi - 128) - 400 * (ui - 128)) >> 10;
-      bi = (a0 + 2066 * (ui - 128)) >> 10;
+      yi = yData[yIdx];
+      yi = (yi - 16) < 0 ? 0 : (yi - 16);
+      ui -= 128;
+      vi -= 128;
+      a0 = 1192 * yi;
+      ri = (a0 + 1634 * vi) >> 10;
+      gi = (a0 - 833 * vi - 400 * ui) >> 10;
+      bi = (a0 + 2066 * ui) >> 10;
       outData[wr++] = (clamp0255(ri) - normMeanRm255) / normStdRm255;
       outData[wg++] = (clamp0255(gi) - normMeanGm255) / normStdGm255;
       outData[wb++] = (clamp0255(bi) - normMeanBm255) / normStdBm255;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50871 [android] Fix YUV camera image to tensor**
Issue: https://discuss.pytorch.org/t/trouble-with-yuv420-to-float-tensor-conversion/106721/3
Decoding was wrong and the result image had artifacts.

Testing:
Patch test_app with:
[input_tensor_to_bitmap.txt](https://github.com/pytorch/pytorch/files/5847553/input_tensor_to_bitmap.txt)

gradle -p android test_app:installMnetLocalCameraDebug -PABI_FILTERS=arm64-v8a


Before fix:
![before_yuv_fix](https://user-images.githubusercontent.com/6638825/105317604-63a35980-5b90-11eb-9609-2ed5818130bd.png)

After fix:
![after_yuv_fix](https://user-images.githubusercontent.com/6638825/105317643-70c04880-5b90-11eb-88b7-92dd90db8ed2.png)

Differential Revision: [D25992519](https://our.internmc.facebook.com/intern/diff/D25992519)