### PR TITLE
[PyTorch] "Fix" wrong-looking move in TensorImpl

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -59,7 +59,8 @@ TensorImpl::TensorImpl(
     Storage&& storage,
     DispatchKeySet key_set,
     const caffe2::TypeMeta data_type)
-    : TensorImpl(std::move(storage), key_set, data_type, storage.device()) {}
+    // Use std::forward to suppress static analyzer false positive.
+    : TensorImpl(std::forward<Storage>(storage), key_set, data_type, storage.device()) {}
 
 TensorImpl::TensorImpl(DispatchKeySet key_set, const caffe2::TypeMeta data_type, c10::optional<c10::Device> device_opt)
     : TensorImpl({}, key_set, data_type, std::move(device_opt)) {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52344 [PyTorch] "Fix" wrong-looking move in TensorImpl**

This line is a bug-prone use of std::move combined with a reference to the moved-from parameter in the same series of function call arguments. This is normally a problem because the order of evaluation is undefined -- if the move happens before the call to `storage.device()`, we may have problems. It is not a problem here because we are merely forwarding from one `Storage&&` parameter to another.

Differential Revision: [D26436550](https://our.internmc.facebook.com/intern/diff/D26436550/)