### PR TITLE
ZeroRedundancyOptimizer: backporting all the changes from fairscale + native broadcast object …

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 from typing import List, Any, Type, cast
 from torch.distributed.optim import ZeroRedundancyOptimizer
 from torch.optim import SGD
-from torch.testing._internal.common_distributed import skip_if_no_gpu, MultiProcessTestCase
+from torch.testing._internal.common_distributed import skip_if_no_gpu, MultiProcessTestCase, skip_if_not_multigpu
 from torch.testing._internal.common_distributed import skip_if_rocm
 
 import copy
@@ -335,7 +335,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         all_trainable()
         some_trainable()
 
-    @skip_if_no_gpu
+    @skip_if_not_multigpu
     def test_collect_shards(self):
         """ Check the state consolidation mechanism, and the state dict exposed by ZeroRedundancyOptimizer"""
         self.dist_init(self.rank)
@@ -450,7 +450,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             )
             check(optimizer)
 
-    @skip_if_no_gpu
+    @skip_if_not_multigpu
     def test_state_dict_distributed(self):
         self.dist_init(self.rank)
         RECIPIENT_RANK = 0
@@ -557,7 +557,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             run_grad_step(model_oss2, head_oss2, sharded_optimizer2)
             check_equal_models("parameters of the two identical models have diverged (after reloading)")
 
-    @skip_if_no_gpu
+    @skip_if_not_multigpu
     def test_pytorch_parity(self):
         """When combined with DDP, check that ZeroRedundancyOptimizer(optimizer) and the same monolithic optimizer
         give the exact same results

--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -458,7 +458,8 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
         with torch.cuda.device(self.device):
             torch.manual_seed(self.rank)  # make sure that the different rank get different data
 
-            # Setup two problems in parallel, we'll make sure that the second track (with save/load) follows the first one(untouched)
+            # Setup two problems in parallel, we'll make sure that the second track (with save/load)
+            # follows the first one(untouched)
             # We split the model in two to test the multiple param groups support
             batch, input_width, hidden, target_width = 3, 20, 10, 5
             target = torch.rand((batch, target_width), device=self.device)
@@ -472,7 +473,8 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             model_oss2 = copy.deepcopy(model_oss1)
             head_oss2 = copy.deepcopy(head_oss1)
 
-            # For this test the gradients are (all) reduced in the same way in between the torch reference and fairscale.
+            # For this test the gradients are (all) reduced in the same way in between
+            # the torch reference and zeroredundancyoptimizer.
             # Normally OSS would use ShardedDDP and only reduce to the proper rank, but this does not change the
             # gradient norm computation from OSS and adds a dependency.
             # to keep the comparison apples-to-apples DDP is used in both cases

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -6,8 +6,7 @@
 from collections import OrderedDict, deque
 import copy
 from itertools import chain
-import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Deque
+from typing import Any, Callable, Dict, List, Optional, Type, Deque
 
 import torch
 import torch.distributed as dist
@@ -130,6 +129,8 @@ class ZeroRedundancyOptimizer(Optimizer):
         ] = OrderedDict()  # device, rank, params
         self._param_rank: Dict[torch.Tensor, int] = {}
         self._partition_parameters: List[List[Dict]] = []
+        self._index_to_param: Dict[int, torch.Tensor] = {}
+        self._param_to_index: Dict[int, int] = {}
 
         # Build the wrapped optimizer, responsible for a shard of the params
         self.group = group if group is not None else dist.group.WORLD
@@ -176,9 +177,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         super().add_param_group(param_group)
         if self.initialized:
             # Force a re-partitioning
-            self._partition_parameters.clear()
-            self._per_device_params.clear()
-            self._param_rank.clear()
+            self._clear_cache()
 
             param_groups = self.partition_parameters()[self.rank]
             if len(param_groups) == len(self.optim.param_groups) + 1:
@@ -186,59 +185,6 @@ class ZeroRedundancyOptimizer(Optimizer):
 
             # Update the bucketing strategy accordingly
             self._setup_bucket_strategy()
-
-    def consolidate_state_dict(self, recipient_rank: int = 0) -> None:
-        """Update the consolidated state_dict list, one per rank.
-
-        .. warning: This needs to be called on all replicas"""
-
-        # Sync lr and other attributes in case its been updated
-        self._update_param_groups()
-
-        empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._device)
-
-        # Pull the sharded state from all the other replicas
-        # Store all the states in order, rank by rank
-
-        # NOTE: In practice, `broadcast` is used, which is wasteful (gather would have been appropriate)
-        # compatibility issues with some backends make the use of broadcast mandatory for now.
-        # a possible follow up would be to move all sharded state management to RPC RRef
-
-        self._all_states = []
-        for rank in range(self.world_size):
-            global_rank = _get_global_rank(self.group, rank)
-
-            # This rank collects the whole state
-            if self.rank == recipient_rank:
-                if rank == self.rank:
-                    self._all_states.append(
-                        _recursive_copy_to_device(
-                            self.local_state_dict(), non_blocking=True, device=torch.device("cpu")
-                        )
-                    )
-                else:
-                    # Fetch the optim state from the other replicas
-                    replica_state = _broadcast_object(
-                        empty_messenger, src_rank=global_rank, group=self.group, dist_device=self._device
-                    )
-
-                    self._all_states.append(
-                        _recursive_copy_to_device(replica_state, non_blocking=True, device=torch.device("cpu"))
-                    )
-            else:
-                # Acknowledge broadcasts, and send this rank's shard when needed
-                # Default to CPU space to gain some memory headroom
-                if rank == self.rank:
-                    # Send the state to the reference replica
-                    _ = _broadcast_object(
-                        self.local_state_dict(), src_rank=self.global_rank, group=self.group, dist_device=self._device
-                    )
-
-                elif rank != recipient_rank:
-                    # Discard this tensor/rank, broadcast was being use for compatibility reasons
-                    _ = _broadcast_object(
-                        empty_messenger, src_rank=global_rank, group=self.group, dist_device=self._device
-                    )
 
     def partition_parameters(self) -> List[List[Dict]]:
         """Partitions parameters across distributed data parallel ranks.
