### PR TITLE
Lower ReLu6/Relu6_ to C++/ATen

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -173,8 +173,16 @@ Tensor selu(const Tensor & self) {
   return at::elu(self, SELU_ALPHA, SELU_SCALE);
 }
 
+Tensor relu6(const Tensor & self) {
+  return at::hardtanh(self, /*min_val=*/0, /*max_val=*/6);
+}
+
 Tensor & selu_(Tensor & self) {
   return at::elu_(self, SELU_ALPHA, SELU_SCALE);
+}
+
+Tensor & relu6_(Tensor & self) {
+  return at::hardtanh_(self, /*min_val=*/0, /*max_val=*/6);
 }
 
 Tensor celu(const Tensor & self, Scalar alpha) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3220,6 +3220,10 @@
     MkldnnCPU: mkldnn_relu_
     QuantizedCPU: relu_quantized_cpu_
 
+- func: relu6(Tensor self) -> Tensor
+
+- func: relu6_(Tensor(a!) self) -> Tensor(a!)
+
 - func: prelu(Tensor self, Tensor weight) -> Tensor
   variants: function, method
   dispatch:

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -386,7 +386,11 @@ inline Tensor relu(Tensor input, const ReLUFuncOptions& options = {}) {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
 inline Tensor relu6(Tensor input, bool inplace) {
-  return detail::hardtanh(input, /*min_val=*/0, /*max_val=*/6, /*inplace=*/inplace);
+  if (inplace) {
+    return torch::relu6_(input);
+  } else {
+    return torch::relu6(input);
+  }
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1277,7 +1277,11 @@ def relu6(input: Tensor, inplace: bool = False) -> Tensor:
     """
     if has_torch_function_unary(input):
         return handle_torch_function(relu6, (input,), input, inplace=inplace)
-    return hardtanh(input, 0.0, 6.0, inplace)
+    if inplace:
+        result = torch.relu6_(input)
+    else:
+        result = torch.relu6(input)
+    return result
 
 
 def elu(input: Tensor, alpha: float = 1.0, inplace: bool = False) -> Tensor:

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -768,6 +768,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.view_as_complex: lambda input: -1,
         torch.reciprocal: lambda input, out=None: -1,
         torch.relu: lambda input, inplace=False: -1,
+        torch.relu6: lambda input, inplace=False: -1,
         torch.remainder: lambda input, other, out=None: -1,
         torch.renorm: lambda input, p, dim, maxnorm, out=None: -1,
         torch.repeat_interleave: lambda input, dim=None: -1,


### PR DESCRIPTION
- Lower Relu6 to ATen
- Change Python and C++ to reflect change
- adds an entry in native_functions.yaml for that new function
- this is needed as we would like to intercept ReLU6 at a higher level with an XLA-approach codegen.
- Functional C++ tests pass. But please let me know if more tests are required.