### PR TITLE
Fix shape inference for multiple outputs with different output dtypes

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -247,7 +247,8 @@ TensorShape& BoundShapeInferencer::CheckAndSetTensorBoundShape(
     shape_info.q_info.offset.push_back(offset);
     shape_info.q_info.axis = 1;
   }
-  // If the shape information exists in shape_info_ already and we want to compare old/new shapes
+  // If the shape information exists in shape_info_ already and we want to
+  // compare old/new shapes
   if (!rt.second && !in_place_op) {
     // Check dim size consistency
     CAFFE_ENFORCE_EQ(
@@ -323,10 +324,10 @@ void BoundShapeInferencer::InferGivenTensorFill(const OperatorDef& op) {
     it->second.setDimType(std::vector<TensorBoundShape::DimType>(
         it->second.shape.dims_size(), TensorBoundShape_DimType_CONSTANT));
     if (op.type() == "ConstantFill" && op.input_size() >= 1) {
-        auto it_input = shape_info_.find(op.input(0));
-        if (it_input != shape_info_.end()) {
-          it->second.setDimType(it_input->second.getDimType());
-        }
+      auto it_input = shape_info_.find(op.input(0));
+      if (it_input != shape_info_.end()) {
+        it->second.setDimType(it_input->second.getDimType());
+      }
     }
   }
 }
@@ -865,31 +866,33 @@ void BoundShapeInferencer::InferTile(const OperatorDef& op) {
 }
 
 void BoundShapeInferencer::InferCommonOp(
-  const OperatorDef& op,
-  const OpSchema* schema,
-  bool bypass_input_check,
-  bool in_place_op
-) {
+    const OperatorDef& op,
+    const OpSchema* schema,
+    bool bypass_input_check,
+    bool in_place_op) {
   // First, we need to check that all the input shape/types are already
   // presented
   try {
     const static std::unordered_set<std::string>
-        types_with_independent_output_shape = {"Int8GenQuantParams",
-                                               "Int8QuantSchemeBlobFill",
-                                               "ComputeEqualizationScale",
-                                               "Int8GenQuantParamsMinMax"};
-    const static std::unordered_set<std::string>
-        pruning_ops = {"RowwisePruneI64", "RowwisePruneI32"};
+        types_with_independent_output_shape = {
+            "Int8GenQuantParams",
+            "Int8QuantSchemeBlobFill",
+            "ComputeEqualizationScale",
+            "Int8GenQuantParamsMinMax"};
+    const static std::unordered_set<std::string> pruning_ops = {
+        "RowwisePruneI64", "RowwisePruneI32"};
     std::vector<TensorShape> input_shapes;
     for (const auto& input : op.input()) {
       const auto it = shape_info_.find(input);
       if (it == shape_info_.end() &&
-          !types_with_independent_output_shape.count(op.type()) && !bypass_input_check) {
+          !types_with_independent_output_shape.count(op.type()) &&
+          !bypass_input_check) {
         LOG(WARNING) << "Cannot find shape info for " << input << ". Skipping "
                      << op.type();
         return;
       }
-      if (types_with_independent_output_shape.count(op.type()) || (bypass_input_check && it == shape_info_.end())) {
+      if (types_with_independent_output_shape.count(op.type()) ||
+          (bypass_input_check && it == shape_info_.end())) {
         TensorShape input_shape;
         input_shapes.emplace_back(std::move(input_shape));
       } else {
@@ -948,11 +951,13 @@ void BoundShapeInferencer::InferCommonOp(
 
     for (int i = 0; i < output_shapes.size(); i++) {
       const auto& shape = output_shapes[i];
-      if (infered_data_type == TensorProto::UNDEFINED || pruning_ops.find(op.type()) != pruning_ops.end()) {
-        infered_data_type = shape.data_type();
-      }
       if (shape.unknown_shape()) {
         continue;
+      }
+      auto tmp_dtype = infered_data_type;
+      if (infered_data_type == TensorProto::UNDEFINED ||
+          pruning_ops.find(op.type()) != pruning_ops.end()) {
+        infered_data_type = shape.data_type();
       }
       CheckAndSetTensorBoundShape(
           op.output(i),
@@ -964,6 +969,7 @@ void BoundShapeInferencer::InferCommonOp(
           scale,
           offset,
           in_place_op);
+      infered_data_type = tmp_dtype;
     }
   } catch (const caffe2::EnforceNotMet& e) {
     LOG(ERROR) << "Enforce not met while inferring shapes for " << op.type()


### PR DESCRIPTION
Summary: When we have multiple outputs, previously, we will set `infered_data_type` to the first output and stick to it. This is not correct if we have more outputs that has different dtype. The fix here will revert `infered_data_type` back to previous value (`UNDEFINED`) so that we can still enter the conditional check and set the right dtype for second and more outputs.

Test Plan:
```
buck test caffe2/caffe2/fb/operators:infer_bound_shape_op_test
```

Reviewed By: khabinov

Differential Revision: D26502161

