### PR TITLE
Benchmark for torch.ops.quantized.linear_prepack_fp16 operator

### DIFF
--- a/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_prepack_fp16_test.py
@@ -1,0 +1,44 @@
+import operator_benchmark as op_bench
+import torch
+
+"""Microbenchmarks for linear_prepack_fp16_ operator. Supports both Caffe2/PyTorch."""
+
+# Configs for PT linear_prepack_fp16 operator
+linear_prepack_fp16_long_configs = op_bench.cross_product_configs(
+    M=[8, 128],
+    N=[32, 64],
+    K=[256, 512],
+    device=['cpu'],
+    tags=["long"]
+)
+
+linear_prepack_fp16_short_configs = op_bench.config_list(
+    attr_names=["M", "N", "K"],
+    attrs=[
+        [1, 1, 1],
+        [64, 64, 64],
+        [64, 64, 128],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+class LinearPrepackFP16Benchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device):
+        self.inputs = {
+            "input_one": torch.rand(M, N, K, device=device, requires_grad=False, dtype=torch.float32)
+        }
+        self.set_module_name("linear_prepack_fp16")
+
+    def forward(self, input_one):
+        return torch.ops.quantized.linear_prepack_fp16(input_one)
+
+# The generated test names based on linear_prepack_fp16_short_configs will be in the following pattern:
+# linear_prepack_fp16_M8_N16_K32_devicecpu
+
+op_bench.generate_pt_test(linear_prepack_fp16_long_configs + linear_prepack_fp16_short_configs, LinearPrepackFP16Benchmark)
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()

--- a/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
+++ b/benchmarks/operator_benchmark/pt/linear_unpack_fp16_test.py
@@ -1,0 +1,46 @@
+import operator_benchmark as op_bench
+import torch
+
+"""Microbenchmarks for linear_unpack_fp16_ operator. Supports both Caffe2/PyTorch."""
+
+# Configs for PT linear_unpack_fp16 operator
+linear_unpack_fp16_long_configs = op_bench.cross_product_configs(
+    M=[8, 128],
+    N=[32, 64],
+    K=[256, 512],
+    device=['cpu'],
+    tags=["long"]
+)
+
+linear_unpack_fp16_short_configs = op_bench.config_list(
+    attr_names=["M", "N", "K"],
+    attrs=[
+        [1, 1, 1],
+        [64, 64, 64],
+        [64, 64, 128],
+    ],
+    cross_product_configs={
+        'device': ['cpu'],
+    },
+    tags=["short"],
+)
+
+class LinearUnpackFP16Benchmark(op_bench.TorchBenchmarkBase):
+    def init(self, M, N, K, device):
+        self.inputs = {
+            "input_one": torch.ops.quantized.linear_prepack_fp16(torch.rand(M, N, K, device=device,
+                                                                            requires_grad=False,
+                                                                            dtype=torch.float32))
+        }
+        self.set_module_name("linear_unpack_fp16")
+
+    def forward(self, input_one):
+        return torch.ops.quantized.linear_unpack_fp16(input_one)
+
+# The generated test names based on linear_unpack_fp16_short_configs will be in the following pattern:
+# linear_unpack_fp16_M8_N16_K32_devicecpu
+
+op_bench.generate_pt_test(linear_unpack_fp16_long_configs + linear_unpack_fp16_short_configs, LinearUnpackFP16Benchmark)
+
+if __name__ == "__main__":
+    op_bench.benchmark_runner.main()


### PR DESCRIPTION
Summary:
Create benchmarks for
torch.ops.quantized.linear_prepack_fp16  and torch.ops.quantized.linear_unpack_fp16 operators

Benchmark for these operators are written in the same format as the other benchmarks for other operators.

Test Plan:
linear_prepack_fp16 test was successfully run with various parameters:

Sample test run output:
 ----------------------------------------
 PyTorch/Caffe2 Operator Micro-benchmarks
 ----------------------------------------
 Tag : long

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M8_N32_K256_cpu
 Input: M: 8, N: 32, K: 256, device: cpu
Forward Execution Time (us) : 14.002

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M8_N32_K512_cpu
 Input: M: 8, N: 32, K: 512, device: cpu
Forward Execution Time (us) : 14.114

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M8_N64_K256_cpu
 Input: M: 8, N: 64, K: 256, device: cpu
Forward Execution Time (us) : 19.355

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M8_N64_K512_cpu
 Input: M: 8, N: 64, K: 512, device: cpu
Forward Execution Time (us) : 19.056

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M128_N32_K256_cpu
 Input: M: 128, N: 32, K: 256, device: cpu
Forward Execution Time (us) : 115.963

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M128_N32_K512_cpu
 Input: M: 128, N: 32, K: 512, device: cpu
Forward Execution Time (us) : 116.259

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M128_N64_K256_cpu
 Input: M: 128, N: 64, K: 256, device: cpu
Forward Execution Time (us) : 229.336

 Benchmarking PyTorch: linear_prepack_fp16
 Mode: Eager
 Name: linear_prepack_fp16_M128_N64_K512_cpu
 Input: M: 128, N: 64, K: 512, device: cpu
Forward Execution Time (us) : 220.016

linear_unpack_fp16 test was successfully run with identical parameters

Differential Revision: D26403343

