### PR TITLE
[fx/package] make GraphModules packageable

### DIFF
--- a/test/package_a/subpackage.py
+++ b/test/package_a/subpackage.py
@@ -1,3 +1,6 @@
 result = 'package_a.subpackage'
 class PackageASubpackageObject:
     pass
+
+def leaf_function(a, b):
+    return a + b

--- a/test/package_a/test_module.py
+++ b/test/package_a/test_module.py
@@ -1,0 +1,12 @@
+import torch
+from torch.fx import wrap
+
+wrap('a_non_torch_leaf')
+
+class SimpleTest(torch.nn.Module):
+    def forward(self, x):
+        x = a_non_torch_leaf(x, x)
+        return torch.relu(x + 3.0)
+
+def a_non_torch_leaf(a, b):
+    return a + b

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1,6 +1,7 @@
 from .node import Node, Argument, Target, map_arg, _type_repr, _get_qualified_name
 
-from typing import Callable, Any, List, Dict, Optional, Tuple, Set
+from typing import Callable, Any, List, Dict, Optional, Tuple, Set, Union
+from torch.package.module_environment import ModuleEnv, get_current_module_env
 import torch
 import keyword
 import re
@@ -44,8 +45,13 @@ def _get_print_name(qualname: str) -> str:
         return qualname
     return qualname.rpartition('.')[2]
 
+# Representation of module dependencies.
+# str -> 'import str'
+# (str1, str2) -> 'from str1 import str2'
+_Import = Union[str, Tuple[str, str]]
 
-def _get_import_str(qualname: str) -> Optional[str]:
+
+def _get_import(qualname: str) -> Optional[_Import]:
     """
     Encodes the following import rule:
     - 'torch' is always imported as a base name (e.g. 'import torch').
@@ -57,14 +63,23 @@ def _get_import_str(qualname: str) -> Optional[str]:
     """
     base_module_name = qualname.partition('.')[0]
     if base_module_name == 'torch' or base_module_name == 'typing':
-        return f'import {base_module_name}'
+        return base_module_name
 
     module_name, _sep, type_name = qualname.rpartition('.')
     if len(module_name) == 0:
         # This was a single-atom qualified name, like 'getattr', or 'len'
         return None
 
-    return f'from {module_name} import {type_name}'
+    return module_name, type_name
+
+
+def _format_import(import_: _Import):
+    if isinstance(import_, str):
+        return f'import {import_}'
+    elif isinstance(import_, tuple):
+        return f'from {import_[0]} import {import_[1]}'
+    else:
+        raise AssertionError(f'unexpected type: {type(import_)}')
 
 
 # this is fixed on master, WAR for 1.5
@@ -177,6 +192,8 @@ class Graph:
         self._used_names : Dict[str, int] = {}  # base name -> number
         self._insert = self._root.prepend
         self._len = 0
+        self._imports : Set[_Import] = set()
+        self._module_env: ModuleEnv = get_current_module_env()
 
     @property
     def nodes(self) -> _node_list:
@@ -602,7 +619,7 @@ class Graph:
         maybe_return_annotation : List[str] = ['']
 
         def type_repr(o : Any):
-            typename = _type_repr(o)
+            typename = _type_repr(o, self._module_env)
 
             # Common case: this is a regular module name like 'foo.bar.baz'
             if all(x.isidentifier() for x in typename.split('.')):
@@ -615,7 +632,6 @@ class Graph:
                 # make sure we have torch.Tensor
                 type_repr(sub_type)
             return typename
-
 
         # Run through reverse nodes and record the first instance of a use
         # of a given node. This represents the *last* use of the node in the
@@ -674,7 +690,7 @@ class Graph:
                     assert isinstance(node.args, tuple)
                     body.append(f'{node.name} = {magic_methods[node.target.__name__].format(*(repr(a) for a in node.args))}')
                     return
