### PR TITLE
Store test file in S3 as well for every TestSuite

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -166,19 +166,24 @@ test_libtorch() {
     # Start background download
     python tools/download_mnist.py --quiet -d test/cpp/api/mnist &
 
+    # Make test_reports directory
+    # NB: the ending test_libtorch must match the current function name for the current
+    # test reporting process (in print_test_stats.py) to function as expected.
+    TEST_REPORTS_DIR=test/test-reports/cpp-unittest/test_libtorch
+    mkdir -p $TEST_REPORTS_DIR
+
     # Run JIT cpp tests
-    mkdir -p test/test-reports/cpp-unittest
     python test/cpp/jit/tests_setup.py setup
     if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
-      build/bin/test_jit  --gtest_output=xml:test/test-reports/cpp-unittest/test_jit.xml
+      build/bin/test_jit  --gtest_output=xml:$TEST_REPORTS_DIR/test_jit.xml
     else
-      build/bin/test_jit  --gtest_filter='-*CUDA' --gtest_output=xml:test/test-reports/cpp-unittest/test_jit.xml
+      build/bin/test_jit  --gtest_filter='-*CUDA' --gtest_output=xml:$TEST_REPORTS_DIR/test_jit.xml
     fi
     python test/cpp/jit/tests_setup.py shutdown
     # Wait for background download to finish
     wait
-    OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api --gtest_output=xml:test/test-reports/cpp-unittest/test_api.xml
-    build/bin/test_tensorexpr --gtest_output=xml:test/test-reports/cpp-unittests/test_tensorexpr.xml
+    OMP_NUM_THREADS=2 TORCH_CPP_TEST_MNIST_PATH="test/cpp/api/mnist" build/bin/test_api --gtest_output=xml:$TEST_REPORTS_DIR/test_api.xml
+    build/bin/test_tensorexpr --gtest_output=xml:$TEST_REPORTS_DIR/test_tensorexpr.xml
     assert_git_not_dirty
   fi
 }