@@ -265,6 +211,22 @@ class ZeroRedundancyOptimizer(Optimizer):
                     self._partition_parameters[rank].append(param_group_rank)
 
         return self._partition_parameters
+
+    @property
+    def index_to_param(self) -> Dict[int, torch.Tensor]:
+        """Hash table in between parameter indices in the global optimizer scheme, and the actual params"""
+        if len(self._index_to_param) == 0:
+            self._index_to_param = {i: p for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))}
+
+        return self._index_to_param
+
+    @property
+    def param_to_index(self) -> Dict[int, int]:
+        """Hash table in between parameter indices in the global optimizer scheme, and the actual params"""
+        if len(self._param_to_index) == 0:
+            self._param_to_index = {id(p): i for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))}
+
+        return self._param_to_index
 
     @property
     def per_device_params(self) -> Dict[torch.device, List[List[Parameter]]]:
@@ -312,7 +274,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         .. note: Any extra parameter is passed to the base optimizer as-is"""
 
         # Sync oss param_groups attributes in case they've been updated by a scheduler.
-        self._update_param_groups()
+        ZeroRedundancyOptimizer._sync_param_groups(self.param_groups, self.optim.param_groups)
 
         # Run the optimizer step on this shard only:
         if closure is not None:
@@ -324,72 +286,9 @@ class ZeroRedundancyOptimizer(Optimizer):
         self._broadcast_params()
 
         # Sync hypothethical new results from the wrapped optimizer to the exposed param_groups
-        self._update_param_groups(local_to_global=True)
+        ZeroRedundancyOptimizer._sync_param_groups(self.optim.param_groups, self.param_groups)
 
         return loss
-
-    def load_local_state_dict(self, state_dict: dict) -> None:
-        """Loads this rank's state_dict.
-
-        .. warning: This is not meant to load the global state dict.
-        """
-
-        self.optim.load_state_dict(state_dict)
-
-        # Workaround PyTorch bug that casts state (https://github.com/pytorch/pytorch/issues/43706)
-        # Copied from https://github.com/pytorch/fairseq/blob/v0.9.0/fairseq/optim/fp16_optimizer.py#L251-L268
-        groups = self.optim.param_groups
-        saved_groups = state_dict["param_groups"]
-        id_map = {
-            old_id: p
-            for old_id, p in zip(chain(*(g["params"] for g in saved_groups)), chain(*(g["params"] for g in groups)))
-        }
-        for k, v in state_dict["state"].items():
-            if k in id_map:
-                param = id_map[k]
-                self.optim.state[param] = _recursive_copy_to_device(v, non_blocking=True, device=param.device)
-
-        # Restore the global param_groups (the params themselves are already correct)
-        for global_group, local_group in zip(self.param_groups, groups):
-            for k, v in local_group.items():
-                if k != "params":
-                    global_group[k] = v
-
-        # Force a re-partitioning, in case the model changed with the new state
-        self._partition_parameters.clear()
-        self._per_device_params.clear()
-        self._param_rank.clear()
-
-        # Update the bucketing strategy accordingly
-        self._setup_bucket_strategy()
-
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        """Restore the global parameter groups as well as the shard.
-
-        Arguments:
-            state_dict (dict): optimizer state. Should be an object returned
-                from a call to :meth:`state_dict`
-        """
-
-        # Check whether we got a local or global dict
-        if "local_state_dict" in state_dict and state_dict["local_state_dict"]:
-            self.load_local_state_dict(state_dict)
-        else:
-            # Dispatch this rank's state dictionary to the wrapped shard optimizer
-            self.load_local_state_dict(ZeroRedundancyOptimizer.rank_local_state_dict(self.rank, state_dict))
-
-    def local_state_dict(self) -> Dict:
-        """Gets this rank's ``state_dict``.
-
-        Returns:
-            The state of the optimizer as a :class:`dict`.
-            It contains two entries:
-
-            * state - a dict holding current optimization state. Its content
-                differs between optimizer classes.
-            * param_groups - a dict containing all parameter groups
-        """
-        return self.optim.state_dict()
 
     def state_dict(self) -> Dict[str, Any]:
         """
