### PR TITLE
[pytorch] DistributedSampler ensure contiguous chunk for each worker

### DIFF
--- a/torch/utils/data/distributed.py
+++ b/torch/utils/data/distributed.py
@@ -115,7 +115,8 @@ class DistributedSampler(Sampler[T_co]):
         assert len(indices) == self.total_size
 
         # subsample
-        indices = indices[self.rank:self.total_size:self.num_replicas]
+        start_idx = self.rank * self.num_samples
+        indices = list(filter(lambda x: start_idx <= x < start_idx + self.num_samples, indices))
         assert len(indices) == self.num_samples
 
         return iter(indices)


### PR DESCRIPTION
Summary:
This currently sub samples shuffled indices meaning each worker can get indices from all over the full dataset. This is not ideal for a memory mapped dataset which would benefit a lot if each worker only accesses a particular contiguous chunk of the indices.

Hence i switch the way sub sampling works here so that each worker get shuffled indices within its contiguous chunk of the dataset.

This would not result in a change in the overall behavior as the total batch across all workers is still shuffled the exact same way

Test Plan: Automated tests

Differential Revision: D26646252