@@ -186,30 +191,39 @@ test_libtorch() {
 test_vulkan() {
   if [[ "$BUILD_ENVIRONMENT" == *vulkan-linux* ]]; then
     export VK_ICD_FILENAMES=/var/lib/jenkins/swiftshader/build/Linux/vk_swiftshader_icd.json
-    mkdir -p test/test-reports/cpp-vulkan
-    build/bin/vulkan_test --gtest_output=xml:test/test-reports/cpp-vulkan/vulkan_test.xml
+    # NB: the ending test_vulkan must match the current function name for the current
+    # test reporting process (in print_test_stats.py) to function as expected.
+    TEST_REPORTS_DIR=test/test-reports/cpp-vulkan/test_vulkan
+    mkdir -p $TEST_REPORTS_DIR
+    build/bin/vulkan_test --gtest_output=xml:$TEST_REPORTS_DIR/vulkan_test.xml
   fi
 }
 
 test_distributed() {
   if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
     echo "Testing distributed C++ tests"
-    mkdir -p test/test-reports/cpp-distributed
-    build/bin/FileStoreTest --gtest_output=xml:test/test-reports/cpp-distributed/FileStoreTest.xml
-    build/bin/HashStoreTest --gtest_output=xml:test/test-reports/cpp-distributed/HashStoreTest.xml
-    build/bin/TCPStoreTest --gtest_output=xml:test/test-reports/cpp-distributed/TCPStoreTest.xml
+    # NB: the ending test_distributed must match the current function name for the current
+    # test reporting process (in print_test_stats.py) to function as expected.
+    TEST_REPORTS_DIR=test/test-reports/cpp-distributed/test_distributed
+    mkdir -p $TEST_REPORTS_DIR
+    build/bin/FileStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/FileStoreTest.xml
+    build/bin/HashStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/HashStoreTest.xml
+    build/bin/TCPStoreTest --gtest_output=xml:$TEST_REPORTS_DIR/TCPStoreTest.xml
 
-    build/bin/ProcessGroupGlooTest --gtest_output=xml:test/test-reports/cpp-distributed/ProcessGroupGlooTest.xml
-    build/bin/ProcessGroupNCCLTest --gtest_output=xml:test/test-reports/cpp-distributed/ProcessGroupNCCLTest.xml
-    build/bin/ProcessGroupNCCLErrorsTest --gtest_output=xml:test/test-reports/cpp-distributed/ProcessGroupNCCLErrorsTest.xml
+    build/bin/ProcessGroupGlooTest --gtest_output=xml:$TEST_REPORTS_DIR/ProcessGroupGlooTest.xml
+    build/bin/ProcessGroupNCCLTest --gtest_output=xml:$TEST_REPORTS_DIR/ProcessGroupNCCLTest.xml
+    build/bin/ProcessGroupNCCLErrorsTest --gtest_output=xml:$TEST_REPORTS_DIR/ProcessGroupNCCLErrorsTest.xml
   fi
 }
 
 test_rpc() {
   if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
     echo "Testing RPC C++ tests"
-    mkdir -p test/test-reports/cpp-rpc
-    build/bin/test_cpp_rpc --gtest_output=xml:test/test-reports/cpp-rpc/test_cpp_rpc.xml
+    # NB: the ending test_rpc must match the current function name for the current
+    # test reporting process (in print_test_stats.py) to function as expected.
+    TEST_REPORTS_DIR=test/test-reports/cpp-rpc/test_rpc
+    mkdir -p $TEST_REPORTS_DIR
+    build/bin/test_cpp_rpc --gtest_output=xml:$TEST_REPORTS_DIR/test_cpp_rpc.xml
   fi
 }
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -289,7 +289,7 @@ class TestCheckpoint(TestCase):
             out = checkpoint(run_fn2, input_var, input_var2)
             out.sum().backward()
 
-class TestDataLoader(TestCase):
+class TestDataLoaderUtils(TestCase):
     def setUp(self):
         self.dataset = torch.randn(5, 3, 3, 2)
         self.batch_size = 3

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -44,7 +44,12 @@ class Case(TypedDict):
     skipped: bool
 
 
-class Suite(TypedDict):
+# The original format of the s3 reports did not have this filename field. This maintains backwards-compatibility
+class SuiteMeta(TypedDict, total=False):
+    filename: str
+
+
+class Suite(SuiteMeta):
     total_seconds: float
     cases: List[Case]
 

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -6,11 +6,11 @@ import json
 import subprocess
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import boto3  # type: ignore[import]
 import botocore  # type: ignore[import]
-from typing_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 
 def get_git_commit_history(
@@ -36,36 +36,70 @@ def get_object_summaries(*, bucket: Any, sha: str) -> Dict[str, List[Any]]:
     return dict(by_job)
 
 
-class Case(TypedDict):
-    name: str
+# TODO: consolidate these typedefs with the identical ones in
+# torch/testing/_internal/print_test_stats.py
+
+Commit = str  # 40-digit SHA-1 hex string
+Status = Optional[Literal['errored', 'failed', 'skipped']]
+
+
+class CaseMeta(TypedDict):
     seconds: float
+
+
+class Version1Case(CaseMeta):
+    name: str
     errored: bool
     failed: bool
     skipped: bool
 
 
-# The original format of the s3 reports did not have this filename field. This maintains backwards-compatibility
-class SuiteMeta(TypedDict, total=False):
-    filename: str
-
-
-class Suite(SuiteMeta):
+class Version1Suite(TypedDict):
     total_seconds: float
-    cases: List[Case]
+    cases: List[Version1Case]
 
 
-class ReportMeta(TypedDict):
+class ReportMetaMeta(TypedDict):
     build_pr: str
     build_tag: str
-    build_sha1: str
+    build_sha1: Commit
     build_branch: str
     build_job: str
     build_workflow_id: str
 
 
-class Report(ReportMeta):
+class ReportMeta(ReportMetaMeta):
     total_seconds: float
-    suites: Dict[str, Suite]
+
+
+class Version1Report(ReportMeta):
+    suites: Dict[str, Version1Suite]
+
+
+class Version2Case(CaseMeta):
+    status: Status
+
+
+class Version2Suite(TypedDict):
+    total_seconds: float
+    cases: Dict[str, Version2Case]
+
+
+class Version2File(TypedDict):
+    total_seconds: float
+    suites: Dict[str, Version2Suite]
+
+
+class VersionedReport(ReportMeta):
+    format_version: int
+
+
+# report: Version2Report implies report['format_version'] == 2
+class Version2Report(VersionedReport):
+    files: Dict[str, Version2File]
+
+
+Report = Union[Version1Report, VersionedReport]
 
 
 def get_jsons(
@@ -82,32 +116,63 @@ def get_jsons(
     }
 
 
+# TODO: consolidate this with the case_status function from
+# torch/testing/_internal/print_test_stats.py
+def case_status(case: Version1Case) -> Status:
+    for k in {'errored', 'failed', 'skipped'}:
+        if case[k]:  # type: ignore[misc]
+            return cast(Status, k)
+    return None
+
+
+# TODO: consolidate this with the newify_case function from
+# torch/testing/_internal/print_test_stats.py
+def newify_case(case: Version1Case) -> Version2Case:
+    return {
+        'seconds': case['seconds'],
+        'status': case_status(case),
+    }
+
+
+# TODO: consolidate this with the simplify function from
+# torch/testing/_internal/print_test_stats.py
 def get_cases(
     *,
     data: Report,
+    filename: Optional[str],
     suite_name: Optional[str],
     test_name: str,
-) -> List[Case]:
-    cases = []
-    suites = data['suites']
-    for name, suite in suites.items():
-        if name == suite_name or not suite_name:
-            for case in suite['cases']:
-                if case['name'] == test_name:
-                    cases.append(case)
+) -> List[Version2Case]:
+    cases: List[Version2Case] = []
+    if 'format_version' not in data:  # version 1 implicitly
+        v1report = cast(Version1Report, data)
+        suites = v1report['suites']
+        for sname, v1suite in suites.items():
+            if sname == suite_name or not suite_name:
+                for v1case in v1suite['cases']:
+                    if v1case['name'] == test_name:
+                        cases.append(newify_case(v1case))
+    else:
+        v_report = cast(VersionedReport, data)
+        version = v_report['format_version']
+        if version == 2:
+            v2report = cast(Version2Report, v_report)
+            for fname, v2file in v2report['files'].items():
+                if fname == filename or not filename:
+                    for sname, v2suite in v2file['suites'].items():
+                        if sname == suite_name or not suite_name:
+                            v2case = v2suite['cases'].get(test_name)
+                            if v2case:
+                                cases.append(v2case)
+        else:
+            raise RuntimeError(f'Unknown format version: {version}')
     return cases
-
-
-def case_status(case: Case) -> Optional[str]:
-    for k in {'errored', 'failed', 'skipped'}:
-        if case[k]:  # type: ignore[misc]
-            return k
-    return None
 
 
 def make_column(
     *,
     data: Optional[Report],
+    filename: Optional[str],
     suite_name: Optional[str],
     test_name: str,
     digits: int,
@@ -117,12 +182,13 @@ def make_column(
     if data:
         cases = get_cases(
             data=data,
+            filename=filename,
             suite_name=suite_name,
             test_name=test_name
         )
         if cases:
             case = cases[0]
-            status = case_status(case)
+            status = case['status']
             omitted = len(cases) - 1
             if status:
                 return f'{status.rjust(num_length)} ', omitted
@@ -139,6 +205,7 @@ def make_columns(
     jobs: List[str],
     jsons: Dict[str, Report],
     omitted: Dict[str, int],
+    filename: Optional[str],
     suite_name: Optional[str],
     test_name: str,
     digits: int,
@@ -150,6 +217,7 @@ def make_columns(
         data = jsons.get(job)
         column, omitted_suites = make_column(
             data=data,
+            filename=filename,
             suite_name=suite_name,
             test_name=test_name,
             digits=digits,
@@ -170,6 +238,7 @@ def make_lines(
     jobs: Set[str],
     jsons: Dict[str, Report],
     omitted: Dict[str, int],
+    filename: Optional[str],
     suite_name: Optional[str],
     test_name: str,
 ) -> List[str]:
@@ -177,12 +246,13 @@ def make_lines(
     for job, data in jsons.items():
         cases = get_cases(
             data=data,
+            filename=filename,
             suite_name=suite_name,
             test_name=test_name,
         )
         if cases:
             case = cases[0]
-            status = case_status(case)
+            status = case['status']
             line = f'{job} {case["seconds"]}s{f" {status}" if status else ""}'
             if job in omitted and omitted[job] > 0:
                 line += f' ({omitted[job]} S3 reports omitted)'
@@ -202,6 +272,7 @@ def display_history(
     bucket: Any,
     commits: List[Tuple[str, datetime]],
     jobs: Optional[List[str]],
+    filename: Optional[str],
     suite_name: Optional[str],
     test_name: str,
     delta: int,
@@ -231,6 +302,7 @@ def display_history(
                 jobs=jobs,
                 jsons=jsons,
                 omitted=omitted,
+                filename=filename,
                 suite_name=suite_name,
                 test_name=test_name,
                 digits=digits,
@@ -241,6 +313,7 @@ def display_history(
                 jobs=set(jobs or []),
                 jsons=jsons,
                 omitted=omitted,
+                filename=filename,
                 suite_name=suite_name,
                 test_name=test_name,
             )
@@ -358,6 +431,10 @@ indicated test was not found in that report.
         help='(multiline) ignore listed jobs, show all jobs for each commit',
     )
     parser.add_argument(
+        '--file',
+        help='name of the file containing the test',
+    )
+    parser.add_argument(
         '--suite',
         help='name of the suite containing the test',
     )
@@ -386,6 +463,7 @@ indicated test was not found in that report.
         bucket=bucket,
         commits=commits,
         jobs=jobs,
+        filename=args.file,
         suite_name=args.suite,
         test_name=args.test,
         delta=args.delta,

--- a/torch/testing/_internal/print_test_stats.py
+++ b/torch/testing/_internal/print_test_stats.py
@@ -14,7 +14,7 @@ from glob import glob
 from pathlib import Path
 from typing import (Any, DefaultDict, Dict, Iterable, Iterator, List, Optional,
                     Tuple)
-from xml.dom import minidom
+from xml.dom import minidom  # type: ignore[import]
 
 import requests
 from typing_extensions import TypedDict

--- a/torch/testing/_internal/print_test_stats.py
+++ b/torch/testing/_internal/print_test_stats.py
@@ -25,6 +25,126 @@ try:
 except ImportError:
     HAVE_BOTO3 = False
 
+
+# TODO: this is ugly duplicated code from run_test.py we should probably abstract out to common_utils.py
+TESTS = [
+    'test_type_hints',
+    'test_autograd',
+    'benchmark_utils/test_benchmark_utils',
+    'test_binary_ufuncs',
+    'test_bundled_inputs',
+    'test_complex',
+    'test_cpp_api_parity',
+    'test_cpp_extensions_aot_no_ninja',
+    'test_cpp_extensions_aot_ninja',
+    'test_cpp_extensions_jit',
+    'distributed/test_c10d',
+    'distributed/test_jit_c10d',
+    'distributed/test_c10d_spawn',
+    'test_cuda',
+    'test_jit_cuda_fuser',
+    'test_cuda_primary_ctx',
+    'test_dataloader',
+    'test_dataset',
+    'test_datapipe',
+    'distributed/test_data_parallel',
+    'distributed/test_distributed_fork',
+    'distributed/test_distributed_spawn',
+    'distributions/test_constraints',
+    'distributions/test_distributions',
+    'test_dispatch',
+    'test_expecttest',
+    'test_foreach',
+    'test_indexing',
+    'test_jit',
+    'test_linalg',
+    'test_logging',
+    'test_mkldnn',
+    'test_multiprocessing',
+    'test_multiprocessing_spawn',
+    'distributed/test_nccl',
+    'test_native_functions',
+    'test_numba_integration',
+    'test_nn',
+    'test_ops',
+    'test_optim',
+    'test_pytree',
+    'test_mobile_optimizer',
+    'test_set_default_mobile_cpu_allocator',
+    'test_xnnpack_integration',
+    'test_vulkan',
+    'test_sparse',
+    'test_quantization',
+    'test_pruning_op',
+    'test_spectral_ops',
+    'test_serialization',
+    'test_shape_ops',
+    'test_show_pickle',
+    'test_sort_and_select',
+    'test_tensor_creation_ops',
+    'test_testing',
+    'test_torch',
+    'test_type_info',
+    'test_unary_ufuncs',
+    'test_utils',
+    'test_view_ops',
+    'test_vmap',
+    'test_namedtuple_return_api',
+    'test_numpy_interop',
+    'test_jit_profiling',
+    'test_jit_legacy',
+    'test_jit_fuser_legacy',
+    'test_tensorboard',
+    'test_namedtensor',
+    'test_reductions',
+    'test_type_promotion',
+    'test_jit_disabled',
+    'test_function_schema',
+    'test_op_aliases',
+    'test_overrides',
+    'test_jit_fuser_te',
+    'test_tensorexpr',
+    'test_tensorexpr_pybind',
+    'test_openmp',
+    'test_profiler',
+    'distributed/nn/jit/test_instantiator',
+    'distributed/rpc/test_faulty_agent',
+    'distributed/rpc/test_process_group_agent',
+    'distributed/rpc/test_tensorpipe_agent',
+    'test_jit_py3',
+    'test_determination',
+    'test_futures',
+    'test_fx',
+    'test_fx_experimental',
+    'test_functional_autograd_benchmark',
+    'test_package',
+    'test_license',
+    'distributed/pipeline/sync/skip/test_api',
+    'distributed/pipeline/sync/skip/test_gpipe',
+    'distributed/pipeline/sync/skip/test_inspect_skip_layout',
+    'distributed/pipeline/sync/skip/test_leak',
+    'distributed/pipeline/sync/skip/test_portal',
+    'distributed/pipeline/sync/skip/test_stash_pop',
+    'distributed/pipeline/sync/skip/test_tracker',
+    'distributed/pipeline/sync/skip/test_verify_skippables',
+    'distributed/pipeline/sync/test_balance',
+    'distributed/pipeline/sync/test_bugs',
+    'distributed/pipeline/sync/test_checkpoint',
+    'distributed/pipeline/sync/test_copy',
+    'distributed/pipeline/sync/test_deferred_batch_norm',
+    'distributed/pipeline/sync/test_dependency',
+    'distributed/pipeline/sync/test_inplace',
+    'distributed/pipeline/sync/test_microbatch',
+    'distributed/pipeline/sync/test_phony',
+    'distributed/pipeline/sync/test_pipe',
+    'distributed/pipeline/sync/test_pipeline',
+    'distributed/pipeline/sync/test_stream',
+    'distributed/pipeline/sync/test_transparency',
+    'distributed/pipeline/sync/test_worker',
+    'distributed/optim/test_zero_redundancy_optimizer',
+]
+
+
 Commit = str  # 40-digit SHA-1 hex string
 Status = Optional[str]  # errored, failed, skipped, or None
 
@@ -595,14 +715,16 @@ def parse_reports(folder: str) -> Dict[str, TestSuite]:
     tests_by_class = dict()
     for report in reports:
         test_filename = re.sub(r'\.', '/', os.path.basename(os.path.dirname(report)))
-        for test_case in parse_report(report):
-            class_name = test_case.class_name
-            if class_name not in tests_by_class:
-                tests_by_class[class_name] = TestSuite(class_name, test_filename)
-            orig_filename = tests_by_class[class_name].filename
-            if test_filename != orig_filename:
-                raise RuntimeError(f'Suite belongs to different test files: {0} vs {1}', test_filename, orig_filename)
-            tests_by_class[class_name].append(test_case)
+        # Ignore non-Python tests (any test NOT defined in TESTS)
+        if test_filename in TESTS:
+            for test_case in parse_report(report):
+                class_name = test_case.class_name
+                if class_name not in tests_by_class:
+                    tests_by_class[class_name] = TestSuite(class_name, test_filename)
+                orig_filename = tests_by_class[class_name].filename
+                if test_filename != orig_filename:
+                    raise RuntimeError(f'Suite {class_name} belongs to different test files: {test_filename} vs {orig_filename}')
+                tests_by_class[class_name].append(test_case)
     return tests_by_class
 
 

--- a/torch/testing/_internal/print_test_stats.py
+++ b/torch/testing/_internal/print_test_stats.py
@@ -793,6 +793,7 @@ def assemble_s3_object(
     return {
         **build_info(),  # type: ignore[misc]
         'total_seconds': total_seconds,
+        'format_version': 2,
         'files' : {
             name: {
                 'total_seconds': test_file.total_time,


### PR DESCRIPTION
We want to store the file names that triggers each test suite so that we can use this data for categorizing those test files.

~~After considering several solutions, this one is the most backwards compatible, and the current test cases in test_testing.py for print test stats don't break.~~

The previous plan did not work, as there are multiple Python test jobs that spawn the same suites. Instead, the new S3 format will store test files (e.g., `test_nn` and `distributed/test_distributed_fork`) which will contain the suites they spawn, which will contain the test cases run within the suite. (Currently, there is no top layer of test files.)

Because of this major structural change, a lot of changes have now been made (thank you @samestep!) to test_history.py and print_test_stats.py to make this new format backwards compatible.

Old test plan:
Make sure that the data is as expected in S3 after https://github.com/pytorch/pytorch/pull/52873 finishes.

Test plan:
Added tests to test_testing.py which pass, and CI.