### PR TITLE
Improve PyTorch profiler flop computation formulas

### DIFF
--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -2321,29 +2321,40 @@ TEST(ComputeFlopsTest, Basic) {
 
   // Test aten::conv2d
   extra_args.clear();
-  std::vector<int64_t> input_sizes = {4, 5, 6, 7};
-  std::vector<int64_t> weight_sizes = {3, 5, 2, 1};
-  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_sizes));
-  extra_args["weight_size"] = at::IValue(at::IntArrayRef(weight_sizes));
-  extra_args["stride"] = 1;
-  extra_args["dilation"] = 0;
+  std::vector<int64_t> input_size = {4, 5, 6, 7};
+  std::vector<int64_t> weight_size = {3, 5, 2, 1};
+  std::vector<int64_t> padding = {1, 0};
+  std::vector<int64_t> stride = {1, 1};
+  std::vector<int64_t> dilation = {0, 0};
+  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_size));
+  extra_args["weight_size"] = at::IValue(at::IntArrayRef(weight_size));
   extra_args["groups"] = 1;
+  extra_args["padding"] = at::IValue(at::IntArrayRef(padding));
+  extra_args["stride"] = at::IValue(at::IntArrayRef(stride));
+  extra_args["dilation"] = at::IValue(at::IntArrayRef(dilation));
   flops = computeFlops(std::string("aten::conv2d"), extra_args);
-  ASSERT_EQ(flops, 10080);
+  ASSERT_EQ(flops, 13440);
 
   // Test aten::conv2d fail
-  extra_args.clear();
-  input_sizes = {4, 5, 6, 7};
-  weight_sizes = {4, 5, 6};
-  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_sizes));
-  extra_args["weight_size"] = at::IValue(at::IntArrayRef(weight_sizes));
+  input_size = {4, 5, 6, 7};
+  weight_size = {4, 5, 6};
+  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_size));
+  extra_args["weight_size"] = at::IValue(at::IntArrayRef(weight_size));
   flops = computeFlops(std::string("aten::conv2d"), extra_args);
   ASSERT_EQ(flops, 0);
 
   // Test aten::conv2d fail 2
+  weight_size = {3, 5, 2, 1};
+  stride = {0, 0};
+  extra_args["weight_size"] = at::IValue(at::IntArrayRef(input_size));
+  extra_args["stride"] = at::IValue(at::IntArrayRef(stride));
+  flops = computeFlops(std::string("aten::conv2d"), extra_args);
+  ASSERT_EQ(flops, 0);
+
+  // Test aten::conv2d fail 3
   extra_args.clear();
-  input_sizes = {4, 5, 6, 7};
-  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_sizes));
+  input_size = {4, 5, 6, 7};
+  extra_args["input_size"] = at::IValue(at::IntArrayRef(input_size));
   flops = computeFlops(std::string("aten::conv2d"), extra_args);
   ASSERT_EQ(flops, 0);
 
