### PR TITLE
Pass child error to parent in distributed tests.

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -364,6 +364,8 @@ class MultiProcessTestCase(TestCase):
         # We're retrieving a corresponding test and executing it.
         try:
             getattr(self, test_name)()
+            # Close pipe after done with test.
+            pipe.close()
         except Exception as e:
             logging.error(
                 'Caught exception: \n{}exiting process with exit code: {}'
@@ -415,6 +417,10 @@ class MultiProcessTestCase(TestCase):
             else:
                 self._check_return_codes(elapsed_time)
         finally:
+            # Close all pipes
+            for pid, pipe in self.pid_to_pipe.items():
+                pipe.close()
+
             global TEST_SKIPS
             TEST_SKIPS = self.old_test_skips
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -355,6 +355,11 @@ class MultiProcessTestCase(TestCase):
         self.rank = rank
         self.file_name = file_name
 
+        self.run_test(test_name, pipe)
+        # exit to avoid run teardown() for fork processes
+        sys.exit(0)
+
+    def run_test(self, test_name, pipe):
         # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
         # We're retrieving a corresponding test and executing it.
         try:
@@ -368,8 +373,6 @@ class MultiProcessTestCase(TestCase):
             pipe.send(traceback.format_exc())
             pipe.close()
             sys.exit(MultiProcessTestCase.TEST_ERROR_EXIT_CODE)
-        # exit to avoid run teardown() for fork processes
-        sys.exit(0)
 
     def _join_processes(self, fn):
         timeout = get_timeout(self.id())

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -285,12 +285,7 @@ class MultiProcessTestCase(TestCase):
             if self.rank == self.MAIN_PROCESS_RANK:
                 self._join_processes(fn)
             else:
-                try:
-                    fn()
-                except Exception as e:
-                    logging.error('Caught exception: \n{}exiting process with exit code: {}'
-                                  .format(traceback.format_exc(), MultiProcessTestCase.TEST_ERROR_EXIT_CODE))
-                    sys.exit(MultiProcessTestCase.TEST_ERROR_EXIT_CODE)
+                fn()
         return types.MethodType(wrapper, self)
 
     # The main process spawns N subprocesses that run the test.
@@ -310,6 +305,8 @@ class MultiProcessTestCase(TestCase):
         self.file_name = tempfile.NamedTemporaryFile(delete=False).name
         global TEST_SKIPS
         self.old_test_skips = TEST_SKIPS.copy()
+        # pid to pipe consisting of error message from process.
+        self.pid_to_pipe = {}
 
     def tearDown(self):
         super().tearDown()
@@ -334,11 +331,14 @@ class MultiProcessTestCase(TestCase):
 
         self.processes = []
         for rank in range(int(self.world_size)):
+            parent_conn, child_conn = torch.multiprocessing.Pipe()
             process = proc(
                 target=self.__class__._run,
                 name='process ' + str(rank),
-                args=(rank, self._current_test_name(), self.file_name))
+                args=(rank, self._current_test_name(), self.file_name, child_conn))
             process.start()
+            logging.info('Started process {} with pid {}'.format(rank, process.pid))
+            self.pid_to_pipe[process.pid] = parent_conn
             self.processes.append(process)
 
     def _fork_processes(self):
@@ -350,14 +350,24 @@ class MultiProcessTestCase(TestCase):
         self._start_processes(proc)
 
     @classmethod
-    def _run(cls, rank, test_name, file_name):
+    def _run(cls, rank, test_name, file_name, pipe):
         self = cls(test_name)
         self.rank = rank
         self.file_name = file_name
 
         # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
         # We're retrieving a corresponding test and executing it.
-        getattr(self, test_name)()
+        try:
+            getattr(self, test_name)()
+        except Exception as e:
+            logging.error(
+                'Caught exception: \n{}exiting process with exit code: {}'
+                .format(traceback.format_exc(), MultiProcessTestCase.TEST_ERROR_EXIT_CODE)
+            )
+            # Send error to parent process.
+            pipe.send(traceback.format_exc())
+            pipe.close()
+            sys.exit(MultiProcessTestCase.TEST_ERROR_EXIT_CODE)
         # exit to avoid run teardown() for fork processes
         sys.exit(0)
 
