### PR TITLE
Removes nonzero method warning

### DIFF
--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -4,6 +4,7 @@ import numpy as np
 from itertools import product, combinations, permutations
 from functools import partial
 import random
+import warnings
 
 from torch._six import nan
 from torch.testing._internal.common_utils import (
@@ -490,6 +491,17 @@ class TestShapeOps(TestCase):
             torch_fn = partial(torch.rot90, k=rot_times, dims=[0, 1])
             np_fn = partial(np.rot90, k=rot_times, axes=[0, 1])
             self.compare_with_numpy(torch_fn, np_fn, data)
+
+    # TODO: update once warning flag is available to always trigger ONCE warnings
+    # Ensures nonzero does not throw a warning, even when the as_tuple argument
+    #   is not provided
+    def test_nonzero_no_warning(self, device):
+        t = torch.randn((2, 2), device=device)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            torch.nonzero(t)
+            t.nonzero()
+            self.assertEqual(len(w), 0)
 
     @dtypes(*torch.testing.get_all_dtypes(include_complex=False))
     def test_nonzero(self, device, dtype):

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -467,7 +467,7 @@ static PyObject * THPVariable_nonzero(PyObject* self, PyObject* args, PyObject* 
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "nonzero()|deprecated",
+    "nonzero()",
     "nonzero(*, bool as_tuple)",
   });
   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/44284

https://github.com/pytorch/pytorch/pull/45413 incorrectly left this only partially fixed because it did not update the separate list of method signatures that were deprecated. This PR correctly fixes #44284. A test is added for the behavior, but until the WARN_ONCE flag is added it's toothless. 
