### PR TITLE
[PyTorch] Make IValue::toTensor() inlineable

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -841,6 +841,10 @@ IValue IValue::deepcopy(
   return copy;
 }
 
+void IValue::reportToTensorTypeError() const {
+  TORCH_CHECK(false, "Expected Tensor but got ", tagKind());
+}
+
 std::string ivalue::Object::name() const {
   return type()->name()->qualifiedName();
 }

--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -359,6 +359,12 @@ struct TORCH_API IValue final {
   bool isTensor() const {
     return Tag::Tensor == tag;
   }
+
+ private:
+  // Outlined error path so that toTensor() can be inlined.
+  [[noreturn]] void reportToTensorTypeError() const;
+
+ public:
   at::Tensor toTensor() &&;
   at::Tensor& toTensor() &;
   const at::Tensor& toTensor() const&;

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -139,7 +139,9 @@ inline c10::complex<double> IValue::toComplexDouble() const {
   return (*ptr).val;
 }
 inline at::Tensor IValue::toTensor() && {
-  AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
+  if (C10_UNLIKELY(!isTensor())) {
+    reportToTensorTypeError();
+  }
   auto result = std::move(payload.as_tensor);
   // As far as I can tell, omitting the usual explicit destructor call
   // is not UB in and of itself, and it's a slight perf win. The
@@ -154,11 +156,15 @@ inline at::Tensor IValue::toTensor() && {
   return result;
 }
 inline at::Tensor& IValue::toTensor() & {
-  AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
+  if (C10_UNLIKELY(!isTensor())) {
+    reportToTensorTypeError();
+  }
   return payload.as_tensor;
 }
 inline const at::Tensor& IValue::toTensor() const& {
-  AT_ASSERT(isTensor(), "Expected Tensor but got ", tagKind());
+  if (C10_UNLIKELY(!isTensor())) {
+    reportToTensorTypeError();
+  }
   return payload.as_tensor;
 }
 inline c10::Storage IValue::toStorage() && {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53213 [PyTorch] Make IValue::toTensor() inlineable**

The failure path for toTensor() is fairly long because it has to stringify tagKind() and construct a std::string. Forcibly outlining it should allow inlining the happy path.

Differential Revision: [D26793481](https://our.internmc.facebook.com/intern/diff/D26793481/)