### PR TITLE
[caffe2] move the SaveOp implementation from a header to a .cc file

### DIFF
--- a/caffe2/operators/load_save_op.cc
+++ b/caffe2/operators/load_save_op.cc
@@ -41,6 +41,90 @@ std::vector<TensorShape> LoadTensorInference(
   return out;
 }
 
+namespace internal {
+
+SaveOpImpl::SaveOpImpl(
+    OperatorBase* op,
+    const OperatorDef& operator_def,
+    Workspace* ws)
+    : operator_(op),
+      strip_prefix_(op->template GetSingleArgument<string>("strip_prefix", "")),
+      db_type_(op->template GetSingleArgument<string>("db_type", "")),
+      blob_names_(
+          op->template GetRepeatedArgument<string>("blob_name_overrides")),
+      chunk_size_(op->template GetSingleArgument<int>(
+          "chunk_size",
+          kDefaultChunkSize)) {
+  CAFFE_ENFORCE_GT(db_type_.size(), 0, "Must specify a db type.");
+  CAFFE_ENFORCE(
+      blob_names_.empty() || blob_names_.size() == op->Inputs().size(),
+      "Number of blobs and blob_name_overrides mismatch.");
+    CAFFE_ENFORCE(
+        blob_names_.empty() || strip_prefix_.empty(),
+        "strip_prefix and blob_name_overrides are mutually exclusive.");
+
+  auto absolute_path =
+      op->template GetSingleArgument<int>("absolute_path", false);
+  auto db_name = op->template GetSingleArgument<string>("db", "");
+  CAFFE_ENFORCE_GT(db_name.size(), 0, "Must specify a db name.");
+  full_db_name_ = absolute_path ? db_name : (ws->RootFolder() + "/" + db_name);
+
+  if (blob_names_.empty()) {
+    std::set<std::string> input_names;
+    blob_names_.resize(op->Inputs().size());
+    for (int i = 0; i < blob_names_.size(); ++i) {
+      std::string name;
+      if (strip_prefix_.empty()) {
+        name = operator_def.input(i);
+      } else {
+        auto match_pos = operator_def.input(i).find(strip_prefix_);
+        if (match_pos == string::npos) {
+          name = operator_def.input(i);
+        } else {
+          name = operator_def.input(i).substr(
+              match_pos + strip_prefix_.size(), string::npos);
+        }
+      }
+      CAFFE_ENFORCE(
+          input_names.insert(name).second, "Duplicated input: ", name);
+      blob_names_[i] = name;
+    }
+  }
+}
+
+bool SaveOpImpl::RunOnDevice() {
+  std::unique_ptr<DB> out_db(
+      caffe2::db::CreateDB(db_type_, full_db_name_, caffe2::db::NEW));
+  CAFFE_ENFORCE(
+      out_db.get(),
+      "Cannot find db implementation of type ",
+      db_type_,
+      " (while trying to open ",
+      full_db_name_,
+      ")");
+
+  BlobSerializerBase::SerializationAcceptor acceptor =
+      [&](const std::string& blobName, const std::string& data) {
+        // transaction should take care of locking
+        VLOG(2) << "Sending " << blobName << " blob's data of size "
+                << data.size() << " to db";
+        auto transaction = out_db->NewTransaction();
+        transaction->Put(blobName, data);
+        transaction->Commit();
+      };
+
+  const vector<const Blob*>& inputs = operator_->OperatorBase::Inputs();
+  VLOG(0) << "Saving " << inputs.size() << " inputs to " << db_type_ << ": "
+          << full_db_name_;
+  for (int i = 0; i < inputs.size(); ++i) {
+    SerializeBlob(*inputs[i], blob_names_[i], acceptor, chunk_size_);
+  }
+  out_db->Close();
+  return true;
+}
+
+} // namespace internal
+
 REGISTER_CPU_OPERATOR(DBExists, DBExistsOp<CPUContext>);
 REGISTER_CPU_OPERATOR(Load, LoadOp<CPUContext>);
 REGISTER_CPU_OPERATOR(Save, SaveOp<CPUContext>);

--- a/caffe2/operators/load_save_op.h
+++ b/caffe2/operators/load_save_op.h
@@ -296,98 +296,37 @@ class LoadOp final : public Operator<Context> {
   std::vector<int64_t> shape_;
 };
 
