### PR TITLE
Fix the behavior of data.new() when the tensor layout is torch.mkldnn

### DIFF
--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -341,7 +341,8 @@ void check_base_legacy_new(c10::DispatchKey dispatch_key, at::Layout expected_la
             dispatch_key == c10::DispatchKey::CUDA ||
             dispatch_key == c10::DispatchKey::HIP ||
             dispatch_key == c10::DispatchKey::XLA ||
-            dispatch_key == c10::DispatchKey::XPU,
+            dispatch_key == c10::DispatchKey::XPU ||
+            dispatch_key == c10::DispatchKey::MkldnnCPU,
         "new(): expected DispatchKey: ",
         c10::DispatchKey::CPU,
         " or ",
@@ -352,6 +353,8 @@ void check_base_legacy_new(c10::DispatchKey dispatch_key, at::Layout expected_la
         c10::DispatchKey::XLA,
         " or ",
         c10::DispatchKey::XPU,
+        " or ",
+        c10::DispatchKey::MkldnnCPU,
         " but got: ",
         dispatch_key);
   } else if(expected_layout == c10::kSparse) {


### PR DESCRIPTION
If the layout of the tensor is ``torch.mkldnn``, calling ``data.new()`` raises a RuntimeError.
Error message is bellow:
"new(): expected DispatchKey: CPU or CUDA or HIP or XLA but got: MkldnnCPU"

Environment
・CPU : Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz
・OS : Ubuntu 16.04.6 LTS
・compiler : gcc 5.4.0
・branch : master
・commit ID: 345844d
・build Environment variable: USE_DISTRIBUTED=0, USE_MKLDNN=1
・Python: 3.7.9

Steps to reproduce
```
% python3 TestScript.py
```

TestScript.py
```
import torch

torch.manual_seed(4)

a = torch.randn(4, 4)
b = a.data.new(a.size())
print(a)
print(b)

a_mkl = a.to_mkldnn()
c = a_mkl.data.new(a.size())  # <= error
print(a_mkl)
print(c)
```

Expected Result
```
tensor([[-0.9414,  1.2632, -0.1838,  0.1505],
        [ 0.1075, -0.2780, -2.6021,  0.6245],
        [-0.8684, -0.2051,  0.3976,  0.6699],
        [-0.0537,  0.0467, -1.7671, -2.1205]])
tensor([[9.3637e+36, 4.5612e-41, 9.3637e+36, 4.5612e-41],
        [1.4013e-45, 4.5914e-41, 6.7000e-37, 0.0000e+00],
        [6.7262e-44, 0.0000e+00, 6.7262e-44, 0.0000e+00],
        [4.0432e-38, 0.0000e+00, 2.3822e-44, 4.5612e-41]])
tensor([[-0.9414,  1.2632, -0.1838,  0.1505],
        [ 0.1075, -0.2780, -2.6021,  0.6245],
        [-0.8684, -0.2051,  0.3976,  0.6699],
        [-0.0537,  0.0467, -1.7671, -2.1205]], layout=torch._mkldnn)
tensor([[9.3637e+36, 4.5612e-41, 6.7000e-37, 0.0000e+00],
        [2.3822e-44, 0.0000e+00, 0.0000e+00, 0.0000e+00],
        [4.0132e-38, 0.0000e+00, 8.4078e-45, 0.0000e+00],
        [7.3909e+22, 1.4764e-41, 0.0000e+00, 0.0000e+00]],
       layout=torch._mkldnn)
```

Execution Result
```
tensor([[-0.9414,  1.2632, -0.1838,  0.1505],
        [ 0.1075, -0.2780, -2.6021,  0.6245],
        [-0.8684, -0.2051,  0.3976,  0.6699],
        [-0.0537,  0.0467, -1.7671, -2.1205]]) torch.strided
tensor([[2.8026e-44, 0.0000e+00, 0.0000e+00, 0.0000e+00],
        [3.3541e-37, 0.0000e+00, 3.9236e-44, 0.0000e+00],
        [3.9236e-44, 0.0000e+00, 1.4013e-45, 0.0000e+00],
        [6.2071e-37, 0.0000e+00, 2.3822e-44, 0.0000e+00]])
Traceback (most recent call last):
  File "pytorch_bug_2.py", line 11, in <module>
    c = a_mkl.data.new(a.size())
RuntimeError: new(): expected DispatchKey: CPU or CUDA or HIP or XLA or XPU but got: MkldnnCPU
```

Modification policy for the code
If the layout of the tensor is not ``torch.mkldnn``, calling ``data.new()`` does not raise a RuntimeError.
However, if the layout of the tensor is torch.mkldnn, an exception is raised by TORCH_CHECK in the check_base_legacy_new function of ``torch/csrc/utils/tensor_new.cpp``.
Therefore, to solve this problem, the following conditional expression ``dispatch_key == c10::DispatchKey::MkldnnCPU`` was added to the argument of TORCH_CHECK to prevent the occurrence of an exception.