### PR TITLE
[FX] add TracingAnalysis pass

### DIFF
--- a/torch/fx/examples/fx_profiler.py
+++ b/torch/fx/examples/fx_profiler.py
@@ -1,0 +1,112 @@
+import time
+from collections import Counter
+from typing import Any, Dict, List, Callable
+
+from torch.fx import GraphModule
+from torch.fx.experimental.tracing_analysis import TracingAnalysis
+from torch.fx.node import Node
+
+
+class FXProfiler(TracingAnalysis):
+    """
+    An example showing how to write a simple profiler analysis pass
+    utilizing TracingAnalysis.
+
+    See also PyTorch profiler:
+        https://pytorch.org/tutorials/recipes/recipes/profiler.html
+
+    Example usage:
+        mod = torch.fx.symbolic_trace(...)
+        prof = FXProfiler(mod)
+        prof.run(*example_input)
+        print(prof.summary())
+
+    Example output:
+       conv2d:49% linear:28% pixelshuffle:10% relu:7% sub:2% sigmoid:2% view:0% other:2%
+    """
+
+    def __init__(self, module: GraphModule):
+        super(FXProfiler, self).__init__(module)
+        # tracks how many seconds are spent in each function name
+        self.times: Dict[str, float] = Counter()
+        self.total = 0.0
+
+    def run_call_any(self, node: Node, fn: Callable, args: List[Any], kwargs: Dict[str, Any]) -> Any:
+        # Called to run a "call_function", "call_method", or "call_module" node
+        start = time.perf_counter()
+        result = super(FXProfiler, self).run_call_any(node, fn, args, kwargs)
+        # consider calling `torch.cuda.synchronize()` here
+        self.times[nameof(fn)] += time.perf_counter() - start
+        return result
+
+    def run(self, *args: List[Any]) -> Any:
+        start = time.perf_counter()
+        result = super(FXProfiler, self).run(*args)
+        self.total += time.perf_counter() - start
+        return result
+
+    def summary(self, n=8):
+        # generates a one-line report
+        outputs = []
+        other = 1.0
+        for k, v in self.times.most_common(n - 1):
+            v = v / self.total
+            outputs.append(f"{k}:{v:.0%}")
+            other -= v
+        outputs.append(f"other:{other:.0%}")
+        return " ".join(outputs)
+
+
+class BigramCounter(TracingAnalysis):
+    """
+    An example showing an analysis pass in FX that looks at sliding
+    windows of an op and its direct inputs and counts frequencies.
+
+    Example usage:
+        mod = torch.fx.symbolic_trace(...)
+        prof = BigramCounter(mod)
+        prof.run(*example_input)
+        print(prof.summary(4))
+
+    Example output:
+        batchnorm2d(conv2d):53 conv2d(relu):50 relu(batchnorm2d):33 relu(add):16
+    """
+
+    def __init__(self, module: GraphModule):
+        super(BigramCounter, self).__init__(module)
+        # Keep track of what function names the inputs to this node came from
+        self.current_node_sources: List[str] = []
+        # Shadow structure to self.env the stores the name of the function that wrote it
+        self.env_sources: Dict[str, str] = dict()
+        # How many times we have seen each bigram
+        self.counts: Dict[str, int] = Counter()
+
+    def before_node(self, node: Node):
+        # reset state at start of each node
+        self.current_node_sources.clear()
+        return super(BigramCounter, self).before_node(node)
+
+    def load(self, node: Node):
+        try:
+            # record the function that wrote this input value
+            self.current_node_sources.append(self.env_sources[node.name])
+        except KeyError:
+            pass  # from a placeholder or constant
+        # do original behavior
+        return super(BigramCounter, self).load(node)
+
+    def run_call_any(self, node: Node, fn: Callable, args: List[Any], kwargs: Dict[str, Any]) -> Any:
+        # count the bigram
+        self.counts[f"{nameof(fn)}({','.join(self.current_node_sources)})"] += 1
+        # tracking used to compute self.current_node_sources for the next node
+        self.env_sources[node.name] = nameof(fn)
+        return super(BigramCounter, self).run_call_any(node, fn, args, kwargs)
+
+    def summary(self, n=8):
+        # generates a one-line report
+        return " ".join(f"{k}:{v}" for k, v in self.counts.most_common(n))
+
+
+def nameof(fn: Callable):
+    """ Convert a function, method, or nn.Module to a string """
+    return (getattr(fn, "__name__", None) or fn.__class__.__name__).lower()

