### PR TITLE
Removed typographical error from tech docs

### DIFF
--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1159,7 +1159,7 @@ def atleast_1d(*tensors):
 
 def atleast_2d(*tensors):
     r"""
-    Returns a 2-dimensional view of each each input tensor with zero dimensions.
+    Returns a 2-dimensional view of each input tensor with zero dimensions.
     Input tensors with two or more dimensions are returned as-is.
     Args:
         input (Tensor or list of Tensors)
@@ -1193,7 +1193,7 @@ def atleast_2d(*tensors):
 
 def atleast_3d(*tensors):
     r"""
-    Returns a 3-dimensional view of each each input tensor with zero dimensions.
+    Returns a 3-dimensional view of each input tensor with zero dimensions.
     Input tensors with three or more dimensions are returned as-is.
     Args:
         input (Tensor or list of Tensors)


### PR DESCRIPTION
Dublications removed from tech docs.

![Screenshot](https://user-images.githubusercontent.com/71665475/106158807-6e5b8100-6184-11eb-9036-bccdf2086c31.png)

