### PR TITLE
Fix reference cycle in sparse coalesce graph

### DIFF
--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -53,6 +53,12 @@ SparseTensorImpl::SparseTensorImpl(at::DispatchKeySet key_set, const caffe2::Typ
   set_storage_access_should_throw();
 }
 
+void SparseTensorImpl::release_resources() {
+  TensorImpl::release_resources();
+  values_.reset();
+  indices_.reset();
+}
+
 IntArrayRef SparseTensorImpl::strides() const {
   AT_ERROR("sparse tensors do not have strides");
 }

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -33,6 +33,8 @@ public:
   // Public for now...
   explicit SparseTensorImpl(at::DispatchKeySet, const caffe2::TypeMeta);
 
+  void release_resources() override;
+
   int64_t nnz() const { return values_.size(0); }
   int64_t sparse_dim() const { return sparse_dim_; }
   int64_t dense_dim() const { return dense_dim_; }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4293,8 +4293,6 @@
 # Instead, the derivative is registered on the slow-path "_coalesce"
 - func: coalesce(Tensor(a) self) -> Tensor(a)
   variants: method
-  dispatch:
-    Math: coalesce_sparse
 
 - func: _coalesce(Tensor self) -> Tensor
   dispatch:

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4286,11 +4286,20 @@
     SparseCPU, SparseCUDA: _nnz_sparse
   device_guard: False
 
-- func: coalesce(Tensor self) -> Tensor
+# NOTE: [ coalesce autograd ]
+# coalesce returns self directly for already coalesced sparse tensors.
+# This means coalesce cannot have a derivative registered, otherwise it creates
+# circular references in the autograd graph (see gh-52874).
+# Instead, the derivative is registered on the slow-path "_coalesce"
+- func: coalesce(Tensor(a) self) -> Tensor(a)
   variants: method
   dispatch:
-    SparseCPU: coalesce_sparse_cpu
-    SparseCUDA: coalesce_sparse_cuda
+    Math: coalesce_sparse
+
+- func: _coalesce(Tensor self) -> Tensor
+  dispatch:
+    SparseCPU: _coalesce_sparse_cpu
+    SparseCUDA: _coalesce_sparse_cuda
 
 - func: is_coalesced(Tensor self) -> bool
   variants: method

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -402,7 +402,7 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
   AT_ASSERT(self.is_sparse());
 
   if (self.is_coalesced()) {
-    return self;
+    return self.clone();
   }
   // NOTE: Since `coalesce` is not an in-place operation when `is_coalesced` is false,
   // we should keep the original tensor intact and do coalesce on a copy of the tensor

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -396,14 +396,20 @@ SparseTensor& copy_sparse_(SparseTensor& self, const SparseTensor& src, bool non
   return self._coalesced_(src.is_coalesced());
 }
 
-SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
+SparseTensor coalesce_sparse(const SparseTensor& self) {
+  // See NOTE: [ coalesce autograd ]
+  if (self.is_coalesced()) {
+    return self;
+  }
+  return at::_coalesce(self);
+}
+
+SparseTensor _coalesce_sparse_cpu(const SparseTensor& self) {
   AT_ASSERT(self.defined());
   TORCH_INTERNAL_ASSERT(at::impl::variable_excluded_from_dispatch());
   AT_ASSERT(self.is_sparse());
+  TORCH_INTERNAL_ASSERT(!self.is_coalesced());
 
-  if (self.is_coalesced()) {
-    return self.clone();
-  }
   // NOTE: Since `coalesce` is not an in-place operation when `is_coalesced` is false,
   // we should keep the original tensor intact and do coalesce on a copy of the tensor
   if (self._nnz() < 2) {

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -396,7 +396,7 @@ SparseTensor& copy_sparse_(SparseTensor& self, const SparseTensor& src, bool non
   return self._coalesced_(src.is_coalesced());
 }
 
-SparseTensor coalesce_sparse(const SparseTensor& self) {
+SparseTensor coalesce(const SparseTensor& self) {
   // See NOTE: [ coalesce autograd ]
   if (self.is_coalesced()) {
     return self;

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -229,6 +229,10 @@ SparseTensor pow_sparse_scalar(const SparseTensor& t, const Scalar& value) {
 // --------------------------------------------------------------------
 
 static SparseTensor& coalesce_(SparseTensor& tensor) {
+  if (tensor.is_coalesced()) {
+    return tensor;
+  }
+
   SparseTensor coalesced = tensor.coalesce();
   tensor._values().resize_as_(coalesced._values());
   tensor._indices().resize_as_(coalesced._indices());

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -68,11 +68,9 @@ __global__ void _sparse_mask_copy_kernel(
 
 } // end namespace
 
-SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
+SparseTensor _coalesce_sparse_cuda(const SparseTensor& self) {
   int64_t nnz = self._nnz();
-  if (self.is_coalesced()) {
-    return self.clone();
-  }
+  TORCH_INTERNAL_ASSERT(!self.is_coalesced());
   // NOTE: Since `coalesce` is not an in-place operation when `is_coalesced` is false,
   // we should keep the original tensor intact and do coalesce on a copy of the tensor
   if (nnz < 2) {

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -71,7 +71,7 @@ __global__ void _sparse_mask_copy_kernel(
 SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
   int64_t nnz = self._nnz();
   if (self.is_coalesced()) {
-    return self;
+    return self.clone();
   }
   // NOTE: Since `coalesce` is not an in-place operation when `is_coalesced` is false,
   // we should keep the original tensor intact and do coalesce on a copy of the tensor

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -852,7 +852,7 @@ Tensor& _bmm_out_sparse_cuda(const SparseTensor& self, const Tensor& mat2, bool 
 
   // First need to coalesce to get all of the first dimension indices
   // in order since we'll be sending each matrix into the MM operation
-  SparseTensor self_coalesced = coalesce_sparse_cuda(self);
+  SparseTensor self_coalesced = self.coalesce();
 
   int64_t nnz =        self_coalesced._nnz();
   Tensor indices = self_coalesced._indices();

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -76,6 +76,7 @@ allow_list = [
     ("aten::_foreach_addcmul", datetime.date(2021, 4, 2)),
     ("aten::mkldnn_linear", datetime.date(2021, 3, 2)),
     ("aten::linalg_multi_dot", datetime.date(2021, 3, 25)),
+    ("aten::coalesce", datetime.date(2021, 3, 31)),
     ("aten::empty_meta", datetime.date(2021, 4, 1)),
     ("aten::batch_norm_backward_elemt", datetime.date(2021, 5, 1)),
     ("aten::assert_async", datetime.date(2021, 5, 1)),

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4021,9 +4021,11 @@ class TestAutograd(TestCase):
         def fn(sparse):
             return torch.sparse.sum(sparse)
 
-        gradcheck(fn, torch.rand(10).to_sparse().requires_grad_(True), check_sparse_nnz=True)
+        gradcheck(fn, torch.rand(10).to_sparse().requires_grad_(True),
+                  check_sparse_nnz=True, check_batched_grad=False)
         with self.assertRaisesRegex(RuntimeError, 'gradcheck expects all tensor inputs are dense'):
-            gradcheck(fn, torch.rand(10).to_sparse().requires_grad_(True), check_sparse_nnz=False)
+            gradcheck(fn, torch.rand(10).to_sparse().requires_grad_(True),
+                      check_sparse_nnz=False, check_batched_grad=False)
 
     def test_gradcheck_nondeterministic(self):
         class NonDetFunc(Function):

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -246,6 +246,31 @@ class TestSparse(TestCase):
             t, _, _ = self._gen_sparse(len(sparse_size), nnz, sparse_size + dense_size)
             _test_coalesce(t)  # this tests correctness
 
+    def test_coalesce_reference_cycle(self):
+        # Test coalesce doesn't create autograd graph cycles (gh-52253)
+
+        # Sanity check that the helper class works as expected
+        t = torch.rand(2)
+        t_ref = torch._C._WeakTensorRef(t)
+        self.assertFalse(t_ref.expired())
+
+        del t
+        self.assertTrue(t_ref.expired())
+
+        def test_sparse_sum():
+            i = torch.tensor([[0], [4]], dtype=torch.long, device=self.device)
+            v = torch.tensor([[[-0.4567, -1.8797, 0.0380, 1.4316]]],
+                             dtype=torch.double, device=self.device)
+            S = torch.sparse_coo_tensor(i, v)
+            S = S.coalesce()
+            S.requires_grad_(True)
+            S2 = S.coalesce()
+            self.assertTrue(S2.is_coalesced())
+            return torch._C._WeakTensorRef(S2)
+
+        ref = test_sparse_sum()
+        self.assertTrue(ref.expired())
+
     def test_ctor_size_checks(self):
         indices = self.index_tensor([
             [0, 0, 0],

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -317,7 +317,7 @@
 - name: clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
   self: grad
 
-- name: coalesce(Tensor self) -> Tensor
+- name: _coalesce(Tensor self) -> Tensor
   self: grad
 
 - name: complex(Tensor real, Tensor imag) -> Tensor

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -770,6 +770,20 @@ static void LogAPIUsageOnceFromPython(const std::string& event) {
   }
 }
 
+// Weak reference to tensor, used to test a tensor isn't leaked
+class WeakTensorRef {
+  c10::weak_intrusive_ptr<c10::TensorImpl> weakref_;
+
+public:
+  WeakTensorRef(const at::Tensor& t):
+    weakref_(t.getIntrusivePtr()) {
+  }
+
+  bool expired() {
+    return weakref_.expired();
+  }
+};
+
 extern "C"
 #ifdef _WIN32
 __declspec(dllexport)
@@ -967,6 +981,12 @@ Call this whenever a new thread is created in order to propagate values from
       #endif
     }
   );
+
+  py::class_<WeakTensorRef>(py_module, "_WeakTensorRef")
+    .def(py::init([](py::object tensor) {
+      return WeakTensorRef(THPVariable_Unpack(tensor.ptr()));
+    }))
+    .def("expired", &WeakTensorRef::expired);
 
 #ifdef USE_CUDA
   PyObject *has_cuda = Py_True;


### PR DESCRIPTION
Fixes #52253

In the issue reproducer we can replace `torch.sparse.sum(S)` with `S.coalesce()` and get the same memory leak. The reason is that calling `coalesce()` on an already coalesced tensor returns `self`. With autograd, the result gets it's `grad_fn` set to a node that contains a reference to the input tensor, creating a reference cycle. Cloning the tensor fixes this, so `coalesce` always returns a new tensor.

As an aside, `torch.sparse.sum(S)` doesn't need to coalesce. The result should be the same either way.