### PR TITLE
[static runtime] Fix up deprecated exact equality in tests

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -154,7 +154,7 @@ TEST(StaticRuntime, LongModel) {
   torch::jit::StaticRuntime runtime(g);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   runtime.check_for_memory_leak();
-  EXPECT_TRUE(output_1.equal(output_2));
+  EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
 TEST(StaticRuntime, TrivialModel) {
@@ -173,7 +173,7 @@ TEST(StaticRuntime, TrivialModel) {
   torch::jit::StaticRuntime runtime(g);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   runtime.check_for_memory_leak();
-  EXPECT_TRUE(output_1.equal(output_2));
+  EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
 TEST(StaticRuntime, LeakyReLU) {
@@ -190,7 +190,7 @@ TEST(StaticRuntime, LeakyReLU) {
   torch::jit::StaticRuntime runtime(g);
   at::Tensor output_2 = runtime.run(input_tensors)[0];
   runtime.check_for_memory_leak();
-  EXPECT_TRUE(output_1.equal(output_2));
+  EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 }
 
 TEST(StaticRuntime, DeepWide) {
@@ -214,8 +214,7 @@ TEST(StaticRuntime, DeepWide) {
       std::vector<at::Tensor> input_tensors({ad_emb_packed, user_emb, wide});
       at::Tensor output_2 = runtime.run(input_tensors)[0];
       runtime.check_for_memory_leak();
-
-      EXPECT_TRUE(output_1.equal(output_2));
+      EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
     }
   }
 }
@@ -242,7 +241,7 @@ TEST(StaticRuntime, KWargsAPI_1) {
         runtime.check_for_memory_leak();
 
         at::Tensor output_2 = getTensor(output_ivalue);
-        EXPECT_TRUE(output_1.equal(output_2));
+        EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 
         // check for output aliasing
         EXPECT_EQ(output_ivalue.use_count(), 1);
@@ -287,7 +286,7 @@ TEST(StaticRuntime, KWargsAPI_2) {
         runtime.check_for_memory_leak();
 
         at::Tensor output_2 = getTensor(output_ivalue);
-        EXPECT_TRUE(output_1.equal(output_2));
+        EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
 
         // check for output aliasing
         EXPECT_EQ(output_ivalue.use_count(), 1);
@@ -331,8 +330,7 @@ TEST(StaticRuntime, CleanUpMemory) {
               {ad_emb_packed, user_emb, wide});
           at::Tensor output_2 = runtime.run(input_tensors)[0];
           runtime.check_for_memory_leak();
-
-          EXPECT_TRUE(output_1.equal(output_2));
+          EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
         }
       }
     }
@@ -364,7 +362,7 @@ TEST(StaticRuntime, FusionPass) {
       }
       EXPECT_TRUE(hit);
       auto output_2 = getTensor(module.forward(inputs));
-      EXPECT_TRUE(output_1.equal(output_2));
+      EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
     }
   }
 }


### PR DESCRIPTION
Summary:
swaps `.equals` with `torch::allclose`

tests are broken right now

Test Plan: buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- --run-disabled

Reviewed By: bertmaher, yinghai

Differential Revision: D26585079

