### PR TITLE
[sparsity][refactor] Rename row/col to out/in features

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/include/pack_block_sparse.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/include/pack_block_sparse.h
@@ -31,8 +31,8 @@ typedef struct BCSRMatrix {
   std::vector<uint32_t> row_values;
   std::vector<uint8_t> values;
 #endif
-  uint32_t col_block_size;
-  uint32_t row_block_size;
+  uint32_t col_block_size;  // input features block size
+  uint32_t row_block_size;  // output features block size
   void print() {
     std::cout << "row block size:" << row_block_size << std::endl;
     std::cout << "col block size:" << col_block_size << std::endl;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Names such as `row_block_size` and `col_block_size` might be ambiguous, especially if different engines use different tensor layouts (i.e. rows=output features, etc.). Having names such as `out_features_block_size` and `in_features_block_size` makes more sense

Differential Revision: [D26747065](https://our.internmc.facebook.com/intern/diff/D26747065/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26747065/)!