### PR TITLE
Fix complex acos edge cases

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_complex_float.h
+++ b/aten/src/ATen/cpu/vec256/vec256_complex_float.h
@@ -241,10 +241,7 @@ public:
     return Vec256(_mm256_permute_ps(ln.values, 0xB1)).conj();         //-i*ln()
   }
   Vec256<c10::complex<float>> acos() const {
-    // acos(x) = pi/2 - asin(x)
-    constexpr float pi_2f = c10::pi<float> / 2;
-    const __m256 pi_2 = _mm256_setr_ps(pi_2f, 0.0, pi_2f, 0.0, pi_2f, 0.0, pi_2f, 0.0);
-    return _mm256_sub_ps(pi_2, asin());
+    return map(std::acos);
   }
   Vec256<c10::complex<float>> atan() const;
   Vec256<c10::complex<float>> atan2(const Vec256<c10::complex<float>> &b) const {

--- a/c10/util/complex_math.cpp
+++ b/c10/util/complex_math.cpp
@@ -1,9 +1,6 @@
 #include <c10/util/complex.h>
 
 #include <cmath>
-#include <istream>
-#include <limits>
-#include <iomanip>
 
 // Note [ Complex Square root in libc++]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -16,7 +13,7 @@
 #ifdef _LIBCPP_VERSION
 
 namespace {
-template<typename T>
+template <typename T>
 c10::complex<T> compute_csqrt(const c10::complex<T>& z) {
   constexpr auto half = T(.5);
 
@@ -45,7 +42,12 @@ c10::complex<T> compute_csqrt(const c10::complex<T>& z) {
   return c10::complex<T>(half * std::abs(z.imag() / t), std::copysign(t, z.imag()));
 }
 
-template<typename T>
+
+// Compute complex arccosine using formula from W. Kahan
+// "Branch Cuts for Complex Elementary Functions" 1986 paper:
+// cacos(z).re = 2*atan2(sqrt(1-z).re(), sqrt(1+z).re())
+// cacos(z).im = asinh((sqrt(conj(1+z))*sqrt(1-z)).im())
+template <typename T>
 c10::complex<T> compute_cacos(const c10::complex<T>& z) {
   auto constexpr one = T(1);
   // Trust standard library to correctly handle infs and NaNs
@@ -55,12 +57,14 @@ c10::complex<T> compute_cacos(const c10::complex<T>& z) {
   }
   auto a = compute_csqrt(c10::complex<T>(one - z.real(), -z.imag()));
   auto b = compute_csqrt(c10::complex<T>(one + z.real(),  z.imag()));
-  auto c = compute_csqrt(c10::complex<T>(one + z.real(),  -z.imag()));
+  auto c = compute_csqrt(c10::complex<T>(one + z.real(), -z.imag()));
   auto r = T(2) * std::atan2(a.real(), b.real());
-  auto i = std::asinh(a.real() * c.imag() + a.imag()  * c.real());
+  // Explicitly unroll (a*c).imag()
+  auto i = std::asinh(a.real() * c.imag() + a.imag() * c.real());
   return c10::complex<T>(r, i);
 }
 } // anonymous namespace
+
 
 namespace c10_complex_math { namespace _detail {
 c10::complex<float> sqrt(const c10::complex<float>& in) {
@@ -79,5 +83,5 @@ c10::complex<double> acos(const c10::complex<double>& in) {
   return compute_cacos(in);
 }
 
-}}
+}} // namespace c10_complex_math::_detail
 #endif

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -46,6 +46,8 @@ C10_HOST_DEVICE inline c10::complex<T> log2(const c10::complex<T> &x) {
 namespace _detail {
 TORCH_API c10::complex<float> sqrt(const c10::complex<float>& in);
 TORCH_API c10::complex<double> sqrt(const c10::complex<double>& in);
+TORCH_API c10::complex<float> acos(const c10::complex<float>& in);
+TORCH_API c10::complex<double> acos(const c10::complex<double>& in);
 };
 #endif
 
@@ -158,8 +160,10 @@ template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> acos(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::acos(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
-#else
+#elif !defined(_LIBCPP_VERSION)
   return static_cast<c10::complex<T>>(std::acos(static_cast<std::complex<T>>(x)));
+#else
+  return _detail::acos(x);
 #endif
 }
 

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -12,7 +12,7 @@ from torch._six import inf, nan
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, torch_to_numpy_dtype_dict, numpy_to_torch_dtype_dict,
     suppress_warnings, make_tensor, TEST_SCIPY, slowTest, skipIfNoSciPy,
-    gradcheck)
+    gradcheck, IS_WINDOWS)
 from torch.testing._internal.common_methods_invocations import (
     unary_ufuncs)
 from torch.testing._internal.common_device_type import (
@@ -470,7 +470,10 @@ class TestUnaryUfuncs(TestCase):
         x = torch.tensor(0. - 1.0e+20j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)
         # acos test reference: https://github.com/pytorch/pytorch/issue/42952A
-        self.compare_with_numpy(torch.acos, np.arccos, x)
+        # Skip on Windows, as CUDA acos  returns conjugate value
+        # see https://github.com/pytorch/pytorch/issues/52299
+        if not (IS_WINDOWS and dtype==torch.cdouble and "cuda" in device):
+            self.compare_with_numpy(torch.acos, np.arccos, x)
 
         x = torch.tensor((-1.0e+60 if dtype == torch.cdouble else -1.0e+20) - 4988429.2j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -469,10 +469,10 @@ class TestUnaryUfuncs(TestCase):
         # sqrt Test Reference: https://github.com/pytorch/pytorch/pull/47424
         x = torch.tensor(0. - 1.0e+20j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)
-        # acos test reference: https://github.com/pytorch/pytorch/issue/42952A
+        # acos test reference: https://github.com/pytorch/pytorch/issue/42952
         # Skip on Windows, as CUDA acos  returns conjugate value
         # see https://github.com/pytorch/pytorch/issues/52299
-        if not (IS_WINDOWS and dtype==torch.cdouble and "cuda" in device):
+        if not (IS_WINDOWS and dtype == torch.cdouble and "cuda" in device):
             self.compare_with_numpy(torch.acos, np.arccos, x)
 
         x = torch.tensor((-1.0e+60 if dtype == torch.cdouble else -1.0e+20) - 4988429.2j, dtype=dtype, device=device)

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -465,10 +465,12 @@ class TestUnaryUfuncs(TestCase):
             self.assertEqual(result, out)
 
     @dtypes(torch.cfloat, torch.cdouble)
-    def test_sqrt_complex_edge_values(self, device, dtype):
-        # Test Reference: https://github.com/pytorch/pytorch/pull/47424
-        x = torch.tensor(0. - 1.0000e+20j, dtype=dtype, device=device)
+    def test_complex_edge_values(self, device, dtype):
+        # sqrt Test Reference: https://github.com/pytorch/pytorch/pull/47424
+        x = torch.tensor(0. - 1.0e+20j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)
+        # acos test reference: https://github.com/pytorch/pytorch/issue/42952A
+        self.compare_with_numpy(torch.acos, np.arccos, x)
 
         x = torch.tensor((-1.0e+60 if dtype == torch.cdouble else -1.0e+20) - 4988429.2j, dtype=dtype, device=device)
         self.compare_with_numpy(torch.sqrt, np.sqrt, x)


### PR DESCRIPTION
Use `std::acos` even when avx2 is available
Add slow but accurate implementation of complex arc cosine based on
W. Kahan "Branch Cuts for Complex Elementary Functions" paper, where
cacos(z).re = 2*atan2(sqrt(1-z).re(), sqrt(1+z).re())
cacos(z).im = asinh((sqrt(conj(1+z))*sqrt(1-z)).im())

Fixes #42952