### PR TITLE
[PyTorch] s/__attribute__((__noinline__))/__attribute__((noinline))/

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -179,7 +179,7 @@ namespace at { namespace cuda { using namespace c10::hip; }}
 /// C10_NOINLINE - Functions whose declaration is annotated with this will not
 /// be inlined.
 #ifdef __GNUC__
-#define C10_NOINLINE __attribute__((__noinline__))
+#define C10_NOINLINE __attribute__((noinline))
 #elif _MSC_VER
 #define C10_NOINLINE __declspec(noinline)
 #else


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52362 [PyTorch] s/__attribute__((__noinline__))/__attribute__((noinline))/**

AFAICT, it is documented to be the latter and not the former.
GCC: https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
Clang: https://clang.llvm.org/docs/AttributeReference.html

Both versions work in the oldest and newest GCC & Clang versions on Godbolt: https://godbolt.org/z/s6f4PW

So why change?
1) lack of underscores matches the documentation
2) AMD HIP defines `__noinline__` as a macro, which doesn't play well with the underscore version.
See https://github.com/ROCm-Developer-Tools/HIP/blob/2080cc113a2d767352b512b9d24c0620b6dee790/include/hip/hcc_detail/host_defines.h#L54

Differential Revision: [D26488991](https://our.internmc.facebook.com/intern/diff/D26488991/)