### PR TITLE
[Pytorch Mobile] Expose _export_operator_list to python

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -639,6 +639,14 @@ py::list debugMakeNamedList(const T& list) {
   }
   return result;
 }
+template <typename T>
+py::set debugMakeSet(const T& list) {
+  py::set result;
+  for (const auto& elem : list) {
+    result.add(py::cast(elem));
+  }
+  return result;
+}
 
 static py::dict _jit_debug_module_iterators(Module& module) {
   py::dict result;
@@ -1544,6 +1552,9 @@ void initJitScriptBindings(PyObject* module) {
         }
         return _load_for_mobile(in, optional_device);
       });
+  m.def("_export_operator_list", [](torch::jit::mobile::Module& sm) {
+    return debugMakeSet(torch::jit::mobile::_export_operator_list(sm));
+  });
 
   m.def("_jit_set_emit_hooks", setEmitHooks);
   m.def("_jit_get_emit_hooks", getEmitHooks);

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -51,7 +51,6 @@ def _load_for_lite_interpreter(f, map_location=None):
 
     return LiteScriptModule(cpp_module)
 
-
 class LiteScriptModule(object):
     def __init__(self, cpp_module):
         self._c = cpp_module
@@ -68,3 +67,11 @@ class LiteScriptModule(object):
 
     def run_method(self, method_name, *input):
         return self._c.run_method(method_name, input)
+
+def _export_operator_list(module: LiteScriptModule):
+    r"""
+        return a set of root operator names (with overload name) that are used by any method
+        in this mobile module.
+    """
+    # TODO fix mypy here
+    return torch._C._export_operator_list(module._c)  # type: ignore


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51312 [Pytorch Mobile] Expose _export_operator_list to python**

Follow up to D24690094 exposing the api in python. Created matching unit test.

Differential Revision: [D26112765](https://our.internmc.facebook.com/intern/diff/D26112765/)