### PR TITLE
Added torch.no_grad() to update_bn

### DIFF
--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -112,6 +112,7 @@ class AveragedModel(Module):
         self.n_averaged += 1
 
 
+@torch.no_grad()
 def update_bn(loader, model, device=None):
     r"""Updates BatchNorm running_mean, running_var buffers in the model.
 


### PR DESCRIPTION
Fixes #52055

This fixes the **out of memory error** while using update_bn in **SWA**, by not allocating memory for backpropagation.