### PR TITLE
fix logcumsumexp functor to properly handle infs and nans

### DIFF
--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -118,7 +118,7 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
             scalar_t max = std::isnan(y) ? y : std::max(x,y); //std::max returns first arg if one of the args is nan
             if (min != max) {
               // nan will be propagated here
-              return ::log1p(std::exp(min - max)) + std::max(x, y);
+              return std::log1p(std::exp(min - max)) + std::max(x, y);
             } else {
            // special case to correctly handle -inf and -inf
               return static_cast<scalar_t>(::log(2.)) + x;

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -121,7 +121,7 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
               return ::log1p(std::exp(min - max)) + std::max(x, y);
             } else {
            // special case to correctly handle -inf and -inf
-              return static_cast<scalar_t>(::log(2.))+x;
+              return static_cast<scalar_t>(::log(2.)) + x;
             }
           };
           cum_number = log_add_exp(x, cum_number);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -116,12 +116,12 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
           auto log_add_exp = [](scalar_t x, scalar_t y) -> scalar_t {
             scalar_t min = std::isnan(y) ? y : std::min(x,y); //std::min returns first arg if one of the args is nan
             scalar_t max = std::isnan(y) ? y : std::max(x,y); //std::max returns first arg if one of the args is nan
-            if (min != max) {
+            if (min != max || std::isfinite(min)) {
               // nan will be propagated here
-              return std::log1p(std::exp(min - max)) + std::max(x, y);
+              return std::log1p(std::exp(min - max)) + max;
             } else {
-           // special case to correctly handle -inf and -inf
-              return static_cast<scalar_t>(std::log(2.)) + x;
+           // special case to correctly handle infinite cases
+              return x;
             }
           };
           cum_number = log_add_exp(x, cum_number);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -114,7 +114,15 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
 
           // Reference : https://www.tensorflow.org/api_docs/python/tf/math/cumulative_logsumexp
           auto log_add_exp = [](scalar_t x, scalar_t y) -> scalar_t {
-            return std::log1p(std::exp(std::min(x, y) - std::max(x, y))) + std::max(x, y);
+            scalar_t min = std::isnan(y) ? y : std::min(x,y); //std::min returns first arg if one of the args is nan
+            scalar_t max = std::isnan(y) ? y : std::max(x,y); //std::max returns first arg if one of the args is nan
+            if (min != max) {
+              // nan will be propagated here
+              return ::log1p(std::exp(min - max)) + std::max(x, y);
+            } else {
+           // special case to correctly handle -inf and -inf
+              return static_cast<scalar_t>(::log(2.))+x;
+            }
           };
           cum_number = log_add_exp(x, cum_number);
           result_data[i * result_dim_stride] = static_cast<scalar_t>(cum_number);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -121,7 +121,7 @@ static void logcumsumexp_cpu_kernel(Tensor& result, const Tensor& self, int64_t 
               return std::log1p(std::exp(min - max)) + std::max(x, y);
             } else {
            // special case to correctly handle -inf and -inf
-              return static_cast<scalar_t>(::log(2.)) + x;
+              return static_cast<scalar_t>(std::log(2.)) + x;
             }
           };
           cum_number = log_add_exp(x, cum_number);

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -563,7 +563,7 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
     auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x, const scalar_t y) -> scalar_t {
       scalar_t min = at::_isnan(y) ? y : std::min<scalar_t>(x,y); //std::min returns first arg if one of the args is nan
       scalar_t max = at::_isnan(y) ? y : std::max<scalar_t>(x,y); //std::max returns first arg if one of the args is nan
-      if (min != max || std::isfinite(min)) {
+      if (min != max || ::isfinite(min)) {
       // nan will be propagated here
           return ::log1p(std::exp(min - max)) + max;
       } else {

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -563,12 +563,12 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
     auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x, const scalar_t y) -> scalar_t {
       scalar_t min = at::_isnan(y) ? y : std::min<scalar_t>(x,y); //std::min returns first arg if one of the args is nan
       scalar_t max = at::_isnan(y) ? y : std::max<scalar_t>(x,y); //std::max returns first arg if one of the args is nan
-      if (min != max) {
+      if (min != max || std::isfinite(min)) {
       // nan will be propagated here
-          return ::log1p(std::exp(min - max)) + std::max(x, y);
+          return ::log1p(std::exp(min - max)) + max;
       } else {
       // special case to correctly handle -inf and -inf
-         return static_cast<scalar_t>(::log(2.))+x;
+         return x;
       }
     };
     scan_dim<scalar_t>(self, result, wrap_dim, init, log_add_exp);

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -563,7 +563,7 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
     auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x, const scalar_t y) -> scalar_t {
       scalar_t min = at::_isnan(y) ? y : std::min<scalar_t>(x,y); //std::min returns first arg if one of the args is nan
       scalar_t max = at::_isnan(y) ? y : std::max<scalar_t>(x,y); //std::max returns first arg if one of the args is nan
-      if (min != max || ::isfinite(min)) {
+      if (min != max || ::isfinite(static_cast<float>(min))) {
       // nan will be propagated here
           return ::log1p(std::exp(min - max)) + max;
       } else {

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -1,5 +1,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/NumericLimits.cuh>
+#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/NumericUtils.h>
@@ -559,15 +560,16 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
 
   AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Half,
     self.scalar_type(), "logcumsumexp_cuda", [&]() {
+    using accscalar_t = acc_type<scalar_t, true>;
     scalar_t init = -std::numeric_limits<scalar_t>::infinity();
     auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x, const scalar_t y) -> scalar_t {
       scalar_t min = at::_isnan(y) ? y : std::min<scalar_t>(x,y); //std::min returns first arg if one of the args is nan
       scalar_t max = at::_isnan(y) ? y : std::max<scalar_t>(x,y); //std::max returns first arg if one of the args is nan
-      if (min != max || ::isfinite(static_cast<float>(min))) {
+      if (min != max || ::isfinite(static_cast<accscalar_t>(min))) {
       // nan will be propagated here
           return ::log1p(std::exp(min - max)) + max;
       } else {
-      // special case to correctly handle -inf and -inf
+      // special case to correctly handle infinite inputs
          return x;
       }
     };

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -2,6 +2,7 @@
 #include <ATen/cuda/NumericLimits.cuh>
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
+#include <ATen/NumericUtils.h>
 #include <c10/util/accumulate.h>
 #include <THC/THCGeneral.h>
 #include <THC/THCNumerics.cuh>
@@ -560,8 +561,8 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
     self.scalar_type(), "logcumsumexp_cuda", [&]() {
     scalar_t init = -std::numeric_limits<scalar_t>::infinity();
     auto log_add_exp = [] C10_HOST_DEVICE (const scalar_t x, const scalar_t y) -> scalar_t {
-      scalar_t min = std::isnan(y) ? y : std::min(x,y); //std::min returns first arg if one of the args is nan
-      scalar_t max = std::isnan(y) ? y : std::max(x,y); //std::max returns first arg if one of the args is nan
+      scalar_t min = at::_isnan(y) ? y : std::min<scalar_t>(x,y); //std::min returns first arg if one of the args is nan
+      scalar_t max = at::_isnan(y) ? y : std::max<scalar_t>(x,y); //std::max returns first arg if one of the args is nan
       if (min != max) {
       // nan will be propagated here
           return ::log1p(std::exp(min - max)) + std::max(x, y);

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -564,8 +564,7 @@ Tensor& _logcumsumexp_out_cuda(Tensor& result, const Tensor& self, int64_t dim) 
       scalar_t max = std::isnan(y) ? y : std::max(x,y); //std::max returns first arg if one of the args is nan
       if (min != max) {
       // nan will be propagated here
-          return ::log1p(std::exp(min - max)) +
-          std::max(x, y);
+          return ::log1p(std::exp(min - max)) + std::max(x, y);
       } else {
       // special case to correctly handle -inf and -inf
          return static_cast<scalar_t>(::log(2.))+x;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4137,14 +4137,23 @@ class TestTorchDeviceType(TestCase):
         def logcumsumexp(a, axis):
             return torch.cumsum(a.exp(), axis=axis).log_()
 
-        axis = 1
+        axis = -1
         a = torch.randn(100, 100, device=device)
 
-        actual = a.logcumsumexp(1)
+        actual = a.logcumsumexp(axis)
         expected = logcumsumexp(a, axis)
         self.assertEqual(a.dtype, actual.dtype)
         self.assertEqual(expected.shape, actual.shape)
         self.assertEqual(expected, actual)
+
+        # check -inf and nan handling
+        x = torch.tensor([-float('inf'), -float('inf'), 1.0, float('nan'), 1.0, 1.0], device=device)
+        x2d = x.unsqueeze(0).expand(2, -1)
+
+        for inp in (x, x2d):
+            actual = inp.logcumsumexp(axis)
+            expected = logcumsumexp(inp, axis)
+            self.assertEqual(expected, actual)
 
         # Check that out is actually inplace
         b = torch.randn(5, 2, device=device)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4147,7 +4147,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(expected, actual)
 
         # check -inf and nan handling
-        x = torch.tensor([-float('inf'), -float('inf'), 1.0, float('nan'), 1.0, 1.0], device=device)
+        x = torch.tensor([-float('inf'), -float('inf'), 1.0, 1.0, float('inf'), float('inf'), float('nan'), 1.0, 1.0], device=device)
         x2d = x.unsqueeze(0).expand(2, -1)
 
         for inp in (x, x2d):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4147,7 +4147,8 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(expected, actual)
 
         # check -inf and nan handling
-        x = torch.tensor([-float('inf'), -float('inf'), 1.0, 1.0, float('inf'), float('inf'), float('nan'), 1.0, 1.0], device=device)
+        x = torch.tensor([-float('inf'), -float('inf'), 1.0, 1.0, float('inf'),
+                         float('inf'), float('nan'), 1.0, 1.0], device=device)
         x2d = x.unsqueeze(0).expand(2, -1)
 
         for inp in (x, x2d):


### PR DESCRIPTION
Fixes #52213
Nans were previously inconsistently propagated due to std::min always returning first argument if one of the args in nan
when reduction functor was called on 2 `-inf` arguments, `std::min(x,y) - std::max(x,y)` resulted in `-inf - (-inf)` = nan, even though logcumsumexp is well defined for `-inf, -inf` pair. 