### PR TITLE
fix output dtype test in compute_types

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -297,19 +297,25 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
       common_device = op.tensor.device();
     }
 
-    // Determines if there are varying input dtypes
-    // NOTE: the common dtype is set to the first defined input dtype observed
-    if (!op.is_output && op.target_dtype != common_dtype_) {
-      if (common_dtype_ == ScalarType::Undefined) {
-        common_dtype_ = op.target_dtype;
-      } else {
-        has_different_input_dtypes = true;
+    if (!op.is_output) {
+      // Determines if there are varying input dtypes
+      // NOTE: the common dtype is set to the first defined input dtype observed
+      if (op.target_dtype != common_dtype_) {
+        if (common_dtype_ == ScalarType::Undefined) {
+          common_dtype_ = op.target_dtype;
+        } else {
+          has_different_input_dtypes = true;
+        }
       }
-    } else if (op.is_output && op.target_dtype != common_dtype_) {
-      if (output_dtype == ScalarType::Undefined) {
-        output_dtype = op.target_dtype;
-      } else {
-        has_different_output_dtypes = true;
+    } else {  // op.is_output
+      // Determines if there are varying output dtypes
+      // NOTE: the output dtype is set to the first defined output dtype observed
+      if (op.target_dtype != output_dtype) {
+        if (output_dtype == ScalarType::Undefined) {
+          output_dtype = op.target_dtype;
+        } else {
+          has_different_output_dtypes = true;
+        }
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52731 fix output dtype test in compute_types**

Fixes `compute_types` logic for computing a common output dtype from multiple output tensors.

Differential Revision: [D26630251](https://our.internmc.facebook.com/intern/diff/D26630251)