### PR TITLE
DOC: udate left navbar links for vision and text

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -95,8 +95,8 @@ Features described in this documentation are classified by release status:
    :caption: Libraries
 
    torchaudio <https://pytorch.org/audio/stable>
-   torchtext <https://pytorch.org/text>
-   torchvision <https://pytorch.org/vision>
+   torchtext <https://pytorch.org/text/stable>
+   torchvision <https://pytorch.org/vision/stable>
    TorchElastic <https://pytorch.org/elastic/>
    TorchServe <https://pytorch.org/serve>
    PyTorch on XLA Devices <http://pytorch.org/xla/>


### PR DESCRIPTION
A tiny PR to update the links in the lefthand navbar under Libraries. The canonical link for vision and text is `https://pytorch.org/vision/stable` and `https://pytorch.org/text/stable` respectively. The link without the `/stable` works via a redirect, this is cleaner.