### PR TITLE
Skip test_lc_1d for ROCM

### DIFF
--- a/caffe2/python/operator_test/locally_connected_op_test.py
+++ b/caffe2/python/operator_test/locally_connected_op_test.py
@@ -6,9 +6,10 @@ import numpy as np
 from hypothesis import given, settings, assume
 import hypothesis.strategies as st
 
-from caffe2.python import core, utils
+from caffe2.python import core, utils, workspace
 import caffe2.python.hypothesis_test_util as hu
 import caffe2.python.serialized_test.serialized_test_util as serial
+
 
 
 class TestLocallyConnectedOp(serial.SerializedTestCase):
@@ -104,6 +105,9 @@ class TestLocallyConnectedOp(serial.SerializedTestCase):
            **hu.gcs)
     @settings(deadline=1000)
     def test_lc_1d(self, N, C, size, M, kernel, op_name, use_bias, gc, dc):
+        if workspace.has_hip_support:
+            # Skip as test flaky on ROCM with deadline set to 1000
+            return
         if size < kernel:
             kernel = size
 


### PR DESCRIPTION
The test is flaky on ROCM when deadline is set to 1 second. This is affecting builds as it is failing randomly.
Disabling for now.

Signed-off-by: Arindam Roy <rarindam@gmail.com>