### PR TITLE
Add streams boundary check to `torch::cuda::scatter``

### DIFF
--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -278,7 +278,7 @@ std::vector<at::Tensor>& scatter_out(
       tensor.split_with_sizes(/*split_sizes=*/chunk_sizes, /*dim=*/dim);
   at::cuda::OptionalCUDAStreamGuard cuda_guard;
   for (size_t i = 0; i < chunks.size(); i++) {
-    if (streams && (*streams)[i]) {
+    if (i < (streams ? streams->size() : 0U) && (*streams)[i]) {
       const auto device_index =
           static_cast<int16_t>(out_tensors[i].get_device());
       TORCH_CHECK(
@@ -328,7 +328,7 @@ std::vector<at::Tensor> scatter(
   for (size_t i = 0; i < chunks.size(); ++i) {
     const auto device_index = static_cast<int16_t>(devices[i]);
     if (device_index != tensor.get_device()) {
-      if (streams && (*streams)[i]) {
+      if (i < (streams ? streams->size() : 0U) && (*streams)[i]) {
         TORCH_CHECK(
             (*streams)[i]->device_index() == device_index,
             "Expected the device associated with the stream at index ",


### PR DESCRIPTION
Accessing elements of `std::vector` outside of its boundaries can lead to crashes/memory corruptions

Fixes #52526
