### PR TITLE
Out variant for embedding_bag_4bit_rowwise_offsets

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -114,7 +114,8 @@ at::Tensor& embedding_lookup_fallback_impl(
 }
 
 template <typename IndexType, typename OffsetType>
-at::Tensor embedding_bag_4bit_impl(
+at::Tensor& embedding_bag_4bit_impl(
+    at::Tensor& output,
     const at::Tensor& weight,
     const at::Tensor& indices,
     const at::Tensor& offsets,
@@ -171,7 +172,7 @@ at::Tensor embedding_bag_4bit_impl(
   }
 
   const std::vector<int64_t> shape = {output_size, D};
-  auto output = at::empty(shape, weight.options().dtype(at::kFloat));
+  output.resize_(shape);
   auto* output_data = output.data_ptr<float>();
 
   const int64_t block_size = D;
@@ -490,7 +491,8 @@ at::Tensor& embedding_bag_byte_helper(
       is_embedding_op);
 }
 
-at::Tensor embedding_bag_4bit_helper(
+at::Tensor& embedding_bag_4bit_helper(
+    at::Tensor& output,
     const at::Tensor& weight,
     const at::Tensor& indices,
     const c10::optional<at::Tensor>& offsets_in,
@@ -539,6 +541,7 @@ at::Tensor embedding_bag_4bit_helper(
   // need to cast, which can be additional performance overhead
   if (indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kInt) {
     return embedding_bag_4bit_impl<int, int>(
+        output,
         weight,
         indices,
         offsets,
@@ -549,6 +552,7 @@ at::Tensor embedding_bag_4bit_helper(
   } else if (
       indices.scalar_type() == at::kInt && offsets.scalar_type() == at::kLong) {
     return embedding_bag_4bit_impl<int, int64_t>(
+        output,
         weight,
         indices,
         offsets,
@@ -559,6 +563,7 @@ at::Tensor embedding_bag_4bit_helper(
   } else if (
       indices.scalar_type() == at::kLong && offsets.scalar_type() == at::kInt) {
     return embedding_bag_4bit_impl<int64_t, int>(
+        output,
         weight,
         indices,
         offsets,
@@ -568,6 +573,7 @@ at::Tensor embedding_bag_4bit_helper(
         include_last_offset);
   }
   return embedding_bag_4bit_impl<int64_t, int64_t>(
+      output,
       weight,
       indices,
       offsets,
@@ -615,16 +621,18 @@ at::Tensor PackedEmbeddingBagWeight::embeddingbag_4bit(
         " instead")
   }
 
+  auto output = at::empty({0}, packed_w.options().dtype(at::kFloat));
   return embedding_bag_4bit_helper(
-      packed_w,
-      indices,
-      offsets_in,
-      pruned_weights,
-      per_sample_weights_.has_value()
-          ? per_sample_weights_.value().to(at::kFloat)
-          : per_sample_weights_,
-      compressed_indices_mapping,
-      include_last_offset);
+    output,
+    packed_w,
+    indices,
+    offsets_in,
+    pruned_weights,
+    per_sample_weights_.has_value()
+        ? per_sample_weights_.value().to(at::kFloat)
+        : per_sample_weights_,
+    compressed_indices_mapping,
+    include_last_offset);
 }
 
 namespace at {
@@ -680,6 +688,39 @@ Tensor embedding_bag_byte_rowwise_offsets(
   return output;
 }
 
+Tensor& embedding_bag_4bit_rowwise_offsets_out(
+    Tensor& output,
+    const Tensor& weight,
+    const Tensor& indices,
+    const c10::optional<Tensor>& offsets_in,
+    const bool /* scale_grad_by_freq */,
+    const int64_t /* mode */,
+    bool pruned_weights,
+    const c10::optional<Tensor>& per_sample_weights_,
+    const c10::optional<Tensor>& compressed_indices_mapping,
+    bool include_last_offset) {
+
+  if (per_sample_weights_.has_value()) {
+    TORCH_CHECK(
+        (per_sample_weights_.value().scalar_type() == at::kFloat ||
+         per_sample_weights_.value().scalar_type() == at::kHalf),
+        "Expect fp32 or fp16 weights, but found",
+        per_sample_weights_.value().scalar_type(),
+        " instead")
+  }
+  return embedding_bag_4bit_helper(
+      output,
+      weight,
+      indices,
+      offsets_in,
+      pruned_weights,
+      per_sample_weights_.has_value()
+          ? per_sample_weights_.value().to(at::kFloat)
+          : per_sample_weights_,
+      compressed_indices_mapping,
+      include_last_offset);
+}
+
 Tensor embedding_bag_4bit_rowwise_offsets(
     const Tensor& weight,
     const Tensor& indices,
@@ -690,25 +731,21 @@ Tensor embedding_bag_4bit_rowwise_offsets(
     const c10::optional<Tensor>& per_sample_weights_,
     const c10::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
-  if (per_sample_weights_.has_value()) {
-    TORCH_CHECK(
-        (per_sample_weights_.value().scalar_type() == at::kFloat ||
-         per_sample_weights_.value().scalar_type() == at::kHalf),
-        "Expect fp32 or fp16 weights, but found",
-        per_sample_weights_.value().scalar_type(),
-        " instead")
-  }
 
-  return embedding_bag_4bit_helper(
-      weight,
-      indices,
-      offsets_in,
-      pruned_weights,
-      per_sample_weights_.has_value()
-          ? per_sample_weights_.value().to(at::kFloat)
-          : per_sample_weights_,
-      compressed_indices_mapping,
-      include_last_offset);
+  auto output = at::empty({0}, weight.options().dtype(at::kFloat));
+  embedding_bag_4bit_rowwise_offsets_out(
+    output,
+    weight,
+    indices,
+    offsets_in,
+    false, // unused scale_grad_by_freq
+    0, // unused mode
+    pruned_weights,
+    per_sample_weights_,
+    compressed_indices_mapping,
+    include_last_offset
+  );
+  return output;
 }
 
 template <int bit_rate>

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.h
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.h
@@ -13,5 +13,17 @@ Tensor& embedding_bag_byte_rowwise_offsets_out(
     const c10::optional<Tensor>& per_sample_weights_,
     const c10::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset);
+
+Tensor embedding_bag_4bit_rowwise_offsets_out(
+    Tensor& output,
+    const Tensor& weight,
+    const Tensor& indices,
+    const c10::optional<Tensor>& offsets_in,
+    const bool /* scale_grad_by_freq */,
+    const int64_t /* mode */,
+    bool pruned_weights,
+    const c10::optional<Tensor>& per_sample_weights_,
+    const c10::optional<Tensor>& compressed_indices_mapping,
+    bool include_last_offset);
 } // native
 } // at

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -413,6 +413,40 @@ REGISTER_OPERATOR_FUNCTOR_OPT(
             include_last_offset);
       };
     });
+REGISTER_OPERATOR_FUNCTOR_OPT(
+    quantized::embedding_bag_4bit_rowwise_offsets_out,
+    embedding_bag_4bit_rowwise_offsets_out,
+    false, // don't reuse byte inputs
+    true,
+    [](Node* n) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        auto& weight = p_node->Input(0).toTensor();
+        auto& indices = p_node->Input(1).toTensor();
+        auto offsets = p_node->Input(2).toOptional<at::Tensor>();
+        auto pruned_weights = p_node->Input(5).toBool();
+        auto per_sample_weights = p_node->Input(6).toOptional<at::Tensor>();
+        auto compressed_indices_mapping =
+            p_node->Input(7).toOptional<at::Tensor>();
+        auto include_last_offset = p_node->Input(8).toBool();
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) =
+              at::empty({0}, weight.options().dtype(at::kFloat));
+        }
+        auto& out_t = p_node->Output(0).toTensor();
+        fastResizeToZero(out_t);
+        return at::native::embedding_bag_byte_rowwise_offsets_out(
+            out_t,
+            weight,
+            indices,
+            offsets,
+            false, // unused scale_grad_by_freq
+            0, // unused mode
+            pruned_weights,
+            per_sample_weights,
+            compressed_indices_mapping,
+            include_last_offset);
+      };
+    });
 
 // The out variant takes precedence over native
 REGISTER_OPERATOR_FUNCTOR(aten::narrow, aten_narrow, [](Node* n) -> SROperator {


### PR DESCRIPTION
Summary: Add out variant for embedding_bag_4bit_rowwise_offsets and add it to static runtime registry

Test Plan: TDB

Differential Revision: D26138322