@@ -2354,7 +2365,7 @@ TEST(ComputeFlopsTest, Basic) {
   extra_args["mat1_size"] = at::IValue(at::IntArrayRef(mat1_sizes));
   extra_args["mat2_size"] = at::IValue(at::IntArrayRef(mat2_sizes));
   flops = computeFlops(std::string("aten::mm"), extra_args);
-  ASSERT_EQ(flops, 21600);
+  ASSERT_EQ(flops, 43200);
 
   // Test mm out of range
   extra_args.clear();
@@ -2365,14 +2376,14 @@ TEST(ComputeFlopsTest, Basic) {
   extra_args.clear();
   std::vector<int64_t> mat_sizes = {3, 4, 5, 6};
   extra_args["mat_size"] = at::IValue(at::IntArrayRef(mat_sizes));
-  flops = computeFlops(std::string("aten::add.Tensor"), extra_args);
+  flops = computeFlops(std::string("aten::add"), extra_args);
   ASSERT_EQ(flops, 360);
 
   // Test aten::mul.Tensor
   extra_args.clear();
   mat_sizes = {3, 4, 5, 6};
   extra_args["mat_size"] = at::IValue(at::IntArrayRef(mat_sizes));
-  flops = computeFlops(std::string("aten::mul.Tensor"), extra_args);
+  flops = computeFlops(std::string("aten::mul"), extra_args);
   ASSERT_EQ(flops, 360);
 }
 

--- a/torch/csrc/autograd/profiler_utils.cpp
+++ b/torch/csrc/autograd/profiler_utils.cpp
@@ -10,15 +10,15 @@ static constexpr auto kConv2dGroups = 6;
 // List of supported operators
 static constexpr auto kConv2dOp = "aten::conv2d";
 static constexpr auto kGemmOp = "aten::mm";
-static constexpr auto kMulOp = "aten::mul.Tensor";
-static constexpr auto kAddOp = "aten::add.Tensor";
+static constexpr auto kMulOp = "aten::mul";
+static constexpr auto kAddOp = "aten::add";
 
 static constexpr auto kInputSize = "input_size";
 static constexpr auto kWeightSize = "weight_size";
-static constexpr auto kStride = "stride";
-static constexpr auto kPadding = "padding";
-static constexpr auto kDilation = "dilation";
 static constexpr auto kGroups = "groups";
+static constexpr auto kPadding = "padding";
+static constexpr auto kStride = "stride";
+static constexpr auto kDilation = "dilation";
 static constexpr auto kMatSize = "mat_size";
 static constexpr auto kMat1Size = "mat1_size";
 static constexpr auto kMat2Size = "mat2_size";
@@ -115,21 +115,49 @@ std::unordered_map<std::string, c10::IValue> saveExtraArgs(const at::RecordFunct
 uint64_t computeFlops(const std::string &op_name, const std::unordered_map<std::string, c10::IValue> &extra_args) {
   if (op_name == kConv2dOp) {
     if (extra_args.find(kInputSize) == extra_args.end()
-        || extra_args.find(kWeightSize) == extra_args.end()) {
-      TORCH_WARN("Calculating flops for aten::conv2d requires input_size and weight_size in saved arguments.");
+        || extra_args.find(kWeightSize) == extra_args.end()
+        || extra_args.find(kGroups) == extra_args.end()
+        || extra_args.find(kPadding) == extra_args.end()
+        || extra_args.find(kStride) == extra_args.end()
+        || extra_args.find(kDilation) == extra_args.end()) {
+      TORCH_WARN("Calculating flops for aten::conv2d requires groups, padding, stride, dilation, input_size, and weight_size in saved arguments.");
       return 0;
     }
     auto input_sizes_ref = extra_args.at(kInputSize);
     auto kernel_sizes_ref = extra_args.at(kWeightSize);
+    auto groups_ref = extra_args.at(kGroups);
+    auto padding_ref = extra_args.at(kPadding);
+    auto stride_ref = extra_args.at(kStride);
+    auto dilation_ref = extra_args.at(kDilation);
     if (!input_sizes_ref.isIntList() || !kernel_sizes_ref.isIntList()) {
       TORCH_WARN("Failed to compute flops for op aten::conv2d because it requires input and weight tensor sizes.");
+      return 0;
+    }
+    if (!padding_ref.isIntList() || !stride_ref.isIntList() || !dilation_ref.isIntList()) {
+      TORCH_WARN("Failed to compute flops for op aten::conv2d because it requires padding, stride, and dilation values.");
       return 0;
     }
 
     const std::vector<int64_t> input_sizes = input_sizes_ref.toIntVector();
     const std::vector<int64_t> kernel_sizes = kernel_sizes_ref.toIntVector();
+    const uint64_t groups = groups_ref.toInt();
+    const std::vector<int64_t> padding = padding_ref.toIntVector();
+    const std::vector<int64_t> stride = stride_ref.toIntVector();
+    const std::vector<int64_t> dilation = dilation_ref.toIntVector();
     if (input_sizes.size() != 4 || kernel_sizes.size() != 4) {
       TORCH_WARN("Failed to compute flops for op aten::conv2d because both input and weight must be size 4.");
+      return 0;
+    }
+    if (!groups) {
+      TORCH_WARN("Failed to compute flops for op aten::conv2d because group size must not be 0.");
+      return 0;
+    }
+    if (padding.size() != 2 || dilation.size() != 2) {
+      TORCH_WARN("Failed to compute flops for op aten::conv2d because both padding and dilation must be size 2.");
+      return 0;
+    }
+    if (stride.size() != 2 || (stride[0] * stride[1] == 0)) {
+      TORCH_WARN("Failed to compute flops for op aten::conv2d because stride must be size 2 and cannot be 0.");
       return 0;
     }
     // format of the input is defined in torch.nn.quantized.functional.conv2d()
@@ -140,9 +168,11 @@ uint64_t computeFlops(const std::string &op_name, const std::unordered_map<std::
                                                                          input_sizes[2], input_sizes[3]);
     std::tie(out_channels, std::ignore, kernel_h, kernel_w) = std::make_tuple(kernel_sizes[0], kernel_sizes[1],
                                                                               kernel_sizes[2], kernel_sizes[3]);
+    uint64_t output_h = (input_h + 2 * padding[0] - dilation[0] * (kernel_h - 1) - 1) / stride[0] + 1;
+    uint64_t output_w = (input_w + 2 * padding[1] - dilation[1] * (kernel_w - 1) - 1) / stride[1] + 1;
 
-    // grouping is NOT properly handled yet
-    return conv2d_multiply_factor * minibatch * input_h * input_w * kernel_h * kernel_w * in_channels * out_channels;
+    return conv2d_multiply_factor * minibatch * output_h * output_w *
+           kernel_h * kernel_w * in_channels * out_channels / groups;
   } else if (op_name == kGemmOp) {
     if (extra_args.find(kMat1Size) == extra_args.end()
         || extra_args.find(kMat2Size) == extra_args.end()) {
@@ -162,6 +192,7 @@ uint64_t computeFlops(const std::string &op_name, const std::unordered_map<std::
       return 0;
     } else {
       int64_t overlap_dim = mat1_size.back();
+      const uint64_t gemm_multiply_factor = 2;
       uint64_t flops = 1;
       for(int64_t dim : mat1_size) {
         flops *= dim;
@@ -170,6 +201,7 @@ uint64_t computeFlops(const std::string &op_name, const std::unordered_map<std::
       for(int64_t dim : mat2_size) {
         flops *= dim;
       }
+      flops *= gemm_multiply_factor;
       return flops;
     }
   } else if (op_name == kMulOp) {


### PR DESCRIPTION
Summary:

Improve the flops computation formula of aten::conv2d operator to support stride, pad, dilation, and groups arguments.

This diff also fixes the following issues:
- Apply a factor of 2 to aten::mm because output accounts for multiplication and addition.
- Fix incorrect names of scalar operators to aten::mul and aten::add.

Test Plan:

```python
python test/test_profiler.py
```

