### PR TITLE
[SobolEngine] Fix edge case of dtype of first sample

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1566,6 +1566,18 @@ class AbstractTestCases:
         def test_sobolengine_draw_scrambled(self):
             self.test_sobolengine_draw(scramble=True)
 
+        def test_sobolengine_first_point(self):
+            for dtype in (torch.float, torch.double):
+                engine = torch.quasirandom.SobolEngine(2, scramble=False)
+                sample = engine.draw(1, dtype=dtype)
+                self.assertTrue(torch.all(sample == 0))
+                self.assertEqual(sample.dtype, dtype)
+            for dtype in (torch.float, torch.double):
+                engine = torch.quasirandom.SobolEngine(2, scramble=True, seed=123456)
+                sample = engine.draw(1, dtype=dtype)
+                self.assertTrue(torch.all(sample != 0))
+                self.assertEqual(sample.dtype, dtype)
+
         def test_sobolengine_continuing(self, scramble: bool = False):
             ref_sample = self._sobol_reference_samples(scramble=scramble)
             engine = torch.quasirandom.SobolEngine(2, scramble=scramble, seed=123456)

--- a/torch/quasirandom.py
+++ b/torch/quasirandom.py
@@ -83,7 +83,7 @@ class SobolEngine(object):
         """
         if self.num_generated == 0:
             if n == 1:
-                result = self._first_point
+                result = self._first_point.to(dtype)
             else:
                 result, self.quasi = torch._sobol_engine_draw(
                     self.quasi, n - 1, self.sobolstate, self.dimension, self.num_generated, dtype=dtype,


### PR DESCRIPTION
Summary:
https://github.com/pytorch/pytorch/pull/49710 introduced an edge case in which drawing a single sample resulted in ignoring the `dtype` arg to `draw`. This fixes this and adds a unit test to cover this behavior.

Test Plan: Unit tests

Differential Revision: D26204393

