### PR TITLE
Update test cases generated by make_test() method to support running them in script mode.

### DIFF
--- a/test/onnx/model_defs/lstm_flattening_result.py
+++ b/test/onnx/model_defs/lstm_flattening_result.py
@@ -1,7 +1,34 @@
 from torch import nn
+from torch.nn.utils.rnn import PackedSequence
 
 
 class LstmFlatteningResult(nn.LSTM):
     def forward(self, input, *fargs, **fkwargs):
         output, (hidden, cell) = nn.LSTM.forward(self, input, *fargs, **fkwargs)
+        return output, hidden, cell
+
+class LstmFlatteningResultWithSeqLength(nn.Module):
+    def __init__(self, input_size, hidden_size, layers, bidirect, dropout, batch_first):
+        super(LstmFlatteningResultWithSeqLength, self).__init__()
+
+        self.batch_first = batch_first
+        self.inner_model = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=layers, 
+                                   bidirectional=bidirect, dropout=dropout,
+                                   batch_first=batch_first)
+
+    def forward(self, input: PackedSequence, hx=None):
+        output, (hidden, cell) = self.inner_model.forward(input, hx)
+        return output, hidden, cell
+
+class LstmFlatteningResultWithoutSeqLength(nn.Module):
+    def __init__(self, input_size, hidden_size, layers, bidirect, dropout, batch_first):
+        super(LstmFlatteningResultWithoutSeqLength, self).__init__()
+
+        self.batch_first = batch_first
+        self.inner_model = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=layers, 
+                                   bidirectional=bidirect, dropout=dropout,
+                                   batch_first=batch_first)
+
+    def forward(self, input, hx=None):
+        output, (hidden, cell) = self.inner_model.forward(input, hx)
         return output, hidden, cell

--- a/test/onnx/model_defs/rnn_model_with_packed_sequence.py
+++ b/test/onnx/model_defs/rnn_model_with_packed_sequence.py
@@ -21,4 +21,4 @@ class RnnModelWithPackedSequence(nn.Module):
         rets = self.model(input)
         ret, rets = rets[0], rets[1:]
         ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
-        return tuple([ret] + list(rets))    
+        return tuple([ret] + list(rets))

--- a/test/onnx/model_defs/rnn_model_with_packed_sequence.py
+++ b/test/onnx/model_defs/rnn_model_with_packed_sequence.py
@@ -15,7 +15,7 @@ class RnnModelWithPackedSequence(nn.Module):
         ret, rets = rets[0], rets[1:]
         ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
         return tuple([ret] + list(rets))
-    
+
 class RnnModelWithPackedSequenceWithoutState(nn.Module):
     def __init__(self, model, batch_first):
         super(RnnModelWithPackedSequenceWithoutState, self).__init__()
@@ -28,7 +28,7 @@ class RnnModelWithPackedSequenceWithoutState(nn.Module):
         ret, rets = rets[0], rets[1:]
         ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
         return list([ret] + list(rets))
-    
+
 class RnnModelWithPackedSequenceWithState(nn.Module):
     def __init__(self, model, batch_first):
         super(RnnModelWithPackedSequenceWithState, self).__init__()

--- a/test/onnx/model_defs/rnn_model_with_packed_sequence.py
+++ b/test/onnx/model_defs/rnn_model_with_packed_sequence.py
@@ -8,17 +8,36 @@ class RnnModelWithPackedSequence(nn.Module):
         self.model = model
         self.batch_first = batch_first
 
-    # def forward(self, input, *args):
-    #     args, seq_lengths = args[:-1], args[-1]
-    #     input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
-    #     rets = self.model(input, *args)
-    #     ret, rets = rets[0], rets[1:]
-    #     ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
-    #     return tuple([ret] + list(rets))
+    def forward(self, input, *args):
+        args, seq_lengths = args[:-1], args[-1]
+        input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
+        rets = self.model(input, *args)
+        ret, rets = rets[0], rets[1:]
+        ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
+        return tuple([ret] + list(rets))
+    
+class RnnModelWithPackedSequenceWithoutState(nn.Module):
+    def __init__(self, model, batch_first):
+        super(RnnModelWithPackedSequenceWithoutState, self).__init__()
+        self.model = model
+        self.batch_first = batch_first
 
     def forward(self, input, seq_lengths):
         input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
         rets = self.model(input)
         ret, rets = rets[0], rets[1:]
         ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
-        return tuple([ret] + list(rets))
+        return list([ret] + list(rets))
+    
+class RnnModelWithPackedSequenceWithState(nn.Module):
+    def __init__(self, model, batch_first):
+        super(RnnModelWithPackedSequenceWithState, self).__init__()
+        self.model = model
+        self.batch_first = batch_first
+
+    def forward(self, input, hx, seq_lengths):
+        input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
+        rets = self.model(input, hx)
+        ret, rets = rets[0], rets[1:]
+        ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
+        return list([ret] + list(rets))

--- a/test/onnx/model_defs/rnn_model_with_packed_sequence.py
+++ b/test/onnx/model_defs/rnn_model_with_packed_sequence.py
@@ -8,10 +8,17 @@ class RnnModelWithPackedSequence(nn.Module):
         self.model = model
         self.batch_first = batch_first
 
