### PR TITLE
Modernize for-loops in caffe2/torch (#50797)

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -419,9 +419,9 @@ std::unordered_map<std::string, std::string> BytecodeDeserializer::
     return res;
   }
   auto ivalue_dict = readArchive("metadata", mcu).toGenericDict();
-  for (auto it = ivalue_dict.begin(); it != ivalue_dict.end(); ++it) {
-    auto key = it->key().toString()->string();
-    auto value = it->value().toString()->string();
+  for (const auto& it : ivalue_dict) {
+    const auto key = it.key().toString()->string();
+    const auto value = it.value().toString()->string();
     res[key] = value;
   }
   return res;

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -42,8 +42,8 @@ std::string getAtenOpPattern(
           extra_arg + "_scalar = aten::item(" + extra_arg + ")";
     }
 
-    for (size_t i = 0; i < _extra_op_args.size(); ++i) {
-      _extra_op_args[i] = _extra_op_args[i] + "_scalar";
+    for (auto& _extra_op_arg : _extra_op_args) {
+      _extra_op_arg = _extra_op_arg + "_scalar";
     }
   }
   const auto& extra_op_arg_list = getExtraArgList(_extra_op_args);

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -800,8 +800,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     const Var* buffer_var = v->buffer_var();
     std::vector<const Expr*> dims = v->dims();
     int total_byte_size = v->dtype().byte_size();
-    for (size_t i = 0; i < dims.size(); i++) {
-      dims[i]->accept(this);
+    for (auto& dim : dims) {
+      dim->accept(this);
       total_byte_size *= value_.as<int>();
     }
     int int_count = (total_byte_size + sizeof(int) - 1) / sizeof(int);

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -2212,8 +2212,7 @@ std::vector<CodeGen::CallArg> TensorExprKernel::prepareRunArgs(
   std::vector<CodeGen::CallArg> runArgs;
   runArgs.reserve(inputs.size() + tensorOutputs_.size());
 
-  for (size_t i = 0, e = inputs.size(); i < e; i++) {
-    auto const& input = inputs[i];
+  for (const auto& input : inputs) {
     if (input.isInt()) {
       runArgs.emplace_back(input.toInt());
     } else if (input.isDouble()) {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -64,11 +64,11 @@ class TORCH_API Block : public StmtNode<Block> {
  public:
   static Block* make(const std::vector<Stmt*>& stmts) {
     std::vector<Stmt*> valid_stmts;
-    for (size_t i = 0; i < stmts.size(); i++) {
-      if (!stmts[i]) {
+    for (auto& stmt : stmts) {
+      if (!stmt) {
         continue;
       }
-      valid_stmts.push_back(stmts[i]);
+      valid_stmts.push_back(stmt);
     }
     if (valid_stmts.empty()) {
       return nullptr;

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -81,14 +81,14 @@ void checkSingleTensor(const std::vector<at::Tensor>& tensors) {
 }
 
 void checkSameSizeAndType(
-    const at::Tensor& tensor,
+    const at::Tensor& t_in,
     const std::vector<at::Tensor>& tensors) {
-  for (const auto & i : tensors) {
-    if ((i.numel() != tensor.numel()) ||
-        (i.scalar_type() != tensor.scalar_type())) {
+  for (const auto & tensor : tensors) {
+    if ((tensor.numel() != t_in.numel()) ||
+        (tensor.scalar_type() != t_in.scalar_type())) {
       throw std::runtime_error("Tensors are not equal in size or data type");
     }
-    checkSingleTensorHelper(i);
+    checkSingleTensorHelper(tensor);
   }
 }
 

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -1,5 +1,6 @@
 #include <ATen/cuda/CUDAMultiStreamGuard.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/irange.h>
 
 #include <c10d/FileStore.hpp>
 #include <c10d/ProcessGroupGloo.hpp>
@@ -243,9 +244,9 @@ void runAsyncBroadcastTest(
       const auto expected = (rootRank * numTensors + rootTensor);
       for (size_t i = 0; i < numProcesses; i++) {
         auto tensors = tests[i].getTensors();
-        for (auto & tensor : tensors) {
-          auto data = tensor.data_ptr<float>();
-          for (auto k = 0; k < tensor.numel(); k++) {
+        for (const auto & tensor : tensors) {
+          const auto *const data = tensor.data_ptr<float>();
+          for (const auto k : c10::irange(tensor.numel())) {
             EXPECT_EQ(data[k], expected);
           }
         }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/50797

Modernize for-loops throughout caffe2/ subdirs to use ranged-loops where possible (all `.cpp` files were examined).

```
find caffe2/ -iname "*.cpp" > /home/rbarnes/files
buck run mode/opt foundation/clangr:clangr_local -- -j 10 --file=/home/rbarnes/files --multi --apply-replacements=true tidy '--checks=-*,modernize-loop-convert'
```

Test Plan: Sandcastle tests

Differential Revision: D26585065

