### PR TITLE
Enable FLOPS Computation for Experimental Kineto Profiler

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -263,7 +263,7 @@ class TestProfiler(TestCase):
             nn.ReLU(),
         )
         inputs = torch.randn(40, 16, 18, 260)
-        with _profile(record_shapes=True, with_flops=True) as prof:
+        with _profile(record_shapes=True, with_flops=True, use_kineto=kineto_available()) as prof:
             model(inputs)
         profiler_output = prof.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total", row_limit=10)
         print(profiler_output)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1168,6 +1168,7 @@ def parse_kineto_results(result):
             sequence_nr=kineto_event.sequence_nr(),
             device_type=kineto_event.device_type(),
             device_index=kineto_event.device_index(),
+            flops=kineto_event.flops(),
         )
         function_events.append(fe)
         if kineto_event.device_type() == DeviceType.CUDA:

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -159,7 +159,11 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject *unused) {
         return e.deviceType();
       })
       // correlation id of a linked event
-      .def("linked_correlation_id", &KinetoEvent::linkedCorrelationId);
+      .def("linked_correlation_id", &KinetoEvent::linkedCorrelationId)
+      // compute flops
+      .def("flops", [](const KinetoEvent& e) {
+        return e.flops();
+      });
 
   py::class_<ProfilerResult>(m, "ProfilerResult")
     .def("events", &ProfilerResult::events)

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -72,10 +72,13 @@ struct TORCH_API KinetoThreadLocalState : public ProfilerThreadLocalState {
           .fwdThreadId(ctx->fwdThreadId)
           .scope(ctx->recFunScope);
       if (ctx->shapes && !ctx->shapes->empty()) {
-          kineto_events_.back().shapes(*ctx->shapes);
+        kineto_events_.back().shapes(*ctx->shapes);
       }
       if (ctx->stack && !ctx->stack->empty()) {
         kineto_events_.back().stack(*ctx->stack);
+      }
+      if (ctx->extraArgs && !ctx->extraArgs->empty()) {
+        kineto_events_.back().flops(computeFlops(std::string(fn.name().str()), *ctx->extraArgs));
       }
       cpu_trace->activities.emplace_back(std::move(op));
     }
@@ -153,6 +156,10 @@ void pushProfilingCallbacks() {
 
         if (state_ptr->config().report_input_shapes) {
           ctx_ptr->shapes = inputSizes(fn);
+        }
+
+        if (state_ptr->config().with_flops) {
+          ctx_ptr->extraArgs = saveExtraArgs(fn);
         }
 
         ctx_ptr->sequenceNr = fn.seqNr();

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -31,6 +31,8 @@ struct KinetoObserverContext : public at::ObserverContext {
   uint64_t fwdThreadId;
   uint8_t recFunScope;
   c10::optional<std::vector<std::string>> stack;
+  // Extra arguments for computing op flops
+  c10::optional<std::unordered_map<std::string, c10::IValue>> extraArgs;
 };
 
 struct TORCH_API KinetoEvent {
@@ -58,6 +60,10 @@ struct TORCH_API KinetoEvent {
 
   const std::vector<std::vector<int64_t>>& shapes() const {
     return *shapes_;
+  }
+
+  uint64_t flops() const {
+    return flops_;
   }
 
   int64_t sequenceNr() const {
@@ -93,6 +99,11 @@ struct TORCH_API KinetoEvent {
 
   KinetoEvent& shapes(const std::vector<std::vector<int64_t>>& shapes) {
     shapes_ = shapes;
+    return *this;
+  }
+
+  KinetoEvent& flops(uint64_t flops) {
+    flops_ = flops;
     return *this;
   }
 
@@ -159,6 +170,7 @@ struct TORCH_API KinetoEvent {
   uint8_t activity_type_;
   c10::optional<std::vector<std::vector<int64_t>>> shapes_;
   c10::optional<std::vector<std::string>> stack_;
+  uint64_t flops_;
 
   std::string name_;
   uint64_t device_index_ = 0;


### PR DESCRIPTION
Summary:

Add the FLOPS metric computation to the experimental Kineto profiler.
This includes saving necessary extra arguments and compute flops in the C++ code,
and extract the FLOPS value from the Python frontend.

Test Plan:

Build PyTorch with USE_KINETO option, then run the unit test:

```python
python test/test_profiler.py -k test_flops
```

The test will automatically use kineto profiler if it is available.
