### PR TITLE
`maybe_resize_storage_cuda` new_size argument should be unsigned

### DIFF
--- a/aten/src/ATen/native/cuda/Resize.cuh
+++ b/aten/src/ATen/native/cuda/Resize.cuh
@@ -12,24 +12,25 @@ namespace at { namespace native {
 // They are not in THC/THCTensor.cpp because the at namespace is easier
 // to benchmark than THC; I can't get gbenchmark to call fns from THTensor.cpp
 
-static inline void maybe_resize_storage_cuda(TensorImpl* self, int64_t new_size) {
+static inline void maybe_resize_storage_cuda(TensorImpl* self, uint64_t new_size) {
   // It does not make sense to try to resize a storage
   // to hold 0 elements, and this can break
   // if storage_offset is positive but
   // new_size is 0, so just bail in that case
   // (same comment is in Resize.h)
-  if (new_size > 0) {
-    if (!THTensor_getStoragePtr(self)) {
-      AT_ERROR("Tensor: invalid null storage");
-    }
-    uint64_t new_size_bytes = (new_size + self->storage_offset()) * self->dtype().itemsize();
-    if (new_size_bytes > self->storage().nbytes()) {
-      THCStorage_resizeBytes(
-          globalContext().getTHCState(),
-          THTensor_getStoragePtr(self),
-          new_size_bytes
-      );
-    }
+  if (new_size == 0) {
+    return;
+  }
+  if (!THTensor_getStoragePtr(self)) {
+    TORCH_CHECK(false, "Tensor: invalid null storage");
+  }
+  uint64_t new_size_bytes = (new_size + self->storage_offset()) * self->dtype().itemsize();
+  if (new_size_bytes > self->storage().nbytes()) {
+    THCStorage_resizeBytes(
+        globalContext().getTHCState(),
+        THTensor_getStoragePtr(self),
+        new_size_bytes
+    );
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52672 `maybe_resize_storage_cuda` new_size argument should be unsigned**
* #52671 Change `maybe_resize_storage_cpu` `new_size` arg to unsigned
* #52670 Fix wrong TORCH_CHECK usages

This allows correct handling on a very large tensor allocations

Also, replace AT_ERROR with TORCH_CHECK(false)

Differential Revision: [D26607547](https://our.internmc.facebook.com/intern/diff/D26607547)