### PR TITLE
[JIT] allow fbcode hooks to be saved with flag

### DIFF
--- a/torch/csrc/jit/api/module_save.cpp
+++ b/torch/csrc/jit/api/module_save.cpp
@@ -1,18 +1,29 @@
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/serialization/export.h>
 
+C10_DEFINE_bool(
+  torch_jit_serialize_modules_with_hooks_fbcode,
+  false,
+  "Allows modules with hooks to be serialized in FBCODE. WARNING: only "
+  "enable after you verify the PyTorch binary which will load the "
+  "serialized modules with hooks is older than 1/21/2021. Otherwise the "
+  "loading binary will throw a Runtime error.");
+
 namespace torch {
 namespace jit {
 
 void Module::save(std::ostream& out, const ExtraFilesMap& extra_files) const {
 #ifdef FBCODE_CAFFE2
-  if (this->type()->getForwardHooks().size() > 0 ||
-      this->type()->getForwardPreHooks().size() > 0) {
+  if ((this->type()->getForwardHooks().size() > 0 ||
+      this->type()->getForwardPreHooks().size() > 0) &&
+      !FLAGS_torch_jit_serialize_modules_with_hooks_fbcode) {
     throw std::runtime_error(
         "Cannot save module '" + this->type()->name()->name() +
         "' because it has forward hooks or pre-hooks attached. " +
-        "Saving modules with hooks not supported in FBCODE yet. Please " +
-        "remove the hooks before scripting if you want to save this model.");
+        "To enable serializing modules with hooks attached, set " +
+        "flag 'torch_jit_serialize_modules_with_hooks_fbcode' " +
+        "to true after verifying that the PyTorch binary which is to load " +
+        "the module with serizliaed hooks is older than 1/21/2021. ");
   }
 #endif
   ExportModule(*this, out, extra_files, false /* bytecode_format */);
@@ -21,13 +32,16 @@ void Module::save(std::ostream& out, const ExtraFilesMap& extra_files) const {
 void Module::save(const std::string& filename, const ExtraFilesMap& extra_files)
     const {
 #ifdef FBCODE_CAFFE2
-  if (this->type()->getForwardHooks().size() > 0 ||
-      this->type()->getForwardPreHooks().size() > 0) {
+  if ((this->type()->getForwardHooks().size() > 0 ||
+      this->type()->getForwardPreHooks().size() > 0) &&
+      !FLAGS_torch_jit_serialize_modules_with_hooks_fbcode) {
     throw std::runtime_error(
         "Cannot save module '" + this->type()->name()->name() +
         "' because it has forward hooks or pre-hooks attached. " +
-        "Saving modules with hooks not supported in FBCODE yet. Please " +
-        "remove the hooks before scripting if you want to save this model.");
+        "To enable serializing modules with hooks attached, set " +
+        "flag 'torch_jit_serialize_modules_with_hooks_fbcode' " +
+        "to true after verifying that the PyTorch binary which is to load " +
+        "the module with serizliaed hooks is older than 1/21/2021. ");
   }
 #endif
   ExportModule(*this, filename, extra_files, false /* bytecode_format */);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51371 [JIT] allow fbcode hooks to be saved with flag**

Differential Revision: [D26155850](https://our.internmc.facebook.com/intern/diff/D26155850)