### PR TITLE
[JIT] Create torch._C._jit submodule for JIT bindings

### DIFF
--- a/benchmarks/cpp/tensorexpr/bench_ops.py
+++ b/benchmarks/cpp/tensorexpr/bench_ops.py
@@ -1,8 +1,8 @@
 import timeit
 import torch
 
-torch._C._jit_override_can_fuse_on_cpu(True)
-torch._C._debug_set_fusion_group_inlining(False)
+torch._C._jit.override_can_fuse_on_cpu(True)
+torch._C._jit._debug_set_fusion_group_inlining(False)
 torch.set_num_threads(1)
 
 

--- a/benchmarks/fastrnns/bench.py
+++ b/benchmarks/fastrnns/bench.py
@@ -229,11 +229,11 @@ if __name__ == '__main__':
     set_fuser(args.fuser, args.executor)
 
     if args.cuda_pointwise_loop_level:
-        torch._C._jit_set_te_cuda_pointwise_loop_levels(args.cuda_pointwise_loop_level)
+        torch._C._jit.set_te_cuda_pointwise_loop_levels(args.cuda_pointwise_loop_level)
     if args.cuda_pointwise_block_count:
-        torch._C._jit_set_te_cuda_pointwise_block_count(args.cuda_pointwise_block_count)
+        torch._C._jit.set_te_cuda_pointwise_block_count(args.cuda_pointwise_block_count)
     if args.cuda_pointwise_block_size:
-        torch._C._jit_set_te_cuda_pointwise_block_size(args.cuda_pointwise_block_size)
+        torch._C._jit.set_te_cuda_pointwise_block_size(args.cuda_pointwise_block_size)
 
     rnns = args.rnns or ['cudnn', 'aten', 'jit', 'jit_premul', 'jit_premul_bias', 'jit_simple',
                          'jit_multilayer', 'py']

--- a/benchmarks/fastrnns/fuser.py
+++ b/benchmarks/fastrnns/fuser.py
@@ -3,34 +3,34 @@ import torch
 def set_fuser(fuser_name, executor_name):
     assert fuser_name in ['te', 'old', 'none', 'default']
     if fuser_name == 'te':
-        torch._C._jit_set_profiling_executor(True)
-        torch._C._jit_set_profiling_mode(True)
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_override_can_fuse_on_gpu(True)
-        torch._C._jit_set_texpr_fuser_enabled(True)
+        torch._C._jit.set_profiling_executor(True)
+        torch._C._jit.set_profiling_mode(True)
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.override_can_fuse_on_gpu(True)
+        torch._C._jit.set_texpr_fuser_enabled(True)
     elif fuser_name == 'old':
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
-        torch._C._jit_override_can_fuse_on_gpu(True)
-        torch._C._jit_set_texpr_fuser_enabled(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
+        torch._C._jit.override_can_fuse_on_gpu(True)
+        torch._C._jit.set_texpr_fuser_enabled(False)
     elif fuser_name == 'none':
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
-        torch._C._jit_override_can_fuse_on_gpu(False)
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_set_texpr_fuser_enabled(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
+        torch._C._jit.override_can_fuse_on_gpu(False)
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.set_texpr_fuser_enabled(False)
     elif fuser_name == 'default':
         pass
 
     # --executor overrides settings of --fuser
     if executor_name == 'profiling':
-        torch._C._jit_set_profiling_executor(True)
-        torch._C._jit_set_profiling_mode(True)
+        torch._C._jit.set_profiling_executor(True)
+        torch._C._jit.set_profiling_mode(True)
     elif executor_name == 'simple':
-        torch._C._jit_set_profiling_executor(True)
-        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit.set_profiling_executor(True)
+        torch._C._jit.set_profiling_mode(False)
     elif executor_name == 'legacy':
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
     elif executor_name == 'default':
         pass

--- a/benchmarks/profiler_benchmark/profiler_bench.py
+++ b/benchmarks/profiler_benchmark/profiler_bench.py
@@ -26,7 +26,7 @@ def parallel_workload(x):
 
 
 if __name__ == '__main__':
-    torch._C._set_graph_executor_optimize(False)
+    torch._C._jit._set_graph_executor_optimize(False)
     parser = argparse.ArgumentParser(
         description='Profiler benchmark')
 

--- a/benchmarks/tensorexpr/__main__.py
+++ b/benchmarks/tensorexpr/__main__.py
@@ -121,21 +121,21 @@ Works only with Python3.\n A few examples:
 
     if args.cuda_fuser == "te":
         import torch
-        torch._C._jit_set_profiling_executor(True)
-        torch._C._jit_set_texpr_fuser_enabled(True)
-        torch._C._jit_override_can_fuse_on_gpu(True)
-        torch._C._jit_set_profiling_mode(True)
+        torch._C._jit.set_profiling_executor(True)
+        torch._C._jit.set_texpr_fuser_enabled(True)
+        torch._C._jit.override_can_fuse_on_gpu(True)
+        torch._C._jit.set_profiling_mode(True)
     elif args.cuda_fuser == "old":
         import torch
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_texpr_fuser_enabled(False)
-        torch._C._jit_override_can_fuse_on_gpu(True)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_texpr_fuser_enabled(False)
+        torch._C._jit.override_can_fuse_on_gpu(True)
     elif args.cuda_fuser == "nvf":
         import torch
-        torch._C._jit_set_profiling_executor(True)
-        torch._C._jit_set_texpr_fuser_enabled(False)
-        torch._C._jit_set_nvfuser_enabled(True)
-        torch._C._jit_set_profiling_mode(True)
+        torch._C._jit.set_profiling_executor(True)
+        torch._C._jit.set_texpr_fuser_enabled(False)
+        torch._C._jit.set_nvfuser_enabled(True)
+        torch._C._jit.set_profiling_mode(True)
     else :
         raise ValueError("Undefined fuser: {}".format(args.cuda_fuser))
 

--- a/benchmarks/tensorexpr/benchmark.py
+++ b/benchmarks/tensorexpr/benchmark.py
@@ -122,12 +122,12 @@ class Benchmark(object):
     def run(self, args):
         self.print_ir = args.print_ir
         if args.cuda_fuser == "old" :
-            torch._C._jit_override_can_fuse_on_gpu(True)
+            torch._C._jit.override_can_fuse_on_gpu(True)
             if args.print_kernel :
                 os.environ['PYTORCH_FUSION_DEBUG'] = '1'
             return self.run_impl(True)
         elif args.cuda_fuser == "te" :
-            torch._C._jit_set_texpr_fuser_enabled(True)
+            torch._C._jit.set_texpr_fuser_enabled(True)
             with cuda_pointwise_context(
                 args.cuda_pointwise_loop_levels,
                 args.cuda_pointwise_block_count,
@@ -135,12 +135,12 @@ class Benchmark(object):
             ):
                 return self.run_impl(True)
         elif args.cuda_fuser == "nvf" :
-            torch._C._jit_set_nvfuser_enabled(True)
-            torch._C._jit_set_profiling_executor(True)
-            torch._C._jit_set_profiling_mode(True)
-            torch._C._jit_override_can_fuse_on_cpu(False)
-            torch._C._jit_override_can_fuse_on_gpu(False)
-            torch._C._jit_set_bailout_depth(20)
+            torch._C._jit.set_nvfuser_enabled(True)
+            torch._C._jit.set_profiling_executor(True)
+            torch._C._jit.set_profiling_mode(True)
+            torch._C._jit.override_can_fuse_on_cpu(False)
+            torch._C._jit.override_can_fuse_on_gpu(False)
+            torch._C._jit.set_bailout_depth(20)
             if args.print_kernel :
                 os.environ['PYTORCH_CUDA_FUSER_DEBUG'] = '1'
             return self.run_impl(True)
@@ -219,30 +219,30 @@ class Benchmark(object):
 @contextlib.contextmanager
 def cuda_pointwise_context(loop_levels, block_count, block_size):
     if loop_levels:
-        old_loop_levels = torch._C._jit_get_te_cuda_pointwise_loop_levels()
-        torch._C._jit_set_te_cuda_pointwise_loop_levels(loop_levels)
+        old_loop_levels = torch._C._jit.get_te_cuda_pointwise_loop_levels()
+        torch._C._jit.set_te_cuda_pointwise_loop_levels(loop_levels)
     if block_count:
-        old_block_count = torch._C._jit_get_te_cuda_pointwise_block_count()
-        torch._C._jit_set_te_cuda_pointwise_block_count(block_count)
+        old_block_count = torch._C._jit.get_te_cuda_pointwise_block_count()
+        torch._C._jit.set_te_cuda_pointwise_block_count(block_count)
     if block_size:
-        old_block_size = torch._C._jit_get_te_cuda_pointwise_block_size()
-        torch._C._jit_set_te_cuda_pointwise_block_size(block_size)
+        old_block_size = torch._C._jit.get_te_cuda_pointwise_block_size()
+        torch._C._jit.set_te_cuda_pointwise_block_size(block_size)
 
     yield
 
     if loop_levels:
-        torch._C._jit_set_te_cuda_pointwise_loop_levels(old_loop_levels)
+        torch._C._jit.set_te_cuda_pointwise_loop_levels(old_loop_levels)
     if block_count:
-        torch._C._jit_set_te_cuda_pointwise_block_count(old_block_count)
+        torch._C._jit.set_te_cuda_pointwise_block_count(old_block_count)
     if block_size:
-        torch._C._jit_set_te_cuda_pointwise_block_size(old_block_size)
+        torch._C._jit.set_te_cuda_pointwise_block_size(old_block_size)
 
 # Auxiliary class to facilitate dynamic input shape
 class DynamicShape(object):
     r'''
     An Auxiliary class for dynamic shape benchmarks
 
-    Pre-computes input with random shapes and also 
+    Pre-computes input with random shapes and also
     modifies the compute method so in each call the
     fuser sees a different input tensor shape
     '''

--- a/caffe2/python/workspace_test.py
+++ b/caffe2/python/workspace_test.py
@@ -773,7 +773,7 @@ class TestScriptModule(test_util.TestCase):
                 load_all=1))
             self.assertTrue(workspace.HasBlob('m'))
             # TODO: make caffe2 side load return python-sided module
-            # right now it returns the base class (torch._C.ScriptModule)
+            # right now it returns the base class (torch._C._jit.ScriptModule)
             # self.assertTrue(isinstance(workspace.FetchBlob('m'), torch.jit.ScriptModule))
 
             # do something with the module

--- a/mypy.ini
+++ b/mypy.ini
@@ -47,7 +47,7 @@ python_version = 3.6
 # Extension modules without stubs.
 #
 
-[mypy-torch._C._jit_tree_views]
+[mypy-torch._C._jit.tree_views]
 ignore_missing_imports = True
 
 [mypy-torch.for_onnx.onnx]

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -109,8 +109,8 @@ def dont_parse(schema_line):
 
 
 def check_bc(existing_schemas):
-    new_schemas = torch._C._jit_get_all_schemas()
-    new_schemas += torch._C._jit_get_custom_class_schemas()
+    new_schemas = torch._C._jit.get_all_schemas()
+    new_schemas += torch._C._jit.get_custom_class_schemas()
     new_schema_dict = defaultdict(list)
     for s in new_schemas:
         new_schema_dict[s.name].append(s)

--- a/test/backward_compatibility/dump_all_function_schemas.py
+++ b/test/backward_compatibility/dump_all_function_schemas.py
@@ -4,8 +4,8 @@ import torch
 
 
 def dump(filename):
-    schemas = torch._C._jit_get_all_schemas()
-    schemas += torch._C._jit_get_custom_class_schemas()
+    schemas = torch._C._jit.get_all_schemas()
+    schemas += torch._C._jit.get_custom_class_schemas()
     with open(filename, 'w') as f:
         for s in schemas:
             f.write(str(s))

--- a/test/custom_backend/backend.py
+++ b/test/custom_backend/backend.py
@@ -24,7 +24,7 @@ def get_custom_backend_library_path():
 
 def to_custom_backend(module):
     """
-    This is a helper that wraps torch._C._jit_to_test_backend and compiles
+    This is a helper that wraps torch._C._jit.to_test_backend and compiles
     only the forward method with an empty compile spec.
 
     Args:
@@ -33,7 +33,7 @@ def to_custom_backend(module):
     Returns:
         The module, lowered so that it can run on TestBackend.
     """
-    lowered_module = torch._C._jit_to_backend("custom_backend", module, {"forward": {"": ""}})
+    lowered_module = torch._C._jit.to_backend("custom_backend", module, {"forward": {"": ""}})
     return lowered_module
 
 

--- a/test/jit/test_async.py
+++ b/test/jit/test_async.py
@@ -411,7 +411,7 @@ class TestAsync(JitTestCase):
             return val[1]
 
         traced = torch.jit.trace(fn, (torch.rand(3, 4),))
-        torch._C._jit_pass_inline_fork_wait(traced.graph)
+        torch._C._jit.pass_inline_fork_wait(traced.graph)
         self.assertGraphContainsExactly(traced.graph, kind='prim::fork', num_kind_nodes=0)
         self.assertGraphContainsExactly(traced.graph, kind='aten::wait', num_kind_nodes=0)
         self.assertGraphContainsExactly(traced.graph, kind='aten::add', num_kind_nodes=2)

