### PR TITLE
Add `acc_get_device_type` weak symbol to `kineto_profler`

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -9,11 +9,9 @@
 #include <pthread.h>
 #include <torch/cuda.h>
 #include <libkineto.h>
-#endif
 
 namespace torch { namespace autograd { namespace profiler {
 
-#ifdef USE_KINETO
 namespace {
 // TODO: consider TLS (tid + tls counter)
 uint64_t next_correlation_id() {
@@ -381,14 +379,6 @@ void ProfilerResult::save(const std::string& path) {
   saved_ = true;
 }
 
-#endif
 
-bool kinetoAvailable() {
-#ifdef USE_KINETO
-  return true;
-#else
-  return false;
-#endif
-}
-
-}}}
+}}} // namespace torch::autograd::profiler
+#endif /* USE_KINETO */

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -4,11 +4,24 @@
 #include <torch/csrc/jit/runtime/operator.h>
 
 #include <sstream>
+#include <stdexcept>
 
 #ifdef USE_KINETO
 #include <pthread.h>
 #include <torch/cuda.h>
 #include <libkineto.h>
+
+// TODO: TO be removed, once this properly works from libkineto
+// Literal copy-n-paste from third_party/kineto/libkineto/src/WeakSymbols.cpp
+#ifdef USE_CUDA
+extern "C" {
+// This function is needed to avoid superfluous dependency on GNU OpenMP library when cuPTI is linked statically
+// For more details see https://github.com/pytorch/pytorch/issues/51026
+__attribute__((weak)) int acc_get_device_type() {
+  throw std::runtime_error("Dummy implementation of acc_get_device_type is not supposed to be called!");
+}
+} // extern "C"
+#endif /* USE_CUDA */
 
 namespace torch { namespace autograd { namespace profiler {
 

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -219,7 +219,13 @@ TORCH_API void prepareProfiler(
     const std::set<ActivityType>& activities);
 #endif // USE_KINETO
 
-TORCH_API bool kinetoAvailable();
+TORCH_API constexpr bool kinetoAvailable() {
+#ifdef USE_KINETO
+  return true;
+#else
+  return false;
+#endif // USE_KINETO
+}
 
 } // namespace profiler
 }} // namespace torch::autograd


### PR DESCRIPTION
Move `kinetoAvailable` to profiler_kineto.h and make it a constexpr
Update kineto submodule
Fixes https://github.com/pytorch/pytorch/issues/51026
