### PR TITLE
Fix gradfn attr bindings when saved variable is of an output

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -4354,6 +4354,10 @@ for shape in [(1,), ()]:
         out = a.as_strided((3,), (1,))
         self.assertIsNone(out.grad_fn._saved_storage_offset)
 
+        a = torch.ones(2, requires_grad=True)
+        out = torch.tanh(a)
+        self.assertEqual(out, out.grad_fn._saved_result)                  # saved variable when output
+
     def test_autograd_views_codegen(self):
         # This is not necessarily the absolute correct behavior, but this is the current
         # one. This test is here to make sure that any change to this behavior is detected

--- a/tools/autograd/gen_autograd_functions.py
+++ b/tools/autograd/gen_autograd_functions.py
@@ -144,13 +144,13 @@ PyObject* THP${op}_${name}_getter(THPCppFunction *self, void *_unused) {
 
 # Getter body
 GETTER_BODY_SAVEDVAR = """\
-return THPVariable_Wrap(prop.unpack());
+return THPVariable_Wrap(prop.unpack(self->cdata));
 """
 
 GETTER_BODY_VEC_SAVEDVAR = """\
 PyObject* tup = PyTuple_New((Py_ssize_t) prop.size());
 for (int i = 0; i < prop.size(); i++) {
-  PyTuple_SetItem(tup, (Py_ssize_t) i, THPVariable_Wrap(prop[i].unpack()));
+  PyTuple_SetItem(tup, (Py_ssize_t) i, THPVariable_Wrap(prop[i].unpack(self->cdata)));
 }
 return tup;
 """


### PR DESCRIPTION
When saved variable is of an output, its grad_fn is not saved in SavedVariable, so it must be passed in during `unpack`.
Here, we can always pass in grad_fn (whether or not saved variable is an output) because it is ignored if the saved variable is not an output.
