### PR TITLE
Add default arguments to cuda stream and events

### DIFF
--- a/test/cpp/jit/tests_setup.py
+++ b/test/cpp/jit/tests_setup.py
@@ -72,8 +72,7 @@ class TorchSaveJitStream_CUDA(FileSetup):
 
         class Model(torch.nn.Module):
             def forward(self):
-                device_index = torch.cuda._current_device()
-                s = torch.jit.cuda.Stream(device_index, 0)
+                s = torch.jit.cuda.Stream()
                 a = torch.rand(3, 4, device="cuda")
                 b = torch.rand(3, 4, device="cuda")
 

--- a/test/jit/test_cuda.py
+++ b/test/jit/test_cuda.py
@@ -49,6 +49,44 @@ class TestCUDA(JitTestCase):
         torch.cuda.empty_cache()
         super(TestCUDA, self).tearDown()
 
+    def test_stream_args(self):
+        # Test stream creation with default arguments
+        @torch.jit.script
+        def stream_default_args() -> bool:
+            s = torch.jit.cuda.Stream()
+            return s.device_index() == torch.cuda._current_device()
+
+        @torch.jit.script
+        def stream_default_args_for_device() -> bool:
+            s = torch.jit.cuda.Stream(priority=0)
+            return s.device_index() == torch.cuda._current_device()
+
+        @torch.jit.script
+        def stream_default_args_for_priority() -> bool:
+            d = torch.device("cuda:1")
+            s = torch.jit.cuda.Stream(d)
+            return s.device_index() == 1
+
+        @torch.jit.script
+        def stream_args_all() -> bool:
+            d = torch.device("cuda:0")
+            s = torch.jit.cuda.Stream(d, 0)
+            return s.device_index() == 0
+
+        self.assertTrue(stream_default_args)
+        self.assertTrue(stream_default_args_for_device)
+        self.assertTrue(stream_default_args_for_priority)
+        self.assertTrue(stream_args_all)
+
+    def test_event_args(self):
+        # Test Event creation with default arguments
+        @torch.jit.script
+        def event_default_args() -> bool:
+            e = torch.jit.cuda.Event()
+            return e is not None
+
+        self.assertTrue(event_default_args)
+
     @skipIfRocm
     @unittest.skipIf(not TEST_MULTIGPU, "detected only one GPU")
     def test_current_stream(self):
@@ -149,7 +187,7 @@ class TestCUDA(JitTestCase):
         @torch.jit.script
         def test_simple_stream():
             device_index = torch.cuda._current_device()
-            s = torch.jit.cuda.Stream(device_index, 0)
+            s = torch.jit.cuda.Stream()
             return device_index == s.device_index()
 
         self.assertTrue(test_simple_stream(), "Could not create Stream!")
@@ -172,7 +210,7 @@ class TestCUDA(JitTestCase):
             device_index = torch.cuda._current_device()
             current_stream = torch.cuda.current_stream(device_index)
             default_stream = torch.cuda.default_stream(device_index)
-            user_stream = torch.jit.cuda.Stream(device_index, 0)
+            user_stream = torch.jit.cuda.Stream()
 
             # Check if the current and default streams are the same on the device
             is_current_and_default_stream_same = current_stream.id() == default_stream.id()
@@ -214,7 +252,7 @@ class TestCUDA(JitTestCase):
         def test_stream_context():
             device_index = torch.cuda._current_device()
             current_stream = torch.cuda.current_stream(device_index)
-            user_stream = torch.jit.cuda.Stream(device_index, 0)
+            user_stream = torch.jit.cuda.Stream()
             A = torch.rand(1000, 1000, device="cuda")
 
             with torch.jit.cuda.stream(user_stream):
@@ -238,8 +276,10 @@ class TestCUDA(JitTestCase):
         def test_multiple_stream():
             prev_device_index = torch.cuda._current_device()
             prev_current_stream = torch.cuda.current_stream(prev_device_index)
