### PR TITLE
[iOS GPU] Fix max_pool_2d

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
@@ -153,10 +153,9 @@ Tensor max_pool2d(
       strideInPixelsX:stride[0]
       strideInPixelsY:stride[1]];
   [pool setEdgeMode:MPSImageEdgeModeClamp];
-  [pool setOffset:{.x = static_cast<NSInteger>(kernel_size[0] / 2),
-                   .y = static_cast<NSInteger>(kernel_size[1] / 2),
+  [pool setOffset:{.x = computeMPSAlignOffset(kernel_size[0], padding[0]),
+                   .y = computeMPSAlignOffset(kernel_size[1], padding[1]),
                    .z = 0}];
-
   int64_t oN = iN;
   int64_t oC = iC;
   int64_t oH = pooling_output_shape(iH, kH, pH, sH, dH, ceil_mode);

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
@@ -8,6 +8,7 @@ bool test_conv2d();
 bool test_depthwiseConv();
 bool test_max_pool2d();
 bool test_max_pool2d_ceil();
+bool test_max_pool2d_padding();
 bool test_relu();
 bool test_addmm();
 bool test_add();

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -213,6 +213,18 @@ bool test_max_pool2d() {
   });
 }
 
+bool test_max_pool2d_padding() {
+    __block std::vector<int64_t> size{1, 3, 4, 4};
+    return TEST(size, __PRETTY_FUNCTION__, ^bool {
+      auto X = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+      auto Y1 = at::native::max_pool2d(X, {2, 2}, {2, 2}, {1, 1}, {1, 1}, false);
+      auto X2 = X.metal();
+      auto Y2 =
+          mpscnn::max_pool2d(X2, {2, 2}, {2, 2}, {1, 1}, {1, 1}, false).cpu();
+      return almostEqual(Y1, Y2);
+    });
+}
+
 bool test_max_pool2d_ceil() {
   __block std::vector<int64_t> size{1, 96, 55, 55};
   return TEST(size, __PRETTY_FUNCTION__, ^bool {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52431 [iOS GPU] Fix max_pool_2d**

The previous implementation was missing the padding information. Thus is not correct.

Differential Revision: [D26508482](https://our.internmc.facebook.com/intern/diff/D26508482/)