### PR TITLE
ns for fx: clean up duplicate code in get_matching_activations_a_shadows_b

### DIFF
--- a/torch/quantization/ns/numeric_suite_core_apis_fx.py
+++ b/torch/quantization/ns/numeric_suite_core_apis_fx.py
@@ -296,20 +296,5 @@ def get_matching_activations_a_shadows_b(
     TODO(future PR): real docblock
     """
     results: NSResultsType = collections.defaultdict(dict)
-    for name, mod in gm_a_shadows_b.named_modules():
-        # TODO(future PR): better check when scripted
-        is_logger = (
-            isinstance(mod, logger_cls)  # type: ignore
-            or (
-                isinstance(mod, torch.jit.RecursiveScriptModule)
-                and mod.original_name == 'OutputLogger'
-            )
-        )
-        if is_logger:
-            results[mod.ref_name][mod.model_name] = {
-                'type': NSSingleResultValuesType.NODE_OUTPUT.value,
-                'values': mod.stats,
-                'node_name': mod.node_name,
-                'node_target_type': mod.node_target_type,
-            }
+    add_activation_info_to_dict(gm_a_shadows_b, results, logger_cls)
     return dict(results)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #52928 ns for fx: remove subgraphs from user facing API
* **#52927 ns for fx: clean up duplicate code in get_matching_activations_a_shadows_b**
* #52926 ns for fx: remove model_name from get_matching_activations API
* #52925 ns for fx: docblock fixes

Summary:

Refactor to use an existing util instead of duplicating code, no logic
change.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D26693474](https://our.internmc.facebook.com/intern/diff/D26693474)