### PR TITLE
[ONNX] Add repeat_interleave symbolic

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3553,6 +3553,21 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.tensor([4, 5, 8, 9])
         self.run_test(RepeatModel(), (x, y))
 
+    def test_repeat_interleave(self):
+        class FlattenModel(torch.nn.Module):
+            def forward(self, x):
+                return x.repeat_interleave(2)
+                
+        x = torch.tensor([1, 2, 3])
+        self.run_test(FlattenModel(), (x,))
+
+        class DimsModel(torch.nn.Module):
+            def forward(self, x):
+                return x.repeat_interleave(2, dim=1)
+                
+        x = torch.tensor([[1, 2], [3, 4]])
+        self.run_test(DimsModel(), (x,))
+
     def test_view(self):
         class ViewModel(torch.nn.Module):
             def forward(self, input):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3569,6 +3569,30 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2], [3, 4]])
         self.run_test(DimsModel(), (x,))
 
+        class DimsModel2(torch.nn.Module):
+            def forward(self, x):
+                repeats = torch.tensor([4])
+                return torch.repeat_interleave(x, repeats, dim=1)
+
+        x = torch.tensor([[1, 2], [3, 4]])
+        self.run_test(DimsModel2(), (x,))
+
+        class RepeatsDimsModel(torch.nn.Module):
+            def forward(self, x):
+                repeats = torch.tensor([1, 2])
+                return torch.repeat_interleave(x, repeats, dim=0)
+
+        x = torch.tensor([[1, 2], [3, 4]])
+        self.run_test(RepeatsDimsModel(), (x,))
+
+        class RepeatsDimsModel2(torch.nn.Module):
+            def forward(self, x):
+                repeats = torch.tensor([1, 2])
+                return torch.repeat_interleave(x, repeats, dim=1)
+
+        x = torch.tensor([[1, 2], [3, 4]])
+        self.run_test(RepeatsDimsModel2(), (x,))
+
     def test_view(self):
         class ViewModel(torch.nn.Module):
             def forward(self, input):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3563,7 +3563,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class DimsModel(torch.nn.Module):
             def forward(self, x):
