### PR TITLE
.github: Remove title from stale alert

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-pr-message: >
-            \## Stale alert!
             Looks like this PR hasn't been updated in a while so we're going to go ahead and mark this as `Stale`. <br>
             Feel free to remove the `Stale` label if you feel this was a mistake. <br>
             `Stale` pull requests will automatically be closed 30 days after being marked `Stale` <br>
@@ -26,7 +25,6 @@ jobs:
       - uses: actions/stale@v3
         with:
           stale-pr-message: >
-            \## Stale alert!
             Looks like this PR hasn't been updated in a while so we're going to go ahead and mark this as `Stale`. <br>
             Feel free to remove the `Stale` label if you feel this was a mistake. <br>
             If you are unable to remove the `Stale` label please contact a maintainer in order to do so. <br>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51306 .github: Remove title from stale alert**

Title wasn't rendering correctly so let's just remove it altogether, it
shouldn't matter that much in the long run

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D26134907](https://our.internmc.facebook.com/intern/diff/D26134907)