### PR TITLE
[PyTorch] Port Caffe2 opti for BatchMatMul batch size 1 to baddbmm

### DIFF
--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -32,6 +32,36 @@ Tensor& _baddbmm_mkl_(Tensor& self, const Tensor& batch1, const Tensor& batch2, 
 
 namespace at { namespace native {
 
+static inline void gemm(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int  M, const int N, const int K, const float alpha, const float* A,
+  const int lda, const float* B, const int ldb, const float beta, float* C, const int ldc) {
+  cblas_sgemm(CblasRowMajor, trans_A, trans_B, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+}
+
+static inline void gemm(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int  M, const int N, const int K, const double alpha, const double* A,
+  const int lda, const double* B, const int ldb, const double beta, double* C, const int ldc) {
+  cblas_dgemm(CblasRowMajor, trans_A, trans_B, M, N, K, alpha, A, lda, B, ldb, beta, C, ldc);
+}
+
+static inline void gemm(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int  M, const int N, const int K, const c10::complex<float> alpha,
+  const c10::complex<float>* A, const int lda, const c10::complex<float>* B, const int ldb,
+  const c10::complex<float> beta, c10::complex<float>* C, const int ldc) {
+  cblas_cgemm(CblasRowMajor, trans_A, trans_B, M, N, K, reinterpret_cast<const void *>(&alpha),
+    reinterpret_cast<const void*>(A), lda, reinterpret_cast<const void*>(B), ldb,
+    reinterpret_cast<const void*>(&beta), reinterpret_cast<void*>(C), ldc);
+}
+
+static inline void gemm(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
+  const int  M, const int N, const int K, const c10::complex<double> alpha,
+  const c10::complex<double>* A, const int lda, const c10::complex<double>* B, const int ldb,
+  const c10::complex<double> beta, c10::complex<double>* C, const int ldc) {
+  cblas_zgemm(CblasRowMajor, trans_A, trans_B, M, N, K, reinterpret_cast<const void *>(&alpha),
+    reinterpret_cast<const void*>(A), lda, reinterpret_cast<const void*>(B), ldb,
+    reinterpret_cast<const void*>(&beta), reinterpret_cast<void*>(C), ldc);
+}
+
 static inline void gemm_batched(const CBLAS_TRANSPOSE trans_A, const CBLAS_TRANSPOSE trans_B,
   const int batch_size, const int M, const int N, const int K, const float alpha,
   const float** A, const int lda, const float** B, const int ldb, const float beta,
@@ -101,6 +131,32 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
   const int ldb = trans_B == CblasTrans ? mat2_strides[2] : mat2_strides[1];
   const int ldc = res.strides()[1];
 
+  // avoid using tensor accessor in the case of mat1/mat2 not being transposed
+  // or only transposed in the last two axes
+  const bool canAvoidTensorAccessor = mat1_strides[0] == mat1_sizes[1] * mat1_sizes[2] &&
+    mat2_strides[0] == mat2_sizes[1] * mat2_sizes[2];
+
+  scalar_t* const res_data = static_cast<scalar_t*>(res.data_ptr());
+
+  if (batch_size == 1) {
+    const scalar_t* A;
+    const scalar_t* B;
+    scalar_t* const C = res_data;
+    if (canAvoidTensorAccessor) {
+      scalar_t* mat1_data = static_cast<scalar_t*>(mat1.data_ptr());
+      scalar_t* mat2_data = static_cast<scalar_t*>(mat2.data_ptr());
+      A = mat1_data;
+      B = mat2_data;
+    } else {
+      auto mat1_acc = mat1.accessor<scalar_t, 3>();
+      auto mat2_acc = mat2.accessor<scalar_t, 3>();
+      A = mat1_acc[0].data();
+      B = mat2_acc[0].data();
+    }
+    gemm(trans_A, trans_B, M, N, K, alpha, A, lda, B, ldb, beta, res_data, ldc);
+    return;
+  }
+
   std::vector<const scalar_t*> A;
   A.reserve(batch_size);
   std::vector<const scalar_t*> B;
@@ -110,10 +166,8 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
 
   // avoid using tensor accessor in the case of mat1/mat2 not being transposed
   // or only transposed in the last two axis
-  scalar_t* res_data = static_cast<scalar_t*>(res.data_ptr());
   const auto res_sizes = res.sizes();
-  if (mat1_strides[0] == mat1_sizes[1] * mat1_sizes[2] &&
-      mat2_strides[0] == mat2_sizes[1] * mat2_sizes[2]) {
+  if (canAvoidTensorAccessor) {
     scalar_t* mat1_data = static_cast<scalar_t*>(mat1.data_ptr());
     scalar_t* mat2_data = static_cast<scalar_t*>(mat2.data_ptr());
     for (int64_t batch = 0; batch < batch_size; batch++) {

--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -141,7 +141,6 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
   if (batch_size == 1) {
     const scalar_t* A;
     const scalar_t* B;
-    scalar_t* const C = res_data;
     if (canAvoidTensorAccessor) {
       scalar_t* mat1_data = static_cast<scalar_t*>(mat1.data_ptr());
       scalar_t* mat2_data = static_cast<scalar_t*>(mat2.data_ptr());

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4696,7 +4696,7 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
     @dtypes(*torch.testing.get_all_fp_dtypes(), *torch.testing.get_all_complex_dtypes())
     @tf32_on_and_off(0.05)
     def test_bmm(self, device, dtype):
-        num_batches = 10
+        batch_sizes = [1, 10]
         M, N, O = 23, 8, 12
         numpy_dtype = dtype if dtype != torch.bfloat16 else torch.float32
 
@@ -4706,16 +4706,17 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
             is_supported = True if dtype != torch.bfloat16 else AMPERE_OR_ROCM
 
         if not is_supported:
-            b1 = torch.randn(num_batches, M, N, device=device).to(dtype)
-            b2 = torch.randn(num_batches, N, O, device=device).to(dtype)
-            self.assertRaisesRegex(RuntimeError, "type|Type|not implemented|Ampere", lambda: torch.bmm(b1, b2))
+            for num_batches in batch_sizes:
+                b1 = torch.randn(num_batches, M, N, device=device).to(dtype)
+                b2 = torch.randn(num_batches, N, O, device=device).to(dtype)
+                self.assertRaisesRegex(RuntimeError, "type|Type|not implemented|Ampere", lambda: torch.bmm(b1, b2))
             return
 
         def invert_perm(p):
             d = {x: i for i, x in enumerate(p)}
             return (d[0], d[1], d[2])
 
-        def generate_inputs():
+        def generate_inputs(num_batches):
             # transposed tensors
             for perm1, perm2 in itertools.product(itertools.permutations((0, 1, 2)), repeat=2):
                 b1 = make_tensor((num_batches, M, N), device, dtype, low=-1, high=1)
@@ -4738,21 +4739,22 @@ scipy_lobpcg  | {:10.2e}  | {:10.2e}  | {:6} | N/A
                 b2 = torch.randn(shape2, dtype=dtype, device=device)
                 yield b1, b2
 
-        for (b1, b2), perm3 in itertools.product(generate_inputs(), itertools.permutations((0, 1, 2))):
-            res1 = torch.bmm(b1, b2)
-            res2 = torch.full((num_batches, M, O), math.nan, dtype=dtype, device=device) \
-                .permute(perm3).contiguous().permute(invert_perm(perm3))
-            torch.bmm(b1, b2, out=res2)
-            expect = torch.from_numpy(
-                b1.to(numpy_dtype).cpu().numpy() @ b2.to(numpy_dtype).cpu().numpy()).to(device=device, dtype=dtype)
-            self.assertEqual(expect, res1)
-            self.assertEqual(expect, res2)
+        for num_batches in batch_sizes:
+            for (b1, b2), perm3 in itertools.product(generate_inputs(num_batches), itertools.permutations((0, 1, 2))):
+                res1 = torch.bmm(b1, b2)
+                res2 = torch.full((num_batches, M, O), math.nan, dtype=dtype, device=device) \
+                    .permute(perm3).contiguous().permute(invert_perm(perm3))
+                torch.bmm(b1, b2, out=res2)
+                expect = torch.from_numpy(
+                    b1.to(numpy_dtype).cpu().numpy() @ b2.to(numpy_dtype).cpu().numpy()).to(device=device, dtype=dtype)
+                self.assertEqual(expect, res1)
+                self.assertEqual(expect, res2)
 
-            if self.device_type == 'cuda':
-                # check that mixed arguments are rejected
-                self.assertRaises(RuntimeError, lambda: torch.bmm(b1, b2.cpu()))
-                self.assertRaises(RuntimeError, lambda: torch.bmm(b1.cpu(), b2))
-                self.assertRaises(RuntimeError, lambda: torch.bmm(b1, b2, out=res2.cpu()))
+                if self.device_type == 'cuda':
+                    # check that mixed arguments are rejected
+                    self.assertRaises(RuntimeError, lambda: torch.bmm(b1, b2.cpu()))
+                    self.assertRaises(RuntimeError, lambda: torch.bmm(b1.cpu(), b2))
+                    self.assertRaises(RuntimeError, lambda: torch.bmm(b1, b2, out=res2.cpu()))
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51057 [PyTorch] Port Caffe2 opti for BatchMatMul batch size 1 to baddbmm**

Caffe2 has an
[optimization](https://github.com/pytorch/pytorch/blob/f8eefbdf7a229abbb864e47e0b664c7628d80224/caffe2/operators/batch_matmul_op.h#L192)
for the case where the batch size is 1 that uses the underlying `gemm`
instead of `gemm_batched` BLAS function. This diff tries to port that
optimization to `baddbmm_mkl`.

Note that I have very little linear algebra background and am just
going off existing code and cblas API documentation, so please
review without assuming I know what I'm doing with the math itself.

Differential Revision: [D26056613](https://our.internmc.facebook.com/intern/diff/D26056613/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26056613/)!