### PR TITLE
Add custom implementation for  `csqrt` if libc++ is used

### DIFF
--- a/c10/test/util/complex_test_common.h
+++ b/c10/test/util/complex_test_common.h
@@ -548,6 +548,10 @@ void test_values_() {
 TEST(TestStd, BasicFunctions) {
   test_values_<float>();
   test_values_<double>();
+  // CSQRT edge cases: checks for overflows which are likely to occur
+  // if square root is computed using polar form
+  ASSERT_LT(std::abs(std::sqrt(c10::complex<float>(-1e20, -4988429.2)).real()), 3e-4);
+  ASSERT_LT(std::abs(std::sqrt(c10::complex<double>(-1e60, -4988429.2)).real()), 3e-4);
 }
 
 } // namespace test_std

--- a/c10/util/complex_math.cpp
+++ b/c10/util/complex_math.cpp
@@ -1,0 +1,59 @@
+#include <c10/util/complex.h>
+
+#include <cmath>
+#include <istream>
+#include <limits>
+#include <iomanip>
+
+// Note [ Complex Square root in libc++]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// In libc++ complex square root is computed using polar form
+// This is a reasonably fast algorithm, but can result in significant
+// numerical errors when arg is close to 0, pi/2, pi, or 3pi/4
+// In that case provide a more conservative implementation which is
+// slower but less prone to those kinds of errors
+
+#ifdef _LIBCPP_VERSION
+
+namespace {
+template<typename T>
+c10::complex<T> compute_csqrt(const c10::complex<T>& z) {
+  constexpr auto half = T(.5);
+
+  // Trust standard library to correctly handle infs and NaNs
+  if (std::isinf(z.real()) || std::isinf(z.imag()) ||
+      std::isnan(z.real()) || std::isnan(z.imag())) {
+    return static_cast<c10::complex<T>>(std::sqrt(static_cast<std::complex<T>>(z)));
+  }
+
+  // Special case for square root of pure imaginary values
+  if (z.real() == T(0)) {
+    if (z.imag() == T(0)) {
+      return c10::complex<T>(T(0), z.imag());
+    }
+    auto v = std::sqrt(half * std::abs(z.imag()));
+    return c10::complex<T>(v, std::copysign(v, z.imag()));
+  }
+
+  // At this point, z is non-zero and finite
+  if (z.real() >= 0.0) {
+    auto t = std::sqrt((z.real() + std::abs(z)) * half);
+    return c10::complex<T>(t, half * (z.imag() / t));
+  }
+
+  auto t = std::sqrt((-z.real() + std::abs(z)) * half);
+  return c10::complex<T>(half * std::abs(z.imag() / t), std::copysign(t, z.imag()));
+}
+} // anonymous namespace
+
+namespace c10_complex_math { namespace _detail {
+c10::complex<float> sqrt(const c10::complex<float>& in) {
+  return compute_csqrt(in);
+}
+
+c10::complex<double> sqrt(const c10::complex<double>& in) {
+  return compute_csqrt(in);
+}
+
+}}
+#endif

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -41,13 +41,22 @@ C10_HOST_DEVICE inline c10::complex<T> log2(const c10::complex<T> &x) {
 }
 
 // Power functions
+//
+#ifdef _LIBCPP_VERSION
+namespace _detail {
+TORCH_API c10::complex<float> sqrt(const c10::complex<float>& in);
+TORCH_API c10::complex<double> sqrt(const c10::complex<double>& in);
+};
+#endif
 
 template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> sqrt(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::sqrt(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
-#else
+#elif !defined(_LIBCPP_VERSION)
   return static_cast<c10::complex<T>>(std::sqrt(static_cast<std::complex<T>>(x)));
+#else
+  return _detail::sqrt(x);
 #endif
 }
 

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -11,7 +11,7 @@ import unittest
 from torch._six import inf, nan
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, torch_to_numpy_dtype_dict, numpy_to_torch_dtype_dict,
-    suppress_warnings, IS_MACOS, make_tensor, TEST_SCIPY, slowTest, skipIfNoSciPy,
+    suppress_warnings, make_tensor, TEST_SCIPY, slowTest, skipIfNoSciPy,
     gradcheck)
 from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs)
@@ -464,14 +464,13 @@ class TestUnaryUfuncs(TestCase):
             torch.nan_to_num(x, out=out, nan=nan, posinf=posinf, neginf=neginf)
             self.assertEqual(result, out)
 
-    @unittest.skipIf(IS_MACOS, "Skip Reference: https://github.com/pytorch/pytorch/issues/47500")
     @dtypes(torch.cfloat, torch.cdouble)
     def test_sqrt_complex_edge_values(self, device, dtype):
         # Test Reference: https://github.com/pytorch/pytorch/pull/47424
         x = torch.tensor(0. - 1.0000e+20j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)
 
-        x = torch.tensor(-1.0000e+20 - 4988429.2000j, dtype=dtype, device=device)
+        x = torch.tensor((-1.0e+60 if dtype == torch.cdouble else -1.0e+20) - 4988429.2j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)
 
     @unittest.skipIf(not TEST_SCIPY, "Requires SciPy")


### PR DESCRIPTION
libc++ implements csqrt using polar form of the number, which results in higher numerical error, if `arg` is close to 0, pi/2, pi, 3pi/4

Fixes https://github.com/pytorch/pytorch/issues/47500