### PR TITLE
remove unreachable portion enable RuntimeError use

### DIFF
--- a/tools/codegen/api/python.py
+++ b/tools/codegen/api/python.py
@@ -816,12 +816,14 @@ def argument_type_str_pyi(t: Type) -> str:
         else:
             elem = argument_type_str_pyi(t.elem)
             ret = f'Sequence[{elem}]'
+    
+    else: 
+        raise RuntimeError(f'unrecognized type {repr(t)}')
 
     if add_optional:
         ret = 'Optional[' + ret + ']'
+        
     return ret
-
-    raise RuntimeError(f'unrecognized type {repr(t)}')
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #


### PR DESCRIPTION
Fixes #52189

I moved the RuntimeError exception as an else statement if none of the other branches testing for types are triggered. 

In all preceding branches **ret** is defined so this should not be able to trigger a NameError should one of the types tested for in the body not be passed in. 