### PR TITLE
[TensorPipe] Update [Cpu|Cuda]Buffer fwd declarations

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -21,10 +21,10 @@
 
 namespace tensorpipe {
 
-class CpuBuffer;
+struct CpuBuffer;
 
 #ifdef USE_CUDA_NOT_ROCM
-class CudaBuffer;
+struct CudaBuffer;
 #endif
 
 class Context;


### PR DESCRIPTION
They've changed from class to struct in tensorpipe repo, but have not
been updated in the header, which triggers compiler warning if clang is
used and would have triggered a linker error if the same code is
compiled with MSVC

