### PR TITLE
Adding **kwargs usage to nn.Sequential

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -51,7 +51,7 @@ class Sequential(Module):
                   ('relu2', nn.ReLU())
                 ]))
 
-        # Example of using Sequential with **kwargs
+        # Example of using Sequential with kwargs
         model = nn.Sequential(
             conv1=nn.Conv2d(1, 20, 5),
             relu1=nn.ReLU(),

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -31,6 +31,7 @@ class Sequential(Module):
     r"""A sequential container.
     Modules will be added to it in the order they are passed in the constructor.
     Alternatively, an ordered dict of modules can also be passed in.
+    You can also use **kwargs to pass in modules, since Python 3.6 **kwargs are order preserving.
 
     To make it easier to understand, here is a small example::
 
@@ -49,6 +50,14 @@ class Sequential(Module):
                   ('conv2', nn.Conv2d(20,64,5)),
                   ('relu2', nn.ReLU())
                 ]))
+
+        # Example of using Sequential with **kwargs
+        model = nn.Sequential(
+            conv1=nn.Conv2d(1, 20, 5),
+            relu1=nn.ReLU(),
+            conv2=nn.Con2d(20,64,5),
+            relu2=nn.ReLU(),
+        )
     """
 
     @overload
@@ -59,9 +68,16 @@ class Sequential(Module):
     def __init__(self, arg: 'OrderedDict[str, Module]') -> None:
         ...
 
-    def __init__(self, *args):
+    @overload
+    def __init__(self, **kwargs) -> None:
+        ...
+
+    def __init__(self, *args, **kwargs):
         super(Sequential, self).__init__()
-        if len(args) == 1 and isinstance(args[0], OrderedDict):
+        if len(args) == 0 and len(kwargs) > 0:
+            for key, module in kwargs.items():
+                self.add_module(key, module)
+        elif len(args) == 1 and isinstance(args[0], OrderedDict):
             for key, module in args[0].items():
                 self.add_module(key, module)
         else:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -55,7 +55,7 @@ class Sequential(Module):
         model = nn.Sequential(
             conv1=nn.Conv2d(1, 20, 5),
             relu1=nn.ReLU(),
-            conv2=nn.Con2d(20,64,5),
+            conv2=nn.Conv2d(20,64,5),
             relu2=nn.ReLU(),
         )
     """


### PR DESCRIPTION
Pep 468 (https://www.python.org/dev/peps/pep-0468/) made it so as of python 3.6, **kwargs passed into a function are iterated in the same order that they are specified in code. Since **kwargs has the same interface as a dictionary, we can use it in the same way as `nn.Sequential` already uses `OrderedDict`.

This MR allows you to use kwargs instead of an OrderedDict which results in the same behavior with cleaner looking code.

