### PR TITLE
[pyper] casted_batch_one_hot_lengths with 4-arg to

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -131,3 +131,28 @@ const auto aten_sum_1_true = R"JIT(
   def forward(self, input):
       return torch.sum(input, 1, True)
 )JIT";
+
+const auto pow_script_ten_sca = R"JIT(
+  def forward(self, input : Tensor, exponent : int):
+      return torch.pow(input, exponent)
+)JIT";
+
+const auto pow_script_ten_ten = R"JIT(
+  def forward(self, input : Tensor, exponent : Tensor):
+      return torch.pow(input, exponent)
+)JIT";
+
+const auto pow_script_sca_ten = R"JIT(
+  def forward(self, input : int, exponent : Tensor):
+      return torch.pow(input, exponent)
+)JIT";
+
+const auto to_script_0 = R"JIT(
+  def forward(self, input: Tensor, dtype: int, non_blocking: bool, copy: bool, memory_format: int):
+      return torch.to(input, dtype, non_blocking, copy, memory_format)
+)JIT";
+
+const auto to_script_1 = R"JIT(
+  def forward(self, input:Tensor, dtype: int, non_blocking: bool, copy: bool):
+      return torch.to(input, dtype, non_blocking, copy)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -145,6 +145,36 @@ TEST(StaticRuntime, IndividualOps_flatten) {
   test_flatten({}, 0, 0);
 }
 
+TEST(StaticRuntime, IndividualOps_pow) {
+  auto a = at::randn({2, 3});
+  auto b = at::randn({2, 3});
+
+  std::vector<IValue> args0{a, 4};
+  testStaticRuntime(pow_script_ten_sca, args0);
+
+  std::vector<IValue> args1{at::abs(a), b};
+  testStaticRuntime(pow_script_ten_ten, args1);
+
+  std::vector<IValue> args2{5, b};
+  testStaticRuntime(pow_script_sca_ten, args2);
+}
+
+TEST(StaticRuntime, IndividualOps_to) {
+  auto test_to =
+      [](at::ScalarType b, bool c, bool d, c10::MemoryFormat e) {
+        auto a = at::randn({2, 3});
+        std::vector<IValue> args0{a, b, c, d, e};
+        std::vector<IValue> args1{a, b, c, d};
+        testStaticRuntime(to_script_0, args0);
+        testStaticRuntime(to_script_1, args1);
+      };
+
+  test_to(at::ScalarType::Float, true, true, c10::MemoryFormat::Contiguous);
+  test_to(at::ScalarType::Half, true, false, c10::MemoryFormat::Preserve);
+  test_to(at::ScalarType::Float, false, false, c10::MemoryFormat::Contiguous);
+  test_to(at::ScalarType::Half, false, true, c10::MemoryFormat::Preserve);
+}
+
 TEST(StaticRuntime, LongModel) {
   torch::jit::Module mod = getLongScriptModel();
   auto a = torch::randn({2, 2});

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -74,6 +74,19 @@ void CastedBatchOneHotLengths(std::shared_ptr<torch::jit::Graph>& graph) {
   SubgraphRewriter fuse;
   fuse.RegisterRewritePattern(pattern, fused_pattern);
   fuse.runOnGraph(graph);
+
+  std::string pattern2 = R"IR(
+    graph(%a, %b, %c, %d, %e, %f):
+        %y0 : Tensor = aten::to(%a, %b, %c, %c)
+        %y1 : Tensor = fb::batch_one_hot_lengths(%y0, %d, %e)
+        %res : Tensor = aten::to(%y1, %f, %c, %c)
+        return (%res))IR";
+  std::string fused_pattern2 = R"IR(
+    graph(%a, %b, %c, %d, %e, %f):
+        %res : Tensor = fb::casted_batch_one_hot_lengths(%a, %d, %e)
+        return (%res))IR";
+  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
+  fuse.runOnGraph(graph);
 }
 
 void ConcatBatchMatMulBatchGather(std::shared_ptr<torch::jit::Graph>& graph) {


### PR DESCRIPTION
Summary: The current 5-arg version doesn't fuse the inline_cvr model instances

Test Plan:
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --c2_weights=/data/users/ansha/tmp/adfinder/models/c2_local_weight_data.pb --c2_inputs=/data/users/ansha/tmp/adfinder/models/c2_local_input_data.pb --pred_net=/data/users/ansha/tmp/adfinder/models/c2_local_net.pb --c2_sigrid_transforms_opt=1 --c2_apply_nomnigraph_passes=1 --c2_use_memonger=1 --scripted_model=/data/users/ansha/tmp/adfinder/models_dianshi/210494966_0.predictor.disagg.local.pt --pt_inputs=/data/users/ansha/tmp/adfinder/models/local_wrapped_input_data.pt --pt_enable_static_runtime=1 --pt_cleanup_activations=true --pt_enable_out_variant=1 --compare_results=1 --iters=2000 --warmup_iters=2000 --num_threads=1 --do_profile=1 --do_benchmark --benchmark_c2_predictor=1
```

```
Time per node type:
        3.82029 ms.    71.8523%. aten::addmm (9 nodes)
       0.926298 ms.    17.4219%. fb::sigrid_transforms (1 nodes)
       0.122496 ms.    2.30391%. fb::clip_ranges_gather (210 nodes)
        0.11985 ms.    2.25416%. fb::clip_ranges_gather_sigrid_hash_precompute_v3 (54 nodes)
      0.0973721 ms.    1.83138%. aten::sigmoid (3 nodes)
      0.0352937 ms.   0.663807%. fb::batch_box_cox (1 nodes)
       0.034759 ms.    0.65375%. prim::TupleConstruct (1 nodes)
      0.0222235 ms.   0.417981%. aten::index (4 nodes)
      0.0215314 ms.   0.404964%. fb::casted_batch_one_hot_lengths (1 nodes)
      0.0199659 ms.   0.375521%. fb::concat_add_mul_replacenan_clip (1 nodes)
      0.0192885 ms.   0.362779%. aten::cat (2 nodes)
      0.0181285 ms.   0.340963%. aten::mul (2 nodes)
      0.0109381 ms.   0.205725%. aten::pow (1 nodes)
      0.0091476 ms.   0.172049%. prim::ListConstruct (8 nodes)
     0.00794012 ms.   0.149338%. aten::relu (2 nodes)
     0.00668873 ms.   0.125802%. prim::ListUnpack (1 nodes)
     0.00569745 ms.   0.107158%. aten::to (4 nodes)
     0.00527507 ms.   0.099214%. aten::narrow_copy (4 nodes)
     0.00483189 ms.  0.0908785%. fb::lengths_range (4 nodes)
     0.00399056 ms.  0.0750548%. aten::logit (1 nodes)
     0.00324574 ms.  0.0610462%. fb::gather_ranges (4 nodes)
     0.00161166 ms.  0.0303122%. fb::clip_ranges (2 nodes)
        5.31686 ms. in Total
StaticRuntime setup time: 0.016461 ms
Memory allocation time: 0.00220284 ms
Memory deallocation time: 0.118134 ms
Outputs deallocation time: 0.0674883 ms
Total memory managed: 716352 bytes
Total number of reused tensors: 22
```

Reviewed By: hlu1

Differential Revision: D26789260

