### PR TITLE
Fix RPC get_worker_info for rank=0

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -347,7 +347,7 @@ def get_worker_info(worker_name=None):
         ``worker_name`` or :class:`~torch.distributed.rpc.WorkerInfo` of the
         current worker if ``worker_name`` is ``None``.
     """
-    if worker_name:
+    if worker_name is not None:
         return _get_current_rpc_agent().get_worker_info(worker_name)
     else:
         return _get_current_rpc_agent().get_worker_info()

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -885,6 +885,19 @@ class RpcTest(RpcAgentTestFixture):
         )
         self.assertEqual(ret, torch.ones(n, n) * 2)
 
+    @staticmethod
+    def return_callee_id():
+        return rpc.get_worker_info().id
+
+    @dist_init
+    def test_int_callee(self):
+        dst_rank = (self.rank + 1) % self.world_size
+        ret = rpc.rpc_sync(
+            worker_name(dst_rank),
+            RpcTest.return_callee_id,
+        )
+        self.assertEqual(ret, dst_rank)
+
     @dist_init
     def test_add_with_id(self):
         n = self.rank + 1

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -893,7 +893,7 @@ class RpcTest(RpcAgentTestFixture):
     def test_int_callee(self):
         dst_rank = (self.rank + 1) % self.world_size
         ret = rpc.rpc_sync(
-            worker_name(dst_rank),
+            dst_rank,
             RpcTest.return_callee_id,
         )
         self.assertEqual(ret, dst_rank)

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -892,10 +892,7 @@ class RpcTest(RpcAgentTestFixture):
     @dist_init
     def test_int_callee(self):
         dst_rank = (self.rank + 1) % self.world_size
-        ret = rpc.rpc_sync(
-            dst_rank,
-            RpcTest.return_callee_id,
-        )
+        ret = rpc.rpc_sync(dst_rank, RpcTest.return_callee_id)
         self.assertEqual(ret, dst_rank)
 
     @dist_init


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52804 Fix RPC get_worker_info for rank=0**

`rpc.get_worker_info` used to only take string in v1.6. We recently
allow it to accept `int` and `WorkerInfo`, but the previous check
on `worker_name` is no longer correct. This commit adds explicit
`not None` check.

Differential Revision: [D26655089](https://our.internmc.facebook.com/intern/diff/D26655089)