### PR TITLE
Included docs for `feature_dropout` method and classes

### DIFF
--- a/docs/source/nn.functional.rst
+++ b/docs/source/nn.functional.rst
@@ -338,6 +338,11 @@ Dropout functions
 
 .. autofunction:: alpha_dropout
 
+:hidden:`feature_dropout`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autofunction:: feature_dropout
+
 :hidden:`feature_alpha_dropout`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -242,6 +242,8 @@ Dropout Layers
     nn.Dropout2d
     nn.Dropout3d
     nn.AlphaDropout
+    nn.FeatureDropout
+    nn.FeatureAlphaDropout
 
 Sparse Layers
 -------------

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1134,13 +1134,35 @@ def dropout3d(input: Tensor, p: float = 0.5, training: bool = True, inplace: boo
     return _VF.feature_dropout_(input, p, training) if inplace else _VF.feature_dropout(input, p, training)
 
 
+def feature_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
+    r"""
+    Randomly masks out entire channels (a channel is a feature map,
+    e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
+    is a tensor :math:`\text{input}[i, j]`) of the input tensor).
+    Each channel will be zeroed out independently on every forward call with
+    probability :attr:`p` using samples from a Bernoulli distribution.
+
+    See :class:`~torch.nn.FeatureDropout` for details.
+
+    Args:
+        p: probability of a channel to be zeroed. Default: 0.5
+        training: apply dropout if is ``True``. Default: ``True``
+        inplace: If set to ``True``, will do this operation in-place. Default: ``False``
+    """
+    if has_torch_function_unary(input):
+        return handle_torch_function(feature_dropout, (input,), input, p=p, training=training, inplace=inplace)
+    if p < 0.0 or p > 1.0:
+        raise ValueError("dropout probability has to be between 0 and 1, " "but got {}".format(p))
+    return _VF.feature_dropout_(input, p, training) if inplace else _VF.feature_dropout(input, p, training)
+
+
 def feature_alpha_dropout(input: Tensor, p: float = 0.5, training: bool = False, inplace: bool = False) -> Tensor:
     r"""
     Randomly masks out entire channels (a channel is a feature map,
     e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
-    is a tensor :math:`\text{input}[i, j]`) of the input tensor). Instead of
-    setting activations to zero, as in regular Dropout, the activations are set
-    to the negative saturation value of the SELU activation function.
+    is a tensor :math:`\text{input}[i, j]`) of the input tensor). Additionally,
+    instead of setting activations to zero, as in regular Dropout, the activations
+    are set to the negative saturation value of the SELU activation function.
 
     Each element will be masked independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -104,6 +104,9 @@ def dropout2d(input: Tensor, p: float = ..., training: bool = ..., inplace: bool
 def dropout3d(input: Tensor, p: float = ..., training: bool = ..., inplace: bool = ...) -> Tensor: ...
 
 
+def feature_dropout(input: Tensor, p: float = ..., training: bool = ..., inplace: bool = ...) -> Tensor: ...
+
+
 def feature_alpha_dropout(input: Tensor, p: float = ..., training: bool = ..., inplace: bool = ...) -> Tensor: ...
 
 

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -19,7 +19,7 @@ from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d, SyncBatchNorm, \
     LazyBatchNorm1d, LazyBatchNorm2d, LazyBatchNorm3d
 from .instancenorm import InstanceNorm1d, InstanceNorm2d, InstanceNorm3d
 from .normalization import LocalResponseNorm, CrossMapLRN2d, LayerNorm, GroupNorm
-from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout, FeatureAlphaDropout
+from .dropout import Dropout, Dropout2d, Dropout3d, AlphaDropout, FeatureDropout, FeatureAlphaDropout
 from .padding import ReflectionPad1d, ReflectionPad2d, ReplicationPad1d, ReplicationPad2d, \
     ReplicationPad3d, ZeroPad2d, ConstantPad1d, ConstantPad2d, ConstantPad3d
 from .sparse import Embedding, EmbeddingBag
@@ -48,7 +48,7 @@ __all__ = [
     'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d', "FractionalMaxPool3d",
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
     'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'SyncBatchNorm',
-    'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'FeatureAlphaDropout',
+    'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'FeatureDropout', 'FeatureAlphaDropout',
     'ReflectionPad1d', 'ReflectionPad2d', 'ReplicationPad2d', 'ReplicationPad1d', 'ReplicationPad3d',
     'CrossMapLRN2d', 'Embedding', 'EmbeddingBag', 'RNNBase', 'RNN', 'LSTM', 'GRU', 'RNNCellBase', 'RNNCell',
     'LSTMCell', 'GRUCell', 'PixelShuffle', 'PixelUnshuffle', 'Upsample', 'UpsamplingNearest2d', 'UpsamplingBilinear2d',

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -192,8 +192,6 @@ class FeatureDropout(_DropoutNd):
     Each channel will be zeroed out independently on every forward call with
     probability :attr:`p` using samples from a Bernoulli distribution.
 
-    Internally used by `DropoutXd` making stack traces less confusing.
-
     As described in the paper
     `Efficient Object Localization Using Convolutional Networks`_ ,
     if adjacent pixels within feature maps are strongly correlated

--- a/torch/nn/modules/dropout.py
+++ b/torch/nn/modules/dropout.py
@@ -184,6 +184,46 @@ class AlphaDropout(_DropoutNd):
         return F.alpha_dropout(input, self.p, self.training)
 
 
+class FeatureDropout(_DropoutNd):
+    r"""Randomly masks out entire channels (a channel is a feature map,
+    e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input
+    is a tensor :math:`\text{input}[i, j]`) of the input tensor).
+
+    Each channel will be zeroed out independently on every forward call with
+    probability :attr:`p` using samples from a Bernoulli distribution.
+
+    Internally used by `DropoutXd` making stack traces less confusing.
+
+    As described in the paper
+    `Efficient Object Localization Using Convolutional Networks`_ ,
+    if adjacent pixels within feature maps are strongly correlated
+    (as is normally the case in early convolution layers) then i.i.d. dropout
+    will not regularize the activations and will otherwise just result
+    in an effective learning rate decrease.
+
+    Args:
+        p (float, optional): probability of an element to be zeroed. Default: 0.5
+        inplace (bool, optional): If set to ``True``, will do this operation
+            in-place
+
+    Shape:
+        - Input: :math:`(N, C, D, H, W)`
+        - Output: :math:`(N, C, D, H, W)` (same shape as input)
+
+    Examples::
+
+        >>> m = nn.FeatureDropout(p=0.2)
+        >>> input = torch.randn(20, 16, 4, 32, 32)
+        >>> output = m(input)
+
+    .. _Efficient Object Localization Using Convolutional Networks:
+       https://arxiv.org/abs/1411.4280
+    """
+
+    def forward(self, input: Tensor) -> Tensor:
+        return F.feature_dropout(input, self.p, self.training)
+
+
 class FeatureAlphaDropout(_DropoutNd):
     r"""Randomly masks out entire channels (a channel is a feature map, 
     e.g. the :math:`j`-th channel of the :math:`i`-th sample in the batch input 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -616,6 +616,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
                                             scale_grad_by_freq=False, mode='mean', sparse=False, per_sample_weights=None,
                                             include_last_offset=False: -1),
         torch.nn.functional.feature_alpha_dropout: lambda input, p=0.5, training=False, inplace=False: -1,
