### PR TITLE
Remove notion of "level" from `Module::dump_to_str`.

### DIFF
--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -396,8 +396,7 @@ void Module::apply(const std::function<void(Module&)>& fn) {
 std::string Module::dump_to_str(
     bool print_method_bodies,
     bool print_attr_values,
-    bool print_param_values,
-    int level = 0) const {
+    bool print_param_values) const {
   std::stringstream ss;
   std::stringstream parameters_ss;
   std::stringstream attributes_ss;
@@ -444,16 +443,18 @@ std::string Module::dump_to_str(
   ss << "  }" << std::endl;
   ss << "  submodules {" << std::endl;
   for (const NameModule& s : named_children()) {
-    // We do level + 2, because one level of indentation comes from 'submodules'
-    // scope and the other one goes from a specific submodule we're printing.
-    ss << s.value.dump_to_str(
-        print_method_bodies, print_attr_values, print_param_values, level + 2);
+    // We do 4 spaces here, because one level of indentation comes from
+    // 'submodules' scope and the other one goes from a specific submodule we're
+    // printing.
+    ss << torch::jit::jit_log_prefix(
+        "    ",
+        s.value.dump_to_str(
+            print_method_bodies, print_attr_values, print_param_values));
   }
   ss << "  }" << std::endl;
   ss << "}" << std::endl;
 
-  std::string indent(2 * level, ' ');
-  return torch::jit::jit_log_prefix(indent, ss.str());
+  return ss.str();
 }
 
 void Module::dump(

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -173,8 +173,7 @@ struct TORCH_API Module : public Object {
   std::string dump_to_str(
       bool print_method_bodies,
       bool print_attr_values,
-      bool print_param_values,
-      int level) const;
+      bool print_param_values) const;
 
   /// Enables "training" mode.
   void train(bool on = true);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -966,8 +966,7 @@ void initJitScriptBindings(PyObject* module) {
           &Module::dump_to_str,
           py::arg("code") = true,
           py::arg("attrs") = true,
-          py::arg("params") = true,
-          py::arg("indent") = 0)
+          py::arg("params") = true)
       .def(
           "_replicate_for_data_parallel",
           [](Module& module) {


### PR DESCRIPTION
The code uses `torch::jit::jit_log_prefix` for handling recursive
indenting in most places in this function. There was one place that was
using "level", but it was buggy -- it would result in a compounding
superlinear indent. Note that changing it to "level+1" doesn't fix the
bug.

Before/after:
https://gist.github.com/silvasean/8ee3ef115a48de6c9c54fbc40838d8d7

The new code establishes a recursive invariant for
`Module::dump_to_str`: the function returns the module printed at the
base indent level (i.e. no indent). `torch::jit:log_prefix` is used
to prefix recursive calls. The code was already nearly there, except for
this spurious use of "level".
