### PR TITLE
[complex] Complex support for masked_scatter and autograd support for masked_scatter and masked_select

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -192,15 +192,20 @@ void cpu_masked_scatter_kernel(TensorIterator& iter, const Tensor& source) {
 }
 
 void masked_scatter_kernel(TensorIterator& iter, const Tensor& source) {
-  AT_DISPATCH_ALL_TYPES_AND2(ScalarType::Bool, ScalarType::BFloat16,
-    iter.dtype(), "masked_scatter", [&] {
-      auto mask_dtype = iter.input_dtype(0);
-      if (mask_dtype == ScalarType::Bool) {
-        cpu_masked_scatter_kernel<scalar_t, bool>(iter, source);
-      } else {
-        cpu_masked_scatter_kernel<scalar_t, unsigned char>(iter, source);
-      }
-    });
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+      ScalarType::Bool,
+      ScalarType::BFloat16,
+      ScalarType::Half,
+      iter.dtype(),
+      "masked_scatter",
+      [&] {
+        auto mask_dtype = iter.input_dtype(0);
+        if (mask_dtype == ScalarType::Bool) {
+          cpu_masked_scatter_kernel<scalar_t, bool>(iter, source);
+        } else {
+          cpu_masked_scatter_kernel<scalar_t, unsigned char>(iter, source);
+        }
+      });
 }
 
 template <typename scalar_t, typename mask_t, typename func_t>

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -302,7 +302,7 @@ void masked_scatter_cuda_impl(Tensor& self, const Tensor& mask, const Tensor& so
       .add_input(maskPrefixSum)
       .build();
 
-  AT_DISPATCH_ALL_TYPES_AND3(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
       ScalarType::Bool,
       ScalarType::BFloat16,
       ScalarType::Half,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4499,12 +4499,6 @@ class TestTorchDeviceType(TestCase):
                     # in a separate test
                     return
 
-                # TODO: update test when masked scatter is supported for complex
-                # and cpu supports half
-                if (dt == torch.half and self.device_type == 'cpu') or dt.is_complex:
-                    self.assertRaises(RuntimeError, lambda: dest.masked_scatter_(mask, src))
-                    return
-
                 dest.masked_scatter_(mask, src)
                 j = 0
                 for i in range(num_dest):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -89,6 +89,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'reflection_pad1d_backward', 'reflection_pad2d_backward',
     'replication_pad1d', 'replication_pad2d', 'replication_pad3d',
     'replication_pad1d_backward', 'replication_pad2d_backward', 'replication_pad3d_backward',
+    'masked_scatter', 'masked_select'
 }
 
 # Some operators invalidate the grad_accumulator. Let's reset it.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -993,19 +993,20 @@ def sample_inputs_fliplr_flipud(op_info, device, dtype, requires_grad):
     )
     return [SampleInput(tensor) for tensor in tensors]
 
+
 def sample_inputs_masked_scatter(op_info, device, dtype, requires_grad):
     samples = (
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn(M, M, device=device) > 0, make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
+                    args=(torch.randn(M, M, device=device) > 0,
+                          make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
 
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn((M,), device=device) > 0, make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
+                    args=(torch.randn((M,), device=device) > 0,
+                          make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
 
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(bernoulli_scalar().to(device), make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
-        # Inplace variants fail
-        # SampleInput(make_tensor((M,), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        # args=(torch.randn(M, M, device=device) > 0, make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
+                    args=(bernoulli_scalar().to(device),
+                          make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad))),
     )
 
     return samples
@@ -1013,25 +1014,25 @@ def sample_inputs_masked_scatter(op_info, device, dtype, requires_grad):
 def sample_inputs_masked_select(op_info, device, dtype, requires_grad):
     samples = (
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn(M, M, device=device) > 0,)),
+                    args=(torch.randn(M, M, device=device) > 0,)),
 
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn((M,), device=device) > 0,)),
+                    args=(torch.randn((M,), device=device) > 0,)),
 
         SampleInput(make_tensor((M,), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn((M, M), device=device) > 0,)),
+                    args=(torch.randn((M, M), device=device) > 0,)),
 
         SampleInput(make_tensor((M, 1, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn((M, M), device=device) > 0,)),
+                    args=(torch.randn((M, M), device=device) > 0,)),
 
         SampleInput(make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.tensor(1, device=device, dtype=torch.bool),)),
+                    args=(torch.tensor(1, device=device, dtype=torch.bool),)),
 
         SampleInput(make_tensor((M, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.tensor(1, device=device, dtype=torch.bool),)),
+                    args=(torch.tensor(1, device=device, dtype=torch.bool),)),
 
         SampleInput(make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(torch.randn((M, M), device=device) > 0,)),
+                    args=(torch.randn((M, M), device=device) > 0,)),
     )
 
     return samples


### PR DESCRIPTION
Reference: #33152

Changes
* Enable complex support for masked_scatter
* Enable half support for masked_scatter CPU
* Enable complex autograd support for masked_scatter CPU and masked_select (both CPU and CUDA).

**Note**:
Complex Support for masked_scatter CUDA is disabled as it depends on `masked_fill` which is yet to be ported to ATen.