### PR TITLE
Intermezzo: Add Timer support for callgrind repeats

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -524,6 +524,7 @@ def _disabled_torch_function_impl(func: Callable, types: Iterable[Type], args: T
 # Defined in `valgrind.h` and `callgrind.h` respecitively.
 def _valgrind_supported_platform() -> _bool: ...  # NVALGRIND
 def _valgrind_toggle() -> None: ...  # CALLGRIND_TOGGLE_COLLECT
+def _valgrind_dump_stats() -> None: ...  # CALLGRIND_DUMP_STATS
 
 has_openmp: _bool
 has_mkl: _bool

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -863,6 +863,21 @@ Call this whenever a new thread is created in order to propagate values from
     }
   );
 
+  py_module.def(
+    "_valgrind_dump_stats", [](){
+      #if defined(USE_VALGRIND)
+      // NB: If we don't toggle collect around dump stats, callgrind_annotate
+      //     won't process the results correctly. Specifically,
+      //     `callgrind_annotate --inclusive=no` will be almost completely empty.
+      CALLGRIND_TOGGLE_COLLECT;
+      CALLGRIND_DUMP_STATS;
+      CALLGRIND_TOGGLE_COLLECT;
+      #else
+      TORCH_CHECK(false, "Valgrind is not supported.");
+      #endif
+    }
+  );
+
 #ifdef USE_CUDA
   PyObject *has_cuda = Py_True;
 #else

--- a/torch/utils/benchmark/utils/historic/compat_bindings.cpp
+++ b/torch/utils/benchmark/utils/historic/compat_bindings.cpp
@@ -19,7 +19,19 @@ void _valgrind_toggle() {
     #endif
 }
 
+void _valgrind_dump_stats() {
+    #if defined(NVALGRIND)
+    TORCH_CHECK(false, "Valgrind is not supported.");
+    #else
+    // NB: See note in Module.cpp
+    CALLGRIND_TOGGLE_COLLECT;
+    CALLGRIND_DUMP_STATS;
+    CALLGRIND_TOGGLE_COLLECT;
+    #endif
+}
+
 PYBIND11_MODULE(callgrind_bindings, m) {
     m.def("_valgrind_supported_platform", &_valgrind_supported_platform);
     m.def("_valgrind_toggle", &_valgrind_toggle);
+    m.def("_valgrind_dump_stats", &_valgrind_dump_stats);
 }

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
@@ -24,15 +24,18 @@ static_assert(false);
 int main(int argc, char* argv[]) {
     // This file should only be called inside of `Timer`, so we can adopt a
     // very simple and rigid argument parsing scheme.
-    assert(argc == 7);
+    assert(argc == 9);
     assert(std::string(argv[1]) == "--number");
     auto number = std::stoi(argv[2]);
 
     assert(std::string(argv[3]) == "--number_warmup");
     auto number_warmup = std::stoi(argv[4]);
 
-    assert(std::string(argv[5]) == "--number_threads");
-    auto number_threads = std::stoi(argv[6]);
+    assert(std::string(argv[5]) == "--repeats");
+    auto repeats = std::stoi(argv[6]);
+
+    assert(std::string(argv[7]) == "--number_threads");
+    auto number_threads = std::stoi(argv[8]);
     torch::set_num_threads(number_threads);
 
     // Setup
@@ -45,8 +48,15 @@ int main(int argc, char* argv[]) {
 
     // Main loop
     CALLGRIND_TOGGLE_COLLECT;
-    for (int i = 0; i < number; i++) {
+    for (int repeat = 0; repeat < repeats; repeat++) {
+        for (int i = 0; i < number; i++) {
         // STMT_TEMPLATE_LOCATION
+        }
+
+        // NB: See note in Module.cpp
+        CALLGRIND_TOGGLE_COLLECT;
+        CALLGRIND_DUMP_STATS;
+        CALLGRIND_TOGGLE_COLLECT;
     }
     CALLGRIND_TOGGLE_COLLECT;
 }

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -463,7 +463,7 @@ class GlobalsBridge:
 class _ValgrindWrapper(object):
     def __init__(self) -> None:
         self._bindings_module: Optional[CallgrindModuleType] = None
-        if hasattr(torch._C, "_valgrind_supported_platform"):
+        if hasattr(torch._C, "_valgrind_dump_stats"):
             self._supported_platform: bool = torch._C._valgrind_supported_platform()
 
         else:
@@ -490,8 +490,6 @@ class _ValgrindWrapper(object):
         if build_search is not None:
             self._build_type = build_search.groups()[0].split(",")[0]
 
-        self._baseline_cache: Dict[Tuple[int, int], Tuple[FunctionCounts, FunctionCounts]] = {}
-
     def _validate(self) -> None:
         if not self._supported_platform:
             raise OSError("Valgrind is not supported on this platform.")
@@ -505,44 +503,29 @@ class _ValgrindWrapper(object):
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
         number: int,
+        repeats: int,
         collect_baseline: bool,
         is_python: bool,
         retain_out_file: bool,
-    ) -> CallgrindStats:
+    ) -> Tuple[CallgrindStats, ...]:
         """Collect stats, and attach a reference run which can be used to filter interpreter overhead."""
         self._validate()
