### PR TITLE
disable TCPStore multi_worker tests for windows

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -48,6 +48,7 @@ from torch.testing._internal.common_utils import (
     ADDRESS_IN_USE,
     CONNECT_TIMEOUT,
     TEST_WITH_TSAN,
+    IS_WINDOWS,
 )
 
 
@@ -386,9 +387,15 @@ class TCPStoreTest(TestCase, StoreTestBase):
         if any([p.exitcode != 0 for p in processes]):
             raise RuntimeError(error_message)
 
+    @unittest.skipIf(
+        IS_WINDOWS, "Skip test for windows due to multiprocessing library error when using windows spawn"
+    )
     def test_multi_worker_with_fixed_world_size(self):
         self._multi_worker_helper(5)
 
+    @unittest.skipIf(
+        IS_WINDOWS, "Skip test for windows due to multiprocessing library error when using windows spawn"
+    )
     def test_multi_worker_with_nonfixed_world_size(self):
         self._multi_worker_helper(-1)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53156 disable TCPStore multi_worker tests for windows**

Will SSH into windows machine to validate that these tests are skipped.

Differential Revision: [D26769791](https://our.internmc.facebook.com/intern/diff/D26769791)