### PR TITLE
[testing] UnaryOps: out= device mismatch test

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -452,6 +452,13 @@ Tensor& nan_to_num_out(
       self.scalar_type());
 
   if (c10::isIntegralType(self.scalar_type(), /*include_bool=*/true)) {
+    // Manually check for device as `copy_` allows cross-device copies.
+    TORCH_CHECK(
+        self.device() == result.device(),
+        "torch.nan_to_num(): Expected all tensors to be on the same device but input is on ",
+        self.device(),
+        " out is on ",
+        result.device())
     result.resize_as_(self);
     result.copy_(self);
     return result;

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -494,7 +494,7 @@ class TestUnaryUfuncs(TestCase):
             self._test_out_arg(op, input, out, expected)
 
     @onlyCUDA
-    @ops(unary_ufuncs, dtypes=OpDTypes.basic)
+    @ops(unary_ufuncs)
     def test_out_mismatched_device(self, device, dtype, op):
         input_cuda = make_tensor((3,), dtype=dtype, device=device,
                                  low=op.domain[0], high=op.domain[1])


### PR DESCRIPTION
Takes about 2 mins 15 seconds to run these tests,

```
pytest test/test_unary_ufuncs.py -k _out_mis 
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/kshiteej/Pytorch/pytorch_mismatched_device_unary_ops
plugins: hypothesis-5.38.1
collected 11721 items / 10874 deselected / 847 selected                                                                                                                

test/test_unary_ufuncs.py ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 15%]
ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 34%]
ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss........................................ [ 53%]
................................................sssssssss....................................................................................................... [ 72%]
................................................................................................................................................................ [ 91%]
.........................................................................                                                                                        [100%]

============================================== 424 passed, 423 skipped, 10874 deselected, 2 warnings in 135.38s (0:02:15) ==============================================
```