### PR TITLE
Add onnxifi interface for set/get options (#52388)

### DIFF
--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -49,6 +49,21 @@ struct OnnxifiTransformerOptions final : public BackendTransformOptions {
   std::unordered_map<int, ShapeInfoMap> shape_hints_per_bs;
 };
 
+class TORCH_API OnnxifiOptionHelper final {
+ public:
+  OnnxifiOptionHelper();
+
+  // Set Onnxifi option
+  bool setOnnxifiOption(const std::string& option, const std::string& value);
+
+  //  Get Onnxifi option
+  std::string getOnnxifiOption(const std::string& option);
+
+ private:
+  // Pointer to loaded onnxifi library
+  onnxifi_library* lib_{nullptr};
+};
+
 class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
  public:
   explicit OnnxifiTransformer(const OnnxifiTransformerOptions& opts);
@@ -84,14 +99,14 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       Workspace* ws,
       onnx::OnnxExporter* exporter,
       ShapeInfoMap* shape_hints_max_bs,
-      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
+      const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Convert a cutoff subgraph net to an Onnxifi op
   caffe2::NetDef SubnetToOnnxifiOpViaC2(
       const caffe2::NetDef& net,
       const std::unordered_set<std::string>& weights_in_ws,
       const ShapeInfoMap& shape_hints_max_bs,
-      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
+      const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Check that output shape hints are present to ensure we can pass them to
   // OnnxifiOp
@@ -106,7 +121,7 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::vector<std::string>& external_inputs,
       const std::vector<std::string>& external_outputs,
       const ShapeInfoMap& shape_hints_max_bs,
-      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
+      const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Transform by passing C2 proto to backend
   NetDef TransformViaC2(
@@ -114,7 +129,7 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_set<std::string>& weights,
       const std::unordered_set<int>& blocklisted_ops,
       const ShapeInfoMap& shape_hints_max_bs,
-      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
+      const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Transform by passing ONNX proto to backend
   NetDef TransformViaOnnx(
@@ -123,7 +138,7 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_set<std::string>& weights,
       const std::unordered_set<int>& blocklisted_ops,
       ShapeInfoMap* shape_hints_max_bs,
-      const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs);
+      const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Query whether an operator is supported by passing ONNX protobuf
   bool supportOpOnnx(

--- a/caffe2/python/onnx/onnxifi.py
+++ b/caffe2/python/onnx/onnxifi.py
@@ -5,14 +5,22 @@
 ONNXIFI a Caffe2 net
 """
 
-
-
-
-
-
 from caffe2.proto import caffe2_pb2
 import caffe2.python._import_c_extension as C
 
+
+def onnxifi_set_option(option_name, option_value):
+    """
+    Set onnxifi option
+    """
+    return C.onnxifi_set_option(option_name, str(option_value))
+
+
+def onnxifi_get_option(option_name):
+    """
+    Get onnxifi option
+    """
+    return C.onnxifi_get_option(option_name)
 
 def onnxifi_caffe2_net(
         pred_net,

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -23,13 +23,13 @@
 #include "caffe2/onnx/offline_tensor.h"
 #include "caffe2/onnx/onnx_exporter.h"
 #include "caffe2/opt/converter.h"
+#include "caffe2/opt/fakefp16_transform.h"
 #include "caffe2/opt/fusion.h"
 #include "caffe2/opt/mobile.h"
 #include "caffe2/opt/onnxifi_transformer.h"
 #include "caffe2/opt/optimize_ideep.h"
 #include "caffe2/opt/passes.h"
 #include "caffe2/opt/shape_info.h"
-#include "caffe2/opt/fakefp16_transform.h"
 #include "caffe2/predictor/emulator/data_filler.h"
 #include "caffe2/predictor/predictor.h"
 #include "caffe2/python/pybind_state_registry.h"
@@ -85,13 +85,12 @@ Workspace* GetCurrentWorkspace() {
   return gWorkspace;
 }
 
-Workspace* GetWorkspaceByName(const std::string &name) {
+Workspace* GetWorkspaceByName(const std::string& name) {
   if (gWorkspaces.count(name)) {
     return gWorkspaces[name].get();
   }
   return nullptr;
 }
-
 
 class StringFetcher : public BlobFetcherBase {
  public:
@@ -376,10 +375,9 @@ void addObjectMethods(py::module& m) {
             py::gil_scoped_release g;
             CAFFE_ENFORCE(net->Run());
           })
-      .def("cancel",
-          [](NetBase* net) {
-            py::gil_scoped_release g;
-            net->Cancel();
+      .def("cancel", [](NetBase* net) {
+        py::gil_scoped_release g;
+        net->Cancel();
       });
 
   py::class_<ObserverBase<NetBase>>(m, "Observer")
@@ -1763,6 +1761,17 @@ void addGlobalMethods(py::module& m) {
         return true;
       });
   m.def(
+      "onnxifi_set_option",
+      [](const std::string& optionName,
+         const std::string& optionValue) -> bool {
+        OnnxifiOptionHelper ts;
+        return ts.setOnnxifiOption(optionName, optionValue);
+      });
+  m.def("onnxifi_get_option", [](const std::string& optionName) -> std::string {
+    OnnxifiOptionHelper ts;
+    return ts.getOnnxifiOption(optionName);
+  });
+  m.def(
       "onnxifi",
       [](const py::bytes& pred_net_str,
          const py::bytes& shapes_str,
@@ -1840,8 +1849,7 @@ void addGlobalMethods(py::module& m) {
   m.def("fakeFp16FuseOps", [](const py::bytes& net_str) {
     caffe2::NetDef netDef;
     CAFFE_ENFORCE(
-        ParseProtoFromLargeString(
-            net_str.cast<std::string>(), &netDef),
+        ParseProtoFromLargeString(net_str.cast<std::string>(), &netDef),
         "broken pred_net protobuf");
     opt::fakeFp16FuseOps(&netDef);
     std::string out_net;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

This allows us to change global variables through onnxifi calls. And add python bindings along with it. Note that we supply a dummy backend_id as it's not needed by glow due to setting being global.

#codemod

Test Plan:
```
buck test mode/dev //glow/fb/test:test_onnxifi_optionnnpi
```

Reviewed By: jfix71, khabinov

Differential Revision: D26481652

fbshipit-source-id: 19b8201c77f653cf7d93ad68760aa7fb5ec45ff4