### PR TITLE
Warn if mypy version doesn't match CI

### DIFF
--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -9,6 +9,7 @@
 
 [mypy]
 python_version = 3.6
+plugins = mypy_plugins/check_mypy_version.py
 
 cache_dir = .mypy_cache/strict
 strict_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,8 @@
 # test_run_mypy in test/test_type_hints.py uses this string)
 
 [mypy]
+plugins = mypy_plugins/check_mypy_version.py
+
 cache_dir = .mypy_cache/normal
 warn_unused_configs = True
 warn_redundant_casts = True

--- a/mypy_plugins/check_mypy_version.py
+++ b/mypy_plugins/check_mypy_version.py
@@ -29,6 +29,5 @@ For example, if you installed mypy via pip, run this:
 Or if you installed mypy via conda, run this:
 
     conda install -c conda-forge mypy={correct_version}
-''', end='', file=sys.stderr)
-        sys.exit(2)  # https://github.com/python/mypy/issues/6003
+''', file=sys.stderr)
     return Plugin

--- a/mypy_plugins/check_mypy_version.py
+++ b/mypy_plugins/check_mypy_version.py
@@ -1,0 +1,34 @@
+import re
+import sys
+from pathlib import Path
+
+from mypy.plugin import Plugin
+
+
+def get_correct_mypy_version():
+    # there's probably a more elegant way to do this
+    match, = re.finditer(
+        r'mypy==(\d+(?:\.\d+)*)',
+        Path('.circleci/docker/common/install_conda.sh').read_text(),
+    )
+    version, = match.groups()
+    return version
+
+
+def plugin(version: str):
+    correct_version = get_correct_mypy_version()
+    if version != correct_version:
+        print(f'''\
+You are using mypy version {version}, which is not supported
+in the PyTorch repo. Please switch to mypy version {correct_version}.
+
+For example, if you installed mypy via pip, run this:
+
+    pip install mypy=={correct_version}
+
+Or if you installed mypy via conda, run this:
+
+    conda install -c conda-forge mypy={correct_version}
+''', end='', file=sys.stderr)
+        sys.exit(2)  # https://github.com/python/mypy/issues/6003
+    return Plugin


### PR DESCRIPTION
This PR adds a local [`mypy` plugin](https://mypy.readthedocs.io/en/stable/extending_mypy.html#extending-mypy-using-plugins) that warns if you accidentally run `mypy` using a version that doesn't match [the version we install for CI](https://github.com/pytorch/pytorch/blob/6045663f391e9bebac31e006a98c1dd381792936/.circleci/docker/common/install_conda.sh#L117), since this trips people up sometimes when `mypy` gives errors in some versions (see #51513) but not others.

**Test plan:**

To check that this doesn't break our `mypy` test(s) when you have the correct version installed:
```
python test/test_type_hints.py
```
To check that this does indeed warn when you have an incorrect `mypy` version installed, switch to a different version (e.g. 0.782), and run the above command or either of these:
```
mypy
mypy --config-file=mypy-strict.ini
```
You should get the following message on stderr:
```
You are using mypy version 0.782, which is not supported
in the PyTorch repo. Please switch to mypy version 0.770.

For example, if you installed mypy via pip, run this:

    pip install mypy==0.770

Or if you installed mypy via conda, run this:

    conda install -c conda-forge mypy=0.770
```