### PR TITLE
Probable fix for out of place BinaryOpScalar bad values and/or IMAs on 11.2

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachFunctors.cuh
+++ b/aten/src/ATen/native/cuda/ForeachFunctors.cuh
@@ -99,7 +99,8 @@ __device__ __forceinline__ void binary_op_scalar(
         }
         else {
             for(int i_start = 0; i_start < n && i_start < chunk_size; i_start += blockDim.x * kILP) {
-                load_args<depth>(r_args, args, i_start, chunk_size, n);
+                // Regardless if "depth" is 1 (for inplace) or 2 (for out of place), r_args has depth 1
+                load_args<1>(r_args, args, i_start, chunk_size, n);
 #pragma unroll
                 for(int ii = 0; ii < kILP; ii++) {
                     r_args[0][ii] = static_cast<T>(op(static_cast<opmath_t>(r_args[0][ii]),

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -307,7 +307,6 @@ class TestOptim(TestCase):
             )
 
     @skipIfRocm
-    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_multi_tensor_optimizers(self):
         if not torch.cuda.is_available():
             return
@@ -381,7 +380,6 @@ class TestOptim(TestCase):
             for p1, p2 in zip(res[0], res[1]):
                 self.assertEqual(p1, p2)
 
-    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adam(self):
         for optimizer in [optim.Adam, optim_mt.Adam]:
             self._test_basic_cases(
@@ -427,7 +425,6 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
                 optimizer(None, lr=1e-2, weight_decay=-1)
 
-    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adamw(self):
         for optimizer in [optim.AdamW, optim_mt.AdamW]:
             self._test_basic_cases(
@@ -462,7 +459,6 @@ class TestOptim(TestCase):
 
     # ROCm precision is too low to pass this test
     @skipIfRocm
-    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_adadelta(self):
         for optimizer in [optim.Adadelta, optim_mt.Adadelta]:
             self._test_basic_cases(
@@ -539,7 +535,6 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
-    @skipCUDAVersionIn([(11, 2)])  # test does not pass for CUDA 11.2
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
             self._test_basic_cases(


### PR DESCRIPTION
Should close https://github.com/pytorch/pytorch/issues/51992.

Suggested by one of our compiler people (Hari Sandanagobalane, don't know github handle). Also big thanks to @ngimel @zasdfgbnm for distilling a minimal repro of the original failures.

Good news is, the bug is a likely a foreach kernel bug and not an 11.2 compiler bug. Therefore, in theory it could affect any cuda version. We think 11.2 exposed it by optimizing more aggressively than previous toolkits.

IIRC some foreach tests were disabled because of this bug, but I'm not sure which or how many. @ngimel @izdeby what tests should I reenable?