### PR TITLE
[quant] Fix conv packed param serialization in state_dict

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -125,7 +125,22 @@ ConvParamsSerializationType parse_conv_serialized_state(c10::IValue v) {
     return std::tie(version, non_optional, optional);
   } else if (version == 2) {
     // version 2
-    return v.to<ConvParamsSerializationType>();
+    auto elements = v.toTuple()->elements();
+    std::vector<at::Tensor> non_optional = elements[1].toTensorList().vec();
+    std::vector<c10::optional<at::Tensor>> optional;
+
+    if (elements[2].isTensorList()) {
+      for (const auto& elem : elements[2].toTensorList()) {
+        optional.emplace_back(std::move(static_cast<at::Tensor>(elem)));
+      }
+    } else {
+      for (const auto& elem : elements[2].toList()) {
+        optional.emplace_back(std::move(static_cast<c10::IValue>(elem).toOptional<at::Tensor>()));
+      }
+    }
+
+    std::string version = "2";
+    return std::tie(version, non_optional, optional);
   } else {
     TORCH_INTERNAL_ASSERT(false, "Unexpected serialized qconv version: ",
         version);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52802 [do not land] ad hoc test for conv serialization
* #51639 [quant][graphmode][fx] Add support for packed params in state_dict
* **#52787 [quant] Fix conv packed param serialization in state_dict**

Summary:
Current conv packed param can be serialized/deserialized with `torch.jit.save/torch.jit.load`, but
can't be saved with `torch.load(m.state_dict())/torch.save(m.state_dict())`

reason is (from James):
```
I think the issue probably has to do with the normal pickle deserialization not detecting List[Optional[Tensor]] if it doesn't witness a None in the list. IIRC this is implemented on the TorchScript side through this type tag mechanism: https://github.com/.../jit/serialization/unpickler.cpp...
```

This PR is a hack but acceptable to JIT team until a proper solution is proposed.

Test Plan:
Will be tested in next PR

BC test (from: https://github.com/pytorch/pytorch/commit/b3f0297a94977636fd90c0fe6fa9b971ff9f81e2):
```
python test/test_quantization.py TestSerialization.test_conv2d_graph_v2
python test/test_quantization.py TestSerialization.test_conv2d_nobias_graph_v2
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26649272](https://our.internmc.facebook.com/intern/diff/D26649272)