### PR TITLE
[ONNX] Modifications in remove inplace ops passes to better handle binary inplace ops

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4040,6 +4040,20 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(2, 3, 4)
         self.run_test(Arithmetic(), (x, y))
 
+    def test_inplace_arithmetic_half(self):
+        class InplaceAddModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x.add_(y)
+
+        class InplaceMulModel(torch.nn.Module):
+            def forward(self, x, y):
+                return x.mul_(y)
+
+        x = torch.randn(2, 2, dtype=torch.half)
+        y = torch.randn(2, 2, dtype=torch.float)
+        self.run_test(InplaceAddModel(), (x, y), rtol=1e-2, atol=1e-2)
+        self.run_test(InplaceMulModel(), (x, y), rtol=1e-2, atol=1e-2)
+
     @disableScriptTest()
     def test_sort(self):
         class SortModel(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -534,48 +534,6 @@ static void PrepareListAppendAndInsertForONNX(Block* b) {
   }
 }
 
-// Handles special case of binary inplace ops, where the first input node
-// has a lower type precedence than the second input node. When the
-// inplace node is converted to a regular op, this information is lost and
-// the resulting type is based on type precedence, just like regular ops.
-// To avoid this loss of information, we add a cast node before the input
-// node with the higher data type precedence, so that both the input types
-// are the same.
-// An example scenario would be:
-// Before:
-// graph(%0 : Float),
-//        %1 : Half):
-//   %4 : Float = onnx::Cast[to=1](%1)
-//   %5 : Float = onnx::Add(%4, %0)
-//   ...
-// After:
-// graph(%0 : Float),
-//        %1 : Half):
-//   %4 : Half = onnx::Cast[to=10](%0)
-//   %5 : Half = onnx::Add(%1, %4)
-//   ...
-
-static void ImplicitCastForBinaryInplaceOps(Node* inplaceNode) {
-  // Check type if inplace operation is a binary node
-  if ((inplaceNode->kind() == aten::add_) ||
-      (inplaceNode->kind() == aten::sub_) ||
-      (inplaceNode->kind() == aten::mul_) ||
-      (inplaceNode->kind() == aten::div_)) {
-    auto orignalInputs = inplaceNode->inputs();
-    if (orignalInputs.at(0)
-            ->type()
-            ->cast<TensorType>()
-            ->scalarType()
-            .has_value()) {
-      auto newInputNode = inplaceNode->owningGraph()->create(aten::type_as, 1);
-      newInputNode->insertBefore(inplaceNode);
-      newInputNode->addInput(orignalInputs.at(1));
-      newInputNode->addInput(orignalInputs.at(0));
-      inplaceNode->replaceInput(1, newInputNode->outputs()[0]);
-    }
-  }
-}
-
 // Remove Mutation pass does not handle mutation on block inputs.
 // To fix this, insert a clone node following the graph input:
 // Example for graph input node %0:
@@ -603,7 +561,6 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
       if (!mr.inplaceOpVariant(node)) {
         continue;
       }
-      ImplicitCastForBinaryInplaceOps(node);
 
       auto it = std::find(node->inputs().begin(), node->inputs().end(), input);
 
@@ -642,6 +599,53 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
 
 } // namespace
 
+// Handles special case of binary inplace ops, where the first input node
+// has a lower type precedence than the second input node. When the
+// inplace node is converted to a regular op, this information is lost and
+// the resulting type is based on type precedence, just like regular ops.
+// To avoid this loss of information, we add a cast node before the input
+// node with the higher data type precedence, so that both the input types
+// are the same.
+// An example scenario would be:
+// Before:
+// graph(%0 : Float),
+//        %1 : Half):
+//   %4 : Float = onnx::Cast[to=1](%1)
+//   %5 : Float = onnx::Add(%4, %0)
+//   ...
+// After:
+// graph(%0 : Float),
+//        %1 : Half):
+//   %4 : Half = onnx::Cast[to=10](%0)
+//   %5 : Half = onnx::Add(%1, %4)
+//   ...
+
+void ImplicitCastForBinaryInplaceOps(Block* b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      ImplicitCastForBinaryInplaceOps(child_block);
+    }
+
+    // Check type if inplace operation is a binary node
+    if ((it->kind() == aten::add_) || (it->kind() == aten::sub_) ||
+        (it->kind() == aten::mul_) || (it->kind() == aten::div_)) {
+      auto orignalInputs = it->inputs();
+      TensorTypePtr firstInp_tensor =
+          orignalInputs.at(0)->type()->cast<TensorType>();
+      TensorTypePtr secondInp_tensor =
+          orignalInputs.at(1)->type()->cast<TensorType>();
+      if ((firstInp_tensor) && (secondInp_tensor) &&
+          (firstInp_tensor->scalarType().has_value())) {
+        auto newInputNode = it->owningGraph()->create(aten::type_as, 1);
+        newInputNode->insertBefore(*it);
+        newInputNode->addInput(orignalInputs.at(1));
+        newInputNode->addInput(orignalInputs.at(0));
+        it->replaceInput(1, newInputNode->outputs().at(0));
+      }
+    }
+  }
+}
+
 void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
   PrepareCopyForONNX(graph->block());
   PrepareIndexPutForONNX(graph->block());
