### PR TITLE
[Pytorch Mobile] Improve export_opnames Documentation

### DIFF
--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -108,7 +108,12 @@ using ExportModuleMobileInfoConverter =
 TORCH_API void SetExportModuleMobileInfoConverter(
     ExportModuleMobileInfoConverter converter);
 
-// Returns a list of names of all operators in the module and its submodules.
+/**
+ * Generates new bytecode for a Script module and returns what the op list
+ * would be for a LiteScriptModule based off the current code base. If you
+ * have a LiteScriptModule and want to get the currently present
+ * list of ops call _export_operator_list instead.
+ */
 TORCH_API std::vector<std::string> export_opnames(const Module& m);
 
 namespace mobile {

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -54,7 +54,10 @@ _wait = wait
 
 def export_opnames(m):
     r"""
-        Returns a list of operator names of a script module and its submodules
+        Generates new bytecode for a Script module and returns what the op list
+        would be for a Script Module based off the current code base. If you
+        have a LiteScriptModule and want to get the currently present
+        list of ops call _export_operator_list instead.
     """
     return torch._C._export_opnames(m._c)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52333 [Pytorch Mobile] Improve export_opnames Documentation**

Export_opnames current documentation is a bit misleading. Change it to better clarify what it does.

Differential Revision: [D26471803](https://our.internmc.facebook.com/intern/diff/D26471803/)