### PR TITLE
[package] catch exceptions from calling reduce function.

### DIFF
--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -74,9 +74,12 @@ class Importer(ABC):
             # TODO: I guess we should do copyreg too?
             reduce = getattr(obj, "__reduce__", None)
             if reduce is not None:
-                rv = reduce()
-                if isinstance(rv, str):
-                    name = rv
+                try:
+                    rv = reduce()
+                    if isinstance(rv, str):
+                        name = rv
+                except Exception:
+                    pass
         if name is None:
             name = getattr(obj, "__qualname__", None)
         if name is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53061 [package] catch exceptions from calling reduce function.**

We only care about evaluating the string return version. If `reduce()`
throws an error, we should just continue on with pickling.

Differential Revision: [D26737652](https://our.internmc.facebook.com/intern/diff/D26737652)