### PR TITLE
[Gradient Compression] Replace torch.sqrt(torch.sum(col ** 2)) by torch.norm()

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -23,9 +23,9 @@ def _orthogonalize(matrix, epsilon=1e-8):
         if epsilon == 0:
             # Note that col ** 2 can underflow/overflow if we use FP16.
             # May need to consider multiplying a scaling factor and dividing it later, or using bfloat16 instead.
-            col /= torch.sqrt(torch.sum(col ** 2))
+            col /= torch.norm(col)
         else:
-            col /= torch.sqrt(torch.sum(col ** 2)) + epsilon
+            col /= torch.norm(col) + epsilon
         # Project it on the rest and remove it.
         if i + 1 < num_cols:
             rest = matrix[:, i + 1 :]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51629 [Gradient Compression] Replace torch.sqrt(torch.sum(col ** 2)) by torch.norm()**

Leverage the existing util functions as much as possible for potential performance gain.

Original PR issue: Investigate Applying PowerSGD to Communication Hook for Gradient Compression #47202

Differential Revision: [D26219835](https://our.internmc.facebook.com/intern/diff/D26219835/)