### PR TITLE
Create op benchmark for stack

### DIFF
--- a/benchmarks/operator_benchmark/pt/stack_test.py
+++ b/benchmarks/operator_benchmark/pt/stack_test.py
@@ -1,0 +1,98 @@
+import operator_benchmark as op_bench
+import torch
+import random
+from typing import List
+
+
+"""Microbenchmarks for Stack operator"""
+
+# Configs for PT stack operator
+stack_configs_static_runtime = op_bench.config_list(
+    attr_names=['sizes', 'N'],
+    attrs=[
+        [(20, 40), 5], # noqa
+        [(1, 40), 5], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dim': list(range(3))
+    },
+    tags=['static_runtime'],
+)
+
+stack_configs_short = op_bench.config_list(
+    attr_names=['sizes', 'N'],
+    attrs=[
+        [(1,    1,      1), 2], # noqa
+        [(512,  512,    2), 2], # noqa
+        [(128, 1024,    2), 2], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dim': list(range(4))
+    },
+    tags=['short'],
+)
+
+stack_configs_long = op_bench.config_list(
+    attr_names=['sizes', 'N'],
+    attrs=[
+        [(2**10,    2**10,      2), 2], # noqa
+        [(2**10+1,  2**10-1,    2), 2], # noqa
+        [(2**10,    2**10,      2), 2], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dim': list(range(4))
+    },
+    tags=['long'],
+)
+
+# There is a different codepath on CUDA for >4 dimensions
+stack_configs_multidim = op_bench.config_list(
+    attr_names=['sizes', 'N'],
+    attrs=[
+        [(2**6,     2**5,   2**2,   2**4,   2**5), 2], # noqa
+        [(2**4,     2**5,   2**2,   2**4,   2**5), 8], # noqa
+        [(2**3+1,   2**5-1, 2**2+1, 2**4-1, 2**5+1), 17], # noqa
+    ],
+    cross_product_configs={
+        'device': ['cpu', 'cuda'],
+        'dim': list(range(6))
+    },
+    tags=['multidim'],
+)
+
+class StackBenchmark(op_bench.TorchBenchmarkBase):
+    def init(self, sizes, N, dim, device):
+        random.seed(42)
+        inputs = []
+        gen_sizes = []
+        if type(sizes) == list and N == -1:
+            gen_sizes = sizes
+        else:
+            for i in range(N):
+                gen_sizes.append([old_size() if callable(old_size) else old_size for old_size in sizes])
+
+        for s in gen_sizes:
+            inputs.append(torch.rand(s, device=device))
+        result = torch.rand(gen_sizes[0], device=device)
+        self.inputs = {
+            "result": result,
+            "inputs": inputs,
+            "dim": dim
+        }
+        self.set_module_name('stack')
+
+    def forward(self, result: torch.Tensor, inputs: List[torch.Tensor], dim: int):
+        return torch.stack(inputs, dim=dim, out=result)
+
+
+op_bench.generate_pt_test(stack_configs_static_runtime +
+                          stack_configs_short +
+                          stack_configs_long +
+                          stack_configs_multidim,
+                          StackBenchmark)
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary: - Add benchmark for stack op

Test Plan:
```
buck build mode/opt //caffe2/benchmarks/operator_benchmark/pt:stack_test --show-output
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 buck-out/gen/caffe2/benchmarks/operator_benchmark/pt/stack_test.par --tag_filter=static_runtime | grep Execution

Forward Execution Time (us) : 6.380
Forward Execution Time (us) : 6.553
Forward Execution Time (us) : 14.904
Forward Execution Time (us) : 5.657
Forward Execution Time (us) : 5.612
Forward Execution Time (us) : 6.051
Forward Execution Time (us) : 4.225
Forward Execution Time (us) : 4.240
Forward Execution Time (us) : 6.280
Forward Execution Time (us) : 6.267
Forward Execution Time (us) : 418.932
Forward Execution Time (us) : 417.694
Forward Execution Time (us) : 1592.455
Forward Execution Time (us) : 2919.261
Forward Execution Time (us) : 211.458
Forward Execution Time (us) : 211.518
Forward Execution Time (us) : 783.953
Forward Execution Time (us) : 1457.823
Forward Execution Time (us) : 2032.816
Forward Execution Time (us) : 2090.662
Forward Execution Time (us) : 6487.098
Forward Execution Time (us) : 11874.702
Forward Execution Time (us) : 2123.830
Forward Execution Time (us) : 2195.453
Forward Execution Time (us) : 6435.978
Forward Execution Time (us) : 11852.205
Forward Execution Time (us) : 2036.526
Forward Execution Time (us) : 2055.618
Forward Execution Time (us) : 6417.192
Forward Execution Time (us) : 12468.744
Forward Execution Time (us) : 4959.704
Forward Execution Time (us) : 5121.823
Forward Execution Time (us) : 5082.105
Forward Execution Time (us) : 5395.936
Forward Execution Time (us) : 5162.756
Forward Execution Time (us) : 23798.080
Forward Execution Time (us) : 4957.921
Forward Execution Time (us) : 4971.234
Forward Execution Time (us) : 5005.909
Forward Execution Time (us) : 5159.614
Forward Execution Time (us) : 5013.221
Forward Execution Time (us) : 20238.741
Forward Execution Time (us) : 7632.439
Forward Execution Time (us) : 7589.376
Forward Execution Time (us) : 7859.937
Forward Execution Time (us) : 8214.213
Forward Execution Time (us) : 11606.562
Forward Execution Time (us) : 34612.919
```

Differential Revision: D25859143

