### PR TITLE
[FX] Fix leaf modules in Transformer

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1082,6 +1082,13 @@ class TestFX(JitTestCase):
         result = interp.run(torch.ones(3, 4), torch.ones(3, 4), torch.rand(3, 4))
         self.assertEqual(result, torch.ones(3, 4) * 2.0)
 
+    @skipIfNoTorchVision
+    def test_interpreter_noop_resnet18(self):
+        rn18 = resnet18()
+        transformed = torch.fx.Transformer(symbolic_trace(rn18)).transform()
+        inp = torch.randn(5, 3, 224, 224)
+        self.assertEqual(transformed(inp), rn18(inp))
+
     def test_transformer_noop(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -376,6 +376,12 @@ class Transformer(Interpreter):
         assert isinstance(target, str)
         return Proxy(self.new_graph.get_attr(target), self.tracer)
 
+    def call_module(self, target : 'Target', args : Tuple[Any], kwargs : Dict[str, Any]) -> Any:
+        # Override so that the leaf module policy from `self.tracer` is respected.
+        assert isinstance(target, str)
+        submod = self.fetch_attr(target)
+        return self.tracer.call_module(submod, submod.forward, args, kwargs)
+
     def transform(self) -> GraphModule:
         """
         Transform ``self.module`` and return the transformed


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #51816 [WIP][FX] Normalize torch.nn.functional calls and standard Module calls
* #52010 [FX][EZ] Fix tuple type annotations
* **#51998 [FX] Fix leaf modules in Transformer**

Previously leaf module preservation in `Transformer` silently didn't work. This makes it work

Differential Revision: [D26352087](https://our.internmc.facebook.com/intern/diff/D26352087)