### PR TITLE
fix(docs): remove redundant hardsigmoid() in docstring to show up `inplace` parameter

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1711,9 +1711,7 @@ def sigmoid(input):
 
 
 def hardsigmoid(input: Tensor, inplace: bool = False) -> Tensor:
-    r"""hardsigmoid(input) -> Tensor
-
-    Applies the element-wise function
+    r"""Applies the element-wise function
 
     .. math::
         \text{Hardsigmoid}(x) = \begin{cases}


### PR DESCRIPTION
Fixes #50016