-                qualified_name = _get_qualified_name(node.target)
+                qualified_name = _get_qualified_name(node.target, self._module_env)
                 qualnames_used.add(qualified_name)
                 print_name = _get_print_name(qualified_name)
                 if print_name == 'getattr' and \
@@ -707,15 +723,13 @@ class Graph:
             emit_node(node)
             delete_unused_values(node)
 
-        # repr() for inf and nan floating point values aren't parseable by
-        # python as literals. Explicitly import the names from the ``math`` module.
-        import_strs: Set[str] = set()
+        self._imports = set()
         for qualname in qualnames_used:
-            import_str = _get_import_str(qualname)
-            if import_str is not None:
-                import_strs.add(import_str)
+            import_ = _get_import(qualname)
+            if import_ is not None:
+                self._imports.add(import_)
 
-        import_block = '\n'.join(sorted(import_strs))
+        import_block = '\n'.join(sorted([_format_import(i) for i in self._imports]))
 
         if len(body) == 0:
             # If the Graph has no non-placeholder nodes, no lines for the body

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -404,6 +404,7 @@ def _create_wrapped_func(orig_fn):
         if proxy is not None:
             return proxy.tracer.create_proxy('call_function', orig_fn, args, kwargs)
         return orig_fn(*args, **kwargs)
+    wrapped.__fx_wrapped__ = True
 
     return wrapped
 

--- a/torch/package/__init__.py
+++ b/torch/package/__init__.py
@@ -1,2 +1,2 @@
-from .importer import PackageImporter
+from .importer import PackageImporter, BaseImporter
 from .exporter import PackageExporter

--- a/torch/package/_custom_import_pickler.py
+++ b/torch/package/_custom_import_pickler.py
@@ -1,16 +1,15 @@
-from pickle import Pickler, whichmodule, _Pickler, _getattribute, _extension_registry, _compat_pickle  # type: ignore
+from pickle import Pickler, _Pickler, _getattribute, _extension_registry, _compat_pickle  # type: ignore
 from pickle import GLOBAL, STACK_GLOBAL, EXT1, EXT2, EXT4, PicklingError
 from types import FunctionType
 from struct import pack
-from ._mangling import demangle, is_mangled, get_mangle_prefix
-import importlib
 
+from .module_environment import ModuleEnv, DefaultImporter, ModuleEnvError
 
 class CustomImportPickler(_Pickler):
     dispatch = _Pickler.dispatch.copy()
 
-    def __init__(self, import_module, *args, **kwargs):
-        self.import_module = import_module
+    def __init__(self, module_env: ModuleEnv, *args, **kwargs):
+        self.module_env = module_env
         super().__init__(*args, **kwargs)
 
     def save_global(self, obj, name=None):
@@ -20,65 +19,27 @@ class CustomImportPickler(_Pickler):
         write = self.write
         memo = self.memo
 
-        if name is None:
-            name = getattr(obj, '__qualname__', None)
-        if name is None:
-            name = obj.__name__
+        # CHANGED: Get the name from the module enviroment instead of Python environment.
+        module_name, name = self.module_env.get_name(obj, name, check_obj=False)
 
-        orig_module_name = whichmodule(obj, name)
-        # CHANGED: demangle the module name before importing. If this obj came
-        # out of a PackageImporter, `__module__` will be mangled. See
-        # mangling.md for details.
-        module_name = demangle(orig_module_name)
         try:
-            # CHANGED: self.import_module rather than
+            # CHANGED: import module from module environment instead of
             # __import__
-            module = self.import_module(module_name)
+            module = self.module_env.import_module(module_name)
             obj2, parent = _getattribute(module, name)
         except (ImportError, KeyError, AttributeError):
             raise PicklingError(
                 "Can't pickle %r: it's not found as %s.%s" %
                 (obj, module_name, name)) from None
         else:
