### PR TITLE
change logging.warn to logging.warning

### DIFF
--- a/caffe2/python/experiment_util.py
+++ b/caffe2/python/experiment_util.py
@@ -110,5 +110,5 @@ class ModelTrainerLog():
             try:
                 logger.log(logdict)
             except Exception as e:
-                logging.warn(
+                logging.warning(
                     "Failed to call ExternalLogger: {}".format(e), e)


### PR DESCRIPTION
Summary: logging.warn() is deprecated since Python 3.3 in favor of logging.warning()

Reviewed By: yinghai

Differential Revision: D25785598

