### PR TITLE
[ZeroRedundancyOptimizer] Buckets as tensor view + minimize public interface

### DIFF
--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -14,14 +14,13 @@ import torch
 import torch.distributed as dist
 from torch.nn import Parameter
 from torch.optim import Optimizer
+import logging
 
 __all__ = ["ZeroRedundancyOptimizer"]
 
 
 # Credits:  classy_vision/generic/distributed_util.py
-def _recursive_copy_to_device(
-    value: Any, non_blocking: bool, device: torch.device
-) -> Any:
+def _recursive_copy_to_device(value: Any, non_blocking: bool, device: torch.device) -> Any:
     """
     Recursively searches lists, tuples, dicts and copies tensors to device if
     possible. Non-tensor values are passed as-is in the result.
@@ -35,21 +34,19 @@ def _recursive_copy_to_device(
         return value.to(device, non_blocking=non_blocking)
 
     if isinstance(value, (list, tuple)):
-        values = [
-            _recursive_copy_to_device(val, non_blocking=non_blocking, device=device)
-            for val in value
-        ]
+        values = [_recursive_copy_to_device(val, non_blocking=non_blocking, device=device) for val in value]
         return values if isinstance(value, list) else tuple(values)
 
     if isinstance(value, collections.abc.Mapping):
         return {
-            key: _recursive_copy_to_device(
-                val, non_blocking=non_blocking, device=device
-            )
-            for key, val in value.items()
+            key: _recursive_copy_to_device(val, non_blocking=non_blocking, device=device) for key, val in value.items()
         }
 
     return value
+
+
+def _is_trainable(param: torch.Tensor) -> bool:
+    return param.requires_grad
 
 
 def _broadcast_object(
@@ -76,9 +73,7 @@ def _broadcast_object(
         # Fetch from the source
         length_tensor = torch.LongTensor([0]).to(dist_device)
         dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        data_recv_tensor = torch.empty(
-            [int(length_tensor.item())], dtype=torch.uint8, device=dist_device
-        )
+        data_recv_tensor = torch.empty([int(length_tensor.item())], dtype=torch.uint8, device=dist_device)
         dist.broadcast(data_recv_tensor, src=src_rank, group=group, async_op=False)
         buffer = io.BytesIO(data_recv_tensor.cpu().numpy())
         obj = torch.load(buffer, map_location=dist_device)
@@ -109,10 +104,15 @@ class ZeroRedundancyOptimizer(Optimizer):
         params (list of tensors):
             parameters to be optimized
     Keyword Args:
-        optim (torch.nn.Optimizer): optimizer to shard
-        group (group): torch.distributed group (default: group.WORLD)
-        bucket_cap (int): the size of the buffer used to batch the small parameter tensors,
-            in number of elements (default 16M)
+        optim (torch.nn.Optimizer):
+            optimizer to shard
+
+        group (group):
+            torch.distributed group (default: group.WORLD)
+
+        parameters_as_bucket_views (bool):
+            whether to pack the parameters into bigger buckets, which speeds up communications.
+            If this is enabled, `params.data` should not be modified outside of ZeroRedundancyOptimizer.
         **default: all trailing arguments will be forwarded to the requested optimizer
 
     .. warning: ZeroRedundancyOptimizer is experimental and subject to change.
@@ -126,7 +126,7 @@ class ZeroRedundancyOptimizer(Optimizer):
         params,
         optim: Type[Optimizer],
         group: Optional[Any] = None,
-        bucket_cap_kb: int = 2 ** 24,
+        parameters_as_bucket_view: bool = False,
         **default: Any,
     ):
         # Hold all the model params in the root .param_groups
@@ -137,46 +137,40 @@ class ZeroRedundancyOptimizer(Optimizer):
         super().__init__(params, default)
 
         # Partition information. lazy evaluation, computed if requested
-        self._per_device_params: "OrderedDict[torch.device, List[List[Parameter]]]" = (
+        self._per_device_params_cache: "OrderedDict[torch.device, List[List[Parameter]]]" = (
             OrderedDict()
         )  # device, rank, params
-        self._param_rank: Dict[torch.Tensor, int] = {}
+        self._param_rank_cache: Dict[torch.Tensor, int] = {}
         self._param_to_index_cache: Dict[int, int] = {}
-        self._partition_parameters: List[List[Dict]] = []
+        self._partition_parameters_cache: List[List[Dict]] = []
         self._index_to_param_cache: Dict[int, torch.Tensor] = {}
+        self._all_params = params
+        self._reference_is_trainable_mask = list(map(_is_trainable, self._all_params))
 
         # Build the wrapped optimizer, responsible for a shard of the params
         self.group = group if group is not None else dist.group.WORLD
         self.world_size = dist.get_world_size(self.group)
         self.rank = dist.get_rank(self.group)
         self.global_rank = _get_global_rank(self.group, self.rank)
+        self.parameters_as_bucket_view = parameters_as_bucket_view
 
-        self.optim = optim(self.partition_parameters()[self.rank], **default)
-
-        # - Sync local and global param_groups keys
-        for global_group, local_group in zip(
-            self.param_groups, self.optim.param_groups
-        ):
-            for k, v in local_group.items():
-                if k != "params":
-                    global_group[k] = v
+        self._optim_defaults = default
+        self._optim_constructor = optim
 
         #  Optional consolidated optimizer state
         self._all_states: List[Dict[str, Any]] = []
 
         # Current default device is set by the parameters allocated to this rank
-        self._device = list(self.per_device_params.keys())[0]
+        self._device = list(self._per_device_params.keys())[0]
         self.buckets: Dict[torch.device, List[torch.Tensor]] = {}
-        self.bucket_max_size = bucket_cap_kb
 
-        self.should_bucket_param: List[bool] = []
-        self._setup_bucket_strategy()
+        self._update_trainable()
         self.initialized = True
 
     def _clear_cache(self) -> None:
-        self._partition_parameters.clear()
-        self._per_device_params.clear()
-        self._param_rank.clear()
+        self._partition_parameters_cache.clear()
+        self._per_device_params_cache.clear()
+        self._param_rank_cache.clear()
         self._index_to_param_cache.clear()
         self._param_to_index_cache.clear()
 
@@ -205,7 +199,8 @@ class ZeroRedundancyOptimizer(Optimizer):
                 self.optim.add_param_group(param_groups[-1])
 
             # Update the bucketing strategy accordingly
-            self._setup_bucket_strategy()
+            if self.parameters_as_bucket_view:
+                self._setup_flat_buffers()
 
     def consolidate_state_dict(self, recipient_rank: int = 0) -> None:
         """Update the consolidated state_dict list, one per rank.
