### PR TITLE
Store only coverage info as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,9 @@ jobs:
     - store_test_results:
         path: test-reports
     - store_artifacts:
-        path: test/*coverage*
+        path: test/.coverage
+    - store_artifacts:
+        path: test/coverage.xml
 
   pytorch_windows_build:
     <<: *pytorch_windows_params

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,7 +668,7 @@ jobs:
     - store_test_results:
         path: test-reports
     - store_artifacts:
-        path: test
+        path: test/*coverage*
 
   pytorch_windows_build:
     <<: *pytorch_windows_params

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -223,7 +223,9 @@ jobs:
     - store_test_results:
         path: test-reports
     - store_artifacts:
-        path: test/*coverage*
+        path: test/.coverage
+    - store_artifacts:
+        path: test/coverage.xml
 
   pytorch_windows_build:
     <<: *pytorch_windows_params

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -223,7 +223,7 @@ jobs:
     - store_test_results:
         path: test-reports
     - store_artifacts:
-        path: test
+        path: test/*coverage*
 
   pytorch_windows_build:
     <<: *pytorch_windows_params


### PR DESCRIPTION
I noticed #53126 stored everything in the test folder as an artifact, which isn't exactly what we want. Here, I try to store just the relevant info, coverage files.