### PR TITLE
Allow broadcasting against lerp weights.

### DIFF
--- a/aten/src/ATen/native/Lerp.cpp
+++ b/aten/src/ATen/native/Lerp.cpp
@@ -11,8 +11,6 @@ namespace native {
 
 Tensor& lerp_cpu_tensor_out(Tensor& result, const Tensor& self,
                             const Tensor& end, const Tensor& weight) {
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   lerp_kernel_tensor_weight(kCPU, result, self, end, weight);
   return result;
 }
@@ -24,8 +22,6 @@ Tensor& lerp_cpu_scalar_out(Tensor& result, const Tensor& self,
 }
 
 Tensor& lerp_cpu_tensor_(Tensor& self, const Tensor& end, const Tensor& weight) {
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   lerp_kernel_tensor_weight(kCPU, self, self, end, weight);
   return self;
 }
@@ -36,8 +32,6 @@ Tensor& lerp_cpu_scalar_(Tensor& self, const Tensor& end, Scalar weight) {
 }
 
 Tensor lerp_cpu_tensor(const Tensor& self, const Tensor& end, const Tensor& weight) {
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   Tensor result = at::empty({0}, self.options());
   lerp_kernel_tensor_weight(kCPU, result, self, end, weight);
   return result;

--- a/aten/src/ATen/native/cuda/Lerp.cu
+++ b/aten/src/ATen/native/cuda/Lerp.cu
@@ -49,8 +49,6 @@ namespace native {
 Tensor& lerp_cuda_tensor_out(Tensor& result, const Tensor& self,
                             const Tensor& end, const Tensor& weight) {
   Tensor b_self, b_end, b_weight;
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   std::tie(b_self, b_end, b_weight) = expand_outplace(self, end, weight, "lerp_out_cuda");
   lerp_cuda(result, b_self, b_end, b_weight);
   return result;
@@ -72,8 +70,6 @@ Tensor& lerp_cuda_tensor_(Tensor& self, const Tensor& end, const Tensor& weight)
   TORCH_CHECK(b_self.sizes() == self.sizes(),
            "output with shape ", self.sizes(),
            " doesn't match the broadcast shape ", b_self.sizes());
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   lerp_cuda(self, b_self, b_end, b_weight);
   return self;
 }
@@ -92,8 +88,6 @@ Tensor& lerp_cuda_scalar_(Tensor& self, const Tensor& end, Scalar weight) {
 
 Tensor lerp_cuda_tensor(const Tensor& self, const Tensor& end, const Tensor& weight) {
   Tensor b_self, b_end, b_weight;
-  TORCH_CHECK(weight.dim() <= std::max(self.dim(), end.dim()),
-           "weight should be of dimension max(self.dim(), end.dim()) or lesser");
   std::tie(b_self, b_end, b_weight) = expand_outplace(self, end, weight, "lerp_cuda");
   Tensor result = at::empty_like(b_self, b_self.suggest_memory_format());
   lerp_cuda(result, b_self, b_end, b_weight);

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2063,13 +2063,13 @@ class TestBinaryUfuncs(TestCase):
         self.assertEqual(np_outcome, pt_outcome)
 
     def test_lerp(self, device):
-        start_end_shapes = [(), (5,), (5, 5), (5, 5, 5)]
-        for shapes in product(start_end_shapes, start_end_shapes):
+        start_end_weight_shapes = [(), (5,), (5, 5)]
+        for shapes in product(start_end_weight_shapes, start_end_weight_shapes, start_end_weight_shapes):
             start = torch.randn(shapes[0], device=device)
             end = torch.randn(shapes[1], device=device)
 
             # Tensor weights
-            for weight in [torch.randn(shapes[0], device=device), random.random()]:
+            for weight in [torch.randn(shapes[2], device=device), random.random()]:
                 actual = torch.lerp(start, end, weight)
                 actual_method = start.lerp(end, weight)
                 self.assertEqual(actual, actual_method)

--- a/torch/csrc/jit/runtime/symbolic_script.cpp
+++ b/torch/csrc/jit/runtime/symbolic_script.cpp
@@ -408,7 +408,7 @@ const std::vector<std::string> functions = {
                    weight : Tensor,
                    bias : Optional[Tensor]):
             result = torch.linear(input, weight, bias)
- 
+
             def backward(grad_output):
                 if bias is not None:
                    grad_bias = grad_output._grad_sum_to_size(bias.size())
@@ -512,11 +512,14 @@ const std::vector<std::string> functions = {
             result = torch.lerp(self, end, weight)
             self_size = torch._size_if_not_equal(self.size(), result.size())
             end_size = torch._size_if_not_equal(end.size(), result.size())
+            weight_size = torch._size_if_not_equal(weight.size(), result.size())
 
             def backward(grad_output):
                 grad_self = (grad_output * (1 - weight))._grad_sum_to_size(self_size)
                 grad_end = (grad_output * weight)._grad_sum_to_size(end_size)
-                return grad_self, grad_end, None
+                grad_weight = (grad_output * (end - self))._grad_sum_to_size(weight_size)
+                return grad_self, grad_end, grad_weight
+
             return result, backward
 
         def reshape(self,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2704,7 +2704,7 @@ def method_tests():
         ('lerp', (), ((), 0.4), 'scalar', (True,)),
         ('lerp', (S, S, S), ((), 0.4), 'scalar_broadcast_rhs', (True,)),
         ('lerp', (), ((S, S, S), 0.4), 'scalar_broadcast_lhs', (True,)),
-        ('lerp', (S, 1, S), ((S, S), (M, S, 1, S)), 'tensor_broadcast_all', (True,)),
+        ('lerp', (S, 1, S), ((S, S), (S, 1, 1, S)), 'tensor_broadcast_all', (True,)),
         ('max', (S, S, S), NO_ARGS),
         ('max', (S, S, S), (1,), 'dim', (), [0]),
         ('max', (S, S, S), (1, True,), 'keepdim_dim', (), [0]),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1161,13 +1161,13 @@ def sample_inputs_fliplr_flipud(op_info, device, dtype, requires_grad):
 def sample_inputs_clamp(op_info, device, dtype, requires_grad):
     tensors = (
         make_tensor((S, M, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        make_tensor((S, 0, M), device, dtype, low=None, high=None, requires_grad=requires_grad),        
+        make_tensor((S, 0, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
     )
     if dtype is torch.uint8:
         min_max_vals = ((2, 5), (3, 7))
     else:
         min_max_vals = ((0, 1), (-1, 1))
-    output = [SampleInput(tensor, args=vals) for tensor, vals in product(tensors, min_max_vals)]    
+    output = [SampleInput(tensor, args=vals) for tensor, vals in product(tensors, min_max_vals)]
     output += [SampleInput(tensors[0], args=(0.5, None)), SampleInput(tensors[0], args=(None, 0.5))]
     empty_tensor = make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad)
     output += [SampleInput(empty_tensor, args=(0.0, 1.0)), ]
@@ -2697,13 +2697,14 @@ def method_tests():
         ('remainder', (S, 1, S), (non_differentiable(torch.rand(S, S) + 1.5),), 'tensor_broadcast_all'),
         ('remainder', (), (non_differentiable(uniform_scalar(1.5)),), 'scalar_tensor'),
         ('remainder', (), (non_differentiable(torch.rand(S, S, S) + 1.5),), 'scalar_tensor_broadcast_lhs'),
-        ('lerp', (S, S, S), ((S, S, S), 0.4), 'scalar_no_broadcast', (True,)),
+        ('lerp', (S, S, S), ((S, S, S), 0.4), 'no_broadcast', (True,)),
         ('lerp', (S, S, S), ((S,), 0.4), 'broadcast_rhs', (True,)),
         ('lerp', (S,), ((S, S, S), 0.4), 'broadcast_lhs', (True,)),
         ('lerp', (S, 1, S), ((S, S), 0.4), 'broadcast_all', (True,)),
         ('lerp', (), ((), 0.4), 'scalar', (True,)),
         ('lerp', (S, S, S), ((), 0.4), 'scalar_broadcast_rhs', (True,)),
         ('lerp', (), ((S, S, S), 0.4), 'scalar_broadcast_lhs', (True,)),
+        ('lerp', (S, 1, S), ((S, S), (M, S, 1, S)), 'tensor_broadcast_all', (True,)),
         ('max', (S, S, S), NO_ARGS),
         ('max', (S, S, S), (1,), 'dim', (), [0]),
         ('max', (S, S, S), (1, True,), 'keepdim_dim', (), [0]),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52319 Allow broadcasting against lerp weights.**

Fixes: https://github.com/pytorch/pytorch/issues/52254

Differential Revision: [D26488411](https://our.internmc.facebook.com/intern/diff/D26488411)