### PR TITLE
update sccache wrapper to accommodate new sccache for macos build

### DIFF
--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -12,6 +12,10 @@ if [ -z "${IN_CI}" ]; then
   export DEVELOPER_DIR=/Applications/Xcode9.app/Contents/Developer
 fi
 
+# This helper function wraps calls to binaries with sccache, but only if they're not already wrapped with sccache.
+# For example, `clang` will be `sccache clang`, but `sccache clang` will not become `sccache sccache clang`.
+# The way this is done is by detecting the command of the parent pid of the current process and checking whether
+# that is sccache, and wrapping sccache around the process if its parent were not already sccache.
 function write_sccache_stub() {
   printf "#!/bin/sh\nif [ \$(ps auxc \$(ps auxc -o ppid \$\$ | grep \$\$ | rev | cut -d' ' -f1 | rev) | tr '\\\\n' ' ' | rev | cut -d' ' -f2 | rev) != sccache ]; then\n  exec sccache %s \"\$@\"\nelse\n  exec %s \"\$@\"\nfi" "$(which $1)" "$(which $1)" > "${WORKSPACE_DIR}/$1"
   chmod a+x "${WORKSPACE_DIR}/$1"

--- a/.jenkins/pytorch/macos-build.sh
+++ b/.jenkins/pytorch/macos-build.sh
@@ -13,7 +13,7 @@ if [ -z "${IN_CI}" ]; then
 fi
 
 function write_sccache_stub() {
-  printf "#!/bin/sh\nif [ \$(ps auxc \$(ps auxc -o ppid \$\$ | grep \$\$ | rev | cut -d' ' -f1 | rev) | tr '\\\\n' ' ' | rev | cut -d' ' -f2 | rev) != sccache ]; then\n  exec sccache $(which $1) \"\$@\"\nelse\n  exec $(which $1) \"\$@\"\nfi" > "${WORKSPACE_DIR}/$1"
+  printf "#!/bin/sh\nif [ \$(ps auxc \$(ps auxc -o ppid \$\$ | grep \$\$ | rev | cut -d' ' -f1 | rev) | tr '\\\\n' ' ' | rev | cut -d' ' -f2 | rev) != sccache ]; then\n  exec sccache %s \"\$@\"\nelse\n  exec %s \"\$@\"\nfi" "$(which $1)" "$(which $1)" > "${WORKSPACE_DIR}/$1"
   chmod a+x "${WORKSPACE_DIR}/$1"
 }
 


### PR DESCRIPTION
Before I change sccache to point to the newer version in the S3 bucket, this PR makes sure the new sccache wrapper works.

This PR previously tested a newer version of sccache for macos build jobs. Last sccache used is over a year old. The results of using both are different, but the speed isn't too impacted, see below.

With newer sccache and alternate wrapper script from this PR: https://app.circleci.com/pipelines/github/pytorch/pytorch/271777/workflows/b5c6a75e-781a-4c0f-8c99-ff2cbe1e877c/jobs/10808567

With old sccache: https://app.circleci.com/pipelines/github/pytorch/pytorch/271875/workflows/962079ce-e146-482e-b493-c99004f8d89a/jobs/10805680