@@ -248,9 +243,7 @@ class ZeroRedundancyOptimizer(Optimizer):
                     )
 
                     self._all_states.append(
-                        _recursive_copy_to_device(
-                            replica_state, non_blocking=True, device=torch.device("cpu")
-                        )
+                        _recursive_copy_to_device(replica_state, non_blocking=True, device=torch.device("cpu"))
                     )
             else:
                 # Acknowledge broadcasts, and send this rank's shard when needed
@@ -281,8 +274,8 @@ class ZeroRedundancyOptimizer(Optimizer):
             corresponds to rank 0, etc. We need all the ranks for the broadcast
             inside ``step()``.
         """
-        if len(self._partition_parameters) == 0:
-            self._partition_parameters = [list() for _ in range(self.world_size)]
+        if len(self._partition_parameters_cache) == 0:
+            self._partition_parameters_cache = [list() for _ in range(self.world_size)]
             sizes = [0] * self.world_size
             for param_group in self.param_groups:
                 param_lists: List[List] = [list() for _ in range(self.world_size)]
@@ -295,55 +288,50 @@ class ZeroRedundancyOptimizer(Optimizer):
                 for rank, params in enumerate(param_lists):
                     param_group_rank = copy.copy(param_group)
                     param_group_rank["params"] = params
-                    self._partition_parameters[rank].append(param_group_rank)
+                    self._partition_parameters_cache[rank].append(param_group_rank)
 
-        return self._partition_parameters
+        return self._partition_parameters_cache
 
     @property
-    def per_device_params(self) -> Dict[torch.device, List[List[Parameter]]]:
+    def _per_device_params(self) -> Dict[torch.device, List[List[Parameter]]]:
         """Sorted list of all the params, first per device then per rank.
 
         Within a list params are sorted per number of elements to allow for an easy bucketing.
         """
-        if len(self._per_device_params) == 0:
+        if len(self._per_device_params_cache) == 0:
             # Go through all params, log them per device
             # The ordering is important here, needs to be the same on all ranks
             # So that ulterior broadcast calls are matching
             for param_group in self.param_groups:
                 for param in param_group["params"]:
                     device = param.device
-                    if self._per_device_params.get(device) is None:
-                        self._per_device_params[device] = [
-                            [] for _ in range(self.world_size)
-                        ]
-                    self._per_device_params[device][self.param_to_rank[param]] += [
-                        param
-                    ]
+                    if self._per_device_params_cache.get(device) is None:
+                        self._per_device_params_cache[device] = [[] for _ in range(self.world_size)]
+                    self._per_device_params_cache[device][self._param_to_rank[param]] += [param]
 
             # Sort param_lists by size
-            for k in self._per_device_params.keys():
-                for r in self._per_device_params[k]:
+            for k in self._per_device_params_cache.keys():
+                for r in self._per_device_params_cache[k]:
                     r.sort(key=lambda x: x.numel())
 
-        return self._per_device_params
+        return self._per_device_params_cache
 
     @property
-    def param_to_rank(self) -> Dict[torch.Tensor, int]:
+    def _param_to_rank(self) -> Dict[torch.Tensor, int]:
         """Look up table to match a given param with a data parallel rank"""
-        if len(self._param_rank) == 0:
+        if len(self._param_rank_cache) == 0:
             for rank, param_groups in enumerate(self.partition_parameters()):
                 for param_group in param_groups:
                     for param in param_group["params"]:
-                        self._param_rank[param] = rank
-        return self._param_rank
+                        self._param_rank_cache[param] = rank
+        return self._param_rank_cache
 
     @property
     def _param_to_index(self) -> Dict[int, int]:
         """Hash table in between parameter indices in the global optimizer scheme, and the actual params"""
         if len(self._param_to_index_cache) == 0:
             self._param_to_index_cache = {
-                id(p): i
-                for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
+                id(p): i for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
             }
 
         return self._param_to_index_cache
@@ -352,16 +340,11 @@ class ZeroRedundancyOptimizer(Optimizer):
     def _index_to_param(self) -> Dict[int, torch.Tensor]:
         """Hash table in between parameter indices in the global optimizer scheme, and the actual params"""
         if len(self._index_to_param_cache) == 0:
-            self._index_to_param_cache = {
-                i: p
-                for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
-            }
+            self._index_to_param_cache = {i: p for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))}
 
         return self._index_to_param_cache
 
-    def step(
-        self, closure: Optional[Callable[[], float]] = None, **kwargs: Any
-    ) -> Optional[float]:
+    def step(self, closure: Optional[Callable[[], float]] = None, **kwargs: Any) -> Optional[float]:
         """Performs a single optimization step (parameter update).
 
         Arguments:
