### PR TITLE
ns for fx: add node name and type to results

### DIFF
--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -35,8 +35,16 @@ def _insert_logger_after_node(
     # create new name
     logger_node_name = \
         get_new_attr_name_with_prefix(node.name + logger_node_name_suffix)(gm)
+    # create a string representation of the node's target type
+    target_type = ''
+    if node.op == 'call_function':
+        target_type = str(node.target)
+    elif node.op == 'call_module':
+        assert isinstance(node.target, str)
+        target_mod = getattr_from_fqn(gm, node.target)
+        target_type = str(type(target_mod))
     # create the logger object
-    logger_obj = logger_cls(node.name, model_name, ref_name)
+    logger_obj = logger_cls(node.name, model_name, ref_name, target_type)
     # attach the logger object to the parent module
     setattr(gm, logger_node_name, logger_obj)
     logger_node = node.graph.create_node(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52799 ns for fx: remove ".stats" suffix
* **#52798 ns for fx: add node name and type to results**
* #52789 ns for fx: make return type of ns APIs future proof
* #52779 ns for fx: unify return types of weight and activation APIs
* #52771 ns for fx: decouple subgraph names from node names
* #52681 ns for fx: update graph matching to handle dicts and tuples in node args
* #52402 ns for fx: update graph matching to not match nodes with equal types
* #52395 ns for fx: support linear_relu for weight matching
* #52368 ns for fx: allow graph matching of parents of cat

Summary:

Adds the node name and node target type to Numerical Suite outputs.
This is useful to debug which node got matched to which node,
and what is the type of the operation.

```
// before
{
  layer_name: {
    model_name: {
      'type': 'weight',
      'values': [...],
    },
  },
}

// after
{
  layer_name: {
    model_name: {
      'type': 'weight',
      'values': [...],
      'node_name': '0',
      'node_target_type': "<class 'torch.nn.modules.conv.Conv2d'>",
    },
  },
}
```

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26652637](https://our.internmc.facebook.com/intern/diff/D26652637)