### PR TITLE
[package] Pull out _UnpicklerWrapper into PackageUnpickler

### DIFF
--- a/torch/_deploy.py
+++ b/torch/_deploy.py
@@ -1,12 +1,9 @@
 import io
 import torch
-import importlib
 from torch.package._package_pickler import create_pickler
-from torch.package.package_importer import _UnpicklerWrapper
+from torch.package._package_unpickler import PackageUnpickler
 from torch.package import sys_importer, OrderedImporter, PackageImporter, Importer
 from torch.serialization import _maybe_decode_ascii
-from typing import Callable
-from types import ModuleType
 
 def _save_storages(importer, obj):
     serialized_storages = []
@@ -50,17 +47,11 @@ def _load_storages(id, zip_reader, obj_bytes, serialized_storages):
         return serialized_storages[data[0]]
 
 
-    import_module : Callable[[str], ModuleType] = importlib.import_module
+    importer: Importer
     if zip_reader is not None:
-        importer = _get_package(zip_reader)
+        importer = OrderedImporter(_get_package(zip_reader), sys_importer)
 
-        def import_module(name: str):
-            try:
-                return importer.import_module(name)
-            except ModuleNotFoundError:
-                return importlib.import_module(name)
-
-    unpickler = _UnpicklerWrapper(import_module, io.BytesIO(obj_bytes))
+    unpickler = PackageUnpickler(importer, io.BytesIO(obj_bytes))
     unpickler.persistent_load = persistent_load
     result = _deploy_objects[id] = unpickler.load()
     return result

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -7,6 +7,11 @@ from .importer import Importer, sys_importer, ObjMismatchError, ObjNotFoundError
 
 
 class PackagePickler(_Pickler):
+    """Package-aware pickler.
+
+    This behaves the same as a normal pickler, except it uses an `Importer`
+    to find objects and modules to save.
+    """
     dispatch = _Pickler.dispatch.copy()
 
     def __init__(self, importer: Importer, *args, **kwargs):

--- a/torch/package/_package_unpickler.py
+++ b/torch/package/_package_unpickler.py
@@ -1,0 +1,26 @@
+import pickle
+
+import _compat_pickle  # type: ignore
+
+from .importer import Importer
+
+
+class PackageUnpickler(pickle._Unpickler):  # type: ignore
+    """Package-aware unpickler.
+
+    This behaves the same as a normal unpickler, except it uses `importer` to
+    find any global names that it encounters while unpickling.
+    """
+    def __init__(self, importer: Importer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._importer = importer
+
+    def find_class(self, module, name):
+        # Subclasses may override this.
+        if self.proto < 3 and self.fix_imports:
+            if (module, name) in _compat_pickle.NAME_MAPPING:
+                module, name = _compat_pickle.NAME_MAPPING[(module, name)]
+            elif module in _compat_pickle.IMPORT_MAPPING:
+                module = _compat_pickle.IMPORT_MAPPING[module]
+        mod = self._importer.import_module(module)
+        return getattr(mod, name)

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -8,7 +8,6 @@ from weakref import WeakValueDictionary
 import pickle
 import torch
 from torch.serialization import _get_restore_location, _maybe_decode_ascii
-import _compat_pickle  # type: ignore
 import types
 import os.path
 from pathlib import Path
@@ -18,6 +17,7 @@ from ._importlib import _normalize_line_endings, _resolve_name, _sanity_check, _
 from ._file_structure_representation import _create_folder_from_file_list, Folder
 from ._glob_group import GlobPattern
 from ._mock_zipreader import MockZipReader
+from ._package_unpickler import PackageUnpickler
 from ._mangling import PackageMangler, demangle
 from .importer import Importer
 
@@ -91,7 +91,7 @@ class PackageImporter(Importer):
         self._mangler = PackageMangler()
 
         # used for torch.serialization._load
-        self.Unpickler = lambda *args, **kwargs: _UnpicklerWrapper(self.import_module, *args, **kwargs)
+        self.Unpickler = lambda *args, **kwargs: PackageUnpickler(self, *args, **kwargs)
 
     def import_module(self, name: str, package=None):
         """Load a module from the package if it hasn't already been loaded, and then return
@@ -195,11 +195,11 @@ class PackageImporter(Importer):
         return self._mangler.parent_name()
 
     def file_structure(self, *, include: 'GlobPattern' = "**", exclude: 'GlobPattern' = ()) -> Folder:
-        """Returns a file structure representation of package's zipfile. 
+        """Returns a file structure representation of package's zipfile.
 
         Args:
             include (Union[List[str], str]): An optional string e.g. "my_package.my_subpackage", or optional list of strings
-                for the names of the files to be inluded in the zipfile representation. This can also be 
+                for the names of the files to be inluded in the zipfile representation. This can also be
                 a glob-style pattern, as described in exporter's :meth:`mock`
 
             exclude (Union[List[str], str]): An optional pattern that excludes files whose name match the pattern.
@@ -455,21 +455,6 @@ class PackageImporter(Importer):
 _NEEDS_LOADING = object()
 _ERR_MSG_PREFIX = 'No module named '
 _ERR_MSG = _ERR_MSG_PREFIX + '{!r}'
-
-class _UnpicklerWrapper(pickle._Unpickler):  # type: ignore
-    def __init__(self, importer, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._importer = importer
-
-    def find_class(self, module, name):
-        # Subclasses may override this.
-        if self.proto < 3 and self.fix_imports:
-            if (module, name) in _compat_pickle.NAME_MAPPING:
-                module, name = _compat_pickle.NAME_MAPPING[(module, name)]
-            elif module in _compat_pickle.IMPORT_MAPPING:
-                module = _compat_pickle.IMPORT_MAPPING[module]
-        mod = self._importer(module)
-        return getattr(mod, name)
 
 class _PathNode:
     pass


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52923 [rpc] make pickler/unpickler pluggable in RPC
* **#52922 [package] Pull out _UnpicklerWrapper into PackageUnpickler**
* #52921 [package] _custom_import_pickler -> _package_pickler

This makes our API symmetric--now we have an `Importer` aware Pickler
and Unpickler implementation that have similar interfaces.

Differential Revision: [D26693251](https://our.internmc.facebook.com/intern/diff/D26693251)