### PR TITLE
[static runtime] register pow out variant

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -131,3 +131,18 @@ const auto aten_sum_1_true = R"JIT(
   def forward(self, input):
       return torch.sum(input, 1, True)
 )JIT";
+
+const auto pow_script_ten_sca = R"JIT(
+  def forward(self, input : Tensor, exponent : int):
+      return torch.pow(input, exponent)
+)JIT";
+
+const auto pow_script_ten_ten = R"JIT(
+  def forward(self, input : Tensor, exponent : Tensor):
+      return torch.pow(input, exponent)
+)JIT";
+
+const auto pow_script_sca_ten = R"JIT(
+  def forward(self, input : int, exponent : Tensor):
+      return torch.pow(input, exponent)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -145,6 +145,20 @@ TEST(StaticRuntime, IndividualOps_flatten) {
   test_flatten({}, 0, 0);
 }
 
+TEST(StaticRuntime, IndividualOps_pow) {
+  auto a = at::randn({2, 3});
+  auto b = at::randn({2, 3});
+
+  std::vector<IValue> args0{a, 4};
+  testStaticRuntime(pow_script_ten_sca, args0);
+
+  std::vector<IValue> args1{at::abs(a), b};
+  testStaticRuntime(pow_script_ten_ten, args1);
+
+  std::vector<IValue> args2{5, b};
+  testStaticRuntime(pow_script_sca_ten, args2);
+}
+
 TEST(StaticRuntime, LongModel) {
   torch::jit::Module mod = getLongScriptModel();
   auto a = torch::randn({2, 2});


### PR DESCRIPTION
Test Plan:
adfinder local net
Before:
7.13307 ms/iter
0.0222672 ms.   0.311136%. aten::pow (1 nodes)
After:
7.10623 ms/iter
0.0174462 ms.   0.242774%. aten::pow (1 nodes)

Differential Revision: D26521717

