### PR TITLE
move rnn cell size check to cpp

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -689,6 +689,22 @@ tpair_of<Tensor> hidden_slice(const tpair_of<Tensor>& t, int64_t start, int64_t 
 // It's a struct only because functional programming in C++ is a pain, and it's easier
 // to pass around "vtable pointers" than actual function pointers.
 
+void check_rnn_cell_forward_input(const Tensor& input, int64_t input_size) {
+  TORCH_CHECK(
+    input.size(1) == input_size,
+    "input has inconsistent input_size: got ", input.size(1), " expected ", input_size);
+}
+
+void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, int64_t hidden_size, std::string hidden_label) {
+  TORCH_CHECK(
+    input.size(0) == hx.size(0),
+    "Input batch size ", input.size(0), " doesn't match hidden", hidden_label, " batch size ", hx.size(0));
+
+  TORCH_CHECK(
+    hx.size(1) == hidden_size,
+    "hidden", hidden_label, " has inconsistent hidden_size: got ", hx.size(1), ", expected ", hidden_size);
+}
+
 template<typename hidden_type_tmpl, typename cell_params_tmpl>
 struct Cell {
   using hidden_type = hidden_type_tmpl;
@@ -1496,6 +1512,10 @@ std::tuple<Tensor, Tensor> lstm_cell(
     const Tensor& input, TensorList hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
   TORCH_CHECK(hx.size() == 2, "lstm_cell expects two hidden states");
+  check_rnn_cell_forward_input(input, w_ih.size(1));
+  auto hidden_size = w_hh.size(1);
+  check_rnn_cell_forward_hidden(input, hx[0], hidden_size, "[0]");
+  check_rnn_cell_forward_hidden(input, hx[1], hidden_size, "[1]");
   static at::Tensor undefined;
   return LSTMCell<CellParams>{}(input, std::make_tuple(hx[0], hx[1]), CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
@@ -1594,7 +1614,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_differentiable_gru_cell
 Tensor gru_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
+  check_rnn_cell_forward_input(input, w_ih.size(1));
   static at::Tensor undefined;
+  check_rnn_cell_forward_hidden(input, hx, w_hh.size(1), "");
   return GRUCell<CellParams>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
 

--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -695,7 +695,7 @@ void check_rnn_cell_forward_input(const Tensor& input, int64_t input_size) {
     "input has inconsistent input_size: got ", input.size(1), " expected ", input_size);
 }
 
-void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, int64_t hidden_size, std::string hidden_label) {
+void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, int64_t hidden_size, int64_t hidden_label) {
   TORCH_CHECK(
     input.size(0) == hx.size(0),
     "Input batch size ", input.size(0), " doesn't match hidden", hidden_label, " batch size ", hx.size(0));
@@ -1514,8 +1514,8 @@ std::tuple<Tensor, Tensor> lstm_cell(
   TORCH_CHECK(hx.size() == 2, "lstm_cell expects two hidden states");
   check_rnn_cell_forward_input(input, w_ih.size(1));
   auto hidden_size = w_hh.size(1);
-  check_rnn_cell_forward_hidden(input, hx[0], hidden_size, "[0]");
-  check_rnn_cell_forward_hidden(input, hx[1], hidden_size, "[1]");
+  check_rnn_cell_forward_hidden(input, hx[0], hidden_size, 0);
+  check_rnn_cell_forward_hidden(input, hx[1], hidden_size, 0);
   static at::Tensor undefined;
   return LSTMCell<CellParams>{}(input, std::make_tuple(hx[0], hx[1]), CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
@@ -1615,8 +1615,8 @@ Tensor gru_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
   check_rnn_cell_forward_input(input, w_ih.size(1));
+  check_rnn_cell_forward_hidden(input, hx, w_hh.size(1), 0);
   static at::Tensor undefined;
-  check_rnn_cell_forward_hidden(input, hx, w_hh.size(1), "");
   return GRUCell<CellParams>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
 
@@ -1624,6 +1624,8 @@ Tensor rnn_tanh_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
   static at::Tensor undefined;
+  check_rnn_cell_forward_input(input, w_ih.size(1));
+  check_rnn_cell_forward_hidden(input, hx, w_hh.size(1), 0);
   return SimpleCell<tanh_f, CellParams>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
 
@@ -1631,6 +1633,8 @@ Tensor rnn_relu_cell(
     const Tensor& input, const Tensor& hx,
     const Tensor& w_ih, const Tensor& w_hh, const Tensor& b_ih, const Tensor& b_hh) {
   static at::Tensor undefined;
+  check_rnn_cell_forward_input(input, w_ih.size(1));
+  check_rnn_cell_forward_hidden(input, hx, w_hh.size(1), 0);
   return SimpleCell<relu_f, CellParams>{}(input, hx, CellParams{w_ih, w_hh, b_ih, b_hh, undefined});
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5126,6 +5126,23 @@ class TestNN(NNTestCase):
 
                 hx.sum().backward()
 
+    def test_RNN_cell_forward_input_size(self):
+        input = torch.randn(3, 11)
+        hx = torch.randn(3, 20)
+        for module in (nn.RNNCell, nn.GRUCell):
+            cell = module(10, 20)
+            self.assertRaises(Exception, lambda: cell(input, hx))
+    
+    def test_RNN_cell_forward_hidden_size(self):
+        input = torch.randn(3, 10)
+        hx = torch.randn(3, 21)
+        cell_shared_param = (10, 20)
+        for cell in (nn.RNNCell(*cell_shared_param, nonlinearity="relu"),
+                     nn.RNNCell(*cell_shared_param, nonlinearity="tanh"), 
+                     nn.GRUCell(*cell_shared_param)):
+            self.assertRaises(Exception, lambda: cell(input, hx))
+
+
     def _test_loss_equal_input_target_shape(self, cast):
         # Tests losses whose inputs should have the same size.
         losses = {
@@ -5539,6 +5556,22 @@ class TestNN(NNTestCase):
                 hx, cx = lstm(input, (hx, cx))
 
             (hx + cx).sum().backward()
+
+    def test_LSTM_cell_forward_input_size(self):
+         input = torch.randn(3, 11)
+         hx = torch.randn(3, 20)
+         cx = torch.randn(3, 20)
+         lstm = nn.LSTMCell(10, 20)
+         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
+
+    def test_LSTM_cell_forward_hidden_size(self):
+         input = torch.randn(3, 10)
+         hx = torch.randn(3, 21)
+         cx = torch.randn(3, 20)
+         lstm = nn.LSTMCell(10, 20)
+         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
+         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
+
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
     def test_pack_sequence_batch_sizes_throw(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5132,7 +5132,7 @@ class TestNN(NNTestCase):
         for module in (nn.RNNCell, nn.GRUCell):
             cell = module(10, 20)
             self.assertRaises(Exception, lambda: cell(input, hx))
-    
+
     def test_RNN_cell_forward_hidden_size(self):
         input = torch.randn(3, 10)
         hx = torch.randn(3, 21)
@@ -5558,19 +5558,19 @@ class TestNN(NNTestCase):
             (hx + cx).sum().backward()
 
     def test_LSTM_cell_forward_input_size(self):
-         input = torch.randn(3, 11)
-         hx = torch.randn(3, 20)
-         cx = torch.randn(3, 20)
-         lstm = nn.LSTMCell(10, 20)
-         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
+        input = torch.randn(3, 11)
+        hx = torch.randn(3, 20)
+        cx = torch.randn(3, 20)
+        lstm = nn.LSTMCell(10, 20)
+        self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
 
     def test_LSTM_cell_forward_hidden_size(self):
-         input = torch.randn(3, 10)
-         hx = torch.randn(3, 21)
-         cx = torch.randn(3, 20)
-         lstm = nn.LSTMCell(10, 20)
-         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
-         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
+        input = torch.randn(3, 10)
+        hx = torch.randn(3, 21)
+        cx = torch.randn(3, 20)
+        lstm = nn.LSTMCell(10, 20)
+        self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
+        self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
 
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5138,7 +5138,7 @@ class TestNN(NNTestCase):
         hx = torch.randn(3, 21)
         cell_shared_param = (10, 20)
         for cell in (nn.RNNCell(*cell_shared_param, nonlinearity="relu"),
-                     nn.RNNCell(*cell_shared_param, nonlinearity="tanh"), 
+                     nn.RNNCell(*cell_shared_param, nonlinearity="tanh"),
                      nn.GRUCell(*cell_shared_param)):
             self.assertRaises(Exception, lambda: cell(input, hx))
 


### PR DESCRIPTION
Fixes #32193. 

Possible further improvements:
- do the same for quantized cells
- reuse newly written functions in https://github.com/pytorch/pytorch/blob/56034636b9f37b54dacfab8794e93ba6b10bdfc7/torch/csrc/api/src/nn/modules/rnn.cpp#L699-L715
