### PR TITLE
Fix flaky TestTrainingLoop - TestE2ETensorPipe

### DIFF
--- a/test/cpp/rpc/test_e2e_tensorpipe.cpp
+++ b/test/cpp/rpc/test_e2e_tensorpipe.cpp
@@ -50,13 +50,13 @@ TEST_F(TestE2ETensorPipe, TestTrainingLoop) {
   runTrainingLoop();
   // Ensure the tensorpipe internal state is cleared up.
   auto tensorpipeAgent = std::static_pointer_cast<TensorPipeAgent>(rpcAgent);
-  // Wait a while for async RPCs to propagate through (ex: dist autograd
-  // cleanup)
-  while (tensorpipeAgent->numPendingResponses() != 0) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+
+  // Shutdown RPC agent for all RPCs to clean up.
+  tensorpipeAgent->join();
+  tensorpipeAgent->shutdown();
   ASSERT_EQ(0, tensorpipeAgent->numPendingResponses());
   ASSERT_EQ(0, tensorpipeAgent->timeoutMapSize());
+  ASSERT_EQ(0, tensorpipeAgent->messageIdToTimeoutMapSize());
 }
 
 #endif

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -223,13 +223,12 @@ class TensorPipeAgent : public RpcAgent {
   // For testing purposes.
   size_t timeoutMapSize();
   size_t numPendingResponses();
+  size_t messageIdToTimeoutMapSize();
 
  private:
   // Removes the given messageId with the given expirationTime from the
   // timeoutMap_.
-  void removeFromTimeoutMap(
-      uint64_t messageId,
-      steady_clock_time_point expirationTime);
+  void removeFromTimeoutMap(uint64_t messageId);
 
   // Populates workerIdToInfo_ and workerNameToInfo_ using addressStore_
   void collectNames();
@@ -385,6 +384,9 @@ class TensorPipeAgent : public RpcAgent {
   // Map to store the expiration times for each message.
   std::map<steady_clock_time_point, std::vector<TimeoutMessageMetadata>>
       timeoutMap_;
+
+  // Map to store the messageId to expiry time.
+  std::unordered_map<uint64_t, steady_clock_time_point> messageIdToTimeout_;
 
   // Thread that will poll the timeoutMap_ for timed out messages and mark them
   // with an error accordingly


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51939 Fix flaky TestTrainingLoop - TestE2ETensorPipe**

TestTrainingLoop - TestE2ETensorPipe was flaky since there would still
be inflight background RPCs running as we performed the assertions. This
resulted in these assertions failing since we didn't wait for all RPCs on the
agent to finish.

To resolve this issue, in this PR we join() and shutdown() the RPC agent to
ensure no further RPCs are done. Then we assertion the map sizes to ensure no
leaks occurred.

In addition to this, added messageIdToTimeout map to lookup the appropriate
timeout for a messageId. This ensures we remove the appropriate entry from the
map. The previous solution was passing the expirationTime through the lambda,
but it is not guaranteed the lambda would read the response of the request we
just sent out.

Differential Revision: [D26331585](https://our.internmc.facebook.com/intern/diff/D26331585/)