### PR TITLE
[TensorExpr] LoopNest: Cleanup LoopNest constructors.

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -3557,7 +3557,7 @@ TEST(LoopNest, DeadStoreElimination) {
   Stmt* stmt = Block::make({stmt1});
 
   // Will eliminate if not used by an output.
-  LoopNest loop(stmt, {f.node()}, {});
+  LoopNest loop(stmt, {f.node()});
   loop.eliminateDeadStores();
 
   std::ostringstream oss;
@@ -3571,7 +3571,7 @@ TEST(LoopNest, DeadStoreElimination) {
   torch::jit::testing::FileCheck().run(expected_ir, oss.str());
 
   // But won't eliminate if used by different outputs.
-  LoopNest loop2(stmt, {f.node(), g.node()}, {});
+  LoopNest loop2(stmt, {f.node(), g.node()});
   loop2.eliminateDeadStores();
 
   oss.clear();
@@ -3612,7 +3612,7 @@ TEST(LoopNest, DeadStoreEliminationWithIntermediates) {
 
   // Will eliminate the write to g, but not f since it used by the producer of
   // h.
-  LoopNest loop(stmt, {h.node()}, {});
+  LoopNest loop(stmt, {h.node()});
   loop.eliminateDeadStores();
 
   std::ostringstream oss;
@@ -3627,7 +3627,7 @@ TEST(LoopNest, DeadStoreEliminationWithIntermediates) {
   torch::jit::testing::FileCheck().run(expected_ir, oss.str());
 
   // Sanity check won't eliminate if g is an output.
-  LoopNest loop2(stmt, {h.node(), g.node()}, {});
+  LoopNest loop2(stmt, {h.node(), g.node()});
   loop2.eliminateDeadStores();
 
   oss.clear();
@@ -3739,7 +3739,7 @@ TEST(LoopNest, InlineFromLoad) {
   auto store_a = For::make(i, 0, N, Store::make(a, {i}, i, mask));
   auto store_b =
       For::make(j, 0, N, Store::make(b, {j}, Load::make(a, {j}, mask), mask));
-  LoopNest l(Block::make({store_a, store_b}), {b.node()}, {}, {a.node()});
+  LoopNest l(Block::make({store_a, store_b}), {b.node()});
 
   l.computeInline(a.node());
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -25,8 +25,21 @@ namespace tensorexpr {
 
 LoopNest::LoopNest(const LoopNest& other)
     : root_stmt_(Stmt::clone(other.root_stmt_)),
-      output_bufs_(other.output_bufs_),
-      intermediate_bufs_(other.intermediate_bufs_) {}
+      output_bufs_(other.output_bufs_) {}
+
+LoopNest::LoopNest(
+    const std::vector<Tensor*>& output_tensors,
+    const std::vector<Tensor*>& tensors_to_compute) {
+  initialize(output_tensors, tensors_to_compute);
+}
+
+LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
+  // Find all tensors we need to compute (including dependencies) and put them
+  // in a topological order
+  std::vector<Tensor*> tensors_to_compute =
+      findAllNeededTensors(output_tensors);
+  initialize(output_tensors, tensors_to_compute);
+}
 
 class FunctionCallUseCount : public IRVisitor {
  public:
@@ -49,6 +62,36 @@ class FunctionCallUseCount : public IRVisitor {
   std::unordered_map<const Buf*, std::unordered_set<const FunctionCall*>>
       function_calls_;
 };
+
+const std::unordered_set<const Buf*> LoopNest::getIntermediateBufs() const {
+  std::unordered_set<const Buf*> result;
+  auto input_bufs = getInputBufs();
+  auto bufs = NodeFinder<Buf>::find(root_stmt_);
+  for (auto* buf : bufs) {
+    if (!output_bufs_.count(buf) && !input_bufs.count(buf)) {
+      result.insert(buf);
+    }
+  }
+  return result;
+}
+
+const std::unordered_set<const Buf*> LoopNest::getInputBufs() const {
+  std::unordered_set<const Buf*> result;
+  auto buf_load_store_uses = findLoadOrStoreUses(root_stmt_);
+  for (const auto& kv : buf_load_store_uses) {
+    bool has_store = false;
+    for (const auto& use : kv.second) {
+      if (use.isStore) {
+        has_store = true;
+        break;
+      }
+    }
+    if (!has_store) {
+      result.insert(kv.first);
+    }
+  }
+  return result;
+}
 
 class IndexFlattener : public IRMutator {
  public:
@@ -448,14 +491,6 @@ void LoopNest::initialize(
     output_bufs_.insert(t->buf());
   }
 
-  // Find all intermediate tensors, we'll need that for inserting alloc/free
-  // statements
-  for (Tensor* t : tensors_to_compute) {
-    if (!output_bufs_.count(t->buf())) {
-      intermediate_bufs_.insert(t->buf());
-    }
-  }
-
   std::vector<Stmt*> loops;
   for (Tensor* t : tensors_to_compute) {
     Stmt* loop = t->stmt();
@@ -476,29 +511,6 @@ void LoopNest::initialize(
   }
 
   root_stmt_ = new Block(loops);
-
-  // If it's referenced in the root_stmt, but it's not in output_bufs_ or
-  // intermediate_bufs_ then it must be an input.
-  auto bufs = NodeFinder<Buf>::find(root_stmt_);
-  for (auto* buf : bufs) {
-    if (!output_bufs_.count(buf) && !intermediate_bufs_.count(buf)) {
-      input_bufs_.insert(buf);
-    }
-  }
-}
-
-LoopNest::LoopNest(
-    const std::vector<Tensor*>& output_tensors,
-    const std::vector<Tensor*>& tensors_to_compute) {
-  initialize(output_tensors, tensors_to_compute);
-}
-
-LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
-  // Find all tensors we need to compute (including dependencies) and put them
-  // in a topological order
-  std::vector<Tensor*> tensors_to_compute =
-      findAllNeededTensors(output_tensors);
-  initialize(output_tensors, tensors_to_compute);
 }
 
 class FunctionInliner : public IRMutator {
@@ -752,8 +764,6 @@ bool LoopNest::computeInline(const Buf* b) {
   FunctionInliner inliner(relevant_store, output_bufs_);
   root_stmt_ = root_stmt_->accept_mutator(&inliner);
 
-  // No longer computing this intermediate tensor, so don't alloc it.
-  intermediate_bufs_.erase(b);
   return true;
 }
 
@@ -762,20 +772,18 @@ bool LoopNest::computeInline(const Buf* b) {
 // difficult synchronization logic across blocks. Inlining trivial reads does
 // not duplicate work
 void LoopNest::inlineIntermediateBufs(bool allow_duplicated_work) {
-  // We need to collect all intermediate buffers as the buffers to be inlined
-  // before calling 'computeInline' since the buffers that are inlined are
-  // erased from the set 'intermediate_bufs_' in that function.
   std::unordered_set<const Buf*> bufs_to_inline;
 
+  auto intermediate_bufs = getIntermediateBufs();
   if (allow_duplicated_work) {
-    bufs_to_inline.insert(intermediate_bufs_.begin(), intermediate_bufs_.end());
+    bufs_to_inline.insert(intermediate_bufs.begin(), intermediate_bufs.end());
   } else {
     FunctionCallUseCount fcu;
     auto function_call_uses = fcu.findUses(root_stmt_);
     auto buf_load_store_uses = findLoadOrStoreUses(root_stmt_);
     auto input_bufs = getInputBufs();
 
-    for (auto buf : intermediate_bufs_) {
+    for (auto buf : intermediate_bufs) {
       TORCH_INTERNAL_ASSERT(buf_load_store_uses.count(buf));
       std::vector<BufLoadOrStoreUse>& uses = buf_load_store_uses[buf];
       auto stores = c10::filter(
@@ -929,7 +937,8 @@ Block* findLowestContainingBlock(const std::vector<BufLoadOrStoreUse>& uses) {
 }
 
 Stmt* LoopNest::insertAllocFree(Stmt* stmt) {
-  if (intermediate_bufs_.size() == 0ULL) {
+  auto intermediate_bufs = getIntermediateBufs();
+  if (intermediate_bufs.size() == 0ULL) {
     return stmt;
   }
 
@@ -942,7 +951,7 @@ Stmt* LoopNest::insertAllocFree(Stmt* stmt) {
       findLoadOrStoreUses(stmt);
   // Insert allocations and frees for temporary buffers in the innermost
   // possible scope.
-  for (const Buf* buf : intermediate_bufs_) {
+  for (const Buf* buf : intermediate_bufs) {
     Stmt* alloc = new Allocate(buf);
     Stmt* free = new Free(buf);
     Block* alloc_block = findLowestContainingBlock(uses.at(buf));
@@ -1867,8 +1876,6 @@ LoopNest::AccessResult LoopNest::cacheAccesses(
   Stmt* new_consumer =
       IRSimplifier::simplify(consumer->accept_mutator(&replacer));
 
-  intermediate_bufs_.insert(tmp_buf);
-
   // replace the old consumer with the replaced consumer.
   Block* consumer_block = nullptr;
   // if the consumer is a block, we should mutate it in place.
@@ -2150,10 +2157,6 @@ void LoopNest::computeAt(Stmt* s, For* f) {
     Block* bb = dynamic_cast<Block*>(f->get_parent());
     bb->replace_stmt(f, new_f);
   }
-
-  // Mark the new temp buffer as requiring an alloc (it will be inserted as a
-  // part of prepareForCodegen).
-  intermediate_bufs_.insert(temp_buf);
 }
 
 class SwapReduce : public IRMutator {
@@ -2460,7 +2463,6 @@ void LoopNest::rfactor(
 
   std::vector<const Expr*> tmp_dims = getBoundExtents(bounds_it->second);
   tmp_buf->set_dims(tmp_dims);
-  intermediate_bufs_.insert(tmp_buf);
 }
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -30,25 +30,13 @@ class TORCH_API LoopNest {
       const std::vector<Tensor*>& output_tensors,
       const std::vector<Tensor*>& tensors_to_compute);
 
-  // A constructor for building a LoopNest from a pre-baked Stmt and meta-info
-  // TODO: Nuke intermediate_bufs_ from here if they can be deduced.
-  LoopNest(
-      Stmt* stmt,
-      const std::unordered_set<const Buf*>& output_bufs,
-      const std::unordered_set<const Buf*>& input_bufs,
-      const std::unordered_set<const Buf*>& intermediate_bufs)
-      : root_stmt_(stmt),
-        input_bufs_(input_bufs),
-        output_bufs_(output_bufs),
-        intermediate_bufs_(intermediate_bufs) {}
-  LoopNest(
-      Stmt* stmt,
-      const std::unordered_set<const Buf*>& output_bufs,
-      const std::unordered_set<const Buf*>& intermediate_bufs)
-      : root_stmt_(stmt),
-        output_bufs_(output_bufs),
-        intermediate_bufs_(intermediate_bufs) {}
+  // A constructor for building a LoopNest from an Stmt and a list of output
+  // buffers.
+  LoopNest(Stmt* stmt, const std::unordered_set<const Buf*>& output_bufs)
+      : root_stmt_(stmt), output_bufs_(output_bufs) {}
 
+  // A constructor for building a LoopNest from another loopnest. It clones the
+  // other loopnest's stmt.
   LoopNest(const LoopNest& other);
 
   Stmt* root_stmt() const {
@@ -126,10 +114,8 @@ class TORCH_API LoopNest {
   // for the LLVM backend, when no reductions are involved.
   void vectorizeInnerLoops();
 
-  const std::unordered_set<const Buf*> getInputBufs() {
-    return input_bufs_;
-  }
-  const std::unordered_set<const Buf*> getOutputBufs() {
+  const std::unordered_set<const Buf*> getInputBufs() const;
+  const std::unordered_set<const Buf*> getOutputBufs() const {
     return output_bufs_;
   }
 
@@ -138,12 +124,11 @@ class TORCH_API LoopNest {
       const std::vector<Tensor*>& output_tensors,
       const std::vector<Tensor*>& tensors_to_compute);
   Stmt* insertAllocFree(Stmt* stmt);
+  const std::unordered_set<const Buf*> getIntermediateBufs() const;
 
   Stmt* root_stmt_;
 
-  std::unordered_set<const Buf*> input_bufs_;
   std::unordered_set<const Buf*> output_bufs_;
-  std::unordered_set<const Buf*> intermediate_bufs_;
 };
 
 TORCH_API Stmt* FlattenIndexes(Stmt* s);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52726 [TensorExpr] LoopNest: Cleanup LoopNest constructors.**

This change removes `input_bufs_` and `intermediate_bufs_` from
`LoopNest` class as they can be deduced from the root stmt and the list
of output bufs. As a result, the constuctor of the LoopNest also becomes
simpler as we now need to pass just one list of bufs.

Note: we might consider passing list of input bufs for verification
purposes (only inputs buffers are allowed to not have a definition), but
since we don't really have an IR verifier yet, there is no need in it
now. Once we add IR verifier, we could reconsider it.

Differential Revision: [D26629596](https://our.internmc.facebook.com/intern/diff/D26629596)