### PR TITLE
[doc] FX Graph Mode Quantization - fix preamble

### DIFF
--- a/docs/source/quantization.rst
+++ b/docs/source/quantization.rst
@@ -392,11 +392,11 @@ tutorial
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Quantization types supported by FX Graph Mode can be classified in two ways:
 
-1.
-- Post Training Quantization (apply quantization after training, quantization parameters are calculated based on sample calibration data)
-- Quantization Aware Training (simulate quantization during training so that the quantization parameters can be learned together with the model using training data)
+1. Post Training Quantization (apply quantization after training, quantization parameters are calculated based on sample calibration data)
+2. Quantization Aware Training (simulate quantization during training so that the quantization parameters can be learned together with the model using training data)
 
-2.
+And then each of these two may include any or all of the following types:
+
 - Weight Only Quantization (only weight is statically quantized)
 - Dynamic Quantization (weight is statically quantized, activation is dynamically quantized)
 - Static Quantization (both weight and activations are statically quantized)


### PR DESCRIPTION
The pre-amble here is misformatted at least and is hard to make sense of: https://pytorch.org/docs/master/quantization.html#prototype-fx-graph-mode-quantization

This PR is trying to make things easier to understand.

As I'm new to this please verify that my modifications remain in line with what may have been meant originally.

Thanks.