### PR TITLE
use obj str when jit trace can't track the python class name

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -903,6 +903,8 @@ def _qualified_name(obj):
     # Enum classes do not have `__name__` attr, instead they have `name`.
     elif isinstance(obj, enum.Enum):
         name = obj.name
+    elif hasattr(obj, '__str__'):
+        return obj.__str__()
     else:
         raise RuntimeError("Could not get name of python class object")
 


### PR DESCRIPTION
this suggested fix helps avoiding an error in torch.jit.trace when tracing a detectron2 model from detectron2.engine
```
Traceback (most recent call last):
 File "demo.py", line 92, in <module>
  predictions, visualized_output = demo.run_on_image(img)
 File "/home/ubuntu/detectron2/demo/predictor.py", line 50, in run_on_image
  jit_script = torch.jit.trace(self.predictor, example_inputs= image)
 File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/torch/jit/_trace.py", line 777, in trace
  name = _qualified_name(func)
 File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/torch/_jit_internal.py", line 793, in _qualified_name
  raise RuntimeError("Could not get name of python class object")
RuntimeError: Could not get name of python class object
```
Further details: 
It seems that jit.trace tries to keep track of classes names and to preserve the hierarchy of these classes to be added in the torch script system. It depends on jit.internal.py the method _qualified_name to achieve this tracking. This method, when failing to catch the original name, seems to depend on the python object name attribute.
The issue we faced was that the object doesn’t have a name attribute. hence tracing crashes.