-    def forward(self, input, *args):
-        args, seq_lengths = args[:-1], args[-1]
+    # def forward(self, input, *args):
+    #     args, seq_lengths = args[:-1], args[-1]
+    #     input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
+    #     rets = self.model(input, *args)
+    #     ret, rets = rets[0], rets[1:]
+    #     ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
+    #     return tuple([ret] + list(rets))
+
+    def forward(self, input, seq_lengths):
         input = rnn_utils.pack_padded_sequence(input, seq_lengths, self.batch_first)
-        rets = self.model(input, *args)
+        rets = self.model(input)
         ret, rets = rets[0], rets[1:]
         ret, _ = rnn_utils.pad_packed_sequence(ret, self.batch_first)
-        return tuple([ret] + list(rets))
+        return tuple([ret] + list(rets))    

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6970,6 +6970,13 @@ def make_test(name, base, layer, bidirectional, initial_state,
 
     # Cannot export with older opsets because of 'ConstantFill' op
     # ConstantFill was a temp op removed at opset 8. This is no longer supported by onnxruntime
+    # There are still some issues prevent us from enabling script test for these scenarios:
+    # test_gru_*:
+    #   Operator aten::as_tensor is not supported by exporter yet.
+    #       - https://msdata.visualstudio.com/Vienna/_workitems/edit/1055382
+    #   Operator aten::_pack_padded_sequence is not supported by exporter yet.
+    #       - https://msdata.visualstudio.com/Vienna/_workitems/edit/1055384
+    @disableScriptTest()
     @skipIfUnsupportedMinOpsetVersion(9)
     def f(self):
         self._dispatch_rnn_test(

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -10,7 +10,9 @@ import os
 
 from torch.nn.utils import rnn as rnn_utils
 from model_defs.lstm_flattening_result import LstmFlatteningResult
-from model_defs.rnn_model_with_packed_sequence import RnnModelWithPackedSequence, RnnModelWithPackedSequenceWithState, RnnModelWithPackedSequenceWithoutState
+from model_defs.rnn_model_with_packed_sequence import (RnnModelWithPackedSequence, 
+                                                       RnnModelWithPackedSequenceWithState, 
+                                                       RnnModelWithPackedSequenceWithoutState)
 from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, skipIfUnsupportedOpsetVersion,
                                  skipIfNoLapack, disableScriptTest, disableOldJitPassesTest,
                                  skipIfUnsupportedMaxOpsetVersion, skipIfONNXShapeInference)
@@ -6027,18 +6029,22 @@ class TestONNXRuntime(unittest.TestCase):
 
         if packed_sequence == 0:
             if initial_state:
-                model = GRUNoSeqLengthWithStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
+                model = GRUNoSeqLengthWithStateModel(layers=layers, bidirect=bidirectional, 
+                                                     dropout=dropout, batch_first=batch_first)
             else:
-                model = GRUNoSeqLengthWithoutStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)            
+                model = GRUNoSeqLengthWithoutStateModel(layers=layers, bidirect=bidirectional, 
+                                                        dropout=dropout, batch_first=batch_first)            
         else:
             if initial_state:
-                model = GRUWithStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
+                model = GRUWithStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, 
+                                          batch_first=batch_first)
                 if packed_sequence == 1: 
                     model = RnnModelWithPackedSequenceWithState(model, False)
                 if packed_sequence == 2:
                     model = RnnModelWithPackedSequenceWithState(model, True)                
             else:
-                model = GRUWithoutStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
+                model = GRUWithoutStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, 
+                                             batch_first=batch_first)
                 if packed_sequence == 1:
                     model = RnnModelWithPackedSequenceWithoutState(model, False)
                 if packed_sequence == 2:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5991,7 +5991,8 @@ class TestONNXRuntime(unittest.TestCase):
                 super(GRUWithStateModel, self).__init__()
 
                 self.batch_first = batch_first
-                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, 
+                                                bidirectional=bidirectional, dropout=dropout,
                                                 batch_first=batch_first)
 
             def forward(self, input, hx):
@@ -6001,7 +6002,8 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, layers, bidirect, dropout, batch_first):
                 super(GRUWithoutStateModel, self).__init__()
                 self.batch_first = batch_first
-                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, 
+                                                bidirectional=bidirectional, dropout=dropout,
                                                 batch_first=batch_first)
 
             def forward(self, input):
@@ -6998,7 +7000,7 @@ def setup_rnn_tests():
                 TestONNXRuntime.disable_rnn_script_test = False
 
             make_test(name, base, layer, bidirectional, initial_state,
-                      variable_length, dropout, 
+                      variable_length, dropout,
                       **extra_kwargs)
             test_count += 1
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5950,7 +5950,8 @@ class TestONNXRuntime(unittest.TestCase):
                 super(GRUWithStateModel, self).__init__()
 
                 self.batch_first = batch_first
-                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, 
+                                                bidirectional=bidirectional, dropout=dropout,
                                                 batch_first=batch_first)
 
             def forward(self, input, hx):
