### PR TITLE
[quant][graphmode][fx] Add packed params to state_dict

### DIFF
--- a/torch/quantization/fx/graph_module.py
+++ b/torch/quantization/fx/graph_module.py
@@ -60,4 +60,8 @@ class QuantizedGraphModule(GraphModule):
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
         super()._save_to_state_dict(destination, prefix, keep_vars)
-        print("save to statedict:", dir(self))
+        for attr_name in dir(self):
+            if "_packed_weight" in attr_name and \
+               isinstance(getattr(self, attr_name), torch._C.ScriptObject):
+                packed_weight = getattr(self, attr_name)
+                destination[prefix + attr_name] = packed_weight

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -955,7 +955,7 @@ class Quantizer:
             else:
                 # copy other nodes
                 env[node.name] = folded_graph.node_copy(node, load_arg)
-        quantized = GraphModule(quantized_root, folded_graph)
+        quantized = QuantizedGraphModule(quantized_root, folded_graph)
         return quantized
 
     def convert(self, model: GraphModule, debug: bool = False,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51640 [quant][graphmode][fx] Add packed params to state_dict**
* #51639 [quant][graphmode][fx] Add support for packed params in state_dict

Summary:
Previously we don't have packed params (from quantized linear and quantized conv) in state_dict
because they are not registered as attributes, similar to https://github.com/pytorch/pytorch/blob/master/torch/nn/quantized/modules/conv.py#L99 we overwrite _save_to_state_dict to include packed params in state_dict

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: