### PR TITLE
Fix SIGSEGV in CudaIPCTypes.cpp.

### DIFF
--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -34,6 +34,11 @@ struct CudaIPCGlobalEntities {
   CudaIPCGlobalEntities() : ref_counters_files_() {}
   ~CudaIPCGlobalEntities() {
     CudaIPCSentDataLimbo_.collect();
+    // Clear shared blocks to avoid releasing shared blocks after
+    // ~CudaIPCGlobalEntities is done since circular references causes the
+    // destructor of ~CudaIPCSentData to access the cuda_ipc_global_entities
+    // again.
+    CudaIPCSentDataLimbo_.clear_shared_blocks();
     safe_clean_current_file();
     if (next_available_ref_counters_file_) {
       warnProducerTerminatedBeforeSharedTensorsReleased();
@@ -56,6 +61,10 @@ CudaIPCSentDataLimbo::~CudaIPCSentDataLimbo() {
   if (shared_blocks_.size() > 0) {
     warnProducerTerminatedBeforeSharedTensorsReleased();
   }
+}
+
+void CudaIPCSentDataLimbo::clear_shared_blocks() {
+  shared_blocks_.clear();
 }
 
 bool CudaIPCSentDataLimbo::collect() {
@@ -108,11 +117,13 @@ void CudaIPCSentDataDelete(void* ptr) {
 void ReturnRefCounter(const std::string& handle, uint64_t offset /* unused */) {
   std::lock_guard<std::mutex> lock(
       cuda_ipc_global_entities.ref_counters_mutex_);
-  cuda_ipc_global_entities.ref_counters_files_[handle]->return_offset(offset);
-  if (cuda_ipc_global_entities.ref_counters_files_[handle]->offsets_in_use() ==
-          0 &&
-      !cuda_ipc_global_entities.ref_counters_files_[handle]->have_offsets()) {
-    cuda_ipc_global_entities.ref_counters_files_.erase(handle);
+  auto& map = cuda_ipc_global_entities.ref_counters_files_;
+  auto it = map.find(handle);
+  if (it != map.end()) {
+    it->second->return_offset(offset);
+    if (it->second->offsets_in_use() == 0 && !it->second->have_offsets()) {
+      map.erase(handle);
+    }
   }
 }
 

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -63,6 +63,7 @@ constexpr int64_t CUDA_IPC_MAXIMUM_EVENTS_TO_USE = 1000;
 struct CudaIPCSentDataLimbo final {
   ~CudaIPCSentDataLimbo();
   bool collect();
+  void clear_shared_blocks();
   void add(std::unique_ptr<CudaIPCSentData> shared_block);
   uint64_t size() {
     return shared_blocks_.size();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53080 Fix SIGSEGV in CudaIPCTypes.cpp.**

As described in https://github.com/pytorch/pytorch/issues/51619,
ProcessGroupShareTensorTest was failing due to segfaults in CudaIPCTypes.cpp.
There were two issues that had to be fixed for this:

1. The ref_counter_files_ map was looked up and the result was used without
checking whether or not the appropriate key existed in the map. This would
result in default construction in the map if the key didn't exist resulting in
a nullptr being stored in the map.
2. ~CudaIPCSentData uses the global cuda_ipc_global_entities variable. But as
part of destroying cuda_ipc_global_entities, ~CudaIPCSentData is called which
accesses an already destroyed cuda_ipc_global_entities. This is now avoided by
clearing all shared blocks in ~CudaIPCGlobalEntities to ensure they are all
cleaned up before the destructor exits.

#Closes: https://github.com/pytorch/pytorch/issues/51619

Differential Revision: [D26742332](https://our.internmc.facebook.com/intern/diff/D26742332/)