### PR TITLE
[rfc][wip] Introduce a new way of expressing reductions

### DIFF
--- a/test/cpp/tensorexpr/test_conv.cpp
+++ b/test/cpp/tensorexpr/test_conv.cpp
@@ -68,9 +68,12 @@ TEST(Conv, Conv2D) {
 
   // FIXME: It'd be nice to have a single header that pulls in things like
   // LoopNest, IRSimplifier, etc.
+  std::clog << "tensor stmt:\n" << *conv->stmt() << "\n";
   te::LoopNest loop({conv});
+  std::clog << "root stmt before codegen:\n" << *loop.root_stmt() << "\n";
   loop.prepareForCodegen();
   te::Stmt* s = loop.root_stmt();
+  std::clog << "root stmt after codegen:\n" << *loop.root_stmt() << "\n";
   s = te::IRSimplifier::simplify(s);
 
   at::Tensor result = at::empty_like(ref);

--- a/test/cpp/tensorexpr/test_sparse.cpp
+++ b/test/cpp/tensorexpr/test_sparse.cpp
@@ -1,0 +1,130 @@
+#include <gtest/gtest.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/torch.h>
+
+namespace torch {
+namespace jit {
+
+namespace te = torch::jit::tensorexpr;
+namespace F = torch::nn::functional;
+
+TEST(Sparse, SparseDenseCSRMV) {
+  te::KernelScope ks;
+
+  int M = 1, K = 16;
+  int N = K * 2;
+
+  auto data = torch::linspace(1.f, M * K, M * K).reshape({M, K});
+  auto weight_data = torch::linspace(1.f, N, N).reshape({N});
+  auto weight_indices = torch::linspace(0, K - 1, N, at::TensorOptions().dtype(at::kInt));
+  auto weight_indptr = torch::arange(0, N + 2, 2, at::TensorOptions().dtype(torch::kInt));
+
+  te::Placeholder data_t("data", te::kFloat, {M, K});
+  te::Placeholder weight_data_t("weight_data", te::kFloat, {N});
+  te::Placeholder weight_indices_t("weight_indices", te::kInt, {N});
+  te::Placeholder weight_indptr_t("weight_indices", te::kInt, {K + 1});
+
+  /*
+    def f(i, row):
+        row_start = weight_indptr[row]
+        row_end = weight_indptr[row + 1]
+        row_elems = row_end - row_start
+        elem_idx = tvm.reduce_axis((0, row_elems), name="elem_idx")
+        elem = row_start + elem_idx
+        a_val = weight_data[elem]
+        weight_val = data[i, weight_indices[elem]]
+        return tvm.sum(a_val * weight_val, axis=elem_idx)
+    return tvm.compute(oshape, f)
+  */
+
+/*
+  te::Tensor* output_t = te::Compute(
+      "output",
+      {{M, "M"}, {K, "K"}},
+      [&](const te::VarHandle& i, const te::VarHandle& row) {
+        auto row_start = weight_indptr_t.load(row);
+        auto row_end = weight_indptr_t.load(row + 1);
+        auto row_elems = row_end - row_start;
+
+        return te::Sum()(
+            {row_elems},
+            [&](const VarHandle& elem_idx) {
+              auto elem = row_start + elem_idx;
+              auto a_val = weight_data.load(elem);
+              auto weight_val = data.load(i, weight_indices.load(elem));
+              return a_val * weight_val;
+            }
+        );
+      });
+*/
+
+  /*
+  te::Tensor* output_t = te::Reduce(
+      "output",
+      {{M, "M"}, {K, "K"}},
+      te::Sum(),
+      [&](const te::VarHandle& i, const te::VarHandle& row, const te::VarHandle& row_elems) {
+        auto row_start = weight_indptr_t.load(row);
+        auto row_end = weight_indptr_t.load(row + 1);
+        auto row_elems = row_end - row_start;
+
+        auto elem = row_start + elem_idx;
+        auto a_val = data.load(i, weight_indices.load(elem));
+        auto weight_val = weight_data.load(elem);
+        return a_val * weight_val;
+      },
+      {{row_elems, "row_elems"}}
+  );
+  */
+
+  te::Tensor* output_t = te::Compute(
+      "output",
+      {{M, "M"}, {K, "K"}},
+      [&](const te::VarHandle& i, const te::VarHandle& row) {
+        auto row_start = weight_indptr_t.load(row);
+        auto row_end = weight_indptr_t.load(row + 1);
+        auto row_elems = row_end - row_start;
+
+        auto sum = te::SumX(
+            {{row_elems, "row_elems"}},
+            [&](const std::vector<te::VarHandle>& args) {
+              auto elem_idx = args[0];
+              auto elem = row_start + elem_idx;
+              auto weight_val = weight_data_t.load(elem);
+              auto a_val = data_t.load(i, weight_indices_t.load(elem));
+              return a_val * weight_val;
+            }
+        );
+        return te::ExprHandle(sum);
+      });
+  std::clog << "tensor stmt:\n" << *output_t->stmt() << "\n";
+
+  te::LoopNest nest({output_t});
+  std::clog << "loop nest pre cg:\n" << *nest.root_stmt() << "\n";
+
+  nest.prepareForCodegen();
+  te::Stmt* s = nest.root_stmt();
+  std::clog << "loop nest post cg:\n" << *nest.root_stmt() << "\n";
+  s = te::IRSimplifier::simplify(s);
+
+  at::Tensor output = torch::empty({M, K});
+  te::LLVMCodeGen cg(s, {data_t, weight_data_t, weight_indices_t, weight_indptr_t, output_t});
+  cg.call({
+      data.data_ptr<float>(),
+        weight_data.data_ptr<float>(),
+        weight_indices.data_ptr<int32_t>(),
+        weight_indptr.data_ptr<int32_t>(),
+        output.data_ptr<float>(),
+    });
+  std::clog << data << "\n"
+            << weight_data << "\n"
+            << weight_indices << "\n"
+            << weight_indptr << "\n"
+            << output << "\n";
+}
+
+}
+}

--- a/torch/csrc/jit/tensorexpr/ir_mutator.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.cpp
@@ -295,6 +295,21 @@ const Expr* IRMutator::mutate(const ReduceOp* v) {
       buf_new, body_new, new_output_args, new_reduce_args, v->reducer());
 }
 
