### PR TITLE
[caffe2] Delete some unused fields from TensorProto

### DIFF
--- a/caffe2/proto/caffe2.proto
+++ b/caffe2/proto/caffe2.proto
@@ -11,33 +11,6 @@ package caffe2;
 //     is mainly for backward compatibility purposes but we may consider using
 //     those in the future.
 
-// ExternalDataProto stores the pointer to the content of TensorProto
-// the content are stored in the raw format as little endian
-message ExternalDataProto {
-  // type of the external storage type, can be the following:
-  enum SourceType {
-    // the container defined in torch/csrc/jit/serialization.h is used,
-    // and record_id is the tag to help the runtime identify the data
-    // this type of storage is set as DEFAULT and recommended for external
-    // data storage
-    INLINE_CONTAINER = 0;
-    // use external file to store the data, and record_id is the POSIX relative path
-    // to the file. this (simple) file is only for the data, and the data is stored
-    // as little endian in the file
-    SIMPLE_FILE = 1;
-  }
-  optional SourceType source_type = 1 [default = INLINE_CONTAINER];
-  // used together with type
-  optional string record_id = 2;
-  // the size of the entire record (in bytes)
-  optional uint64 record_size = 5;
-  // the offset of the starting point, the content may be shared between
-  // multiple tensors
-  optional int64 offset = 3 [default = 0];
-  // the strides of the content
-  repeated int64 strides = 4;
-}
-
 // TensorProto stores serialized Tensor objects.
 message TensorProto {
   // The dimensions in the tensor.
@@ -68,22 +41,6 @@ message TensorProto {
   }
   optional DataType data_type = 2 [default = FLOAT];
 
-  // data storage
-  enum StorageType {
-    // the content is stored in typed field, for example, if the data_type is
-    // FLOAT, float_data is used to store the content.
-    TYPED = 1;
-    // the content is serialized in field raw_data as little-endian
-    RAW = 2;
-    // the pointer to the content is stored in field external_data
-    // the content is serialized as little-endian
-    EXTERNAL = 3;
-    // When StorageType is NO_CONTENT, we use TensorProto to store only type
-    // and shape information. Reuse TensorProto to store type and shape
-    // because we can just have one proto, not having another ValueInfoProto
-    NO_CONTENT = 4;
-  }
-  optional StorageType storage_type = 12 [default = TYPED];
   // For float
   repeated float float_data = 3 [packed = true];
   // For int32, uint8, int8, uint16, int16, bool, and float16
@@ -100,8 +57,6 @@ message TensorProto {
   repeated int64 int64_data = 10 [packed = true];
   // store the raw data, contents are serialized as little-endian
   optional bytes raw_data = 13;
-  // store the pointer to the data
-  optional ExternalDataProto external_data = 14;
 
   // Optionally, a name for the tensor.
   optional string name = 7;
@@ -118,6 +73,9 @@ message TensorProto {
     required int64 end = 2;
   }
   optional Segment segment = 11;
+
+  // Field numbers 12 and 14 were previously used for now-deprecated fields.
+  reserved 12;
 }
 
 message QTensorProto {

--- a/caffe2/proto/caffe2_pb2.pyi
+++ b/caffe2/proto/caffe2_pb2.pyi
@@ -40,40 +40,6 @@ PROTO_MSNPU = DeviceTypeProto.V(8)
 PROTO_XLA = DeviceTypeProto.V(9)
 PROTO_COMPILE_TIME_MAX_DEVICE_TYPES = DeviceTypeProto.V(10)
 
-class ExternalDataProto(google.protobuf.message.Message):
-    DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
-    class _SourceType(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[SourceType.V], builtins.type):
-        DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
-        INLINE_CONTAINER = ExternalDataProto.SourceType.V(0)
-        SIMPLE_FILE = ExternalDataProto.SourceType.V(1)
-    class SourceType(metaclass=_SourceType):
-        V = typing.NewType('V', builtins.int)
-    INLINE_CONTAINER = ExternalDataProto.SourceType.V(0)
-    SIMPLE_FILE = ExternalDataProto.SourceType.V(1)
-
-    SOURCE_TYPE_FIELD_NUMBER: builtins.int
-    RECORD_ID_FIELD_NUMBER: builtins.int
-    RECORD_SIZE_FIELD_NUMBER: builtins.int
-    OFFSET_FIELD_NUMBER: builtins.int
-    STRIDES_FIELD_NUMBER: builtins.int
-    source_type: global___ExternalDataProto.SourceType.V = ...
-    record_id: typing.Text = ...
-    record_size: builtins.int = ...
-    offset: builtins.int = ...
-    strides: google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int] = ...
-
-    def __init__(self,
-        *,
-        source_type : typing.Optional[global___ExternalDataProto.SourceType.V] = ...,
-        record_id : typing.Optional[typing.Text] = ...,
-        record_size : typing.Optional[builtins.int] = ...,
-        offset : typing.Optional[builtins.int] = ...,
-        strides : typing.Optional[typing.Iterable[builtins.int]] = ...,
-        ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal[u"offset",b"offset",u"record_id",b"record_id",u"record_size",b"record_size",u"source_type",b"source_type"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal[u"offset",b"offset",u"record_id",b"record_id",u"record_size",b"record_size",u"source_type",b"source_type",u"strides",b"strides"]) -> None: ...
-global___ExternalDataProto = ExternalDataProto
-
 class TensorProto(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
     class _DataType(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[DataType.V], builtins.type):
@@ -92,6 +58,7 @@ class TensorProto(google.protobuf.message.Message):
         FLOAT16 = TensorProto.DataType.V(12)
         DOUBLE = TensorProto.DataType.V(13)
         ZERO_COLLISION_HASH = TensorProto.DataType.V(14)
+        REBATCHING_BUFFER = TensorProto.DataType.V(15)
     class DataType(metaclass=_DataType):
         V = typing.NewType('V', builtins.int)
     UNDEFINED = TensorProto.DataType.V(0)
@@ -108,19 +75,7 @@ class TensorProto(google.protobuf.message.Message):
     FLOAT16 = TensorProto.DataType.V(12)
     DOUBLE = TensorProto.DataType.V(13)
     ZERO_COLLISION_HASH = TensorProto.DataType.V(14)
-
-    class _StorageType(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[StorageType.V], builtins.type):
-        DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor = ...
-        TYPED = TensorProto.StorageType.V(1)
-        RAW = TensorProto.StorageType.V(2)
-        EXTERNAL = TensorProto.StorageType.V(3)
-        NO_CONTENT = TensorProto.StorageType.V(4)
-    class StorageType(metaclass=_StorageType):
-        V = typing.NewType('V', builtins.int)
-    TYPED = TensorProto.StorageType.V(1)
-    RAW = TensorProto.StorageType.V(2)
-    EXTERNAL = TensorProto.StorageType.V(3)
-    NO_CONTENT = TensorProto.StorageType.V(4)
+    REBATCHING_BUFFER = TensorProto.DataType.V(15)
 
     class Segment(google.protobuf.message.Message):
         DESCRIPTOR: google.protobuf.descriptor.Descriptor = ...
@@ -139,7 +94,6 @@ class TensorProto(google.protobuf.message.Message):
 
     DIMS_FIELD_NUMBER: builtins.int
     DATA_TYPE_FIELD_NUMBER: builtins.int
-    STORAGE_TYPE_FIELD_NUMBER: builtins.int
     FLOAT_DATA_FIELD_NUMBER: builtins.int
     INT32_DATA_FIELD_NUMBER: builtins.int
     BYTE_DATA_FIELD_NUMBER: builtins.int
@@ -147,13 +101,11 @@ class TensorProto(google.protobuf.message.Message):
     DOUBLE_DATA_FIELD_NUMBER: builtins.int
     INT64_DATA_FIELD_NUMBER: builtins.int
     RAW_DATA_FIELD_NUMBER: builtins.int
-    EXTERNAL_DATA_FIELD_NUMBER: builtins.int
     NAME_FIELD_NUMBER: builtins.int
     DEVICE_DETAIL_FIELD_NUMBER: builtins.int
     SEGMENT_FIELD_NUMBER: builtins.int
     dims: google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int] = ...
     data_type: global___TensorProto.DataType.V = ...
-    storage_type: global___TensorProto.StorageType.V = ...
     float_data: google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.float] = ...
     int32_data: google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int] = ...
     byte_data: builtins.bytes = ...
