### PR TITLE
[reland][quant][graphmode][fx][fp16] Add fp16 support for {add|mul}{_relu} (#52714)

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -1870,7 +1870,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             self.checkGraphModeFxOp(
                 model, data, QuantType.DYNAMIC, qlinear_fun,
                 is_reference=is_reference,
-                custom_qconfig=float16_dynamic_qconfig,
+                custom_qconfig_dict={"": float16_dynamic_qconfig},
                 prepare_expected_node_occurrence=prepare_node_occurrence,
                 expected_node_occurrence=convert_node_occurrence)
 
@@ -1921,7 +1921,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             self.checkGraphModeFxOp(
                 model, data, QuantType.DYNAMIC, linear_fun,
                 is_reference=is_reference,
-                custom_qconfig=float16_static_qconfig,
+                custom_qconfig_dict={"": float16_static_qconfig},
                 prepare_expected_node_occurrence=prepare_node_occurrence,
                 expected_node_occurrence=convert_node_occurrence)
 
@@ -2132,11 +2132,40 @@ class TestQuantizeFxOps(QuantizationTestCase):
         quantized_node = ns.call_function(quantized_op)
         options = itertools.product([True, False], [True, False])
         quant_type = QuantType.STATIC
+        # testing for default int8 static quant
         for is_inplace, is_scalar in options:
             self.checkGraphModeFxOp(
                 Op(is_inplace, is_scalar), data, quant_type, quantized_node)
             self.checkGraphModeFxOp(
-                NonQuantizedInput(is_inplace, is_scalar), data, quant_type, quantized_node, print_debug_info=True)
+                NonQuantizedInput(is_inplace, is_scalar), data, quant_type, quantized_node)
+
+        # testing for fp16 static quant
+        # we are producing fp16 patterns
+        options = itertools.product([True, False], [True, False])
+        custom_qconfig_dict = {
+            "object_type": [(binary_op, float16_static_qconfig)]
+        }
+        for is_inplace, is_scalar in options:
+            node_occurrence = {
+                # output_conv1, output_add1, output_add2 for scalar
+                # output_conv1, output_conv2, output_add1, output_add2 for non-scalar
+                ns.call_method("to"): 3 if is_scalar else 4
+            }
+            self.checkGraphModeFxOp(
+                Op(is_inplace, is_scalar), data, quant_type,
+                expected_node_occurrence=node_occurrence,
+                custom_qconfig_dict=custom_qconfig_dict)
+
+            node_occurrence = {
+                # input_add, output_add for scalar
+                # input_add1, input_add2, output_add for non-scalar
+                ns.call_method("to"): 2 if is_scalar else 3
+            }
+            self.checkGraphModeFxOp(
+                NonQuantizedInput(is_inplace, is_scalar), data, quant_type,
+                expected_node_occurrence=node_occurrence,
+                custom_qconfig_dict=custom_qconfig_dict)
+
 
     def _test_quantized_binary_op_relu_impl(self, binary_op, ibinary_op, quantized_op):
         class OpRelu(torch.nn.Module):
@@ -2170,6 +2199,23 @@ class TestQuantizeFxOps(QuantizationTestCase):
             self.checkGraphModeFxOp(
                 OpRelu(is_inplace_op, is_functional_relu, is_scalar),
                 data, quant_type, quantized_node)
+
+        options = itertools.product(
+            [True, False], [True, False], [True, False])
+        custom_qconfig_dict = {
+            "": float16_static_qconfig,
+            "object_type": [(torch.nn.Conv2d, None)]
+        }
+        for is_inplace_op, is_functional_relu, is_scalar in options:
+            node_occurrence = {
+                ns.call_method("to"): 3 if is_scalar else 4
+            }
+            self.checkGraphModeFxOp(
+                OpRelu(is_inplace_op, is_functional_relu, is_scalar),
+                data, quant_type, custom_qconfig_dict=custom_qconfig_dict,
+                expected_node_occurrence=node_occurrence,
+                print_debug_info=True)
+
 
     @skipIfNoFBGEMM
     def test_add(self):
@@ -2957,7 +3003,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 inputs,
                 QuantType.DYNAMIC,
                 quantized_node,
-                custom_qconfig=float_qparams_qconfig
+                custom_qconfig_dict={"": float_qparams_qconfig}
             )
 
         # check it works in None and static qconfig

--- a/torch/quantization/fx/qconfig_utils.py
+++ b/torch/quantization/fx/qconfig_utils.py
@@ -1,6 +1,6 @@
 import torch
 from collections import OrderedDict
-from typing import Union, Callable, Any
+from typing import Union, Callable, Any, Dict
 import re
 
 from .utils import _parent_name
@@ -38,14 +38,14 @@ def get_flattened_qconfig_dict(qconfig_dict):
 
     def flatten_key(key):
         if key in qconfig_dict:
-            for obj, qconfig in qconfig_dict[key]:
+            for (obj, qconfig) in qconfig_dict[key].items():
                 flattened[obj] = qconfig
 
     flatten_key('object_type')
     flatten_key('module_name')
     return flattened
 
