### PR TITLE
Update vec_mergee operand specifiers (_vecb)

### DIFF
--- a/aten/src/ATen/cpu/vec256/vsx/vec256_complex_float_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_complex_float_vsx.h
@@ -328,12 +328,12 @@ class Vec256<ComplexFlt> {
 
   Vec256<ComplexFlt> el_mergee() const {
     // as mergee phased in , we can use vec_perm with mask
-    return {vec_mergee(_vec0, _vec0), vec_mergee(_vec1, _vec1)};
+    return {vec_mergee(_vecb0, _vecb0), vec_mergee(_vecb1, _vecb1)};
   }
 
   Vec256<ComplexFlt> el_mergeo() const {
     // as mergeo phased in , we can use vec_perm with mask
-    return {vec_mergeo(_vec0, _vec0), vec_mergeo(_vec1, _vec1)};
+    return {vec_mergeo(_vecb0, _vecb0), vec_mergeo(_vecb1, _vecb1)};
   }
 
   Vec256<ComplexFlt> el_madd(
@@ -349,8 +349,8 @@ class Vec256<ComplexFlt> {
       Vec256<ComplexFlt>& second) {
     // as mergee phased in , we can use vec_perm with mask
     return {
-        vec_mergee(first._vec0, second._vec0),
-        vec_mergee(first._vec1, second._vec1)};
+        vec_mergee(first._vecb0, second._vecb0),
+        vec_mergee(first._vecb1, second._vecb1)};
   }
 
   Vec256<ComplexFlt> angle_() const {


### PR DESCRIPTION
Patch needed in order to build on ppc64le with compiler g++V7.  (w/o fix, only works on minimum compiler V8).

Fixes #51592

To be clear, credit where due: 
I tested this patch on a ppc64 RHEL container using gcc/g++ 7.4 compiler to ensure a complete pytorch build was successful -- and it was. However, I do not take credit for this patch.  I found and reported the issue, but the full brainpower to identify the cause of the error and the appropriate solution and thus the credit for this fix truly belongs to @quickwritereader (and I am just helping with the legwork to integrate it after having tested it).