### PR TITLE
[nnc] Add dummy reference to llvm::cfg::Update<BasicBlock>

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -15,6 +15,7 @@
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Mangler.h>
+#include <llvm/Support/CFGUpdate.h>
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/raw_ostream.h>
@@ -261,6 +262,12 @@ TargetMachine& PytorchLLVMJIT::getTargetMachine() {
 
 const DataLayout& PytorchLLVMJIT::getDataLayout() {
   return impl_->getDataLayout();
+}
+
+void dumpCFG(const llvm::cfg::Update<llvm::BasicBlock*>& update) {
+  // XXX: This method is only here to placate gcov builds, which for some
+  // reason become confused over the existence of this template method.
+  update.dump();
 }
 
 } // end namespace orc

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -264,11 +264,14 @@ const DataLayout& PytorchLLVMJIT::getDataLayout() {
   return impl_->getDataLayout();
 }
 
+#if !defined(NDEBUG)
 void dumpCFG(const llvm::cfg::Update<llvm::BasicBlock*>& update) {
-  // XXX: This method is only here to placate gcov builds, which for some
-  // reason become confused over the existence of this template method.
+  // XXX: This method call is only here to placate gcov builds.  The `dump`
+  // method is conditionally defined when NDEBUG is unset, so if you try to
+  // link a debug-mode pytorch with an opt-mode llvm, the symbol is undefined.
   update.dump();
 }
+#endif
 
 } // end namespace orc
 } // end namespace llvm


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52321 [nnc] Add dummy reference to llvm::cfg::Update<BasicBlock>**

We're seeing undefined references to this function in coverage builds.
I don't even know why the toolchain is trying to look for it, because it's not
actually used in our code anywhere.

Obviously dropping in a dummy reference is a workaround more than a real
solution, but I'd like to get the coverage build back online.

Differential Revision: [D26467484](https://our.internmc.facebook.com/intern/diff/D26467484/)