### PR TITLE
[cuda] masked_scatter : static_cast init_value to circumvent cuda 11.2 issue

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -325,7 +325,7 @@ void masked_scatter_cuda_impl(Tensor& self, const Tensor& mask, const Tensor& so
   TORCH_CHECK(totalElements <= srcSize, "source nElements must be == mask `1` elements");
 
 
-#if CUDA_VERSION >= 1120
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11020
   // FIXME: there appears to be a bug in Thrust (CUDA 11.2) for mixed
   // iterator prefix sums? Convert `mask` to the same datatype as what
   // we're accumulating the prefix sum in (int64_t) to get around it

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -332,7 +332,7 @@ void masked_scatter_cuda_impl(Tensor& self, const Tensor& mask, const Tensor& so
   // Reference: https://github.com/pytorch/pytorch/issues/51544
   auto mask_cont = mask.to(kLong).contiguous();
   thrust::device_ptr<int64_t> maskData(mask_cont.data_ptr<int64_t>());
-#elif
+#else
   auto mask_cont = mask.contiguous();
   thrust::device_ptr<mask_t> maskData(mask_cont.data_ptr<mask_t>());
 #endif


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/51544

Tested locally as there is no CI for 11.2 as of now.