### PR TITLE
Fix OpenBLAS discovery

### DIFF
--- a/cmake/Modules/FindBLAS.cmake
+++ b/cmake/Modules/FindBLAS.cmake
@@ -140,23 +140,15 @@ endif()
 
 if((NOT BLAS_LIBRARIES)
     AND ((NOT WITH_BLAS) OR (WITH_BLAS STREQUAL "open")))
-  FIND_PACKAGE(OpenBLAS)
-  if(OpenBLAS_FOUND)
-    SET(BLAS_INFO "open")
-    SET(BLAS_LIBRARIES ${OpenBLAS_LIB})
-    SET(BLAS_INCLUDE_DIR ${OpenBLAS_INCLUDE_DIR})
-    SET(BLAS_VERSION ${OpenBLAS_VERSION})
-  else()
-    check_fortran_libraries(
-    BLAS_LIBRARIES
-    BLAS
-    sgemm
-    ""
-    "openblas")
-    if(BLAS_LIBRARIES)
-      set(BLAS_INFO "open")
-    endif(BLAS_LIBRARIES)
-  endif()
+  check_fortran_libraries(
+  BLAS_LIBRARIES
+  BLAS
+  sgemm
+  ""
+  "openblas")
+  if(BLAS_LIBRARIES)
+    set(BLAS_INFO "open")
+  endif(BLAS_LIBRARIES)
 endif()
 
 if((NOT BLAS_LIBRARIES)


### PR DESCRIPTION
Fix accidental regression introduced by #47940

`FIND_PACKAGE(OpenBLAS)` does not validate that discovered library can actually be used, while `check_fortran_libraries` does that

Test Plan: Build PyTorch with static OpenBLAS and check that `torch.svd(torch.ones(3, 3)).S` do not raise an exception

