### PR TITLE
Fix Python.h discovery logic on some MacOS platforms

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1707,8 +1707,10 @@ def _write_ninja_file_to_build_library(path,
 
     # include_paths() gives us the location of torch/extension.h
     system_includes = include_paths(with_cuda)
-    # sysconfig.get_paths()['include'] gives us the location of Python.h
-    system_includes.append(sysconfig.get_paths()['include'])
+    # sysconfig.get_path('include') gives us the location of Python.h
+    # Explicitly specify 'posix_prefix' scheme on non-Windows platforms to workaround error on some MacOS
+    # installations where default `get_path` points to non-existing `/Library/Python/M.m/include` folder
+    system_includes.append(sysconfig.get_path('include', scheme = 'nt' if IS_WINDOWS else 'posix_prefix'))
 
     # Windows does not understand `-isystem`.
     if IS_WINDOWS:

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1710,7 +1710,9 @@ def _write_ninja_file_to_build_library(path,
     # sysconfig.get_path('include') gives us the location of Python.h
     # Explicitly specify 'posix_prefix' scheme on non-Windows platforms to workaround error on some MacOS
     # installations where default `get_path` points to non-existing `/Library/Python/M.m/include` folder
-    system_includes.append(sysconfig.get_path('include', scheme = 'nt' if IS_WINDOWS else 'posix_prefix'))
+    python_include_path = sysconfig.get_path('include', scheme='nt' if IS_WINDOWS else 'posix_prefix')
+    if python_include_path is not None:
+        system_includes.append(python_include_path)
 
     # Windows does not understand `-isystem`.
     if IS_WINDOWS:


### PR DESCRIPTION
On all non-Windows platforms we should use 'posix_prefix' schema to discover location of Python.h header

