### PR TITLE
Moving 11.2 CI to master only

### DIFF
--- a/.circleci/cimodel/data/pytorch_build_data.py
+++ b/.circleci/cimodel/data/pytorch_build_data.py
@@ -72,7 +72,7 @@ CONFIG_TREE_DATA = [
                     X(True),
                     ("libtorch", [
                         (True, [
-                            ('build_only', [XImportant(True)]),
+                            ('build_only', [X(True)]),
                         ]),
                     ]),
                 ]),

--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -137,7 +137,7 @@ WORKFLOW_DATA = [
     WindowsJob(1, _VC2019, CudaVersion(11, 1), master_only_pred=TruePred),
     WindowsJob(2, _VC2019, CudaVersion(11, 1), master_only_pred=TruePred),
     # VS2019 CUDA-11.2
-    WindowsJob(None, _VC2019, CudaVersion(11, 2)),
+    WindowsJob(None, _VC2019, CudaVersion(11, 2), master_only_pred=TruePred),
     WindowsJob(1, _VC2019, CudaVersion(11, 2), master_only_pred=TruePred),
     WindowsJob(2, _VC2019, CudaVersion(11, 2), master_only_pred=TruePred),
     # VS2019 CPU-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7134,6 +7134,12 @@ workflows:
           name: pytorch_libtorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
           requires:
             - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           build_environment: "pytorch-libtorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
       - pytorch_linux_build:
@@ -7657,6 +7663,12 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.2"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda11.2_build
           python_version: "3.6"
           use_cuda: "1"


### PR DESCRIPTION
Moves the 11.2 linux and windows builds to master only.