@@ -162,9 +114,6 @@ class TensorProto(google.protobuf.message.Message):
     int64_data: google.protobuf.internal.containers.RepeatedScalarFieldContainer[builtins.int] = ...
     raw_data: builtins.bytes = ...
     name: typing.Text = ...
-
-    @property
-    def external_data(self) -> global___ExternalDataProto: ...
 
     @property
     def device_detail(self) -> global___DeviceOption: ...
@@ -176,7 +125,6 @@ class TensorProto(google.protobuf.message.Message):
         *,
         dims : typing.Optional[typing.Iterable[builtins.int]] = ...,
         data_type : typing.Optional[global___TensorProto.DataType.V] = ...,
-        storage_type : typing.Optional[global___TensorProto.StorageType.V] = ...,
         float_data : typing.Optional[typing.Iterable[builtins.float]] = ...,
         int32_data : typing.Optional[typing.Iterable[builtins.int]] = ...,
         byte_data : typing.Optional[builtins.bytes] = ...,
@@ -184,13 +132,12 @@ class TensorProto(google.protobuf.message.Message):
         double_data : typing.Optional[typing.Iterable[builtins.float]] = ...,
         int64_data : typing.Optional[typing.Iterable[builtins.int]] = ...,
         raw_data : typing.Optional[builtins.bytes] = ...,
