### PR TITLE
[FX] Support Optional types in FX + TorchScript

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -974,6 +974,25 @@ class TestFX(JitTestCase):
             return a[0]
         torch.jit.script(symbolic_trace(forward))
 
+    def test_fn_type_annotation_optional(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x: torch.Tensor, k: Optional[int]) -> torch.Tensor:
+                return x
+
+        foo = symbolic_trace(Foo())
+        foo_scripted = torch.jit.script(foo)
+        foo_scripted(torch.rand(5), k=None)
+        foo_scripted(torch.rand(5), k=3)
+
+    def test_fn_type_recursive_optional(self):
+        class Foo(torch.nn.Module):
+            def forward(self, x: List[Optional[torch.Tensor]]) -> Optional[torch.Tensor]:
+                return x[0]
+
+        foo = symbolic_trace(Foo())
+        foo_scripted = torch.jit.script(foo)
+        foo_scripted([None, torch.rand(5)])
+
     def test_wrapped_method(self):
         def wrap_with_relu(fn):
             @functools.wraps(fn)


### PR DESCRIPTION
Summary:
When FX-tracing modules with an Optional forward argument, the FX-tracer preserves the type annotations using `_type_repr`. However, because Optional is just an alias for Union, optional arguments will show up as Union types in GraphModules, which are not TorchScript compatible. This diff/PR adds functionality to recursively modify a type expr to change Union[…, NoneType] annotations to their Optional equivalents.

This is actually fixed in Python 3.9, where `__repr__` for Union actually accounts for this case, so this is for the use cases for pre-3.9 Python.

The practicality of Optional types for tracing is not extremely useful since in most cases they will be used in control flow, but this would cover cases where the optional argument is unused or the argument is passed to a leaf (which would be a solution for being used in control flow).

Differential Revision: D26175132

