### PR TITLE
[quant][fx] Make packed_weight a module buffer

### DIFF
--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -934,7 +934,8 @@ class Quantizer:
                 packed_weight = packed_weights[node.name]
                 # add a prepacked attribute to root
                 packed_weight_name = get_new_packed_weight_name(quantized_root)
-                setattr(quantized_root, packed_weight_name, packed_weight)
+                # setattr(quantized_root, packed_weight_name, packed_weight)
+                quantized_root.register_buffer(packed_weight_name, packed_weight)
                 # replace prepack node with a getattr node
                 env[node.name] = folded_graph.create_node(
                     'get_attr', packed_weight_name, (), {})


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51087 [quant][fx] Make packed_weight a module buffer**
* #51086 [quant][fx] Extend scope to support all node type

Summary:
This enables the packed weights to be stored as getattr nodes in the graph
And also allows for packed_weight to show up in the model state_dict of fx quantized model.

Test Plan:
python test/test_quantization.py TestQuantizeFx.test_attrs_are_buffers

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26077601](https://our.internmc.facebook.com/intern/diff/D26077601)