### PR TITLE
Back out "[PT QNNPACK] Temporarily disable input pointer caching"

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/conv-run.cc
@@ -328,17 +328,11 @@ enum pytorch_qnnp_status qnnpackConv(
   // We need to check if the corresponding values on this
   // invocation is same as cached values.
   // If so we can skip setup step.
-
-  bool recalculate_indirection_buffer{true};
-#ifndef __APPLE__
-  recalculate_indirection_buffer =
-      (convolution->input != input ||
+  if (convolution->input != input ||
       convolution->batch_size != batch_size ||
       convolution->input_height != input_height ||
       convolution->input_width != input_width ||
-      convolution->input_pixel_stride != input_pixel_stride);
-#endif
-  if (recalculate_indirection_buffer) {
+      convolution->input_pixel_stride != input_pixel_stride) {
     pytorch_qnnp_status status = pytorch_qnnp_setup_convolution2d_nhwc_q8(
         convolution,
         batch_size,


### PR DESCRIPTION
Summary: Original commit changeset: f6ceef606994

Test Plan:
FB:
This was an attempt to fix ig crashes but we root caused it to pthreadpool changes. Thus this is not needed anymore.

Differential Revision: D26485737

