### PR TITLE
[Static Runtime] Add memoray alloc/dealloc time to benchmark

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -400,7 +400,6 @@ void StaticRuntime::benchmark(
 
   IndividualMetrics results =
       benchmark_individual_ops(args, kwargs, warmup_runs, main_runs);
-  std::cout << "Setting up took " << results.setup_time << " ms" << std::endl;
 
   for (size_t i = 0; i < nodes_.size(); i++) {
     const Node* node = nodes_[i].get_node();
@@ -427,6 +426,14 @@ void StaticRuntime::benchmark(
   }
   std::cout << std::setw(15) << results.total_time << " ms. in Total"
             << std::endl;
+  std::cout << "StaticRuntime setup time: " << results.setup_time << " ms"
+            << std::endl;
+  std::cout << "Memory allocation time: " << results.memory_alloc_time
+            << " ms\n";
+  std::cout << "Memory deallocation time: " << results.memory_dealloc_time
+            << " ms" << std::endl;
+  std::cout << "Outputs deallocation time: " << results.output_dealloc_time
+            << " ms" << std::endl;
 
   if (planner_) {
     std::cout << "Total memory managed: " << planner_->total_managed()
@@ -468,6 +475,9 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   at::AutoNonVariableTypeMode non_var_type_mode(true);
 
   IndividualMetrics results;
+  results.memory_alloc_time = 0.0;
+  results.memory_dealloc_time = 0.0;
+  results.output_dealloc_time = 0.0;
   results.total_time = 0.0;
   results.time_per_node.resize(nodes_.size(), 0);
 
@@ -493,26 +503,61 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
   }
 
   // main runs
-  for (size_t i = 0; i < stack.size(); i++) {
-    Input(i) = stack[i];
-  }
   for (int i = 0; i < main_runs; i++) {
+    for (size_t i = 0; i < stack.size(); i++) {
+      Input(i) = stack[i];
+    }
+    timer.Start();
     if (planner_) {
       planner_->allocate();
     }
+    float millis = timer.MilliSeconds();
+    results.memory_alloc_time += millis;
+
     for (size_t j = 0; j < nodes_.size(); j++) {
       timer.Start();
       nodes_[j].run();
-      float millis = timer.MilliSeconds();
+      millis = timer.MilliSeconds();
       results.time_per_node[j] += millis;
     }
+    timer.Start();
     if (opts_.cleanup_activations) {
       if (!planner_) {
         std::unordered_map<Value*, std::vector<Value*>> shared;
         planner_ = std::make_unique<MemoryPlanner>(this, shared);
       }
       planner_->deallocate();
+      // clean up owning refs of input tensors
+      for (IValue& ival : inputs_) {
+        ival = IValue();
+      }
     }
+    millis = timer.MilliSeconds();
+    results.memory_dealloc_time += millis;
+
+    timer.Start();
+    // no need to keep references of outputs in static runtime anymore
+    c10::IValue output;
+    if (num_outputs() > 1) {
+      std::vector<c10::IValue> outputs;
+      outputs.reserve(num_outputs());
+      for (auto i = 0; i < num_outputs(); ++i) {
+        // use move here. Otherwise, clean up outputs_[i] explicitly
+        outputs.emplace_back(std::move(*outputs_[i]));
+      }
+      output = c10::ivalue::Tuple::create(std::move(outputs));
+    }
+
+#ifndef NDEBUG
+    check_for_memory_leak(false);
+#endif
+
+    // use move here. Otherwise, clean up outputs_[0] explicitly
+    output = std::move(*outputs_[0]);
+    // release outputs explicitly to measure the time it takes
+    output = IValue();
+    millis = timer.MilliSeconds();
+    results.output_dealloc_time += millis;
   }
 
   // post processing
@@ -524,6 +569,9 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
     results.instances_per_node_type[kind]++;
     results.total_time += results.time_per_node[i];
   }
+  results.memory_alloc_time /= static_cast<float>(main_runs);
+  results.memory_dealloc_time /= static_cast<float>(main_runs);
+  results.output_dealloc_time /= static_cast<float>(main_runs);
   for (const auto& p : results.time_per_node_type) {
     const std::string& kind = p.first;
     results.percent_per_node_type[kind] = p.second / results.total_time * 100;

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -128,6 +128,9 @@ class TORCH_API StaticRuntime {
 
   struct IndividualMetrics {
     float setup_time;
+    float memory_alloc_time;
+    float memory_dealloc_time;
+    float output_dealloc_time;
     float total_time;
     std::vector<float> time_per_node;
     std::unordered_map<std::string, float> time_per_node_type;

--- a/torch/csrc/jit/runtime/static/init.cpp
+++ b/torch/csrc/jit/runtime/static/init.cpp
@@ -13,6 +13,15 @@ void initStaticRuntimeBindings(PyObject* module) {
   py::class_<StaticRuntime::IndividualMetrics>(
       static_runtime, "IndividualMetrics")
       .def_readonly("setup_time", &StaticRuntime::IndividualMetrics::setup_time)
+      .def_readonly(
+          "memory_alloc_time",
+          &StaticRuntime::IndividualMetrics::memory_alloc_time)
+      .def_readonly(
+          "memory_dealloc_time",
+          &StaticRuntime::IndividualMetrics::memory_dealloc_time)
+      .def_readonly(
+          "output_dealloc_time",
+          &StaticRuntime::IndividualMetrics::output_dealloc_time)
       .def_readonly("total_time", &StaticRuntime::IndividualMetrics::total_time)
       .def_readonly(
           "time_per_node", &StaticRuntime::IndividualMetrics::time_per_node)


### PR DESCRIPTION
Summary: Add more metrics to track memory_alloc_time, memory_dealloc_time, and output_dealloc_time.

Reviewed By: maratsubkhankulov

Differential Revision: D26660715

