### PR TITLE
[PyTorch] RFC: Macro if constexpr in make_boxed_from_unboxed_functor

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -374,17 +374,34 @@ namespace impl {
 
       using ReturnType = typename guts::infer_function_traits_t<KernelFunctor>::return_type;
       constexpr bool has_outputs = !std::is_same<void, ReturnType>::value;
+#ifndef __cpp_if_constexpr
       guts::if_constexpr<has_outputs>([&] (auto delay_check) {
+#else
+      if constexpr (has_outputs) {
+#endif
         // Decay ReturnType to ReturnType_ so that if a reference gets returned, we actually store it by value
         // and don't get a dangling reference. This is only required because some kernels still return `Tensor&`.
+#ifndef __cpp_if_constexpr
         using ReturnType_ = std::decay_t<typename decltype(delay_check)::template type_identity<ReturnType>>;
         ReturnType_ output = call_functor_with_args_from_stack<KernelFunctor, AllowDeprecatedTypes>(functor_, delay_check(stack));
+#else
+        using ReturnType_ = std::decay_t<ReturnType>;
+        ReturnType_ output = call_functor_with_args_from_stack<KernelFunctor, AllowDeprecatedTypes>(functor_, stack);
+#endif
         torch::jit::drop(*stack, num_inputs);
         push_outputs<ReturnType_, AllowDeprecatedTypes>::call(std::move(output), stack);
+#ifndef __cpp_if_constexpr
       }, /* else */ [&] {
+#else
+      } else {
+#endif
         call_functor_with_args_from_stack<KernelFunctor, AllowDeprecatedTypes>(functor_, stack);
         torch::jit::drop(*stack, num_inputs);
+#ifndef __cpp_if_constexpr
       });
+#else
+      }
+#endif
     }
   };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51294 [PyTorch] RFC: Macro if constexpr in make_boxed_from_unboxed_functor**
* #51293 [PyTorch] IWYU in torch/csrc/utils/future.h
* #51269 [PyTorch] Outline OperatorEntry::assertSignatureIsCorrect fail path
* #51247 [PyTorch] check isValidUnboxed() in the dispatcher
* #51165 [PyTorch] Pass TensorOptions by value
* #51245 [PyTorch] Add C10_ALWAYS_INLINE to critical dispatcher paths
* #51163 [PyTorch] Refactor Dispatcher to inline less code in fast path

This is really ugly, but it approximately halves the total build time spent on make_boxed_from_unboxed_functor in an optimized build when C++17 is available , going from about 351 seconds to about 173 seconds.

Differential Revision: [D26128711](https://our.internmc.facebook.com/intern/diff/D26128711/)