### PR TITLE
[TensorExpr] Add an unmasked `Load` constructor.

### DIFF
--- a/test/cpp/tensorexpr/test_boundsinference.cpp
+++ b/test/cpp/tensorexpr/test_boundsinference.cpp
@@ -452,9 +452,9 @@ TEST(BoundsInference, MultipleTopLoopStore) {
   // Same as above but the offsets are on the Store now.
   // Can't do this through ComputeAPI without transforms we don't have yet.
   Stmt* stmt = Block::make(
-      {For::make(x, 0, 64, Store::make(b, {x}, Load::make(a, {x}, 1), 1)),
-       For::make(x, 0, 32, Store::make(c, {x + 10}, Load::make(a, {x}, 1), 1)),
-       For::make(x, 0, 96, Store::make(d, {x + 2}, Load::make(a, {x}, 1), 1))});
+      {For::make(x, 0, 64, Store::make(b, {x}, Load::make(a, {x}))),
+       For::make(x, 0, 32, Store::make(c, {x + 10}, Load::make(a, {x}))),
+       For::make(x, 0, 96, Store::make(d, {x + 2}, Load::make(a, {x})))});
 
   auto bounds_info = inferBounds(stmt);
 
@@ -612,10 +612,10 @@ void testGetPotentialHazards() {
      * C[0] = 5;
      */
 
-    Store* store1 = Store::make(a, {0}, Load::make(b, {0}, 1), 1);
-    Store* store2 = Store::make(b, {0}, 3, 1);
-    Store* store3 = Store::make(a, {0}, Load::make(b, {0}, 1), 1);
-    Store* store4 = Store::make(c, {0}, 5, 1);
+    Store* store1 = Store::make(a, {0}, Load::make(b, {0}));
+    Store* store2 = Store::make(b, {0}, 3);
+    Store* store3 = Store::make(a, {0}, Load::make(b, {0}));
+    Store* store4 = Store::make(c, {0}, 5);
     Stmt* stmt = Block::make({store1, store2, store3, store4});
 
     MemDependencyChecker analyzer;

--- a/test/cpp/tensorexpr/test_cuda.cpp
+++ b/test/cpp/tensorexpr/test_cuda.cpp
@@ -452,8 +452,8 @@ TEST(Cuda, OneBlockOneThreadGlobalReduce1_CUDA) {
 
   Store* init_store = output_buf.store({0}, 0.f);
   VarHandle i1("i1", kInt);
-  ExprHandle load_data = Load::make(BufHandle(data_buf.data()), {i1}, 1);
-  ExprHandle load_output = Load::make(BufHandle(output_buf.data()), {0}, 1);
+  ExprHandle load_data = Load::make(BufHandle(data_buf.data()), {i1});
+  ExprHandle load_output = Load::make(BufHandle(output_buf.data()), {0});
   ExprHandle add_value = load_output + load_data;
   Store* store_output = output_buf.store({0}, add_value);
   For* for_output = For::make(i1, 0, N, store_output);
@@ -535,8 +535,8 @@ TEST(Cuda, OneBlockMultiThreadGlobalReduce1_CUDA) {
 
   //  for t in 0..1024: // thread-idx
   //    b[0] = b[0] + a[t] // implied atomic
-  ExprHandle load_a = Load::make(BufHandle(a_buf.data()), {t}, 1);
-  ExprHandle load_b = Load::make(BufHandle(b_buf.data()), {0}, 1);
+  ExprHandle load_a = Load::make(BufHandle(a_buf.data()), {t});
+  ExprHandle load_b = Load::make(BufHandle(b_buf.data()), {0});
   ExprHandle add_value = load_b + load_a;
   Store* store_b = b_buf.store({0}, add_value);
   For* for_b = For::make(t, 0, N, store_b, thread_idx_options);
@@ -610,7 +610,7 @@ TEST(Cuda, NoThreadIdxWrite_1_CUDA) {
   //   for n in 0..2:
   //     a[0] = a[0] + n
   Store* store_a0_0 = a_buf.store({0}, 0.f);
-  ExprHandle load_a0 = Load::make(BufHandle(a_buf.data()), {0}, 1);
+  ExprHandle load_a0 = Load::make(BufHandle(a_buf.data()), {0});
   ExprHandle v1 = load_a0 + n;
   Store* store_a0_v1 = a_buf.store({0}, v1);
   For* loop_a_0 = For::make(n, 0, 2, store_a0_v1);
@@ -719,7 +719,7 @@ TEST(Cuda, SharedMemReduce_1_CUDA) {
   {
     //    for n in 0..64:  // thread-idx
     //      c(n) = 0
-    Store* store_cn_0 = Store::make(c, {n}, 0.f, 1);
+    Store* store_cn_0 = Store::make(c, {n}, 0.f);
     For* loop_n1 = For::make(n, 0, N, store_cn_0, thread_idx_opt);
     block.push_back(loop_n1);
   }
@@ -728,9 +728,9 @@ TEST(Cuda, SharedMemReduce_1_CUDA) {
     //  for m in 0..128:
     //    for n in 0..64:  // thread_idx
     //      c(n) = c(n) + a(k, m, n)
-    ExprHandle load_cn = Load::make(kFloat, c, {n}, 1);
+    ExprHandle load_cn = Load::make(kFloat, c, {n});
     ExprHandle a_kmn =
-        Load::make(BufHandle(a.data()), {k * (M * N) + m * N + n}, 1);
+        Load::make(BufHandle(a.data()), {k * (M * N) + m * N + n});
     ExprHandle v_add = load_cn + a_kmn;
     Store* store_cn_v = Store::make(c, {n}, v_add);
     For* loop_n2 = For::make(n, 0, N, store_cn_v, thread_idx_opt);
@@ -745,7 +745,7 @@ TEST(Cuda, SharedMemReduce_1_CUDA) {
     Store* store_bk_0 = b.store({k}, 0.f);
     block.push_back(store_bk_0);
     ExprHandle load_bk = b.load(k);
-    ExprHandle load_cn = Load::make(kFloat, c, {n}, 1);
+    ExprHandle load_cn = Load::make(kFloat, c, {n});
     ExprHandle v_add = load_bk + load_cn;
     Store* store_bk = b.store({k}, v_add);
     For* loop_n3 = For::make(n, 0, N, store_bk, thread_idx_opt);
@@ -857,13 +857,13 @@ TEST(Cuda, LocalMemReduce_1_CUDA) {
   }
   {
     // c(0) = 0
-    Store* store_c0_0 = Store::make(c, {0}, 0.f, 1);
+    Store* store_c0_0 = Store::make(c, {0}, 0.f);
     block_n.push_back(store_c0_0);
   }
   {
     //      for m in 0..128:
     //        c(0) = c(0) + a(k, m, n)
-    ExprHandle load_c0 = Load::make(kFloat, c, {0}, 1);
+    ExprHandle load_c0 = Load::make(kFloat, c, {0});
     ExprHandle a_kmn = a.load(k * (M * N) + m * N + n);
     ExprHandle v_add = load_c0 + a_kmn;
     Store* store_c0_v = Store::make(c, {0}, v_add);
@@ -873,7 +873,7 @@ TEST(Cuda, LocalMemReduce_1_CUDA) {
   {
     //      b(k) = b(k) + c(0)
     ExprHandle load_bk = b.load(k);
-    ExprHandle load_c0 = Load::make(kFloat, c, {0}, 1);
+    ExprHandle load_c0 = Load::make(kFloat, c, {0});
     ExprHandle v_add = load_bk + load_c0;
     Store* store_bk = b.store({k}, v_add);
     block_n.push_back(store_bk);
@@ -1106,8 +1106,8 @@ TEST(Cuda, PrioritizeDependents_CUDA) {
    *   c[i] = (i < 10 ? a[i] + b[i] : b[i]);
    * }
    */
-  ExprHandle load_a = Load::make(BufHandle(a.data()), {i}, 1);
-  ExprHandle load_b = Load::make(BufHandle(b.data()), {i}, 1);
+  ExprHandle load_a = Load::make(BufHandle(a.data()), {i});
+  ExprHandle load_b = Load::make(BufHandle(b.data()), {i});
   ExprHandle cmp = CompareSelect::make(i, 10, CompareSelectOperation::kLT);
   ExprHandle ite = IfThenElse::make(cmp, Add::make(load_a, load_b), load_b);
 

--- a/test/cpp/tensorexpr/test_registerizer.cpp
+++ b/test/cpp/tensorexpr/test_registerizer.cpp
@@ -17,13 +17,13 @@ TEST(Registerizer, RegisterizerSimple) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(a, {0}, Add::make(Load::make(a, {0}), x))}))});
 
   /*
    * A[0] = 0;
@@ -62,13 +62,13 @@ TEST(Registerizer, RegisterizerLoop) {
   BufHandle a("A", {10}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {x}, Add::make(Load::make(a, {x}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(a, {x}, Add::make(Load::make(a, {x}), x))}))});
 
   /*
    * A[0] = 0;
@@ -109,13 +109,13 @@ TEST(Registerizer, RegisterizerLoopFixedLoad) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {x}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(a, {x}, Add::make(Load::make(a, {0}), x))}))});
 
   /*
    * A[0] = 0;
@@ -160,8 +160,8 @@ TEST(Registerizer, RegisterizerLoopInternal) {
       0,
       10,
       Block::make(
-          {Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), x), 1),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), x), 1)}))});
+          {Store::make(a, {x}, Add::make(Load::make(a, {x}), x)),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), x))}))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -209,11 +209,7 @@ TEST(Registerizer, RegisterizerLoopInternalLoadOverlap) {
       x,
       0,
       10,
-      Store::make(
-          a,
-          {x},
-          Add::make(Load::make(b, {y}, 1), Load::make(b, {z}, 1)),
-          1))});
+      Store::make(a, {x}, Add::make(Load::make(b, {y}), Load::make(b, {z}))))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -243,15 +239,15 @@ TEST(Registerizer, RegisterizerLoopInternalRepeated) {
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {1}, 1), x), 1),
-                Store::make(a, {0}, Add::make(Load::make(a, {1}, 1), x), 1)})),
+               {Store::make(a, {0}, Add::make(Load::make(a, {1}), x)),
+                Store::make(a, {0}, Add::make(Load::make(a, {1}), x))})),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {1}, 1), x), 1),
-                Store::make(a, {0}, Add::make(Load::make(a, {1}, 1), x), 1)}))
+               {Store::make(a, {0}, Add::make(Load::make(a, {1}), x)),
+                Store::make(a, {0}, Add::make(Load::make(a, {1}), x))}))
 
       });
 
@@ -315,15 +311,15 @@ TEST(Registerizer, RegisterizerLoopInternalRepeatedOverlapLoopVar) {
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {x}, 1), x), 1),
-                Store::make(a, {0}, Add::make(Load::make(a, {x}, 1), x), 1)})),
+               {Store::make(a, {0}, Add::make(Load::make(a, {x}), x)),
+                Store::make(a, {0}, Add::make(Load::make(a, {x}), x))})),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {x}, 1), x), 1),
-                Store::make(a, {0}, Add::make(Load::make(a, {x}, 1), x), 1)}))
+               {Store::make(a, {0}, Add::make(Load::make(a, {x}), x)),
+                Store::make(a, {0}, Add::make(Load::make(a, {x}), x))}))
 
       });
 
@@ -361,15 +357,15 @@ TEST(Registerizer, RegisterizerLoopInternalRepeatedOverlapOther) {
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(x, Load::make(a, {y}, 1)), 1),
-                Store::make(a, {0}, Add::make(x, Load::make(a, {y}, 1)), 1)})),
+               {Store::make(a, {0}, Add::make(x, Load::make(a, {y}))),
+                Store::make(a, {0}, Add::make(x, Load::make(a, {y})))})),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(x, Load::make(a, {y}, 1)), 1),
-                Store::make(a, {0}, Add::make(x, Load::make(a, {y}, 1)), 1)}))
+               {Store::make(a, {0}, Add::make(x, Load::make(a, {y}))),
+                Store::make(a, {0}, Add::make(x, Load::make(a, {y})))}))
 
       });
 
@@ -402,15 +398,15 @@ TEST(Registerizer, RegisterizerMultiVar) {
   BufHandle a("A", {2}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make({
-      Store::make(a, {0}, 0, 1),
-      Store::make(a, {1}, 0, 1),
+      Store::make(a, {0}, 0),
+      Store::make(a, {1}, 0),
       For::make(
           x,
           0,
           10,
           Block::make(
-              {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
-               Store::make(a, {1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+              {Store::make(a, {0}, Add::make(Load::make(a, {0}), x)),
+               Store::make(a, {1}, Sub::make(Load::make(a, {1}), x))})),
   });
 
   /*
@@ -460,8 +456,8 @@ TEST(Registerizer, RegisterizerVariableLoad) {
   VarHandle x("x", kInt);
   VarHandle x2("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
-       For::make(x, 0, 10, Store::make(b, {x}, x, 1)),
+      {Store::make(a, {0}, 0),
+       For::make(x, 0, 10, Store::make(b, {x}, x)),
        For::make(
            x2,
            0,
@@ -469,7 +465,7 @@ TEST(Registerizer, RegisterizerVariableLoad) {
            Block::make({Store::make(
                a,
                {0},
-               Add::make(Load::make(a, {0}, 1), Load::make(b, {x2}, 1)),
+               Add::make(Load::make(a, {0}), Load::make(b, {x2})),
                1)}))});
 
   /*
@@ -519,13 +515,13 @@ TEST(Registerizer, RegisterizerSymbolicIndices) {
   BufHandle a("A", {N}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {i}, 0, 1),
+      {Store::make(a, {i}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {i}, Add::make(Load::make(a, {i}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(a, {i}, Add::make(Load::make(a, {i}), x))}))});
 
   /*
    * A[i] = 0;
@@ -565,7 +561,7 @@ TEST(Registerizer, RegisterizerMultiLoop) {
   VarHandle x("x", kInt);
   VarHandle y("y", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
@@ -577,7 +573,7 @@ TEST(Registerizer, RegisterizerMultiLoop) {
                Block::make({Store::make(
                    a,
                    {0},
-                   Mul::make(Add::make(Load::make(a, {0}, 1), x), y),
+                   Mul::make(Add::make(Load::make(a, {0}), x), y),
                    1)})))});
 
   /*
@@ -622,15 +618,15 @@ TEST(Registerizer, RegisterizerRepeated) {
   BufHandle a("A", {2}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make({
-      Store::make(a, {0}, 0, 1),
-      Store::make(a, {1}, 0, 1),
+      Store::make(a, {0}, 0),
+      Store::make(a, {1}, 0),
       For::make(
           x,
           0,
           10,
           Block::make(
-              {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
-               Store::make(a, {1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+              {Store::make(a, {0}, Add::make(Load::make(a, {0}), x)),
+               Store::make(a, {1}, Sub::make(Load::make(a, {1}), x))})),
   });
 
   // Registerize manually to make sure we only replace a single target.
@@ -679,9 +675,9 @@ TEST(Registerizer, RegisterizerNoLoads) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
-           x, 0, 10, Block::make({Store::make(a, {0}, Add::make(x, 1), 1)}))});
+           x, 0, 10, Block::make({Store::make(a, {0}, Add::make(x, 1))}))});
 
   /*
    * A[0] = 0;
@@ -721,13 +717,13 @@ TEST(Registerizer, RegisterizerNoRepeatedStores) {
   BufHandle b("B", {10}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               b, {x}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(b, {x}, Add::make(Load::make(a, {0}), x))}))});
 
   /*
    * A[0] = 0;
@@ -769,16 +765,15 @@ TEST(Registerizer, RegisterizerMultiVarOverlap) {
   BufHandle a("A", {2}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make({
-      Store::make(a, {0}, 0, 1),
-      Store::make(a, {1}, 0, 1),
+      Store::make(a, {0}, 0),
+      Store::make(a, {1}, 0),
       For::make(
           x,
           0,
           10,
           Block::make(
-              {Store::make(a, {x}, Add::make(Load::make(a, {0}, 1), x), 1),
-               Store::make(
-                   a, {x + 1}, Sub::make(Load::make(a, {1}, 1), x), 1)})),
+              {Store::make(a, {x}, Add::make(Load::make(a, {0}), x)),
+               Store::make(a, {x + 1}, Sub::make(Load::make(a, {1}), x))})),
   });
 
   std::ostringstream before;
@@ -800,19 +795,19 @@ TEST(Registerizer, RegisterizerAllocs) {
   BufHandle c("C", {1}, kInt);
   VarHandle x("x", kInt);
 
-  BufHandle b("B", {Load::make(c, {0}, 1)}, kInt);
+  BufHandle b("B", {Load::make(c, {0})}, kInt);
 
   Stmt* stmt = Block::make(
       {Allocate::make(b),
-       Store::make(a, {0}, Load::make(c, {0}, 1), 1),
-       Store::make(b, {0}, 0, 1),
+       Store::make(a, {0}, Load::make(c, {0})),
+       Store::make(b, {0}, 0),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(b, {0}, Add::make(Load::make(b, {0}, 1), x), 1),
-                Store::make(a, {0}, Load::make(c, {0}, 1), 1)})),
+               {Store::make(b, {0}, Add::make(Load::make(b, {0}), x)),
+                Store::make(a, {0}, Load::make(c, {0}))})),
        Free::make(b)});
 
   /*
@@ -869,8 +864,7 @@ TEST(Registerizer, RegisterizerNoInitializer) {
       x,
       0,
       10,
-      Block::make(
-          {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+      Block::make({Store::make(a, {0}, Add::make(Load::make(a, {0}), x))}))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -910,8 +904,7 @@ TEST(Registerizer, RegisterizerNoInitializerLoopVar) {
       x,
       0,
       10,
-      Block::make(
-          {Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), x), 1)}))});
+      Block::make({Store::make(a, {x}, Add::make(Load::make(a, {x}), x))}))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -941,8 +934,8 @@ TEST(Registerizer, RegisterizerLoadThenStore) {
       0,
       10,
       Block::make(
-          {Store::make(b, {0}, Add::make(Load::make(a, {0}, 1), x), 1),
-           Store::make(a, {0}, Load::make(b, {0}, 1), 1)}))});
+          {Store::make(b, {0}, Add::make(Load::make(a, {0}), x)),
+           Store::make(a, {0}, Load::make(b, {0}))}))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -989,13 +982,12 @@ TEST(Registerizer, RegisterizerParallelized) {
   LoopOptions loopOpts;
   loopOpts.set_gpu_block_index(0);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}),
+           Block::make({Store::make(a, {0}, Add::make(Load::make(a, {0}), x))}),
            loopOpts)});
 
   /*
@@ -1020,11 +1012,11 @@ TEST(Registerizer, RegisterizerConditionAfter) {
   VarHandle x("x", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(c, {x}, Load::make(a, {x})),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr)});
 
   /*
@@ -1072,10 +1064,10 @@ TEST(Registerizer, RegisterizerConditionBefore) {
   Stmt* stmt = Block::make(
       {Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr),
-       Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1)});
+       Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(c, {x}, Load::make(a, {x}))});
 
   /*
    * if (x<5 ? 1 : 0) {
@@ -1122,14 +1114,14 @@ TEST(Registerizer, RegisterizerConditionInside) {
   VarHandle x("x", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(c, {x}, Load::make(a, {x})),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr),
-       Store::make(b, {x}, Load::make(a, {x}, 1), 1),
-       Store::make(a, {x}, Load::make(c, {x}, 1), 1)});
+       Store::make(b, {x}, Load::make(a, {x})),
+       Store::make(a, {x}, Load::make(c, {x}))});
 
   /*
    * A[x] = B[x];
@@ -1183,18 +1175,18 @@ TEST(Registerizer, RegisterizerConditionInsideOverlap1) {
   VarHandle y("y", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(c, {x}, Load::make(a, {x})),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make({
-               Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
-               Store::make(a, {0}, 3, 1),
-               Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+               Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
+               Store::make(a, {0}, 3),
+               Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            }),
            nullptr),
-       Store::make(b, {x}, Load::make(a, {x}, 1), 1),
-       Store::make(a, {x}, Load::make(c, {x}, 1), 1)});
+       Store::make(b, {x}, Load::make(a, {x})),
+       Store::make(a, {x}, Load::make(c, {x}))});
 
   /*
    * A[x] = B[x];
@@ -1242,20 +1234,20 @@ TEST(Registerizer, RegisterizerConditionInsideOverlap2) {
   VarHandle y("y", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(a, {x}, Load::make(b, {x + 1}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(a, {x}, Load::make(b, {x + 1})),
+       Store::make(c, {x}, Load::make(a, {x})),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make({
-               Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
-               Store::make(a, {0}, 3, 1),
-               Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+               Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
+               Store::make(a, {0}, 3),
+               Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            }),
            nullptr),
-       Store::make(b, {x}, Load::make(a, {x}, 1), 1),
-       Store::make(b, {x + 1}, Load::make(a, {x}, 1), 1),
-       Store::make(a, {x}, Load::make(c, {x}, 1), 1)});
+       Store::make(b, {x}, Load::make(a, {x})),
+       Store::make(b, {x + 1}, Load::make(a, {x})),
+       Store::make(a, {x}, Load::make(c, {x}))});
 
   /*
    * A[x] = B[x];
@@ -1328,11 +1320,11 @@ TEST(Registerizer, RegisterizerConditionHidden) {
   Stmt* stmt = Block::make(
       {Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kGT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr)});
 
   /*
@@ -1370,12 +1362,12 @@ TEST(Registerizer, RegisterizerConditionUnhidden) {
   Stmt* stmt = Block::make(
       {Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr),
-       Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+       Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kGT),
-           Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
+           Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
            nullptr)});
 
   /*
@@ -1429,12 +1421,12 @@ TEST(Registerizer, RegisterizerCondCondition) {
   VarHandle x("x", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(b, {x}, 1), 1),
-       Store::make(c, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(b, {x})),
+       Store::make(c, {x}, Load::make(a, {x})),
        Cond::make(
            CompareSelect::make(
-               Load::make(a, {x}, 1), 5, CompareSelectOperation::kLT),
-           Store::make(c, {x}, Add::make(Load::make(c, {x}, 1), 1), 1),
+               Load::make(a, {x}), 5, CompareSelectOperation::kLT),
+           Store::make(c, {x}, Add::make(Load::make(c, {x}), 1)),
            nullptr)});
 
   /*
@@ -1480,10 +1472,9 @@ TEST(Registerizer, RegisterizerCondConditionUnhidden) {
   VarHandle x("x", kInt);
 
   Stmt* stmt = Block::make({Cond::make(
-      CompareSelect::make(
-          Load::make(a, {x}, 1), 5, CompareSelectOperation::kLT),
-      Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 1), 1),
-      Store::make(a, {x}, Add::make(Load::make(a, {x}, 1), 10), 1))});
+      CompareSelect::make(Load::make(a, {x}), 5, CompareSelectOperation::kLT),
+      Store::make(a, {x}, Add::make(Load::make(a, {x}), 1)),
+      Store::make(a, {x}, Add::make(Load::make(a, {x}), 10)))});
 
   /*
    * if ((A[x])<5 ? 1 : 0) {
@@ -1536,16 +1527,16 @@ TEST(Registerizer, RegisterizerIfThenElseHidden) {
            {y},
            IfThenElse::make(
                CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-               Add::make(Load::make(a, {x}, 1), 1),
-               Add::make(Load::make(a, {x + 1}, 1), 2)),
+               Add::make(Load::make(a, {x}), 1),
+               Add::make(Load::make(a, {x + 1}), 2)),
            1),
        Store::make(
            b,
            {y + 1},
            IfThenElse::make(
                CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-               Add::make(Load::make(a, {x}, 1), 1),
-               Add::make(Load::make(a, {x + 1}, 1), 2)),
+               Add::make(Load::make(a, {x}), 1),
+               Add::make(Load::make(a, {x + 1}), 2)),
            1)});
 
   /*
@@ -1575,22 +1566,22 @@ TEST(Registerizer, RegisterizerIfThenElseUnhidden) {
   VarHandle y("y", kInt);
 
   Stmt* stmt = Block::make({
-      Store::make(a, {x}, 0, 1),
+      Store::make(a, {x}, 0),
       Store::make(
           b,
           {y},
           IfThenElse::make(
               CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-              Add::make(Load::make(a, {x}, 1), 1),
-              Add::make(Load::make(a, {x + 1}, 1), 2)),
+              Add::make(Load::make(a, {x}), 1),
+              Add::make(Load::make(a, {x + 1}), 2)),
           1),
       Store::make(
           b,
           {y + 1},
           IfThenElse::make(
               CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-              Add::make(Load::make(a, {x}, 1), 1),
-              Add::make(Load::make(a, {x + 1}, 1), 2)),
+              Add::make(Load::make(a, {x}), 1),
+              Add::make(Load::make(a, {x + 1}), 2)),
           1),
   });
 
@@ -1638,12 +1629,12 @@ TEST(Registerizer, RegisterizerIfThenElseNested) {
           CompareSelect::make(x, 3, CompareSelectOperation::kLT),
           IfThenElse::make(
               CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-              Load::make(d, {x}, 1),
-              Load::make(b, {x}, 1)),
+              Load::make(d, {x}),
+              Load::make(b, {x})),
           IfThenElse::make(
               CompareSelect::make(x, 5, CompareSelectOperation::kEQ),
-              Load::make(c, {x}, 1),
-              Load::make(d, {x}, 1))),
+              Load::make(c, {x}),
+              Load::make(d, {x}))),
       1)});
 
   /*
@@ -1680,8 +1671,8 @@ TEST(Registerizer, RegisterizerIfThenElseInternal) {
       {x},
       IfThenElse::make(
           CompareSelect::make(x, 3, CompareSelectOperation::kLT),
-          Add::make(Load::make(b, {x}, 1), Load::make(b, {x}, 1)),
-          Load::make(b, {x}, 1)),
+          Add::make(Load::make(b, {x}), Load::make(b, {x})),
+          Load::make(b, {x})),
       1)});
 
   /*
@@ -1706,9 +1697,8 @@ TEST(Registerizer, RegisterizerIfThenElseInternal) {
 
   stmt = Block::make({Cond::make(
       CompareSelect::make(x, 3, CompareSelectOperation::kLT),
-      Store::make(
-          a, {x}, Add::make(Load::make(b, {x}, 1), Load::make(b, {x}, 1)), 1),
-      Store::make(a, {x}, Load::make(b, {x}, 1), 1))});
+      Store::make(a, {x}, Add::make(Load::make(b, {x}), Load::make(b, {x}))),
+      Store::make(a, {x}, Load::make(b, {x})))});
 
   /*
    * if (x<3 ? 1 : 0) {
@@ -1757,16 +1747,15 @@ TEST(Registerizer, RegisterizerIfThenElseCondition) {
   VarHandle x("x", kInt);
 
   Stmt* stmt = Block::make(
-      {Store::make(a, {x}, Load::make(a, {x}, 1), 1),
+      {Store::make(a, {x}, Load::make(a, {x})),
        Store::make(
            a,
            {x},
            IfThenElse::make(
                CompareSelect::make(
-                   Load::make(a, {x}, 1), 5, CompareSelectOperation::kLT),
-               Load::make(b, {0}, 1),
-               Load::make(c, {0}, 1)),
-           1)});
+                   Load::make(a, {x}), 5, CompareSelectOperation::kLT),
+               Load::make(b, {0}),
+               Load::make(c, {0})))});
 
   /*
    * A[x] = A[x];       <---- just here so there are enough accesses to combine.
@@ -1808,9 +1797,9 @@ TEST(Registerizer, RegisterizerIfThenElseConditionUnhidden) {
       {x},
       IfThenElse::make(
           CompareSelect::make(
-              Load::make(a, {x}, 1), 5, CompareSelectOperation::kLT),
-          Add::make(Load::make(a, {x}, 1), 1),
-          Add::make(Load::make(a, {x}, 1), 10)),
+              Load::make(a, {x}), 5, CompareSelectOperation::kLT),
+          Add::make(Load::make(a, {x}), 1),
+          Add::make(Load::make(a, {x}), 10)),
       1)});
 
   /*
@@ -1853,16 +1842,16 @@ TEST(Registerizer, RegisterizerConditionBranchOnly) {
                   {x},
                   IfThenElse::make(
                       CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-                      Add::make(Load::make(a, {x}, 1), x),
-                      Add::make(Load::make(a, {x - 5}, 1), x)),
+                      Add::make(Load::make(a, {x}), x),
+                      Add::make(Load::make(a, {x - 5}), x)),
                   1),
               Store::make(
                   a,
                   {x - 5},
                   IfThenElse::make(
                       CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-                      Add::make(Load::make(a, {x}, 1), x),
-                      Add::make(Load::make(a, {x - 5}, 1), x)),
+                      Add::make(Load::make(a, {x}), x),
+                      Add::make(Load::make(a, {x - 5}), x)),
                   1)),
       }))});
 
@@ -1900,12 +1889,12 @@ TEST(Registerizer, RegisterizerCondIfThenElse) {
       CompareSelect::make(
           IfThenElse::make(
               CompareSelect::make(
-                  Load::make(a, {x}, 1), 5, CompareSelectOperation::kLT),
-              Load::make(a, {x}, 1),
-              Load::make(b, {x}, 1)),
+                  Load::make(a, {x}), 5, CompareSelectOperation::kLT),
+              Load::make(a, {x}),
+              Load::make(b, {x})),
           x,
           CompareSelectOperation::kEQ),
-      Store::make(c, {x}, Add::make(Load::make(c, {x}, 1), 1), 1),
+      Store::make(c, {x}, Add::make(Load::make(c, {x}), 1)),
       nullptr)});
 
   /*
@@ -1955,8 +1944,8 @@ TEST(Registerizer, RegisterizerIfThenElseLoop) {
           {x},
           IfThenElse::make(
               CompareSelect::make(x, 3, CompareSelectOperation::kLT),
-              Load::make(a, {x}, 1),
-              Load::make(b, {y}, 1)),
+              Load::make(a, {x}),
+              Load::make(b, {y})),
           1));
 
   /*
@@ -2006,8 +1995,8 @@ TEST(Registerizer, RegisterizerIfThenElseLoopCut) {
           {x},
           IfThenElse::make(
               CompareSelect::make(x, 3, CompareSelectOperation::kLT),
-              Load::make(a, {x}, 1),
-              Load::make(a, {y}, 1)),
+              Load::make(a, {x}),
+              Load::make(a, {y})),
           1))});
 
   /*
@@ -2035,14 +2024,14 @@ TEST(Registerizer, RegisterizerPartialAfter) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 0, 1),
+      {Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)})),
-       For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1))});
+               {Store::make(a, {0}, Add::make(Load::make(a, {0}), x))})),
+       For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1})))});
 
   /*
    * A[0] = 0;
@@ -2092,14 +2081,14 @@ TEST(Registerizer, RegisterizerPartialBefore) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1)),
-       Store::make(a, {0}, 0, 1),
+      {For::make(x, 1, 10, Store::make(a, {x}, Load::make(a, {x - 1}))),
+       Store::make(a, {0}, 0),
        For::make(
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)}))});
+           Block::make(
+               {Store::make(a, {0}, Add::make(Load::make(a, {0}), x))}))});
 
   /*
    * for (int x = 1; x < 10; x++) {
@@ -2151,19 +2140,12 @@ TEST(Registerizer, RegisterizerPartialInside) {
   VarHandle x2("x2", kInt);
   VarHandle x3("x3", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 2, 1),
+      {Store::make(a, {0}, 2),
        For::make(
-           x1,
-           0,
-           10,
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x1), 1)),
+           x1, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), x1))),
+       For::make(x2, 1, 10, Store::make(a, {x2}, Load::make(a, {x2 - 1}))),
        For::make(
-           x2, 1, 10, Store::make(a, {x2}, Load::make(a, {x2 - 1}, 1), 1)),
-       For::make(
-           x3,
-           0,
-           10,
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x3), 1))});
+           x3, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), x3)))});
 
   /*
    * A[0] = 2;
@@ -2226,21 +2208,15 @@ TEST(Registerizer, RegisterizerPartialCondition) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 2, 1),
+      {Store::make(a, {0}, 2),
        For::make(
-           x,
-           0,
-           10,
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1)),
+           x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), x))),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Store::make(a, {x}, Load::make(a, {x - 1}, 1), 1),
+           Store::make(a, {x}, Load::make(a, {x - 1})),
            nullptr),
        For::make(
-           x,
-           0,
-           10,
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), x), 1))});
+           x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), x)))});
 
   /*
    * A[0] = 2;
@@ -2302,14 +2278,14 @@ TEST(Registerizer, RegisterizerPartialConditionInternalCut) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 1, 1),
-       Store::make(a, {0}, 3, 1),
+      {Store::make(a, {0}, 1),
+       Store::make(a, {0}, 3),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Block::make({Store::make(a, {x}, 1, 1), Store::make(a, {x}, 3, 1)}),
+           Block::make({Store::make(a, {x}, 1), Store::make(a, {x}, 3)}),
            nullptr),
-       Store::make(a, {0}, 4, 1),
-       Store::make(a, {0}, 6, 1)});
+       Store::make(a, {0}, 4),
+       Store::make(a, {0}, 6)});
 
   /*
    * A[0] = 1;
@@ -2365,14 +2341,14 @@ TEST(Registerizer, RegisterizerPartialConditionInternalStart) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, 1, 1),
-       Store::make(a, {0}, 3, 1),
+      {Store::make(a, {0}, 1),
+       Store::make(a, {0}, 3),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
-           Block::make({Store::make(a, {x}, 1, 1), Store::make(a, {x}, 3, 1)}),
+           Block::make({Store::make(a, {x}, 1), Store::make(a, {x}, 3)}),
            nullptr),
-       Store::make(a, {x}, 4, 1),
-       Store::make(a, {x}, 6, 1)});
+       Store::make(a, {x}, 4),
+       Store::make(a, {x}, 6)});
 
   /*
    * A[0] = 1;
@@ -2429,13 +2405,13 @@ TEST(Registerizer, RegisterizerPartialOverlapsTwo) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {1}, Load::make(a, {0}, 1), 1),
-       Store::make(a, {0}, Load::make(a, {1}, 1), 1),
-       Store::make(a, {0}, Load::make(a, {1}, 1), 1),
-       For::make(x, 1, 10, Store::make(a, {x}, x, 1)),
-       Store::make(a, {1}, Load::make(a, {0}, 1), 1),
-       Store::make(a, {0}, Load::make(a, {1}, 1), 1),
-       Store::make(a, {0}, Load::make(a, {1}, 1), 1)});
+      {Store::make(a, {1}, Load::make(a, {0})),
+       Store::make(a, {0}, Load::make(a, {1})),
+       Store::make(a, {0}, Load::make(a, {1})),
+       For::make(x, 1, 10, Store::make(a, {x}, x)),
+       Store::make(a, {1}, Load::make(a, {0})),
+       Store::make(a, {0}, Load::make(a, {1})),
+       Store::make(a, {0}, Load::make(a, {1}))});
 
   /*
    * A[1] = A[0];
@@ -2500,13 +2476,12 @@ TEST(Registerizer, RegisterizerNestedBlocks) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+      {Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
+       Block::make({Store::make(a, {0}, Add::make(Load::make(a, {0}), 2))}),
        Block::make(
-           {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 2), 1)}),
-       Block::make(
-           {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 3), 1),
-            Block::make({Store::make(
-                a, {0}, Add::make(Load::make(a, {0}, 1), 4), 1)})})});
+           {Store::make(a, {0}, Add::make(Load::make(a, {0}), 3)),
+            Block::make(
+                {Store::make(a, {0}, Add::make(Load::make(a, {0}), 4))})})});
 
   /*
    * A[0] = (A[0]) + 1;
@@ -2556,10 +2531,10 @@ TEST(Registerizer, RegisterizerNestedConditions) {
   Stmt* stmt = Block::make({Cond::make(
       CompareSelect::make(x, 5, CompareSelectOperation::kLT),
       Block::make(
-          {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+          {Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
            Cond::make(
                CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+               Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                nullptr)}),
       nullptr)});
 
@@ -2610,14 +2585,14 @@ TEST(Registerizer, RegisterizerNestedConditionsUnhidden) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+      {Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make(
-               {Store::make(a, {1}, 1, 1),
+               {Store::make(a, {1}, 1),
                 Cond::make(
                     CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-                    Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+                    Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                     nullptr)}),
            nullptr)});
 
@@ -2668,13 +2643,13 @@ TEST(Registerizer, RegisterizerNestedConditionsHiddenFirst) {
   Stmt* stmt = Block::make(
       {Cond::make(
            CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+           Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
            nullptr),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make({Cond::make(
                CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+               Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                nullptr)}),
            nullptr)});
 
@@ -2712,12 +2687,12 @@ TEST(Registerizer, RegisterizerNestedConditionsHiddenSecond) {
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make({Cond::make(
                CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+               Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                nullptr)}),
            nullptr),
        Cond::make(
            CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+           Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
            nullptr)});
 
   /*
@@ -2752,14 +2727,14 @@ TEST(Registerizer, RegisterizerNestedConditionsCut) {
   BufHandle a("A", {1}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+      {Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            Block::make(
-               {Store::make(a, {x}, 1, 1),
+               {Store::make(a, {x}, 1),
                 Cond::make(
                     CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-                    Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+                    Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                     nullptr)}),
            nullptr)});
 
@@ -2794,17 +2769,17 @@ TEST(Registerizer, RegisterizerNestedConditionLoopHidden) {
   Stmt* stmt = Block::make(
       {Cond::make(
            CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-           Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+           Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
            nullptr),
        For::make(
            x,
            0,
            10,
            Block::make(
-               {Store::make(b, {x}, 0, 1),
+               {Store::make(b, {x}, 0),
                 Cond::make(
                     CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
-                    Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+                    Store::make(a, {0}, Add::make(Load::make(a, {0}), 1)),
                     nullptr)}))});
 
   /*
@@ -2839,7 +2814,7 @@ TEST(Registerizer, RegisterizerNestedConditionThreeDeep) {
   BufHandle b("B", {10}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {4}, 0, 1),
+      {Store::make(a, {4}, 0),
        Cond::make(
            CompareSelect::make(x, 2, CompareSelectOperation::kGT),
            Cond::make(
@@ -2849,18 +2824,18 @@ TEST(Registerizer, RegisterizerNestedConditionThreeDeep) {
                        CompareSelect::make(x, 4, CompareSelectOperation::kGT),
                        Block::make({
                            Store::make(
-                               a, {1}, Add::make(Load::make(a, {1}, 1), 1), 1),
+                               a, {1}, Add::make(Load::make(a, {1}), 1)),
                            Store::make(
-                               a, {2}, Add::make(Load::make(a, {2}, 1), 1), 1),
+                               a, {2}, Add::make(Load::make(a, {2}), 1)),
                            Store::make(
-                               a, {3}, Add::make(Load::make(a, {3}, 1), 1), 1),
+                               a, {3}, Add::make(Load::make(a, {3}), 1)),
                            Store::make(
-                               a, {4}, Add::make(Load::make(a, {4}, 1), 1), 1),
+                               a, {4}, Add::make(Load::make(a, {4}), 1)),
                            Store::make(
-                               a, {1}, Add::make(Load::make(a, {1}, 1), 1), 1),
+                               a, {1}, Add::make(Load::make(a, {1}), 1)),
                        }),
                        nullptr),
-                   Store::make(a, {2}, Add::make(Load::make(a, {2}, 1), 1), 1),
+                   Store::make(a, {2}, Add::make(Load::make(a, {2}), 1)),
                }),
                nullptr),
            nullptr)});
@@ -2946,8 +2921,8 @@ TEST(Registerizer, RegisterizerNestedLoopSimple) {
           x,
           0,
           10,
-          Block::make({Store::make(
-              a, {y}, Add::make(Load::make(a, {y}, 1), x), 1)})))});
+          Block::make(
+              {Store::make(a, {y}, Add::make(Load::make(a, {y}), x))})))});
 
   /*
    * for (int y = 0; y < 10; y++) {
@@ -2997,13 +2972,13 @@ TEST(Registerizer, RegisterizerHiddenAccessYes) {
   Stmt* stmt = Block::make({Cond::make(
       CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
       Block::make(
-          {Store::make(a, {0}, 0, 1),
+          {Store::make(a, {0}, 0),
            For::make(
                x,
                0,
                10,
                Block::make(
-                   {Store::make(b, {x}, 0, 1),
+                   {Store::make(b, {x}, 0),
                     Cond::make(
                         CompareSelect::make(x, 3, CompareSelectOperation::kEQ),
                         For::make(
@@ -3011,10 +2986,7 @@ TEST(Registerizer, RegisterizerHiddenAccessYes) {
                             0,
                             10,
                             Store::make(
-                                a,
-                                {0},
-                                Add::make(Load::make(a, {0}, 1), 1),
-                                1)),
+                                a, {0}, Add::make(Load::make(a, {0}), 1))),
                         nullptr)}))}),
       nullptr)});
 
@@ -3086,15 +3058,14 @@ TEST(Registerizer, RegisterizerHiddenAccessNo) {
           0,
           10,
           Block::make(
-              {Store::make(b, {x}, 0, 1),
+              {Store::make(b, {x}, 0),
                Cond::make(
                    CompareSelect::make(x, 3, CompareSelectOperation::kEQ),
                    For::make(
                        y,
                        0,
                        10,
-                       Store::make(
-                           a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1)),
+                       Store::make(a, {0}, Add::make(Load::make(a, {0}), 1))),
                    nullptr)}))}),
       nullptr)});
 
@@ -3162,7 +3133,7 @@ TEST(Registerizer, RegisterizerHiddenAccessMultiLoop) {
   Stmt* stmt = Block::make({Cond::make(
       CompareSelect::make(x, 2, CompareSelectOperation::kEQ),
       Block::make(
-          {Store::make(a, {0}, 0, 1),
+          {Store::make(a, {0}, 0),
            For::make(
                x,
                0,
@@ -3175,12 +3146,9 @@ TEST(Registerizer, RegisterizerHiddenAccessMultiLoop) {
                        CompareSelect::make(y, 3, CompareSelectOperation::kEQ),
                        Block::make(
                            {Store::make(
-                                a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1),
+                                a, {0}, Add::make(Load::make(a, {0}), 1)),
                             Store::make(
-                                b,
-                                {0},
-                                Add::make(Load::make(b, {0}, 1), 1),
-                                1)}),
+                                b, {0}, Add::make(Load::make(b, {0}), 1))}),
                        nullptr)})))}),
       nullptr)});
 
@@ -3246,18 +3214,12 @@ TEST(Registerizer, RegisterizerTwoConditionalLoops) {
       {Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            For::make(
-               x,
-               0,
-               10,
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1)),
+               x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), 1))),
            nullptr),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kGT),
            For::make(
-               x,
-               0,
-               10,
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1)),
+               x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), 1))),
            nullptr)});
 
   /*
@@ -3324,19 +3286,13 @@ TEST(Registerizer, RegisterizerTwoConditionalLoopsCut) {
       {Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kLT),
            For::make(
-               x,
-               0,
-               10,
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1)),
+               x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), 1))),
            nullptr),
-       For::make(x, 0, 10, Store::make(a, {x}, 1, 1)),
+       For::make(x, 0, 10, Store::make(a, {x}, 1)),
        Cond::make(
            CompareSelect::make(x, 5, CompareSelectOperation::kGT),
            For::make(
-               x,
-               0,
-               10,
-               Store::make(a, {0}, Add::make(Load::make(a, {0}, 1), 1), 1)),
+               x, 0, 10, Store::make(a, {0}, Add::make(Load::make(a, {0}), 1))),
            nullptr)});
 
   /*
@@ -3415,7 +3371,7 @@ TEST(Registerizer, RegisterizerLoopLetVar) {
       10,
       Block::make(
           {Let::make(y, 30),
-           Store::make(a, {y}, Add::make(x, Load::make(a, {y}, 1)), 1)}))});
+           Store::make(a, {y}, Add::make(x, Load::make(a, {y})))}))});
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -3449,8 +3405,8 @@ TEST(Registerizer, RegisterizerLoopLetVarOuter) {
            x,
            0,
            10,
-           Block::make({Store::make(
-               a, {y}, Add::make(x, Load::make(a, {y}, 1)), 1)}))});
+           Block::make(
+               {Store::make(a, {y}, Add::make(x, Load::make(a, {y})))}))});
 
   /*
    * int y = 30;
@@ -3491,13 +3447,13 @@ TEST(Registerizer, RegisterizerMultiDim) {
   BufHandle a("A", {3, 4, 5}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0, 1, 2}, 0, 1),
+      {Store::make(a, {0, 1, 2}, 0),
        For::make(
            x,
            0,
            10,
            Block::make({Store::make(
-               a, {0, 1, 2}, Add::make(Load::make(a, {0, 1, 2}, 1), x), 1)}))});
+               a, {0, 1, 2}, Add::make(Load::make(a, {0, 1, 2}), x))}))});
 
   /*
    * A[0, 1, 2] = 0;
@@ -3537,13 +3493,13 @@ TEST(Registerizer, RegisterizerMultiDimPartial) {
   BufHandle a("A", {3, 4, 5}, kInt);
   VarHandle x("x", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0, 1, 2}, 0, 1),
+      {Store::make(a, {0, 1, 2}, 0),
        For::make(
            x,
            0,
            10,
            Block::make({Store::make(
-               a, {0, 2, 2}, Add::make(Load::make(a, {0, 1, 4}, 1), x), 1)}))});
+               a, {0, 2, 2}, Add::make(Load::make(a, {0, 1, 4}), x))}))});
 
   /*
    * A[0, 1, 2] = 0;
@@ -3586,13 +3542,13 @@ TEST(Registerizer, RegisterizerMultiDimOverlap) {
   VarHandle x("x", kInt);
   VarHandle y("y", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0, 1, 2}, 0, 1),
+      {Store::make(a, {0, 1, 2}, 0),
        For::make(
            x,
            0,
            10,
            Block::make({Store::make(
-               a, {0, x, 2}, Add::make(Load::make(a, {y, 2, 2}, 1), x), 1)}))});
+               a, {0, x, 2}, Add::make(Load::make(a, {y, 2, 2}), x))}))});
 
   /*
    * A[0, 1, 2] = 0;
@@ -3620,13 +3576,13 @@ TEST(Registerizer, RegisterizerMultiDimPartialOverlap) {
   VarHandle x("x", kInt);
   VarHandle y("y", kInt);
   Stmt* stmt = Block::make(
-      {Store::make(a, {0, 1, 2}, 0, 1),
+      {Store::make(a, {0, 1, 2}, 0),
        For::make(
            x,
            0,
            10,
            Block::make({Store::make(
-               a, {0, x, 2}, Add::make(Load::make(a, {y, 2, 4}, 1), x), 1)}))});
+               a, {0, x, 2}, Add::make(Load::make(a, {y, 2, 4}), x))}))});
 
   /*
    * A[0, 1, 2] = 0;                          <---- 2nd dim overlaps with store.
@@ -3684,10 +3640,9 @@ TEST(Registerizer, RegisterizerMultiDim3DReduction1) {
                   c,
                   {x, y, z},
                   Add::make(
-                      Load::make(c, {x, y, z}, 1),
+                      Load::make(c, {x, y, z}),
                       Mul::make(
-                          Load::make(b, {x, y}, 1), Load::make(a, {x}, 1))),
-                  1))));
+                          Load::make(b, {x, y}, 1), Load::make(a, {x}, 1)))))));
 
   /*
    * for (int x = 0; x < 10; x++) {
@@ -3758,9 +3713,8 @@ TEST(Registerizer, RegisterizerMultiDim3DReduction2) {
                   c,
                   {x},
                   Add::make(
-                      Load::make(c, {x}, 1),
-                      Mul::make(Load::make(b, {y}, 1), Load::make(a, {x}, 1))),
-                  1))));
+                      Load::make(c, {x}),
+                      Mul::make(Load::make(b, {y}), Load::make(a, {x})))))));
 
   /*
    * for (int x = 0; x < 10; x++) {

--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -508,7 +508,6 @@ TEST(Simplify, HashLargeExpression) {
   BufHandle a("A", {N}, kInt);
   BufHandle b("B", {N}, kInt);
   BufHandle c("C", {N}, kInt);
-  auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
   auto memcpy_stmt = For::make(
       i,
@@ -518,10 +517,9 @@ TEST(Simplify, HashLargeExpression) {
           c,
           {i},
           CompareSelect::make(
-              Load::make(a, {i}, mask),
-              Load::make(b, {i}, mask),
-              CompareSelectOperation::kEQ),
-          mask));
+              Load::make(a, {i}),
+              Load::make(b, {i}),
+              CompareSelectOperation::kEQ)));
 
   BufHandle d("D", {1}, kInt);
   BufHandle e("E", {1}, kInt);
@@ -533,9 +531,7 @@ TEST(Simplify, HashLargeExpression) {
 
   auto if_stmt = Cond::make(
       CompareSelect::make(
-          Load::make(a, {i}, mask),
-          Load::make(b, {i}, mask),
-          CompareSelectOperation::kGE),
+          Load::make(a, {i}), Load::make(b, {i}), CompareSelectOperation::kGE),
       memcpy_stmt,
       store_ramp_stmt);
 
@@ -559,7 +555,6 @@ TEST(Simplify, HashForLoopOptions) {
   BufHandle a("A", {N}, kInt);
   BufHandle b("B", {N}, kInt);
   BufHandle c("C", {N}, kInt);
-  auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
   auto for_stmt = For::make(
       i,
@@ -569,10 +564,9 @@ TEST(Simplify, HashForLoopOptions) {
           c,
           {i},
           CompareSelect::make(
-              Load::make(a, {i}, mask),
-              Load::make(b, {i}, mask),
-              CompareSelectOperation::kEQ),
-          mask));
+              Load::make(a, {i}),
+              Load::make(b, {i}),
+              CompareSelectOperation::kEQ)));
 
   HashProvider hasher;
   auto hash_before = hasher.hash(for_stmt);
@@ -3160,10 +3154,8 @@ TEST(Simplify, SimplifyEliminateZeroLengthFor) {
     // Will eliminate zero loop For.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 0, 0, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 0, 0, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     ASSERT_EQ(block->nstmts(), 0);
@@ -3173,10 +3165,8 @@ TEST(Simplify, SimplifyEliminateZeroLengthFor) {
     // still works if start is not zero.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 2, 2, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 2, 2, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     ASSERT_EQ(block->nstmts(), 0);
@@ -3187,10 +3177,8 @@ TEST(Simplify, SimplifyEliminateZeroLengthFor) {
     VarHandle x("x", kInt);
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, x, x, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, x, x, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     ASSERT_EQ(block->nstmts(), 0);
@@ -3201,10 +3189,8 @@ TEST(Simplify, SimplifyEliminateZeroLengthFor) {
     VarHandle x("x", kInt);
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body = For::make(
-        i, 0, x - x, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 0, x - x, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     ASSERT_EQ(block->nstmts(), 0);
@@ -3214,10 +3200,8 @@ TEST(Simplify, SimplifyEliminateZeroLengthFor) {
     // Sanity check does nothing if the condition is not met.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 0, 3, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 0, 3, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE(For, simplified);
   }
@@ -3230,10 +3214,8 @@ TEST(Simplify, SimplifyOneLoopFor) {
     // Will remove the loop if the body is run once.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     IS_NODE_WITH_NAME(Store, block->front(), store);
@@ -3245,10 +3227,8 @@ TEST(Simplify, SimplifyOneLoopFor) {
     // still works if start is not zero.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 2, 3, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 2, 3, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     IS_NODE_WITH_NAME(Store, block->front(), store);
@@ -3261,10 +3241,8 @@ TEST(Simplify, SimplifyOneLoopFor) {
     VarHandle x("x", kInt);
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body = For::make(
-        i, x, x + 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, x, x + 1, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     IS_NODE_WITH_NAME(Store, block->front(), store);
@@ -3277,10 +3255,9 @@ TEST(Simplify, SimplifyOneLoopFor) {
     VarHandle x("x", kInt);
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body = For::make(
-        i, 0, x - x + 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body =
+        For::make(i, 0, x - x + 1, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     Block* block = dynamic_cast<Block*>(simplified);
     IS_NODE_WITH_NAME(Store, block->front(), store);
@@ -3292,10 +3269,8 @@ TEST(Simplify, SimplifyOneLoopFor) {
     // Sanity check does nothing if the condition is not met.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
-    auto body =
-        For::make(i, 0, 3, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto body = For::make(i, 0, 3, Store::make(c, {i}, Load::make(a, {i})));
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE(For, simplified);
   }
@@ -3308,12 +3283,11 @@ TEST(Simplify, SimplifyForWontLoseLoopOptions) {
     // Sanity check does nothing if the condition is not met.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
     LoopOptions options;
     options.set_gpu_block_index(12);
-    auto body = For::make(
-        i, 0, 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask), options);
+    auto body =
+        For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i})), options);
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(For, simplified, for_);
     LoopOptions options2 = for_->loop_options();
@@ -3328,11 +3302,9 @@ TEST(Simplify, SimplifyMultilevelFor) {
     // Multiple layers of For will be simplified out.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
     VarHandle j("j", kInt);
-    auto* body =
-        For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto* body = For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i})));
     auto outer = For::make(j, 0, 1, body);
     Stmt* simplified = IRSimplifier::simplify(outer);
     Block* block = dynamic_cast<Block*>(simplified);
@@ -3345,11 +3317,9 @@ TEST(Simplify, SimplifyMultilevelFor) {
     // Will maintain an outer loop if the inner loop is eliminated.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
     VarHandle j("j", kInt);
-    auto* body =
-        For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto* body = For::make(i, 0, 1, Store::make(c, {i}, Load::make(a, {i})));
     auto outer = For::make(j, 0, 2, body);
     Stmt* simplified = IRSimplifier::simplify(outer);
     For* for__ = static_cast<For*>(simplified);
@@ -3368,11 +3338,9 @@ TEST(Simplify, SimplifyMultilevelFor) {
     // Will maintain inner loop if outer loops is eliminated.
     BufHandle a("A", {4}, kInt);
     BufHandle c("C", {4}, kInt);
-    auto mask = IntImm::make(1);
     VarHandle i("i", kInt);
     VarHandle j("j", kInt);
-    auto* body =
-        For::make(i, 0, 2, Store::make(c, {i}, Load::make(a, {i}, mask), mask));
+    auto* body = For::make(i, 0, 2, Store::make(c, {i}, Load::make(a, {i})));
     auto outer = For::make(j, 0, 1, body);
     Stmt* simplified = IRSimplifier::simplify(outer);
     Block* block = dynamic_cast<Block*>(simplified);
@@ -3630,7 +3598,6 @@ TEST(Simplify, SimplifyReorderForCond) {
   BufHandle a("A", {4}, kInt);
   BufHandle b("B", {1}, kInt);
   BufHandle c("C", {4}, kInt);
-  auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
   VarHandle j("j", kInt);
 
@@ -3642,7 +3609,7 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-            Store::make(c, {i}, Load::make(a, {i}, mask), mask),
+            Store::make(c, {i}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3659,7 +3626,7 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(c, {i}, Load::make(a, {i}, mask), mask),
+            Store::make(c, {i}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3676,8 +3643,8 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(c, {0}, mask), 10, CompareSelectOperation::kLT),
-            Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                Load::make(c, {0}), 10, CompareSelectOperation::kLT),
+            Store::make(c, {0}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3693,8 +3660,8 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(b, {0}, mask), 10, CompareSelectOperation::kLT),
-            Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                Load::make(b, {0}), 10, CompareSelectOperation::kLT),
+            Store::make(c, {0}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3711,8 +3678,8 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(a, {0}, mask), 10, CompareSelectOperation::kLT),
-            Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                Load::make(a, {0}), 10, CompareSelectOperation::kLT),
+            Store::make(c, {0}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3731,7 +3698,7 @@ TEST(Simplify, SimplifyReorderForCond) {
             {Let::make(j, 3),
              Cond::make(
                  CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-                 Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                 Store::make(c, {0}, Load::make(a, {i})),
                  nullptr)}));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3749,10 +3716,10 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(a, {0}, mask), 10, CompareSelectOperation::kLT),
+                Load::make(a, {0}), 10, CompareSelectOperation::kLT),
             Cond::make(
                 CompareSelect::make(j, 10, CompareSelectOperation::kEQ),
-                Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                Store::make(c, {0}, Load::make(a, {i})),
                 nullptr),
             nullptr));
 
@@ -3773,10 +3740,10 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(a, {0}, mask), 10, CompareSelectOperation::kLT),
+                Load::make(a, {0}), 10, CompareSelectOperation::kLT),
             Cond::make(
                 CompareSelect::make(i, 10, CompareSelectOperation::kEQ),
-                Store::make(c, {0}, Load::make(a, {i}, mask), mask),
+                Store::make(c, {0}, Load::make(a, {i})),
                 nullptr),
             nullptr));
 
@@ -3797,8 +3764,8 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-            Store::make(c, {0}, Load::make(a, {i}, mask), mask),
-            Store::make(c, {0}, 0, mask)));
+            Store::make(c, {0}, Load::make(a, {i})),
+            Store::make(c, {0}, 0)));
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(For, simplified, loop);
@@ -3815,8 +3782,8 @@ TEST(Simplify, SimplifyReorderForCond) {
         4,
         Cond::make(
             CompareSelect::make(
-                Load::make(c, {0}, mask), 10, CompareSelectOperation::kLT),
-            Store::make(c, {1}, Load::make(a, {i}, mask), mask),
+                Load::make(c, {0}), 10, CompareSelectOperation::kLT),
+            Store::make(c, {1}, Load::make(a, {i})),
             nullptr));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3829,7 +3796,6 @@ TEST(Simplify, SimplifyFuseConditions) {
   KernelScope kernel_scope;
   BufHandle a("A", {2}, kInt);
   BufHandle b("B", {2}, kInt);
-  auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
   VarHandle j("j", kInt);
 
@@ -3839,11 +3805,11 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3860,11 +3826,11 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3886,11 +3852,11 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(i, 11, CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3913,11 +3879,11 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kGT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3947,7 +3913,7 @@ TEST(Simplify, SimplifyFuseConditions) {
                  new IntImm(1),
                  new IntImm(0),
                  CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(
@@ -3956,7 +3922,7 @@ TEST(Simplify, SimplifyFuseConditions) {
                  new IntImm(2),
                  new IntImm(0),
                  CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -3980,11 +3946,11 @@ TEST(Simplify, SimplifyFuseConditions) {
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
              nullptr,
-             Store::make(a, {0}, i, mask)),
+             Store::make(a, {0}, i)),
          Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
              nullptr,
-             Store::make(a, {1}, i, mask))});
+             Store::make(a, {1}, i))});
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4000,12 +3966,12 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
-             Store::make(b, {0}, i, mask)),
+             Store::make(a, {0}, i),
+             Store::make(b, {0}, i)),
          Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
-             Store::make(b, {1}, i, mask))});
+             Store::make(a, {1}, i),
+             Store::make(b, {1}, i))});
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4022,12 +3988,12 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make(
         {Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(i, 10, CompareSelectOperation::kLT),
              nullptr,
-             Store::make(b, {1}, i, mask))});
+             Store::make(b, {1}, i))});
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4060,19 +4026,19 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make({
         Cond::make(
             CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, j, mask),
+            Store::make(a, {0}, j),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, i, mask),
+            Store::make(a, {0}, i),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {1}, i, mask),
+            Store::make(a, {1}, i),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 11, CompareSelectOperation::kLT),
-            Store::make(a, {1}, j, mask),
+            Store::make(a, {1}, j),
             nullptr),
     });
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -4091,19 +4057,19 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make({
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, j, mask),
+            Store::make(a, {0}, j),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, i, mask),
+            Store::make(a, {0}, i),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {1}, i, mask),
+            Store::make(a, {1}, i),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {1}, j, mask),
+            Store::make(a, {1}, j),
             nullptr),
     });
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -4120,20 +4086,20 @@ TEST(Simplify, SimplifyFuseConditions) {
     auto body = Block::make({
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, j, mask),
+            Store::make(a, {0}, j),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {0}, i, mask),
+            Store::make(a, {0}, i),
             nullptr),
-        Store::make(b, {1}, i + j, mask),
+        Store::make(b, {1}, i + j),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {1}, i, mask),
+            Store::make(a, {1}, i),
             nullptr),
         Cond::make(
             CompareSelect::make(i, 10, CompareSelectOperation::kLT),
-            Store::make(a, {1}, j, mask),
+            Store::make(a, {1}, j),
             nullptr),
     });
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -4162,14 +4128,14 @@ TEST(Simplify, SimplifyFuseConditions) {
                  i * 2,
                  ExprHandle(87) % ExprHandle(11),
                  CompareSelectOperation::kLT),
-             Store::make(a, {0}, i, mask),
+             Store::make(a, {0}, i),
              nullptr),
          Cond::make(
              CompareSelect::make(
                  i * 2,
                  ExprHandle(300) / ExprHandle(30),
                  CompareSelectOperation::kLT),
-             Store::make(a, {1}, i, mask),
+             Store::make(a, {1}, i),
              nullptr)});
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4184,8 +4150,8 @@ TEST(Simplify, SimplifyFuseConditions) {
     // Can fuse non-CompareSelects.
     // if (i) { X } if (i) { Y } => if (i) { X; Y }
     auto body = Block::make(
-        {Cond::make(i, Store::make(a, {0}, i, mask), nullptr),
-         Cond::make(i, Store::make(a, {1}, i, mask), nullptr)});
+        {Cond::make(i, Store::make(a, {0}, i), nullptr),
+         Cond::make(i, Store::make(a, {1}, i), nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4199,8 +4165,8 @@ TEST(Simplify, SimplifyFuseConditions) {
   {
     // Sanity check wont fuse different non-CompareSelects.
     auto body = Block::make(
-        {Cond::make(i, Store::make(a, {0}, i, mask), nullptr),
-         Cond::make(j, Store::make(a, {1}, i, mask), nullptr)});
+        {Cond::make(i, Store::make(a, {0}, i), nullptr),
+         Cond::make(j, Store::make(a, {1}, i), nullptr)});
 
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
@@ -4213,8 +4179,8 @@ TEST(Simplify, SimplifyFuseConditions) {
     // Sanity check constant condition elimination still occurs when merging is
     // possible.
     auto body = Block::make(
-        {Cond::make(1, Store::make(a, {0}, i, mask), nullptr),
-         Cond::make(1, Store::make(a, {1}, i, mask), nullptr)});
+        {Cond::make(1, Store::make(a, {0}, i), nullptr),
+         Cond::make(1, Store::make(a, {1}, i), nullptr)});
     Stmt* simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Block, simplified, block);
     ASSERT_EQ(block->nstmts(), 2);
@@ -4231,11 +4197,11 @@ TEST(Simplify, SimplifyFuseConditions) {
         Block::make(
             {Cond::make(
                  CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-                 Store::make(a, {1}, Load::make(b, {0}, mask), mask),
+                 Store::make(a, {1}, Load::make(b, {0})),
                  nullptr),
              Cond::make(
                  CompareSelect::make(j, 10, CompareSelectOperation::kLT),
-                 Store::make(a, {2}, Load::make(b, {0}, mask), mask),
+                 Store::make(a, {2}, Load::make(b, {0})),
                  nullptr)}));
 
     Stmt* simplified = IRSimplifier::simplify(body);
@@ -4248,7 +4214,6 @@ TEST(Simplify, SimplifyFuseConditions) {
 TEST(Simplify, SimplifySyncThreads) {
   KernelScope kernel_scope;
   BufHandle a("A", {4}, kInt);
-  auto mask = IntImm::make(1);
   VarHandle i("i", kInt);
 
   {

--- a/test/cpp/tensorexpr/tutorial.cpp
+++ b/test/cpp/tensorexpr/tutorial.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
     // Let's construct a simple load:
     BufHandle A("A", {ExprHandle(64), ExprHandle(32)}, kInt);
     ExprHandle i = Var::make("i", kInt), j = Var::make("j", kInt);
-    ExprHandle load = Load::make(A.dtype(), A, {i, j}, /* mask= */ 1);
+    ExprHandle load = Load::make(A.dtype(), A, {i, j});
     std::cout << "Tensor expression: " << *load.node() << std::endl;
     // Prints: Tensor expression: A[i, j]
   }

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -89,6 +89,19 @@ ExprHandle Load::make(
   return Load::make(buf.dtype(), buf, indices, mask);
 }
 
+ExprHandle Load::make(
+    Dtype dtype,
+    const BufHandle& buf,
+    const std::vector<ExprHandle>& indices) {
+  return Load::make(dtype, buf, indices, IntImm::make(1));
+}
+
+ExprHandle Load::make(
+    const BufHandle& buf,
+    const std::vector<ExprHandle>& indices) {
+  return Load::make(buf.dtype(), buf, indices);
+}
+
 Store::Store(
     const Buf* buf,
     std::vector<const Expr*> indices,

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -418,6 +418,13 @@ class TORCH_API Load : public ExprNode<Load> {
       const BufHandle& buf,
       const std::vector<ExprHandle>& indices,
       const ExprHandle& mask);
+  static ExprHandle make(
+      Dtype dtype,
+      const BufHandle& buf,
+      const std::vector<ExprHandle>& indices);
+  static ExprHandle make(
+      const BufHandle& buf,
+      const std::vector<ExprHandle>& indices);
 
   Load(
       Dtype dtype,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52793 [TensorExpr] Add `Placeholder::handle` method to get the corresponding `BufHandle`.
* **#52790 [TensorExpr] Add an unmasked `Load` constructor.**

Fixes #52774.

Differential Revision: [D26649542](https://our.internmc.facebook.com/intern/diff/D26649542)