### PR TITLE
Use `int8_t` instead of `char` in [load|store]_scalar`

### DIFF
--- a/torch/csrc/utils/python_scalars.h
+++ b/torch/csrc/utils/python_scalars.h
@@ -11,7 +11,7 @@ namespace torch { namespace utils {
 inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
   switch (scalarType) {
     case at::kByte: *(uint8_t*)data = (uint8_t)THPUtils_unpackLong(obj); break;
-    case at::kChar: *(char*)data = (char)THPUtils_unpackLong(obj); break;
+    case at::kChar: *(int8_t*)data = (int8_t)THPUtils_unpackLong(obj); break;
     case at::kShort: *(int16_t*)data = (int16_t)THPUtils_unpackLong(obj); break;
     case at::kInt: *(int32_t*)data = (int32_t)THPUtils_unpackLong(obj); break;
     case at::kLong: *(int64_t*)data = THPUtils_unpackLong(obj); break;
@@ -34,7 +34,7 @@ inline void store_scalar(void* data, at::ScalarType scalarType, PyObject* obj) {
 inline PyObject* load_scalar(void* data, at::ScalarType scalarType) {
   switch (scalarType) {
     case at::kByte: return THPUtils_packInt64(*(uint8_t*)data);
-    case at::kChar: return THPUtils_packInt64(*(char*)data);
+    case at::kChar: return THPUtils_packInt64(*(int8_t*)data);
     case at::kShort: return THPUtils_packInt64(*(int16_t*)data);
     case at::kInt: return THPUtils_packInt64(*(int32_t*)data);
     case at::kLong: return THPUtils_packInt64(*(int64_t*)data);


### PR DESCRIPTION
Since `char` is not guaranteed to be signed on all platforms (it is unsigned on ARM)
Fixes https://github.com/pytorch/pytorch/issues/52146