### PR TITLE
Out versions for matmul and sum

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -48,3 +48,28 @@ const auto flatten_script_2 = R"JIT(
       b = a.transpose(0, 1)
       return torch.flatten(b, start_dim, end_dim)
 )JIT";
+
+const auto aten_sum = R"JIT(
+  def forward(self, input):
+      return torch.sum(input)
+)JIT";
+
+const auto aten_sum_0 = R"JIT(
+  def forward(self, input):
+      return torch.sum(input, 0)
+)JIT";
+
+const auto aten_sum_1 = R"JIT(
+  def forward(self, input):
+      return torch.sum(input, 1)
+)JIT";
+
+const auto aten_sum_0_true = R"JIT(
+  def forward(self, input):
+      return torch.sum(input, 0, True)
+)JIT";
+
+const auto aten_sum_1_true = R"JIT(
+  def forward(self, input):
+      return torch.sum(input, 1, True)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -86,6 +86,18 @@ void testStaticRuntime(
 }
 } // namespace
 
+TEST(StaticRuntime, UnaryOps) {
+  auto a = at::ones({2, 3});
+
+  std::vector<IValue> args{a};
+
+  testStaticRuntime(aten_sum, args);
+  testStaticRuntime(aten_sum_0, args);
+  testStaticRuntime(aten_sum_1, args);
+  testStaticRuntime(aten_sum_0_true, args);
+  testStaticRuntime(aten_sum_1_true, args);
+}
+
 TEST(StaticRuntime, IndividualOps_Binary) {
   auto a = at::randn({2, 3});
   auto b = at::ones({2, 3});


### PR DESCRIPTION
Summary: Supported out versions for matmaul and sum for SR

Test Plan:
buck test caffe2/torch/fb/sparsenn:sparsenn_lambdas_test

matmul node runtime before out version (1000 time run): 8171 us

matmul node runtime after out version (1000 time run): 6690 us

sum node runtime before out version (1000 time run): 3558us

sum node runtime after out version (1000 time run): 2173 us

Differential Revision: D26259744

