### PR TITLE
[PyTorch] Don't read 1 char per iteration in Unpickler::readString

### DIFF
--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -838,19 +838,32 @@ inline bool is_valid_python_id_char(char c) {
 std::string Unpickler::readString() {
   std::string ss;
   while (true) {
-    char c = read<char>();
-    if (c == '\n') {
+    auto* const bufferStart = buffer_.data() + buffer_pos_;
+    const auto bufferLeft = buffer_.size() - buffer_pos_;
+    char* const newlinePtr =
+        static_cast<char*>(memchr(bufferStart, '\n', bufferLeft));
+    if (newlinePtr) {
+      // read up to newline and we are done.
+      auto const charsRead = newlinePtr - bufferStart;
+      ss.append(bufferStart, newlinePtr - bufferStart);
+      buffer_remaining_ -= charsRead + 1;
+      buffer_pos_ += charsRead + 1;
       break;
+    } else {
+      // read whole buffer, refill
+      for (const char* p = bufferStart; p < bufferStart + bufferLeft; ++p) {
+        // Simple check just in case there is no terminating '\n'
+        TORCH_CHECK(
+            is_valid_python_id_char(*p),
+            "Found character '",
+            int(uint8_t(*p)),
+            "' in string, ",
+            "strings must be qualified Python identifiers");
+      }
+      ss.append(bufferStart, bufferLeft);
+      buffer_remaining_ = reader_(buffer_.data(), buffer_.size());
+      buffer_pos_ = 0;
     }
-    ss.push_back(c);
-
-    // Simple check just in case there is no terminating '\n'
-    TORCH_CHECK(
-        is_valid_python_id_char(c),
-        "Found character '",
-        int(uint8_t(c)),
-        "' in string, ",
-        "strings must be qualified Python identifiers");
   }
   return ss;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51902 [PyTorch] Avoid some extra intrusive_ptr<Tuple> copies in Unpickler
* **#51901 [PyTorch] Don't read 1 char per iteration in Unpickler::readString**

It's much more efficient to read multiple chars with 1 memcpy than to call `read<char>` multiple times.

Differential Revision: [D26321083](https://our.internmc.facebook.com/intern/diff/D26321083/)