### PR TITLE
Gh/taylorrobie/import timer fbcode

### DIFF
--- a/torch/utils/benchmark/utils/cpp_jit.py
+++ b/torch/utils/benchmark/utils/cpp_jit.py
@@ -63,12 +63,12 @@ CXX_FLAGS: Optional[List[str]]
 if hasattr(torch.__config__, "_cxx_flags"):
     try:
         CXX_FLAGS = torch.__config__._cxx_flags().strip().split()
+        if "-g" not in CXX_FLAGS:
+            CXX_FLAGS.append("-g")
+
     except RuntimeError:
         # We are in FBCode.
         CXX_FLAGS = None
-
-    if "-g" not in CXX_FLAGS:
-        CXX_FLAGS.append("-g")
 else:
     # FIXME: Remove when back testing is no longer required.
     CXX_FLAGS = ["-O2", "-fPIC", "-g"]

--- a/torch/utils/benchmark/utils/cpp_jit.py
+++ b/torch/utils/benchmark/utils/cpp_jit.py
@@ -63,7 +63,7 @@ CXX_FLAGS: Optional[List[str]]
 if hasattr(torch.__config__, "_cxx_flags"):
     try:
         CXX_FLAGS = torch.__config__._cxx_flags().strip().split()
-        if "-g" not in CXX_FLAGS:
+        if CXX_FLAGS is not None and "-g" not in CXX_FLAGS:
             CXX_FLAGS.append("-g")
 
     except RuntimeError:

--- a/torch/utils/benchmark/utils/cpp_jit.py
+++ b/torch/utils/benchmark/utils/cpp_jit.py
@@ -59,8 +59,14 @@ BUILD_ROOT = os.path.join(
 #   analysis and the shims no longer justify their maintenance and code
 #   complexity costs) back testing paths will be removed.
 
+CXX_FLAGS: Optional[List[str]]
 if hasattr(torch.__config__, "_cxx_flags"):
-    CXX_FLAGS = torch.__config__._cxx_flags().strip().split()
+    try:
+        CXX_FLAGS = torch.__config__._cxx_flags().strip().split()
+    except RuntimeError:
+        # We are in FBCode.
+        CXX_FLAGS = None
+
     if "-g" not in CXX_FLAGS:
         CXX_FLAGS.append("-g")
 else:


### PR DESCRIPTION
`torch.__config__._cxx_flags` gets called on import, but this means that Timer can't be used if it fails. (Even just the wall time parts.) This is needlessly restrictive.