### PR TITLE
Prevent wasteful work by some OpenMP threads

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -61,7 +61,7 @@ git --no-pager log --max-count 1
 popd
 
 # Clone the Builder master repo
-retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+retry git clone -q https://github.com/peterjc123/builder.git -b mkl_update "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_mkl.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_mkl.bat
@@ -1,8 +1,8 @@
 if "%REBUILD%"=="" (
   if "%BUILD_ENVIRONMENT%"=="" (
-    curl --retry 3 -k https://s3.amazonaws.com/ossci-windows/mkl_2020.0.166.7z --output %TMP_DIR_WIN%\mkl.7z
+    curl --retry 3 -k https://s3.amazonaws.com/ossci-windows/mkl_2020.2.254.7z --output %TMP_DIR_WIN%\mkl.7z
   ) else (
-    aws s3 cp s3://ossci-windows/mkl_2020.0.166.7z %TMP_DIR_WIN%\mkl.7z --quiet
+    aws s3 cp s3://ossci-windows/mkl_2020.2.254.7z %TMP_DIR_WIN%\mkl.7z --quiet
   )
   7z x -aoa %TMP_DIR_WIN%\mkl.7z -o%TMP_DIR_WIN%\mkl
 )

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -35,10 +35,10 @@ inline void parallel_for(
   if (grain_size > 0) {
     num_threads = std::min(num_threads, divup((end - begin), grain_size));
   }
-  int64_t chunk_size = divup((end - begin), num_threads);
 
 #pragma omp parallel if ((end - begin) > grain_size) num_threads(num_threads)
   {
+    int64_t chunk_size = divup((end - begin), omp_get_num_threads());
     int64_t tid = omp_get_thread_num();
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1062,6 +1062,12 @@ if(USE_OPENMP AND OPENMP_FOUND)
   message(STATUS "pytorch is compiling with OpenMP. \n"
     "OpenMP CXX_FLAGS: ${OpenMP_CXX_FLAGS}. \n"
     "OpenMP libraries: ${OpenMP_CXX_LIBRARIES}.")
+  if(UNIX)
+    separate_arguments(OpenMP_CXX_OPTIONS UNIX_COMMAND "${OpenMP_CXX_FLAGS}")
+  else()
+    separate_arguments(OpenMP_CXX_OPTIONS WINDOWS_COMMAND "${OpenMP_CXX_FLAGS}")
+  endif()
+  target_compile_options(torch_cpu PRIVATE ${OpenMP_CXX_OPTIONS})
   target_compile_options(torch_cpu PRIVATE ${OpenMP_CXX_FLAGS})
   target_link_libraries(torch_cpu PRIVATE ${OpenMP_CXX_LIBRARIES})
 endif()

--- a/cmake/Modules/FindOpenMP.cmake
+++ b/cmake/Modules/FindOpenMP.cmake
@@ -101,7 +101,7 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
       set(OMP_FLAG_Intel "-qopenmp")
     endif()
     set(OMP_FLAG_MIPSpro "-mp")
-    set(OMP_FLAG_MSVC "-openmp:experimental" "-openmp")
+    set(OMP_FLAG_MSVC "-openmp:experimental" "-openmp:experimental -I${__header_dir}" "-openmp" "-openmp -I${__header_dir}")
     set(OMP_FLAG_PathScale "-openmp")
     set(OMP_FLAG_NAG "-openmp")
     set(OMP_FLAG_Absoft "-openmp")
@@ -132,6 +132,7 @@ set(OpenMP_C_CXX_TEST_SOURCE
 int main(void) {
 #ifdef _OPENMP
   omp_get_max_threads();
+  omp_get_level();
   return 0;
 #else
   breaks_on_purpose

--- a/docs/source/notes/windows.rst
+++ b/docs/source/notes/windows.rst
@@ -15,8 +15,8 @@ MKL and MAGMA. Here are the steps to build with them.
     REM Make sure you have 7z and curl installed.
 
     REM Download MKL files
-    curl https://s3.amazonaws.com/ossci-windows/mkl_2020.0.166.7z -k -O
-    7z x -aoa mkl_2020.0.166.7z -omkl
+    curl https://s3.amazonaws.com/ossci-windows/mkl_2020.2.254.7z -k -O
+    7z x -aoa mkl_2020.2.254.7z -omkl
 
     REM Download MAGMA files
     REM version available:


### PR DESCRIPTION
### Summary
Prevent some OpenMP threads from doing wasteful work - if there are 32 threads in the OpenMP thread-pool and only 2 are required for a parallel operation, the rest (30) should not be assigned wasteful work.

### Status
libgomp needs to be patched to prevent idle threads of the OpenMP thread-pool from exiting, so I'm closing this issue.
This approach can be used with clang or icc, as both of them use Intel's OpenMP. `num_threads()` is meant to be applicable only to the current OpenMP block, but `libgomp` makes idle threads exit, if a subsequent `num_threads` clause requires fewer threads.
First, I'll measure the difference in power consumption incurred over training a very huge model with this PR compiled with clang++. If this step would be successful (if the idle threads simply spin, then there's no benefit with using this patch), then I'll try to add such an enhancement to `libgomp` & measure the difference in power consumption for training huge models.

### Problem statement & Pitch
Say, a user sets `torch.set_num_threads(4)` in order to use fewer cores on a many-core machine.
In the [current implementation](https://github.com/pytorch/pytorch/blob/b2520ab3dc9943d5a2e57d923d7cd55bf304d937/aten/src/ATen/ParallelOpenMP.h#L15-L33), even if  `at::parallel_for` requires 2 OpenMP threads, the other 2 threads will do wasteful work, which can adversely affect other jobs running on the cores those threads will run on (personally, I wouldn't run any other jobs on those cores to prevent thrashing).
For example, run `torch.eye(250)` in the current implementation on a machine with a large number of cores.
Only 2 threads need to work, but other threads of the OpenMP thread-pool would do wasteful work.

### History
Auto-scaling was disabled after #32008.

### Solution
Both OpenMP `if` & `num_threads` clauses can be used in conjunction to solve this issue with `omp_get_level`. Made some other changes  on the basis of @peterbell10's astute observations. Thanks to some awesome work by @peterjc123, Windows builds wouldn't fail if `omp_get_level` would be used. 


### TODO: Benchmarks
Most users probably saturate their systems by using environment variables, taskset and/or numactl to assign specific number of cores to specific tasks. Moreover, sharing cores among jobs can lead to thrashing, so users are probably wary of it. So, the impetus for this change should be quantifiable. Towards that end, I'll try to benchmark power consumption in the current implementation & this one.
Why? : Energy and Policy Considerations for Deep Learning in NLP (ACL, 2019)