### PR TITLE
[Usability] Add explicit and early check for unsupported script targets

### DIFF
--- a/test/jit/test_enum.py
+++ b/test/jit/test_enum.py
@@ -348,13 +348,3 @@ class TestEnum(JitTestCase):
         # PURPLE always appears last because we follow Python's Enum definition order.
         self.assertEqual(scripted(Color.RED), [Color.GREEN.value, Color.BLUE.value])
         self.assertEqual(scripted(Color.GREEN), [Color.RED.value, Color.BLUE.value])
-
-    # Tests that explicitly and/or repeatedly scripting an Enum class is permitted.
-    def test_enum_explicit_script(self):
-
-        @torch.jit.script
-        class Color(Enum):
-            RED = 1
-            GREEN = 2
-
-        torch.jit.script(Color)

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -904,7 +904,7 @@ def _qualified_name(obj):
     elif isinstance(obj, enum.Enum):
         name = obj.name
     else:
-        raise RuntimeError("Could not get name of python class object")
+        raise RuntimeError("Could not get name of python object")
 
 
     if name == '<lambda>':


### PR DESCRIPTION
Previously, we don't explicitly check if argument passed to `torch.jit.script` is of supported type. It sometimes leads to ugly error messages when user pass in unsupported objects.  This PR makes the check explicit and improves error messaging.