### PR TITLE
Fix Pytorch docker image name by adding the registry prefix

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -17,10 +17,10 @@ make -f docker.Makefile \
 
 # Get the PYTORCH_NIGHTLY_COMMIT from the docker image
 PYTORCH_NIGHTLY_COMMIT=$(docker run \
-       pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
+       ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
        python -c 'import torch; print(torch.version.git_version)' | head -c 7)
-docker tag pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
-       pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}
+docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
+       ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}
 
 # Push the nightly docker to GitHub Container Registry
 echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -13,8 +13,10 @@ jobs:
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           ref: master
-      - run: |
+      - name: Build and upload nightly docker
+        run: |
           bash .github/scripts/build_publish_nightly_docker.sh


### PR DESCRIPTION
Test plan:
 Manually trigger the CI

Fixes the [nightly docker pipeline failure](https://github.com/pytorch/pytorch/actions?query=workflow%3A%22Build+PyTorch+nightly+Docker+image+and+push+to+GitHub+Container+Registry%22)