### PR TITLE
torch_warn_once for calling completed() on cuda future

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -479,7 +479,7 @@ struct C10_EXPORT ivalue::Future : c10::intrusive_ptr_target {
   }
 
   // Check if the current future has completed
-  bool completed() const {
+  virtual bool completed() const {
     return completed_;
   }
 

--- a/aten/src/ATen/cuda/CUDAFuture.h
+++ b/aten/src/ATen/cuda/CUDAFuture.h
@@ -142,6 +142,16 @@ struct TORCH_CUDA_CPP_API CUDAFuture : at::ivalue::Future {
     return data_ptrs;
   }
 
+  bool completed() const override {
+    TORCH_WARN_ONCE(
+        "Calling completed() on instance of at::CUDAFuture. Note that this "
+        "does not have the same semantics as completed() on a vanilla "
+        "at::ivalue::future, as this returns true if the CUDA operation has "
+        "enqueued on the stream and makes no guarantees regarding actual "
+        "execution or stream synchronization.");
+    return at::ivalue::Future::completed();
+  }
+
  private:
   // The device that was current when markCompleted was called, which we'll
   // restore when invoking callbacks.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52906 torch_warn_once for calling completed() on cuda future**

CUDAFuture completed() semantics are different from at::ivalue::Future semantics, hence adding a warning only once when this is called to warn user about this.

This could be helpful for both DDP developers and comm. hook developers to avoid bugs that can arise from this assumption.

Differential Revision: [D26659806](https://our.internmc.facebook.com/intern/diff/D26659806/)