### PR TITLE
[TensorExpr] Add another test for ExternalCalls.

### DIFF
--- a/test/cpp/tensorexpr/test_external_calls.cpp
+++ b/test/cpp/tensorexpr/test_external_calls.cpp
@@ -237,7 +237,9 @@ TEST(ExternalCall, Matmul) {
   ASSERT_TRUE(at::allclose(nnc_result, ref));
 }
 
-TEST(ExternalCall, SeveralCallsUsedInEachOther) {
+TEST(ExternalCall, ComputeInterop) {
+  // This test verifies that Tensors using external calls can be used by and can
+  // use Tensors built with Compute API.
   KernelScope kernel_scope;
 
   BufHandle ConvResultBuf("ConvResult", {1, 16, 112, 112}, kFloat);

--- a/test/cpp/tensorexpr/test_external_calls.cpp
+++ b/test/cpp/tensorexpr/test_external_calls.cpp
@@ -285,7 +285,6 @@ TEST(ExternalCall, SeveralCallsUsedInEachOther) {
   LoopNest l({Input, Weight, ConvResult, MatmulResult, Result});
   l.prepareForCodegen();
   l.simplify();
-  std::cerr << *l.root_stmt() << "\n";
 
   auto options = at::TensorOptions()
                      .dtype(at::kFloat)

--- a/test/cpp/tensorexpr/test_external_calls.cpp
+++ b/test/cpp/tensorexpr/test_external_calls.cpp
@@ -237,5 +237,92 @@ TEST(ExternalCall, Matmul) {
   ASSERT_TRUE(at::allclose(nnc_result, ref));
 }
 
+TEST(ExternalCall, SeveralCallsUsedInEachOther) {
+  KernelScope kernel_scope;
+
+  BufHandle ConvResultBuf("ConvResult", {1, 16, 112, 112}, kFloat);
+  BufHandle MatmulResultBuf("MatmulResult", {1, 16, 112, 112}, kFloat);
+
+  Tensor* Input = Compute(
+      "Input",
+      {{1, "n"}, {16, "c"}, {112, "h"}, {112, "w"}},
+      [&](const VarHandle& n,
+          const VarHandle& c,
+          const VarHandle& h,
+          const VarHandle& w) { return FloatImm::make(5.0f); });
+  Tensor* Weight = Compute(
+      "Weight",
+      {{16, "n"}, {16, "c"}, {1, "kh"}, {1, "kw"}},
+      [&](const VarHandle& n,
+          const VarHandle& c,
+          const VarHandle& h,
+          const VarHandle& w) { return FloatImm::make(6.0f); });
+
+  Tensor* ConvResult = new Tensor(
+      ConvResultBuf.node(),
+      ExternalCall::make(
+          ConvResultBuf,
+          "nnc_aten_conv2d",
+          {BufHandle(Input->buf()), BufHandle(Weight->buf())},
+          {}));
+  Tensor* MatmulResult = new Tensor(
+      MatmulResultBuf.node(),
+      ExternalCall::make(
+          MatmulResultBuf,
+          "nnc_aten_matmul",
+          {BufHandle(ConvResult->buf()), BufHandle(ConvResult->buf())},
+          {}));
+  Tensor* Result = Compute(
+      "Result",
+      {{1, "n"}, {16, "c"}, {112, "h"}, {112, "w"}},
+      [&](const VarHandle& n,
+          const VarHandle& c,
+          const VarHandle& h,
+          const VarHandle& w) {
+        return ConvResult->call(n, c, h, w) + MatmulResult->call(n, c, h, w);
+      });
+
+  LoopNest l({Input, Weight, ConvResult, MatmulResult, Result});
+  l.prepareForCodegen();
+  l.simplify();
+  std::cerr << *l.root_stmt() << "\n";
+
+  auto options = at::TensorOptions()
+                     .dtype(at::kFloat)
+                     .layout(at::kStrided)
+                     .device(at::kCPU)
+                     .requires_grad(false);
+  at::Tensor input = at::ones({1, 16, 112, 112}, options) * 5.f;
+  at::Tensor weight = at::ones({16, 16, 1, 1}, options) * 6.f;
+  at::Tensor t = at::conv2d(input, weight);
+  at::Tensor t2 = at::matmul(t, t);
+  at::Tensor ref = t + t2;
+
+  at::Tensor nnc_result;
+  std::vector<float> input_buf(1 * 16 * 112 * 112, 5.f);
+  std::vector<float> weight_buf(16 * 16 * 1 * 1, 6.f);
+  std::vector<float> conv_result_buf(1 * 16 * 112 * 112, -1.f);
+  std::vector<float> matmul_result_buf(1 * 16 * 112 * 112, -1.f);
+  std::vector<float> result_buf(1 * 16 * 112 * 112, -1.f);
+
+#ifdef TORCH_ENABLE_LLVM
+  LLVMCodeGen llvm_codegen(
+      l.root_stmt(), {Input, Weight, ConvResult, MatmulResult, Result});
+
+  llvm_codegen.call(
+      {input_buf, weight_buf, conv_result_buf, matmul_result_buf, result_buf});
+  nnc_result = at::from_blob(result_buf.data(), {1, 16, 112, 112}, options);
+  ASSERT_TRUE(at::allclose(nnc_result, ref));
+#endif
+
+  SimpleIREvaluator ir_eval(
+      l.root_stmt(), {Input, Weight, ConvResult, MatmulResult, Result});
+
+  ir_eval.call(
+      {input_buf, weight_buf, conv_result_buf, matmul_result_buf, result_buf});
+  nnc_result = at::from_blob(result_buf.data(), {1, 16, 112, 112}, options);
+  ASSERT_TRUE(at::allclose(nnc_result, ref));
+}
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52162 [TensorExpr] Add another test for ExternalCalls.**

This test demonstrates how external calls can interoperate with other
tensor computations and between themselves.

Differential Revision: [D26410813](https://our.internmc.facebook.com/intern/diff/D26410813)