### PR TITLE
[iOS][PyTorch][OSS] fix iOS nightly build

### DIFF
--- a/.circleci/scripts/binary_ios_build.sh
+++ b/.circleci/scripts/binary_ios_build.sh
@@ -15,7 +15,7 @@ export PATH="~/anaconda/bin:${PATH}"
 source ~/anaconda/bin/activate
 
 # Install dependencies
-conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi requests --yes
+conda install numpy ninja pyyaml mkl mkl-include setuptools cmake cffi requests typing_extensions --yes
 conda install -c conda-forge valgrind --yes
 export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52197 [iOS][PyTorch][OSS] fix iOS nightly build**

D26187854 added `from typing_extensions import Literal` to `tools/codegen/gen.py` whereas `typing_extensions` was not installed while building iOS binary

Differential Revision: [D26420298](https://our.internmc.facebook.com/intern/diff/D26420298/)