### PR TITLE
add dumping callstack to kineto

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -217,7 +217,7 @@ std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes) {
 
 std::string stacksToStr(const std::vector<std::string>& stacks) {
   std::ostringstream oss;
-  for (auto idx = 0; idx < stacks.size(); ++idx) {
+  for (std::vector<std::string>::size_type idx = 0; idx < stacks.size(); ++idx) {
     if (idx > 0) {
       oss << ";";
     }

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -27,6 +27,7 @@ inline int64_t getTimeUs() {
 }
 
 std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes);
+std::string stacksToStr(const std::vector<std::string>& stacks);
 
 struct TORCH_API KinetoThreadLocalState : public ProfilerThreadLocalState {
   using ProfilerThreadLocalState::ProfilerThreadLocalState;
@@ -119,6 +120,9 @@ struct TORCH_API KinetoThreadLocalState : public ProfilerThreadLocalState {
       } else {
         cpu_trace->activities[idx].inputDims = "[]";
       }
+      if (kineto_events_[idx].hasStack()) {
+        cpu_trace->activities[idx].callStack = stacksToStr(kineto_events_[idx].stack());
+      }
     }
   }
 
@@ -208,6 +212,17 @@ std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes) {
     oss << "]";
   }
   oss << "]";
+  return oss.str();
+}
+
+std::string stacksToStr(const std::vector<std::string>& stacks) {
+  std::ostringstream oss;
+  for (auto idx = 0; idx < stacks.size(); ++idx) {
+    if (idx > 0) {
+      oss << ";";
+    }
+    oss << stacks[idx];
+  }
   return oss.str();
 }
 

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -217,13 +217,10 @@ std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes) {
 
 std::string stacksToStr(const std::vector<std::string>& stacks) {
   std::ostringstream oss;
-  for (std::vector<std::string>::size_type idx = 0; idx < stacks.size(); ++idx) {
-    if (idx > 0) {
-      oss << ";";
-    }
-    oss << stacks[idx];
-  }
-  return oss.str();
+  std::copy(stacks.begin(), stacks.end(), std::ostream_iterator<std::string>(oss, ";"));
+  auto rc = oss.str();
+  rc.pop_back();
+  return rc;
 }
 
 } // namespace


### PR DESCRIPTION
In profiler, pass operators' callstack to kineto and dump them into chrome tracing file.
The kineto side update is merged [here](https://github.com/pytorch/kineto/commit/66a4cad380d3ce4fb8d7b38351f841899d9bf950)