@@ -405,45 +304,120 @@ class ZeroRedundancyOptimizer(Optimizer):
         """
 
         if len(self._all_states) == 0:
-            logging.warning("Optimizer state has not been consolidated. Returning the local state")
-            logging.warning("Please call `consolidate_state_dict()` beforehand if you meant to save the global state")
-            state_dict = self.local_state_dict()
-            state_dict["local_state_dict"] = True
-            return state_dict
+            raise RuntimeError(
+                "Optimizer state has not been consolidated on this rank. \
+                Please call `consolidate_state_dict()` on all ranks beforehand if you meant to save the global state"
+            )
 
-        # Flatten the param_groups, save the partition which logs the rank <> shard correspondence
-        partition: List[Tuple[int, int]] = []
-        param_groups: List[Dict[Any, Any]] = []
+        # Unify the shard states and the state that pytorch would expect, given the model.
+        # Indexation needs several redirections, since each shard only knows a limited scope of the model
+        # - get the pytorch compliant parameter indexing
+        state_dict = super().state_dict()
 
-        start = 0
-        for i, s in enumerate(self._all_states):
-            param_groups.extend(s["param_groups"])
-            end = start + len(s["param_groups"])
-            partition.append((start, end))
-            start = end
+        # - go through the per-shard states, which are all indexed locally
+        for rank, s in enumerate(self._all_states):
+            # -- match the local indexing and the global partition, update the corresponding saved state globally
+            for local_pg, global_pg in zip(s["param_groups"], self.partition_parameters()[rank]):
+                local_index_to_param_id = {
+                    i_param: id(global_pg["params"][i]) for i, i_param in enumerate(local_pg["params"])
+                }
 
-        return {
-            "state": [s["state"] for s in self._all_states],
-            "param_groups": param_groups,
-            "partition": partition,
-            "local_state_dict": False,
-        }
+                for local_param_index in local_pg["params"]:
+                    # Update the state, if any
+                    if local_param_index in s["state"].keys():
+                        global_id = self.param_to_index[local_index_to_param_id[local_param_index]]
+                        state_dict["state"][global_id] = s["state"][local_param_index]
 
-    @staticmethod
-    def rank_local_state_dict(rank: int, state_dict: dict) -> dict:
-        """Returns the local_state_dict for a given rank.
+        return state_dict
 
