### PR TITLE
Add shape inference for SparseLengthsSumSparseLookup

### DIFF
--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -167,6 +167,8 @@ void BoundShapeInferencer::InferOps(
     InferUnPackRecords(op);
   } else if (op.type() == "Tile") {
     InferTile(op);
+  } else if (op.type() == "SparseLengthsSumSparseLookup") {
+    InferSparseLengthsSumSparseLookup(op);
   } else {
     InferCommonOp(op);
   }
@@ -350,6 +352,37 @@ void BoundShapeInferencer::InferLengthsRangeFill(const OperatorDef& op) {
       TensorProto_DataType_INT32,
       false);
   current_dim_type_ = TensorBoundShape_DimType_BATCH_OF_FEATURE_MAX_DEFAULT;
+}
+
+void BoundShapeInferencer::InferSparseLengthsSumSparseLookup(
+    const OperatorDef& op) {
+  CAFFE_ENFORCE_GT(
+      op.input_size(),
+      2,
+      "SparseLengthsSumSparseLookup must have more than 2 input");
+  CAFFE_ENFORCE_GT(
+      op.output_size(),
+      1,
+      "SparseLengthsSumSparseLookup must have more than 1 output");
+  CAFFE_ENFORCE(
+      shape_info_.find(op.input(2)) != shape_info_.end(),
+      "Shape of COMPRESSED_INDICES_MAPPING input of SparseLengthsSumSparseLookup",
+      op.input(2),
+      " needs to be presented");
+  for (int i = 0; i < 2; ++i) {
+    const auto it = shape_info_.find(op.input(i));
+    if (it != shape_info_.end()) {
+      shape_info_[op.output(i)] = it->second;
+    }
+  }
+  // Handle the weights
+  if (op.input_size() == 4) {
+    CAFFE_ENFORCE_EQ(op.output_size(), 3);
+    const auto it = shape_info_.find(op.input(3));
+    if (it != shape_info_.end()) {
+      shape_info_[op.output(2)] = it->second;
+    }
+  }
 }
 
 void BoundShapeInferencer::InferSparseLengthsSum(const OperatorDef& op) {

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -134,6 +134,7 @@ class TORCH_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferQuantizationTransformation(const OperatorDef& op);
   void InferUnPackRecords(const OperatorDef& op);
   void InferTile(const OperatorDef& op);
+  void InferSparseLengthsSumSparseLookup(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference
   // function


### PR DESCRIPTION
Summary: Just copy whatever corresponding input shape info.

Test Plan:
```
buck test caffe2/caffe2/opt:bound_shape_inference_test
```

Differential Revision: D26769226

