### PR TITLE
Reenables skipped tests for all CUDA versions except 11.2

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5040,7 +5040,7 @@ complex_list = ['t', 'view', 'reshape', 'reshape_as', 'view_as', 'roll', 'clone'
 
 # TODO: Add back 'sgn' to complex_list; removed because of Windows test failure with 11.2
 # See: https://github.com/pytorch/pytorch/issues/51980
-if _get_torch_cuda_version() != [11, 2]:
+if _get_torch_cuda_version() != (11, 2):
     complex_list.append('sgn')
     print(complex_list)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -28,7 +28,7 @@ from torch.autograd.profiler import (profile, format_time, EventList,
                                      record_function, emit_nvtx)
 import torch.autograd.functional as autogradF
 from torch.utils.checkpoint import checkpoint
-from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_cuda import TEST_CUDA, _get_torch_cuda_version
 from torch.testing._internal.common_utils import (TestCase, run_tests, skipIfNoLapack,
                                                   suppress_warnings, slowTest,
                                                   load_tests, random_symmetric_matrix,
@@ -5025,8 +5025,6 @@ separate_complex_tests = ['view_as_real', 'real', 'imag', 'div', 'pow', 'rsqrt',
 # NOTE: Some non-holomorphic are separately tested in TestAutogradComplex until gradcheck works properly
 # for non-holomorphic functions
 
-# TODO: Add back 'sgn' to complex_list; removed because of Windows test failure with 11.2
-# See: https://github.com/pytorch/pytorch/issues/51980
 # allow list for complex
 complex_list = ['t', 'view', 'reshape', 'reshape_as', 'view_as', 'roll', 'clone',
                 'repeat', 'expand', 'rot90', 'transpose',
@@ -5039,6 +5037,12 @@ complex_list = ['t', 'view', 'reshape', 'reshape_as', 'view_as', 'roll', 'clone'
                 'addcdiv', 'linalg.tensorinv', 'matrix_exp', 'qr',
                 'narrow', 'swapaxes', 'swapdims', 'tensor_split', 'tile',
                 'baddbmm', 'addbmm', 'addmv'] + separate_complex_tests
+
+# TODO: Add back 'sgn' to complex_list; removed because of Windows test failure with 11.2
+# See: https://github.com/pytorch/pytorch/issues/51980
+if _get_torch_cuda_version() != [11, 2]:
+    complex_list.append('sgn')
+    print(complex_list)
 
 # deny list for batched grad computation
 EXCLUDE_BATCHED_GRAD_TESTS = set([

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -15,7 +15,7 @@ from torch.optim.lr_scheduler import LambdaLR, MultiplicativeLR, StepLR, \
     MultiStepLR, ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau, \
     _LRScheduler, CyclicLR, CosineAnnealingWarmRestarts, OneCycleLR
 from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
-from torch.testing._internal.common_device_type import skipCUDAVersion
+from torch.testing._internal.common_device_type import skipCUDAVersionIn
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
     skipIfRocm
 
@@ -307,7 +307,7 @@ class TestOptim(TestCase):
             )
 
     @skipIfRocm
-    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
     def test_multi_tensor_optimizers(self):
         if not torch.cuda.is_available():
             return
@@ -381,7 +381,7 @@ class TestOptim(TestCase):
             for p1, p2 in zip(res[0], res[1]):
                 self.assertEqual(p1, p2)
 
-    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
     def test_adam(self):
         for optimizer in [optim.Adam, optim_mt.Adam]:
             self._test_basic_cases(
@@ -427,7 +427,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
                 optimizer(None, lr=1e-2, weight_decay=-1)
 
-    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
     def test_adamw(self):
         for optimizer in [optim.AdamW, optim_mt.AdamW]:
             self._test_basic_cases(
@@ -462,7 +462,7 @@ class TestOptim(TestCase):
 
     # ROCm precision is too low to pass this test
     @skipIfRocm
-    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
     def test_adadelta(self):
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
@@ -539,7 +539,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
-    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
             self._test_basic_cases(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -15,6 +15,7 @@ from torch.optim.lr_scheduler import LambdaLR, MultiplicativeLR, StepLR, \
     MultiStepLR, ExponentialLR, CosineAnnealingLR, ReduceLROnPlateau, \
     _LRScheduler, CyclicLR, CosineAnnealingWarmRestarts, OneCycleLR
 from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
+from torch.testing._internal.common_device_type import skipCUDAVersion
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_UBSAN, load_tests, \
     skipIfRocm
 
@@ -306,7 +307,7 @@ class TestOptim(TestCase):
             )
 
     @skipIfRocm
-    @unittest.skipIf(True, "test does not pass for CUDA 11.2")
+    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
     def test_multi_tensor_optimizers(self):
         if not torch.cuda.is_available():
             return
@@ -380,7 +381,7 @@ class TestOptim(TestCase):
             for p1, p2 in zip(res[0], res[1]):
                 self.assertEqual(p1, p2)
 
-    @unittest.skipIf(True, "test does not pass for CUDA 11.2")
+    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
     def test_adam(self):
         for optimizer in [optim.Adam, optim_mt.Adam]:
             self._test_basic_cases(
@@ -426,7 +427,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
                 optimizer(None, lr=1e-2, weight_decay=-1)
 
-    @unittest.skipIf(True, "test does not pass for CUDA 11.2")
+    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
     def test_adamw(self):
         for optimizer in [optim.AdamW, optim_mt.AdamW]:
             self._test_basic_cases(
@@ -461,7 +462,7 @@ class TestOptim(TestCase):
 
     # ROCm precision is too low to pass this test
     @skipIfRocm
-    @unittest.skipIf(True, "test does not pass for CUDA 11.2")
+    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
     def test_adadelta(self):
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
@@ -538,7 +539,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
-    @unittest.skipIf(True, "test does not pass for CUDA 11.2")
+    @skipCUDAVersion([11, 2])  # test does not pass for CUDA 11.2
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
             self._test_basic_cases(

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -307,7 +307,7 @@ class TestOptim(TestCase):
             )
 
     @skipIfRocm
-    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_multi_tensor_optimizers(self):
         if not torch.cuda.is_available():
             return
@@ -381,7 +381,7 @@ class TestOptim(TestCase):
             for p1, p2 in zip(res[0], res[1]):
                 self.assertEqual(p1, p2)
 
-    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adam(self):
         for optimizer in [optim.Adam, optim_mt.Adam]:
             self._test_basic_cases(
@@ -427,7 +427,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
                 optimizer(None, lr=1e-2, weight_decay=-1)
 
-    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adamw(self):
         for optimizer in [optim.AdamW, optim_mt.AdamW]:
             self._test_basic_cases(
@@ -462,7 +462,7 @@ class TestOptim(TestCase):
 
     # ROCm precision is too low to pass this test
     @skipIfRocm
-    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adadelta(self):
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
@@ -539,7 +539,7 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
-    @skipCUDAVersionIn([[11, 2]])  # test does not pass for CUDA 11.2
+    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
             self._test_basic_cases(

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_utils import (
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    skipCUDAIfNoMagma,
+    skipCUDAIfNoMagma, skipCUDAVersion,
     onlyCUDA, onlyCPU,
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast,
     PYTORCH_CUDA_MEMCHECK, largeTensorTest, onlyOnCPUAndCUDA,
@@ -6362,8 +6362,7 @@ class TestTorchDeviceType(TestCase):
 
         self._test_where_scalar_template(device, dtype, checkRaises)
 
-    # See https://github.com/pytorch/pytorch/issues/51980
-    @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA misaligned address error on Windows w/ 11.2')
+    @skipCUDAVersion([11, 2])  # test fails for 11.2, see https://github.com/pytorch/pytorch/issues/51980
     @dtypes(*(torch.testing.get_all_int_dtypes() + torch.testing.get_all_fp_dtypes() +
               torch.testing.get_all_complex_dtypes()))
     def test_where_scalar_valid_combination(self, device, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_utils import (
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    skipCUDAIfNoMagma, skipCUDAVersion,
+    skipCUDAIfNoMagma, skipCUDAVersionIn,
     onlyCUDA, onlyCPU,
     dtypes, dtypesIfCUDA, dtypesIfCPU, deviceCountAtLeast,
     PYTORCH_CUDA_MEMCHECK, largeTensorTest, onlyOnCPUAndCUDA,
@@ -6362,7 +6362,7 @@ class TestTorchDeviceType(TestCase):
 
         self._test_where_scalar_template(device, dtype, checkRaises)
 
-    @skipCUDAVersion([11, 2])  # test fails for 11.2, see https://github.com/pytorch/pytorch/issues/51980
+    @skipCUDAVersionIn([[11, 2]])  # test fails for 11.2, see https://github.com/pytorch/pytorch/issues/51980
     @dtypes(*(torch.testing.get_all_int_dtypes() + torch.testing.get_all_fp_dtypes() +
               torch.testing.get_all_complex_dtypes()))
     def test_where_scalar_valid_combination(self, device, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6362,7 +6362,7 @@ class TestTorchDeviceType(TestCase):
 
         self._test_where_scalar_template(device, dtype, checkRaises)
 
-    @skipCUDAVersionIn([[11, 2]])  # test fails for 11.2, see https://github.com/pytorch/pytorch/issues/51980
+    @skipCUDAVersionIn([(11, 2)])  # test fails for 11.2, see https://github.com/pytorch/pytorch/issues/51980
     @dtypes(*(torch.testing.get_all_int_dtypes() + torch.testing.get_all_fp_dtypes() +
               torch.testing.get_all_complex_dtypes()))
     def test_where_scalar_valid_combination(self, device, dtype):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -877,6 +877,20 @@ def skipCUDAIfRocm(fn):
 def skipCUDAIfNotRocm(fn):
     return skipCUDAIf(not TEST_WITH_ROCM, "test doesn't currently work on the CUDA stack")(fn)
 
+# Skips a test for specified CUDA version, given in [major, minor] form.
+def skipCUDAVersion(version : [int] = None):
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, device, *args, **kwargs):
+            if self.device_type == 'cuda':
+                cuda_version = _get_torch_cuda_version()
+                if cuda_version == version:
+                    reason = "test skipped for CUDA version {0}.{1}".format(version[0], version[1])
+                    raise unittest.SkipTest(reason)
+            return fn(self, device, *args, **kwargs)
+
+        return wrap_fn
+    return dec_fn
 
 # Skips a test on CUDA if cuDNN is unavailable or its version is lower than requested.
 def skipCUDAIfCudnnVersionLessThan(version=0):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -881,13 +881,13 @@ def skipCUDAIfNotRocm(fn):
 def skipCUDAVersionIn(versions : List[List[int]] = None):
     def dec_fn(fn):
         @wraps(fn)
-        def wrap_fn(self, device, *args, **kwargs):
+        def wrap_fn(self, *args, **kwargs):
             if self.device_type == 'cuda':
                 version = _get_torch_cuda_version()
                 if version in (versions or []):
                     reason = "test skipped for CUDA version {0}.{1}".format(version[0], version[1])
                     raise unittest.SkipTest(reason)
-            return fn(self, device, *args, **kwargs)
+            return fn(self, *args, **kwargs)
 
         return wrap_fn
     return dec_fn

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -5,7 +5,7 @@ import runpy
 import threading
 from enum import Enum
 from functools import wraps
-from typing import List, Any, ClassVar, Optional, Sequence
+from typing import List, Any, ClassVar, Optional, Sequence, Tuple
 import unittest
 import os
 import torch
@@ -878,15 +878,16 @@ def skipCUDAIfNotRocm(fn):
     return skipCUDAIf(not TEST_WITH_ROCM, "test doesn't currently work on the CUDA stack")(fn)
 
 # Skips a test for specified CUDA versions, given in the form of a list of [major, minor]s.
-def skipCUDAVersionIn(versions : List[List[int]] = None):
+def skipCUDAVersionIn(versions : List[Tuple[int, int]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
-            if self.device_type == 'cuda':
-                version = _get_torch_cuda_version()
-                if version in (versions or []):
-                    reason = "test skipped for CUDA version {0}.{1}".format(version[0], version[1])
-                    raise unittest.SkipTest(reason)
+            version = _get_torch_cuda_version()
+            if version == (0, 0):  # cpu
+                return fn(self, *args, **kwargs)
+            if version in (versions or []):
+                reason = "test skipped for CUDA version {0}".format(version)
+                raise unittest.SkipTest(reason)
             return fn(self, *args, **kwargs)
 
         return wrap_fn

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -877,14 +877,14 @@ def skipCUDAIfRocm(fn):
 def skipCUDAIfNotRocm(fn):
     return skipCUDAIf(not TEST_WITH_ROCM, "test doesn't currently work on the CUDA stack")(fn)
 
-# Skips a test for specified CUDA version, given in [major, minor] form.
-def skipCUDAVersion(version : [int] = None):
+# Skips a test for specified CUDA versions, given in the form of a list of [major, minor]s.
+def skipCUDAVersionIn(versions : List[List[int]] = None):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, device, *args, **kwargs):
             if self.device_type == 'cuda':
-                cuda_version = _get_torch_cuda_version()
-                if cuda_version == version:
+                version = _get_torch_cuda_version()
+                if version in versions:
                     reason = "test skipped for CUDA version {0}.{1}".format(version[0], version[1])
                     raise unittest.SkipTest(reason)
             return fn(self, device, *args, **kwargs)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -884,7 +884,7 @@ def skipCUDAVersionIn(versions : List[List[int]] = None):
         def wrap_fn(self, device, *args, **kwargs):
             if self.device_type == 'cuda':
                 version = _get_torch_cuda_version()
-                if version in versions:
+                if version in (versions or []):
                     reason = "test skipped for CUDA version {0}.{1}".format(version[0], version[1])
                     raise unittest.SkipTest(reason)
             return fn(self, device, *args, **kwargs)


### PR DESCRIPTION
This PR adds functionality to skip a test based on CUDA version. 

This way, we can be more specific when skipping a test, such as when the test only fails for a particular CUDA version. 

This allows us to add back the skipped tests for CUDA 11.2 for other CUDA versions, such as 10.1 and 11.1.

I tested this locally (by using 11.0 instead of 11.2), but will run all the CI to make sure it works.