### PR TITLE
[FX] Support ellipsis as arg

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1166,6 +1166,18 @@ class TestFX(JitTestCase):
         output : torch.fx.Node = graph.output(b)
         self.assertTrue('typing.List[float]' in str(graph))
 
+    def test_ellipsis(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, y):
+                return x + y[:, 1:10, ...]
+
+        traced = symbolic_trace(M())
+        x, y = torch.rand(5, 9, 3, 4), torch.rand(5, 15, 3, 4)
+        self.assertEqual(traced(x, y), x + y[:, 1:10, ...])
+
     def test_inf_nan(self):
         class FooMod(torch.nn.Module):
             def forward(self, x):

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -71,7 +71,7 @@ class TracerBase:
         if isinstance(a, Proxy):
             # base case: we unwrap the Proxy object
             return a.node
-        elif isinstance(a, base_types) or a is None:
+        elif isinstance(a, base_types) or a is None or a is ...:
             return a
 
         raise NotImplementedError(f"argument of type: {type(a)}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51502 [FX] Support ellipsis as arg**

Closes https://github.com/pytorch/pytorch/issues/51501

Previously, `create_arg` would fail if it encountered a `...` argument. Ellipsis in Python is a singleton object similar to `None`, so let's treat ellipsis the exact same way as `None`.

Differential Revision: [D26186578](https://our.internmc.facebook.com/intern/diff/D26186578)