### PR TITLE
Early terminate CUDA on common_utils TestCases 

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -441,7 +441,6 @@ class TestTesting(TestCase):
         self.assertEqual("no_user_msg", self._get_assert_msg(msg=None, debug_msg="no_user_msg"))
         self.assertEqual("debug_msg\nuser_msg", self._get_assert_msg(msg="user_msg", debug_msg="debug_msg"))
 
-
     # The following 2 tests are added to ensure that test suite terminates early when
     # CUDA assert was thrown since all subsequent test will fail.
     # See: https://github.com/pytorch/pytorch/issues/49019

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -441,17 +441,18 @@ class TestTesting(TestCase):
         self.assertEqual("no_user_msg", self._get_assert_msg(msg=None, debug_msg="no_user_msg"))
         self.assertEqual("debug_msg\nuser_msg", self._get_assert_msg(msg="user_msg", debug_msg="debug_msg"))
 
+
+    # The following 2 tests are added to ensure that test suite terminates early when
+    # CUDA assert was thrown since all subsequent test will fail.
+    # See: https://github.com/pytorch/pytorch/issues/49019
+    # Tests are slow because it spawn another process to run test suite.
     @onlyCUDA
     @slowTest
-    def test_cuda_assert_should_stop_test_suite(self, device):
-        # This test is slow because it spawn another process to run another test suite.
-
-        # Test running of cuda assert test suite should early terminate.
+    def test_cuda_assert_should_stop_device_test_suite(self, device):
         stderr = TestCase.runWithPytorchAPIUsageStderr("""\
 #!/usr/bin/env python
 
 import torch
-
 from torch.testing._internal.common_utils import (TestCase, run_tests, slowTest)
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 
@@ -478,6 +479,38 @@ instantiate_device_type_tests(
     globals(),
     only_for='cuda'
 )
+
+if __name__ == '__main__':
+    run_tests()
+""")
+        # should capture CUDA error
+        self.assertIn('CUDA error: device-side assert triggered', stderr)
+        # should run only 1 test because it throws unrecoverable error.
+        self.assertIn('Ran 1 test', stderr)
+
+
+    @onlyCUDA
+    @slowTest
+    def test_cuda_assert_should_stop_common_test_suite(self, device):
+        stderr = TestCase.runWithPytorchAPIUsageStderr("""\
+#!/usr/bin/env python
+
+import torch
+from torch.testing._internal.common_utils import (TestCase, run_tests, slowTest)
+
+class TestThatContainsCUDAAssertFailure(TestCase):
+
+    @slowTest
+    def test_throw_unrecoverable_cuda_exception(self):
+        x = torch.rand(10, device='cuda')
+        # cause unrecoverable CUDA exception, recoverable on CPU
+        y = x[torch.tensor([25])].cpu()
+
+    @slowTest
+    def test_trivial_passing_test_case_on_cpu_cuda(self):
+        x1 = torch.tensor([0., 1.], device='cuda')
+        x2 = torch.tensor([0., 1.], device='cpu')
+        self.assertEqual(x1, x2)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -335,7 +335,6 @@ class DeviceTypeTestBase(TestCase):
     def run(self, result=None):
         super().run(result=result)
         # Early terminate test if _stop_test_suite is set.
-        # Using this flag avoids unnecessary check invoke of torch.cuda.synchronize()
         if self._stop_test_suite:
             result.stop()
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -232,9 +232,6 @@ class DeviceTypeTestBase(TestCase):
             return self.precision
         return test.precision_overrides.get(dtype, self.precision)
 
-    def _should_stop_test_suite(self, rte):
-        return False
-
     # Creates device-specific tests.
     @classmethod
     def instantiate_test(cls, name, test, *, generic_cls=None):
@@ -290,7 +287,7 @@ class DeviceTypeTestBase(TestCase):
                     result = test_fn(self, *args)
                 except RuntimeError as rte:
                     # check if rte should stop entire test suite.
-                    self._stop_test_suite = self._should_stop_test_suite(rte)
+                    self._stop_test_suite = self._should_stop_test_suite()
                     # raise the runtime error as is for the test suite to record.
                     raise rte
                 finally:
@@ -338,6 +335,7 @@ class DeviceTypeTestBase(TestCase):
     def run(self, result=None):
         super().run(result=result)
         # Early terminate test if _stop_test_suite is set.
+        # Using this flag avoids unnecessary check invoke of torch.cuda.synchronize()
         if self._stop_test_suite:
             result.stop()
 
@@ -345,6 +343,9 @@ class DeviceTypeTestBase(TestCase):
 class CPUTestBase(DeviceTypeTestBase):
     device_type = 'cpu'
 
+    # No critical error should stop CPU test suite
+    def _should_stop_test_suite(self):
+        return False
 
 class CUDATestBase(DeviceTypeTestBase):
     device_type = 'cuda'
@@ -354,15 +355,6 @@ class CUDATestBase(DeviceTypeTestBase):
     cudnn_version: ClassVar[Any]
     no_magma: ClassVar[bool]
     no_cudnn: ClassVar[bool]
-
-    def _should_stop_test_suite(self, rte):
-        # CUDA device side error will cause subsequence test cases to fail.
-        # stop entire test suite if catches RuntimeError during torch.cuda.synchronize().
-        try:
-            torch.cuda.synchronize()
-        except RuntimeError as rte:
-            return True
-        return False
 
     def has_cudnn(self):
         return not self.no_cudnn

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -271,6 +271,10 @@ class MultiProcessTestCase(TestCase):
     # but we still want to ensure we didn't run into any other errors.
     TEST_ERROR_EXIT_CODE = 10
 
+    # do not early terminate for distributed tests.
+    def _should_stop_test_suite(self):
+        return False
+
     @property
     def world_size(self):
         return 4

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -819,7 +819,7 @@ class TestCase(expecttest.TestCase):
 
     # checker to early terminate test suite if unrecoverable failure occurs.
     def _should_stop_test_suite(self):
-        if torch.cuda.is_available():
+        if torch.cuda.is_initialized():
             # CUDA device side error will cause subsequence test cases to fail.
             # stop entire test suite if catches RuntimeError during torch.cuda.synchronize().
             try:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -817,6 +817,19 @@ class TestCase(expecttest.TestCase):
     # TODO: provide a better mechanism for generated tests to set rtol/atol.
     _precision: float = 0
 
+    # checker to early terminate test suite if unrecoverable failure occurs.
+    def _should_stop_test_suite(self):
+        if torch.cuda.is_available():
+            # CUDA device side error will cause subsequence test cases to fail.
+            # stop entire test suite if catches RuntimeError during torch.cuda.synchronize().
+            try:
+                torch.cuda.synchronize()
+            except RuntimeError as rte:
+                return True
+            return False
+        else:
+            return False
+
     @property
     def precision(self) -> float:
         return self._precision
@@ -877,6 +890,11 @@ class TestCase(expecttest.TestCase):
     def wrap_with_cuda_memory_check(self, method):
         return self.wrap_method_with_cuda_policy(method, self.assertLeaksNoCudaTensors)
 
+    def run(self, result=None):
+        super().run(result=result)
+        # Early terminate test if necessary.
+        if self._should_stop_test_suite():
+            result.stop()
 
     def setUp(self):
 


### PR DESCRIPTION
This is a follow up on #49869.

Previously CUDA early termination only happens for generic test classes that extends from `DeviceTypeTestBase`. However, JIT test cases which extends from common_utils.TestCase cannot benefit from the early termination. 

This change moves the early termination logic into common_utils.TestCase class. 
- all tests extended from common_utils.TestCase now should early terminate if CUDA assert occurs.
- For TestCases that extends from common_device_type.DeviceTypeTestBase, still only do torch.cuda.synchronize() when RTE is thrown.
- For TestCases extends common_utils.TestCase, regardless of whether a test case uses GPU or not, it will always synchronize CUDA as long as `torch.cuda.is_initialize()` returns true.
- Disabling this on common_distributed.py 
