### PR TITLE
Fix more JIT tests under Python-3.9

### DIFF
--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -9,7 +9,7 @@ from typing import Any, List
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
-from torch.testing._internal.jit_utils import JitTestCase
+from torch.testing._internal.jit_utils import JitTestCase, make_global
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -18,23 +18,19 @@ if __name__ == '__main__':
 
 class TestEnum(JitTestCase):
     def test_enum_value_types(self):
-        global IntEnum
-
         class IntEnum(Enum):
             FOO = 1
             BAR = 2
-
-        global FloatEnum
 
         class FloatEnum(Enum):
             FOO = 1.2
             BAR = 2.3
 
-        global StringEnum
-
         class StringEnum(Enum):
             FOO = "foo as in foo bar"
             BAR = "bar as in foo bar"
+
+        make_global(IntEnum, FloatEnum, StringEnum)
 
         @torch.jit.script
         def supported_enum_types(a: IntEnum, b: FloatEnum, c: StringEnum):
@@ -46,11 +42,11 @@ class TestEnum(JitTestCase):
             .check("StringEnum") \
             .run(str(supported_enum_types.graph))
 
-        global TensorEnum
-
         class TensorEnum(Enum):
             FOO = torch.tensor(0)
             BAR = torch.tensor(1)
+
+        make_global(TensorEnum)
 
         def unsupported_enum_types(a: TensorEnum):
             return a.name
