### PR TITLE
[PyTorch] Fix TORCH_CHECK_INDEX(false, ...) in IndexKernel

### DIFF
--- a/aten/src/ATen/native/cpu/IndexKernel.cpp
+++ b/aten/src/ATen/native/cpu/IndexKernel.cpp
@@ -36,9 +36,8 @@ struct Indexer {
     for (int j = 0; j < num_indexers; j++) {
       int64_t value = *(int64_t*)&indexers[j][idx * indexer_strides[j]];
       int64_t size = original_sizes[j];
-      if (value < -size || value >= size) {
-        TORCH_CHECK_INDEX(false, "index ", value, " is out of bounds for dimension ", j, " with size ", size);
-      }
+      TORCH_CHECK_INDEX(value >= -size && value < size,
+                        "index ", value, " is out of bounds for dimension ", j, " with size ", size);
       if (value < 0) {
         value += size;
       }
@@ -151,11 +150,9 @@ void index_fill_kernel(
       for (int64_t elem = 0; elem < n; ++elem) {
         auto* self_data = reinterpret_cast<scalar_t*>(self_data_bytes);
         auto idx = *reinterpret_cast<int64_t*>(index_data_bytes);
-        if (idx < -self_dim_size || idx >= self_dim_size) {
-          TORCH_CHECK_INDEX(false,
-            "index ", idx, " is out of bounds for dimension ",
-            dim, " with size ", self_dim_size);
-        }
+        TORCH_CHECK_INDEX(idx >= -self_dim_size && idx < self_dim_size,
+                          "index ", idx, " is out of bounds for dimension ",
+                          dim, " with size ", self_dim_size);
         if (idx < 0) {
           idx += self_dim_size;
         }
@@ -170,11 +167,9 @@ void index_fill_kernel(
       auto* self_data_bytes = data[0];
       auto* index_data_bytes = data[1];
       auto idx = *reinterpret_cast<int64_t*>(index_data_bytes);
-      if (idx < -self_dim_size || idx >= self_dim_size) {
-        TORCH_CHECK_INDEX(false,
-          "index ", idx, " is out of bounds for dimension ",
-          dim, " with size ", self_dim_size);
-      }
+      TORCH_CHECK_INDEX(idx >= -self_dim_size && idx < self_dim_size,
+                        "index ", idx, " is out of bounds for dimension ",
+                        dim, " with size ", self_dim_size);
       if (idx < 0) {
         idx += self_dim_size;
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53028 [PyTorch] Fix TORCH_CHECK_INDEX(false, ...) in IndexKernel**

TORCH_CHECK (and variants) wrap the condition in C10_UNLIKELY, so this code is both prettier and better.

Differential Revision: [D26522821](https://our.internmc.facebook.com/intern/diff/D26522821/)