### PR TITLE
Rewrite kron with broadcasting at::mul

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2223,67 +2223,32 @@ Tensor chain_matmul(TensorList matrices) {
 /*
 Calculates the Kronecker product between two Tensors.
 */
-Tensor kron(const Tensor& self, const Tensor& other) {
-  /*
-  We can obtain the kron result using tensordot or einsum. The implementation below uses tensordot.
-  In einsum notation suppose we have `self` with dim 4 and `other` with dim 2
-  the result of below tensordot is in einsum 0123, 45 -> 012345.
-  To obtain the correct kron we need to permute and reshape the array.
-  The permutation rule is the following: going from right to left
-  take axes in turn to form the permutation
-  with our example the correct permutation is 012435 and
-  the kron shape is (shape_self[0], shape_self[1], shape_self[3]*shape_other[0],
-  shape_self[4]*shape_other[1])
-  */
-  std::vector<int64_t> self_sizes = self.sizes().vec();
-  std::vector<int64_t> other_sizes = other.sizes().vec();
-  int64_t self_ndim = self.dim();
-  int64_t other_ndim = other.dim();
-  int64_t min_ndim = std::min(self_ndim, other_ndim);
-  int64_t ndim_diff = std::abs(self_ndim - other_ndim);
-
-  std::vector<int64_t> a_axes(self_ndim);
-  std::vector<int64_t> b_axes(other_ndim);
-  std::iota(a_axes.begin(), a_axes.end(), 0);
-  std::iota(b_axes.begin(), b_axes.end(), 0 + self_ndim);
-
-  bool is_a_larger = self_ndim >= other_ndim;
-  std::vector<int64_t> kron_permutation(self_ndim + other_ndim);
-  for (int64_t i = 0; i < ndim_diff; i++) {
-    kron_permutation[i] = is_a_larger ? a_axes[i] : b_axes[i];
+Tensor& kron_out(Tensor& result, const Tensor& self, const Tensor& other) {
+  auto maxdim = std::max(self.dim(), other.dim());
+  auto pad_self = maxdim - self.dim();
+  auto pad_other = maxdim - other.dim();
+  std::vector<int64_t> a_reshape(2 * maxdim);
+  std::vector<int64_t> b_reshape(2 * maxdim);
+  std::vector<int64_t> result_reshape(maxdim);
+  for (int i = 0; i < maxdim; i++) {
+    a_reshape[2 * i] = i >= pad_self ? self.sizes()[i - pad_self] : 1;
+    a_reshape[2 * i + 1] = 1;
+    b_reshape[2 * i] = 1;
+    b_reshape[2 * i + 1] = i >= pad_other ? other.sizes()[i - pad_other] : 1;
+    result_reshape[i] = a_reshape[2 * i] * b_reshape[2 * i + 1];
   }
-  for (int64_t i = 0, j = 0; i < min_ndim; i++, j += 2) {
-    kron_permutation[self_ndim + other_ndim - 1 - j] = b_axes[other_ndim - 1 - i];
-    kron_permutation[self_ndim + other_ndim - 1 - j - 1] = a_axes[self_ndim - 1 - i];
+  if (!result.defined()) {
+    result = at::mul(self.reshape(a_reshape), other.reshape(b_reshape)).reshape(result_reshape);
+  } else {
+    at::mul_out(result, self.reshape(a_reshape), other.reshape(b_reshape));
+    result.resize_(result_reshape);
   }
-
-  std::vector<int64_t> result_shape(std::max(self_ndim, other_ndim));
-  for (int64_t i = 0; i < ndim_diff; i++) {
-    result_shape[i] = is_a_larger ? self_sizes[i] : other_sizes[i];
-  }
-  for (int64_t i = 0; i < min_ndim; i++) {
-    result_shape[ndim_diff + i] = is_a_larger
-        ? self_sizes[ndim_diff + i] * other_sizes[i]
-        : other_sizes[ndim_diff + i] * self_sizes[i];
-  }
-
-  Tensor result = at::tensordot(self, other, {}, {});
-  // Step 2: now permute result
-  result = result.permute(kron_permutation);
-  // Step 3: reshape
-  result = result.reshape(result_shape);
-
   return result;
 }
 
-Tensor& kron_out(Tensor& result, const Tensor& self, const Tensor& other) {
-  TORCH_CHECK(result.scalar_type() == self.scalar_type(),
-    "result dtype ", result.scalar_type(), " does not match self dtype ", self.scalar_type());
-
-  Tensor result_tmp = at::kron(self, other);
-  at::native::resize_output(result, result_tmp.sizes());
-  result.copy_(result_tmp);
-  return result;
+Tensor kron(const Tensor& self, const Tensor& other) {
+  at::Tensor result;
+  return at::kron_out(result, self, other);
 }
 
 } // namespace native

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2227,9 +2227,9 @@ Tensor& kron_out(Tensor& result, const Tensor& self, const Tensor& other) {
   auto maxdim = std::max(self.dim(), other.dim());
   auto pad_self = maxdim - self.dim();
   auto pad_other = maxdim - other.dim();
-  DimVector a_reshape(2 * maxdim);
-  DimVector b_reshape(2 * maxdim);
-  DimVector result_reshape(maxdim);
+  c10::SmallVector<int64_t, 10> a_reshape(2 * maxdim);
+  c10::SmallVector<int64_t, 10> b_reshape(2 * maxdim);
+  c10::SmallVector<int64_t, 10> result_reshape(maxdim);
   for (int i = 0; i < maxdim; i++) {
     a_reshape[2 * i] = i >= pad_self ? self.sizes()[i - pad_self] : 1;
     a_reshape[2 * i + 1] = 1;

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -864,7 +864,7 @@ class TestLinalg(TestCase):
 
         # dtypes should match
         out = torch.empty_like(a).to(torch.int)
-        with self.assertRaisesRegex(RuntimeError, "result dtype Int does not match self dtype"):
+        with self.assertRaisesRegex(RuntimeError, "can't be cast to the desired output type"):
             torch.kron(a, b, out=out)
 
     # This test confirms that torch.linalg.norm's dtype argument works


### PR DESCRIPTION
Because it is shorter, faster, and does not have TF32 issue.

Benchmark: https://github.com/zasdfgbnm/things/blob/master/2021Q1/kron.ipynb