### PR TITLE
Use .gv instead of .dot for Graphviz in fast_nvcc

### DIFF
--- a/tools/fast_nvcc/fast_nvcc.py
+++ b/tools/fast_nvcc/fast_nvcc.py
@@ -37,7 +37,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '--graph',
-    metavar='FILE.dot',
+    metavar='FILE.gv',
     help='write Graphviz DOT file with execution graph',
 )
 parser.add_argument(


### PR DESCRIPTION
See this page for context: https://marc.info/?l=graphviz-devel&m=129418103126092

**Test plan:**

```
tools/fast_nvcc/fast_nvcc.py --help
```