### PR TITLE
Fix anomaly mode memory leak

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3826,6 +3826,7 @@ class TestAutograd(TestCase):
                 # We want to test that when grad goes out of scope at the end of this function that PyObject is destroyed
                 # We can test this by seeing whether Foo is not kept alive once t is destroyed
                 meta_dict = t.grad_fn.metadata
+
                 class Foo(object):
                     pass
                 my_obj = Foo()
@@ -3856,6 +3857,7 @@ class TestAutograd(TestCase):
             # The answer is that custom function's PyObject (THPFunction) actually only hold
             # a weak reference to the c++ node!
             size = 10
+
             class MyFunc(Function):
                 @staticmethod
                 def forward(ctx, inp1):
@@ -3894,6 +3896,7 @@ class TestAutograd(TestCase):
                         gsum.backward()
 
             meta_dict = out.grad_fn.metadata
+
             class Foo(object):
                 pass
             my_obj = Foo()

--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -41,23 +41,23 @@ void PyAnomalyMetadata::print_stack(const std::string& current_node_name) {
   // if there is no "parent_" in metadata, then it means this metadata's node
   // is the root and stop printing the traceback
   while (pyparent) {
-    PyObject* parent_metadata(PyObject_GetAttrString(pyparent, "metadata"));
+    THPObjectPtr parent_metadata(PyObject_GetAttrString(pyparent, "metadata"));
     if (!parent_metadata) {
       throw python_error();
     }
-    PyObject* parent_name_pyobj(PyObject_CallMethod(pyparent, "name", ""));
+    THPObjectPtr parent_name_pyobj(PyObject_CallMethod(pyparent, "name", ""));
     if (!parent_name_pyobj) {
       throw python_error();
     }
-    const char* parent_name_char = PyUnicode_AsUTF8(parent_name_pyobj);
+    const char* parent_name_char = PyUnicode_AsUTF8(parent_name_pyobj.get());
     if (!parent_name_char) {
       throw python_error();
     }
     const std::string parent_name(parent_name_char);
-    PyObject* parent_stack = PyDict_GetItemString(parent_metadata, ANOMALY_TRACE_KEY);
+    PyObject* parent_stack = PyDict_GetItemString(parent_metadata.get(), ANOMALY_TRACE_KEY);
     _print_stack(parent_stack, parent_name, true);
     // get the parent of this node, if this node is a root, pyparent is simply null
-    pyparent = PyDict_GetItemString(parent_metadata, ANOMALY_PARENT_KEY);
+    pyparent = PyDict_GetItemString(parent_metadata.get(), ANOMALY_PARENT_KEY);
   }
 }
 
@@ -69,15 +69,13 @@ void PyAnomalyMetadata::assign_parent(const std::shared_ptr<Node>& parent_node) 
   pybind11::gil_scoped_acquire gil;
   if (!parent_node) return;
 
-  PyObject* pyobj = functionToPyObject(parent_node);
-  if (!pyobj) {
+  THPObjectPtr parent_node_(functionToPyObject(parent_node));
+  if (!parent_node_) {
     throw python_error();
   }
-  if (PyDict_SetItemString(dict(), ANOMALY_PARENT_KEY, pyobj)) {
+  if (PyDict_SetItemString(dict(), ANOMALY_PARENT_KEY, parent_node_.get())) {
     throw python_error();
   }
-  // Decrement extra refcount because inserting into dict already increments refcount
-  Py_DECREF(pyobj);
 }
 
 void _print_stack(PyObject* stack, const std::string& current_node_name, bool is_parent) {

--- a/torch/csrc/autograd/python_anomaly_mode.cpp
+++ b/torch/csrc/autograd/python_anomaly_mode.cpp
@@ -76,6 +76,8 @@ void PyAnomalyMetadata::assign_parent(const std::shared_ptr<Node>& parent_node) 
   if (PyDict_SetItemString(dict(), ANOMALY_PARENT_KEY, pyobj)) {
     throw python_error();
   }
+  // Decrement extra refcount because inserting into dict already increments refcount
+  Py_DECREF(pyobj);
 }
 
 void _print_stack(PyObject* stack, const std::string& current_node_name, bool is_parent) {


### PR DESCRIPTION
Fixes #51349

The memory leak happens when 1) `create_graph` is True AND 2) detect anomaly mode is on. When a backward node's constructor is called during backward, the current evaluating node is assigned as a "parent" of the created node. The code that assigns the parent encounters the below issue:

`functionToPyObject(parent_node)` returns a new PyObject (with refcount 1) or if PyObject already exists, increments its refcount by 1. However [PyDict_SetItem](https://github.com/python/cpython/blob/1b55b65638254aa78b005fbf0b71fb02499f1852/Objects/dictobject.c#L1532) calls into [insertdict](https://github.com/python/cpython/blob/v3.8.1/Objects/dictobject.c#L1034) which increments refcount again. This means that when dict is destroyed, the refcount of the PyObject is at least one. This keeps `parent_node` (the backward function) alive, which then keeps the saved tensor alive.

Similar calls in the codebase to `functionToPyObject` won't require Py_DECREF if it is then passed into a tuple (instead of dict), because the analogous PyTuple_SetItem call does not increment refcount.