### PR TITLE
Save embeddings for Tensorboard as binary instead of tsv

### DIFF
--- a/torch/utils/tensorboard/_embedding.py
+++ b/torch/utils/tensorboard/_embedding.py
@@ -44,10 +44,11 @@ def make_sprite(label_img, save_path):
     fs.write(fs.join(save_path, 'sprite.png'), im_bytes, binary_mode=True)
 
 
-def get_embedding_info(metadata, label_img, filesys, subdir, global_step, tag):
+def get_embedding_info(metadata, label_img, filesys, subdir, global_step, tag, mat_shape):
     info = EmbeddingInfo()
     info.tensor_name = "{}:{}".format(tag, str(global_step).zfill(5))
-    info.tensor_path = filesys.join(subdir, 'tensors.tsv')
+    info.tensor_path = filesys.join(subdir, 'tensors.bin')
+    info.tensor_shape.extend(mat_shape)
     if metadata is not None:
         info.metadata_path = filesys.join(subdir, 'metadata.tsv')
     if label_img is not None:
@@ -62,9 +63,6 @@ def write_pbtxt(save_path, contents):
     fs.write(config_path, tf.compat.as_bytes(contents), binary_mode=True)
 
 
-def make_mat(matlist, save_path):
+def make_mat(mat, save_path):
     fs = tf.io.gfile.get_filesystem(save_path)
-    with tf.io.gfile.GFile(fs.join(save_path, 'tensors.tsv'), 'wb') as f:
-        for x in matlist:
-            x = [str(i.item()) for i in x]
-            f.write(tf.compat.as_bytes('\t'.join(x) + '\n'))
+    mat.tofile(fs.join(save_path, 'tensors.bin'))

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -822,7 +822,7 @@ class SummaryWriter(object):
         if not hasattr(self, "_projector_config"):
             self._projector_config = ProjectorConfig()
         embedding_info = get_embedding_info(
-            metadata, label_img, fs, subdir, global_step, tag)
+            metadata, label_img, fs, subdir, global_step, tag, mat.shape)
         self._projector_config.embeddings.extend([embedding_info])
 
         from google.protobuf import text_format  # type: ignore


### PR DESCRIPTION
Fixes #51445. (Updated version of #51446)

This PR makes `add_embedding()` of Tensorboard save embeddings as binary instead of TSV.

Because the first arg of `make_mat()` was `matlist`, I thought that the arg can be a list of arrays.
However, according to the doc of `add_embedding()`, it must be an array.
So I suppose there is no degrades caused by this PR, as long as users follow the doc.
Note that I also changed the name of the arg (`matlist`->`mat`) for this reason.
