### PR TITLE
[Pytorch, sparsity] Bug fix to update requantization and zp parameters of input

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/operator-run.c
@@ -1045,6 +1045,12 @@ enum pytorch_qnnp_status pytorch_qnnp_run_operator(
       const size_t m_stride = (output_size + (mr - 1)) & -mr;
       op->prepacked_a =
         (uint8_t*)realloc((void*)op->prepacked_a, k_stride * m_stride);
+      if (op->prepacked_a == NULL) {
+        pytorch_qnnp_log_error(
+            "failed to allocate %zu bytes for packed activation buffer",
+            (k_stride * m_stride));
+        return pytorch_qnnp_status_out_of_memory;
+      }
 
       struct q8gemm_prepackA_sparse_dq_context
         q8gemm_prepack_sparse_dq_context = {


### PR DESCRIPTION
Summary:
Also sneaking in change to check for realloc failure for packed activation buffer

FB:
In dynamic quantization input's quantization scale and zero point can be
different on every iterations. Thus requantization scale needs to be
recomputed.

Earlier bug that calculated those only at op creation time results in wrong
results on subsequent runs.

This diff fixes that.

Test Plan:
FB:
buck test caffe2/torch/fb/model_optimization:sparsity_test

Reviewed By: jiatongzhou

Differential Revision: D26651968

