### PR TITLE
[typing] ignore mypy false positives in aten_test.py

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -136,6 +136,9 @@ ignore_errors = True
 [mypy-caffe2.experiments.python.convnet_benchmarks]
 ignore_errors = True
 
+[mypy-caffe2.contrib.aten.aten_test]
+ignore_errors = True
+
 [mypy-caffe2.contrib.aten.docs.sample]
 ignore_errors = True
 


### PR DESCRIPTION
Summary: After adding .pyi stubs for torch / caffe2 protos, there were some mypy false positives (https://github.com/pytorch/pytorch/pull/52341). We tell mypy to ignore the offending file here.

Test Plan: Let CI run.

Reviewed By: dzhulgakov

Differential Revision: D26490302

