### PR TITLE
fix multi_output_kernel

### DIFF
--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -260,10 +260,37 @@ struct vectorized {
 };
 
 template <typename data_t, typename inp_calc_t, typename out_calc_t, int num_outputs>
-struct multi_outputs_unroll : unroll<data_t, inp_calc_t, out_calc_t, LoadWithoutCast, StoreWithoutCast, num_outputs> {
+struct multi_outputs_unroll {
+  data_t data;
+  int remaining;
+  inp_calc_t input_offset_calculator;
+  out_calc_t output_offset_calculator;
+  LoadWithoutCast loader;
+  StoreWithoutCast storer;
 
   __device__ multi_outputs_unroll(data_t data, int remaining, inp_calc_t ic, out_calc_t oc):
-    unroll<data_t, inp_calc_t, out_calc_t, LoadWithoutCast, StoreWithoutCast, num_outputs>(data, remaining, ic, oc, LoadWithoutCast(), StoreWithoutCast()) {}
+  data(data), remaining(remaining), input_offset_calculator(ic), output_offset_calculator(oc) {}
+
+  __device__ inline bool check_inbounds(int thread_work_elem) {
+    return ((threadIdx.x  + thread_work_elem*num_threads) < remaining);
+  }
+
+  template<typename args_t>
+  __device__ inline void load(args_t *args, int idx) {
+    constexpr int arity = std::tuple_size<args_t>::value;
+    int thread_idx = threadIdx.x;
+    #pragma unroll
+    for (int i = 0; i < thread_work_size; i++) {
+      if (thread_idx >= remaining) {
+        return;
+      }
+      int linear_idx = thread_idx + block_work_size * idx;
+      auto offset = input_offset_calculator.get(linear_idx);
+      detail::static_unroll<detail::unroll_load_helper, arity>::with_args(*this, args, offset, loader, i, num_outputs);
+      thread_idx += num_threads;
+    }
+  }
+
 
   template <typename return_t>
   __device__ inline void store(return_t *from, int idx) {

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -261,6 +261,8 @@ struct vectorized {
 
 template <typename data_t, typename inp_calc_t, typename out_calc_t, int num_outputs>
 struct multi_outputs_unroll {
+  //multi_outputs_unroll struct members and check_inbounds and load methods are copypasted from unroll struct
+  //we don't use inheritance because of compiler bug in cuda 10.2+
   data_t data;
   int remaining;
   inp_calc_t input_offset_calculator;

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -864,19 +864,20 @@ class TestFakeQuantize(TestCase):
 
     def _test_forward_per_tensor_cachemask_impl(self, device):
         for torch_type in (torch.qint8, torch.quint8):
-            X = torch.randn(4, 8).to(device)
+            Xs = (torch.randn(4, 8, device=device), torch.randn(4,16, device=device)[:,::2])
             # pick the scale + zp so that some values get clipped
-            obs = torch.quantization.MinMaxObserver(torch_type)
-            obs(X * 0.75)
-            scale, zero_point = obs.calculate_qparams()
-            scale, zero_point = float(scale), int(zero_point)
-            quant_min, quant_max = obs._calculate_qmin_qmax()
+            for X in Xs:
+                obs = torch.quantization.MinMaxObserver(torch_type)
+                obs(X * 0.75)
+                scale, zero_point = obs.calculate_qparams()
+                scale, zero_point = float(scale), int(zero_point)
+                quant_min, quant_max = obs._calculate_qmin_qmax()
 
-            Y_test, _mask = torch.fake_quantize_per_tensor_affine_cachemask(
-                X, scale, zero_point, quant_min, quant_max)
-            Y_ref = _fake_quantize_per_tensor_affine_reference(
-                X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
-            self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
+                Y_test, _mask = torch.fake_quantize_per_tensor_affine_cachemask(
+                    X, scale, zero_point, quant_min, quant_max)
+                Y_ref = _fake_quantize_per_tensor_affine_reference(
+                    X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
+                self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
 
     def test_forward_per_tensor_cachemask_cpu(self):
         device = torch.device('cpu')

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -864,7 +864,7 @@ class TestFakeQuantize(TestCase):
 
     def _test_forward_per_tensor_cachemask_impl(self, device):
         for torch_type in (torch.qint8, torch.quint8):
-            Xs = (torch.randn(4, 8, device=device), torch.randn(4,16, device=device)[:,::2])
+            Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
             # pick the scale + zp so that some values get clipped
             for X in Xs:
                 obs = torch.quantization.MinMaxObserver(torch_type)


### PR DESCRIPTION
With @zasdfgbnm's help and with his small TensorIterator kernel repro https://github.com/zasdfgbnm/tensoriterator we've found a workaround for what looks like a compiler bug in multi_output_kernel that manifests itself with cuda 10.2 and cuda 11 when there is a non-trivial OffsetCalculator. 
It looks like those nvcc versions cannot handle inheritance in device structs, so instead of inheriting `multi_outputs_unroll` from `unroll` we make it independent. 
cc @vkuzo, @haichuan-fb I verified that reverting #49315 to bring back multi_output_kernel and running `test_learnable_backward_per_channel_cuda` test passes, but I didn't do it in this PR - can you take it up as a follow-up?
