### PR TITLE
Fake Quantization support for f16 and f32

### DIFF
--- a/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
+++ b/aten/src/ATen/native/quantized/cuda/fake_quantize_core.cu
@@ -36,19 +36,20 @@ void fake_quantize_tensor_cachemask_kernel_cuda(
     .add_output(mask)
     .add_input(input)
     .build();
-
-  gpu_kernel_multiple_outputs(
-    iter,
-    [=] GPU_LAMBDA (float input_val) -> thrust::tuple<float, bool> {
-      const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
-      return {
-        // fake_quantized value
-        (fminf(quant_max, fmaxf(quant_min, qval)) - zero_point) * scale,
-        // mask for grad
-        ((quant_min <= qval) && (qval <= quant_max))
-      };
-    }
-  );
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(input.scalar_type(), "fake_quantize_tensor_cachemask_kernel_types", [&] {
+    gpu_kernel_multiple_outputs(
+      iter,
+      [=] GPU_LAMBDA (scalar_t input_val) -> thrust::tuple<scalar_t, bool> {
+        const auto qval = static_cast<int64_t>(std::nearbyint(input_val * inv_scale) + zero_point);
+        return {
+          // fake_quantized value
+          (fminf(quant_max, fmaxf(quant_min, qval)) - zero_point) * scale,
+          // mask for grad
+          ((quant_min <= qval) && (qval <= quant_max))
+        };
+      }
+    );
+  });
 }
 
 void _fake_quantize_grad_learnable_tensor_kernel_cuda(

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -60,7 +60,6 @@ std::tuple<Tensor, Tensor> fake_quantize_per_tensor_affine_cachemask(
     int64_t zero_point,
     int64_t quant_min,
     int64_t quant_max) {
-  TORCH_CHECK(self.scalar_type() == ScalarType::Float);
   TORCH_CHECK(
       quant_min <= quant_max,
       "`quant_min` should be less than or \
@@ -90,7 +89,6 @@ Returns:
 Tensor fake_quantize_per_tensor_affine_cachemask_backward(
     const Tensor& dY,
     const Tensor& mask) {
-  TORCH_CHECK(dY.scalar_type() == ScalarType::Float);
   TORCH_CHECK(mask.scalar_type() == ScalarType::Bool);
   TORCH_CHECK(mask.numel() == dY.numel(),
       "`mask` and `dY` are not the same size: ",

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -55,16 +55,18 @@ from torch.testing._internal.common_quantized import (
 
 # Reference method for fake quantize
 def _fake_quantize_per_tensor_affine_reference(X, scale, zero_point, quant_min, quant_max):
-    res = (torch.clamp(torch.round(X * (1.0 / scale) + zero_point), quant_min, quant_max) - zero_point) * scale
-    return res
+    dtype = X.dtype
+    res = ((torch.clamp(torch.round(X.to(torch.float32) * (1.0 / scale) + zero_point), quant_min, quant_max) - zero_point) * scale)
+    return res.to(dtype)
 
 # Reference method for the gradient of the fake quantize operator
 def _fake_quantize_per_tensor_affine_grad_reference(dY, X, scale, zero_point, quant_min, quant_max):
-    Xq = torch.round(X * (1.0 / scale) + zero_point)
+    dtype = X.dtype
+    Xq = torch.round(X.to(torch.float32) * (1.0 / scale) + zero_point)
     mask = (Xq >= quant_min) * (Xq <= quant_max)
     res = torch.zeros_like(dY)
     res[mask] = dY[mask]
-    return res
+    return res.to(dtype)
 
 # Reference method for the gradients of the fake quantize operator
 def _fake_quantize_learnable_per_tensor_affine_grad_reference(dY, X, scale, zero_point, quant_min, quant_max, device):
@@ -206,7 +208,6 @@ def to_tensor(X, device):
 
 NP_RANDOM_SEED = 19
 tolerance = 1e-6
-
 
 class TestObserver(QuantizationTestCase):
     @given(qdtype=st.sampled_from((torch.qint8, torch.quint8)),
@@ -862,8 +863,7 @@ class TestFakeQuantize(TestCase):
         Y_prime.backward(dout)
         np.testing.assert_allclose(dX.cpu(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
-    def test_forward_backward_per_tensor_cachemask_with_amp(self):
-        self.assertTrue(torch.cuda.is_available())
+    def test_forward_backward_per_tensor_with_amp(self):
         net = nn.Sequential(nn.Conv2d(1, 1, 3))
         net.qconfig = torch.quantization.get_default_qat_qconfig('fbgemm')
         net_prep = torch.quantization.prepare_qat(net)
@@ -874,24 +874,50 @@ class TestFakeQuantize(TestCase):
             out.backward()
             self.assertTrue(net_prep[0].weight.grad is not None)
 
-    def _test_forward_per_tensor_cachemask_impl(self, device):
-        for float_type in (torch.float32, torch.float16, torch.float64):
-            for torch_type in (torch.qint8, torch.quint8):
-                Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
-                # pick the scale + zp so that some values get clipped
-                for X in Xs:
-                    X = X.to(float_type)
-                    obs = torch.quantization.MinMaxObserver(torch_type)
-                    obs(X * 0.75)
-                    scale, zero_point = obs.calculate_qparams()
-                    scale, zero_point = float(scale), int(zero_point)
-                    quant_min, quant_max = obs._calculate_qmin_qmax()
+    def test_forward_per_tensor_half_precision_numerics(self):
+        scale = .1
+        zero = 0
+        maxi = 255
+        mini = 0
 
-                    Y_test = torch.fake_quantize_per_tensor_affine(
-                        X, scale, zero_point, quant_min, quant_max)
-                    Y_ref = _fake_quantize_per_tensor_affine_reference(
-                        X.cpu().to(torch.float32), scale, zero_point, quant_min, quant_max).to(device).to(float_type)
-                    self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
+        for i in range(20):
+            X1 = torch.randn(5, 5).to(torch.float16)
+            Y1 = torch.fake_quantize_per_tensor_affine(X1, scale, zero, mini, maxi)
+            Y1r = _fake_quantize_per_tensor_affine_reference(X1, scale, zero, mini, maxi)
+            self.assertTrue(torch.allclose(Y1, Y1r, rtol=tolerance, atol=tolerance))
+
+        # to force overflow
+        X2 = torch.tensor(2**15 + .01).to(torch.float16)
+        Y2 = torch.fake_quantize_per_tensor_affine(X2, scale, zero, mini, maxi)
+        Y2r = _fake_quantize_per_tensor_affine_reference(X2, scale, zero, mini, maxi)
+        self.assertTrue(torch.allclose(Y2, Y2r, rtol=tolerance, atol=tolerance))
+
+        scale = 10
+
+        # to force underflow
+        X3 = torch.tensor(2**-24).to(torch.float16)
+        Y3 = torch.fake_quantize_per_tensor_affine(X3, scale, zero, mini, maxi)
+        Y3r = _fake_quantize_per_tensor_affine_reference(X3, scale, zero, mini, maxi)
+        self.assertTrue(torch.allclose(Y3, Y3r, rtol=tolerance, atol=tolerance))
+
+    def _test_forward_per_tensor_cachemask_impl(self, device):
+        float_types = (torch.float32, torch.float16, torch.float64)
+        torch_types = (torch.qint8, torch.quint8)
+        Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
+        for float_type, torch_type, X in itertools.product(float_types, torch_types, Xs):
+            # pick the scale + zp so that some values get clipped
+            X = X.to(float_type)
+            obs = torch.quantization.MinMaxObserver(torch_type)
+            obs(X * 0.75)
+            scale, zero_point = obs.calculate_qparams()
+            scale, zero_point = float(scale), int(zero_point)
+            quant_min, quant_max = obs._calculate_qmin_qmax()
+
+            Y_test = torch.fake_quantize_per_tensor_affine(
+                X, scale, zero_point, quant_min, quant_max)
+            Y_ref = _fake_quantize_per_tensor_affine_reference(
+                X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
+            self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
 
     def test_forward_per_tensor_cachemask_cpu(self):
         device = torch.device('cpu')
@@ -903,30 +929,31 @@ class TestFakeQuantize(TestCase):
         self._test_forward_per_tensor_cachemask_impl(device)
 
     def _test_backward_per_tensor_cachemask_impl(self, device):
-        for float_type in (torch.float32, torch.float16, torch.float64):
-            for torch_type in (torch.qint8, torch.quint8):
-                X = torch.randn(4, 8).to(device).to(float_type)
-                X.requires_grad_()
-                # pick the scale + zp so that some values get clipped
-                obs = torch.quantization.MinMaxObserver(torch_type)
-                obs(X * 0.75)
-                scale, zero_point = obs.calculate_qparams()
-                scale, zero_point = float(scale), int(zero_point)
-                quant_min, quant_max = obs._calculate_qmin_qmax()
+        float_types = (torch.float32, torch.float16, torch.float64)
+        torch_types = (torch.qint8, torch.quint8)
+        for float_type, torch_type in itertools.product(float_types, torch_types):
+            X = torch.randn(4, 8).to(device).to(float_type)
+            X.requires_grad_()
+            # pick the scale + zp so that some values get clipped
+            obs = torch.quantization.MinMaxObserver(torch_type)
+            obs(X * 0.75)
+            scale, zero_point = obs.calculate_qparams()
+            scale, zero_point = float(scale), int(zero_point)
+            quant_min, quant_max = obs._calculate_qmin_qmax()
 
-                # forward pass
-                Y_test = torch.fake_quantize_per_tensor_affine(
-                    X, scale, zero_point, quant_min, quant_max)
-                Y_ref = _fake_quantize_per_tensor_affine_reference(
-                    X.cpu().to(torch.float32), scale, zero_point, quant_min, quant_max).to(device).to(float_type)
-                self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
+            # forward pass
+            Y_test = torch.fake_quantize_per_tensor_affine(
+                X, scale, zero_point, quant_min, quant_max)
+            Y_ref = _fake_quantize_per_tensor_affine_reference(
+                X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
+            self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
 
-                # backward pass
-                dout = torch.rand(X.shape, dtype=torch.float).to(device)
-                dX = _fake_quantize_per_tensor_affine_grad_reference(
-                    dout, X.to(torch.float32), scale, zero_point, quant_min, quant_max).to(float_type)
-                Y_test.backward(dout)
-                self.assertTrue(torch.allclose(dX, X.grad))
+            # backward pass
+            dout = torch.rand(X.shape, dtype=torch.float).to(device)
+            dX = _fake_quantize_per_tensor_affine_grad_reference(
+                dout, X, scale, zero_point, quant_min, quant_max)
+            Y_test.backward(dout)
+            self.assertTrue(torch.allclose(dX, X.grad))
 
     def test_backward_per_tensor_cachemask_cpu(self):
         device = torch.device('cpu')

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -862,22 +862,36 @@ class TestFakeQuantize(TestCase):
         Y_prime.backward(dout)
         np.testing.assert_allclose(dX.cpu(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
-    def _test_forward_per_tensor_cachemask_impl(self, device):
-        for torch_type in (torch.qint8, torch.quint8):
-            Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
-            # pick the scale + zp so that some values get clipped
-            for X in Xs:
-                obs = torch.quantization.MinMaxObserver(torch_type)
-                obs(X * 0.75)
-                scale, zero_point = obs.calculate_qparams()
-                scale, zero_point = float(scale), int(zero_point)
-                quant_min, quant_max = obs._calculate_qmin_qmax()
+    def test_forward_backward_per_tensor_cachemask_with_amp(self):
+        self.assertTrue(torch.cuda.is_available())
+        net = nn.Sequential(nn.Conv2d(1, 1, 3))
+        net.qconfig = torch.quantization.get_default_qat_qconfig('fbgemm')
+        net_prep = torch.quantization.prepare_qat(net)
 
-                Y_test = torch.fake_quantize_per_tensor_affine(
-                    X, scale, zero_point, quant_min, quant_max)
-                Y_ref = _fake_quantize_per_tensor_affine_reference(
-                    X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
-                self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
+        with torch.cuda.amp.autocast():
+            x=torch.randn(4,1,5,5)
+            out=net_prep(x).sum()
+            out.backward()
+            self.assertTrue(net_prep[0].weight.grad is not None)
+
+    def _test_forward_per_tensor_cachemask_impl(self, device):
+        for float_type in (torch.float32, torch.float16, torch.float64):
+            for torch_type in (torch.qint8, torch.quint8):
+                Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
+                # pick the scale + zp so that some values get clipped
+                for X in Xs:
+                    X = X.to(float_type)
+                    obs = torch.quantization.MinMaxObserver(torch_type)
+                    obs(X * 0.75)
+                    scale, zero_point = obs.calculate_qparams()
+                    scale, zero_point = float(scale), int(zero_point)
+                    quant_min, quant_max = obs._calculate_qmin_qmax()
+
+                    Y_test = torch.fake_quantize_per_tensor_affine(
+                        X, scale, zero_point, quant_min, quant_max)
+                    Y_ref = _fake_quantize_per_tensor_affine_reference(
+                        X.cpu().to(torch.float32), scale, zero_point, quant_min, quant_max).to(device).to(float_type)
+                    self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
 
     def test_forward_per_tensor_cachemask_cpu(self):
         device = torch.device('cpu')
@@ -889,29 +903,31 @@ class TestFakeQuantize(TestCase):
         self._test_forward_per_tensor_cachemask_impl(device)
 
     def _test_backward_per_tensor_cachemask_impl(self, device):
-        for torch_type in (torch.qint8, torch.quint8):
-            X = torch.randn(4, 8).to(device)
-            X.requires_grad_()
-            # pick the scale + zp so that some values get clipped
-            obs = torch.quantization.MinMaxObserver(torch_type)
-            obs(X * 0.75)
-            scale, zero_point = obs.calculate_qparams()
-            scale, zero_point = float(scale), int(zero_point)
-            quant_min, quant_max = obs._calculate_qmin_qmax()
+        for float_type in (torch.float32, torch.float16, torch.float64):
+            print(float_type)
+            for torch_type in (torch.qint8, torch.quint8):
+                X = torch.randn(4, 8).to(device).to(float_type)
+                X.requires_grad_()
+                # pick the scale + zp so that some values get clipped
+                obs = torch.quantization.MinMaxObserver(torch_type)
+                obs(X * 0.75)
+                scale, zero_point = obs.calculate_qparams()
+                scale, zero_point = float(scale), int(zero_point)
+                quant_min, quant_max = obs._calculate_qmin_qmax()
 
-            # forward pass
-            Y_test = torch.fake_quantize_per_tensor_affine(
-                X, scale, zero_point, quant_min, quant_max)
-            Y_ref = _fake_quantize_per_tensor_affine_reference(
-                X.cpu(), scale, zero_point, quant_min, quant_max).to(device)
-            self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
+                # forward pass
+                Y_test = torch.fake_quantize_per_tensor_affine(
+                    X, scale, zero_point, quant_min, quant_max)
+                Y_ref = _fake_quantize_per_tensor_affine_reference(
+                    X.cpu().to(torch.float32), scale, zero_point, quant_min, quant_max).to(device).to(float_type)
+                self.assertTrue(torch.allclose(Y_test, Y_ref, rtol=tolerance, atol=tolerance))
 
-            # backward pass
-            dout = torch.rand(X.shape, dtype=torch.float).to(device)
-            dX = _fake_quantize_per_tensor_affine_grad_reference(
-                dout, X, scale, zero_point, quant_min, quant_max)
-            Y_test.backward(dout)
-            self.assertTrue(torch.allclose(dX, X.grad))
+                # backward pass
+                dout = torch.rand(X.shape, dtype=torch.float).to(device)
+                dX = _fake_quantize_per_tensor_affine_grad_reference(
+                    dout, X.to(torch.float32), scale, zero_point, quant_min, quant_max).to(float_type)
+                Y_test.backward(dout)
+                self.assertTrue(torch.allclose(dX, X.grad))
 
     def test_backward_per_tensor_cachemask_cpu(self):
         device = torch.device('cpu')

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -869,8 +869,8 @@ class TestFakeQuantize(TestCase):
         net_prep = torch.quantization.prepare_qat(net)
 
         with torch.cuda.amp.autocast():
-            x=torch.randn(4,1,5,5)
-            out=net_prep(x).sum()
+            x = torch.randn(4, 1, 5, 5)
+            out = net_prep(x).sum()
             out.backward()
             self.assertTrue(net_prep[0].weight.grad is not None)
 
@@ -904,7 +904,6 @@ class TestFakeQuantize(TestCase):
 
     def _test_backward_per_tensor_cachemask_impl(self, device):
         for float_type in (torch.float32, torch.float16, torch.float64):
-            print(float_type)
             for torch_type in (torch.qint8, torch.quint8):
                 X = torch.randn(4, 8).to(device).to(float_type)
                 X.requires_grad_()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52612 Fake Quantization support for f16 and f32**

Used the float type macro to generalize the fake_quantization per tensor functions to f16 and f64.

Summary:

Test Plan:
added test to show it works in AMP and extended the forward and backward tests below to test float16 and float64 operations. Note: the reference function doesn't work with with these types so I had to convert in and back out of these types to compare.

```
>test python test/test_quantization.py 
TestFakeQuantize.test_forward_backward_per_tensor_with_amp
...

>test python test/test_quantization.py 
TestFakeQuantize.test_forward_per_tensor_half_precision_numerics
...

>test python test/test_quantization.py TestFakeQuantize.test_forward_per_tensor_cachemask_cpu
...

>test python test/test_quantization.py TestFakeQuantize.test_backwards_per_tensor_cachemask_cpu
...

>test python test/test_quantization.py TestFakeQuantize.test_forward_per_tensor_cachemask_cuda
...

>test python test/test_quantization.py TestFakeQuantize.test_backwards_per_tensor_cachemask_cuda
...

>test python test/test_quantization.py
Ran 484 tests in 356.999s

OK (skipped=8)
```

Reviewers:

Subscribers:

Tasks: T84497471

Tags:

Differential Revision: [D26586416](https://our.internmc.facebook.com/intern/diff/D26586416)