### PR TITLE
Add a way to get the default kwargs of a C++-override from within __torch_function__

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -573,7 +573,7 @@ libtorch_python_core_sources = [
     "torch/csrc/utils/tensor_new.cpp",
     "torch/csrc/utils/tensor_numpy.cpp",
     "torch/csrc/utils/tensor_types.cpp",
-    "torch/csrc/utils/disable_torch_function.cpp",
+    "torch/csrc/utils/torch_function_misc.cpp",
 ]
 
 libtorch_python_distributed_core_sources = [

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -38,7 +38,7 @@
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/csrc/multiprocessing/init.h>
 #include <torch/csrc/tensor/python_tensor.h>
-#include <torch/csrc/utils/disable_torch_function.h>
+#include <torch/csrc/utils/torch_function_misc.h>
 #include <torch/csrc/utils/tensor_dtypes.h>
 #include <torch/csrc/utils/python_compat.h>
 #include <torch/csrc/utils/python_strings.h>

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -687,6 +687,37 @@ void FunctionParameter::set_default_str(const std::string& str) {
   }
 }
 
+PyObject *FunctionParameter::get_default() {
+  if (!optional) {
+    throw std::runtime_error("optional must be true to call this function.");
+  }
+
+  switch (type_) {
+    case ParameterType::TENSOR: Py_RETURN_NONE;
+    case ParameterType::SCALAR: // TODO
+    case ParameterType::INT64: return PyLong_FromLongLong(default_int);
+    case ParameterType::DOUBLE: return PyFloat_FromDouble(default_double);
+    case ParameterType::COMPLEX: return PyComplex_FromDoubles(default_complex[0], default_complex[1]);
+    case ParameterType::TENSOR_LIST: return "tuple of Tensors";
+    case ParameterType::INT_LIST: return "tuple of ints";
+    case ParameterType::FLOAT_LIST: return "tuple of floats";
+    case ParameterType::GENERATOR: return "torch.Generator";
+    case ParameterType::BOOL: return "bool";
+    case ParameterType::STORAGE: return "torch.Storage";
+    case ParameterType::PYOBJECT: return "object";
+    case ParameterType::SCALARTYPE: return "torch.dtype";
+    case ParameterType::LAYOUT: return "torch.layout";
+    case ParameterType::MEMORY_FORMAT: return "torch.memory_format";
+    case ParameterType::QSCHEME: return "torch.qscheme";
+    case ParameterType::DEVICE: return "torch.device";
+    case ParameterType::STRING: return "str";
+    case ParameterType::DIMNAME: return "name";
+    case ParameterType::DIMNAME_LIST: return "tuple of names";
+    case ParameterType::SCALAR_LIST: return "tuple of Scalars";
+    default: throw std::runtime_error("unknown parameter type");
+  }
+}
+
 FunctionSignature::FunctionSignature(const std::string& fmt, int index)
   : min_args(0)
   , max_args(0)
@@ -960,7 +991,20 @@ bool FunctionSignature::parse(PyObject* self, PyObject* args, PyObject* kwargs, 
     }
     return false;
   }
+
+  if (!overloaded_args.empty()) {
+    dump_default_kwargs();
+  }
+
   return true;
+}
+
+inline void FunctionSignature::dump_default_kwargs() {
+  py::dict default_kwargs;
+  for (auto param : params) {
+    if (param.optional) {
+    }
+  }
 }
 
 PythonArgParser::PythonArgParser(std::vector<std::string> fmts, bool traceable)

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -61,7 +61,7 @@
 #include <torch/csrc/utils/pybind.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
-#include <torch/csrc/utils/disable_torch_function.h>
+#include <torch/csrc/utils/torch_function_misc.h>
 #include <torch/csrc/utils/six.h>
 #include <torch/csrc/autograd/variable.h>
 
@@ -138,6 +138,8 @@ struct PYBIND11_EXPORT FunctionSignature {
   bool hidden;
   bool deprecated;
   bool disable_torch_function;
+private:
+  void dump_default_kwargs();
 };
 
 struct PythonArgs {
@@ -217,6 +219,7 @@ struct FunctionParameter {
   bool check(PyObject* obj, std::vector<py::handle> &overloaded_args, int argnum);
 
   void set_default_str(const std::string& str);
+  PyObject* get_default();
   std::string type_name() const;
 
   ParameterType type_;

--- a/torch/csrc/utils/torch_function_misc.h
+++ b/torch/csrc/utils/torch_function_misc.h
@@ -10,6 +10,8 @@ namespace torch {
   PyObject* disabled_torch_function_impl();
   void set_disabled_torch_function_impl(PyObject* value);
   bool check_has_torch_function(PyObject* obj);
+  PyObject* get_current_overload_default_kwargs();
+  void set_current_overload_default_kwargs(PyObject* kwargs);
 }
 
 PyObject* THPModule_isEnabledTorchFunction(PyObject* self, PyObject *unused);
@@ -18,3 +20,5 @@ PyObject* THPModule_disable_torch_function(PyObject *self, PyObject *args);
 PyObject* THPModule_has_torch_function(PyObject*, PyObject *arg);
 PyObject* THPModule_has_torch_function_unary(PyObject*, PyObject *obj);
 PyObject* THPModule_has_torch_function_variadic(PyObject*, PyObject *const *args, Py_ssize_t nargs);
+PyObject* THPModule_get_current_overload_default_kwargs(PyObject*, PyObject*);
+PyObject* THPModule_set_current_overload_default_kwargs(PyObject*, PyObject* kwargs);


### PR DESCRIPTION
Fixes #45565 