### PR TITLE
Clarify usage and output of tools/test_history.py

### DIFF
--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -4,7 +4,6 @@ import argparse
 import bz2
 import json
 import subprocess
-import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -199,7 +198,7 @@ if __name__ == "__main__":
     parser.add_argument(
         '--delta',
         type=int,
-        help='minimum number of hours between rows',
+        help='minimum number of hours between commits',
         default=12,
     )
     parser.add_argument(
@@ -231,7 +230,7 @@ if __name__ == "__main__":
 
     jobs = None if args.all else args.job
     if jobs == []:  # no jobs, and not None (which would mean all jobs)
-        sys.exit('No jobs specified.')
+        parser.error('No jobs specified.')
 
     commits = get_git_commit_history(path=args.pytorch, ref=args.ref)
 

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -200,6 +200,7 @@ def display_history(
     suite_name: Optional[str],
     test_name: str,
     delta: int,
+    sha_length: int,
     mode: str,
     digits: int,
 ) -> None:
@@ -239,7 +240,7 @@ def display_history(
                 test_name=test_name,
             )
         for line in lines:
-            print(f"{time} {sha} {line}".rstrip())
+            print(f"{time} {sha[:sha_length]} {line}".rstrip())
 
 
 class HelpFormatter(
@@ -264,45 +265,48 @@ In multiline mode, each line next includes the name of a CircleCI job,
 followed by the time of the specified test in that job at that commit.
 Example:
 
-    $ tools/test_history.py multiline --ref=594a66 --delta=0 test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
-    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
-    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
-    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
-    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78 pytorch_linux_xenial_py3_6_gcc7_test 0.449s
-    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268 pytorch_linux_xenial_py3_6_gcc5_4_test 0.361s
-    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268 pytorch_linux_xenial_py3_6_gcc7_test 0.454s
-    2021-02-10 02:09:10 2e35fe953553247d8a22fc38b039374e426f13b8 (no reports in S3)
-    2021-02-10 02:09:07 ff73be7e45616fe106b9e5040bc091ca5cdbfc7f (no reports in S3)
-    2021-02-10 02:05:39 74082f0d6f8dfd60f28c0de0fe43bcb97b95ee5a (no reports in S3)
-    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc pytorch_linux_xenial_py3_6_gcc5_4_test 0.414s (1 S3 reports omitted)
-    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc pytorch_linux_xenial_py3_6_gcc7_test 0.377s (1 S3 reports omitted)
+    $ tools/test_history.py multiline --ref=594a66 --delta=0 --sha-length=8 \
+      test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
+    2021-02-10 03:13:34 594a66d7 pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
+    2021-02-10 03:13:34 594a66d7 pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
+    2021-02-10 02:13:25 9c0caf03 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
+    2021-02-10 02:13:25 9c0caf03 pytorch_linux_xenial_py3_6_gcc7_test 0.449s
+    2021-02-10 02:09:14 602434bc pytorch_linux_xenial_py3_6_gcc5_4_test 0.361s
+    2021-02-10 02:09:14 602434bc pytorch_linux_xenial_py3_6_gcc7_test 0.454s
+    2021-02-10 02:09:10 2e35fe95 (no reports in S3)
+    2021-02-10 02:09:07 ff73be7e (no reports in S3)
+    2021-02-10 02:05:39 74082f0d (no reports in S3)
+    2021-02-09 23:42:29 0620c96f pytorch_linux_xenial_py3_6_gcc5_4_test 0.414s (1 S3 reports omitted)
+    2021-02-09 23:42:29 0620c96f pytorch_linux_xenial_py3_6_gcc7_test 0.377s (1 S3 reports omitted)
 
 Another multiline example, this time with the --all flag:
 
-    $ tools/test_history.py multiline --all --ref=321b9 test_qr_square_many_batched_complex_cuda
-    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 424.284s
-    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
-    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 402.572s
-    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.164s
-    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 436.732s
-    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
-    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 407.616s
-    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.044s
+    $ tools/test_history.py multiline --all --ref=321b9 --sha-length=8 \
+      test_qr_square_many_batched_complex_cuda
+    2021-01-07 02:04:56 321b9883 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 424.284s
+    2021-01-07 02:04:56 321b9883 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
+    2021-01-07 02:04:56 321b9883 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 402.572s
+    2021-01-07 02:04:56 321b9883 pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.164s
+    2021-01-06 12:58:28 fcb69d2e pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 436.732s
+    2021-01-06 12:58:28 fcb69d2e pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
+    2021-01-06 12:58:28 fcb69d2e pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 407.616s
+    2021-01-06 12:58:28 fcb69d2e pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.044s
 
 In columns mode, the name of the job isn't printed, but the order of the
 columns is guaranteed to match the order of the jobs passed on the
 command line. Example:
 
-    $ tools/test_history.py columns --ref=3cf783 --delta=0 test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
-    2021-02-10 04:18:50 3cf78395cbc32fa9c83b585c9ec63f960b32d17f    0.644s    0.312s
-    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff    0.360s  errored
-    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78    0.819s    0.449s
-    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268    0.361s    0.454s
-    2021-02-10 02:09:10 2e35fe953553247d8a22fc38b039374e426f13b8
-    2021-02-10 02:09:07 ff73be7e45616fe106b9e5040bc091ca5cdbfc7f
-    2021-02-10 02:05:39 74082f0d6f8dfd60f28c0de0fe43bcb97b95ee5a
-    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc    0.414s    0.377s (2 S3 reports omitted)
-    2021-02-09 23:27:53 33afb5f19f4e427f099653139ae45b661b8bc596    0.381s    0.294s
+    $ tools/test_history.py columns --ref=3cf783 --delta=0 --sha-length=8 \
+      test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
+    2021-02-10 04:18:50 3cf78395    0.644s    0.312s
+    2021-02-10 03:13:34 594a66d7    0.360s  errored
+    2021-02-10 02:13:25 9c0caf03    0.819s    0.449s
+    2021-02-10 02:09:14 602434bc    0.361s    0.454s
+    2021-02-10 02:09:10 2e35fe95
+    2021-02-10 02:09:07 ff73be7e
+    2021-02-10 02:05:39 74082f0d
+    2021-02-09 23:42:29 0620c96f    0.414s    0.377s (2 S3 reports omitted)
+    2021-02-09 23:27:53 33afb5f1    0.381s    0.294s
 
 Minor note: in columns mode, a blank cell means that no report was found
 in S3, while the word "absent" means that a report was found but the
@@ -330,6 +334,12 @@ indicated test was not found in that report.
         type=int,
         help='minimum number of hours between commits',
         default=12,
+    )
+    parser.add_argument(
+        '--sha-length',
+        type=int,
+        help='length of the prefix of the SHA1 hash to show',
+        default=40,
     )
     parser.add_argument(
         '--digits',
@@ -375,6 +385,7 @@ indicated test was not found in that report.
         test_name=args.test,
         delta=args.delta,
         mode=args.mode,
+        sha_length=args.sha_length,
         digits=args.digits,
     )
 

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -4,11 +4,13 @@ import argparse
 import bz2
 import json
 import subprocess
+from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import boto3  # type: ignore[import]
 import botocore  # type: ignore[import]
+from typing_extensions import TypedDict
 
 
 def get_git_commit_history(
@@ -25,108 +27,169 @@ def get_git_commit_history(
     ]
 
 
-def get_ossci_jsons(
-    *,
-    bucket: Any,
-    sha: str,
-    jobs: Optional[List[str]]
-) -> Dict[str, Any]:
-    prefix = f"test_time/{sha}/"
-    objs: List[Any]
+def get_object_summaries(*, bucket: Any, sha: str) -> Dict[str, List[Any]]:
+    summaries = list(bucket.objects.filter(Prefix=f'test_time/{sha}/'))
+    by_job = defaultdict(list)
+    for summary in summaries:
+        job = summary.key.split('/')[2]
+        by_job[job].append(summary)
+    return dict(by_job)
+
+
+class Case(TypedDict):
+    name: str
+    seconds: float
+    errored: bool
+    failed: bool
+    skipped: bool
+
+
+class Suite(TypedDict):
+    total_seconds: float
+    cases: List[Case]
+
+
+class ReportMeta(TypedDict):
+    build_pr: str
+    build_tag: str
+    build_sha1: str
+    build_branch: str
+    build_job: str
+    build_workflow_id: str
+
+
+class Report(ReportMeta):
+    total_seconds: float
+    suites: Dict[str, Suite]
+
+
+def get_jsons(
+    jobs: Optional[List[str]],
+    summaries: Dict[str, Any],
+) -> Dict[str, Report]:
     if jobs is None:
-        objs = list(bucket.objects.filter(Prefix=prefix))
+        keys = sorted(summaries.keys())
     else:
-        objs = []
-        for job in jobs:
-            objs.extend(list(bucket.objects.filter(Prefix=f"{prefix}{job}/")))
-    # initial pass to avoid downloading more than necessary
-    # in the case where there are multiple reports for a single sha+job
-    uniqueified = {obj.key.split('/')[2]: obj for obj in objs}
+        keys = [job for job in jobs if job in summaries]
     return {
-        job: json.loads(bz2.decompress(obj.get()['Body'].read()))
-        for job, obj in uniqueified.items()
+        job: json.loads(bz2.decompress(summaries[job].get()['Body'].read()))
+        for job in keys
     }
 
 
-def get_case(
+def get_cases(
     *,
-    data: Any,
-    suite_name: str,
+    data: Report,
+    suite_name: Optional[str],
     test_name: str,
-) -> Optional[Dict[str, Any]]:
-    suite = data.get('suites', {}).get(suite_name)
-    if suite:
-        testcase_times = {
-            case['name']: case
-            for case in suite['cases']
-        }
-        return testcase_times.get(test_name)
-    return None
+) -> List[Case]:
+    cases = []
+    suites = data['suites']
+    for name, suite in suites.items():
+        if name == suite_name or not suite_name:
+            for case in suite['cases']:
+                if case['name'] == test_name:
+                    cases.append(case)
+    return cases
 
 
-def case_status(case: Dict[str, Any]) -> Optional[str]:
+def case_status(case: Case) -> Optional[str]:
     for k in {'errored', 'failed', 'skipped'}:
-        if case[k]:
+        if case[k]:  # type: ignore[misc]
             return k
     return None
 
 
 def make_column(
     *,
-    data: Any,
-    suite_name: str,
+    data: Optional[Report],
+    suite_name: Optional[str],
     test_name: str,
     digits: int,
-) -> str:
+) -> Tuple[str, int]:
     decimals = 3
     num_length = digits + 1 + decimals
-    case = get_case(data=data, suite_name=suite_name, test_name=test_name)
-    if case:
-        status = case_status(case)
-        if status:
-            return f'{status.rjust(num_length)} '
+    if data:
+        cases = get_cases(
+            data=data,
+            suite_name=suite_name,
+            test_name=test_name
+        )
+        if cases:
+            case = cases[0]
+            status = case_status(case)
+            omitted = len(cases) - 1
+            if status:
+                return f'{status.rjust(num_length)} ', omitted
+            else:
+                return f'{case["seconds"]:{num_length}.{decimals}f}s', omitted
         else:
-            return f'{case["seconds"]:{num_length}.{decimals}f}s'
-    return ' ' * (num_length + 1)
+            return f'{"absent".rjust(num_length)} ', 0
+    else:
+        return ' ' * (num_length + 1), 0
 
 
 def make_columns(
     *,
-    bucket: Any,
-    sha: str,
     jobs: List[str],
-    suite_name: str,
+    jsons: Dict[str, Report],
+    omitted: Dict[str, int],
+    suite_name: Optional[str],
     test_name: str,
     digits: int,
 ) -> str:
-    jsons = get_ossci_jsons(bucket=bucket, sha=sha, jobs=jobs)
-    return ' '.join(
-        make_column(
-            data=jsons.get(job, {}),
+    columns = []
+    total_omitted = 0
+    total_suites = 0
+    for job in jobs:
+        data = jsons.get(job)
+        column, omitted_suites = make_column(
+            data=data,
             suite_name=suite_name,
             test_name=test_name,
             digits=digits,
         )
-        for job in jobs
-    )
+        columns.append(column)
+        total_suites += omitted_suites
+        if job in omitted:
+            total_omitted += omitted[job]
+    if total_omitted > 0:
+        columns.append(f'({total_omitted} S3 reports omitted)')
+    if total_suites > 0:
+        columns.append(f'({total_suites}) matching suites omitted)')
+    return ' '.join(columns)
 
 
 def make_lines(
     *,
-    bucket: Any,
-    sha: str,
-    jobs: Optional[List[str]],
-    suite_name: str,
+    jobs: Set[str],
+    jsons: Dict[str, Report],
+    omitted: Dict[str, int],
+    suite_name: Optional[str],
     test_name: str,
 ) -> List[str]:
-    jsons = get_ossci_jsons(bucket=bucket, sha=sha, jobs=jobs)
     lines = []
     for job, data in jsons.items():
-        case = get_case(data=data, suite_name=suite_name, test_name=test_name)
-        if case:
+        cases = get_cases(
+            data=data,
+            suite_name=suite_name,
+            test_name=test_name,
+        )
+        if cases:
+            case = cases[0]
             status = case_status(case)
-            lines.append(f'{job} {case["seconds"]} {status or ""}')
-    return lines
+            line = f'{job} {case["seconds"]}s{f" {status}" if status else ""}'
+            if job in omitted and omitted[job] > 0:
+                line += f' ({omitted[job]} S3 reports omitted)'
+            if len(cases) > 1:
+                line += f' ({len(cases) - 1} matching suites omitted)'
+            lines.append(line)
+        elif job in jobs:
+            lines.append(f'{job} (test not found)')
+    if lines:
+        return lines
+    else:
+        return ['(no reports in S3)']
 
 
 def display_history(
@@ -134,25 +197,34 @@ def display_history(
     bucket: Any,
     commits: List[Tuple[str, datetime]],
     jobs: Optional[List[str]],
-    suite_name: str,
+    suite_name: Optional[str],
     test_name: str,
     delta: int,
     mode: str,
     digits: int,
 ) -> None:
-    any_yet = False
     prev_time = datetime.now()
     for sha, time in commits:
         if (prev_time - time).total_seconds() < delta * 3600:
             continue
         prev_time = time
-        lines: List[str]
+        summaries = get_object_summaries(bucket=bucket, sha=sha)
+        # we assume that get_object_summaries doesn't return empty lists
+        jsons = get_jsons(
+            jobs=jobs,
+            summaries={job: l[0] for job, l in summaries.items()},
+        )
+        omitted = {
+            job: len(l) - 1
+            for job, l in summaries.items()
+            if len(l) > 1
+        }
         if mode == 'columns':
             assert jobs is not None
             lines = [make_columns(
-                bucket=bucket,
-                sha=sha,
                 jobs=jobs,
+                jsons=jsons,
+                omitted=omitted,
                 suite_name=suite_name,
                 test_name=test_name,
                 digits=digits,
@@ -160,25 +232,83 @@ def display_history(
         else:
             assert mode == 'multiline'
             lines = make_lines(
-                bucket=bucket,
-                sha=sha,
-                jobs=jobs,
+                jobs=set(jobs or []),
+                jsons=jsons,
+                omitted=omitted,
                 suite_name=suite_name,
                 test_name=test_name,
             )
-        if lines:
-            any_yet = True
-        elif not any_yet:
-            lines = [f'no jobs found with test {suite_name}.{test_name}']
         for line in lines:
             print(f"{time} {sha} {line}".rstrip())
 
 
-if __name__ == "__main__":
+class HelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    pass
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         __file__,
-        description='Display the history of a test.',
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description='''
+Display the history of a test.
+
+Each line of (non-error) output starts with the timestamp and SHA1 hash
+of the commit it refers to, in this format:
+
+    YYYY-MM-DD hh:mm:ss 0123456789abcdef0123456789abcdef01234567
+
+In multiline mode, each line next includes the name of a CircleCI job,
+followed by the time of the specified test in that job at that commit.
+Example:
+
+    $ tools/test_history.py multiline --ref=594a66 --delta=0 test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
+    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
+    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
+    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
+    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78 pytorch_linux_xenial_py3_6_gcc7_test 0.449s
+    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268 pytorch_linux_xenial_py3_6_gcc5_4_test 0.361s
+    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268 pytorch_linux_xenial_py3_6_gcc7_test 0.454s
+    2021-02-10 02:09:10 2e35fe953553247d8a22fc38b039374e426f13b8 (no reports in S3)
+    2021-02-10 02:09:07 ff73be7e45616fe106b9e5040bc091ca5cdbfc7f (no reports in S3)
+    2021-02-10 02:05:39 74082f0d6f8dfd60f28c0de0fe43bcb97b95ee5a (no reports in S3)
+    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc pytorch_linux_xenial_py3_6_gcc5_4_test 0.414s (1 S3 reports omitted)
+    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc pytorch_linux_xenial_py3_6_gcc7_test 0.377s (1 S3 reports omitted)
+
+Another multiline example, this time with the --all flag:
+
+    $ tools/test_history.py multiline --all --ref=321b9 test_qr_square_many_batched_complex_cuda
+    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 424.284s
+    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
+    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 402.572s
+    2021-01-07 02:04:56 321b98830e17e9e1a366ababeb5475f9f202c815 pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.164s
+    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 436.732s
+    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
+    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 407.616s
+    2021-01-06 12:58:28 fcb69d2ebaede960e7708706436d372b68807921 pytorch_linux_xenial_cuda9_2_cudnn7_py3_gcc7_test 287.044s
+
+In columns mode, the name of the job isn't printed, but the order of the
+columns is guaranteed to match the order of the jobs passed on the
+command line. Example:
+
+    $ tools/test_history.py columns --ref=3cf783 --delta=0 test_set_dir pytorch_linux_xenial_py3_6_gcc{5_4,7}_test
+    2021-02-10 04:18:50 3cf78395cbc32fa9c83b585c9ec63f960b32d17f    0.644s    0.312s
+    2021-02-10 03:13:34 594a66d778a660faed0b0fbbe1dd8c2c318707ff    0.360s  errored
+    2021-02-10 02:13:25 9c0caf0384690cb67dcccb7066ece5184f72ca78    0.819s    0.449s
+    2021-02-10 02:09:14 602434bcbebb82c6f3741b2a3d5ebac7ee482268    0.361s    0.454s
+    2021-02-10 02:09:10 2e35fe953553247d8a22fc38b039374e426f13b8
+    2021-02-10 02:09:07 ff73be7e45616fe106b9e5040bc091ca5cdbfc7f
+    2021-02-10 02:05:39 74082f0d6f8dfd60f28c0de0fe43bcb97b95ee5a
+    2021-02-09 23:42:29 0620c96fd6a140e68c49d68ed14721b1ee108ecc    0.414s    0.377s (2 S3 reports omitted)
+    2021-02-09 23:27:53 33afb5f19f4e427f099653139ae45b661b8bc596    0.381s    0.294s
+
+Minor note: in columns mode, a blank cell means that no report was found
+in S3, while the word "absent" means that a report was found but the
+indicated test was not found in that report.
+''',
+        formatter_class=HelpFormatter,
     )
     parser.add_argument(
         'mode',
@@ -213,7 +343,7 @@ if __name__ == "__main__":
         help='(multiline) ignore listed jobs, show all jobs for each commit',
     )
     parser.add_argument(
-        'suite',
+        '--suite',
         help='name of the suite containing the test',
     )
     parser.add_argument(
@@ -247,3 +377,7 @@ if __name__ == "__main__":
         mode=args.mode,
         digits=args.digits,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR makes several UX improvements to `tools/test_history.py`:
- warn if `--all` is unset and no jobs are passed
- print output even in `multiline` mode if no reports are found for a commit
  - this makes it easier to tell whether the script is just hanging
- if there are multiple reports for a commit/job pair, say so
- distinguish between not finding any reports and just not finding the desired test in the reports found
- don't require the suite name as a CLI arg, just use the test name

**Test plan:**

Example shell session: https://pastebin.com/SSemHqP8