--- a/test/jit/test_backends.py
+++ b/test/jit/test_backends.py
@@ -29,18 +29,18 @@ if __name__ == "__main__":
 
 
 def to_test_backend(module, method_compile_spec):
-    return torch._C._jit_to_backend("test_backend", module, {"forward": method_compile_spec})
+    return torch._C._jit.to_backend("test_backend", module, {"forward": method_compile_spec})
 
 
 def to_test_backend_multi(module, method_compile_spec):
-    return torch._C._jit_to_backend("test_backend", module, method_compile_spec)
+    return torch._C._jit.to_backend("test_backend", module, method_compile_spec)
 
 
 def to_test_backend_selective(module, method_compile_spec, submodules):
     def _to_test_backend(module):
         return to_test_backend(module, method_compile_spec)
 
-    return torch._C._jit_to_backend_selective(module, _to_test_backend, submodules)
+    return torch._C._jit.to_backend_selective(module, _to_test_backend, submodules)
 
 
 class BasicModule(torch.nn.Module):

--- a/test/jit/test_custom_operators.py
+++ b/test/jit/test_custom_operators.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
                        "instead.")
 
 def canonical(graph):
-    return torch._C._jit_pass_canonicalize(graph).str(False)
+    return torch._C._jit.pass_canonicalize(graph).str(False)
 
 class TestCustomOperators(JitTestCase):
 

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -47,7 +47,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(2, 2)
         output_s = m.forward(input)
-        m._c = torch._C._freeze_module(m._c)
+        m._c = torch._C._jit._freeze_module(m._c)
         buffer = io.BytesIO()
         torch.jit.save(m._c, buffer)
         buffer.seek(0)
@@ -166,7 +166,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(20, 20)
         output_s = m.forward(input)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
 
         # Check if frozen module looks as below:
         # module m {
@@ -220,7 +220,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(20, 20)
         output_s = m.forward(input)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
         # Check if frozen module looks as below:
         # module m {
         #   attributes {
@@ -258,7 +258,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(2, 2)
         output_s = m.forward(input)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
 
         # Check if frozen module looks as below:
         # module m {
@@ -307,7 +307,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(2, 2)
         output_s = m.forward(input)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
         # Check if frozen module looks as below:
         # module m {
         #   attributes {
@@ -367,7 +367,7 @@ class TestFreezing(JitTestCase):
         m.eval()
         input = torch.randn(2, 2)
         output_s = m.forward(input)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
 
         # Checking if  Frozen module looks as  below
         # module mf {
@@ -455,7 +455,7 @@ class TestFreezing(JitTestCase):
 
         m = torch.jit.script(TestModule())
         m.eval()
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
         self.assertTrue(mf.hasattr('sub1'))
         self.assertTrue(mf.sub1.hasattr('a'))
         self.assertFalse(mf.sub1.hasattr('b'))
@@ -511,7 +511,7 @@ class TestFreezing(JitTestCase):
         m = TestModule()
         ms = torch.jit.script(m)
         ms.eval()
-        mf = torch._C._freeze_module(ms._c)
+        mf = torch._C._jit._freeze_module(ms._c)
         self.assertTrue(mf.hasattr('sub1'))
         self.assertTrue(mf.sub1.hasattr('a'))
         self.assertFalse(mf.sub1.hasattr('b'))
@@ -547,7 +547,7 @@ class TestFreezing(JitTestCase):
         m = TestModule()
         ms = torch.jit.script(m)
         ms.eval()
-        mf = torch._C._freeze_module(ms._c, ["sub1"])
+        mf = torch._C._jit._freeze_module(ms._c, ["sub1"])
 
         # Test that 'sub1' is preserved entirely and 'sub2' is completely folded
         self.assertTrue(mf.hasattr('sub1'))
@@ -581,7 +581,7 @@ class TestFreezing(JitTestCase):
         m = TestModule()
         ms = torch.jit.script(m)
         ms.eval()
-        mf = torch._C._freeze_module(ms._c, ["sub1"])
+        mf = torch._C._jit._freeze_module(ms._c, ["sub1"])
 
         # Test that be both sub1 and sub1 are preserved and 'b' is preserved
         # even if it is not used. To fulfill user request to preserve 'sub1'
@@ -623,7 +623,7 @@ class TestFreezing(JitTestCase):
         m = torch.jit.script(TestModule())
         m.eval()
         input = torch.randn(2, 2)
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
         self.assertFalse(mf.hasattr('sub'))
         self.assertFalse(mf.hasattr('a'))
         self.assertTrue(mf.hasattr('b'))
@@ -644,7 +644,7 @@ class TestFreezing(JitTestCase):
 
         m = FreezeMe()
         m.eval()
-        m_f = torch._C._freeze_module(m._c)
+        m_f = torch._C._jit._freeze_module(m._c)
         self.assertTrue(m_f.hasattr('a'))
         m.forward(torch.tensor([3]))
         out = m_f.forward(torch.tensor([5]))
@@ -669,7 +669,7 @@ class TestFreezing(JitTestCase):
         v.append(4)
         m_s.a = v
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         # Post-freezing mutating m_s.a  does not affect m_f (m_f has its own copy).
         v = m_s.a
         v.append(5)
@@ -700,7 +700,7 @@ class TestFreezing(JitTestCase):
         t = torch.tensor(5)
         m_s.modify_a(t)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         m.a["layer2"] += "2"
         m_s.modify_a(t)
         self.assertFalse(m_f.hasattr('a'))
@@ -721,7 +721,7 @@ class TestFreezing(JitTestCase):
         m_s = torch.jit.script(m)
         m_s.a[1] += 3.0
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         # Post-freezing tensor attribute mutations affect m_f.
         # FIXME: deep copy all folded attributes so that m_f has full ownership.
         m_s.a[0] += 5.0
@@ -747,7 +747,7 @@ class TestFreezing(JitTestCase):
         inp = torch.tensor([2.0])
         expected = m_s.forward(inp)
         m_s.a[0][0] = 1
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertFalse(m_f.hasattr('a'))
         out = m_f.forward(inp)
         self.assertEqual(out, expected)
@@ -768,7 +768,7 @@ class TestFreezing(JitTestCase):
         m_s.eval()
         inp = torch.tensor([5])
         expected = m_s.forward(inp)
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('a'))
         m_f.a[0] -= 10
         out = m_f.forward(inp)
@@ -790,7 +790,7 @@ class TestFreezing(JitTestCase):
         inp = torch.tensor([5])
         expected = m_s.forward(inp)
         m_s.a[0][1] -= 10
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertFalse(m_f.hasattr('a'))
         out = m_f.forward(inp)
         self.assertEqual(out, expected)
@@ -809,7 +809,7 @@ class TestFreezing(JitTestCase):
         m = FreezeMe()
         m_s = torch.jit.script(m)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('a'))
         inp = torch.tensor([5])
         out = m_f.forward(inp)
@@ -835,7 +835,7 @@ class TestFreezing(JitTestCase):
         inp = torch.tensor([5])
         expected = m_s.forward(inp)
         with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
-            m_f = torch._C._freeze_module(m_s._c)
+            m_f = torch._C._jit._freeze_module(m_s._c)
 
     def test_freeze_module_with_aliased_tensor_attr3(self):
         class FreezeMe(nn.Module):
@@ -853,7 +853,7 @@ class TestFreezing(JitTestCase):
         m_s.eval()
         inp = torch.tensor([5])
         expected = m_s.forward(inp)
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('a'))
         self.assertTrue(m_f.hasattr('b'))
         out = m_f.forward(inp)
@@ -878,7 +878,7 @@ class TestFreezing(JitTestCase):
         expected = m_s.forward(inp)
         m_s.a[0] -= 10
         with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
-            m_f = torch._C._freeze_module(m_s._c)
+            m_f = torch._C._jit._freeze_module(m_s._c)
 
     def test_freeze_module_with_overlapping_attrs(self):
         a = torch.tensor([1, 2, 3, 4, 5, 6])
@@ -900,7 +900,7 @@ class TestFreezing(JitTestCase):
         expected = m_s.forward(inp)
         a[0] -= 10
         with self.assertRaisesRegex(RuntimeError, "module contains attributes values that overlaps"):
-            m_f = torch._C._freeze_module(m_s._c)
+            m_f = torch._C._jit._freeze_module(m_s._c)
 
     def test_freeze_module_with_aliased_attr(self):
         class FreezeMe(nn.Module):
@@ -917,7 +917,7 @@ class TestFreezing(JitTestCase):
         m = FreezeMe()
         m_s = torch.jit.script(m)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         # FIXME: It should be assertTrue. Currently scripting is making a copy for setting self.b (see #33034)
         self.assertFalse(m_f.hasattr('a'))
         self.assertFalse(m_f.hasattr('c'))
@@ -946,7 +946,7 @@ class TestFreezing(JitTestCase):
         m = FreezeMe()
         m_s = torch.jit.script(m)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('a'))
         inp = torch.tensor([5])
         out = m_f.forward(inp)
@@ -970,7 +970,7 @@ class TestFreezing(JitTestCase):
         m = FreezeMe()
         m_s = torch.jit.script(m)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('a'))
         inp = torch.tensor([5])
         out = m_f.forward(inp)
@@ -990,7 +990,7 @@ class TestFreezing(JitTestCase):
         m_s = torch.jit.script(m)
         m_s.eval()
         with self.assertRaisesRegex(RuntimeError, "attempted to freeze a module that return itself"):
-            m_f = torch._C._freeze_module(m_s._c)
+            m_f = torch._C._jit._freeze_module(m_s._c)
 
     def test_freeze_module_return_sub_module(self):
 
@@ -1005,7 +1005,7 @@ class TestFreezing(JitTestCase):
         m = FreezeMe()
         m_s = torch.jit.script(m)
         m_s.eval()
-        m_f = torch._C._freeze_module(m_s._c)
+        m_f = torch._C._jit._freeze_module(m_s._c)
         self.assertTrue(m_f.hasattr('conv1'))
 
 
@@ -1036,7 +1036,7 @@ class TestFreezing(JitTestCase):
 
         model = torch.jit.script(Net())
         model.train()
-        mTrain_freezed = torch._C._freeze_module(model._c)
+        mTrain_freezed = torch._C._jit._freeze_module(model._c)
         # verify mTrain_freezed looks exactly as:
         # module {
         #   attributes {
@@ -1109,7 +1109,7 @@ class TestFreezing(JitTestCase):
         self.assertTrue(mTrain_freezed.fc2.hasattr('weight'))
         self.assertTrue(mTrain_freezed.fc2.hasattr('bias'))
         model.eval()
-        mEval_freezed = torch._C._freeze_module(model._c)
+        mEval_freezed = torch._C._jit._freeze_module(model._c)
         self.assertFalse(mEval_freezed.hasattr('conv1'))
         self.assertFalse(mEval_freezed.hasattr('conv2'))
         self.assertFalse(mEval_freezed.hasattr('dropout1'))
@@ -1125,7 +1125,7 @@ class TestFreezing(JitTestCase):
         m = torch.jit.load(buffer)
         FileCheck().check_not('GetAttr[name=') \
                    .run(m._c._get_method('forward').graph)
-        m2 = torch._C._freeze_module(model._c, preserveParameters=True)
+        m2 = torch._C._jit._freeze_module(model._c, preserveParameters=True)
         self.assertTrue(m2.hasattr('conv1'))
         self.assertTrue(m2.hasattr('conv2'))
         self.assertFalse(m2.hasattr('dropout1'))
@@ -1139,7 +1139,7 @@ class TestFreezing(JitTestCase):
         self.assertTrue(mod.weight.requires_grad)
         smod = torch.jit.script(mod)
         smod.eval()
-        fmod = torch._C._freeze_module(smod._c)
+        fmod = torch._C._jit._freeze_module(smod._c)
         self.assertTrue(mod.weight.requires_grad)
         self.assertTrue(smod.weight.requires_grad)
         self.assertFalse(fmod.hasattr('weight'))
@@ -1165,7 +1165,7 @@ class TestFreezing(JitTestCase):
 
         m = torch.jit.script(Module())
         m.eval()
-        fm = torch._C._freeze_module(m._c, ["a"])
+        fm = torch._C._jit._freeze_module(m._c, ["a"])
         # Attribute "a" is preserved
         self.assertTrue(fm.hasattr("a"))
         self.assertFalse(fm.hasattr("b"))
@@ -1192,7 +1192,7 @@ class TestFreezing(JitTestCase):
 
         m = torch.jit.script(Module())
         m.eval()
-        fm = torch._C._freeze_module(m._c, ["modify_a"])
+        fm = torch._C._jit._freeze_module(m._c, ["modify_a"])
         # Both attribute "a" and method "modify_a" are preserved
         self.assertTrue(fm.hasattr("a"))
         self.assertFalse(fm.hasattr("b"))
@@ -1219,7 +1219,7 @@ class TestFreezing(JitTestCase):
 
         m = torch.jit.script(Module())
         m.eval()
-        fm = torch._C._freeze_module(m._c, ["modify_a"])
+        fm = torch._C._jit._freeze_module(m._c, ["modify_a"])
         FileCheck().check('prim::GetAttr[name="a"]').run(fm.forward.graph)
         FileCheck().check('prim::GetAttr[name="b"]').run(fm.modify_a.graph)
 
