### PR TITLE
Re-enable test_standalone_load for Windows 11.1

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -669,7 +669,7 @@ class TestAssert(TestCase):
             ms(torch.tensor([False], dtype=torch.bool))
 
 
-@unittest.skipIf(IS_SANDCASTLE or IS_WINDOWS, "cpp_extension is OSS only and temp disabling for Windows")
+@unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1433,7 +1433,7 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone):
         if with_cuda:
             extra_ldflags.append('c10_cuda.lib')
         extra_ldflags.append('torch_cpu.lib')
-        if BUILD_SPLIT_CUDA:
+        if BUILD_SPLIT_CUDA and with_cuda:
             extra_ldflags.append('torch_cuda_cu.lib')
             # /INCLUDE is used to ensure torch_cuda_cu is linked against in a project that relies on it.
             extra_ldflags.append('-INCLUDE:?searchsorted_cuda@native@at@@YA?AVTensor@2@AEBV32@0_N1@Z')
@@ -1458,7 +1458,7 @@ def _prepare_ldflags(extra_ldflags, with_cuda, verbose, is_standalone):
         if with_cuda:
             extra_ldflags.append('-lc10_hip' if IS_HIP_EXTENSION else '-lc10_cuda')
         extra_ldflags.append('-ltorch_cpu')
-        if BUILD_SPLIT_CUDA:
+        if BUILD_SPLIT_CUDA and with_cuda:
             extra_ldflags.append('-ltorch_hip' if IS_HIP_EXTENSION else '-ltorch_cuda_cu -ltorch_cuda_cpp')
         elif with_cuda:
             extra_ldflags.append('-ltorch_hip' if IS_HIP_EXTENSION else '-ltorch_cuda')


### PR DESCRIPTION
This fixes the previous erroring out by adding stricter conditions in cpp_extension.py.

To test, run a split torch_cuda build on Windows with `export BUILD_SPLIT_CUDA=ON && python setup.py develop` and then run the following test: `python test/test_utils.py TestStandaloneCPPJIT.test_load_standalone`. It should pass.