### PR TITLE
Fix compiler warning for MathConstants.h

### DIFF
--- a/c10/util/BFloat16.h
+++ b/c10/util/BFloat16.h
@@ -81,7 +81,7 @@ struct alignas(2) BFloat16 {
 #endif
 
   struct from_bits_t {};
-  static constexpr from_bits_t from_bits() {
+  static constexpr C10_HOST_DEVICE from_bits_t from_bits() {
     return from_bits_t();
   }
 


### PR DESCRIPTION
Summary:
Compiler currently complains:
```
caffe2/c10/util/MatchConstants.h(18): warning: calling a constexpr __host__ function("from_bits") from a __host__ __device__ function("pi") is not allowed.
```

Differential Revision: D26379485

