### PR TITLE
Add sgn to torch.rst so that it appears in the built docs

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -340,6 +340,7 @@ Pointwise Ops
     rsqrt
     sigmoid
     sign
+    sgn
     signbit
     sin
     sinc


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/50146
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51479 Add sgn to torch.rst so that it appears in the built docs**

Differential Revision: [D26179734](https://our.internmc.facebook.com/intern/diff/D26179734)