### PR TITLE
[Gradient Compression] Don't provide default values in GradBucket constructor

### DIFF
--- a/torch/lib/c10d/comm.hpp
+++ b/torch/lib/c10d/comm.hpp
@@ -22,9 +22,9 @@ class GradBucket {
   explicit GradBucket(
       size_t index,
       const std::vector<at::Tensor>& tensors,
-      const std::vector<size_t>& offsets = {},
-      const std::vector<size_t>& lengths = {},
-      const std::vector<c10::IntArrayRef>& sizes_vec = {})
+      const std::vector<size_t>& offsets,
+      const std::vector<size_t>& lengths,
+      const std::vector<c10::IntArrayRef>& sizes_vec)
       : index_(index),
         tensors_(tensors),
         offsets_(offsets),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53102 [Gradient Compression] Don't provide default values in GradBucket constructor**
* #53009 [Gradient Compression] Add get_per_parameter_tensors method to GradBucket class
* #53008 Clang-format c10d/init.cpp

In `GradBucket` constructor, `offsets`, `lengths`, and `sizes_vec` are optional arguments and could possibly be empty. It will be safe to remove the default values.

Differential Revision: [D26748199](https://our.internmc.facebook.com/intern/diff/D26748199/)