### PR TITLE
enable OneDNN Convolution in case of groups = 24

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -243,12 +243,7 @@ auto ConvParams::use_mkldnn(const at::Tensor& input, const at::Tensor& weight) c
      (groups > 1
       || (weight.size(-1) > 3 && weight.size(-2) > 3)
       || input.size(0) > 1
-      || input.size(0)*input.size(1)*input.size(2)*input.size(3) > 20480) // for some case, native is faster
-      // OneDNN < 1.8.1 produce incorrect results in this case (see #50042)
-      // TODO(VitalyFedyunin): Remove this patch after OneDNN 1.8.1 merged in
-      && !(groups == 24 && weight.size(0) == 24 && weight.size(1) == 1)
-      );
-
+      || input.size(0)*input.size(1)*input.size(2)*input.size(3) > 20480)); // for some case, native is faster
 #endif
   return false;
 }


### PR DESCRIPTION
https://github.com/pytorch/pytorch/issues/50042 has been sovled by  upgrade OneDNN to [v1.8.1](https://github.com/pytorch/pytorch/pull/51184). So re-enable OneDNN Convolution in case of groups = 24.