### PR TITLE
[caffe2] Fix shape inference for Softmax

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -46,7 +46,7 @@ void verifyShapeInfo(
   const auto& shape = shape_info.shape;
   ASSERT_EQ(shape.dims_size(), dims.size());
   for (int i = 0; i < dims.size(); ++i) {
-    EXPECT_EQ(shape.dims(i), dims[i]);
+    EXPECT_EQ(dims[i], shape.dims(i));
   }
   EXPECT_EQ(shape.data_type(), dtype);
   EXPECT_EQ(shape_info.is_quantized, quantized);
@@ -981,4 +981,30 @@ TEST(BoundShapeInference, Combo0) {
       "Gout",
       {TensorBoundShape_DimType_BATCH, TensorBoundShape_DimType_CONSTANT},
       {spec.max_batch_size, 2});
+}
+
+TEST(BoundShapeInference, Softmax) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "Softmax",
+      "",
+      {"input"},
+      {"output"},
+      {MakeArgument<int>("axis", 1)}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "input",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 16}));
+  BoundShapeSpec spec(32, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "output",
+      {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
+      {1, 16});
 }

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -169,6 +169,8 @@ void BoundShapeInferencer::InferOps(
     InferTile(op);
   } else if (op.type() == "SparseLengthsSumSparseLookup") {
     InferSparseLengthsSumSparseLookup(op);
+  } else if (op.type() == "Softmax") {
+    InferSoftmax(op);
   } else {
     InferCommonOp(op);
   }
@@ -897,6 +899,24 @@ void BoundShapeInferencer::InferTile(const OperatorDef& op) {
       op.output(0),
       setDimTypeWithFirst(TensorBoundShape_DimType_BATCH, ndims),
       ConvertToVec(shape.dims()),
+      it->second.shape.data_type(),
+      false);
+}
+
+void BoundShapeInferencer::InferSoftmax(const OperatorDef& op) {
+  CAFFE_ENFORCE_EQ(op.input_size(), 1, op.type(), " must have 1 input");
+  CAFFE_ENFORCE_EQ(op.output_size(), 1, op.type(), " must have 1 output");
+
+  auto it = shape_info_.find(op.input(0));
+  if (it == shape_info_.end()) {
+    LOG(WARNING) << "Didn't find shape info for the input of Softmax";
+    return;
+  }
+
+  CheckAndSetTensorBoundShape(
+      op.output(0),
+      setDimTypeWithFirst(it->second.getDimType(0), it->second.shape.dims_size()),
+      ConvertToVec(it->second.shape.dims()),
       it->second.shape.data_type(),
       false);
 }

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -135,6 +135,7 @@ class TORCH_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferUnPackRecords(const OperatorDef& op);
   void InferTile(const OperatorDef& op);
   void InferSparseLengthsSumSparseLookup(const OperatorDef& op);
+  void InferSoftmax(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference
   // function


### PR DESCRIPTION
Summary: Input and output should have the same shape for Softmax https://caffe2.ai/docs/operators-catalogue.html#softmax.

Differential Revision: D26536592

