### PR TITLE
Remove _th_take

### DIFF
--- a/aten/src/ATen/LegacyTHFunctionsCPU.h
+++ b/aten/src/ATen/LegacyTHFunctionsCPU.h
@@ -23,8 +23,6 @@ Tensor & _th_masked_scatter_bool_(Tensor & self, const Tensor & mask, const Tens
 Tensor & _th_nonzero_out(Tensor & result, const Tensor & self);
 Tensor _th_nonzero(const Tensor & self);
 Tensor & _th_index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & source);
-Tensor & _th_take_out(Tensor & result, const Tensor & self, const Tensor & index);
-Tensor _th_take(const Tensor & self, const Tensor & index);
 Tensor & _th_put_(Tensor & self, const Tensor & index, const Tensor & source, bool accumulate);
 std::tuple<Tensor &,Tensor &> _th_mode_out(Tensor & values, Tensor & indices, const Tensor & self, int64_t dim, bool keepdim);
 std::tuple<Tensor,Tensor> _th_mode(const Tensor & self, int64_t dim, bool keepdim);

--- a/aten/src/ATen/LegacyTHFunctionsCUDA.h
+++ b/aten/src/ATen/LegacyTHFunctionsCUDA.h
@@ -21,8 +21,6 @@ namespace cuda {
 Tensor & _th_masked_fill_(Tensor & self, const Tensor & mask, Scalar value);
 Tensor & _th_masked_fill_bool_(Tensor & self, const Tensor & mask, Scalar value);
 Tensor & _th_index_copy_(Tensor & self, int64_t dim, const Tensor & index, const Tensor & source);
-Tensor & _th_take_out(Tensor & result, const Tensor & self, const Tensor & index);
-Tensor _th_take(const Tensor & self, const Tensor & index);
 Tensor & _th_put_(Tensor & self, const Tensor & index, const Tensor & source, bool accumulate);
 std::tuple<Tensor &,Tensor &> _th_mode_out(Tensor & values, Tensor & indices, const Tensor & self, int64_t dim, bool keepdim);
 std::tuple<Tensor,Tensor> _th_mode(const Tensor & self, int64_t dim, bool keepdim);


### PR DESCRIPTION
These definitions of TH functions were left in the codebase after they were ported to ATen in https://github.com/pytorch/pytorch/pull/45283 and https://github.com/pytorch/pytorch/pull/45430