### PR TITLE
[Static Runtime] output clip_ranges result

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -131,15 +131,46 @@ void ClipRangesGatherSigridHash(std::shared_ptr<torch::jit::Graph>& graph) {
 void ClipRangesGatherRangesSigridHash(
     std::shared_ptr<torch::jit::Graph>& graph) {
   std::string pattern = R"IR(
-    graph(%a, %b, %c, %d, %e, %f):
-        %y0 : Tensor = fb::clip_ranges(%b, %c)
-        %y1 : Tensor, %y2 : Tensor = fb::gather_ranges(%a, %y0)
-        %y3 : Tensor = fb::sigrid_hash(%y1, %d, %e, %f)
-        return (%y3, %y2))IR";
+      graph(%a, %b, %c, %d, %e, %f):
+           %y0 : Tensor = fb::clip_ranges(%b, %c)
+           %y1 : Tensor, %y2 : Tensor = fb::gather_ranges(%a, %y0)
+           %y3 : Tensor = fb::sigrid_hash(%y1, %d, %e, %f)
+           return (%y3, %y2))IR";
   std::string fused_pattern = R"IR(
     graph(%a, %b, %c, %d, %e, %f):
         %off : Tensor, %out : Tensor = fb::clip_ranges_gather_sigrid_hash_v3(%b, %a, %c, %d, %e, %f)
         return (%out, %off))IR";
+
+  std::string pattern2 = R"IR(
+      graph(%a, %b, %c, %d, %e, %f):
+           %y0 : Tensor = fb::clip_ranges(%b, %c)
+           %y1 : Tensor, %y2 : Tensor = fb::gather_ranges(%a, %y0)
+           %y3 : Tensor = fb::sigrid_hash(%y1, %d, %e, %f)
+           return (%y3, %y2, %y0))IR";
+  std::string fused_pattern2 = R"IR(
+    graph(%a, %b, %c, %d, %e, %f):
+        %off : Tensor, %out : Tensor, %clip_ranges_out : Tensor = fb::clip_ranges_out_gather_sigrid_hash_v3(%b, %a, %c, %d, %e, %f)
+        return (%out, %off, %clip_ranges_out))IR";
+  SubgraphRewriter fuse;
+  fuse.RegisterRewritePattern(pattern, fused_pattern);
+  fuse.runOnGraph(graph);
+
+  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
+  fuse.runOnGraph(graph);
+}
+
+void ClipRangesGatherRangesSigridHashClipRangesOut(
+    std::shared_ptr<torch::jit::Graph>& graph) {
+  std::string pattern = R"IR(
+      graph(%a, %b, %c, %d, %e, %f):
+           %y0 : Tensor = fb::clip_ranges(%b, %c)
+           %y1 : Tensor, %y2 : Tensor = fb::gather_ranges(%a, %y0)
+           %y3 : Tensor = fb::sigrid_hash(%y1, %d, %e, %f)
+           return (%y3, %y2, %y0))IR";
+  std::string fused_pattern = R"IR(
+    graph(%a, %b, %c, %d, %e, %f):
+        %off : Tensor, %out : Tensor, %clip_ranges_out : Tensor = fb::clip_ranges_out_gather_sigrid_hash_v3(%b, %a, %c, %d, %e, %f)
+        return (%out, %off, %clip_ranges_out))IR";
   SubgraphRewriter fuse;
   fuse.RegisterRewritePattern(pattern, fused_pattern);
   fuse.runOnGraph(graph);


### PR DESCRIPTION
Summary: New fusion op to output intermediate clip_ranges result

Test Plan: MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 1 buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --scripted_model=$INLINE_CVR_DIR/210494966_0.predictor.disagg.local_ro.pt --pt_inputs=$INLINE_CVR_DIR/local_wrapped_input_data.pt --pt_enable_static_runtime=true --pt_cleanup_activations=true --pt_enable_out_variant=true --compare_results=true --iters=5000 --warmup_iters=5000 --num_threads=1 --do_profile=1

Differential Revision: D26412199

