### PR TITLE
[quant][fix] MHA tensor assignment fix

### DIFF
--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2413,11 +2413,16 @@ class TestQuantizedOps(TestCase):
 
         qengine = torch.backends.quantized.engine
 
+        min_power = 30
+        max_mse = 2
+
         num_heads = 16
         batch_size = 4
         target_seq_length = 128
         source_seq_length = 64
-        embed_dim = 512  # Must be divisible by the number of heads
+        qembed_dim = 512  # Must be divisible by the number of heads
+        kembed_dim = 128
+        vembed_dim = 256
 
         dropout = 0  # This is not supported
 
@@ -2437,68 +2442,67 @@ class TestQuantizedOps(TestCase):
             }
         }
 
-        fp_data = [
-            torch.randn(target_seq_length, batch_size, embed_dim),  # Q
-            torch.randn(source_seq_length, batch_size, embed_dim),  # K
-            torch.randn(source_seq_length, batch_size, embed_dim)   # V
-        ]
+        for kdim, vdim in ((kembed_dim, vembed_dim), (None, None)):
+            fp_data = [
+                torch.randn(target_seq_length, batch_size, qembed_dim),  # Q
+                torch.randn(source_seq_length, batch_size,
+                            qembed_dim if kdim is None else kembed_dim),  # K
+                torch.randn(source_seq_length, batch_size,
+                            qembed_dim if vdim is None else vembed_dim)   # V
+            ]
 
-        q_data = []
-        reduce_range = (qengine == 'fbgemm')
-        for idx, x in enumerate(fp_data):
-            scale, zero_point = _calculate_dynamic_qparams(x, dtype=dtype, reduce_range=reduce_range)
-            x = x.to(torch.float)
-            qx = torch.quantize_per_tensor(x, scale=scale,
-                                           zero_point=zero_point, dtype=qtype)
-            q_data.append(qx)
+            q_data = []
+            reduce_range = (qengine == 'fbgemm')
+            for idx, x in enumerate(fp_data):
+                scale, zero_point = _calculate_dynamic_qparams(
+                    x, dtype=dtype, reduce_range=reduce_range)
+                x = x.to(torch.float)
+                qx = torch.quantize_per_tensor(x, scale=scale,
+                                               zero_point=zero_point, dtype=qtype)
+                q_data.append(qx)
 
-            # Dequantize the data back for reference
-            fp_data[idx] = qx.dequantize()
+                # Dequantize the data back for reference
+                fp_data[idx] = qx.dequantize()
 
-        # TODO: need to investigate why resetting the bias reduces SNR
-        #       https://github.com/pytorch/pytorch/issues/51662
-        min_power = 30
-        max_mse = 2
+            with torch.no_grad():
+                for bias, add_bias_kv, add_zero_attn in itertools.product(
+                        Bias, Add_bias_kv, Add_zero_attn):
+                    mha = MultiheadAttentionModel(qembed_dim, num_heads, dropout,
+                                                  bias, add_bias_kv, add_zero_attn,
+                                                  kdim=kdim, vdim=vdim)
+                    mha.eval()
 
+                    # Prepare
+                    mha.qconfig = torch.quantization.get_default_qconfig(qengine)
+                    mha_prepared = torch.quantization.prepare(
+                        mha, prepare_custom_config_dict=custom_module_config)
 
-        with torch.no_grad():
-            for bias, add_bias_kv, add_zero_attn in itertools.product(
-                    Bias, Add_bias_kv, Add_zero_attn):
-                mha = MultiheadAttentionModel(embed_dim, num_heads, dropout,
-                                              bias, add_bias_kv, add_zero_attn)
-                mha.eval()
+                    # Calibrate
+                    y = mha_prepared(*fp_data)
+                    y_ref = mha(*fp_data)
+                    # Check the result of the prepare
+                    self.assertEqual(y_ref[0], y[0])  # Attention
+                    self.assertEqual(y_ref[1], y[1])  # Weight
 
-                # Prepare
-                mha.qconfig = torch.quantization.get_default_qconfig(qengine)
-                mha_prepared = torch.quantization.prepare(
-                    mha, prepare_custom_config_dict=custom_module_config)
+                    # Quantize
+                    mha_quantized = torch.quantization.convert(
+                        mha_prepared,
+                        convert_custom_config_dict=custom_module_config)
+                    qy = mha_quantized(*q_data)
 
-                # Calibrate
-                y = mha_prepared(*fp_data)
-                y_ref = mha(*fp_data)
-                # Check the result of the prepare
-                self.assertEqual(y_ref[0], y[0])  # Attention
-                self.assertEqual(y_ref[1], y[1])  # Weight
+                    # Reference result
+                    mha.layer = mha_quantized.layer.dequantize()
+                    y_ref = mha(*fp_data)
 