+namespace internal {
+class SaveOpImpl {
+ public:
+  SaveOpImpl(OperatorBase* op, const OperatorDef& operator_def, Workspace* ws);
+
+  bool RunOnDevice();
+
+ private:
+  OperatorBase* operator_;
+  Workspace* ws_;
+  string strip_prefix_;
+  string full_db_name_;
+  string db_type_;
+  std::vector<std::string> blob_names_;
+  int chunk_size_;
+};
+} // namespace internal
+
 template <class Context>
 class SaveOp final : public Operator<Context> {
  public:
   USE_OPERATOR_CONTEXT_FUNCTIONS;
   explicit SaveOp(const OperatorDef& operator_def, Workspace* ws)
-      : Operator<Context>(operator_def, ws),
-        ws_(ws),
-        absolute_path_(
-            this->template GetSingleArgument<int>("absolute_path", false)),
-        strip_prefix_(
-            this->template GetSingleArgument<string>("strip_prefix", "")),
-        db_name_(this->template GetSingleArgument<string>("db", "")),
-        db_type_(this->template GetSingleArgument<string>("db_type", "")),
-        blob_names_(
-            this->template GetRepeatedArgument<string>("blob_name_overrides")),
-        chunk_size_(this->template GetSingleArgument<int>(
-            "chunk_size",
-            kDefaultChunkSize)) {
-    CAFFE_ENFORCE_GT(db_name_.size(), 0, "Must specify a db name.");
-    CAFFE_ENFORCE_GT(db_type_.size(), 0, "Must specify a db type.");
-    CAFFE_ENFORCE(
-        blob_names_.empty() ||
-            blob_names_.size() == OperatorBase::Inputs().size(),
-        "Number of blobs and blob_name_overrides mismatch.");
-    CAFFE_ENFORCE(
-        blob_names_.empty() || strip_prefix_.empty(),
-        "strip_prefix and blob_name_overrides are mutually exclusive.");
-
-    if (blob_names_.empty()) {
-      std::set<std::string> input_names;
-      blob_names_.resize(OperatorBase::Inputs().size());
-      for (int i = 0; i < blob_names_.size(); ++i) {
-        std::string name;
-        if (strip_prefix_.empty()) {
-          name = operator_def.input(i);
-        } else {
-          auto match_pos = operator_def.input(i).find(strip_prefix_);
-          if (match_pos == string::npos) {
-            name = operator_def.input(i);
-          } else {
-            name = operator_def.input(i).substr(
-                match_pos + strip_prefix_.size(), string::npos);
-          }
-        }
-        CAFFE_ENFORCE(
-            input_names.insert(name).second, "Duplicated input: ", name);
-        blob_names_[i] = name;
-      }
-    }
-  }
+      : Operator<Context>(operator_def, ws), impl_(this, operator_def, ws) {}
 
   bool RunOnDevice() override {
-    string full_db_name =
-        absolute_path_ ? db_name_ : (ws_->RootFolder() + "/" + db_name_);
-    std::unique_ptr<DB> out_db(
-        caffe2::db::CreateDB(db_type_, full_db_name, caffe2::db::NEW));
-    CAFFE_ENFORCE(
-        out_db.get(),
-        "Cannot find db implementation of type ",
-        db_type_,
-        " (while trying to open ",
-        full_db_name,
-        ")");
-
-    BlobSerializerBase::SerializationAcceptor acceptor =
-        [&](const std::string& blobName, const std::string& data) {
-          // transaction should take care of locking
-          VLOG(2) << "Sending " << blobName << " blob's data of size "
-                  << data.size() << " to db";
-          auto transaction = out_db->NewTransaction();
-          transaction->Put(blobName, data);
-          transaction->Commit();
-        };
-
-    const vector<const Blob*>& inputs = OperatorBase::Inputs();
-    VLOG(0) << "Saving " << inputs.size() << " inputs to " << db_type_ << ": "
-            << full_db_name;
-    for (int i = 0; i < inputs.size(); ++i) {
-      SerializeBlob(*inputs[i], blob_names_[i], acceptor, chunk_size_);
-    }
-    out_db->Close();
-    return true;
+    return impl_.RunOnDevice();
   }
 
  private:
-  Workspace* ws_;
-  bool absolute_path_;
-  string strip_prefix_;
-  string db_name_;
-  string db_type_;
-  std::vector<std::string> blob_names_;
-  int chunk_size_;
+  internal::SaveOpImpl impl_;
 };
 
 template <typename... Ts>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53231 [caffe2] move the SaveOp implementation from a header to a .cc file**

Move the `SaveOp` code from `load_save_op.h` to `load_save_op.cc`.

Previously this implementation was all in the templatized `SaveOp` class, even
though most of the logic didn't depend on the template parameters.  Having
this code be in the header file slows down the build, and forces more files to
be rebuilt than necessary when changing the SaveOp code.  Having this code be
in a template class can also increase the generated code size be larger than
needed, as we don't need separate copies instantiated for each context type.

This is a re-land of D26641600, after addressing CMake build issues that were
causing the hip targets not to link against load_save_op.cc

Differential Revision: [D26802576](https://our.internmc.facebook.com/intern/diff/D26802576/)