### PR TITLE
[PyTorch] Put functor at the end of wrap_kernel_functor_unboxed params

### DIFF
--- a/aten/src/ATen/core/boxing/KernelFunction_impl.h
+++ b/aten/src/ATen/core/boxing/KernelFunction_impl.h
@@ -40,9 +40,9 @@ inline void KernelFunction::callBoxed(const OperatorHandle& opHandle, Stack* sta
 
 template<class Return, class... Args>
 inline Return callUnboxedKernelFunction(void* unboxed_kernel_func, OperatorKernel* functor, Args&&... args) {
-    using ActualSignature = Return (OperatorKernel*, Args...);
+    using ActualSignature = Return (Args..., OperatorKernel*);
     ActualSignature* func = reinterpret_cast<ActualSignature*>(unboxed_kernel_func);
-    return (*func)(functor, std::forward<Args>(args)...);
+    return (*func)(std::forward<Args>(args)..., functor);
 }
 
 template<class Return, class... Args>

--- a/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h
+++ b/aten/src/ATen/core/boxing/impl/WrapFunctionIntoFunctor.h
@@ -9,7 +9,7 @@ namespace impl {
     template<class FuncPtr, class ReturnType, class... Parameters>
     class WrapFunctionIntoFunctor_<FuncPtr, ReturnType, guts::typelist::typelist<Parameters...>> final : public c10::OperatorKernel {
     public:
-      decltype(auto) operator()(Parameters... args) {
+      C10_ALWAYS_INLINE decltype(auto) operator()(Parameters... args) {
         return (*FuncPtr::func_ptr())(std::forward<Parameters>(args)...);
       }
     };

--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -400,7 +400,7 @@ namespace impl {
     static_assert(std::is_same<guts::typelist::typelist<ParameterTypes...>, typename guts::infer_function_traits_t<KernelFunctor>::parameter_types>::value,
       "Parameter types mismatch");
 
-    static ReturnType call(OperatorKernel* functor, ParameterTypes... args) {
+    static ReturnType call(ParameterTypes... args, OperatorKernel* functor) {
       KernelFunctor* functor_ = static_cast<KernelFunctor*>(functor);
       return (*functor_)(std::forward<ParameterTypes>(args)...);
     }

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -133,6 +133,7 @@ public:
   // Like call, but override the default DispatchKey calculation code,
   // instead dispatching straight to the provided DispatchKey
   template<class Return, class... Args>
+  C10_ALWAYS_INLINE
   Return callWithDispatchKey(const TypedOperatorHandle<Return (Args...)>& op, DispatchKey dispatchKey, Args... args) const;
 
   template<class Return, class... Args>
@@ -362,7 +363,7 @@ public:
     return c10::Dispatcher::singleton().call<Return, Args...>(*this, std::forward<Args>(args)...);
   }
 
-  Return callWithDispatchKey(DispatchKey dispatchKey, Args... args) const {
+  C10_ALWAYS_INLINE Return callWithDispatchKey(DispatchKey dispatchKey, Args... args) const {
     return c10::Dispatcher::singleton().callWithDispatchKey<Return, Args...>(*this, dispatchKey, std::forward<Args>(args)...);
   }
 

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -812,6 +812,7 @@ DispatchKeySet _dk_set = c10::DispatchKeySet({dispatch_key}) | c10::detail::mult
                 compute_dk = f"DispatchKey _dk = {dispatch_key};"
             return f"""\
 // aten::{f.func}
+C10_ALWAYS_INLINE
 {sig.defn(name)} {{
   static auto op = c10::Dispatcher::singleton()
     .findSchemaOrThrow("aten::{f.func.name.name}", "{f.func.name.overload_name}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51165 [PyTorch] Pass TensorOptions by value
* **#51164 [PyTorch] Put functor at the end of wrap_kernel_functor_unboxed params**
* #51163 [PyTorch] Refactor Dispatcher to inline less code in fast path
* #51162 [PyTorch] Remove unnecessary dispatcher.h include in torch/library.h

In the (hopefully) common case where the unboxed functor is
really a `c10::CompileTimeFunctionPointer`, this enables a jump
straight to said functor.

Note that I had no end of trouble getting this to have decent
performance without the previous diff, and even with it, all the
manual C10_ALWAYS_INLINE I added were necessary.

Differential Revision: [D26069629](https://our.internmc.facebook.com/intern/diff/D26069629/)