-            s1 = torch.jit.cuda.Stream(0, 0)
-            s2 = torch.jit.cuda.Stream(1, 0)
+            d1 = torch.device("cuda:0")
+            d2 = torch.device("cuda:1")
+            s1 = torch.jit.cuda.Stream(d1, 0)
+            s2 = torch.jit.cuda.Stream(d2, 0)
 
             A = torch.rand(1000, 1000, device="cuda")
             B = torch.rand(1000, 1000, device="cuda")
@@ -280,8 +320,9 @@ class TestCUDA(JitTestCase):
         def test_data_dependency_between_streams():
             device_index = torch.cuda._current_device()
             prev_current_stream = torch.cuda.current_stream(device_index)
-            s1 = torch.jit.cuda.Stream(0, 0)
-            s2 = torch.jit.cuda.Stream(0, 0)
+            d = torch.device("cuda:0")
+            s1 = torch.jit.cuda.Stream(d, 0)
+            s2 = torch.jit.cuda.Stream(d, 0)
             event = torch.jit.cuda.Event(False, False, False)
 
             A = torch.rand(1000, 1000, device="cuda")
@@ -344,7 +385,7 @@ class TestCUDA(JitTestCase):
         @torch.jit.script
         def test_stream_synchronize() -> float:
             device_index = torch.cuda._current_device()
-            s = torch.jit.cuda.Stream(device_index, 0)
+            s = torch.jit.cuda.Stream()
             e_tik = torch.jit.cuda.Event(True, False, False)
             e_tok = torch.jit.cuda.Event(True, False, False)
 
@@ -369,8 +410,7 @@ class TestCUDA(JitTestCase):
         # and the stream.query evaluates to true.
         @torch.jit.script
         def test_event_synchronize() -> float:
-            device_index = torch.cuda._current_device()
-            s = torch.jit.cuda.Stream(device_index, 0)
+            s = torch.jit.cuda.Stream()
             e_tik = torch.jit.cuda.Event(True, False, False)
             e_tok = torch.jit.cuda.Event(True, False, False)
 
@@ -399,7 +439,7 @@ class TestCUDA(JitTestCase):
         def test_event_wait() -> float:
             device_index = torch.cuda._current_device()
             s0 = torch.cuda.current_stream(device_index)
-            s1 = torch.jit.cuda.Stream(device_index, 0)
+            s1 = torch.jit.cuda.Stream()
             e_tik = torch.jit.cuda.Event(True, True, False)
             e_tok = torch.jit.cuda.Event(True, True, False)
 
@@ -449,8 +489,7 @@ class TestCUDA(JitTestCase):
         def test_save_load(self):
             class Model(torch.nn.Module):
                 def forward(self):
-                    device_index = torch.cuda._current_device()
-                    s = torch.jit.cuda.Stream(device_index, 0)
+                    s = torch.jit.cuda.Stream()
                     a = torch.rand(3, 4, device="cuda")
                     b = torch.rand(3, 4, device="cuda")
 

