### PR TITLE
[package] Introduce ModuleEnv to manage module namespace collisions.

### DIFF
--- a/torch/package/__init__.py
+++ b/torch/package/__init__.py
@@ -1,2 +1,2 @@
-from .importer import PackageImporter
+from .importer import PackageImporter, BaseImporter
 from .exporter import PackageExporter

--- a/torch/package/_custom_import_pickler.py
+++ b/torch/package/_custom_import_pickler.py
@@ -1,16 +1,15 @@
-from pickle import Pickler, whichmodule, _Pickler, _getattribute, _extension_registry, _compat_pickle  # type: ignore
+from pickle import Pickler, _Pickler, _getattribute, _extension_registry, _compat_pickle  # type: ignore
 from pickle import GLOBAL, STACK_GLOBAL, EXT1, EXT2, EXT4, PicklingError
 from types import FunctionType
 from struct import pack
-from ._mangling import demangle, is_mangled, get_mangle_prefix
-import importlib
 
+from .module_environment import ModuleEnv, DefaultImporter, ModuleEnvError
 
 class CustomImportPickler(_Pickler):
     dispatch = _Pickler.dispatch.copy()
 
-    def __init__(self, import_module, *args, **kwargs):
-        self.import_module = import_module
+    def __init__(self, module_env: ModuleEnv, *args, **kwargs):
+        self.module_env = module_env
         super().__init__(*args, **kwargs)
 
     def save_global(self, obj, name=None):
@@ -20,65 +19,27 @@ class CustomImportPickler(_Pickler):
         write = self.write
         memo = self.memo
 
-        if name is None:
-            name = getattr(obj, '__qualname__', None)
-        if name is None:
-            name = obj.__name__
+        # CHANGED: Get the name from the module enviroment instead of Python environment.
+        module_name, name = self.module_env.get_name(obj, name, check_obj=False)
 
-        orig_module_name = whichmodule(obj, name)
-        # CHANGED: demangle the module name before importing. If this obj came
-        # out of a PackageImporter, `__module__` will be mangled. See
-        # mangling.md for details.
-        module_name = demangle(orig_module_name)
         try:
-            # CHANGED: self.import_module rather than
+            # CHANGED: import module from module environment instead of
             # __import__
-            module = self.import_module(module_name)
+            module = self.module_env.import_module(module_name)
             obj2, parent = _getattribute(module, name)
         except (ImportError, KeyError, AttributeError):
             raise PicklingError(
                 "Can't pickle %r: it's not found as %s.%s" %
                 (obj, module_name, name)) from None
         else:
-            if obj2 is not obj:
-                # CHANGED: More specific error message in the case of mangling.
-                obj_module_name = getattr(obj, "__module__", orig_module_name)
-                obj2_module_name = getattr(obj2, "__module__", orig_module_name)
-
-                msg = f"Can't pickle {obj}: it's not the same object as {obj2_module_name}.{name}."
-
-                is_obj_mangled = is_mangled(obj_module_name)
-                is_obj2_mangled = is_mangled(obj2_module_name)
-
-                if is_obj_mangled or is_obj2_mangled:
-                    obj_location = (
-                        get_mangle_prefix(obj_module_name)
-                        if is_obj_mangled
-                        else "the current Python environment"
-                    )
-                    obj2_location = (
-                        get_mangle_prefix(obj2_module_name)
-                        if is_obj2_mangled
-                        else "the current Python environment"
-                    )
-
-                    obj_importer_name = (
-                        f"the importer for {get_mangle_prefix(obj_module_name)}"
-                        if is_obj_mangled
-                        else "'importlib.import_module'"
-                    )
-                    obj2_importer_name = (
-                        f"the importer for {get_mangle_prefix(obj2_module_name)}"
-                        if is_obj2_mangled
-                        else "'importlib.import_module'"
-                    )
-
-                    msg += (f"\n\nThe object being pickled is from '{orig_module_name}', "
-                            f"which is coming from {obj_location}."
-                            f"\nHowever, when we import '{orig_module_name}', it's coming from {obj2_location}."
-                            "\nTo fix this, make sure 'PackageExporter.importers' lists "
-                            f"{obj_importer_name} before {obj2_importer_name}")
-                raise PicklingError(msg)
+            # CHANGED: error check is sunk into check_obj to provide a better error message
+            try:
+                self.module_env.check_obj(obj, obj2, name)
+            except ModuleEnvError as err:
+                obj2_module_name = getattr(obj2, "__module__", module_name)
+                msg = f"Can't pickle {obj}: it's not the same object as '{obj2_module_name}.{name}'."
+                msg += str(err)
+                raise PicklingError(msg) from err
 
         if self.proto >= 2:
             code = _extension_registry.get((module_name, name))
