### PR TITLE
[Vulkan] Remove redundant qualifiers on writeonly images.

### DIFF
--- a/aten/src/ATen/native/vulkan/glsl/adaptive_avg_pool2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/adaptive_avg_pool2d.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 kernel;
   vec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/add.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add.glsl
@@ -5,10 +5,10 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput0;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uInput1;
-layout(set = 0, binding = 3)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput0;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uInput1;
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec3 size;
   float alpha;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/add_scalar.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/add_scalar.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/addmm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/addmm.glsl
@@ -5,11 +5,11 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uM1;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uM2;
-layout(set = 0, binding = 3)          uniform PRECISION                    sampler3D uT;
-layout(set = 0, binding = 4)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uM1;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uM2;
+layout(set = 0, binding = 3) uniform PRECISION                    sampler3D uT;
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 multiplier;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/avg_pool2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/avg_pool2d.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/clamp.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/clamp.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   vec2 clamp;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d.glsl
@@ -5,13 +5,13 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uKernel;
-layout(set = 0, binding = 3)          buffer  PRECISION restrict readonly  Bias {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uKernel;
+layout(set = 0, binding = 3) buffer  PRECISION restrict readonly  Bias {
   vec4 data[];
 } uBias;
-layout(set = 0, binding = 4)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 ikernel;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_dw.glsl
@@ -5,13 +5,13 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uKernel;
-layout(set = 0, binding = 3)          buffer  PRECISION restrict readonly  Bias {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uKernel;
+layout(set = 0, binding = 3) buffer  PRECISION restrict readonly  Bias {
   vec4 data[];
 } uBias;
-layout(set = 0, binding = 4)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 kernel;
   ivec2 stride;

--- a/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/conv2d_pw.glsl
@@ -5,13 +5,13 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uKernel;
-layout(set = 0, binding = 3)          buffer  PRECISION restrict readonly  Bias {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uKernel;
+layout(set = 0, binding = 3) buffer  PRECISION restrict readonly  Bias {
   vec4 data[];
 } uBias;
-layout(set = 0, binding = 4)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 4) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 stride;
   ivec2 padding;

--- a/aten/src/ATen/native/vulkan/glsl/mean.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mean.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 isize;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/mean2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mean2d.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 isize;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/mm.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mm.glsl
@@ -5,10 +5,10 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uM1;
-layout(set = 0, binding = 2)          uniform PRECISION                    sampler3D uM2;
-layout(set = 0, binding = 3)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uM1;
+layout(set = 0, binding = 2) uniform PRECISION                    sampler3D uM2;
+layout(set = 0, binding = 3) uniform PRECISION restrict           Block {
   ivec4 size;
 } uBlock;
 

--- a/aten/src/ATen/native/vulkan/glsl/mul_scalar.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/mul_scalar.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec3 size;
   float other;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/nchw_to_image.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/nchw_to_image.glsl
@@ -5,11 +5,11 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D uImage;
-layout(set = 0, binding = 1)          buffer  PRECISION restrict readonly  Buffer {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D uImage;
+layout(set = 0, binding = 1) buffer  PRECISION restrict readonly  Buffer {
   float data[];
 } uBuffer;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec4 offset;
 } uBlock;

--- a/aten/src/ATen/native/vulkan/glsl/upsample_nearest2d.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/upsample_nearest2d.glsl
@@ -5,9 +5,9 @@ layout(std430) buffer;
 
 /* Qualifiers: layout - storage - precision - memory */
 
-layout(set = 0, binding = 0, rgba16f) uniform PRECISION restrict writeonly image3D   uOutput;
-layout(set = 0, binding = 1)          uniform PRECISION                    sampler3D uInput;
-layout(set = 0, binding = 2)          uniform PRECISION restrict           Block {
+layout(set = 0, binding = 0) uniform PRECISION restrict writeonly image3D   uOutput;
+layout(set = 0, binding = 1) uniform PRECISION                    sampler3D uInput;
+layout(set = 0, binding = 2) uniform PRECISION restrict           Block {
   ivec4 size;
   ivec2 isize;
   vec2 scale;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51425 [Vulkan] Remove redundant qualifiers on writeonly images.**
* #51423 [Vulkan] Improve error handling in a few places.

Differential Revision: [D26179605](https://our.internmc.facebook.com/intern/diff/D26179605)