### PR TITLE
[atem] Add dtype check to bmm_out_or_baddbmm_

### DIFF
--- a/aten/src/ATen/native/mkl/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/LinearAlgebra.cpp
@@ -136,14 +136,14 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
   const bool canAvoidTensorAccessor = mat1_strides[0] == mat1_sizes[1] * mat1_sizes[2] &&
     mat2_strides[0] == mat2_sizes[1] * mat2_sizes[2];
 
-  scalar_t* const res_data = static_cast<scalar_t*>(res.data_ptr());
+  scalar_t* const res_data = res.data_ptr<scalar_t>();
 
   if (batch_size == 1) {
     const scalar_t* A;
     const scalar_t* B;
     if (canAvoidTensorAccessor) {
-      scalar_t* mat1_data = static_cast<scalar_t*>(mat1.data_ptr());
-      scalar_t* mat2_data = static_cast<scalar_t*>(mat2.data_ptr());
+      scalar_t* mat1_data = mat1.data_ptr<scalar_t>();
+      scalar_t* mat2_data = mat2.data_ptr<scalar_t>();
       A = mat1_data;
       B = mat2_data;
     } else {
@@ -167,8 +167,8 @@ static inline void baddbmm_mkl_template(const Tensor& res, const Tensor& mat1, c
   // or only transposed in the last two axis
   const auto res_sizes = res.sizes();
   if (canAvoidTensorAccessor) {
-    scalar_t* mat1_data = static_cast<scalar_t*>(mat1.data_ptr());
-    scalar_t* mat2_data = static_cast<scalar_t*>(mat2.data_ptr());
+    scalar_t* mat1_data = mat1.data_ptr<scalar_t>();
+    scalar_t* mat2_data = mat2.data_ptr<scalar_t>();
     for (int64_t batch = 0; batch < batch_size; batch++) {
       A.emplace_back(mat1_data + batch * mat1_sizes[1] * mat1_sizes[2]);
       B.emplace_back(mat2_data + batch * mat2_sizes[1] * mat2_sizes[2]);

--- a/aten/src/ATen/test/math_kernel_test.cpp
+++ b/aten/src/ATen/test/math_kernel_test.cpp
@@ -112,3 +112,14 @@ TEST(MathKernelTest, NarrowCopy)  {
     ASSERT_ALLCLOSE_TOLERANCES(y_ref, y_test, 0, 0);
   }
 }
+
+TEST(MathKernelTest, Bmm)  {
+  auto test_bmm = [](int64_t last_dim) {
+    auto x = rand({1, 4, 4}, at::kFloat);
+    auto y = rand({1, 4, last_dim}, at::kDouble);
+    EXPECT_THROW(auto z = at::bmm(x, y), std::exception);
+  };
+
+  test_bmm(5);
+  test_bmm(1000);
+}


### PR DESCRIPTION
Summary: Fix bug raised in https://github.com/pytorch/pytorch/issues/50980 by adding a dtype check in bmm_out_or_baddbmm_.

Test Plan:
```
buck test //caffe2/test:linalg
buck test //caffe2/aten:math_kernel_test
```

Differential Revision: D26113575