+        torch.nn.functional.feature_dropout: lambda input, p=0.5, training=False, inplace=False: -1,
         torch.nn.functional.fold: lambda input, output_size, kernel_size, dilation=1, padding=0, stride=1: -1,
         torch.nn.functional.fractional_max_pool2d: (lambda input, kernel_size, output_size=None, output_ratio=None,
                                                     return_indices=False, _random_samples=None: -1),

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -73,6 +73,7 @@ nn_functional_tests = [
     ('alpha_dropout', (S, S, S), (0.5,)),
     ('dropout2d', (S, S, S), (0.5,)),
     ('dropout3d', (S, S, S), (0.5,)),
+    ('feature_dropout', (S, S, S), (0.5,)),
     ('feature_alpha_dropout', (S, S, S), (0.5,)),
     ('threshold', (S, S, S), (0.1, 2.), '', (True,)),
     ('threshold', (S, S, S), (0.1, 2., True), 'inplace'),


### PR DESCRIPTION
Addresses #9886 

Hi @vadimkantorov!

Here's PR for linking `feature_dropout` method in docs and including `FeatureDropout` and `FeatureAlphaDropout` there also. 

Listing `feature_dropout` method required including it in `nn/functional.pyi.in` and providing implementation. Also for consistency I've added `FeatureDropout` class, as those methods have links to class implementations with more details.

Is it correct?

## Screenshots from built docs

1. `featuredropout` method:
![featuredropout](https://i.imgur.com/ZY93POK.png)

2. Dropout classes list:
![classes list](https://i.imgur.com/aygZu2j.png)

3. Additional `FeatureDropout` class:
![featuredropout class](https://i.imgur.com/nbJ1Hj7.png)

---

P.S. I think this should close #9886 as missing docs for `torch.default_generator` already have some PRs #39139 and #27847