### PR TITLE
Use finer-grained mutexes in TensorPipe RPC agent

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_TENSORPIPE
 
 #include <limits>
+#include <tuple>
+#include <utility>
 
 #include <fmt/format.h>
 #include <tensorpipe/tensorpipe.h>
@@ -840,26 +842,34 @@ std::shared_ptr<JitFuture> TensorPipeAgent::send(
 
   const auto& url = findWorkerURL(toWorkerInfo);
 
-  std::unique_lock<std::mutex> lock(mutex_);
+  decltype(connectedPipes_)::iterator it;
+  {
+    std::unique_lock<std::mutex> lock(connectedPipesMutex_);
 
-  // See if we already have a connection to this address or not
-  auto it = connectedPipes_.find(toWorkerInfo.id_);
-  if (it == connectedPipes_.end()) {
-    std::tie(it, std::ignore) = connectedPipes_.emplace(
-        toWorkerInfo.id_,
-        ClientPipe(context_->connect(
-            url, tensorpipe::PipeOptions().remoteName(toWorkerInfo.name_))));
+    // See if we already have a connection to this address or not
+    it = connectedPipes_.find(toWorkerInfo.id_);
+    if (it == connectedPipes_.end()) {
+      // An instance of ClientPipe cannot be copied or moved as it contains a
+      // mutex, and to force in-place construction in GCC 5 we need piecewise
+      // construction in order to work around an issue.
+      std::tie(it, std::ignore) = connectedPipes_.emplace(
+          std::piecewise_construct,
+          std::forward_as_tuple(toWorkerInfo.id_),
+          std::forward_as_tuple(context_->connect(
+              url, tensorpipe::PipeOptions().remoteName(toWorkerInfo.name_))));
+    }
   }
   ClientPipe& clientPipe = it->second;
-  auto& pendingResponseMessage = clientPipe.pendingResponseMessage_;
 
   auto futureResponseMessage = std::make_shared<AtomicJitFuture>(
       reverseDeviceMaps_.empty() && opts_.deviceMaps.empty());
   uint64_t messageId = nextMessageID_++;
   requestMessage.setId(messageId);
-  pendingResponseMessage[messageId] = futureResponseMessage;
 
-  lock.unlock();
+  {
+    std::unique_lock<std::mutex> lock(clientPipe.mutex_);
+    clientPipe.pendingResponseMessage_[messageId] = futureResponseMessage;
+  }
 
   // Get devices for tensors in the request message. This can throw if device
   // maps are not configured properly for this request.
@@ -928,11 +938,21 @@ std::shared_ptr<JitFuture> TensorPipeAgent::send(
                          << clientPipe.pipe_->getRemoteName() << ": "
                          << error.what();
           }
-          auto pendingFutIt =
-              clientPipe.pendingResponseMessage_.find(messageId);
-          if (pendingFutIt != clientPipe.pendingResponseMessage_.end()) {
-            markFutureWithError(pendingFutIt->second, error.what());
+          std::shared_ptr<AtomicJitFuture> futureResponseMessage;
+          {
+            std::lock_guard<std::mutex> lock(clientPipe.mutex_);
+            auto pendingFutIt =
+                clientPipe.pendingResponseMessage_.find(messageId);
+            TORCH_INTERNAL_ASSERT(
+                pendingFutIt != clientPipe.pendingResponseMessage_.end(),
+                "message ID ",
+                messageId,
+                " is not recognized");
+            futureResponseMessage = std::move(pendingFutIt->second);
+            clientPipe.pendingResponseMessage_.erase(pendingFutIt);
           }
+          markFutureWithError(futureResponseMessage, error.what());
+          removeFromTimeoutMap(messageId);
           return;
         }
 
@@ -961,7 +981,7 @@ std::shared_ptr<JitFuture> TensorPipeAgent::send(
                 // error state.
                 decltype(clientPipe.pendingResponseMessage_) pendingMsgs;
                 {
-                  std::lock_guard<std::mutex> lock(mutex_);
+                  std::lock_guard<std::mutex> lock(clientPipe.mutex_);
                   std::swap(clientPipe.pendingResponseMessage_, pendingMsgs);
                   clientPipe.readError_ = true;
                 }
@@ -985,7 +1005,7 @@ std::shared_ptr<JitFuture> TensorPipeAgent::send(
 
               std::shared_ptr<AtomicJitFuture> futureResponseMessage;
               {
-                std::lock_guard<std::mutex> lock(mutex_);
+                std::lock_guard<std::mutex> lock(clientPipe.mutex_);
                 // A read error will lead all following callbacks to be
                 // invoked with error, and shouldn't reach here.
                 TORCH_INTERNAL_ASSERT(
@@ -1360,13 +1380,10 @@ size_t TensorPipeAgent::timeoutMapSize() {
 }
 
 size_t TensorPipeAgent::numPendingResponses() {
-  size_t totalPending = 0;
-  std::unique_lock<std::mutex> lock(mutex_);
-  for (const auto& entry : connectedPipes_) {
-    totalPending += entry.second.pendingResponseMessage_.size();
-  }
-  return totalPending;
+  std::unique_lock<std::mutex> lock(callCountMutex_);
+  return clientActiveCalls_;
 }
+
 size_t TensorPipeAgent::messageIdToTimeoutMapSize() {
   std::unique_lock<std::mutex> lock(timeoutMapMutex_);
   return messageIdToTimeout_.size();

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -336,6 +336,7 @@ class TensorPipeAgent : public RpcAgent {
   struct ClientPipe {
     explicit ClientPipe(std::shared_ptr<tensorpipe::Pipe> pipe) : pipe_(pipe) {}
     std::shared_ptr<tensorpipe::Pipe> pipe_;
+    mutable std::mutex mutex_;
     bool readError_{false};
     // Map from Message Request ID's to corresponding futures.
     std::unordered_map<uint64_t, std::shared_ptr<AtomicJitFuture>>
@@ -348,6 +349,8 @@ class TensorPipeAgent : public RpcAgent {
   ThreadPool threadPool_;
   std::shared_ptr<tensorpipe::Context> context_;
   std::shared_ptr<tensorpipe::Listener> listener_;
+
+  mutable std::mutex connectedPipesMutex_;
   std::unordered_map<worker_id_t, ClientPipe> connectedPipes_;
 
   // Maps keyed on name and id for easy WorkerInfo lookup.
@@ -364,8 +367,7 @@ class TensorPipeAgent : public RpcAgent {
   // group, but probably one day we might want to re-implement them using RPCs.
   const c10::intrusive_ptr<::c10d::ProcessGroup> processGroup_;
 
-  mutable std::mutex mutex_;
-  uint64_t nextMessageID_{0};
+  std::atomic<uint64_t> nextMessageID_{0};
 
   // Metadata used for tracking of whether certain RPCs have timed out or not.
   struct TimeoutMessageMetadata {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52749 Use finer-grained mutexes in TensorPipe RPC agent**

TensorPipe has recently changed some implementation details in how it schedules callbacks and this has exposed an issue in the RPC agent. Previously the callbacks of each pipe were executed independently and possibly simultaneously. For safety reasons (especially during shutdown) TensorPipe now synchronizes the pipes and thus invokes one callback at a time. Another characteristic of TensorPipe is that it "hijacks" some user threads to run some callbacks inline (e.g., if a low-level event loop completes an operation while a pipe is already busy, this completion is queued up and the user callback could be invoked later by a different thread, including the user's own thread).

These two effects combined caused a "reentrancy" phenomenon, where calling `context->connect` (formerly on line 850) to create a new client-side pipe could cause invoking a read callback on another pipe. Since we were holding `mutex_` when calling `context->connect`, and we were trying to re-acquire `mutex_` inside the read callback, this lead to a deadlock.

One solution to this problem is using finer-grained mutexes. In particular, introduce a mutex for each outgoing pipe (rather than a global one), which thus becomes the only one we need to acquire inside callbacks. At this point, the old `mutex_` is only guarding the vector of ClientPipes, thus we can rename it and release it earlier.

I also fixed the agent not acquiring any mutex when it set a message to error after a failed write (and also not removing the message from the timeout map).

Differential Revision: [D26636345](https://our.internmc.facebook.com/intern/diff/D26636345/)