### PR TITLE
require non-empty inputs to grad() calls in the API

### DIFF
--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -160,6 +160,13 @@ TEST(CustomAutogradTest, GradUnreachableDiscoveryTest) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+TEST(AutogradAPITests, EmptyInput) {
+  Variable x = torch::ones({1}, torch::requires_grad());
+  ASSERT_THROWS_WITH(grad({x * 2}, /*inputs=*/{}, {x}),
+                     "grad requires non-empty inputs.");
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(AutogradAPITests, RetainGrad) {
   auto input = torch::rand({1, 3}, torch::requires_grad());
   auto h1 = input * 3;

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -660,6 +660,11 @@ class TestAutograd(TestCase):
         y = x ** 2
         torch.autograd.grad(y, x)  # this should succeed now
 
+    def test_grad_empty_inputs(self):
+        x = torch.tensor([1.0], requires_grad=True)
+        with self.assertRaisesRegex(ValueError, "grad requires non-empty inputs."):
+            torch.autograd.grad(2 * x, [], grad_outputs=torch.tensor([1.0]))
+
     def test_grad_fn_badcalls(self):
         error_regex = 'expected .* arguments, got .* instead'
         x = torch.ones(1, requires_grad=True)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -15776,9 +15776,16 @@ def add_nn_module_test(*args, **kwargs):
         args_variable, kwargs_variable = create_input(input, dtype=dtype)
         f_args_variable = deepcopy(unpack_variables(args_variable))
 
+        # TODO(issue#52052) Neither this nor no_grad should be required
+        # if check_against_reference() is updated to check gradients
+        # w.r.t. weights and then only check w.r.t. inputs if any
+        # inputs require it.
+        any_requires_grad = any(input.requires_grad for input in f_args_variable)
+
         # Check against Python module as reference
         check_against_reference(self, create_script_module, create_nn_module,
-                                lambda x: x, f_args_variable, no_grad=no_grad)
+                                lambda x: x, f_args_variable,
+                                no_grad=no_grad or not any_requires_grad)
 
     if 'slowTest' in kwargs:
         do_test = slowTest(do_test)

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1379,7 +1379,8 @@ def gradgradcheck(
         input_args = args[:-num_outputs]
         grad_outputs = args[-num_outputs:]
         outputs = _differentiable_outputs(func(*input_args))
-        input_args = tuple(x for x in input_args if isinstance(x, torch.Tensor) and x.requires_grad)
+        input_args = tuple(x for x in input_args
+                           if is_tensor_like(x) and x.requires_grad)
         grad_inputs = torch.autograd.grad(outputs, input_args, grad_outputs, create_graph=True,
                                           allow_unused=True)
         grad_inputs = tuple(g for g in grad_inputs if g is not None)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -976,6 +976,13 @@ auto Engine::execute(const edge_list& roots,
       "If you have to use this function, make sure to reset the .grad fields of "
       "your parameters to None after use to break the cycle and avoid the leak.");
   }
+
+  // accumulate_grad is true if and only if the frontend call was to
+  // grad(), not backward(). grad() returns the sum of the gradients
+  // w.r.t. the inputs and thus needs the inputs to be present.
+  TORCH_CHECK_VALUE(accumulate_grad || !outputs.empty(),
+                    "grad requires non-empty inputs.");
+
   // A fresh first time Engine::execute call should start on the CPU device, initialize
   // a new thread local ready queue on CPU or reuse the existing one (if there is one
   // allocated already, i.e. consecutive backward calls, re-entrant backward calls),

--- a/torch/testing/_internal/common_jit.py
+++ b/torch/testing/_internal/common_jit.py
@@ -39,6 +39,12 @@ nn_functional_single_grad = frozenset('test_nn_' + name for name in [
 
 def check_against_reference(self, func, reference_func, output_func, args, kwargs=None,
                             allow_unused=True, check_types=True, no_grad=False, no_gradgrad=False):
+    """Verifies a function performs identically to some reference implementation.
+
+    Commonly, this is used to verify that a JIT implementation
+    (output_func) matches the behavior of the eager implementation
+    (reference_func).
+    """
     kwargs = kwargs if kwargs else {}
 
     def allSum(vs):


### PR DESCRIPTION
Summary:
The grad() function needs to return the updated values, and hence
needs a non-empty inputs to populate.

Test Plan:
Passes Python and C++ unit tests, and added new tests to catch this behavior.

Reviewers: alband

Subscribers: soulitzer

Tasks: https://github.com/pytorch/pytorch/issues/47061

Tags:

Fixes #47061


cc @ezyang @gchanan