### PR TITLE
disabling BUILD_SPLIT_CUDA=ON for windows 11.1 temporarily

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -112,7 +112,8 @@ if "%REBUILD%" == "" (
 )
 :: tests if BUILD_ENVIRONMENT contains cuda11 as a substring
 if not x%BUILD_ENVIRONMENT:cuda11=%==x%BUILD_ENVIRONMENT% (
-   set BUILD_SPLIT_CUDA=ON
+   :: temporarily disabled
+   :: set BUILD_SPLIT_CUDA=ON
 )
 
 python setup.py install --cmake && sccache --show-stats && (


### PR DESCRIPTION
BUILD_SPLIT_CUDA needs to be exported to true in order for cpp_extensions.py to work properly--it's currently not working properly, so disabling the build option for now