### PR TITLE
Fix upsample bicubic2d batching handling on CPU.

### DIFF
--- a/aten/src/ATen/native/UpSampleBicubic2d.cpp
+++ b/aten/src/ATen/native/UpSampleBicubic2d.cpp
@@ -26,7 +26,7 @@ static void upsample_bicubic2d_out_frame(
         const scalar_t* in = &idata[output_y * input_width + output_x];
         scalar_t* out = &odata[output_y * output_width + output_x];
 
-        for (int64_t c = 0; c < channels; ++c) {
+        for (int64_t c = 0; c < channels * nbatch; ++c) {
           out[0] = in[0];
           in += input_width * input_height;
           out += output_width * output_height;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8683,7 +8683,7 @@ class TestNN(NNTestCase):
             kwargs = dict(mode='bicubic', align_corners=align_corners)
             # test float scale factor up & downsampling
             for device in device_list:
-                for scale_factor in [0.5, 1.5, 2]:
+                for scale_factor in [0.5, 1, 1.5, 2]:
                     in_t = torch.ones(2, 2, 2, 2).to(device)
                     out_t = F.interpolate(in_t, scale_factor=scale_factor, **kwargs)
                     out_size = int(math.floor(in_t.shape[-1] * scale_factor))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52389 Fix upsample bicubic2d batching handling on CPU.**

Fixes: https://github.com/pytorch/pytorch/issues/49159

Differential Revision: [D26496319](https://our.internmc.facebook.com/intern/diff/D26496319)