### PR TITLE
Move is_complex() directly onto Tensor

### DIFF
--- a/aten/src/ATen/BatchingRegistrations.cpp
+++ b/aten/src/ATen/BatchingRegistrations.cpp
@@ -1027,7 +1027,6 @@ TORCH_LIBRARY_IMPL(aten, Batched, m) {
   m.impl("_remove_batch_dim", native::_remove_batch_dim);
 
   m.impl("sum.dim_IntList", sum_batching_rule);
-  m.impl("is_complex", native::is_complex);
   m.impl("conj", native::conj);
 
   // inplace operations

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -786,7 +786,7 @@ static inline Tensor& bmm_out_or_baddbmm_(Tensor& self_or_result, const Tensor& 
             self_or_result.scalar_type() != kHalf &&
             self_or_result.scalar_type() != kBFloat16 &&
             at::native::is_floating_point(self_or_result)) ||
-            at::native::is_complex(self_or_result))
+            at::is_complex(self_or_result))
             && batch_items_contiguous_or_transposed(batch1)
             && batch_items_contiguous_or_transposed(batch2)
             && self_or_result.is_contiguous()) {

--- a/aten/src/ATen/native/TypeProperties.cpp
+++ b/aten/src/ATen/native/TypeProperties.cpp
@@ -14,10 +14,6 @@ bool is_distributed(const Tensor& self) {
   return false;
 }
 
-bool is_complex(const Tensor& self) {
-  return self.is_complex();
-}
-
 bool is_floating_point(const Tensor& self) {
   return at::isFloatingType(self.scalar_type());
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2083,11 +2083,6 @@
   variants: function, method
   device_guard: False
 
-- func: is_complex(Tensor self) -> bool
-  variants: function, method
-  device_guard: False
-  manual_cpp_binding: True
-
 - func: isreal(Tensor self) -> Tensor
   variants: function, method
 

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -377,6 +377,9 @@ class TORCH_API Tensor {
   /// also have other designations.
   bool is_meta() const;
 
+  /// Returns if a `Tensor` has a complex datatype.
+  bool is_complex() const;
+
   /// If a tensor is a quantized tensor, returns its quantizer
   /// TODO: it's not in native_functions.yaml yet as it's not exposed to python
   QuantizerPtr quantizer() const;
@@ -780,6 +783,8 @@ protected:
 #endif
 
 int64_t get_device(Tensor self);
+
+bool is_complex(const Tensor& self);
 
 template <typename T>
 auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_void_t<T> {

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -780,8 +780,6 @@ protected:
 
 int64_t get_device(Tensor self);
 
-bool is_complex(const Tensor& self);
-
 template <typename T>
 auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_void_t<T> {
   // Return the grad argument in case of a hook with void return type to have an

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -125,10 +125,6 @@ class TORCH_API Tensor {
     }
   }
 
-  bool is_complex() const {
-    return at::isComplexType(this->scalar_type());
-  }
-
   int64_t size(int64_t dim) const {
     // false is passed to maybe_wrap_dim so behavior is identical to array access (but with wrapping)
     dim = c10::maybe_wrap_dim(dim, this->dim(), false);

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -96,10 +96,6 @@ bool Tensor::is_complex() const {
   return at::isComplexType(this->scalar_type());
 }
 
-bool is_complex(const Tensor& self) {
-  return self.is_complex();
-}
-
 NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -91,6 +91,15 @@ bool Tensor::is_xla() const {
     return impl_->is_xla();
 }
 
+bool Tensor::is_complex() const {
+  // NB: this is not a native function to avoid dispatching overhead.
+  return at::isComplexType(this->scalar_type());
+}
+
+bool is_complex(const Tensor& self) {
+  return self.is_complex();
+}
+
 NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }

--- a/tools/autograd/templates/python_torch_functions.cpp
+++ b/tools/autograd/templates/python_torch_functions.cpp
@@ -451,6 +451,8 @@ static PyObject * THPVariable_get_device(PyObject* self_, PyObject* args, PyObje
 
 static PyObject * THPVariable_numel(PyObject* self_, PyObject* args, PyObject* kwargs);
 
+static PyObject * THPVariable_is_complex(PyObject* self_, PyObject* args, PyObject* kwargs);
+
 // generated forward declarations start here
 
 ${py_forwards}
@@ -480,6 +482,7 @@ static PyMethodDef torch_functions[] = {
   {"from_numpy", THPVariable_from_numpy, METH_STATIC | METH_O, NULL},
   {"full", castPyCFunctionWithKeywords(THPVariable_full), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"hsmm", castPyCFunctionWithKeywords(THPVariable_hspmm), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
+  {"is_complex", castPyCFunctionWithKeywords(THPVariable_is_complex), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"nonzero", castPyCFunctionWithKeywords(THPVariable_nonzero), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"randint", castPyCFunctionWithKeywords(THPVariable_randint), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
   {"range", castPyCFunctionWithKeywords(THPVariable_range), METH_VARARGS | METH_KEYWORDS | METH_STATIC, NULL},
@@ -605,6 +608,27 @@ static PyObject * THPVariable_numel(PyObject* self_, PyObject* args, PyObject* k
 
   if (r.idx == 0) {
     return wrap(r.tensor(0).numel());
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject * THPVariable_is_complex(PyObject* self_, PyObject* args, PyObject* kwargs)
+{
+  HANDLE_TH_ERRORS
+  static PythonArgParser parser({
+    "is_complex(Tensor input)",
+  }, /*traceable=*/false);
+
+  ParsedArgs<1> parsed_args;
+  auto r = parser.parse(args, kwargs, parsed_args);
+
+  if(r.has_torch_function()){
+    return handle_torch_function(r, args, kwargs, THPVariableFunctionsModule, "torch");
+  }
+
+  if (r.idx == 0) {
+    return wrap(r.tensor(0).is_complex());
   }
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -226,6 +226,18 @@ static PyObject * THPVariable_numel(PyObject* self, PyObject* args)
    END_HANDLE_TH_ERRORS
 }
 
+// implemented on the python object to avoid dispatch overhead
+static PyObject * THPVariable_is_complex(PyObject* self, PyObject* args)
+{
+   HANDLE_TH_ERRORS
+   if (check_has_torch_function(self)) {
+     return handle_torch_function(self, "is_complex", args);
+   }
+   auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+   return wrap(self_.is_complex());
+   END_HANDLE_TH_ERRORS
+}
+
 static Tensor dispatch_contiguous(const Tensor & self, at::MemoryFormat memory_format) {
   pybind11::gil_scoped_release no_gil;
   OptionalDeviceGuard device_guard(device_of(self));
@@ -1185,6 +1197,7 @@ PyMethodDef variable_methods[] = {
   {"half", castPyCFunctionWithKeywords(THPVariable_half), METH_VARARGS | METH_KEYWORDS, NULL},
   {"int", castPyCFunctionWithKeywords(THPVariable_int), METH_VARARGS | METH_KEYWORDS, NULL},
   {"is_contiguous", castPyCFunctionWithKeywords(THPVariable_is_contiguous), METH_VARARGS | METH_KEYWORDS, NULL},
+  {"is_complex", THPVariable_is_complex, METH_NOARGS, NULL},
   {"item", THPVariable_item, METH_NOARGS, NULL},
   {"long", castPyCFunctionWithKeywords(THPVariable_long), METH_VARARGS | METH_KEYWORDS, NULL},
   {"map_", castPyCFunctionWithKeywords(THPVariable_map_), METH_VARARGS | METH_KEYWORDS, NULL},

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -444,6 +444,7 @@ def gen_pyi(native_yaml_path: str, deprecated_yaml_path: str, fm: FileManager) -
         'has_names': ['def has_names(self) -> _bool: ...'],
         'is_contiguous': ['def is_contiguous(self, memory_format=torch.contiguous_format) -> _bool: ...'],
         '_is_view': ['def _is_view(self) -> _bool: ...'],
+        'is_complex': ['def is_complex(self) -> _bool: ...'],
         'is_cuda': ['is_cuda: _bool'],
         'is_leaf': ['is_leaf: _bool'],
         'is_sparse': ['is_sparse: _bool'],

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -533,6 +533,16 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      OperatorGenerator(
+         TORCH_SELECTIVE_SCHEMA("aten::is_complex(Tensor self) -> bool"),
+         [](Stack* stack) {
+           RECORD_FUNCTION("is_complex", std::vector<c10::IValue>());
+           auto result =
+               ((std::move(peek(stack, 0, 1))).toTensor()).is_complex();
+           drop(stack, 1);
+           pack(stack, result);
+         },
+         aliasAnalysisFromSchema()),
+     OperatorGenerator(
          TORCH_SELECTIVE_SCHEMA("aten::is_contiguous(Tensor self) -> bool"),
          [](Stack* stack) {
            RECORD_FUNCTION("is_contiguous", std::vector<c10::IValue>());


### PR DESCRIPTION
Addresses `is_complex` for #44809

Removes `is_complex` from `native_functions.yaml` and implements it directly within `TensorBody.h` / `TensorMethods.cpp`. Supports both function and method forms and exposes them to Python.