### PR TITLE
[1.8] Update XNNPACK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,7 +121,7 @@
 [submodule "third_party/XNNPACK"]
     ignore = dirty
     path = third_party/XNNPACK
-    url = https://github.com/google/XNNPACK.git
+    url = https://github.com/malfet/XNNPACK.git
 [submodule "third_party/fmt"]
     ignore = dirty
     path = third_party/fmt


### PR DESCRIPTION
Cherry-pick https://github.com/google/XNNPACK/commit/55d53a4e7079d38e90acd75dd9e4f9e781d2da35 into release/1.8 branch as bare-minimum needed to fix crash discussed in  #52463