### PR TITLE
Remove DepTracker from LoopNest

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -238,6 +238,7 @@ core_sources_full_mobile = [
     "torch/csrc/jit/serialization/pickle.cpp",
     "torch/csrc/jit/serialization/python_print.cpp",
     "torch/csrc/jit/serialization/source_range_serialization.cpp",
+    "torch/csrc/jit/tensorexpr/analysis.cpp",
     "torch/csrc/jit/tensorexpr/block_codegen.cpp",
     "torch/csrc/jit/tensorexpr/bounds_inference.cpp",
     "torch/csrc/jit/tensorexpr/bounds_overlap.cpp",

--- a/torch/csrc/jit/tensorexpr/analysis.cpp
+++ b/torch/csrc/jit/tensorexpr/analysis.cpp
@@ -1,0 +1,72 @@
+#include <torch/csrc/jit/tensorexpr/analysis.h>
+
+#include <queue>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+class DepTracker : public IRVisitor {
+ public:
+  std::vector<Tensor*> findUsedTensors(Tensor* tensor) {
+    used_tensors.clear();
+    tensor->stmt()->accept(this);
+    return used_tensors;
+  }
+
+ private:
+  void visit(const FunctionCall* v) override {
+    used_tensors.push_back(const_cast<Tensor*>(v->tensor())); // NOLINT
+  }
+
+  std::vector<Tensor*> used_tensors;
+};
+
+std::vector<Tensor*> findAllNeededTensors(const std::vector<Tensor*>& tensors) {
+  DepTracker d;
+  std::queue<Tensor*> q;
+  std::unordered_set<Tensor*> queued;
+  std::vector<Tensor*> result;
+  std::unordered_set<Tensor*> processed;
+  for (Tensor* t : tensors) {
+    if (queued.insert(t).second) {
+      q.push(t);
+    }
+  }
+  while (!q.empty()) {
+    Tensor* t = q.front();
+    q.pop();
+    queued.erase(t);
+    std::vector<Tensor*> deps = d.findUsedTensors(t);
+    bool all_processed = true;
+    for (Tensor* dep : deps) {
+      if (!processed.count(dep)) {
+        if (queued.insert(dep).second) {
+          q.push(dep);
+        }
+        all_processed = false;
+      }
+    }
+    if (all_processed) {
+      result.push_back(t);
+      if (processed.count(t)) {
+        throw malformed_input("failure to find all processed Tensors");
+      }
+
+      processed.insert(t);
+    } else {
+      if (queued.count(t)) {
+        throw malformed_input("failure to find all queued Tensors");
+      }
+
+      q.push(t);
+      queued.insert(t);
+    }
+  }
+
+  return result;
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -189,6 +189,9 @@ class CreateBufferMap : public IRVisitor {
   }
   std::unordered_map<std::string, const Buf*> map_input_to_tensor_bufs_;
 };
+
+std::vector<Tensor*> findAllNeededTensors(const std::vector<Tensor*>& tensors);
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1532,7 +1532,12 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
 }
 
 Stmt* TensorExprKernel::generateStmt(BackendType backendType) {
-  torch::jit::tensorexpr::LoopNest l(tensorOutputs_);
+  // Find all tensors we need to compute (including dependencies) and put them
+  // in a topological order
+  std::vector<Tensor*> tensors_to_compute =
+      findAllNeededTensors(tensorOutputs_);
+
+  torch::jit::tensorexpr::LoopNest l(tensorOutputs_, tensors_to_compute);
   GRAPH_DEBUG("Original Stmt:\n", std::to_string(l.root_stmt()), "\n");
 
   bool hasReduction = NodeFinder<ReduceOp>::find(l.root_stmt()).size() != 0;

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1,6 +1,5 @@
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 
-#include <queue>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -441,82 +440,15 @@ class Flattener : public IRMutator {
   }
 };
 
