### PR TITLE
.github: Update stale messaging add newlines

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -12,9 +12,10 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-pr-message: >
-            Looks like this PR hasn't been updated in a while! Going to go ahead and mark this as `stale`.
-            Feel free to update / remove the `stale` label if you feel this is a mistake
-            `stale` pull requests will automatically be closed 30 days after being marked `stale`
+            \## Stale alert!
+            Looks like this PR hasn't been updated in a while so we're going to go ahead and mark this as `Stale`. <br>
+            Feel free to remove the `Stale` label if you feel this was a mistake. <br>
+            `Stale` pull requests will automatically be closed 30 days after being marked `Stale` <br>
           exempt-pr-labels: "no-stale,open source,high priority"
           days-before-stale: 60
           days-before-close: 90
@@ -25,9 +26,11 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-pr-message: >
-            Looks like this PR hasn't been updated in a while! Going to go ahead and mark this as `stale`.
-            Feel free to update / remove the `stale` label if you feel this is a mistake
-            `stale` pull requests will automatically be closed 30 days after being marked `stale`
+            \## Stale alert!
+            Looks like this PR hasn't been updated in a while so we're going to go ahead and mark this as `Stale`. <br>
+            Feel free to remove the `Stale` label if you feel this was a mistake. <br>
+            If you are unable to remove the `Stale` label please contact a maintainer in order to do so. <br>
+            `Stale` pull requests will automatically be closed 30 days after being marked `Stale` <br>
           exempt-pr-labels: "no-stale,high priority"
           only-labels: "open source"
           days-before-stale: 150


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51298 .github: Update stale messaging add newlines**

newlines weren't being respected so just add them through the `<br>` html
tag.

Also changes the wording for open source ones to designate that a
maintainer may be needed to unstale a particular PR.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D26131126](https://our.internmc.facebook.com/intern/diff/D26131126)