### PR TITLE
[PyTorch] Add doc string for lite interpreter related api in Android

### DIFF
--- a/android/pytorch_android/src/main/java/org/pytorch/LiteModuleLoader.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/LiteModuleLoader.java
@@ -2,10 +2,25 @@ package org.pytorch;
 
 public class LiteModuleLoader {
 
+  /**
+   * Loads a serialized TorchScript module from the specified path on the disk to run on specified
+   * device. The model should be generated from this api _save_for_lite_interpreter().
+   *
+   * @param modelPath path to file that contains the serialized TorchScript module.
+   * @param device {@link org.pytorch.Device} to use for running specified module.
+   * @return new {@link org.pytorch.Module} object which owns torch::jit::mobile::Module.
+   */
   public static Module load(final String modelPath, final Device device) {
     return new Module(new LiteNativePeer(modelPath, device));
   }
 
+  /**
+   * Loads a serialized TorchScript module from the specified path on the disk to run on CPU. The
+   * model should be generated from this api _save_for_lite_interpreter().
+   *
+   * @param modelPath path to file that contains the serialized TorchScript module.
+   * @return new {@link org.pytorch.Module} object which owns torch::jit::mobile::Module.
+   */
   public static Module load(final String modelPath) {
     return new Module(new LiteNativePeer(modelPath, Device.CPU));
   }

--- a/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
+++ b/android/pytorch_android/src/main/java/org/pytorch/LiteNativePeer.java
@@ -21,11 +21,30 @@ class LiteNativePeer implements INativePeer {
     mHybridData = initHybrid(moduleAbsolutePath, device.jniCode);
   }
 
+  /**
+   * Explicitly destroys the native torch::jit::mobile::Module. Calling this method is not required,
+   * as the native object will be destroyed when this object is garbage-collected. However, the
+   * timing of garbage collection is not guaranteed, so proactively calling {@code resetNative} can
+   * free memory more quickly. See {@link com.facebook.jni.HybridData#resetNative}.
+   */
   public void resetNative() {
     mHybridData.resetNative();
   }
 
+  /**
+   * Runs the 'forward' method of this module with the specified arguments.
+   *
+   * @param inputs arguments for the TorchScript module's 'forward' method.
+   * @return return value from the 'forward' method.
+   */
   public native IValue forward(IValue... inputs);
 
+  /**
+   * Runs the specified method of this module with the specified arguments.
+   *
+   * @param methodName name of the TorchScript method to run.
+   * @param inputs arguments that will be passed to TorchScript method.
+   * @return return value from the method.
+   */
   public native IValue runMethod(String methodName, IValue... inputs);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53079 [PyTorch] Add doc string for lite interpreter related api in Android**

As title, doc string in ios, c++ and python is ready.

As a reference, the doc string for other lite interpreter related apis
[_load_for_mobile](https://www.internalfb.com/intern/diffusion/FBS/browsefile/master/fbcode/caffe2/torch/csrc/jit/mobile/import.h?commit=c95d12f9d67ee198aa4b5aafec980e9048de1702&lines=16-43)
[_save_for_lite_interpreter](https://www.internalfb.com/intern/diffusion/FBS/browsefile/master/fbcode/caffe2/torch/jit/_script.py?commit=b1d7f0ba6001beed6ba3b0a69a225abab4ed3866&lines=496-509)

Differential Revision: [D26742092](https://our.internmc.facebook.com/intern/diff/D26742092/)