### PR TITLE
[Vulkan]: Fix build warnings-treated-as-error on Linux.

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -180,7 +180,7 @@ Descriptor::Set& Descriptor::Set::bind(
       "This descriptor set is in an invalid state! "
       "Potential reason: This descriptor set is moved from.");
 
-  update({
+  update(Item{
       binding,
       shader_layout_signature_[binding],
       {

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -72,7 +72,7 @@ struct Pipeline final {
 
       typedef Layout::Descriptor Descriptor;
       typedef VK_DELETER(PipelineLayout) Deleter;
-      typedef Handle<VkPipelineLayout, Deleter> Handle;
+      typedef api::Handle<VkPipelineLayout, Deleter> Handle;
 
       struct Hasher {
         size_t operator()(const Descriptor& descriptor) const;
@@ -131,7 +131,7 @@ struct Pipeline final {
 
     typedef Pipeline::Descriptor Descriptor;
     typedef VK_DELETER(Pipeline) Deleter;
-    typedef Handle<VkPipeline, Deleter> Handle;
+    typedef api::Handle<VkPipeline, Deleter> Handle;
 
     struct Hasher {
       size_t operator()(const Descriptor& descriptor) const;

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -168,7 +168,7 @@ struct Resource final {
 
         typedef Sampler::Descriptor Descriptor;
         typedef VK_DELETER(Sampler) Deleter;
-        typedef Handle<VkSampler, Deleter> Handle;
+        typedef api::Handle<VkSampler, Deleter> Handle;
 
         struct Hasher {
           size_t operator()(const Descriptor& descriptor) const;

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -65,7 +65,7 @@ struct Shader final {
 
       typedef Layout::Descriptor Descriptor;
       typedef VK_DELETER(DescriptorSetLayout) Deleter;
-      typedef Handle<VkDescriptorSetLayout, Deleter> Handle;
+      typedef api::Handle<VkDescriptorSetLayout, Deleter> Handle;
 
       struct Hasher {
         size_t operator()(const Descriptor& descriptor) const;
@@ -156,7 +156,7 @@ struct Shader final {
 
     typedef Shader::Descriptor Descriptor;
     typedef VK_DELETER(ShaderModule) Deleter;
-    typedef Handle<VkShaderModule, Deleter> Handle;
+    typedef api::Handle<VkShaderModule, Deleter> Handle;
 
     struct Hasher {
       size_t operator()(const Descriptor& descriptor) const;

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -389,6 +389,8 @@ class vTensor final {
   std::shared_ptr<View> view_;
 
  private:
+  friend class View::State;
+
   // Debug
   friend std::ostream& operator<<(
       std::ostream&,

--- a/aten/src/ATen/native/vulkan/ops/Tensor.h
+++ b/aten/src/ATen/native/vulkan/ops/Tensor.h
@@ -324,6 +324,11 @@ class vTensor final {
       Component::Flags available_;
       Component::Flags dirty_;
       Bundle bundle_;
+
+     private:
+     #ifdef VULKAN_TENSOR_DEBUG
+      friend class View;
+     #endif /* VULKAN_TENSOR_DEBUG */
     };
 
     typedef State::Component Component;
@@ -362,10 +367,12 @@ class vTensor final {
     c10::SmallVector<int64_t, 6u> strides_;
 
    private:
-    // Debug
+   #ifdef VULKAN_TENSOR_DEBUG
+    friend class vTensor;
     friend std::ostream& operator<<(
       std::ostream&,
       const View::State::Bundle&);
+   #endif /* VULKAN_TENSOR_DEBUG */
   };
 
   // Even at the cost of a heap allocation plus the resulting negative impact
@@ -389,12 +396,11 @@ class vTensor final {
   std::shared_ptr<View> view_;
 
  private:
-  friend class View::State;
-
-  // Debug
+ #ifdef VULKAN_TENSOR_DEBUG
   friend std::ostream& operator<<(
       std::ostream&,
       const View::State::Bundle&);
+ #endif /* VULKAN_TENSOR_DEBUG */
 };
 
 const vTensor& convert(const Tensor& tensor);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51843 [Vulkan]: Fix build warnings-treated-as-error on Linux.**
* #51005 Modifying CMake header and library search path to match new Vulkan SDK on Linux.