+    def consolidate_state_dict(self, recipient_rank: int = 0) -> None:
+        """Update the consolidated state_dict list, one per rank.
+
+        .. warning: This needs to be called on all replicas"""
+
+        # Sync lr and other attributes in case its been updated
+        ZeroRedundancyOptimizer._sync_param_groups(self.param_groups, self.optim.param_groups)
+
+        # Pull the sharded state from all the other replicas
+        # Store all the states in order, rank by rank
+
+        # NOTE: In practice, `broadcast` is used, which is wasteful (gather would have been appropriate)
+        # compatibility issues with some backends make the use of broadcast mandatory for now.
+        # a possible follow up would be to move all sharded state management to RPC RRef
+
+        self._all_states = []
+
+        with torch.cuda.device(self._device):
+            empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._device)
+
+            for rank in range(self.world_size):
+                global_rank = _get_global_rank(self.group, rank)
+
+                # This rank collects the whole state
+                if self.rank == recipient_rank:
+                    if rank == self.rank:
+                        self._all_states.append(
+                            _recursive_copy_to_device(
+                                self.optim.state_dict(), non_blocking=True, device=torch.device("cpu")
+                            )
+                        )
+                    else:
+                        # Fetch the optim state from the other replicas
+                        replica_state = [empty_messenger]
+                        dist.broadcast_object_list(object_list=replica_state, src=global_rank, group=self.group)
+
+                        self._all_states.append(
+                            _recursive_copy_to_device(replica_state[0], non_blocking=True, device=torch.device("cpu"))
+                        )
+                else:
+                    # Acknowledge broadcasts, and send this rank's shard when needed
+                    # Default to CPU space to gain some memory headroom
+                    if rank == self.rank:
+                        # Send the state to the reference replica
+                        dist.broadcast_object_list(
+                            object_list=[self.optim.state_dict()], src=self.global_rank, group=self.group
+                        )
+
+                    elif rank != recipient_rank:
+                        # Discard this tensor/rank, broadcast was being use for compatibility reasons
+                        dist.broadcast_object_list(object_list=[empty_messenger], src=global_rank, group=self.group)
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        """Restore the global parameter groups as well as the shard.
         Arguments:
-            rank (int): rank to get local_state_dict for
-            state_dict (dict): global state_dict
+            state_dict (dict): optimizer state. Should be an object returned
+                from a call to :meth:`state_dict`
         """
-        param_groups = state_dict["param_groups"][state_dict["partition"][rank][0] : state_dict["partition"][rank][1]]
-        return {"state": state_dict["state"][rank], "param_groups": param_groups}
+
+        for i_param, (key, value) in enumerate(state_dict["state"].items()):
+            param = self.index_to_param[i_param]
+
+            # Populate the sharded optimizer state on the fly
+            if self.param_to_rank[param] != self.rank:
+                state_dict["state"][key] = None
+
+            if key in self.index_to_param:
+                param = self.index_to_param[i_param]
+
+                # Only add this state to the sharded optimizer if it owns this param
+                for pg in self.optim.param_groups:
+                    if id(param) in [id(p) for p in pg["params"]]:
+                        self.optim.state[param] = _recursive_copy_to_device(
+                            value, non_blocking=True, device=param.device
+                        )
+
+        super().load_state_dict(state_dict)
+
+        # Sync with the optimizer param groups
+        ZeroRedundancyOptimizer._sync_param_groups(state_dict["param_groups"], self.param_groups)
+        ZeroRedundancyOptimizer._sync_param_groups(self.param_groups, self.optim.param_groups)
 
     def _broadcast_params(self) -> None:
         """Helper function to broadcast all the parameters from a given device"""
 
         i_param = 0
