### PR TITLE
Propagate CreationMeta when chaining views

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7157,6 +7157,20 @@ class TestAutogradDeviceType(TestCase):
         with self.assertRaises(RuntimeError):
             v1[0].mul_(2)
 
+    def test_inplace_view_of_multiple_output_view(self, device):
+        a = torch.rand(10, device=device, requires_grad=True).clone()
+        b = a.unbind(0)
+        c = b[0].view_as(b[0])
+        with self.assertRaises(RuntimeError):
+            c.mul_(2)
+
+    def test_inplace_multiple_output_view_of_view(self, device):
+        a = torch.rand(10, device=device, requires_grad=True).clone()
+        b = a.view_as(a)
+        c = b.unbind(0)
+        with self.assertRaises(RuntimeError):
+            c[0].mul_(2)
+
     def test_inplace_view_makes_base_require_grad(self, device):
         # in-place modification to view makes base require grad
         a = torch.randn(4, 4, device=device, requires_grad=False)

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -145,6 +145,7 @@ inline Tensor as_view(const Tensor & base, const Tensor & tensor, bool is_bw_dif
       if (base.is_view()) {
         auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base));
         const auto& base_bw_info = diff_view_meta->get_backward_view();
+        creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
         return make_variable_differentiable_view(tensor, base_bw_info.chain(base, tensor, view_func),
                                                  c10::nullopt, creation_meta, allow_tensor_metadata_change);
       } else {
@@ -166,6 +167,7 @@ inline Tensor as_view(const Tensor & base, const Tensor & tensor, bool is_bw_dif
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base));
       const auto& base_bw_info = diff_view_meta->get_backward_view();
       new_bw_info = base_bw_info.chain(base, tensor, view_func);
+      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_bw_info = ViewInfo(base, view_func);
     }
@@ -182,6 +184,7 @@ inline Tensor as_view(const Tensor & base, const Tensor & tensor, bool is_bw_dif
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(base_meta);
       const auto& base_fw_info = diff_view_meta->get_forward_view();
       new_fw_info = base_fw_info.chain(base, tensor, view_func);
+      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_fw_info = ViewInfo(base, view_func);
     }
@@ -210,6 +213,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed
       new_bw_info = ViewInfo(base_bw_info.base_, /* view_func */ nullptr);
+      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_bw_info = ViewInfo(base, /* view_func */ nullptr);
     }
@@ -229,6 +233,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed
       new_fw_info = ViewInfo(base_fw_info.base_, /* view_func */ nullptr);
+      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_fw_info = ViewInfo(base, /* view_func */ nullptr);
     }

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -167,7 +167,6 @@ inline Tensor as_view(const Tensor & base, const Tensor & tensor, bool is_bw_dif
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base));
       const auto& base_bw_info = diff_view_meta->get_backward_view();
       new_bw_info = base_bw_info.chain(base, tensor, view_func);
-      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_bw_info = ViewInfo(base, view_func);
     }
@@ -184,13 +183,16 @@ inline Tensor as_view(const Tensor & base, const Tensor & tensor, bool is_bw_dif
       auto diff_view_meta = static_cast<DifferentiableViewMeta*>(base_meta);
       const auto& base_fw_info = diff_view_meta->get_forward_view();
       new_fw_info = base_fw_info.chain(base, tensor, view_func);
-      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_fw_info = ViewInfo(base, view_func);
     }
   }
 
   if (is_fw_differentiable || is_bw_differentiable) {
+    if (base.is_view()) {
+      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base));
+      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
+    }
     return make_variable_differentiable_view(tensor, std::move(new_bw_info), std::move(new_fw_info),
                                              creation_meta, allow_tensor_metadata_change);
   } else {
@@ -213,7 +215,6 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed
       new_bw_info = ViewInfo(base_bw_info.base_, /* view_func */ nullptr);
-      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_bw_info = ViewInfo(base, /* view_func */ nullptr);
     }
@@ -233,10 +234,14 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed
       new_fw_info = ViewInfo(base_fw_info.base_, /* view_func */ nullptr);
-      creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
     } else {
       new_fw_info = ViewInfo(base, /* view_func */ nullptr);
     }
+  }
+
+  if ((is_fw_differentiable || is_bw_differentiable) && base.is_view()) {
+    auto diff_view_meta = static_cast<DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(base));
+    creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
   }
 
   for(Tensor &tensor : tensors) {

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -502,6 +502,15 @@ struct TORCH_API ViewInfo {
 enum class CreationMeta: uint8_t { DEFAULT, IN_CUSTOM_FUNCTION, MULTI_OUTPUT_NODE,
                                    NO_GRAD_MODE, MULTI_OUTPUT_SAFE };
 
+/// Handles correctly propagating CreationMeta when a new view is created from a previous view.
+/// In general, we don't want the new view to be _less_ restrictive than the previous view
+/// (it's okay to be _more_ restrictive). A CreationMeta value of DEFAULT is currently the least
+/// restrictive, as the behavior for all other CreationMeta values is to error out for in-place ops.
+/// If this changes, the logic here will need to be updated to properly handle the new semantics.
+inline CreationMeta propagate_creation_meta(CreationMeta prev_view_creation_meta, CreationMeta new_view_creation_meta) {
+  return (new_view_creation_meta == CreationMeta::DEFAULT) ? prev_view_creation_meta : new_view_creation_meta;
+}
+
 /// Unified function to handle error checking when rebase happens
 /// indirect=true means that the caller is not doing the inplace, but the inplace happened
 /// somewhere else.


### PR DESCRIPTION
Fixes #49824

## Background

When creating a view of a view, there was a possibility that the new view would be less restrictive than the previous view, incorrectly sidestepping the error that should be thrown when using in-place operations on the new view.

The fix addresses this by propagating `CreationMeta` from the previous view to the new view. Currently, the old view's `creation_meta` is only propagated when the new view's `creation_meta == CreationMeta::DEFAULT`. This ensures that the new view is not less restrictive than the previous view wrt. allowing in-place operations.

## Test Plan
```
python test/test_autograd.py TestAutogradDeviceTypeCPU.test_inplace_view_of_multiple_output_view_cpu
python test/test_autograd.py TestAutogradDeviceTypeCUDA.test_inplace_view_of_multiple_output_view_cuda
python test/test_autograd.py TestAutogradDeviceTypeCPU.test_inplace_multiple_output_view_of_view_cpu
python test/test_autograd.py TestAutogradDeviceTypeCUDA.test_inplace_multiple_output_view_of_view_cuda
```

## BC-Breaking Note
After this fix, an error will properly be thrown to avoid wrong gradients when an in-place operation is performed on a view of a view, where the second view has `creation_meta == CreationMeta::DEFAULT` (e.g. a standard single output view) while the first view has `creation_meta != CreationMeta::DEFAULT` (e.g. a multiple output or other restricted view).

Since previous behavior allowed such in-place operations without an error, this change is BC-breaking.