### PR TITLE
[package] use WeakValueDictionary for global imported module registry

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import inspect
 import linecache
+from weakref import WeakValueDictionary
 from torch.serialization import _load
 import pickle
 import torch
@@ -437,7 +438,7 @@ class _ExternNode(_PathNode):
     pass
 
 # A private global registry of all modules that have been package-imported.
-_package_imported_modules: Dict[str, ModuleType] = {}
+_package_imported_modules: WeakValueDictionary = WeakValueDictionary()
 
 # `inspect` by default only looks in `sys.modules` to find source files for classes.
 # Patch it to check our private registry of package-imported modules as well.

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,5 +1,4 @@
 from typing import List, Callable, Dict, Optional, Any, Union, BinaryIO
-from types import ModuleType
 import builtins
 import importlib
 import inspect


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51666 [package] use WeakValueDictionary for global imported module registry**

This ensures the modules will get properly unloaded when all references
to them die

Differential Revision: [D26232574](https://our.internmc.facebook.com/intern/diff/D26232574)