### PR TITLE
Enable TCPStore fixed slow test

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -339,8 +339,6 @@ class TCPStoreTest(TestCase, StoreTestBase):
         self.assertEqual(b"value1", fs.get("key1"))
         self.assertEqual(b"value2", fs.get("key4"))
 
-    # https://github.com/pytorch/pytorch/issues/46064 <- takes 5+ min to finish
-    @slowTest
     def test_numkeys_delkeys(self):
         self._test_numkeys_delkeys(self._create_store())
 

--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -51,7 +51,6 @@ from torch.testing._internal.common_utils import (
     CONNECT_TIMEOUT,
     TEST_WITH_TSAN,
     IS_WINDOWS,
-    slowTest,
 )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52511 Enable TCPStore fixed slow test**

Re-enable a test that was previously fixed but forgot to be re-enabled.

Differential Revision: [D26586980](https://our.internmc.facebook.com/intern/diff/D26586980)