@@ -123,24 +84,10 @@ class CustomImportPickler(_Pickler):
         self.memoize(obj)
     dispatch[FunctionType] = save_global
 
-def import_module_from_importers(module_name, importers):
-    last_err = None
-    for import_module in importers:
-        try:
-            return import_module(module_name)
-        except ModuleNotFoundError as err:
-            last_err = err
-
-    if last_err is not None:
-        raise last_err
-    else:
-        raise ModuleNotFoundError(module_name)
-
-def create_custom_import_pickler(data_buf, importers):
-    if importers == [importlib.import_module]:
+def create_custom_import_pickler(data_buf, module_env):
+    if module_env.is_default():
         # if we are using the normal import library system, then
         # we can use the C implementation of pickle which is faster
         return Pickler(data_buf, protocol=3)
     else:
-        return CustomImportPickler(lambda mod: import_module_from_importers(mod, importers),
-                                   data_buf, protocol=3)
+        return CustomImportPickler(module_env, data_buf, protocol=3)

--- a/torch/package/module_environment.py
+++ b/torch/package/module_environment.py
@@ -1,0 +1,238 @@
+import importlib
+import sys
+from contextlib import contextmanager
+from pickle import _getattribute  # type: ignore
+from types import ModuleType
+from typing import Any, List, Optional, Tuple
+
+from ._mangling import demangle, get_mangle_prefix, is_mangled
+from .importer import BaseImporter
+
+
+class ModuleEnvError(Exception):
+    """Raised by ModuleEnv.check_obj."""
+
+    pass
+
+
+class _DefaultImporter(BaseImporter):
+    """An importer that implements the default behavior of Python."""
+
+    def __init__(self):
+        self.modules = sys.modules
+
+    def import_module(self, module_name: str):
+        return importlib.import_module(module_name)
+
+
+DefaultImporter = _DefaultImporter()
+
+
+class ModuleEnv:
+    """An environment that manages multiple module importers with overlapping names.
+
+    By default, you can figure out what module an object belongs by checking
+    __module__ and importing the result using __import__ or importlib.import_module.
+
+    torch.package introduces module importers other than the default one.
+    Each PackageImporter introduces a new namespace. Potentially a single
+    name (e.g. 'foo.bar') is present in multiple namespaces.
+
+    ModuleEnv provides a structured way to represent a collection of
+    importers and ensuring that we are retrieving the correct modules for a
+    given name.
+
+    It supports two main operations:
+        get_name: object -> (parent module name, name of obj within module)
+        import_module: module_name -> module
+
+    The guarantee is that following round-trip will succeed or throw a ModuleEnvError.
+        module_name, obj_name = env.get_name(obj)
+        module = env.import_module(module_name)
+        obj2 = getattr(module, obj_name)
+        assert obj1 is obj2
+    """
+
+    def __init__(self, importers: Optional[List[BaseImporter]] = None):
+        if importers is None:
+            importers = [DefaultImporter]
+        self._importers = importers
+
+    def import_module(self, module_name: str) -> ModuleType:
+        """Import 'module_name' from this environment.
+
+        Importers will be tried in order of `self.importers`, and the first match will be taken.
+        """
+        last_err = None
+        for importer in self._importers:
+            if not isinstance(importer, BaseImporter):
+                raise TypeError(
+                    f"{importer} is not a BaseImporter. "
+                    "All importers in ModuleEnv must inherit from BaseImporter."
+                )
+            try:
+                return importer.import_module(module_name)
+            except ModuleNotFoundError as err:
+                last_err = err
+
+        if last_err is not None:
+            raise last_err
+        else:
+            raise ModuleNotFoundError(module_name)
+
+    def get_name(
+        self, obj: Any, name: Optional[str] = None, check_obj: bool = True
+    ) -> Tuple[str, str]:
+        """Given an object, return a name that can be used to retrieve the
+        object from this environment.
+
+        Args:
+            obj: An object to get the the module-environment-relative name for.
+            name: If set, use this name instead of looking up __name__ or __qualname__ on `obj`.
+                This is only here to match how Pickler handles __reduce__ functions that return a string,
+                don't use otherwise.
+            check_obj: If true, check that retrieving the returned name produces the same object as `obj`.
+                This should only be false if you plan to call `check_obj()` somewhere else.
+
+        Returns:
+            A tuple (parent_module_name, attr_name) that can be used to retrieve `obj` from this environment.
+            Use it like:
+                mod = module_env.import_module(parent_module_name)
+                obj = getattr(mod, attr_name)
+
+        Raises:
+            ModuleEnvError: `check_obj()` has failed.
+        """
+        if name is None:
+            name = getattr(obj, "__qualname__", None)
+        if name is None:
+            name = obj.__name__
+
+        orig_module_name = self._whichmodule(obj, name)
+        # Demangle the module name before importing. If this obj came out of a
+        # PackageImporter, `__module__` will be mangled. See mangling.md for
+        # details.
+        module_name = demangle(orig_module_name)
+
+        if check_obj:
+            module = self.import_module(module_name)
+            obj2, _ = _getattribute(module, name)
+            self.check_obj(obj, obj2, name)
+
+        return module_name, name
+
+    def is_default(self) -> bool:
+        """Returns true if this ModuleEnv only represents the default Python environment."""
+        return self._importers == [DefaultImporter]
+
+    def check_obj(self, obj, obj2, name=None):
+        """Checks that two objects are the same identity.
+
+        Don't use this method, prefer to use the automatic check in `get_name`.
+        It's only separate to help implement CustomImportPickler.
+
+        Args:
+            obj: The object that the user gave us. This will be treated as such in error messaging.
+            obj2: The object retrieve by looking up a name in `self`.
+            name: If set, use this name instead of looking up __name__ or __qualname__ in error reporting.
+                This is only here to match how Pickler handles __reduce__ functions that return a string,
+                don't use otherwise.
+
+        Returns:
+            None
+
+        Raises:
+            ModuleEnvError: The two objects are not the same identity. The exception message will contain
+                a description and suggestions for fixing the issue.
+        """
+        if obj is obj2:
+            return
+
+        if name is None:
+            name = getattr(obj, "__qualname__", None)
+        if name is None:
+            name = obj.__name__
+
+        orig_module_name = self._whichmodule(obj, name)
+        obj_module_name = getattr(obj, "__module__", orig_module_name)
+        obj2_module_name = getattr(obj2, "__module__", self._whichmodule(obj2, name))
+
+        is_obj_mangled = is_mangled(obj_module_name)
+        is_obj2_mangled = is_mangled(obj2_module_name)
+
+        msg = ""
+        if is_obj_mangled or is_obj2_mangled:
+            obj_location = (
+                get_mangle_prefix(obj_module_name)
+                if is_obj_mangled
+                else "the current Python environment"
+            )
+            obj2_location = (
+                get_mangle_prefix(obj2_module_name)
+                if is_obj2_mangled
+                else "the current Python environment"
+            )
+
+            obj_importer_name = (
+                f"the importer for {get_mangle_prefix(obj_module_name)}"
+                if is_obj_mangled
+                else "'DefaultImporter'"
+            )
+            obj2_importer_name = (
+                f"the importer for {get_mangle_prefix(obj2_module_name)}"
+                if is_obj2_mangled
+                else "'DefaultImporter'"
+            )
+
+            msg = (
+                f"\n\nThe object provided is from '{orig_module_name}', "
+                f"which is coming from {obj_location}."
+                f"\nHowever, when we import '{obj2_module_name}', it's coming from {obj2_location}."
+                "\nTo fix this, make sure 'PackageExporter.importers' lists "
+                f"{obj_importer_name} before {obj2_importer_name}."
+            )
+        raise ModuleEnvError(msg)
+
+    def _whichmodule(self, obj, name):
+        """Find the module an object belongs to.
+
+        Taken from pickle.py, but modified to search our importer module
+        lists instead of sys.modules.
+        """
+        module_name = getattr(obj, "__module__", None)
+        if module_name is not None:
+            return module_name
+        # Protect the iteration by using a list copy of importer.modules against dynamic
+        # modules that trigger imports of other modules upon calls to getattr.
+        for importer in self._importers:
+            for module_name, module in importer.modules.copy().items():
+                if (
+                    module_name == "__main__"
+                    or module_name == "__mp_main__"  # bpo-42406
+                    or module is None
+                ):
+                    continue
+                try:
+                    if _getattribute(module, name)[0] is obj:
+                        return module_name
+                except AttributeError:
+                    pass
+        return "__main__"
+
+
+_current_module_env = ModuleEnv()
+
+
+def get_current_module_env() -> ModuleEnv:
+    return _current_module_env
+
+
+@contextmanager
+def set_module_env(module_env: ModuleEnv):
+    global _current_module_env
+    orig = _current_module_env
+    _current_module_env = module_env
+    try:
+        yield _current_module_env
+    finally:
+        _current_module_env = orig


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51973 [fx/package] make GraphModules packageable
* **#51972 [package] Introduce ModuleEnv to manage module namespace collisions.**
* #51970 [fx] Make imports more selective in imported code.

See comments in code.