@@ -651,6 +655,7 @@ void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
 
 void RemoveInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
   MutationRemover mr(graph);
+  ImplicitCastForBinaryInplaceOps(graph->block());
   PrepareForRemoveMutations(mr, graph->block());
   RemoveTensorMutation(graph);
   RemoveListMutation(graph);

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -599,53 +599,6 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
 
 } // namespace
 
-// Handles special case of binary inplace ops, where the first input node
-// has a lower type precedence than the second input node. When the
-// inplace node is converted to a regular op, this information is lost and
-// the resulting type is based on type precedence, just like regular ops.
-// To avoid this loss of information, we add a cast node before the input
-// node with the higher data type precedence, so that both the input types
-// are the same.
-// An example scenario would be:
-// Before:
-// graph(%0 : Float),
-//        %1 : Half):
-//   %4 : Float = onnx::Cast[to=1](%1)
-//   %5 : Float = onnx::Add(%4, %0)
-//   ...
-// After:
-// graph(%0 : Float),
-//        %1 : Half):
-//   %4 : Half = onnx::Cast[to=10](%0)
-//   %5 : Half = onnx::Add(%1, %4)
-//   ...
-
-void ImplicitCastForBinaryInplaceOps(Block* b) {
-  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
-    for (auto* child_block : it->blocks()) {
-      ImplicitCastForBinaryInplaceOps(child_block);
-    }
-
-    // Check type if inplace operation is a binary node
-    if ((it->kind() == aten::add_) || (it->kind() == aten::sub_) ||
-        (it->kind() == aten::mul_) || (it->kind() == aten::div_)) {
-      auto orignalInputs = it->inputs();
-      TensorTypePtr firstInp_tensor =
-          orignalInputs.at(0)->type()->cast<TensorType>();
-      TensorTypePtr secondInp_tensor =
-          orignalInputs.at(1)->type()->cast<TensorType>();
-      if ((firstInp_tensor) && (secondInp_tensor) &&
-          (firstInp_tensor->scalarType().has_value())) {
-        auto newInputNode = it->owningGraph()->create(aten::type_as, 1);
-        newInputNode->insertBefore(*it);
-        newInputNode->addInput(orignalInputs.at(1));
-        newInputNode->addInput(orignalInputs.at(0));
-        it->replaceInput(1, newInputNode->outputs().at(0));
-      }
-    }
-  }
-}
-
 void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph) {
   PrepareCopyForONNX(graph->block());
   PrepareIndexPutForONNX(graph->block());

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -535,10 +535,10 @@ static void PrepareListAppendAndInsertForONNX(Block* b) {
 }
 
 // Handles special case of binary inplace ops, where the first input node
-// has a lower type precedence than the second input node. When the 
+// has a lower type precedence than the second input node. When the
 // inplace node is converted to a regular op, this information is lost and
 // the resulting type is based on type precedence, just like regular ops.
-// To avoid this loss of information, we add a cast node before the input 
+// To avoid this loss of information, we add a cast node before the input
 // node with the higher data type precedence, so that both the input types
 // are the same.
 // An example scenario would be:
@@ -557,9 +557,10 @@ static void PrepareListAppendAndInsertForONNX(Block* b) {
 
 static void ImplicitCastForBinaryInplaceOps(Node* inplaceNode) {
   // Check type if inplace operation is a binary node
-  auto name = inplaceNode->schema().name();
-  if((name == "aten::add_") || (name == "aten::sub_") ||
-     (name == "aten::mul_") || (name == "aten::div_")) {
+  if ((inplaceNode->kind() == aten::add_) ||
+      (inplaceNode->kind() == aten::sub_) ||
+      (inplaceNode->kind() == aten::mul_) ||
+      (inplaceNode->kind() == aten::div_)) {
     auto newInputNode = inplaceNode->owningGraph()->create(aten::type_as, 1);
     auto orignalInputs = inplaceNode->inputs();
     newInputNode->insertBefore(inplaceNode);

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -563,8 +563,8 @@ static void ImplicitCastForBinaryInplaceOps(Node* inplaceNode) {
     auto newInputNode = inplaceNode->owningGraph()->create(aten::type_as, 1);
     auto orignalInputs = inplaceNode->inputs();
     newInputNode->insertBefore(inplaceNode);
-    newInputNode->addInput(orignalInputs[1]);
-    newInputNode->addInput(orignalInputs[0]);
+    newInputNode->addInput(orignalInputs.at(1));
+    newInputNode->addInput(orignalInputs.at(0));
     inplaceNode->replaceInput(1, newInputNode->outputs()[0]);
   }
 }

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -561,12 +561,18 @@ static void ImplicitCastForBinaryInplaceOps(Node* inplaceNode) {
       (inplaceNode->kind() == aten::sub_) ||
       (inplaceNode->kind() == aten::mul_) ||
       (inplaceNode->kind() == aten::div_)) {
-    auto newInputNode = inplaceNode->owningGraph()->create(aten::type_as, 1);
     auto orignalInputs = inplaceNode->inputs();
-    newInputNode->insertBefore(inplaceNode);
-    newInputNode->addInput(orignalInputs.at(1));
-    newInputNode->addInput(orignalInputs.at(0));
-    inplaceNode->replaceInput(1, newInputNode->outputs()[0]);
+    if (orignalInputs.at(0)
+            ->type()
+            ->cast<TensorType>()
+            ->scalarType()
+            .has_value()) {
+      auto newInputNode = inplaceNode->owningGraph()->create(aten::type_as, 1);
+      newInputNode->insertBefore(inplaceNode);
+      newInputNode->addInput(orignalInputs.at(1));
+      newInputNode->addInput(orignalInputs.at(0));
+      inplaceNode->replaceInput(1, newInputNode->outputs()[0]);
+    }
   }
 }
 

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
@@ -9,5 +9,7 @@ TORCH_API void RemoveInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
 TORCH_API void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
+void ImplicitCastForBinaryInplaceOps(Block* block);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
@@ -9,7 +9,7 @@ TORCH_API void RemoveInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
 TORCH_API void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
-void ImplicitCastForBinaryInplaceOps(Block* block);
+TORCH_API void ImplicitCastForBinaryInplaceOps(Block* block);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h
@@ -9,7 +9,5 @@ TORCH_API void RemoveInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
 TORCH_API void PrepareInplaceOpsForONNX(const std::shared_ptr<Graph>& graph);
 
-TORCH_API void ImplicitCastForBinaryInplaceOps(Block* block);
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -1,4 +1,3 @@
-#include <torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h>
 #include <torch/csrc/jit/passes/remove_inplace_ops.h>
 
 namespace torch {
@@ -76,6 +75,53 @@ void RemoveInplaceOps(Block* block) {
   }
 }
 } // namespace
+
+// Handles special case of binary inplace ops, where the first input node
+// has a lower type precedence than the second input node. When the
+// inplace node is converted to a regular op, this information is lost and
+// the resulting type is based on type precedence, just like regular ops.
+// To avoid this loss of information, we add a cast node before the input
+// node with the higher data type precedence, so that both the input types
+// are the same.
+// An example scenario would be:
+// Before:
+// graph(%0 : Float),
+//        %1 : Half):
+//   %4 : Float = onnx::Cast[to=1](%1)
+//   %5 : Float = onnx::Add(%4, %0)
+//   ...
+// After:
+// graph(%0 : Float),
+//        %1 : Half):
+//   %4 : Half = onnx::Cast[to=10](%0)
+//   %5 : Half = onnx::Add(%1, %4)
+//   ...
+
+void ImplicitCastForBinaryInplaceOps(Block* b) {
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      ImplicitCastForBinaryInplaceOps(child_block);
+    }
+
+    // Check type if inplace operation is a binary node
+    if ((it->kind() == aten::add_) || (it->kind() == aten::sub_) ||
+        (it->kind() == aten::mul_) || (it->kind() == aten::div_)) {
+      auto orignalInputs = it->inputs();
+      TensorTypePtr firstInp_tensor =
+          orignalInputs.at(0)->type()->cast<TensorType>();
+      TensorTypePtr secondInp_tensor =
+          orignalInputs.at(1)->type()->cast<TensorType>();
+      if ((firstInp_tensor) && (secondInp_tensor) &&
+          (firstInp_tensor->scalarType().has_value())) {
+        auto newInputNode = it->owningGraph()->create(aten::type_as, 1);
+        newInputNode->insertBefore(*it);
+        newInputNode->addInput(orignalInputs.at(1));
+        newInputNode->addInput(orignalInputs.at(0));
+        it->replaceInput(1, newInputNode->outputs().at(0));
+      }
+    }
+  }
+}
 
 void RemoveInplaceOps(const std::shared_ptr<Graph>& graph) {
   ImplicitCastForBinaryInplaceOps(graph->block());

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -107,18 +107,22 @@ void ImplicitCastForBinaryInplaceOps(Block* b) {
     if ((it->kind() == aten::add_) || (it->kind() == aten::sub_) ||
         (it->kind() == aten::mul_) || (it->kind() == aten::div_)) {
       auto orignalInputs = it->inputs();
+      if (orignalInputs.at(0) == orignalInputs.at(1)) {
+        continue;
+      }
       TensorTypePtr firstInp_tensor =
           orignalInputs.at(0)->type()->cast<TensorType>();
       TensorTypePtr secondInp_tensor =
           orignalInputs.at(1)->type()->cast<TensorType>();
-      if ((firstInp_tensor) && (secondInp_tensor) &&
-          (firstInp_tensor->scalarType().has_value())) {
-        auto newInputNode = it->owningGraph()->create(aten::type_as, 1);
-        newInputNode->insertBefore(*it);
-        newInputNode->addInput(orignalInputs.at(1));
-        newInputNode->addInput(orignalInputs.at(0));
-        it->replaceInput(1, newInputNode->outputs().at(0));
+      if (!(firstInp_tensor) || !(secondInp_tensor) ||
+          !(firstInp_tensor->scalarType().has_value())) {
+        continue;
       }
+      auto newInputNode = it->owningGraph()->create(aten::type_as, 1);
+      newInputNode->insertBefore(*it);
+      newInputNode->addInput(orignalInputs.at(1));
+      newInputNode->addInput(orignalInputs.at(0));
+      it->replaceInput(1, newInputNode->outputs().at(0));
     }
   }
 }

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -1,3 +1,4 @@
+#include <torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.h>
 #include <torch/csrc/jit/passes/remove_inplace_ops.h>
 
 namespace torch {
@@ -77,6 +78,7 @@ void RemoveInplaceOps(Block* block) {
 } // namespace
 
 void RemoveInplaceOps(const std::shared_ptr<Graph>& graph) {
+  ImplicitCastForBinaryInplaceOps(graph->block());
   RemoveInplaceOps(graph->block());
 }
 } // namespace jit

--- a/torch/csrc/jit/passes/remove_inplace_ops.h
+++ b/torch/csrc/jit/passes/remove_inplace_ops.h
@@ -8,5 +8,7 @@ namespace torch {
 namespace jit {
 // see .cpp for docs
 TORCH_API void RemoveInplaceOps(const std::shared_ptr<Graph>& graph);
+
+TORCH_API void ImplicitCastForBinaryInplaceOps(Block* block);
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Modifications in remove_inplace_ops_for_onnx pass and remove_inplace_ops pass to better handle binary inplace ops

* Handles special case of binary inplace ops, where the first input node has a lower type precedence than the second input node. 
* When the inplace node is converted to a regular op, this information is lost and the resulting type is based on type precedence, just like regular ops. To avoid this loss of information, we add a cast node before the input node with the higher data type precedence, so that both the input types are the same.