### PR TITLE
ns for fx: unify return types of weight and activation APIs

### DIFF
--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -681,7 +681,7 @@ class QuantizationTestCase(TestCase):
                     f"Layer {layer_name} does not have exactly two model results.")
                 k0, k1 = layer_data.keys()
                 self.assertTrue(
-                    layer_data[k0].shape == layer_data[k1].shape,
+                    layer_data[k0][0].shape == layer_data[k1][0].shape,
                     f"Layer {layer_name}, {k0} and {k1} have a shape mismatch.")
 
         def assert_ns_logger_act_compare_dict_valid(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52799 ns for fx: remove ".stats" suffix
* #52798 ns for fx: add node name and type to results
* #52789 ns for fx: make return type of ns APIs future proof
* **#52779 ns for fx: unify return types of weight and activation APIs**
* #52771 ns for fx: decouple subgraph names from node names
* #52681 ns for fx: update graph matching to handle dicts and tuples in node args
* #52402 ns for fx: update graph matching to not match nodes with equal types
* #52395 ns for fx: support linear_relu for weight matching
* #52368 ns for fx: allow graph matching of parents of cat

Summary:

1. makes the return type of the weight comparison APIs match the return
type of the activation comparison APIs:

```
# before
{layer_name: {model_name: weight_tensor}}
{layer_name: {model_name: [activation_tensor]}}

# after
{layer_name: {model_name: [weight_tensor]}}
{layer_name: {model_name: [activation_tensor]}}
```

2. makes a type alias for the type, so future changes are easier

Test Plan:

```
mypy torch/quantization
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26652639](https://our.internmc.facebook.com/intern/diff/D26652639)