### PR TITLE
[ROCm] add 4.0.1 docker image

### DIFF
--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -29,6 +29,7 @@ IMAGE_NAMES = [
     "pytorch-linux-xenial-py3.6-gcc5.4",  # this one is used in doc builds
     "pytorch-linux-xenial-py3.6-gcc7.2",
     "pytorch-linux-xenial-py3.6-gcc7",
+    "pytorch-linux-bionic-rocm3.9-py3.6",
     "pytorch-linux-bionic-rocm3.10-py3.6",
     "pytorch-linux-bionic-rocm4.0.1-py3.6",
 ]

--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -29,8 +29,8 @@ IMAGE_NAMES = [
     "pytorch-linux-xenial-py3.6-gcc5.4",  # this one is used in doc builds
     "pytorch-linux-xenial-py3.6-gcc7.2",
     "pytorch-linux-xenial-py3.6-gcc7",
-    "pytorch-linux-bionic-rocm3.9-py3.6",
     "pytorch-linux-bionic-rocm3.10-py3.6",
+    "pytorch-linux-bionic-rocm4.0.1-py3.6",
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6620,6 +6620,9 @@ workflows:
           name: "docker-pytorch-linux-xenial-py3.6-gcc7"
           image_name: "pytorch-linux-xenial-py3.6-gcc7"
       - docker_build_job:
+          name: "docker-pytorch-linux-bionic-rocm3.9-py3.6"
+          image_name: "pytorch-linux-bionic-rocm3.9-py3.6"
+      - docker_build_job:
           name: "docker-pytorch-linux-bionic-rocm3.10-py3.6"
           image_name: "pytorch-linux-bionic-rocm3.10-py3.6"
       - docker_build_job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6620,11 +6620,11 @@ workflows:
           name: "docker-pytorch-linux-xenial-py3.6-gcc7"
           image_name: "pytorch-linux-xenial-py3.6-gcc7"
       - docker_build_job:
-          name: "docker-pytorch-linux-bionic-rocm3.9-py3.6"
-          image_name: "pytorch-linux-bionic-rocm3.9-py3.6"
-      - docker_build_job:
           name: "docker-pytorch-linux-bionic-rocm3.10-py3.6"
           image_name: "pytorch-linux-bionic-rocm3.10-py3.6"
+      - docker_build_job:
+          name: "docker-pytorch-linux-bionic-rocm4.0.1-py3.6"
+          image_name: "pytorch-linux-bionic-rocm4.0.1-py3.6"
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           requires:

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -274,6 +274,13 @@ case "$image" in
     VISION=yes
     KATEX=yes
     ;;
+  pytorch-linux-bionic-rocm3.9-py3.6)
+    ANACONDA_PYTHON_VERSION=3.6
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
+    ROCM_VERSION=3.9
+    ;;
   pytorch-linux-bionic-rocm3.10-py3.6)
     ANACONDA_PYTHON_VERSION=3.6
     PROTOBUF=yes

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -274,19 +274,19 @@ case "$image" in
     VISION=yes
     KATEX=yes
     ;;
-  pytorch-linux-bionic-rocm3.9-py3.6)
-    ANACONDA_PYTHON_VERSION=3.6
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    ROCM_VERSION=3.9
-    ;;
   pytorch-linux-bionic-rocm3.10-py3.6)
     ANACONDA_PYTHON_VERSION=3.6
     PROTOBUF=yes
     DB=yes
     VISION=yes
     ROCM_VERSION=3.10
+    ;;
+  pytorch-linux-bionic-rocm4.0.1-py3.6)
+    ANACONDA_PYTHON_VERSION=3.6
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
+    ROCM_VERSION=4.0.1
     ;;
   *)
     # Catch-all for builds that are not hardcoded.


### PR DESCRIPTION
Add a ROCm 4.0.1 docker image for CI. Keep the 3.10 image.
Keep the 3.9 image until the 3.9 image is no longer needed.
Plan is to keep two ROCm versions at a time.