### PR TITLE
Adding learning rate schedulers to C++ API

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -698,6 +698,8 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_SRC_DIR}/csrc/api/src/optim/rmsprop.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/serialize.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/optim/sgd.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/optim/schedulers/lr_scheduler.cpp
+      ${TORCH_SRC_DIR}/csrc/api/src/optim/schedulers/step_lr.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/serialize/input-archive.cpp
       ${TORCH_SRC_DIR}/csrc/api/src/serialize/output-archive.cpp
     )

--- a/setup.py
+++ b/setup.py
@@ -964,6 +964,7 @@ if __name__ == '__main__':
                 'include/torch/csrc/api/include/torch/nn/parallel/*.h',
                 'include/torch/csrc/api/include/torch/nn/utils/*.h',
                 'include/torch/csrc/api/include/torch/optim/*.h',
+                'include/torch/csrc/api/include/torch/optim/schedulers/*.h',
                 'include/torch/csrc/api/include/torch/serialize/*.h',
                 'include/torch/csrc/autograd/*.h',
                 'include/torch/csrc/autograd/functions/*.h',

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -493,6 +493,8 @@ torch_cpp_srcs = [
     "torch/csrc/api/src/optim/rmsprop.cpp",
     "torch/csrc/api/src/optim/serialize.cpp",
     "torch/csrc/api/src/optim/sgd.cpp",
+    "torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp",
+    "torch/csrc/api/src/optim/schedulers/step_lr.cpp",
     "torch/csrc/api/src/serialize/input-archive.cpp",
     "torch/csrc/api/src/serialize/output-archive.cpp",
 ]

--- a/torch/csrc/api/include/torch/optim.h
+++ b/torch/csrc/api/include/torch/optim.h
@@ -7,3 +7,6 @@
 #include <torch/optim/optimizer.h>
 #include <torch/optim/rmsprop.h>
 #include <torch/optim/sgd.h>
