### PR TITLE
[static runtime] Register both TupleConstruct and ListConstruct as out variants

### DIFF
--- a/benchmarks/static_runtime/deep_wide_pt_bench.cc
+++ b/benchmarks/static_runtime/deep_wide_pt_bench.cc
@@ -149,10 +149,10 @@ BENCHMARK(BM_leaky_relu_const)->RangeMultiplier(8)->Ranges({{1, 20}});
 
 static void BM_long_static_memory_optimization(benchmark::State& state) {
   auto mod = getLongScriptModel();
-  torch::jit::InferenceModuleOptions opts;
+  auto g = torch::jit::PrepareForStaticRuntime(mod);
+  torch::jit::StaticRuntimeOptions opts;
   opts.optimize_memory = state.range(1);
-  auto g = torch::jit::PrepareForStaticRuntime(mod, opts);
-  torch::jit::StaticRuntime runtime(g);
+  torch::jit::StaticRuntime runtime(g, opts);
 
   const auto N = state.range(0);
   auto a = torch::randn({N, N});

--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -7,6 +7,18 @@ const auto list_construct_script = R"JIT(
     return [a, b]
 )JIT";
 
+const auto list_construct_script_2 = R"JIT(
+  def forward(self, a, b):
+    c = a + a
+    return [c, c]
+)JIT";
+
+const auto list_construct_script_3 = R"JIT(
+  def forward(self, a, b):
+    c = a + a
+    return [c, c.flatten()]
+)JIT";
+
 const auto list_unpack_script = R"JIT(
   def forward(self, a, b):
     c = [a, b]
@@ -15,9 +27,22 @@ const auto list_unpack_script = R"JIT(
     return z
 )JIT";
 
+const auto list_unpack_script_2 = R"JIT(
+  def forward(self, a, b):
+    c = [a, b]
+    x, y = c
+    z = (x, y)
+    return z
+)JIT";
+
 const auto tuple_construct_script = R"JIT(
   def forward(self, a, b):
     return (a, b)
+)JIT";
+
+const auto tuple_construct_script_2 = R"JIT(
+  def forward(self, a, b):
+    return (a.flatten(), b)
 )JIT";
 
 const auto add_script = R"JIT(

--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -37,6 +37,39 @@ const auto reshape_script_2 = R"JIT(
       return b.reshape(shape)
 )JIT";
 
+const auto reshape_script_3 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = a.reshape(shape)
+      c = a.reshape(shape)
+      d = c + c
+      e = d + d
+      f = e * e
+      g = f * f
+      return b.reshape(shape), g
+)JIT";
+
+const auto reshape_script_4 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      k = inp + inp
+      a = k + k
+      b = a.reshape(shape)
+      c = a.flatten().reshape(shape)
+      return b + c
+)JIT";
+
+const auto reshape_script_5 = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = a.reshape(shape)
+      c = a.reshape(shape)
+      d = c + c
+      e = d + d
+      f = e * e
+      g = f * f
+      return g
+)JIT";
+
 const auto flatten_script_1 = R"JIT(
   def forward(self, a: Tensor, start_dim: int, end_dim: int):
       b = torch.flatten(a, start_dim, end_dim)

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -118,6 +118,9 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
 
   testStaticRuntime(reshape_script_1, args);
   testStaticRuntime(reshape_script_2, args);
