### PR TITLE
Added mixed precision support for update_bn in swa_utils

### DIFF
--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -3,7 +3,7 @@ import math
 from torch.nn import Module
 from copy import deepcopy
 from torch.optim.lr_scheduler import _LRScheduler
-
+from torch.cuda.amp import autocast
 
 class AveragedModel(Module):
     r"""Implements averaged model for Stochastic Weight Averaging (SWA).
@@ -159,7 +159,8 @@ def update_bn(loader, model, device=None):
         if device is not None:
             input = input.to(device)
 
-        model(input)
+        with autocast():
+            model(input)
 
     for bn_module in momenta.keys():
         bn_module.momentum = momenta[bn_module]

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.cuda.amp import autocast
 
+
 class AveragedModel(Module):
     r"""Implements averaged model for Stochastic Weight Averaging (SWA).
 


### PR DESCRIPTION
Enhancement to support automatic mixed precision for updating batch norm layers when updating the statistics in the update_bn function.

Avoids CUDA throwing an OOM when you use update_bn right after training with the same batch size that you used to train with.