### PR TITLE
[ONNX] enable several script unit tests using new jit passes

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2986,7 +2986,7 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.rnn = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False)
- 
+
             def forward(self, x, h0, c0):
                 return self.rnn(x, (h0, c0))
 
@@ -3001,7 +3001,7 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self):
                 super().__init__()
                 self.rnn = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False)
- 
+
             def forward(self, x):
                 return self.rnn(x)
 
@@ -3057,7 +3057,7 @@ class TestONNXRuntime(unittest.TestCase):
                 super(LstmNet, self).__init__()
                 self.lstm = torch.nn.LSTM(input_size, hidden_size, num_layers, bidirectional=bidirectional)
 
-            def forward(self, input, initial_state:Tuple[torch.Tensor, torch.Tensor]):
+            def forward(self, input, initial_state: Tuple[torch.Tensor, torch.Tensor]):
                 return self.lstm(input, initial_state)
 
         def get_LstmNet_model_and_inputs(input_size, hidden_size, num_layers, batch_size,
@@ -3084,7 +3084,7 @@ class TestONNXRuntime(unittest.TestCase):
                 super(LstmNet, self).__init__()
                 self.lstm = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers, bias=False, bidirectional=bidirectional)
 
-            def forward(self, input, initial_state:Tuple[torch.Tensor, torch.Tensor]):
+            def forward(self, input, initial_state: Tuple[torch.Tensor, torch.Tensor]):
                 return self.lstm(input, initial_state)
 
         def get_LstmNet_model_and_inputs(num_layers, bidirectional):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2089,9 +2089,14 @@ class TestONNXRuntime(unittest.TestCase):
                         self._interpolate(xi, mode_i, False, is_upsample, True)
                     self._interpolate(xi, mode_i, False, is_upsample)
 
-    # ONNX export failed on interpolate because dynamic size not supported for opsets below 9.
+    # ONNX export failed on interpolate scripting because dynamic size not supported for opsets below 9.
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_interpolate_upsample(self):
+        self._interpolate_tests(True)
+
+    @skipIfUnsupportedMaxOpsetVersion(8)
+    @disableScriptTest()
+    def test_interpolate_upsample_trace(self):
         self._interpolate_tests(True)
 
     @skipIfUnsupportedMinOpsetVersion(9)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2089,6 +2089,7 @@ class TestONNXRuntime(unittest.TestCase):
                         self._interpolate(xi, mode_i, False, is_upsample, True)
                     self._interpolate(xi, mode_i, False, is_upsample)
 
+    # ONNX export failed on interpolate because dynamic size not supported for opsets below 9.
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_interpolate_upsample(self):
         self._interpolate_tests(True)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2089,6 +2089,7 @@ class TestONNXRuntime(unittest.TestCase):
                         self._interpolate(xi, mode_i, False, is_upsample, True)
                     self._interpolate(xi, mode_i, False, is_upsample)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_interpolate_upsample(self):
         self._interpolate_tests(True)
 
@@ -2139,6 +2140,8 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(16, 16, requires_grad=True)
         self.run_test(MyModel(), (x, y))
 
+    # scripting will throw the OnnxRuntimeError
+    @disableScriptTest()
     def test_interpolate_adaptive_pooling_error(self):
         x = torch.randn(1, 2, 6, requires_grad=True)
         with self.assertRaises(RuntimeError) as cm:


### PR DESCRIPTION
Tests that have been enabled include:
### Passed
- test_interpolate_upsample
- test_interpolate_function_substitution
- test_interpolate_downsample
- test_interpolate_no_shape
- test_lstm
- test_lstm_default_init_state
- test_lstm_fixed_batch_size
- test_lstm_constant_folding
- test_lstm_no_bias
- test_einsum
- test_lstm_post_fix_init_state
- test_binary_cross_entropy_with_logits

### Fixed annotation type, but still failed.
- test_rnn_no_bias 
- test_pad_types
- test_roi_heads
- test_multi_scale_roi_align
- test_rpn
- test_transform_images
- test_clip_boxes_to_image