### PR TITLE
Enabled BFloat16 support for argmax & argmin on both CPU & CUDA

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -375,7 +375,7 @@ static void max_values_kernel_impl(TensorIterator& iter) {
 }
 
 static void argmax_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(1), "argmax_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmax_cpu", [&] {
     binary_kernel_reduce(
       iter,
       ArgMaxOps<scalar_t>{},
@@ -384,7 +384,7 @@ static void argmax_kernel_impl(TensorIterator &iter) {
 }
 
 static void argmin_kernel_impl(TensorIterator &iter) {
-  AT_DISPATCH_ALL_TYPES_AND(kHalf, iter.dtype(1), "argmin_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, iter.dtype(1), "argmin_cpu", [&] {
     binary_kernel_reduce(
       iter,
       ArgMinOps<scalar_t>{},

--- a/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
+++ b/aten/src/ATen/native/cuda/ReduceMinMaxKernel.cu
@@ -70,10 +70,12 @@ void argmin_kernel_cuda_impl(TensorIterator& iter) {
 };
 
 void argmax_kernel_cuda(TensorIterator& iter) {
+  // For float16 & bfloat16, instead of implementing is_nan and warp_shfl_down,
+  // we can convert float16 & bfloat16 to float and do all the operations in float.
   if (iter.dtype(1) == kHalf) {
-    // Instead of implementing is_nan and warp_shfl_down
-    // we can convert halves to float and do all the operations in float
     argmax_kernel_cuda_impl<at::Half, float>(iter);
+  } else if (iter.dtype(1) == kBFloat16) {
+    argmax_kernel_cuda_impl<at::BFloat16, float>(iter);
   } else {
     AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmax_cuda", [&]() {
       argmax_kernel_cuda_impl<scalar_t>(iter);
@@ -82,10 +84,12 @@ void argmax_kernel_cuda(TensorIterator& iter) {
 }
 
 void argmin_kernel_cuda(TensorIterator& iter) {
+  // For float16 & bfloat16, instead of implementing is_nan and warp_shfl_down,
+  // we can convert float16 & bfloat16 to float and do all the operations in float.
   if (iter.dtype(1) == kHalf) {
-    // Instead of implementing is_nan and warp_shfl_down
-    // we can convert halves to float and do all the operations in float
     argmin_kernel_cuda_impl<at::Half, float>(iter);
+  } else if (iter.dtype(1) == kBFloat16) {
+    argmin_kernel_cuda_impl<at::BFloat16, float>(iter);
   } else {
     AT_DISPATCH_ALL_TYPES(iter.dtype(1), "argmin_cuda", [&]() {
       argmin_kernel_cuda_impl<scalar_t>(iter);

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -14,7 +14,8 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests, onlyCPU, dtypes, dtypesIfCUDA, dtypesIfCPU,
-    onlyOnCPUAndCUDA, onlyCUDA, expectedAlertNondeterministic, largeTensorTest)
+    onlyOnCPUAndCUDA, onlyCUDA, expectedAlertNondeterministic, largeTensorTest,
+    precisionOverride)
 
 # TODO: replace with make_tensor
 def _generate_input(shape, dtype, device, with_extremal):
@@ -1361,8 +1362,7 @@ class TestReductions(TestCase):
         with self.assertRaisesRegex(RuntimeError, rmsg):
             torch.min(x, dim=0, out=(illegal_values, illegal_indices))
 
-    @dtypes(torch.float, torch.double, torch.int64, torch.int32, torch.int16)
-    @dtypesIfCUDA(torch.float, torch.double, torch.int64, torch.int32, torch.int16, torch.half)
+    @dtypes(*torch.testing.get_all_dtypes(include_bool=False, include_complex=False))
     def test_dim_arg_reduction_scalar(self, device, dtype):
         example = 4.0
 
@@ -1379,40 +1379,35 @@ class TestReductions(TestCase):
         self.assertEqual(x.argmin(dim=0, keepdim=True), torch.tensor(0, dtype=torch.int64))
 
 
-    def test_dim_reduction(self, device):
+    @precisionOverride({torch.float16: 1e-2, torch.bfloat16: 1e-2})
+    @dtypes(*(set(torch.testing.get_all_dtypes(include_bool=False, include_complex=False)) - {torch.uint8}))
+    def test_dim_reduction(self, device, dtype):
         example = [[-1, 2, 1], [5, 3, 6]]
 
-        types = [torch.double,
-                 torch.float,
-                 torch.int64,
-                 torch.int32,
-                 torch.int16]
-        if self.device_type == 'cuda':  # 'cpu' and 'xla' do not support half
-            types.append(torch.half)
-
         sum_dtype = {
+            torch.bfloat16: torch.bfloat16,
             torch.double: torch.double,
             torch.float: torch.float,
             torch.half: torch.half,
             torch.int64: torch.int64,
             torch.int32: torch.int64,
             torch.int16: torch.int64,
+            torch.int8: torch.int64
         }
 
         # This won't test for 256bit instructions, since we usually
         # only work on 1 cacheline (512bit) at a time and these
         # examples aren't big enough to trigger that.
-        for dtype in types:
-            x = torch.tensor(example, device=device, dtype=dtype)
-            self.assertEqual(x.sum().item(), 16)
-            self.assertEqual(x.sum(0), torch.tensor([4, 5, 7], dtype=sum_dtype[dtype]))
-            self.assertEqual(x.sum(1), torch.tensor([2, 14], dtype=sum_dtype[dtype]))
-            y = torch.tensor(example, device=device, dtype=sum_dtype[dtype])
-            torch.sum(x, 0, out=y)
-            self.assertEqual(x.sum(0), y)
+        x = torch.tensor(example, device=device, dtype=dtype)
+        self.assertEqual(x.sum().item(), 16)
+        self.assertEqual(x.sum(0), torch.tensor([4, 5, 7], dtype=sum_dtype[dtype]))
+        self.assertEqual(x.sum(1), torch.tensor([2, 14], dtype=sum_dtype[dtype]))
+        y = torch.tensor(example, device=device, dtype=sum_dtype[dtype])
+        torch.sum(x, 0, out=y)
+        self.assertEqual(x.sum(0), y)
 
         # Mean not supported for Int types
-        for dtype in types[:2]:
+        if dtype in [torch.float16, torch.bfloat16, torch.float32, torch.float64]:
             x = torch.tensor(example, device=device, dtype=dtype)
             self.assertEqual(x.mean().item(), 16.0 / 6)
             self.assertEqual(x.mean(0), torch.tensor([2.0, 2.5, 7.0 / 2], dtype=dtype))
@@ -1420,86 +1415,87 @@ class TestReductions(TestCase):
             self.assertEqual(x.mean(), x.mean((0, 1)))
 
         prod_dtype = {
+            torch.bfloat16: torch.bfloat16,
             torch.double: torch.double,
             torch.float: torch.float,
-            torch.half: torch.half,
+            torch.float16: torch.float16,
             torch.int64: torch.int64,
             torch.int32: torch.int64,
-            torch.int16: torch.int64
+            torch.int16: torch.int64,
+            torch.int8: torch.int64,
         }
 
-        for dtype in types:
+        # prod is not supported for float16 & bfloat16 on CPU
+        if not (self.device_type == 'cpu' and dtype in [torch.float16, torch.bfloat16]):
             x = torch.tensor(example, device=device, dtype=dtype)
             self.assertEqual(x.prod().item(), -180)
             self.assertEqual(x.prod(0), torch.tensor([-5, 6, 6], dtype=prod_dtype[dtype]))
             self.assertEqual(x.prod(1), torch.tensor([-2, 90], dtype=prod_dtype[dtype]))
 
-        for dtype in types:
-            x = torch.tensor(example, device=device, dtype=dtype)
+        x = torch.tensor(example, device=device, dtype=dtype)
 
-            self.assertEqual(x.min().item(), -1)
-            self.assertEqual(x.argmin().item(), 0)
+        self.assertEqual(x.min().item(), -1)
+        self.assertEqual(x.argmin().item(), 0)
 
-            # TODO: torch.min does not support the same operation as argmin
-            # for the same case, should we enable it?
-            self.assertEqual(x.argmin(dim=None).item(), 0)
+        # TODO: torch.min does not support the same operation as argmin
+        # for the same case, should we enable it?
+        self.assertEqual(x.argmin(dim=None).item(), 0)
 
-            self.assertEqual(x.min(0), (torch.tensor([-1, 2, 1], dtype=dtype),
-                                        torch.tensor([0, 0, 0], dtype=torch.int64)))
-            self.assertEqual(x.amin(0), torch.tensor([-1, 2, 1], dtype=dtype))
-            self.assertEqual(x.argmin(0), torch.tensor([0, 0, 0], dtype=torch.int64))
+        self.assertEqual(x.min(0), (torch.tensor([-1, 2, 1], dtype=dtype),
+                                    torch.tensor([0, 0, 0], dtype=torch.int64)))
+        self.assertEqual(x.amin(0), torch.tensor([-1, 2, 1], dtype=dtype))
+        self.assertEqual(x.argmin(0), torch.tensor([0, 0, 0], dtype=torch.int64))
 
-            self.assertEqual(x.min(dim=0, keepdim=True), (torch.tensor([[-1, 2, 1]], dtype=dtype),
-                                                          torch.tensor([[0, 0, 0]], dtype=torch.int64)))
-            self.assertEqual(x.amin(dim=0, keepdim=True), torch.tensor([[-1, 2, 1]], dtype=dtype))
-            self.assertEqual(x.argmin(dim=0, keepdim=True), torch.tensor([[0, 0, 0]], dtype=torch.int64))
+        self.assertEqual(x.min(dim=0, keepdim=True), (torch.tensor([[-1, 2, 1]], dtype=dtype),
+                         torch.tensor([[0, 0, 0]], dtype=torch.int64)))
+        self.assertEqual(x.amin(dim=0, keepdim=True), torch.tensor([[-1, 2, 1]], dtype=dtype))
+        self.assertEqual(x.argmin(dim=0, keepdim=True), torch.tensor([[0, 0, 0]], dtype=torch.int64))
 
-            self.assertEqual(x.min(1), (torch.tensor([-1, 3], dtype=dtype),
-                                        torch.tensor([0, 1], dtype=torch.int64)))
-            self.assertEqual(x.amin(1), torch.tensor([-1, 3], dtype=dtype))
-            self.assertEqual(x.argmin(1), torch.tensor([0, 1], dtype=torch.int64))
+        self.assertEqual(x.min(1), (torch.tensor([-1, 3], dtype=dtype),
+                         torch.tensor([0, 1], dtype=torch.int64)))
+        self.assertEqual(x.amin(1), torch.tensor([-1, 3], dtype=dtype))
+        self.assertEqual(x.argmin(1), torch.tensor([0, 1], dtype=torch.int64))
 
-            self.assertEqual(x.min(dim=1, keepdim=True), (torch.tensor([[-1], [3]], dtype=dtype),
-                                                          torch.tensor([[0], [1]], dtype=torch.int64)))
-            self.assertEqual(x.amin(dim=1, keepdim=True), torch.tensor([[-1], [3]], dtype=dtype))
-            self.assertEqual(x.argmin(dim=1, keepdim=True), torch.tensor([[0], [1]], dtype=torch.int64))
+        self.assertEqual(x.min(dim=1, keepdim=True), (torch.tensor([[-1], [3]], dtype=dtype),
+                         torch.tensor([[0], [1]], dtype=torch.int64)))
+        self.assertEqual(x.amin(dim=1, keepdim=True), torch.tensor([[-1], [3]], dtype=dtype))
+        self.assertEqual(x.argmin(dim=1, keepdim=True), torch.tensor([[0], [1]], dtype=torch.int64))
 
-            # test that non-contiguous tensors work
-            self.assertEqual(x[:, :2].min().item(), -1)
-            self.assertEqual(x[:, :2].amin().item(), -1)
-            self.assertEqual(x[:, :2].argmin().item(), 0)
+        # test that non-contiguous tensors work
+        self.assertEqual(x[:, :2].min().item(), -1)
+        self.assertEqual(x[:, :2].amin().item(), -1)
+        self.assertEqual(x[:, :2].argmin().item(), 0)
 
-        for dtype in types:
-            x = torch.tensor(example, device=device, dtype=dtype)
+        x = torch.tensor(example, device=device, dtype=dtype)
 
-            self.assertEqual(x.max().item(), 6)
-            self.assertEqual(x.amax().item(), 6)
-            self.assertEqual(x.argmax().item(), 5)
+        self.assertEqual(x.max().item(), 6)
+        self.assertEqual(x.amax().item(), 6)
+        self.assertEqual(x.argmax().item(), 5)
 
-            self.assertEqual(x.max(0), (torch.tensor([5, 3, 6], dtype=dtype),
-                                        torch.tensor([1, 1, 1], dtype=torch.int64)))
-            self.assertEqual(x.amax(0), torch.tensor([5, 3, 6], dtype=dtype))
-            self.assertEqual(x.argmax(dim=0), torch.tensor([1, 1, 1], dtype=torch.int64))
+        self.assertEqual(x.max(0), (torch.tensor([5, 3, 6], dtype=dtype),
+                                    torch.tensor([1, 1, 1], dtype=torch.int64)))
+        self.assertEqual(x.amax(0), torch.tensor([5, 3, 6], dtype=dtype))
+        self.assertEqual(x.argmax(dim=0), torch.tensor([1, 1, 1], dtype=torch.int64))
 
-            self.assertEqual(x.max(dim=0, keepdim=True), (torch.tensor([[5, 3, 6]], dtype=dtype),
-                                                          torch.tensor([[1, 1, 1]], dtype=torch.int64)))
-            self.assertEqual(x.amax(dim=0, keepdim=True), torch.tensor([[5, 3, 6]], dtype=dtype))
-            self.assertEqual(x.argmax(dim=0, keepdim=True), torch.tensor([[1, 1, 1]], dtype=torch.int64))
+        self.assertEqual(x.max(dim=0, keepdim=True), (torch.tensor([[5, 3, 6]], dtype=dtype),
+                                                      torch.tensor([[1, 1, 1]], dtype=torch.int64)))
+        self.assertEqual(x.amax(dim=0, keepdim=True), torch.tensor([[5, 3, 6]], dtype=dtype))
+        self.assertEqual(x.argmax(dim=0, keepdim=True), torch.tensor([[1, 1, 1]], dtype=torch.int64))
 
-            self.assertEqual(x.max(1), (torch.tensor([2, 6], dtype=dtype),
-                                        torch.tensor([1, 2], dtype=torch.int64)))
-            self.assertEqual(x.amax(1), torch.tensor([2, 6], dtype=dtype))
-            self.assertEqual(x.argmax(dim=1), torch.tensor([1, 2], dtype=torch.int64))
+        self.assertEqual(x.max(1), (torch.tensor([2, 6], dtype=dtype),
+                                    torch.tensor([1, 2], dtype=torch.int64)))
+        self.assertEqual(x.amax(1), torch.tensor([2, 6], dtype=dtype))
+        self.assertEqual(x.argmax(dim=1), torch.tensor([1, 2], dtype=torch.int64))
 
-            self.assertEqual(x.max(1, keepdim=True), (torch.tensor([[2], [6]], dtype=dtype),
-                                                      torch.tensor([[1], [2]], dtype=torch.int64)))
-            self.assertEqual(x.amax(1, keepdim=True), torch.tensor([[2], [6]], dtype=dtype))
-            self.assertEqual(x.argmax(dim=1, keepdim=True), torch.tensor([[1], [2]], dtype=torch.int64))
+        self.assertEqual(x.max(1, keepdim=True), (torch.tensor([[2], [6]], dtype=dtype),
+                                                  torch.tensor([[1], [2]], dtype=torch.int64)))
+        self.assertEqual(x.amax(1, keepdim=True), torch.tensor([[2], [6]], dtype=dtype))
+        self.assertEqual(x.argmax(dim=1, keepdim=True), torch.tensor([[1], [2]], dtype=torch.int64))
 
-            # test that non-contiguous tensors work
-            self.assertEqual(x[:, :2].max().item(), 5)
-            self.assertEqual(x[:, :2].amax().item(), 5)
-            self.assertEqual(x[:, :2].argmax().item(), 2)
+        # test that non-contiguous tensors work
+        self.assertEqual(x[:, :2].max().item(), 5)
+        self.assertEqual(x[:, :2].amax().item(), 5)
+        self.assertEqual(x[:, :2].argmax().item(), 2)
 
         dim_red_fns = [
             "mean", "median", "nanmedian", "mode", "norm", "prod",
@@ -1572,7 +1568,7 @@ class TestReductions(TestCase):
         self.assertEqual(result, expect)
 
     @onlyCUDA
-    @dtypes(torch.half, torch.float, torch.double)
+    @dtypes(torch.half, torch.float, torch.double, torch.bfloat16)
     def test_reduction_vectorize_along_input_corner(self, device, dtype):
         # 1D case: sum
         size = 1024 * 1024 * 64 + 3
@@ -1670,7 +1666,7 @@ class TestReductions(TestCase):
                 self.assertEqual(xs2[j].item(), size[1] - i)
 
     @onlyCUDA
-    @dtypes(torch.half, torch.float, torch.double)
+    @dtypes(torch.half, torch.float, torch.double, torch.bfloat16)
     def test_reduction_vectorize_along_output(self, device, dtype):
         def run_test(input_):
             M, N = input_.shape

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -679,6 +679,33 @@ def sample_inputs_amax_amin(op_info, device, dtype, requires_grad):
                              args=args)
                  for size, args in test_cases)
 
+def sample_inputs_argmax_argmin(op_info, device, dtype, requires_grad):
+    test_cases = (
+        ((2, 2, 2), ()),
+        ((2, 2, 2), (0,)),
+        ((2, 2, 2), (1,)),
+        ((2, 2, 2), (2,)),
+        ((2, 2, 2), (2, True,)),
+        ((2, 2, 2), (None,)),
+        ((), (0,)),
+        ((), ()),
+        ((), (None, True,)),
+        ((1,), ()),
+        ((1,), (0,)),
+        ((1,), (0, True)),
+        ((2,), ()),
+        ((2,), (0,)),
+        ((2,), (0, True)),
+        ((2, 2, 3), ()),
+        ((2, 2, 3), (0,)),
+        ((2, 2, 3), (1,)),
+        ((2, 2, 3), (None, True)),
+    )
+    return tuple(SampleInput((make_tensor(size, device, dtype,
+                                          requires_grad=requires_grad)),
+                             args=args)
+                 for size, args in test_cases)
+
 def sample_inputs_diff(op_info, device, dtype, requires_grad):
     test_cases = (
         ((1,), 0, None, None),
@@ -1929,8 +1956,6 @@ op_db: List[OpInfo] = [
     OpInfo('amax',
            op=torch.amax,
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_amax_amin,
            skips=(
@@ -1939,12 +1964,24 @@ op_db: List[OpInfo] = [
     OpInfo('amin',
            op=torch.amin,
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_amax_amin,
            skips=(
                # amin does not correctly warn when resizing out= inputs
+               SkipInfo('TestCommon', 'test_out'),)),
+    OpInfo('argmax',
+           dtypes=all_types_and(torch.float16, torch.bfloat16),
+           supports_autograd=False,
+           sample_inputs_func=sample_inputs_argmax_argmin,
+           skips=(
+               # argmax does not correctly warn when resizing out= inputs
+               SkipInfo('TestCommon', 'test_out'),)),
+    OpInfo('argmin',
+           dtypes=all_types_and(torch.float16, torch.bfloat16),
+           supports_autograd=False,
+           sample_inputs_func=sample_inputs_argmax_argmin,
+           skips=(
+               # argmin does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),)),
     UnaryUfuncInfo('asin',
                    aliases=('arcsin', ),


### PR DESCRIPTION
### SUMMARY

1. Enabled `BFloat16` support for `argmax` & `argmin` on both CPU & CUDA
2. Added `OpInfo`s for `argmax` & `argmin`
3. Enabled `test_argminmax_multiple` for `float16`. It can't be enabled for `bfloat16`, as comparison is done with numpy, which doesn't currently support `bfloat16`.
4. Enabled `test_dim_arg_reduction_scalar` for `float16` & `bfloat16`.
5. Enabled `test_reduction_vectorize_along_output` for `bfloat16`.
6. Enabled `test_reduction_vectorize_along_input_corner` for `bfloat16`.
7. Enabled `test_dim_reduction` for both `float16` and `bfloat16`, except that both of them don't support `prod` on CPU.
8. Unskipped `TestCommonCPU.test_variant_consistency_jit` for dtype `bfloat16` for `amax` & `amin`, as they're passing.