### PR TITLE
[FX][EZ] Hoist custom class .so loading into setUp

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -83,6 +83,13 @@ class Pair(NamedTuple):
     y : torch.Tensor
 
 class TestFX(JitTestCase):
+    def setUp(self):
+        if TEST_WITH_ROCM or IS_SANDCASTLE or IS_WINDOWS or IS_MACOS:
+            return
+        torch_root = Path(__file__).resolve().parent.parent
+        p = torch_root / 'build' / 'lib' / 'libtorchbind_test.so'
+        torch.ops.load_library(str(p))
+
     def checkGraphModule(self, m: torch.nn.Module, args, kwargs=None):
         """Check that an nn.Module's results match the GraphModule version
         for a given set of args/kwargs.
@@ -376,9 +383,6 @@ class TestFX(JitTestCase):
     def test_native_callable(self):
         if TEST_WITH_ROCM or IS_SANDCASTLE or IS_WINDOWS or IS_MACOS:
             raise unittest.SkipTest("non-portable load_library call used in test")
-        torch_root = Path(__file__).resolve().parent.parent
-        p = torch_root / 'build' / 'lib' / 'libtorchbind_test.so'
-        torch.ops.load_library(str(p))
         # This test exercises the case where we use FX to translate from Python
         # code to some native callable object
         #


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52884 [WIP][FX] Fix tracing support for torchbind
* **#52883 [FX][EZ] Hoist custom class .so loading into setUp**

Previously `test_torchbind_class_attribute_in_fx` couldn't be run standalone. The only reason it ran and pass in the full test suite was that `test_native_callable` ran before it and was loading in the custom class `.so` file. This pulls that loading out into the `setUp` method so it's available for all tests

Differential Revision: [D26675802](https://our.internmc.facebook.com/intern/diff/D26675802)