### PR TITLE
quant norm layers: move scale + zp to buffers

### DIFF
--- a/torch/nn/quantized/modules/normalization.py
+++ b/torch/nn/quantized/modules/normalization.py
@@ -16,8 +16,8 @@ class LayerNorm(torch.nn.LayerNorm):
             normalized_shape, eps=eps, elementwise_affine=elementwise_affine)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor(scale))
+        self.register_buffer('zero_point', torch.tensor(zero_point))
 
     def forward(self, input):
         return torch.ops.quantized.layer_norm(
@@ -49,8 +49,8 @@ class GroupNorm(torch.nn.GroupNorm):
         super(GroupNorm, self).__init__(num_groups, num_channels, eps, affine)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor(scale))
+        self.register_buffer('zero_point', torch.tensor(zero_point))
 
     def forward(self, input):
         return torch.ops.quantized.group_norm(
@@ -83,8 +83,8 @@ class InstanceNorm1d(torch.nn.InstanceNorm1d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor(scale))
+        self.register_buffer('zero_point', torch.tensor(zero_point))
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(
@@ -117,8 +117,8 @@ class InstanceNorm2d(torch.nn.InstanceNorm2d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor(scale))
+        self.register_buffer('zero_point', torch.tensor(zero_point))
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(
@@ -151,8 +151,8 @@ class InstanceNorm3d(torch.nn.InstanceNorm3d):
             num_features, eps, momentum, affine, track_running_stats)
         self.weight = weight
         self.bias = bias
-        self.scale = scale
-        self.zero_point = zero_point
+        self.register_buffer('scale', torch.tensor(scale))
+        self.register_buffer('zero_point', torch.tensor(zero_point))
 
     def forward(self, input):
         return torch.ops.quantized.instance_norm(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52861 quant norm layers: move scale + zp to buffers**

Summary:

Currently, scale and zp in these layers are not buffers, which
means they do not get saved to the state dict.  Moving them
into buffers to allow people to properly use state_dict.

Note: this is a redo of https://github.com/pytorch/pytorch/pull/45313,
with BN taken out. Not doing this for BN because it has dependencies on existing
behavior.  We should clean it up eventually.

Note: not handling BC because it's 100% broken now, so there is
no practical value in handling BC.

Test Plan:

```
python test/test_quantization.py TestPostTrainingStatic.test_normalization
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26671761](https://our.internmc.facebook.com/intern/diff/D26671761)