### PR TITLE
Remove hacky_wrapper from a TensorOptions operator

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -650,7 +650,13 @@ Tensor& randn_out(Tensor& result, IntArrayRef size, c10::optional<Generator> gen
 }
 
 Tensor normal(double mean, double std, IntArrayRef size,
-              c10::optional<Generator> generator, const TensorOptions& options) {
+              c10::optional<Generator> generator, c10::optional<ScalarType> dtype, c10::optional<Layout> layout,
+              c10::optional<Device> device, c10::optional<bool> pinned_memory) {
+  const TensorOptions options = TensorOptions()
+    .dtype(dtype)
+    .layout(layout)
+    .device(device)
+    .pinned_memory(pinned_memory);
   auto result = at::empty(size, options);
   return result.normal_(mean, std, generator);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6533,7 +6533,6 @@
     CPU, CUDA: normal
 
 - func: normal.float_float(float mean, float std, int[] size, *, Generator? generator=None, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
-  use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
 
 - func: normal.float_float_out(float mean, float std, int[] size, *, Generator? generator=None, Tensor(a!) out) -> Tensor(a!)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50897 Remove hacky_wrapper from a TensorOptions operator**

This PR is an example for porting an operator with a TensorOptions argument so that it doesn't need hacky_wrapper anymore.

This intentionally doesn't follow the optimal solution of passing through the individual dtype, layout, device, pinned_memory arguments to at::empty
in favor of a generic solution pattern that can be applied to all ops without thinking, maybe even with a codemod.

Differential Revision: [D26002081](https://our.internmc.facebook.com/intern/diff/D26002081/)