### PR TITLE
[FX][RFC] explicit dim annotations

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1630,6 +1630,26 @@ class TestFX(JitTestCase):
         input = torch.rand(3, 4)
         self.assertEqual(traced(input), Pair(input, input))
 
+    def test_dim_specialized_annotation(self):
+        def foo(x):
+            x = torch.fx.proxy.annotate_dim(x, 2)
+            for x in range(x.dim()):
+                x = x + 2.0
+            return x
+
+        self.checkGraphModule(foo, (torch.rand(3, 4),))
+
+    def test_dim_specialized_annotation_iter(self):
+        def foo(x):
+            x = torch.fx.proxy.annotate_dim(x, 2)
+            for s_x in x.shape:
+                x = x + s_x
+            return x
+
+        traced = symbolic_trace(foo)
+
+        self.checkGraphModule(foo, (torch.randn(3, 4),))
+
     def test_return_type_exists(self):
         class ReturnTypeModule(torch.nn.Module):
             def other(self, x: List[str]) -> List[str]:

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1633,7 +1633,7 @@ class TestFX(JitTestCase):
     def test_dim_specialized_annotation(self):
         def foo(x):
             x = torch.fx.proxy.annotate_dim(x, 2)
-            for x in range(x.dim()):
+            for _ in range(x.dim()):
                 x = x + 2.0
             return x
 
@@ -1645,8 +1645,6 @@ class TestFX(JitTestCase):
             for s_x in x.shape:
                 x = x + s_x
             return x
-
-        traced = symbolic_trace(foo)
 
         self.checkGraphModule(foo, (torch.randn(3, 4),))
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -231,12 +231,12 @@ class DimSpecializedProxy(Proxy):
         return self._dim
 
     def __iter__(self) -> Iterable['Proxy']:
-        return (self[i] for i in range(self._dim))
+        return (self[i] for i in range(self._dim))  # type: ignore
 
     @property
     def shape(self):
         shape = Proxy(self.node).shape
-        return tuple(shape[i] for i in range(self._dim))
+        return tuple(shape[i] for i in range(self._dim))  # type: ignore
 
     def __repr__(self):
         return f'DimSpecializedProxy({self.node}, dim={self.dim})'


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#52950 [FX][RFC] explicit dim annotations**

This patch demonstrates an API that can be used to inform `PyTorch` of preconditions on the dimensionality of certain tensors in the program. This allows for a) better program capture via symbolic tracing, as we can use this information to allow some restricted forms of control flow and b) potentially more predictable optimization opportunities.

The tests demonstrate two different cases:

```
def foo(x):
    x = torch.fx.proxy.annotate_dim(x, 2)
    for _ in range(x.dim()):
        x = x + 2.0
    return x
```

In this case, the user informs the system that x should have dimensionality 2. The annotate_dim function emits an assert and returns a special DimSpecializedProxy object with certain methods/properties defined.

For context, the emitted code for tracing that function looks like:

```
def forward(self, x):
    dim = x.dim()
    eq = dim == 2;  dim = None
    _assert = torch._assert(eq, 'Expected tensor to have dimension 2');  eq = None
    add = x + 2.0;  x = None
    add_1 = add + 2.0;  add = None
    return add_1
```

The code works as expected.

Similarly, the other test case is:

```
def foo(x):
    x = torch.fx.proxy.annotate_dim(x, 2)
    for s_x in x.shape:
        x = x + s_x
    return x
```

With emitted code:

```
def forward(self, x):
    dim = x.dim()
    eq = dim == 2;  dim = None
    _assert = torch._assert(eq, 'Expected tensor to have dimension 2');  eq = None
    getattr_1 = x.shape
    getitem = getattr_1[0]
    getitem_1 = getattr_1[1];  getattr_1 = None
    add = x + getitem;  x = getitem = None
    add_1 = add + getitem_1;  add = getitem_1 = None
    return add_1
```

Differential Revision: [D26703612](https://our.internmc.facebook.com/intern/diff/D26703612)