### PR TITLE
Add a make_tempdir() utility function to the TestCase base class

### DIFF
--- a/caffe2/python/operator_test/load_save_test.py
+++ b/caffe2/python/operator_test/load_save_test.py
@@ -8,8 +8,9 @@ from hypothesis import given, assume, settings
 import numpy as np
 import os
 import shutil
-import tempfile
 import unittest
+from pathlib import Path
+from typing import List, Tuple
 
 from caffe2.proto import caffe2_pb2
 from caffe2.python import core, test_util, workspace
@@ -54,82 +55,76 @@ class TestLoadSaveBase(test_util.TestCase):
             self.assertTrue(workspace.FeedBlob(str(i), arr, src_device_option))
             self.assertTrue(workspace.HasBlob(str(i)))
 
-        try:
-            # Saves the blobs to a local db.
-            tmp_folder = tempfile.mkdtemp()
+        # Saves the blobs to a local db.
+        tmp_folder = self.make_tempdir()
+        op = core.CreateOperator(
+            "Save",
+            [str(i) for i in range(len(arrays))], [],
+            absolute_path=1,
+            db=str(tmp_folder / "db"), db_type=self._db_type)
+        self.assertTrue(workspace.RunOperatorOnce(op))
+
+        # Reset the workspace so that anything we load is surely loaded
+        # from the serialized proto.
+        workspace.ResetWorkspace()
+        self.assertEqual(len(workspace.Blobs()), 0)
+
+        def _LoadTest(keep_device, device_type, gpu_id, blobs, loadAll):
+            """A helper subfunction to test keep and not keep."""
             op = core.CreateOperator(
-                "Save",
-                [str(i) for i in range(len(arrays))], [],
+                "Load",
+                [], blobs,
                 absolute_path=1,
-                db=os.path.join(tmp_folder, "db"), db_type=self._db_type)
+                db=str(tmp_folder / "db"), db_type=self._db_type,
+                device_option=dst_device_option,
+                keep_device=keep_device,
+                load_all=loadAll)
             self.assertTrue(workspace.RunOperatorOnce(op))
+            for i, arr in enumerate(arrays):
+                self.assertTrue(workspace.HasBlob(str(i)))
+                fetched = workspace.FetchBlob(str(i))
+                self.assertEqual(fetched.dtype, arr.dtype)
+                np.testing.assert_array_equal(
+                    workspace.FetchBlob(str(i)), arr)
+                proto = caffe2_pb2.BlobProto()
+                proto.ParseFromString(workspace.SerializeBlob(str(i)))
+                self.assertTrue(proto.HasField('tensor'))
+                self.assertEqual(proto.tensor.device_detail.device_type,
+                                 device_type)
+                if core.IsGPUDeviceType(device_type):
+                    self.assertEqual(proto.tensor.device_detail.device_id,
+                                     gpu_id)
 
-            # Reset the workspace so that anything we load is surely loaded
-            # from the serialized proto.
-            workspace.ResetWorkspace()
-            self.assertEqual(len(workspace.Blobs()), 0)
+        blobs = [str(i) for i in range(len(arrays))]
+        # Load using device option stored in the proto, i.e.
+        # src_device_option
+        _LoadTest(1, src_device_type, src_gpu_id, blobs, 0)
+        # Load again, but this time load into dst_device_option.
+        _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 0)
+        # Load back to the src_device_option to see if both paths are able
+        # to reallocate memory.
+        _LoadTest(1, src_device_type, src_gpu_id, blobs, 0)
+        # Reset the workspace, and load directly into the dst_device_option.
+        workspace.ResetWorkspace()
+        _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 0)
 
