### PR TITLE
[BE] .gitignore adding test-reports/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ dropout_model.pt
 test/generated_type_hints_smoketest.py
 test/htmlcov
 test/cpp_extensions/install/
-test/test-reports/
 third_party/build/
 tools/shared/_utils_internal.py
 tools/fast_nvcc/wrap_nvcc.sh

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/cpp/source/html/
 docs/cpp/source/latex/
 docs/source/generated/
 log
+test-reports/
 test/.coverage
 test/.hypothesis/
 test/cpp/api/mnist


### PR DESCRIPTION
Cant think of a reason not .gitignore test-reports folder. this can be helpful when 
1. running `python test/test*.py` from github root directory since it creates the folder at root.
2. CI test report path generated by `torch/testing/_internal/common_utils.py` creates the folder in the same path where the test python file locates.

Creating a PR to make sure CI is happy. this is also needed by #50923