-        assert is_python or not collect_baseline
+        *task_stats, baseline_stats = self._invoke(
+            task_spec, globals, number, repeats, collect_baseline, is_python, retain_out_file)
+        assert len(task_stats) == repeats
 
-        baseline_inclusive_stats = FunctionCounts((), inclusive=True)
-        baseline_exclusive_stats = FunctionCounts((), inclusive=False)
-        if collect_baseline:
-            cache_key = (number, task_spec.num_threads)
-            if cache_key not in self._baseline_cache:
-                self._baseline_cache[cache_key] = self._invoke(
-                    common.TaskSpec(
-                        stmt="pass",
-                        setup="pass",
-                        num_threads=task_spec.num_threads,
-                    ),
-                    globals={},
-                    number=number,
-                    is_python=True,
-                    retain_out_file=False,
-                )
-            baseline_inclusive_stats, baseline_exclusive_stats, _ = \
-                self._baseline_cache[cache_key]
-
-        stmt_inclusive_stats, stmt_exclusive_stats, out_contents = self._invoke(
-            task_spec, globals, number, is_python, retain_out_file)
-        return CallgrindStats(
-            task_spec=task_spec,
-            number_per_run=number,
-            built_with_debug_symbols=self._build_type == "RelWithDebInfo",
-            baseline_inclusive_stats=baseline_inclusive_stats,
-            baseline_exclusive_stats=baseline_exclusive_stats,
-            stmt_inclusive_stats=stmt_inclusive_stats,
-            stmt_exclusive_stats=stmt_exclusive_stats,
-            stmt_callgrind_out=out_contents,
+        return tuple(
+            CallgrindStats(
+                task_spec=task_spec,
+                number_per_run=number,
+                built_with_debug_symbols=self._build_type == "RelWithDebInfo",
+                baseline_inclusive_stats=baseline_stats[0],
+                baseline_exclusive_stats=baseline_stats[1],
+                stmt_inclusive_stats=stmt_inclusive_stats,
+                stmt_exclusive_stats=stmt_exclusive_stats,
+                stmt_callgrind_out=out_contents,
+            )
+            for stmt_inclusive_stats, stmt_exclusive_stats, out_contents in task_stats
         )
 
     def _invoke(
@@ -550,9 +533,11 @@ class _ValgrindWrapper(object):
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
         number: int,
+        repeats: int,
+        collect_baseline: bool,
         is_python: bool,
         retain_out_file: bool,
-    ) -> Tuple[FunctionCounts, FunctionCounts, Optional[str]]:
+    ) -> Tuple[Tuple[FunctionCounts, FunctionCounts, Optional[str]], ...]:
         """Core invocation method for Callgrind collection.
 
         Valgrind operates by effectively replacing the CPU with an emulated
@@ -610,11 +595,14 @@ class _ValgrindWrapper(object):
                         task_spec,
                         globals=GlobalsBridge(globals, data_dir),
                         number=number,
+                        repeats=repeats,
+                        collect_baseline=collect_baseline,
                         error_log=error_log,
                         stat_log=stat_log,
                         bindings=self._bindings_module))
                 run_loop_cmd = ["python", script_file]
             else:
+                assert not collect_baseline
                 run_loop_exec = cpp_jit.compile_callgrind_template(
                     task_spec.stmt,
                     task_spec.setup,
@@ -624,6 +612,7 @@ class _ValgrindWrapper(object):
                     run_loop_exec,
                     "--number", str(number),
                     "--number_warmup", str(min(number, 10)),
+                    "--repeats", str(repeats),
                     "--number_threads", str(task_spec.num_threads),
                 ]
 
@@ -647,44 +636,82 @@ class _ValgrindWrapper(object):
 
                 raise OSError(f"Failed to collect callgrind profile:\n{error_report}")
 
-            def parse_output(inclusive: bool) -> FunctionCounts:
+            def parse_output(fpath: str, inclusive: bool) -> FunctionCounts:
                 annotate_invocation, annotate_invocation_output = run([
                     "callgrind_annotate",
                     f"--inclusive={'yes' if inclusive else 'no'}",
-                    callgrind_out
+                    "--threshold=100",
+                    "--show-percs=no",
+                    fpath
                 ], check=True)
 
-                begin_collecting = False
+                total_pattern = re.compile(r"^([0-9,]+)\s+PROGRAM TOTALS")
+                begin_pattern = re.compile(r"Ir\s+file:function")
+                function_pattern = re.compile(r"^\s*([0-9,]+)\s+(.+:.+)$")
+
+                class ScanState(enum.Enum):
+                    SCANNING_FOR_TOTAL = 0
+                    SCANNING_FOR_START = 1
+                    PARSING = 2
+
+                scan_state = ScanState.SCANNING_FOR_TOTAL
                 fn_counts = []
                 for l in annotate_invocation_output.splitlines(keepends=False):
-                    if not begin_collecting and re.match(r"Ir\s+file:function", l):
-                        begin_collecting = True
-                        continue
+                    if scan_state == ScanState.SCANNING_FOR_TOTAL:
+                        total_match = total_pattern.match(l)
+                        if total_match:
+                            program_totals = int(total_match.groups()[0].replace(",", ""))
+                            scan_state = ScanState.SCANNING_FOR_START
 
-                    count_match = re.match(r"^\s*([0-9,]+)\s+(.+:.+)$", l)
-                    if count_match:
-                        ir_str, file_function = count_match.groups()
-                        ir = int(ir_str.replace(",", ""))
-                        fn_counts.append(FunctionCount(ir, file_function))
-                        continue
+                    elif scan_state == ScanState.SCANNING_FOR_START:
+                        if begin_pattern.match(l):
+                            scan_state = ScanState.PARSING
 
-                    if begin_collecting and re.match(r"-+", l):
-                        continue
+                    else:
+                        assert scan_state == ScanState.PARSING
+                        fn_match = function_pattern.match(l)
+                        if fn_match:
+                            ir_str, file_function = fn_match.groups()
+                            ir = int(ir_str.replace(",", ""))
+                            if ir == program_totals:
+                                # Callgrind includes some top level red herring symbols when
+                                # a program dumps multiple profiles.
+                                continue
+                            fn_counts.append(FunctionCount(ir, file_function))
 
-                    begin_collecting = False
+                        elif re.match(r"-+", l):
+                            # Ignore heading separator lines.
+                            continue
 
+                        else:
+                            break
+
+                assert scan_state == ScanState.PARSING, f"Failed to parse {fpath}"
                 return FunctionCounts(tuple(sorted(fn_counts, reverse=True)), inclusive=inclusive)
 
-            callgrind_out_contents: Optional[str] = None
-            if retain_out_file:
-                with open(callgrind_out, "rt") as f:
-                    callgrind_out_contents = f.read()
+            def read_results(i: int) -> Tuple[FunctionCounts, FunctionCounts, Optional[str]]:
+                if i == repeats and not collect_baseline:
+                    # Null baseline.
+                    return (
+                        FunctionCounts((), inclusive=True),
+                        FunctionCounts((), inclusive=False),
+                        None,
+                    )
 
-            return (
-                parse_output(inclusive=True),
-                parse_output(inclusive=False),
-                callgrind_out_contents,
-            )
+                fpath = f"{callgrind_out}.{i + 1}"  # Callgrind one-indexes files.
+                callgrind_out_contents: Optional[str] = None
+                if retain_out_file:
+                    with open(fpath, "rt") as f:
+                        callgrind_out_contents = f.read()
+
+                return (
+                    parse_output(fpath, inclusive=True),
+                    parse_output(fpath, inclusive=False),
+                    callgrind_out_contents
+                )
+
+            return tuple(read_results(i) for i in range(repeats + 1))
+
         finally:
             shutil.rmtree(working_dir)
 
@@ -693,26 +720,39 @@ class _ValgrindWrapper(object):
         task_spec: common.TaskSpec,
         globals: GlobalsBridge,
         number: int,
+        repeats: int,
+        collect_baseline: bool,
         error_log: str,
         stat_log: str,
         bindings: Optional[CallgrindModuleType],
     ) -> str:
-        # The naive template looks something like:
-        #   "for _ in range({number}): {stmt}"
-        # However a loop in Python is surprisingly expensive, and significantly
-        # increases the number of background Python instructions. So instead we
-        # partially unroll the loops, with a block size of 100 chosen to keep
-        # the instruction overhead from `range` low while also not ballooning
-        # the size of the generated file.
-        block_size = 100
-        loop_count = number // block_size
-        remainder = number - block_size * loop_count
-        blocked_stmt = ""
-        if loop_count:
-            unrolled_stmts = textwrap.indent("\n".join([task_spec.stmt] * block_size), " " * 4)
-            blocked_stmt += f"for _ in range({loop_count}):\n{unrolled_stmts}\n"
-        if remainder:
-            blocked_stmt += "\n".join([task_spec.stmt] * remainder)
+        def block_stmt(stmt: str):
+            """Partially unroll benchmark loop.
+
+            The naive template looks something like:
+                "for _ in range({number}): {stmt}"
+            However a loop in Python is surprisingly expensive, and significantly
+            increases the number of background Python instructions. So instead we
+            partially unroll the loops, with a block size of 100 chosen to keep
+            the instruction overhead from `range` low while also not ballooning
+            the size of the generated file.
+            """
+            block_size = 100
+            loop_count = number // block_size
+            remainder = number - block_size * loop_count
+            blocked_stmt = ""
+
+            if loop_count:
+                unrolled_stmts = textwrap.indent("\n".join([stmt] * block_size), " " * 4)
+                blocked_stmt += f"for _ in range({loop_count}):\n{unrolled_stmts}\n"
+
+            if remainder:
+                blocked_stmt += "\n".join([stmt] * remainder)
+
+            return blocked_stmt
+
+        pass_baseline = f"{block_stmt('pass')}\ncallgrind_bindings._valgrind_dump_stats()"
+        blocked_stmt = block_stmt(task_spec.stmt)
 
         return textwrap.dedent(r"""
             import gc
