### PR TITLE
[PyTorch][easy] Make shared empty string static instead of thread_local

### DIFF
--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -76,7 +76,7 @@ struct _str_wrapper<const char*> final {
 template<>
 struct _str_wrapper<> final {
   static const std::string& call() {
-    thread_local const std::string empty_string_literal;
+    static const std::string empty_string_literal;
     return empty_string_literal;
   }
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

D21268320 made this thread_local, but I don't think it was necessary to do so.

Differential Revision: [D26378724](https://our.internmc.facebook.com/intern/diff/D26378724/)