### PR TITLE
[Static Runtime] Use native version of at::empty

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/Utils.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 
@@ -56,7 +57,13 @@ C10_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 C10_DECLARE_REGISTRY(SRViewOperatorRegistry, SROperatorFunctor);
 
 inline at::Tensor create_empty_from(const at::Tensor& t) {
-  return at::empty({0}, t.options());
+  return at::detail::empty_cpu(
+      {0},
+      c10::typeMetaToScalarType(t.dtype()),
+      t.layout(),
+      t.device(),
+      c10::nullopt,
+      c10::nullopt);
 }
 
 inline bool checkResizedDataPtr(at::Tensor& t) {


### PR DESCRIPTION
Summary:
- at::native::empty_cpu calls at::detail::empty_cpu without any changes to the arguments. So we could call at::detail::empty_cpu directly.
- There is no need to create a TensorOptions object first since we can get all the relevant information from the tensor directly.

Reviewed By: bertmaher, swolchok

Differential Revision: D26792255