-                return x.repeat_interleave(2, dim=1)
+                return x.repeat_interleave(4, dim=1)
 
         x = torch.tensor([[1, 2], [3, 4]])
         self.run_test(DimsModel(), (x,))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3553,6 +3553,7 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.tensor([4, 5, 8, 9])
         self.run_test(RepeatModel(), (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_repeat_interleave(self):
         class FlattenModel(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3557,14 +3557,14 @@ class TestONNXRuntime(unittest.TestCase):
         class FlattenModel(torch.nn.Module):
             def forward(self, x):
                 return x.repeat_interleave(2)
-                
+
         x = torch.tensor([1, 2, 3])
         self.run_test(FlattenModel(), (x,))
 
         class DimsModel(torch.nn.Module):
             def forward(self, x):
                 return x.repeat_interleave(2, dim=1)
-                
+
         x = torch.tensor([[1, 2], [3, 4]])
         self.run_test(DimsModel(), (x,))
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -603,7 +603,7 @@ def _repeat_interleave_split_helper(g, self, reps, dim):
         return g.op("Split", self, split_i=[1] * reps, axis_i=dim, outputs=reps)
     else:
         from torch.onnx.symbolic_opset13 import split  # type: ignore
-        repeats = g.op("Constant", value_t=torch.tensor([1] *reps))
+        repeats = g.op("Constant", value_t=torch.tensor([1] * reps))
         return split(g, self, repeats, dim, _outputs=reps)
 
 def _arange_cast_helper(g, end, start=None, step=None, dtype=None):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -599,13 +599,11 @@ def _scatter_helper(g, self, dim, index, src):
     return scatter(g, self, dim, index, src)
 
 def _repeat_interleave_split_helper(g, self, reps, dim):
-    if _export_onnx_opset_version <= 10:
+    if _export_onnx_opset_version <= 12:
         return g.op("Split", self, split_i=[1] * reps, axis_i=dim, outputs=reps)
     else:
-        from torch.onnx.symbolic_opset11 import split  # type: ignore
-        from torch.onnx.symbolic_opset9 import expand
-        repeats = g.op("Constant", value_t=torch.tensor([reps]))
-        repeats = expand(g, g.op("Constant", value_t=torch.tensor([1])), repeats, None)
+        from torch.onnx.symbolic_opset13 import split  # type: ignore
+        repeats = g.op("Constant", value_t=torch.tensor([1] *reps))
         return split(g, self, repeats, dim, _outputs=reps)
 
 def _arange_cast_helper(g, end, start=None, step=None, dtype=None):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -606,7 +606,7 @@ def _repeat_interleave_split_helper(g, self, reps, dim):
         from torch.onnx.symbolic_opset9 import expand
         repeats = g.op("Constant", value_t=torch.tensor([reps]))
         repeats = expand(g, g.op("Constant", value_t=torch.tensor([1])), repeats, None)
-    return split(g, self, repeats, dim, _outputs=reps)
+        return split(g, self, repeats, dim, _outputs=reps)
 
 def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
     def _is_all_integral(scalars):

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -70,7 +70,13 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         return g.op("Split", self, split_size_or_sizes, axis_i=dim, outputs=_outputs)
     split_size = sym_help._get_const(split_size_or_sizes, 'i', 'split_size')
 
-    size = self.type().sizes()[dim]
+    try:
+        size = self.type().sizes()[dim]
+    except:
+        if _outputs is not None:
+            size = split_size * _outputs
+        else:
+            raise RuntimeError('Unknown dimension size not supported')
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -70,9 +70,9 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         return g.op("Split", self, split_size_or_sizes, axis_i=dim, outputs=_outputs)
     split_size = sym_help._get_const(split_size_or_sizes, 'i', 'split_size')
 
-    try:
+    if self.type().sizes()[dim] is not None:
         size = self.type().sizes()[dim]
-    except:
+    else:
         if _outputs is not None:
             size = split_size * _outputs
         else:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -42,7 +42,8 @@ import warnings
 block_listed_operators = [
     "nonzero", "where", "scatter", "scatter_add", "erf", "sign", "isnan", "gather",
     "arange", "masked_fill",
-    "index_fill", "index_copy"
+    "index_fill", "index_copy",
+    "repeat_interleave"
 ]
 
 for block_listed_op in block_listed_operators:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -42,8 +42,7 @@ import warnings
 block_listed_operators = [
     "nonzero", "where", "scatter", "scatter_add", "erf", "sign", "isnan", "gather",
     "arange", "masked_fill",
-    "index_fill", "index_copy",
-    "repeat_interleave"
+    "index_fill", "index_copy", "repeat_interleave"
 ]
 
 for block_listed_op in block_listed_operators:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1954,7 +1954,7 @@ def repeat(g, self, repeats):
     return g.op("Tile", self, repeats)
 
 
-def repeat_interleave(g, self, repeats, dim):
+def repeat_interleave(g, self, repeats, dim=None):
     input = self
     # if dim = 0 flatten
     if sym_help._is_none(dim):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1990,8 +1990,8 @@ def repeat_interleave(g, self, repeats, dim=None):
         raise RuntimeError("repeats must be 0-dim or 1-dim tensor")
 
     final_splits = list()
-    r_splits = g.op("Split", repeats, split_i=[1] * reps, axis_i=0, outputs=reps)
-    i_splits = g.op("Split", input, split_i=[1] * reps, axis_i=dim, outputs=reps)
+    r_splits = sym_help._repeat_interleave_split_helper(g, repeats, reps, 0)
+    i_splits = sym_help._repeat_interleave_split_helper(g, input, reps, dim)
     input_sizes[dim], input_sizes_temp[dim] = -1, 1
     for idx, r_split in enumerate(r_splits):
         i_split = unsqueeze(g, i_splits[idx], dim + 1)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1965,10 +1965,9 @@ def repeat_interleave(g, self, repeats, dim):
 
     # cases where repeats is a single number
     if (repeats_dim == 0 or (repeats_dim == 1 and repeats_sizes[0] == 1)):
-        #repeats = reshape(g, repeats, g.op("Constant", value_t=torch.tensor([1])))
-        input = unsqueeze(g, input, dim+1)
+        input = unsqueeze(g, input, dim + 1)
         input_sizes_temp = input_sizes.copy()
-        input_sizes_temp.insert(dim+1, sym_help._maybe_get_scalar(repeats))
+        input_sizes_temp.insert(dim + 1, sym_help._maybe_get_scalar(repeats))
         input = expand(g, input, torch.tensor(input_sizes_temp), None)
         input_sizes[dim] *= 2
         input = reshape(g, input, g.op("Constant", value_t=torch.tensor(input_sizes)))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1990,14 +1990,14 @@ def repeat_interleave(g, self, repeats, dim=None):
         raise RuntimeError("repeats must be 0-dim or 1-dim tensor")
 
     final_splits = list()
-    r_splits = g.op("Split", repeats, split_i=[1]*reps, axis_i=0, outputs=reps)
-    i_splits = g.op("Split", input, split_i=[1]*reps, axis_i=dim, outputs=reps)
+    r_splits = g.op("Split", repeats, split_i=[1] * reps, axis_i=0, outputs=reps)
+    i_splits = g.op("Split", input, split_i=[1] * reps, axis_i=dim, outputs=reps)
     input_sizes[dim], input_sizes_temp[dim] = -1, 1
     for idx, r_split in enumerate(r_splits):
         i_split = unsqueeze(g, i_splits[idx], dim + 1)
-        r_concat = [g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[:dim+1])), 
+        r_concat = [g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[:dim + 1])), 
                     r_split, 
-                    g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[dim+1:]))]
+                    g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[dim + 1:]))]
         r_concat = g.op("Concat", *r_concat, axis_i=0)
         i_split = expand(g, i_split, r_concat, None)
         i_split = reshape(g, i_split, g.op("Constant", value_t=torch.LongTensor(input_sizes)))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1969,13 +1969,13 @@ def repeat_interleave(g, self, repeats, dim=None):
     input_sizes = sym_help._get_tensor_sizes(input)
     if repeats_dim is None:
         raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                               'repeats rank.')
+                           'repeats rank.')
     if repeats_sizes is None:
         raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                               'repeats size.')
+                           'repeats size.')
     if input_sizes is None:
         raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                               'input size.')
+                           'input size.')
 
     input_sizes_temp = input_sizes.copy()
     for idx, input_size in enumerate(input_sizes):


### PR DESCRIPTION
- Add support for aten::repeat_interleave
- NOTE: Also adds fix for cases with split op where input tensor sizes are not known but _outputs is provided