### PR TITLE
[FX] Optionally record stack traces when symtracing

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -198,7 +198,7 @@ class TestFX(JitTestCase):
         class NoMutableCallTracer(Tracer):
             def create_node(self, kind : str, target : Union[str, Callable],
                             args : Tuple[Argument, ...], kwargs : Dict[str, Any], name : Optional[str] = None,
-                            type_expr : Optional[Any] = None, stack_trace : Optional[str] = None) -> Node:
+                            type_expr : Optional[Any] = None) -> Node:
                 name = target if isinstance(target, str) else torch.typename(target)
                 if name[-1] == '_':
                     raise RuntimeError('In-place operations are not supported')
@@ -562,7 +562,7 @@ class TestFX(JitTestCase):
         class TaggingTracer(Tracer):
             def create_node(self, kind : str, target : Union[str, Callable],
                             args : Tuple[Argument, ...], kwargs : Dict[str, Any], name : Optional[str] = None,
-                            type_expr : Optional[Any] = None, stack_trace : Optional[str] = None) -> Node:
+                            type_expr : Optional[Any] = None) -> Node:
                 n = super().create_node(kind, target, args, kwargs, name)
                 n.tag = 'foo'
                 return n

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -322,8 +322,7 @@ class Graph:
                     args: Optional[Tuple['Argument', ...]] = None,
                     kwargs: Optional[Dict[str, 'Argument']] = None,
                     name: Optional[str] = None,
-                    type_expr: Optional[Any] = None,
-                    stack_trace: Optional[str] = None) -> Node:
+                    type_expr: Optional[Any] = None) -> Node:
         """
         Create a ``Node`` and add it to the ``Graph`` at the current insert-point.
         Note that the current insert-point can be set via :meth:`Graph.inserting_before`
@@ -357,7 +356,7 @@ class Graph:
 
         candidate = name if name is not None else self._target_to_str(target)
         name = self._graph_namespace.create_name(candidate, None)
-        n = Node(self, name, op, target, args, kwargs, type_expr, stack_trace)
+        n = Node(self, name, op, target, args, kwargs, type_expr)
 
         self._graph_namespace.associate_name_with_obj(name, n)
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -322,7 +322,8 @@ class Graph:
                     args: Optional[Tuple['Argument', ...]] = None,
                     kwargs: Optional[Dict[str, 'Argument']] = None,
                     name: Optional[str] = None,
-                    type_expr: Optional[Any] = None) -> Node:
+                    type_expr: Optional[Any] = None,
+                    stack_trace: Optional[str] = None) -> Node:
         """
         Create a ``Node`` and add it to the ``Graph`` at the current insert-point.
         Note that the current insert-point can be set via :meth:`Graph.inserting_before`
@@ -356,7 +357,7 @@ class Graph:
 
         candidate = name if name is not None else self._target_to_str(target)
         name = self._graph_namespace.create_name(candidate, None)
-        n = Node(self, name, op, target, args, kwargs, type_expr)
+        n = Node(self, name, op, target, args, kwargs, type_expr, stack_trace)
 
         self._graph_namespace.associate_name_with_obj(name, n)
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -111,7 +111,7 @@ class Node:
     """
     def __init__(self, graph: 'Graph', name: str, op: str, target: 'Target',
                  args: Tuple['Argument', ...], kwargs: Dict[str, 'Argument'],
-                 type : Optional[Any] = None) -> None:
+                 type : Optional[Any] = None, stack_trace : Optional[str] = None) -> None:
         self.graph = graph
         self.name = name  # unique name of value being created
         assert op in ['placeholder', 'call_method', 'call_module', 'call_function', 'get_attr', 'output', 'root']
@@ -150,6 +150,7 @@ class Node:
 
         # If set, use this fn to print this node
         self._repr_fn : Optional[Callable[[Node], str]] = None
+        self.stack_trace = stack_trace
 
     @property
     def next(self) -> 'Node':

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -111,7 +111,7 @@ class Node:
     """
     def __init__(self, graph: 'Graph', name: str, op: str, target: 'Target',
                  args: Tuple['Argument', ...], kwargs: Dict[str, 'Argument'],
-                 type : Optional[Any] = None, stack_trace : Optional[str] = None) -> None:
+                 type : Optional[Any] = None) -> None:
         self.graph = graph
         self.name = name  # unique name of value being created
         assert op in ['placeholder', 'call_method', 'call_module', 'call_function', 'get_attr', 'output', 'root']
@@ -150,7 +150,7 @@ class Node:
 
         # If set, use this fn to print this node
         self._repr_fn : Optional[Callable[[Node], str]] = None
-        self.stack_trace = stack_trace
+        self._stack_trace : Optional[str] = None
 
     @property
     def next(self) -> 'Node':
@@ -265,6 +265,20 @@ class Node:
             ``Node``, in that order.
         """
         return list(self._input_nodes.keys())
+
+    @property
+    def stack_trace(self) -> Optional[str]:
+        """
+        Return the Python stack trace that was recorded during tracing, if any.
+        This property is usually populated by `Tracer.create_proxy`. To record
+        stack traces during tracing for debug purposes, set
+        `record_stack_traces = True` on the `Tracer` instance.
+        """
+        return self._stack_trace
+
+    @stack_trace.setter
+    def stack_trace(self, trace : Optional[str]):
+        self._stack_trace = trace
 
     def __update_args_kwargs(self, new_args : Tuple['Argument', ...], new_kwargs : Dict[str, 'Argument']):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53081 [WIP][FX] Optionally record stack traces when symtracing**

Add a flag to `Tracer`, `record_stack_traces` that causes the `Tracer` to extract the Python stack trace and store it away on the `Node` whenever we record an operation. Example script:

```
import torch
import torch.fx
import torchvision.models as models


rn18 = models.resnet18()

class StackTraceTracer(torch.fx.Tracer):
    record_stack_traces : bool = True

graph = StackTraceTracer().trace(rn18)

for node in graph.nodes:
    if node.stack_trace is not None:
        print(node.format_node())
        print(node.stack_trace)
```

With output: https://gist.github.com/jamesr66a/6d628adf1defd334405660a1274f0f8f

Differential Revision: [D26742402](https://our.internmc.facebook.com/intern/diff/D26742402)