### PR TITLE
[PyTorch Mobile] Add an overload for deserialize() that doesn't accept the extra_files map.

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -231,6 +231,8 @@ class BytecodeDeserializer final {
  public:
   explicit BytecodeDeserializer(std::unique_ptr<PyTorchStreamReader> reader);
   mobile::Module deserialize(
+      c10::optional<at::Device> device);
+  mobile::Module deserialize(
       c10::optional<at::Device> device,
       ExtraFilesMap& extra_files);
   std::unordered_map<std::string, std::string> deserializeMetadata(
@@ -274,6 +276,12 @@ mobile::Module BytecodeDeserializer::deserialize(
           std::string(static_cast<char*>(meta_ptr.get()), meta_size);
     }
   }
+  return deserialize(device);
+}
+
+mobile::Module BytecodeDeserializer::deserialize(
+    c10::optional<at::Device> device) {
+  device_ = device;
   auto mcu = std::make_shared<mobile::CompilationUnit>();
 
   // bvals can have 2 possible formats:

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -279,8 +279,7 @@ mobile::Module BytecodeDeserializer::deserialize(
   return deserialize(device);
 }
 
-mobile::Module BytecodeDeserializer::deserialize(
-    c10::optional<at::Device> device) {
+mobile::Module BytecodeDeserializer::deserialize(c10::optional<at::Device> device) {
   device_ = device;
   auto mcu = std::make_shared<mobile::CompilationUnit>();
 

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -230,8 +230,7 @@ void parseMethods(
 class BytecodeDeserializer final {
  public:
   explicit BytecodeDeserializer(std::unique_ptr<PyTorchStreamReader> reader);
-  mobile::Module deserialize(
-      c10::optional<at::Device> device);
+  mobile::Module deserialize(c10::optional<at::Device> device);
   mobile::Module deserialize(
       c10::optional<at::Device> device,
       ExtraFilesMap& extra_files);
@@ -279,7 +278,8 @@ mobile::Module BytecodeDeserializer::deserialize(
   return deserialize(device);
 }
 
-mobile::Module BytecodeDeserializer::deserialize(c10::optional<at::Device> device) {
+mobile::Module BytecodeDeserializer::deserialize(
+    c10::optional<at::Device> device) {
   device_ = device;
   auto mcu = std::make_shared<mobile::CompilationUnit>();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50932 [PyTorch Mobile] Add an overload for deserialize() that doesn't accept the extra_files map.**

After the change to split `_load_for_mobile()` into multiple methods, one which takes in the `extra_files` map, and one which doesn't, we can change the implementation of the `deserialize()` method with different overloads as well. Suggested by @razy on D25968216.

#accept2ship

Differential Revision: [D26014084](https://our.internmc.facebook.com/intern/diff/D26014084/)