### PR TITLE
[FX acc]Store shape and dtype in serialized output node args

### DIFF
--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -5,7 +5,7 @@ from torch.fx.experimental.param_fetch import lift_lowering_attrs_to_nodes
 from torch.fx.node import _get_qualified_name
 from torch.fx.graph_module import GraphModule
 from torch.fx.graph import Graph
-from torch.fx.node import Node, Target, map_arg
+from torch.fx.node import Node, Target, Argument, map_arg
 from torch.fx.passes.shape_prop import ShapeProp
 
 
@@ -54,6 +54,18 @@ def get_size_of_all_nodes(fx_module: GraphModule, args: List[torch.Tensor]) -> N
     return
 
 
+def get_shape_and_dtype(node: Node) -> Any:
+    shape = getattr(node, "shape", None)
+    if not shape:
+        raise RuntimeError("Node has no shape attr")
+
+    dtype = getattr(node, "dtype", None)
+    if not dtype:
+        raise RuntimeError("Node has no dtype attr")
+
+    return shape, dtype
+
+
 def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
     """Given a node with node.dtype and node.shape, return its total size and its output size.
     total_size = weights + bias + output_size
@@ -70,18 +82,10 @@ def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
             total_num_of_elems += p.numel()
     # Don't forget the output size
     # node.shape is the shape of this node's output
-    shape = getattr(node, "shape", None)
-    if shape:
-        output_elem = shape.numel()
-    else:
-        raise RuntimeError("Node has no shape attr")
+    shape, dtype = get_shape_and_dtype(node)
+    output_elem = shape.numel()
     total_num_of_elems += output_elem
-    size_per_elem_bytes = 0
-    dtype = getattr(node, "dtype", None)
-    if dtype:
-        size_per_elem_bytes = torch.tensor([], dtype=dtype).element_size()
-    else:
-        raise RuntimeError("Node has no dtype attr")
+    size_per_elem_bytes = torch.tensor([], dtype=dtype).element_size()
     total_size = size_per_elem_bytes * total_num_of_elems
     output_size = size_per_elem_bytes * output_elem
     return size_bytes(output_size, total_size)
@@ -195,20 +199,9 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
         if node.op != "call_module" or not isinstance(
             submodules[node.target], GraphModule
         ):
-            shape = getattr(node, "shape", None)
-            if shape:
-                node_rep["shape"] = serialize_shape(shape)
-            else:
-                raise RuntimeError(
-                    "Node has no shape attr, this is likely because shape propagation has not been run on this Graph."
-                )
-            dtype = getattr(node, "dtype", None)
-            if dtype:
-                node_rep["dtype"] = str(dtype)
-            else:
-                raise RuntimeError(
-                    "Node has no dtype attr, this is likely because shape propagation has not been run on this Graph."
-                )
+            shape, dtype = get_shape_and_dtype(node)
+            node_rep["shape"] = serialize_shape(shape)
+            node_rep["dtype"] = str(dtype)
 
         # Recurse down into any submodules we are calling.
         if node.op == "call_module":
@@ -255,9 +248,31 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
 
         node_rep["op_code"] = node.op
         node_rep["name"] = node.name
-        node_rep["args"] = map_arg(
-            node.args, lambda arg: {"is_node": True, "name": str(arg)}
-        )
+
+        if node.op == "output":
+            def get_output_info(arg: Node) -> Argument:
+                shape, dtype = get_shape_and_dtype(arg)
+                return {
+                    "is_node": True,
+                    "name": str(arg),
+                    "shape": serialize_shape(shape),
+                    "dtype": str(dtype),
+                }
+
+            node_rep["args"] = map_arg(
+                node.args,
+                get_output_info,
+            )
+
+            # If there're multiple outputs then node_rep["args"][0] will be a tuple.
+            # In this case we want to unpack the tuple.
+            if isinstance(node_rep["args"][0], tuple):
+                node_rep["args"] = node_rep["args"][0]
+        else:
+            node_rep["args"] = map_arg(
+                node.args, lambda arg: {"is_node": True, "name": str(arg)}
+            )
+
         node_rep["kwargs"] = map_arg(
             node.kwargs, lambda arg: {"is_node": True, "name": str(arg)}
         )


### PR DESCRIPTION
Summary:
This is the step one for supporting multiple outputs in fx nnpi path.

During serialization, we store the shape and dtype in output args, so that importer doesn't need to go back and find the nodes.

The output nodes will looks like
```
                {
                    "target": "output",
                    "op_code": "output",
                    "name": "output",
                    "args": [
                        {
                            "is_node": true,
                            "name": "add_1",
                            "shape": "[1, 1]",
                            "dtype": "torch.float32"
                        }
                    ],
                    "kwargs": {}
                }
```

Test Plan: Doesn't break existing tests and will test on step two.

Differential Revision: D26500742

