### PR TITLE
Removes deprecated preprocess method from the backend interface

### DIFF
--- a/test/cpp/jit/test_backend_lib.cpp
+++ b/test/cpp/jit/test_backend_lib.cpp
@@ -12,12 +12,6 @@ class TestBackend : public PyTorchBackendInterface {
   explicit TestBackend() {}
   virtual ~TestBackend() = default;
 
-  c10::IValue preprocess(
-      c10::IValue mod,
-      c10::impl::GenericDict method_compile_spec) override {
-    return mod;
-  }
-
   c10::impl::GenericDict compile(
       c10::IValue processed,
       c10::impl::GenericDict method_compile_spec) override {

--- a/test/custom_backend/custom_backend.h
+++ b/test/custom_backend/custom_backend.h
@@ -12,12 +12,6 @@ class CustomBackend : public torch::jit::PyTorchBackendInterface {
   explicit CustomBackend() {}
   virtual ~CustomBackend() = default;
 
-  c10::IValue preprocess(
-      c10::IValue mod,
-      c10::impl::GenericDict method_compile_spec) override {
-    return mod;
-  }
-
   c10::impl::GenericDict compile(
       c10::IValue processed,
       c10::impl::GenericDict method_compile_spec) override {

--- a/torch/csrc/jit/backends/backend.h
+++ b/torch/csrc/jit/backends/backend.h
@@ -2,7 +2,6 @@
 
 #include <ATen/core/builtin_function.h>
 #include <ATen/core/stack.h>
-#include <c10/util/Deprecated.h>
 #include <torch/csrc/jit/backends/backend_detail.h>
 #include <torch/csrc/jit/backends/backend_interface.h>
 #include <torch/custom_class.h>
@@ -19,24 +18,6 @@ class backend {
   std::string backend_name_;
 
  public:
-  C10_DEPRECATED
-  explicit backend(const std::string& name) : backend_name_(name) {
-    static auto cls =
-        torch::class_<TBackendInterface>(detail::kBackendsNamespace, name)
-            .def(torch::init<>())
-            ._def_unboxed(
-                "preprocess",
-                detail::getPreprocessFunc<TBackendInterface>(),
-                detail::getPreprocessSchema())
-            ._def_unboxed(
-                "compile",
-                detail::getCompileFunc<TBackendInterface>(),
-                detail::getCompileSchema())
-            ._def_unboxed(
-                "execute",
-                detail::getExecuteFunc<TBackendInterface>(),
-                detail::getExecuteSchema());
-  }
   // Registers a new backend with /p name, and the given /p preprocess
   // function.
   backend(

--- a/torch/csrc/jit/backends/backend_detail.h
+++ b/torch/csrc/jit/backends/backend_detail.h
@@ -13,20 +13,8 @@ namespace detail {
 
 constexpr static auto kBackendsNamespace = "__backends__";
 
-c10::FunctionSchema TORCH_API getPreprocessSchema();
 c10::FunctionSchema TORCH_API getCompileSchema();
 c10::FunctionSchema TORCH_API getExecuteSchema();
-
-template <typename TBackendInterface>
-std::function<void(Stack&)> getPreprocessFunc() {
-  return [](Stack& stack) {
-    auto method_compile_spec = pop(stack).toGenericDict();
-    auto mod = pop(stack);
-    auto self = pop(stack).toCustomClass<TBackendInterface>();
-    auto ret = self->preprocess(mod, method_compile_spec);
-    push(stack, ret);
-  };
-}
 
 template <typename TBackendInterface>
 std::function<void(Stack&)> getCompileFunc() {

--- a/torch/csrc/jit/backends/backend_interface.h
+++ b/torch/csrc/jit/backends/backend_interface.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <c10/util/Deprecated.h>
 #include <torch/custom_class.h>
 
 namespace torch {
@@ -11,13 +10,6 @@ class TORCH_API PyTorchBackendInterface : public torch::CustomClassHolder {
  public:
   PyTorchBackendInterface();
   virtual ~PyTorchBackendInterface();
-
-  // Preprocess \p mod as per \p method_compile_spec to prepare it for
-  // compilation.
-  C10_DEPRECATED
-  virtual c10::IValue preprocess(
-      c10::IValue mod,
-      c10::impl::GenericDict method_compile_spec) = 0;
 
   // Compile the module contained in \p processed using the details provided in
   // \p method_compile_spec for each module method that should be compiled for


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52258 Removes deprecated preprocess method from the backend interface**

Removes deprecated preprocess method from the backend interface.

Preprocessing logic should be now registered along with the backend interface (i.e. PyTorchBackendInterface) via the BackendPreprocessFunction.

Also refactored internal dependencies.

Differential Revision: [D26443479](https://our.internmc.facebook.com/intern/diff/D26443479/)