@@ -371,6 +354,15 @@ class ZeroRedundancyOptimizer(Optimizer):
             optional loss, depends on the underlying optimizer
 
         .. note: Any extra parameter is passed to the base optimizer as-is"""
+
+        # Check whether the model trainability graph changed
+        trainable_mask = list(map(_is_trainable, self._all_params))
+        if trainable_mask != self._reference_is_trainable_mask:
+            logging.warning(
+                "ZeroRedundancyOptimizer detected that the trainable params changed, updating the partitioning"
+            )
+            self._update_trainable()
+            self._reference_is_trainable_mask = trainable_mask
 
         # Sync oss param_groups attributes in case they've been updated by a scheduler.
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
@@ -382,7 +374,22 @@ class ZeroRedundancyOptimizer(Optimizer):
             loss = self.optim.step(**kwargs)
 
         # Sync all the updated shards in between the ranks
-        self._broadcast_params()
+        handles = []
+        if self.parameters_as_bucket_view:
+            for device in self.buckets.keys():
+                for src_rank, bucket in enumerate(self.buckets[device]):
+                    global_src_rank = _get_global_rank(self.group, src_rank)
+                    handles.append(dist.broadcast(tensor=bucket, src=global_src_rank, group=self.group, async_op=True))
+        else:
+            for device, per_rank_params in self._per_device_params.items():
+                for dst_rank, params in enumerate(per_rank_params):
+                    global_dst_rank = _get_global_rank(self.group, dst_rank)
+                    for param in params:
+                        handles.append(
+                            dist.broadcast(tensor=param.data, src=global_dst_rank, group=self.group, async_op=True)
+                        )
+
+        _ = list(map(lambda x: x.wait(), handles))
 
         # Sync hypothethical new results from the wrapped optimizer to the exposed param_groups
         self._sync_param_groups(self.optim.param_groups, self.param_groups)
@@ -401,22 +408,16 @@ class ZeroRedundancyOptimizer(Optimizer):
             param = self._index_to_param[key]
 
             # Populate the sharded optimizer state on the fly
-            if self.param_to_rank[param] != self.rank:
+            if self._param_to_rank[param] != self.rank:
                 state_dict["state"][key] = None
             else:
-                self.optim.state[param] = _recursive_copy_to_device(
-                    value, non_blocking=True, device=param.device
-                )
+                self.optim.state[param] = _recursive_copy_to_device(value, non_blocking=True, device=param.device)
 
         super().load_state_dict(state_dict)
 
         # Sync with the optimizer param groups
-        ZeroRedundancyOptimizer._sync_param_groups(
-            state_dict["param_groups"], self.param_groups
-        )
-        ZeroRedundancyOptimizer._sync_param_groups(
-            self.param_groups, self.optim.param_groups
-        )
+        ZeroRedundancyOptimizer._sync_param_groups(state_dict["param_groups"], self.param_groups)
+        ZeroRedundancyOptimizer._sync_param_groups(self.param_groups, self.optim.param_groups)
 
     def local_state_dict(self) -> Dict:
         """Gets this rank's ``state_dict``.
