### PR TITLE
test_lc_1d: Increase deadline to 5 seconds

### DIFF
--- a/caffe2/python/operator_test/locally_connected_op_test.py
+++ b/caffe2/python/operator_test/locally_connected_op_test.py
@@ -103,11 +103,9 @@ class TestLocallyConnectedOp(serial.SerializedTestCase):
            op_name=st.sampled_from(["LC", "LC1D"]),
            use_bias=st.booleans(),
            **hu.gcs)
-    @settings(deadline=1000)
+    @settings(deadline=5000)
+    # Increased timeout from 1 second to 5 for ROCM
     def test_lc_1d(self, N, C, size, M, kernel, op_name, use_bias, gc, dc):
-        if workspace.has_hip_support:
-            # Skip as test flaky on ROCM with deadline set to 1000
-            return
         if size < kernel:
             kernel = size
 


### PR DESCRIPTION
Increasing the deadline as to avoid
flakiness of the test on ROCM.

Signed-off-by: Roy, Arindam <rarindam@gmail.com>

Fixes #{issue number}
