### PR TITLE
[pytorch] Fix mkldnn heuristic for multithreaded convolution

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -236,7 +236,7 @@ auto ConvParams::use_mkldnn(const at::Tensor& input, const at::Tensor& weight) c
      input.scalar_type() == kFloat && // only on CPU Float Tensors
      !transposed && // or transposed tensors
      (is_strided() || is_dilated() || input.size(0) >= 16 ||
-      weight.size(-1) != 1 || weight.size(-2) != 1) &&
+      weight.size(-1) != 1 || weight.size(-2) != 1 || at::get_num_threads() > 1) &&
      (groups > 1
       || (weight.size(-1) > 3 && weight.size(-2) > 3)
       || input.size(0) > 1
@@ -244,7 +244,7 @@ auto ConvParams::use_mkldnn(const at::Tensor& input, const at::Tensor& weight) c
       // OneDNN < 1.8.1 produce incorrect results in this case (see #50042)
       // TODO(VitalyFedyunin): Remove this patch after OneDNN 1.8.1 merged in
       && !(groups == 24 && weight.size(0) == 24 && weight.size(1) == 1)
-      ); 
+      );
 
 #endif
   return false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52909 [pytorch] Fix mkldnn heuristic for multithreaded convolution**

PR #46675 introduced heuristics to use thnn_conv2d for 1x1
convolutions, since mkldnn had a bug that was slowing those cases
down. Unfortunately, the test plan for that PR only tested single-threaded
convolutions; mkldnn is considerably faster on multithreaded convolutions.

An example from yolov3, on 24 cores of a Xeon Platinum 8175M CPU @ 2.50GHz
```
input:{1, 64, 192, 256}, weight:{32, 64, 1, 1}
thnn_conv2d: GFLOPS/s=104.574G/s
mkldnn_convolution: GFLOPS/s=467.357G/s
```

Differential Revision: [D26685272](https://our.internmc.facebook.com/intern/diff/D26685272/)