### PR TITLE
quant: fix conv transpose with qconfig == None

### DIFF
--- a/test/quantization/test_quantize.py
+++ b/test/quantization/test_quantize.py
@@ -765,6 +765,16 @@ class TestPostTrainingStatic(QuantizationTestCase):
             str(context.exception) ==
             'Per channel weight observer is not supported yet for ConvTranspose{n}d.')
 
+    @skipIfNoFBGEMM
+    def test_convtranspose_per_channel_qconfig_none(self):
+        r"""
+        Verifies that having qconfig==None for conv transpose does not crash
+        """
+        m = torch.nn.Sequential(torch.nn.ConvTranspose2d(1, 1, 1))
+        m.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+        m[0].qconfig = None
+        mp = torch.quantization.prepare(m)
+
 
 @skipIfNoFBGEMM
 class TestPostTrainingDynamic(QuantizationTestCase):

--- a/torch/quantization/qconfig.py
+++ b/torch/quantization/qconfig.py
@@ -3,7 +3,7 @@ from .observer import *
 from .fake_quantize import *
 import torch.nn as nn
 
-from typing import Union
+from typing import Union, Optional
 
 class QConfig(namedtuple('QConfig', ['activation', 'weight'])):
     """
@@ -112,8 +112,10 @@ def get_default_qat_qconfig(backend='fbgemm'):
         qconfig = default_qat_qconfig
     return qconfig
 
-def assert_valid_qconfig(qconfig: Union[QConfig, QConfigDynamic],
+def assert_valid_qconfig(qconfig: Optional[Union[QConfig, QConfigDynamic]],
                          mod: torch.nn.Module) -> None:
+    if qconfig is None:
+        return
     is_conv_transpose_mod = (
         isinstance(mod, torch.nn.ConvTranspose1d) or
         isinstance(mod, torch.nn.ConvTranspose2d) or


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52844 quant: fix conv transpose with qconfig == None**

Summary:

Fixes a crash in qconfig checking which happened if a model had conv transpose
with qconfig set to None.

Test Plan:

```
python test/test_quantization.py TestPostTrainingStatic.test_convtranspose_per_channel_qconfig_none
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26666043](https://our.internmc.facebook.com/intern/diff/D26666043)