### PR TITLE
Handle repeated jit.script calls on function gracefully

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2489,6 +2489,16 @@ class TestFrontend(JitTestCase):
 
 
 class TestScript(JitTestCase):
+
+    # Tests that calling torch.jit.script repeated on function is allowed.
+    def test_repeated_script_on_function(self):
+        @torch.jit.script
+        @torch.jit.script
+        def fn(x):
+            return x
+
+        torch.jit.script(torch.jit.script(fn))
+
     def test_pretty_print_function(self):
         @torch.jit.script
         def foo(x):

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -929,7 +929,11 @@ def script(obj, optimize=None, _frames_up=0, _rcb=None):
         warnings.warn(
             "`optimize` is deprecated and has no effect. Use `with torch.jit.optimized_execution() instead"
         )
+
+    # No-op for modules and functions that are already scripted
     if isinstance(obj, ScriptModule):
+        return obj
+    if isinstance(obj, ScriptFunction):
         return obj
 
     if isinstance(obj, torch.nn.Module):


### PR DESCRIPTION
Repeated calls on `class` is not handled since `class`'s compilation process will change soon in #44324