### PR TITLE
[PyTorch] Add comment to unify macro and rename one macro

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1095,7 +1095,7 @@ if(USE_ROCM)
 endif()
 
 if(BUILD_LITE_INTERPRETER)
-  target_compile_definitions(torch_cpu PRIVATE DBUILD_LITE_INTERPRETER)
+  target_compile_definitions(torch_cpu PRIVATE BUILD_LITE_INTERPRETER)
 endif()
 
 # Pass USE_DISTRIBUTED to torch_cpu, as some codes in jit/pickler.cpp and

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -230,7 +230,9 @@ void ProfilerThreadLocalState::pushRange(
       evt.setExtraArgs(saveExtraArgs(fn));
       evt.setFlops(computeFlops(std::string(fn.name().str()), evt.extraArgs()));
     }
-#if !defined DBUILD_LITE_INTERPRETER && !defined C10_MOBILE
+
+// TODO: will unify the two macros BUILD_LITE_INTERPRETER and C10_MOBILE soon.
+#if !defined BUILD_LITE_INTERPRETER && !defined C10_MOBILE
     // backward nodes source range corresponds to the forward node
     // TODO: consider using C++ stack trace
     if (config_.with_stack && fn.scope() != at::RecordScope::BACKWARD_FUNCTION) {


### PR DESCRIPTION
## Summary
Address comments in https://github.com/pytorch/pytorch/pull/52540
1. Add a comment to indicate that the macros `BUILD_LITE_INTERPRETER` and `C10_MOBILE` will be unified.
2. Rename the macro `DBUILD_LITE_INTERPRETER` to `BUILD_LITE_INTERPRETER`

## Test plan
1. `MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ USE_CUDA=0 DEBUG=1 MAX_JOBS=16 BUILD_LITE_INTERPRETER=1  python setup.py develop`
2. `/Users/chenlai/pytorch/cmake-build-debug/bin/test_lite_interpreter_runtime --gtest_filter=* --gtest_color=no`


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52573 [PyTorch] Add comment to unify macro and rename one macro**

Differential Revision: [D26572742](https://our.internmc.facebook.com/intern/diff/D26572742)