### PR TITLE
[ONNX] Enable Constant Folding for ONNX Opset 13

### DIFF
--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -284,7 +284,12 @@ class TestUtilityFuns(TestCase):
             assert node.kind() != "onnx::Slice"
             assert node.kind() != "onnx::Concat"
             assert node.kind() != "onnx::Unsqueeze"
-        assert len(list(graph.nodes())) == 3
+            
+        if self.opset_version <= 12:
+            assert len(list(graph.nodes())) == 3
+        else:
+            # Unsqueeze op parameter 'axie' as an input instand of as an attribute for opset >= 13
+            assert len(list(graph.nodes())) == 4
 
     def test_constant_fold_transpose_matmul(self):
         class MatMulNet(torch.nn.Module):
@@ -619,7 +624,7 @@ class TestUtilityFuns(TestCase):
         assert next(iter).kind() == "aten::dequantize"
 
     # prim::ListConstruct is exported as onnx::SequenceConstruct for opset >= 11
-    @skipIfUnsupportedOpsetVersion([11, 12])
+    @skipIfUnsupportedOpsetVersion([11, 12, 13])
     def test_prim_fallthrough(self):
         # Test prim op
         class PrimModule(torch.jit.ScriptModule):
@@ -792,16 +797,27 @@ TestUtilityFuns_opset12 = type(str("TestUtilityFuns_opset12"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=12))
 
+# opset 13 tests
+TestUtilityFuns_opset13 = type(str("TestUtilityFuns_opset13"),
+                               (TestCase,),
+                               dict(TestUtilityFuns.__dict__, opset_version=13))
+
 # opset 11 tests
