### PR TITLE
change back to multiple_outputs_gpu_kernel for learnable fake per-channel quantization

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2165,57 +2165,41 @@ void fake_quant_per_channel_cachemask_cpu(
 }
 
 void fake_quantize_learnable_channel_grad_kernel_cpu(
-    TensorIterator& iter_x,
-    TensorIterator& iter_scale,
-    TensorIterator& iter_zero_point,
+    TensorIterator& iter,
     int64_t quant_min,
     int64_t quant_max,
     float grad_factor) {
-      // write x.grad
-  cpu_kernel(iter_x,
-    [=] (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dx_output;
-      float inv_scale = 1.0f / scale_input;
-      // Calculate gradients for X.
-      int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
-      dx_output = dy_input * (xqi >= quant_min && xqi <= quant_max);
-      return dx_output;
-    });
+  iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
+    /*  To see how the input and outputs are referenced and assigned,
+        please see the implemenetation of
+        fake_quantize_learnable_tensor_grad_kernel_cpu.
+    */
+    for (int64_t i = 0; i < n; i++) {
+      float* dx_output = (float*)(data[0] + i * strides[0]);
+      float* dscale_output = (float*)(data[1] + i * strides[1]);
+      float* dzero_point_output = (float*)(data[2] + i * strides[2]);
+      float* x_input = (float*)(data[3] + i * strides[3]);
+      float* dy_input = (float*)(data[4] + i * strides[4]);
+      float* scale_input = (float*)(data[5] + i * strides[5]);
+      float* zero_point_input = (float*)(data[6] + i * strides[6]);
 
-  // write scale.grad
-  cpu_kernel(iter_scale,
-    [=] (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dscale_output;
-      float inv_scale = 1.0f / scale_input;
-      float dscale_small = quant_min - zero_point_input;
-      float dscale_big = quant_max - zero_point_input;
+      float inv_scale = 1.0f / (*scale_input);
+      float dscale_small = quant_min - (*zero_point_input);
+      float dscale_big = quant_max - (*zero_point_input);
       // Calculate gradients for X.
-      int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
+      int64_t xqi = std::nearbyint((*zero_point_input) + (*x_input) * inv_scale);
+      *dx_output = (*dy_input) * (xqi >= quant_min && xqi <= quant_max);
       // Calculate gradients for scale and zero point.
-      float xfqi = static_cast<float>((std::max(std::min(xqi, quant_max), quant_min) - zero_point_input) * scale_input);
+      float xfqi = static_cast<float>((std::max(std::min(xqi, quant_max), quant_min) - (*zero_point_input)) * (*scale_input));
       if (xqi < quant_min || xqi > quant_max) {
-        dscale_output = ((xqi < quant_min) ? (dy_input * dscale_small) : (dy_input * dscale_big)) * grad_factor;
+        *dzero_point_output = (*dy_input) * (-1) * (*scale_input) * grad_factor;
+        *dscale_output = ((xqi < quant_min) ? ((*dy_input) * dscale_small) : ((*dy_input) * dscale_big)) * grad_factor;
       } else {
-        dscale_output = dy_input * (xfqi - x_input) * inv_scale * grad_factor;
+        *dzero_point_output = 0;
+        *dscale_output = (*dy_input) * (xfqi - (*x_input)) * inv_scale * grad_factor;
       }
-      return dscale_output;
-    });
-
-  // write zero_point_grad
-  cpu_kernel(iter_zero_point,
-    [=] (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dzero_point_output;
-      float inv_scale = 1.0f / scale_input;
-      // Calculate gradients for X.
-      int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
-      // Calculate gradients for scale and zero point.
-      if (xqi < quant_min || xqi > quant_max) {
-        dzero_point_output = dy_input * (-1) * scale_input * grad_factor;
-      } else {
-        dzero_point_output = 0;
-      }
-      return dzero_point_output;
-    });
+    }
+  });
 }
 
 // Assumes X is composed of M groups of N elements. Normalizes each of the

--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -112,54 +112,26 @@ void fake_quant_per_channel_cachemask_cuda(
     });
 }
 
