### PR TITLE
Change `maybe_resize_storage_cpu` `new_size` arg to unsigned

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -22,23 +22,24 @@ TORCH_API void resize_output(Tensor& output, IntArrayRef shape);
 // They are not in TH/THTensor.cpp because the at namespace is easier
 // to benchmark than TH; I can't get gbenchmark to call fns from THTensor.cpp
 
-static inline void maybe_resize_storage_cpu(TensorImpl* self, int64_t new_size) {
+static inline void maybe_resize_storage_cpu(TensorImpl* self, uint64_t new_size) {
   // It does not make sense to try to resize a storage
   // to hold 0 elements, and this can break
   // if storage_offset is positive but
   // new_size is 0, so just bail in that case
   // (same comment is in Resize.cuh)
-  if (new_size > 0) {
-    if (!THTensor_getStoragePtr(self)) {
-      caffe2::TypeMeta dtype = self->dtype();
-      THTensor_stealAndSetStoragePtr(self, THStorage_new());
-      TORCH_INTERNAL_ASSERT(dtype == self->dtype());
-    }
-    int64_t new_size_bytes =
-        (new_size + self->storage_offset()) * self->dtype().itemsize();
-    if (new_size_bytes > self->storage().nbytes()) {
-      THStorage_resizeBytes(THTensor_getStoragePtr(self), new_size_bytes);
-    }
+  if (new_size == 0) {
+    return;
+  }
+  if (!THTensor_getStoragePtr(self)) {
+    caffe2::TypeMeta dtype = self->dtype();
+    THTensor_stealAndSetStoragePtr(self, THStorage_new());
+    TORCH_INTERNAL_ASSERT(dtype == self->dtype());
+  }
+  uint64_t new_size_bytes =
+      (new_size + self->storage_offset()) * self->dtype().itemsize();
+  if (new_size_bytes > self->storage().nbytes()) {
+    THStorage_resizeBytes(THTensor_getStoragePtr(self), new_size_bytes);
   }
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3816,6 +3816,15 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
+
+    def test_adaptive_pooling_size_overflow(self):
+        # 0x0x3fffffffffffffff * 2 * 2 = 0xfffffffffffffffc = -4 as int64_t
+        # Tensor::numel() return int64_t, so following check that negative allocs are correctly handled
+        self.assertRaises(
+                RuntimeError,
+                lambda: torch.nn.AdaptiveMaxPool1d(0x3fffffffffffffff)(torch.empty([2,2,2]))
+                )
+
     def test_adaptive_pooling_avg_nhwc(self):
         device_list = ['cpu']
         if TEST_CUDA:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3816,14 +3816,12 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
-
     def test_adaptive_pooling_size_overflow(self):
         # 0x0x3fffffffffffffff * 2 * 2 = 0xfffffffffffffffc = -4 as int64_t
         # Tensor::numel() return int64_t, so following check that negative allocs are correctly handled
         self.assertRaises(
-                RuntimeError,
-                lambda: torch.nn.AdaptiveMaxPool1d(0x3fffffffffffffff)(torch.empty([2,2,2]))
-                )
+            RuntimeError,
+            lambda: torch.nn.AdaptiveMaxPool1d(0x3fffffffffffffff)(torch.empty([2, 2, 2])))
 
     def test_adaptive_pooling_avg_nhwc(self):
         device_list = ['cpu']

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3816,6 +3816,7 @@ class TestNN(NNTestCase):
                 output = module(input)
                 self.assertEqual(output.size(), (4,) + (2,) * (numel - 1) + (4,))
 
+    @unittest.skipIf(TEST_WITH_UBSAN, "signed integer overflow error with UBSAN")
     def test_adaptive_pooling_size_overflow(self):
         # 0x0x3fffffffffffffff * 2 * 2 = 0xfffffffffffffffc = -4 as int64_t
         # Tensor::numel() return int64_t, so following check that negative allocs are correctly handled


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52672 `maybe_resize_storage_cuda` new_size argument should be unsigned
* **#52671 Change `maybe_resize_storage_cpu` `new_size` arg to unsigned**
* #52670 Fix wrong TORCH_CHECK usages

Code is written with the assumption that `new_size` is unsigned value,
and when function is called with negative value it silently returns a nullptr rather than raise an exception.
Fix abovementioned logic by converting new_size to unsigned type and let cpu_allocator raise exception on negative alloc.

Unroll nested if blocks by returning early if `new_size` is 0

Add `TestNN.test_adaptive_pooling_size_overflow` to indirecty validate the fix.

Fixes https://github.com/pytorch/pytorch/issues/50960

Differential Revision: [D26607549](https://our.internmc.facebook.com/intern/diff/D26607549)