### PR TITLE
[ROCm] Enable RNN test in test_c10d_spawn.py for ROCm

### DIFF
--- a/test/distributed/test_c10d_spawn.py
+++ b/test/distributed/test_c10d_spawn.py
@@ -13,7 +13,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU
 from torch.testing._internal.common_distributed import requires_gloo, \
     create_device, MultiProcessTestCase, skip_if_not_multigpu
 from torch.testing._internal.common_utils import TestCase, load_tests, \
-    run_tests, skipIfRocm
+    run_tests
 from torch.testing._internal.common_utils import NO_MULTIPROCESSING_SPAWN, TEST_WITH_TSAN
 
 
@@ -286,7 +286,6 @@ class DistributedDataParallelSingleProcessTest(TestCase):
 
     @requires_gloo()
     @unittest.skipIf(not TEST_CUDA, "At least 1 CUDA GPUS needed")
-    @skipIfRocm
     def test_rnn(self):
         # This test is inspired by the bug reported in
         # https://github.com/pytorch/pytorch/issues/36268


### PR DESCRIPTION
Enabling test_rnn test because it is passing for ROCm.

Signed-off-by: Kyle Chen <kylechen@amd.com>