@@ -1265,8 +1265,8 @@ class TestFreezing(JitTestCase):
             m = _static_quant(m)
             m = torch.jit.script(m)
             m.eval()
-            torch._C._jit_pass_inline(m.graph)
-            m_frozen = wrap_cpp_module(torch._C._freeze_module(m._c))
+            torch._C._jit.pass_inline(m.graph)
+            m_frozen = wrap_cpp_module(torch._C._jit._freeze_module(m._c))
             # Earlier bug resulted in _packed_params set to false.
             FileCheck().check_not('_packed_params = False').run(m_frozen._c.dump_to_str(True, True, False))
 
@@ -1331,7 +1331,7 @@ class TestFreezing(JitTestCase):
         m = torch.jit.script(Mod())
         m.eval()
         with self.assertRaisesRegex(RuntimeError, "Freezing modules containing prim::ModuleDictIndex is not supported"):
-            mf = torch._C._freeze_module(m._c)
+            mf = torch._C._jit._freeze_module(m._c)
 
     def test_freeze_non_module_class_getattr(self):
         class BoxCoder(object):

--- a/test/jit/test_list_dict.py
+++ b/test/jit/test_list_dict.py
@@ -1190,7 +1190,7 @@ class TestList(JitTestCase):
 
     def test_list_none(self):
         with self.assertRaisesRegex(RuntimeError, "Can not create ListType with None type"):
-            x = torch._C.ListType(None)
+            x = torch._C._jit.ListType(None)
 
 
 

--- a/test/jit/test_module_interface.py
+++ b/test/jit/test_module_interface.py
@@ -462,9 +462,9 @@ class TestModuleInterface(JitTestCase):
 
         m = torch.jit.script(TestModule())
         m.eval()
-        mf = torch._C._freeze_module(m._c)
+        mf = torch._C._jit._freeze_module(m._c)
         # Assume interface has no aliasing
-        mf = torch._C._freeze_module(m._c, freezeInterfaces = True)
+        mf = torch._C._jit._freeze_module(m._c, freezeInterfaces = True)
         input = torch.tensor([1])
         out_s = m.forward(input)
         out_f = mf.forward(input)
@@ -511,7 +511,7 @@ class TestModuleInterface(JitTestCase):
         m.proxy_mod = m.sub
         m.eval()
         with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
-            mf = torch._C._freeze_module(m._c, freezeInterfaces = True)
+            mf = torch._C._jit._freeze_module(m._c, freezeInterfaces = True)
 
     def test_freeze_module_with_inplace_mutation_in_interface(self):
         class SubModule(torch.nn.Module):
@@ -557,7 +557,7 @@ class TestModuleInterface(JitTestCase):
         m.sub.b = m.proxy_mod.b
         m.eval()
         with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
-            mf = torch._C._freeze_module(m._c, freezeInterfaces = True)
+            mf = torch._C._jit._freeze_module(m._c, freezeInterfaces = True)
 
     def test_freeze_module_with_mutated_interface(self):
         class SubModule(torch.nn.Module):
@@ -601,7 +601,7 @@ class TestModuleInterface(JitTestCase):
         m = torch.jit.script(TestModule())
         m.eval()
         with self.assertRaisesRegex(RuntimeError, "failed to freeze interface attribute 'proxy_mod'"):
-            mf = torch._C._freeze_module(m._c, freezeInterfaces = True)
+            mf = torch._C._jit._freeze_module(m._c, freezeInterfaces = True)
 
     def test_freeze_module_with_interface_and_fork(self):
         class SubModule(torch.nn.Module):
@@ -652,7 +652,7 @@ class TestModuleInterface(JitTestCase):
 
         m = torch.jit.script(MainModule())
         m.eval()
-        mf = torch._C._freeze_module(m._c, freezeInterfaces = True)
+        mf = torch._C._jit._freeze_module(m._c, freezeInterfaces = True)
 
     def test_module_apis_interface(self):
         @torch.jit.interface

--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -348,7 +348,7 @@ class TestONNXExport(JitTestCase):
         for n in graph.nodes():
             nodes.append(n.kind())
         self.assertEqual(nodes, ['aten::linear'])
-        torch._C._jit_pass_onnx_preprocess(graph)
+        torch._C._jit.pass_onnx_preprocess(graph)
 
         nodes = []
         for n in graph.nodes():

--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -72,7 +72,7 @@ class TestPeephole(JitTestCase):
 
         fn = torch.jit.script(f)
         s = str(fn.graph)
-        torch._C._jit_pass_peephole(fn.graph)
+        torch._C._jit.pass_peephole(fn.graph)
         self.assertEqual(s, str(fn.graph))
 
     def test_peephole_list_ops(self):

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -15,28 +15,28 @@ if __name__ == '__main__':
 
 class TestProfiler(JitTestCase):
     def setUp(self):
-        self.prev_exec = torch._C._jit_set_profiling_executor(True)
-        self.prev_profiling = torch._C._jit_set_profiling_mode(True)
-        self.inline_autodiff = torch._C._debug_set_autodiff_subgraph_inlining(False)
-        self.texpr_fuser_state = torch._C._jit_texpr_fuser_enabled()
-        self.can_fuse_on_cpu = torch._C._jit_can_fuse_on_cpu()
-        torch._C._jit_set_texpr_fuser_enabled(True)
-        torch._C._jit_override_can_fuse_on_cpu(True)
+        self.prev_exec = torch._C._jit.set_profiling_executor(True)
+        self.prev_profiling = torch._C._jit.set_profiling_mode(True)
+        self.inline_autodiff = torch._C._jit._debug_set_autodiff_subgraph_inlining(False)
+        self.texpr_fuser_state = torch._C._jit.texpr_fuser_enabled()
+        self.can_fuse_on_cpu = torch._C._jit.can_fuse_on_cpu()
+        torch._C._jit.set_texpr_fuser_enabled(True)
+        torch._C._jit.override_can_fuse_on_cpu(True)
         self.default_dtype = torch.get_default_dtype()
-        self.old_reduction_enabled = torch._C._jit_set_texpr_reductions_enabled(True)
+        self.old_reduction_enabled = torch._C._jit.set_texpr_reductions_enabled(True)
         torch.set_default_dtype(torch.double)
-        self.old_fusion_inlining = torch._C._debug_get_fusion_group_inlining()
-        torch._C._debug_set_fusion_group_inlining(False)
+        self.old_fusion_inlining = torch._C._jit._debug_get_fusion_group_inlining()
+        torch._C._jit._debug_set_fusion_group_inlining(False)
 
     def tearDown(self):
-        torch._C._jit_set_profiling_executor(self.prev_exec)
-        torch._C._jit_set_profiling_mode(self.prev_profiling)
-        torch._C._debug_set_autodiff_subgraph_inlining(self.inline_autodiff)
-        torch._C._jit_set_texpr_fuser_enabled(self.texpr_fuser_state)
-        torch._C._jit_override_can_fuse_on_cpu(self.can_fuse_on_cpu)
+        torch._C._jit.set_profiling_executor(self.prev_exec)
+        torch._C._jit.set_profiling_mode(self.prev_profiling)
+        torch._C._jit._debug_set_autodiff_subgraph_inlining(self.inline_autodiff)
+        torch._C._jit.set_texpr_fuser_enabled(self.texpr_fuser_state)
+        torch._C._jit.override_can_fuse_on_cpu(self.can_fuse_on_cpu)
         torch.set_default_dtype(self.default_dtype)
-        torch._C._jit_set_texpr_reductions_enabled(self.old_reduction_enabled)
-        torch._C._debug_set_fusion_group_inlining(self.old_fusion_inlining)
+        torch._C._jit.set_texpr_reductions_enabled(self.old_reduction_enabled)
+        torch._C._jit._debug_set_fusion_group_inlining(self.old_fusion_inlining)
 
     def test_tensor_type_not_determined_by_inputs(self):
         @torch.jit.script
@@ -150,7 +150,7 @@ class TestProfiler(JitTestCase):
         t = torch.rand(8, dtype=torch.float)
 
         foo_script = torch.jit.script(foo)
-        for _ in range(torch._C._jit_get_num_profiled_runs() + 1):
+        for _ in range(torch._C._jit.get_num_profiled_runs() + 1):
             foo_script(t, t, t, t, 0.1)
 
         self.assertEqual(foo(t, t, t, t, 0.1), foo_script(t, t, t, t, 0.1))

--- a/test/jit/test_python_bindings.py
+++ b/test/jit/test_python_bindings.py
@@ -25,7 +25,7 @@ class TestPythonBindings(JitTestCase):
         def fn(x: torch.Tensor):
             return 2 * x
 
-        cu = torch._C.CompilationUnit()
+        cu = torch._C._jit.CompilationUnit()
         cu.create_function("test_fn", fn.graph)
 
         inp = torch.randn(5)
@@ -46,7 +46,7 @@ class TestPythonBindings(JitTestCase):
         v = n.output()
         # check that they work
         str((n, v))
-        torch._C._jit_pass_dce(gr)
+        torch._C._jit.pass_dce(gr)
         with self.assertRaisesRegex(RuntimeError, "invalidated"):
             str(n)
         with self.assertRaisesRegex(RuntimeError, "invalidated"):

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -51,7 +51,7 @@ class TestModels(TestCase):
     def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7):
         with torch.onnx.select_model_mode_for_export(model, None):
             graph = torch.onnx.utils._trace(model, inputs, OperatorExportTypes.ONNX)
