### PR TITLE
ns for fx: remove model_name from get_matching_activations API

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -787,8 +787,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         mq_ns(input_fp32)
 
         # check activation result correctness
-        act_compare_dict = get_matching_activations(
-            'fp32_prepared', mp_ns, 'int8', mq_ns, OutputLogger)
+        act_compare_dict = get_matching_activations(mp_ns, mq_ns, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 
@@ -839,8 +838,7 @@ class TestFXNumericSuiteCoreAPIs(QuantizationTestCase):
         mq_ns(input_fp32)
 
         # check activation result correctness
-        act_compare_dict = get_matching_activations(
-            'fp32_prepared', mp_ns, 'int8', mq_ns, OutputLogger)
+        act_compare_dict = get_matching_activations(mp_ns, mq_ns, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 
@@ -948,7 +946,7 @@ class TestFXNumericSuiteCoreAPIsModels(QuantizationTestCase):
 
         # inspect results
         act_compare_dict = get_matching_activations(
-            'fp32_prepared', sparse_nn, 'int8', sparse_nn_q, OutputLogger)
+            sparse_nn, sparse_nn_q, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 4)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 

--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -215,7 +215,6 @@ def prepare_model_outputs(
     return (gm_a, gm_b)
 
 def add_activation_info_to_dict(
-    model_name: str,
     model: GraphModule,
     results: NSResultsType,
     logger_cls: Callable,
@@ -233,7 +232,7 @@ def add_activation_info_to_dict(
             key = mod.ref_name
             if key not in results:
                 results[key] = {}
-            results[key][model_name] = {
+            results[key][mod.model_name] = {
                 'type': NSSingleResultValuesType.NODE_OUTPUT.value,
                 'values': mod.stats,
                 'node_name': mod.node_name,
@@ -246,9 +245,7 @@ def add_activation_info_to_dict(
 # TODO(future PR): align on naming
 # this is equivalent of just the comparison extraction part of `ns.compare_model_outputs`
 def get_matching_activations(
-    model_name_a: str,
     gm_a: GraphModule,
-    model_name_b: str,
     gm_b: GraphModule,
     logger_cls: Callable,
 ) -> NSResultsType:
@@ -262,8 +259,8 @@ def get_matching_activations(
     """
     results: NSResultsType = {}
     for gm in (gm_a, gm_b):
-        add_activation_info_to_dict(model_name_a, gm_a, results, logger_cls)
-        add_activation_info_to_dict(model_name_b, gm_b, results, logger_cls)
+        add_activation_info_to_dict(gm_a, results, logger_cls)
+        add_activation_info_to_dict(gm_b, results, logger_cls)
     return results
 
 # Note: this is not a user facing API


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52928 ns for fx: remove subgraphs from user facing API
* #52927 ns for fx: clean up duplicate code in get_matching_activations_a_shadows_b
* **#52926 ns for fx: remove model_name from get_matching_activations API**
* #52925 ns for fx: docblock fixes

Summary:

Model name is already stored in the Loggers in the prepare call.
Removing the need to specify it again in the extract activations
functions, to simplify things.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26693473](https://our.internmc.facebook.com/intern/diff/D26693473)