--- a/torch/csrc/jit/cuda/cuda.h
+++ b/torch/csrc/jit/cuda/cuda.h
@@ -13,14 +13,15 @@ class CUDAEvent;
 // c10/cuda/CUDAStream.h.
 class CUDAStream final : public CustomClassHolder {
  public:
-  CUDAStream(int64_t device = -1, int64_t priority = 0) {
+  CUDAStream(
+      c10::optional<c10::Device> device = c10::nullopt,
+      int64_t priority = 0) {
     constexpr int64_t PRIORITY_INDEX = 0;
-    stream_ = std::make_unique<c10::cuda::CUDAStream>(
-        c10::cuda::getStreamFromPool(priority < PRIORITY_INDEX, device));
-  }
 
-  CUDAStream(c10::cuda::CUDAStream s) {
-    stream_ = std::make_unique<c10::cuda::CUDAStream>(s);
+    c10::DeviceIndex device_index =
+        device.has_value() ? device->index() : c10::cuda::current_device();
+    stream_ = std::make_unique<c10::cuda::CUDAStream>(
+        c10::cuda::getStreamFromPool(priority < PRIORITY_INDEX, device_index));
   }
 
   bool query() {
@@ -154,9 +155,15 @@ void CUDAEvent::wait(c10::intrusive_ptr<CUDAStream> stream) {
 
 TORCH_LIBRARY(cuda, m) {
   auto stream_class = m.class_<torch::jit::CUDAStream>("Stream").def(
-      torch::init<int64_t, int64_t>());
+      torch::init<c10::optional<c10::Device>, int64_t>(),
+      "",
+      {torch::arg("device") = c10::nullopt, torch::arg("priority") = 0});
   auto event_class = m.class_<torch::jit::CUDAEvent>("Event").def(
-      torch::init<bool, bool, bool>());
+      torch::init<bool, bool, bool>(),
+      "",
+      {torch::arg("enable_timing") = false,
+       torch::arg("blocking") = false,
+       torch::arg("interprocess") = false});
 
   stream_class.def("query", &CUDAStream::query)
       .def("record_event", &CUDAStream::recordEvent)

--- a/torch/csrc/jit/cuda/cuda.h
+++ b/torch/csrc/jit/cuda/cuda.h
@@ -13,10 +13,15 @@ class CUDAEvent;
 // c10/cuda/CUDAStream.h.
 class CUDAStream final : public CustomClassHolder {
  public:
-  CUDAStream(int64_t device = -1, int64_t priority = 0) {
+  CUDAStream(
+      c10::optional<c10::Device> device = c10::nullopt,
+      int64_t priority = 0) {
     constexpr int64_t PRIORITY_INDEX = 0;
+
+    c10::DeviceIndex device_index =
+        device.has_value() ? device->index() : c10::cuda::current_device();
     stream_ = std::make_unique<c10::cuda::CUDAStream>(
-        c10::cuda::getStreamFromPool(priority < PRIORITY_INDEX, device));
+        c10::cuda::getStreamFromPool(priority < PRIORITY_INDEX, device_index));
   }
 
   CUDAStream(c10::cuda::CUDAStream s) {
@@ -154,9 +159,15 @@ void CUDAEvent::wait(c10::intrusive_ptr<CUDAStream> stream) {
 
 TORCH_LIBRARY(cuda, m) {
   auto stream_class = m.class_<torch::jit::CUDAStream>("Stream").def(
-      torch::init<int64_t, int64_t>());
+      torch::init<c10::optional<c10::Device>, int64_t>(),
+      "",
+      {torch::arg("device") = c10::nullopt, torch::arg("priority") = 0});
   auto event_class = m.class_<torch::jit::CUDAEvent>("Event").def(
-      torch::init<bool, bool, bool>());
+      torch::init<bool, bool, bool>(),
+      "",
+      {torch::arg("enable_timing") = false,
+       torch::arg("blocking") = false,
+       torch::arg("interprocess") = false});
 
   stream_class.def("query", &CUDAStream::query)
       .def("record_event", &CUDAStream::recordEvent)

--- a/torch/jit/cuda.py
+++ b/torch/jit/cuda.py
@@ -148,15 +148,15 @@ def stream(stream: Optional['torch.classes.cuda.Stream']) -> StreamContext:
     """
     return StreamContext(stream)
 
-def Stream(device: int = -1, priority: int = 0) -> 'torch.classes.cuda.Stream':
+def Stream(device: Optional[torch.device] = None, priority: int = 0) -> 'torch.classes.cuda.Stream':
     r"""Wrapper around a CUDA stream.
     A CUDA stream is a linear sequence of execution that belongs to a specific
     device, independent from other streams.  See :ref:`cuda-semantics` for
     details.
     Arguments:
-        device(int, optional): a device on which to allocate
-            the stream. If :attr:`device` is ``None`` (default) or a negative
-            integer, this will use the current device.
+        device(torch.device, optional): a device on which to allocate
+            the stream. If :attr:`device` is ``None`` (default), stream will be
+            created on the current device.
         priority(int, optional): priority of the stream. Can be either
             -1 (high priority) or 0 (low priority). By default, streams have
             priority 0.


### PR DESCRIPTION
* **#53025 Add default args for CUDA stream and events**

Tests:
=====
python test/test_jit.py -v TestCUDA