### PR TITLE
[JIT] Allow __exit__ to have a return value

### DIFF
--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1915,11 +1915,11 @@ struct to_ir {
       // Check the schema of __exit__.
       auto& exitSchema = exitMethod->getSchema();
       if (exitSchema.arguments().size() != 4) {
-        throw ErrorReport(e.range())
-            << "__exit__ must have four arguments and no return value";
+        throw ErrorReport(e.range()) << "__exit__ must have four arguments";
       } else {
-        if (exitSchema.returns().at(0).type() != NoneType::get()) {
-          throw ErrorReport(e.range()) << "__exit__ must have no return value";
+        auto returnType = exitSchema.returns().at(0).type();
+        if (!returnType->isSubtypeOf(OptionalType::create(BoolType::get()))) {
+          throw ErrorReport(e.range()) << "__exit__ must return Optional[bool]";
         }
 
         for (unsigned i = 1; i < 4; ++i) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52336 [JIT] Allow __exit__ to have a return value**
* #52335 [JIT] Display an error message when with item is not an object

**Summary**
In Python, the boolean interpretation of the return value of `__exit__` of objects that are used as context managers with `with` statements is used to determine
whether or not to propagate exceptions thrown inside the body of the with
statement. This latter feature is not possible to add to TorchScript at
the moment, but the current requirement that `__exit__` not have any
return values can make it difficult to script a context manager whose
`__exit__` *does* have a return value.

Accordingly, this commit removes the requirement that `__exit__` must
not have any return value. TorchScript does not interpret this return
value in the same way Python does (or at all), but this should make it
easier to share context managers between eager mode and script code.

**Test Plan**
This commit adds a return value to one of the context managers used in
`TestWith`.

Differential Revision: [D26504910](https://our.internmc.facebook.com/intern/diff/D26504910)