### PR TITLE
Add sample validation for LKJCholesky.log_prob

### DIFF
--- a/docs/source/distributions.rst
+++ b/docs/source/distributions.rst
@@ -176,6 +176,15 @@ Probability distributions - torch.distributions
     :undoc-members:
     :show-inheritance:
 
+:hidden:`LKJCholesky`
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: torch.distributions.lkj_cholesky
+.. autoclass:: LKJCholesky
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :hidden:`Laplace`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -337,7 +346,7 @@ Probability distributions - torch.distributions
     :members:
     :undoc-members:
     :show-inheritance:
-    
+
 :hidden:`Weibull`
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/torch/distributions/__init__.py
+++ b/torch/distributions/__init__.py
@@ -135,6 +135,7 @@ __all__ = [
     'HalfNormal',
     'Independent',
     'Kumaraswamy',
+    'LKJCholesky',
     'Laplace',
     'LogNormal',
     'LogisticNormal',

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -109,6 +109,8 @@ class LKJCholesky(Distribution):
         # So the probability of a Cholesky factor is propotional to
         #   prod(L_ii ^ (2 * concentration - 2 + D - i)) = prod(L_ii ^ order_i)
         # with order_i = 2 * concentration - 2 + D - i
+        if self._validate_args:
+            self._validate_sample(value)
         diag_elems = value.diagonal(dim1=-1, dim2=-2)[..., 1:]
         order = torch.arange(2, self.dim + 1)
         order = 2 * (self.concentration - 1).unsqueeze(-1) + self.dim - order


### PR DESCRIPTION
Fixes #52724.

This fixes the following for the LKJCholesky distribution in master:
 - `log_prob` does sample validation when `validate_args=True`.
 - exposes documentation for the LKJCholesky distribution.

cc. @fehiepsi, @fritzo 
