### PR TITLE
Add support for constants to fx_glow

### DIFF
--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, NamedTuple, Any
 
 import torch
-from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.experimental.param_fetch import lift_lowering_attrs_to_nodes
 from torch.fx.node import _get_qualified_name
 from torch.fx.graph_module import GraphModule
 from torch.fx.graph import Graph
 from torch.fx.node import Node, Target, map_arg
+from torch.fx.passes.shape_prop import ShapeProp
 
 
 def replace_target_nodes_with(
@@ -230,12 +230,20 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
 
         # Make sure we capture all constants.
         if node.op == "get_attr":
-            target = getattr(fx_module, node.target)
             qualname = prefix + node.target
-            if isinstance(target, torch.Tensor) and qualname not in weights:
-                weight = serialize_weight(target)
-                serialized_dict["weights"][prefix + node.target] = weight
-                weights[prefix + node.target] = target
+            # If we are targeting a parent constant we update the target.
+            if node.target.startswith("parent."):
+                node.name = node.name[len("parent."):]
+                node_rep["target"] = str(node.target[len("parent."):])
+                weight = serialize_weight(weights[node.target[len("parent."):]])
+                serialized_dict["weights"][node.target[len("parent."):]] = weight
+            else:
+                target = getattr(fx_module, node.target)
+                # Check that the target is a tensor, and that we haven't added it already from a leaf module.
+                if isinstance(target, torch.Tensor) and qualname not in weights:
+                    weight = serialize_weight(target)
+                    serialized_dict["weights"][prefix + node.target] = weight
+                    weights[prefix + node.target] = target
 
         node_rep["op_code"] = node.op
         node_rep["name"] = node.name


### PR DESCRIPTION
Summary: Nested constants are created as placeholders by the graph_splitter used in the partitioner. So we change them back to get_attr nodes before serializing the graph.

Differential Revision: D26375577