-            if obj2 is not obj:
-                # CHANGED: More specific error message in the case of mangling.
-                obj_module_name = getattr(obj, "__module__", orig_module_name)
-                obj2_module_name = getattr(obj2, "__module__", orig_module_name)
-
-                msg = f"Can't pickle {obj}: it's not the same object as {obj2_module_name}.{name}."
-
-                is_obj_mangled = is_mangled(obj_module_name)
-                is_obj2_mangled = is_mangled(obj2_module_name)
-
-                if is_obj_mangled or is_obj2_mangled:
-                    obj_location = (
-                        get_mangle_prefix(obj_module_name)
-                        if is_obj_mangled
-                        else "the current Python environment"
-                    )
-                    obj2_location = (
-                        get_mangle_prefix(obj2_module_name)
-                        if is_obj2_mangled
-                        else "the current Python environment"
-                    )
-
-                    obj_importer_name = (
-                        f"the importer for {get_mangle_prefix(obj_module_name)}"
-                        if is_obj_mangled
-                        else "'importlib.import_module'"
-                    )
-                    obj2_importer_name = (
-                        f"the importer for {get_mangle_prefix(obj2_module_name)}"
-                        if is_obj2_mangled
-                        else "'importlib.import_module'"
-                    )
-
-                    msg += (f"\n\nThe object being pickled is from '{orig_module_name}', "
-                            f"which is coming from {obj_location}."
-                            f"\nHowever, when we import '{orig_module_name}', it's coming from {obj2_location}."
-                            "\nTo fix this, make sure 'PackageExporter.importers' lists "
-                            f"{obj_importer_name} before {obj2_importer_name}")
-                raise PicklingError(msg)
+            # CHANGED: error check is sunk into check_obj to provide a better error message
+            try:
+                self.module_env.check_obj(obj, obj2, name)
+            except ModuleEnvError as err:
+                obj2_module_name = getattr(obj2, "__module__", module_name)
+                msg = f"Can't pickle {obj}: it's not the same object as '{obj2_module_name}.{name}'."
+                msg += str(err)
+                raise PicklingError(msg) from err
 
         if self.proto >= 2:
             code = _extension_registry.get((module_name, name))
@@ -123,24 +84,10 @@ class CustomImportPickler(_Pickler):
         self.memoize(obj)
     dispatch[FunctionType] = save_global
 
-def import_module_from_importers(module_name, importers):
-    last_err = None
-    for import_module in importers:
-        try:
-            return import_module(module_name)
-        except ModuleNotFoundError as err:
-            last_err = err
-
-    if last_err is not None:
-        raise last_err
-    else:
-        raise ModuleNotFoundError(module_name)
-
-def create_custom_import_pickler(data_buf, importers):
-    if importers == [importlib.import_module]:
+def create_custom_import_pickler(data_buf, module_env):
+    if module_env.importers == [DefaultImporter]:
         # if we are using the normal import library system, then
         # we can use the C implementation of pickle which is faster
         return Pickler(data_buf, protocol=3)
     else:
-        return CustomImportPickler(lambda mod: import_module_from_importers(mod, importers),
-                                   data_buf, protocol=3)
+        return CustomImportPickler(module_env, data_buf, protocol=3)

--- a/torch/package/exporter.py
+++ b/torch/package/exporter.py
@@ -3,17 +3,19 @@ from torch.serialization import normalize_storage_type, location_tag
 import io
 import pickletools
 from .find_file_dependencies import find_files_source_depends_on
-from ._custom_import_pickler import create_custom_import_pickler, import_module_from_importers
+from ._custom_import_pickler import create_custom_import_pickler
 from ._importlib import _normalize_path
 from ._mangling import is_mangled
 from ._stdlib import is_stdlib_module
+from .module_environment import ModuleEnv, get_current_module_env
+from .importer import BaseImporter
 import types
-import importlib
 from typing import List, Any, Callable, Dict, Tuple, Union, Iterable, BinaryIO, Optional
 from pathlib import Path
 import linecache
 from urllib.parse import quote
 import re
+
 
 
 class PackageExporter:
