### PR TITLE
Share VS Code workspace settings and recommended extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,7 +243,6 @@ cmake-build-debug
 # Below files are not deleted by "setup.py clean".
 
 # Visual Studio Code files
-.vscode
 .vs
 
 # YouCompleteMe config file

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "python.pythonPath": "${env:HOME}/miniconda3/envs/pytorch/bin/python",
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true,
+  "python.linting.mypyEnabled": true,
+  "python.linting.mypyPath": "${workspaceFolder}/torch/testing/_internal/mypy_wrapper.py",
+  "python.linting.mypyArgs": []
+}


### PR DESCRIPTION
This is just an idea that might make it easier to share VS Code conveniences among PyTorch devs. It might not be a good idea, but I figured it wouldn't hurt to at least consider it and discuss it with the team.

This style of syncing `.vscode` in Git is already used by some existing projects; for example:

- [microsoft/vscode-python](https://github.com/microsoft/vscode-python/tree/2021.1.502429796/.vscode)

To make this (hopefully) work, I'm using VS Code's [variable syntax](https://code.visualstudio.com/docs/editor/variables-reference) and [workspace recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) feature. ~I'm not entirely sure whether this variable syntax works properly here, since the discussion in https://github.com/microsoft/vscode/issues/2809 makes it seem like there are many places where they actually don't work.~ I've been using this locally, and both the settings I'm using variables for (`python.pythonPath` and `python.linting.mypyPath`) seem to work correctly.

Advantages:

- allows VS Code conveniences (such as our `mypy` wrapper) to be easily shared by all PyTorch devs who use VS Code
- running `git clean -fdx` no longer removes `.vscode/settings.json`

Disadvantages:

- not great if people have different preferences for settings that they don't want to put their own global user config
- people might accidentally commit changes to `.vscode/settings.json` in unrelated PRs