-def convert_dict_to_ordered_dict(qconfig_dict):
+def convert_dict_to_ordered_dict(qconfig_dict: Any) -> Dict[str, Dict[Any, Any]]:
     """ Convert dict in qconfig_dict to ordered dict
     """
     # convert a qconfig list for a type to OrderedDict
@@ -55,6 +55,7 @@ def convert_dict_to_ordered_dict(qconfig_dict):
     _convert_to_ordered_dict('object_type', qconfig_dict)
     _convert_to_ordered_dict('module_name_regex', qconfig_dict)
     _convert_to_ordered_dict('module_name', qconfig_dict)
+    return qconfig_dict
 
 def get_object_type_qconfig(
         qconfig_dict: Any,

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -171,7 +171,8 @@ class BinaryOp(QuantizeHandler):
                 op = quantizer.quantized_graph.create_node(
                     'call_function', self.qop, add_args, kwargs)
                 return op
-        elif dtypes in [(torch.float16, torch.float16, None)]:
+        else:
+            assert dtypes == (torch.float16, torch.float16, None)
             # TODO (refactor) this is duplicated, maybe have a helper function
             if self.relu_node:
                 op_out = quantizer.quantized_graph.node_copy(self.bop_node, load_arg(quantized=False))

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -221,6 +221,14 @@ def insert_observer_for_output_of_the_node(
             if (input_is_observed(input_node.args[0]) or
                     input_is_observed(input_node.args[1])):
                 observed_node_names_set.add(node.name)
+
+            if activation_dtype(qconfig) == torch.float16:
+                # observer for outputs
+                new_observer = qconfig.activation()
+                insert_observer(
+                    node, new_observer, model,
+                    activation_post_process_map, env, observed_graph,
+                    load_arg, observed_node_names_set)
         elif isinstance(quantize_handler,
                         StandaloneModuleQuantizeHandler):
             assert node.op == "call_module"
@@ -423,6 +431,7 @@ class Quantizer:
         self.patterns = get_combined_dict(
             get_default_quant_patterns(), additional_quant_patterns)
 
+        convert_dict_to_ordered_dict(qconfig_dict)
         flattened_qconfig_dict = get_flattened_qconfig_dict(qconfig_dict)
         # TODO: support regex as well
         propagate_qconfig_(model, flattened_qconfig_dict)
@@ -433,7 +442,6 @@ class Quantizer:
 
         self.modules = dict(model.named_modules())
 
-        convert_dict_to_ordered_dict(qconfig_dict)
         # map from node name to qconfig, used in _find_matches
         self._generate_qconfig_map(model, model.graph, qconfig_dict, node_name_to_scope)
 

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -698,7 +698,7 @@ class QuantizationTestCase(TestCase):
                                expected_node_list=None,
                                is_reference=False,
                                print_debug_info=False,
-                               custom_qconfig=None,
+                               custom_qconfig_dict=None,
                                prepare_expected_node=None,
                                prepare_expected_node_occurrence=None,
                                prepare_expected_node_list=None,
@@ -723,7 +723,7 @@ class QuantizationTestCase(TestCase):
                                 NodeSpec.call_method('dequantize')]
                     is_reference: if True, enables reference mode
                     print_debug_info: if True, prints debug info
-                    custom_qconfig: overrides default qconfig
+                    custom_qconfig_dict: overrides default qconfig_dict
                     prepare_expected_node: same as expected_node, but for prepare
                     prepare_expected_node_occurrence: same as
                         expected_node_occurrence, but for prepare
@@ -744,16 +744,15 @@ class QuantizationTestCase(TestCase):
                 qconfig = default_dynamic_qconfig
                 model.eval()
 
-            # overwrite qconfig with custom_qconfig
-            if custom_qconfig is not None:
-                qconfig = custom_qconfig
-
             if quant_type == QuantType.QAT:
                 prepare = prepare_qat_fx
             else:
                 prepare = prepare_fx
 
-            qconfig_dict = {'': qconfig}
+            qconfig_dict = {"": qconfig}
+            # overwrite qconfig_dict with custom_qconfig_dict
+            if custom_qconfig_dict is not None:
+                qconfig_dict = custom_qconfig_dict
             prepared = prepare(
                 model, qconfig_dict,
                 prepare_custom_config_dict=prepare_custom_config_dict)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53021 [quant][graphmode][fx] Add support for fp16 bmm pattern (#52808)
* #53020 [reland][quant][graphmode][fx][test][refactor] Refactoring binary op tests to split int8 and float16 tests (#52807)
* **#53019 [reland][quant][graphmode][fx][fp16] Add fp16 support for {add|mul}{_relu} (#52714)**

Summary:

Test Plan:
python test/test_quantization.py TestQuantizedOps.test_add
python test/test_quantization.py TestQuantizedOps.test_mul
python test/test_quantization.py TestQuantizedOps.test_add_relu
python test/test_quantization.py TestQuantizedOps.test_mul_relu

Imported from OSS

Reviewed By: vkuzo

Differential Revision: [D26725350](https://our.internmc.facebook.com/intern/diff/D26725350)