@@ -47,7 +49,7 @@ class PackageExporter:
 
     """
 
-    importers: List[Callable[[str], Any]]
+    importers: List[BaseImporter]
     """ A list of functions that will be called in order to find the module assocated
     with module names referenced by other modules or by pickled objects. Initialized to
     `[importlib.import_module]` by default. When pickling code or objects that was loaded
@@ -79,9 +81,10 @@ class PackageExporter:
         self.external : List[str] = []
         self.provided : Dict[str, bool] = {}
         self.verbose = verbose
-        self.importers = [importlib.import_module]
+        self.module_env : ModuleEnv = get_current_module_env()
         self.patterns : List[Tuple[Any, Callable[[str], None]]] = []  # 'any' is 're.Pattern' but breaks old mypy
         self.debug_deps : List[Tuple[str, str]] = []
+        self._unique_id = 0
 
     def save_source_file(self, module_name: str, file_or_directory: str, dependencies=True):
         """Adds the local file system `file_or_directory` to the source package to provide the code
@@ -124,6 +127,12 @@ class PackageExporter:
         else:
             is_package = path.name == '__init__.py'
             self.save_source_string(module_name, _read_file(file_or_directory), is_package, dependencies, file_or_directory)
+
+    def get_unique_id(self) -> str:
+        """Get an id. This id is guaranteed to only be handed out once for this package."""
+        ret = str(self._unique_id)
+        self._unique_id += 1
+        return ret
 
     def save_source_string(self, module_name: str, src: str, is_package: bool = False,
                            dependencies: bool = True, orig_file_name: str = None):
@@ -173,7 +182,7 @@ class PackageExporter:
 
     def _import_module(self, module_name: str):
         try:
-            return import_module_from_importers(module_name, self.importers)
+            return self.module_env.import_module(module_name)
         except ModuleNotFoundError as e:
             if not is_mangled(module_name):
                 raise
@@ -272,7 +281,7 @@ node [shape=box];
         filename = self._filename(package, resource)
         # Write the pickle data for `obj`
         data_buf = io.BytesIO()
-        pickler = create_custom_import_pickler(data_buf, self.importers)
+        pickler = create_custom_import_pickler(data_buf, self.module_env)
         pickler.persistent_id = self._persistent_id
         pickler.dump(obj)
         data_value = data_buf.getvalue()
@@ -384,11 +393,6 @@ node [shape=box];
         return qualified_name in self.provided
 
     def _persistent_id(self, obj):
-        # FIXME: the docs say that persistent_id should only return a string
-        # but torch store returns tuples. This works only in the binary protocol
-        # see
-        # https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-external-objects
-        # https://github.com/python/cpython/blob/master/Lib/pickle.py#L527-L537
         if torch.is_storage(obj):
             storage_type = normalize_storage_type(type(obj))
             obj_key = str(obj._cdata)
@@ -400,6 +404,9 @@ node [shape=box];
                     obj_key,
                     location,
                     obj.size())
+        if hasattr(obj, '__reduce_package__'):
+            return ('reduce_package', *obj.__reduce_package__(self))
+
         return None
 
     def __enter__(self):

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -1,4 +1,5 @@
 from typing import List, Callable, Dict, Optional, Any, Union, BinaryIO
+from abc import ABC, abstractmethod
 import builtins
 import importlib
 import inspect
@@ -9,16 +10,25 @@ import pickle
 import torch
 from torch.serialization import _get_restore_location, _maybe_decode_ascii
 import _compat_pickle  # type: ignore
-import types
 import os.path
 from pathlib import Path
+from types import ModuleType
 
 from ._importlib import _normalize_line_endings, _resolve_name, _sanity_check, _calc___package__, \
     _normalize_path
 from ._mock_zipreader import MockZipReader
 from ._mangling import PackageMangler, demangle
 
-class PackageImporter:
+
+class BaseImporter(ABC):
+    modules: Dict[str, ModuleType]
+
+    @abstractmethod
+    def import_module(self, module_name: str) -> ModuleType:
+        pass
+
+
+class PackageImporter(BaseImporter):
     """Importers allow you to load code written to packages by PackageExporter.
     Code is loaded in a hermetic way, using files from the package
     rather than the normal python import system. This allows
