### PR TITLE
Add size op in nnapi serializer

### DIFF
--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -593,6 +593,8 @@ class _NnapiSerializer(object):
             self.add_tuple_construct(node),
         "aten::reshape": lambda self, node:
             self.add_reshape(node),
+        "aten::size": lambda self, node:
+            self.add_size(node),
         "aten::quantize_per_tensor": lambda self, node:
             self.add_quantize(node),
         "aten::dequantize": lambda self, node:
@@ -705,6 +707,16 @@ class _NnapiSerializer(object):
         outputs[0] = self.add_tensor_operand(node.outputsAt(0), out_oper)
 
         self.add_operation(NNAPI_OperationCode.RESHAPE, inputs, outputs)
+
+    def add_size(self, node):
+        assert node.inputsSize() == 2
+        assert node.outputsSize() == 1
+
+        _, in_oper = self.get_tensor_operand_by_jitval(node.inputsAt(0))
+        _, value = self.constants[node.inputsAt(1)]
+        res = in_oper.shape[value]
+        output = node.outputsAt(0)
+        self.add_constant_value(output, output.type(), res)
 
     def add_quantize(self, node):
         assert node.inputsSize() == 4


### PR DESCRIPTION
Summary:

serializer didn't support aten::size

Test Plan:

Torchvision Mobilenetv2 [script](https://pytorch.org/tutorials/prototype/nnapi_mobilenetv2.html) works. [Test](https://github.com/pytorch/pytorch/commit/ecfed07cc599b7c95e98d692984d47cbee769a85) to be merged after [this PR](https://github.com/pytorch/pytorch/pull/47521/files) is merged
