### PR TITLE
update sphinx to 3.5.1

### DIFF
--- a/docs/cpp/requirements.txt
+++ b/docs/cpp/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.1.2
+sphinx==3.5.1
 breathe==4.25.0
 exhale==0.2.3
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.4.4
+sphinx==3.5.1
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 sphinxcontrib.katex
 matplotlib


### PR DESCRIPTION
Related to  #8817

Sphinx is pinned to 2.4.4. Update it to ~3.4.3~, 3.5.1 the latest release.