### PR TITLE
Exclude 'test' from codecoverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,8 @@ coverage:
     project:
       default:
         threshold: 1%
+    patch: off
+        
 codecov:
   notify:
     # Code coverage is collected by 6 configs: codecov_test[12], onnx[12] and windows_test[2]
@@ -25,3 +27,4 @@ fixes:
 ignore:
   - "caffe2"
   - "third_party"
+  - "test"


### PR DESCRIPTION
Also, do not generate coverage report on patch level
