### PR TITLE
Intermezzo: quality of life tweaks to Timer. (Retain callgrind.out, change collect_baseline default, add __mul__ for FunctionCounts)

### DIFF
--- a/torch/utils/benchmark/utils/timeit_template.cpp
+++ b/torch/utils/benchmark/utils/timeit_template.cpp
@@ -16,6 +16,8 @@ sections with user provided statements.
 
 
 double timeit(int n) {
+    pybind11::gil_scoped_release no_gil;
+
     // Setup
     // SETUP_TEMPLATE_LOCATION
 

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -403,7 +403,8 @@ class Timer(object):
     def collect_callgrind(
         self,
         number: int = 100,
-        collect_baseline: bool = True
+        collect_baseline: bool = False,
+        retain_out_file: bool = False,
     ) -> valgrind_timer_interface.CallgrindStats:
         """Collect instruction counts using Callgrind.
 
@@ -450,4 +451,6 @@ class Timer(object):
             globals=self._globals,
             number=number,
             collect_baseline=collect_baseline and is_python,
-            is_python=is_python)
+            is_python=is_python,
+            retain_out_file=retain_out_file,
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51123 Instruction count benchmark (7): Use  when collecting callgrind.
* #51122 Intermezzo: Add Timer support for callgrind repeats
* **#51121 Intermezzo: quality of life tweaks to Timer. (Retain callgrind.out, change collect_baseline default, add __mul__ for FunctionCounts)**
* #50610 Instruction count benchmark (6): Add frontend to drive microbenchmarks, and start README
* #50609 Instruction count benchmark (5): Add benchmark runner.
* #50608 Instruction count benchmark (4): Extend the benchmarks in both coverage and complexity.
* #50607 Instruction count benchmark (3): Enable TorchScript benchmarks
* #50606 Instruction count benchmark (2): Initial benchmark definitions.
* #50605 Instruction count benchmark (1): Types and interfaces
* #50604 add global_setup for C++ includes
* #50603 add utility to back test Timer

This PR adds a couple tweaks that came up in the course of building this ubenchmark suite, but aren't large enough to warrant their own PR:
1) C++ wall time should release the GIL
2) Add option to retain `callgrind.out` contents. This will allow processing with kCachegrind for more detailed analysis.
3) Changed the default of `collect_baseline`. This is mostly there so I can check that the harness isn't too expensive, but as Python measurements get more reliable it is liable to be a distraction / source of noise for other users.
4) Add a `__mul__` overload to function counts. e.g. suppose `c0` was run with `number=100`, and `c1` was run with `number=200`, then `c0 * 2 - c1` is needed to properly diff them. (Obviously there are correctness concerns, but I think it's fine as a caveat emptor convenience method.)