### PR TITLE
[android] fix yuv conversion - remove define

### DIFF
--- a/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
+++ b/android/pytorch_android_torchvision/src/main/cpp/pytorch_vision_jni.cpp
@@ -4,8 +4,6 @@
 
 #include "jni.h"
 
-#define clamp0255(x) x > 255 ? 255 : x < 0 ? 0 : x
-
 namespace pytorch_vision_jni {
 
 static void imageYUV420CenterCropToFloatBuffer(
@@ -112,9 +110,12 @@ static void imageYUV420CenterCropToFloatBuffer(
       ri = (a0 + 1634 * vi) >> 10;
       gi = (a0 - 833 * vi - 400 * ui) >> 10;
       bi = (a0 + 2066 * ui) >> 10;
-      outData[wr++] = (clamp0255(ri) - normMeanRm255) / normStdRm255;
-      outData[wg++] = (clamp0255(gi) - normMeanGm255) / normStdGm255;
-      outData[wb++] = (clamp0255(bi) - normMeanBm255) / normStdBm255;
+      ri = ri > 255 ? 255 : ri < 0 ? 0 : ri;
+      gi = gi > 255 ? 255 : gi < 0 ? 0 : gi;
+      bi = bi > 255 ? 255 : bi < 0 ? 0 : bi;
+      outData[wr++] = (ri - normMeanRm255) / normStdRm255;
+      outData[wg++] = (gi - normMeanGm255) / normStdGm255;
+      outData[wb++] = (bi - normMeanBm255) / normStdBm255;
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#50951 [android] fix yuv conversion - remove define**

Differential Revision: [D26021488](https://our.internmc.facebook.com/intern/diff/D26021488)

Explanation of the issue: https://discuss.pytorch.org/t/trouble-with-yuv420-to-float-tensor-conversion/106721/4

Prevent expansion of macro that does " - normMeanRm255" first - remove macro
