### PR TITLE
concantenate LICENSE files when building a wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -553,10 +553,12 @@ class build_ext(setuptools.command.build_ext.build_ext):
                 f.write(new_contents)
 
 class concat_license_files():
-    """Merge LICENSE.txt and LICENSES_BUNDLED.txt as a context manager
+    """Merge LICENSE and LICENSES_BUNDLED.txt as a context manager
 
-    Done this way to keep LICENSE.txt in repo as exact BSD 3-clause.
-    This makes GitHub web gui state correctly how the repo is licensed.
+    LICENSE is the main PyTorch license, LICENSES_BUNDLED.txt is auto-generated
+    from all the licenses found in ./third_party/. We concatenate them so there
+    is a single license file in the sdist and wheels with all of the necessary
+    licensing info.
     """
     def __init__(self):
         self.f1 = 'LICENSE'
@@ -582,7 +584,7 @@ class concat_license_files():
 try:
     from wheel.bdist_wheel import bdist_wheel
 except ImportError:
-    # This is useful when wheel is not isntalled and bdist_wheel is not
+    # This is useful when wheel is not installed and bdist_wheel is not
     # specified on the command line. If it _is_ specified, parsing the command
     # line will fail before wheel_concatenate is needed
     wheel_concatenate = None

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -109,10 +109,6 @@ TESTS = [
     'test_functional_autograd_benchmark',
     'test_package',
     'test_license',
-:qa
-
-
-
     'distributed/pipeline/sync/skip/test_api',
     'distributed/pipeline/sync/skip/test_gpipe',
     'distributed/pipeline/sync/skip/test_inspect_skip_layout',

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -108,6 +108,11 @@ TESTS = [
     'test_fx_experimental',
     'test_functional_autograd_benchmark',
     'test_package',
+    'test_license',
+:qa
+
+
+
     'distributed/pipeline/sync/skip/test_api',
     'distributed/pipeline/sync/skip/test_gpipe',
     'distributed/pipeline/sync/skip/test_inspect_skip_layout',

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -1,6 +1,9 @@
+import glob
 import io
+import os
 import unittest
 
+import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
 
 
@@ -10,11 +13,12 @@ except ImportError:
     create_bundled = None
 
 license_file = 'third_party/LICENSES_BUNDLED.txt'
+starting_txt = 'The Pytorch repository and source distributions bundle'
 
 class TestLicense(TestCase):
 
     @unittest.skipIf(not create_bundled, "can only be run in a source tree")
-    def test_license_in_wheel(self):
+    def test_license_for_wheel(self):
         current = io.StringIO()
         create_bundled('third_party', current)
         with open(license_file) as fid:
@@ -25,6 +29,21 @@ class TestLicense(TestCase):
                 'match the current state of the third_party files. Use '
                 '"python third_party/build_bundled.py" to regenerate it')
 
+
+    def test_distinfo_license(self):
+        """If run when pytorch is installed via a wheel, the license will be in
+        site-package/torch-*dist-info/LICENSE. Make sure it contains the third
+        party bundle of licenses"""
+
+        site_packages = os.path.dirname(os.path.dirname(torch.__file__))
+        distinfo = glob.glob(os.path.join(site_packages, 'torch-*dist-info'))
+        if len(distinfo) > 1:
+            raise AssertionError(f'Found too many "torch-*dist-info" directories '
+                                 'in "{site_packages}, expected only one')
+        elif len(distinfo) > 0:
+            with open(os.path.join(os.path.join(distinfo[0], 'LICENSE'))) as fid:
+                txt = fid.read()
+                self.assertTrue(starting_txt in txt)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -14,6 +14,8 @@ except ImportError:
 
 license_file = 'third_party/LICENSES_BUNDLED.txt'
 starting_txt = 'The Pytorch repository and source distributions bundle'
+site_packages = os.path.dirname(os.path.dirname(torch.__file__))
+distinfo = glob.glob(os.path.join(site_packages, 'torch-*dist-info'))
 
 class TestLicense(TestCase):
 
@@ -29,21 +31,18 @@ class TestLicense(TestCase):
                 'match the current state of the third_party files. Use '
                 '"python third_party/build_bundled.py" to regenerate it')
 
-
+    @unittest.skipIf(len(distinfo) == 0, "no installation in site-package to test")
     def test_distinfo_license(self):
         """If run when pytorch is installed via a wheel, the license will be in
         site-package/torch-*dist-info/LICENSE. Make sure it contains the third
         party bundle of licenses"""
 
-        site_packages = os.path.dirname(os.path.dirname(torch.__file__))
-        distinfo = glob.glob(os.path.join(site_packages, 'torch-*dist-info'))
         if len(distinfo) > 1:
             raise AssertionError('Found too many "torch-*dist-info" directories '
                                  f'in "{site_packages}, expected only one')
-        elif len(distinfo) > 0:
-            with open(os.path.join(os.path.join(distinfo[0], 'LICENSE'))) as fid:
-                txt = fid.read()
-                self.assertTrue(starting_txt in txt)
+        with open(os.path.join(os.path.join(distinfo[0], 'LICENSE'))) as fid:
+            txt = fid.read()
+            self.assertTrue(starting_txt in txt)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_license.py
+++ b/test/test_license.py
@@ -38,8 +38,8 @@ class TestLicense(TestCase):
         site_packages = os.path.dirname(os.path.dirname(torch.__file__))
         distinfo = glob.glob(os.path.join(site_packages, 'torch-*dist-info'))
         if len(distinfo) > 1:
-            raise AssertionError(f'Found too many "torch-*dist-info" directories '
-                                 'in "{site_packages}, expected only one')
+            raise AssertionError('Found too many "torch-*dist-info" directories '
+                                 f'in "{site_packages}, expected only one')
         elif len(distinfo) > 0:
             with open(os.path.join(os.path.join(distinfo[0], 'LICENSE'))) as fid:
                 txt = fid.read()


### PR DESCRIPTION
Fixes #50695

I checked locally that the concatenated license file appears at `torch-<version>.dist-info/LICENSE` in the wheel.