### PR TITLE
Fix autograd when `inputs` contains tensors without materialized grad_fn 

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -129,6 +129,29 @@ TEST(AutogradAPITests, GradUnreachableTest) {
   ASSERT_THROWS_WITH(grad({x * 2}, {x, y}, {}, {}, false, false), "Set allow_unused=True");
 }
 
+TEST(CustomAutogradTest, GradUnreachableDiscoveryTest) {
+  // Test that certain nodes are not erroneously executed when an input
+  // is unreachable. See #39784
+  struct MyFunction : public Function<MyFunction> {
+    static Variable forward(AutogradContext *ctx, Variable var) {
+      return var;
+    }
+
+    static variable_list backward(AutogradContext *ctx, variable_list grad_output) {
+      ADD_FAILURE() << "This node should not be executed!";
+      return grad_output;
+    }
+  };
+
+  auto x = torch::randn(1, torch::requires_grad());
+  auto x1 = torch::randn(1);
+  auto x2 = MyFunction::apply(x + x1);
+
+  auto y = torch::randn(1, torch::requires_grad());
+  auto grad_res = torch::autograd::grad({x2}, {y}, {}, {}, false, true);
+  ASSERT_FALSE(grad_res[0].defined());
+}
+
 TEST(AutogradAPITests, RetainGrad) {
   auto input = torch::rand({1, 3}, torch::requires_grad());
   auto h1 = input * 3;

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -600,6 +600,35 @@ class TestAutograd(TestCase):
                                     "Set allow_unused=True"):
             grad_x, grad_y = torch.autograd.grad(x * 2, [x, y], allow_unused=False)
 
