### PR TITLE
[nnc] Per-operator benchmarks

### DIFF
--- a/benchmarks/cpp/tensorexpr/bench_ops.py
+++ b/benchmarks/cpp/tensorexpr/bench_ops.py
@@ -1,0 +1,56 @@
+import timeit
+import torch
+
+torch._C._jit_override_can_fuse_on_cpu(True)
+torch._C._debug_set_fusion_group_inlining(False)
+
+def hardswish(x):
+    return x * torch.clamp(x + 3., 0., 6.) / 6.
+
+
+unary_ops = [
+    hardswish,
+    torch._C._nn.hardswish,
+    torch.sigmoid,
+    torch.reciprocal,
+    torch.neg,
+    torch.relu,
+    torch.isnan,
+    torch.log,
+    torch.log10,
+    torch.log1p,
+    torch.log2,
+    torch.exp,
+    torch.expm1,
+    torch.erf,
+    torch.erfc,
+    torch.cos,
+    torch.sin,
+    torch.tan,
+    torch.acos,
+    torch.asin,
+    torch.cosh,
+    torch.sinh,
+    torch.atan,
+    torch.tanh,
+    torch.sqrt,
+    torch.rsqrt,
+    torch.abs,
+    torch.ceil,
+    torch.floor,
+    torch.round,
+    torch.trunc,
+    torch.lgamma,
+]
+
+print("{:20s} {:>10s} {:>10s} {:>10s}".format(
+    "op", "eager", "nnc", "speedup"))
+
+for op in unary_ops:
+    x = torch.rand((1024, 1024))
+    traced = torch.jit.trace(lambda x: op(x), (x))
+    [traced(x) for _ in range(2)]
+    torch.testing.assert_allclose(op(x), traced(x))
+    teager = timeit.timeit(stmt="op(x)", globals=globals(), number=100)
+    tjit = timeit.timeit(stmt="traced(x)", globals=globals(), number=100)
+    print(f"{op.__name__:20s} {teager:10.3f} {tjit:10.3f} {teager/tjit:10.2f}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51125 [nnc] Refactor generation of intrinsics to reduce the amount of macro-hell
* **#51093 [nnc] Per-operator benchmarks**

Operator level benchmarks comparing eager-mode PyTorch to
NNC-generated fused kernels.  We wouldn't normally see these in isolation, but
it points out where NNC is falling short (or doing well).

I threw in a composed hardswish for fun, because it's my favorite activation
function.

Notably, it exposes a bug in our build process that's preventing vectorization
from using `sleef`, so we're using scalar calls to libm with predictably lousy
performance.  Fix incoming.

This benchmark is similar to the pure NNC approach in `microbenchmarks.py`, but
will include the overhead of dispatching the fused kernel through TorchScript.

Differential Revision: [D26069791](https://our.internmc.facebook.com/intern/diff/D26069791/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26069791/)!