### PR TITLE
[CI] Update scipy version to 1.6.0

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -104,7 +104,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Pin MyPy version because new errors are likely to appear with each release
   # Pin hypothesis to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
   as_jenkins pip install --progress-bar off pytest \
-    scipy==1.1.0 \
+    scipy==1.6.0 \
     scikit-image \
     librosa>=0.6.2 \
     psutil \


### PR DESCRIPTION
As SciPy 1.1.0 is not compatible with Python-3.9

Discovered while working on #50992