### PR TITLE
[PyTorch Mobile] Fix case when error messages are stripped, and stack value isn't popped off in lite-interpreter

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -208,7 +208,13 @@ bool InterpreterState::run(Stack& stack) {
       } break;
       case WARN: {
         drop(stack, 1);
-        TORCH_WARN(pop(stack).toStringRef());
+        // Note: Please don't move the pop(stack) code below into the TORCH_WARN
+        // macro since TORCH_WARN fails to evaluate its arguments when
+        // STRIP_ERROR_MESSAGES is defined (which happens for production
+        // mobile builds). This will cause the stack to be in an inconsistent
+        // state. It has previously resulted in a SEV (S22350).
+        auto sref = pop(stack).toStringRef();
+        TORCH_WARN(sref);
         ++pc;
       } break;
       default:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53201 [PyTorch Mobile] Fix case when error messages are stripped, and stack value isn't popped off in lite-interpreter**

This resulted in [S22350](https://www.internalfb.com/intern/sevmanager/view/s/223540), which caused truoble on Android.

1. The Python has a call to `warnings.warn()`, which resulted in code generated to emit the `WARN` instruction on lite-interpreter.
2. The code for handling that instruction/op-code popped off the value in a call to the `TORCH_WARN()` *macro*.
3. This macro conditionally compiled out evaluation of the arguments if `STRIP_ERROR_MESSAGES` was defined, which resulted in the stack not getting popped, and the lite-interpreter returning the last pushed value on to the stack.

I've attempted to re-produce it using this python code: {P243842428}

Differential Revision: [D26765662](https://our.internmc.facebook.com/intern/diff/D26765662/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26765662/)!