### PR TITLE
Fix constexpr __host__ warning

### DIFF
--- a/c10/util/Half.h
+++ b/c10/util/Half.h
@@ -339,7 +339,7 @@ struct alignas(2) Half {
   unsigned short x;
 
   struct from_bits_t {};
-  static constexpr from_bits_t from_bits() {
+  C10_HOST_DEVICE static constexpr from_bits_t from_bits() {
     return from_bits_t();
   }
 


### PR DESCRIPTION
Summary:
Fixes:
```
stderr: caffe2/c10/util/MathConstants.h(22): warning: calling a constexpr __host__ function("from_bits") from a __host__ __device__ function("pi") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
```

Differential Revision: D26589533

