### PR TITLE
Refactor autograd discovery code

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1133,7 +1133,8 @@ void GraphTask::init_to_execute(Node& graph_root, const edge_list& outputs, bool
   //       seen.add(child_fn)
   //       if compute_is_needed(child_fn):
   //         is_needed[fn] = true                         # (2)
-  //                                                      # (3)
+  //                                                      # (3) exit for-loop
+  //   return is_needed[fn]
   // compute_is_needed(graph_root)
   //
   int output_idx = 0;
@@ -1201,7 +1202,7 @@ void GraphTask::init_to_execute(Node& graph_root, const edge_list& outputs, bool
       // (3) no next child exists for `fn` means its `needed` has already been
       // finalized. pop stack and update parent
       stack.pop_back();
-      if (!stack.empty() && nodeShouldExecute(fn)) {
+      if (nodeShouldExecute(fn) && !stack.empty()) {
         exec_info_[stack.back().fn_].needed_ = true;
       }
     }

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -1121,6 +1121,9 @@ void GraphTask::init_to_execute(Node& graph_root, const edge_list& outputs, bool
   // Only nodes that have a path to any edge in `outputs` should be executed.
   // The code below populates exec_info using recursion, but the actual code does this
   // iteratively. Refer to the numbering to see how the actual code corresponds.
+  // A difference to note is that in the iterative version, when you are working with
+  // the current Node, you are reponsible to update your parent's is_needed after all your
+  // children have been updated.
   //
   // is_needed = {fn: True for fn in outputs}             # (0)
   // seen = {}
@@ -1137,6 +1140,9 @@ void GraphTask::init_to_execute(Node& graph_root, const edge_list& outputs, bool
   //   return is_needed[fn]
   // compute_is_needed(graph_root)
   //
+  // NB: you might be wondering why we don't populate `seen` with outputs. We cannot
+  // because in the case where two outputs lie on the same path, we still need to explore past
+  // the first output or we would miss the nodes that are required to compute the second output.
   int output_idx = 0;
   for (auto & output_edge : outputs) {
     // (0) `is_needed` above corresponds to `exec_info_[fn].needed_`


### PR DESCRIPTION
Fixes #34067 by using #34426 by @hczhu 
In addition to removing the unnecessary any() we do also:
 - Get rid of the outer loop since graph_root also needs to be checked
 - Update psuedo code description so it matches what the code does
 - Add some comments explaining the difference between assigning `info.needed_` and `info.captures_` in terms of how that affects discovery
 - [edit: another benefit is that exec_info entries are no longer created for all reachable nodes]

This PR is on top of #51940, so once that lands rebasing on top of master should get rid of the extra commits and changes

I'm not sure if this change will bring a lot of performance gains, but the main benefit is that the code is easier to read.

Trivial graph:
```
torch.autograd.grad(a*b, [a, b], gradient)
setup:
  a = torch.rand((2, 2), requires_grad=True)
  b = torch.rand((2, 2), requires_grad=True)
  gradient = torch.ones(2, 2)

Timer before:
  15.45 us
Time after:
  14.33 us
1 measurement, 10000 runs , 1 thread

Instructions after:
                           All          Noisy symbols removed
    Instructions:      8271213                    8193169
    Baseline:             4244                       3838
Instructions before:
                           All          Noisy symbols removed
    Instructions:      8142843                    8054463
    Baseline:             4280                       3838
100 runs per measurement, 1 thread
```
Small graph:
```
torch.autograd.grad((b*a.exp()+a*b.exp()).sum(), (a, b))
setup:
  a = torch.rand((2, 2), requires_grad=True)
  b = torch.rand((2, 2), requires_grad=True)

Time before:
  52.25 us
Time after:
  50.80 us
1 measurement, 10000 runs , 1 thread

Instruction count before:
                           All          Noisy symbols removed
    Instructions:     25601257                   25518229
    Baseline:             4228                       3838
Instruction count after:
                           All          Noisy symbols removed
    Instructions:     25606533                   25522797
    Baseline:             4228   
100 runs per measurement, 1 thread
```