@@ -458,20 +459,15 @@ class ZeroRedundancyOptimizer(Optimizer):
         # - go through the per-shard states, which are all indexed locally
         for rank, s in enumerate(self._all_states):
             # -- match the local indexing and the global partition, update the corresponding saved state globally
-            for local_pg, global_pg in zip(
-                s["param_groups"], self.partition_parameters()[rank]
-            ):
+            for local_pg, global_pg in zip(s["param_groups"], self.partition_parameters()[rank]):
                 local_index_to_param_id = {
-                    i_param: id(global_pg["params"][i])
-                    for i, i_param in enumerate(local_pg["params"])
+                    i_param: id(global_pg["params"][i]) for i, i_param in enumerate(local_pg["params"])
                 }
 
                 for local_param_index in local_pg["params"]:
                     # Update the state, if any
                     if local_param_index in s["state"].keys():
-                        global_id = self._param_to_index[
-                            local_index_to_param_id[local_param_index]
-                        ]
+                        global_id = self._param_to_index[local_index_to_param_id[local_param_index]]
                         state_dict["state"][global_id] = s["state"][local_param_index]
 
         # Make sure that the parameters are sorted in the state, as expected
@@ -486,15 +482,11 @@ class ZeroRedundancyOptimizer(Optimizer):
             rank (int): rank to get local_state_dict for
             state_dict (dict): global state_dict
         """
-        param_groups = state_dict["param_groups"][
-            state_dict["partition"][rank][0] : state_dict["partition"][rank][1]
-        ]
+        param_groups = state_dict["param_groups"][state_dict["partition"][rank][0] : state_dict["partition"][rank][1]]
         return {"state": state_dict["state"][rank], "param_groups": param_groups}
 
     @staticmethod
-    def _sync_param_groups(
-        source: List[Dict[Any, Any]], destination: List[Dict[Any, Any]]
-    ) -> None:
+    def _sync_param_groups(source: List[Dict[Any, Any]], destination: List[Dict[Any, Any]]) -> None:
         """Sync learning rate and other optimizer attributes (needed to support schedulers)."""
 
         for source_group, destination_group in zip(source, destination):
@@ -502,96 +494,57 @@ class ZeroRedundancyOptimizer(Optimizer):
             for k in filter(lambda x: x != "params", source_group.keys()):
                 destination_group[k] = source_group[k]
 
-    def _broadcast_params(self) -> None:
-        """Helper function to broadcast all the parameters from a given device"""
-
-        i_param = 0
-        handles: List[Any] = []
-
-        for (
-            device,
-            device_params,
-        ) in (
-            self.per_device_params.items()
-        ):  # all the params on this device (inc all ranks)
-            buckets = self.buckets[device]
-            # Bucket and issue all the async calls
-            for (src_rank, params), bucket in zip(enumerate(device_params), buckets):
-                global_src_rank = _get_global_rank(self.group, src_rank)
-
-                # Direct broadcasts only
-                for param in params:
-                    if not self.should_bucket_param[i_param]:
-                        handles.append(
-                            dist.broadcast(
-                                tensor=param.data,
-                                src=global_src_rank,
-                                group=self.group,
-                                async_op=True,
-                            )
-                        )
-
-                    i_param += 1
-
-                # Bucket broadcasts
-                if bucket.numel() > 0:
-                    handles.append(
-                        dist.broadcast(
-                            tensor=bucket,
-                            src=global_src_rank,
-                            group=self.group,
-                            async_op=True,
-                        )
-                    )
-
-        # Wait for all the calls
-        _ = list(map(lambda x: x.wait(), handles))
-
-    def _setup_bucket_strategy(self) -> None:
-        """Tag parameters to either bucket them or broadcast/reduce them directly.
-
-        The parameters are ordered (smallest first), the bucket will hold the smallest elements,
-        the remaining ones will be directly sent.
-
-        Generating the partition once and for all allows us to save some time at runtime, and to know when all the
-        network requests have been issued. The parameters which are part of a bucket become tensor views.
+    def _setup_flat_buffers(self) -> None:
+        """Make all params which are on the same device and tied to the same rank views of a single buffer.
+        This is used at construction time, and anytime parameter trainability is changed (frozen or unfrozen) and
+        `_update_trainable` is called.
         """
 
