### PR TITLE
[test] testing arm64 package name changes

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -61,7 +61,8 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+# retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+retry git clone -q -b fix-arm64-package-names https://github.com/janeyx99/builder.git "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1


### PR DESCRIPTION
The current mac 3.8 wheels and conda packages collide in name with the cross compiled ones. This tests a builder change that tries to differentiate them.