-            torch._C._jit_pass_lint(graph)
+            torch._C._jit.pass_lint(graph)
             verify(model, inputs, backend, rtol=rtol, atol=atol)
 
     def test_ops(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -462,8 +462,8 @@ class TestONNXRuntime(unittest.TestCase):
 
     def test_paste_mask_in_image(self):
         # disable profiling
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
 
         masks = torch.rand(10, 1, 26, 26)
         boxes = torch.rand(10, 4)
@@ -513,8 +513,8 @@ class TestONNXRuntime(unittest.TestCase):
 
     def test_heatmaps_to_keypoints(self):
         # disable profiling
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
 
         maps = torch.rand(10, 1, 26, 26)
         rois = torch.rand(10, 4)
@@ -2752,7 +2752,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(ScatterModel(), input=(input, indices, values))
 
         @torch.jit.script
-        def scatter_sum(src: torch.Tensor, index: torch.Tensor): 
+        def scatter_sum(src: torch.Tensor, index: torch.Tensor):
             size = src.size()
             out = torch.zeros(size, dtype=src.dtype)
             return out.scatter_add_(1, index, src)

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -444,7 +444,7 @@ def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode
             backend_out = prepared.run(backend_args(args))
             if isinstance(torch_out, torch.Tensor):
                 torch_out = (torch_out,)
-            torch_out, _ = torch._C._jit_flatten(torch_out)
+            torch_out, _ = torch._C._jit.flatten(torch_out)
             # NB: onnx backend NEVER returns bare numpy array
             msg = "ONNX backend returned different results from PyTorch"
             result_hint = ("If you are not using trained parameters, a difference in results\n"

--- a/test/quantization/test_fusion_passes.py
+++ b/test/quantization/test_fusion_passes.py
@@ -33,8 +33,8 @@ class TestFusionPasses(QuantizationTestCase):
         # In this test case since we are directly calling ops
         # it does not matter, however if we are calling nn
         # modules we have to inline graph.
-        torch._C._jit_pass_inline(scripted_m.graph)
-        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        torch._C._jit.pass_inline(scripted_m.graph)
+        torch._C._jit.pass_fuse_quantized_add_relu(scripted_m.graph)
         FileCheck().check_not("aten::relu") \
                    .check("quantized::add_relu") \
                    .run(scripted_m.graph)
@@ -62,8 +62,8 @@ class TestFusionPasses(QuantizationTestCase):
         # In this test case since we are directly calling ops
         # it does not matter, however if we are calling nn
         # modules we have to inline graph.
-        torch._C._jit_pass_inline(scripted_m.graph)
-        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        torch._C._jit.pass_inline(scripted_m.graph)
+        torch._C._jit.pass_fuse_quantized_add_relu(scripted_m.graph)
         FileCheck().check_not("aten::relu") \
                    .check_not("quantized::add_out") \
                    .check("quantized::add_relu_out") \
@@ -84,8 +84,8 @@ class TestFusionPasses(QuantizationTestCase):
         m = MAddScalar()
         scripted_m = torch.jit.script(m)
         ref_output = scripted_m(qA, 3.)
-        torch._C._jit_pass_inline(scripted_m.graph)
-        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        torch._C._jit.pass_inline(scripted_m.graph)
+        torch._C._jit.pass_fuse_quantized_add_relu(scripted_m.graph)
         FileCheck().check_not("aten::relu") \
                    .check_not("quantized::add_scalar(") \
                    .check("quantized::add_scalar_relu") \
@@ -109,8 +109,8 @@ class TestFusionPasses(QuantizationTestCase):
         m = MAddScalarOut()
         scripted_m = torch.jit.script(m)
         ref_output = scripted_m(qA, 3., qC)
-        torch._C._jit_pass_inline(scripted_m.graph)
-        torch._C._jit_pass_fuse_quantized_add_relu(scripted_m.graph)
+        torch._C._jit.pass_inline(scripted_m.graph)
+        torch._C._jit.pass_fuse_quantized_add_relu(scripted_m.graph)
         FileCheck().check_not("aten::relu") \
                    .check_not("quantized::add_scalar_out") \
                    .check("quantized::add_scalar_relu_out") \

--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -2314,7 +2314,7 @@ class TestDeprecatedJitQuantized(JitTestCase):
 
         with torch._jit_internal._disable_emit_hooks():
             x = torch.jit.script(Linear(10, 10))
-            torch._C._jit_pass_erase_shape_information(x.graph)
+            torch._C._jit.pass_erase_shape_information(x.graph)
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"

--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -6,7 +6,7 @@ from torch._C import parse_schema
 
 class TestFunctionSchema(TestCase):
     def test_serialize_and_deserialize(self):
-        schemas = torch._C._jit_get_all_schemas()
+        schemas = torch._C._jit.get_all_schemas()
         # so far we have around 1700 registered schemas
         self.assertGreater(len(schemas), 1000)
         for schema in schemas:

--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -18,9 +18,9 @@ os.environ['PYTORCH_CUDA_FUSER_DISABLE_FMA'] = '1'
 os.environ['PYTORCH_CUDA_FUSER_JIT_OPT_LEVEL'] = '0'
 
 if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
-    torch._C._jit_set_texpr_fuser_enabled(False)
-    torch._C._jit_set_profiling_executor(True)
-    torch._C._jit_set_profiling_mode(True)
+    torch._C._jit.set_texpr_fuser_enabled(False)
+    torch._C._jit.set_profiling_executor(True)
+    torch._C._jit.set_profiling_mode(True)
 
 FUSION_GROUP = 'prim::CudaFusionGroup'
 FUSION_GUARD = 'prim::CudaFusionGuard'
@@ -46,21 +46,21 @@ class TestCudaFuser(JitTestCase):
 
     def setUp(self):
         super(TestCudaFuser, self).setUp()
-        self.old_cpu_fuse = torch._C._jit_can_fuse_on_cpu()
-        self.old_gpu_fuse = torch._C._jit_can_fuse_on_gpu()
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_override_can_fuse_on_gpu(False)
-        self.old_guard = torch._C._jit_set_nvfuser_guard_mode(False)
+        self.old_cpu_fuse = torch._C._jit.can_fuse_on_cpu()
+        self.old_gpu_fuse = torch._C._jit.can_fuse_on_gpu()
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.override_can_fuse_on_gpu(False)
+        self.old_guard = torch._C._jit.set_nvfuser_guard_mode(False)
 
         if(RUN_CUDA):
-            self.old_nvfuser = torch._C._jit_set_nvfuser_enabled(True)
+            self.old_nvfuser = torch._C._jit.set_nvfuser_enabled(True)
 
     def tearDown(self):
         if(RUN_CUDA):
-            torch._C._jit_set_nvfuser_enabled(self.old_nvfuser)
-        torch._C._jit_override_can_fuse_on_cpu(self.old_cpu_fuse)
-        torch._C._jit_override_can_fuse_on_gpu(self.old_gpu_fuse)
-        torch._C._jit_set_nvfuser_guard_mode(self.old_guard)
+            torch._C._jit.set_nvfuser_enabled(self.old_nvfuser)
+        torch._C._jit.override_can_fuse_on_cpu(self.old_cpu_fuse)
+        torch._C._jit.override_can_fuse_on_gpu(self.old_gpu_fuse)
+        torch._C._jit.set_nvfuser_guard_mode(self.old_guard)
         super(TestCudaFuser, self).tearDown()
 
     def _run_helper(self, jit_op, op, *args):
@@ -498,8 +498,8 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     def test_dynamic_size(self):
-        old_guard = torch._C._jit_set_nvfuser_guard_mode(True)
-        torch._C._jit_set_bailout_depth(20)
+        old_guard = torch._C._jit.set_nvfuser_guard_mode(True)
+        torch._C._jit.set_bailout_depth(20)
 
         def t(x: torch.Tensor, y: torch.Tensor, z: float):
             o = x + y
@@ -532,7 +532,7 @@ class TestCudaFuser(JitTestCase):
         o = t(x, y, 2.0)
         self.assertEqual(o, jit_o)
         self.assertGraphContains(t_jit.graph_for(x, y, 2.0), FUSION_GUARD)
-        torch._C._jit_set_nvfuser_guard_mode(old_guard)
+        torch._C._jit.set_nvfuser_guard_mode(old_guard)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     def test_random_topo(self):
@@ -651,8 +651,8 @@ class TestCudaFuser(JitTestCase):
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     def test_reduction_multiple_output(self):
-        old_guard = torch._C._jit_set_nvfuser_guard_mode(True)
-        torch._C._jit_set_bailout_depth(20)
+        old_guard = torch._C._jit.set_nvfuser_guard_mode(True)
+        torch._C._jit.set_bailout_depth(20)
 
         def t(x: torch.Tensor, y: torch.Tensor, scale: float, z: torch.Tensor):
             o = torch.mul(x, y)
@@ -684,7 +684,7 @@ class TestCudaFuser(JitTestCase):
             self.assertEqual(oo.dtype, jit_oo.dtype)
             self.assertEqual(oo, jit_oo)
         self.assertGraphContains(t_jit.graph_for(x, y, scale, z), FUSION_GUARD)
-        torch._C._jit_set_nvfuser_guard_mode(old_guard)
+        torch._C._jit.set_nvfuser_guard_mode(old_guard)
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
@@ -847,12 +847,12 @@ class TestPassManagerCudaFuser(JitTestCase):
 
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     def test_register_fuser(self):
-        self.assertFalse(torch._C._jit_set_nvfuser_enabled(True))
-        self.assertTrue(torch._C._jit_nvfuser_enabled())
-        self.assertTrue(torch._C._jit_set_nvfuser_enabled(True))
-        self.assertTrue(torch._C._jit_nvfuser_enabled())
-        self.assertTrue(torch._C._jit_set_nvfuser_enabled(False))
-        self.assertFalse(torch._C._jit_nvfuser_enabled())
+        self.assertFalse(torch._C._jit.set_nvfuser_enabled(True))
+        self.assertTrue(torch._C._jit.nvfuser_enabled())
+        self.assertTrue(torch._C._jit.set_nvfuser_enabled(True))
+        self.assertTrue(torch._C._jit.nvfuser_enabled())
+        self.assertTrue(torch._C._jit.set_nvfuser_enabled(False))
+        self.assertFalse(torch._C._jit.nvfuser_enabled())
 
 
 if __name__ == '__main__':

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -18,8 +18,8 @@ from test_jit import backward_graph, all_backward_graphs, get_lstm_inputs, get_m
     LSTMCellC, LSTMCellF, LSTMCellS, MiLSTMCell
 
 if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
-    torch._C._jit_set_profiling_executor(True)
-    torch._C._jit_set_profiling_mode(True)
+    torch._C._jit.set_profiling_executor(True)
+    torch._C._jit.set_profiling_mode(True)
 
 
 def strip_profiling_nodes(nodes):
@@ -682,14 +682,14 @@ class TestFuser(JitTestCase):
             torch.randn(4, 4, dtype=torch.float, device='cuda:1'),
         ]
 
-        prev_cache_size = torch._C._jit_debug_fuser_num_cached_kernel_specs()
+        prev_cache_size = torch._C._jit.debug_fuser_num_cached_kernel_specs()
 
         # There are 3 FusionGroups. Because they have the same graph, they
         # should reuse the same KernelSpec in the KernelSpec cache.
         ge = self.checkScript(fn, inputs)
         self.assertGraphContainsExactly(
             ge.graph_for(*inputs), 'prim::FusionGroup', 3, True)
-        new_cache_size = torch._C._jit_debug_fuser_num_cached_kernel_specs()
+        new_cache_size = torch._C._jit.debug_fuser_num_cached_kernel_specs()
         # XXX: This assumes that the same kernel isn't already used by another test
         self.assertEqual(new_cache_size - prev_cache_size, 1)
 

--- a/test/test_jit_py3.py
+++ b/test/test_jit_py3.py
@@ -305,7 +305,7 @@ class TestScriptPy3(JitTestCase):
             return tup
 
         FileCheck().check('TupleConstruct').run(foo.graph)
-        torch._C._jit_pass_lower_all_tuples(foo.graph)
+        torch._C._jit.pass_lower_all_tuples(foo.graph)
         FileCheck().check_not('TupleConstruct').run(foo.graph)
 
     def test_named_tuple_type_annotation(self):

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -19,13 +19,13 @@ class TestMetalRewritePass(TestCase):
         scripted_model.eval()
         input_data = torch.normal(1, 20, size=data_shape)
         ref_result = scripted_model(input_data)
-        torch._C._jit_pass_metal_insert_prepacked_ops(scripted_model._c)
+        torch._C._jit.pass_metal_insert_prepacked_ops(scripted_model._c)
         if fuse_clamping_ops or prepack_removal:
-            scripted_model._c = torch._C._freeze_module(scripted_model._c)
+            scripted_model._c = torch._C._jit._freeze_module(scripted_model._c)
         if fuse_clamping_ops:
-            torch._C._jit_pass_metal_fuse_clamp_w_prepacked_conv(scripted_model._c)
+            torch._C._jit.pass_metal_fuse_clamp_w_prepacked_conv(scripted_model._c)
         if prepack_removal:
-            torch._C._jit_pass_metal_fold_prepacking_ops(scripted_model._c)
+            torch._C._jit.pass_metal_fold_prepacking_ops(scripted_model._c)
 
         buffer = io.BytesIO()
         torch.jit.save(scripted_model, buffer)

--- a/test/test_mobile_optimizer.py
+++ b/test/test_mobile_optimizer.py
@@ -10,7 +10,7 @@ from torch.nn import functional as F
 from torch._C import MobileOptimizerType
 from torch.testing._internal.common_quantized import override_quantized_engine
 
-FileCheck = torch._C.FileCheck
+FileCheck = torch._C._jit.FileCheck
 
 class TestOptimizer(TestCase):
 

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -59,8 +59,8 @@ class TestProfiler(TestCase):
         """Checks that source code attribution works for eager, TS and autograd mode
         """
         # avoid automatic inlining
-        prev_opt = torch._C._get_graph_executor_optimize()
-        torch._C._set_graph_executor_optimize(False)
+        prev_opt = torch._C._jit._get_graph_executor_optimize()
+        torch._C._jit._set_graph_executor_optimize(False)
 
         @torch.jit.script
         def ts_method_2(x, y):
@@ -102,7 +102,7 @@ class TestProfiler(TestCase):
                     "ts_method_1" in entry or
                     "ts_method_2" in entry) for entry in e.stack]))
 
-        torch._C._set_graph_executor_optimize(prev_opt)
+        torch._C._jit._set_graph_executor_optimize(prev_opt)
 
     def payload(self):
         x = torch.randn(10, 10).cuda()

--- a/test/test_static_runtime.py
+++ b/test/test_static_runtime.py
@@ -9,9 +9,9 @@ class StaticRuntime:
     def __init__(self, scripted):
         # this is an nn.Module
         if hasattr(scripted, "_c"):
-            self.static_runtime = torch._C._jit_to_static_runtime(scripted._c)
+            self.static_runtime = torch._C._jit.to_static_runtime(scripted._c)
         else:
-            self.static_runtime = torch._C._jit_to_static_runtime(scripted.graph)
+            self.static_runtime = torch._C._jit.to_static_runtime(scripted.graph)
 
     def __call__(self, *args, **kwargs):
         if not kwargs:

--- a/test/test_vulkan.py
+++ b/test/test_vulkan.py
@@ -22,13 +22,13 @@ class TestVulkanRewritePass(TestCase):
         scripted_model.eval()
         input_data = torch.normal(1, 20, size=data_shape)
         ref_result = scripted_model(input_data)
-        torch._C._jit_pass_vulkan_insert_prepacked_ops(scripted_model._c)
+        torch._C._jit.pass_vulkan_insert_prepacked_ops(scripted_model._c)
         if fuse_clamping_ops or prepack_removal:
-            scripted_model._c = torch._C._freeze_module(scripted_model._c)
+            scripted_model._c = torch._C._jit._freeze_module(scripted_model._c)
         if fuse_clamping_ops:
-            torch._C._jit_pass_vulkan_fuse_clamp_w_prepacked_conv(scripted_model._c)
+            torch._C._jit.pass_vulkan_fuse_clamp_w_prepacked_conv(scripted_model._c)
         if prepack_removal:
-            torch._C._jit_pass_vulkan_fold_prepacking_ops(scripted_model._c)
+            torch._C._jit.pass_vulkan_fold_prepacking_ops(scripted_model._c)
 
         buffer = io.BytesIO()
         torch.jit.save(scripted_model, buffer)

--- a/test/test_xnnpack_integration.py
+++ b/test/test_xnnpack_integration.py
@@ -574,13 +574,13 @@ class TestXNNPACKRewritePass(TestCase):
                 scripted_model = torch.jit.trace(module_instance, input_data)
             scripted_model.eval()
             ref_result = scripted_model(input_data)
-            torch._C._jit_pass_insert_prepacked_ops(scripted_model._c)
+            torch._C._jit.pass_insert_prepacked_ops(scripted_model._c)
             if fuse_clamping_ops or prepack_removal:
