### PR TITLE
[fbgemm_gpu] Use the latest philox_cuda_state API for stochastic rounding

### DIFF
--- a/aten/src/ATen/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/CUDAGeneratorImpl.h
@@ -56,7 +56,7 @@ namespace at {
  *
  * Example (see e.g. native/cuda/Dropout.cu):
  *
- * #include <ATen/cuda/CUDAGeneratorImpl.h>
+ * #include <ATen/CUDAGeneratorImpl.h>
  * #include <ATen/cuda/CUDAGraphsUtils.cuh>
  *
  * __global__ void kernel(..., PhiloxCudaState philox_args) {


### PR DESCRIPTION
Summary:
Follow up on the failure case on FP16 stochastic rounding:
- https://github.com/pytorch/pytorch/pull/50148
- D26006041

From Natalia:
- https://github.com/pytorch/pytorch/pull/50916 is the fix, philox_engine_inputs is deprecated btw so if you could refactor it to use philox_cuda_state that would be great.
- instructions to change the call https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/CUDAGeneratorImpl.h#L48-L83, it will be important to use philox_cuda_state with graph capture.

Test Plan: CI

Differential Revision: D26038596

