### PR TITLE
Fix local version generation

### DIFF
--- a/tools/generate_torch_version.py
+++ b/tools/generate_torch_version.py
@@ -24,7 +24,7 @@ def get_torch_version(sha: Optional[str] = None) -> str:
     elif sha != 'Unknown':
         if sha is None:
             sha = get_sha(pytorch_root)
-        version += '+' + sha[:7]
+        version += '+git' + sha[:7]
     return version
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add "git" prefix to PyTorch local version, otherwise it might strip leading zeroes from git hashum according to https://www.python.org/dev/peps/pep-0440/#local-version-identifiers:
> If a segment consists entirely of ASCII digits then that section should be considered an integer for comparison purposes

Fixes #52857