+
+#include <torch/optim/schedulers/lr_scheduler.h>
+#include <torch/optim/schedulers/step_lr.h>

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -31,6 +31,8 @@ public:
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const AdagradOptions& lhs, const AdagradOptions& rhs);
   ~AdagradOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API AdagradParamState : public OptimizerCloneableParamState<AdagradParamState> {

--- a/torch/csrc/api/include/torch/optim/adam.h
+++ b/torch/csrc/api/include/torch/optim/adam.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
@@ -31,6 +30,8 @@ public:
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const AdamOptions& lhs, const AdamOptions& rhs);
   ~AdamOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API AdamParamState : public OptimizerCloneableParamState<AdamParamState> {

--- a/torch/csrc/api/include/torch/optim/adamw.h
+++ b/torch/csrc/api/include/torch/optim/adamw.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
@@ -31,6 +30,8 @@ public:
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const AdamWOptions& lhs, const AdamWOptions& rhs);
   ~AdamWOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API AdamWParamState : public OptimizerCloneableParamState<AdamWParamState> {

--- a/torch/csrc/api/include/torch/optim/lbfgs.h
+++ b/torch/csrc/api/include/torch/optim/lbfgs.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
@@ -28,6 +27,8 @@ struct TORCH_API LBFGSOptions : public OptimizerCloneableOptions<LBFGSOptions> {
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const LBFGSOptions& lhs, const LBFGSOptions& rhs);
   ~LBFGSOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API LBFGSParamState : public OptimizerCloneableParamState<LBFGSParamState> {

--- a/torch/csrc/api/include/torch/optim/optimizer.h
+++ b/torch/csrc/api/include/torch/optim/optimizer.h
@@ -5,6 +5,7 @@
 #include <c10/util/Exception.h>
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/arg.h>
 
 #include <algorithm>
 #include <functional>
@@ -52,10 +53,13 @@ class TORCH_API OptimizerOptions {
   virtual void serialize(torch::serialize::InputArchive& archive);
   virtual void serialize(torch::serialize::OutputArchive& archive) const;
   virtual ~OptimizerOptions() = default;
+  virtual double get_lr() const;
+  virtual void set_lr(const double lr);
 };
 
 template <typename Derived>
 class OptimizerCloneableOptions : public OptimizerOptions {
+private:
   std::unique_ptr<OptimizerOptions> clone() const override {
     return std::make_unique<Derived>(static_cast<const Derived&>(*this));
   }

--- a/torch/csrc/api/include/torch/optim/rmsprop.h
+++ b/torch/csrc/api/include/torch/optim/rmsprop.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
@@ -36,6 +35,8 @@ struct TORCH_API RMSpropOptions : public OptimizerCloneableOptions<RMSpropOption
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const RMSpropOptions& lhs, const RMSpropOptions& rhs);
   ~RMSpropOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API RMSpropParamState : public OptimizerCloneableParamState<RMSpropParamState> {

--- a/torch/csrc/api/include/torch/optim/schedulers/lr_scheduler.h
+++ b/torch/csrc/api/include/torch/optim/schedulers/lr_scheduler.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <torch/optim/optimizer.h>
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+
+namespace torch {
+namespace optim {
+
+class TORCH_API LRScheduler {
+public:
+
+  //This class needs to take a reference of an optimizer from outside such that it can
+  //modify its learning rates; due to this the lifetime of said optimizer must be maintained
+  LRScheduler(torch::optim::Optimizer& optimizer);
+
+  virtual ~LRScheduler() = default;
+
+  void step();
+
+protected:
+  //A vector of learning rates is calculated and returned from the specific subclass.
+  //A vector is returned with each element being a separate learning rate for each
+  //param group - although the normal use case would be to return a vector of identical
+  //elements.
+  virtual std::vector<double> get_lrs() = 0;
+
+  //Get current learning rates from the optimizer
+  std::vector<double> get_current_lrs() const;
+
+  unsigned step_count_;
+
+private:
+  void set_optimizer_lrs(const std::vector<double>& learning_rates);
+
+  torch::optim::Optimizer& optimizer_;
+
+};
+} // namespace optim
+} // namspace torch

--- a/torch/csrc/api/include/torch/optim/schedulers/step_lr.h
+++ b/torch/csrc/api/include/torch/optim/schedulers/step_lr.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <torch/optim/schedulers/lr_scheduler.h>
+
+namespace torch {
+namespace optim {
+
+class TORCH_API StepLR : public LRScheduler {
+public:
+
+  StepLR(torch::optim::Optimizer& optimizer,
+         const unsigned step_size,
+         const double gamma = 0.1);
+
+private:
+  std::vector<double> get_lrs() override;
+
+  const unsigned step_size_;
+  const double gamma_;
+
+};
+} // namespace optim
+} // namespace torch

--- a/torch/csrc/api/include/torch/optim/sgd.h
+++ b/torch/csrc/api/include/torch/optim/sgd.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <torch/arg.h>
 #include <torch/nn/module.h>
 #include <torch/optim/optimizer.h>
 #include <torch/optim/serialize.h>
@@ -33,6 +32,8 @@ public:
   void serialize(torch::serialize::OutputArchive& archive) const override;
   TORCH_API friend bool operator==(const SGDOptions& lhs, const SGDOptions& rhs);
   ~SGDOptions() = default;
+  double get_lr() const override;
+  void set_lr(const double lr) override;
 };
 
 struct TORCH_API SGDParamState : public OptimizerCloneableParamState<SGDParamState> {

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -38,6 +38,14 @@ void AdagradOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(double, eps);
 }
 
+double AdagradOptions::get_lr() const {
+  return lr();
+}
+
+void AdagradOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 bool operator==(const AdagradParamState& lhs, const AdagradParamState& rhs) {
   return (lhs.step() == rhs.step()) &&
             torch::equal(lhs.sum(), rhs.sum());

--- a/torch/csrc/api/src/optim/adam.cpp
+++ b/torch/csrc/api/src/optim/adam.cpp
@@ -40,6 +40,14 @@ void AdamOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, amsgrad);
 }
 
+double AdamOptions::get_lr() const {
+  return lr();
+}
+
+void AdamOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 bool operator==(const AdamParamState& lhs, const AdamParamState& rhs) {
   return (lhs.step() == rhs.step()) &&
           torch::equal(lhs.exp_avg(), rhs.exp_avg()) &&

--- a/torch/csrc/api/src/optim/adamw.cpp
+++ b/torch/csrc/api/src/optim/adamw.cpp
@@ -40,6 +40,14 @@ void AdamWOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, amsgrad);
 }
 
+double AdamWOptions::get_lr() const {
+  return lr();
+}
+
+void AdamWOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 bool operator==(const AdamWParamState& lhs, const AdamWParamState& rhs) {
   return (lhs.step() == rhs.step()) &&
           torch::equal(lhs.exp_avg(), rhs.exp_avg()) &&

--- a/torch/csrc/api/src/optim/lbfgs.cpp
+++ b/torch/csrc/api/src/optim/lbfgs.cpp
@@ -47,6 +47,14 @@ void LBFGSOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG_OPTIONAL(std::string, line_search_fn);
 }
 
+double LBFGSOptions::get_lr() const {
+  return lr();
+}
+
+void LBFGSOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 template <typename T>
 bool if_container_equal(T lhs, T rhs) {
   if (!(lhs.size() == rhs.size())) return false;

--- a/torch/csrc/api/src/optim/optimizer.cpp
+++ b/torch/csrc/api/src/optim/optimizer.cpp
@@ -56,6 +56,14 @@ void OptimizerParamState::serialize(torch::serialize::OutputArchive& archive) co
     "You must override it in your subclass of torch::optim::OptimizerCloneableParamState<YourOptimizerParamState>.");
 }
 
