### PR TITLE
Fix wrong TORCH_CHECK usages

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -128,9 +128,7 @@ static inline void checkSetStorage(Tensor& result, Storage storage, int64_t stor
   }
 
   // storageOffset
-  if (storage_offset < 0) {
-    TORCH_CHECK("Tensor: invalid storage offset ", storage_offset);
-  }
+  TORCH_CHECK(storage_offset >= 0, "Tensor: invalid storage offset ", storage_offset);
 }
 
 /**

--- a/test/cpp/jit/test_gpu.cpp
+++ b/test/cpp/jit/test_gpu.cpp
@@ -2426,9 +2426,9 @@ Val* gen_jit_operand(std::pair<ValType, DataType> desc) {
     else if (desc.second == DataType::Int)
       return new Int();
     else
-      TORCH_CHECK("Not currently supported type", desc.first);
+      TORCH_CHECK(false, "Not currently supported type", desc.first);
   } else {
-    TORCH_CHECK("Not currently supported type", desc.first);
+    TORCH_CHECK(false, "Not currently supported type", desc.first);
   }
   return nullptr;
 }

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -80,7 +80,7 @@ c10::optional<at::ScalarType> ONNXTypeToATenType(int32_t onnx_type) {
     case ::ONNX_NAMESPACE::TensorProto_DataType_BFLOAT16:
       return at::kBFloat16;
     default:
-      TORCH_CHECK("unexpected tensor scalar type");
+      TORCH_CHECK(false, "unexpected tensor scalar type");
   }
   return c10::optional<at::ScalarType>{};
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52672 `maybe_resize_storage_cuda` new_size argument should be unsigned
* #52671 `maybe_resize_storage_cpu` to error on negative numbers
* **#52670 Fix wrong TORCH_CHECK usages**

TORCH_CHECK followed by a string literal is a no-op, and from the text of the message its clear that authors intended those instances to be `TORCH_CHECK(false, "msg")`

Discovered while trying to figure out of tensor_offset can be negative in Resize.h

s/TORCH_CHECK\("/TORCH_CHECK(false, "/

Differential Revision: [D26607546](https://our.internmc.facebook.com/intern/diff/D26607546)