### PR TITLE
fetch git submodules during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,8 @@ if(USE_SYSTEM_LIBS)
   set(USE_SYSTEM_XNNPACK ON)
 endif()
 
+option(GIT_SUBMODULE "Fetch git submodules" ON)
+
 # Used when building Caffe2 through setup.py
 option(BUILDING_WITH_TORCH_LIBS "Tell cmake if Caffe2 is being built alongside torch libs" ON)
 
@@ -490,6 +492,13 @@ endif()
 
 # ---[ Utils
 include(cmake/public/utils.cmake)
+
+# ---[ git submodules
+if(GIT_SUBMODULE AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  find_package(Git REQUIRED)
+  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
 
 # ---[ Version numbers for generated libraries
 file(READ version.txt TORCH_DEFAULT_VERSION)


### PR DESCRIPTION
This adds the option `GIT_SUBMODULE` to fetch the git submodules automatically during a build.

This makes it easier to use PyTorch as part of a meta-build-system that does not support additional options for git, and also reduces build errors due to people forgetting to check out the submodules manually.

Inspired by https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html.