### PR TITLE
Fixes docs

### DIFF
--- a/docs/source/notes/broadcasting.rst
+++ b/docs/source/notes/broadcasting.rst
@@ -3,7 +3,8 @@
 Broadcasting semantics
 ======================
 
-Many PyTorch operations support :any:`NumPy Broadcasting Semantics <numpy.doc.broadcasting>`.
+Many PyTorch operations support NumPy's broadcasting semantics.
+See https://numpy.org/doc/stable/user/basics.broadcasting.html for details.
 
 In short, if a PyTorch operation supports broadcast, then its Tensor arguments can be
 automatically expanded to be of equal sizes (without making copies of the data).


### PR DESCRIPTION
pytorch_python_doc_build is failing with:

```
Jan 31 04:30:45 /var/lib/jenkins/workspace/docs/source/notes/broadcasting.rst:6: WARNING: 'any' reference target not found: numpy.doc.broadcasting
```

this removes the incorrect reference and adds an updated link.