### PR TITLE
Add kernel launch checks in caffe2/aten

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -471,7 +471,8 @@ inline bool CUDA_tensor_apply2(at::Tensor a,
                         max_threads_per_block,                         \
                         min_blocks_per_sm>                             \
    <<<grid, block, 0, at::cuda::getCurrentCUDAStream(curDevice)>>>(    \
-       aInfo, bInfo, static_cast<TYPE>(totalElements), op);
+       aInfo, bInfo, static_cast<TYPE>(totalElements), op);            \
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
 #define HANDLE_B_CASE(TYPE, A, B) {         \
   switch (B) {                              \

--- a/aten/src/ATen/native/cuda/AveragePool2d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool2d.cu
@@ -293,7 +293,7 @@ void avg_pool2d_out_cuda_template(
   bool use_divisor = divisor_override.has_value();
   const auto divisor_override_value = use_divisor ? divisor_override.value() : 0;
 
-  if (count != 0) {  
+  if (count != 0) {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
       "avg_pool2d_out_cuda_frame",
       [&] {
@@ -319,6 +319,7 @@ void avg_pool2d_out_cuda_template(
                   output_data,
                   divisor_override_value,
                   count_include_pad, use_divisor);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
             break;
           }
           case MemoryFormat::Contiguous: {
@@ -336,7 +337,8 @@ void avg_pool2d_out_cuda_template(
                 output_data,
                 divisor_override_value,
                 count_include_pad, use_divisor);
-            break; 
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+            break;
           }
           default: TORCH_CHECK(false, "Unsupported memory format. Supports only ChannelsLast, Contiguous");
         }
@@ -413,7 +415,7 @@ Tensor& avg_pool2d_backward_out_cuda_template(
   if (count == 0) {
     return gradInput;
   }
-  
+
   const uint32_t num_threads = std::min(at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
   const uint32_t num_blocks = cuda::ATenCeilDiv<uint32_t>(count, num_threads);
 

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -147,7 +147,7 @@ __global__ void kernelHistogram1D(
          SHARED_MEM,                                                       \
          getCurrentCUDAStream()>>>(                    \
           aInfo, pInfo, bInfo, nbins, minvalue, maxvalue, totalElements, WEIGHTS_OP);        \
-  TORCH_INTERNAL_ASSERT(cudaGetLastError() == cudaSuccess, "kernelHistogram1D failed");
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
 #define HANDLE_SWITCH_CASE(mType, getOp)                                   \
   switch (mType) {                                                         \

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -106,6 +106,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
           newNnz,
           stride
         );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       });
   }
 

--- a/aten/src/ATen/test/cuda_atomic_ops_test.cu
+++ b/aten/src/ATen/test/cuda_atomic_ops_test.cu
@@ -47,6 +47,7 @@ void test_atomic_add() {
   cudaMemcpy(sumd, sum, arraysize * sizeof(T), cudaMemcpyHostToDevice);
 
   addition_test_kernel<<<dimGrid, dimBlock>>>(ad, sumd);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   cudaMemcpy(sum, sumd, arraysize * sizeof(T), cudaMemcpyDeviceToHost);
 
@@ -85,6 +86,7 @@ void test_atomic_mul() {
   cudaMemcpy(sumd, sum, arraysize * sizeof(T), cudaMemcpyHostToDevice);
 
   mul_test_kernel<<<dimGrid, dimBlock>>>(ad, sumd);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   cudaMemcpy(sum, sumd, arraysize * sizeof(T), cudaMemcpyDeviceToHost);
 

--- a/aten/src/ATen/test/cuda_distributions_test.cu
+++ b/aten/src/ATen/test/cuda_distributions_test.cu
@@ -40,6 +40,7 @@ void assert_with_expected_uniforms(uint64_t counter_offset) {
 
   // launch kernel to get expected randoms
   expected_uniforms<<<1, 1>>>(x, counter_offset);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // Wait for GPU to finish before accessing on host
   cudaDeviceSynchronize();

--- a/aten/src/ATen/test/cuda_integer_divider_test.cu
+++ b/aten/src/ATen/test/cuda_integer_divider_test.cu
@@ -123,6 +123,7 @@ class IntDividerTester {
 
     int numCases = testCases_.size();
     testIntDivider<Value><<<512, 512>>>(dividersBuf_, testCasesBuf_, numCases);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     dividers_.clear();
     testCases_.clear();

--- a/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
+++ b/aten/src/ATen/test/cuda_packedtensoraccessor_test.cu
@@ -37,6 +37,8 @@ TEST(PackedtensoraccessorTest, PackedtensoraccessorTestCUDA) {
   auto stream = at::cuda::getCurrentCUDAStream();
 
   test_tensor_packed_accessor_kernel<<<1, 1, 0, stream>>>(resa, t1a, t2a);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
   cudaError_t err = cudaDeviceSynchronize();
   bool isEQ = err == cudaSuccess;
   ASSERT_TRUE(isEQ);

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -99,6 +99,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   reset_buffers();
   cudaDeviceSynchronize();
   vectorized_copy<double, 4><<<16, 64>>>(b2, b1);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   cudaDeviceSynchronize();
   ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   for (int i = 0; i < 1024; i++) {
@@ -112,6 +113,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   reset_buffers();
   cudaDeviceSynchronize();
   vectorized_copy<double, 2><<<16, 64>>>(b2, b1);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   cudaDeviceSynchronize();
   ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   for (int i = 0; i < 1024; i++) {
@@ -125,6 +127,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
   reset_buffers();
   cudaDeviceSynchronize();
   vectorized_copy<double, 1><<<16, 64>>>(b2, b1);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   cudaDeviceSynchronize();
   ASSERT_EQ(cudaGetLastError(), cudaSuccess);
   for (int i = 0; i < 1024; i++) {
@@ -142,6 +145,7 @@ TEST(TestVectorizedMemoryAccess, CopyKernel) {
       cudaGetLastError();
       cudaDeviceSynchronize();
       vectorized_copy<double, 4><<<1, 64>>>(b2, b1);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
       cudaDeviceSynchronize();
       auto err = cudaGetLastError();
       if (i % 16 == 0 && j % 16 == 0) {

--- a/aten/src/THC/THCSleep.cu
+++ b/aten/src/THC/THCSleep.cu
@@ -17,5 +17,5 @@ void THC_sleep(THCState* state, int64_t cycles)
   dim3 grid(1);
   dim3 block(1);
   spin_kernel<<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(cycles);
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/aten/src/THCUNN/generic/ClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/ClassNLLCriterion.cu
@@ -63,8 +63,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         weights ? THCTensor_(data)(state, weights) : NULL,
         n_classes,
         ignore_index);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-    THCudaCheck(cudaGetLastError());
     if (weights) {
       THCTensor_(free)(state, weights);
     }
@@ -96,7 +96,7 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         n_classes,
         ignore_index
     );
-
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else if (THCTensor_(nDimensionLegacyNoScalars)(state, input) == 2) {
     cunn_ClassNLLCriterion_updateOutput_kernel<scalar_t, accreal>
       <<<1, NTHREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
@@ -111,8 +111,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
         n_classes,
         ignore_index
     );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
-  THCudaCheck(cudaGetLastError());
 
   if (weights) {
     THCTensor_(free)(state, weights);
@@ -186,8 +186,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         weights ? THCTensor_(data)(state, weights) : NULL,
         n_classes,
         ignore_index);
-
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     if (weights) {
       THCTensor_(free)(state, weights);
@@ -217,6 +216,7 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         n_classes,
         ignore_index
     );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
     cunn_ClassNLLCriterion_updateGradInput_kernel<scalar_t>
       <<<1, NTHREADS, 0, c10::cuda::getCurrentCUDAStream()>>>(
@@ -231,8 +231,8 @@ void THNN_(ClassNLLCriterion_updateGradInput)(
         n_classes,
         ignore_index
     );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
-  THCudaCheck(cudaGetLastError());
 
   if (weights) {
     THCTensor_(free)(state, weights);

--- a/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiLabelMarginCriterion.cu
@@ -66,7 +66,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
         1, dim,
         reduction == at::Reduction::Mean
         );
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   else if(input->dim() == 2)
   {
@@ -89,7 +89,7 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
           nframe, dim,
           reduction == at::Reduction::Mean
           );
-      THCudaCheck(cudaGetLastError());
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
       auto t = THTensor_wrap(output_tmp);
       auto r = THTensor_wrap(output);
       at::native::sum_out(r, t, at::IntArrayRef(std::vector<int64_t>{}), false, r.scalar_type());
@@ -108,11 +108,11 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
           nframe, dim,
           false
           );
-      THCudaCheck(cudaGetLastError());
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
   }
   else {
-    TORCH_CHECK(false, "Expected 2D input with optional zero batch dim, or 1D input with non-zero dims, but got sizes: ", 
+    TORCH_CHECK(false, "Expected 2D input with optional zero batch dim, or 1D input with non-zero dims, but got sizes: ",
       input->sizes());
   }
 
@@ -162,7 +162,7 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         1, dim,
         reduction == at::Reduction::Mean,
         reduction != at::Reduction::None);
-
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   else if(gradInput->dim() == 2)
   {
@@ -186,13 +186,12 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
         gradInput->size(0), gradInput->size(1),
         reduction == at::Reduction::Mean,
         reduction != at::Reduction::None);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   else {
     TORCH_CHECK(false, "Expected 2D input with optional zero batch dim, or 1D input with non-zero dims, but got sizes: ",
       gradInput->sizes());
   }
-
-  THCudaCheck(cudaGetLastError());
 
   THCTensor_(free)(state, input);
   THCIndexTensor_(free)(state, target);

--- a/aten/src/THCUNN/generic/MultiMarginCriterion.cu
+++ b/aten/src/THCUNN/generic/MultiMarginCriterion.cu
@@ -69,6 +69,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         reduction == at::Reduction::Mean,
         margin
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
     else if (p == 2)
     {
@@ -81,8 +82,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
         reduction == at::Reduction::Mean,
         margin
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
-    THCudaCheck(cudaGetLastError());
   }
   else if (input->dim() == 2)
   {
@@ -107,6 +108,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           false,
           margin
         );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
       else if (p == 2)
       {
@@ -119,8 +121,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           false,
           margin
         );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
-      THCudaCheck(cudaGetLastError());
     }
     else
     {
@@ -137,6 +139,7 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           reduction == at::Reduction::Mean,
           margin
         );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
       else if (p == 2)
       {
@@ -149,8 +152,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
           reduction == at::Reduction::Mean,
           margin
         );
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
-      THCudaCheck(cudaGetLastError());
       auto t = THTensor_wrap(output_);
       auto r = THTensor_wrap(output);
       at::native::sum_out(r, t, at::IntArrayRef(std::vector<int64_t>{}), false, r.scalar_type());
@@ -211,6 +214,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         margin,
         reduction != at::Reduction::None
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
     else if (p == 2)
     {
@@ -225,8 +229,8 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         margin,
         reduction != at::Reduction::None
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
-    THCudaCheck(cudaGetLastError());
   }
   else if (input->dim() == 2)
   {
@@ -249,6 +253,7 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         margin,
         reduction != at::Reduction::None
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
     else if (p == 2)
     {
@@ -263,12 +268,12 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
         margin,
         reduction != at::Reduction::None
       );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
-    THCudaCheck(cudaGetLastError());
   }
   else
   {
-    TORCH_CHECK(false, "Expected 2D input with optional zero batch dim, or 1D input with non-zero dims, but got sizes: ", 
+    TORCH_CHECK(false, "Expected 2D input with optional zero batch dim, or 1D input with non-zero dims, but got sizes: ",
     input->sizes());
   }
 

--- a/aten/src/THCUNN/generic/RReLU.cu
+++ b/aten/src/THCUNN/generic/RReLU.cu
@@ -41,6 +41,7 @@ void THNN_(RReLU_updateOutput)(
     {
       rreluUpdateOutputTrain<<<grid, BLOCK_SIZE, 0, c10::cuda::getCurrentCUDAStream()>>>(
         n, rng_engine_inputs, input_data, noise_data, input_data, lower, upper);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
       THCTensor_(set)(state, output, input);
     }
     else
@@ -49,8 +50,8 @@ void THNN_(RReLU_updateOutput)(
       scalar_t *output_data = THCTensor_(data)(state, output);
       rreluUpdateOutputTrain<<<grid, BLOCK_SIZE, 0, c10::cuda::getCurrentCUDAStream()>>>(
         n, rng_engine_inputs, input_data, noise_data, output_data, lower, upper);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
-    THCudaCheck(cudaGetLastError());
   }
   else
   {

--- a/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/generic/SpatialClassNLLCriterion.cu
@@ -91,6 +91,7 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
         toDeviceTensor<scalar_t, 3>(state, output),
         weights ? THCTensor_(data)(state, weights) : NULL,
         ignore_index);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     if (weights) {
       THCTensor_(free)(state, weights);
@@ -131,13 +132,13 @@ void THNN_(SpatialClassNLLCriterion_updateOutput)(
         blocks_per_sample,
         ignore_index
     );
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
   if (reduction == at::Reduction::Mean) {
     cunn_SpatialClassNLLCriterion_sizeAverage_kernel<<<1, 1, 0, c10::cuda::getCurrentCUDAStream()>>>(
       output_data, total_weight_data, THCTensor_(nElement)(state, input)
     );
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   if (weights)
@@ -195,6 +196,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
         toDeviceTensor<scalar_t, 4>(state, gradInput),
         weights ? THCTensor_(data)(state, weights) : NULL,
         ignore_index);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
 
     if (weights) {
       THCTensor_(free)(state, weights);
@@ -233,7 +235,7 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
         blocks_per_sample,
         ignore_index
     );
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
 
   if (weights)

--- a/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
+++ b/aten/src/THCUNN/generic/SpatialDepthwiseConvolution.cu
@@ -70,23 +70,24 @@ void THNN_(SpatialDepthwiseConvolution_updateOutput)(
   dim3 grid(blocks);
   dim3 block(CUDA_NUM_THREADS);
   if (kW == 3 && kH == 3) {
-  spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 3><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
-    width, height, outputWidth, outputHeight,
-    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 3><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
+      dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+      width, height, outputWidth, outputHeight,
+      kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else if (kW == 1 && kH == 1) {
-  spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 1><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
-    width, height, outputWidth, outputHeight,
-    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 1><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
+      dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+      width, height, outputWidth, outputHeight,
+      kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   } else {
-  spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 0><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-    dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
-    width, height, outputWidth, outputHeight,
-    kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    spatialDepthwiseConvolutionUpdateOutput<scalar_t, accreal, unsigned int, 0><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
+      dInput, dOutput, dWeight, dBias, bias != NULL, n, outputChannels, depthwiseMultiplier,
+      width, height, outputWidth, outputHeight,
+      kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
-
-  THCudaCheck(cudaGetLastError());
 
   THCTensor_(free)(state, input);
   THCTensor_(free)(state, weight);
@@ -151,48 +152,54 @@ void THNN_(SpatialDepthwiseConvolution_updateGradInput)(
   if (kW == 3 && kH == 3)
     if (dW == 1 && dH == 1){
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 3, 1><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (dW == 2 && dH == 2) {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 3, 2><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 3, 0><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
   else if (kW == 1 && kH == 1)
     if (dW == 1 && dH == 1){
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 1, 1><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (dW == 2 && dH == 2) {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 1, 2><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 1, 0><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
   else
     if (dW == 1 && dH == 1){
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 0, 1><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else if (dW == 2 && dH == 2) {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 0, 2><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       spatialDepthwiseConvolutionUpdateGradInput<scalar_t, accreal, unsigned int, 0, 0><<<grid, block, 0, c10::cuda::getCurrentCUDAStream()>>>(
-      dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
-      height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+        dGradOutput, dGradInput, dWeight, n, inputChannels, depthwiseMultiplier, outputChannels, width,
+        height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
     }
-
-
-  THCudaCheck(cudaGetLastError());
 
   THCTensor_(free)(state, weight);
   THCTensor_(free)(state, gradOutput);
@@ -256,8 +263,7 @@ void THNN_(SpatialDepthwiseConvolution_accGradParameters)(
   spatialDepthwiseConvolutionAccGradParameters<scalar_t, accreal, unsigned int><<<grid, block, smem, c10::cuda::getCurrentCUDAStream()>>>(
       dGradOutput, dInput, dGradWeight, batchSize, inputChannels, outputChannels, depthwiseMultiplier,
       width, height, outputWidth, outputHeight, kW, kH, dW, dH, padW, padH, dilationW, dilationH);
-
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   THCTensor_(free)(state, gradOutput);
 }


### PR DESCRIPTION
Summary:
Add kernel launch checks in caffe2/aten

See details in T83680962

Test Plan:
```
buck test //caffe2/aten:
```

Differential Revision: D26108962

