### PR TITLE
Avoid TensorPipe agent spamming logs when unable to guess IP address

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -86,28 +86,32 @@ C10_DEFINE_REGISTRY(TensorPipeCpuChannelRegistry, CpuChannelRegistration);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_REGISTRY(TensorPipeCudaChannelRegistry, CudaChannelRegistration);
 
-std::string TensorPipeAgent::guessUvAddress() {
-  tensorpipe::Error error;
-  std::string uvAddress;
-  char* ifnameEnv = std::getenv(kSocketIfnameEnvVar.c_str());
-  if (ifnameEnv != nullptr) {
-    std::tie(error, uvAddress) =
-        tensorpipe::transport::uv::lookupAddrForIface(ifnameEnv);
-    if (error) {
-      LOG(WARNING) << "Failed to look up the IP address for interface "
-                   << ifnameEnv << " (" << error.what() << "), defaulting to "
-                   << kDefaultUvAddress;
-      uvAddress = kDefaultUvAddress;
+const std::string& TensorPipeAgent::guessAddress() {
+  static const std::string uvAddress = []() {
+    tensorpipe::Error error;
+    std::string result;
+    char* ifnameEnv = std::getenv(kSocketIfnameEnvVar.c_str());
+    if (ifnameEnv != nullptr) {
+      std::tie(error, result) =
+          tensorpipe::transport::uv::lookupAddrForIface(ifnameEnv);
+      if (error) {
+        LOG(WARNING) << "Failed to look up the IP address for interface "
+                     << ifnameEnv << " (" << error.what() << "), defaulting to "
+                     << kDefaultUvAddress;
+        return kDefaultUvAddress;
+      }
+    } else {
+      std::tie(error, result) =
+          tensorpipe::transport::uv::lookupAddrForHostname();
+      if (error) {
+        LOG(WARNING) << "Failed to look up the IP address for the hostname ("
+                     << error.what() << "), defaulting to "
+                     << kDefaultUvAddress;
+        return kDefaultUvAddress;
+      }
     }
-  } else {
-    std::tie(error, uvAddress) =
-        tensorpipe::transport::uv::lookupAddrForHostname();
-    if (error) {
-      LOG(WARNING) << "Failed to look up the IP address for the hostname ("
-                   << error.what() << "), defaulting to " << kDefaultUvAddress;
-      uvAddress = kDefaultUvAddress;
-    }
-  }
+    return result;
+  }();
   return uvAddress;
 }
 
@@ -142,7 +146,7 @@ constexpr int64_t kCudaBasicChannelPriority = 100;
 
 std::unique_ptr<TransportRegistration> makeUvTransport() {
   auto context = tensorpipe::transport::uv::create();
-  std::string address = TensorPipeAgent::guessUvAddress();
+  std::string address = TensorPipeAgent::guessAddress();
   return std::make_unique<TransportRegistration>(TransportRegistration{
       std::move(context), kUvTransportPriority, std::move(address)});
 }
@@ -183,34 +187,9 @@ C10_REGISTER_CREATOR(TensorPipeTransportRegistry, shm, makeShmTransport);
 
 #if TENSORPIPE_HAS_IBV_TRANSPORT
 
-std::string guessIbvAddress() {
-  tensorpipe::Error error;
-  std::string ibvAddress;
-  char* ifnameEnv = std::getenv(kSocketIfnameEnvVar.c_str());
-  if (ifnameEnv != nullptr) {
-    std::tie(error, ibvAddress) =
-        tensorpipe::transport::ibv::lookupAddrForIface(ifnameEnv);
-    if (error) {
-      LOG(WARNING) << "Failed to look up the IP address for interface "
-                   << ifnameEnv << " (" << error.what() << "), defaulting to "
-                   << kDefaultUvAddress;
-      ibvAddress = kDefaultUvAddress;
-    }
-  } else {
-    std::tie(error, ibvAddress) =
-        tensorpipe::transport::ibv::lookupAddrForHostname();
-    if (error) {
-      LOG(WARNING) << "Failed to look up the IP address for the hostname ("
-                   << error.what() << "), defaulting to " << kDefaultUvAddress;
-      ibvAddress = kDefaultUvAddress;
-    }
-  }
-  return ibvAddress;
-}
-
 std::unique_ptr<TransportRegistration> makeIbvTransport() {
   auto context = tensorpipe::transport::ibv::create();
-  std::string address = guessIbvAddress();
+  std::string address = TensorPipeAgent::guessAddress();
   return std::make_unique<TransportRegistration>(TransportRegistration{
       std::move(context), kIbvTransportPriority, std::move(address)});
 }
@@ -261,7 +240,7 @@ std::unique_ptr<CpuChannelRegistration> makeMultiplexedUvChannel() {
   std::vector<std::shared_ptr<tensorpipe::transport::Listener>> listeners;
   for (int laneIdx = 0; laneIdx < kNumUvThreads; ++laneIdx) {
     auto context = tensorpipe::transport::uv::create();
-    std::string address = TensorPipeAgent::guessUvAddress();
+    std::string address = TensorPipeAgent::guessAddress();
     contexts.push_back(std::move(context));
     listeners.push_back(contexts.back()->listen(address));
   }

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -218,7 +218,7 @@ class TensorPipeAgent : public RpcAgent {
   // Returns NetworkSourceInfo struct
   NetworkSourceInfo getNetworkSourceInfo();
 
-  static std::string guessUvAddress();
+  static const std::string& guessAddress();
 
   // For testing purposes.
   size_t timeoutMapSize();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51785 Silence harmless error logs of TensorPipe agent during shutdown
* **#51784 Avoid TensorPipe agent spamming logs when unable to guess IP address**

The TensorPipe agent mimics Gloo when trying to guess the most reasonable IP address to bind to. When that fails, it prints a warning to inform the user. It turns out, we were attempting to guess the address a lot of times (I counted at least 18: 1 for the UV transport, 1 for the IBV transport, 16 for the multiplexed UV channel) and thus they might all print that same identical warning message. That's noisy. Since the outcome of all these guesses will be the same (unless the system config changes underneath, which is unlikely) we can just do it once, print the warning (at most) once, cache the result and reuse it over and over.

Also, we used to have two identical but distinct ways of doing this, one provided by the UV transport and one by the IBV one. TensorPipe offers both methods because backends are modular and independent. However PyTorch always requires the UV one to be present, hence we can always rely on the UV helpers, and avoid using the IBV ones.

Differential Revision: [D26275838](https://our.internmc.facebook.com/intern/diff/D26275838/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26275838/)!