### PR TITLE
[PyTorch][CI] Enable test_lite_interpreter_runtime unittest in CI (macos)

### DIFF
--- a/.circleci/cimodel/data/simple/macos_definitions.py
+++ b/.circleci/cimodel/data/simple/macos_definitions.py
@@ -1,7 +1,10 @@
+import cimodel.lib.miniutils as miniutils
+
 class MacOsJob:
-    def __init__(self, os_version, is_test=False):
+    def __init__(self, os_version, is_test=False, extra_props=None):
         self.os_version = os_version
         self.is_test = is_test
+        self.extra_props = extra_props
 
     def gen_tree(self):
         non_phase_parts = ["pytorch", "macos", self.os_version, "py3"]
@@ -9,6 +12,8 @@ class MacOsJob:
         phase_name = "test" if self.is_test else "build"
 
         full_job_name = "_".join(non_phase_parts + [phase_name])
+        if self.extra_props:
+            full_job_name = "_".join([full_job_name] + list(self.extra_props.keys()))
 
         test_build_dependency = "_".join(non_phase_parts + ["build"])
         extra_dependencies = [test_build_dependency] if self.is_test else []
@@ -18,10 +23,22 @@ class MacOsJob:
         # for the YAML output to work.
         props_dict = {"requires": job_dependencies, "name": full_job_name}
 
+        # if self.extra_props:
+        #     props_dict.update(self.extra_props)
+
         return [{full_job_name: props_dict}]
 
 
-WORKFLOW_DATA = [MacOsJob("10_15"), MacOsJob("10_13"), MacOsJob("10_13", True)]
+WORKFLOW_DATA = [
+    MacOsJob("10_15"),
+    MacOsJob("10_13"),
+    MacOsJob("10_13", True),
+    MacOsJob(
+        "10_13",
+        True,
+        extra_props={"build_lite_interpreter": miniutils.quote(str(int(True)))}
+    )
+]
 
 
 def get_workflow_jobs():

--- a/.circleci/cimodel/data/simple/macos_definitions.py
+++ b/.circleci/cimodel/data/simple/macos_definitions.py
@@ -1,8 +1,9 @@
 import cimodel.lib.miniutils as miniutils
 
 class MacOsJob:
-    def __init__(self, os_version, is_test=False, extra_props=None):
+    def __init__(self, os_version, is_build=False, is_test=False, extra_props={}):
         self.os_version = os_version
+        self.is_build = is_build
         self.is_test = is_test
         self.extra_props = extra_props
 
@@ -10,10 +11,16 @@ class MacOsJob:
         non_phase_parts = ["pytorch", "macos", self.os_version, "py3"]
 
         phase_name = "test" if self.is_test else "build"
+        extra_name = phase_name
+        extra_name = "_".join([phase_name] + list(self.extra_props.keys()))
+        extended_name = [
+            'build' if self.is_build else '',
+            'test' if self.is_build else '',
+            list(self.extra_props.keys())
+        ]
+        full_job_name = "_".join(extended_name)
 
-        full_job_name = "_".join(non_phase_parts + [phase_name])
-        if self.extra_props:
-            full_job_name = "_".join([full_job_name] + list(self.extra_props.keys()))
+        # full_job_name = "_".join(non_phase_parts + [extra_name])
 
         test_build_dependency = "_".join(non_phase_parts + ["build"])
         extra_dependencies = [test_build_dependency] if self.is_test else []