-                scripted_model._c = torch._C._freeze_module(scripted_model._c)
+                scripted_model._c = torch._C._jit._freeze_module(scripted_model._c)
             if fuse_clamping_ops:
-                torch._C._jit_pass_fuse_clamp_w_prepacked_linear_conv(scripted_model._c)
+                torch._C._jit.pass_fuse_clamp_w_prepacked_linear_conv(scripted_model._c)
             if (prepack_removal):
-                torch._C._jit_pass_fold_prepacking_ops(scripted_model._c)
+                torch._C._jit.pass_fold_prepacking_ops(scripted_model._c)
 
             buffer = io.BytesIO()
             torch.jit.save(scripted_model, buffer)
@@ -933,7 +933,7 @@ class TestXNNPACKConv1dTransformPass(TestCase):
                 scripted_model = torch.jit.trace(module_instance, input_data)
             scripted_model.eval()
             ref_result = scripted_model(input_data)
-            torch._C._jit_pass_transform_conv1d_to_conv2d(scripted_model._c)
+            torch._C._jit.pass_transform_conv1d_to_conv2d(scripted_model._c)
             optimized_scripted_model = optimize_for_mobile(scripted_model)
 
             buffer = io.BytesIO()

--- a/torch/_classes.py
+++ b/torch/_classes.py
@@ -7,7 +7,7 @@ class _ClassNamespace(types.ModuleType):
         self.name = name
 
     def __getattr__(self, attr):
-        proxy = torch._C._get_custom_class_python_wrapper(self.name, attr)
+        proxy = torch._C._jit._get_custom_class_python_wrapper(self.name, attr)
         if proxy is None:
             raise RuntimeError(f'Class {self.name}.{attr} not registered!')
         return proxy

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -864,7 +864,7 @@ def _qualified_name(obj):
     if hasattr(obj, '_jit_override_qualname'):
         return obj._jit_override_qualname
     # short-circuit in cases where the object already has a known qualified name
-    if isinstance(obj, torch._C.ScriptFunction):
+    if isinstance(obj, torch._C._jit.ScriptFunction):
         return obj.qualified_name
 
     if getattr(obj, "__name__", None):
@@ -912,7 +912,7 @@ def _qualified_name(obj):
 
 # Thin wrapper around SourceRangeFactory to store extra metadata
 # about the function-to-be-compiled.
-class SourceContext(torch._C._jit_tree_views.SourceRangeFactory):
+class SourceContext(torch._C._jit.tree_views.SourceRangeFactory):
     def __init__(self, source, filename, file_lineno, leading_whitespace_len, uses_true_division=True):
         super(SourceContext, self).__init__(source, filename, file_lineno, leading_whitespace_len)
         self.uses_true_division = uses_true_division
@@ -938,7 +938,7 @@ def _get_named_tuple_properties(obj):
             the_type = torch.jit.annotations.ann_to_type(obj.__annotations__[field], fake_range())
             annotations.append(the_type)
         else:
-            annotations.append(torch._C.TensorType.getInferred())
+            annotations.append(torch._C._jit.TensorType.getInferred())
     return type(obj).__name__, fields, annotations
 
 
@@ -950,19 +950,19 @@ def _create_named_tuple(t, unqual_name: str, field_names: List[str]):
 
 @contextlib.contextmanager
 def _disable_emit_hooks():
-    hooks = torch._C._jit_get_emit_hooks()
-    torch._C._jit_set_emit_hooks(None, None)
+    hooks = torch._C._jit.get_emit_hooks()
+    torch._C._jit.set_emit_hooks(None, None)
     yield
-    torch._C._jit_set_emit_hooks(hooks[0], hooks[1])
+    torch._C._jit.set_emit_hooks(hooks[0], hooks[1])
 
 
 def _disable_emit_hooks_decorator(_DecoratorContextManager):  # noqa: F811
     def __enter__(self):
-        self.hooks = torch._C._jit_get_emit_hooks()
-        torch._C._jit_set_emit_hooks(None, None)
+        self.hooks = torch._C._jit.get_emit_hooks()
+        torch._C._jit.set_emit_hooks(None, None)
 
     def __exit__(self, *args):
-        torch._C._jit_set_emit_hooks(self.hooks[0], self.hooks[1])
+        torch._C._jit.set_emit_hooks(self.hooks[0], self.hooks[1])
 
 def _is_exception(obj):
     if not inspect.isclass(obj):

--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -57,7 +57,7 @@ class _OpNamespace(types.ModuleType):
         # Get the op `my_namespace::my_op` if available. This will also check
         # for overloads and raise an exception if there are more than one.
         qualified_op_name = '{}::{}'.format(self.name, op_name)
-        op = torch._C._jit_get_operation(qualified_op_name)
+        op = torch._C._jit.get_operation(qualified_op_name)
         # let the script frontend know that op is identical to the builtin op
         # with qualified_op_name
         torch.jit._builtins._register_builtin(op, qualified_op_name)

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -348,7 +348,7 @@ def _unflatten(input, proto):
     return unflatten_helper(input, proto)[0]
 
 
