### PR TITLE
Fix optim.lr_scheduler.CosineAnnealingWarmRestarts with last_epoch > 0

### DIFF
--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -962,9 +962,9 @@ class CosineAnnealingWarmRestarts(_LRScheduler):
         self.T_mult = T_mult
         self.eta_min = eta_min
 
-        super(CosineAnnealingWarmRestarts, self).__init__(optimizer, last_epoch, verbose)
+        self.T_cur = last_epoch
 
-        self.T_cur = self.last_epoch
+        super(CosineAnnealingWarmRestarts, self).__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:


### PR DESCRIPTION
It used to fail due to `T_cur` not yet initialized when `step()` is called from the parent constructor.

To the best of my code analysis skills, this little line order change fixes the problem without additional side effects or changes in the rest of the behaviour.

Fixes #52236
