### PR TITLE
[Fuser] Do not attempt to use OpenMP if build without OpenMP support

### DIFF
--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -518,7 +518,9 @@ std::string generateKernel(
   // Note: Random number generation is only supported for CUDA kernels.
   // Note: Constant None node is ignored and we will handle it in the
   //       places where the constant None node is used
-  for (const auto& n : graph.nodes()) {
+  // Note: No need to iterate over reference as n is a pointer
+  for (const auto n : graph.nodes()) {
+    static_assert(std::is_pointer<decltype(n)>::value, "n must be a pointer");
     // Note: FusedConcat nodes work by narrowing the output Tensors before the
     // kernel runs
     if (n->kind() == prim::FusedConcat)

--- a/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
@@ -196,11 +196,18 @@ struct CompilerConfig {
 #ifdef _MSC_VER
   std::string cxx = "cl";
   const std::string openmp_flags = "/openmp";
+#elif defined(__APPLE__)
+  std::string cxx = "clang++";
+  const std::string openmp_flags = "";
 #else
   std::string cxx = "g++";
   const std::string openmp_flags = "-fopenmp";
 #endif
+#if defined(__APPLE__)
+  bool openmp = false;
+#else
   bool openmp = true;
+#endif
 };
 
 static CompilerConfig& getConfig() {

--- a/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp
@@ -196,17 +196,19 @@ struct CompilerConfig {
 #ifdef _MSC_VER
   std::string cxx = "cl";
   const std::string openmp_flags = "/openmp";
-#elif defined(__APPLE__)
+#elif defined(__clang__)
   std::string cxx = "clang++";
-  const std::string openmp_flags = "";
+  const std::string openmp_flags = "-fopenmp";
 #else
   std::string cxx = "g++";
   const std::string openmp_flags = "-fopenmp";
 #endif
-#if defined(__APPLE__)
-  bool openmp = false;
-#else
+// Set openmp to true only if PyTorch is compiled with OpenMP support
+// OpenMP is typically not availabel on MacOS platform
+#if defined(_OPENMP)
   bool openmp = true;
+#else
+  bool openmp = false;
 #endif
 };
 

--- a/torch/csrc/jit/codegen/fuser/kernel_spec.h
+++ b/torch/csrc/jit/codegen/fuser/kernel_spec.h
@@ -66,7 +66,9 @@ struct TORCH_API KernelSpec {
         inputChunks_{},
         has_random_{false},
         kernels_{} {
-    for (const auto& n : graph_->nodes()) {
+    // No need to iterate over reference since n is pointer
+    for (const auto n : graph_->nodes()) {
+      static_assert(std::is_pointer<decltype(n)>::value, "n must be a pointer");
       if (n->kind() == aten::rand_like) {
         has_random_ = true;
         break;


### PR DESCRIPTION
Clang from XCode does not support `-fopenmp` option, no need to try to compile with it.
Infer whether OpenMP is supported by checking _OPENMP define.
Also, use clang compiler if host app was compiled with clang rather than gcc.
Fix few range loop warnings and add static_asserts that range loop variables are raw pointers.

This changes makes fuser tests on OS X a bit faster.

Before:
```
% python3 test_jit.py -v  TestScript.test_batchnorm_fuser_cpu
Fail to import hypothesis in common_utils, tests are not derandomized
CUDA not available, skipping tests
test_batchnorm_fuser_cpu (__main__.TestScript) ... clang: error: unsupported option '-fopenmp'
clang: error: unsupported option '-fopenmp'
warning: pytorch jit fuser failed to compile with openmp, trying without it...
ok

----------------------------------------------------------------------
Ran 1 test in 0.468s

OK
```

After:
```
% python3 test_jit.py -v  TestScript.test_batchnorm_fuser_cpu
Fail to import hypothesis in common_utils, tests are not derandomized
CUDA not available, skipping tests
test_batchnorm_fuser_cpu (__main__.TestScript) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.435s

OK
```
