### PR TITLE
Make bias in lazy modules lazy and avoid create empty tensors

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14356,11 +14356,13 @@ class TestLazyModules(TestCase):
     def test_linear(self):
         module = nn.LazyLinear(10)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        self.assertIsInstance(module.bias, UninitializedParameter)
         input = torch.ones(5, 5)
         module(input)
         self.assertIsInstance(module, nn.Linear)
         self.assertNotIsInstance(module, nn.LazyLinear)
         self.assertTrue(module.weight.shape == (10, 5))
+        self.assertTrue(module.bias.shape == (10,))
         y = module(input)
         self.assertTrue(torch.equal(torch.nn.functional.linear(input, module.weight, module.bias), y))
 
@@ -14368,9 +14370,11 @@ class TestLazyModules(TestCase):
     def test_lazy_linear_pickle(self):
         module = nn.LazyLinear(10)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        self.assertIsInstance(module.bias, UninitializedParameter)
         module = pickle.loads(pickle.dumps(module))
         self.assertIsInstance(module, nn.LazyLinear)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        self.assertIsInstance(module.bias, UninitializedParameter)
         input = torch.ones(5, 5)
         module(input)  # fully materialized
         new_module = pickle.loads(pickle.dumps(module))
@@ -14378,6 +14382,8 @@ class TestLazyModules(TestCase):
         self.assertNotIsInstance(new_module, nn.LazyLinear)
         self.assertTrue(new_module.weight.shape == (10, 5))
         self.assertNotIsInstance(new_module.weight, UninitializedParameter)
+        self.assertTrue(new_module.bias.shape == (10,))
+        self.assertNotIsInstance(new_module.bias, UninitializedParameter)
 
     @suppress_warnings
     def test_linear_state(self):
@@ -14389,29 +14395,40 @@ class TestLazyModules(TestCase):
         # limitations on the state_dict loading logic
         self.assertFalse(lazy_module.has_uninitialized_params())
         self.assertTrue(lazy_module.weight.shape == (10, 5))
+        self.assertTrue(lazy_module.bias.shape == (10,))
 
         module = nn.Linear(5, 10)
         lazy_module = nn.LazyLinear(10)
         with self.assertRaisesRegex(RuntimeError, 'shape of an uninitialized'):
             module.load_state_dict(lazy_module.state_dict())
 
-    def _check_lazy_conv(self, cls, lazy_cls, func, init_args, input_shape, expected_weight_shape):
+    def _check_lazy_conv(self, cls, lazy_cls, func, init_args, input_shape,
+                         expected_weight_shape, expected_bias_shape):
         module = lazy_cls(*init_args)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        if module.bias is not None:
+            self.assertIsInstance(module.bias, UninitializedParameter)
         input = torch.ones(*input_shape)
         module(input)
         self.assertIsInstance(module, cls)
         self.assertNotIsInstance(module, lazy_cls)
         self.assertEqual(module.weight.shape, expected_weight_shape)
+        if module.bias is not None:
+            self.assertEqual(module.bias.shape, expected_bias_shape)
         y = module(input)
         self.assertTrue(torch.equal(func(input, module.weight, module.bias), y))
 
-    def _check_lazy_conv_pickle(self, cls, lazy_cls, init_args, input_shape, expected_weight_shape):
+    def _check_lazy_conv_pickle(self, cls, lazy_cls, init_args, input_shape,
+                                expected_weight_shape, expected_bias_shape):
         module = lazy_cls(*init_args)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        if module.bias is not None:
+            self.assertIsInstance(module.bias, UninitializedParameter)
         module = pickle.loads(pickle.dumps(module))
         self.assertIsInstance(module, lazy_cls)
         self.assertIsInstance(module.weight, UninitializedParameter)
+        if module.bias is not None:
+            self.assertIsInstance(module.bias, UninitializedParameter)
         input = torch.ones(*input_shape)
         module(input)  # fully materialized
         new_module = pickle.loads(pickle.dumps(module))
@@ -14419,8 +14436,12 @@ class TestLazyModules(TestCase):
         self.assertNotIsInstance(new_module, lazy_cls)
         self.assertEqual(new_module.weight.shape, expected_weight_shape)
         self.assertNotIsInstance(new_module.weight, UninitializedParameter)