-                # Quantize
-                mha_quantized = torch.quantization.convert(
-                    mha_prepared,
-                    convert_custom_config_dict=custom_module_config)
-                qy = mha_quantized(*q_data)
-
-                # Reference result
-                mha.layer = mha_quantized.layer.dequantize()
-                y_ref = mha(*fp_data)
-
-                snr = _snr(y, qy)
-                for signal, mse, power in snr:
-                    self.assertTrue(
-                        power > min_power or mse < max_mse,
-                        msg=(f"Error is too high: SNR(dB): {power}, "
-                             f"Signal: {signal}, MSE: {mse}; "
-                             f"Run with bias={bias}, "
-                             f"add_bias_kv={add_bias_kv}, "
-                             f"add_zero_attn={add_zero_attn}"))
+                    snr = _snr(y, qy)
+                    for signal, mse, power in snr:
+                        self.assertTrue(
+                            power > min_power or mse < max_mse,
+                            msg=(f"Error is too high: SNR(dB): {power}, "
+                                 f"Signal: {signal}, MSE: {mse}; "
+                                 f"Run with bias={bias}, "
+                                 f"add_bias_kv={add_bias_kv}, "
+                                 f"add_zero_attn={add_zero_attn}"))
 
 
 class TestDynamicQuantizedLinear(TestCase):

--- a/torch/nn/quantizable/modules/activation.py
+++ b/torch/nn/quantizable/modules/activation.py
@@ -127,17 +127,17 @@ class MultiheadAttention(nn.MultiheadAttention):
                                                           weight.requires_grad)
             observed.linear_V.bias = bias
         else:
-            observed.linear_Q = other.q_proj_weight
-            observed.linear_K = other.k_proj_weight
-            observed.linear_V = other.v_proj_weight
+            observed.linear_Q.weight = nn.Parameter(other.q_proj_weight)
+            observed.linear_K.weight = nn.Parameter(other.k_proj_weight)
+            observed.linear_V.weight = nn.Parameter(other.v_proj_weight)
             if other.in_proj_bias is None:
                 observed.linear_Q.bias = None  # type: ignore
                 observed.linear_K.bias = None  # type: ignore
                 observed.linear_V.bias = None  # type: ignore
             else:
-                observed.linear_Q.bias = other.in_proj_bias[0:other.embed_dim]
-                observed.linear_K.bias = other.in_proj_bias[other.embed_dim:(other.embed_dim * 2)]
-                observed.linear_V.bias = other.in_proj_bias[(other.embed_dim * 2):]
+                observed.linear_Q.bias = nn.Parameter(other.in_proj_bias[0:other.embed_dim])
+                observed.linear_K.bias = nn.Parameter(other.in_proj_bias[other.embed_dim:(other.embed_dim * 2)])
+                observed.linear_V.bias = nn.Parameter(other.in_proj_bias[(other.embed_dim * 2):])
         observed.eval()
         # Explicit prepare
         observed = torch.quantization.prepare(observed, inplace=True)
@@ -197,17 +197,17 @@ class MultiheadAttention(nn.MultiheadAttention):
                 assert all(bV == 0)
                 fp.in_proj_bias[_start:] = bV
         else:
-            fp.q_proj_weight = wQ
-            fp.k_proj_weight = wK
-            fp.v_proj_weight = wV
+            fp.q_proj_weight = nn.Parameter(wQ)
+            fp.k_proj_weight = nn.Parameter(wK)
+            fp.v_proj_weight = nn.Parameter(wV)
             if fp.in_proj_bias is None:
                 self.linear_Q.bias = None  # type: ignore
                 self.linear_K.bias = None  # type: ignore
                 self.linear_V.bias = None  # type: ignore
             else:
-                fp.in_proj_bias[0:fp.embed_dim] = self.linear_Q.bias
-                fp.in_proj_bias[fp.embed_dim:(fp.embed_dim * 2)] = self.linear_K.bias
-                fp.in_proj_bias[(fp.embed_dim * 2):] = self.linear_V.bias
+                fp.in_proj_bias[0:fp.embed_dim] = bQ
+                fp.in_proj_bias[fp.embed_dim:(fp.embed_dim * 2)] = bK
+                fp.in_proj_bias[(fp.embed_dim * 2):] = bV
 
         return fp
 


### PR DESCRIPTION
Summary: During the module conversion, the weight was assigned directly to the linear layer inside the quantizable MHA. Instead the weight must be assigned to the `layer.weight`.

Test Plan:
`buck test mode/opt //caffe2/test:quantization -- test_custom_module_multi_head_attention`

```
Building: finished in 6.9 sec (100%) 7316/7316 jobs, 3 updated
  Total time: 7.4 sec
More details at https://www.internalfb.com/intern/buck/build/914cb095-806e-4891-8822-e2644283f05c
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: fcccbd0b-a887-4874-8455-d1cf8411be1d
Trace available for this run at /tmp/tpx-20210301-004359.492205/trace.log
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/1688849910412609
    ✓ ListingSuccess: caffe2/test:quantization - main (2.440)
    ✓ Pass: caffe2/test:quantization - test_custom_module_multi_head_attention (quantization.test_quantized_op.TestQuantizedOps) (5.672)
Summary
  Pass: 1
  ListingSuccess: 1
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/1688849910412609
```

Differential Revision: D26720500

