### PR TITLE
[PyTorch][easy] Coalesce string literals in data_ptr error message

### DIFF
--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -175,15 +175,15 @@ bool is_quantized(Tensor self) {
   return self.is_quantized();
 }
 
-#define DEFINE_CAST(T, name)                     \
-  template <>                                    \
-  TORCH_API T* Tensor::data_ptr() const {           \
-    TORCH_CHECK(                                 \
-        scalar_type() == ScalarType::name,       \
-        "expected scalar type ",                 \
-        #name,                                   \
-        " but found ",                           \
-        c10::toString(scalar_type()));           \
+#define DEFINE_CAST(T, name)                                        \
+  template <>                                                       \
+  TORCH_API T* Tensor::data_ptr() const {                           \
+    TORCH_CHECK(                                                    \
+        scalar_type() == ScalarType::name,                          \
+        "expected scalar type "                                     \
+        #name                                                       \
+        " but found ",                                              \
+        scalar_type());                                             \
     return static_cast<T*>(this->unsafeGetTensorImpl()->data());    \
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52379 [PyTorch][easy] Coalesce string literals in data_ptr error message**

There's no reason to create and concatenate multiple string literals here when we could just combine them.

Differential Revision: [D26492399](https://our.internmc.facebook.com/intern/diff/D26492399/)