### PR TITLE
fix nest openmp performance bug in thnn_conv2d

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -22,6 +22,10 @@ inline void parallel_for(
   if (begin >= end) {
     return;
   }
+  if (end - begin == 1) {
+    f(begin, end);
+    return;
+  }
 #ifdef _OPENMP
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52577 fix nest openmp performance bug in thnn_conv2d**

Differential Revision: [D27063800](https://our.internmc.facebook.com/intern/diff/D27063800)