### PR TITLE
Add GH Actions CI to build nightly Docker and push to GitHub Container Registry

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -xeuo pipefail
+
+git fetch origin nightly
+PYTORCH_NIGHTLY_COMMIT=$(git log -1 --pretty=%B origin/nightly | head -1 | \
+                             sed 's,.*(\([[:xdigit:]]*\)),\1,' | head -c 7)
+
+# Build PyTorch Nightly Docker
+# Full name: ghcr.io/pytorch-nightly/pytorch:${PYTORCH_NIGHTLY_COMMIT}
+make -f docker.Makefile \
+     DOCKER_REGISTRY=ghcr.io \
+     DOCKER_ORG=pytorch-nightly \
+     DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT} \
+     INSTALL_CHANNEL=pytorch-nightly BUILD_TYPE=official devel-image
+
+# Push the nightly docker to GitHub Container Registry
+make -f docker.Makefile \
+     DOCKER_REGISTRY=ghcr.io \
+     DOCKER_ORG=pytorch-nightly \
+     DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT} \
+     devel-push

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -7,7 +7,7 @@ PYTORCH_NIGHTLY_COMMIT=$(git log -1 --pretty=%B origin/nightly | head -1 | \
                              sed 's,.*(\([[:xdigit:]]*\)),\1,' | head -c 7)
 
 # Build PyTorch Nightly Docker
-# Full name: ghcr.io/pytorch-nightly/pytorch:${PYTORCH_NIGHTLY_COMMIT}
+# Full name: ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -2,9 +2,9 @@
 
 set -xeuo pipefail
 
-PYTORCH_DOCKER_TAG=$(git describe --tags)-devel
+PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
 
-# Build PyTorch Nightly Docker
+# Build PyTorch nightly docker
 # Full name: ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG}
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
@@ -13,11 +13,10 @@ make -f docker.Makefile \
      DOCKER_TAG=${PYTORCH_DOCKER_TAG} \
      INSTALL_CHANNEL=pytorch-nightly BUILD_TYPE=official devel-image
 
-# Get the PYTORCH_NIGHTLY_COMMIT from docker build
+# Get the PYTORCH_NIGHTLY_COMMIT from the docker image
 PYTORCH_NIGHTLY_COMMIT=$(docker run \
        pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
-       python -c 'import torch; print(torch.version.git_version)')
-
+       python -c 'import torch; print(torch.version.git_version)' | head -c 7)
 docker tag pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
        pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}
 

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -10,13 +10,16 @@ PYTORCH_NIGHTLY_COMMIT=$(git log -1 --pretty=%B origin/nightly | head -1 | \
 # Full name: ghcr.io/pytorch-nightly/pytorch:${PYTORCH_NIGHTLY_COMMIT}
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
-     DOCKER_ORG=pytorch-nightly \
+     DOCKER_ORG=pytorch \
+     DOCKER_IMAGE=pytorch-nightly \
      DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT} \
      INSTALL_CHANNEL=pytorch-nightly BUILD_TYPE=official devel-image
 
 # Push the nightly docker to GitHub Container Registry
+echo $CR_PAT | docker login ghcr.io -u pytorch --password-stdin
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
-     DOCKER_ORG=pytorch-nightly \
+     DOCKER_ORG=pytorch \
+     DOCKER_IMAGE=pytorch-nightly \
      DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT} \
      devel-push

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -16,7 +16,7 @@ make -f docker.Makefile \
      INSTALL_CHANNEL=pytorch-nightly BUILD_TYPE=official devel-image
 
 # Push the nightly docker to GitHub Container Registry
-echo $CR_PAT | docker login ghcr.io -u pytorch --password-stdin
+echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -10,7 +10,7 @@ jobs:
   build-publish-docker:
     runs-on: ubuntu-18.04
     env:
-      CR_PAT: ${{ secrets.CR_PAT }}
+      GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-publish-docker:
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -1,4 +1,4 @@
-name: Build PyTorch nightly docker and push to GitHub Container Registry
+name: Build PyTorch nightly Docker image and push to GitHub Container Registry
 on:
   schedule:
     # Push the nightly docker daily at 1 PM UTC
@@ -9,6 +9,8 @@ on:
 jobs:
   build-publish-docker:
     runs-on: ubuntu-18.04
+    env:
+      CR_PAT: ${{ secrets.CR_PAT }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -1,0 +1,17 @@
+name: Build PyTorch nightly docker and push to GitHub Container Registry
+on:
+  schedule:
+    # Push the nightly docker daily at 1 PM UTC
+    - cron: '0 13 * * *'
+  # Have the ability to trigger this job manually using the API as well
+  workflow_dispatch:
+
+jobs:
+  build-publish-docker:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - run: |
+          bash .github/scripts/build_publish_nightly_docker.sh

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -17,7 +17,7 @@ BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-de
 INSTALL_CHANNEL           = pytorch
 
 PYTHON_VERSION            = 3.7
-PYTORCH_VERSION           = $(shell git describe --tags)
+PYTORCH_VERSION           = $(shell git describe --tags --always)
 # Can be either official / dev
 BUILD_TYPE                = dev
 BUILD_PROGRESS            = auto


### PR DESCRIPTION
Summary:
Currently PyTorch repository provides Dockerfile to build Docker with nightly builds, but it doesn't have CI to actually build those Dockers.
This PR adds a GitHub action workflow to create PyTorch nightly build Docker and publish them to GitHub Container Registry.
Also, add "--always" option to the `git describe --tags` command that generates the Docker image tag.

Test plan:
Manually trigger the workflow build in the GitHub Actions web UI.