### PR TITLE
Caffe2: RFC:Increase the timeout for test_lc_1d

### DIFF
--- a/caffe2/python/operator_test/locally_connected_op_test.py
+++ b/caffe2/python/operator_test/locally_connected_op_test.py
@@ -102,7 +102,7 @@ class TestLocallyConnectedOp(serial.SerializedTestCase):
            op_name=st.sampled_from(["LC", "LC1D"]),
            use_bias=st.booleans(),
            **hu.gcs)
-    @settings(deadline=1000)
+    @settings(deadline=2000)
     def test_lc_1d(self, N, C, size, M, kernel, op_name, use_bias, gc, dc):
         if size < kernel:
             kernel = size


### PR DESCRIPTION
In caffe2/python/operator_test/locally_connected_op_test.py
the test_lc_1d test sometimes takes more than one second
to complete.
Increasing the time out for this test based on the
total range of time taken across different failures.

Signed-off-by: Arindam Roy <rarindam@gmail.com>

Fixes #{issue number}