-class DepTracker : public IRVisitor {
- public:
-  std::vector<Tensor*> findUsedTensors(Tensor* tensor) {
-    used_tensors.clear();
-    tensor->stmt()->accept(this);
-    return used_tensors;
-  }
-
- private:
-  void visit(const FunctionCall* v) override {
-    used_tensors.push_back(const_cast<Tensor*>(v->tensor())); // NOLINT
-  }
-
-  std::vector<Tensor*> used_tensors;
-};
-
-std::vector<Tensor*> LoopNest::findAllNeededTensors(
-    const std::vector<Tensor*>& tensors) {
-  DepTracker d;
-  std::queue<Tensor*> q;
-  std::unordered_set<Tensor*> queued;
-  std::vector<Tensor*> result;
-  std::unordered_set<Tensor*> processed;
-  for (Tensor* t : tensors) {
-    if (queued.insert(t).second) {
-      q.push(t);
-    }
-  }
-  while (!q.empty()) {
-    Tensor* t = q.front();
-    q.pop();
-    queued.erase(t);
-    std::vector<Tensor*> deps = d.findUsedTensors(t);
-    bool all_processed = true;
-    for (Tensor* dep : deps) {
-      if (!processed.count(dep)) {
-        if (queued.insert(dep).second) {
-          q.push(dep);
-        }
-        all_processed = false;
-      }
-    }
-    if (all_processed) {
-      result.push_back(t);
-      if (processed.count(t)) {
-        throw malformed_input("failure to find all processed Tensors");
-      }
-
-      processed.insert(t);
-    } else {
-      if (queued.count(t)) {
-        throw malformed_input("failure to find all queued Tensors");
-      }
-
-      q.push(t);
-      queued.insert(t);
-    }
-  }
-
-  return result;
-}
-
-LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
-  // Find all tensors we need to compute (including dependencies) and put them
-  // in a topological order
-  std::vector<Tensor*> tensors_to_compute =
-      findAllNeededTensors(output_tensors);
-
+void LoopNest::initialize(
+    const std::vector<Tensor*>& output_tensors,
+    const std::vector<Tensor*>& tensors_to_compute) {
   for (auto t : output_tensors) {
     output_bufs_.insert(t->buf());
   }
 
   // Find all intermediate tensors, we'll need that for inserting alloc/free
   // statements
-  std::unordered_set<Tensor*> tensors_to_compute_set(
-      tensors_to_compute.begin(), tensors_to_compute.end());
   for (Tensor* t : tensors_to_compute) {
     if (!output_bufs_.count(t->buf())) {
       intermediate_bufs_.insert(t->buf());
@@ -552,6 +484,20 @@ LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
       input_bufs_.insert(buf);
     }
   }
+}
+
+LoopNest::LoopNest(
+    const std::vector<Tensor*>& output_tensors,
+    const std::vector<Tensor*>& tensors_to_compute) {
+  initialize(output_tensors, tensors_to_compute);
+}
+
+LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
+  // Find all tensors we need to compute (including dependencies) and put them
+  // in a topological order
+  std::vector<Tensor*> tensors_to_compute =
+      findAllNeededTensors(output_tensors);
+  initialize(output_tensors, tensors_to_compute);
 }
 
 class FunctionInliner : public IRMutator {

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -26,6 +26,9 @@ class TORCH_API LoopNest {
  public:
   // A constructor for building a LoopNest from a list of Tensors
   LoopNest(const std::vector<Tensor*>& output_tensors);
+  LoopNest(
+      const std::vector<Tensor*>& output_tensors,
+      const std::vector<Tensor*>& tensors_to_compute);
 
   // A constructor for building a LoopNest from a pre-baked Stmt and meta-info
   // TODO: Nuke intermediate_bufs_ from here if they can be deduced.
@@ -122,8 +125,9 @@ class TORCH_API LoopNest {
   }
 
  private:
-  std::vector<Tensor*> findAllNeededTensors(
-      const std::vector<Tensor*>& tensors);
+  void initialize(
+      const std::vector<Tensor*>& output_tensors,
+      const std::vector<Tensor*>& tensors_to_compute);
   Stmt* insertAllocFree(Stmt* stmt);
 
   Stmt* root_stmt_;


### PR DESCRIPTION
Remove the dependency tracker that works on Tensors, DepTracker, from LoopNest. This is essential to the goal of removing Tensors from LoopNest.