@@ -35,7 +45,7 @@ class PackageImporter:
     """The dictionary of already loaded modules from this package, equivalent to `sys.modules` but
     local to this importer.
     """
-    modules : Dict[str, Optional[types.ModuleType]]
+    modules : Dict[str, ModuleType]
 
     def __init__(self, file_or_buffer: Union[str, torch._C.PyTorchFileReader, Path, BinaryIO],
                  module_allowed: Callable[[str], bool] = lambda module_name: True):
@@ -160,13 +170,17 @@ class PackageImporter:
             typename = _maybe_decode_ascii(saved_id[0])
             data = saved_id[1:]
 
-            assert typename == 'storage', \
+            if typename == 'storage':
+                data_type, key, location, size = data
+                if key not in loaded_storages:
+                    load_tensor(data_type, size, key, _maybe_decode_ascii(location), restore_location)
+                storage = loaded_storages[key]
+                return storage
+            elif typename == 'reduce_package':
+                func, args = data
+                return func(self, *args)
+            else:
                 f"Unknown typename for persistent_load, expected 'storage' but got '{typename}'"
-            data_type, key, location, size = data
-            if key not in loaded_storages:
-                load_tensor(data_type, size, key, _maybe_decode_ascii(location), restore_location)
-            storage = loaded_storages[key]
-            return storage
 
         # Load the data (which may in turn use `persistent_load` to load tensors)
         data_file = io.BytesIO(self.zip_reader.get_record(pickle_file))
@@ -251,7 +265,7 @@ class PackageImporter:
         module = self.import_module(demangle(module_name))
         return self.zip_reader.get_record(demangle(module.__file__)).decode('utf-8')
 
-    def _install_on_parent(self, parent: str, name: str, module: types.ModuleType):
+    def _install_on_parent(self, parent: str, name: str, module: ModuleType):
         if not parent:
             return
         # Set the module as an attribute on its parent.

