### PR TITLE
Expose Store's timeout and TCPStore's host and port in Python API

### DIFF
--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -632,7 +632,11 @@ Example::
     >>> store = dist.TCPStore("127.0.0.1", 0, 1, True, timedelta(seconds=30))
     >>> # This will throw an exception after 10 seconds
     >>> store.wait(["bad_key"], timedelta(seconds=10))
-)");
+)")
+      .def_property_readonly(
+            "timeout",
+            &::c10d::Store::getTimeout,
+            R"(Gets the timeout of the store.)");
 
   intrusive_ptr_class_<::c10d::FileStore>(
       module,
@@ -719,7 +723,17 @@ Example::
           // prevents accidental implicit conversion to bool
           py::arg("is_master").noconvert() = false,
           py::arg("timeout") =
-              std::chrono::milliseconds(::c10d::Store::kDefaultTimeout));
+              std::chrono::milliseconds(::c10d::Store::kDefaultTimeout))
+
+      .def_property_readonly(
+            "host",
+            &::c10d::TCPStore::getHost,
+            R"(Gets the hostname on which the store listens for requests.)")
+
+      .def_property_readonly(
+            "port",
+            &::c10d::TCPStore::getPort,
+            R"(Gets the port number on which the store listens for requests.)");
 
   intrusive_ptr_class_<::c10d::PrefixStore>(
       module,

--- a/torch/lib/c10d/Store.cpp
+++ b/torch/lib/c10d/Store.cpp
@@ -8,6 +8,10 @@ constexpr std::chrono::milliseconds Store::kNoTimeout;
 // Define destructor symbol for abstract base class.
 Store::~Store() {}
 
+const std::chrono::milliseconds& Store::getTimeout() const noexcept {
+    return timeout_;
+}
+
 // Set timeout function
 void Store::setTimeout(const std::chrono::milliseconds& timeout) {
   timeout_ = timeout;

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -51,6 +51,8 @@ class Store : public torch::CustomClassHolder {
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) = 0;
 
+  const std::chrono::milliseconds& getTimeout() const noexcept;
+
   void setTimeout(const std::chrono::milliseconds& timeout);
 
  protected:

--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -578,7 +578,11 @@ void TCPStore::waitHelper_(
   }
 }
 
-PortType TCPStore::getPort() {
+const std::string& TCPStore::getHost() const noexcept {
+  return tcpStoreAddr_;
+}
+
+PortType TCPStore::getPort() const noexcept {
   return tcpStorePort_;
 }
 

--- a/torch/lib/c10d/TCPStore.hpp
+++ b/torch/lib/c10d/TCPStore.hpp
@@ -99,8 +99,11 @@ class TCPStore : public Store {
   // Waits for all workers to join.
   void waitForWorkers();
 
+  // Returns the hostname used by the TCPStore.
+  const std::string& getHost() const noexcept;
+
   // Returns the port used by the TCPStore.
-  PortType getPort();
+  PortType getPort() const noexcept;
 
  protected:
   int64_t addHelper_(const std::string& key, int64_t value);


### PR DESCRIPTION
This PR introduces the `timeout` accessor to `Store` and `host`, `port` accessors to `TCPStore` to help testing and troubleshooting higher level APIs. 