+
+        last_work_handle = None
 
         for (
             device,
@@ -457,20 +431,28 @@ class ZeroRedundancyOptimizer(Optimizer):
                 # Direct broadcasts only
                 for param in params:
                     if not self.should_bucket_param[i_param]:
-                        self.work_handles.append(
-                            dist.broadcast(tensor=param.data, src=global_src_rank, group=self.group, async_op=True)
+                        last_work_handle = dist.broadcast(
+                            tensor=param.data, src=global_src_rank, group=self.group, async_op=True
                         )
+
                     i_param += 1
 
                 # Bucket broadcasts
-                self.work_handles.append(
-                    dist.broadcast(tensor=bucket, src=global_src_rank, group=self.group, async_op=True)
-                )
+                if bucket.numel() > 0:
+                    last_work_handle = dist.broadcast(
+                        tensor=bucket, src=global_src_rank, group=self.group, async_op=True
+                    )
 
-        # Consume all async calls
-        while len(self.work_handles) > 0:
-            work_handle = self.work_handles.popleft()
-            work_handle.wait()
+        # Consume the last async call only, all calls are sequential
+        if last_work_handle is not None:
+            last_work_handle.wait()
+
+    def _clear_cache(self) -> None:
+        self._partition_parameters.clear()
+        self._per_device_params.clear()
+        self._param_rank.clear()
+        self._index_to_param.clear()
+        self._param_to_index.clear()
 
     def _update_param_groups(self, local_to_global: bool = False) -> None:
         """Sync learning rate and other optimizer attributes (needed to support schedulers).
@@ -527,3 +509,12 @@ class ZeroRedundancyOptimizer(Optimizer):
 
                 # Resize the bucket to remove lost space in the end
                 self.buckets[device][dst_rank].resize_(offset)
+
+    @staticmethod
+    def _sync_param_groups(source: List[Dict[Any, Any]], destination: List[Dict[Any, Any]]) -> None:
+        """Sync learning rate and other optimizer attributes (needed to support schedulers)."""
+
+        for source_group, destination_group in zip(source, destination):
+            # Sync everything but the parameters
+            for k in filter(lambda x: x != "params", source_group.keys()):
+                destination_group[k] = source_group[k]

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -13,7 +13,6 @@ import torch.distributed as dist
 from torch.nn import Parameter
 from torch._six import container_abcs
 from torch.optim import Optimizer
-import io
 
 __all__ = ["ZeroRedundancyOptimizer"]
 
@@ -373,7 +372,7 @@ class ZeroRedundancyOptimizer(Optimizer):
 
                 # Only add this state to the sharded optimizer if it owns this param
                 for pg in self.optim.param_groups:
-                    if id(param) in [id(p) for p in pg["params"]]:
+                    if id(param) in map(lambda x: id(x), pg["params"]):
                         self.optim.state[param] = _recursive_copy_to_device(
                             value, non_blocking=True, device=param.device
                         )

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -3,10 +3,10 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import OrderedDict, deque
+from collections import OrderedDict
 import copy
 from itertools import chain
-from typing import Any, Callable, Dict, List, Optional, Type, Deque
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import torch
 import torch.distributed as dist
@@ -127,7 +127,6 @@ class ZeroRedundancyOptimizer(Optimizer):
         self.bucket_max_size = bucket_cap_kb
 
         self.should_bucket_param: List[bool] = []
-        self.work_handles: Deque[Any] = deque()
         self._setup_bucket_strategy()
         self.initialized = True
 

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -13,6 +13,7 @@ import torch.distributed as dist
 from torch.nn import Parameter
 from torch._six import container_abcs
 from torch.optim import Optimizer
+import contextlib
 
 __all__ = ["ZeroRedundancyOptimizer"]
 
@@ -318,7 +319,9 @@ class ZeroRedundancyOptimizer(Optimizer):
 
         self._all_states = []
 
-        with torch.cuda.device(self._device):
+        with torch.cuda.device(self._device) if self._device.type == torch.device(
+            "cuda"
+        ).type else contextlib.suppress():
             empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._device)
 
             for rank in range(self.world_size):


### PR DESCRIPTION
- cleaning up the state dict logic, now completely compatible with the underlying optimizers' state dict, the sharding is hidden (except for the extra .consolidate() call). This also means that the state is elastic, it can be reloaded with a different world size
- sticking to the pytorch broadcast_object_list
- minor speed improvements