### PR TITLE
ns for fx: decouple subgraph names from node names

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -466,7 +466,10 @@ class TestFXGraphMatcher(QuantizationTestCase):
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
 
-        expected_types = {'0': ((nn.Conv2d, nn.Conv2d), (nnq.Conv2d, nnq.Conv2d))}
+        expected_types = {
+            'base_op_torch.nn.Conv2d_0':
+                ((nn.Conv2d, nn.Conv2d), (nnq.Conv2d, nnq.Conv2d)),
+        }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
     @override_qengines
@@ -489,7 +492,10 @@ class TestFXGraphMatcher(QuantizationTestCase):
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
 
-        expected_types = {'linear': ((F.linear, F.linear), (toq.linear, toq.linear))}
+        expected_types = {
+            'base_op_torch.nn.functional.linear_0':
+                ((F.linear, F.linear), (toq.linear, toq.linear))
+        }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
     @override_qengines
@@ -514,7 +520,10 @@ class TestFXGraphMatcher(QuantizationTestCase):
         mq = convert_fx(mp_copy)
         results = get_matching_subgraph_pairs(mp, mq)
 
-        expected_types = {'linear_relu': ((F.linear, F.relu), (toq.linear_relu, toq.linear_relu))}
+        expected_types = {
+            'base_op_torch.nn.functional.linear_0':
+                ((F.linear, F.relu), (toq.linear_relu, toq.linear_relu)),
+        }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
     @override_qengines