@@ -59,11 +55,11 @@ class TestEnum(JitTestCase):
             torch.jit.script(unsupported_enum_types)
 
     def test_enum_comp(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def enum_comp(x: Color, y: Color) -> bool:
@@ -75,8 +71,6 @@ class TestEnum(JitTestCase):
         self.assertEqual(enum_comp(Color.RED, Color.GREEN), False)
 
     def test_enum_comp_diff_classes(self):
-        global Foo, Bar
-
         class Foo(Enum):
             ITEM1 = 1
             ITEM2 = 2
@@ -84,6 +78,8 @@ class TestEnum(JitTestCase):
         class Bar(Enum):
             ITEM1 = 1
             ITEM2 = 2
+
+        make_global(Foo, Bar)
 
         @torch.jit.script
         def enum_comp(x: Foo) -> bool:
@@ -98,11 +94,11 @@ class TestEnum(JitTestCase):
         self.assertEqual(enum_comp(Foo.ITEM1), False)
 
     def test_heterogenous_value_type_enum_error(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = "green"
+
+        make_global(Color)
 
         def enum_comp(x: Color, y: Color) -> bool:
             return x == y
@@ -111,11 +107,11 @@ class TestEnum(JitTestCase):
             torch.jit.script(enum_comp)
 
     def test_enum_name(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def enum_name(x: Color) -> str:
@@ -131,11 +127,11 @@ class TestEnum(JitTestCase):
         self.assertEqual(enum_name(Color.GREEN), Color.GREEN.name)
 
     def test_enum_value(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def enum_value(x: Color) -> int:
@@ -151,11 +147,11 @@ class TestEnum(JitTestCase):
         self.assertEqual(enum_value(Color.GREEN), Color.GREEN.value)
 
     def test_enum_as_const(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def enum_const(x: Color) -> bool:
@@ -171,11 +167,11 @@ class TestEnum(JitTestCase):
         self.assertEqual(enum_const(Color.GREEN), False)
 
     def test_non_existent_enum_value(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         def enum_const(x: Color) -> bool:
             if x == Color.PURPLE:
@@ -187,11 +183,11 @@ class TestEnum(JitTestCase):
             torch.jit.script(enum_const)
 
     def test_enum_ivalue_type(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def is_color_enum(x: Any):
@@ -207,8 +203,6 @@ class TestEnum(JitTestCase):
         self.assertEqual(is_color_enum(1), False)
 
     def test_closed_over_enum_constant(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
@@ -240,8 +234,6 @@ class TestEnum(JitTestCase):
         self.assertEqual(closed_over_aliased_value(), Color.RED.value)
 
     def test_enum_as_module_attribute(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
@@ -268,8 +260,6 @@ class TestEnum(JitTestCase):
         self.assertEqual(scripted(), Color.RED.value)
 
     def test_string_enum_as_module_attribute(self):
-        global Color
-
         class Color(Enum):
             RED = "red"
             GREEN = "green"
@@ -282,17 +272,18 @@ class TestEnum(JitTestCase):
             def forward(self):
                 return (self.e.name, self.e.value)
 
+        make_global(Color)
         m = TestModule(Color.RED)
         scripted = torch.jit.script(m)
 
         self.assertEqual(scripted(), (Color.RED.name, Color.RED.value))
 
     def test_enum_return(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
+
+        make_global(Color)
 
         @torch.jit.script
         def return_enum(cond: bool):
@@ -305,8 +296,6 @@ class TestEnum(JitTestCase):
         self.assertEqual(return_enum(False), Color.GREEN)
 
     def test_enum_module_return(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
@@ -319,6 +308,7 @@ class TestEnum(JitTestCase):
             def forward(self):
                 return self.e
 
+        make_global(Color)
         m = TestModule(Color.RED)
         scripted = torch.jit.script(m)
 
@@ -333,8 +323,6 @@ class TestEnum(JitTestCase):
 
 
     def test_enum_iterate(self):
-        global Color
-
         class Color(Enum):
             RED = 1
             GREEN = 2
@@ -347,6 +335,7 @@ class TestEnum(JitTestCase):
                     res.append(e.value)
             return res
 
+        make_global(Color)
         scripted = torch.jit.script(iterate_enum)
 
         FileCheck() \

--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, List
 
 import torch
-from torch.testing._internal.jit_utils import JitTestCase
+from torch.testing._internal.jit_utils import JitTestCase, make_global
 
 
 # Make the helper files in test/ importable
@@ -29,8 +29,6 @@ class TestWith(JitTestCase):
         Check that with statements that use the 'as' keyword to bind expressions
         to targets work as expected.
         """
-        global Context
-
         @torch.jit.script
         class Context(object):
             """
@@ -49,6 +47,8 @@ class TestWith(JitTestCase):
 
             def __exit__(self, type: Any, value: Any, tb: Any):
                 self.count.sub_(0.3)
+
+        make_global(Context)
 
         def test_basic(x: torch.Tensor) -> torch.Tensor:
             """Basic test with one with-statement."""
@@ -185,8 +185,6 @@ class TestWith(JitTestCase):
         Check that with statements that do not use the 'as' keyword to bind expressions
         to targets work as expected.
         """
-        global Context
-
         @torch.jit.script
         class Context(object):
             """
@@ -205,6 +203,8 @@ class TestWith(JitTestCase):
 
             def __exit__(self, type: Any, value: Any, tb: Any):
                 self.count.sub_(0.3)
+
+        make_global(Context)
 
         def test_basic(x: torch.Tensor) -> torch.Tensor:
             """Basic test with one with-statement."""
@@ -341,8 +341,6 @@ class TestWith(JitTestCase):
         Check that exceptions thrown in the bodies of with-statements are
         handled correctly.
         """
-        global Context
-
         @torch.jit.script
         class Context(object):
             """
@@ -361,6 +359,8 @@ class TestWith(JitTestCase):
 
             def __exit__(self, type: Any, value: Any, tb: Any):
                 self.count.sub_(0.3)
+
+        make_global(Context)
 
         @torch.jit.script
         def method_that_raises() -> torch.Tensor:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -65,7 +65,7 @@ from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, TEST_WIT
     freeze_rng_state, set_rng_seed, slowTest, TemporaryFileName, skipIfCompiledWithoutNumpy, \
     enable_profiling_mode_for_profiling_tests, TEST_MKL, set_default_dtype, num_profiled_runs
 from torch.testing._internal.jit_utils import JitTestCase, enable_cpu_fuser, disable_autodiff_subgraph_inlining, \
-    _trace, enable_cpu_fuser_if, do_input_map, get_execution_plan, \
+    _trace, enable_cpu_fuser_if, do_input_map, get_execution_plan, make_global, \
     execWrapper, _inline_everything, _tmp_donotuse_dont_inline_everything, \
     RUN_CUDA
 from torch.testing._internal.jit_metaprogramming_utils import create_script_fn, nn_functional_tests, get_script_args, \
@@ -6609,8 +6609,6 @@ a")
                    .check("in foo").check("in baz").run(str(cm.exception))
 
     def test_error_stacktrace_interface(self):
-        global IFace
-
         @torch.jit.script
         def baz(c, b):
             return c + b
@@ -6633,6 +6631,8 @@ a")
             def one(self, x, y):
                 # type: (Tensor, Tensor) -> Tensor
                 pass
+
+        make_global(IFace)
 
         @torch.jit.script
         def as_interface(x):

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -241,7 +241,9 @@ def get_annotation_str(annotation):
     elif isinstance(annotation, ast.Attribute):
         return '.'.join([get_annotation_str(annotation.value), annotation.attr])
     elif isinstance(annotation, ast.Subscript):
-        return f"{get_annotation_str(annotation.value)}[{get_annotation_str(annotation.slice.value)}]"  # type: ignore
+        # In Python3.9+ subscript indicies are not wrapped in ast.Index
+        subscript_slice = annotation.slice if sys.version_info >= (3, 9) else annotation.slice.value  # type: ignore
+        return f"{get_annotation_str(annotation.value)}[{get_annotation_str(subscript_slice)}]"
     elif isinstance(annotation, ast.Tuple):
         return ','.join([get_annotation_str(elt) for elt in annotation.elts])
     elif isinstance(annotation, ast.Constant) or isinstance(annotation, ast.NameConstant):


### PR DESCRIPTION
Mostly replace `global Foo` with `make_global(Foo)`
The only real fix is generating Subscript annotation, which is a follow up from https://github.com/pytorch/pytorch/pull/48676

Fixes #49617
