### PR TITLE
fix C++ standard library confusion

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1347,7 +1347,7 @@ if(BUILD_SHARED_LIBS)
     set_target_properties(torch_global_deps PROPERTIES
         VERSION ${TORCH_VERSION} SOVERSION ${TORCH_SOVERSION})
   endif()
-  set_target_properties(torch_global_deps PROPERTIES LINKER_LANGUAGE C)
+  set_target_properties(torch_global_deps PROPERTIES LINKER_LANGUAGE CXX)
   if(USE_MPI)
       target_link_libraries(torch_global_deps ${MPI_CXX_LIBRARIES})
   endif()


### PR DESCRIPTION
commit ddff4efa introduced an "empty" library that is used to pull in
libraries neede to be loaded globally. From the commit log:

"As long as none of these libraries have C++ symbols, we can avoid
confusion about C++ standard library."

If py-torch is built with new enough compilers and new cuda packages,
pulling in the cuda libs will pull in the system libstdc++, which
might be unsatisfactory to what the newer compiler just generated.
However, if this empty library is compiled as a CXX object, it will
pull in the correct libstdc++ first and satisfy both cuda and py-torch.

see:

https://github.com/spack/spack/issues/18867
