### PR TITLE
Fix Dirichlet.arg_constraints event_dim

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3926,6 +3926,11 @@ class TestConstraints(TestCase):
                     except KeyError:
                         continue  # ignore optional parameters
 
+                    # Check param shape is compatible with distribution shape.
+                    self.assertGreaterEqual(value.dim(), constraint.event_dim)
+                    value_batch_shape = value.shape[:value.dim() - constraint.event_dim]
+                    torch.broadcast_shapes(dist.batch_shape, value_batch_shape)
+
                     if is_dependent(constraint):
                         continue
 

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -40,7 +40,7 @@ class Dirichlet(ExponentialFamily):
         concentration (Tensor): concentration parameter of the distribution
             (often referred to as alpha)
     """
-    arg_constraints = {'concentration': constraints.positive}
+    arg_constraints = {'concentration': constraints.independent(constraints.positive, 1)}
     support = constraints.simplex
     has_rsample = True
 


### PR DESCRIPTION
This fix ensures
```py
Dirichlet.arg_constraints["concentration"].event_dim == 1
```
which was missed in #50547

## Tested
- [x] added a regression test, covering all distributions