### PR TITLE
[Gradient Compression] Add register_comm_hook API to DDP communication hooks documentation page

### DIFF
--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -20,8 +20,9 @@ How to Use a Communication Hook?
 --------------------------------
 
 To use a communication hook, the user just needs to let the DDP model register
-the hook before the training loop by calling
-:func:`torch.nn.parallel.DistributedDataParallel.register_comm_hook`.
+the hook before the training loop as below.
+
+.. automethod:: torch.nn.parallel.DistributedDataParallel.register_comm_hook
 
 Default Communication Hooks
 ---------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51845 [Gradient Compression] Add register_comm_hook API to DDP communication hooks documentation page**
* #51773 [Resubmission] Add a documentation page for DDP communication hooks

`register_comm_hook` method is defined in DistributedDataParallel module, but it is not covered in `distributed.rst`. Since it's closely related to DDP communication hook, add the docstrings to `ddp_comm_hooks.rst` instead of a reference.

Differential Revision: [D26298191](https://our.internmc.facebook.com/intern/diff/D26298191/)