-_iter_jit_values = _iter_filter(lambda o: o is None or isinstance(o, torch._C.Value),
+_iter_jit_values = _iter_filter(lambda o: o is None or isinstance(o, torch._C._jit.Value),
                                 condition_msg="jit's Values or None")
 _iter_tensors = _iter_filter(lambda x: isinstance(x, torch.Tensor), condition_msg="Tensors",
                              conversion=_jit_unwrap_structured)

--- a/torch/contrib/_tensorboard_vis.py
+++ b/torch/contrib/_tensorboard_vis.py
@@ -30,7 +30,7 @@ def visualize(graph, name_prefix='', pb_graph=None, executors_it=None):
     value_map = {}
     pb_graph = pb_graph or graph_pb2.GraphDef()
 
-    if isinstance(graph, torch._C.GraphExecutorState):
+    if isinstance(graph, torch._C._jit.GraphExecutorState):
         visualize_graph_executor(graph, name_prefix, pb_graph,
                                  partial(visualize, pb_graph=pb_graph))
         return pb_graph

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -111,7 +111,7 @@ class PYBIND11_EXPORT PythonRpcHandler {
   RRefTypeFunctions rrefTypeFunctions_;
 
   // Shared ptr to python compilation unit in jit, it is constructed in python
-  // side (see _python_cu = torch._C.CompilationUnit() in jit/__init__.py)
+  // side (see _python_cu = torch._C._jit.CompilationUnit() in jit/__init__.py)
   // and imported in C++ (see get_python_cu() in
   // csrc/jit/python/pybind_utils.h). We import the compilation unit here only
   // once for less cost and thread safety.

--- a/torch/csrc/jit/backends/backend_init.cpp
+++ b/torch/csrc/jit/backends/backend_init.cpp
@@ -127,7 +127,7 @@ void initJitBackendBindings(PyObject* module) {
   //
   // this function must be called like
   //
-  //  torch._C._jit_to_backend("example_backend", module, spec)
+  //  torch._C._jit.to_backend("example_backend", module, spec)
   auto codegen_lambda = [=](const std::string& backend_name,
                             const Module& orig_module,
                             const py::dict& method_compile_spec) {

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -178,9 +178,7 @@ void initJITBindings(PyObject* module) {
             return paramsDict;
           },
           pybind11::return_value_policy::move)
-      .def(
-          "pass_onnx_cast_all_constant_to_floating",
-          CastAllConstantToFloating)
+      .def("pass_onnx_cast_all_constant_to_floating", CastAllConstantToFloating)
       .def(
           "pass_onnx_constant_fold",
           [](std::shared_ptr<Graph>& graph,
@@ -204,11 +202,8 @@ void initJITBindings(PyObject* module) {
           },
           pybind11::return_value_policy::move)
       .def("pass_onnx_scalar_type_analysis", ScalarTypeAnalysisForONNX)
-      .def(
-          "pass_onnx_remove_inplace_ops_for_onnx", RemoveInplaceOpsForONNX)
-      .def(
-          "pass_onnx_prepare_inplace_ops_for_onnx",
-          PrepareInplaceOpsForONNX)
+      .def("pass_onnx_remove_inplace_ops_for_onnx", RemoveInplaceOpsForONNX)
+      .def("pass_onnx_prepare_inplace_ops_for_onnx", PrepareInplaceOpsForONNX)
       .def(
           "pass_onnx_node_shape_type_inference",
           [](Node* n,
@@ -1313,14 +1308,14 @@ void initJITBindings(PyObject* module) {
     toIValue(std::move(obj), type);
   });
 
-  initPythonCustomClassBindings(module);
-  initPythonIRBindings(module);
-  tracer::initPythonTracerBindings(module);
-  initTreeViewBindings(module);
-  initJitScriptBindings(module);
-  initJitBackendBindings(module);
-  initStaticRuntimeBindings(module);
-  initTensorExprBindings(module);
+  initPythonCustomClassBindings(m.ptr());
+  initPythonIRBindings(m.ptr());
+  tracer::initPythonTracerBindings(m.ptr());
+  initTreeViewBindings(m.ptr());
+  initJitScriptBindings(m.ptr());
+  initJitBackendBindings(m.ptr());
+  initStaticRuntimeBindings(m.ptr());
+  initTensorExprBindings(m.ptr());
 
   setPrintHandler([](const std::string& str) {
     py::gil_scoped_acquire acquire;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -134,8 +134,8 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
   }
 
   // The py::function cb arg must take a std::shared_ptr<PythonFutureWrapper>
-  // (i.e., torch._C._jit.Future) as the only argument. If the type mismatches, an
-  // error will be thrown when waiting for the value of this returned Future.
+  // (i.e., torch._C._jit.Future) as the only argument. If the type mismatches,
+  // an error will be thrown when waiting for the value of this returned Future.
   std::shared_ptr<PythonFutureWrapper> then(py::function cb) {
     // We need this an additional layer of wrapper here to guard the
     // destruction of the py::function object. Because, the

--- a/torch/csrc/jit/python/python_tree_views.cpp
+++ b/torch/csrc/jit/python/python_tree_views.cpp
@@ -73,8 +73,8 @@ Maybe<T> wrap_maybe(const SourceRange& fallback_pos, T* val) {
 }
 
 void initTreeViewBindings(PyObject* module) {
-  auto _C = py::handle(module).cast<py::module>();
-  auto m = _C.def_submodule("_jit_tree_views");
+  auto _jit = py::handle(module).cast<py::module>();
+  auto m = _jit.def_submodule("tree_views");
 
   py::class_<SourceRange>(m, "SourceRange")
       .def(

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -1558,9 +1558,7 @@ void initJitScriptBindings(PyObject* module) {
 
   m.def("set_emit_hooks", setEmitHooks);
   m.def("get_emit_hooks", getEmitHooks);
-  m.def("clear_class_registry", []() {
-    get_python_cu()->_clear_python_cu();
-  });
+  m.def("clear_class_registry", []() { get_python_cu()->_clear_python_cu(); });
   m.def(
       "_debug_set_autodiff_subgraph_inlining",
       debugSetAutodiffSubgraphInlining);

--- a/torch/distributed/rpc/rref_proxy.py
+++ b/torch/distributed/rpc/rref_proxy.py
@@ -20,7 +20,7 @@ def _invoke_rpc(rref, rpc_api, func_name, timeout, *args, **kwargs):
     _invoke_func = _local_invoke
     # Bypass ScriptModules when checking for async function attribute.
     bypass_type = issubclass(rref_type, torch.jit.ScriptModule) or issubclass(
-        rref_type, torch._C.ScriptModule
+        rref_type, torch._C._jit.ScriptModule
     )
     if not bypass_type:
         func = getattr(rref_type, func_name)

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -51,7 +51,7 @@ class Exponential(ExponentialFamily):
 
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
-        if torch._C._get_tracing_state():
+        if torch._C._jit._get_tracing_state():
             # [JIT WORKAROUND] lack of support for ._exponential()
             u = torch.rand(shape, dtype=self.rate.dtype, device=self.rate.device)
             return -(-u).log1p() / self.rate

--- a/torch/distributions/geometric.py
+++ b/torch/distributions/geometric.py
@@ -77,7 +77,7 @@ class Geometric(Distribution):
         shape = self._extended_shape(sample_shape)
         tiny = torch.finfo(self.probs.dtype).tiny
         with torch.no_grad():
-            if torch._C._get_tracing_state():
+            if torch._C._jit._get_tracing_state():
                 # [JIT WORKAROUND] lack of support for .uniform_()
                 u = torch.rand(shape, dtype=self.probs.dtype, device=self.probs.device)
                 u = u.clamp(min=tiny)

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -55,7 +55,7 @@ class Laplace(Distribution):
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         finfo = torch.finfo(self.loc.dtype)
-        if torch._C._get_tracing_state():
+        if torch._C._jit._get_tracing_state():
             # [JIT WORKAROUND] lack of support for .uniform_()
             u = torch.rand(shape, dtype=self.loc.dtype, device=self.loc.device) * 2 - 1
             return self.loc - self.scale * u.sign() * torch.log1p(-u.abs().clamp(min=finfo.tiny))

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -41,7 +41,7 @@ def broadcast_all(*values):
 
 
 def _standard_normal(shape, dtype, device):
-    if torch._C._get_tracing_state():
+    if torch._C._jit._get_tracing_state():
         # [JIT WORKAROUND] lack of support for .normal_()
         return torch.normal(torch.zeros(shape, dtype=dtype, device=device),
                             torch.ones(shape, dtype=dtype, device=device))
@@ -118,7 +118,7 @@ def tril_matrix_to_vec(mat, diag=0):
     which comprises of lower triangular elements from the matrix in row order.
     """
     n = mat.shape[-1]
-    if not torch._C._get_tracing_state() and (diag < -n or diag >= n):
+    if not torch._C._jit._get_tracing_state() and (diag < -n or diag >= n):
         raise ValueError(f'diag ({diag}) provided is outside [{-n}, {n-1}].')
     arange = torch.arange(n, device=mat.device)
     tril_mask = arange < arange.view(-1, 1) + (diag + 1)
@@ -134,7 +134,7 @@ def vec_to_tril_matrix(vec, diag=0):
     # +ve root of D**2 + (1+2*diag)*D - |diag| * (diag+1) - 2*vec.shape[-1] = 0
     n = (-(1 + 2 * diag) + ((1 + 2 * diag)**2 + 8 * vec.shape[-1] + 4 * abs(diag) * (diag + 1))**0.5) / 2
     eps = torch.finfo(vec.dtype).eps
-    if not torch._C._get_tracing_state() and (round(n) - n > eps):
+    if not torch._C._jit._get_tracing_state() and (round(n) - n > eps):
         raise ValueError(f'The size of last dimension is {vec.shape[-1]} which cannot be expressed as ' +
                          'the lower triangular part of a square D x D matrix.')
     n = torch.round(n).long() if isinstance(n, torch.Tensor) else round(n)

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -56,11 +56,11 @@ def export_opnames(m):
     r"""
         Returns a list of operator names of a script module and its submodules
     """
-    return torch._C._export_opnames(m._c)
+    return torch._C._jit._export_opnames(m._c)
 
 
 # torch.jit.Error
-Error = torch._C.JITException
+Error = torch._C._jit.JITException
 set_module(Error, "torch.jit")
 # This is not perfect but works in common cases
 Error.__name__ = "Error"
@@ -136,5 +136,5 @@ def isinstance(obj, target_type):
     return _isinstance(obj, target_type)
 
 
-if not torch._C._jit_init():
+if not torch._C._jit.init():
     raise RuntimeError("JIT initialization failed")

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -79,7 +79,7 @@ def fork(func, *args, **kwargs):
         mod = Mod()
         assert mod(input) == torch.jit.script(mod).forward(input)
     """
-    return torch._C.fork(func, *args, **kwargs)
+    return torch._C._jit.fork(func, *args, **kwargs)
 
 
 def wait(future):
@@ -91,7 +91,7 @@ def wait(future):
     Returns:
         `T`: the return value of the the completed task
     """
-    return torch._C.wait(future)
+    return torch._C._jit.wait(future)
 
 
 _register_builtin(wait, "aten::wait")

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -77,7 +77,7 @@ _builtin_ops = [
     (torch.nn.init._no_grad_normal_, "aten::_no_grad_normal_"),
     (torch.nn.init._no_grad_uniform_, "aten::_no_grad_uniform_"),
     (torch.nn.init._no_grad_zero_, "aten::_no_grad_zero_"),
-    (torch._C._get_tracing_state, "aten::_get_tracing_state"),
+    (torch._C._jit._get_tracing_state, "aten::_get_tracing_state"),
     (warnings.warn, "aten::warn"),
     (torch._VF.stft, "aten::stft"),  # type: ignore
     (torch._VF.istft, "aten::istft"),  # type: ignore

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -100,7 +100,7 @@ def freeze(mod, preserved_attrs: Optional[List[str]] = None, optimize: bool = Tr
 
     preserved_attrs = preserved_attrs if preserved_attrs is not None else []
 
-    out = RecursiveScriptModule(torch._C._freeze_module(mod._c, preserved_attrs))
+    out = RecursiveScriptModule(torch._C._jit._freeze_module(mod._c, preserved_attrs))
     RecursiveScriptModule._finalize_scriptmodule(out)
     if optimize:
         optimize_frozen_module(out)
@@ -140,4 +140,4 @@ def optimize_frozen_module(mod):
         assert "batch_norm" not in str(frozen_mod.graph)
 
     """
-    torch._C._jit_pass_optimize_frozen_graph(mod.graph)
+    torch._C._jit.pass_optimize_frozen_graph(mod.graph)

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -8,12 +8,12 @@ def optimized_execution(should_optimize):
     A context manager that controls whether the JIT's executor will run
     optimizations before executing a function.
     """
-    stored_flag = torch._C._get_graph_executor_optimize()
-    torch._C._set_graph_executor_optimize(should_optimize)
+    stored_flag = torch._C._jit._get_graph_executor_optimize()
+    torch._C._jit._set_graph_executor_optimize(should_optimize)
     try:
         yield
     finally:
-        torch._C._set_graph_executor_optimize(stored_flag)
+        torch._C._jit._set_graph_executor_optimize(stored_flag)
 
 @contextlib.contextmanager
 def fuser(name):
@@ -26,43 +26,43 @@ def fuser(name):
     * ``fuser1`` - enables only NNC
     * ``fuser2`` - enables only nvFuser
     """
-    old_cpu_fuse = torch._C._jit_can_fuse_on_cpu()
-    old_gpu_fuse = torch._C._jit_can_fuse_on_gpu()
-    old_texpr_fuser_state = torch._C._jit_texpr_fuser_enabled()
-    old_nvfuser_state = torch._C._jit_nvfuser_enabled()
+    old_cpu_fuse = torch._C._jit.can_fuse_on_cpu()
+    old_gpu_fuse = torch._C._jit.can_fuse_on_gpu()
+    old_texpr_fuser_state = torch._C._jit.texpr_fuser_enabled()
+    old_nvfuser_state = torch._C._jit.nvfuser_enabled()
     if name == 'fuser0':  # legacy fuser
-        torch._C._jit_override_can_fuse_on_cpu(True)
-        torch._C._jit_override_can_fuse_on_gpu(True)
-        torch._C._jit_set_texpr_fuser_enabled(False)
-        torch._C._jit_set_nvfuser_enabled(False)
+        torch._C._jit.override_can_fuse_on_cpu(True)
+        torch._C._jit.override_can_fuse_on_gpu(True)
+        torch._C._jit.set_texpr_fuser_enabled(False)
+        torch._C._jit.set_nvfuser_enabled(False)
     elif name == 'fuser1':  # NNC
-        old_profiling_executor = torch._C._jit_set_profiling_executor(True)
-        old_profiling_mode = torch._C._jit_set_profiling_mode(True)
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_override_can_fuse_on_gpu(True)
-        torch._C._jit_set_texpr_fuser_enabled(True)
-        torch._C._jit_set_nvfuser_enabled(False)
+        old_profiling_executor = torch._C._jit.set_profiling_executor(True)
+        old_profiling_mode = torch._C._jit.set_profiling_mode(True)
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.override_can_fuse_on_gpu(True)
+        torch._C._jit.set_texpr_fuser_enabled(True)
+        torch._C._jit.set_nvfuser_enabled(False)
     elif name == 'fuser2':  # nvFuser
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_override_can_fuse_on_gpu(False)
-        torch._C._jit_set_texpr_fuser_enabled(False)
-        torch._C._jit_set_nvfuser_enabled(True)
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.override_can_fuse_on_gpu(False)
+        torch._C._jit.set_texpr_fuser_enabled(False)
+        torch._C._jit.set_nvfuser_enabled(True)
     else:
         raise Exception("unrecognized fuser option")
     try:
         yield
     finally:
         if name == 'fuser1':  # NNC
-            torch._C._jit_set_profiling_executor(old_profiling_executor)
-            torch._C._jit_set_profiling_mode(old_profiling_mode)
+            torch._C._jit.set_profiling_executor(old_profiling_executor)
+            torch._C._jit.set_profiling_mode(old_profiling_mode)
         # recover the previous values
-        torch._C._jit_override_can_fuse_on_cpu(old_cpu_fuse)
-        torch._C._jit_override_can_fuse_on_gpu(old_gpu_fuse)
-        torch._C._jit_set_texpr_fuser_enabled(old_texpr_fuser_state)
-        torch._C._jit_set_nvfuser_enabled(old_nvfuser_state)
+        torch._C._jit.override_can_fuse_on_cpu(old_cpu_fuse)
+        torch._C._jit.override_can_fuse_on_gpu(old_gpu_fuse)
+        torch._C._jit.set_texpr_fuser_enabled(old_texpr_fuser_state)
+        torch._C._jit.set_nvfuser_enabled(old_nvfuser_state)
 
 
-last_executed_optimized_graph = torch._C._last_executed_optimized_graph
+last_executed_optimized_graph = torch._C._jit._last_executed_optimized_graph
 
 
 def _graph_for(self, *args, **kwargs):

--- a/torch/jit/_logging.py
+++ b/torch/jit/_logging.py
@@ -2,9 +2,9 @@ import torch
 
 add_stat_value = torch.ops.prim.AddStatValue
 
-set_logger = torch._C._logging_set_logger
-LockingLogger = torch._C.LockingLogger
-AggregationType = torch._C.AggregationType
-NoopLogger = torch._C.NoopLogger
+set_logger = torch._C._jit._logging_set_logger
+LockingLogger = torch._C._jit.LockingLogger
+AggregationType = torch._C._jit.AggregationType
+NoopLogger = torch._C._jit.NoopLogger
 
 time_point = torch.ops.prim.TimePoint

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -156,11 +156,11 @@ def load(f, map_location=None, _extra_files=None):
     if _extra_files is None:
         _extra_files = {}
 
-    cu = torch._C.CompilationUnit()
+    cu = torch._C._jit.CompilationUnit()
     if isinstance(f, str) or isinstance(f, pathlib.Path):
-        cpp_module = torch._C.import_ir_module(cu, str(f), map_location, _extra_files)
+        cpp_module = torch._C._jit.import_ir_module(cu, str(f), map_location, _extra_files)
     else:
-        cpp_module = torch._C.import_ir_module_from_buffer(
+        cpp_module = torch._C._jit.import_ir_module_from_buffer(
             cu, f.read(), map_location, _extra_files
         )
 

--- a/torch/jit/_state.py
+++ b/torch/jit/_state.py
@@ -54,7 +54,7 @@ def enable():
 # The Python CompilationUnit. All functions and modules defined in Python will
 # live in here. It's defined in Python because doing in cpp creates static
 # destruction order issues.
-_python_cu = torch._C.CompilationUnit()
+_python_cu = torch._C._jit.CompilationUnit()
 
 
 # qualified_name => ScriptClass mapping

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -24,8 +24,8 @@ from torch._jit_internal import _qualified_name
 from torch.autograd import function
 from torch.nn import Module
 
-_flatten = torch._C._jit_flatten
-_unflatten = torch._C._jit_unflatten
+_flatten = torch._C._jit.flatten
+_unflatten = torch._C._jit.unflatten
 
 
 def _create_interpreter_name_lookup_fn(frames_up=1):
@@ -122,7 +122,7 @@ class ONNXTracedModule(torch.nn.Module):
             else:
                 return tuple(out_vars)
 
-        graph, out = torch._C._create_graph_by_tracing(
+        graph, out = torch._C._jit._create_graph_by_tracing(
             wrapper,
             in_vars + module_state,
             _create_interpreter_name_lookup_fn(),
@@ -332,7 +332,7 @@ def _check_trace(
                 strict=strict,
                 _force_outplace=force_outplace,
                 _module_class=_module_class,
-                _compilation_unit=torch._C.CompilationUnit(),
+                _compilation_unit=torch._C._jit.CompilationUnit(),
             )
             check_mod_func = check_mod._c._get_method(traced_func.name)
             inputs = inputs[traced_func.name]
@@ -350,14 +350,14 @@ def _check_trace(
             check_mod_func = check_mod
 
         def graph_diagnostic_info():
-            mod_canonicalized = torch._C._jit_pass_canonicalize(traced_func.graph)
-            torch._C._jit_pass_inline(mod_canonicalized)
-            torch._C._jit_pass_erase_shape_information(mod_canonicalized)
+            mod_canonicalized = torch._C._jit.pass_canonicalize(traced_func.graph)
+            torch._C._jit.pass_inline(mod_canonicalized)
+            torch._C._jit.pass_erase_shape_information(mod_canonicalized)
             mod_str = str(mod_canonicalized)
             mod_str = re.sub(r"___torch_mangle_[0-9]+\.", "", mod_str)
-            check_canonicalized = torch._C._jit_pass_canonicalize(check_mod_func.graph)
-            torch._C._jit_pass_inline(check_canonicalized)
-            torch._C._jit_pass_erase_shape_information(check_canonicalized)
+            check_canonicalized = torch._C._jit.pass_canonicalize(check_mod_func.graph)
+            torch._C._jit.pass_inline(check_canonicalized)
+            torch._C._jit.pass_erase_shape_information(check_canonicalized)
             check_str = str(check_canonicalized)
             check_str = re.sub(r"___torch_mangle_[0-9]+\.", "", check_str)
 
@@ -531,7 +531,7 @@ class TracerWarning(Warning):
 # We ignore the tracer warnings coming form inside the library, because all our shape
 # checks in nn will trigger them.
 TracerWarning.ignore_lib_warnings()
-torch._C._tracer_warn_use_python()
+torch._C._jit._tracer_warn_use_python()
 
 
 def make_tuple(example_inputs):
@@ -775,7 +775,7 @@ def trace(
         )
 
     name = _qualified_name(func)
-    traced = torch._C._create_function_from_trace(
+    traced = torch._C._jit._create_function_from_trace(
         name, func, example_inputs, var_lookup_fn, strict, _force_outplace
     )
 
@@ -976,7 +976,7 @@ def is_tracing():
     Returns ``True`` in tracing (if a function is called during the tracing of
     code with ``torch.jit.trace``) and ``False`` otherwise.
     """
-    return torch._C._is_tracing()
+    return torch._C._jit._is_tracing()
 
 
 class TracedModule(ScriptModule):
@@ -1022,7 +1022,7 @@ class TracedModule(ScriptModule):
                 check_unique(buf)
         for name, val in orig.__dict__.items():
             if (
-                torch._C._jit_is_script_object(val)
+                torch._C._jit.is_script_object(val)
                 and name not in orig._parameters
                 and name not in orig._buffers
             ):

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -9,7 +9,7 @@ from .._jit_internal import List, Tuple, is_tuple, is_list, Dict, is_dict, Optio
 from .._jit_internal import BroadcastingList1, BroadcastingList2, BroadcastingList3  # type: ignore
 from ._state import _get_script_class
 
-from torch._C import TensorType, TupleType, FloatType, IntType, ComplexType, \
+from torch._C._jit import TensorType, TupleType, FloatType, IntType, ComplexType, \
     ListType, StringType, DictType, BoolType, OptionalType, ClassType, InterfaceType, AnyType, NoneType, \
     DeviceObjType, StreamObjType, FutureType, EnumType
 
@@ -20,7 +20,7 @@ from typing import Type
 
 if torch.distributed.rpc.is_available():
     from .._jit_internal import RRef, is_rref
-    from torch._C import RRefType
+    from torch._C._jit import RRefType
 
 
 class Module(object):
@@ -273,7 +273,7 @@ def get_enum_value_type(e: Type[enum.Enum], loc):
     # Even though Python supports this case, we chose to not implement it to
     # avoid overcomplicate logic here for a rare use case. Please report a
     # feature request if you find it necessary.
-    return torch._C.unify_type_list(ir_types)
+    return torch._C._jit.unify_type_list(ir_types)
 
 
 def try_ann_to_type(ann, loc):
@@ -348,7 +348,7 @@ def try_ann_to_type(ann, loc):
     # Maybe resolve a NamedTuple to a Tuple Type
     def fake_rcb(key):
         return None
-    return torch._C._resolve_type_from_object(ann, loc, fake_rcb)
+    return torch._C._jit._resolve_type_from_object(ann, loc, fake_rcb)
 
 
 def ann_to_type(ann, loc):

--- a/torch/jit/frontend.py
+++ b/torch/jit/frontend.py
@@ -5,7 +5,7 @@ import inspect
 import string
 from textwrap import dedent
 from typing import List
-from torch._C._jit_tree_views import (
+from torch._C._jit.tree_views import (
     ClassDef, Ident, Stmt, Decl, Def, Var,
     EmptyTypeAnnotation, Param, ExprStmt, Assign,
     Delete, Return, Raise, Assert, AugAssign, While,
@@ -93,7 +93,7 @@ class FrontendError(Exception):
 
         # This has to be instantiated here so the ErrorReport is accurate to the
         # call stack when the FrontendError was raised
-        self.error_report = torch._C.ErrorReport(self.source_range)
+        self.error_report = torch._C._jit.ErrorReport(self.source_range)
 
     def __str__(self):
         return self.msg + self.error_report.what().lstrip()
@@ -177,7 +177,7 @@ def get_jit_class_def(cls, self_name):
 
     properties = get_class_properties(cls, self_name)
 
-    sourcelines, file_lineno, filename = get_source_lines_and_file(cls, torch._C.ErrorReport.call_stack())
+    sourcelines, file_lineno, filename = get_source_lines_and_file(cls, torch._C._jit.ErrorReport.call_stack())
     source = ''.join(sourcelines)
     dedent_src = dedent(source)
     py_ast = ast.parse(dedent_src)
@@ -237,7 +237,7 @@ def get_jit_def(fn, def_name, self_name=None, is_classmethod=False):
             but we want the result AST to have the name "forward".
         self_name: If this function is a method, what the type name of `self` is.
     """
-    sourcelines, file_lineno, filename = get_source_lines_and_file(fn, torch._C.ErrorReport.call_stack())
+    sourcelines, file_lineno, filename = get_source_lines_and_file(fn, torch._C._jit.ErrorReport.call_stack())
     sourcelines = normalize_source_lines(sourcelines)
     source = ''.join(sourcelines)
     dedent_src = dedent(source)
@@ -297,8 +297,8 @@ def build_def(ctx, py_def, type_line, def_name, self_name=None):
     decl = Decl(r, param_list, return_type)
     is_method = self_name is not None
     if type_line is not None:
-        type_comment_decl = torch._C.parse_type_comment(type_line)
-        decl = torch._C.merge_type_from_type_comment(decl, type_comment_decl, is_method)
+        type_comment_decl = torch._C._jit.parse_type_comment(type_line)
+        decl = torch._C._jit.merge_type_from_type_comment(decl, type_comment_decl, is_method)
 
     return Def(Ident(r, def_name),
                decl,

--- a/torch/jit/supported_ops.py
+++ b/torch/jit/supported_ops.py
@@ -49,7 +49,7 @@ def _get_tensor_ops():
         self = schema.arguments[0]
         if self.name != 'self':
             return False
-        if not self.type.isSubtypeOf(torch._C.TensorType.get()):
+        if not self.type.isSubtypeOf(torch._C._jit.TensorType.get()):
             return False
         return True
 
@@ -57,7 +57,7 @@ def _get_tensor_ops():
     # discover methods
     for elem in dir(torch.Tensor):
         if not _hidden(elem):
-            schemas = torch._C._jit_get_schemas_for_operator("aten::" + elem)
+            schemas = torch._C._jit.get_schemas_for_operator("aten::" + elem)
             for schema in schemas:
                 if is_tensor_method(schema):
                     methods.append(_emit_schema('Tensor', elem, schema, arg_start=1))
@@ -99,7 +99,7 @@ def _get_nn_functional_ops():
         for elem in dir(mod):
             builtin = _find_builtin(getattr(mod, elem))
             if builtin is not None:
-                schemas = torch._C._jit_get_schemas_for_operator(builtin)
+                schemas = torch._C._jit.get_schemas_for_operator(builtin)
                 for schema in schemas:
                     # remove _tan but not __and__
                     if not _hidden(elem):
@@ -146,7 +146,7 @@ def _get_torchscript_builtins():
             raise RuntimeError(f'Module for {fn} not found')
         builtin = _find_builtin(fn)
         if builtin is not None:
-            schemas = torch._C._jit_get_schemas_for_operator(builtin)
+            schemas = torch._C._jit.get_schemas_for_operator(builtin)
             for schema in schemas:
                 functions.append(_emit_schema(mod.__name__, fn.__name__, schema))
                 pass
@@ -165,7 +165,7 @@ def _get_math_builtins():
             raise RuntimeError(f'Module for {fn} not found')
         builtin = _find_builtin(fn)
         if builtin is not None:
-            schemas = torch._C._jit_get_schemas_for_operator(builtin)
+            schemas = torch._C._jit.get_schemas_for_operator(builtin)
             for schema in schemas:
                 schema_str = _emit_schema(mod.__name__, fn.__name__, schema)
                 if 'Tensor' in schema_str:
@@ -252,7 +252,7 @@ def _get_global_builtins():
         op_name = 'aten::{}'.format(fn)
         if fn in op_renames:
             op_name = op_renames[fn]
-        schemas = torch._C._jit_get_schemas_for_operator(op_name)
+        schemas = torch._C._jit.get_schemas_for_operator(op_name)
         for s in schemas:
             schematized_ops.append(_emit_schema(None, fn, s, padding=0))
         if len(schemas) > 0:

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3515,7 +3515,7 @@ def interpolate(input, size=None, scale_factor=None, mode='nearest', align_corne
     if recompute_scale_factor is not None and recompute_scale_factor:
         # We compute output_size here, then un-set scale_factors.
         # The C++ code will recompute it based on the (integer) output size.
-        if not torch.jit.is_scripting() and torch._C._get_tracing_state():
+        if not torch.jit.is_scripting() and torch._C._jit._get_tracing_state():
             # make scale_factor a tensor in tracing so constant doesn't get baked in
             output_size = [
                 (torch.floor((input.size(i + 2).float() * torch.tensor(scale_factors[i], dtype=torch.float32)).float()))

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -844,13 +844,13 @@ class Module:
         return handle
 
     def _slow_forward(self, *input, **kwargs):
-        tracing_state = torch._C._get_tracing_state()
-        if not tracing_state or isinstance(self.forward, torch._C.ScriptMethod):
+        tracing_state = torch._C._jit._get_tracing_state()
+        if not tracing_state or isinstance(self.forward, torch._C._jit.ScriptMethod):
             return self.forward(*input, **kwargs)
         recording_scopes = torch.jit._trace._trace_module_map is not None
         if recording_scopes:
             # type ignore was added because at this point one knows that
-            # torch.jit._trace._trace_module_map is not Optional and has type Dict[Any, Any] 
+            # torch.jit._trace._trace_module_map is not Optional and has type Dict[Any, Any]
             name = torch.jit._trace._trace_module_map[self] if self in torch.jit._trace._trace_module_map else None  # type: ignore
             if name:
                 tracing_state.push_scope(name)
@@ -883,7 +883,7 @@ class Module:
             bw_hook = hooks.BackwardHook(self, full_backward_hooks)
             input = bw_hook.setup_input_hook(input)
 
-        if torch._C._get_tracing_state():
+        if torch._C._jit._get_tracing_state():
             result = self._slow_forward(*input, **kwargs)
         else:
             result = self.forward(*input, **kwargs)

--- a/torch/nn/parallel/replicate.py
+++ b/torch/nn/parallel/replicate.py
@@ -11,7 +11,7 @@ def _is_script_module(module):
 
 def _is_script_method(module):
     import torch.jit
-    return isinstance(module, torch._C.ScriptMethod)
+    return isinstance(module, torch._C._jit.ScriptMethod)
 
 
 def _init_script_module():

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -226,7 +226,7 @@ def pack_padded_sequence(input, lengths, batch_first=False, enforce_sorted=True)
     Returns:
         a :class:`PackedSequence` object
     """
-    if torch._C._get_tracing_state() and not isinstance(lengths, torch.Tensor):
+    if torch._C._jit._get_tracing_state() and not isinstance(lengths, torch.Tensor):
         warnings.warn('pack_padded_sequence has been called with a Python list of '
                       'sequence lengths. The tracer cannot track the data flow of Python '
                       'values, and it will treat them as constants, likely rendering '

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -11,7 +11,7 @@ import torch.onnx
 import torch.onnx.utils
 
 from functools import wraps
-from torch._C import OptionalType
+from torch._C._jit import OptionalType
 
 
 # Note [Edit Symbolic Files]
@@ -169,7 +169,7 @@ def _if_scalar_type_as(g, self, tensor):
     actually need to insert an ONNX cast operator here; just
     fix up the scalar.
     """
-    if isinstance(self, torch._C.Value):
+    if isinstance(self, torch._C._jit.Value):
         return self
 
     scalar_type = tensor.type().scalarType()
@@ -184,13 +184,13 @@ def _is_none(x):
     return x.node().mustBeNone()
 
 def _is_value(x):
-    return isinstance(x, torch._C.Value)
+    return isinstance(x, torch._C._jit.Value)
 
 def _is_tensor(x):
-    return x.type().isSubtypeOf(torch._C.TensorType.get())
+    return x.type().isSubtypeOf(torch._C._jit.TensorType.get())
 
 def _is_tensor_list(x):
-    return isinstance(x.type(), torch._C.ListType) and isinstance(x.type().getElementType(), torch._C.TensorType)
+    return isinstance(x.type(), torch._C._jit.ListType) and isinstance(x.type().getElementType(), torch._C._jit.TensorType)
 
 def _get_tensor_rank(x):
     if not _is_tensor(x) or x.type() is None:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -58,7 +58,7 @@ def _interpolate(name, dim, interpolate_mode):
             return _unimplemented(name, "align_corners == True")
         output_size = sym_help._maybe_get_const(output_size, 'is')
         if sym_help._is_value(output_size):
-            return _unimplemented(name, "torch._C.Value (output_size) indexing")
+            return _unimplemented(name, "torch._C._jit.Value (output_size) indexing")
         if scales is None:
             scales = [1. if i < 2 else
                       float(output_size[-(dim - i)]) / float(input.type().sizes()[-(dim - i)])

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1,5 +1,5 @@
 import torch
-from torch._C import ListType, OptionalType
+from torch._C._jit import ListType, OptionalType
 from torch.nn.modules.utils import _single, _pair, _triple
 
 import torch.onnx
@@ -2206,7 +2206,7 @@ def _pack_padded_sequence(g, input, lengths, batch_first):
     # PackPadded operators cannot be optimized out.
     if batch_first:
         input = g.op('Transpose', input, perm_i=[1, 0, 2])
-    if not lengths.type().isSubtypeOf(torch._C.TensorType.get()):
+    if not lengths.type().isSubtypeOf(torch._C._jit.TensorType.get()):
         raise RuntimeError("Lengths must be a Tensor for ONNX export")
     # We know it's a TensorType so this check is now safe.
     # It's really only necessary because those operators expand to something that

--- a/torch/package/exporter.py
+++ b/torch/package/exporter.py
@@ -73,7 +73,7 @@ class PackageExporter:
         else:  # is a byte buffer
             self.buffer = f
 
-        self.zip_file = torch._C.PyTorchFileWriter(f)
+        self.zip_file = torch._C._jit.PyTorchFileWriter(f)
         self.zip_file.set_min_version(6)
         self.serialized_storages : Dict[str, Any] = {}
         self.external : List[str] = []

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -37,7 +37,7 @@ class PackageImporter:
     """
     modules : Dict[str, Optional[types.ModuleType]]
 
-    def __init__(self, file_or_buffer: Union[str, torch._C.PyTorchFileReader, Path, BinaryIO],
+    def __init__(self, file_or_buffer: Union[str, torch._C._jit.PyTorchFileReader, Path, BinaryIO],
                  module_allowed: Callable[[str], bool] = lambda module_name: True):
         """Open `file_or_buffer` for importing. This checks that the imported package only requires modules
         allowed by `module_allowed`
@@ -53,18 +53,18 @@ class PackageImporter:
             ImportError: If the package will use a disallowed module.
         """
         self.zip_reader : Any
-        if isinstance(file_or_buffer, torch._C.PyTorchFileReader):
+        if isinstance(file_or_buffer, torch._C._jit.PyTorchFileReader):
             self.filename = '<pytorch_file_reader>'
             self.zip_reader = file_or_buffer
         elif isinstance(file_or_buffer, (Path, str)):
             self.filename = str(file_or_buffer)
             if not os.path.isdir(self.filename):
-                self.zip_reader = torch._C.PyTorchFileReader(self.filename)
+                self.zip_reader = torch._C._jit.PyTorchFileReader(self.filename)
             else:
                 self.zip_reader = MockZipReader(self.filename)
         else:
             self.filename = '<binary>'
-            self.zip_reader = torch._C.PyTorchFileReader(file_or_buffer)
+            self.zip_reader = torch._C._jit.PyTorchFileReader(file_or_buffer)
 
         self.root = _PackageNode(None)
         self.modules = {}

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -239,12 +239,12 @@ def _open_file_like(name_or_buffer, mode):
 
 class _open_zipfile_reader(_opener):
     def __init__(self, name_or_buffer) -> None:
-        super(_open_zipfile_reader, self).__init__(torch._C.PyTorchFileReader(name_or_buffer))
+        super(_open_zipfile_reader, self).__init__(torch._C._jit.PyTorchFileReader(name_or_buffer))
 
 
 class _open_zipfile_writer_file(_opener):
     def __init__(self, name) -> None:
-        super(_open_zipfile_writer_file, self).__init__(torch._C.PyTorchFileWriter(str(name)))
+        super(_open_zipfile_writer_file, self).__init__(torch._C._jit.PyTorchFileWriter(str(name)))
 
     def __exit__(self, *args) -> None:
         self.file_like.write_end_of_file()
@@ -253,7 +253,7 @@ class _open_zipfile_writer_file(_opener):
 class _open_zipfile_writer_buffer(_opener):
     def __init__(self, buffer) -> None:
         self.buffer = buffer
-        super(_open_zipfile_writer_buffer, self).__init__(torch._C.PyTorchFileWriter(buffer))
+        super(_open_zipfile_writer_buffer, self).__init__(torch._C._jit.PyTorchFileWriter(buffer))
 
     def __exit__(self, *args) -> None:
         self.file_like.write_end_of_file()

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -583,7 +583,7 @@ class Tensor(torch._C._TensorBase):
             return handle_torch_function(Tensor.__iter__, (self,), self)
         if self.dim() == 0:
             raise TypeError('iteration over a 0-d tensor')
-        if torch._C._get_tracing_state():
+        if torch._C._jit._get_tracing_state():
             warnings.warn('Iterating over a tensor might cause the trace to be incorrect. '
                           'Passing a tensor of different shape won\'t change the number of '
                           'iterations executed (and might lead to errors or silently give '

--- a/torch/testing/__init__.py
+++ b/torch/testing/__init__.py
@@ -9,7 +9,7 @@ from typing import cast, List, Optional, Tuple, Union
 from .check_kernel_launches import check_cuda_kernel_launches, check_code_for_cuda_kernel_launches
 import operator
 
-FileCheck = torch._C.FileCheck
+FileCheck = torch._C._jit.FileCheck
 
 __all__ = [
     'assert_allclose', 'make_non_contiguous', 'rand_like', 'randn_like'

--- a/torch/testing/_internal/codegen/random_topo_test.py
+++ b/torch/testing/_internal/codegen/random_topo_test.py
@@ -360,17 +360,17 @@ if __name__ == '__main__':
 
     # Register CUDA fuser
     if args.cuda_fuser:
-        torch._C._jit_set_nvfuser_enabled(True)
+        torch._C._jit.set_nvfuser_enabled(True)
 
     # Turn off legacy fuser
     if not args.legacy_fuser:
-        torch._C._jit_override_can_fuse_on_cpu(False)
-        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit.override_can_fuse_on_cpu(False)
+        torch._C._jit.override_can_fuse_on_gpu(False)
 
     # Turn off profiling executor
     if not args.profiling_executor:
-        torch._C._jit_set_profiling_executor(False)
-        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit.set_profiling_executor(False)
+        torch._C._jit.set_profiling_mode(False)
 
     # factor sorta control the depth of the model
     GRAPH_FACTOR = args.depth_factor

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -69,10 +69,10 @@ class ProfilingMode(Enum):
     PROFILING = 3
 
 def cppProfilingFlagsToProfilingMode():
-    old_prof_exec_state = torch._C._jit_set_profiling_executor(True)
-    old_prof_mode_state = torch._C._jit_set_profiling_mode(True)
-    torch._C._jit_set_profiling_executor(old_prof_exec_state)
-    torch._C._jit_set_profiling_mode(old_prof_mode_state)
+    old_prof_exec_state = torch._C._jit.set_profiling_executor(True)
+    old_prof_mode_state = torch._C._jit.set_profiling_mode(True)
+    torch._C._jit.set_profiling_executor(old_prof_exec_state)
+    torch._C._jit.set_profiling_mode(old_prof_mode_state)
 
     if old_prof_exec_state:
         if old_prof_mode_state:
@@ -85,35 +85,35 @@ def cppProfilingFlagsToProfilingMode():
 @contextmanager
 def enable_profiling_mode_for_profiling_tests():
     if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
-        old_prof_exec_state = torch._C._jit_set_profiling_executor(True)
-        old_prof_mode_state = torch._C._jit_set_profiling_mode(True)
+        old_prof_exec_state = torch._C._jit.set_profiling_executor(True)
+        old_prof_mode_state = torch._C._jit.set_profiling_mode(True)
     try:
         yield
     finally:
         if GRAPH_EXECUTOR == ProfilingMode.PROFILING:
-            torch._C._jit_set_profiling_executor(old_prof_exec_state)
-            torch._C._jit_set_profiling_mode(old_prof_mode_state)
+            torch._C._jit.set_profiling_executor(old_prof_exec_state)
+            torch._C._jit.set_profiling_mode(old_prof_mode_state)
 
 @contextmanager
 def enable_profiling_mode():
-    old_prof_exec_state = torch._C._jit_set_profiling_executor(True)
-    old_prof_mode_state = torch._C._jit_set_profiling_mode(True)
+    old_prof_exec_state = torch._C._jit.set_profiling_executor(True)
+    old_prof_mode_state = torch._C._jit.set_profiling_mode(True)
     try:
         yield
     finally:
-        torch._C._jit_set_profiling_executor(old_prof_exec_state)
-        torch._C._jit_set_profiling_mode(old_prof_mode_state)
+        torch._C._jit.set_profiling_executor(old_prof_exec_state)
+        torch._C._jit.set_profiling_mode(old_prof_mode_state)
 
 @contextmanager
 def num_profiled_runs(num_runs):
-    old_num_runs = torch._C._jit_set_num_profiled_runs(num_runs)
+    old_num_runs = torch._C._jit.set_num_profiled_runs(num_runs)
     try:
         yield
     finally:
-        torch._C._jit_set_num_profiled_runs(old_num_runs)
+        torch._C._jit.set_num_profiled_runs(old_num_runs)
 
-func_call = torch._C.ScriptFunction.__call__
-meth_call = torch._C.ScriptMethod.__call__
+func_call = torch._C._jit.ScriptFunction.__call__
+meth_call = torch._C._jit.ScriptMethod.__call__
 
 def prof_callable(callable, *args, **kwargs):
     if 'profile_and_replay' in kwargs:
@@ -132,8 +132,8 @@ def prof_meth_call(*args, **kwargs):
     return prof_callable(meth_call, *args, **kwargs)
 
 # TODO fix when https://github.com/python/mypy/issues/2427 is address
-torch._C.ScriptFunction.__call__ = prof_func_call  # type: ignore[assignment]
-torch._C.ScriptMethod.__call__ = prof_meth_call  # type: ignore[assignment]
+torch._C._jit.ScriptFunction.__call__ = prof_func_call  # type: ignore[assignment]
+torch._C._jit.ScriptMethod.__call__ = prof_meth_call  # type: ignore[assignment]
 
 def _get_test_report_path():
     # allow users to override the test file location. We need this

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -294,7 +294,7 @@ def gen_script_fn_and_args(method_name, func_type, *args, **kwargs):
 # returns a function takes in (args, kwargs) and runs the compiled function
 def create_script_fn(self, method_name, func_type):
     # function returns tuple containing original output and
-    # filtered output to be used in checking gradients 
+    # filtered output to be used in checking gradients
     def script_fn(*args, **kwargs):
         fn, tensors = gen_script_fn_and_args(method_name, func_type, *args, **kwargs)
         self.assertExportImport(fn.graph, tensors)
@@ -475,7 +475,7 @@ def check_alias_annotation(method_name, args, kwargs, *, aten_name, func_type='m
     call = get_call(method_name, func_type, actuals, kwargs)
     script = script_template.format(', '.join(formals), call)
     CU = torch.jit.CompilationUnit(script)
-    torch._C._jit_check_alias_annotation(CU.the_method.graph, tuple(tensors), aten_name)
+    torch._C._jit.check_alias_annotation(CU.the_method.graph, tuple(tensors), aten_name)
 
 def get_nn_module_name_from_kwargs(**kwargs):
     if 'module_name' in kwargs:

--- a/torch/testing/_internal/te_utils.py
+++ b/torch/testing/_internal/te_utils.py
@@ -3,7 +3,7 @@ import torch
 class ExecutionCounter(object):
     def try_get_trigger_value(self):
         try:
-            return torch._C._jit_get_trigger_value(self.name)
+            return torch._C._jit.get_trigger_value(self.name)
         except Exception:
             return 0
 

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -59,14 +59,14 @@ def optimize_for_mobile(
 
     backend = backend.lower()
     if backend == 'cpu':
-        optimized_cpp_module = torch._C._jit_pass_optimize_for_mobile(
+        optimized_cpp_module = torch._C._jit.pass_optimize_for_mobile(
             script_module._c,
             optimization_blocklist,
             preserved_methods_str)
     elif backend == 'vulkan':
-        optimized_cpp_module = torch._C._jit_pass_vulkan_optimize_for_mobile(script_module._c, preserved_methods_str)
+        optimized_cpp_module = torch._C._jit.pass_vulkan_optimize_for_mobile(script_module._c, preserved_methods_str)
     elif backend == 'metal':
-        optimized_cpp_module = torch._C._jit_pass_metal_optimize_for_mobile(script_module._c, preserved_methods_str)
+        optimized_cpp_module = torch._C._jit.pass_metal_optimize_for_mobile(script_module._c, preserved_methods_str)
     else:
         raise TypeError("Unknown backend, must be one of 'CPU', 'Vulkan' or 'Metal'")
 

--- a/torch/utils/tensorboard/_pytorch_graph.py
+++ b/torch/utils/tensorboard/_pytorch_graph.py
@@ -285,7 +285,7 @@ def graph(model, args, verbose=False):
         try:
             trace = torch.jit.trace(model, args)
             graph = trace.graph
-            torch._C._jit_pass_inline(graph)
+            torch._C._jit.pass_inline(graph)
         except RuntimeError as e:
             print(e)
             print('Error occurs, No graph saved')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52157 [JIT] Create torch._C._jit submodule for JIT bindings**
* #52156 Temp

**Summary**
Everything inside `torch._C` is currently added to `torch` (with some
policies to exclude names beginning with `_`, etc.). As a result, some
of the JIT Python IR bindings are inadvertently exposed as `torch.XX`.
This commit adds a `torch._C._jit` submodule for all JIT bindings to
preclude JIT bindings being added to `torch`.

**Test Plan**
Continuous integration.

**Fixes**
This commit fixes #51691.