### PR TITLE
Add missing shutdown call in RPC tests

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4613,6 +4613,8 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture):
 
         self.assertFalse(rpc.api._is_current_rpc_agent_set())
 
+        rpc.shutdown()
+
     @skip_if_lt_x_gpu(2)
     def test_device_maps_wrong_worker_name(self):
         options = self.rpc_backend_options


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52042 Add missing shutdown call in RPC tests**

Differential Revision: [D26367632](https://our.internmc.facebook.com/intern/diff/D26367632/)