-TestUtilityFuns_opset9_new_jit_API = type(str("TestUtilityFuns_opset9_new_jit_API"),
+TestUtilityFuns_opset11_new_jit_API = type(str("TestUtilityFuns_opset11_new_jit_API"),
                                           (TestCase,),
-                                          dict(TestUtilityFuns.__dict__, opset_version=9,
+                                          dict(TestUtilityFuns.__dict__, opset_version=11,
                                           use_new_jit_passes=True))
 
 # opset 12 tests
 TestUtilityFuns_opset12_new_jit_API = type(str("TestUtilityFuns_opset12_new_jit_API"),
                                            (TestCase,),
                                            dict(TestUtilityFuns.__dict__, opset_version=12,
+                                           use_new_jit_passes=True))
+
+# opset 13 tests
+TestUtilityFuns_opset13_new_jit_API = type(str("TestUtilityFuns_opset13_new_jit_API"),
+                                           (TestCase,),
+                                           dict(TestUtilityFuns.__dict__, opset_version=13,
                                            use_new_jit_passes=True))
 
 

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -284,7 +284,7 @@ class TestUtilityFuns(TestCase):
             assert node.kind() != "onnx::Slice"
             assert node.kind() != "onnx::Concat"
             assert node.kind() != "onnx::Unsqueeze"
-            
+
         if self.opset_version <= 12:
             assert len(list(graph.nodes())) == 3
         else:
@@ -786,7 +786,6 @@ TestUtilityFuns_opset10 = type(str("TestUtilityFuns_opset10"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=10))
 
-
 # opset 11 tests
 TestUtilityFuns_opset11 = type(str("TestUtilityFuns_opset11"),
                                (TestCase,),
@@ -804,9 +803,9 @@ TestUtilityFuns_opset13 = type(str("TestUtilityFuns_opset13"),
 
 # opset 11 tests
 TestUtilityFuns_opset11_new_jit_API = type(str("TestUtilityFuns_opset11_new_jit_API"),
-                                          (TestCase,),
-                                          dict(TestUtilityFuns.__dict__, opset_version=11,
-                                          use_new_jit_passes=True))
+                                           (TestCase,),
+                                           dict(TestUtilityFuns.__dict__, opset_version=11,
+                                           use_new_jit_passes=True))
 
 # opset 12 tests
 TestUtilityFuns_opset12_new_jit_API = type(str("TestUtilityFuns_opset12_new_jit_API"),

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -246,7 +246,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       }
       auto axes = inputTensorValues[1].accessor<int64_t, 1>();
       updated_val = inputTensorValues[0];
-      for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
+      for (int64_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
         updated_val = at::unsqueeze(updated_val, axes[i]);
       }
       return c10::optional<at::Tensor>(updated_val);

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -279,10 +279,10 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
   } else if (node->kind() == onnx::Squeeze) {
     assert(inputTensorValues.size() == 2 or inputTensorValues.size() == 1);
     if (opset_version == ONNX_OPSET_13) {
-      // Squeeze version 13 input axes is optional, inputTensorValues.size() == 1 means axes equal to None
+      // Squeeze version 13 input axes is optional, inputTensorValues.size() ==
+      // 1 means axes equal to None
       updated_val = inputTensorValues[0];
-      if (inputTensorValues.size() == 2)
-      {
+      if (inputTensorValues.size() == 2) {
         // Checking validity of 'axes' input
         if (inputTensorValues[1].sizes().size() != 1) {
           std::cerr

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -287,7 +287,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     updated_val = inputTensorValues[0];
     std::vector<int64_t> shape(inputTensorValues[1].sizes()[0], 0);
     auto shape_a = inputTensorValues[1].accessor<int64_t, 1>();
-    for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
+    for (int64_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
       // All shape dim values should be >= -1
       // onnx::Reshape supports a shape dim value to be zero, in
       // which case the actual dim value remains unchanged. However,

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -277,7 +277,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       return c10::nullopt;
     }
   } else if (node->kind() == onnx::Squeeze) {
-    assert(inputTensorValues.size() != 2 or inputTensorValues.size() != 1);
+    assert(inputTensorValues.size() == 2 or inputTensorValues.size() == 1);
     if (opset_version == ONNX_OPSET_13) {
       // Squeeze version 13 input axes is optional, inputTensorValues.size() == 1 means axes equal to None
       updated_val = inputTensorValues[0];
@@ -341,8 +341,8 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     updated_val = inputTensorValues[0];
     std::vector<int64_t> shape(inputTensorValues[1].sizes()[0], 0);
     auto shape_a = inputTensorValues[1].accessor<int64_t, 1>();
-    assert(inputTensorValues[1].sizes()[0] > 0);
-    for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
+    assert(inputTensorValues[1].sizes()[0] >= 0);
+    for (size_t i = 0; i < (size_t)(inputTensorValues[1].sizes()[0]); ++i) {
       // All shape dim values should be >= -1
       // onnx::Reshape supports a shape dim value to be zero, in
       // which case the actual dim value remains unchanged. However,

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -9,6 +9,7 @@ const int ONNX_OPSET_9 = 9;
 const int ONNX_OPSET_10 = 10;
 const int ONNX_OPSET_11 = 11;
 const int ONNX_OPSET_12 = 12;
+const int ONNX_OPSET_13 = 13;
 void ConstantFoldONNX(
     Block* b,
     std::map<std::string, IValue>& paramDict,

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -13,7 +13,7 @@ ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
 ir_version = _C._onnx.IR_VERSION
 producer_name = "pytorch"
 producer_version = _C._onnx.PRODUCER_VERSION
-constant_folding_opset_versions = [9, 10, 11, 12]
+constant_folding_opset_versions = [9, 10, 11, 12, 13]
 
 
 class ExportTypes:


### PR DESCRIPTION
Currently constant folding is only enabled for ONNX opset versions 9 to 12. This PR enables it for the new ONNX opset 13.
Turn on constant folding ONNX pass and enable constant folding tests for opset 13.
Update support for opset 13 version of "onnx::Unsqueeze" op.
Add support for "onnx::Squeeze" op.