-        external_data : typing.Optional[global___ExternalDataProto] = ...,
         name : typing.Optional[typing.Text] = ...,
         device_detail : typing.Optional[global___DeviceOption] = ...,
         segment : typing.Optional[global___TensorProto.Segment] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal[u"byte_data",b"byte_data",u"data_type",b"data_type",u"device_detail",b"device_detail",u"external_data",b"external_data",u"name",b"name",u"raw_data",b"raw_data",u"segment",b"segment",u"storage_type",b"storage_type"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal[u"byte_data",b"byte_data",u"data_type",b"data_type",u"device_detail",b"device_detail",u"dims",b"dims",u"double_data",b"double_data",u"external_data",b"external_data",u"float_data",b"float_data",u"int32_data",b"int32_data",u"int64_data",b"int64_data",u"name",b"name",u"raw_data",b"raw_data",u"segment",b"segment",u"storage_type",b"storage_type",u"string_data",b"string_data"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal[u"byte_data",b"byte_data",u"data_type",b"data_type",u"device_detail",b"device_detail",u"name",b"name",u"raw_data",b"raw_data",u"segment",b"segment"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal[u"byte_data",b"byte_data",u"data_type",b"data_type",u"device_detail",b"device_detail",u"dims",b"dims",u"double_data",b"double_data",u"float_data",b"float_data",u"int32_data",b"int32_data",u"int64_data",b"int64_data",u"name",b"name",u"raw_data",b"raw_data",u"segment",b"segment",u"string_data",b"string_data"]) -> None: ...
 global___TensorProto = TensorProto
 
 class QTensorProto(google.protobuf.message.Message):
@@ -361,18 +308,24 @@ class AOTConfig(google.protobuf.message.Message):
     MAX_BATCH_SIZE_FIELD_NUMBER: builtins.int
     MAX_SEQ_SIZE_FIELD_NUMBER: builtins.int
     IN_BATCH_BROADCAST_FIELD_NUMBER: builtins.int
+    ONNXIFI_BLACKLIST_OPS_FIELD_NUMBER: builtins.int
+    ONNXIFI_MIN_OPS_FIELD_NUMBER: builtins.int
     max_batch_size: builtins.int = ...
     max_seq_size: builtins.int = ...
     in_batch_broadcast: builtins.bool = ...
+    onnxifi_blacklist_ops: typing.Text = ...
+    onnxifi_min_ops: builtins.int = ...
 
     def __init__(self,
         *,
         max_batch_size : typing.Optional[builtins.int] = ...,
         max_seq_size : typing.Optional[builtins.int] = ...,
         in_batch_broadcast : typing.Optional[builtins.bool] = ...,
+        onnxifi_blacklist_ops : typing.Optional[typing.Text] = ...,
+        onnxifi_min_ops : typing.Optional[builtins.int] = ...,
         ) -> None: ...
-    def HasField(self, field_name: typing_extensions.Literal[u"in_batch_broadcast",b"in_batch_broadcast",u"max_batch_size",b"max_batch_size",u"max_seq_size",b"max_seq_size"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal[u"in_batch_broadcast",b"in_batch_broadcast",u"max_batch_size",b"max_batch_size",u"max_seq_size",b"max_seq_size"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal[u"in_batch_broadcast",b"in_batch_broadcast",u"max_batch_size",b"max_batch_size",u"max_seq_size",b"max_seq_size",u"onnxifi_blacklist_ops",b"onnxifi_blacklist_ops",u"onnxifi_min_ops",b"onnxifi_min_ops"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal[u"in_batch_broadcast",b"in_batch_broadcast",u"max_batch_size",b"max_batch_size",u"max_seq_size",b"max_seq_size",u"onnxifi_blacklist_ops",b"onnxifi_blacklist_ops",u"onnxifi_min_ops",b"onnxifi_min_ops"]) -> None: ...
 global___AOTConfig = AOTConfig
 
 class Argument(google.protobuf.message.Message):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52521 [caffe2] Delete some unused fields from TensorProto**

The `storage_type` and `external_data` fields were added a few years ago in
D10246743 but don't appear to have been used anywhere.  Let's remove them to
help simplify the `TensorProto` message definition.

Differential Revision: [D26500028](https://our.internmc.facebook.com/intern/diff/D26500028/)