+    def test_grad_unreachable_discovery(self):
+        # Test that certain nodes are not erroneously executed when an input
+        # is unreachable. See #39784
+        class MyFunc(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, x):
+                self.fail("This node should not be executed!")
+
+        x = MyFunc.apply(torch.randn(1, requires_grad=True) * 2)
+        y = torch.randn(1, requires_grad=True)
+        (gY,) = torch.autograd.grad(x, (y, ), allow_unused=True)
+        self.assertIsNone(gY)
+
+        x = MyFunc.apply(torch.randn(1, requires_grad=True) * 2)
+        y = torch.randn(1, requires_grad=True)
+        z = torch.randn(1, requires_grad=True)
+        (gY, gZ) = torch.autograd.grad(x + z, (y, z), allow_unused=True)
+        self.assertIsNone(gY)
+        self.assertIsNotNone(gZ)
+
+        x = MyFunc.apply(torch.randn(1, requires_grad=True) * 2)
+        y = torch.randn(1, requires_grad=True)
+        torch.autograd.backward(x, inputs=(y, ))  # allow_unused is implicitly True!
+        self.assertIsNone(y.grad)
+
     def test_hooks(self):
         x = torch.ones(5, 5, requires_grad=True)
         y = torch.ones(5, 5) * 4

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -104,8 +104,7 @@ variable_list run_backward(
           input.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        // See python_engine.cpp's run_backward for explanation
-        output_edges.emplace_back(std::make_shared<Identity>(), 0);
+        output_edges.emplace_back();
       } else {
         output_edges.emplace_back(grad_fn, output_nr);
       }

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/autograd/edge.h>
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/function.h>
+#include <torch/csrc/autograd/functions/basic_ops.h>
 
 namespace torch {
 namespace autograd {
@@ -103,7 +104,8 @@ variable_list run_backward(
           input.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        output_edges.emplace_back();
+        // See python_engine.cpp's run_backward for explanation
+        output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);
       }

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -104,7 +104,8 @@ variable_list run_backward(
           input.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        output_edges.emplace_back();
+        // See the python_engine's run_backward for an explanation
+        output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);
       }

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -104,7 +104,7 @@ variable_list run_backward(
           input.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        // See the python_engine's run_backward for an explanation
+        // See NOTE [ Autograd Unreachable Input ] for details
         output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -238,12 +238,10 @@ PyObject *THPEngine_run_backward(PyObject *self, PyObject *args, PyObject *kwarg
       THPUtils_assert(input_var->cdata.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        // Since input has no grad_accumulator, its guaranteed to be not reachable.
-        // We create a dummy edge with no next edges and a non-nullptr grad_fn so
-        // nodes (e.g., mul when an operand is scalar) that have invalid next_edges
-        // don't get erroneously assigned `needed = True` in exec_info. Note that this
-        // doesn't happen in the cpp api because scalars are only wrapped into tensors
-        // in python
+        // Since input has no grad_accumulator, its guaranteed to be unreachable.
+        // We initialize an edge pointing to a non-nullptr Node so nodes in the graph
+        // (e.g., mul when an operand is scalar) that have edges pointing to nullptr
+        // don't get erroneously assigned `needed = True` in exec_info.
         output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -240,8 +240,10 @@ PyObject *THPEngine_run_backward(PyObject *self, PyObject *args, PyObject *kwarg
       if (!grad_fn) {
         // Since input has no grad_accumulator, its guaranteed to be not reachable.
         // We create a dummy edge with no next edges and a non-nullptr grad_fn so
-        // nodes (like mul by scalar) that have invalid next_edges don't get erroneously
-        // assigned `needed = True` in exec_info
+        // nodes (e.g., mul when an operand is scalar) that have invalid next_edges
+        // don't get erroneously assigned `needed = True` in exec_info. Note that this
+        // doesn't happen in the cpp api because scalars are only wrapped into tensors
+        // in python
         output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -5,6 +5,7 @@
 #include <torch/csrc/autograd/edge.h>
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/function.h>
+#include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/python_anomaly_mode.h>
 #include <torch/csrc/autograd/python_function.h>
 #include <torch/csrc/utils/pycfunction_helpers.h>
@@ -237,7 +238,11 @@ PyObject *THPEngine_run_backward(PyObject *self, PyObject *args, PyObject *kwarg
       THPUtils_assert(input_var->cdata.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
-        output_edges.emplace_back();
+        // Since input has no grad_accumulator, its guaranteed to be not reachable.
+        // We create a dummy edge with no next edges and a non-nullptr grad_fn so
+        // nodes (like mul by scalar) that have invalid next_edges don't get erroneously
+        // assigned `needed = True` in exec_info
+        output_edges.emplace_back(std::make_shared<Identity>(), 0);
       } else {
         output_edges.emplace_back(grad_fn, output_nr);
       }

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -238,6 +238,7 @@ PyObject *THPEngine_run_backward(PyObject *self, PyObject *args, PyObject *kwarg
       THPUtils_assert(input_var->cdata.requires_grad(),
           "One of the differentiated Tensors does not require grad");
       if (!grad_fn) {
+        // NOTE [ Autograd Unreachable Input ]
         // Since input has no grad_accumulator, its guaranteed to be unreachable.
         // We initialize an edge pointing to a non-nullptr Node so nodes in the graph
         // (e.g., mul when an operand is scalar) that have edges pointing to nullptr


### PR DESCRIPTION
Fixes #39784
At the time the issue was filed, there was only issue (1) below. 

There are actually now two issues here:
1. We always set all inputs passed in through `inputs` arg as `needed = True` in exec_info. So if we pass in an input that has a grad_fn that is not materialized, we create an entry of exec_info with nullptr as key with `needed = True`. Coincidentally, when we perform simple arithmetic operations, such as "2 * x", one of the next edges of mul is an invalid edge, meaning that its grad_fn is also nullptr. This causes the discovery algorithm to set all grad_fns that have a path to this invalid_edge as `needed = True`.
2. Before the commit that enabled the engine skipped the dummy node, we knew that root node is always needed, i.e., we hardcode `exec_info[&graph_root]=true`. The issue was that this logic wasn't updated after the code was updated to skip the graph root.

To address (1), instead of passing in an invalid edge if an input in `inputs` has no grad_fn, we create a dummy grad_fn. This is done in both python and cpp entry points. The alternative is to add logic for both backward() and grad() cases to check whether the grad_fn is nullptr and set needed=false in that case (the .grad() case would be slightly more complicated than the .backward() case here).

For (2), we perform one final iteration of the discovery algorithm so that we really know whether we need to execute the graph root.