### PR TITLE
[PyTorch] Avoid some extra intrusive_ptr<Tuple> copies in Unpickler

### DIFF
--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -319,19 +319,16 @@ PickleOpCode Unpickler::readInstruction() {
         tuple->elements().emplace_back(*it);
       }
       stack_.erase(start_it, stack_.end());
-      stack_.emplace_back(tuple);
+      stack_.emplace_back(std::move(tuple));
     } break;
     case PickleOpCode::TUPLE1: {
-      auto tuple = c10::ivalue::Tuple::create(pop(stack_, 1));
-      stack_.emplace_back(tuple);
+      stack_.emplace_back(c10::ivalue::Tuple::create(pop(stack_, 1)));
     } break;
     case PickleOpCode::TUPLE2: {
-      auto tuple = c10::ivalue::Tuple::create(pop(stack_, 2));
-      stack_.emplace_back(tuple);
+      stack_.emplace_back(c10::ivalue::Tuple::create(pop(stack_, 2)));
     } break;
     case PickleOpCode::TUPLE3: {
-      auto tuple = c10::ivalue::Tuple::create(pop(stack_, 3));
-      stack_.emplace_back(tuple);
+      stack_.emplace_back(c10::ivalue::Tuple::create(pop(stack_, 3)));
     } break;
     case PickleOpCode::EMPTY_DICT:
       stack_.emplace_back(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51902 [PyTorch] Avoid some extra intrusive_ptr<Tuple> copies in Unpickler**
* #51901 [PyTorch] Don't read 1 char per iteration in Unpickler::readString

These seem like straightforward improvements. (I don't have measurements; feel free to reject if you're skeptical)

Differential Revision: [D26322438](https://our.internmc.facebook.com/intern/diff/D26322438/)