### PR TITLE
Keep alive graph when creating iterators from it

### DIFF
--- a/test/jit/test_python_bindings.py
+++ b/test/jit/test_python_bindings.py
@@ -45,9 +45,23 @@ class TestPythonBindings(JitTestCase):
         n = gr.insertNode(gr.create("prim::profile"))
         v = n.output()
         # check that they work
-        s = str((n, v))
+        str((n, v))
         torch._C._jit_pass_dce(gr)
         with self.assertRaisesRegex(RuntimeError, "invalidated"):
             str(n)
         with self.assertRaisesRegex(RuntimeError, "invalidated"):
             str(v)
+
+    def test_graph_iterator_keepalive(self):
+        @torch.jit.script
+        def test_iterator_keepalive_fn(x: torch.Tensor):
+            return 2 * x
+
+        # the list would segfault before because inlined_graph
+        # is temporary and had been deleted (see issue #50454)
+        n = test_iterator_keepalive_fn.inlined_graph.nodes()
+        list(n)
+        i = test_iterator_keepalive_fn.inlined_graph.inputs()
+        list(i)
+        o = test_iterator_keepalive_fn.inlined_graph.outputs()
+        list(o)

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -316,18 +316,22 @@ void initPythonIRBindings(PyObject* module_) {
           "inputs",
           [](Graph& g) {
             return py::make_iterator(g.inputs().begin(), g.inputs().end());
-          })
+          },
+          py::keep_alive<0, 1>())
       .def(
           "outputs",
           [](Graph& g) {
             return py::make_iterator(g.outputs().begin(), g.outputs().end());
-          })
-      // TODO: Iterator invalidation might make this hazardous
+          },
+          py::keep_alive<0, 1>())
+      // We keep the graph alive while the iterator lives. Destroying
+      // nodes might still be hazardous.
       .def(
           "nodes",
           [](Graph& g) {
             return py::make_iterator(g.nodes().begin(), g.nodes().end());
-          })
+          },
+          py::keep_alive<0, 1>())
       .def(
           "findNode",
           [](Graph& g, const std::string& kind, bool recurse) {


### PR DESCRIPTION
Previously, the graph might have been delete while Python still has iterators, leading to segfaults.

This does not fully work for iterators from Nodes and Blocks as they may be invalidated when the owning graph goes out of scope. I will look into these separately.

Fixes #50454