+const Expr* IRMutator::mutate(const ReduceXOp* v) {
+  const Expr* body_new = v->body()->accept_mutator(this);
+
+  std::vector<const Expr*> new_rdims;
+  std::vector<const Var*> new_rvars;
+  for (auto* e : v->rdims()) {
+    new_rdims.push_back(e->accept_mutator(this));
+  }
+  for (auto* r : v->rvars()) {
+    new_rvars.push_back(static_cast<const Var*>(r->accept_mutator(this)));
+  }
+
+  return new ReduceXOp(body_new, new_rvars, new_rdims, v->reducer());
+}
+
 const Expr* IRMutator::mutate(const BaseCallNode* v) {
   std::vector<const Expr*> params(v->nparams());
   bool any_change = false;

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -52,6 +52,7 @@ class RoundOff;
 class MaxTerm;
 class MinTerm;
 class ReduceOp;
+class ReduceXOp;
 class AtomicAdd;
 class SyncThreads;
 class ExternalCall;
@@ -102,6 +103,7 @@ class TORCH_API IRMutator {
   virtual const Expr* mutate(const MinTerm* v);
 
   virtual const Expr* mutate(const ReduceOp* v);
+  virtual const Expr* mutate(const ReduceXOp* v);
 
   virtual Stmt* mutate(const For* v);
   virtual Stmt* mutate(const Block* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_printer.cpp
@@ -374,6 +374,33 @@ void IRPrinter::visit(const ReduceOp* v) {
   os() << "})";
 }
 
+void IRPrinter::visit(const ReduceXOp* v) {
+  os() << "ReduceXOp(";
+  os() << *v->body() << ", ";
+
+  bool first = true;
+  os() << "rvars={";
+  for (auto* d : v->rvars()) {
+    if (!first) {
+      os() << ", ";
+    }
+    os() << d->name_hint();
+    first = false;
+  }
+  os() << "}, ";
+
+  first = true;
+  os() << "rdims={";
+  for (auto* d : v->rdims()) {
+    if (!first) {
+      os() << ", ";
+    }
+    os() << *d;
+    first = false;
+  }
+  os() << "})";
+}
+
 // === Stmt visitors below ===
 // Some invariants to keep in mind when changing printer visitors for statement:
 //  1) every statement first outputs the indendation with emitIndent

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -49,6 +49,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   void visit(const MaxTerm* v) override;
   void visit(const MinTerm* v) override;
   void visit(const ReduceOp* v) override;
+  void visit(const ReduceXOp* v) override;
 
   void visit(const AtomicAdd* v) override;
   void visit(const SyncThreads* v) override;

--- a/torch/csrc/jit/tensorexpr/ir_visitor.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.cpp
@@ -250,6 +250,17 @@ void IRVisitor::visit(const ReduceOp* v) {
   }
 }
 
+void IRVisitor::visit(const ReduceXOp* v) {
+  v->body()->accept(this);
+
+  for (auto* e : v->rvars()) {
+    e->accept(this);
+  }
+  for (auto* r : v->rdims()) {
+    r->accept(this);
+  }
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -49,6 +49,7 @@ class RoundOff;
 class MaxTerm;
 class MinTerm;
 class ReduceOp;
+class ReduceXOp;
 class AtomicAdd;
 class SyncThreads;
 class ExternalCall;
@@ -106,6 +107,7 @@ class TORCH_API IRVisitor {
   virtual void visit(const MaxTerm* v);
   virtual void visit(const MinTerm* v);
   virtual void visit(const ReduceOp* v);
+  virtual void visit(const ReduceXOp* v);
   virtual void visit(const AtomicAdd* v);
   virtual void visit(const SyncThreads* v);
   virtual void visit(const ExternalCall* v);

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -120,6 +120,36 @@ class TORCH_API Reducer {
   ReduceInteraction interaction_;
 };
 
+class ReduceXOp : public ExprNode<ReduceXOp> {
+ public:
+  ReduceXOp(const Expr* body, const std::vector<const Var*>& rvars,
+            const std::vector<const Expr*>& rdims, const Reducer& reducer)
+      : ExprNodeBase(body->dtype()), body_(body), rvars_(rvars), rdims_(rdims), reducer_(reducer)
+    {}
+
+  const Expr* body() const {
+    return body_;
+  }
+
+  const std::vector<const Var*>& rvars() const {
+    return rvars_;
+  }
+
+  const std::vector<const Expr*>& rdims() const {
+    return rdims_;
+  }
+
+  const Reducer& reducer() const {
+    return reducer_;
+  }
+
+ private:
+  const Expr* body_;
+  std::vector<const Var*> rvars_;
+  std::vector<const Expr*> rdims_;
+  Reducer reducer_;
+};
+
 // An expression representing a Reduction operation (e.g. Sum, Max) broken into
 // it's component parts: initialization, accumulation var, acquisition of value
 // to be reduced and interaction.

--- a/torch/csrc/jit/tensorexpr/tensor.cpp
+++ b/torch/csrc/jit/tensorexpr/tensor.cpp
@@ -8,6 +8,56 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+namespace {
+class LowerReduceX : public IRMutator {
+ public:
+  LowerReduceX(const std::vector<const Expr*> output_args)
+      : IRMutator(), output_args_(output_args)
+    {}
+
+  Stmt* mutate(const Store* v) override {
+    const ReduceXOp* reduceX = dynamic_cast<const ReduceXOp*>(v->value());
+    if (!reduceX) {
+      return const_cast<Store*>(v);
+    }
+    // Turn this store:
+    //     base[indices] = ReduceX(body, rvars, rdims, reducer)
+    // into:
+    //     base[indices] = reducer.init
+    //     for (rvar in rdims):
+    //         base[indices] = Reduce(
+    //             base,
+    //             reducer.apply(base[indices], body),
+    //             output_args,
+    //             rvars,
+    //             reducer)
+    auto const& reducer = reduceX->reducer();
+    const Expr* init_expr = new Cast(reduceX->body()->dtype(), reducer.initializer());
+    Store* init = new Store(v->buf(), v->indices(), init_expr, v->mask());
+    Expr* reduce = reducer(v->buf(), reduceX->body(), output_args_, reduceX->rvars());
+    Stmt* update = new Store(v->buf(), v->indices(), reduce, v->mask());
+
+    auto const& rvars = reduceX->rvars();
+    auto const& rdims = reduceX->rdims();
+    size_t reduce_ndim = rdims.size();
+    for (size_t i = 0; i < reduce_ndim; i++) {
+      size_t dim_index = reduce_ndim - i - 1;
+      update = new For(rvars[dim_index], new IntImm(0), rdims[dim_index], update);
+    }
+    return new Block({init, update});
+  }
+
+ private:
+  std::vector<const Expr*> output_args_;
+};
+}
+
+// Transform ReduceX into For loops surrounding an ordinary Reduce.
+static Stmt* lowerReduceX(Stmt* s, const std::vector<const Var*> output_args) {
+  LowerReduceX lowering(c10::fmap<const Expr*>(output_args));
+  return s->accept_mutator(&lowering);
+}
+
 Stmt* Tensor::constructStmt(
     const std::vector<const Var*>& args,
     const Expr* body,
@@ -45,6 +95,8 @@ Stmt* Tensor::constructStmt(
     size_t dim_index = ndim - i - 1;
     s = new For(args[dim_index], new IntImm(0), buf()->dim(dim_index), s);
   }
+
+  s = lowerReduceX(s, args);
   return s;
 }
 
@@ -162,6 +214,29 @@ Tensor* Reduce(
       [&](ParameterList& p) { return tensor->call(p); },
       reduce_args);
 }
+
+// Tensor* ComputeX(
+//     const std::string& name,
+//     const std::vector<DimArg>& dim_args,
+//     const std::function<Stmt*(const std::vector<VarHandle>&)>& body_func) {
+//   std::vector<const Expr*> dims;
+//   std::vector<const Var*> vars;
+//   unpack_dim_args(dim_args, &dims, &vars);
+
+
+// }
+
+Expr* SumX(
+    const std::vector<DimArg>& rdim_args,
+    const std::function<ExprHandle(const std::vector<VarHandle>&)>& body) {
+  std::vector<const Expr*> rdims;
+  std::vector<const Var*> rvars;
+  unpack_dim_args(rdim_args, &rdims, &rvars);
+
+  auto rvarhs = c10::fmap<VarHandle>(rvars);
+  return new ReduceXOp(body(rvarhs).node(), rvars, rdims, Sum());
+}
+
 
 } // namespace tensorexpr
 } // namespace jit

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -297,6 +297,15 @@ inline ExprHandle Placeholder::load(const std::vector<T>& args) const {
       new Load(data(), ExprHandleVectorToExprVector(params), new IntImm(1)));
 }
 
+// Tensor* ComputeX(
+//     const std::string& name,
+//     const std::vector<DimArg>& dim_args,
+//     const std::function<ExprHandle(const std::vector<VarHandle>&)>& body_func);
+
+Expr* SumX(
+    const std::vector<DimArg>& dim_args,
+    const std::function<ExprHandle(const std::vector<VarHandle>&)>& body);
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

The basic problem I'm trying to solve is that our current APIs don't
give you a way of expressing reduction dimensions that depend on values in the
outer loop.  The specific operation I was attempting to implement is a
compressed sparse row (CSR) matrix-vector multiplication:
