### PR TITLE
Remove android toolchain in Windows CircleCI image

### DIFF
--- a/.circleci/scripts/binary_windows_build.sh
+++ b/.circleci/scripts/binary_windows_build.sh
@@ -27,6 +27,10 @@ if [[ "$CIRCLECI" == 'true' && -d "C:\\ProgramData\\Microsoft\\VisualStudio\\Pac
   mv _Instances "C:\\ProgramData\\Microsoft\\VisualStudio\\Packages"
 fi
 
+if [[ "$CIRCLECI" == 'true' && -d "C:\\Microsoft" ]]; then
+  rm -rf "C:\\Microsoft\\Android*"
+fi
+
 echo "Free space on filesystem before build:"
 df -h
 


### PR DESCRIPTION
Fixes #{issue number}
It can spare nearly 10 GB of disk space.