### PR TITLE
[fx] import torch.fx in torch/__init__.py

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -598,6 +598,7 @@ import torch.autograd
 from torch.autograd import no_grad, enable_grad, set_grad_enabled
 import torch.fft
 import torch.futures
+import torch.fx
 import torch.nn
 import torch.nn.intrinsic
 import torch.nn.quantizable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51433 [fx] import torch.fx in torch/__init__.py**

This makes somthing like:

    import torch
    torch.fx.symbolic_trace(foo)

actually work.

Differential Revision: [D26169082](https://our.internmc.facebook.com/intern/diff/D26169082)