### PR TITLE
[PyTorch] Provide overload of torchCheckFail taking `const char*`

### DIFF
--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -82,6 +82,10 @@ void torchCheckFail(const char *func, const char *file, uint32_t line, const std
   throw ::c10::Error({func, file, line}, msg);
 }
 
+void torchCheckFail(const char *func, const char *file, uint32_t line, const char* msg) {
+  throw ::c10::Error({func, file, line}, msg);
+}
+
 } // namespace detail
 
 namespace Warning {

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -353,6 +353,7 @@ namespace c10 {
 namespace detail {
 
 [[noreturn]] C10_API void torchCheckFail(const char *func, const char *file, uint32_t line, const std::string& msg);
+[[noreturn]] C10_API void torchCheckFail(const char *func, const char *file, uint32_t line, const char* msg);
 
 } // namespace detail
 } // namespace 10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51389 [PyTorch] Provide overload of torchCheckFail taking `const char*`**

This should reduce code size when STRIP_ERROR_MESSAGES is defined by allowing callers of TORCH_CHECK to avoid creating `std::string`s.

Differential Revision: [D25891476](https://our.internmc.facebook.com/intern/diff/D25891476/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D25891476/)!