### PR TITLE
Fix the missing parameter in get_sha function

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from distutils.util import strtobool
 
-def get_sha():
+def get_sha(pytorch_root):
     try:
         return subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=pytorch_root).decode('ascii').strip()
     except Exception:
@@ -22,7 +22,7 @@ def get_torch_version(sha=None):
             version += '.post' + str(build_number)
     elif sha != 'Unknown':
         if sha is None:
-            sha = get_sha()
+            sha = get_sha(pytorch_root)
         version += '+' + sha[:7]
     return version
 
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 
     pytorch_root = Path(__file__).parent.parent
     version_path = pytorch_root / "torch" / "version.py"
-    sha = get_sha()
+    sha = get_sha(pytorch_root)
     version = get_torch_version(sha)
 
     with open(version_path, 'w') as f:


### PR DESCRIPTION
get_sha() function didn't pass in the pytorch_root argument, so subprocess.check_output always raise exception since pytorch_root is not defined, thus always return 'Unknown'.