### PR TITLE
Adding support for optional list to int

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -885,6 +885,16 @@ class TestJit(JitTestCase):
         for m, inp in inputs:
             self.checkModule(m, (inp,))
 
+    def test_optional_inputs(self):
+        @torch.jit.script
+        def test_inputs(t, n: Optional[int]):
+            return torch.fft.fftn(t, n)
+
+        A = torch.rand(2,3)
+        expected = torch.fft.fftn(A, 3)
+        output = test_inputs(A, 3)
+        self.assertEqual(expected, output)
+
     def test_script_autograd_grad(self):
         def test_simple_grad(x, y):
             # type: (Tensor, Tensor) -> List[Optional[Tensor]]


### PR DESCRIPTION
ghstack-source-id: b2b17af5f7236b1635fc75e8bed10f0a22a14e88
Pull Request resolved: https://github.com/pytorch/pytorch/pull/51567

Fixes #48408

Summary:
==========
Given a schema containing an optional sized list (e.g. int[1]?), it should support passing a variable of type int

Test:
=======
python test/test_jit.py -v TestJit.test_optional_inputs