+  testStaticRuntime(reshape_script_3, args);
+  testStaticRuntime(reshape_script_4, args);
+  testStaticRuntime(reshape_script_5, args);
 }
 
 TEST(StaticRuntime, IndividualOps_flatten) {

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -107,8 +107,12 @@ TEST(StaticRuntime, IndividualOps_Binary) {
 
   testStaticRuntime(add_script, args);
   testStaticRuntime(list_construct_script, args);
+  testStaticRuntime(list_construct_script_2, args);
+  testStaticRuntime(list_construct_script_3, args);
   testStaticRuntime(list_unpack_script, args);
+  testStaticRuntime(list_unpack_script_2, args);
   testStaticRuntime(tuple_construct_script, args);
+  testStaticRuntime(tuple_construct_script_2, args);
 }
 
 TEST(StaticRuntime, IndividualOps_Reshape) {

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -5,6 +5,7 @@
 #include <c10/core/CPUAllocator.h>
 #include <caffe2/core/scope_guard.h>
 #include <caffe2/core/timer.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
@@ -31,6 +32,12 @@ namespace {
 void OptimizeGraph(std::shared_ptr<torch::jit::Graph>& graph) {
   PrepareGraphForStaticRuntime(graph);
   FuseInferenceOpsForSparseNN(graph);
+
+  // TODO: we can avoid this guard by moving operations
+  // to exposed folders.
+#ifdef FBCODE_CAFFE2
+  ReplaceWithCopy(graph);
+#endif
   ConstantPropagation(graph);
 }
 
@@ -82,27 +89,83 @@ std::unique_ptr<c10::FunctionSchema> RemoveSelfFromSchema(
   return std::make_unique<c10::FunctionSchema>(s.cloneWithArguments(args));
 }
 
+bool mayContainAlias(AliasDb& db, const Value* a, const Value* b) {
+  return db.mayContainAlias(const_cast<Value*>(a), const_cast<Value*>(b));
+}
+
+bool mayContainAlias(
+    AliasDb& db,
+    const std::unordered_set<const Value*>& a,
+    const std::unordered_set<const Value*>& b) {
+  std::vector<Value*> as;
+  std::vector<Value*> bs;
+  as.reserve(a.size());
+  for (auto* v : a) {
+    as.emplace_back(const_cast<Value*>(v));
+  }
+  bs.reserve(b.size());
+  for (auto* v : b) {
+    bs.emplace_back(const_cast<Value*>(v));
+  }
+  return db.mayContainAlias(as, bs);
+}
+
 // Returns two useful constructs:
 //  first: map each value to all values that are alive
 //    at the same time.
 //  second: set of all inputs/outputs/constants (always alive)
-std::pair<std::unordered_map<Value*, std::set<Value*>>, std::set<Value*>>
-LivenessMap(const std::shared_ptr<torch::jit::Graph>& graph) {
-  std::unordered_map<Value*, std::set<Value*>> liveness_map;
-  std::set<Value*> always_alive;
+//    and their aliases
+//  The algorithm does a traversal of the execution graph
+//  while keeping track of the live values.
+using LivenessInformation = std::pair<
+    std::unordered_map<const Value*, std::set<const Value*>>,
+    std::unordered_set<const Value*>>;
 
-  std::vector<Value*> frontier;
-  // map live values to their deps, invariant: set.size() > 0
-  std::unordered_map<Value*, std::set<Node*>> live_values;
-  for (const auto& input : graph->inputs()) {
-    frontier.emplace_back(input);
+LivenessInformation GetLivenessInformation(
+    const std::shared_ptr<torch::jit::Graph>& graph,
+    AliasDb& db) {
+  std::unordered_map<const Value*, std::set<const Value*>> liveness_map;
+  std::unordered_set<const Value*> always_alive;
+
+  std::vector<const Value*> values_in_creation_order;
+  std::unordered_map<const Value*, size_t> values_in_creation_order_idx;
+  for (const auto* node : graph->nodes()) {
+    for (const auto* v : node->outputs()) {
+      values_in_creation_order_idx[v] = values_in_creation_order.size();
+      values_in_creation_order.emplace_back(v);
+    }
+  }
+
+  // maps values to any nodes that consume or produce them
+  //
+  // updated as we traverse the graph. the presence of a key in `live_values`
+  // means that the value is currently alive.
+  //
+  // invariant: set.size() > 0
+  std::unordered_map<const Value*, std::set<const Node*>> live_values;
+  std::unordered_map<const Node*, std::set<const Value*>> live_nodes;
+
+  // inputs and outputs are marked permanently alive
+  for (const auto* input : graph->inputs()) {
     always_alive.insert(input);
   }
-  for (const auto& output : graph->outputs()) {
+  for (const auto* output : graph->outputs()) {
     always_alive.insert(output);
   }
 
-  auto add_live_value = [&](Value* v) {
+  for (const auto* node : graph->nodes()) {
+    if (node->kind() == prim::Constant) {
+      for (const auto* output : node->outputs()) {
+        always_alive.insert(output);
+      }
+    }
+  }
+
+  std::function<void(const Value* v)> add_live_value;
+  add_live_value = [&](const Value* v) {
+    if (liveness_map.count(v)) {
+      return;
+    }
     liveness_map[v] = {};
 
     for (const auto& live_v : live_values) {
@@ -117,36 +180,58 @@ LivenessMap(const std::shared_ptr<torch::jit::Graph>& graph) {
     }
 
     for (const auto& u : v->uses()) {
-      const auto& node = u.user;
+      const auto* node = u.user;
       // track deps of this value
       live_values.at(v).insert(node);
+      live_nodes[node].insert(v);
+    }
+
+    // values created after this one that alias it
+    std::vector<const Value*> aliased_vs;
+    auto idx = values_in_creation_order_idx[v];
+    for (; idx < values_in_creation_order.size(); ++idx) {
+      auto* alias_v = values_in_creation_order[idx];
+      if (mayContainAlias(db, v, alias_v)) {
+        aliased_vs.emplace_back(alias_v);
+      }
+    }
+    // for all the values in the alias set,
+    // we set them "alive"
+    for (auto* aliased_v : aliased_vs) {
+      add_live_value(aliased_v);
+      for (const auto& u : aliased_v->uses()) {
+        const auto* node = u.user;
+        // track deps of the aliased values is if they
+        // are our own
+        live_values.at(v).insert(node);
+        live_nodes[node].insert(v);
+      }
     }
   };
 
-  auto traverse_node = [&](Node* node, std::vector<Value*>& dead) {
-    for (const auto& input : node->inputs()) {
-      // ignore constant values
-      if (input->node()->kind() == prim::Constant) {
-        always_alive.insert(input);
-        continue;
-      }
-      if (live_values.count(input)) {
-        live_values.at(input).erase(node);
-        if (!live_values.at(input).size()) {
-          dead.emplace_back(input);
+  auto traverse_node = [&](const Node* node, std::vector<const Value*>& dead) {
+    if (live_nodes.count(node)) {
+      for (const auto* v : live_nodes.at(node)) {
+        live_values.at(v).erase(node);
+        if (!live_values.at(v).size()) {
+          dead.emplace_back(v);
         }
       }
     }
   };
 
-  for (const auto& node : graph->nodes()) {
-    for (const auto& v : node->outputs()) {
-      add_live_value(v);
+  for (const auto* node : graph->nodes()) {
+    for (const auto* v : node->outputs()) {
+      if (mayContainAlias(db, ValueSet{v}, always_alive)) {
+        always_alive.insert(v);
+      } else {
+        add_live_value(v);
+      }
     }
 
-    std::vector<Value*> dead;
+    std::vector<const Value*> dead;
     traverse_node(node, dead);
-    for (const auto& dead_value : dead) {
+    for (const auto* dead_value : dead) {
       live_values.erase(dead_value);
     }
   }
@@ -155,9 +240,9 @@ LivenessMap(const std::shared_ptr<torch::jit::Graph>& graph) {
     TORCH_CHECK(always_alive.count(v.first));
   }
 
-  for (const auto& node : graph->nodes()) {
-    for (const auto& input : node->inputs()) {
-      for (const auto& output : node->outputs()) {
+  for (const auto* node : graph->nodes()) {
+    for (const auto* input : node->inputs()) {
+      for (const auto* output : node->outputs()) {
         if (liveness_map.count(input) && liveness_map.count(output)) {
           liveness_map.at(input).insert(output);
           liveness_map.at(output).insert(input);
@@ -169,34 +254,177 @@ LivenessMap(const std::shared_ptr<torch::jit::Graph>& graph) {
   return std::make_pair(liveness_map, always_alive);
 }
 
-std::unordered_set<Value*> GetOptimizableValues(
-    const std::shared_ptr<torch::jit::Graph>& graph) {
-  std::unordered_set<Value*> can_reuse;
+// Implementation specific pruning of values
+// from "optimzable" set.  GetLivenessInformation and FindShared
+// work with any graph, but we prune out values
+// that aren't produced by "_out" variants here.
+//
+// Returns
+//   first: Values that can be optimized
+//   second: A deterministc order of all values
+std::pair<std::vector<const Value*>, std::vector<const Value*>>
+GetOptimizableValues(const std::shared_ptr<torch::jit::Graph>& graph) {
+  // for determinism
+  std::unordered_set<const Value*> seen_values;
+  std::vector<const Value*> all_values;
+  std::unordered_set<const Value*> can_reuse;
   // values used by unsupported ops (as either inputs or outputs)
   // these need to be removed from "can_reuse" after analyzing all nodes
-  std::unordered_set<Value*> cannot_reuse;
-  for (const auto& n : graph->nodes()) {
-    for (const auto& v : n->inputs()) {
-      if (canRunOutOfPlace(n) && canReuseInputsOutputs(n) &&
-          canReuseInputs(n)) {
+  std::unordered_set<const Value*> cannot_reuse;
+  for (auto* n : graph->nodes()) {
+    for (const auto* v : n->inputs()) {
+      if (!seen_values.count(v)) {
+        all_values.emplace_back(v);
+        seen_values.insert(v);
+      }
+      if (canReuseInputsOutputs(n)) {
         can_reuse.insert(v);
       } else {
         cannot_reuse.insert(v);
       }
     }
-    for (const auto& v : n->outputs()) {
-      if (canRunOutOfPlace(n) && canReuseInputsOutputs(n) &&
-          canReuseOutputs(n)) {
+    for (const auto* v : n->outputs()) {
+      all_values.emplace_back(v);
+      seen_values.insert(v);
+      if (canReuseInputsOutputs(n)) {
         can_reuse.insert(v);
       } else {
         cannot_reuse.insert(v);
       }
     }
   }
-  for (auto v : cannot_reuse) {
+  for (const auto* v : cannot_reuse) {
     can_reuse.erase(v);
   }
-  return can_reuse;
+  // find a deterministic order
+  std::vector<const Value*> optimizable;
+  for (const auto* v : all_values) {
+    if (can_reuse.count(v)) {
+      optimizable.emplace_back(v);
+      can_reuse.erase(v);
+    }
+  }
+  return std::make_pair(optimizable, all_values);
+}
+
+// Equipped with a liveness map we can allocate memory to
+// ivalues, reusing memory along the way. However, we are
+// constrained by the set of optimizable_values
+// (inputs/outputs of out variants). Inputs/outputs of view ops
+// can't be reused.
+//
+// Algorithm:
+// # clusters of values sharing the same memory
+// # are called "shared" in the implementation
+// # inserting into a cluster denotes sharing memory.
+//
+// clusters = {}
+// for all v in optimzable_values:
+//   for all cluster in clusters: # can we insert into cluster?
+//     for all live_v in live_during(v):
+//        if cluster.contains(live_v):
+//          skip to next custer
+//     cluster.add(v)
+//     skip to next v
+//   if no cluster found:
+//     clusters.add(cluster{v})
+//
+//
+// NB: This is a deterministic implementation, which makes it easier to tune
+// and debug.
+std::unordered_map<const Value*, std::vector<const Value*>> FindShared(
+    const LivenessInformation& lm,
+    const std::pair<std::vector<const Value*>, std::vector<const Value*>>&
+        optimizable,
+    AliasDb& db) {
+  const auto& alive_during = lm.first;
+  const auto& always_alive = lm.second;
+  const auto& optimizable_values = optimizable.first;
+  const auto& all_values = optimizable.second;
+
+  std::unordered_map<const Value*, std::vector<const Value*>> shared;
+
+  // make these two values share memory
+  auto share = [&](const Value* new_v, const Value* old_v) {
+    if (new_v == old_v) {
+      return;
+    }
+    DCHECK(shared.count(old_v));
+    std::set<const Value*> seen;
+    std::vector<const Value*> values;
+    for (auto* v : shared.at(old_v)) {
+      if (seen.count(v)) {
+        continue;
+      }
+      seen.insert(v);
+      values.emplace_back(v);
+    }
+    for (auto* v : shared.at(new_v)) {
+      if (seen.count(v)) {
+        continue;
+      }
+      seen.insert(v);
+      values.emplace_back(v);
+    }
+    for (const auto* v : values) {
+      shared[v] = values;
+    }
+  };
+
+  // initialize with known shared (aliasing values)
+  for (const auto* v : all_values) {
+    if (!shared.count(v)) {
+      shared[v] = {v};
+    }
+    // skip always alive values (alias inputs/outputs/weights)
+    if (always_alive.count(v)) {
+      continue;
+    }
+    for (const auto& p : shared) {
+      // NB: this means we cannot optimize operations that "sometimes alias"
+      // TODO: add a more robust check of this behavior at runtime
+      if (db.mayAlias(p.first, v)) {
+        share(v, p.first);
+      }
+    }
+  }
+
+  // to preserve determinism
+  std::vector<const Value*> seen;
+
+  for (const auto* v : optimizable_values) {
+    if (always_alive.count(v)) {
+      continue;
+    }
+    // get values that are live during the lifetime of v
+    std::set<const Value*> live;
+    for (const auto* sv : shared.at(v)) {
+      auto l = alive_during.count(sv) ? alive_during.at(sv) : std::set<const Value*>{};
+      live.insert(l.begin(), l.end());
+    }
+    live.insert(always_alive.begin(), always_alive.end());
+
+    for (const auto* s : seen) {
+      // check if any values in this set of shared
+      // are alive at the time of v
+      // effectively finding | set_intersection(live, set_of_shared(s)) | > 0
+      bool intersects = false;
+      for (const auto* candidate_v : shared.at(s)) {
+        if (live.count(candidate_v)) {
+          intersects = true;
+          break;
+        }
+      }
+      // we can share memory if there's no overlap
+      if (!intersects) {
+        share(v, s);
+        break;
+      }
+    }
+    seen.emplace_back(v);
+  }
+
+  return shared;
 }
 } // namespace
 
@@ -206,10 +434,8 @@ void InferenceModule::init() {
   RemoveSelfFromGraphInput(graph);
 }
 
-InferenceModule::InferenceModule(
-    const torch::jit::Module& m,
-    InferenceModuleOptions opts_)
-    : module(m.copy()), graph(nullptr), schema(nullptr), opts(opts_) {
+InferenceModule::InferenceModule(const torch::jit::Module& m)
+    : module(m.copy()), graph(nullptr), schema(nullptr) {
   module.eval();
   module = freeze_module(module);
 
@@ -222,10 +448,8 @@ InferenceModule::InferenceModule(
   init();
 }
 
-InferenceModule::InferenceModule(
-    std::shared_ptr<torch::jit::Graph> g,
-    InferenceModuleOptions opts_)
-    : module(), graph(std::move(g)), schema(nullptr), opts(opts_) {
+InferenceModule::InferenceModule(std::shared_ptr<torch::jit::Graph> g)
+    : module(), graph(std::move(g)), schema(nullptr) {
   init();
 }
 
@@ -256,7 +480,7 @@ StaticRuntime::StaticRuntime(
 
   // fill workspace_ with constants and create ProcessedNodes
   // NB: before optimizing the order of execution, ensure that the
-  // memory optimization pass (LivenessMap + AssignRegisters) is
+  // memory optimization pass (GetLivenessInformation + AssignRegisters) is
   // aware of the new order!
 
   // Fill constants first, so we have a std::vector<IValue> we can reference
@@ -295,6 +519,17 @@ StaticRuntime::StaticRuntime(
   }
   for (auto output : graph->outputs()) {
     outputs_.emplace_back(val_to_ival.at(output));
+  }
+
+  AliasDb alias_db(module_->graph);
+  auto lm = GetLivenessInformation(module_->graph, alias_db);
+  external_values_ = lm.second;
+  if (opts_.optimize_memory) {
+    auto values = GetOptimizableValues(module_->graph);
+    if (!opts_.enable_out_variant) {
+      values.first = {};
+    }
+    shared_values_ = FindShared(lm, values, alias_db);
   }
 }
 
@@ -352,7 +587,7 @@ c10::IValue StaticRuntime::run(
   }
 
   // NB: before optimizing the order of execution, ensure that the
-  // memory optimization pass (LivenessMap + AssignRegisters) is
+  // memory optimization pass (GetLivenessInformation + AssignRegisters) is
   // aware of the new order!
   for (auto& n : nodes_) {
     n.run();
@@ -360,8 +595,8 @@ c10::IValue StaticRuntime::run(
 
   if (opts_.cleanup_activations) {
     if (!planner_) {
-      std::unordered_map<Value*, std::vector<Value*>> shared;
-      planner_ = std::make_unique<MemoryPlanner>(this, shared);
+      planner_ = std::make_unique<MemoryPlanner>(
+          this, shared_values_, external_values_, opts_.enable_out_variant);
     }
     planner_->deallocate();
     // clean up owning refs of input tensors
@@ -438,10 +673,10 @@ void StaticRuntime::benchmark(
   if (planner_) {
     std::cout << "Total memory managed: " << planner_->total_managed()
               << " bytes" << std::endl;
-  }
-  if (module_->opts.optimize_memory) {
-    // std::cout << "Total number of reused registers: " << module_->reused_regs
-    //           << std::endl;
+    if (opts_.optimize_memory) {
+      std::cout << "Total number of reused tensors: "
+                << planner_->total_reused_tensors() << std::endl;
+    }
   }
 }
 
@@ -519,8 +754,8 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     timer.Start();
     if (opts_.cleanup_activations) {
       if (!planner_) {
-        std::unordered_map<Value*, std::vector<Value*>> shared;
-        planner_ = std::make_unique<MemoryPlanner>(this, shared);
+        planner_ = std::make_unique<MemoryPlanner>(
+            this, shared_values_, external_values_, opts_.enable_out_variant);
       }
       planner_->deallocate();
       // clean up owning refs of input tensors
@@ -615,62 +850,42 @@ void StaticRuntime::check_for_memory_leak(bool output_returned) {
 
 MemoryPlanner::MemoryPlanner(
     StaticRuntime* runtime,
-    std::unordered_map<Value*, std::vector<Value*>> should_share) {
-  // get input Value*
-  at::ArrayRef<Value*> inputs =
-      runtime->get_inference_module()->graph->inputs();
-  std::unordered_set<Value*> graph_input_values(inputs.begin(), inputs.end());
-
+    const std::unordered_map<const Value*, std::vector<const Value*>>&
+        should_share,
+    const std::unordered_set<const Value*>& external_values,
+    bool out_variants) {
   // collect register indices of outputs of ops with out variant
-  std::unordered_set<Value*> managed_values;
+  std::unordered_set<const Value*> managed_values;
   std::unordered_set<IValue*> unmanaged_value_set;
-  std::unordered_map<Value*, IValue*> values_map;
   for (ProcessedNode& pnode : runtime->get_nodes()) {
-    bool should_manage = pnode.has_out_variant();
-    if (should_manage && isViewOp(pnode.get_node())) {
-      // outputs of view ops with inputs as the graph inputs shouldn't be
-      // managed by the MemoryPlanner. It may release the storage of the graph
-      // inputs.
-      for (Value* in : pnode.get_node()->inputs()) {
-        if (graph_input_values.count(in) > 0) {
-          should_manage = false;
-          break;
-        }
-      }
-    }
-    if (should_manage) {
-      // Types are stored in the underlying TorchScript IR
-      for (size_t i = 0; i < pnode.outputs().size(); i++) {
-        Value* out = pnode.get_node()->output(i);
-        if (out->type()->cast<TensorType>()) {
-          managed_values.insert(out);
-          values_map[out] = &pnode.Output(i);
+    if (canReuseInputsOutputs(pnode.get_node())) {
+      for (auto i = 0; i < pnode.outputs().size(); ++i) {
+        // Types are stored in the underlying TorchScript IR
+        const Value* out_v = pnode.get_node()->outputs()[i];
+        IValue& out = pnode.Output(i);
+        if (out_variants && out_v->type()->cast<TensorType>() &&
+            !external_values.count(out_v)) {
+          managed_values.insert(out_v);
+        } else {
+          unmanaged_value_set.insert(&out);
         }
       }
     } else {
       for (auto i = 0; i < pnode.outputs().size(); ++i) {
         unmanaged_value_set.insert(&pnode.Output(i));
-        values_map[pnode.get_node()->output(i)] = &pnode.Output(i);
       }
     }
   }
 
   const InferenceModule* module = runtime->get_inference_module();
 
-  // remove tensors in output List/Tuple from managed_values
-  for (Value* output : module->graph->outputs()) {
-    Node* output_node = output->node();
-    if (output_node->kind() == prim::TupleConstruct ||
-        output_node->kind() == prim::ListConstruct) {
-      for (Value* input : output_node->inputs()) {
-        managed_values.erase(input);
-        // Elements in Tuples and Lists are refcounted. MemoryPlanner should not
-        // hold refs of elements in output Tuples/Lists
-        if (graph_input_values.count(input) == 0) {
-          unmanaged_value_set.insert(values_map[input]);
-        }
-      }
-    }
+  // remove model outputs from managed_values
+  for (IValue* output : runtime->outputs()) {
+    unmanaged_value_set.erase(output);
+  }
+
+  for (IValue* out : unmanaged_value_set) {
+    unmanaged_values_.emplace_back(out);
   }
 
   // remove model outputs from managed_values and unmanaged_value_set
@@ -688,7 +903,7 @@ MemoryPlanner::MemoryPlanner(
 
   // some Values should share storage, this map will
   // keep track of the index into managed_storage_
-  std::unordered_map<Value*, size_t> shared;
+  std::unordered_map<const Value*, size_t> shared;
   // the StorageImpls of Tensor views should not be managed
   std::unordered_set<c10::StorageImpl*> managed_storage_impls;
 
@@ -696,7 +911,7 @@ MemoryPlanner::MemoryPlanner(
   for (const auto& pnode : runtime->get_nodes()) {
     for (auto i = 0; i < pnode.outputs().size(); ++i) {
       const auto& ival = pnode.outputs()[i];
-      auto* val = pnode.get_node()->outputs()[i];
+      const auto* val = pnode.get_node()->outputs()[i];
       if (managed_values.count(val)) {
         TORCH_CHECK(ival.isTensor());
         auto* impl = ival.toTensor().storage().unsafeGetStorageImpl();
@@ -714,7 +929,7 @@ MemoryPlanner::MemoryPlanner(
           managed_storage_.emplace_back(std::move(p));
           // first of a group, update the shared map with the index
           if (should_share.count(val)) {
-            for (auto v : should_share.at(val)) {
+            for (const auto* v : should_share.at(val)) {
               shared[v] = managed_storage_.size() - 1;
             }
           }
@@ -744,6 +959,8 @@ void MemoryPlanner::allocate() {
 
   size_t offset = 0;
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
+
+  reused_tensors_ = 0;
   for (const auto& ms : managed_storage_) {
     auto tensor_size = ms.first;
     if (tensor_size == 0) {
@@ -756,7 +973,9 @@ void MemoryPlanner::allocate() {
     for (auto& impl : impls) {
       impl->set_data_ptr_noswap(at::DataPtr(src, src, nullptr, impl->device()));
       impl->set_nbytes(tensor_size);
+      reused_tensors_++;
     }
+    reused_tensors_--;
 
     offset += tensor_size;
   }

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -11,13 +11,10 @@
 namespace torch {
 namespace jit {
 
-struct TORCH_API InferenceModuleOptions {
-  bool optimize_memory{true}; // TODO remove when logic moves to runtime
-};
-
 struct TORCH_API StaticRuntimeOptions {
   bool cleanup_activations{true};
   bool enable_out_variant{true};
+  bool optimize_memory{true};
 };
 
 /// Static runime supports two execution modes.
@@ -63,15 +60,11 @@ struct TORCH_API StaticRuntimeOptions {
 // Group readonly data structures into InferenceModule
 struct TORCH_API InferenceModule {
  public:
-  explicit InferenceModule(const torch::jit::Module& m, InferenceModuleOptions);
-  explicit InferenceModule(
-      std::shared_ptr<torch::jit::Graph> g,
-      InferenceModuleOptions);
+  explicit InferenceModule(const torch::jit::Module& m);
+  explicit InferenceModule(std::shared_ptr<torch::jit::Graph> g);
   torch::jit::Module module;
   std::shared_ptr<torch::jit::Graph> graph;
   std::unique_ptr<c10::FunctionSchema> schema;
-
-  InferenceModuleOptions opts;
 
  private:
   void init();
@@ -81,15 +74,13 @@ TORCH_API void PrepareGraphForStaticRuntime(
     std::shared_ptr<torch::jit::Graph> g);
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    const torch::jit::Module& m,
-    InferenceModuleOptions opts = InferenceModuleOptions()) {
-  return std::make_shared<InferenceModule>(m, opts);
+    const torch::jit::Module& m) {
+  return std::make_shared<InferenceModule>(m);
 }
 
 inline TORCH_API std::shared_ptr<InferenceModule> PrepareForStaticRuntime(
-    std::shared_ptr<torch::jit::Graph> g,
-    InferenceModuleOptions opts = InferenceModuleOptions()) {
-  return std::make_shared<InferenceModule>(g, opts);
+    const std::shared_ptr<torch::jit::Graph>& g) {
+  return std::make_shared<InferenceModule>(g);
 }
 
 class MemoryPlanner;
@@ -180,6 +171,10 @@ class TORCH_API StaticRuntime {
   std::vector<IValue*> outputs_;
   // The nodes we need to run
   std::vector<ProcessedNode> nodes_;
+  // Output of liveness analyis. A mapping from a value to the set of values
+  // with which it could potentially share memory.
+  std::unordered_map<const Value*, std::vector<const Value*>> shared_values_;
+  std::unordered_set<const Value*> external_values_;
 
   // Memory planning is only enabled if opts_.cleanup_activations is true.
   // Otherwise, the memory used by activations is cached inside the static
@@ -228,12 +223,18 @@ class MemoryPlanner {
  public:
   explicit MemoryPlanner(
       StaticRuntime* runtime,
-      std::unordered_map<Value*, std::vector<Value*>> should_share);
+      const std::unordered_map<const Value*, std::vector<const Value*>>&
+          should_share,
+      const std::unordered_set<const Value*>& external_values,
+      bool out_variants);
 
   void allocate();
   void deallocate();
   size_t total_managed() const {
     return managed_bytes_;
+  }
+  size_t total_reused_tensors() const {
+    return reused_tensors_;
   }
 
  private:
@@ -244,6 +245,7 @@ class MemoryPlanner {
   std::vector<std::pair<size_t, std::vector<c10::StorageImpl*>>>
       managed_storage_;
   size_t managed_bytes_{0};
+  size_t reused_tensors_{0};
   at::DataPtr buffer_; // allocated each time we call Run()
 
   static size_t compute_aligned_tensor_size(size_t nbytes);

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -74,6 +74,7 @@ bool canRunOutOfPlace(Node* n);
 bool canReuseInputsOutputs(Node* n);
 bool canReuseInputs(Node* n);
 bool canReuseOutputs(Node* n);
+bool canOptimizeConstruct(Node* n);
 bool isViewOp(Node* n);
 
 std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/runtime/static/passes.h>
 
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 
 namespace torch {
@@ -176,6 +177,73 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
   // clip_ranges+gather_ranges
   ClipRangesGather(graph);
 #endif
+}
+
+TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
+  m.def("static_runtime::pure_inputs() -> Tensor", []() -> at::Tensor {
+    return at::randn({1});
+  });
+  m.def(
+      "static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor",
+      [](at::Tensor self, ArrayRef<int64_t> dims) -> at::Tensor {
+        at::Tensor out = at::empty_like(self);
+        at::native::copy_(out, self);
+        return out.permute(dims);
+      });
+}
+
+void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
+  auto* fake_input =
+      graph->insert(Symbol::fromQualString("static_runtime::pure_inputs"), {});
+  fake_input->node()->moveBefore(*graph->nodes().begin());
+
+  std::vector<std::pair<Value*, Use>> old_inputs;
+  for (auto* input : graph->inputs()) {
+    for (const auto& use : input->uses()) {
+      old_inputs.emplace_back(std::make_pair(input, use));
+    }
+    input->replaceAllUsesWith(fake_input);
+  }
+
+  AliasDb db(graph);
+  for (const auto& p : old_inputs) {
+    p.second.user->replaceInput(p.second.offset, p.first);
+  }
+  fake_input->node()->destroy();
+
+  const std::map<c10::Symbol, c10::Symbol> supported = {
+      {c10::Symbol::fromQualString("aten::permute"),
+       c10::Symbol::fromQualString("static_runtime::permute_copy")},
+      {c10::Symbol::fromQualString("aten::narrow"),
+       c10::Symbol::fromQualString("aten::narrow_copy")}};
+  std::vector<std::pair<Node*, Node*>> replacement;
+  for (auto* n : graph->nodes()) {
+    if (!supported.count(n->kind())) {
+      continue;
+    }
+    DCHECK(n->outputs().size() == 1);
+    auto* out = n->output();
+    if (out->uses().size() > 1) {
+      continue;
+    }
+    if (db.mayContainAlias({out}, graph->outputs())) {
+      continue;
+    }
+    auto new_symbol = supported.at(n->kind());
+    auto* new_node = graph->create(new_symbol, n->outputs().size());
+    new_node->insertBefore(n);
+    for (auto* input : n->inputs()) {
+      new_node->addInput(input);
+    }
+    replacement.emplace_back(std::make_pair(n, new_node));
+  }
+
+  for (const auto& p : replacement) {
+    auto* old_node = p.first;
+    auto* new_node = p.second;
+    old_node->replaceAllUsesWith(new_node);
+    old_node->destroy();
+  }
 }
 
 } // namespace jit

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -4,6 +4,7 @@ namespace torch {
 namespace jit {
 
 void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph);
+void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
With alias analysis we get a much more powerful registration and we can start removing "native" and fallback interpreted implementations.  The current checks for inputs also running out of place are an artifact of the hardcoded "native" and lax fallback implementations.  Ideally every node will run out of place every time.  Afaik, there's never a reason to disable it and we may want to remove that functionality.

This diff does introduce a "leak" in the memory management - containers are not cleaned up.  This only happens when out variants are enabled

Test Plan: buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- --run-disabled

Differential Revision: D26515801

