### PR TITLE
[TensorExpr] LoopNest: make API for creating a loopnest more explicit.

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
 
 namespace torch {
 namespace jit {
@@ -26,6 +27,11 @@ class TORCH_API LoopNest {
  public:
   // A constructor for building a LoopNest from a list of Tensors
   LoopNest(const std::vector<Tensor*>& output_tensors);
+
+  LoopNest(
+      const std::vector<Tensor*>& all_tensors,
+      const std::vector<Placeholder>& input_tensors,
+      const std::vector<Tensor*>& output_tensors);
 
   // A constructor for building a LoopNest from a pre-baked Stmt and meta-info
   // TODO: Nuke intermediate_bufs_ from here if they can be deduced.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52259 [TensorExpr] LoopNest: make API for creating a loopnest more explicit.**

Namely, after this change to create a loopnest we would need to specify
a complete stmt for the aggregate computation and lists of input/output
bufs.

This is done so that all the transformations and analyses uses the same
single source of truth - the root stmt. Before this change some of the
transformations relied on buf<->stmt link existed in Tensor objects.

Differential Revision: [D26443735](https://our.internmc.facebook.com/intern/diff/D26443735)