@@ -432,10 +442,13 @@ class MultiProcessTestCase(TestCase):
             if p.exitcode == MultiProcessTestCase.TEST_ERROR_EXIT_CODE
         ]
         if errored_processes:
-            error = "Processes {} exited with error code {}".format(
-                " ".join([str(i) for (i, _) in errored_processes]),
-                MultiProcessTestCase.TEST_ERROR_EXIT_CODE,
-            )
+            error = ""
+            for i, process in errored_processes:
+                # Get error from pipe.
+                error_message = self.pid_to_pipe[process.pid].recv()
+                error += "Process {} exited with error code {} and exception:\n{}\n".format(
+                    i, MultiProcessTestCase.TEST_ERROR_EXIT_CODE, error_message)
+
             raise RuntimeError(error)
         # If no process exited uncleanly, we check for timeouts, and then ensure
         # each process exited cleanly.

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -349,7 +349,7 @@ class TestDistBackend(MultiProcessTestCase):
         return "{}{file_name}".format(FILE_SCHEMA, file_name=self.file_name)
 
     @classmethod
-    def _run(cls, rank, test_name, file_name):
+    def _run(cls, rank, test_name, file_name, pipe):
         if BACKEND == 'nccl' and not torch.cuda.is_available():
             sys.exit(TEST_SKIPS['no_cuda'].exit_code)
         self = cls(test_name)
@@ -378,9 +378,7 @@ class TestDistBackend(MultiProcessTestCase):
         # immediately exiting due to a skip doesn't cause flakiness.
         self._barrier()
 
-        # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
-        # We're retreiving a corresponding test and executing it.
-        getattr(self, test_name)()
+        self.run_test(test_name, pipe)
         self._barrier()
         dist.destroy_process_group()
         sys.exit(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52632 Pass child error to parent in distributed tests.**

Distributed tests run in a multiprocessing environment, where a parent
process drives the tests through several child processes. As a result, when a
child process fails the parent only prints the following:

```
Process 0 exited with error code 10
```

The child process also logs its own exception, but it is cumberson to go
through the logs and track this down.

To alleviate this, I've added a bunch of pipes for each child process so that
the child process writes the error to the pipe before exiting and the parent
process can read the appropriate error from the pipe and display it.

The new output printed by the parent is as follows:


```
> RuntimeError: Process 0 exited with error code 10 and exception:
Traceback (most recent call last):
  File "torch/testing/_internal/common_distributed.py", line 361, in _run
    getattr(self, test_name)()
  File "torch/testing/_internal/common_distributed.py", line 288, in wrapper
    fn()
  File "test_c10d.py", line 789, in test_broadcast_checks
    pg.broadcast([t1], opts)
ValueError: ProcessGroupGloo::broadcast: invalid root rank: -1

Process 1 exited with error code 10 and exception:
Traceback (most recent call last):
  File "torch/testing/_internal/common_distributed.py", line 361, in _run
    getattr(self, test_name)()
  File "torch/testing/_internal/common_distributed.py", line 288, in wrapper
    fn()
  File "test_c10d.py", line 789, in test_broadcast_checks
    pg.broadcast([t1], opts)
ValueError: ProcessGroupGloo::broadcast: invalid root rank: -1

Process 2 exited with error code 10 and exception:
Traceback (most recent call last):
  File "torch/testing/_internal/common_distributed.py", line 361, in _run
    getattr(self, test_name)()
  File "torch/testing/_internal/common_distributed.py", line 288, in wrapper
    fn()
  File "test_c10d.py", line 789, in test_broadcast_checks
    pg.broadcast([t1], opts)
ValueError: ProcessGroupGloo::broadcast: invalid root rank: -1

Process 3 exited with error code 10 and exception:
Traceback (most recent call last):
  File "torch/testing/_internal/common_distributed.py", line 361, in _run
    getattr(self, test_name)()
  File "torch/testing/_internal/common_distributed.py", line 288, in wrapper
    fn()
  File "test_c10d.py", line 789, in test_broadcast_checks
    pg.broadcast([t1], opts)
ValueError: ProcessGroupGloo::broadcast: invalid root rank: -1
```

Differential Revision: [D26589274](https://our.internmc.facebook.com/intern/diff/D26589274/)