### PR TITLE
move GroupByFilename Dataset to DataPipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -178,6 +178,38 @@ class TestIterableDataPipeBasic(TestCase):
                 self.assertTrue(rec[1] == open(rec[0], 'rb').read().decode('utf-8'))
 
 
+    def test_groupbyfilename_iterable_datapipe(self):
+        temp_dir = self.temp_dir.name
+        temp_tarfile_pathname = os.path.join(temp_dir, "test_tar.tar")
+        file_list = [
+            "a.png", "b.png", "c.json", "a.json", "c.png", "b.json", "d.png",
+            "d.json", "e.png", "f.json", "g.png", "f.png", "g.json", "e.json",
+            "h.txt", "h.json"]
+        with tarfile.open(temp_tarfile_pathname, "w:gz") as tar:
+            for file_name in file_list:
+                file_pathname = os.path.join(temp_dir, file_name)
+                with open(file_pathname, 'w') as f:
+                    f.write('12345abcde')
+                tar.add(file_pathname)
+
+        datapipe1 = dp.iter.ListDirFiles(temp_dir, '*.tar')
+        datapipe2 = dp.iter.LoadFilesFromDisk(datapipe1)
+        datapipe3 = dp.iter.ReadFilesFromTar(datapipe2)
+        datapipe4 = dp.iter.GroupByFilename(datapipe3, group_size=2)
+
+        expected_result = [("a.png", "a.json"), ("c.png", "c.json"), ("b.png", "b.json"), ("d.png", "d.json"), (
+            "f.png", "f.json"), ("g.png", "g.json"), ("e.png", "e.json"), ("h.json", "h.txt")]
+
+        count = 0
+        for rec, expected in zip(datapipe4, expected_result):
+            count = count + 1
+            self.assertEqual(os.path.basename(rec[0][0]), expected[0])
+            self.assertEqual(os.path.basename(rec[1][0]), expected[1])
+            self.assertEqual(rec[0][1].read(), b'12345abcde')
+            self.assertEqual(rec[1][1].read(), b'12345abcde')
+        self.assertEqual(count, 8)
+
+
 class IDP_NoLen(IterDataPipe):
     def __init__(self, input_dp):
         super().__init__()

--- a/torch/utils/data/datapipes/iter/__init__.py
+++ b/torch/utils/data/datapipes/iter/__init__.py
@@ -3,6 +3,7 @@ from torch.utils.data.datapipes.iter.loadfilesfromdisk import LoadFilesFromDiskI
 from torch.utils.data.datapipes.iter.readfilesfromtar import ReadFilesFromTarIterDataPipe as ReadFilesFromTar
 from torch.utils.data.datapipes.iter.readfilesfromzip import ReadFilesFromZipIterDataPipe as ReadFilesFromZip
 from torch.utils.data.datapipes.iter.routeddecoder import RoutedDecoderIterDataPipe as RoutedDecoder
+from torch.utils.data.datapipes.iter.groupbyfilename import GroupByFilenameIterDataPipe as GroupByFilename
 
 # Functional DataPipe
 from torch.utils.data.datapipes.iter.batch import BatchIterDataPipe as Batch, BucketBatchIterDataPipe as BucketBatch
@@ -10,4 +11,5 @@ from torch.utils.data.datapipes.iter.callable import CallableIterDataPipe as Cal
 from torch.utils.data.datapipes.iter.sampler import SamplerIterDataPipe as Sampler
 
 __all__ = ['ListDirFiles', 'LoadFilesFromDisk', 'ReadFilesFormTar', 'ReadFilesFromZip', 'RoutedDecoder',
+           'GroupByFilename',
            'Batch', 'BucketBatch', 'Callable', 'Collate', 'Sampler']

