### PR TITLE
[PyTorch] Avoid creating std::string when TORCH_CHECK is called with no message

### DIFF
--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -19,6 +19,16 @@ C10_API std::string StripBasename(const std::string& full_path);
 
 C10_API std::string ExcludeFileExtension(const std::string& full_path);
 
+struct CompileTimeEmptyString {
+  operator const std::string&() const {
+    static const std::string empty_string_literal;
+    return empty_string_literal;
+  }
+  operator const char*() const {
+    return "";
+  }
+};
+
 template <typename T>
 struct CanonicalizeStrTypes {
   using type = const T&;
@@ -37,6 +47,11 @@ inline std::ostream& _str(std::ostream& ss) {
 template <typename T>
 inline std::ostream& _str(std::ostream& ss, const T& t) {
   ss << t;
+  return ss;
+}
+
+template <>
+inline std::ostream& _str<CompileTimeEmptyString>(std::ostream& ss, const CompileTimeEmptyString& t) {
   return ss;
 }
 
@@ -72,12 +87,11 @@ struct _str_wrapper<const char*> final {
 
 // For c10::str() with an empty argument list (which is common in our assert macros),
 // we don't want to pay the binary size for constructing and destructing a stringstream
-// or even constructing a string. Let's just return a reference to an empty string.
+// or even constructing a string.
 template<>
 struct _str_wrapper<> final {
-  static const std::string& call() {
-    static const std::string empty_string_literal;
-    return empty_string_literal;
+  static CompileTimeEmptyString call() {
+    return CompileTimeEmptyString();
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

The previous code forced a std::string wrapping the default message to be created. Now it's not forced.

Differential Revision: [D26380783](https://our.internmc.facebook.com/intern/diff/D26380783/)