### PR TITLE
Adding infos= variant for torch.linalg.inv

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -687,7 +687,7 @@ Tensor& _linalg_inv_out_helper_cpu(Tensor &result, Tensor& infos_lu, Tensor& inf
 
 // Computes the inverse matrix of 'input', it is is saved to 'result' in-place
 // LAPACK/MAGMA/cuSOLVER error codes are saved in 'infos' tensors, they are not checked here
-static Tensor& linalg_inv_out_info(Tensor& result, Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
+Tensor linalg_inv_out_info(Tensor& result, Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
   squareCheckInputs(input);
   TORCH_INTERNAL_ASSERT(infos_lu.scalar_type() == kInt);
   TORCH_INTERNAL_ASSERT(infos_getri.scalar_type() == kInt);
@@ -722,7 +722,7 @@ static Tensor& linalg_inv_out_info(Tensor& result, Tensor& infos_lu, Tensor& inf
 Tensor& linalg_inv_out(Tensor &result, const Tensor &input) {
   auto infos_lu = at::empty({0}, input.options().dtype(kInt));
   auto infos_getri = at::empty({0}, input.options().dtype(kInt));
-  result = linalg_inv_out_info(result, infos_lu, infos_getri, input);
+  at::native::linalg_inv_out_info(result, infos_lu, infos_getri, input);
 
   // Now check LAPACK/MAGMA/cuSOLVER error codes
   if (result.dim() > 2) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9021,6 +9021,14 @@
   dispatch:
     DefaultBackend: linalg_inv_out
 
+# codegen requires all mutable kwargs to be returned
+# so we can't just register another linalg_inv version with a different number of mutables
+- func: linalg_inv_out_info(Tensor(a!) out, Tensor(b!) infos_lu, Tensor(c!) infos_getri, Tensor input) -> Tensor
+  python_module: linalg
+  variants: function
+  dispatch:
+    DefaultBackend: linalg_inv_out_info
+
 - func: inner(Tensor self, Tensor other) -> Tensor
   variants: function, method
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2441,6 +2441,7 @@ class TestLinalg(TestCase):
             a.requires_grad_()
             infos1 = torch.empty(0, dtype=torch.int, device=device)
             infos2 = torch.empty(0, dtype=torch.int, device=device)
+
             def func(a):
                 return torch.linalg.inv(a, infos=(infos1, infos2))
             gradcheck(func, a)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -593,6 +593,9 @@
 - name: linalg_inv(Tensor self) -> Tensor
   self: -at::matmul(result.conj().transpose(-2, -1), at::matmul(grad, result.conj().transpose(-2, -1)))
 
+- name: linalg_inv_out_info(Tensor(a!) out, Tensor(b!) infos_lu, Tensor(c!) infos_getri, Tensor input) -> Tensor
+  input: -at::matmul(result.conj().transpose(-2, -1), at::matmul(grad, result.conj().transpose(-2, -1)))
+
 - name: isnan(Tensor self) -> Tensor
   self: non_differentiable
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -86,7 +86,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'exp', 'nonzero', 'mean', 'inverse', 'solve', 'linalg_cholesky', 'addcmul', 'addcdiv',
     'matrix_exp', 'linalg_eigh', 'cholesky_solve', 'linalg_qr', '_svd_helper', '_fft_c2c', '_fft_r2c',
     'linalg_solve', 'sqrt', 'stack', 'gather', 'index_select', 'index_add_', 'linalg_inv',
-    'l1_loss_backward', 'baddbmm', 'addbmm', 'addmm', 'addmv', 'addr',
+    'l1_loss_backward', 'baddbmm', 'addbmm', 'addmm', 'addmv', 'addr', 'linalg_inv_out_info',
     'constant_pad_nd', 'reflection_pad1d', 'reflection_pad2d',
     'reflection_pad1d_backward', 'reflection_pad2d_backward',
     'replication_pad1d', 'replication_pad2d', 'replication_pad3d',

--- a/torch/csrc/api/include/torch/linalg.h
+++ b/torch/csrc/api/include/torch/linalg.h
@@ -108,6 +108,16 @@ inline Tensor& inv_out(Tensor& result, const Tensor& input) {
   return torch::linalg_inv_out(result, input);
 }
 
+inline Tensor inv(Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
+  Tensor out = torch::empty({0}, input.options());
+  return torch::linalg_inv_out_info(out, infos_lu, infos_getri, input);
+}
+
+inline Tensor& inv_out(Tensor& result, Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
+  torch::linalg_inv_out_info(result, infos_lu, infos_getri, input);
+  return result;
+}
+
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 
@@ -260,6 +270,14 @@ inline Tensor inv(const Tensor& input) {
 
 inline Tensor& inv_out(Tensor& result, const Tensor& input) {
   return detail::inv_out(result, input);
+}
+
+inline Tensor inv(Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
+  return detail::inv(infos_lu, infos_getri, input);
+}
+
+inline Tensor inv_out(Tensor& result, Tensor& infos_lu, Tensor& infos_getri, const Tensor& input) {
+  return detail::inv_out(result, infos_lu, infos_getri, input);
 }
 
 }} // torch::linalg

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -161,7 +161,7 @@ def inv(input: Tensor, *, out: Tensor = None, infos: Optional[Tuple[Tensor, Tens
         infos_lu, infos_getri = infos
         if out is None:
             out = torch.empty(0, dtype=input.dtype, device=input.device)
-        return torch._C._linalg.linalg_inv_out_info(out, infos_lu, infos_getri, input)
+        return _linalg.linalg_inv_out_info(out, infos_lu, infos_getri, input)
 
 det = _add_docstr(_linalg.linalg_det, r"""
 linalg.det(input) -> Tensor


### PR DESCRIPTION
I open this PR for collecting the feedback and opening the discussion on possible ways to implement variants of functions
that call LAPACK API without checking for error codes returned by LAPACK API. Here LAPACK API refers to LAPACK/MKL/cuSOLVER/MAGMA. There are several reasons not to check the error code:
* for CUDA inputs and if error codes are stored on GPU (it is the case with cuSOLVER and most batched MAGMA functions) checking the actual values causes cross-device memory synchronization.
* for batched inputs if at least one of the matrices in the batch is non-invertible raising the error ruins the whole inversion process

The first question: do we actually want to return the LAPACK error codes?
For example CuPy disables all error checks by default and doesn't have the way to expose the error codes to the user.

If we decide to expose somehow the error codes to the user then how should it be done?
I prefer the option of not changing the return signature and fill the provided Tensor with error codes in-place.
So in code this would be
```python
import torch
a = torch.randn(3, 3)
# torch.linalg.inv has two different LAPACK calls, hence two Tensors for error codes
info1 = torch.empty(1)
info2 = torch.empty(1)
a_inverse = torch.linalg.inv(a, infos=(info1, info2))

# or for batched input case
a = torch.randn(5, 3, 3)
info1 = torch.empty(5)
info1 = torch.empty(5)
a_inverse = torch.linalg.inv(a, infos=(info1, info2))
```

Another option could be (which I dislike because the number of returned elements changes depending on the flag and it is incompatible with other libraries):
```python
a_inverse, info1, info2 = torch.linalg.inv(a, infos=True)
```

There are several issues when trying to implement the variant that returns `infos` tensors such that it behaves as the normal function (supports autograd, etc.):
 * current PyTorch code generation doesn't allow not returning mutable keyword arguments, it's all considered as "out" function and all mutables should be returned
```python
# codegen requires all mutable kwargs to be returned
# so we can't just register another linalg_inv version with a different number of mutables
# then we decide to register a new function
 - func: linalg_inv_no_check.out(Tensor input, *, Tensor(a!) out, Tensor(b!) infos_lu, Tensor(c!) infos_getri) -> (Tensor(a!) out, Tensor(b!) infos_lu, Tensor(c!) infos_getri)
  python_module: linalg
  variants: function
  dispatch:
    DefaultBackend: linalg_inv_out_info

# non-out variant must be registered as well
- func: linalg_inv_no_check(Tensor input) -> Tensor
  python_module: linalg
  variants: function
  dispatch:
    DefaultBackend: linalg_inv
```
 * if "out" variant is used for the implementation then autograd support is disabled
 * current implementation in this PR supports autograd but leads to a duplicated entry in `derivatives.yml`
```python
# Exposing already implemented function to ATen and Python
# Return must be "Tensor" otherwise the program segfaults when this function is called from Python
# and I didn't investigate it further
- func: linalg_inv_out_info(Tensor(a!) out, Tensor(b!) infos_lu, Tensor(c!) infos_getri, Tensor input) -> Tensor
  python_module: linalg
  variants: function
  dispatch:
    DefaultBackend: linalg_inv_out_info
```


This would fix https://github.com/pytorch/pytorch/issues/25095
Ref. #42666, #47953

cc: @rgommers 