### PR TITLE
[pytorch] Fix torch.nn.functional.normalize to be properly scriptable

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -4245,7 +4245,7 @@ def triplet_margin_with_distance_loss(
         return output
 
 
-def normalize(input: Tensor, p: float = 2, dim: int = 1, eps: float = 1e-12, out: Optional[Tensor] = None) -> Tensor:
+def normalize(input: Tensor, p: float = 2.0, dim: int = 1, eps: float = 1e-12, out: Optional[Tensor] = None) -> Tensor:
     r"""Performs :math:`L_p` normalization of inputs over specified dimension.
 
     For a tensor :attr:`input` of sizes :math:`(n_0, ..., n_{dim}, ..., n_k)`, each


### PR DESCRIPTION
Summary:
Several scenarios don't work when trying to script `F.normalize`, notably when you try to symbolically trace through it with using the default argument:

```
import torch.nn.functional as F
import torch
from torch.fx import symbolic_trace

def f(x):
    return F.normalize(x)

gm = symbolic_trace(f)
torch.jit.script(gm)
```
which leads to the error
```
RuntimeError:

normalize(Tensor input, float p=2., int dim=1, float eps=9.9999999999999998e-13, Tensor? out=None) -> (Tensor):
Expected a value of type 'float' for argument 'p' but instead found type 'int'.
:
def forward(self, x):
    normalize_1 = torch.nn.functional.normalize(x, p = 2, dim = 1, eps = 1e-12, out = None);  x = None
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
    return normalize_1

Differential Revision: D26324308

