### PR TITLE
[JIT] Display an error message when with item is not an object

### DIFF
--- a/test/jit/test_with.py
+++ b/test/jit/test_with.py
@@ -507,6 +507,10 @@ class TestWith(JitTestCase):
 
             return x
 
+        def test_enter_without_object():
+            with "not_object" as obj:
+                pass
+
         test_tensor = torch.randn(5, dtype=torch.double)
 
         with self.assertRaisesRegex(
@@ -530,6 +534,9 @@ class TestWith(JitTestCase):
             self.checkScript(
                 test_exit_incorrect_types, (test_tensor, ExitIncorrectTypes())
             )
+
+        with self.assertRaisesRegex(RuntimeError, r"must return an object"):
+            self.checkScript(test_enter_without_object, ())
 
     def test_with_no_grad(self):
         """

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1890,13 +1890,13 @@ struct to_ir {
       auto* rhs = emitExpr(e);
       auto* n = graph->insertNode(graph->create(prim::Enter, {rhs}));
       entered.push(rhs);
-      auto rhsClass = rhs->type()->expect<ClassType>();
 
-      if (!rhsClass) {
+      if (rhs->type()->kind() != TypeKind::ClassType) {
         throw ErrorReport(e.range())
-            << "With item expression does not return a class type";
+            << "With item expression must return an object";
       }
 
+      auto rhsClass = rhs->type()->expect<ClassType>();
       auto* enterMethod = rhsClass->findMethod("__enter__");
       auto* exitMethod = rhsClass->findMethod("__exit__");
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52336 [JIT] Allow __exit__ to have a return value
* **#52335 [JIT] Display an error message when with item is not an object**

**Summary**
`with` statements can only be used with objects that have `__enter__`
and `__exit__` defined. At present, any attempt to use an expression
that returns something that is not an instance of a class type results
in a cryptic internal assert failure instead of a useful error message.
This is because the code that generates IR for `with` statements uses
`Type::expect` as if it were `Type::cast`; that is, as if it returns
`nullptr` on failure.

This commit fixes this issue by checking the `kind()` of the type of the
expression used as the with item before calling `expect<ClassType>()` on
it.

**Test Plan**
This commit adds a unit test to `test_with_errors` to test this case.

Differential Revision: [D26504909](https://our.internmc.facebook.com/intern/diff/D26504909)