-        # Allocate one buffer per rank and per device to group the small parameters
-        for device, per_device in self.per_device_params.items():
-            self.buckets[device] = [
-                torch.zeros(
-                    self.bucket_max_size, dtype=per_device[0][0].dtype, device=device
-                )
-                for _ in range(len(per_device))
-            ]
+        for device, per_rank_params in self._per_device_params.items():
+            # Only wipe the existing buckets if there are none
+            # (could be that this is called twice, when trainability changes)
+            if device not in self.buckets.keys():
+                self.buckets[device] = []
 
-        # Pack the smallest elements in a bucket, depending on their owner shard-wise
-        for device, per_rank_params in self.per_device_params.items():
+            # Make parameters a view of the bucket
             for dst_rank, params in enumerate(per_rank_params):
-                offset = 0
+                if len(params) > 0:
 
-                for param in params:
-                    # Criteria to decide whether this parameter is to be bucketed or not:
-                    # - enough room in the bucket
-                    if (
-                        param.requires_grad
-                        and (offset + param.numel()) < self.bucket_max_size
-                    ):
-                        self.should_bucket_param.append(True)
+                    # Clone the non-trainable params, if in a bucket it will get destroyed
+                    for param in filter(lambda x: not x.requires_grad, params):
+                        param.data = param.data.detach().clone()
 
-                        # This parameter becomes a view of the bucket
+                    # Merge all the trainable params in a single bucket
+                    trainable_params = list(filter(_is_trainable, params))
+                    buffer_size = sum(map(lambda x: x.numel(), trainable_params))
+                    bucket = torch.empty(buffer_size, dtype=params[0].dtype, device=device)
+                    offset = 0
+
+                    for param in trainable_params:
                         offset_next = offset + param.numel()
-
-                        self.buckets[device][dst_rank][
-                            offset:offset_next
-                        ] = param.data.flatten()
-                        param.data = self.buckets[device][dst_rank][
-                            offset:offset_next
-                        ].view_as(param.data)
+                        bucket[offset:offset_next].copy_(param.data.flatten())
+                        param.data = bucket[offset:offset_next].view_as(param.data)
                         offset = offset_next
-                    else:
-                        self.should_bucket_param.append(False)
 
-                # Resize the bucket to remove lost space in the end
-                self.buckets[device][dst_rank].resize_(offset)
+                    # Either replace the existing bucket, or create it
+                    if len(self.buckets[device]) == dst_rank:
+                        self.buckets[device].append(bucket)
+                    else:
+                        self.buckets[device][dst_rank] = bucket
+                else:
+                    self.buckets[device].append(torch.zeros(1, device=device))
+
+    def _update_trainable(self) -> None:
+        """Updates the partitioning and communication patterns if the trainability (`requires_grad`)
+        of some parameters changed.
+        """
+
+        # Create the optim which will work on the param shard
+        if not hasattr(self, "optim"):
+            self._clear_cache()
+            self._default_device = list(self._per_device_params.keys())[0]
+            self.optim = self._optim_constructor(self.partition_parameters()[self.rank], **self._optim_defaults)
+            self._sync_param_groups(self.optim.param_groups, self.param_groups)
+
+        if self.parameters_as_bucket_view:
+            self._setup_flat_buffers()


### PR DESCRIPTION
Updated version following  #52764 (including comments from Shen), but this one I expect to be able to land. 
ZeroRedundancyOptimizer:
- bucket as tensor views, optional
- make a lot of attributes private
- minor unit test refactor
- adding coverage in the unit test for with and without bucket views
