### PR TITLE
[ONNX] Remove the last Cast in pow symbolic_opset9

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2252,6 +2252,27 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randint(10, (2, 3, 4))
         self.run_test(PowModule(), (x, y))
 
+        class PowModule2(torch.nn.Module):
+            def forward(self, x):
+                return torch.pow(2, x)
+
+        x = torch.randn(1, 10)
+        self.run_test(PowModule2(), (x,))
+
+        x = torch.randint(10, (2, 3, 4))
+        self.run_test(PowModule2(), (x,))
+
+        x = torch.randn(1, 10).to(dtype=torch.float64)
+        self.run_test(PowModule2(), (x,))
+
+        class PowModule3(torch.nn.Module):
+            def forward(self, x, y):
+                return y[torch.pow(2, x)]
+
+        x = torch.randint(5, (2, 3, 4))
+        y = torch.rand(100)
+        self.run_test(PowModule3(), (x, y))
+
     def test_std(self):
         class StandardDeviation(torch.nn.Module):
             def forward(self, input):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1524,8 +1524,6 @@ def pow(g, self, exponent):
     if not sym_help._is_fp(exponent):
         exponent = g.op("Cast", exponent, to_i=sym_help.cast_pytorch_to_onnx[f_dtype])
     pow = g.op("Pow", self, exponent)
-    if self_dtype and self_dtype != f_dtype:
-        pow = g.op("Cast", pow, to_i=sym_help.cast_pytorch_to_onnx[self_dtype])
     return pow
 
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/52436
For opset 9 of onnx Pow, if X is int32, Y is float, we will cast back to int32 which is consistent with X type.
However, pytorch is still float. The aten graph sometimes does not bind with the type for operators, 
we are fine with the float type and don't want to cast back.
Even if X, Y are int32, the resulting float32 and int32 makes no difference.

