### PR TITLE
[pyper] register aten::index_out

### DIFF
--- a/aten/src/ATen/native/IndexingUtils.h
+++ b/aten/src/ATen/native/IndexingUtils.h
@@ -71,6 +71,15 @@ inline torch::List<c10::optional<Tensor>> toListOfOptionalTensors(ArrayRef<Tenso
   return result;
 }
 
+inline torch::List<c10::optional<Tensor>> toListOfOptionalTensors(ArrayRef<IValue> list) {
+  torch::List<c10::optional<Tensor>> result;
+  result.reserve(list.size());
+  for (const IValue& a : list) {
+    result.push_back(a.toTensor());
+  }
+  return result;
+}
+
 static bool hasContiguousSubspace(TensorList tl) {
   // true if all the non-null tensors are adjacent
   auto isDefined = [](const Tensor & tensor){ return tensor.defined(); };


### PR DESCRIPTION
Summary: Register aten::index_out with StaticRuntime

Test Plan:
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --c2_weights=/data/users/ansha/tmp/adfinder/models/c2_local_ro_weight_data.pb --c2_inputs=/data/users/ansha/tmp/adfinder/models/c2_local_ro_input_data.pb --pred_net=/data/users/ansha/tmp/adfinder/models/c2_local_ro_net.pb --c2_sigrid_transforms_opt=1 --c2_apply_nomnigraph_passes=1 --c2_use_memonger=1 --scripted_model=/data/users/ansha/tmp/adfinder/models2/210494966_0.predictor.disagg.local_ro.pt --pt_inputs=/data/users/ansha/tmp/adfinder/models/local_wrapped_input_data.pt --pt_enable_static_runtime=1 --pt_cleanup_activations=true --pt_enable_out_variant=true --compare_results=0 --iters=30000 --warmup_iters=10000 --num_threads=1 --do_profile=1 --benchmark_c2_predictor=0
```

Before total ms/iter: 0.699626
Before: 0.0277974 ms.    4.03198%. aten::index (5 nodes)

After total ms/iter: 0.696739
After: 0.0254255 ms.    3.67315%. aten::index (5 nodes)

Differential Revision: D26261215

