### PR TITLE
[PyTorch] Save a refcount bump in make_variable

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -147,6 +147,10 @@ class TORCH_API Tensor {
     return impl_;
   }
 
+  c10::intrusive_ptr<TensorImpl, UndefinedTensorImpl> unsafeReleaseIntrusivePtr()  {
+    return std::move(impl_);
+  }
+
   bool defined() const {
     return impl_;
   }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -657,7 +657,7 @@ inline Variable make_variable(
     bool allow_tensor_metadata_change = true) {
   if (data.defined()) {
     if (data.getIntrusivePtr().use_count() == 1 && data.getIntrusivePtr()->unique_version()) {
-      auto data_impl = data.getIntrusivePtr();
+      auto data_impl = data.unsafeReleaseIntrusivePtr();
       data_impl->set_allow_tensor_metadata_change(allow_tensor_metadata_change);
       if (requires_grad) {
         data_impl->set_autograd_meta(std::make_unique<AutogradMeta>(data_impl.get(), requires_grad));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51180 [PyTorch] Save a refcount bump in make_variable**

This fast path still did a refcount bump because it copied the inner intrusive_ptr to the stack. Now it's moved.

Differential Revision: [D26094951](https://our.internmc.facebook.com/intern/diff/D26094951/)