### PR TITLE
Make te a hidden package for now

### DIFF
--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -1,5 +1,5 @@
 import torch
-import torch._C.te as te
+import torch._C._te as te
 import time
 import numpy as np
 import pandas as pd
@@ -101,8 +101,8 @@ binary_ops = [
 
 def nnc_relu(A, B):
     def f(i, j):
-        return torch._C.te.ifThenElse(A.load([i, j]) < torch._C.te.ExprHandle.float(0),
-                                      torch._C.te.ExprHandle.float(0), A.load([i, j]))
+        return torch._C._te.ifThenElse(A.load([i, j]) < torch._C._te.ExprHandle.float(0),
+                                      torch._C._te.ExprHandle.float(0), A.load([i, j]))
     return f
 
 def pt_relu(a, b, c):
@@ -167,26 +167,26 @@ def run_benchmarks(benchmarks, sizes):
 
                     def get_nnc_type(dtype):
                         if dtype == torch.float:
-                            return torch._C.te.Dtype.Float
+                            return torch._C._te.Dtype.Float
                         elif dtype == torch.long:
-                            return torch._C.te.Dtype.Long
+                            return torch._C._te.Dtype.Long
 
                     dtype = get_nnc_type(tA.dtype)
 
-                    dM = torch._C.te.ExprHandle.int(M)
-                    dN = torch._C.te.ExprHandle.int(N)
+                    dM = torch._C._te.ExprHandle.int(M)
+                    dN = torch._C._te.ExprHandle.int(N)
 
-                    A = torch._C.te.Placeholder('A', dtype, [dM, dN])
-                    B = torch._C.te.Placeholder('B', dtype, [dM, dN])
+                    A = torch._C._te.Placeholder('A', dtype, [dM, dN])
+                    B = torch._C._te.Placeholder('B', dtype, [dM, dN])
 
-                    dim_args = [torch._C.te.DimArg(*args) for args in [(dM, 'm'), (dN, 'n')]]
+                    dim_args = [torch._C._te.DimArg(*args) for args in [(dM, 'm'), (dN, 'n')]]
 
                     compute = nnc_fun(A, B)
-                    X = torch._C.te.Compute('X', dim_args, compute)
-                    loopnest = torch._C.te.LoopNest([X])
+                    X = torch._C._te.Compute('X', dim_args, compute)
+                    loopnest = torch._C._te.LoopNest([X])
                     loopnest.prepare_for_codegen()
-                    stmt = torch._C.te.simplify(loopnest.root_stmt())
-                    cg = torch._C.te.construct_codegen('llvm', stmt, [torch._C.te.BufferArg(x) for x in [A, B, X]])
+                    stmt = torch._C._te.simplify(loopnest.root_stmt())
+                    cg = torch._C._te.construct_codegen('llvm', stmt, [torch._C._te.BufferArg(x) for x in [A, B, X]])
 
 
                     # warmup

--- a/benchmarks/tensorexpr/microbenchmarks.py
+++ b/benchmarks/tensorexpr/microbenchmarks.py
@@ -102,7 +102,7 @@ binary_ops = [
 def nnc_relu(A, B):
     def f(i, j):
         return torch._C._te.ifThenElse(A.load([i, j]) < torch._C._te.ExprHandle.float(0),
-                                      torch._C._te.ExprHandle.float(0), A.load([i, j]))
+                                       torch._C._te.ExprHandle.float(0), A.load([i, j]))
     return f
 
 def pt_relu(a, b, c):

--- a/test/test_tensorexpr_pybind.py
+++ b/test/test_tensorexpr_pybind.py
@@ -5,7 +5,7 @@ from torch.testing._internal.jit_utils import JitTestCase
 
 class kernel_arena_scope(object):
     def __enter__(self):
-        self.scope = torch._C.te.KernelScope()
+        self.scope = torch._C._te.KernelScope()
 
     def __exit__(self, typ, val, traceback):
         self.scope = None
@@ -13,22 +13,22 @@ class kernel_arena_scope(object):
 class TestTensorExprPyBind(JitTestCase):
     def test_simple_sum(self):
         with kernel_arena_scope():
-            dtype = torch._C.te.Dtype.Float
+            dtype = torch._C._te.Dtype.Float
             N = 32
-            dN = torch._C.te.ExprHandle.int(N)
+            dN = torch._C._te.ExprHandle.int(N)
 
-            A = torch._C.te.Placeholder('A', dtype, [dN])
-            B = torch._C.te.Placeholder('B', dtype, [dN])
+            A = torch._C._te.Placeholder('A', dtype, [dN])
+            B = torch._C._te.Placeholder('B', dtype, [dN])
 
             def compute(i):
                 return A.load([i]) + B.load([i])
-            C = torch._C.te.Compute('C', [torch._C.te.DimArg(dN, 'i')], compute)
+            C = torch._C._te.Compute('C', [torch._C._te.DimArg(dN, 'i')], compute)
 
-            loopnest = torch._C.te.LoopNest([C])
+            loopnest = torch._C._te.LoopNest([C])
             loopnest.prepare_for_codegen()
-            stmt = torch._C.te.simplify(loopnest.root_stmt())
+            stmt = torch._C._te.simplify(loopnest.root_stmt())
 
-            cg = torch._C.te.construct_codegen('ir_eval', stmt, [torch._C.te.BufferArg(x) for x in [A, B, C]])
+            cg = torch._C._te.construct_codegen('ir_eval', stmt, [torch._C._te.BufferArg(x) for x in [A, B, C]])
 
             tA = torch.rand(N) * 5
             tB = torch.rand(N) * 6

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -17,7 +17,7 @@ void initTensorExprBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
   // Tensor Expr Classes
-  auto te = m.def_submodule("te");
+  auto te = m.def_submodule("_te");
   py::class_<tensorexpr::KernelScope>(te, "KernelScope").def(py::init<>());
 
   auto dtype_class = py::class_<tensorexpr::Dtype>(te, "Dtype");


### PR DESCRIPTION
As discussed with @suo , having it in `torch._C.XX` means that it automatically gets added to `torch.XX` which is unfortunate. Making it `torch._C._XX` means that it won't be added to `torch.`.

Let me know if that approach to hide it is not good and we can update that.