### PR TITLE
add missing return statement to inlined vec_signed

### DIFF
--- a/aten/src/ATen/cpu/vec256/vsx/vsx_helpers.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vsx_helpers.h
@@ -30,6 +30,7 @@ C10_ALWAYS_INLINE vfloat32 vec_float(const vint32& vec_in) {
 C10_ALWAYS_INLINE vint32 vec_signed(const vfloat32& vec_in) {
   vint32 vec_out;
   __asm__("xvcvspsxws %x0,%x1" : "=wa"(vec_out) : "wf"(vec_in));
+  return vec_out;
 }
 
 C10_ALWAYS_INLINE vint64 vec_signed(const vfloat64& vec_in) {


### PR DESCRIPTION
Fixes #{issue number}
This is not really a new issue, just a proposed minor fix to a recent previous issue (now closed) #50640 which was a fix for #50439.

That fix added inlining for vec_signed (and others) but in one case the return was accidentally omitted.  This results in a build error:
```                 from �[01m�[K../aten/src/ATen/cpu/vec256/vec256.h:19�[m�[K,
                 from �[01m�[Katen/src/ATen/native/cpu/FillKernel.cpp.VSX.cpp:3�[m�[K:
�[01m�[K../aten/src/ATen/cpu/vec256/vsx/vsx_helpers.h:�[m�[K In function ‘�[01m�[Kvint32 vec_signed(const vfloat32&)�[m�[K’:
�[01m�[K../aten/src/ATen/cpu/vec256/vsx/vsx_helpers.h:33:1:�[m�[K �[01;31m�[Kerror: �[m�[Kno return statement in function returning non-void [�[01;31m�[K-Werror=return-type�[m�[K]
```

I've confirmed that the error disappears after this one-line fix.  (Note: There is another issue encountered later in the build unrelated to this particular fix, as I noted in a separate comment in the original issue.  I'm trying to make some sense of that one, but in any event it would be a subject for another issue/PR).