### PR TITLE
Add MANIFEST.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,7 @@ caffe2/version.py
 # setup.py intermediates
 .eggs
 caffe2.egg-info
+MANIFEST
 
 # Atom/Watchman required file
 .watchmanconfig

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -36,4 +36,15 @@ CC="clang" CXX="clang++" LDSHARED="clang --shared" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py install
 
+
+# Test building via the sdist source tarball
+python setup.py sdist
+pushd /tmp
+mkdir tmp
+tar zxf "$(dirname "${BASH_SOURCE[0]}")/../../dist/*.tar.gz"
+cd torch-*
+python setup.py build --cmake-only
+cd ..
+popd tmp
+
 assert_git_not_dirty

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -39,12 +39,11 @@ CC="clang" CXX="clang++" LDSHARED="clang --shared" \
 
 # Test building via the sdist source tarball
 python setup.py sdist
-pushd /tmp
-mkdir tmp
-tar zxf "$(dirname "${BASH_SOURCE[0]}")/../../dist/*.tar.gz"
+mkdir -p /tmp/tmp
+pushd /tmp/tmp
+tar zxf "$(dirname "${BASH_SOURCE[0]}")/../../dist/"*.tar.gz
 cd torch-*
 python setup.py build --cmake-only
-cd ..
-popd tmp
+popd
 
 assert_git_not_dirty

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -317,15 +317,3 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   popd
   assert_git_not_dirty
 fi
-
-# Test building via the sdist source tarball
-if [[ "${BUILD_ENVIRONMENT}" == *asan* ]]; then
-  python setup.py sdist
-  pushd /tmp
-  mkdir tmp
-  tar zxf "$(dirname "${BASH_SOURCE[0]}")/../../dist/*.tar.gz"
-  cd torch-*
-  python setup.py build --cmake-only
-  cd ..
-  popd tmp
-fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -317,3 +317,15 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   popd
   assert_git_not_dirty
 fi
+
+# Test that source package is configurable
+if [[ "${BUILD_ENVIRONMENT}" == *asan* ]]; then
+  python setup.py sdist
+  pushd /tmp
+  mkdir tmp
+  tar zxf "$(dirname "${BASH_SOURCE[0]}")/../../dist/*.tar.gz"
+  cd torch-*
+  python setup.py build --cmake-only
+  cd ..
+  popd tmp
+fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -318,7 +318,7 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   assert_git_not_dirty
 fi
 
-# Test that source package is configurable
+# Test building via the sdist source tarball
 if [[ "${BUILD_ENVIRONMENT}" == *asan* ]]; then
   python setup.py sdist
   pushd /tmp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,12 @@
-include CMakeLists.txt CITATION LICENSE NOTICE .gitmodules mypy.ini requirements.txt version.txt
+include MANIFEST.in
+include CMakeLists.txt
+include CITATION
+include LICENSE
+include NOTICE
+include .gitmodules
+include mypy.ini
+include requirements.txt
+include version.txt
 recursive-include android *.*
 recursive-include aten *.*
 recursive-include binaries *.*
@@ -16,4 +24,5 @@ recursive-include benchmarks *.*
 recursive-include scripts *.*
 recursive-include mypy_plugins *.*
 recursive-include modules *.*
-global-exclude *.o *.so *.dylib *.a .git
+prune */__pycache__
+global-exclude *.o *.so *.dylib *.a .git *.pyc *.swp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,19 @@
+include CMakeLists.txt CITATION LICENSE NOTICE .gitmodules mypy.ini requirements.txt version.txt
+recursive-include android *.*
+recursive-include aten *.*
+recursive-include binaries *.*
+recursive-include c10 *.*
+recursive-include caffe2 *.*
+recursive-include cmake *.*
+recursive-include torch *.*
+recursive-include tools *.*
+recursive-include test *.*
+recursive-include docs *.*
+recursive-include ios *.*
+recursive-include third_party *
+recursive-include test *.*
+recursive-include benchmarks *.*
+recursive-include scripts *.*
+recursive-include mypy_plugins *.*
+recursive-include modules *.*
+global-exclude *.o *.so *.dylib *.a .git

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ for i, arg in enumerate(sys.argv):
         break
     if arg == '-q' or arg == '--quiet':
         VERBOSE_SCRIPT = False
-    if arg == 'clean' or arg == 'egg_info':
+    if arg in ['clean', 'egg_info', 'sdist']:
         RUN_BUILD_DEPS = False
     filtered_args.append(arg)
 sys.argv = filtered_args

--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,7 @@ from distutils.errors import DistutilsArgError
 import setuptools.command.build_ext
 import setuptools.command.install
 import distutils.command.clean
+import distutils.command.sdist
 import distutils.sysconfig
 import filecmp
 import shutil
@@ -286,10 +287,8 @@ report("Building wheel {}-{}".format(package_name, version))
 
 cmake = CMake()
 
-# all the work we need to do _before_ setup runs
-def build_deps():
-    report('-- Building version ' + version)
 
+def check_submodules():
     def check_file(f):
         if bool(os.getenv("USE_SYSTEM_LIBS", False)):
             return
@@ -310,6 +309,12 @@ def build_deps():
     check_file(os.path.join(third_party_path, 'onnx', 'third_party',
                             'benchmark', 'CMakeLists.txt'))
 
+
+# all the work we need to do _before_ setup runs
+def build_deps():
+    report('-- Building version ' + version)
+
+    check_submodules()
     check_pydep('yaml', 'pyyaml')
 
     build_caffe2(version=version,
@@ -599,7 +604,7 @@ else:
 
 class install(setuptools.command.install.install):
     def run(self):
-        setuptools.command.install.install.run(self)
+        super().run()
 
 
 class clean(distutils.command.clean.clean):
@@ -623,8 +628,14 @@ class clean(distutils.command.clean.clean):
                         except OSError:
                             shutil.rmtree(filename, ignore_errors=True)
 
-        # It's an old-style class in Python 2.7...
-        distutils.command.clean.clean.run(self)
+        super().run(self)
+
+
+class sdist(distutils.command.sdist.sdist):
+    def run(self):
+        with concat_license_files():
+            super().run()
+
 
 def configure_extension_build():
     r"""Configures extension build options according to system environment and user's choice.
@@ -765,10 +776,11 @@ def configure_extension_build():
         )
 
     cmdclass = {
+        'bdist_wheel': wheel_concatenate,
         'build_ext': build_ext,
         'clean': clean,
         'install': install,
-        'bdist_wheel': wheel_concatenate,
+        'sdist': sdist,
     }
 
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -628,7 +628,7 @@ class clean(distutils.command.clean.clean):
                         except OSError:
                             shutil.rmtree(filename, ignore_errors=True)
 
-        super().run(self)
+        super().run()
 
 
 class sdist(distutils.command.sdist.sdist):


### PR DESCRIPTION
Do not build PyTorch if `setup.py` is called with  'sdist' option
Regenerate bundled license while sdist package is being built
Refactor `check_submodules` out of `build_deps` and check that submodules project are present during source package build stage.

Test that sdist package is configurable during `asan-build` step

Fixes #52843