@@ -595,9 +604,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
         results = get_matching_subgraph_pairs(mp, mq)
 
         expected_types = {
-            'cat': ((torch.cat, torch.cat), (toq.cat, toq.cat)),
-            'add_1': ((torch.add, torch.add), (toq.add, toq.add)),
-            'add': ((torch.add, torch.add), (toq.add, toq.add)),
+            'base_op_torch.cat_0': ((torch.cat, torch.cat), (toq.cat, toq.cat)),
+            'base_op_torch.add_0': ((torch.add, torch.add), (toq.add, toq.add)),
+            'base_op_torch.add_1': ((torch.add, torch.add), (toq.add, toq.add)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -624,9 +633,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
         results = get_matching_subgraph_pairs(mp, mq)
 
         expected_types = {
-            'add': ((torch.add, torch.add), (toq.add, toq.add)),
-            'add_1': ((torch.add, torch.add), (toq.add, toq.add)),
-            'add_2': ((torch.add, torch.add), (toq.add, toq.add)),
+            'base_op_torch.add_0': ((torch.add, torch.add), (toq.add, toq.add)),
+            'base_op_torch.add_1': ((torch.add, torch.add), (toq.add, toq.add)),
+            'base_op_torch.add_2': ((torch.add, torch.add), (toq.add, toq.add)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 
@@ -666,8 +675,9 @@ class TestFXGraphMatcher(QuantizationTestCase):
         # so its type is the same in mp and mq. sigmoid and relu should not be
         # matched because they use the same function in mp and mq.
         expected_types = {
-            'conv1': ((nn.Conv2d, nn.Conv2d), (nnq.Conv2d, nnq.Conv2d)),
-            'mul': ((torch.mul, torch.mul), (toq.mul, toq.mul)),
+            'base_op_torch.nn.Conv2d_0':
+                ((nn.Conv2d, nn.Conv2d), (nnq.Conv2d, nnq.Conv2d)),
+            'base_op_torch.mul_0': ((torch.mul, torch.mul), (toq.mul, toq.mul)),
         }
         self.assert_types_for_matched_subgraph_pairs(results, expected_types, mp, mq)
 

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -12,7 +12,7 @@ from .utils import (
     return_first_non_observer_node,
 )
 
-from typing import Dict, Tuple, Callable, List, Any, Optional, Union
+from typing import Dict, Tuple, Callable, List, Any, Union
 
 def _insert_logger_after_node(
     node: Node,
@@ -20,7 +20,7 @@ def _insert_logger_after_node(
     logger_cls: Callable,
     logger_node_name_suffix: str,
     model_name: str,
-    other_node_name: Optional[str] = None,
+    ref_name: str,
 ) -> Node:
     """
     Given a starting graph of
@@ -36,7 +36,7 @@ def _insert_logger_after_node(
     logger_node_name = \
         get_new_attr_name_with_prefix(node.name + logger_node_name_suffix)(gm)
     # create the logger object
-    logger_obj = logger_cls(node.name, model_name, other_node_name)
+    logger_obj = logger_cls(node.name, model_name, ref_name)
     # attach the logger object to the parent module
     setattr(gm, logger_node_name, logger_obj)
     logger_node = node.graph.create_node(
@@ -45,7 +45,7 @@ def _insert_logger_after_node(
 
 def remove_observers_add_loggers(
     gm: GraphModule,
-    node_to_instrument_to_ref_node_name: Dict[Node, Optional[str]],
+    node_to_instrument_to_ref_node_name: Dict[Node, str],
     logger_cls: Callable,
     model_name: str,
 ) -> GraphModule:
@@ -72,13 +72,13 @@ def remove_observers_add_loggers(
             env[node.name] = env[node.args[0].name]
 
         elif node in node_to_instrument_to_ref_node_name:
-            other_node_name = node_to_instrument_to_ref_node_name[node]
+            ref_name = node_to_instrument_to_ref_node_name[node]
             # ensure env is populated with base node
             env[node.name] = new_graph.node_copy(node, load_arg)
             # add the logger after the base node
             env[node.name] = _insert_logger_after_node(
                 env[node.name], gm, logger_cls, '_ns_logger_', model_name,
-                other_node_name)
+                ref_name)
 
         else:
             env[node.name] = new_graph.node_copy(node, load_arg)
@@ -311,12 +311,13 @@ def create_a_shadows_b(
     def load_arg(a):
         return map_arg(a, lambda node: env_c[node.name])
 
-    node_b_to_matched_subgraph_a = {}
+    node_b_to_matched_subgraph_a_and_name = {}
     for match_name, match in matched_subgraph_pairs.items():
         (node_start_a, node_end_a), (node_start_b, node_end_b) = match
         assert node_start_b is node_end_b, \
             "Shadowing subgraphs of B with multiple nodes is not yet handled."
-        node_b_to_matched_subgraph_a[node_end_b] = (node_start_a, node_end_a)
+        node_b_to_matched_subgraph_a_and_name[node_end_b] = \
+            ((node_start_a, node_end_a), match_name)
 
     for node_b in gm_b.graph.nodes:
         if node_b.op == 'output':
@@ -327,8 +328,9 @@ def create_a_shadows_b(
             # remove activation post process node
             env_c[node_b.name] = env_c[node_b.args[0].name]  # type: ignore
 
-        elif node_b in node_b_to_matched_subgraph_a:
-            node_start_a, node_end_a = node_b_to_matched_subgraph_a[node_b]
+        elif node_b in node_b_to_matched_subgraph_a_and_name:
+            (node_start_a, node_end_a), ref_name = \
+                node_b_to_matched_subgraph_a_and_name[node_b]
             if False:
                 print('b')
                 print_node(node_b)
@@ -376,7 +378,7 @@ def create_a_shadows_b(
 
             # hook up a logger to the mod_b copy
             env_c[node_b.name] = _insert_logger_after_node(
-                env_c[node_b.name], gm_b, logger_cls, '_ns_logger_b_', name_b)
+                env_c[node_b.name], gm_b, logger_cls, '_ns_logger_b_', name_b, ref_name)
             # subgraph so far:
             #
             #       dtype_cast_node --> subgraph_a_copy
@@ -387,7 +389,7 @@ def create_a_shadows_b(
             # Note: we pass node_b.name to this logger, for easy matching later
             env_c[node_a_shadows_c.name] = _insert_logger_after_node(
                 env_c[node_a_shadows_c.name], gm_b, logger_cls, '_ns_logger_a_', name_a,
-                node_b.name)
+                ref_name)
             # subgraph so far:
             #
             #       dtype_cast_node --> subgraph_a_copy --> logger_a

--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -26,7 +26,7 @@ from .graph_passes import (
     create_a_shadows_b,
 )
 
-from typing import Dict, Tuple, Callable, List, Optional
+from typing import Dict, Tuple, Callable, List
 
 def add_weight_info_to_dict(
     model_name: str,
@@ -38,10 +38,10 @@ def add_weight_info_to_dict(
     type_a_related_to_b = \
         get_type_a_related_to_b(base_name_to_sets_of_related_ops)
 
-    for node, ref_node_name in nodes_and_names_to_instrument:
+    for node, ref_name in nodes_and_names_to_instrument:
 
-        if ref_node_name not in results:
-            results[ref_node_name] = {}
+        if ref_name not in results:
+            results[ref_name] = {}
 
         if node.op == 'call_function':
 
@@ -52,7 +52,7 @@ def add_weight_info_to_dict(
 
             if related_to_linear:
                 weight = get_linear_fun_weight(node, model)
-                results[ref_node_name][model_name] = weight
+                results[ref_name][model_name] = weight
 
         else:  # call_module
             # for call_module, we need to look up the modules to do the type check
@@ -67,7 +67,7 @@ def add_weight_info_to_dict(
             # TODO(future PR): other module types
             if related_to_conv2d_mod:
                 weight = get_conv_mod_weight(mod)
-                results[ref_node_name][model_name] = weight
+                results[ref_name][model_name] = weight
 
 # Note: this is not a user facing API
 # TODO(future PR): wrap this in a user facing API which does not
@@ -108,7 +108,7 @@ class OutputLogger(nn.Module):
         self,
         node_name: str,
         model_name: str,
-        ref_node_name: Optional[str] = None,
+        ref_name: str,
     ):
         super().__init__()
         self.stats: List[torch.Tensor] = []
@@ -116,17 +116,16 @@ class OutputLogger(nn.Module):
         self.node_name = node_name
         # name of the model from which the node originated from
         self.model_name = model_name
-        # name of the reference node with a matching Logger
-        # used to link node_a_copy -> logger_a to node_c -> logger_c
-        # in a_shadows_b
-        self.ref_node_name = ref_node_name
+        # reference name, used to match loggers from separate models
+        # to each other
+        self.ref_name = ref_name
 
     def forward(self, x: torch.Tensor):
         self.stats.append(x.detach())
         return x
 
     def __repr__(self):
-        return f"OutputLogger(node_name={self.node_name}, model_name={self.model_name}, ref_node_name={self.ref_node_name})"
+        return f"OutputLogger(ref_name={self.ref_name}, model_name={self.model_name}, node_name={self.node_name})"
 
 def prepare_single_model_output(
     model_name: str,
@@ -139,14 +138,12 @@ def prepare_single_model_output(
     #   about (both fp32, denylist, etc)
     # Note: for matching activations we always use the end nodes,
     # such as observing the output of relu in linear-relu
-    # Note: ref_node_name is set to None in model B's loggers,
-    # and set to the corresponding model B's node in model A's loggers.
-    node_to_instrument_to_ref_node_name: Dict[Node, Optional[str]] = {}
-    for (node_start, node_end), ref_node_name in subgraphs_to_instrument:
-        node_to_instrument_to_ref_node_name[node_end] = ref_node_name
+    node_to_instrument_to_ref_name: Dict[Node, str] = {}
+    for (node_start, node_end), ref_name in subgraphs_to_instrument:
+        node_to_instrument_to_ref_name[node_end] = ref_name
 
     model = remove_observers_add_loggers(
-        model, node_to_instrument_to_ref_node_name, logger_cls, model_name)
+        model, node_to_instrument_to_ref_name, logger_cls, model_name)
     return model
 
 # Note: this is not a user facing API
@@ -188,7 +185,7 @@ def add_activation_info_to_dict(
             )
         )
         if is_logger:
-            key = mod.ref_node_name + '.stats'
+            key = mod.ref_name + '.stats'
             if key not in results:
                 results[key] = {}
             results[key][model_name] = mod.stats
@@ -278,10 +275,5 @@ def get_matching_activations_a_shadows_b(
             )
         )
         if is_logger:
-            # If logger_obj.ref_node_name is populated, then this logger
-            # is from model A, and ref_node_name is the name from model B.
-            if mod.ref_node_name is None:
-                results[mod.node_name + '.stats'][mod.model_name] = mod.stats
-            else:
-                results[mod.ref_node_name + '.stats'][mod.model_name] = mod.stats
+            results[mod.ref_name + '.stats'][mod.model_name] = mod.stats
     return dict(results)

--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -8,6 +8,7 @@ from torch.fx import GraphModule
 from torch.fx.graph import Node
 from torch.quantization.ns.graph_matcher import (
     get_matching_subgraph_pairs,
+    get_base_name_to_sets_of_related_ops,
     get_type_a_related_to_b,
 )
 
@@ -33,7 +34,9 @@ def add_weight_info_to_dict(
     nodes_and_names_to_instrument: List[Tuple[Node, str]],
     results: Dict[str, Dict[str, torch.Tensor]],
 ) -> None:
-    type_a_related_to_b = get_type_a_related_to_b()
+    base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
+    type_a_related_to_b = \
+        get_type_a_related_to_b(base_name_to_sets_of_related_ops)
 
     for node, ref_node_name in nodes_and_names_to_instrument:
 
@@ -75,7 +78,9 @@ def compare_weights(
     model_name_b: str,
     gm_b: GraphModule,
 ) -> Dict[str, Dict[str, torch.Tensor]]:
-    type_a_related_to_b = get_type_a_related_to_b()
+    base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
+    type_a_related_to_b = \
+        get_type_a_related_to_b(base_name_to_sets_of_related_ops)
     matched_subgraph_pairs = get_matching_subgraph_pairs(gm_a, gm_b)
 
     # split the subgraph pairs into one data structure for each model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52799 ns for fx: remove ".stats" suffix
* #52798 ns for fx: add node name and type to results
* #52789 ns for fx: make return type of ns APIs future proof
* #52779 ns for fx: unify return types of weight and activation APIs
* **#52771 ns for fx: decouple subgraph names from node names**
* #52681 ns for fx: update graph matching to handle dicts and tuples in node args
* #52402 ns for fx: update graph matching to not match nodes with equal types
* #52395 ns for fx: support linear_relu for weight matching
* #52368 ns for fx: allow graph matching of parents of cat

Summary:

Before this PR, subgraph names were derived from node names
in model B.  For example, if we had

```
A: linear0 -> relu0 -> ...
B: linear_relu0 -> ...
```

Then the subgraph name would be `linear_relu0`, and the outputs before this
PR would look like

```
{
  'linear_relu0': {
    'model_a': ...,
    'model_b': ...,
  },
}
```

This PR decouples subgraph naming from node names.
The outputs after this PR look like:

```
{
  # guaranteed to match the right subgraphs across different models
  # without needing more than one model during the prepare passes
  'base_op_torch.nn.functional.linear_0': {
    'model_a': ...,
    'model_b': ...,
  },
}
```

There are future requirements for which using node_name as subgraph name does not work well:
a. the need to support N models, without having all of them in memory at the same time
b. the need to support fusions and match subgraphs with related but non-equal types

This PR changes the naming of subgraphs to be based on two things:
1. the name of the underlying set of related ops (i.e. `torch.nn.functional.linear`)
2. the order in which this subgraph was named (i.e. `foo_0`, `foo_1`, ...)

Basically, we can't use a node name because of (a), since there must be
a reference model which node name other models must use, but that
reference model is not guaranteed to be available.  Note: we could add
some state and require the reference model to go through the APIs first,
saving the reference node names, but I'm deliberately not doing that
to minimize the state used throughout.

To support (b), we need a way to determine a name of a subgraph which is
the same for all related subgraphs (i.e. linear-relu vs quantized_linear
vs quantized_linear_relu). In this PR, this is done by using the base
aten op's name.  We use a string name so it looks nice in the output
(I tried `str(underlying_type)`, and it is not easy for humans to read).

Note: after this PR, it's hard to parse the results to see which layer
is related to which node in the graph. This will be fixed in a future PR
where we will store the node name on the logger, and expose it in the
output.

Test Plan:

```
python test/test_quantization.py TestFXGraphMatcher
python test/test_quantization.py TestFXGraphMatcherModels
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
python test/test_quantization.py TestFXNumericSuiteCoreAPIsModels
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26652641](https://our.internmc.facebook.com/intern/diff/D26652641)