### PR TITLE
Context manager for hiding source ranges

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2579,6 +2579,19 @@ graph(%Ra, %Rb):
 
         torch._C._set_graph_executor_optimize(prev_opt)
 
+    def test_hide_source_ranges_context_manager(self):
+        @torch.jit.script
+        def foo(x):
+            return torch.add(x, x)
+
+        graph = foo.graph
+        source_range_regex = "# .*\\.py"
+        self.assertRegex(graph.__repr__(), source_range_regex)
+        with torch.jit._hide_source_ranges():
+            self.assertNotRegex(graph.__repr__(), source_range_regex)
+            self.assertRegex(graph.str(print_source_ranges=True), source_range_regex)
+        self.assertRegex(graph.__repr__(), source_range_regex)
+
 
 class TestFrontend(JitTestCase):
 

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -22,8 +22,10 @@ namespace torch {
 namespace jit {
 
 // Controls whether graph source ranges are printed by default
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool global_print_source_ranges = true;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 Symbol ConcretePythonOp::Kind = prim::PythonOp;
 
 using c10::Type;

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -21,6 +21,9 @@
 namespace torch {
 namespace jit {
 
+// Controls whether graph source ranges are printed by default
+bool global_print_source_ranges = true;
+
 Symbol ConcretePythonOp::Kind = prim::PythonOp;
 
 using c10::Type;
@@ -212,8 +215,13 @@ void initPythonIRBindings(PyObject* module_) {
 #define GS(name) def(#name, &Graph ::name)
   py::class_<Graph, std::shared_ptr<Graph>>(m, "Graph")
       .def(py::init<>())
-      .def("__repr__", [](Graph& g) { return g.toString(); })
+      .def("__repr__", [&](Graph& g) { return g.toString(global_print_source_ranges); })
       .def("str", &Graph::toString, py::arg("print_source_ranges") = true)
+      .def_readonly_static("global_print_source_ranges",
+          &global_print_source_ranges)
+      .def_static("set_global_print_source_ranges",
+          [&](const bool enabled) { global_print_source_ranges = enabled; },
+          py::arg("enabled") = true)
       .def(
           "dump_alias_db",
           [](std::shared_ptr<Graph> g) {

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -215,11 +215,14 @@ void initPythonIRBindings(PyObject* module_) {
 #define GS(name) def(#name, &Graph ::name)
   py::class_<Graph, std::shared_ptr<Graph>>(m, "Graph")
       .def(py::init<>())
-      .def("__repr__", [&](Graph& g) { return g.toString(global_print_source_ranges); })
+      .def(
+          "__repr__",
+          [&](Graph& g) { return g.toString(global_print_source_ranges); })
       .def("str", &Graph::toString, py::arg("print_source_ranges") = true)
-      .def_readonly_static("global_print_source_ranges",
-          &global_print_source_ranges)
-      .def_static("set_global_print_source_ranges",
+      .def_readonly_static(
+          "global_print_source_ranges", &global_print_source_ranges)
+      .def_static(
+          "set_global_print_source_ranges",
           [&](const bool enabled) { global_print_source_ranges = enabled; },
           py::arg("enabled") = true)
       .def(

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -1,5 +1,8 @@
 import torch._C
 
+from contextlib import contextmanager
+from typing import Iterator
+
 from torch.utils import set_module
 
 # These are imported so users can access them from the `torch.jit` module
@@ -25,7 +28,6 @@ from torch.jit._script import (
     CompilationUnit,
     ScriptFunction,
     _unwrap_optional,
-    _hide_source_ranges,
 )
 from torch.jit._trace import (
     trace,
@@ -138,6 +140,19 @@ def isinstance(obj, target_type):
         m(y)
     """
     return _isinstance(obj, target_type)
+
+
+# Context manager for globally hiding source ranges when printing graphs.
+# Note that these functions are exposed to Python as static members of the
+# Graph class, so mypy checks need to be skipped.
+@contextmanager
+def _hide_source_ranges() -> Iterator[None]:
+    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges # type: ignore
+    try:
+        torch._C.Graph.set_global_print_source_ranges(False) # type: ignore
+        yield
+    finally:
+        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges) # type: ignore
 
 
 if not torch._C._jit_init():

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -147,12 +147,12 @@ def isinstance(obj, target_type):
 # Graph class, so mypy checks need to be skipped.
 @contextmanager
 def _hide_source_ranges() -> Iterator[None]:
-    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges # type: ignore
+    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges  # type: ignore
     try:
-        torch._C.Graph.set_global_print_source_ranges(False) # type: ignore
+        torch._C.Graph.set_global_print_source_ranges(False)  # type: ignore
         yield
     finally:
-        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges) # type: ignore
+        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges)  # type: ignore
 
 
 if not torch._C._jit_init():

--- a/torch/jit/__init__.py
+++ b/torch/jit/__init__.py
@@ -25,6 +25,7 @@ from torch.jit._script import (
     CompilationUnit,
     ScriptFunction,
     _unwrap_optional,
+    _hide_source_ranges,
 )
 from torch.jit._trace import (
     trace,

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -1125,11 +1125,14 @@ _register_builtin(has_torch_function, "aten::has_torch_function")
 _register_builtin(has_torch_function_unary, "aten::has_torch_function")
 _register_builtin(has_torch_function_variadic, "aten::has_torch_function")
 
+# Context manager for globally hiding source ranges when printing graphs.
+# Note that these functions are exposed to Python as static members of the
+# Graph class, so mypy checks need to be skipped.
 @contextmanager
 def _hide_source_ranges() -> Iterator[None]:
-    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges
+    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges # type: ignore
     try:
-        torch._C.Graph.set_global_print_source_ranges(False)
+        torch._C.Graph.set_global_print_source_ranges(False) # type: ignore
         yield
     finally:
-        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges)
+        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges) # type: ignore

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -13,8 +13,7 @@ import inspect
 import copy
 import pickle
 import warnings
-from contextlib import contextmanager
-from typing import Any, Dict, Iterator
+from typing import Any, Dict
 
 
 import torch
@@ -1124,15 +1123,3 @@ _register_builtin(_jit_internal.is_scripting, "aten::is_scripting")
 _register_builtin(has_torch_function, "aten::has_torch_function")
 _register_builtin(has_torch_function_unary, "aten::has_torch_function")
 _register_builtin(has_torch_function_variadic, "aten::has_torch_function")
-
-# Context manager for globally hiding source ranges when printing graphs.
-# Note that these functions are exposed to Python as static members of the
-# Graph class, so mypy checks need to be skipped.
-@contextmanager
-def _hide_source_ranges() -> Iterator[None]:
-    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges # type: ignore
-    try:
-        torch._C.Graph.set_global_print_source_ranges(False) # type: ignore
-        yield
-    finally:
-        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges) # type: ignore

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -13,7 +13,8 @@ import inspect
 import copy
 import pickle
 import warnings
-from typing import Any, Dict
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator
 
 
 import torch
@@ -1123,3 +1124,12 @@ _register_builtin(_jit_internal.is_scripting, "aten::is_scripting")
 _register_builtin(has_torch_function, "aten::has_torch_function")
 _register_builtin(has_torch_function_unary, "aten::has_torch_function")
 _register_builtin(has_torch_function_variadic, "aten::has_torch_function")
+
+@contextmanager
+def _hide_source_ranges() -> Iterator[None]:
+    old_enable_source_ranges = torch._C.Graph.global_print_source_ranges
+    try:
+        torch._C.Graph.set_global_print_source_ranges(False)
+        yield
+    finally:
+        torch._C.Graph.set_global_print_source_ranges(old_enable_source_ranges)


### PR DESCRIPTION
Fixes #52456

## Background

Provides a context manager `_hide_source_ranges()` that disables printing graph source ranges by default. It can be overridden on a per-graph basis if desired.

## Test Plan

```
python test/test_jit.py TestJit.test_hide_source_ranges_context_manager
```

```python
import torch

@torch.jit.script
def foo(x):
    return torch.add(x, x)

print(foo.graph)
with torch.jit._hide_source_ranges():
    print(foo.graph)

    # Override context manager
    print(foo.graph.str(print_source_ranges=True))

print(foo.graph)
```

```
graph(%x.1 : Tensor):
  %3 : int = prim::Constant[value=1]()
  %4 : Tensor = aten::add(%x.1, %x.1, %3) # /Users/jbschlosser/misc/example.py:5:11
  return (%4)

graph(%x.1 : Tensor):
  %3 : int = prim::Constant[value=1]()
  %4 : Tensor = aten::add(%x.1, %x.1, %3)
  return (%4)

graph(%x.1 : Tensor):
  %3 : int = prim::Constant[value=1]()
  %4 : Tensor = aten::add(%x.1, %x.1, %3) # /Users/jbschlosser/misc/example.py:5:11
  return (%4)

graph(%x.1 : Tensor):
  %3 : int = prim::Constant[value=1]()
  %4 : Tensor = aten::add(%x.1, %x.1, %3) # /Users/jbschlosser/misc/example.py:5:11
  return (%4)
```