### PR TITLE
var(single observation) should be 0 not NaN

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -260,8 +260,13 @@ std::tuple<Tensor,Tensor> batch_norm_cpu_update_stats_template(
         running_mean_a[f] = momentum * mean + (1 - momentum) * running_mean_a[f];
       }
       if (running_var.defined()) {
-        accscalar_t unbiased_var = var_sum / (n - 1);
-        running_var_a[f] = momentum * unbiased_var + (1 - momentum) * running_var_a[f];
+        if (n > 1) {
+            accscalar_t unbiased_var = var_sum / (n - 1);
+            running_var_a[f] = momentum * unbiased_var + (1 - momentum) * running_var_a[f];
+        }
+        else {
+            running_var_a[f] = 0.0;
+        }
       }
     }
   });

--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -103,6 +103,11 @@ struct WelfordOps {
   inline C10_DEVICE res_t project(acc_t acc) const {
     auto mean = acc.mean;
     combine_t divisor = unbiased ? (acc.nf - 1) : acc.nf;
+    if (acc.nf == 1) {
+        // one observation, variance is 0
+        detail::pair<scalar_t, scalar_t> results{(scalar_t) 0, (scalar_t) mean};
+        return results;
+    }
     auto ret = (divisor > 0) ?
       (take_sqrt ? device_sqrt(acc.m2 / divisor) : (acc.m2 / divisor))
       : NAN;

--- a/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/batch_norm_kernel.cpp
@@ -37,7 +37,14 @@ void batch_norm_cpu_inference_collect_linear_and_constant_terms(
     scalar_t inv_var = 1 / std::sqrt(var_data[c] + static_cast<scalar_t>(eps));
     scalar_t weight_v = weight_data ? weight_data[c] : 1;
     scalar_t bias_v = bias_data ? bias_data[c] : 0;
-    alpha[c] = inv_var * weight_v;
+    if (var_data[c] == 0.0) {
+      // XXX what should this be if the variance is 0?
+      // Currently try output = bias
+      alpha[c] = 0.0;
+    }
+    else {
+      alpha[c] = inv_var * weight_v;
+    }
     beta[c] = bias_v - mean_data[c] * alpha[c];
   }
 }

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -301,8 +301,14 @@ __global__ void batch_norm_collect_statistics_kernel(
       running_mean[plane] = static_cast<stat_scalar_t>((1 - momentum) * running_mean[plane] + momentum * avg);
     }
     if (running_var.data() != NULL) {
-      stat_accscalar_t unbiasedVar = var_n / (N - 1);
-      running_var[plane] = static_cast<stat_scalar_t>((1 - momentum) * running_var[plane] + momentum * unbiasedVar);
+      if (N == 1) {
+        // Variance of a single observation is 0
+        running_var[plane] = 0.0;
+      }
+      else {
+        stat_accscalar_t unbiasedVar = var_n / (N - 1);
+        running_var[plane] = static_cast<stat_scalar_t>((1 - momentum) * running_var[plane] + momentum * unbiasedVar);
+      }
     }
   }
 


### PR DESCRIPTION
Related to #45687

Currently, `torch.rand(8, 5, 1).var(axis=2)` returns a 8x5 tensor of `NaN`s. This is not really correct, it should be 0. But that has implications for the `InstanceNorm` layers and probably many more.

Is this worth pursuing?

