### PR TITLE
[WIP] Implement `cumulative_trapezoid` operator

### DIFF
--- a/aten/src/ATen/native/Integration.cpp
+++ b/aten/src/ATen/native/Integration.cpp
@@ -69,4 +69,34 @@ Tensor trapz(const Tensor& y, double dx, int64_t dim) {
     return do_trapz(y, dx, dim);
 }
 
+Tensor do_cumulative_trapezoid(const Tensor& y, const Tensor& dx, int64_t dim) {
+  Tensor left = y.slice(dim, 0, -1);
+  Tensor right = y.slice(dim, 1);
+
+  return ((left + right) * dx).cumsum(dim) / 2.;
+}
+
+Tensor cumulative_trapezoid(const Tensor& y, const Tensor& x, int64_t dim) {
+  dim = maybe_wrap_dim(dim, y);
+  // asking for the integral with zero samples is a bit nonsensical,
+  // but we'll return "0" to match numpy behavior.
+  if (y.size(dim) == 0) {
+      return zeros_like_except(y, dim);
+  }
+  Tensor x_viewed;
+  if (x.dim() == 1) {
+      TORCH_CHECK(x.size(0) == y.size(dim), "cumulative_trapezoid: There must be one `x` value for each sample point");
+      DimVector sizes(y.dim(), 1); // shape = [1] * y.
+      sizes[dim] = x.size(0); // shape[axis] = d.shape[0]
+      x_viewed = x.view(sizes);
+  } else {
+    x_viewed = x;
+  }
+  Tensor x_left = x_viewed.slice(dim, 0, -1);
+  Tensor x_right = x_viewed.slice(dim, 1);
+
+  Tensor dx = x_right - x_left;
+  return do_cumulative_trapezoid(y, dx, dim);
+}
+
 }} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3897,6 +3897,8 @@
 
 - func: trapz.dx(Tensor y, *, float dx=1, int dim=-1) -> Tensor
 
+- func: cumulative_trapezoid.x(Tensor y, Tensor x, *, int dim=-1) -> Tensor
+
 - func: _trilinear(Tensor i1, Tensor i2, Tensor i3, int[] expand1, int[] expand2, int[] expand3, int[] sumdim, int unroll_dim=1) -> Tensor
   dispatch:
     DefaultBackend: _trilinear

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -838,6 +838,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.trace: lambda input: -1,
         torch.transpose: lambda input, dim0, dim1: -1,
         torch.trapz: lambda y, x=None, dim=-1: -1,
+        torch.cumulative_trapezoid: lambda y, x=None, dim=-1: -1,
         torch.triangular_solve: lambda input, A, upper=True, transpose=False, unitriangular=False: -1,
         torch.tril: lambda input, diagonal=0, out=None: -1,
         torch.triplet_margin_loss: (lambda anchor, positive, negative, margin=1.0, p=2, eps=1e-06, swap=False,


### PR DESCRIPTION
Fixes #52552

The current PR is a WIP. I tried to implement the `cumulative_trapezoid`.

I saw that combining both the numpy implementation of trapz https://github.com/numpy/numpy/blob/master/numpy/lib/function_base.py#L4082 and the scipy implementation of the cumulative trapezoid would yield that to implement the cumulative trapezoid, we will just have to add the cumulative sum step at the end.

I submitted this PR to get feedback about my approach. After that the next steps for this PR will be:
1. Implement the other version of the same function when `dx` is constant.
2. Implement another version of the function that take the `intial` parameter, similar to the scipy function.
3. Add tests.

