### PR TITLE
[cmake] Add explicit cublas->cudart dependency

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -339,6 +339,7 @@ if(CAFFE2_STATIC_LINK_CUDA AND NOT WIN32)
         TARGET caffe2::cublas APPEND PROPERTY INTERFACE_LINK_LIBRARIES
         "${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublasLt_static.a")
     endif()
+    target_link_libraries(caffe2::cublas INTERFACE torch::cudart)
 else()
     set_property(
         TARGET caffe2::cublas PROPERTY INTERFACE_LINK_LIBRARIES


### PR DESCRIPTION
Necessary to ensure correct link order, especially if libraries are
linked statically. Otherwise, one might run into:
```
/usr/bin/ld: /usr/local/cuda/lib64/libcublasLt_static.a(libcublasLt_static.a.o): undefined reference to symbol 'cudaStreamWaitEvent@@libcudart.so.11.0'
/usr/local/cuda/lib64/libcudart.so: error adding symbols: DSO missing from command line
```

