### PR TITLE
Fixed the error of generator in the RandomSampler.

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -121,7 +121,7 @@ class RandomSampler(Sampler[int]):
                 yield from torch.randint(high=n, size=(32,), dtype=torch.int64, generator=generator).tolist()
             yield from torch.randint(high=n, size=(self.num_samples % 32,), dtype=torch.int64, generator=generator).tolist()
         else:
-            yield from torch.randperm(n, generator=self.generator).tolist()
+            yield from torch.randperm(n, generator=generator).tolist()
 
     def __len__(self):
         return self.num_samples


### PR DESCRIPTION
In  `__iter__` of the `RandomSampler`, when `self.replacement` is `False` in the original code, `self.generator` is always used in the `torch.randperm` instead of the generator we set.

Fixes #52568