### PR TITLE
Added support in builtin_functions.cpp

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -1280,8 +1280,8 @@ graph(%Ra, %Rb):
             return x.type(t)
         scr = torch.jit.script(foo)
         x = torch.rand(3, 4)
-        for t in [torch.int8, torch.float64, torch.float32, \
-                    torch.bfloat16, torch.complex64, torch.complex128, torch.bool]:
+        for t in [torch.int8, torch.float64, torch.float32,
+                  torch.bfloat16, torch.complex64, torch.complex128, torch.bool]:
             self.assertEqual(scr(x, t), foo(x, t))
 
 

--- a/torch/csrc/jit/frontend/builtin_functions.cpp
+++ b/torch/csrc/jit/frontend/builtin_functions.cpp
@@ -66,6 +66,8 @@ def list_with_default(out_size: List[int], defaults: List[int]):
   return out_size
 def _assert(condition : bool, message : str):
   assert condition, message
+def type(self: Tensor, dtype: int, non_blocking: bool=False, copy: bool=False) -> Tensor:
+  return self.to(dtype, non_blocking, copy)
 )SCRIPT";
 
 // an additional overload for Tensor variant of _assert

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -988,22 +988,6 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      OperatorGenerator(
-         TORCH_SELECTIVE_SCHEMA(
-             "aten::type.prim_dtype(Tensor(a) self, int? dtype=None, bool non_blocking=False, bool copy=False) -> Tensor(a|b)"),
-         [](Stack* stack) {
-           bool non_blocking;
-           bool copy;
-           pop(stack, non_blocking, copy);
-           c10::optional<at::ScalarType> scalarType =
-               pop(stack).toOptional<at::ScalarType>();
-           c10::optional<c10::Device> device = c10::nullopt;
-           at::Tensor self = pop(stack).toTensor();
-           push(
-               stack,
-               to_dispatch(self, device, scalarType, non_blocking, copy));
-         },
-         aliasAnalysisFromSchema()),
-     OperatorGenerator(
          TORCH_SELECTIVE_SCHEMA("prim::is_cuda(Tensor a) -> bool"),
          [](Stack* stack) {
            at::Tensor a;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51903 Added support in builtin_functions.cpp

Fixes issue: #25433

Summary:
=========
Makes tensor.type(dtype) scriptable

Test:
======
python test/test_jit.py -v TestJit.test_script_tensor_type