### PR TITLE
Use touch() in pathlib for better compatibility on Windows

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -345,7 +345,7 @@ endif()
 add_custom_command(
   OUTPUT ${TORCH_SRC_DIR}/version.py
   COMMAND
-    touch ${TOOLS_PATH}/generate_torch_version.py
+    "${PYTHON_EXECUTABLE}" -c \"from pathlib import Path\; Path('${TOOLS_PATH}/generate_torch_version.py').touch()\"
   COMMAND
     "${PYTHON_EXECUTABLE}" ${TOOLS_PATH}/generate_torch_version.py
       --is_debug=${TORCH_VERSION_DEBUG}


### PR DESCRIPTION
#52477 introduced the usage of `touch`, which is not available on plain Windows environment, unless you made all the things come with Git Bash available. This PR fixes the build break on those systems by using the `touch` provided by Python pathlib.