### PR TITLE
[static runtime] Generate sigmoid with NNC

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -396,7 +396,8 @@ std::shared_ptr<TEWrapper> wrapTECompute(
     std::shared_ptr<TEWrapper> wrap,
     tensorexpr::Placeholder& in,
     tensorexpr::Tensor* out,
-    tensorexpr::VarHandle& dim) {
+    tensorexpr::VarHandle& dim,
+    int width = kVectorWidth) {
   return wrap;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52424 [static runtime] Generate sigmoid with NNC**
* #52423 [static runtime] Use VML-inspired logarithm with NNC, tweak scheduling

NNC has a fast sigmoid on par with aten.  Using it for static runtime
lets us skip dispatch overhead.

Differential Revision: [D26291425](https://our.internmc.facebook.com/intern/diff/D26291425/)