--- a/torch/package/module_environment.py
+++ b/torch/package/module_environment.py
@@ -1,0 +1,231 @@
+import importlib
+import sys
+from contextlib import contextmanager
+from pickle import _getattribute  # type: ignore
+from types import ModuleType
+from typing import Any, List, Optional, Tuple
+
+from ._mangling import demangle, get_mangle_prefix, is_mangled
+from .importer import BaseImporter
+
+
+class ModuleEnvError(Exception):
+    """Raised by ModuleEnv.check_obj."""
+    pass
+
+
+class _DefaultImporter(BaseImporter):
+    """An importer that implements the default behavior of Python."""
+    def __init__(self):
+        self.modules = sys.modules
+
+    def import_module(self, module_name: str):
+        return importlib.import_module(module_name)
+
+
+DefaultImporter = _DefaultImporter()
+
+
+class ModuleEnv:
+    """An environment that manages multiple module importers with overlapping names.
+
+    By default, you can figure out what module an object belongs by checking
+    __module__ and importing the result using __import__ or importlib.import_module.
+
+    torch.package introduces module importers other than the default one.
+    Each PackageImporter introduces a new namespace. Potentially a single
+    name (e.g. 'foo.bar') is present in multiple namespaces.
+
+    ModuleEnv provides a structured way to represent a collection of
+    importers and ensuring that we are retrieving the correct modules for a
+    given name.
+
+    It supports two main operations:
+        get_name: object -> (parent module name, name of obj within module)
+        import_module: module_name -> module
+
+    The guarantee is that following round-trip will succeed or throw a ModuleEnvError.
+        module_name, obj_name = env.get_name(obj)
+        module = env.import_module(module_name)
+        obj2 = getattr(module, obj_name)
+        assert obj1 is obj2
+    """
+    def __init__(self, importers: Optional[List[BaseImporter]] = None):
+        if importers is None:
+            importers = [DefaultImporter]
+        self._importers = importers
+
+    def import_module(self, module_name: str) -> ModuleType:
+        """Import 'module_name' from this environment.
+
+        Importers will be tried in order of `self.importers`, and the first match will be taken.
+        """
+        last_err = None
+        for importer in self._importers:
+            if not isinstance(importer, BaseImporter):
+                raise TypeError(
+                    f"{importer} is not a BaseImporter. "
+                    "All importers in ModuleEnv must inherit from BaseImporter."
+                )
+            try:
+                return importer.import_module(module_name)
+            except ModuleNotFoundError as err:
+                last_err = err
+
+        if last_err is not None:
+            raise last_err
+        else:
+            raise ModuleNotFoundError(module_name)
+
+    def get_name(
+        self, obj: Any, name: Optional[str] = None, check_obj: bool = True
+    ) -> Tuple[str, str]:
+        """Given an object, return a name that can be used to retrieve the
+        object from this environment.
+
+        Args:
+            obj: An object to get the the module-environment-relative name for.
+            name: If set, use this name instead of looking up __name__ or __qualname__ on `obj`.
+                This is only here to match how Pickler handles __reduce__ functions that return a string,
+                don't use otherwise.
+            check_obj: If true, check that retrieving the returned name produces the same object as `obj`.
+                This should only be false if you plan to call `check_obj()` somewhere else.
+
+        Returns:
+            A tuple (parent_module_name, attr_name) that can be used to retrieve `obj` from this environment.
+            Use it like:
+                mod = module_env.import_module(parent_module_name)
+                obj = getattr(mod, attr_name)
+
+        Raises:
+            ModuleEnvError: `check_obj()` has failed.
+        """
+        if name is None:
+            name = getattr(obj, "__qualname__", None)
+        if name is None:
+            name = obj.__name__
+
+        orig_module_name = self._whichmodule(obj, name)
+        # Demangle the module name before importing. If this obj came out of a
+        # PackageImporter, `__module__` will be mangled. See mangling.md for
+        # details.
+        module_name = demangle(orig_module_name)
+
+        if check_obj:
+            module = self.import_module(module_name)
+            obj2, _ = _getattribute(module, name)
+            self.check_obj(obj, obj2, name)
+
+        return module_name, name
+
+    def check_obj(self, obj, obj2, name=None):
+        """Checks that two objects are the same identity.
+
+        Don't use this method, prefer to use the automatic check in `get_name`.
+        It's only separate to help implement CustomImportPickler.
+
+        Args:
+            obj: The object that the user gave us. This will be treated as such in error messaging.
+            obj2: The object retrieve by looking up a name in `self`.
+            name: If set, use this name instead of looking up __name__ or __qualname__ in error reporting.
+                This is only here to match how Pickler handles __reduce__ functions that return a string,
+                don't use otherwise.
+
+        Returns:
+            None
+
+        Raises:
+            ModuleEnvError: The two objects are not the same identity. The exception message will contain
+                a description and suggestions for fixing the issue.
+        """
+        if obj is obj2:
+            return
+
+        if name is None:
+            name = getattr(obj, "__qualname__", None)
+        if name is None:
+            name = obj.__name__
+
+        orig_module_name = self._whichmodule(obj, name)
+        obj_module_name = getattr(obj, "__module__", orig_module_name)
+        obj2_module_name = getattr(obj2, "__module__", self._whichmodule(obj2, name))
+
+        is_obj_mangled = is_mangled(obj_module_name)
+        is_obj2_mangled = is_mangled(obj2_module_name)
+
+        msg = ""
+        if is_obj_mangled or is_obj2_mangled:
+            obj_location = (
+                get_mangle_prefix(obj_module_name)
+                if is_obj_mangled
+                else "the current Python environment"
+            )
+            obj2_location = (
+                get_mangle_prefix(obj2_module_name)
+                if is_obj2_mangled
+                else "the current Python environment"
+            )
+
+            obj_importer_name = (
+                f"the importer for {get_mangle_prefix(obj_module_name)}"
+                if is_obj_mangled
+                else "'DefaultImporter'"
+            )
+            obj2_importer_name = (
+                f"the importer for {get_mangle_prefix(obj2_module_name)}"
+                if is_obj2_mangled
+                else "'DefaultImporter'"
+            )
+
+            msg = (
+                f"\n\nThe object provided is from '{orig_module_name}', "
+                f"which is coming from {obj_location}."
+                f"\nHowever, when we import '{obj2_module_name}', it's coming from {obj2_location}."
+                "\nTo fix this, make sure 'PackageExporter.importers' lists "
+                f"{obj_importer_name} before {obj2_importer_name}."
+            )
+        raise ModuleEnvError(msg)
+
+    def _whichmodule(self, obj, name):
+        """Find the module an object belongs to.
+
+        Taken from pickle.py, but modified to search our importer module
+        lists instead of sys.modules.
+        """
+        module_name = getattr(obj, "__module__", None)
+        if module_name is not None:
+            return module_name
+        # Protect the iteration by using a list copy of importer.modules against dynamic
+        # modules that trigger imports of other modules upon calls to getattr.
+        for importer in self._importers:
+            for module_name, module in importer.modules.copy().items():
+                if (
+                    module_name == "__main__"
+                    or module_name == "__mp_main__"  # bpo-42406
+                    or module is None
+                ):
+                    continue
+                try:
+                    if _getattribute(module, name)[0] is obj:
+                        return module_name
+                except AttributeError:
+                    pass
+        return "__main__"
+
+
+_current_module_env = ModuleEnv()
+
+
+def get_current_module_env() -> ModuleEnv:
+    return _current_module_env
+
+
+@contextmanager
+def set_module_env(module_env: ModuleEnv):
+    global _current_module_env
+    orig = _current_module_env
+    _current_module_env = module_env
+    try:
+        yield _current_module_env
+    finally:
+        _current_module_env = orig


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#51971 [fx/package] make GraphModules packageable**
* #51970 [fx] Make imports more selective in imported code.

