### PR TITLE
Add RemoteModule to master RPC docs.

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -254,6 +254,20 @@ details.
 
     rpc/rref
 
+.. _remote_module:
+
+RemoteModule
+------------
+
+``RemoteModule`` is an easy way to create an nn.Module remotely on a different 
+process. The actual module resides on a remote host, but the local host has a 
+handle to this module and invoke this module similar to a regular nn.Module. 
+The invocation however incurs RPC calls to the remote end and can be performed 
+asynchronously if needed via additional APIs supported by RemoteModule.
+
+.. autoclass:: torch.distributed.nn.api.remote_module.RemoteModule
+    :members:
+
 
 Distributed Autograd Framework
 ------------------------------

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -333,26 +333,32 @@ class RemoteModule(_RemoteModule):
         It takes care of autograd recording to ensure the backward pass propogates
         gradients back to the corresponding remote module.
 
-        The arguments of ``forward_async`` and ``forward`` are the same as
-        the ``forward`` method of the module returned by the ``module_cls``.
+        It generates two methods ``forward_async`` and ``forward`` based on the
+        signature of the ``forward`` method of ``module_cls``. ``forward_async``
+        runs asynchronously and returns a Future. The arguments of ``forward_async``
+        and ``forward`` are the same as the ``forward`` method of the module
+        returned by the ``module_cls``.
 
         For example, if ``module_cls`` returns an instance of ``nn.Linear``,
-        that has ``forward`` method signature, ``def forward(input: Tensor) -> Tensor:``,
-        the generated ``RemoteModule`` will have 2 methods in signature of
-        ``def forward(input: Tensor) -> Tensor:`` and
-        ``def forward_async(input: Tensor) -> Future[Tensor]:``.
+        that has ``forward`` method signature: ``def forward(input: Tensor) -> Tensor:``,
+        the generated ``RemoteModule`` will have 2 methods with the signatures:
+
+        | ``def forward(input: Tensor) -> Tensor:``
+        | ``def forward_async(input: Tensor) -> Future[Tensor]:``
 
     Args:
         remote_device (str): Device on the destination worker where we‘d like to place this module.
             The format should be "<workername>/<device>", where the device field can be parsed as torch.device type.
             E.g., "trainer0/cpu", "trainer0", "ps0/cuda:0".
             In addition, the device field can be optional and the default value is "cpu".
-        module_cls (nn.Module): For example,
+        module_cls (nn.Module): Class for the module to be created remotely. For example,
+
             >>> class MyModule(nn.Module):
             >>>     def forward(input):
             >>>         return input + 1
             >>>
             >>> module_cls = MyModule
+
         args (Sequence, optional): args to be passed to ``module_cls``.
         kwargs (Dict, optional): kwargs to be passed to ``module_cls``.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53084 Add RemoteModule to master RPC docs.**

Adding RemoteModule to master RPC docs since it is a prototype
feature.

Differential Revision: [D26743372](https://our.internmc.facebook.com/intern/diff/D26743372/)