### PR TITLE
add submodules to sys.modules so their attributes can be pickled

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14926,6 +14926,14 @@ class TestLazyModules(TestCase):
         with self.assertRaisesRegex(ValueError, 'uninitialized parameter'):
             param + param
 
+class TestFunctionalPickle(TestCase):
+
+    # issue gh-38137
+    def test_pickle_softsign(self):
+        # Make sure it does not throw an exception
+        s = pickle.dumps(F.softsign)
+    
+
 instantiate_device_type_tests(TestNNDeviceType, globals())
 
 if __name__ == '__main__':

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -230,6 +230,19 @@ __all__ += [name for name in dir(_C)
             if name[0] != '_' and
             not name.endswith('Base')]
 
+if not TYPE_CHECKING:
+    # issue 38137 and python issue 43367. Submodules of a C extension are
+    # non-standard, and attributes of those submodules cannot be pickled since
+    # pickle expect to be able to import them as "from _C.sub import attr"
+    # which fails with "_C is not a package
+    for attr in dir(_C):
+        candidate = getattr(_C, attr)
+        if type(candidate) is type(_C):
+            # submodule
+            if f'torch._C.{attr}' not in sys.modules:
+                sys.modules[f'torch._C.{attr}'] = candidate
+ 
+
 ################################################################################
 # Define basic utilities
 ################################################################################


### PR DESCRIPTION
Fixes #38137

As mentioned in the issue, this is a workaround for [python issue 43367](https://bugs.python.org/issue43367). There are a number of other places where `sys.modules` is modified, if something changes in python perhaps those should be reviewed as well.
