### PR TITLE
Adding correct error message for for..else

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15263,6 +15263,17 @@ dedent """
         self.checkScript(fn, ({'hi': 2, 'bye': 3},))
         self.checkScript(fn, ({'bye': 3},))
 
+    def test_for_else(self):
+        def fn():
+            c = 0
+            for i in range(4):
+                c += 10
+            else:
+                print("In else block of for...else")
+
+        with self.assertRaisesRegex(torch.jit.frontend.NotSupportedError, "else branches of for loops aren't supported"):
+            torch.jit.script(fn)
+
     def test_split(self):
         def split_two(tensor):
             a, b, c = torch.split(tensor, 2, dim=1)

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -483,6 +483,9 @@ class StmtBuilder(Builder):
     @staticmethod
     def build_For(ctx, stmt):
         r = ctx.make_range(stmt.lineno, stmt.col_offset, stmt.col_offset + len("for"))
+        if stmt.orelse:
+            raise NotSupportedError(r, "else branches of for loops aren't supported")
+
         return For(
             r, [build_expr(ctx, stmt.target)],
             [build_expr(ctx, stmt.iter)], build_stmts(ctx, stmt.body))


### PR DESCRIPTION
Fixes #51040
Summary:
========
Add error message for for..else statement in Torchscript

Test:
=====
pytest -k test_for_else test/test_jit.py
