### PR TITLE
[package] Pull out _UnpicklerWrapper into PackageUnpickler

### DIFF
--- a/torch/_deploy.py
+++ b/torch/_deploy.py
@@ -1,12 +1,9 @@
 import io
 import torch
-import importlib
 from torch.package._package_pickler import create_pickler
-from torch.package.package_importer import _UnpicklerWrapper
+from torch.package._package_unpickler import PackageUnpickler
 from torch.package import sys_importer, OrderedImporter, PackageImporter, Importer
 from torch.serialization import _maybe_decode_ascii
-from typing import Callable
-from types import ModuleType
 
 def _save_storages(importer, obj):
     serialized_storages = []
@@ -50,17 +47,13 @@ def _load_storages(id, zip_reader, obj_bytes, serialized_storages):
         return serialized_storages[data[0]]
 
 
-    import_module : Callable[[str], ModuleType] = importlib.import_module
+    importer: Importer
     if zip_reader is not None:
-        importer = _get_package(zip_reader)
+        importer = OrderedImporter(_get_package(zip_reader), sys_importer)
+    else:
+        importer = sys_importer
 
-        def import_module(name: str):
-            try:
-                return importer.import_module(name)
-            except ModuleNotFoundError:
-                return importlib.import_module(name)
-
-    unpickler = _UnpicklerWrapper(import_module, io.BytesIO(obj_bytes))
+    unpickler = PackageUnpickler(importer, io.BytesIO(obj_bytes))
     unpickler.persistent_load = persistent_load
     result = _deploy_objects[id] = unpickler.load()
     return result

--- a/torch/package/_package_pickler.py
+++ b/torch/package/_package_pickler.py
@@ -7,6 +7,11 @@ from .importer import Importer, sys_importer, ObjMismatchError, ObjNotFoundError
 
 
 class PackagePickler(_Pickler):
+    """Package-aware pickler.
+
+    This behaves the same as a normal pickler, except it uses an `Importer`
+    to find objects and modules to save.
+    """
     dispatch = _Pickler.dispatch.copy()
 
     def __init__(self, importer: Importer, *args, **kwargs):

--- a/torch/package/_package_unpickler.py
+++ b/torch/package/_package_unpickler.py
@@ -1,0 +1,26 @@
+import pickle
+
+import _compat_pickle  # type: ignore
+
+from .importer import Importer
+
+
+class PackageUnpickler(pickle._Unpickler):  # type: ignore
+    """Package-aware unpickler.
+
+    This behaves the same as a normal unpickler, except it uses `importer` to
+    find any global names that it encounters while unpickling.
+    """
+    def __init__(self, importer: Importer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._importer = importer
+
+    def find_class(self, module, name):
+        # Subclasses may override this.
+        if self.proto < 3 and self.fix_imports:
+            if (module, name) in _compat_pickle.NAME_MAPPING:
+                module, name = _compat_pickle.NAME_MAPPING[(module, name)]
+            elif module in _compat_pickle.IMPORT_MAPPING:
+                module = _compat_pickle.IMPORT_MAPPING[module]
+        mod = self._importer.import_module(module)
+        return getattr(mod, name)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53050 [rpc] make pickler/unpickler pluggable in RPC
* **#53049 [package] Pull out _UnpicklerWrapper into PackageUnpickler**
* #53048 [package] _custom_import_pickler -> _package_pickler

This makes our API symmetric--now we have an `Importer` aware Pickler
and Unpickler implementation that have similar interfaces.

Differential Revision: [D26734593](https://our.internmc.facebook.com/intern/diff/D26734593)