-            def _LoadTest(keep_device, device_type, gpu_id, blobs, loadAll):
-                """A helper subfunction to test keep and not keep."""
-                op = core.CreateOperator(
-                    "Load",
-                    [], blobs,
-                    absolute_path=1,
-                    db=os.path.join(tmp_folder, "db"), db_type=self._db_type,
-                    device_option=dst_device_option,
-                    keep_device=keep_device,
-                    load_all=loadAll)
-                self.assertTrue(workspace.RunOperatorOnce(op))
-                for i, arr in enumerate(arrays):
-                    self.assertTrue(workspace.HasBlob(str(i)))
-                    fetched = workspace.FetchBlob(str(i))
-                    self.assertEqual(fetched.dtype, arr.dtype)
-                    np.testing.assert_array_equal(
-                        workspace.FetchBlob(str(i)), arr)
-                    proto = caffe2_pb2.BlobProto()
-                    proto.ParseFromString(workspace.SerializeBlob(str(i)))
-                    self.assertTrue(proto.HasField('tensor'))
-                    self.assertEqual(proto.tensor.device_detail.device_type,
-                                     device_type)
-                    if core.IsGPUDeviceType(device_type):
-                        self.assertEqual(proto.tensor.device_detail.device_id,
-                                         gpu_id)
+        # Test load all which loads all blobs in the db into the workspace.
+        workspace.ResetWorkspace()
+        _LoadTest(1, src_device_type, src_gpu_id, [], 1)
+        # Load again making sure that overwrite functionality works.
+        _LoadTest(1, src_device_type, src_gpu_id, [], 1)
+        # Load again with different device.
+        _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
+        workspace.ResetWorkspace()
+        _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
+        workspace.ResetWorkspace()
+        _LoadTest(1, src_device_type, src_gpu_id, blobs, 1)
+        workspace.ResetWorkspace()
+        _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 1)
 