--- a/torch/fx/experimental/shape_prop.py
+++ b/torch/fx/experimental/shape_prop.py
@@ -1,51 +1,12 @@
 import torch
-import torch.fx
-from torch.fx.node import Node
+from torch.fx.experimental.tracing_analysis import TracingAnalysis
 
-from typing import Dict
 
-class ShapeProp:
-    def __init__(self, mod):
-        self.mod = mod
-        self.graph = mod.graph
-        self.modules = dict(self.mod.named_modules())
+class ShapeProp(TracingAnalysis):
+    def store_result(self, node, result):
+        if isinstance(result, torch.Tensor):
+            node.shape = result.shape
+            node.dtype = result.dtype
+        super(ShapeProp, self).store_result(node, result)
 
-    def propagate(self, *args):
-        args_iter = iter(args)
-        env : Dict[str, Node] = {}
-
-        def load_arg(a):
-            return torch.fx.node.map_arg(a, lambda n: env[n.name])
-
-        def fetch_attr(target : str):
-            target_atoms = target.split('.')
-            attr_itr = self.mod
-            for i, atom in enumerate(target_atoms):
-                if not hasattr(attr_itr, atom):
-                    raise RuntimeError(f"Node referenced nonexistant target {'.'.join(target_atoms[:i])}")
-                attr_itr = getattr(attr_itr, atom)
-            return attr_itr
-
-        for node in self.graph.nodes:
-            if node.op == 'placeholder':
-                result = next(args_iter)
-            elif node.op == 'get_attr':
-                result = fetch_attr(node.target)
-            elif node.op == 'call_function':
-                result = node.target(*load_arg(node.args), **load_arg(node.kwargs))
-            elif node.op == 'call_method':
-                self_obj, *args = load_arg(node.args)
-                kwargs = load_arg(node.kwargs)
-                result = getattr(self_obj, node.target)(*args, **kwargs)
-            elif node.op == 'call_module':
-                result = self.modules[node.target](*load_arg(node.args), **load_arg(node.kwargs))
-            elif node.op == 'output':
-                return load_arg(node.args[0])
-
-            if isinstance(result, torch.Tensor):
-                node.shape = result.shape
-                node.dtype = result.dtype
-
-            env[node.name] = result
-
-        return None
+    propagate = TracingAnalysis.run  # backwards compatibility

