### PR TITLE
[nnc] Vectorize bitwise ops

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -153,6 +153,41 @@ class Vectorizer : public IRMutator {
     });
   }
 
+  const Expr* mutate(const And* v) override {
+    std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
+    return try_vectorize(v, inputs, [&]() {
+      return ExprHandle(inputs[0]) & ExprHandle(inputs[1]);
+    });
+  }
+
+  const Expr* mutate(const Or* v) override {
+    std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
+    return try_vectorize(v, inputs, [&]() {
+      return ExprHandle(inputs[0]) | ExprHandle(inputs[1]);
+    });
+  }
+
+  const Expr* mutate(const Xor* v) override {
+    std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
+    return try_vectorize(v, inputs, [&]() {
+      return ExprHandle(inputs[0]) ^ ExprHandle(inputs[1]);
+    });
+  }
+
+  const Expr* mutate(const Lshift* v) override {
+    std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
+    return try_vectorize(v, inputs, [&]() {
+      return ExprHandle(inputs[0]) << ExprHandle(inputs[1]);
+    });
+  }
+
+  const Expr* mutate(const Rshift* v) override {
+    std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
+    return try_vectorize(v, inputs, [&]() {
+      return ExprHandle(inputs[0]) >> ExprHandle(inputs[1]);
+    });
+  }
+
   const Expr* mutate(const Max* v) override {
     std::vector<const Expr*> inputs = {v->lhs(), v->rhs()};
     return try_vectorize(v, inputs, [&]() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51492 [nnc] Vectorize bitwise ops**
* #51491 [nnc] Tweak log_nnc_sleef so vectorization kicks in

We missed these originally.  This helps vectorize log_fast.

Differential Revision: [D26155792](https://our.internmc.facebook.com/intern/diff/D26155792/)