### PR TITLE
ns for fx: remove ".stats" suffix

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -869,7 +869,6 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         # check activation result correctness
         act_compare_dict = get_matching_activations_a_shadows_b(
             mp_shadows_mq, OutputLogger)
-        print(act_compare_dict)
         self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 

--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -869,6 +869,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         # check activation result correctness
         act_compare_dict = get_matching_activations_a_shadows_b(
             mp_shadows_mq, OutputLogger)
+        print(act_compare_dict)
         self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 

--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -230,7 +230,7 @@ def add_activation_info_to_dict(
             )
         )
         if is_logger:
-            key = mod.ref_name + '.stats'
+            key = mod.ref_name
             if key not in results:
                 results[key] = {}
             results[key][model_name] = {
@@ -324,7 +324,7 @@ def get_matching_activations_a_shadows_b(
             )
         )
         if is_logger:
-            results[mod.ref_name + '.stats'][mod.model_name] = {
+            results[mod.ref_name][mod.model_name] = {
                 'type': NSSingleResultValuesType.NODE_OUTPUT.value,
                 'values': mod.stats,
                 'node_name': mod.node_name,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52799 ns for fx: remove ".stats" suffix**
* #52798 ns for fx: add node name and type to results
* #52789 ns for fx: make return type of ns APIs future proof
* #52779 ns for fx: unify return types of weight and activation APIs
* #52771 ns for fx: decouple subgraph names from node names
* #52681 ns for fx: update graph matching to handle dicts and tuples in node args
* #52402 ns for fx: update graph matching to not match nodes with equal types
* #52395 ns for fx: support linear_relu for weight matching
* #52368 ns for fx: allow graph matching of parents of cat

Summary:

We agreed that it's better to not add this, removing.
We can make Eager mode NS match this in a future PR.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26652638](https://our.internmc.facebook.com/intern/diff/D26652638)