### PR TITLE
Expand benchmark utils docs

### DIFF
--- a/docs/source/benchmark_utils.rst
+++ b/docs/source/benchmark_utils.rst
@@ -10,3 +10,15 @@ Benchmark Utils - torch.utils.benchmark
 .. autoclass:: Timer
     :members:
     :show-inheritance:
+
+.. autoclass:: Measurement
+    :members:
+    :show-inheritance:
+
+.. autoclass:: CallgrindStats
+    :members:
+    :show-inheritance:
+
+.. autoclass:: FunctionCounts
+    :members:
+    :show-inheritance:

--- a/docs/source/benchmark_utils.rst
+++ b/docs/source/benchmark_utils.rst
@@ -9,16 +9,12 @@ Benchmark Utils - torch.utils.benchmark
 
 .. autoclass:: Timer
     :members:
-    :show-inheritance:
 
 .. autoclass:: Measurement
     :members:
-    :show-inheritance:
 
 .. autoclass:: CallgrindStats
     :members:
-    :show-inheritance:
 
 .. autoclass:: FunctionCounts
     :members:
-    :show-inheritance:

--- a/torch/utils/benchmark/utils/common.py
+++ b/torch/utils/benchmark/utils/common.py
@@ -223,8 +223,9 @@ class Measurement:
     @staticmethod
     def merge(measurements):  # type: (Iterable[Measurement]) -> List[Measurement]
         """Convenience method for merging replicates.
-        NB: merge will extrapolate times to `number_per_run=1` and will not
-            transfer any metadata (since it might differ between replicates)
+
+        Merge will extrapolate times to `number_per_run=1` and will not
+        transfer any metadata. (Since it might differ between replicates)
         """
         grouped_measurements: DefaultDict[TaskSpec, List[Measurement]] = collections.defaultdict(list)
         for m in measurements:

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -244,6 +244,8 @@ class CallgrindStats(object):
         issues when diffing profiles. If a key component such as Python
         or PyTorch was built in separate locations in the two profiles, which
         can result in something resembling:
+
+        ```
             23234231 /tmp/first_build_dir/thing.c:foo(...)
              9823794 /tmp/first_build_dir/thing.c:bar(...)
               ...
@@ -251,6 +253,7 @@ class CallgrindStats(object):
               ...
              -9823794 /tmp/second_build_dir/thing.c:bar(...)
             -23234231 /tmp/second_build_dir/thing.c:foo(...)
+        ```
 
         Stripping prefixes can ameliorate this issue by regularizing the
         strings and causing better cancellation of equivilent call sites

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -105,7 +105,7 @@ class FunctionCounts(object):
 
         This can be used to regularize function names (e.g. stripping irrelevant
         parts of the file path), coalesce entries by mapping multiple functions
-        to the same name, etc.
+        to the same name (in which case the counts are added together), etc.
         """
         counts: DefaultDict[str, int] = collections.defaultdict(int)
         for c, fn in self._data:
@@ -114,7 +114,7 @@ class FunctionCounts(object):
         return self._from_dict(counts, self.inclusive)
 
     def filter(self, filter_fn: Callable[[str], bool]) -> "FunctionCounts":
-        """Keep only the elements where `filter_fn` returns True."""
+        """Keep only the elements where `filter_fn` applied to function name returns True."""
         return FunctionCounts(tuple(i for i in self if filter_fn(i.function)), self.inclusive)
 
     def sum(self) -> int:
@@ -190,13 +190,13 @@ class CallgrindStats(object):
         """Returns detailed function counts.
 
         Conceptually, the FunctionCounts returned can be thought of as a tuple
-        of (count, path_and_function_name).
+        of (count, path_and_function_name) tuples.
 
         `inclusive` matches the semantics of callgrind. If True, the counts
         include instructions executed by children. `inclusive=True` is useful
         for identifying hot spots in code; `inclusive=False` is useful for
-        identifying reducing noise when diffing counts from two different
-        runs. (See CallgrindStats.delta(...) for more details)
+        reducing noise when diffing counts from two different runs. (See
+        CallgrindStats.delta(...) for more details)
         """
         if inclusive:
             return self.stmt_inclusive_stats - self.baseline_inclusive_stats

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -243,9 +243,8 @@ class CallgrindStats(object):
         when reporting a function (as it should). However, this can cause
         issues when diffing profiles. If a key component such as Python
         or PyTorch was built in separate locations in the two profiles, which
-        can result in something resembling:
+        can result in something resembling::
 
-        ```
             23234231 /tmp/first_build_dir/thing.c:foo(...)
              9823794 /tmp/first_build_dir/thing.c:bar(...)
               ...
@@ -253,7 +252,6 @@ class CallgrindStats(object):
               ...
              -9823794 /tmp/second_build_dir/thing.c:bar(...)
             -23234231 /tmp/second_build_dir/thing.c:foo(...)
-        ```
 
         Stripping prefixes can ameliorate this issue by regularizing the
         strings and causing better cancellation of equivilent call sites


### PR DESCRIPTION
Add some much needed documentation on the Timer callgrind output format, and expand what is shown on the website.
