### PR TITLE
Remove ci-all and release branches running scheduled tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9021,8 +9021,6 @@ workflows:
             branches:
               only:
                 - master
-                - /ci-all\/.*/
-                - /release\/.*/
     jobs:
       - docker_build_job:
           name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -7,8 +7,6 @@
             branches:
               only:
                 - master
-                - /ci-all\/.*/
-                - /release\/.*/
     jobs:
       - docker_build_job:
           name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"


### PR DESCRIPTION
The previous code allowed these tests to run every four hours on certain ci-all branches...which is really bad and resource intensive. This code removes that, but then disallows the 11.2 and 9.2 tests to be run on ci-all branches.

To debug CUDA 11.2 or 9.2 tests, one must now manually change the config to allow for them. (Look at #51888 and #51598 for examples of how to do that.)