### PR TITLE
[TensorExpr] Add `Placeholder::handle` method to get the corresponding `BufHandle`.

### DIFF
--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -83,6 +83,9 @@ class Placeholder {
   const Buf* data() const {
     return data_;
   }
+  BufHandle handle() const {
+    return BufHandle(data());
+  }
   Dtype dtype() const {
     return data_->dtype();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52793 [TensorExpr] Add `Placeholder::handle` method to get the corresponding `BufHandle`.**
* #52790 [TensorExpr] Add an unmasked `Load` constructor.

Fixes #52776.

Differential Revision: [D26650481](https://our.internmc.facebook.com/intern/diff/D26650481)