@@ -30,13 +37,20 @@ class MacOsJob:
 
 
 WORKFLOW_DATA = [
-    MacOsJob("10_15"),
-    MacOsJob("10_13"),
-    MacOsJob("10_13", True),
+    MacOsJob("10_15", is_build=miniutils.quote(str(int(True))),
+    MacOsJob("10_13", is_build=miniutils.quote(str(int(True))),
     MacOsJob(
         "10_13",
-        True,
-        extra_props={"build_lite_interpreter": miniutils.quote(str(int(True)))}
+        is_build=miniutils.quote(str(int(False))),
+        is_test=miniutils.quote(str(int(True))),
+    ),
+    MacOsJob(
+        "10_13",
+        is_build=miniutils.quote(str(int(True))),
+        is_test=miniutils.quote(str(int(True))),
+        extra_props={
+            "build_lite_interpreter": miniutils.quote(str(int(True))),
+        },
     )
 ]
 

--- a/.circleci/cimodel/data/simple/macos_definitions.py
+++ b/.circleci/cimodel/data/simple/macos_definitions.py
@@ -10,16 +10,16 @@ class MacOsJob:
     def gen_tree(self):
         non_phase_parts = ["pytorch", "macos", self.os_version, "py3"]
 
-        phase_name = "test" if self.is_test else "build"
-        extra_name = phase_name
-        extra_name = "_".join([phase_name] + list(self.extra_props.keys()))
-        extended_name = [
-            'build' if self.is_build else '',
-            'test' if self.is_build else '',
-            list(self.extra_props.keys())
+        extra_name_list = [name for name, exist in self.extra_props.items() if exist]
+        full_job_name_list = non_phase_parts + extra_name_list + [
+            'build' if self.is_build else None,
+            'test' if self.is_test else None,
         ]
-        full_job_name = "_".join(extended_name)
 
+        full_job_name = "_".join(list(filter(None, full_job_name_list)))
+        print("full_job_name: ", full_job_name)
+
+        # phase_name = "test" if self.is_test else "build"
         # full_job_name = "_".join(non_phase_parts + [extra_name])
 
         test_build_dependency = "_".join(non_phase_parts + ["build"])
@@ -37,19 +37,19 @@ class MacOsJob:
 
 
 WORKFLOW_DATA = [
-    MacOsJob("10_15", is_build=miniutils.quote(str(int(True))),
-    MacOsJob("10_13", is_build=miniutils.quote(str(int(True))),
+    MacOsJob("10_15", is_build=True),
+    MacOsJob("10_13", is_build=True),
     MacOsJob(
         "10_13",
-        is_build=miniutils.quote(str(int(False))),
-        is_test=miniutils.quote(str(int(True))),
+        is_build=False,
+        is_test=True,
     ),
     MacOsJob(
         "10_13",
-        is_build=miniutils.quote(str(int(True))),
-        is_test=miniutils.quote(str(int(True))),
+        is_build=True,
+        is_test=True,
         extra_props={
-            "build_lite_interpreter": miniutils.quote(str(int(True))),
+            "lite_interpreter": True,
         },
     )
 ]

--- a/.circleci/cimodel/data/simple/macos_definitions.py
+++ b/.circleci/cimodel/data/simple/macos_definitions.py
@@ -17,7 +17,6 @@ class MacOsJob:
         ]
 
         full_job_name = "_".join(list(filter(None, full_job_name_list)))
-        print("full_job_name: ", full_job_name)
 
         # phase_name = "test" if self.is_test else "build"
         # full_job_name = "_".join(non_phase_parts + [extra_name])

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1389,6 +1389,28 @@ jobs:
       - store_test_results:
           path: test/test-reports
 
+  pytorch_macos_10_13_py3_test_build_lite_interpreter:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+    macos:
+      xcode: "12.0"
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/workspace
+      - run_brew_for_macos_build
+      - run:
+          name: Test
+          no_output_timeout: "1h"
+          command: |
+            set -e
+            export IN_CI=1
+            export BUILD_LITE_INTERPRETER=1
+            chmod a+x macos-lite-interpreter-build-test.sh
+            unbuffer macos-lite-interpreter-build-test.sh 2>&1 | ts
+      - store_test_results:
+          path: test/test-reports
+
   pytorch_android_gradle_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build
@@ -7208,6 +7230,10 @@ workflows:
           name: pytorch_macos_10_13_py3_build
       - pytorch_macos_10_13_py3_test:
           name: pytorch_macos_10_13_py3_test
+          requires:
+            - pytorch_macos_10_13_py3_build
+      - pytorch_macos_10_13_py3_test_build_lite_interpreter:
+          name: pytorch_macos_10_13_py3_test_build_lite_interpreter
           requires:
             - pytorch_macos_10_13_py3_build
       - pytorch_linux_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2039,6 +2039,10 @@ jobs:
 ##############################################################################
 # Workflows
 ##############################################################################
+full_job_name:  pytorch_macos_10_15_py3_build
+full_job_name:  pytorch_macos_10_13_py3_build
+full_job_name:  pytorch_macos_10_13_py3_test
+full_job_name:  pytorch_macos_10_13_py3_lite_interpreter_build_test
 workflows:
   binary_builds:
     jobs:
@@ -7232,8 +7236,8 @@ workflows:
           name: pytorch_macos_10_13_py3_test
           requires:
             - pytorch_macos_10_13_py3_build
-      - pytorch_macos_10_13_py3_test_build_lite_interpreter:
-          name: pytorch_macos_10_13_py3_test_build_lite_interpreter
+      - pytorch_macos_10_13_py3_lite_interpreter_build_test:
+          name: pytorch_macos_10_13_py3_lite_interpreter_build_test
           requires:
             - pytorch_macos_10_13_py3_build
       - pytorch_linux_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1389,7 +1389,7 @@ jobs:
       - store_test_results:
           path: test/test-reports
 
-  pytorch_macos_10_13_py3_test_build_lite_interpreter:
+  pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
     macos:
@@ -2039,10 +2039,6 @@ jobs:
 ##############################################################################
 # Workflows
 ##############################################################################
-full_job_name:  pytorch_macos_10_15_py3_build
-full_job_name:  pytorch_macos_10_13_py3_build
-full_job_name:  pytorch_macos_10_13_py3_test
-full_job_name:  pytorch_macos_10_13_py3_lite_interpreter_build_test
 workflows:
   binary_builds:
     jobs:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -204,6 +204,28 @@
       - store_test_results:
           path: test/test-reports
 
+  pytorch_macos_10_13_py3_test_build_lite_interpreter:
+    environment:
+      BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
+    macos:
+      xcode: "12.0"
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/workspace
+      - run_brew_for_macos_build
+      - run:
+          name: Test
+          no_output_timeout: "1h"
+          command: |
+            set -e
+            export IN_CI=1
+            export BUILD_LITE_INTERPRETER=1
+            chmod a+x macos-lite-interpreter-build-test.sh
+            unbuffer macos-lite-interpreter-build-test.sh 2>&1 | ts
+      - store_test_results:
+          path: test/test-reports
+
   pytorch_android_gradle_build:
     environment:
       BUILD_ENVIRONMENT: pytorch-linux-xenial-py3-clang5-android-ndk-r19c-gradle-build

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -204,7 +204,7 @@
       - store_test_results:
           path: test/test-reports
 
-  pytorch_macos_10_13_py3_test_build_lite_interpreter:
+  pytorch_macos_10_13_py3_lite_interpreter_build_test:
     environment:
       BUILD_ENVIRONMENT: pytorch-macos-10.13-py3-test
     macos:

--- a/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
+++ b/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
@@ -1,0 +1,27 @@
+  # C++ API
+
+echo "BUILD_LITE_INTERPRETER: ${BUILD_LITE_INTERPRETER}"
+if [ "${BUILD_LITE_INTERPRETER}" == 1 ]; then
+    echo "Testing libtorch (lite interpreter)."
+
+    CPP_BUILD="$PWD/../cpp-build"
+    rm -rf $CPP_BUILD
+    mkdir -p $CPP_BUILD/caffe2
+
+    BUILD_LIBTORCH_PY=$PWD/tools/build_libtorch.py
+    pushd $CPP_BUILD/caffe2
+    VERBOSE=1 DEBUG=1 python $BUILD_LIBTORCH_PY
+    popd
+
+    python tools/download_mnist.py --quiet -d test/cpp/api/mnist
+
+    # Unfortunately it seems like the test can't load from miniconda3
+    # without these paths being set
+    export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
+    TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" "$CPP_BUILD"/caffe2/bin/test_api
+
+    assert_git_not_dirty
+else
+    echo "Skipping libtorch (lite interpreter)."
+fi


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52548 [PyTorch][CI] Enable test_lite_interpreter_runtime unittest in CI (macos)**
* #51419 [PyTorch] update CMake to build libtorch lite

