### PR TITLE
[static runtime] aten::to copy out variant

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -146,3 +146,13 @@ const auto pow_script_sca_ten = R"JIT(
   def forward(self, input : int, exponent : Tensor):
       return torch.pow(input, exponent)
 )JIT";
+
+const auto to_script_0 = R"JIT(
+  def forward(self, input: Tensor, dtype: int, non_blocking: bool, copy: bool, memory_format: int):
+      return torch.to(input, dtype, non_blocking, copy, memory_format)
+)JIT";
+
+const auto to_script_1 = R"JIT(
+  def forward(self, input:Tensor, dtype: int, non_blocking: bool, copy: bool):
+      return torch.to(input, dtype, non_blocking, copy)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -159,6 +159,22 @@ TEST(StaticRuntime, IndividualOps_pow) {
   testStaticRuntime(pow_script_sca_ten, args2);
 }
 
+TEST(StaticRuntime, IndividualOps_to) {
+  auto test_to =
+      [](at::ScalarType b, bool c, bool d, c10::MemoryFormat e) {
+        auto a = at::randn({2, 3});
+        std::vector<IValue> args0{a, b, c, d, e};
+        std::vector<IValue> args1{a, b, c, d};
+        testStaticRuntime(to_script_0, args0);
+        testStaticRuntime(to_script_1, args1);
+      };
+
+  test_to(at::ScalarType::Float, true, true, c10::MemoryFormat::Contiguous);
+  test_to(at::ScalarType::Half, true, false, c10::MemoryFormat::Preserve);
+  test_to(at::ScalarType::Float, false, false, c10::MemoryFormat::Contiguous);
+  test_to(at::ScalarType::Half, false, true, c10::MemoryFormat::Preserve);
+}
+
 TEST(StaticRuntime, LongModel) {
   torch::jit::Module mod = getLongScriptModel();
   auto a = torch::randn({2, 2});

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -5,6 +5,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/native/IndexingUtils.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
 #include <ATen/native/quantized/cpu/qembeddingbag.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -100,6 +101,18 @@ at::Tensor& flatten_out(
     shape.push_back(self.sizes()[i]);
   }
   return reshape_out(out, self, shape, false);
+}
+
+at::Tensor& to_copy_out(Tensor& out, const Tensor& self, bool non_blocking) {
+  if (!out.options().memory_format_opt().has_value()) {
+    at::native::resize_impl_cpu_(
+        out.unsafeGetTensorImpl(), self.sizes(), self.strides());
+    at::native::copy_(out, self, non_blocking);
+    return out;
+  }
+  at::native::resize_(out, self.sizes());
+  at::native::copy_(out, self, non_blocking);
+  return out;
 }
 } // namespace native
 } // namespace at
@@ -774,6 +787,37 @@ REGISTER_OPERATOR_FUNCTOR(aten::pow, aten_pow, [](Node* n) -> SROperator {
       at::native::pow_out(
           out_t, p_node->Input(0).toScalar(), p_node->Input(1).toTensor());
     }
+  };
+});
+// out variant takes precedence over native
+REGISTER_OPERATOR_FUNCTOR(aten::to, aten_to, [](Node* n) -> SROperator {
+  return [](ProcessedNode* p_node) {
+    // support 4- or 5-arg for adindexer/adfinder models
+    DCHECK(p_node->inputs().size() >= 4);
+    const auto& in0_t = p_node->Input(0).toTensor();
+    auto in2_i = p_node->Input(2).toBool(); // non_blocking
+    // ignore input 3 (copy)
+    if (p_node->Output(0).isNone()) {
+      auto in1_i = p_node->Input(1).toScalarType();
+      c10::optional<c10::MemoryFormat> in4_o = c10::nullopt;
+      if (p_node->inputs().size() > 4 && p_node->Input(4).isInt()) {
+        in4_o = p_node->Input(4).toOptional<c10::MemoryFormat>();
+      }
+      if (in4_o.value_or(c10::MemoryFormat::Preserve) ==
+          c10::MemoryFormat::Preserve) {
+        if (in0_t.is_non_overlapping_and_dense()) {
+          in4_o = c10::nullopt;
+        } else {
+          in4_o = in0_t.suggest_memory_format();
+        }
+      }
+      // See Note [Explicit nullopt MemoryFormat argument]
+      p_node->Output(0) = at::empty(
+          {0}, in0_t.options().dtype(in1_i).memory_format(in4_o), c10::nullopt);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    fastResizeToZero(out_t);
+    at::native::to_copy_out(out_t, in0_t, in2_i);
   };
 });
 


### PR DESCRIPTION
Summary:
There isn't a separate op for aten::to copy, but instead the same function
with different arguments.

Test Plan:
On AdFinder local_ro:

Before:
0.896742
0.00824827 ms.    0.92773%. aten::to (5 nodes)

After:
0.88233
0.0056607 ms.   0.644675%. aten::to (5 nodes)

Differential Revision: D26477980

