### PR TITLE
[TensorExpr] Reland: "PyBind: bind ExternalCalls."

### DIFF
--- a/test/test_tensorexpr_pybind.py
+++ b/test/test_tensorexpr_pybind.py
@@ -36,5 +36,28 @@ class TestTensorExprPyBind(JitTestCase):
             cg.call([tA, tB, tC])
             torch.testing.assert_allclose(tA + tB, tC)
 
+    def test_external_calls(self):
+        with kernel_arena_scope():
+            dtype = torch._C._te.Dtype.Float
+
+            ZERO = torch._C._te.ExprHandle.int(0)
+            ONE = torch._C._te.ExprHandle.int(1)
+            FOUR = torch._C._te.ExprHandle.int(4)
+            A = torch._C._te.BufHandle('A', [ONE, FOUR], dtype)
+            B = torch._C._te.BufHandle('B', [FOUR, ONE], dtype)
+            C = torch._C._te.BufHandle('C', [ONE, ONE], dtype)
+
+            s = torch._C._te.ExternalCall(C, "nnc_aten_matmul", [A, B], [])
+
+            loopnest = torch._C._te.LoopNest(s, [C])
+            loopnest.prepare_for_codegen()
+            codegen = torch._C._te.construct_codegen('ir_eval', s, [torch._C._te.BufferArg(x) for x in [A, B, C]])
+
+            tA = torch.ones(1, 4)
+            tB = torch.ones(4, 1)
+            tC = torch.empty(1, 1)
+            codegen.call([tA, tB, tC])
+            torch.testing.assert_allclose(torch.matmul(tA, tB), tC)
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -13,24 +13,25 @@
 
 namespace torch {
 namespace jit {
+using namespace torch::jit::tensorexpr;
 
 void initTensorExprBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
   // Tensor Expr Classes
   auto te = m.def_submodule("_te");
-  py::class_<tensorexpr::KernelScope>(te, "KernelScope").def(py::init<>());
+  py::class_<KernelScope>(te, "KernelScope").def(py::init<>());
 
-  auto dtype_class = py::class_<tensorexpr::Dtype>(te, "Dtype");
+  auto dtype_class = py::class_<Dtype>(te, "Dtype");
 
 #define DTYPE_SINGLETON_ACCESSOR(ctype, name) \
   dtype_class.def_property_readonly_static(   \
-      #name, [](py::object) { return tensorexpr::k##name; });
+      #name, [](py::object) { return k##name; }); // NOLINT
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, DTYPE_SINGLETON_ACCESSOR)
 #undef DTYPE_SINGLETON_ACCESSOR
 
   auto expr_handle_class =
-      py::class_<tensorexpr::ExprHandle>(te, "ExprHandle")
+      py::class_<ExprHandle>(te, "ExprHandle")
           .def(py::self + py::self)
           .def(py::self * py::self)
           .def(py::self - py::self)
@@ -47,374 +48,256 @@ void initTensorExprBindings(PyObject* module) {
           .def(py::self ^ py::self)
           .def(py::self << py::self)
           .def(py::self >> py::self)
-          .def(
-              "sin",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::sin(self);
-              })
-          .def(
-              "cos",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::cos(self);
-              })
-          .def(
-              "tan",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::tan(self);
-              })
-          .def(
-              "asin",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::asin(self);
-              })
-          .def(
-              "acos",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::acos(self);
-              })
-          .def(
-              "atan",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::atan(self);
-              })
-          .def(
-              "sinh",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::sinh(self);
-              })
-          .def(
-              "cosh",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::cosh(self);
-              })
-          .def(
-              "tanh",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::tanh(self);
-              })
-          .def(
-              "sigmoid",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::sigmoid(self);
-              })
-          .def(
-              "exp",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::exp(self);
-              })
-          .def(
-              "expm1",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::expm1(self);
-              })
+          .def("sin", [](const ExprHandle& self) { return sin(self); })
+          .def("cos", [](const ExprHandle& self) { return cos(self); })
+          .def("tan", [](const ExprHandle& self) { return tan(self); })
+          .def("asin", [](const ExprHandle& self) { return asin(self); })
+          .def("acos", [](const ExprHandle& self) { return acos(self); })
+          .def("atan", [](const ExprHandle& self) { return atan(self); })
+          .def("sinh", [](const ExprHandle& self) { return sinh(self); })
+          .def("cosh", [](const ExprHandle& self) { return cosh(self); })
+          .def("tanh", [](const ExprHandle& self) { return tanh(self); })
+          .def("sigmoid", [](const ExprHandle& self) { return sigmoid(self); })
+          .def("exp", [](const ExprHandle& self) { return exp(self); })
+          .def("expm1", [](const ExprHandle& self) { return expm1(self); })
           .def(
               "abs",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::abs(self);
-              })
+              [](const ExprHandle& self) { return tensorexpr::abs(self); })
+          .def("log", [](const ExprHandle& self) { return log(self); })
           .def(
-              "log",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::log(self);
-              })
-          .def(
-              "fast_log",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::fast_log(self);
-              })
-          .def(
-              "log2",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::log2(self);
-              })
-          .def(
-              "log10",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::log10(self);
-              })
-          .def(
-              "log1p",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::log1p(self);
-              })
-          .def(
-              "erf",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::erf(self);
-              })
-          .def(
-              "erfc",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::erfc(self);
-              })
+              "fast_log", [](const ExprHandle& self) { return fast_log(self); })
+          .def("log2", [](const ExprHandle& self) { return log2(self); })
+          .def("log10", [](const ExprHandle& self) { return log10(self); })
+          .def("log1p", [](const ExprHandle& self) { return log1p(self); })
+          .def("erf", [](const ExprHandle& self) { return erf(self); })
+          .def("erfc", [](const ExprHandle& self) { return erfc(self); })
           .def(
               "sqrt",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::sqrt(self);
-              })
-          .def(
-              "rsqrt",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::rsqrt(self);
-              })
-          .def(
-              "ceil",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::ceil(self);
-              })
-          .def(
-              "floor",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::floor(self);
-              })
-          .def(
-              "round",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::round(self);
-              })
-          .def(
-              "trunc",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::trunc(self);
-              })
-          .def(
-              "frac",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::frac(self);
-              })
-          .def(
-              "lgamma",
-              [](const tensorexpr::ExprHandle& self) {
-                return tensorexpr::lgamma(self);
-              })
-          .def("isnan", [](const tensorexpr::ExprHandle& self) {
-            return tensorexpr::isnan(self);
-          });
+              [](const ExprHandle& self) { return tensorexpr::sqrt(self); })
+          .def("rsqrt", [](const ExprHandle& self) { return rsqrt(self); })
+          .def("ceil", [](const ExprHandle& self) { return ceil(self); })
+          .def("floor", [](const ExprHandle& self) { return floor(self); })
+          .def("round", [](const ExprHandle& self) { return round(self); })
+          .def("trunc", [](const ExprHandle& self) { return trunc(self); })
+          .def("frac", [](const ExprHandle& self) { return frac(self); })
+          .def("lgamma", [](const ExprHandle& self) { return lgamma(self); })
+          .def("isnan", [](const ExprHandle& self) { return isnan(self); });
   te.def(
       "ifThenElse",
-      [](const tensorexpr::ExprHandle& c,
-         const tensorexpr::ExprHandle& t,
-         const tensorexpr::ExprHandle& f) {
-        return tensorexpr::ifThenElse(c, t, f);
+      [](const ExprHandle& c, const ExprHandle& t, const ExprHandle& f) {
+        return ifThenElse(c, t, f);
       });
-  te.def(
-      "atan2",
-      [](const tensorexpr::ExprHandle& v1, const tensorexpr::ExprHandle& v2) {
-        return tensorexpr::atan2(v1, v2);
-      });
-  te.def(
-      "pow",
-      [](const tensorexpr::ExprHandle& v1, const tensorexpr::ExprHandle& v2) {
-        return tensorexpr::pow(v1, v2);
-      });
-  te.def(
-      "fmod",
-      [](const tensorexpr::ExprHandle& v1, const tensorexpr::ExprHandle& v2) {
-        return tensorexpr::fmod(v1, v2);
-      });
-  te.def(
-      "remainder",
-      [](const tensorexpr::ExprHandle& v1, const tensorexpr::ExprHandle& v2) {
-        return tensorexpr::remainder(v1, v2);
-      });
+  te.def("atan2", [](const ExprHandle& v1, const ExprHandle& v2) {
+    return atan2(v1, v2);
+  });
+  te.def("pow", [](const ExprHandle& v1, const ExprHandle& v2) {
+    return pow(v1, v2);
+  });
+  te.def("fmod", [](const ExprHandle& v1, const ExprHandle& v2) {
+    return fmod(v1, v2);
+  });
+  te.def("remainder", [](const ExprHandle& v1, const ExprHandle& v2) {
+    return remainder(v1, v2);
+  });
 
 #define EXPRHANDLE_CTOR(ctype, name) \
-  expr_handle_class.def_static(      \
-      #ctype, [](ctype v) { return tensorexpr::ExprHandle(v); });
+  expr_handle_class.def_static(#ctype, [](ctype v) { return ExprHandle(v); });
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, EXPRHANDLE_CTOR)
 #undef EXPRHANDLE_CTOR
 
-  py::class_<tensorexpr::VarHandle, tensorexpr::ExprHandle>(te, "VarHandle")
-      .def(py::init<const std::string&, tensorexpr::Dtype>());
-  py::class_<tensorexpr::BufHandle, tensorexpr::ExprHandle>( // NOLINT
+  py::class_<VarHandle, ExprHandle>(te, "VarHandle")
+      .def(py::init<const std::string&, Dtype>());
+  py::class_<BufHandle, ExprHandle>( // NOLINT
       te,
-      "BufHandle");
-
-  py::class_<tensorexpr::Placeholder>(te, "Placeholder")
+      "BufHandle")
       .def(py::init<
            const std::string&,
-           const tensorexpr::Dtype&,
-           std::vector<tensorexpr::ExprHandle>&>())
-      .def(
-          "load",
-          [](tensorexpr::Placeholder& self,
-             const std::vector<tensorexpr::ExprHandle>& v) {
-            return self.load(v);
-          });
-  py::class_<tensorexpr::Tensor>(te, "Tensor")
-      .def(
-          "load",
-          [](tensorexpr::Tensor& self,
-             const std::vector<tensorexpr::ExprHandle>& v) {
-            return self.call(v);
-          });
-  py::class_<tensorexpr::Cast>(te, "Cast")
-      .def_static("make", &tensorexpr::Cast::make);
+           const std::vector<ExprHandle>&,
+           Dtype>());
 
-  py::class_<tensorexpr::DimArg>(te, "DimArg")
-      .def(py::init<const tensorexpr::ExprHandle&>())
-      .def(py::init<const tensorexpr::ExprHandle&, const std::string&>());
+  py::class_<Placeholder>(te, "Placeholder")
+      .def(py::init<
+           const std::string&,
+           const Dtype&,
+           std::vector<ExprHandle>&>())
+      .def("load", [](Placeholder& self, const std::vector<ExprHandle>& v) {
+        return self.load(v);
+      });
+  py::class_<Tensor, std::unique_ptr<Tensor, py::nodelete>>(te, "Tensor")
+      .def(py::init(
+          [](BufHandle& b, Stmt* s) { return new Tensor(b.node(), s); }))
+      .def(
+          "load",
+          [](Tensor& self, const std::vector<ExprHandle>& v) {
+            return self.call(v);
+          })
+      .def(
+          "buf",
+          [](Tensor& self) { return BufHandle(self.buf()); },
+          py::return_value_policy::reference)
+      .def("stmt", &Tensor::stmt, py::return_value_policy::reference);
+  py::class_<Cast>(te, "Cast").def_static("make", &Cast::make);
+
+  py::class_<DimArg>(te, "DimArg")
+      .def(py::init<const ExprHandle&>())
+      .def(py::init<const ExprHandle&, const std::string&>());
 
   te.def(
       "Compute",
       [](const std::string& func_name,
-         const std::vector<tensorexpr::DimArg>& dim_args,
+         const std::vector<DimArg>& dim_args,
          py::function func) {
         if (dim_args.size() == 1) {
-          return tensorexpr::Compute(
-              func_name, dim_args, [&func](const tensorexpr::VarHandle& a) {
-                return py::cast<tensorexpr::ExprHandle>(func(a));
-              });
+          return Compute(func_name, dim_args, [&func](const VarHandle& a) {
+            return py::cast<ExprHandle>(func(a));
+          });
         } else if (dim_args.size() == 2) {
-          return tensorexpr::Compute(
+          return Compute(
               func_name,
               dim_args,
-              [&func](
-                  const tensorexpr::VarHandle& a,
-                  const tensorexpr::VarHandle& b) {
-                return py::cast<tensorexpr::ExprHandle>(func(a, b));
+              [&func](const VarHandle& a, const VarHandle& b) {
+                return py::cast<ExprHandle>(func(a, b));
               });
         } else if (dim_args.size() == 3) {
-          return tensorexpr::Compute(
+          return Compute(
               func_name,
               dim_args,
               [&func](
-                  const tensorexpr::VarHandle& a,
-                  const tensorexpr::VarHandle& b,
-                  const tensorexpr::VarHandle& c) {
-                return py::cast<tensorexpr::ExprHandle>(func(a, b, c));
+                  const VarHandle& a, const VarHandle& b, const VarHandle& c) {
+                return py::cast<ExprHandle>(func(a, b, c));
               });
         } else if (dim_args.size() == 4) {
-          return tensorexpr::Compute(
+          return Compute(
               func_name,
               dim_args,
               [&func](
-                  const tensorexpr::VarHandle& a,
-                  const tensorexpr::VarHandle& b,
-                  const tensorexpr::VarHandle& c,
-                  const tensorexpr::VarHandle& d) {
-                return py::cast<tensorexpr::ExprHandle>(func(a, b, c, d));
+                  const VarHandle& a,
+                  const VarHandle& b,
+                  const VarHandle& c,
+                  const VarHandle& d) {
+                return py::cast<ExprHandle>(func(a, b, c, d));
               });
         } else {
           throw std::runtime_error("Too many args");
         }
       },
       py::return_value_policy::reference);
-  py::class_<tensorexpr::Reducer>(te, "Reducer")
+  py::class_<Reducer>(te, "Reducer")
       .def(py::init<
-           tensorexpr::ExprHandle,
-           std::function<tensorexpr::ExprHandle(
-               tensorexpr::ExprHandle, tensorexpr::ExprHandle)>>());
+           ExprHandle,
+           std::function<ExprHandle(ExprHandle, ExprHandle)>>());
 
-  py::class_<tensorexpr::Sum, tensorexpr::Reducer>(te, "Sum").def(py::init<>());
-  py::class_<tensorexpr::Maximum, tensorexpr::Reducer>(te, "Maximum")
-      .def(py::init<tensorexpr::Dtype>());
+  py::class_<Sum, Reducer>(te, "Sum").def(py::init<>());
+  py::class_<Maximum, Reducer>(te, "Maximum").def(py::init<Dtype>());
   te.def(
       "Reduce",
       [](const std::string& func_name,
-         const std::vector<tensorexpr::DimArg>& dim_args,
-         const tensorexpr::Reducer& reducer,
-         tensorexpr::Tensor* buffer,
-         const std::vector<tensorexpr::DimArg>& reduce_args) {
-        return tensorexpr::Reduce(
-            func_name, dim_args, reducer, buffer, reduce_args);
+         const std::vector<DimArg>& dim_args,
+         const Reducer& reducer,
+         Tensor* buffer,
+         const std::vector<DimArg>& reduce_args) {
+        return Reduce(func_name, dim_args, reducer, buffer, reduce_args);
       },
       py::return_value_policy::reference);
   te.def(
       "Reduce",
       [](const std::string& func_name,
-         const std::vector<tensorexpr::DimArg>& dim_args,
-         const tensorexpr::Reducer& reducer,
-         const tensorexpr::Placeholder& buffer,
-         const std::vector<tensorexpr::DimArg>& reduce_args) {
-        return tensorexpr::Reduce(
-            func_name, dim_args, reducer, buffer, reduce_args);
+         const std::vector<DimArg>& dim_args,
+         const Reducer& reducer,
+         const Placeholder& buffer,
+         const std::vector<DimArg>& reduce_args) {
+        return Reduce(func_name, dim_args, reducer, buffer, reduce_args);
       },
       py::return_value_policy::reference);
 
-  py::class_<tensorexpr::Stmt>(te, "Stmt")
-      .def("__str__", [](const tensorexpr::Stmt& self) {
+  py::class_<Stmt, std::unique_ptr<Stmt, py::nodelete>>(te, "Stmt")
+      .def("__str__", [](const Stmt& self) {
         std::stringstream ss;
         ss << self;
         return ss.str();
       });
-  py::class_<tensorexpr::For, tensorexpr::Stmt>(te, "For")
+  py::class_<For, Stmt, std::unique_ptr<For, py::nodelete>>(te, "For")
       .def(
           "index_var",
-          [](const tensorexpr::For& self) {
-            return tensorexpr::VarHandle(self.var());
-          },
+          [](const For& self) { return VarHandle(self.var()); },
           py::return_value_policy::reference)
-      .def("body", &tensorexpr::For::body, py::return_value_policy::reference);
+      .def("body", &For::body, py::return_value_policy::reference);
 
-  py::class_<tensorexpr::Block, tensorexpr::Stmt>(te, "Block")
+  py::class_<
+      tensorexpr::Block,
+      Stmt,
+      std::unique_ptr<tensorexpr::Block, py::nodelete>>(te, "Block")
       .def(
           "stmts",
           &tensorexpr::Block::stmts,
           py::return_value_policy::reference);
+  py::class_<ExternalCall, Stmt, std::unique_ptr<ExternalCall, py::nodelete>>(
+      te, "ExternalCall")
+      .def(py::init(&ExternalCall::make), py::return_value_policy::reference);
 
-  py::class_<tensorexpr::LoopNest>(te, "LoopNest")
-      .def(py::init<const std::vector<tensorexpr::Tensor*>&>())
-      .def("vectorize_inner_loops", &tensorexpr::LoopNest::vectorizeInnerLoops)
-      .def("prepare_for_codegen", &tensorexpr::LoopNest::prepareForCodegen)
+  py::class_<LoopNest>(te, "LoopNest")
+      .def(py::init<const std::vector<Tensor*>&>())
+      .def(py::init([](Stmt* s, const std::vector<BufHandle>& bufs) {
+        std::unordered_set<const Buf*> buf_nodes;
+        for (const auto& buf : bufs) {
+          buf_nodes.insert(buf.node());
+        }
+        return std::make_unique<LoopNest>(s, buf_nodes);
+      }))
+      .def("vectorize_inner_loops", &LoopNest::vectorizeInnerLoops)
+      .def("prepare_for_codegen", &LoopNest::prepareForCodegen)
       .def(
           "get_loop_body_for",
-          &tensorexpr::LoopNest::getLoopBodyFor,
+          &LoopNest::getLoopBodyFor,
           py::return_value_policy::reference)
       .def(
           "get_loops_for",
-          [](const tensorexpr::LoopNest& self, tensorexpr::Tensor* t) {
+          [](const LoopNest& self, Tensor* t) {
             return self.getLoopStmtsFor(t);
           },
           py::return_value_policy::reference)
       .def(
           "split_with_tail",
-          [](const tensorexpr::LoopNest& self, tensorexpr::For* f, int factor) {
-            tensorexpr::For *outer = nullptr, *inner = nullptr, *tail = nullptr;
+          [](const LoopNest& self, For* f, int factor) {
+            For *outer = nullptr, *inner = nullptr, *tail = nullptr;
             self.splitWithTail(f, factor, &outer, &inner, &tail);
             return std::make_tuple(outer, inner, tail);
           },
           py::return_value_policy::reference)
       .def(
           "split_with_mask",
-          [](const tensorexpr::LoopNest& self, tensorexpr::For* f, int factor) {
-            tensorexpr::For *outer = nullptr, *inner = nullptr;
+          [](const LoopNest& self, For* f, int factor) {
+            For *outer = nullptr, *inner = nullptr;
             self.splitWithMask(f, factor, &outer, &inner);
             return std::make_tuple(outer, inner);
           },
           py::return_value_policy::reference)
       .def(
           "unroll",
-          [](const tensorexpr::LoopNest& self, tensorexpr::For* f) {
-            tensorexpr::Stmt* unrolled = nullptr;
+          [](const LoopNest& self, For* f) {
+            Stmt* unrolled = nullptr;
             self.unroll(f, &unrolled);
             return unrolled;
           },
           py::return_value_policy::reference)
       .def(
           "vectorize",
-          [](const tensorexpr::LoopNest& self, tensorexpr::For* f) {
-            self.vectorize(f);
-          },
+          [](const LoopNest& self, For* f) { self.vectorize(f); },
           py::return_value_policy::reference)
       .def(
           "compute_inline",
-          [](tensorexpr::LoopNest& self, tensorexpr::Stmt* s) {
-            self.computeInline(s);
-          },
+          [](LoopNest& self, Stmt* s) { self.computeInline(s); },
           py::return_value_policy::reference)
       .def(
           "compute_inline",
-          [](tensorexpr::LoopNest& self, const tensorexpr::BufHandle& b) {
+          [](LoopNest& self, const BufHandle& b) {
             self.computeInline(b.node());
           },
           py::return_value_policy::reference)
       .def(
           "rfactor",
-          [](tensorexpr::LoopNest& self,
-             const tensorexpr::Stmt& s,
-             const tensorexpr::VarHandle& v) {
-            auto st = dynamic_cast<const tensorexpr::Store*>(&s);
+          [](LoopNest& self, const Stmt& s, const VarHandle& v) {
+            auto st = dynamic_cast<const Store*>(&s);
             if (!st) {
               return;
             }
@@ -424,11 +307,11 @@ void initTensorExprBindings(PyObject* module) {
           py::return_value_policy::reference)
       .def(
           "rfactor",
-          [](tensorexpr::LoopNest& self,
-             const tensorexpr::Stmt& s,
-             const tensorexpr::VarHandle& v,
+          [](LoopNest& self,
+             const Stmt& s,
+             const VarHandle& v,
              tensorexpr::Block& ins_point) {
-            auto st = dynamic_cast<const tensorexpr::Store*>(&s);
+            auto st = dynamic_cast<const Store*>(&s);
             if (!st) {
               return;
             }
@@ -438,90 +321,80 @@ void initTensorExprBindings(PyObject* module) {
           py::return_value_policy::reference)
       .def(
           "flatten",
-          [](const tensorexpr::LoopNest& self,
-             const std::vector<tensorexpr::For*>& loops) {
-            tensorexpr::For* flattened;
+          [](const LoopNest& self, const std::vector<For*>& loops) {
+            For* flattened = nullptr;
             self.flatten(loops, &flattened);
             return flattened;
           },
           py::return_value_policy::reference)
       .def(
-          "reorder",
-          &tensorexpr::LoopNest::reorderAxis,
-          py::return_value_policy::reference)
-      .def(
-          "simplify",
-          &tensorexpr::LoopNest::simplify,
-          py::return_value_policy::reference)
+          "reorder", &LoopNest::reorderAxis, py::return_value_policy::reference)
+      .def("simplify", &LoopNest::simplify, py::return_value_policy::reference)
       .def(
           "set_GPU_block_index",
-          &tensorexpr::LoopNest::setGPUBlockIndex,
+          &LoopNest::setGPUBlockIndex,
           py::return_value_policy::reference)
       .def(
           "set_GPU_thread_index",
-          &tensorexpr::LoopNest::setGPUThreadIndex,
+          &LoopNest::setGPUThreadIndex,
           py::return_value_policy::reference)
       .def(
           "__str__",
-          [](const tensorexpr::LoopNest& self) {
+          [](const LoopNest& self) {
             std::stringstream ss;
             ss << *self.root_stmt();
             return ss.str();
           })
       .def(
           "root_stmt",
-          &tensorexpr::LoopNest::root_stmt,
+          &LoopNest::root_stmt,
           py::return_value_policy::reference);
 
   te.def(
       "simplify",
-      [](tensorexpr::Stmt* stmt) {
-        return tensorexpr::IRSimplifier::simplify(stmt);
-      },
+      [](Stmt* stmt) { return IRSimplifier::simplify(stmt); },
       py::return_value_policy::reference);
 
-  py::class_<tensorexpr::CodeGen>(te, "CodeGen")
-      .def(
-          "call",
-          [](tensorexpr::CodeGen& self, const std::vector<at::Tensor>& values) {
-            std::vector<tensorexpr::CodeGen::CallArg> value_ptrs;
-            for (const auto& value : values) {
-              value_ptrs.emplace_back(
-                  tensorexpr::CodeGen::CallArg(value.data_ptr()));
-            }
-            self.call(value_ptrs);
-          });
-  py::class_<tensorexpr::SimpleIREvaluator, tensorexpr::CodeGen>(
-      te, "SimpleIREvaluator");
+  py::class_<CodeGen>(te, "CodeGen")
+      .def("call", [](CodeGen& self, const std::vector<at::Tensor>& values) {
+        std::vector<CodeGen::CallArg> value_ptrs;
+        value_ptrs.reserve(values.size());
+        for (const auto& value : values) {
+          value_ptrs.emplace_back(CodeGen::CallArg(value.data_ptr()));
+        }
+        self.call(value_ptrs);
+      });
+  py::class_<SimpleIREvaluator, CodeGen>(te, "SimpleIREvaluator"); // NOLINT
 #ifdef TORCH_ENABLE_LLVM
-  py::class_<tensorexpr::LLVMCodeGen, tensorexpr::CodeGen>(te, "LLVMCodeGen");
+  py::class_<LLVMCodeGen, CodeGen>(te, "LLVMCodeGen"); // NOLINT
 #endif
 
-  py::class_<tensorexpr::CodeGen::BufferArg>(te, "BufferArg")
-      .def(py::init<const tensorexpr::Placeholder&>())
-      .def(py::init<tensorexpr::Tensor*>())
-      .def(py::init<const tensorexpr::VarHandle&>());
+  py::class_<CodeGen::BufferArg>(te, "BufferArg")
+      .def(py::init<const Placeholder&>())
+      .def(py::init<Tensor*>())
+      .def(py::init<const VarHandle&>())
+      .def(py::init<const BufHandle&>());
 
   te.def(
       "construct_codegen",
       [](const std::string& name,
-         tensorexpr::Stmt* stmt,
-         const std::vector<tensorexpr::CodeGen::BufferArg>& args) {
-        tensorexpr::CodeGen* cg = nullptr;
+         Stmt* stmt,
+         const std::vector<CodeGen::BufferArg>& args) {
+        CodeGen* cg = nullptr;
         if (name == "llvm") {
 #ifdef TORCH_ENABLE_LLVM
-          cg = new tensorexpr::LLVMCodeGen(stmt, args);
+          cg = new LLVMCodeGen(stmt, args);
 #else
           throw std::runtime_error("PyTorch not compiled with LLVM support!");
 #endif
         } else if (name == "cuda") {
 #ifdef USE_CUDA
-          cg = new tensorexpr::CudaCodeGen(stmt, args);
+          cg = new CudaCodeGen(stmt, args);
 #else
           throw std::runtime_error("PyTorch not compiled with CUDA support!");
 #endif
         } else {
-          cg = new tensorexpr::SimpleIREvaluator(stmt, args);
+          cg = new SimpleIREvaluator(stmt, args);
         }
         return cg;
       });


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53063 [TensorExpr] Reland: "PyBind: bind ExternalCalls."**

The problem was that a derived class was marked with "py::nodelete",
while the base class wasn't. Now they both are marked correctly.

Differential Revision: [D26737877](https://our.internmc.facebook.com/intern/diff/D26737877)