### PR TITLE
Update _torch_docs.py

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -6846,7 +6846,7 @@ with :math:`Q` being an orthogonal matrix or batch of orthogonal matrices and
 If :attr:`some` is ``True``, then this function returns the thin (reduced) QR factorization.
 Otherwise, if :attr:`some` is ``False``, this function returns the complete QR factorization.
 
-.. warning:: ``torch.qr`` is deprecated. Please use ``torch.linalg.`` :func:`~torch.linalg.qr`
+.. warning:: ``torch.qr`` is deprecated. Please use :func:`torch.linalg.qr`
              instead.
 
              **Differences with** ``torch.linalg.qr``:


### PR DESCRIPTION
Fix `torch.linalg.qr` reference where it's desired to render fully-qualified name into docs.

Suggested fix for https://github.com/pytorch/pytorch/pull/47764/files#r565368195
