### PR TITLE
[doc] reorg dist init and non-init functions

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -263,7 +263,7 @@ This is the default method, meaning that ``init_method`` does not have to be spe
 can be ``env://``).
 
 Post-Initialization
---------------
+-------------------
 
 Once :func:`torch.distributed.init_process_group` was run, the following functions can be used. To
 check whether the process group has already been initialized use :func:`torch.distributed.is_initialized`.

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -174,6 +174,17 @@ joined.
 
 .. autofunction:: init_process_group
 
+.. autofunction:: is_initialized
+
+.. autofunction:: is_mpi_available
+
+.. autofunction:: is_nccl_available
+
+Post-Initialization
+--------------
+
+Once :func:`torch.distributed.init_process_group` was run, the following functions become available. You may need to call :func:`torch.distributed.is_initialized` to make sure it was called before using these functions.
+
 .. autoclass:: Backend
 
 .. autofunction:: get_backend
@@ -181,12 +192,6 @@ joined.
 .. autofunction:: get_rank
 
 .. autofunction:: get_world_size
-
-.. autofunction:: is_initialized
-
-.. autofunction:: is_mpi_available
-
-.. autofunction:: is_nccl_available
 
 --------------------------------------------------------------------------------
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -180,22 +180,6 @@ joined.
 
 .. autofunction:: is_nccl_available
 
-Post-Initialization
---------------
-
-Once :func:`torch.distributed.init_process_group` was run, the following functions can be used. To
-check whether the process group has already been initialized use :func:`torch.distributed.is_initialized`.
-
-.. autoclass:: Backend
-
-.. autofunction:: get_backend
-
-.. autofunction:: get_rank
-
-.. autofunction:: get_world_size
-
---------------------------------------------------------------------------------
-
 Currently three initialization methods are supported:
 
 TCP initialization
@@ -275,6 +259,22 @@ The machine with rank 0 will be used to set up all connections.
 
 This is the default method, meaning that ``init_method`` does not have to be specified (or
 can be ``env://``).
+
+Post-Initialization
+--------------
+
+Once :func:`torch.distributed.init_process_group` was run, the following functions can be used. To
+check whether the process group has already been initialized use :func:`torch.distributed.is_initialized`.
+
+.. autoclass:: Backend
+
+.. autofunction:: get_backend
+
+.. autofunction:: get_rank
+
+.. autofunction:: get_world_size
+
+--------------------------------------------------------------------------------
 
 Distributed Key-Value Store
 ---------------------------

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -183,7 +183,9 @@ joined.
 Post-Initialization
 --------------
 
-Once :func:`torch.distributed.init_process_group` was run, the following functions become available. You may need to call :func:`torch.distributed.is_initialized` to make sure it was called before using these functions.
+Once :func:`torch.distributed.init_process_group` was run, the following functions become available.
+You may need to call :func:`torch.distributed.is_initialized` to make sure it was called before
+using these functions.
 
 .. autoclass:: Backend
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -257,7 +257,7 @@ are:
 * ``WORLD_SIZE`` - required; can be set either here, or in a call to init function
 * ``RANK`` - required; can be set either here, or in a call to init function
 
-The machine with rank 0 will be used to set up all connections.
+The process with rank 0 will be used to set up all connections.
 
 This is the default method, meaning that ``init_method`` does not have to be specified (or
 can be ``env://``).

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -257,7 +257,7 @@ are:
 * ``WORLD_SIZE`` - required; can be set either here, or in a call to init function
 * ``RANK`` - required; can be set either here, or in a call to init function
 
-The process with rank 0 will be used to set up all connections.
+The machine with rank 0 will be used to set up all connections.
 
 This is the default method, meaning that ``init_method`` does not have to be specified (or
 can be ``env://``).

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -180,6 +180,8 @@ joined.
 
 .. autofunction:: is_nccl_available
 
+--------------------------------------------------------------------------------
+
 Currently three initialization methods are supported:
 
 TCP initialization

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -183,9 +183,8 @@ joined.
 Post-Initialization
 --------------
 
-Once :func:`torch.distributed.init_process_group` was run, the following functions become available.
-You may need to call :func:`torch.distributed.is_initialized` to make sure it was called before
-using these functions.
+Once :func:`torch.distributed.init_process_group` was run, the following functions can be used. To
+check whether the process group has already been initialized use :func:`torch.distributed.is_initialized`.
 
 .. autoclass:: Backend
 


### PR DESCRIPTION
This PR proposes to improve the distributed doc:

* [x] putting the init functions together
* [x] moving post-init functions into their own sub-section as they are only available after init and moving that group to after all init sub-sections

If this is too much, could we at least put these 2 functions together:

```
.. autofunction:: init_process_group

.. autofunction:: is_initialized
```
as they are interconnected. and the other functions are not alphabetically sorted in the first place.

Thank you.