### PR TITLE
[TensorExpr] IRVerifier: add index verifier for Store.

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -3612,8 +3612,8 @@ TEST(LoopNest, DeadStoreElimination) {
   KernelScope kernel_scope;
   VarHandle y("y", kInt);
   VarHandle x("x_tail", kInt);
-  BufHandle f("f", {26, 5}, kFloat);
-  BufHandle g("g", {26, 5}, kFloat);
+  BufHandle f("f", {26, 5}, kInt);
+  BufHandle g("g", {26, 5}, kInt);
   ExprHandle x_outer_end = 5;
   ExprHandle x_2 = x + x_outer_end * 4;
   For* stmt1 = For::make(
@@ -3664,9 +3664,9 @@ TEST(LoopNest, DeadStoreEliminationWithIntermediates) {
   VarHandle x("x", kInt);
   VarHandle y("y", kInt);
   VarHandle z("z", kInt);
-  BufHandle f("f", {26 * 5}, kFloat);
-  BufHandle g("g", {26 * 5}, kFloat);
-  BufHandle h("h", {26, 5}, kFloat);
+  BufHandle f("f", {26 * 5}, kInt);
+  BufHandle g("g", {26 * 5}, kInt);
+  BufHandle h("h", {26, 5}, kInt);
   ExprHandle x_outer_end = 5;
   ExprHandle x_2 = x + x_outer_end * 4;
   For* stmt1 = For::make(x, 0, 26 * 5, Store::make(f, {x}, x));

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -23,7 +23,17 @@ Load::Load(
     const Buf* buf,
     const std::vector<const Expr*>& indices,
     const Expr* mask)
-    : ExprNodeBase(dtype), buf_(buf), indices_(indices), mask_(mask) {}
+    : ExprNodeBase(dtype), buf_(buf), indices_(indices), mask_(mask) {
+  // Cast all indices to Int
+  // TODO: Should we use int64 here?
+  auto index_dtype = ScalarType::Int;
+  for (size_t i = 0; i < indices_.size(); i++) {
+    const Dtype& dt = indices_[i]->dtype();
+    if (is_integral(dt.scalar_type()) && dt.scalar_type() != index_dtype) {
+      indices_[i] = new Cast(Dtype(index_dtype, dt.lanes()), indices_[i]);
+    }
+  }
+}
 
 Load::Load(
     const Buf* buf,
@@ -70,27 +80,15 @@ Store::Store(
     const Expr* value,
     const Expr* mask)
     : buf_(buf), indices_(std::move(indices)), value_(value), mask_(mask) {
-  /*
-  TODO: Reenable the checks.
-  The reason they are disabled is that kernel.cpp is using Buffers somewhat
-  loosely: we don't set dimensions properly and just construct index expressions
-  directly. We should harden that part and then we'd be able to turn on these
-  checks.
-
-  if (!indicesValid(indices)) {
-    throw malformed_input();
+  // Cast all indices to Int
+  // TODO: Should we use int64 here?
+  auto index_dtype = ScalarType::Int;
+  for (size_t i = 0; i < indices_.size(); i++) {
+    const Dtype& dt = indices_[i]->dtype();
+    if (is_integral(dt.scalar_type()) && dt.scalar_type() != index_dtype) {
+      indices_[i] = new Cast(Dtype(index_dtype, dt.lanes()), indices_[i]);
+    }
   }
-  if (!mask || !value) {
-    throw malformed_input();
-  }
-  Dtype index_dtype = dtypeOfIndices(indices);
-  if (index_dtype.lanes() != mask->dtype().lanes()) {
-    throw malformed_input();
-  }
-  if (index_dtype.lanes() != value->dtype().lanes()) {
-    throw malformed_input();
-  }
-  */
 }
 
 Store* Store::make(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53137 [TensorExpr] IRVerifier: add index verifier for Store.**

Also, add casting to Int for Load and Store indices.

Fixes #52773.

Differential Revision: [D26760256](https://our.internmc.facebook.com/intern/diff/D26760256)