### PR TITLE
ns for fx: make return type of ns APIs future proof

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -724,7 +724,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         mq = convert_fx(mp_copy)
         results = compare_weights('fp32_prepared', mp, 'int8', mq)
         self.assertTrue(len(results) == 2)
-        self.assert_ns_weight_compare_dict_valid(results)
+        self.assert_ns_compare_dict_valid(results)
 
     @override_qengines
     def test_compare_weights_fun(self):
@@ -750,7 +750,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         mq = convert_fx(mp_copy)
         results = compare_weights('fp32_prepared', mp, 'int8', mq)
         self.assertTrue(len(results) == 2)
-        self.assert_ns_weight_compare_dict_valid(results)
+        self.assert_ns_compare_dict_valid(results)
 
     @override_qengines
     def test_match_activations_mod(self):
@@ -790,7 +790,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         act_compare_dict = get_matching_activations(
             'fp32_prepared', mp_ns, 'int8', mq_ns, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
     @override_qengines
     def test_match_activations_fun(self):
@@ -842,7 +842,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         act_compare_dict = get_matching_activations(
             'fp32_prepared', mp_ns, 'int8', mq_ns, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
     @override_qengines
     def test_prepare_model_with_stubs_mod(self):
@@ -870,7 +870,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         act_compare_dict = get_matching_activations_a_shadows_b(
             mp_shadows_mq, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
     @override_qengines
     def test_prepare_model_with_stubs_fun(self):
@@ -911,7 +911,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         act_compare_dict = get_matching_activations_a_shadows_b(
             mp_shadows_mq, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
 class TestFXNumericSuiteCoreAPIsModels(QuantizationTestCase):
     """
@@ -950,7 +950,7 @@ class TestFXNumericSuiteCoreAPIsModels(QuantizationTestCase):
         act_compare_dict = get_matching_activations(
             'fp32_prepared', sparse_nn, 'int8', sparse_nn_q, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 4)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
     @override_qengines
     def test_sparsenn_shadow(self):
@@ -984,4 +984,4 @@ class TestFXNumericSuiteCoreAPIsModels(QuantizationTestCase):
         act_compare_dict = get_matching_activations_a_shadows_b(
             sparse_nn_q, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 4)
-        self.assert_ns_logger_act_compare_dict_valid(act_compare_dict)
+        self.assert_ns_compare_dict_valid(act_compare_dict)

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -42,7 +42,7 @@ import os
 import unittest
 import numpy as np
 from torch.testing import FileCheck
-from typing import Callable, Tuple, Dict, List
+from typing import Callable, Tuple, Dict, Any
 
 class NodeSpec:
     ''' Used for checking GraphModule Node
@@ -665,32 +665,12 @@ class QuantizationTestCase(TestCase):
                         (act_type_start_a, act_type_end_a, act_type_start_b, act_type_end_b))
                 )
 
-        def assert_ns_weight_compare_dict_valid(
+        def assert_ns_compare_dict_valid(
             self,
-            weight_compare_dict: Dict[str, Dict[str, torch.Tensor]],
+            act_compare_dict: Dict[str, Dict[str, Dict[str, Any]]],
         ) -> None:
             """
-            Verifieds that the weight_compare dict (output of Numeric Suite
-            weight matching APIs) is valid:
-            1. for each layer, results are recorded for two models
-            2. shapes of each pair of weights match
-            """
-            for layer_name, layer_data in weight_compare_dict.items():
-                self.assertTrue(
-                    len(layer_data) == 2,
-                    f"Layer {layer_name} does not have exactly two model results.")
-                k0, k1 = layer_data.keys()
-                self.assertTrue(
-                    layer_data[k0][0].shape == layer_data[k1][0].shape,
-                    f"Layer {layer_name}, {k0} and {k1} have a shape mismatch.")
-
-        def assert_ns_logger_act_compare_dict_valid(
-            self,
-            act_compare_dict: Dict[str, Dict[str, List[torch.Tensor]]],
-        ) -> None:
-            """
-            Verifies that the act_compare_dict (output of Numeric Suite
-            activation matching APIs) is valid:
+            Verifies that the act_compare_dict (output of Numeric Suite APIs) is valid:
             1. for each layer, results are recorded for two models
             2. number of seen tensors match
             3. shapes of each pair of seen tensors match
@@ -699,14 +679,19 @@ class QuantizationTestCase(TestCase):
                 self.assertTrue(
                     len(layer_data) == 2,
                     f"Layer {layer_name} does not have exactly two model results.")
-                k0, k1 = layer_data.keys()
+                model_name_0, model_name_1 = layer_data.keys()
                 self.assertTrue(
-                    len(layer_data[k0]) == len(layer_data[k1]),
-                    f"Layer {layer_name}, {k0} and {k1} do not have the same number of seen Tensors.")
-                for idx in range(len(layer_data[k0])):
+                    layer_data[model_name_0]['type'] == layer_data[model_name_1]['type'],
+                    f"Layer {layer_name}, {model_name_0} and {model_name_1} do not have the same type.")
+                self.assertTrue(
+                    len(layer_data[model_name_0]['values']) ==
+                    len(layer_data[model_name_1]['values']),
+                    f"Layer {layer_name}, {model_name_0} and {model_name_1} do not have the same number of seen Tensors.")
+                for idx in range(len(layer_data[model_name_0]['values'])):
                     self.assertTrue(
-                        layer_data[k0][idx].shape == layer_data[k1][idx].shape,
-                        f"Layer {layer_name}, {k0} and {k1} have a shape mismatch at idx {idx}.")
+                        layer_data[model_name_0]['values'][idx].shape ==
+                        layer_data[model_name_1]['values'][idx].shape,
+                        f"Layer {layer_name}, {model_name_0} and {model_name_1} have a shape mismatch at idx {idx}.")
 
         def checkGraphModeFxOp(self, model, inputs, quant_type,
                                expected_node=None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52799 ns for fx: remove ".stats" suffix
* #52798 ns for fx: add node name and type to results
* **#52789 ns for fx: make return type of ns APIs future proof**
* #52779 ns for fx: unify return types of weight and activation APIs
* #52771 ns for fx: decouple subgraph names from node names
* #52681 ns for fx: update graph matching to handle dicts and tuples in node args
* #52402 ns for fx: update graph matching to not match nodes with equal types
* #52395 ns for fx: support linear_relu for weight matching
* #52368 ns for fx: allow graph matching of parents of cat

Summary:

Changes the return type of NS APIs from

```
{
  layer_name: {
    model_name: [torch.Tensor(...), ...],
  },
}
```

to

```
{
  layer_name: {
    model_name: {
      'type': 'weight',  # or node_output, etc
      'values': [torch.Tensor(...), ...],
      // future info can be added here, such as node name, etc
  },
}
```

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26652640](https://our.internmc.facebook.com/intern/diff/D26652640)