@@ -5960,7 +5961,8 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, layers, bidirect, dropout, batch_first):
                 super(GRUWithoutStateModel, self).__init__()
                 self.batch_first = batch_first
-                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, 
+                                                bidirectional=bidirectional, dropout=dropout,
                                                 batch_first=batch_first)
 
             def forward(self, input):
@@ -6802,7 +6804,7 @@ def setup_rnn_tests():
                 TestONNXRuntime.disable_rnn_script_test = False
 
             make_test(name, base, layer, bidirectional, initial_state,
-                      variable_length, dropout, 
+                      variable_length, dropout,
                       **extra_kwargs)
             test_count += 1
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -218,6 +218,7 @@ class TestONNXRuntime(unittest.TestCase):
     keep_initializers_as_inputs = True  # For IR version 3 type export.
     use_new_jit_passes = True  # For testing main code-path
     onnx_shape_inference = True
+    disable_rnn_script_test = False
 
     def setUp(self):
         torch.manual_seed(0)
@@ -5857,9 +5858,18 @@ class TestONNXRuntime(unittest.TestCase):
 
     def _elman_rnn_test(self, layers, nonlinearity, bidirectional,
                         initial_state, packed_sequence, dropout):
+        class RNNWrappedModel(torch.nn.Module):
+            def __init__(self, layers, nonlinear, bidirect, dropout, batch_first):
+                super(RNNWrappedModel, self).__init__()
+
+                self.inner_model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, nonlinearity=nonlinear, 
+                                                bidirectional=bidirect, dropout=dropout, batch_first=batch_first)
+
+            def forward(self, input, hx: torch.Tensor):
+                return self.inner_model(input, hx)
+
         batch_first = True if packed_sequence == 2 else False
-        model = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, nonlinearity=nonlinearity,
-                             bidirectional=bidirectional, dropout=dropout, batch_first=batch_first)
+        model = RNNWrappedModel(layers, nonlinear=nonlinearity, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
 
         if packed_sequence == 1:
             model = RnnModelWithPackedSequence(model, False)
@@ -5934,9 +5944,34 @@ class TestONNXRuntime(unittest.TestCase):
 
     def _gru_test(self, layers, bidirectional, initial_state,
                   packed_sequence, dropout):
+
+        class GRUWithStateModel(torch.nn.Module):
+            def __init__(self, layers, bidirect, dropout, batch_first):
+                super(GRUWithStateModel, self).__init__()
+
+                self.batch_first = batch_first
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                                                batch_first=batch_first)
+
+            def forward(self, input, hx):
+                return self.inner_model(input, hx)
+
+        class GRUWithoutStateModel(torch.nn.Module):
+            def __init__(self, layers, bidirect, dropout, batch_first):
+                super(GRUWithoutStateModel, self).__init__()
+                self.batch_first = batch_first
+                self.inner_model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, num_layers=layers, bidirectional=bidirectional, dropout=dropout,
+                                                batch_first=batch_first)
+
+            def forward(self, input):
+                return self.inner_model(input, None)
+
         batch_first = True if packed_sequence == 2 else False
-        model = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, layers, bidirectional=bidirectional, dropout=dropout,
-                             batch_first=batch_first)
+        if initial_state:
+            model = GRUWithStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
+        else:
+            model = GRUWithoutStateModel(layers=layers, bidirect=bidirectional, dropout=dropout, batch_first=batch_first)
+
         if packed_sequence == 1:
             model = RnnModelWithPackedSequence(model, False)
         if packed_sequence == 2:
@@ -6707,9 +6742,11 @@ def make_test(name, base, layer, bidirectional, initial_state,
 
     # Cannot export with older opsets because of 'ConstantFill' op
     # ConstantFill was a temp op removed at opset 8. This is no longer supported by onnxruntime
-    @disableScriptTest()  # Test code not scriptable
     @skipIfUnsupportedMinOpsetVersion(9)
     def f(self):
+        if self.disable_rnn_script_test:
+            self.is_script_test_enabled = False
+
         self._dispatch_rnn_test(
             base,
             layers=layer[0],
@@ -6759,8 +6796,13 @@ def setup_rnn_tests():
                 ('lstm', 'lstm', {}),
                 ('gru', 'gru', {})
         ):
+            if not variable_length == 'without_sequence_lengths':
+                TestONNXRuntime.disable_rnn_script_test = True
+            else:
+                TestONNXRuntime.disable_rnn_script_test = False
+
             make_test(name, base, layer, bidirectional, initial_state,
-                      variable_length, dropout,
+                      variable_length, dropout, 
                       **extra_kwargs)
             test_count += 1
 


### PR DESCRIPTION
Update code relative to all test_gru_* test cases. Still disable them running in script mode because of 2 issues:

Operator aten::as_tensor is not supported by exporter yet.
      - https://msdata.visualstudio.com/Vienna/_workitems/edit/1055382
Operator aten::_pack_padded_sequence is not supported by exporter yet.
      - https://msdata.visualstudio.com/Vienna/_workitems/edit/1055384
