### PR TITLE
[alias analysis] Add schema based pure functions to functionalNonEscapingListUse

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -983,8 +983,15 @@ bool AliasDb::functionalNonEscapingListUse(const Use& use) const {
       return true;
   }
   auto op = use.user->maybeOperator();
-  if (op && op->aliasAnalysisKind() == AliasAnalysisKind::PURE_FUNCTION) {
-    return true;
+  if (op) {
+    if (op->aliasAnalysisKind() == AliasAnalysisKind::PURE_FUNCTION) {
+      return true;
+    } else if (op->aliasAnalysisKind() == AliasAnalysisKind::FROM_SCHEMA) {
+      const auto& schema = use.user->schema();
+      if (schema.aliasAnalysis() == AliasAnalysisKind::PURE_FUNCTION) {
+        return true;
+      }
+    }
   }
 
   return false;


### PR DESCRIPTION
Summary: Ops registered with pure schemas (rather than directly annotated with pure alias analysis kinds) need this patch.

Test Plan: CI

Differential Revision: D26493124

