### PR TITLE
Delete dead Backend toSparse

### DIFF
--- a/c10/core/Backend.h
+++ b/c10/core/Backend.h
@@ -49,27 +49,6 @@ enum class Backend {
   NumOptions
 };
 
-static inline Backend toSparse(Backend b) {
-  switch (b) {
-    case Backend::CPU:
-      return Backend::SparseCPU;
-    case Backend::XPU:
-      return Backend::SparseXPU;
-    case Backend::CUDA:
-      return Backend::SparseCUDA;
-    case Backend::HIP:
-      return Backend::SparseHIP;
-    case Backend::SparseCPU:
-      return Backend::SparseCPU;
-    case Backend::SparseCUDA:
-      return Backend::SparseCUDA;
-    case Backend::SparseHIP:
-      return Backend::SparseHIP;
-    default:
-      throw std::runtime_error("Unknown backend");
-  }
-}
-
 static inline Backend toDense(Backend b) {
   switch (b) {
     case Backend::CPU:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53143 Make meta a device (getting rid of empty_meta)
* #53142 Add NoOpDeviceGuardImpl
* **#53116 Delete dead Backend toSparse**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D26753226](https://our.internmc.facebook.com/intern/diff/D26753226)