+        if new_module.bias is not None:
+            self.assertEqual(new_module.bias.shape, expected_bias_shape)
+            self.assertNotIsInstance(new_module.bias, UninitializedParameter)
 
-    def _check_lazy_conv_state(self, gen_module, gen_lazy_module, expected_weight_shape):
+    def _check_lazy_conv_state(self, gen_module, gen_lazy_module,
+                               expected_weight_shape, expected_bias_shape):
         module = gen_module()
         lazy_module = gen_lazy_module()
         lazy_module.load_state_dict(module.state_dict())
@@ -14429,6 +14450,8 @@ class TestLazyModules(TestCase):
         # limitations on the state_dict loading logic
         self.assertFalse(lazy_module.has_uninitialized_params())
         self.assertEqual(lazy_module.weight.shape, expected_weight_shape)
+        if lazy_module.bias is not None:
+            self.assertEqual(lazy_module.bias.shape, expected_bias_shape)
 
         module = gen_module()
         lazy_module = gen_lazy_module()
@@ -14438,92 +14461,98 @@ class TestLazyModules(TestCase):
     @suppress_warnings
     def test_lazy_conv1d(self):
         self._check_lazy_conv(nn.Conv1d, nn.LazyConv1d, torch.nn.functional.conv1d,
-                              (32, 2), (192, 16, 50), (32, 16, 2))
+                              (32, 2), (192, 16, 50), (32, 16, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv1d_pickle(self):
-        self._check_lazy_conv_pickle(nn.Conv1d, nn.LazyConv1d, (32, 2), (192, 16, 50), (32, 16, 2))
+        self._check_lazy_conv_pickle(nn.Conv1d, nn.LazyConv1d, (32, 2), (192, 16, 50),
+                                     (32, 16, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv1d_state(self):
         self._check_lazy_conv_state(lambda: nn.Conv1d(16, 32, 2),
                                     lambda: nn.LazyConv1d(32, 2),
-                                    (32, 16, 2))
+                                    (32, 16, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv2d(self):
         self._check_lazy_conv(nn.Conv2d, nn.LazyConv2d, torch.nn.functional.conv2d,
-                              (32, 2), (192, 16, 8, 6), (32, 16, 2, 2))
+                              (32, 2), (192, 16, 8, 6), (32, 16, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv2d_pickle(self):
-        self._check_lazy_conv_pickle(nn.Conv2d, nn.LazyConv2d, (32, 2), (192, 16, 8, 6), (32, 16, 2, 2))
+        self._check_lazy_conv_pickle(nn.Conv2d, nn.LazyConv2d, (32, 2), (192, 16, 8, 6),
+                                     (32, 16, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv2d_state(self):
         self._check_lazy_conv_state(lambda: nn.Conv2d(16, 32, 2),
                                     lambda: nn.LazyConv2d(32, 2),
-                                    (32, 16, 2, 2))
+                                    (32, 16, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv3d(self):
         self._check_lazy_conv(nn.Conv3d, nn.LazyConv3d, torch.nn.functional.conv3d,
-                              (32, 2), (192, 16, 8, 7, 6), (32, 16, 2, 2, 2))
+                              (32, 2), (192, 16, 8, 7, 6), (32, 16, 2, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv3d_pickle(self):
-        self._check_lazy_conv_pickle(nn.Conv3d, nn.LazyConv3d, (32, 2), (192, 16, 8, 7, 6), (32, 16, 2, 2, 2))
+        self._check_lazy_conv_pickle(nn.Conv3d, nn.LazyConv3d, (32, 2), (192, 16, 8, 7, 6),
+                                     (32, 16, 2, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv3d_state(self):
         self._check_lazy_conv_state(lambda: nn.Conv3d(16, 32, 2),
                                     lambda: nn.LazyConv3d(32, 2),
-                                    (32, 16, 2, 2, 2))
+                                    (32, 16, 2, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transposed1d(self):
         self._check_lazy_conv(nn.ConvTranspose1d, nn.LazyConvTranspose1d, torch.nn.functional.conv_transpose1d,
-                              (32, 2), (192, 16, 50), (16, 32, 2))
+                              (32, 2), (192, 16, 50), (16, 32, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose1d_pickle(self):
-        self._check_lazy_conv_pickle(nn.ConvTranspose1d, nn.LazyConvTranspose1d, (32, 2), (192, 16, 50), (16, 32, 2))
+        self._check_lazy_conv_pickle(nn.ConvTranspose1d, nn.LazyConvTranspose1d, (32, 2),
+                                     (192, 16, 50), (16, 32, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose1d_state(self):
         self._check_lazy_conv_state(lambda: nn.ConvTranspose1d(16, 32, 2),
                                     lambda: nn.LazyConvTranspose1d(32, 2),
-                                    (16, 32, 2))
+                                    (16, 32, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose2d(self):
         self._check_lazy_conv(nn.ConvTranspose2d, nn.LazyConvTranspose2d, torch.nn.functional.conv_transpose2d,
-                              (32, 2), (192, 16, 8, 6), (16, 32, 2, 2))
+                              (32, 2), (192, 16, 8, 6), (16, 32, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose2d_pickle(self):
-        self._check_lazy_conv_pickle(nn.ConvTranspose2d, nn.LazyConvTranspose2d, (32, 2), (192, 16, 8, 6), (16, 32, 2, 2))
+        self._check_lazy_conv_pickle(nn.ConvTranspose2d, nn.LazyConvTranspose2d, (32, 2),
+                                     (192, 16, 8, 6), (16, 32, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose2d_state(self):
         self._check_lazy_conv_state(lambda: nn.ConvTranspose2d(16, 32, 2),
                                     lambda: nn.LazyConvTranspose2d(32, 2),
-                                    (16, 32, 2, 2))
+                                    (16, 32, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose3d(self):
         self._check_lazy_conv(nn.ConvTranspose3d, nn.LazyConvTranspose3d, torch.nn.functional.conv_transpose3d,
-                              (32, 2), (192, 16, 8, 7, 6), (16, 32, 2, 2, 2))
+                              (32, 2), (192, 16, 8, 7, 6), (16, 32, 2, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose3d_pickle(self):
-        self._check_lazy_conv_pickle(nn.ConvTranspose3d, nn.LazyConvTranspose3d, (32, 2), (192, 16, 8, 7, 6), (16, 32, 2, 2, 2))
+        self._check_lazy_conv_pickle(nn.ConvTranspose3d, nn.LazyConvTranspose3d, (32, 2),
+                                     (192, 16, 8, 7, 6), (16, 32, 2, 2, 2), (32,))
 
     @suppress_warnings
     def test_lazy_conv_transpose3d_state(self):
         self._check_lazy_conv_state(lambda: nn.ConvTranspose3d(16, 32, 2),
                                     lambda: nn.LazyConvTranspose3d(32, 2),
-                                    (16, 32, 2, 2, 2))
+                                    (16, 32, 2, 2, 2), (32,))
 
     def _check_lazy_batchnorm(self, cls, lazy_cls, input_shape):
         for affine in [False, True]:
@@ -14679,7 +14708,9 @@ class TestLazyModules(TestCase):
         net = MyNetwork()
         net(torch.ones(5, 10))
         self.assertTrue(net.linear_1.weight.shape == (15, 10))
+        self.assertTrue(net.linear_1.bias.shape == (15,))
         self.assertTrue(net.linear_2.weight.shape == (10, 15))
+        self.assertTrue(net.linear_2.bias.shape == (10,))
 
     @suppress_warnings
     def test_optimizer_pass(self):

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -48,9 +48,9 @@ class _NormBase(Module):
             self.register_buffer('running_var', torch.ones(num_features))
             self.register_buffer('num_batches_tracked', torch.tensor(0, dtype=torch.long))
         else:
-            self.register_parameter('running_mean', None)
-            self.register_parameter('running_var', None)
-            self.register_parameter('num_batches_tracked', None)
+            self.register_buffer('running_mean', None)
+            self.register_buffer('running_var', None)
+            self.register_buffer('num_batches_tracked', None)
         self.reset_parameters()
 
     def reset_running_stats(self) -> None:
@@ -145,6 +145,8 @@ class _LazyBatchNorm(LazyModuleMixin, _BatchNorm):
 
     def __init__(self, eps=1e-5, momentum=0.1, affine=True, track_running_stats=True):
         super(_LazyBatchNorm, self).__init__(
+            # affine and track_running_stats are hardcoded to False to
+            # avoid creating tensors that will soon be overwritten.
             0, eps, momentum, False, False)
         self.affine = affine
         self.track_running_stats = track_running_stats
@@ -152,8 +154,9 @@ class _LazyBatchNorm(LazyModuleMixin, _BatchNorm):
             self.weight = UninitializedParameter()
             self.bias = UninitializedParameter()
         if self.track_running_stats:
-            self.register_buffer('running_mean', UninitializedBuffer())
-            self.register_buffer('running_var', UninitializedBuffer())
+            self.running_mean = UninitializedBuffer()
+            self.running_var = UninitializedBuffer()
+            self.num_batches_tracked = torch.tensor(0, dtype=torch.long)
 
     def reset_parameters(self) -> None:
         if not self.has_uninitialized_params() and self.num_features != 0:
@@ -250,6 +253,8 @@ class LazyBatchNorm1d(_LazyBatchNorm):
     r"""A :class:`torch.nn.BatchNorm1d` module with lazy initialization of
     the ``num_features`` argument of the :class:`BatchNorm1d` that is inferred
     from the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight`, `bias`,
+    `running_mean` and `running_var`.
 
     Args:
         eps: a value added to the denominator for numerical stability.
@@ -352,6 +357,8 @@ class LazyBatchNorm2d(_LazyBatchNorm):
     r"""A :class:`torch.nn.BatchNorm2d` module with lazy initialization of
     the ``num_features`` argument of the :class:`BatchNorm2d` that is inferred
     from the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight`, `bias`,
+    `running_mean` and `running_var`.
 
     Args:
         eps: a value added to the denominator for numerical stability.
@@ -455,6 +462,8 @@ class LazyBatchNorm3d(_LazyBatchNorm):
     r"""A :class:`torch.nn.BatchNorm3d` module with lazy initialization of
     the ``num_features`` argument of the :class:`BatchNorm3d` that is inferred
     from the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight`, `bias`,
+    `running_mean` and `running_var`.
 
     Args:
         eps: a value added to the denominator for numerical stability.

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -145,13 +145,15 @@ class _LazyBatchNorm(LazyModuleMixin, _BatchNorm):
 
     def __init__(self, eps=1e-5, momentum=0.1, affine=True, track_running_stats=True):
         super(_LazyBatchNorm, self).__init__(
-            0, eps, momentum, affine, track_running_stats)
+            0, eps, momentum, False, False)
+        self.affine = affine
+        self.track_running_stats = track_running_stats
         if self.affine:
             self.weight = UninitializedParameter()
             self.bias = UninitializedParameter()
         if self.track_running_stats:
-            self.running_mean = UninitializedBuffer()
-            self.running_var = UninitializedBuffer()
+            self.register_buffer('running_mean', UninitializedBuffer())
+            self.register_buffer('running_var', UninitializedBuffer())
 
     def reset_parameters(self) -> None:
         if not self.has_uninitialized_params() and self.num_features != 0:

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1042,8 +1042,8 @@ class _LazyConvXdMixin(LazyModuleMixin):
             else:
                 self.weight.materialize((
                     self.out_channels, self.in_channels // self.groups, *self.kernel_size))
-            assert isinstance(self.bias, UninitializedParameter)
             if self.bias is not None:
+                assert isinstance(self.bias, UninitializedParameter)
                 self.bias.materialize((self.out_channels,))
             self.reset_parameters()
 
@@ -1053,6 +1053,7 @@ class LazyConv1d(_LazyConvXdMixin, Conv1d):  # type: ignore[misc]
     r"""A :class:`torch.nn.Conv1d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`Conv1d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1095,6 +1096,8 @@ class LazyConv1d(_LazyConvXdMixin, Conv1d):  # type: ignore[misc]
             padding,
             dilation,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             padding_mode
         )
@@ -1109,6 +1112,7 @@ class LazyConv2d(_LazyConvXdMixin, Conv2d):  # type: ignore[misc]
     r"""A :class:`torch.nn.Conv2d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`Conv2d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1151,6 +1155,8 @@ class LazyConv2d(_LazyConvXdMixin, Conv2d):  # type: ignore[misc]
             padding,
             dilation,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             padding_mode
         )
@@ -1165,6 +1171,7 @@ class LazyConv3d(_LazyConvXdMixin, Conv3d):  # type: ignore[misc]
     r"""A :class:`torch.nn.Conv3d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`Conv3d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1207,6 +1214,8 @@ class LazyConv3d(_LazyConvXdMixin, Conv3d):  # type: ignore[misc]
             padding,
             dilation,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             padding_mode
         )
@@ -1221,6 +1230,7 @@ class LazyConvTranspose1d(_LazyConvXdMixin, ConvTranspose1d):  # type: ignore[mi
     r"""A :class:`torch.nn.ConvTranspose1d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`ConvTranspose1d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1261,6 +1271,8 @@ class LazyConvTranspose1d(_LazyConvXdMixin, ConvTranspose1d):  # type: ignore[mi
             padding,
             output_padding,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             dilation,
             padding_mode
@@ -1276,6 +1288,7 @@ class LazyConvTranspose2d(_LazyConvXdMixin, ConvTranspose2d):  # type: ignore[mi
     r"""A :class:`torch.nn.ConvTranspose2d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`ConvTranspose2d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1316,6 +1329,8 @@ class LazyConvTranspose2d(_LazyConvXdMixin, ConvTranspose2d):  # type: ignore[mi
             padding,
             output_padding,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             dilation,
             padding_mode
@@ -1331,6 +1346,7 @@ class LazyConvTranspose3d(_LazyConvXdMixin, ConvTranspose3d):  # type: ignore[mi
     r"""A :class:`torch.nn.ConvTranspose3d` module with lazy initialization of
     the ``in_channels`` argument of the :class:`ConvTranspose3d` that is inferred from
     the ``input.size(1)``.
+    The attributes that will be lazily initialized are `weight` and `bias`.
 
     Args:
         out_channels (int): Number of channels produced by the convolution
@@ -1371,6 +1387,8 @@ class LazyConvTranspose3d(_LazyConvXdMixin, ConvTranspose3d):  # type: ignore[mi
             padding,
             output_padding,
             groups,
+            # bias is hardcoded to False to avoid creating tensor
+            # that will soon be overwritten.
             False,
             dilation,
             padding_mode

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -1018,6 +1018,7 @@ class _LazyConvXdMixin(LazyModuleMixin):
     out_channels: int 
     kernel_size: Tuple[int, ...]
     weight: UninitializedParameter
+    bias: UninitializedParameter
 
     def reset_parameters(self) -> None:
         # has_uninitialized_params is defined in parent class and it is using a protocol on self
@@ -1041,6 +1042,9 @@ class _LazyConvXdMixin(LazyModuleMixin):
             else:
                 self.weight.materialize((
                     self.out_channels, self.in_channels // self.groups, *self.kernel_size))
+            assert isinstance(self.bias, UninitializedParameter)
+            if self.bias is not None:
+                self.bias.materialize((self.out_channels,))
             self.reset_parameters()
 
 
@@ -1085,16 +1089,19 @@ class LazyConv1d(_LazyConvXdMixin, Conv1d):  # type: ignore[misc]
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             dilation,
             groups,
-            bias,
+            False,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()
 
 
 # LazyConv2d defines weight as a Tensor but derived class defines it as UnitializeParameter 
@@ -1138,16 +1145,19 @@ class LazyConv2d(_LazyConvXdMixin, Conv2d):  # type: ignore[misc]
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             dilation,
             groups,
-            bias,
+            False,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()
 
 
 # LazyConv3d defines weight as a Tensor but derived class defines it as UnitializeParameter 
@@ -1191,16 +1201,19 @@ class LazyConv3d(_LazyConvXdMixin, Conv3d):  # type: ignore[misc]
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             dilation,
             groups,
-            bias,
+            False,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()
 
 
 # LazyConvTranspose1d defines weight as a Tensor but derived class defines it as UnitializeParameter 
@@ -1242,17 +1255,20 @@ class LazyConvTranspose1d(_LazyConvXdMixin, ConvTranspose1d):  # type: ignore[mi
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             output_padding,
             groups,
-            bias,
+            False,
             dilation,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()
 
 
 # LazyConvTranspose2d defines weight as a Tensor but derived class defines it as UnitializeParameter 
@@ -1294,17 +1310,20 @@ class LazyConvTranspose2d(_LazyConvXdMixin, ConvTranspose2d):  # type: ignore[mi
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             output_padding,
             groups,
-            bias,
+            False,
             dilation,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()
 
 
 # LazyConvTranspose3d defines weight as a Tensor but derived class defines it as UnitializeParameter 
@@ -1346,14 +1365,17 @@ class LazyConvTranspose3d(_LazyConvXdMixin, ConvTranspose3d):  # type: ignore[mi
     ) -> None:
         super().__init__(
             0,
-            out_channels,
+            0,
             kernel_size,
             stride,
             padding,
             output_padding,
             groups,
-            bias,
+            False,
             dilation,
             padding_mode
         )
         self.weight = UninitializedParameter()
+        self.out_channels = out_channels
+        if bias:
+            self.bias = UninitializedParameter()

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -184,8 +184,9 @@ class LazyLinear(LazyModuleMixin, Linear):
     r"""A :class:`torch.nn.Linear` module with lazy initialization.
 
     In this module, the `weight` and `bias` are of :class:`torch.nn.UninitializedParameter`
-    class. They will be initialized  after the first call to ``forward`` is done and the 
-    module will become a regular :class:`torch.nn.Linear` module.
+    class. They will be initialized after the first call to ``forward`` is done and the
+    module will become a regular :class:`torch.nn.Linear` module. The ``in_features`` argument
+    of the :class:`Linear` is inferred from the ``input.shape[-1]``.
 
     Check the :class:`torch.nn.modules.lazy.LazyModuleMixin` for further documentation
     on lazy modules and their limitations.
@@ -212,6 +213,8 @@ class LazyLinear(LazyModuleMixin, Linear):
     weight: UninitializedParameter
 
     def __init__(self, out_features: int, bias: bool = True) -> None:
+        # bias is hardcoded to False to avoid creating tensor
+        # that will soon be overwritten.
         super().__init__(0, 0, False)
         self.weight = UninitializedParameter()
         self.out_features = out_features
@@ -227,6 +230,7 @@ class LazyLinear(LazyModuleMixin, Linear):
             with torch.no_grad():
                 self.in_features = input.shape[-1]
                 self.weight.materialize((self.out_features, self.in_features))  # type: ignore
-                self.bias.materialize((self.out_features,))  # type: ignore
+                if self.bias is not None:
+                    self.bias.materialize((self.out_features,))  # type: ignore
                 self.reset_parameters()
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -212,8 +212,11 @@ class LazyLinear(LazyModuleMixin, Linear):
     weight: UninitializedParameter
 
     def __init__(self, out_features: int, bias: bool = True) -> None:
-        super().__init__(0, out_features, bias)
-        self.weight = UninitializedParameter()    
+        super().__init__(0, 0, False)
+        self.weight = UninitializedParameter()
+        self.out_features = out_features
+        if bias:
+            self.bias = UninitializedParameter()
 
     def reset_parameters(self) -> None:
         if not self.has_uninitialized_params() and self.in_features != 0:
@@ -224,5 +227,6 @@ class LazyLinear(LazyModuleMixin, Linear):
             with torch.no_grad():
                 self.in_features = input.shape[-1]
                 self.weight.materialize((self.out_features, self.in_features))  # type: ignore
+                self.bias.materialize((self.out_features,))  # type: ignore
                 self.reset_parameters()
 # TODO: PartialLinear - maybe in sparse?


### PR DESCRIPTION
Some minor improvement for lazy modules introduced in #44538, #47350 and #51548.

This PR mainly turn the bias to `UninitializedParameter` and instead of creating empty tensors like 
```python
self.bias = Parameter(torch.Tensor(0))
self.bias = UninitializedParameter()
```
I think it would be better to 
```python
self.register_parameter('bias', None)
self.bias = UninitializedParameter()
```

In addition, I change the constructor of the `LazyBatchNorm` from
```python
self.running_mean = UninitializedBuffer()
```
to
```python
self.register_buffer('running_mean', UninitializedBuffer())
```
as the original one would not change the underlying `self._buffers`.

Thank you for your time on reviewing this PR :).

Gently ping @albanD, @mruberry