### PR TITLE
Python API for Vitals

### DIFF
--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -1,8 +1,11 @@
 #include <ATen/core/Vitals.h>
 #include <cstdlib>
 
+
 namespace at {
 namespace vitals {
+
+APIVitals VitalsAPI;
 
 TorchVitalAttr& TorchVital::create(const std::string& attr) {
   if (!torchVitalEnabled()) {
@@ -28,6 +31,27 @@ bool torchVitalEnabled() {
     return false;
   }();
   return enabled;
+}
+
+bool APIVitals::setVital(
+    const std::string& vital_name,
+    const std::string& attr_name,
+    const std::string& value) {
+  if (!torchVitalEnabled()) {
+    return false;
+  }
+
+  auto iter = name_map_.find(vital_name);
+  TorchVital *vital = nullptr;
+  if (iter == name_map_.end()) {
+    auto r = name_map_.emplace(std::make_pair(vital_name, TorchVital(vital_name)));
+    vital = &r.first->second;
+  } else {
+    vital = &iter->second;
+  }
+
+  vital->create(attr_name) << value;
+  return true;
 }
 
 } // namespace at

--- a/aten/src/ATen/test/vitals.cpp
+++ b/aten/src/ATen/test/vitals.cpp
@@ -89,3 +89,24 @@ TEST(Vitals, OnAndOff) {
     }
   }
 }
+
+TEST(Vitals, APIVitals) {
+  std::stringstream buffer;
+  bool rvalue;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+  {
+#ifdef _WIN32
+    _putenv("TORCH_VITAL=1");
+#else
+    setenv("TORCH_VITAL", "1", 1);
+#endif
+    APIVitals api_vitals;
+    rvalue = api_vitals.setVital("TestingSetVital", "TestAttr", "TestValue");
+  }
+  std::cout.rdbuf(sbuf);
+
+  auto s = buffer.str();
+  ASSERT_TRUE(rvalue);
+  ASSERT_TRUE(s.find("TestingSetVital.TestAttr\t\t TestValue") != std::string::npos);
+}

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2,12 +2,14 @@
 import torch
 import numpy as np
 
+import contextlib
 import io
 import inspect
 import math
 import random
 import re
 import copy
+import os
 import tempfile
 import unittest
 import warnings
@@ -2879,6 +2881,39 @@ def add_neg_dim_tests():
 
         assert not hasattr(AbstractTestCases._TestTorchMixin, test_name), "Duplicated test name: " + test_name
         setattr(AbstractTestCases._TestTorchMixin, test_name, make_neg_dim_test(name, tensor_arg, arg_constr, types, extra_dim))
+
+
+@contextlib.contextmanager
+def torch_vital_set(value):
+    stash = None
+    if 'TORCH_VITAL' in os.environ:
+        stash = os.environ['TORCH_VITAL']
+    os.environ['TORCH_VITAL'] = value
+    try:
+        yield
+    finally:
+        if stash:
+            os.environ['TORCH_VITAL'] = stash
+        else:
+            del os.environ['TORCH_VITAL']
+
+
+# Tests Vital Signs for Torch
+class TestVitalSigns(TestCase):
+    def test_basic_vitals(self):
+        with torch_vital_set(''):
+            self.assertFalse(torch.vitals_enabled())
+        with torch_vital_set('ON'):
+            self.assertTrue(torch.vitals_enabled())
+
+    def test_write_vital(self):
+        with torch_vital_set('ON'):
+            self.assertTrue(torch.vitals_enabled())
+            # This tests the code path of setting a vital
+            self.assertTrue(torch.set_vital('Dataloader', 'basic_unit_test', 'TEST'))
+            # Ideally we would have a read test for vitals, though because the the C++ design
+            # pattern of loggers we use, we can't know the whole list of vitals until the
+            # global C++ namespace is destructed.
 
 
 # Device-generic tests. Instantiated below and not run directly.

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -696,6 +696,7 @@ aten_cpu_source_non_codegen_list = [
     "aten/src/ATen/core/Tensor.cpp",
     "aten/src/ATen/core/VariableFallbackKernel.cpp",
     "aten/src/ATen/core/VariableHooksInterface.cpp",
+    "aten/src/ATen/core/Vitals.cpp",
     "aten/src/ATen/core/boxing/KernelFunction.cpp",
     "aten/src/ATen/core/custom_class.cpp",
     "aten/src/ATen/core/dispatch/DispatchKeyExtractor.cpp",

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -5,20 +5,21 @@
 #include <sys/socket.h>
 #endif
 
-#include <unordered_map>
-#include <cstdlib>
-#include <libshm.h>
-#include <TH/TH.h>
-#include <c10/util/Logging.h>
 #include <ATen/ATen.h>
-#include <ATen/ExpandUtils.h>
-#include <ATen/dlpack.h>
 #include <ATen/DLConvertor.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/Utils.h>
 #include <ATen/VmapMode.h>
+#include <ATen/dlpack.h>
+#include <ATen/core/Vitals.h>
+#include <TH/TH.h>
+#include <c10/util/Logging.h>
+#include <cstdlib>
+#include <libshm.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <unordered_map>
 
 #include <torch/csrc/THP.h>
 #include <torch/csrc/DynamicTypes.h>
@@ -933,6 +934,11 @@ PyObject* initModule() {
   auto py_module = py::reinterpret_borrow<py::module>(module);
   py_module.def("_demangle", &c10::demangle);
   py_module.def("_log_api_usage_once", &LogAPIUsageOnceFromPython);
+
+  py_module.def("vitals_enabled", &at::vitals::torchVitalEnabled);
+  py_module.def("set_vital", [](const std::string &vital, const std::string &attr, const std::string value){
+    return at::vitals::VitalsAPI.setVital(vital, attr, value);
+  });
 
   py_module.def(
     "init_num_threads",

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -193,6 +193,8 @@ def get_ignored_functions() -> Set[Callable]:
         torch.unify_type_list,
         torch.is_warn_always_enabled,
         torch.set_warn_always,
+        torch.vitals_enabled,
+        torch.set_vital,
         Tensor.__delitem__,
         Tensor.__dir__,
         Tensor.__getattribute__,


### PR DESCRIPTION
Summary:
This adds a Python API for vital signs. This keeps the existing semantics of the TorchVital object but extends it with a global map which the python API can use to resolve string names to TorchVital objects.

This map is kept safe through the use of weak_ptrs.

Test Plan:
buck test mode/dev caffe2/test:torch -- --regex vital
buck test //caffe2/aten:vitals

Differential Revision: D26736443