@@ -796,16 +836,20 @@ class _ValgrindWrapper(object):
             # == User code block ==========================================================
             # =============================================================================
             callgrind_bindings._valgrind_toggle()
-            {blocked_stmt}
 
-            # Sleep is to allow the interpreter to catch up before we stop collecting in
-            # order to reduce jitter.
-            time.sleep(0.01)
+            for _ in range({repeats}):
+            {blocked_stmt}
+                callgrind_bindings._valgrind_dump_stats()
+
+            {baseline}
+
             callgrind_bindings._valgrind_toggle()
         """).strip().format(
             indented_stmt=textwrap.indent(task_spec.stmt, " " * 4),
-            blocked_stmt=blocked_stmt,
+            blocked_stmt=textwrap.indent(blocked_stmt, " " * 4),
+            baseline=(pass_baseline if collect_baseline else ""),
             number=number,
+            repeats=repeats,
             load_globals=globals.construct(),
             setup=task_spec.setup,
             warmup_number=min(number, 10),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51123 Instruction count benchmark (7): Use  when collecting callgrind.
* **#51122 Intermezzo: Add Timer support for callgrind repeats**
* #51121 Intermezzo: quality of life tweaks to Timer. (Retain callgrind.out, change collect_baseline default, add __mul__ for FunctionCounts)
* #50610 Instruction count benchmark (6): Add frontend to drive microbenchmarks, and start README
* #50609 Instruction count benchmark (5): Add benchmark runner.
* #50608 Instruction count benchmark (4): Extend the benchmarks in both coverage and complexity.
* #50607 Instruction count benchmark (3): Enable TorchScript benchmarks
* #50606 Instruction count benchmark (2): Initial benchmark definitions.
* #50605 Instruction count benchmark (1): Types and interfaces
* #50604 add global_setup for C++ includes
* #50603 add utility to back test Timer

A lot of the cost of Callgrind is in startup and shutdown. `import torch` alone takes ~20 seconds when run under Valgrind. Moreover, there is sometimes warmup that needs to happen beyond just lazy init. (e.g. warming up malloc arenas or unicode caches.) This PR uses the `CALLGRIND_DUMP_STATS` macro to add a `repeats` arg to `Timer.collect_callgrind`. For most snippets where `stmt` is modest and `number` isn't too large, executing the body of the benchmark loop is a minority of the overall time and repeats are nearly free.

Empirically, this also does a great deal to stabilize Python since spurious events like hitting a `gc` collection or jitter in the interpreter will generally be the minority, and most of the repeats will have the same number of instructions. It is, however, worth noting that the asymptotic instruction counts for Python processes tends to vary by process, so there is still some noise in A/B testing.

Some of these warmups (such as malloc warmup) are also present in C++, so sequential repeats are not identical. However this behavior is still deterministic.

One minor finesse is the addition of `--threshold=100` to the `callgrind_annotate` call. The default value is 99%, so previously we have been inadvertently doing some filtering. 