### PR TITLE
Remove some ArrayRef special cases

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -666,7 +666,7 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
         input_base = 'input_base'
         replay_view_func = ''
         updated_unpacked_args: List[str] = []
-        known_view_arg_simple_types: List[str] = ['int64_t', 'c10::optional<int64_t>', 'bool', 'IntArrayRef']
+        known_view_arg_simple_types: List[str] = ['int64_t', 'c10::optional<int64_t>', 'bool', 'ArrayRef<int64_t>']
         for unpacked_binding in unpacked_bindings:
             arg, arg_type = unpacked_binding.name, unpacked_binding.type
             if arg == 'self_':
@@ -679,7 +679,7 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                                 'over by value, also add a test in pytorch/xla/test/test_operations.py where this code '
                                 'is exercised.')
 
-            if arg_type == 'IntArrayRef':
+            if arg_type == 'ArrayRef<int64_t>':
                 # It's not safe to close over IntArrayRef by value, since this is a
                 # reference type, so materialize a vector to close over by value
                 arg_vec = arg + '_vec'

--- a/tools/autograd/templates/VariableType.h
+++ b/tools/autograd/templates/VariableType.h
@@ -27,6 +27,7 @@ using at::Dimname;
 using at::DimnameList;
 using at::Generator;
 using at::IntArrayRef;
+using at::ArrayRef;
 using at::MemoryFormat;
 using at::QScheme;
 using at::Scalar;

--- a/tools/autograd/templates/python_fft_functions.cpp
+++ b/tools/autograd/templates/python_fft_functions.cpp
@@ -30,6 +30,7 @@ using at::Generator;
 using at::TensorList;
 using at::Dimname;
 using at::DimnameList;
+using at::ArrayRef;
 
 using torch::utils::check_out_type_matches;
 using namespace torch::autograd::utils;

--- a/tools/autograd/templates/python_linalg_functions.cpp
+++ b/tools/autograd/templates/python_linalg_functions.cpp
@@ -17,6 +17,7 @@ using at::ScalarType;
 using at::MemoryFormat;
 using at::Generator;
 using at::IntArrayRef;
+using at::ArrayRef;
 
 using namespace torch::autograd::utils;
 

--- a/tools/autograd/templates/variable_factories.h
+++ b/tools/autograd/templates/variable_factories.h
@@ -50,6 +50,7 @@ inline at::Tensor tensor(detail::TensorDataContainer tensor_data_container, cons
 /// A generic deleter function.
 using Deleter = std::function<void(void*)>;
 using at::MemoryFormat;
+using at::Dimname;
 
 /// Exposes the given `data` as a `Tensor` without taking ownership of the
 /// original data. `sizes` should specify the shape of the tensor, `strides` the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51500 Use Literal to model targets.
* #51499 Add support for generating faithful at::cpu signatures
* #51490 Switch structured kernels to use const Tensor& everywhere
* **#51485 Remove some ArrayRef special cases**
* #51477 Relax type signature for tools.codegen.api.translate

TensorList special case must stay as we do ArrayRef<Tensor> not
ArrayRef<const Tensor&> (maybe we should support this though!)
But the rest of them can just directly desugar into ArrayRef.
This isn't risk free as there was at least one case where we were
keying on a specific spelling of the type (hope there aren't any
external repository cases).

I'm not sure why variable_factories.h needed a new using for Dimname
but empirically it seems to be necessary.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D26182412](https://our.internmc.facebook.com/intern/diff/D26182412)