### PR TITLE
Suppress unsigned comparison warning

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -6,6 +6,8 @@
 #include <ATen/native/BinaryOps.h>
 #include <c10/cuda/CUDAGuard.h>
 
+#include <type_traits>
+
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
@@ -104,7 +106,7 @@ void div_floor_kernel_cuda(TensorIterator& iter) {
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        if ((a < 0) != (b < 0)) {
+        if (!std::is_unsigned<scalar_t>::value && (a < 0) != (b < 0)) {
           // Subtracts one from the results of truncation division if the
           // divisor and dividend have different sign(bit)s and the remainder of
           // the division is nonzero


### PR DESCRIPTION
Summary:
Fixes:
```
caffe2/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu(105): warning: pointless comparison of unsigned integer with zero
```

Differential Revision: D26588918