--- a/torch/fx/experimental/tracing_analysis.py
+++ b/torch/fx/experimental/tracing_analysis.py
@@ -1,0 +1,219 @@
+from typing import Any, Dict, Iterable, List, Callable
+
+import torch
+from torch.fx.node import Node
+from torch.fx.symbolic_trace import GraphModule
+
+
+class TracingAnalysis(object):
+    """
+    `TracingAnalysis` is designed to be subclassed in order to build
+    FX analysis passes that operate by running an example input through
+    the graph and observing values along the way.
+
+    As an example, you could implement shape propagation via:
+
+        class ShapeProp(TracingAnalysis):
+            def store_result(self, node, result):
+                if isinstance(result, torch.Tensor):
+                    node.shape = result.shape
+                    node.dtype = result.dtype
+                super().store_result(node, result)
+
+        mod = torch.fx.symbolic_trace(...)
+        ShapeProp(mod).run(*example_input)
+        # nodes in mod now contain `.shape` and `.dtype`
+    """
+
+    def __init__(self, module: GraphModule):
+        """
+        Construct a `TracingAnalysis` object.
+
+        Args:
+
+            module (torch.fx.GraphModule): module to run analysis on.
+        """
+        super(TracingAnalysis, self).__init__()
+        self.module: GraphModule = module
+        self.env: Dict[str, Any] = dict()
+        self._named_modules: Dict[str, torch.Module] = dict()
+        self._args_iter: Iterable = iter([])
+
+    def run(self, *args: List[Any]) -> Any:
+        """
+        Run this analysis and execute self.module.
+
+        Args:
+            *args: Args to pass to self.module
+
+        Returns:
+            The return value of self.module
+        """
+        self._args_iter = iter(args)
+        self._named_modules: Dict[str, torch.Module] = dict(self.module.named_modules())
+        try:
+            for node in self.module.graph.nodes:
+                self.before_node(node)
+                result = getattr(self, f"run_{node.op}")(node)
+                self.store_result(node, result)
+                if node.op == 'output':
+                    return result
+        finally:
+            self._args_iter = iter([])
+            self._named_modules.clear()
+            self.env.clear()
+
+    def run_placeholder(self, node: Node) -> Any:
+        """
+        Execute a "placeholder" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The next arg passed to the graph
+        """
+        return next(self._args_iter)
+
+    def run_get_attr(self, node: Node) -> Any:
+        """
+        Execute a "get_attr" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The value of the loaded attribute
+        """
+        target = node.target
+        target_atoms = target.split('.')
+        attr_itr = self.module
+        for i, atom in enumerate(target_atoms):
+            if not hasattr(attr_itr, atom):
+                raise RuntimeError(f"Node referenced non-existant target {'.'.join(target_atoms[:i])}")
+            attr_itr = getattr(attr_itr, atom)
+        return attr_itr
+
+    def run_call_function(self, node: Node) -> Any:
+        """
+        Execute a "call_function" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The return value of the called function
+        """
+        return self.run_call_any(node,
+                                 node.target,
+                                 self.load_args(node, node.args),
+                                 self.load_args(node, node.kwargs))
+
+    def run_call_method(self, node: Node) -> Any:
+        """
+        Execute a "call_method" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The return value of the called method
+        """
+        self_obj, *args = self.load_args(node, node.args)
+        kwargs = self.load_args(node, node.kwargs)
+        return self.run_call_any(node,
+                                 getattr(self_obj, node.target),
+                                 args,
+                                 kwargs)
+
+    def run_call_module(self, node: Node) -> Any:
+        """
+        Execute a "call_module" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The return value of the called module
+        """
+        return self.run_call_any(node,
+                                 self._named_modules[node.target],
+                                 self.load_args(node, node.args),
+                                 self.load_args(node, node.kwargs))
+
+    def run_call_any(self, node: Node, fn: Callable, args: List[Any], kwargs: Dict[str, Any]) -> Any:
+        """
+        Common hook used by "call_function", "call_method", and
+        "call_module" nodes in graph.  This is meant to be overridden
+        to add analysis around all call_* nodes.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+            fn (Callable): function, method, or module to call
+            args (List[Any]): *args to pass to callable
+            kwargs (Dict[str, Any]): **kwargs to pass to callable
+
+        Returns:
+            The return value of fn(*args, **kwargs)
+        """
+        return fn(*args, **kwargs)
+
+    def run_output(self, node: Node) -> Any:
+        """
+        Execute a "output" node in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+
+        Returns:
+            The return value of the graph
+        """
+        return self.load_args(node, node.args)[0]
+
+    def load_args(self, node: Node, arg: Any) -> Any:
+        """
+        Load the args for node. `arg` will be either node.args
+        or node.kwargs and may be a nested data structure of
+        dict/list/tuple/slice.  Leaf nodes in that data structure are
+        pointers to other nodes in the graph.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+            arg (Any): args that should be loaded
+
+        Returns:
+            Loaded args
+        """
+        return torch.fx.node.map_arg(arg, self.load)
+
+    def load(self, node: Node):
+        """
+        Load the output value of a node that has previously been executed.
+
+        Args:
+            node (torch.fx.node.Node): node to read the output of
+
+        Returns:
+            the output value of node from `self.env`
+        """
+        return self.env[node.name]
+
+    def store_result(self, node: Node, result: Any):
+        """
+        This is run after executing each node and stores the output of
+        that node in `self.env`
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+            result (Any): the output value generated by node
+        """
+        self.env[node.name] = result
+
+    def before_node(self, node: Node):
+        """
+        Hook to allow custom code to be run before executing a node.
+
+        Args:
+            node (torch.fx.node.Node): node the in graph current being run
+        """
+        pass


### PR DESCRIPTION
I wanted to write something similar to ShapeProp, but felt bad about copy and pasting the logic to trace through the execution of a graph, so I refactored it out into a common base class to make writing passes like this easier.

Test Plan: added tests, also covered by ShapeProp tests