### PR TITLE
Fixes cat backward formula to return correct gradient values for R -> C case

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7792,6 +7792,7 @@ class TestMultithreadAutograd(TestCase):
     def test_cat_r_to_c(self):
         inp_c = torch.rand(3, 2, dtype=torch.cdouble, requires_grad=True)
         inp_r = torch.randn(3, 2, dtype=torch.double, requires_grad=True)
+
         def fn(x1, x2):
             return torch.cat((x1, x2), dim=-1)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7797,6 +7797,7 @@ class TestMultithreadAutograd(TestCase):
             return torch.cat((x1, x2), dim=-1)
 
         torch.autograd.gradcheck(fn, [inp_r, inp_c])
+        torch.autograd.gradcheck(fn, [inp_c, inp_r])
 
 for test in method_tests():
     add_test(*test)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7787,6 +7787,16 @@ class TestMultithreadAutograd(TestCase):
             tb_str = "\n".join(traceback.format_tb(tb))
             self.assertTrue('raise ValueError("something")' in tb_str)
 
+    # TODO(@anjali411): add an OpInfo based test for torch.cat
+    # Issue: https://github.com/pytorch/pytorch/issues/51627
+    def test_cat_r_to_c(self):
+        inp_c = torch.rand(3, 2, dtype=torch.cdouble, requires_grad=True)
+        inp_r = torch.randn(3, 2, dtype=torch.double, requires_grad=True)
+        def fn(x1, x2):
+            return torch.cat((x1, x2), dim=-1)
+
+        torch.autograd.gradcheck(fn, [inp_r, inp_c])
+
 for test in method_tests():
     add_test(*test)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -283,7 +283,7 @@
   mat2: at::_bmm(self.transpose(1, 2), grad, deterministic)
 
 - name: cat(Tensor[] tensors, int dim=0) -> Tensor
-  tensors: cat_tensors_backward(grad, to_args_sizes(tensors), dim)
+  tensors: cat_tensors_backward(grad, to_args_sizes(tensors), to_args_scalartypes(tensors), dim)
 
 - name: cauchy_(Tensor(a!) self, float median=0, float sigma=1, *, Generator? generator=None) -> Tensor(a!)
   self: zeros_like(grad)

--- a/tools/autograd/load_derivatives.py
+++ b/tools/autograd/load_derivatives.py
@@ -279,6 +279,11 @@ def saved_variables(
             'suffix': '_args_sizes',
             'type': 'std::vector<std::vector<int64_t>>',
         }),
+        # replace to_args_scalartypes(self) with self_args_scalartypes
+        (r'to_args_scalartypes\({}\)', {
+            'suffix': '_args_scalartypes',
+            'type': 'std::vector<ScalarType>',
+        }),
         # replace TensorGeometry(self) with self_geometry
         (r'TensorGeometry\({}\)', {
             'suffix': '_geometry',

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -553,23 +553,25 @@ Tensor unsqueeze_to(const Tensor & self, int64_t dim, IntArrayRef sizes) {
   return self;
 }
 
-std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim) {
+std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, const std::vector<ScalarType> &dtypes, int64_t dim) {
   std::vector<Tensor> grad_inputs(sizes.size());
   if (!grad.defined()) {
     return grad_inputs;
   }
   dim = at::legacy_cat_wrap_dim(dim, sizes);
   int64_t accumulate = 0;
+
   for (size_t i = 0; i < sizes.size(); ++i) {
     auto& shape = sizes[i];
+    auto grad_ = handle_r_to_c(dtypes[i], grad);
     // If input was empty tensor, gradInput should be empty tensor.
     if (shape == std::vector<int64_t>({0})) {
-      grad_inputs[i] = at::zeros({0}, grad.options());
+      grad_inputs[i] = at::zeros({0}, grad_.options());
       continue;
     }
     auto size = shape[dim];
     accumulate += size;
-    grad_inputs[i] = grad.narrow(dim, accumulate - size, size);
+    grad_inputs[i] = grad_.narrow(dim, accumulate - size, size);
   }
   return grad_inputs;
 }

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -76,7 +76,7 @@ at::Tensor logcumsumexp_backward(at::Tensor grad, const at::Tensor & self, at::T
 at::Tensor unbind_backward(const variable_list& grads, int64_t dim);
 at::Tensor unsqueeze_to(const at::Tensor & self, at::IntArrayRef sizes);
 at::Tensor unsqueeze_to(const at::Tensor & self, int64_t dim, at::IntArrayRef sizes);
-std::vector<at::Tensor> cat_tensors_backward(const at::Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, int64_t dim);
+std::vector<at::Tensor> cat_tensors_backward(const at::Tensor & grad, const std::vector<std::vector<int64_t>> &sizes, const std::vector<ScalarType> &dtypes, int64_t dim);
 at::Tensor clamp_backward(const at::Tensor & grad, const at::Tensor &self, const optional<at::Scalar> & min, const optional<at::Scalar> & max);
 at::IntArrayRef strides_or_error(const Tensor & input, c10::string_view const & input_name);
 at::Tensor mm_mat1_backward(const Tensor & grad, const Tensor & mat2, at::IntArrayRef mat1_sizes, at::IntArrayRef mat1_strides, const Scalar & alpha);

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -309,4 +309,11 @@ inline std::vector<std::vector<int64_t>> to_args_sizes(TensorList tensors) {
   return args_sizes;
 }
 
+inline std::vector<ScalarType> to_args_scalartypes(TensorList tensors) {
+  std::vector<ScalarType> args_scalartypes(tensors.size());
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    args_scalartypes[i] = tensors[i].scalar_type();
+  }
+  return args_scalartypes;
+}
 }} // namespace torch::autograd


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/51627
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51681 Fixes cat backward formula to return correct gradient values for R -> C case**

Differential Revision: [D26238748](https://our.internmc.facebook.com/intern/diff/D26238748)