### PR TITLE
ns for fx: docblock fixes

### DIFF
--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -53,8 +53,8 @@ NSSingleResultType = Dict[str, Any]
 
 # {
 #   'logger_name_1': {
-#     'model_name_a': [torch.Tensor(...), ...],
-#     'model_name_b': [torch.Tensor(...), ...],
+#     'model_name_a': NSSingleResultType,
+#     'model_name_b': NSSingleResultType,
 #   },
 # }
 #
@@ -258,22 +258,7 @@ def get_matching_activations(
 
     TODO(future PR): real docblock
 
-    Output format:
-
-    {
-        'layer1.stats': {
-            'name_a': [torch.Tensor(...), ...],
-            'name_b': [torch.Tensor(...), ...],
-        },
-        ...
-    }
-
-    Note, there are three differences from the output format of Eager NS:
-    1. `name_a` and `name_b` are used instead of hardcoding names
-       to `float` and `quantized`.
-    2. Lists of Tensors are returned instead of individual Tensors, to unify
-       the return type for calibrating with 1 input vs N inputs.
-    3. `logger_cls` is included in the API for easy result extraction
+    Output format: NSResultsType
     """
     results: NSResultsType = {}
     for gm in (gm_a, gm_b):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52928 ns for fx: remove subgraphs from user facing API
* #52927 ns for fx: clean up duplicate code in get_matching_activations_a_shadows_b
* #52926 ns for fx: remove model_name from get_matching_activations API
* **#52925 ns for fx: docblock fixes**

Summary:

Cleans up some incorrect comments and docblocks in
`numeric_suite_core_apis.py`.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26693472](https://our.internmc.facebook.com/intern/diff/D26693472)