### PR TITLE
[c10] Define __PRETTY_FUNCTION__ for EDG compiler frontend

### DIFF
--- a/c10/util/TypeIndex.h
+++ b/c10/util/TypeIndex.h
@@ -113,6 +113,15 @@ inline C10_TYPENAME_CONSTEXPR c10::string_view fully_qualified_type_name_impl() 
       "c10::string_view c10::util::detail::fully_qualified_type_name_impl() [T = ",
       "]",
       __PRETTY_FUNCTION__);
+#elif defined(__EDG__)
+  return extract(
+    #if C10_TYPENAME_SUPPORTS_CONSTEXPR
+      "constexpr c10::basic_string_view<char> c10::util::detail::fully_qualified_type_name_impl() [with T = ",
+    #else
+      "c10::basic_string_view<char> c10::util::detail::fully_qualified_type_name_impl() [with T = ",
+    #endif
+      "]",
+      __PRETTY_FUNCTION__);
 #elif defined(__GNUC__)
   return extract(
     #if C10_TYPENAME_SUPPORTS_CONSTEXPR


### PR DESCRIPTION
**Summary:** 
In EDG compiler frontend __PRETTY_FUNCTION__ implementation differs from GNUC.

For example,
x86_64, gcc 7.3.0
c10::string_view c10::util::detail::fully_qualified_type_name_impl() [with T = float; c10::string_view = c10::basic_string_view<char>]

e2k, lcc 1.25.11 (compiler for elbrus CPU, using EDG frontend)
c10::basic_string_view<char> c10::util::detail::fully_qualified_type_name_impl() [with T = float]

Commit defines prefix and suffix of __PRETTY_FUNCTION__ for EDG.