-            blobs = [str(i) for i in range(len(arrays))]
-            # Load using device option stored in the proto, i.e.
-            # src_device_option
-            _LoadTest(1, src_device_type, src_gpu_id, blobs, 0)
-            # Load again, but this time load into dst_device_option.
-            _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 0)
-            # Load back to the src_device_option to see if both paths are able
-            # to reallocate memory.
-            _LoadTest(1, src_device_type, src_gpu_id, blobs, 0)
-            # Reset the workspace, and load directly into the dst_device_option.
-            workspace.ResetWorkspace()
-            _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 0)
-
-            # Test load all which loads all blobs in the db into the workspace.
-            workspace.ResetWorkspace()
-            _LoadTest(1, src_device_type, src_gpu_id, [], 1)
-            # Load again making sure that overwrite functionality works.
-            _LoadTest(1, src_device_type, src_gpu_id, [], 1)
-            # Load again with different device.
-            _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
-            workspace.ResetWorkspace()
-            _LoadTest(0, dst_device_type, dst_gpu_id, [], 1)
-            workspace.ResetWorkspace()
-            _LoadTest(1, src_device_type, src_gpu_id, blobs, 1)
-            workspace.ResetWorkspace()
-            _LoadTest(0, dst_device_type, dst_gpu_id, blobs, 1)
-        finally:
-            # clean up temp folder.
-            try:
-                shutil.rmtree(tmp_folder)
-            except OSError as e:
-                if e.errno != errno.ENOENT:
-                    raise
-
-    def saveFile(self, tmp_folder, db_name, db_type, start_blob_id):
+    def saveFile(
+        self, tmp_folder: Path, db_name: str, db_type: str, start_blob_id: int
+    ) -> Tuple[str, List[np.ndarray]]:
         dtypes = [np.float16, np.float32, np.float64, np.bool, np.int8,
                   np.int16, np.int32, np.int64, np.uint8, np.uint16]
         arrays = [np.random.permutation(6).reshape(2, 3).astype(T)
@@ -140,7 +135,7 @@ class TestLoadSaveBase(test_util.TestCase):
             self.assertTrue(workspace.HasBlob(str(i + start_blob_id)))
 
         # Saves the blobs to a local db.
-        tmp_file = os.path.join(tmp_folder, db_name)
+        tmp_file = str(tmp_folder / db_name)
         op = core.CreateOperator(
             "Save",
             [str(i + start_blob_id) for i in range(len(arrays))], [],
@@ -166,22 +161,17 @@ class TestLoadSave(TestLoadSaveBase):
             self.assertTrue(workspace.HasBlob(str(i)))
 
         # Saves the blobs to a local db.
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         op = core.CreateOperator(
             "Save",
             [str(i) for i in range(len(arrays))] * 2, [],
             absolute_path=1,
-            db=os.path.join(tmp_folder, "db"), db_type=self._db_type)
+            db=str(tmp_folder / "db"), db_type=self._db_type)
         with self.assertRaises(RuntimeError):
             workspace.RunOperatorOnce(op)
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testLoadExcessblobs(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         tmp_file, arrays = self.saveFile(tmp_folder, "db", self._db_type, 0)
 
         op = core.CreateOperator(
@@ -213,14 +203,8 @@ class TestLoadSave(TestLoadSaveBase):
             workspace.ResetWorkspace()
             workspace.RunOperatorOnce(op)
 
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
-
     def testTruncatedFile(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         tmp_file, arrays = self.saveFile(tmp_folder, "db", self._db_type, 0)
 
         with open(tmp_file, 'wb+') as fdest:
@@ -244,11 +228,6 @@ class TestLoadSave(TestLoadSaveBase):
             load_all=True)
         with self.assertRaises(RuntimeError):
             workspace.RunOperatorOnce(op)
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testBlobNameOverrides(self):
         original_names = ['blob_a', 'blob_b', 'blob_c']
@@ -259,100 +238,92 @@ class TestLoadSave(TestLoadSaveBase):
             self.assertTrue(workspace.HasBlob(original_names[i]))
         self.assertEqual(len(workspace.Blobs()), 3)
 
-        try:
-            # Saves the blobs to a local db.
-            tmp_folder = tempfile.mkdtemp()
-            with self.assertRaises(RuntimeError):
-                workspace.RunOperatorOnce(
-                    core.CreateOperator(
-                        "Save", original_names, [],
-                        absolute_path=1,
-                        strip_prefix='.temp',
-                        blob_name_overrides=new_names,
-                        db=os.path.join(tmp_folder, "db"),
-                        db_type=self._db_type
-                    )
-                )
-            self.assertTrue(
-                workspace.RunOperatorOnce(
-                    core.CreateOperator(
-                        "Save", original_names, [],
-                        absolute_path=1,
-                        blob_name_overrides=new_names,
-                        db=os.path.join(tmp_folder, "db"),
-                        db_type=self._db_type
-                    )
+        # Saves the blobs to a local db.
+        tmp_folder = self.make_tempdir()
+        with self.assertRaises(RuntimeError):
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    "Save", original_names, [],
+                    absolute_path=1,
+                    strip_prefix='.temp',
+                    blob_name_overrides=new_names,
+                    db=str(tmp_folder / "db"),
+                    db_type=self._db_type
                 )
             )
-            self.assertTrue(workspace.ResetWorkspace())
-            self.assertEqual(len(workspace.Blobs()), 0)
-            self.assertTrue(
-                workspace.RunOperatorOnce(
-                    core.CreateOperator(
-                        "Load", [], [],
-                        absolute_path=1,
-                        db=os.path.join(tmp_folder, "db"),
-                        db_type=self._db_type,
-                        load_all=1
-                    )
+        self.assertTrue(
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    "Save", original_names, [],
+                    absolute_path=1,
+                    blob_name_overrides=new_names,
+                    db=str(tmp_folder / "db"),
+                    db_type=self._db_type
                 )
             )
-            self.assertEqual(len(workspace.Blobs()), 3)
-            for i, name in enumerate(new_names):
-                self.assertTrue(workspace.HasBlob(name))
-                self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
-            # moved here per @cxj's suggestion
-            load_new_names = ['blob_x', 'blob_y', 'blob_z']
-            # load 'x' into 'blob_x'
-            self.assertTrue(
-                workspace.RunOperatorOnce(
-                    core.CreateOperator(
-                        "Load", [], load_new_names[0:1],
-                        absolute_path=1,
-                        db=os.path.join(tmp_folder, "db"),
-                        db_type=self._db_type,
-                        source_blob_names=new_names[0:1]
-                    )
+        )
+        self.assertTrue(workspace.ResetWorkspace())
+        self.assertEqual(len(workspace.Blobs()), 0)
+        self.assertTrue(
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    "Load", [], [],
+                    absolute_path=1,
+                    db=str(tmp_folder / "db"),
+                    db_type=self._db_type,
+                    load_all=1
                 )
             )
-            # we should have 'blob_a/b/c/' and 'blob_x' now
-            self.assertEqual(len(workspace.Blobs()), 4)
-            for i, name in enumerate(load_new_names[0:1]):
-                self.assertTrue(workspace.HasBlob(name))
-                self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
-            self.assertTrue(
-                workspace.RunOperatorOnce(
-                    core.CreateOperator(
-                        "Load", [], load_new_names[0:3],
-                        absolute_path=1,
-                        db=os.path.join(tmp_folder, "db"),
-                        db_type=self._db_type,
-                        source_blob_names=new_names[0:3]
-                    )
+        )
+        self.assertEqual(len(workspace.Blobs()), 3)
+        for i, name in enumerate(new_names):
+            self.assertTrue(workspace.HasBlob(name))
+            self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
+        # moved here per @cxj's suggestion
+        load_new_names = ['blob_x', 'blob_y', 'blob_z']
+        # load 'x' into 'blob_x'
+        self.assertTrue(
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    "Load", [], load_new_names[0:1],
+                    absolute_path=1,
+                    db=str(tmp_folder / "db"),
+                    db_type=self._db_type,
+                    source_blob_names=new_names[0:1]
                 )
             )
-            # we should have 'blob_a/b/c/' and 'blob_x/y/z' now
-            self.assertEqual(len(workspace.Blobs()), 6)
-            for i, name in enumerate(load_new_names[0:3]):
-                self.assertTrue(workspace.HasBlob(name))
-                self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
-        finally:
-            # clean up temp folder.
-            try:
-                shutil.rmtree(tmp_folder)
-            except OSError as e:
-                if e.errno != errno.ENOENT:
-                    raise
+        )
+        # we should have 'blob_a/b/c/' and 'blob_x' now
+        self.assertEqual(len(workspace.Blobs()), 4)
+        for i, name in enumerate(load_new_names[0:1]):
+            self.assertTrue(workspace.HasBlob(name))
+            self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
+        self.assertTrue(
+            workspace.RunOperatorOnce(
+                core.CreateOperator(
+                    "Load", [], load_new_names[0:3],
+                    absolute_path=1,
+                    db=str(tmp_folder / "db"),
+                    db_type=self._db_type,
+                    source_blob_names=new_names[0:3]
+                )
+            )
+        )
+        # we should have 'blob_a/b/c/' and 'blob_x/y/z' now
+        self.assertEqual(len(workspace.Blobs()), 6)
+        for i, name in enumerate(load_new_names[0:3]):
+            self.assertTrue(workspace.HasBlob(name))
+            self.assertTrue((workspace.FetchBlob(name) == blobs[i]).all())
 
     def testMissingFile(self):
-        tmp_folder = tempfile.mkdtemp()
-        tmp_file = os.path.join(tmp_folder, "missing_db")
+        tmp_folder = self.make_tempdir()
+        tmp_file = tmp_folder / "missing_db"
 
         op = core.CreateOperator(
             "Load",
             [], [],
             absolute_path=1,
-            db=tmp_file, db_type=self._db_type,
+            db=str(tmp_file), db_type=self._db_type,
             load_all=True)
         with self.assertRaises(RuntimeError):
             try:
@@ -360,14 +331,9 @@ class TestLoadSave(TestLoadSaveBase):
             except RuntimeError as e:
                 print(e)
                 raise
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testLoadMultipleFilesGivenSourceBlobNames(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         db_file_1, arrays_1 = self.saveFile(tmp_folder, "db1", self._db_type, 0)
         db_file_2, arrays_2 = self.saveFile(
             tmp_folder, "db2", self._db_type, len(arrays_1)
@@ -397,14 +363,9 @@ class TestLoadSave(TestLoadSaveBase):
             np.testing.assert_array_equal(
                 workspace.FetchBlob(str(i + len(arrays_1))), arrays_2[i]
             )
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testLoadAllMultipleFiles(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         db_file_1, arrays_1 = self.saveFile(tmp_folder, "db1", self._db_type, 0)
         db_file_2, arrays_2 = self.saveFile(
             tmp_folder, "db2", self._db_type, len(arrays_1)
@@ -433,14 +394,9 @@ class TestLoadSave(TestLoadSaveBase):
             np.testing.assert_array_equal(
                 workspace.FetchBlob(str(i + len(arrays_1))), arrays_2[i]
             )
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testLoadAllMultipleFilesWithSameKey(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         db_file_1, arrays_1 = self.saveFile(tmp_folder, "db1", self._db_type, 0)
         db_file_2, arrays_2 = self.saveFile(tmp_folder, "db2", self._db_type, 0)
 
@@ -455,14 +411,9 @@ class TestLoadSave(TestLoadSaveBase):
             load_all=True)
         with self.assertRaises(RuntimeError):
             workspace.RunOperatorOnce(op)
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
     def testLoadRepeatedFiles(self):
-        tmp_folder = tempfile.mkdtemp()
+        tmp_folder = self.make_tempdir()
         tmp_file, arrays = self.saveFile(tmp_folder, "db", self._db_type, 0)
 
         db_files = [tmp_file, tmp_file]
@@ -476,11 +427,6 @@ class TestLoadSave(TestLoadSaveBase):
             load_all=False)
         with self.assertRaises(RuntimeError):
             workspace.RunOperatorOnce(op)
-        try:
-            shutil.rmtree(tmp_folder)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
 
 
 if __name__ == '__main__':

--- a/caffe2/python/test_util.py
+++ b/caffe2/python/test_util.py
@@ -7,8 +7,13 @@
 import numpy as np
 from caffe2.python import core, workspace
 
-import unittest
 import os
+import pathlib
+import shutil
+import tempfile
+import unittest
+from typing import Any, Callable, Tuple, Type
+from types import TracebackType
 
 
 def rand_array(*dims):
@@ -91,3 +96,20 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         workspace.ResetWorkspace()
+
+    def make_tempdir(self) -> pathlib.Path:
+        tmp_folder = pathlib.Path(tempfile.mkdtemp(prefix="caffe2_test."))
+        self.addCleanup(self._remove_tempdir, tmp_folder)
+        return tmp_folder
+
+    def _remove_tempdir(self, path: pathlib.Path) -> None:
+        def _onerror(
+            fn: Callable[..., Any],
+            path: str,
+            exc_info: Tuple[Type[BaseException], BaseException, TracebackType],
+        ) -> None:
+            # Ignore FileNotFoundError, but re-raise anything else
+            if not isinstance(exc_info[1], FileNotFoundError):
+                raise exc_info[1].with_traceback(exc_info[2])
+
+        shutil.rmtree(str(path), onerror=_onerror)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51762 Add a make_tempdir() utility function to the TestCase base class**

Summary:
Update test_util.py to add a `make_tempdir()` function to the `TestCase`
class.  The main advantage of this function is that the temporary
directory will be automatically cleaned up when the test case finishes,
so that test case does not need to worry about manually cleaning up this
directory.

This also prefixes the directory name with `caffe2_test.` so that it is
more obvious where the temporary directories came from if they are ever
left behind after a crashed or killed test process.

This updates the tests in `operator_test/load_save_test.py` to use this
new function, so they no longer have to perform their own manual cleanup
in each test.

Test Plan:
  python caffe2/python/operator_test/load_save_test.py