-void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter_x, TensorIterator &iter_scale, TensorIterator &iter_zero_point, int64_t quant_min, int64_t quant_max, float grad_factor) {
-  // TODO(future, optional): use three gpu_kernel calls instead of one gpu_kernel_multiple_outputs
-  // because current gpu_kernel_multiple_outputs gives incorrect results on CUDA11
-  // change to use gpu_kernel_multiple_outputs for efficiency when it get fixed
-  // write x.grad
-  gpu_kernel(iter_x,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dx_output;
-      float inv_scale = 1.0f / scale_input;
-      // Calculate gradients for X.
-      int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
-      dx_output = dy_input * (xqi >= quant_min && xqi <= quant_max);
-      return dx_output;
-    });
-
-  // write scale.grad
-  gpu_kernel(iter_scale,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dscale_output;
+void _fake_quantize_grad_learnable_channel_kernel_cuda(TensorIterator &iter, int64_t quant_min, int64_t quant_max, float grad_factor) {
+  gpu_kernel_multiple_outputs(iter,
+    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> thrust::tuple<float, float, float> {
+      float dx_output, dscale_output, dzero_point_output;
       float inv_scale = 1.0f / scale_input;
       float dscale_small = quant_min - zero_point_input;
       float dscale_big = quant_max - zero_point_input;
       // Calculate gradients for X.
       int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
+      dx_output = dy_input * (xqi >= quant_min && xqi <= quant_max);
       // Calculate gradients for scale and zero point.
       float xfqi = static_cast<float>((std::max(std::min(xqi, quant_max), quant_min) - zero_point_input) * scale_input);
       if (xqi < quant_min || xqi > quant_max) {
+        dzero_point_output = dy_input * (-1) * scale_input * grad_factor;
         dscale_output = ((xqi < quant_min) ? (dy_input * dscale_small) : (dy_input * dscale_big)) * grad_factor;
       } else {
+        dzero_point_output = 0;
         dscale_output = dy_input * (xfqi - x_input) * inv_scale * grad_factor;
       }
-      return dscale_output;
-    });
-
-  // write zero_point_grad
-  gpu_kernel(iter_zero_point,
-    [=] GPU_LAMBDA (float x_input, float dy_input, float scale_input, float zero_point_input) -> float {
-      float dzero_point_output;
-      float inv_scale = 1.0f / scale_input;
-      // Calculate gradients for X.
-      int64_t xqi = std::nearbyint(x_input * inv_scale) + static_cast<int64_t>(zero_point_input);
-      // Calculate gradients for scale and zero point.
-      if (xqi < quant_min || xqi > quant_max) {
-        dzero_point_output = dy_input * (-1) * scale_input * grad_factor;
-      } else {
-        dzero_point_output = 0;
-      }
-      return dzero_point_output;
+      return {dx_output, dscale_output, dzero_point_output};
     });
 }
 

--- a/aten/src/ATen/native/quantized/fake_quant_affine.h
+++ b/aten/src/ATen/native/quantized/fake_quant_affine.h
@@ -44,9 +44,7 @@ using fake_quant_per_channel_cachemask_fn = void (*)(
 DECLARE_DISPATCH(fake_quant_per_channel_cachemask_fn, fake_quant_per_channel_cachemask_stub);
 
 using fake_quant_learnable_per_channel_fn = void (*)(
-    TensorIterator &iter_x,
-    TensorIterator &iter_scale,
-    TensorIterator &iter_zero_point,
+    TensorIterator &iter,
     int64_t quant_min,
     int64_t quant_max,
     float grad_factor);

--- a/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_channel_affine.cpp
@@ -227,23 +227,9 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
   auto scale_vectorized = scale.reshape(at::IntArrayRef(axis_mask, numDimensions)).expand(X_shape);
   auto zero_point_vectorized = zero_point.reshape(at::IntArrayRef(axis_mask, numDimensions)).expand(X_shape);
 
-  auto iter_x = TensorIteratorConfig()
+  auto iter = TensorIteratorConfig()
     .add_output(dX)
-    .add_input(X)
-    .add_input(dY)
-    .add_input(scale_vectorized)
-    .add_input(zero_point_vectorized)
-    .build();
-
-  auto iter_scale = TensorIteratorConfig()
     .add_output(dScale_vec)
-    .add_input(X)
-    .add_input(dY)
-    .add_input(scale_vectorized)
-    .add_input(zero_point_vectorized)
-    .build();
-
-  auto iter_zero_point = TensorIteratorConfig()
     .add_output(dZeroPoint_vec)
     .add_input(X)
     .add_input(dY)
@@ -252,7 +238,7 @@ std::tuple<Tensor, Tensor, Tensor> _fake_quantize_learnable_per_channel_affine_b
     .build();
 
   fake_quant_grad_learnable_channel_stub(
-    X.device().type(), iter_x, iter_scale, iter_zero_point, quant_min, quant_max, grad_factor);
+    X.device().type(), iter, quant_min, quant_max, grad_factor);
 
   auto numElements = X.ndimension() - 1;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52017 change back to multiple_outputs_gpu_kernel for learnable fake per-channel quantization**

Change back to multiple_outputs_gpu_kernel for per-channel quantization backward c++/cuda implementations (for diff D24479735)

Differential Revision: [D26357325](https://our.internmc.facebook.com/intern/diff/D26357325/)