### PR TITLE
[quantization] Fix QuantizedLayerNorm zero_point and scale loading via register_buffer

### DIFF
--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -16,8 +16,8 @@ class LayerNorm(torch.nn.LayerNorm):
             normalized_shape, eps=eps, elementwise_affine=elementwise_affine)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor([scale]))
+        self.register_buffer('zero_point', torch.tensor([zero_point]))
 
     def forward(self, input):
         return torch.ops.quantized.layer_norm(


### PR DESCRIPTION
Summary: Register zero_point and scale of QuantizedLayerNorm as buffers so that they are saved to state_dicts.

Test Plan: TBD

Differential Revision: D26111722

