### PR TITLE
fix AdaptiveAveragePooling crash problem for non support input

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
@@ -30,52 +30,49 @@ static void adaptive_avg_pool3d_out_frame(
     int64_t istrideT,
     int64_t istrideH,
     int64_t istrideW) {
-  int64_t d = 0;
-  at::internal::lazy_init_num_threads();
-#pragma omp parallel for private(d)
-  for (d = 0; d < sizeD; d++) {
-    /* loop over output */
-    int64_t ot, oh, ow;
-    for (ot = 0; ot < osizeT; ot++) {
-      int istartT = start_index(ot, osizeT, isizeT);
-      int iendT = end_index(ot, osizeT, isizeT);
-      int kT = iendT - istartT;
+  at::parallel_for(0, sizeD, 1, [&](int64_t start, int64_t end) {
+    for (int64_t d = start; d < end; d++) {
+      /* loop over output */
+      for (int64_t ot = 0; ot < osizeT; ot++) {
+        int istartT = start_index(ot, osizeT, isizeT);
+        int iendT = end_index(ot, osizeT, isizeT);
+        int kT = iendT - istartT;
 
-      for (oh = 0; oh < osizeH; oh++) {
-        int istartH = start_index(oh, osizeH, isizeH);
-        int iendH = end_index(oh, osizeH, isizeH);
-        int kH = iendH - istartH;
+        for (int64_t oh = 0; oh < osizeH; oh++) {
+          int istartH = start_index(oh, osizeH, isizeH);
+          int iendH = end_index(oh, osizeH, isizeH);
+          int kH = iendH - istartH;
 
-        for (ow = 0; ow < osizeW; ow++) {
-          int istartW = start_index(ow, osizeW, isizeW);
-          int iendW = end_index(ow, osizeW, isizeW);
-          int kW = iendW - istartW;
+          for (int64_t ow = 0; ow < osizeW; ow++) {
+            int istartW = start_index(ow, osizeW, isizeW);
+            int iendW = end_index(ow, osizeW, isizeW);
+            int kW = iendW - istartW;
 
-          /* local pointers */
-          scalar_t* ip = input_p + d * istrideD + istartT * istrideT +
-              istartH * istrideH + istartW * istrideW;
-          scalar_t* op = output_p + d * osizeT * osizeH * osizeW +
-              ot * osizeH * osizeW + oh * osizeW + ow;
+            /* local pointers */
+            scalar_t* ip = input_p + d * istrideD + istartT * istrideT +
+                istartH * istrideH + istartW * istrideW;
+            scalar_t* op = output_p + d * osizeT * osizeH * osizeW +
+                ot * osizeH * osizeW + oh * osizeW + ow;
 
-          /* compute local average: */
-          scalar_t sum = 0;
-          int it, ih, iw;
-          for (it = 0; it < kT; it++) {
-            for (ih = 0; ih < kH; ih++) {
-              for (iw = 0; iw < kW; iw++) {
-                scalar_t val =
-                    *(ip + it * istrideT + ih * istrideH + iw * istrideW);
-                sum += val;
+            /* compute local average: */
+            scalar_t sum = 0;
+            for (int it = 0; it < kT; it++) {
+              for (int ih = 0; ih < kH; ih++) {
+                for (int iw = 0; iw < kW; iw++) {
+                  scalar_t val =
+                      *(ip + it * istrideT + ih * istrideH + iw * istrideW);
+                  sum += val;
+                }
               }
             }
-          }
 
-          /* set output to local average */
-          *op = sum / kT / kH / kW;
+            /* set output to local average */
+            *op = sum / kT / kH / kW;
+          }
         }
       }
     }
-  }
+  });
 }
 
 void adaptive_avg_pool3d_out_cpu_template(
@@ -138,30 +135,31 @@ void adaptive_avg_pool3d_out_cpu_template(
         });
   } else {
     output.resize_({input.size(-5), sizeD, osizeT, osizeH, osizeW});
-    at::internal::lazy_init_num_threads();
-    int64_t b = 0;
-#pragma omp parallel for private(b)
-    for (b = 0; b < input.size(0); b++) {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-          input.scalar_type(), "adaptive_avg_pool3d_cpu", [&] {
-            auto input_data = input.data_ptr<scalar_t>();
-            auto output_data = output.data_ptr<scalar_t>();
-            adaptive_avg_pool3d_out_frame<scalar_t>(
-                input_data + b * input.stride(0),
-                output_data + b * sizeD * osizeT * osizeH * osizeW,
-                sizeD,
-                isizeT,
-                isizeH,
-                isizeW,
-                osizeT,
-                osizeH,
-                osizeW,
-                istrideD,
-                istrideT,
-                istrideH,
-                istrideW);
+    int64_t n = input.size(0);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        input.scalar_type(), "adaptive_avg_pool3d_cpu", [&] {
+          auto input_data = input.data_ptr<scalar_t>();
+          auto output_data = output.data_ptr<scalar_t>();
+          at::parallel_for(0, n, 1, [&](int64_t start, int64_t end) {
+            for (int64_t b = start; b < end; ++b) {
+              adaptive_avg_pool3d_out_frame<scalar_t>(
+                  input_data + b * input.stride(0),
+                  output_data + b * sizeD * osizeT * osizeH * osizeW,
+                  sizeD,
+                  isizeT,
+                  isizeH,
+                  isizeW,
+                  osizeT,
+                  osizeH,
+                  osizeW,
+                  istrideD,
+                  istrideT,
+                  istrideH,
+                  istrideW);
+            }
           });
-    }
+    });
   }
 }
 
@@ -176,48 +174,45 @@ static void adaptive_avg_pool3d_backward_out_frame(
     int64_t osizeT,
     int64_t osizeH,
     int64_t osizeW) {
-  int64_t d = 0;
-  at::internal::lazy_init_num_threads();
-#pragma omp parallel for private(d)
-  for (d = 0; d < sizeD; d++) {
-    scalar_t* gradInput_p_d = gradInput_p + d * isizeT * isizeW * isizeH;
-    scalar_t* gradOutput_p_d = gradOutput_p + d * osizeT * osizeW * osizeH;
+  at::parallel_for(0, sizeD, 1, [&](int64_t start, int64_t end) {
+    for (int64_t d = start; d < end; d++) {
+      scalar_t* gradInput_p_d = gradInput_p + d * isizeT * isizeW * isizeH;
+      scalar_t* gradOutput_p_d = gradOutput_p + d * osizeT * osizeW * osizeH;
 
-    /* calculate average */
-    int64_t ot, oh, ow;
-    for (ot = 0; ot < osizeT; ot++) {
-      int istartT = start_index(ot, osizeT, isizeT);
-      int iendT = end_index(ot, osizeT, isizeT);
-      int kT = iendT - istartT;
+      /* calculate average */
+      for (int64_t ot = 0; ot < osizeT; ot++) {
+        int istartT = start_index(ot, osizeT, isizeT);
+        int iendT = end_index(ot, osizeT, isizeT);
+        int kT = iendT - istartT;
 
-      for (oh = 0; oh < osizeH; oh++) {
-        int istartH = start_index(oh, osizeH, isizeH);
-        int iendH = end_index(oh, osizeH, isizeH);
-        int kH = iendH - istartH;
+        for (int64_t oh = 0; oh < osizeH; oh++) {
+          int istartH = start_index(oh, osizeH, isizeH);
+          int iendH = end_index(oh, osizeH, isizeH);
+          int kH = iendH - istartH;
 
-        for (ow = 0; ow < osizeW; ow++) {
-          int istartW = start_index(ow, osizeW, isizeW);
-          int iendW = end_index(ow, osizeW, isizeW);
-          int kW = iendW - istartW;
+          for (int64_t ow = 0; ow < osizeW; ow++) {
+            int istartW = start_index(ow, osizeW, isizeW);
+            int iendW = end_index(ow, osizeW, isizeW);
+            int kW = iendW - istartW;
 
-          scalar_t grad_delta =
-              gradOutput_p_d[ot * osizeH * osizeW + oh * osizeW + ow] / kT /
-              kH / kW;
+            scalar_t grad_delta =
+                gradOutput_p_d[ot * osizeH * osizeW + oh * osizeW + ow] / kT /
+                kH / kW;
 
-          int it, ih, iw;
-          for (it = istartT; it < iendT; it++) {
-            for (ih = istartH; ih < iendH; ih++) {
-              for (iw = istartW; iw < iendW; iw++) {
-                /* update gradient */
-                gradInput_p_d[it * isizeH * isizeW + ih * isizeW + iw] +=
-                    grad_delta;
+            for (int it = istartT; it < iendT; it++) {
+              for (int ih = istartH; ih < iendH; ih++) {
+                for (int iw = istartW; iw < iendW; iw++) {
+                  /* update gradient */
+                  gradInput_p_d[it * isizeH * isizeW + ih * isizeW + iw] +=
+                      grad_delta;
+                }
               }
             }
           }
         }
       }
     }
-  }
+  });
 }
 
 Tensor& adaptive_avg_pool3d_backward_out_cpu_template(
@@ -256,27 +251,28 @@ Tensor& adaptive_avg_pool3d_backward_out_cpu_template(
               osizeW);
         });
   } else {
-    at::internal::lazy_init_num_threads();
-    int64_t b = 0;
-#pragma omp parallel for private(b)
-    for (b = 0; b < input.size(0); b++) {
-      AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-          input.scalar_type(), "adaptive_avg_pool3d_backward_cpu", [&] {
-            /* get raw pointers */
-            scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
-            scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
-            adaptive_avg_pool3d_backward_out_frame<scalar_t>(
-                gradInput_data + b * sizeD * isizeT * isizeH * isizeW,
-                gradOutput_data + b * sizeD * osizeT * osizeH * osizeW,
-                sizeD,
-                isizeT,
-                isizeH,
-                isizeW,
-                osizeT,
-                osizeH,
-                osizeW);
+    int64_t n = input.size(0);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+        input.scalar_type(), "adaptive_avg_pool3d_backward_cpu", [&] {
+          /* get raw pointers */
+          scalar_t* gradInput_data = gradInput.data_ptr<scalar_t>();
+          scalar_t* gradOutput_data = gradOutput.data_ptr<scalar_t>();
+          at::parallel_for(0, n, 1, [&](int64_t start, int64_t end) {
+            for (int64_t b = start; b < end; b++) {
+              adaptive_avg_pool3d_backward_out_frame<scalar_t>(
+                  gradInput_data + b * sizeD * isizeT * isizeH * isizeW,
+                  gradOutput_data + b * sizeD * osizeT * osizeH * osizeW,
+                  sizeD,
+                  isizeT,
+                  isizeH,
+                  isizeW,
+                  osizeT,
+                  osizeH,
+                  osizeW);
+            }
           });
-    }
+    });
   }
   return gradInput;
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11571,6 +11571,19 @@ class TestNNDeviceType(NNTestCase):
         for mf in (torch.contiguous_format, torch.channels_last, 'non_contiguous'):
             helper((2, 3, 6, 6), mf)
 
+    @onlyOnCPUAndCUDA
+    @dtypes(torch.uint8, torch.int8, torch.short, torch.int, torch.long)
+    def test_adaptive_pooling_no_suppot_input(self, device, dtype):
+        for numel in (2, 3):
+            for pool_type in ('Max', 'Avg'):
+                cls_name = 'Adaptive{}Pool{}d'.format(pool_type, numel)
+                module_cls = getattr(nn, cls_name)
+                output_size = (2,) * numel
+                module = module_cls(output_size)
+                input = torch.randn((4,) * (numel + 1), device=device).to(dtype)
+                with self.assertRaisesRegex(RuntimeError, "not implemented"):
+                    output = module(input)
+
     @onlyCUDA
     @dtypesIfCUDA(torch.half, torch.float, torch.double)
     def test_avg_pool2d_nhwc(self, device, dtype):


### PR DESCRIPTION
For none support input, we should not do check in a parallel region, this PR will first do the dtype check, and then do parallel for.
Fixes https://github.com/pytorch/pytorch/issues/51352.