+double OptimizerOptions::get_lr() const {
+  TORCH_CHECK(false, "double get_lr() has not been overidden and implemented in subclass of torch::optim::OptimizerOptions, you must override it in your subclass.");
+}
+
+void OptimizerOptions::set_lr(const double lr) {
+  TORCH_CHECK(false, "double set_lr() has not been overidden and implemented in subclass of torch::optim::OptimizerOptions, you must override it in your subclass.");
+}
+
 std::unique_ptr<OptimizerOptions> OptimizerOptions::clone() const {
   TORCH_CHECK(false,
       "clone() has not been implemented for torch::optim::OptimizerOptions. ",

--- a/torch/csrc/api/src/optim/rmsprop.cpp
+++ b/torch/csrc/api/src/optim/rmsprop.cpp
@@ -40,6 +40,14 @@ void RMSpropOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, centered);
 }
 
+double RMSpropOptions::get_lr() const {
+  return lr();
+}
+
+void RMSpropOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 bool operator==(const RMSpropParamState& lhs, const RMSpropParamState& rhs) {
   return (lhs.step() == rhs.step()) &&
          torch::equal(lhs.square_avg(), rhs.square_avg()) &&

--- a/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
+++ b/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
@@ -1,0 +1,36 @@
+#include <torch/optim/schedulers/lr_scheduler.h>
+
+namespace torch {
+namespace optim {
+
+LRScheduler::LRScheduler(torch::optim::Optimizer& optimizer) :
+  step_count_(0),
+  optimizer_(optimizer) {}
+
+void LRScheduler::step() {
+  std::vector<double> learning_rates = get_lrs();
+  set_optimizer_lrs(learning_rates);
+  step_count_++;
+}
+
+void LRScheduler::set_optimizer_lrs(const std::vector<double>& learning_rates) {
+  //Check the number of learning rates is equal to the number of parameters groups in the
+  //optimizer
+  TORCH_CHECK(learning_rates.size() == optimizer_.param_groups().size(),
+              "Number of learning rates not equal to the number of param groups\n",
+              "Number of learning rates given: ", learning_rates.size(),
+              "\nNumber of param groups: ", optimizer_.param_groups().size());
+
+  for(std::size_t i = 0; i < optimizer_.param_groups().size(); i++)
+    optimizer_.param_groups()[i].options().set_lr(learning_rates[i]);
+}
+
+std::vector<double> LRScheduler::get_current_lrs() const {
+  std::vector<double> learnings_rates(optimizer_.param_groups().size());
+  for(std::size_t i = 0; i < optimizer_.param_groups().size(); i++)
+      learnings_rates[i] = optimizer_.param_groups()[i].options().get_lr();
+  return learnings_rates;
+}
+
+} // namespace optim
+} // namespace torch

--- a/torch/csrc/api/src/optim/schedulers/step_lr.cpp
+++ b/torch/csrc/api/src/optim/schedulers/step_lr.cpp
@@ -1,0 +1,25 @@
+#include <torch/optim/schedulers/step_lr.h>
+
+namespace torch {
+namespace optim {
+
+StepLR::StepLR(torch::optim::Optimizer& optimizer,
+               const unsigned step_size,
+               const double gamma) :
+  LRScheduler(optimizer),
+  step_size_(step_size),
+  gamma_(gamma) {}
+
+std::vector<double> StepLR::get_lrs() {
+  if(step_count_ == 0 || step_count_ % step_size_ != 0)
+    return get_current_lrs();
+  else {
+    std::vector<double> lrs = get_current_lrs();
+    std::transform(lrs.begin(), lrs.end(), lrs.begin(),
+                   [this](const double& v){ return this->gamma_ * v; });
+    return lrs;
+  }
+}
+
+} // namespace optim
+} // namespace torch

--- a/torch/csrc/api/src/optim/sgd.cpp
+++ b/torch/csrc/api/src/optim/sgd.cpp
@@ -40,6 +40,14 @@ void SGDOptions::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(bool, nesterov);
 }
 
+double SGDOptions::get_lr() const {
+  return lr();
+}
+
+void SGDOptions::set_lr(const double lr) {
+  this->lr(lr);
+}
+
 bool operator==(const SGDParamState& lhs, const SGDParamState& rhs) {
   return torch::equal(lhs.momentum_buffer(), rhs.momentum_buffer());
 }


### PR DESCRIPTION
Fixes #50577

Learning rate schedulers had not yet been implemented for the C++ API. 

This pull request introduces the learning rate scheduler base class and the StepLR subclass. Furthermore, it modifies the existing OptimizerOptions such that the learning rate scheduler can modify the learning rate.
