### PR TITLE
extend init_group_test timeout to 5s

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -550,7 +550,7 @@ class DistributedTest:
         @skip_if_small_worldsize
         @unittest.skipIf(BACKEND != "gloo", "Only gloo backend supports timeouts")
         def test_barrier_timeout_group(self):
-            timeout = timedelta(seconds=1)
+            timeout = timedelta(seconds=5)
             _, group_id, _ = self._init_group_test(timeout=timeout)
             if group_id is not None:
                 self._test_barrier_timeout(group_id, timeout)


### PR DESCRIPTION
Fixes #50662

![image](https://user-images.githubusercontent.com/16190118/106225549-58030300-6220-11eb-948d-1998bdafc245.png)

From: https://circleci.com/api/v1.1/project/github/pytorch/pytorch/10203733/output/105/0?file=true&allocation-id=60022ee190b8596d279f4531-0-build%2F195A7D58


