### PR TITLE
[PyTorch] Remove extra RNN.cpp file

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -729,7 +729,6 @@ aten_cpu_source_list = [
 # Files in ATen/native with a few exceptions
 # TODO: move the exceptions to proper locations
 aten_native_source_list = [
-    "aten/src/ATen/native/RNN.cpp",
     "aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp",
     "aten/src/ATen/native/quantized/cpu/int_repr_quant.cpp",
     "aten/src/ATen/native/quantized/cpu/make_per_tensor_quantized_tensor.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53169 [PyTorch] Remove extra RNN.cpp file**

As title, there are two `aten/src/ATen/native/RNN.cpp` in `aten_native_source_list`

Differential Revision: [D26715640](https://our.internmc.facebook.com/intern/diff/D26715640/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26715640/)!