### PR TITLE
Workaround Python3.9 limitations in test_jit_py3

### DIFF
--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from torch.testing._internal.common_utils import run_tests
-from torch.testing._internal.jit_utils import JitTestCase
+from torch.testing._internal.jit_utils import JitTestCase, make_global
 from torch.testing import FileCheck
 from torch import jit
 from textwrap import dedent
@@ -727,7 +727,6 @@ class TestScriptPy3(JitTestCase):
 
 
     def test_export_opnames_interface(self):
-        global OneTwoModule
 
         @torch.jit.interface
         class OneTwoModule(nn.Module):
@@ -759,6 +758,8 @@ class TestScriptPy3(JitTestCase):
 
             def forward(self, x: torch.Tensor) -> torch.Tensor:
                 return self.two(self.one(x, x))
+
+        make_global(OneTwoModule)
 
         class M(nn.Module):
             sub : OneTwoModule

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -194,6 +194,9 @@ def get_closure(fn):
 # functions will be defined at a global scope like MyGlobalClass. In cases
 # where they are not, it is possible to work around issues by declaring the
 # values global in the function.
+# In Python 3.9 declaring class as global will make it invisible to
+# `inspect.getsource`, see https://bugs.python.org/issue42666 .
+# This could be worked around by manualy adding it to `global()` dictionary.
 
 
 

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -686,3 +686,8 @@ def warmup_backward(f, *args):
             f.backward(retain_graph=True)
 
     return results
+
+# TODO: Remove me once https://bugs.python.org/issue42666 is resolved
+def make_global(*args):
+    for arg in args:
+        setattr(sys.modules[arg.__module__], arg.__name__, arg)


### PR DESCRIPTION
In Python-3.9 and above `inspect.getsource` of a local class does not work if it was marked as default, see https://bugs.python.org/issue42666 https://github.com/pytorch/pytorch/issues/49617
Workaround by defining `make_global` function that programmatically accomplishes the same

Partially addresses issue raised in #49617
