### PR TITLE
.github: Up frequency of stale checks

### DIFF
--- a/.github/workflows/stale_pull_requests.yml
+++ b/.github/workflows/stale_pull_requests.yml
@@ -1,7 +1,8 @@
 name: 'Close stale pull requests'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    # TODO: Reduce frequency once we work through the backlog of pull requests
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51365 .github: Up frequency of stale checks**

We have a pretty big backlog of PRs when it comes to checking for stale and the action only supports processing 30 PRs at a given time.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D26153785](https://our.internmc.facebook.com/intern/diff/D26153785)