### PR TITLE
Fix: Bad autograd side effects from printing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7355,6 +7355,19 @@ class TestAutogradDeviceType(TestCase):
         x.sum().backward()
         self.assertEqual(root.grad.tolist(), [[1, 2], [1, 1]])
 
+    def test_inplace_view_then_no_grad(self, device):
+        # Perform an in-place operation on a view of a non-leaf variable.
+        a = torch.ones(3, 1, device=device, requires_grad=True)
+        b = a * 2
+        c = b.view_as(b)
+        c[0][0] = 3
+
+        # Force a graph update with grad disabled.
+        with torch.no_grad():
+            c.grad_fn
+
+        c.sum().backward()
+
     def test_inplace_view_gradcheck(self, device):
         # gradcheck modifications to views
         a = torch.randn(4, 4, device=device, requires_grad=True)

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -212,7 +212,7 @@ auto Function<T>::apply(Args&&... args) -> std::enable_if_t<std::is_same<X,T>::v
   extract_vars(node->is_variable_input_, input_vars, args...);
 
   bool is_executable =  GradMode::is_enabled() && any_variable_requires_grad(input_vars);
-  auto next_edges = collect_next_edges(input_vars);
+  auto next_edges = (is_executable ? collect_next_edges(input_vars) : edge_list());
   node->set_ctx_grad_fn(node);
   node->set_next_edges(std::move(next_edges));
   node->clear_input_metadata();

--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -504,8 +504,6 @@ inline bool any_variable_requires_grad(const variable_list& variables) {
 /// Return the next edges of all the given variables, or tuples of variables.
 template <typename... Variables>
 edge_list collect_next_edges(Variables&&... variables) {
-  if (!GradMode::is_enabled())
-    return {};
   detail::MakeNextFunctionList make;
   make.apply(std::forward<Variables>(variables)...);
   return std::move(make.next_edges);

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -22,7 +22,7 @@ variable_list wrap_outputs(const variable_list& inputs, tensor_list&& outputs,
       }
     }
   } else {
-    auto grad_fn = ctr(collect_next_edges(inputs));
+    auto grad_fn = ctr(GradMode::is_enabled() ? collect_next_edges(inputs) : edge_list());
     for (auto& output : outputs) {
       if (output.defined()) {
         auto variable = autograd::make_variable(output, /*requires_grad=*/false);

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -487,7 +487,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
   }
 
   flags.is_executable = GradMode::is_enabled() && any_variable_requires_grad(unpacked.input_vars);
-  flags.next_edges = collect_next_edges(unpacked.input_vars);
+  flags.next_edges = (flags.is_executable ? collect_next_edges(unpacked.input_vars) : edge_list());
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -452,14 +452,14 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(const Tenso
           fn->storage_offset = self.storage_offset();
 
           // If we are here, the tensor we are operating on is a differentiable view, meaning
-          // that a valid graph exists and its validity should be maintained. To ensure this,
-          // we temporarily enable grad mode here while collecting edges. Without this logic,
-          // the collected edges will be an empty set, and the graph will be invalidated by
-          // connecting the new node to nowhere.
-          auto grad_enabled = GradMode::is_enabled();
-          GradMode::set_enabled(true);
-          fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
-          GradMode::set_enabled(grad_enabled);
+          // that a valid graph exists to which we should attach the new node. To do this
+          // correctly, we temporarily disable grad mode here while collecting edges. Without
+          // this logic, the collected edges will be an empty set, and the graph will be
+          // invalidated by connecting the new node to nowhere.
+          {
+            AutoGradMode grad_mode(true);
+            fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
+          }
 
           fn->add_input_metadata(
             view_info.base_.options(),

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -450,17 +450,7 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(const Tenso
           fn->size = self.sizes().vec();
           fn->stride = self.strides().vec();
           fn->storage_offset = self.storage_offset();
-
-          // If we are here, the tensor we are operating on is a differentiable view, meaning
-          // that a valid graph exists to which we should attach the new node. To do this
-          // correctly, we temporarily disable grad mode here while collecting edges. Without
-          // this logic, the collected edges will be an empty set, and the graph will be
-          // invalidated by connecting the new node to nowhere.
-          {
-            AutoGradMode grad_mode(true);
-            fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
-          }
-
+          fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
           fn->add_input_metadata(
             view_info.base_.options(),
             self.sizes(), // Note: sizes(), not base_.sizes(), is intentional


### PR DESCRIPTION
Fixes #49756

## Background
Fix applied here is to remove the grad enabled check from `collect_next_edges`, unconditionally returning the actual collected edges. This pushes the responsibility for determining whether the function should be called without grad mode to its call-sites. With this update, `collect_next_edges` will no longer incorrectly return an empty list, which caused the problem described in the issue. Three call-sites depended on this behavior and have been updated.

Beyond bad printing side effects, this fix addresses the more general issue of accessing `grad_fn` with grad mode disabled after an in-place operation on a view. The included test verifies this without the use of print.

## Test Plan
```
python test/test_autograd.py TestAutogradDeviceTypeCPU.test_inplace_view_then_no_grad_cpu
```