### PR TITLE
Split anonymous and namespaced definitions in RegisterDispatchKey

### DIFF
--- a/aten/src/ATen/templates/DispatchKeyFunctions.h
+++ b/aten/src/ATen/templates/DispatchKeyFunctions.h
@@ -8,7 +8,7 @@
 namespace at {
 namespace ${dispatch_namespace} {
 
-${dispatch_declarations}
+${dispatch_namespaced_declarations}
 
 } // namespace ${dispatch_namespace}
 } // namespace at

--- a/aten/src/ATen/templates/RegisterDispatchKey.cpp
+++ b/aten/src/ATen/templates/RegisterDispatchKey.cpp
@@ -37,17 +37,23 @@ $legacy_th_headers
 
 namespace at {
 
-${dispatch_definitions}
-
 // NB: TORCH_LIBRARY_IMPL must be in an anonymous namespace to avoid
 // ambiguity with conflicting identifiers that may have been defined in
 // at namespace already.
 namespace {
+
+${dispatch_anonymous_definitions}
 
 TORCH_LIBRARY_IMPL(aten, ${DispatchKey}, m) {
   ${dispatch_registrations}
 }
 
 } // anonymous namespace
+
+namespace ${dispatch_namespace} {
+
+${dispatch_namespaced_definitions}
+
+} // namespace ${dispatch_namespace}
 
 } // namespace at

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -861,8 +861,15 @@ def main() -> None:
                 '#include <ATen/LegacyTHFunctionsCUDA.h>' if dispatch_key == DispatchKey.CUDA else
                 '',
             'DispatchKey': dispatch_key,
-            'dispatch_definitions': list(concatMap(
-                dest.RegisterDispatchKey(dispatch_key, Target.DEFINITION, selector, rocm=options.rocm),
+            'dispatch_namespace': dispatch_key.lower(),
+            'dispatch_namespaced_definitions': list(concatMap(
+                dest.RegisterDispatchKey(
+                    dispatch_key, Target.NAMESPACED_DEFINITION, selector, rocm=options.rocm),
+                grouped_native_functions
+            )),
+            'dispatch_anonymous_definitions': list(concatMap(
+                dest.RegisterDispatchKey(
+                    dispatch_key, Target.ANONYMOUS_DEFINITION, selector, rocm=options.rocm),
                 grouped_native_functions
             )),
             'dispatch_registrations': list(concatMap(
@@ -874,8 +881,9 @@ def main() -> None:
         if dispatch_key in functions_keys:
             fm.write_with_template(f'{dispatch_key}Functions.h', 'DispatchKeyFunctions.h', lambda: {
                 'dispatch_namespace': dispatch_key.lower(),
-                'dispatch_declarations': list(concatMap(
-                    dest.RegisterDispatchKey(dispatch_key, Target.DECLARATION, selector, rocm=options.rocm),
+                'dispatch_namespaced_declarations': list(concatMap(
+                    dest.RegisterDispatchKey(
+                        dispatch_key, Target.NAMESPACED_DECLARATION, selector, rocm=options.rocm),
                     grouped_native_functions
                 )),
             })

--- a/tools/codegen/utils.py
+++ b/tools/codegen/utils.py
@@ -8,7 +8,22 @@ import textwrap
 # and declaration (for example, the function signature is the same), so
 # we organize them into one function that takes a Target to say which
 # code we want.
-Target = Enum('Target', ('DEFINITION', 'DECLARATION', 'REGISTRATION'))
+#
+# This is an OPEN enum (we may add more cases to it in the future), so be sure
+# to explicitly specify with Union[Literal[Target.XXX]] what targets are valid
+# for your use.
+Target = Enum('Target', (
+    # top level namespace (not including at)
+    'DEFINITION',
+    'DECLARATION',
+    # TORCH_LIBRARY(...) { ... }
+    'REGISTRATION',
+    # namespace { ... }
+    'ANONYMOUS_DEFINITION',
+    # namespace cpu { ... }
+    'NAMESPACED_DEFINITION',
+    'NAMESPACED_DECLARATION',
+))
 
 # Matches "foo" in "foo, bar" but not "foobar". Used to search for the
 # occurrence of a parameter in the derivative formula


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51590 Support at::cpu on non-structured kernels
* **#51585 Split anonymous and namespaced definitions in RegisterDispatchKey**
* #51583 Factor out structured generation into its own subclass.
* #51508 Split out RegisterDispatchKey to its own file
* #51500 Use Literal to model targets.
* #51499 Add support for generating faithful at::cpu signatures
* #51490 Add api.structured; switch structured kernels to use const Tensor& everywhere
* #51477 Relax type signature for tools.codegen.api.translate

Some payoff from the stack of refactors.  When I initially landed
at::cpu, Brian asked me why I couldn't just separate the anonymous
and namespaced definitions.  Well, it used to be annoying.  Now it's
not annoying anymore, so go ahead and split them up.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D26209873](https://our.internmc.facebook.com/intern/diff/D26209873)