### PR TITLE
[ONNX] Symbolic shape inference

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -159,7 +159,7 @@ pip install --user pytest-sugar
 # torchvision tests #
 #####################
 if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
-  # Check out torch/vision at Jun 11 2020 commit
+  # Check out torch/vision at Jan 19 2021 commit
   # This hash must match one in .jenkins/pytorch/test.sh
   pip install -q --user git+https://github.com/pytorch/vision.git@ae0d80b3c52dc98b3a9763bdb974c3ef7b6eb83d
   pip install -q --user ninja

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -349,6 +349,11 @@ namespace c10 {
   _(onnx, Conv)                      \
   _(onnx, BatchNormalization)        \
   _(onnx, ReduceProd)                \
+  _(onnx, Neg)                       \
+  _(onnx, NonZero)                   \
+  _(onnx, Range)                     \
+  _(onnx, Tile)                      \
+  _(onnx, Where)                     \
   FORALL_ATTR_BASE_SYMBOLS(_)        \
   _(attr, Subgraph)                  \
   _(attr, ReverseSubgraph)           \

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -81,9 +81,6 @@ if [[ "$BUILD_ENVIRONMENT" == *ort_test2* ]]; then
     pytest "${args[@]}" \
       "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset$i"
   done
-  pytest "${args[@]}" \
-    "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset12_onnx_shape_inference" \
-    "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset12_IRv4_old_jit_API"
 fi
 
 # Our CI expects both coverage.xml and .coverage to be within test/

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -81,6 +81,9 @@ if [[ "$BUILD_ENVIRONMENT" == *ort_test2* ]]; then
     pytest "${args[@]}" \
       "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset$i"
   done
+  pytest "${args[@]}" \
+    "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset12_onnx_shape_inference" \
+    "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset12_IRv4_old_jit_API"
 fi
 
 # Our CI expects both coverage.xml and .coverage to be within test/

--- a/test/onnx/expect/TestOperators.test_arange_dynamic.expect
+++ b/test/onnx/expect/TestOperators.test_arange_dynamic.expect
@@ -146,7 +146,7 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "Range13_dim_0"
+            dim_value: 10
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_empty_like.expect
+++ b/test/onnx/expect/TestOperators.test_empty_like.expect
@@ -47,10 +47,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ConstantOfShape2_dim_0"
+            dim_value: 5
           }
           dim {
-            dim_param: "ConstantOfShape2_dim_1"
+            dim_value: 8
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_full.expect
+++ b/test/onnx/expect/TestOperators.test_full.expect
@@ -137,10 +137,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ConstantOfShape10_dim_0"
+            dim_value: 3
           }
           dim {
-            dim_param: "ConstantOfShape10_dim_1"
+            dim_value: 4
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_full_like.expect
+++ b/test/onnx/expect/TestOperators.test_full_like.expect
@@ -47,10 +47,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ConstantOfShape2_dim_0"
+            dim_value: 3
           }
           dim {
-            dim_param: "ConstantOfShape2_dim_1"
+            dim_value: 4
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_nonzero.expect
+++ b/test/onnx/expect/TestOperators.test_nonzero.expect
@@ -47,7 +47,7 @@ graph {
         elem_type: 7
         shape {
           dim {
-            dim_value: 5
+            dim_param: "Transpose2_dim_0"
           }
           dim {
             dim_value: 3

--- a/test/onnx/expect/TestOperators.test_ones_like.expect
+++ b/test/onnx/expect/TestOperators.test_ones_like.expect
@@ -47,10 +47,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ConstantOfShape2_dim_0"
+            dim_value: 6
           }
           dim {
-            dim_param: "ConstantOfShape2_dim_1"
+            dim_value: 10
           }
         }
       }

--- a/test/onnx/expect/TestOperators.test_zeros_like.expect
+++ b/test/onnx/expect/TestOperators.test_zeros_like.expect
@@ -47,10 +47,10 @@ graph {
         elem_type: 1
         shape {
           dim {
-            dim_param: "ConstantOfShape2_dim_0"
+            dim_value: 5
           }
           dim {
-            dim_param: "ConstantOfShape2_dim_1"
+            dim_value: 8
           }
         }
       }

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3590,6 +3590,20 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(6, 4)
         self.run_test(ViewModel(), (x, y))
 
+    def test_linear(self):
+        class LinearModel(torch.nn.Module):
+            def __init__(self):
+                super(LinearModel, self).__init__()
+                self.fc = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                out = self.fc(x)
+                out = self.fc(out)
+                return out
+
+        x = torch.randn(3, 16)
+        self.run_test(LinearModel(), (x,))
+
     @disableScriptTest()
     def test_weight_norm(self):
         # addmm for 3-d inputs converts to onnx::MatMul

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3590,20 +3590,6 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(6, 4)
         self.run_test(ViewModel(), (x, y))
 
-    def test_linear(self):
-        class LinearModel(torch.nn.Module):
-            def __init__(self):
-                super(LinearModel, self).__init__()
-                self.fc = torch.nn.Linear(16, 16)
-
-            def forward(self, x):
-                out = self.fc(x)
-                out = self.fc(out)
-                return out
-
-        x = torch.randn(3, 16)
-        self.run_test(LinearModel(), (x,))
-
     @disableScriptTest()
     def test_weight_norm(self):
         # addmm for 3-d inputs converts to onnx::MatMul
@@ -7191,6 +7177,30 @@ TestONNXRuntime_opset13 = type(str("TestONNXRuntime_opset13"),
                                dict(TestONNXRuntime.__dict__, opset_version=13,
                                     keep_initializers_as_inputs=False,
                                     onnx_shape_inference=True))
+
+# opset 9 tests, with use_new_jit_passes=True for using new jit API,
+# and with keep_initializers_as_inputs=False for IR version 4 style export.
+TestONNXRuntime_IRv4_old_jit_API = type(str("TestONNXRuntime_IRv4_old_jit_API"),
+                                        (unittest.TestCase,),
+                                        dict(TestONNXRuntime.__dict__,
+                                             keep_initializers_as_inputs=False,
+                                             use_new_jit_passes=False))
+
+
+# opset 12 tests, with use_new_jit_passes=True for using new jit API,
+# and keep_initializers_as_inputs=False for IR version 4 style export.
+TestONNXRuntime_opset12_IRv4_old_jit_API = type(str("TestONNXRuntime_opset12_IRv4_old_jit_API"),
+                                                (unittest.TestCase,),
+                                                dict(TestONNXRuntime.__dict__, opset_version=12,
+                                                     keep_initializers_as_inputs=False,
+                                                     use_new_jit_passes=False))
+
+
+# opset 12 tests, with _onnx_shape_inference=True.
+TestONNXRuntime_opset12_onnx_shape_inference = type(str("TestONNXRuntime_opset12_onnx_shape_inference"),
+                                                    (unittest.TestCase,),
+                                                    dict(TestONNXRuntime.__dict__, opset_version=12,
+                                                         onnx_shape_inference=True))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7209,6 +7209,7 @@ TestONNXRuntime_opset12_IRv4_old_jit_API = type(str("TestONNXRuntime_opset12_IRv
                                                      keep_initializers_as_inputs=False,
                                                      use_new_jit_passes=False))
 
+<<<<<<< HEAD
 
 # opset 12 tests, with _onnx_shape_inference=True.
 TestONNXRuntime_opset12_onnx_shape_inference = type(str("TestONNXRuntime_opset12_onnx_shape_inference"),
@@ -7216,5 +7217,7 @@ TestONNXRuntime_opset12_onnx_shape_inference = type(str("TestONNXRuntime_opset12
                                                     dict(TestONNXRuntime.__dict__, opset_version=12,
                                                          onnx_shape_inference=True))
 
+=======
+>>>>>>> [ONNX] Fix graph sequence output from loop node (#51305)
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7,6 +7,7 @@ import io
 import itertools
 import copy
 import os
+import random
 
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
@@ -163,12 +164,14 @@ def _init_test_rpn():
     rpn_pre_nms_top_n = dict(training=2000, testing=1000)
     rpn_post_nms_top_n = dict(training=2000, testing=1000)
     rpn_nms_thresh = 0.7
+    rpn_score_thresh = 0.0
 
     rpn = RegionProposalNetwork(
         rpn_anchor_generator, rpn_head,
         rpn_fg_iou_thresh, rpn_bg_iou_thresh,
         rpn_batch_size_per_image, rpn_positive_fraction,
-        rpn_pre_nms_top_n, rpn_post_nms_top_n, rpn_nms_thresh)
+        rpn_pre_nms_top_n, rpn_post_nms_top_n, rpn_nms_thresh,
+        score_thresh=rpn_score_thresh)
     return rpn
 
 def _init_test_roi_heads_faster_rcnn():
@@ -207,6 +210,11 @@ def _init_test_roi_heads_faster_rcnn():
         bbox_reg_weights,
         box_score_thresh, box_nms_thresh, box_detections_per_img)
     return roi_heads
+
+def set_rng_seed(seed):
+    torch.manual_seed(seed)
+    random.seed(seed)
+    np.random.seed(seed)
 
 class TestONNXRuntime(unittest.TestCase):
     from torch.onnx.symbolic_helper import _export_onnx_opset_version
@@ -6494,6 +6502,7 @@ class TestONNXRuntime(unittest.TestCase):
     @skipIfUnsupportedMinOpsetVersion(11)
     @disableScriptTest()
     def test_rpn(self):
+        set_rng_seed(0)
 
         class RPNModule(torch.nn.Module):
             def __init__(self):
@@ -7049,6 +7058,213 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(1, 18)
         self.run_test(model, x, input_names=['x'])
 
+    def test_symbolic_shape_inference(self):
+        # ConstantOfShape is tested in test_embedding_bag
+        # Tile is tested in test_repeat
+        # test Shape, Reshape, Transpose, Gather
+        class ShapeModel(torch.nn.Module):
+            def forward(self, x, y):
+                shape = x.size()[:3] + (-1,)  # shape [4], ('batch', 3, 4, -1)
+                y = y.reshape(shape)  # batch, 3, 4, 10/batch
+                return y.transpose(1, 2)
+
+        model = ShapeModel()
+        model.eval()
+        x = torch.ones(2, 3, 4, 5)
+        y = torch.ones(3, 4, 5, 2)
+        self.run_test(model, (x, y))
+
+        class ViewModel(torch.nn.Module):
+            def forward(self, x):
+                return x.view(-1)
+
+        model = ViewModel()
+        model.eval()
+        x = torch.tensor(2.)
+        self.run_test(model, (x,))
+
+        # test prim::ListConstruct for Reshape input 1
+        class ViewModel_2(torch.nn.Module):
+            def forward(self, x):
+                N, C, H, W = x.shape[0], x.shape[2], x.shape[3], x.shape[4]
+                x1 = x.view(N, -1, C, H, W)
+                x2 = x1.permute(0, 3, 4, 1, 2)
+                return x2.reshape(N, -1, C)
+
+        model = ViewModel_2()
+        model.eval()
+        x = torch.ones(2, 3, 4, 5, 6)
+        self.run_test(model, x)
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_symbolic_shape_inference_arange(self):
+        # test Range
+        class ArangeModel(torch.nn.Module):
+            def forward(self, signal):
+                frame_step = 2
+                outer_dimensions = signal.size()[:-2]
+                frames, frame_length = signal.size()[-2:]
+
+                subframe_length = signal.size()[0]
+                subframe_step = frame_step // subframe_length
+                subframes_per_frame = frame_length // subframe_length
+                output_size = frame_step * (frames - 1) + frame_length
+                output_subframes = output_size // subframe_length
+
+                frame = torch.arange(0, output_subframes)
+                return frame
+
+        model = ArangeModel()
+        model.eval()
+        M, C, K, N = 1, 2, 3, 4
+        x = torch.randint(5, (M, C, K, N))
+        y = torch.randint(5, (M, C + 1, K + 1, N + 1))
+        self.run_test(model, x)
+        self.run_test(model, x, input_names=['x'],
+                      dynamic_axes={'x' : [0, 1, 2, 3]}, test_with_inputs=[(x,), (y,)])
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_symbolic_shape_inference_box(self):
+        # test NonZero
+        class BoxModel(torch.nn.Module):
+            def forward(self, boxes):
+                min_size = 1e-2
+                ws, hs = boxes[:, 2] - boxes[:, 0], boxes[:, 3] - boxes[:, 1]
+                keep = (ws >= min_size) & (hs >= min_size)
+                keep = torch.where(keep)[0]
+                return keep
+
+        model = BoxModel()
+        model.eval()
+        x = torch.ones(2, 4)
+        y = torch.ones(3, 5)
+        self.run_test(model, x)
+        self.run_test(model, x, input_names=['x'],
+                      dynamic_axes={'x' : [0, 1]}, test_with_inputs=[(x,), (y,)])
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_symbolic_shape_inference_box_if(self):
+        # test If
+        class BoxIfModel(torch.nn.Module):
+            def forward(self, boxes, scores):
+                score_thresh = 0.0
+                inds = torch.where(scores > score_thresh)[0]
+                boxes_1 = boxes[inds]
+                if boxes_1.numel() > 3:
+                    return boxes_1
+                else:
+                    return boxes_1 * 2
+
+        model = BoxIfModel()
+        model.eval()
+        boxes = torch.ones(2, 4)
+        scores = torch.ones(1, 4)
+        self.run_test(model, (boxes, scores))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_symbolic_shape_inference_arange_2(self):
+        # test Range
+        class ArangeModel(torch.nn.Module):
+            def forward(self, start):
+                return torch.arange(start.size(0), 8.5, 1.5, dtype=torch.int64)
+        x = torch.randn(2, 3, 4)
+        self.run_test(ArangeModel(), (x,))
+
+        class ArangeModel2(torch.nn.Module):
+            def forward(self, start):
+                return torch.arange(start.size(0), 8.5, 1.5, dtype=torch.double)
+        x = torch.randn(2, 3, 4)
+        self.run_test(ArangeModel2(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_symbolic_shape_inference_nonzero(self):
+        class OneLikeModel(torch.nn.Module):
+            def forward(self, x):
+                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                return torch.nonzero(ones)
+
+        x = torch.randn(2)
+        self.run_test(OneLikeModel(), x)
+        x = torch.randn(2, 3, 4)
+        self.run_test(OneLikeModel(), x)
+
+        class ZeroLikeModel(torch.nn.Module):
+            def forward(self, x):
+                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                return torch.nonzero(zeros)
+
+        x = torch.randn(2)
+        self.run_test(ZeroLikeModel(), x)
+        x = torch.randn(2, 3, 4)
+        self.run_test(ZeroLikeModel(), x)
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_symbolic_shape_inference_expand_1(self):
+        class ExpandModel(torch.nn.Module):
+            def forward(self, x):
+                return x.expand(4, 6, 2)
+        x = torch.randn(6, 1, requires_grad=True)
+        self.run_test(ExpandModel(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()  # Test code not scriptable
+    def test_symbolic_shape_inference_expand_2(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                input_shape = x.size()
+                batch_size, seq_length = input_shape
+                seq_ids = torch.arange(seq_length)
+                causal_mask = seq_ids[None, None, :].repeat(batch_size, seq_length, 1) <= seq_ids[None, :, None]
+                return causal_mask.transpose(0, 1)
+        x = torch.randn(3, 16)
+        self.run_test(M(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(10)
+    @disableScriptTest()  # Test code not scriptable
+    def test_symbolic_shape_inference_slice(self):
+        class M(torch.nn.Module):
+            def forward(self, x, position_bias):
+                input_shape = x.size()
+                batch_size, seq_length = input_shape
+                position_bias = position_bias[:, :, -seq_length:, :]
+                return position_bias.transpose(0, 1)
+        x = torch.randn(3, 16)
+        position_bias = torch.randn(1, 3, 20, 8)
+        self.run_test(M(), (x, position_bias))
+
+    def test_symbolic_shape_inference_slice_2(self):
+        class M(torch.nn.Module):
+            def forward(self, position_bias):
+                position_bias = position_bias[:, :, -2:, :]
+                return position_bias.transpose(0, 1)
+        position_bias = torch.randn(1, 3, 20, 8)
+        self.run_test(M(), (position_bias,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    @disableScriptTest()
+    def test_symbolic_shape_inference_time(self):
+        input = torch.randn(RNN_SEQUENCE_LENGTH, BATCH_SIZE, RNN_INPUT_SIZE)
+        h0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
+        c0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
+        model_lstm = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False)
+        self.run_test(model_lstm, (input, (h0, c0)), input_names=['x', 'y'],
+                      dynamic_axes={'x' : [0, 1]})
+        model_gru = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False, bias=False)
+        self.run_test(model_gru, (input, h0), input_names=['x', 'y'],
+                      dynamic_axes={'x' : [0, 1]})
+        model_rnn = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False, bias=False)
+        self.run_test(model_rnn, (input, h0), input_names=['x', 'y'],
+                      dynamic_axes={'x' : [0, 1]})
+
+    def test_symbolic_shape_inference_dynamic_axes(self):
+        class M(torch.nn.Module):
+            def forward(self, input_ids):
+                input_shape = input_ids.size()
+                input_ids = input_ids.view(-1, input_shape[-1])
+                return input_ids.transpose(0, 1)
+        x = torch.randn(3, 16)
+        self.run_test(M(), (x,), input_names=['input_ids'],
+                      dynamic_axes={'input_ids': {0: 'batch', 1: 'sequence'}})
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout,
@@ -7192,32 +7408,5 @@ TestONNXRuntime_opset13 = type(str("TestONNXRuntime_opset13"),
                                     keep_initializers_as_inputs=False,
                                     onnx_shape_inference=True))
 
-# opset 9 tests, with use_new_jit_passes=True for using new jit API,
-# and with keep_initializers_as_inputs=False for IR version 4 style export.
-TestONNXRuntime_IRv4_old_jit_API = type(str("TestONNXRuntime_IRv4_old_jit_API"),
-                                        (unittest.TestCase,),
-                                        dict(TestONNXRuntime.__dict__,
-                                             keep_initializers_as_inputs=False,
-                                             use_new_jit_passes=False))
-
-
-# opset 12 tests, with use_new_jit_passes=True for using new jit API,
-# and keep_initializers_as_inputs=False for IR version 4 style export.
-TestONNXRuntime_opset12_IRv4_old_jit_API = type(str("TestONNXRuntime_opset12_IRv4_old_jit_API"),
-                                                (unittest.TestCase,),
-                                                dict(TestONNXRuntime.__dict__, opset_version=12,
-                                                     keep_initializers_as_inputs=False,
-                                                     use_new_jit_passes=False))
-
-<<<<<<< HEAD
-
-# opset 12 tests, with _onnx_shape_inference=True.
-TestONNXRuntime_opset12_onnx_shape_inference = type(str("TestONNXRuntime_opset12_onnx_shape_inference"),
-                                                    (unittest.TestCase,),
-                                                    dict(TestONNXRuntime.__dict__, opset_version=12,
-                                                         onnx_shape_inference=True))
-
-=======
->>>>>>> [ONNX] Fix graph sequence output from loop node (#51305)
 if __name__ == '__main__':
     unittest.main()

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -530,6 +530,7 @@ libtorch_python_core_sources = [
     "torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp",
     "torch/csrc/jit/passes/onnx/eval_peephole.cpp",
     "torch/csrc/jit/passes/onnx/constant_fold.cpp",
+    "torch/csrc/jit/passes/onnx/constant_map.cpp",
     "torch/csrc/jit/passes/onnx/eliminate_unused_items.cpp",
     "torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp",
     "torch/csrc/jit/passes/onnx/list_model_parameters.cpp",

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -164,6 +164,8 @@ void PreprocessCaffe2Ops(std::shared_ptr<Graph>& graph) {
 std::shared_ptr<Graph> ToONNX(
     std::shared_ptr<Graph>& graph,
     ::torch::onnx::OperatorExportTypes operator_export_type) {
+  auto constant_value_map = ConstantValueMap::getInstance();
+  ConstantValueMap::ClearMaps();
   auto new_graph = std::make_shared<Graph>(graph->current_scope());
   std::unordered_map<Value*, Value*> env;
   BlockToONNX(graph->block(), new_graph->block(), operator_export_type, env);

--- a/torch/csrc/jit/passes/onnx.h
+++ b/torch/csrc/jit/passes/onnx.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/passes/onnx/constant_map.h>
 #include <torch/csrc/onnx/onnx.h>
 
 namespace torch {

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/Optional.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 namespace torch {
@@ -10,6 +11,14 @@ const int ONNX_OPSET_10 = 10;
 const int ONNX_OPSET_11 = 11;
 const int ONNX_OPSET_12 = 12;
 const int ONNX_OPSET_13 = 13;
+
+namespace onnx_constant_fold {
+c10::optional<at::Tensor> runTorchBackendForOnnx(
+    const Node* node,
+    std::vector<at::Tensor>& inputTensorValues,
+    int opset_version);
+}
+
 void ConstantFoldONNX(
     Block* b,
     std::map<std::string, IValue>& paramDict,

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -1,0 +1,184 @@
+#include <torch/csrc/jit/passes/onnx/constant_map.h>
+
+#include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/onnx/helper.h>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace torch {
+namespace jit {
+
+namespace onnx {
+using namespace ::c10::onnx;
+}
+
+// Meyer’s Singleton for C++ 14
+ConstantValueMap& ConstantValueMap::getInstance() {
+  static ConstantValueMap s;
+  return s;
+}
+
+void ConstantValueMap::SetRank(
+    const std::string& tensorName,
+    size_t rankValue) {
+  ConstantValueMap::getInstance().rankMap.emplace(tensorName, rankValue);
+}
+
+bool ConstantValueMap::HasRank(const std::string& tensorName) {
+  return ConstantValueMap::getInstance().rankMap.find(tensorName) !=
+      ConstantValueMap::getInstance().rankMap.end();
+}
+
+c10::optional<size_t> ConstantValueMap::GetRank(const std::string& tensorName) {
+  if (!HasRank(tensorName)) {
+    return c10::nullopt;
+  }
+  return ConstantValueMap::getInstance().rankMap[tensorName];
+}
+
+void ConstantValueMap::SetShape(
+    const std::string& tensorName,
+    const c10::SymbolicShape& shapeValue) {
+  ConstantValueMap::getInstance().shapeMap.emplace(tensorName, shapeValue);
+}
+
+bool ConstantValueMap::HasShape(const std::string& tensorName) {
+  return ConstantValueMap::getInstance().shapeMap.find(tensorName) !=
+      ConstantValueMap::getInstance().shapeMap.end();
+}
+
+c10::optional<c10::SymbolicShape> ConstantValueMap::GetShape(
+    const std::string& tensorName) {
+  if (!HasShape(tensorName)) {
+    return c10::nullopt;
+  }
+  return ConstantValueMap::getInstance().shapeMap[tensorName];
+}
+
+void ConstantValueMap::SetValue(
+    const std::string& tensorName,
+    const at::Tensor& value) {
+  ConstantValueMap::getInstance().tensorValueMap.emplace(tensorName, value);
+}
+
+bool ConstantValueMap::HasValue(const std::string& tensorName) {
+  return ConstantValueMap::getInstance().tensorValueMap.find(tensorName) !=
+      ConstantValueMap::getInstance().tensorValueMap.end();
+}
+
+c10::optional<at::Tensor> ConstantValueMap::GetValue(
+    const std::string& tensorName) {
+  if (!HasValue(tensorName)) {
+    return c10::nullopt;
+  }
+  return ConstantValueMap::getInstance().tensorValueMap[tensorName];
+}
+
+std::vector<int64_t> ConstantValueMap::GetCompleteShapeInto1DInt64Vector(
+    const c10::SymbolicShape& shape) {
+  TORCH_INTERNAL_ASSERT(shape.isComplete());
+  std::vector<int64_t> shape_value;
+  auto shape_symbol_list = shape.sizes().value();
+  shape_value.reserve(shape_symbol_list.size());
+  for (const auto& v : shape_symbol_list) {
+    shape_value.emplace_back(v.static_size());
+  }
+  return shape_value;
+}
+
+c10::optional<std::vector<int64_t>> ConstantValueMap::GetShapeInto1DInt64Vector(
+    const std::string& value_name) {
+  if (ConstantValueMap::HasShape(value_name)) {
+    auto shape_size = ConstantValueMap::GetShape(value_name).value();
+    if (shape_size.isComplete()) {
+      auto shape_value =
+          ConstantValueMap::GetCompleteShapeInto1DInt64Vector(shape_size);
+      return shape_value;
+    }
+  }
+  return c10::nullopt;
+}
+
+c10::optional<std::vector<int64_t>> ConstantValueMap::
+    GetShapeInto1DInt64VectorWithOneUnknown(const std::string& value_name) {
+  if (ConstantValueMap::HasShape(value_name)) {
+    auto shape_size = ConstantValueMap::GetShape(value_name).value();
+    std::vector<int64_t> shape_value;
+    if (shape_size.isComplete()) {
+      shape_value =
+          ConstantValueMap::GetCompleteShapeInto1DInt64Vector(shape_size);
+      return shape_value;
+    } else {
+      size_t count_unknown = 0;
+      auto shape_size_sizes = shape_size.sizes();
+      if (shape_size_sizes.has_value()) {
+        auto shape_symbol_list = shape_size_sizes.value();
+        for (const auto& v : shape_symbol_list) {
+          if (v.is_static()) {
+            shape_value.emplace_back(v.static_size());
+          } else {
+            shape_value.emplace_back(-1);
+            count_unknown += 1;
+          }
+        }
+        if (count_unknown == 1) {
+          return shape_value;
+        }
+      }
+    }
+  }
+  return c10::nullopt;
+}
+
+// accessor<int64_t, 1> for 1DInt64 case.
+std::vector<int64_t> ConstantValueMap::GetValueInto1DInt64Vector(
+    const std::string& value_name) {
+  auto value = ConstantValueMap::GetValue(value_name).value();
+  auto value_int64_t = value.toType(at::ScalarType::Long);
+  std::vector<int64_t> value_vector;
+  value_vector.reserve(value_int64_t.size(0));
+  auto value_size_a = value_int64_t.accessor<int64_t, 1>();
+  for (auto i = 0; i < value_int64_t.size(0); i++) {
+    value_vector.emplace_back(static_cast<int64_t>(value_size_a[i]));
+  }
+  return value_vector;
+}
+
+void ConstantValueMap::ClearMaps() {
+  ConstantValueMap::getInstance().rankMap.clear();
+  ConstantValueMap::getInstance().shapeMap.clear();
+  ConstantValueMap::getInstance().tensorValueMap.clear();
+}
+
+// For debug only.
+void ConstantValueMap::PrintMaps() {
+  std::cout << "Print rank/shape Maps:" << std::endl;
+  for (const auto& x : ConstantValueMap::getInstance().rankMap) {
+    std::stringstream ss;
+    if (ConstantValueMap::getInstance().shapeMap.find(x.first) !=
+        ConstantValueMap::getInstance().shapeMap.end()) {
+      auto shape_symbols =
+          ConstantValueMap::getInstance().shapeMap[x.first].sizes();
+      if (shape_symbols.has_value()) {
+        for (const auto& shape_symbol : shape_symbols.value()) {
+          if (shape_symbol.is_static()) {
+            ss << shape_symbol.static_size() << ", ";
+          } else {
+            ss << "*, ";
+          }
+        }
+      }
+    }
+    ss << " (rank = " << x.second << ")";
+    std::cout << "node " << x.first << ": " << ss.str() << std::endl;
+  }
+  std::cout << std::endl;
+  std::cout << "Print Value Maps:" << std::endl;
+  for (const auto& x : ConstantValueMap::getInstance().tensorValueMap) {
+    std::cout << "node " << x.first << ": " << x.second << std::endl;
+  }
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/onnx/constant_map.h
+++ b/torch/csrc/jit/passes/onnx/constant_map.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <torch/csrc/jit/ir/ir.h>
+#include <mutex>
+#include <unordered_map>
+
+namespace torch {
+namespace jit {
+
+class ConstantValueMap {
+ public:
+  static ConstantValueMap& getInstance();
+
+  static void SetRank(const std::string& tensorName, size_t rankValue);
+  static bool HasRank(const std::string& tensorName);
+  static c10::optional<size_t> GetRank(const std::string& tensorName);
+
+  static void SetShape(
+      const std::string& tensorName,
+      const c10::SymbolicShape& shapeValue);
+  static bool HasShape(const std::string& tensorName);
+  static c10::optional<c10::SymbolicShape> GetShape(
+      const std::string& tensorName);
+
+  static void SetValue(const std::string& tensorName, const at::Tensor& value);
+  static bool HasValue(const std::string& tensorName);
+  static c10::optional<at::Tensor> GetValue(const std::string& tensorName);
+
+  static std::vector<int64_t> GetCompleteShapeInto1DInt64Vector(
+      const c10::SymbolicShape& shape);
+  static c10::optional<std::vector<int64_t>> GetShapeInto1DInt64Vector(
+      const std::string& value_name);
+  static c10::optional<std::vector<int64_t>>
+  GetShapeInto1DInt64VectorWithOneUnknown(const std::string& value_name);
+  static std::vector<int64_t> GetValueInto1DInt64Vector(
+      const std::string& value_name);
+
+  static void PrintMaps();
+  static void ClearMaps();
+  ~ConstantValueMap() = default;
+
+ private:
+  ConstantValueMap(){};
+  ConstantValueMap& operator=(const ConstantValueMap&) = delete;
+
+  std::unordered_map<std::string, size_t> rankMap;
+  std::unordered_map<std::string, c10::SymbolicShape> shapeMap;
+  std::unordered_map<std::string, at::Tensor> tensorValueMap;
+};
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1,6 +1,8 @@
 #include <torch/csrc/jit/passes/onnx/shape_type_inference.h>
 
 #include <torch/csrc/jit/jit_log.h>
+#include <torch/csrc/jit/passes/onnx/constant_fold.h>
+#include <torch/csrc/jit/passes/onnx/constant_map.h>
 #include <torch/csrc/jit/passes/onnx/fold_if_node.h>
 #include <torch/csrc/jit/passes/onnx/helper.h>
 #include <torch/csrc/jit/passes/onnx/scalar_type_analysis.h>
@@ -9,6 +11,8 @@
 #include <torch/csrc/jit/serialization/onnx.h>
 
 #include <onnx/shape_inference/implementation.h>
+#include <algorithm>
+#include <cmath>
 
 namespace torch {
 namespace jit {
@@ -377,6 +381,751 @@ bool IsBlockReturnTypeSame(Node* n) {
   return true;
 }
 
+c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
+  if (n->inputs().size() == 0) {
+    return c10::nullopt;
+  }
+  std::vector<at::Tensor> inputTensorValues;
+  for (auto i = 0; i < n->inputs().size(); i++) {
+    if (TensorTypePtr input_type = n->input(i)->type()->cast<TensorType>()) {
+      if (!ConstantValueMap::HasValue(n->input(i)->debugName())) {
+        return c10::nullopt;
+      }
+      auto tensor_value =
+          ConstantValueMap::GetValue(n->input(i)->debugName()).value();
+      inputTensorValues.emplace_back(tensor_value);
+    }
+  }
+  if (inputTensorValues.size() < n->inputs().size()) {
+    return c10::nullopt;
+  }
+  // The _jit_pass_onnx_fold_if pass is processed after onnx pass,
+  // therefore the onnx graph here may contain the if blocks that is never
+  // traced. Constant folding on those if blocks may rely on the input shape
+  // which does not meet the criteria, so it may get errors. A possible solution
+  // is to put _jit_pass_onnx_fold_if pass in an earlier stage.
+  try {
+    return onnx_constant_fold::runTorchBackendForOnnx(
+        n, inputTensorValues, opset_version);
+  } catch (const std::exception& ex) {
+    TORCH_WARN(
+        "Constant folding in symbolic shape inference fails: ", ex.what());
+    return c10::nullopt;
+  }
+}
+
+// When the Reshape node's two inputs are constant, compute the output shape.
+// The reshape value 0 and -1 are converted to the real value explicitly.
+std::vector<int64_t> ComputeShapeFromReshape(
+    const std::vector<int64_t>& input_shape,
+    const std::vector<int64_t>& reshape) {
+  TORCH_INTERNAL_ASSERT(
+      input_shape.size() > 0 || reshape.size() > 0,
+      "Reshape node should have at least one input size > 0 when constant folding.");
+  // Case: reshape.size() == 0
+  // %22 : int[] = prim::Constant[value=annotate(List[int], [])]()
+  // %15 : Float(requires_grad=0, device=cpu) = aten::view(%1, %22)
+  if (reshape.size() == 0) {
+    return input_shape;
+  }
+  // Case: input_shape.size() == 0
+  // (1) input_shape is not obtained,
+  // (2) input_shape is scalar (output is still a tensor, not a scalar),
+  // Both cases return reshape
+  // TODO: for (1), multiple -1 may conflict each other. Consider use
+  // newSymbol() in shapeMap.
+  if (input_shape.size() == 0) {
+    return reshape;
+  }
+  auto reshape_size = static_cast<int>(reshape.size());
+  auto it_0 = std::find(reshape.begin(), reshape.end(), 0);
+  auto reshape_has_zero = it_0 != reshape.end();
+  auto input_shape_size = static_cast<int>(input_shape.size());
+  auto it_minus_one = std::find(reshape.begin(), reshape.end(), -1);
+  int minus_one_pos = it_minus_one == reshape.end()
+      ? -1
+      : std::distance(reshape.begin(), it_minus_one);
+
+  if (!reshape_has_zero && minus_one_pos == -1) {
+    return reshape;
+  }
+  std::vector<int64_t> final_shape;
+  // shape_ratio is used to calculate the real value of -1.
+  // it is updated on each dimension to avoid overflow.
+  double shape_ratio = 1.0;
+  for (auto i = 0; i < input_shape_size; i++) {
+    if (i < minus_one_pos) {
+      if (reshape[i] != 0) {
+        shape_ratio *= static_cast<double>(input_shape[i]) / reshape[i];
+      }
+    } else if (minus_one_pos > -1) {
+      if (i < input_shape_size - reshape_size + minus_one_pos + 1) {
+        shape_ratio *= static_cast<double>(input_shape[i]);
+      } else {
+        auto reshape_idx = i - input_shape_size + reshape_size;
+        if (reshape[reshape_idx] != 0) {
+          shape_ratio *=
+              static_cast<double>(input_shape[i]) / reshape[reshape_idx];
+        }
+      }
+    }
+  }
+
+  for (auto i = 0; i < minus_one_pos; i++) {
+    int64_t cur_shape = reshape[i] == 0 ? input_shape[i] : reshape[i];
+    final_shape.push_back(cur_shape);
+  }
+  final_shape.push_back(static_cast<int64_t>(std::round(shape_ratio)));
+  for (auto i = minus_one_pos + 1; i < reshape_size; i++) {
+    int64_t cur_shape = reshape[i] == 0
+        ? input_shape[i + input_shape_size - reshape_size]
+        : reshape[i];
+    final_shape.push_back(cur_shape);
+  }
+  return final_shape;
+}
+
+c10::optional<::c10::SymbolicShape> ComputeShapeFromExpand(
+    const std::vector<::c10::ShapeSymbol>& input_shape,
+    const std::vector<int64_t>& reshape) {
+  for (auto it = reshape.begin(); it != reshape.end(); ++it) {
+    if (*it < 0) {
+      return c10::nullopt;
+    }
+  }
+  std::vector<::c10::ShapeSymbol> final_shape;
+  if (input_shape.size() >= reshape.size()) {
+    final_shape = input_shape;
+  } else {
+    for (auto v : reshape) {
+      final_shape.emplace_back(::c10::ShapeSymbol::fromStaticSize(v));
+    }
+  }
+  auto min_size = std::min(input_shape.size(), reshape.size());
+  for (auto i = 0; i < min_size; i++) {
+    auto idx = final_shape.size() - i - 1;
+    auto input_shape_idx = input_shape.size() - i - 1;
+    auto reshape_idx = reshape.size() - i - 1;
+    if (input_shape[input_shape_idx].is_static()) {
+      auto input_shape_value = input_shape[input_shape_idx].static_size();
+      auto reshape_value = reshape[reshape_idx];
+      TORCH_INTERNAL_ASSERT(
+          input_shape_value == reshape_value || input_shape_value == 1 ||
+              reshape_value == 1,
+          "ONNX Expand input shape constraint not satisfied.");
+      final_shape[idx] = ::c10::ShapeSymbol::fromStaticSize(
+          std::max(input_shape_value, reshape_value));
+
+    } else {
+      final_shape[idx] = ::c10::ShapeSymbol::newSymbol();
+    }
+  }
+  ::c10::SymbolicShape shape(final_shape);
+  return shape;
+}
+
+c10::optional<::c10::SymbolicShape> ComputeShapeFromTile(
+    const std::vector<::c10::ShapeSymbol>& input_shape,
+    const std::vector<int64_t>& reshape) {
+  TORCH_INTERNAL_ASSERT(
+      input_shape.size() == reshape.size(),
+      "ONNX Tile input shapes do not match.");
+  for (auto it = reshape.begin(); it != reshape.end(); ++it) {
+    if (*it < 0) {
+      return c10::nullopt;
+    }
+  }
+  std::vector<::c10::ShapeSymbol> final_shape;
+  final_shape.reserve(input_shape.size());
+  for (auto i = 0; i < input_shape.size(); i++) {
+    if (input_shape[i].is_static()) {
+      final_shape.emplace_back(::c10::ShapeSymbol::fromStaticSize(
+          input_shape[i].static_size() * reshape[i]));
+    } else {
+      final_shape.emplace_back(::c10::ShapeSymbol::newSymbol());
+    }
+  }
+  ::c10::SymbolicShape shape(final_shape);
+  return shape;
+}
+
+void UpdateRank(Value* value, size_t rank) {
+  ConstantValueMap::SetRank(value->debugName(), rank);
+  if (TensorTypePtr value_type = value->type()->cast<TensorType>()) {
+    c10::optional<size_t> rank_opt = rank;
+    auto shape = ::c10::SymbolicShape(rank_opt);
+    value->setType(value_type->withSymbolicShapes(shape));
+  }
+}
+
+void UpdateShapeFromVector(
+    Value* value,
+    const std::vector<int64_t>& shape_size) {
+  ::c10::SymbolicShape shape(shape_size);
+  ConstantValueMap::SetShape(value->debugName(), shape);
+  if (shape_size.empty()) {
+    UpdateRank(value, 0);
+    return;
+  }
+  ConstantValueMap::SetRank(value->debugName(), shape_size.size());
+  if (TensorTypePtr value_type = value->type()->cast<TensorType>()) {
+    value->setType(value_type->withSymbolicShapes(shape));
+  }
+}
+
+void UpdateShape(Value* value, const ::c10::SymbolicShape& shape) {
+  ConstantValueMap::SetShape(value->debugName(), shape);
+  if (shape.rank().has_value()) {
+    auto rank = shape.rank().value();
+    if (rank == 0) {
+      UpdateRank(value, 0);
+      return;
+    }
+    ConstantValueMap::SetRank(value->debugName(), rank);
+    if (TensorTypePtr value_type = value->type()->cast<TensorType>()) {
+      value->setType(value_type->withSymbolicShapes(shape));
+    }
+  }
+}
+
+c10::optional<std::vector<int64_t>> GetValueFromListConstructNode(
+    Node* lc_node) {
+  auto rank = lc_node->inputs().size();
+  std::vector<int64_t> shape_size;
+  for (size_t i = 0; i < rank; i++) {
+    if (TensorTypePtr shape_type =
+            lc_node->input(i)->type()->cast<TensorType>()) {
+      if (ConstantValueMap::HasValue(lc_node->input(i)->debugName())) {
+        auto lc_value =
+            ConstantValueMap::GetValue(lc_node->input(i)->debugName()).value();
+        if (lc_value.dim() == 0) {
+          auto lc_value_0 = lc_value.item<int64_t>();
+          shape_size.emplace_back(static_cast<int64_t>(lc_value_0));
+        }
+      }
+    }
+  }
+  return rank == shape_size.size()
+      ? c10::optional<std::vector<int64_t>>(shape_size)
+      : c10::nullopt;
+}
+
+void ProcessReshapeNode(Node* n) {
+  if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
+    auto shape_temp =
+        ConstantValueMap::GetValueInto1DInt64Vector(n->input(1)->debugName());
+    auto shape_vector_0 =
+        ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
+            n->input(0)->debugName());
+    if (shape_vector_0.has_value()) {
+      auto final_shape =
+          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp);
+      UpdateShapeFromVector(n->output(), final_shape);
+      return;
+    }
+  }
+
+  if (ConstantValueMap::HasShape(n->input(1)->debugName())) {
+    auto shape_vector_1 =
+        ConstantValueMap::GetShapeInto1DInt64Vector(n->input(1)->debugName());
+    if (shape_vector_1.has_value()) {
+      TORCH_INTERNAL_ASSERT(shape_vector_1.value().size() == 1);
+      UpdateRank(n->output(), shape_vector_1.value()[0]);
+      return;
+    }
+  }
+
+  // ListConstruct is handled at the beginning of ProcessConstantValueMap, no
+  // further process here.
+  if (TensorTypePtr shape_type = n->input(1)->type()->cast<TensorType>()) {
+    // Set rank to Reshape output if possible.
+    // From shape inference, we have:
+    // %4236 : Float(*, device=cpu) = onnx::Transpose[perm=[0]](%4235)
+    // %4237 : Long(2, strides=[1], device=cpu) = onnx::Concat[axis=0](%4232)
+    // %4238 : FloatTensor(device=cpu) = onnx::Reshape(%4236, %4237)
+    // We can have it as SymbolicShape with known rank:
+    // %4238 : Float(*, *, strides=[2480, 1], requires_grad=0, device=cpu) =
+    // onnx::Reshape(%4236, %4237)
+    auto shape_type_dim = shape_type->dim();
+    if (shape_type_dim.has_value()) {
+      auto shape_type_size = shape_type->sizes()[0];
+      if (shape_type_size.has_value()) {
+        size_t rank = shape_type_size.value();
+        UpdateRank(n->output(), rank);
+      }
+    }
+  }
+}
+
+c10::SymbolicShape ComputeShapeForSlice(
+    const std::vector<c10::ShapeSymbol>& input_shape,
+    const std::vector<int64_t>& start_vector,
+    const std::vector<int64_t>& end_vector,
+    const std::vector<int64_t>& axes_vector,
+    const std::vector<int64_t>& step_vector) {
+  TORCH_INTERNAL_ASSERT(axes_vector.size() <= input_shape.size());
+  TORCH_INTERNAL_ASSERT(axes_vector.size() == start_vector.size());
+  TORCH_INTERNAL_ASSERT(axes_vector.size() == end_vector.size());
+  TORCH_INTERNAL_ASSERT(axes_vector.size() == step_vector.size());
+  std::vector<c10::ShapeSymbol> final_shape;
+  final_shape = input_shape;
+  for (auto idx = 0; idx < axes_vector.size(); ++idx) {
+    auto axis = axes_vector[idx];
+    if (axis < 0) {
+      axis += input_shape.size();
+    }
+    if (!input_shape[axis].is_static()) {
+      final_shape[axis] = c10::ShapeSymbol::newSymbol();
+      continue;
+    }
+    auto input_shape_axis_value = input_shape[axis].static_size();
+    auto cur_start = start_vector[idx];
+    auto cur_end = end_vector[idx];
+    auto cur_step = step_vector[idx];
+    if (cur_start < -input_shape_axis_value) {
+      cur_start = 0;
+    } else if (cur_start < 0) {
+      cur_start = input_shape_axis_value + cur_start;
+    } else if (cur_start > input_shape_axis_value - 1) {
+      cur_start = input_shape_axis_value;
+    }
+    if (cur_end < -input_shape_axis_value) {
+      cur_end = -1;
+    } else if (cur_end < 0) {
+      cur_end = input_shape_axis_value + cur_end;
+    } else if (cur_end > input_shape_axis_value - 1) {
+      cur_end = input_shape_axis_value;
+    }
+    TORCH_INTERNAL_ASSERT(cur_step != 0);
+    if (cur_step > 0) {
+      final_shape[axis] = c10::ShapeSymbol::fromStaticSize(
+          (cur_end - cur_start - 1) / cur_step + 1);
+    } else {
+      final_shape[axis] = c10::ShapeSymbol::fromStaticSize(
+          (cur_start - cur_end - 1) / (-cur_step) + 1);
+    }
+  }
+  return c10::SymbolicShape(final_shape);
+}
+
+void ProcessSliceNode(Node* n, int opset_version) {
+  if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+    auto shape_size_0 =
+        ConstantValueMap::GetShape(n->input(0)->debugName()).value();
+    if (shape_size_0.rank().has_value()) {
+      auto input0_shape_value = shape_size_0.sizes().value();
+      auto valid = true;
+      if (opset_version >= 10) {
+        valid = ConstantValueMap::HasValue(n->input(1)->debugName()) &&
+            ConstantValueMap::HasValue(n->input(2)->debugName());
+        for (auto input_idx = 3; input_idx < 5; ++input_idx) {
+          if (n->inputs().size() > input_idx) {
+            valid = valid &&
+                ConstantValueMap::HasValue(n->input(input_idx)->debugName());
+          }
+        }
+      }
+      if (!valid) {
+        if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
+          auto rank =
+              ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+          UpdateRank(n->output(), rank);
+        }
+        return;
+      }
+
+      std::vector<int64_t> start_vector;
+      std::vector<int64_t> end_vector;
+      std::vector<int64_t> axes_vector(input0_shape_value.size(), 0);
+      for (int64_t i = 0; i < input0_shape_value.size(); i++) {
+        axes_vector[i] = i;
+      }
+      std::vector<int64_t> step_vector;
+
+      if (opset_version < 10) {
+        start_vector = n->is(attr::starts);
+        end_vector = n->is(attr::ends);
+        if (n->hasAttributeS("axes")) {
+          axes_vector = n->is(attr::axes);
+        }
+      } else {
+        start_vector = ConstantValueMap::GetValueInto1DInt64Vector(
+            n->input(1)->debugName());
+        end_vector = ConstantValueMap::GetValueInto1DInt64Vector(
+            n->input(2)->debugName());
+        if (n->inputs().size() > 3) {
+          axes_vector = ConstantValueMap::GetValueInto1DInt64Vector(
+              n->input(3)->debugName());
+        }
+        if (n->inputs().size() > 4) {
+          step_vector = ConstantValueMap::GetValueInto1DInt64Vector(
+              n->input(4)->debugName());
+        }
+      }
+
+      if (step_vector.empty()) {
+        step_vector = std::vector<int64_t>(axes_vector.size(), 1);
+      }
+
+      auto final_shape = ComputeShapeForSlice(
+          input0_shape_value,
+          start_vector,
+          end_vector,
+          axes_vector,
+          step_vector);
+      UpdateShape(n->output(), final_shape);
+    }
+  }
+}
+
+void ProcessTimeSeriesNode(Node* n) {
+  auto input0_shape = ConstantValueMap::GetShape(n->input(0)->debugName());
+  auto input1_shape = ConstantValueMap::GetShape(n->input(1)->debugName());
+  if (!(input0_shape.has_value() && input1_shape.has_value())) {
+    return;
+  }
+  auto input0_shape_value = input0_shape.value().sizes();
+  auto input1_shape_value = input1_shape.value().sizes();
+  c10::ShapeSymbol seq_length;
+  c10::ShapeSymbol num_directions;
+  c10::ShapeSymbol batch_size;
+  c10::ShapeSymbol hidden_size;
+  if (input0_shape_value.has_value()) {
+    seq_length = input0_shape_value.value()[0];
+    batch_size = input0_shape_value.value()[1];
+  }
+
+  if (input1_shape_value.has_value()) {
+    num_directions = input1_shape_value.value()[0];
+    if (input1_shape_value.value()[1].is_static()) {
+      auto input1_value = input1_shape_value.value()[1].static_size();
+      switch (n->kind()) {
+        case ::c10::onnx::RNN:
+          hidden_size = c10::ShapeSymbol::fromStaticSize(input1_value);
+          break;
+        case ::c10::onnx::LSTM:
+          hidden_size = c10::ShapeSymbol::fromStaticSize(input1_value / 4);
+          break;
+        case ::c10::onnx::GRU:
+          hidden_size = c10::ShapeSymbol::fromStaticSize(input1_value / 3);
+          break;
+        default:
+          throw std::runtime_error(
+              std::string() + "This is not a valid TimeSeries Node with type " +
+              n->kind().toDisplayString());
+      }
+    } else {
+      hidden_size = c10::ShapeSymbol::newSymbol();
+    }
+  }
+
+  if (n->outputs().size() > 1) {
+    std::vector<c10::ShapeSymbol> final_shape = {
+        seq_length, num_directions, batch_size, hidden_size};
+    UpdateShape(n->output(0), c10::SymbolicShape(final_shape));
+  }
+  for (size_t idx = 2; idx < 4; ++idx) {
+    if (n->outputs().size() > idx) {
+      std::vector<c10::ShapeSymbol> final_shape = {
+          num_directions, batch_size, hidden_size};
+      UpdateShape(n->output(idx - 1), c10::SymbolicShape(final_shape));
+    }
+  }
+}
+
+// As an addition to onnx shape inference, this function leverages constant
+// folding and a per-Op based process to update rank/shape for the graph, also
+// it update ConstantValueMap accordingly.
+void ComputeConstant(Node* n, int opset_version) {
+  if (n->kind() == ::c10::onnx::Constant) {
+    if (n->kindOf(attr::value) == AttributeKind::t) {
+      at::Tensor const_val = n->t(attr::value);
+      at::Tensor const_val_copy =
+          at::empty(const_val.sizes(), const_val.options());
+      const_val_copy.copy_(const_val);
+      ConstantValueMap::SetValue(n->output()->debugName(), const_val_copy);
+    }
+    return;
+  }
+  auto only_rank_available = false;
+  size_t rank = 0;
+
+  // Constant folding.
+  auto const_fold_val = ComputeConstantFolding(n, opset_version);
+  if (const_fold_val.has_value()) {
+    at::Tensor const_fold_val_copy = at::empty(
+        const_fold_val.value().sizes(), const_fold_val.value().options());
+    const_fold_val_copy.copy_(const_fold_val.value());
+    ConstantValueMap::SetValue(n->output()->debugName(), const_fold_val_copy);
+    UpdateShapeFromVector(n->output(), const_fold_val_copy.sizes().vec());
+    return;
+  }
+
+  switch (n->kind()) {
+    case ::c10::onnx::Shape: {
+      auto input_shape =
+          ConstantValueMap::GetShapeInto1DInt64Vector(n->input()->debugName());
+      if (input_shape.has_value()) {
+        auto shape_value = input_shape.value();
+        // TODO: getDevice() ?
+        auto options = c10::TensorOptions().dtype(at::kLong).device(at::kCPU);
+        auto shape_value_size = static_cast<int64_t>(shape_value.size());
+        auto f =
+            at::from_blob(shape_value.data(), {shape_value_size}, at::kLong)
+                .to(at::kCPU);
+        // Need copy here
+        at::Tensor f_copy = at::empty({shape_value_size}, options);
+        f_copy.copy_(f);
+        ConstantValueMap::SetValue(n->output()->debugName(), f_copy);
+      }
+      break;
+    }
+    case ::c10::onnx::Reshape: {
+      ProcessReshapeNode(n);
+      break;
+    }
+    case ::c10::onnx::Gather: {
+      if (ConstantValueMap::HasRank(n->input(0)->debugName()) &&
+          ConstantValueMap::HasRank(n->input(1)->debugName())) {
+        auto rank_0 =
+            ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+        auto rank_1 =
+            ConstantValueMap::GetRank(n->input(1)->debugName()).value();
+        only_rank_available = true;
+        rank = rank_0 + rank_1 - 1;
+      }
+      break;
+    }
+    case ::c10::onnx::Transpose: {
+      if (n->hasAttributeS("perm")) {
+        auto perm_v = n->is(attr::perm);
+        rank = perm_v.size();
+        auto is_default_perm = false;
+        if (rank == 2 && perm_v[0] == 1 && perm_v[1] == 0) {
+          is_default_perm = true;
+        }
+        auto shape_updated = false;
+        if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+          auto shape_size_0 =
+              ConstantValueMap::GetShape(n->input(0)->debugName())
+                  .value()
+                  .sizes();
+          if (shape_size_0.has_value()) {
+            auto shape_vector_0 = shape_size_0.value();
+            std::vector<::c10::ShapeSymbol> final_shape_vector(
+                shape_vector_0.size(), ::c10::ShapeSymbol());
+            if (is_default_perm) {
+              std::reverse_copy(
+                  std::begin(shape_vector_0),
+                  std::end(shape_vector_0),
+                  std::begin(final_shape_vector));
+            } else {
+              for (auto i = 0; i < shape_vector_0.size(); i++) {
+                final_shape_vector[i] = shape_vector_0[perm_v[i]];
+              }
+            }
+            ::c10::SymbolicShape final_shape(final_shape_vector);
+            UpdateShape(n->output(), final_shape);
+            shape_updated = true;
+          }
+        }
+        if (!shape_updated) {
+          if (!is_default_perm) {
+            only_rank_available = true;
+          } else if (ConstantValueMap::HasRank(n->input(0)->debugName())) {
+            rank = ConstantValueMap::GetRank(n->input(0)->debugName()).value();
+            only_rank_available = true;
+          }
+        }
+      }
+      break;
+    }
+    case ::c10::onnx::ConstantOfShape: {
+      if (ConstantValueMap::HasValue(n->input()->debugName())) {
+        auto shape_temp = ConstantValueMap::GetValueInto1DInt64Vector(
+            n->input()->debugName());
+        UpdateShapeFromVector(n->output(), shape_temp);
+        if (!shape_temp.empty()) {
+          if (n->hasAttributeS("value")) {
+            auto value = n->t(attr::value).repeat(shape_temp);
+            ConstantValueMap::SetValue(n->output()->debugName(), value);
+          } else {
+            auto options =
+                c10::TensorOptions().dtype(at::kFloat).device(at::kCPU);
+            auto value = at::full({1}, 0.0, options).repeat(shape_temp);
+            ConstantValueMap::SetValue(n->output()->debugName(), value);
+          }
+        }
+      }
+      break;
+    }
+    case ::c10::onnx::Expand: {
+      if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+        auto input0_shape_size =
+            ConstantValueMap::GetShape(n->input(0)->debugName())
+                .value()
+                .sizes();
+        if (input0_shape_size.has_value()) {
+          auto input0_shape_value = input0_shape_size.value();
+          if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
+            auto shape_temp = ConstantValueMap::GetValueInto1DInt64Vector(
+                n->input(1)->debugName());
+            auto final_shape =
+                ComputeShapeFromExpand(input0_shape_value, shape_temp);
+            if (final_shape.has_value()) {
+              UpdateShape(n->output(), final_shape.value());
+            }
+          }
+        }
+      }
+      break;
+    }
+    case ::c10::onnx::NonZero: {
+      if (ConstantValueMap::HasRank(n->input()->debugName())) {
+        auto rank = ConstantValueMap::GetRank(n->input()->debugName()).value();
+        std::vector<c10::ShapeSymbol> dims;
+        dims.emplace_back(
+            c10::ShapeSymbol::fromStaticSize(static_cast<int64_t>(rank)));
+        auto input_node = n->input()->node();
+        if (input_node->kind() == ::c10::onnx::ConstantOfShape) {
+          if (input_node->hasAttributeS("value")) {
+            auto value =
+                input_node->t(attr::value).toType(at::ScalarType::Float);
+            auto value_a = value.accessor<float, 1>();
+            if (value_a.size(0) == 1 && std::abs(value_a[0]) > 1e-6) {
+              if (ConstantValueMap::HasShape(n->input()->debugName())) {
+                auto shape_size_0 =
+                    ConstantValueMap::GetShape(n->input()->debugName()).value();
+                if (shape_size_0.isComplete()) {
+                  auto shape_vector_0 = shape_size_0.sizes().value();
+                  int64_t num_elements = 1;
+                  for (auto cur_dim : shape_vector_0) {
+                    num_elements *= cur_dim.static_size();
+                  }
+                  dims.emplace_back(c10::ShapeSymbol::fromStaticSize(
+                      static_cast<int64_t>(num_elements)));
+                }
+              }
+            }
+          }
+        }
+        if (dims.size() == 1) {
+          dims.emplace_back(c10::ShapeSymbol::newSymbol());
+        }
+        c10::SymbolicShape shape_v(dims);
+        UpdateShape(n->output(), shape_v);
+      }
+      break;
+    }
+    case ::c10::onnx::RNN:
+    case ::c10::onnx::LSTM:
+    case ::c10::onnx::GRU: {
+      ProcessTimeSeriesNode(n);
+      break;
+    }
+    case ::c10::onnx::Slice: {
+      ProcessSliceNode(n, opset_version);
+      break;
+    }
+    case ::c10::onnx::Tile: {
+      if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+        auto input0_shape_size =
+            ConstantValueMap::GetShape(n->input(0)->debugName())
+                .value()
+                .sizes();
+        if (input0_shape_size.has_value()) {
+          auto input0_shape_value = input0_shape_size.value();
+          if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
+            auto shape_temp = ConstantValueMap::GetValueInto1DInt64Vector(
+                n->input(1)->debugName());
+            auto final_shape =
+                ComputeShapeFromTile(input0_shape_value, shape_temp);
+            if (final_shape.has_value()) {
+              UpdateShape(n->output(), final_shape.value());
+            }
+          }
+        }
+      }
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+  if (n->outputs().size() > 1 ||
+      ConstantValueMap::HasShape(n->output(0)->debugName())) {
+    return;
+  }
+  if (only_rank_available) {
+    UpdateRank(n->output(), rank);
+  }
+}
+
+bool IsListConstructIntType(const Value* v) {
+  if (v->node()->kind() == prim::ListConstruct) {
+    auto listType = v->node()->output()->type();
+    auto containedType = listType->containedTypes().at(0);
+    if (containedType == IntType::get()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ProcessConstantValueMap(Node* n, int opset_version) {
+  // Update ConstantValueMap on node outputs from onnx shape inference
+  // For outputs, only update static shapes. For input, we update symbolic
+  // shapes also. ONNX If can have different types on different branches, skip
+  // here.
+  for (auto i = 0; i < n->outputs().size(); i++) {
+    if (TensorTypePtr output_type = n->output(i)->type()->cast<TensorType>()) {
+      if (output_type->dim().has_value()) {
+        size_t rank = static_cast<size_t>(output_type->dim().value());
+        ConstantValueMap::SetRank(n->output(i)->debugName(), rank);
+        auto shape = output_type->symbolic_sizes();
+        if (shape.isComplete()) {
+          UpdateShape(n->output(i), shape);
+        }
+      }
+    }
+  }
+  // Update ConstantValueMap on node inputs from onnx shape inference.
+  // ListConstruct is handled here (we only consider IntType, not TensorType) ,
+  // no need to have a per-op based process.
+  for (auto i = 0; i < n->inputs().size(); i++) {
+    if (TensorTypePtr input_type = n->input(i)->type()->cast<TensorType>()) {
+      if (input_type->dim().has_value()) {
+        size_t rank = static_cast<size_t>(input_type->dim().value());
+        ConstantValueMap::SetRank(n->input(i)->debugName(), rank);
+        auto shape = input_type->symbolic_sizes();
+        if (!ConstantValueMap::HasShape(n->input(i)->debugName())) {
+          UpdateShape(n->input(i), shape);
+        }
+      }
+    } else if (IsListConstructIntType(n->input(i))) {
+      auto lc_node = n->input(i)->node();
+      auto rank = lc_node->inputs().size();
+      auto lc_vector_optional = GetValueFromListConstructNode(lc_node);
+      if (lc_vector_optional.has_value()) {
+        auto lc_vector = lc_vector_optional.value();
+        auto options = c10::TensorOptions().dtype(at::kLong).device(at::kCPU);
+        auto lc_vector_size = static_cast<int64_t>(lc_vector.size());
+        auto f = at::from_blob(lc_vector.data(), {lc_vector_size}, at::kLong)
+                     .to(at::kCPU);
+        // Need copy here
+        at::Tensor f_copy = at::empty({lc_vector_size}, options);
+        f_copy.copy_(f);
+        ConstantValueMap::SetValue(n->input(i)->debugName(), f_copy);
+        UpdateShapeFromVector(n->input(i), {lc_vector_size});
+      } else {
+        UpdateShapeFromVector(n->input(i), {static_cast<int64_t>(rank)});
+      }
+    }
+  }
+  // Additional logic to update the graph and ConstantValueMap
+  ComputeConstant(n, opset_version);
+}
+
 // Any additional post process that are specific to individual node kind.
 void SpecialPostProcess(Node* n) {
   switch (n->kind()) {
@@ -456,6 +1205,25 @@ void ONNXShapeTypeInference(
     const ParamMap& params_dict,
     int opset_version) {
   FetchBlockInputMetadataFromParent(b);
+  auto valsToParamsMap = buildValueToParamsMap(b, params_dict);
+  for (auto const& it : valsToParamsMap) {
+    auto key = it.first;
+    auto value = it.second;
+    if (key->node()->kind() == prim::Param) {
+      if (value.second.isTensor()) {
+        ConstantValueMap::SetValue(value.first, value.second.toTensor());
+      }
+    } else if (key->node()->kind() == ::c10::onnx::Constant) {
+      at::Tensor const_val = key->node()->t(attr::value);
+      at::Tensor const_val_copy =
+          at::empty(const_val.sizes(), const_val.options());
+      const_val_copy.copy_(const_val);
+      ConstantValueMap::SetValue(value.first, const_val_copy);
+    } else {
+      throw std::runtime_error(
+          "ONNXShapeTypeInference - Unsupported kind of constant node found.");
+    }
+  }
   for (auto n : b->nodes()) {
     for (auto subblock : n->blocks()) {
       ONNXShapeTypeInference(subblock, params_dict, opset_version);
@@ -525,6 +1293,7 @@ void ONNXShapeTypeInference(
   }
 
   SpecialPostProcess(n);
+  ProcessConstantValueMap(n, opset_version);
   GRAPH_DEBUG(
       "Torch graph after shape inference:", n->owningGraph()->toString());
 }
@@ -736,6 +1505,7 @@ void ONNXShapeTypeInference(
     std::shared_ptr<Graph>& graph,
     const ParamMap& params_dict,
     int opset_version) {
+  ConstantValueMap::ClearMaps();
   ONNXShapeTypeInference(graph->block(), params_dict, opset_version);
 }
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -203,8 +203,8 @@ def _optimize_graph(graph, operator_export_type, _disable_torch_constant_prop=Fa
         torch._C._jit_pass_onnx_scalar_type_analysis(graph)
         torch._C._jit_pass_lint(graph)
 
-        if dynamic_axes is None or not bool(dynamic_axes):
-            torch._C._jit_pass_onnx_fold_if(graph)
+        torch._C._jit_pass_onnx_fold_if(graph)
+
         from torch.onnx.symbolic_helper import _export_onnx_opset_version
         torch._C._jit_pass_onnx_peephole(graph, _export_onnx_opset_version, fixed_batch_size)
         torch._C._jit_pass_lint(graph)


### PR DESCRIPTION
This PR did symbolic shape inference, in the onnx pass _jit_pass_onnx_graph_shape_type_inference.
It creates a singleton ConstantValueMap.
It leverages constant folding technique and did a per-op based handling for ConstantValueMap.
As a byproduct, it enables fold_if pass for dynamic axes cases, typically for faster-rcnn etc.

The core change is in `torch/csrc/jit/passes/onnx/shape_type_inference.cpp` and `torch/csrc/jit/passes/onnx/constant_map.cpp`.

We usually need copy tensor to store in the ConstantValueMap, otherwise the underlying value may change. I see this issue in (1) from_blob (2) get value from Constant node.