--- a/torch/utils/data/datapipes/iter/groupbyfilename.py
+++ b/torch/utils/data/datapipes/iter/groupbyfilename.py
@@ -1,0 +1,102 @@
+from torch.utils.data import IterDataPipe
+from typing import Dict, List, Tuple, Any, Callable, Iterable, Iterator
+
+import os
+import functools
+
+
+def default_group_key_fn(dataitem : Tuple[str, Any]):
+    return os.path.splitext(dataitem[0])[0]
+
+
+def default_sort_data_fn(datalist : List[Tuple[str, Any]]):
+    txt_ext = ['.json', '.jsn', '.txt', '.text']
+
+    def cmp_fn(a : Tuple[str, Any], b : Tuple[str, Any]):
+        a_is_txt = os.path.splitext(a[0])[1] in txt_ext
+        b_is_txt = os.path.splitext(b[0])[1] in txt_ext
+
+        # if a is txt but b is not, b go front
+        if a_is_txt and not b_is_txt:
+            return 1
+        # if a is not txt but b is txt, a go front
+        if not a_is_txt and b_is_txt:
+            return -1
+        # if a and b both are or are not txt, sort in alphabetic order
+        if a[0] < b[0]:
+            return -1
+        elif a[0] > b[0]:
+            return 1
+        return 0
+
+    return sorted(datalist, key=functools.cmp_to_key(cmp_fn))
+
+
+class GroupByFilenameIterDataPipe(IterDataPipe):
+    r""" :class:`GroupByFilenameIterDataPipe`.
+
+    Iterable datapipe to group binary streams from input iterables by pathname without extension,
+    yield a list with `group_size` items in it, each item in the list is a tuple of
+    pathname and binary stream
+
+    args:
+        datapipe: Iterable datapipe that provides pathname and zip binary stream in tuples
+        group_size: the size of group
+        max_buffer_size: the max size of stream buffer which is used to store not yet grouped but iterated data stream
+        group_key_fn: a function which is used to generate group key from pathname of the data stream
+        sort_data_fn: a function which is used to sort the grouped data stream before yield back
+        length: a nominal length of the datapipe
+    """
+
+    def __init__(
+            self,
+            datapipe : Iterable[Tuple[str, Any]],
+            group_size : int = 1,
+            max_buffer_size : int = 10,
+            group_key_fn : Callable = default_group_key_fn,
+            sort_data_fn : Callable = default_sort_data_fn,
+            length: int = -1):
+        super().__init__()
+        self.datapipe : Iterable[Tuple[str, Any]] = datapipe
+        self.group_size : int = group_size
+        self.max_buffer_size : int = max_buffer_size
+        self.group_key_fn : Callable = group_key_fn
+        self.sort_data_fn : Callable = sort_data_fn
+        self.curr_buffer_size : int = 0
+        self.stream_buffer : Dict[str, List[Tuple[str, Any]]] = {}
+        self.length : int = length
+
+
+    def __iter__(self) -> Iterator[list]:
+        assert self.group_size > 0
+        assert self.max_buffer_size >= 0
+
+        if self.group_size == 1:
+            for data in self.datapipe:
+                yield [data]
+
+        for data in self.datapipe:
+            key = self.group_key_fn(data)
+            res = self.stream_buffer.get(key, []) + [data]
+            if len(res) == self.group_size:
+                yield self.sort_data_fn(res)
+                del self.stream_buffer[key]
+                self.curr_buffer_size = self.curr_buffer_size - self.group_size + 1
+            else:
+                if self.curr_buffer_size == self.max_buffer_size:
+                    raise OverflowError(
+                        "stream_buffer is overflow, please adjust the order of data "
+                        "in the input datapipe or increase the buffer size!")
+                self.stream_buffer[key] = res
+                self.curr_buffer_size = self.curr_buffer_size + 1
+
+        if self.curr_buffer_size > 0:
+            msg = "Not able to group [{}] with group size {}.".format(
+                ','.join([v[0] for _, vs in self.stream_buffer.items() for v in vs]), str(self.group_size))
+            raise RuntimeError(msg)
+
+
+    def __len__(self):
+        if self.length == -1:
+            raise NotImplementedError
+        return self.length


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51707 move GroupByFilename Dataset to DataPipe**
* #51704 move RoutedDecoder Dataset to DataPipe

