### PR TITLE
Remove unnecessary statement in `capture_stderr`

### DIFF
--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -125,7 +125,6 @@ class JitTestCase(JitCommonTestCase):
             return self
 
         def __exit__(self, *args):
-            print(self.stringio.getvalue())
             self.append(str(self.stringio.getvalue()))
             del self.stringio
             sys.stderr = self.sys_stderr


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52366 Remove unnecessary statement in `capture_stderr`**

Differential Revision: [D26489602](https://our.internmc.facebook.com/intern/diff/D26489602)