FX serializes things by serializing Python code as a string and exec'ing
it on load. This accomplishes one goal (we don't have to pickle the
graph object directly) but breaks the pickle abstraction in ways that
are not composable with `torch.package`.

In particular:
1. `forward` is serialized by saving Python code. On load, it's installed
by  `exec`ing that code. This `exec` call needs to have the right
importer installed, otherwise it will not import modules from the
`torch.package` but instead import from the Python environment.
2. Any types/functions used are emitted as `import` statement in the
generated Python code. These are effectively dynamic dependencies of the
`GraphModule` being saved, and need to be registered as such so that the
`PackageImporter` will package them.

To address these, this PR introduces a new protocol for the
importer/exporter: `__reduce_package__`.

A class can implement `__reduce_package__` to customize how it is placed
in the importer/exproter. It functions very similarly to `__reduce__`,
except:
- `__reduce_package__` takes one argument, which is the `PackageExporter`
instance. Users can use this instance to save stuff to the package to
implement their serialization. `__reduce__` takes no args.
- Only the 2-element tuple version of the return value for `__reduce__`
is supported (this could be extended if necessary).
- When the reduction function is called on load, an additional argument
is added to the beginning of the args tuple. This is the `PackageImporter`
instance doing the loading.

The `__reduce_package__` protocol is defined using `persistent_id` and
`persistent_load`, which ensures that we can still use the cpickle
implementation of the pickler by default.

In addition, this PR adds the concept of a `ModuleEnv` to make explicit
the idea that there may be multiple module namespaces floating around.
See the docs for details.

Differential Revision: [D26340128](https://our.internmc.facebook.com/intern/diff/D26340128)