### PR TITLE
[BE] Decorate unused functions with C10_UNUSED

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256.h
+++ b/aten/src/ATen/cpu/vec256/vec256.h
@@ -39,15 +39,15 @@ namespace vec256 {
 // static means something different in the context of classes).
 namespace {
 
- std::ostream& operator<<(std::ostream& stream, const c10::qint32& val) {
+ C10_UNUSED std::ostream& operator<<(std::ostream& stream, const c10::qint32& val) {
      stream << val.val_;
      return stream;
  }
- std::ostream& operator<<(std::ostream& stream, const c10::qint8& val) {
+ C10_UNUSED std::ostream& operator<<(std::ostream& stream, const c10::qint8& val) {
      stream << static_cast<int>(val.val_);
      return stream;
  }
- std::ostream& operator<<(std::ostream& stream, const c10::quint8& val) {
+ C10_UNUSED std::ostream& operator<<(std::ostream& stream, const c10::quint8& val) {
      stream << static_cast<unsigned int>(val.val_);
      return stream;
  }

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1092,22 +1092,22 @@ static inline scalar_t calc_igamma(scalar_t a, scalar_t x) {
 }
 
 template <>
-c10::BFloat16 calc_igamma<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
+C10_UNUSED c10::BFloat16 calc_igamma<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
   return calc_igamma<float>(float(a), float(x));
 }
 
 template <>
-c10::Half calc_igamma<c10::Half>(c10::Half a, c10::Half x) {
+C10_UNUSED c10::Half calc_igamma<c10::Half>(c10::Half a, c10::Half x) {
   return calc_igamma<float>(float(a), float(x));
 }
 
 template <>
-c10::BFloat16 calc_igammac<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
+C10_UNUSED c10::BFloat16 calc_igammac<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
   return calc_igammac<float>(float(a), float(x));
 }
 
 template <>
-c10::Half calc_igammac<c10::Half>(c10::Half a, c10::Half x) {
+C10_UNUSED c10::Half calc_igammac<c10::Half>(c10::Half a, c10::Half x) {
   return calc_igammac<float>(float(a), float(x));
 }
 
@@ -1119,7 +1119,7 @@ static T abs_impl(T v) {
 }
 
 template <>
-uint8_t abs_impl(uint8_t v) {
+C10_UNUSED uint8_t abs_impl(uint8_t v) {
   return v;
 }
 


### PR DESCRIPTION
This suppresses repeated warnings for every file that includes vec256 or
math.h:
```
../aten/src/ATen/native/Math.h:1095:15: warning: unused function 'calc_igamma' [-Wunused-function]
c10::BFloat16 calc_igamma<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
              ^
../aten/src/ATen/native/Math.h:1100:11: warning: unused function 'calc_igamma' [-Wunused-function]
c10::Half calc_igamma<c10::Half>(c10::Half a, c10::Half x) {
          ^
../aten/src/ATen/native/Math.h:1105:15: warning: unused function 'calc_igammac' [-Wunused-function]
c10::BFloat16 calc_igammac<c10::BFloat16>(c10::BFloat16 a, c10::BFloat16 x) {
              ^
../aten/src/ATen/native/Math.h:1110:11: warning: unused function 'calc_igammac' [-Wunused-function]
c10::Half calc_igammac<c10::Half>(c10::Half a, c10::Half x) {
```

