### PR TITLE
Revert nightly docker build cuda version to 11.1.1.

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -3,13 +3,13 @@
 set -xeuo pipefail
 
 PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
+CUDA_VERSION=11.1.1
 
 # Build PyTorch nightly docker
-# Full name: ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG}
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \
-     CUDA_VERSION=11.1.1 \
+     CUDA_VERSION=${CUDA_VERSION} \
      CUDA_CHANNEL=conda-forge \
      DOCKER_IMAGE=pytorch-nightly \
      DOCKER_TAG=${PYTORCH_DOCKER_TAG} \
@@ -19,8 +19,12 @@ make -f docker.Makefile \
 PYTORCH_NIGHTLY_COMMIT=$(docker run \
        ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
        python -c 'import torch; print(torch.version.git_version)' | head -c 7)
+
 docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_DOCKER_TAG} \
-       ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}
+       ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION}
+
+docker tag ghcr.io/pytorch/pytorch-nightly:${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
+       ghcr.io/pytorch/pytorch-nightly:latest
 
 # Push the nightly docker to GitHub Container Registry
 echo $GHCR_PAT | docker login ghcr.io -u pytorch --password-stdin
@@ -28,5 +32,12 @@ make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \
      DOCKER_IMAGE=pytorch-nightly \
-     DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT} \
+     DOCKER_TAG=${PYTORCH_NIGHTLY_COMMIT}-cu${CUDA_VERSION} \
+     devel-push
+
+make -f docker.Makefile \
+     DOCKER_REGISTRY=ghcr.io \
+     DOCKER_ORG=pytorch \
+     DOCKER_IMAGE=pytorch-nightly \
+     DOCKER_TAG=latest \
      devel-push

--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -9,7 +9,7 @@ PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \
-     CUDA_VERSION=11.2.0 \
+     CUDA_VERSION=11.1.1 \
      CUDA_CHANNEL=conda-forge \
      DOCKER_IMAGE=pytorch-nightly \
      DOCKER_TAG=${PYTORCH_DOCKER_TAG} \


### PR DESCRIPTION
CUDA 11.2 has a performance regression, so revert to CUDA 11.1.1.

Test Plan:
[CI](https://github.com/pytorch/pytorch/actions?query=workflow%3A%22Build+PyTorch+nightly+Docker+image+and+push+to+GitHub+Container+Registry%22)