### PR TITLE
Use self-hosted runner for nightly docker build CI.

### DIFF
--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-publish-docker:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: [self-hosted, linux.2xlarge]
+    runs-on: linux.2xlarge
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:

--- a/.github/workflows/push_nightly_docker_ghcr.yml
+++ b/.github/workflows/push_nightly_docker_ghcr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-publish-docker:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ubuntu-18.04
+    runs-on: [self-hosted, linux.2xlarge]
     env:
       GHCR_PAT: ${{ secrets.GHCR_PAT }}
     steps:


### PR DESCRIPTION
The GitHub-hosted runner has maximum 14 GB disk space, which is not enough to host the nightly Docker build.

Test plan:

CI workflow