### PR TITLE
Reset checkpoint_valid flag when error happens during function execution

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4128,6 +4128,16 @@ for shape in [(1,), ()]:
         mean_combined = torch.stack(feat_combined).mean()
         mean_combined.backward()
 
+    def test_checkpoint_valid_reset_on_error(self):
+        a = torch.randn(2, 2, requires_grad=True)
+
+        with self.assertRaisesRegex(Exception, "Checkpointing is not compatible with .grad()"):
+            b = checkpoint(torch.exp, a).sum()
+            torch.autograd.grad(b, (a,))
+
+        c = checkpoint(torch.exp, a).sum()
+        c.backward()
+
     def _test_reentrant_with_callbacks(self, install_callbacks_in_depths):
         counter = {}
         counter["inner"] = 0

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -226,12 +226,11 @@ def grad(
 
 
 # This function applies in case of gradient checkpointing for memory
-# optimization. Currently, for gradient checkpointing, we only support imperative
-# backwards call i.e. torch.autograd.backward() and the torch.autograd.grad() won't
-# work. The reason being that: torch.autograd.grad() only calculates the grads
-# for the inputs that are passed by user but it doesn't calculate grad for
-# anything else e.g. model parameters like weights, bias etc. However, for
-# torch.autograd.backward(), we would actually compute the grad for the weights as well.
+# optimization. Currently, gradient checkpointing is supported only if the
+# execution engine is invoked through torch.autograd.backward() and its
+# inputs argument is not passed. It is not supported for torch.autograd.grad().
+# This is because if inputs are specified, the gradient won't be calculated for
+# anything else e.g. model parameters like weights, bias etc.
 #
 # This function returns whether the checkpointing is valid i.e. torch.autograd.backward
 # or not i.e. torch.autograd.grad. The implementation works by maintaining a thread

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -168,7 +168,7 @@ int NodeTask::getReentrantDepth() const {
   }
 }
 
-CheckpointValidGuard::CheckpointValidGuard(const std::shared_ptr<GraphTask>& graph_task) {
+CheckpointValidGuard::CheckpointValidGuard(const std::shared_ptr<const GraphTask>& graph_task) {
   prev_checkpoint_valid_state = checkpoint_valid;
   checkpoint_valid = graph_task->can_checkpoint() && prev_checkpoint_valid_state;
 }
@@ -385,7 +385,6 @@ auto Engine::thread_main(const std::shared_ptr<GraphTask>& graph_task) -> void {
           // callbacks.
           GraphTaskGuard guard(local_graph_task);
           NodeGuard ndguard(task.fn_);
-          CheckpointValidGuard cpvguard(local_graph_task);
           evaluate_function(local_graph_task, task.fn_.get(), task.inputs_, local_graph_task->cpu_ready_queue_);
         } catch (std::exception& e) {
           thread_on_exception(local_graph_task, task.fn_, e);
@@ -646,6 +645,7 @@ static variable_list call_function(
     std::shared_ptr<GraphTask>& graph_task,
     Node* func,
     InputBuffer& inputBuffer) {
+  CheckpointValidGuard cpvguard(graph_task);
   auto& fn = *func;
   auto inputs =
       call_pre_hooks(fn, InputBuffer::variables(std::move(inputBuffer)));

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -95,9 +95,12 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   // Exec info has a bit complicated semantics. If it's empty, it means the task
   // is run in a "default" mode, which means that all next_edges we encounter
   // should get executed. If it's not empty, only functions that have an entry
-  // and this entry has needed == True should be executed. exec_info_.empty()
-  // means it's .backward(), otherwise it's .grad(). exec_info_ is safe to read
-  // without synchronization
+  // and this entry has needed == True should be executed. exec_info is only empty
+  // when the graph is executed via .backward() and the input parameter is not passed.
+  // Otherwise, when executed through .grad(), or when inputs arg is specified for
+  // .backward(), exec_info will be non-empty.
+  //
+  // exec_info_ is safe to read without synchronization
   std::unordered_map<Node*, ExecInfo> exec_info_;
   // Captures variables are grads captured that we return to the user. After
   // execution of the GraphTask is completed, the captured_vars_ are moved
@@ -118,7 +121,7 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   // The number of parent graph tasks for this graph task
   const int reentrant_depth_;
 
-  bool can_checkpoint() {
+  bool can_checkpoint() const {
     return exec_info_.empty();
   }
 
@@ -216,7 +219,7 @@ struct NodeTask {
 // Guard that sets and restores checkpoint_valid
 class CheckpointValidGuard {
  public:
-  explicit CheckpointValidGuard(const std::shared_ptr<GraphTask>& graph_task);
+  explicit CheckpointValidGuard(const std::shared_ptr<const GraphTask>& graph_task);
   ~CheckpointValidGuard();
  private:
   bool prev_checkpoint_valid_state;

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -213,6 +213,15 @@ struct NodeTask {
         isShutdownTask_(isShutdownTask) {}
 };
 
+// Guard that sets and restores checkpoint_valid
+class CheckpointValidGuard {
+ public:
+  explicit CheckpointValidGuard(const std::shared_ptr<GraphTask>& graph_task);
+  ~CheckpointValidGuard();
+ private:
+  bool prev_checkpoint_valid_state;
+};
+
 
 struct ReadyQueue {
  private:

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -96,7 +96,7 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
   // is run in a "default" mode, which means that all next_edges we encounter
   // should get executed. If it's not empty, only functions that have an entry
   // and this entry has needed == True should be executed. exec_info is only empty
-  // when the graph is executed via .backward() and the input parameter is not passed.
+  // when the graph is executed via .backward() and the inputs parameter is not passed.
   // Otherwise, when executed through .grad(), or when inputs arg is specified for
   // .backward(), exec_info will be non-empty.
   //

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -78,7 +78,10 @@ class CheckpointFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *args):
         if not torch.autograd._is_checkpoint_valid():
-            raise RuntimeError("Checkpointing is not compatible with .grad(), please use .backward() if possible")
+            raise RuntimeError(
+                "Checkpointing is not compatible with .grad() or when an `inputs` parameter"
+                " is passed to .backward(). Please use .backward() and do not pass its `inputs`"
+                " argument.")
         inputs = ctx.saved_tensors
         # Stash the surrounding rng state, and mimic the state that was
         # present at this time during forward.  Restore the surrounding state
@@ -133,8 +136,9 @@ def checkpoint(function, *args, **kwargs):
     the gradients are calculated using these activation values.
 
     .. warning::
-        Checkpointing doesn't work with :func:`torch.autograd.grad`, but only
-        with :func:`torch.autograd.backward`.
+        Checkpointing currently only supports :func:`torch.autograd.backward`
+        and only if its `inputs` argument is not passed. :func:`torch.autograd.grad`
+        is not supported.
 
     .. warning::
         If :attr:`function` invocation during backward does anything different
@@ -190,8 +194,9 @@ def checkpoint_sequential(functions, segments, input, **kwargs):
     See :func:`~torch.utils.checkpoint.checkpoint` on how checkpointing works.
 
     .. warning::
-        Checkpointing doesn't work with :func:`torch.autograd.grad`, but only
-        with :func:`torch.autograd.backward`.
+        Checkpointing currently only supports :func:`torch.autograd.backward`
+        and only if its `inputs` argument is not passed. :func:`torch.autograd.grad`
+        is not supported.
 
     .. warning:
         At least one of the inputs needs to have :code:`requires_grad=True` if


### PR DESCRIPTION
Fixes #37874, #51743

Uses RAII to manage the flag so that it gets reset properly on exception
