### PR TITLE
Simplifes OpInfo test matrix to reduce test time

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2181,7 +2181,7 @@ class TestOperatorSignatures(JitTestCase):
                 # loop via `else`, we haven't found a match
                 for schema in schemas:
                     try:
-                        bound_args = schema.bind(*sample_input.input, *sample_input.args, **sample_input.kwargs)
+                        bound_args = schema.bind(sample_input.input, *sample_input.args, **sample_input.kwargs)
                         bound_args.apply_defaults()
                         op(*bound_args.args, **bound_args.kwargs)
                         break

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -43,7 +43,7 @@ class TestOpInfo(TestCase):
 
             # NOTE: only tests on first sample
             sample = samples[0]
-            op(*sample.input, *sample.args, **sample.kwargs)
+            op(sample.input, *sample.args, **sample.kwargs)
 
     # Verifies that ops have their supported dtypes
     #   registered correctly by testing that each claimed supported dtype
@@ -51,13 +51,26 @@ class TestOpInfo(TestCase):
     @onlyOnCPUAndCUDA
     @ops(op_db, dtypes=OpDTypes.supported)
     def test_supported_dtypes(self, device, dtype, op):
-        samples = op.sample_inputs(device, dtype)
-        if len(samples) == 0:
-            self.skipTest("Skipped! No sample inputs!")
+        for sample in op.sample_inputs(device, dtype):
+            op(sample.input, *sample.args, **sample.kwargs)
 
-        # NOTE: only tests on first sample
-        sample = samples[0]
-        op(*sample.input, *sample.args, **sample.kwargs)
+    # Verifies that backward for each supported floating or complex dtype
+    #   does NOT throw a runtime error.
+    # TODO: support multi-tensor outputs
+    @onlyOnCPUAndCUDA
+    @ops(op_db, allowed_dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16))
+    def test_supported_backward(self, device, dtype, op):
+        if not op.supports_autograd:
+            self.skipTest("Skipped! Autograd not supported.")
+        if not op.supports_complex_autograd and dtype.is_complex:
+            self.skipTest("Skipped! Complex autograd not supported.")
+
+        for sample in op.sample_inputs(device, dtype, requires_grad=True):
+            result = op(sample.input, *sample.args, **sample.kwargs)
+            if not isinstance(result, torch.Tensor):
+                continue
+
+            result.sum().backward()
 
     # Verifies that ops do not have an entry in
     # `method_tests` (legacy testing infra).
@@ -104,15 +117,15 @@ class TestGradients(TestCase):
                 return op.output_func(output)
 
             if check == 'gradcheck':
-                self.assertTrue(gradcheck(fn, (*sample.input,) + sample.args,
+                self.assertTrue(gradcheck(fn, (sample.input,) + sample.args,
                                           check_batched_grad=op.check_batched_grad,
                                           check_grad_dtypes=True))
             elif check == 'gradgradcheck':
-                self.assertTrue(gradgradcheck(fn, (*sample.input,) + sample.args,
+                self.assertTrue(gradgradcheck(fn, (sample.input,) + sample.args,
                                               gen_non_contig_grad_outputs=False,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True))
-                self.assertTrue(gradgradcheck(fn, (*sample.input,) + sample.args,
+                self.assertTrue(gradgradcheck(fn, (sample.input,) + sample.args,
                                               gen_non_contig_grad_outputs=True,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True))
@@ -127,9 +140,9 @@ class TestGradients(TestCase):
 
     def _skip_helper(self, op, dtype):
         if not op.supports_autograd:
-            self.skipTest("Skipped! autograd not supported")
-        if not op.test_complex_grad and dtype.is_complex:
-            self.skipTest("Skipped! complex grad tests marked to skip.")
+            self.skipTest("Skipped! autograd not supported.")
+        if not op.supports_complex_autograd and dtype.is_complex:
+            self.skipTest("Skipped! Complex autograd not supported.")
 
     # Tests that gradients are computed correctly
     @_gradcheck_ops(op_db)
@@ -147,8 +160,8 @@ class TestGradients(TestCase):
     @_gradcheck_ops(op_db)
     def test_inplace_grad(self, device, dtype, op):
         self._skip_helper(op, dtype)
-        if not op.test_inplace_grad:
-            self.skipTest("Skipped! Inplace gradcheck marked to skip.")
+        if not op.supports_inplace_autograd:
+            self.skipTest("Skipped! Operation does not support inplace autograd.")
         self._grad_test_helper(device, dtype, op, self._get_safe_inplace(op.get_inplace()))
 
     # Test that gradients of gradients are computed correctly
@@ -167,8 +180,8 @@ class TestGradients(TestCase):
     @_gradcheck_ops(op_db)
     def test_inplace_gradgrad(self, device, dtype, op):
         self._skip_helper(op, dtype)
-        if not op.test_inplace_grad:
-            self.skipTest("Skipped! Inplace gradgradcheck marked to skip.")
+        if not op.supports_inplace_autograd:
+            self.skipTest("Skipped! Operation does not support inplace autograd.")
         self._gradgrad_test_helper(device, dtype, op, self._get_safe_inplace(op.get_inplace()))
 
 
@@ -180,40 +193,26 @@ class TestGradients(TestCase):
 class TestCommon(JitCommonTestCase):
     exact_dtype = True
 
-    # Compares variant's backward
-    # NOTE: verifies it fails when the forward fails
-    def check_variant_backward(self, input, forward_result, expected_grad, expected_exception):
-        variant_exception_during_backwards = False
-        try:
-            forward_result.sum().backward()
-            variant_grad = input.grad
-            input.grad = None
-        except Exception as e:
-            if not expected_exception:
-                self.fail("Unexpected exception during backwards!")
-            variant_exception_during_backwards = True
-
-        if expected_exception != variant_exception_during_backwards:
-            self.fail("Unexpected success during backwards!")
-
-        if not expected_exception:
-            self.assertEqual(variant_grad, expected_grad)
+    # variant testing is only done with torch.float to avoid excessive
+    #   test times and maximize signal to noise ratio
+    _variant_ops = partial(ops, dtypes=OpDTypes.supported,
+                           allowed_dtypes=[torch.float])
 
     # Tests that the forward and backward passes of operations produce the
     #   same values for the cross-product of op variants (method, inplace)
     #   against eager's gold standard op function variant
-    @ops(op_db)
+    @_variant_ops(op_db)
     def test_variant_consistency_eager(self, device, dtype, op):
-        test_backward = op.supports_autograd and (op.test_complex_grad or not dtype.is_complex)
-        samples = op.sample_inputs(device, dtype, requires_grad=test_backward)
-        if len(samples) == 0:
-            self.skipTest("Skipped! No sample inputs!")
+        samples = op.sample_inputs(device, dtype, requires_grad=op.supports_autograd)
 
         for sample in samples:
-            # Acquires variants to test
+            # Acquires variants (method variant, inplace variant, aliases)
             method = op.get_method()
             inplace = op.get_inplace()
-            inplace_ops = [inplace, ]  # list of all inplace ops: inplace variant + alias inplace variants if exist
+
+            # list of all inplace ops: inplace variant + alias inplace variants if exist
+            inplace_ops = [inplace, ]
+
             aliases = []
             for a_op in op.aliases:
                 aliases.append(a_op.op)
@@ -224,58 +223,44 @@ class TestCommon(JitCommonTestCase):
 
             inplace_ops = tuple(v for v in inplace_ops if v is not None)
             variants = (v for v in (method, inplace) + aliases if v is not None)
-            # Computes expected forward
 
-            # below calls op's function variant
-            expected_forward = op(*sample.input, *sample.args, **sample.kwargs)
-
-            # Computes expected backward
-            # NOTE: backward may fail for some dtypes
-            exception_during_backwards = False
+            # Computes function forward and backward values
+            sample.input.grad = None
+            expected_forward = op(sample.input, *sample.args, **sample.kwargs)
             expected_grad = None
-            try:
+
+            # TODO: backward consistency only supported for single tensor outputs
+            # TODO: backward consistency only checked on sample.input, not all
+            #   tensor inputs
+            # TODO: update to handle checking grads of all tensor inputs as
+            #   derived from each tensor output
+            if (op.supports_autograd and isinstance(expected_forward, torch.Tensor)):
                 expected_forward.sum().backward()
                 expected_grad = sample.input.grad
-                sample.input.grad = None
-            except Exception as e:
-                exception_during_backwards = True
 
             # Test eager consistency
             for variant in variants:
-                # Verifies that inplace operations that promote int->float fail
-                #   on tensors with integer dtypes.
-                if (variant in inplace_ops and not torch.can_cast(expected_forward.dtype, dtype)):
-                    try:
-                        variant_forward = variant(*(clone_input_helper(input) for input in sample.input),
-                                                  *sample.args,
-                                                  **sample.kwargs)
-                    except Exception as e:
-                        continue
-                    self.fail("Inplace operation on integer tensor that should be promoted to float didn't fail!")
                 # Compares variant's forward
-                # Note: copy the tensor-type inputs when testing inplace operation
-                variant_forward = variant(*(clone_input_helper(input) if variant in inplace_ops else input
-                                            for input in sample.input),
+                # Note: copies the to-be-modified input when testing the inplace variant
+                sample.input.grad = None
+                cloned = clone_input_helper(sample.input) if variant in inplace_ops else sample.input
+                variant_forward = variant(cloned,
                                           *sample.args,
                                           **sample.kwargs)
-                self.assertEqual(variant_forward, expected_forward)
+                self.assertEqual(expected_forward, variant_forward)
 
                 # Compares variant's backward
-                if test_backward and (variant not in inplace_ops or op.test_inplace_grad):
-                    self.check_variant_backward(sample.input, variant_forward,
-                                                expected_grad, exception_during_backwards)
+                if expected_grad is not None and (variant not in inplace_ops or op.supports_inplace_autograd):
+                    variant_forward.sum().backward()
+                    self.assertEqual(expected_grad, sample.input.grad)
 
     # Tests that the forward and backward passes of operations produce the
     #   same values for the cross-product of op variants (function, method, inplace)
     #   and runtimes (eager, traced, scripted).
     # TODO WARNING: inplace x {traced, scripted} not currently tested
-    @ops(op_db)
+    @_variant_ops(op_db)
     def test_variant_consistency_jit(self, device, dtype, op):
-        test_backward = op.supports_autograd and (
-            (dtype.is_complex and op.test_complex_grad) or
-            (dtype.is_floating_point and (not op.skip_bfloat16_grad or dtype != torch.bfloat16)))
-
-        samples = op.sample_inputs(device, dtype, requires_grad=test_backward)
+        samples = op.sample_inputs(device, dtype, requires_grad=op.supports_autograd)
         if len(samples) == 0:
             self.skipTest("Skipped! No sample inputs!")
 
@@ -303,8 +288,6 @@ class TestCommon(JitCommonTestCase):
                 #   autodiff support. Context manager forces the graph to contain
                 #   DifferentiableGraph nodes if they are present
                 with disable_autodiff_subgraph_inlining():
-
-
                     # Check scripted forward, grad, and grad grad
                     script_fn = create_script_fn(self, name, func_type)
 
@@ -312,9 +295,9 @@ class TestCommon(JitCommonTestCase):
                                             script_fn,
                                             func,
                                             op.output_func,
-                                            (*sample.input,) + sample.args,
+                                            (sample.input,) + sample.args,
                                             sample.kwargs,
-                                            no_grad=not test_backward)
+                                            no_grad=not op.supports_autograd)
 
                     # Check traced forward, grad, and grad grad
                     traced_fn = create_traced_fn(self, variant)
@@ -322,16 +305,16 @@ class TestCommon(JitCommonTestCase):
                                             traced_fn,
                                             func,
                                             op.output_func,
-                                            (*sample.input,) + sample.args,
+                                            (sample.input,) + sample.args,
                                             sample.kwargs,
-                                            no_grad=not test_backward)
+                                            no_grad=not op.supports_autograd)
 
                     # Check alias annotation schema for correctness (make
                     #   sure inputs that aren't supposed to be modified aren't)
                     # Note: only runs in float32 and int64 because schema isn't affected by dtype,
                     #   so running it on all dtypes is would be excessive
                     if dtype in [torch.float32, torch.int32]:
-                        check_alias_annotation(name, (*sample.input,) + sample.args, sample.kwargs,
+                        check_alias_annotation(name, (sample.input,) + sample.args, sample.kwargs,
                                                func_type=func_type, aten_name=op.aten_name)
 
                     # Check autodifferentiation of nodes for traced and scripted graphs, only need to check once per sample
@@ -348,7 +331,7 @@ class TestCommon(JitCommonTestCase):
                         self.assertAutodiffNode(traced_fn.last_graph, op.assert_autodiffed, nonfusible_nodes, fusible_nodes)
                         self.assertAutodiffNode(script_fn.last_graph, op.assert_autodiffed, nonfusible_nodes, fusible_nodes)
 
-    @ops([op for op in op_db if op.aliases])
+    @_variant_ops([op for op in op_db if op.aliases])
     def test_jit_alias_remapping(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype, requires_grad=True)
         if len(samples) == 0:
@@ -360,13 +343,13 @@ class TestCommon(JitCommonTestCase):
         # Prepare data for test scripting
         # Below we prepare strings of args/kwargs with and without type annotations.
         # These strings are inserted into function template strings which is then torch scripted.
-        # - args string is ["t0", "t1", ...] corresponds to the input tensors required by the op
+        # - args string is ["t0"] corresponding to the "input" tensor required by the op
         # - args_annot_kw is the string for the template function signature, for example,
-        # ["t0", "t1", "s0: float", "s1: bool", "max: float = 1.0", "min: float = 0.0"] ->
-        #    def fn(t0, t1, s0: float, s1: bool, max: float = 1.0, min: float = 0.0)
+        # ["t0", "s0: float", "s1: bool", "max: float = 1.0", "min: float = 0.0"] ->
+        #    def fn(t0, s0: float, s1: bool, max: float = 1.0, min: float = 0.0)
         # - args_kw is the string of args/kwargs used to call the op, same as args_annot_kw but
         # without type annotations
-        args = [f"t{i}" for i in range(len(sample.input))]
+        args = ["t0"]
         args_annot_kw = args + \
             [f"s{i}: {type(v).__name__}" for i, v in enumerate(sample.args)] + \
             [f"{k}: {type(v).__name__} = {v}" for k, v in sample.kwargs.items()]
@@ -383,7 +366,7 @@ class TestCommon(JitCommonTestCase):
 
         original_name = op.name
         original_name_inplace = original_name + "_"
-        expected_dtype = op(*sample.input, *sample.args, **sample.kwargs).dtype
+        expected_dtype = op(sample.input, *sample.args, **sample.kwargs).dtype
 
         for a_op in op.aliases:
             inplace = a_op.inplace_variant
@@ -420,16 +403,16 @@ class TestCommon(JitCommonTestCase):
 
                 if (variant is inplace and not torch.can_cast(expected_dtype, dtype)):
                     try:
-                        inp = (clone_input_helper(input) for input in sample.input)
-                        scripted(*inp, *sample.args, **sample.kwargs)
+                        inp = clone_input_helper(sample.input)
+                        scripted(inp, *sample.args, **sample.kwargs)
                     except Exception as e:
                         continue
                     self.fail("Inplace operation on integer tensor that should be promoted to float didn't fail!")
 
-                inp = (clone_input_helper(input) for input in sample.input)
-                scripted(*inp, *sample.args, **sample.kwargs)
-                inp = (clone_input_helper(input) for input in sample.input)
-                graph = scripted.graph_for(*inp, *sample.args, **sample.kwargs)
+                inp = clone_input_helper(sample.input)
+                scripted(inp, *sample.args, **sample.kwargs)
+                inp = clone_input_helper(sample.input)
+                graph = scripted.graph_for(inp, *sample.args, **sample.kwargs)
                 FileCheck().check(op.aten_name).check_not(variant_name).run(graph)
 
             # Test tracing:
@@ -440,11 +423,11 @@ class TestCommon(JitCommonTestCase):
                 def _fn(*sample_args, **sample_kwargs):
                     return variant(*sample_args, **sample_kwargs)
 
-                inp = (*(clone_input_helper(input) for input in sample.input), ) + sample_args_kwargs
+                inp = (clone_input_helper(sample.input),) + sample_args_kwargs
                 traced = torch.jit.trace(_fn, *inp)
-                inp = (*(clone_input_helper(input) for input in sample.input), ) + sample_args_kwargs
+                inp = (clone_input_helper(sample.input),) + sample_args_kwargs
                 traced(*inp)
-                inp = (*(clone_input_helper(input) for input in sample.input), ) + sample_args_kwargs
+                inp = (clone_input_helper(sample.input),) + sample_args_kwargs
                 graph = traced.graph_for(*inp)
                 FileCheck().check(op_name).check_not(variant_name).run(graph)
 
@@ -464,8 +447,8 @@ class TestCommon(JitCommonTestCase):
         sample = samples[0]
 
         # calls it normally to get the expected result
-        expected = op(*sample.input, *sample.args, **sample.kwargs)
-        op_out = partial(op, *sample.input, *sample.args, **sample.kwargs)
+        expected = op(sample.input, *sample.args, **sample.kwargs)
+        op_out = partial(op, sample.input, *sample.args, **sample.kwargs)
 
         # Short-circuits if output is not a single tensor or an
         #   iterable of tensors
@@ -508,8 +491,18 @@ class TestCommon(JitCommonTestCase):
                 return torch.full_like(t, float('nan'))
 
         out = _apply_out_transform(_case_zero_transform, expected)
-        op_out(out=out)
+        result = op_out(out=out)
         self.assertEqual(expected, out)
+
+        # Checks that the returned value shares storage with out
+        # NOTE: only checks on the CPU and CUDA device types since some
+        #   device types don't have storage
+        if self.device_type == 'cpu' or self.device_type == 'cuda':
+            if isinstance(out, torch.Tensor):
+                self.assertEqual(out.storage().data_ptr(), result.storage().data_ptr())
+            else:
+                for out_t, result_t in zip(out, result):
+                    self.assertEqual(out_t.storage().data_ptr(), result_t.storage().data_ptr())
 
         # Case 1: out= with the correct shape, dtype, and device,
         #   but noncontiguous.

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -620,9 +620,8 @@ class TestShapeFuncs(TestCase):
     def test_repeat_tile_vs_numpy(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype, requires_grad=False)
         for sample in samples:
-            (t, dims) = sample.input
-            expected = op.ref(t.cpu().numpy(), dims, **sample.kwargs)
-            result = op(t, dims, **sample.kwargs).cpu().numpy()
+            expected = op.ref(sample.input.cpu().numpy(), *sample.args, **sample.kwargs)
+            result = op(sample.input, *sample.args, **sample.kwargs).cpu().numpy()
             self.assertEqual(expected, result)
 
 instantiate_device_type_tests(TestShapeOps, globals())

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -238,32 +238,6 @@ class TestUnaryUfuncs(TestCase):
                                                                             high,
                                                                             result.item()))
 
-    # Tests that fn == method == inplace == jit on a simple single tensor input
-    # TODO: should this jitting the method and inplace variants, too?
-    @ops(unary_ufuncs)
-    def test_variant_consistency(self, device, dtype, op):
-        def _fn(t):
-            return op(t)
-
-        t = make_tensor((5, 5), device, dtype, low=op.domain[0], high=op.domain[1])
-        expected = op(t)
-
-        for alt, inplace in ((op.get_method(), False), (op.get_inplace(), True),
-                             (torch.jit.script(_fn), False)):
-            if alt is None:
-                continue
-
-            if inplace and not torch.can_cast(expected.dtype, dtype):
-                # Assert that RuntimeError is raised
-                # for inplace variant of Operators that
-                # promote integer input to floating dtype.
-                with self.assertRaises(RuntimeError):
-                    alt(t.clone())
-                continue
-
-            actual = alt(t.clone())
-            self.assertEqual(actual, expected, rtol=0, atol=0)
-
     # Helper for comparing torch tensors and numpy arrays
     # TODO: should this or assertEqual also validate that strides are equal?
     def assertEqualHelper(self, actual, expected, msg, *, dtype, exact_dtype=True, **kwargs):

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -247,27 +247,32 @@ class DeviceTypeTestBase(TestCase):
             #   Test-sepcific decorators are applied to the original test,
             #   however.
             if op is not None:
-                active_decorators = []
-                if op.should_skip(generic_cls.__name__, name, cls.device_type, dtype):
-                    active_decorators.append(skipIf(True, "Skipped!"))
+                try:
+                    active_decorators = []
+                    if op.should_skip(generic_cls.__name__, name, cls.device_type, dtype):
+                        active_decorators.append(skipIf(True, "Skipped!"))
 
-                if op.decorators is not None:
-                    for decorator in op.decorators:
-                        # Can't use isinstance as it would cause a circular import
-                        if decorator.__class__.__name__ == 'DecorateInfo':
-                            if decorator.is_active(generic_cls.__name__, name, cls.device_type, dtype):
-                                active_decorators += decorator.decorators
-                        else:
-                            active_decorators.append(decorator)
+                    if op.decorators is not None:
+                        for decorator in op.decorators:
+                            # Can't use isinstance as it would cause a circular import
+                            if decorator.__class__.__name__ == 'DecorateInfo':
+                                if decorator.is_active(generic_cls.__name__, name, cls.device_type, dtype):
+                                    active_decorators += decorator.decorators
+                            else:
+                                active_decorators.append(decorator)
 
-                @wraps(test)
-                def test_wrapper(*args, **kwargs):
-                    return test(*args, **kwargs)
+                    @wraps(test)
+                    def test_wrapper(*args, **kwargs):
+                        return test(*args, **kwargs)
 
-                for decorator in active_decorators:
-                    test_wrapper = decorator(test_wrapper)
+                    for decorator in active_decorators:
+                        test_wrapper = decorator(test_wrapper)
 
-                test_fn = test_wrapper
+                    test_fn = test_wrapper
+                except Exception as ex:
+                    # Provides an error message for debugging before rethrowing the exception
+                    print("Failed to instantiate {0} for op {1}!".format(test_name, op.name))
+                    raise ex
             else:
                 test_fn = test
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -81,8 +81,10 @@ class SampleInput(object):
     __slots__ = ['input', 'args', 'kwargs', 'output_process_fn_grad']
 
     def __init__(self, input, *, args=tuple(), kwargs=None, output_process_fn_grad=None):
-        # test_ops.py expects input to be a tuple
-        self.input = input if isinstance(input, tuple) else (input,)
+        # input must be a single tensor, and will be the first argument to the op
+        #   this follows the typical pattern where op(t, ...) = t.op(...)
+        assert isinstance(input, torch.Tensor)
+        self.input = input
         self.args = args
         self.kwargs = kwargs if kwargs is not None else {}
         self.output_process_fn_grad = output_process_fn_grad
@@ -143,9 +145,6 @@ class OpInfo(object):
                  dtypesIfROCM=None,  # dtypes this function is expected to work with on ROCM
                  default_test_dtypes=None,  # dtypes to test with by default. Gets intersected
                                             # with the dtypes support on the tested device
-                 test_inplace_grad=True,  # whether to gradcheck and gradgradcheck the inplace variant
-                 test_complex_grad=True,  # whether to gradcheck and gradgradcheck for complex dtypes
-                 skip_bfloat16_grad=False,  # whether to skip grad and gradgradcheck for bfloat16 dtype
                  assert_autodiffed=False,  # if a op's aten::node is expected to be symbolically autodiffed
                  autodiff_nonfusible_nodes=None,  # a list of strings with node names that are expected to be in a
                                                   # DifferentiableGraph when autodiffed. Ex: ['aten::add', 'aten::mm'],
@@ -164,7 +163,11 @@ class OpInfo(object):
                  aliases=None,  # iterable of aliases, e.g. ("absolute",) for torch.abs
                  variant_test_name='',  # additional string to include in the test name
                  supports_autograd=True,  # support for autograd
-                 supports_sparse=False,  # supported for sparse
+                 supports_inplace_autograd=None,  # whether the operation supports inplace autograd
+                                                  # defaults to supports_autograd's value
+                 supports_complex_autograd=None,  # whether the operation supports complex autograd
+                                                  # defaults to supports_autograd's value
+                 supports_sparse=False,  # whether the op supports sparse inputs
                  check_batched_grad=True,  # check batched grad when doing gradcheck
                  check_batched_gradgrad=True,  # check batched grad grad when doing gradgradcheck
                  ):
@@ -189,10 +192,7 @@ class OpInfo(object):
         inplace_name = name + "_"
         self.inplace_variant = getattr(torch.Tensor, inplace_name, None)
         self.operator_variant = getattr(operator, name, None)
-        self.skip_bfloat16_grad = skip_bfloat16_grad
 
-        self.test_inplace_grad = test_inplace_grad
-        self.test_complex_grad = test_complex_grad
         self.supports_out = supports_out
         self.safe_casts_outputs = safe_casts_outputs
 
@@ -207,10 +207,20 @@ class OpInfo(object):
             self.autodiff_nonfusible_nodes = ['aten::' + self.name]
         else:
             self.autodiff_nonfusible_nodes = autodiff_nonfusible_nodes
+
+        # autograd support
         self.supports_autograd = supports_autograd
-        self.supports_sparse = supports_sparse
+        self.supports_inplace_autograd = supports_inplace_autograd
+        if self.supports_inplace_autograd is None:
+            self.supports_inplace_autograd = supports_autograd
+        self.supports_complex_autograd = supports_complex_autograd
+        if self.supports_complex_autograd is None:
+            self.supports_complex_autograd = supports_autograd
+
         self.check_batched_grad = check_batched_grad
         self.check_batched_gradgrad = check_batched_gradgrad
+
+        self.supports_sparse = supports_sparse
 
         self.aliases = ()  # type: ignore
         if aliases is not None:
@@ -318,6 +328,9 @@ class UnaryUfuncInfo(OpInfo):
                  dtypesIfCPU=floating_and_complex_types_and(torch.bfloat16),
                  dtypesIfCUDA=floating_and_complex_types_and(torch.half),
                  dtypesIfROCM=floating_types_and(torch.half),
+                 default_test_dtypes=(
+                     torch.uint8, torch.long, torch.half, torch.bfloat16,
+                     torch.float32, torch.cfloat),  # dtypes which tests check by default
                  domain=(None, None),  # the [low, high) domain of the function
                  handles_large_floats=True,  # whether the op correctly handles large float values (like 1e20)
                  handles_extremals=True,  # whether the op correctly handles extremal values (like inf)
@@ -481,50 +494,35 @@ def sample_inputs_linalg_vector_norm(op_info, device, dtype, requires_grad):
     return inputs
 
 def sample_inputs_addmm(op_info, device, dtype, requires_grad):
-    input = SampleInput((make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                         make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                         make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=False)))
+    input = SampleInput(
+        make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=False)))
     if dtype.is_complex:
-        another_input = SampleInput((make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                                     make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                                     make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=False)),
-                                    kwargs=dict(beta=1 + 2j, alpha=2 + 3j))
+        another_input = SampleInput(
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(
+                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=False)),
+            kwargs=dict(beta=1 + 2j, alpha=2 + 3j))
         return (input, another_input)
     else:
         return (input, )
 
 def sample_inputs_addr(op_info, device, dtype, requires_grad):
-    input1 = SampleInput((make_tensor((S, M), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((S, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((M, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad)))
+    input1 = SampleInput(
+        make_tensor((S, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, ), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((M, ), device, dtype, low=None, high=None, requires_grad=requires_grad)))
 
-    input2 = SampleInput((make_tensor((), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((S, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((M, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad)))
+    input2 = SampleInput(
+        make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, ), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((M, ), device, dtype, low=None, high=None, requires_grad=requires_grad)))
+
     if dtype.is_complex:
         alpha, beta = 0.1 + 0.3j, 0.4 + 0.6j
     elif dtype.is_floating_point:
@@ -532,37 +530,31 @@ def sample_inputs_addr(op_info, device, dtype, requires_grad):
     else:
         alpha, beta = 2, 3
 
-    input3 = SampleInput((make_tensor((S, M), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((S, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((M, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad)),
-                         kwargs=dict(beta=beta, alpha=alpha))
+    input3 = SampleInput(
+        make_tensor((S, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, ), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((M, ), device, dtype, low=None, high=None, requires_grad=requires_grad)),
+        kwargs=dict(beta=beta, alpha=alpha))
 
-    input4 = SampleInput((make_tensor((), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((S, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad),
-                          make_tensor((M, ), device, dtype,
-                          low=None, high=None,
-                          requires_grad=requires_grad)),
-                         kwargs=dict(beta=beta, alpha=alpha))
+    input4 = SampleInput(
+        make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, ), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((M, ), device, dtype, low=None, high=None, requires_grad=requires_grad)),
+        kwargs=dict(beta=beta, alpha=alpha))
 
     return (input1, input2, input3, input4)
 
 def sample_inputs_xlogy(self, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                         make_tensor((S, S), device, dtype,
-                                     low=0, high=None,
-                                     requires_grad=requires_grad))),)
+    return (
+        SampleInput(
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(
+                make_tensor((S, S), device, dtype, low=0, high=None, requires_grad=requires_grad),
+            )
+        ),
+    )
 
 def sample_inputs_trace(self, device, dtype, requires_grad):
     return (SampleInput((make_tensor((S, S), device, dtype,
@@ -614,10 +606,10 @@ def sample_inputs_broadcast_to(op_info, device, dtype, requires_grad):
         ((), (1, 3, 2)),
     )
 
-    return tuple(SampleInput((make_tensor(size, device, dtype,
-                                          low=None, high=None,
-                                          requires_grad=requires_grad), shape))
-                 for size, shape in test_cases)
+    return tuple(
+        SampleInput(
+            make_tensor(size, device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(shape,)) for size, shape in test_cases)
 
 def sample_inputs_div(self, device, dtype, requires_grad, rounding_mode=None):
     a = make_tensor((S, S, S), device, dtype, low=None, high=None, requires_grad=requires_grad)
@@ -629,55 +621,46 @@ def sample_inputs_div(self, device, dtype, requires_grad, rounding_mode=None):
     if rounding_mode is not None:
         kwargs = dict(rounding_mode=rounding_mode)
 
-    return [
-        SampleInput((a, b), kwargs=kwargs),
-        SampleInput((a,), args=(2,)),
-    ]
+    return (
+        SampleInput(a, args=(b,), kwargs=kwargs),
+        SampleInput(a, args=(2,)),
+    )
 
 def sample_inputs_stack(op_info, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        make_tensor((S, S), device, dtype,
-                                    low=None, high=None,
-                                    requires_grad=requires_grad),
-                        make_tensor((S, S), device, dtype,
-                                    low=None, high=None,
-                                    requires_grad=requires_grad)), kwargs=dict(idx=0)),)
+    return (
+        SampleInput(
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(
+                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad)),
+            kwargs=dict(idx=0)),
+    )
 
 def sample_inputs_hstack_dstack_vstack(op_info, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        make_tensor((S, S), device, dtype,
-                                    low=None, high=None,
-                                    requires_grad=requires_grad),
-                        make_tensor((S, S), device, dtype,
-                                    low=None, high=None,
-                                    requires_grad=requires_grad))),)
+    return (SampleInput(
+        make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        args=(
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad))),)
 
 def sample_inputs_gather(op_info, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((M, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, gather_variable((S, S), 1, M, True, device=device))),
-            SampleInput((make_tensor((M, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        1, gather_variable((M, S // 2), 0, S, True, device=device))),
-            SampleInput((make_tensor((), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, torch.tensor([0], dtype=torch.int64, device=device))),
-            SampleInput((make_tensor((S,), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, torch.tensor(0, dtype=torch.int64, device=device))),
-            SampleInput((make_tensor((), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, torch.tensor(0, dtype=torch.int64, device=device))),
-            )
+    return (
+        SampleInput(
+            make_tensor((M, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, gather_variable((S, S), 1, M, True, device=device))),
+        SampleInput(
+            make_tensor((M, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(1, gather_variable((M, S // 2), 0, S, True, device=device))),
+        SampleInput(
+            make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, torch.tensor([0], dtype=torch.int64, device=device))),
+        SampleInput(
+            make_tensor((S,), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, torch.tensor(0, dtype=torch.int64, device=device))),
+        SampleInput(
+            make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, torch.tensor(0, dtype=torch.int64, device=device))),
+    )
 
 def sample_inputs_amax_amin(op_info, device, dtype, requires_grad):
     test_cases = (
@@ -719,24 +702,22 @@ def sample_inputs_diff(op_info, device, dtype, requires_grad):
                 make_tensor(size_append, device, dtype,
                             low=None, high=None,
                             requires_grad=requires_grad) if size_append else None)
-        sample_inputs += [SampleInput(args)]
+        sample_inputs.append(SampleInput(args[0], args=(args[1], args[2])))
 
     return tuple(sample_inputs)
 
 def sample_inputs_index_select(op_info, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((S, S, S), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, index_variable(2, S, device=device))),
-            SampleInput((make_tensor((), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, torch.tensor([0], dtype=torch.int64, device=device))),
-            SampleInput((make_tensor((), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        0, torch.tensor(0, dtype=torch.int64, device=device))),
-            )
+    return (
+        SampleInput(
+            make_tensor((S, S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, index_variable(2, S, device=device))),
+        SampleInput(
+            make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, torch.tensor([0], dtype=torch.int64, device=device))),
+        SampleInput(
+            make_tensor((), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=(0, torch.tensor(0, dtype=torch.int64, device=device))),
+    )
 
 # Missing to test the nondeterminism of the operation
 # https://github.com/pytorch/pytorch/issues/53352
@@ -755,7 +736,7 @@ def sample_inputs_index_add(op_info, device, dtype, requires_grad):
     idx = make_arg((S,), dtype=torch.int64, low=0, high=S)
     idx_nonctg = make_arg((S,), dtype=torch.int64, low=0, high=S, discontiguous=True)
     idx_neg = -idx - 1
-    samples = [SampleInput((tensor, 1, idx, source))
+    samples = [SampleInput(tensor, args=(1, idx, source))
                for tensor, idx, source in product([t, t_nonctg], [idx, idx_nonctg], [s, s_nonctg])]
 
     # Add scalar cases
@@ -764,7 +745,7 @@ def sample_inputs_index_add(op_info, device, dtype, requires_grad):
     idxs = (make_arg(size, dtype=torch.int64, low=0, high=1) for size in scalar_sizes)
     ss = (make_arg(size) for size in scalar_sizes)
 
-    samples.extend(SampleInput((t, 0, idx, s)) for t, idx, s in product(ts, idxs, ss))
+    samples.extend(SampleInput(t, args=(0, idx, s)) for t, idx, s in product(ts, idxs, ss))
     return samples
 
 def sample_inputs_sort(op_info, device, dtype, requires_grad):
@@ -782,24 +763,24 @@ def sample_inputs_sort(op_info, device, dtype, requires_grad):
 
     # Test cases for small 3d tensors.
     # Imitates legacy tests from test/test_torch.py
-    self = small_3d_unique(dtype, device)
+    t = small_3d_unique(dtype, device)
     dims = range(-3, 3)
     flag = [True, False]
     for dim, descending, stable in product(dims, flag, flag):
         # default schema without stable sort
-        samples.append(SampleInput((self, dim, descending)))
+        samples.append(SampleInput(t, args=(dim, descending)))
         # schema with stable sort, no CUDA support yet
         if torch.device(device).type == 'cpu':
             samples.append(
-                SampleInput(self, kwargs=dict(dim=dim, descending=descending, stable=stable))
+                SampleInput(t, kwargs=dict(dim=dim, descending=descending, stable=stable))
             )
 
     # Test cases for scalar tensor
     scalar = torch.tensor(1, dtype=dtype, device=device)
     apply_grad(scalar)
-    samples.append(SampleInput((scalar)))
-    samples.append(SampleInput((scalar, 0)))
-    samples.append(SampleInput((scalar, 0, True)))
+    samples.append(SampleInput(scalar))
+    samples.append(SampleInput(scalar, args=(0,)))
+    samples.append(SampleInput(scalar, args=(0, True)))
     # no CUDA support for stable sort yet
     if not device.startswith('cuda'):
         samples.append(SampleInput(scalar, kwargs=dict(stable=True)))
@@ -824,9 +805,9 @@ def sample_inputs_index_fill(op_info, device, dtype, requires_grad):
     idx_nonctg.copy_(idx)
     for d in range(t.dim()):
         for tensor in [t, t01, t02, t12]:
-            samples.append(SampleInput((tensor, d, idx, fill_val)))
-            samples.append(SampleInput((tensor, d, -idx - 1, fill_val)))
-            samples.append(SampleInput((tensor, d, idx_nonctg, fill_val)))
+            samples.append(SampleInput(tensor, args=(d, idx, fill_val)))
+            samples.append(SampleInput(tensor, args=(d, -idx - 1, fill_val)))
+            samples.append(SampleInput(tensor, args=(d, idx_nonctg, fill_val)))
     return samples
 
 def sample_inputs_max_min_binary(op_info, device, dtype, requires_grad):
@@ -875,14 +856,14 @@ def sample_inputs_max_min_reduction_no_dim(op_info, device, dtype, requires_grad
     return inputs
 
 def sample_movedim_moveaxis(op_info, device, dtype, requires_grad):
-    return (SampleInput((make_tensor((4, 3, 2, 1), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        (0, 1, 2, 3), (3, 2, 1, 0))),
-            SampleInput((make_tensor((4, 3, 2, 1), device, dtype,
-                                     low=None, high=None,
-                                     requires_grad=requires_grad),
-                        (0, -1, -2, -3), (-3, -2, -1, -0))))
+    return (
+        SampleInput(
+            make_tensor((4, 3, 2, 1), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=((0, 1, 2, 3), (3, 2, 1, 0))),
+        SampleInput(
+            make_tensor((4, 3, 2, 1), device, dtype, low=None, high=None, requires_grad=requires_grad),
+            args=((0, -1, -2, -3), (-3, -2, -1, -0)))
+    )
 
 
 def sample_repeat_tile(op_info, device, dtype, requires_grad):
@@ -906,9 +887,9 @@ def sample_repeat_tile(op_info, device, dtype, requires_grad):
             if op_info.name == 'repeat' and len(rep_dim) >= t.dim():
                 # `torch.repeat` errors for `len(rep_dims) < t.dim()`,
                 # so we filter such combinations.
-                samples.append(SampleInput((t, rep_dim),))
+                samples.append(SampleInput(t, args=(rep_dim,),))
             elif op_info.name == 'tile':
-                samples.append(SampleInput((t, rep_dim),))
+                samples.append(SampleInput(t, args=(rep_dim,),))
 
     return samples
 
@@ -1112,6 +1093,7 @@ class TriangularOpInfo(OpInfo):
             # TODO: implement op.input_func instead of modifying op.get_op()
             # See https://github.com/pytorch/pytorch/issues/50837
             SkipInfo('TestCommon', 'test_variant_consistency_jit'),
+            SkipInfo('TestCommon', 'test_variant_consistency_eager')
         )
 
         super().__init__(name=name,
@@ -1177,7 +1159,7 @@ def sample_inputs_linalg_lstsq(op_info, device, dtype, requires_grad=False):
         # linalg_lstsq is not differentiable
         a = random_well_conditioned_matrix(*shape, dtype=dtype, device=device)
         b = make_tensor(shape, device, dtype, low=None, high=None)
-        out.append(SampleInput((a, b)))
+        out.append(SampleInput(a, args=(b,)))
     return out
 
 def sample_inputs_householder_product(op_info, device, dtype, requires_grad):
@@ -1190,23 +1172,23 @@ def sample_inputs_householder_product(op_info, device, dtype, requires_grad):
     # the Jacobian matrix entries and making the finite-difference result of grad check less accurate.
     # That's why gradcheck with the default range [-9, 9] fails and [-2, 2] is used here.
     samples = (
-        SampleInput((make_tensor((S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
-                    make_tensor((S,), device, dtype, low=-2, high=2, requires_grad=requires_grad))),
+        SampleInput(make_tensor((S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
+                    args=(make_tensor((S,), device, dtype, low=-2, high=2, requires_grad=requires_grad),)),
 
-        SampleInput((make_tensor((S + 1, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
-                    make_tensor((S,), device, dtype, low=-2, high=2, requires_grad=requires_grad))),
+        SampleInput(make_tensor((S + 1, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
+                    args=(make_tensor((S,), device, dtype, low=-2, high=2, requires_grad=requires_grad),)),
 
-        SampleInput((make_tensor((2, 1, S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
-                    make_tensor((2, 1, S,), device, dtype, low=-2, high=2, requires_grad=requires_grad))),
+        SampleInput(make_tensor((2, 1, S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
+                    args=(make_tensor((2, 1, S,), device, dtype, low=-2, high=2, requires_grad=requires_grad),)),
 
-        SampleInput((make_tensor((2, 1, S + 1, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
-                    make_tensor((2, 1, S,), device, dtype, low=-2, high=2, requires_grad=requires_grad))),
+        SampleInput(make_tensor((2, 1, S + 1, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
+                    args=(make_tensor((2, 1, S,), device, dtype, low=-2, high=2, requires_grad=requires_grad),)),
 
-        SampleInput((make_tensor((0, 0), device, dtype, low=None, high=None, requires_grad=requires_grad),
-                    make_tensor((0,), device, dtype, low=None, high=None, requires_grad=requires_grad))),
+        SampleInput(make_tensor((0, 0), device, dtype, low=None, high=None, requires_grad=requires_grad),
+                    args=(make_tensor((0,), device, dtype, low=None, high=None, requires_grad=requires_grad),)),
 
-        SampleInput((make_tensor((S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
-                    make_tensor((0,), device, dtype, low=None, high=None, requires_grad=requires_grad))),
+        SampleInput(make_tensor((S, S), device, dtype, low=-2, high=2, requires_grad=requires_grad),
+                    args=(make_tensor((0,), device, dtype, low=None, high=None, requires_grad=requires_grad),)),
     )
 
     return samples
@@ -1293,7 +1275,7 @@ def sample_inputs_linalg_solve(op_info, device, dtype, requires_grad=False, vect
         a.requires_grad = requires_grad
         b = torch.randn(*batch, n, *rhs, dtype=dtype, device=device)
         b.requires_grad = requires_grad
-        out.append(SampleInput((a, b)))
+        out.append(SampleInput(a, args=(b,)))
     return out
 
 
@@ -1308,8 +1290,11 @@ def sample_inputs_legacy_solve(op_info, device, dtype, requires_grad=False):
     out = sample_inputs_linalg_solve(
         op_info, device, dtype, requires_grad=requires_grad, vector_rhs_allowed=False
     )
+
+    # Reverses tensor order
     for sample in out:
-        sample.input = tuple(reversed(sample.input))
+        sample.input, sample.args = sample.args[0], (sample.input,)
+
     return out
 
 
@@ -1492,10 +1477,11 @@ def sample_inputs_fliplr_flipud(op_info, device, dtype, requires_grad):
     )
     return [SampleInput(tensor) for tensor in tensors]
 
+# TODO: clamp shares tensors among its sample inputs --- we should prohibit this!
 def sample_inputs_clamp(op_info, device, dtype, requires_grad):
     tensors = (
-        make_tensor((S, M, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        make_tensor((S, 0, M), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        make_tensor((2, 3, 2), device, dtype, low=None, high=None, requires_grad=requires_grad),
+        make_tensor((2, 0, 3), device, dtype, low=None, high=None, requires_grad=requires_grad),
     )
     if dtype is torch.uint8:
         min_max_vals = ((2, 5), (3, 7))
@@ -1524,17 +1510,17 @@ def sample_inputs_cumprod(op_info, device, dtype, requires_grad):
     # will not be needed once OpInfo tests suport Iterables
     def sample_generator():
         for dim in range(3):
-            yield SampleInput((make_arg((S, S, S)), dim))
+            yield SampleInput(make_arg((S, S, S)), args=(dim,))
         # Scalar tensors and empty tensor
         for size in [(), (1,), (0,)]:
-            yield SampleInput((make_arg(size), 0))
+            yield SampleInput(make_arg(size), args=(0,))
 
-        yield SampleInput((prod_zeros([0, 1]), 1))
-        yield SampleInput((prod_zeros([0, 2]), 1))
-        yield SampleInput((prod_zeros([1, 2]), 1))
+        yield SampleInput(prod_zeros([0, 1]), args=(1,))
+        yield SampleInput(prod_zeros([0, 2]), args=(1,))
+        yield SampleInput(prod_zeros([1, 2]), args=(1,))
 
         # test dtype kwarg
-        yield SampleInput((prod_zeros([1, 2]), 1), kwargs={'dtype': dtype})
+        yield SampleInput(prod_zeros([1, 2]), args=(1,), kwargs={'dtype': dtype})
 
     return list(sample_generator())
 
@@ -1552,21 +1538,21 @@ def sample_inputs_prod(op_info, device, dtype, requires_grad):
     # will not be needed once OpInfo tests support Iterables
     def sample_generator():
         for sample in sample_inputs_cumprod(op_info, device, dtype, requires_grad):
-            yield SampleInput(sample.input[0])  # only Tensor, ignore other inputs
+            yield SampleInput(sample.input)  # only Tensor, ignore other inputs
             yield sample
             sample.kwargs['keepdim'] = True
             yield sample
         yield SampleInput(prod_single_zero())
-        yield SampleInput((make_arg((3, 3, 3)), 1))
-        yield SampleInput((make_arg((3, 3, 3)), 1), kwargs={'keepdim': True})
+        yield SampleInput(make_arg((3, 3, 3)), args=(1,))
+        yield SampleInput(make_arg((3, 3, 3)), args=(1,), kwargs={'keepdim': True})
 
         # test zero scalar tensor
         zero = make_arg(())
         with torch.no_grad():
             zero.zero_()
         yield SampleInput(zero)
-        yield SampleInput((zero, 0))
-        yield SampleInput((zero, 0), kwargs={'keepdim': True})
+        yield SampleInput(zero, args=(0,))
+        yield SampleInput(zero, args=(0,), kwargs={'keepdim': True})
 
     return list(sample_generator())
 
@@ -1617,9 +1603,9 @@ def sample_inputs_floor_divide(op_info, device, dtype, requires_grad):
         rhs[rhs == 0] = 1
 
     return [
-        SampleInput((lhs, rhs)),
-        SampleInput((lhs, rhs[0])),
-        SampleInput((lhs), args=(3.14,)),
+        SampleInput(lhs, args=(rhs,)),
+        SampleInput(lhs, args=(rhs[0],)),
+        SampleInput(lhs, args=(3.14,)),
     ]
 
 
@@ -1672,8 +1658,8 @@ def sample_inputs_polar(op_info, device, dtype, requires_grad):
         return make_tensor(shape, device, dtype, low=low, high=high, requires_grad=requires_grad)
 
     samples = (
-        SampleInput((_make_tensor_helper((S, S), low=0), _make_tensor_helper((S, S)))),
-        SampleInput((_make_tensor_helper((), low=0), _make_tensor_helper(()))),
+        SampleInput(_make_tensor_helper((S, S), low=0), args=(_make_tensor_helper((S, S)),)),
+        SampleInput(_make_tensor_helper((), low=0), args=(_make_tensor_helper(()),)),
     )
 
     return samples
@@ -1684,12 +1670,12 @@ def sample_inputs_cumsum(op_info, device, dtype, requires_grad):
         return make_tensor(shape, device, dtype, low=low, high=high, requires_grad=requires_grad)
 
     samples = (
-        SampleInput((_make_tensor_helper((S, S, S)), 0)),
-        SampleInput((_make_tensor_helper((S, S, S)), 1)),
+        SampleInput(_make_tensor_helper((S, S, S)), args=(0,)),
+        SampleInput(_make_tensor_helper((S, S, S)), args=(1,)),
         # NOTE: if `dtype` is not same as input, then inplace variants fail with
         # `provided dtype must match the dtype of self tensor in cumsum`
-        SampleInput((_make_tensor_helper((S, S, S)), 1), kwargs={'dtype': dtype}),
-        SampleInput((_make_tensor_helper(()), 0)),
+        SampleInput(_make_tensor_helper((S, S, S)), args=(1,), kwargs={'dtype': dtype}),
+        SampleInput(_make_tensor_helper(()), args=(0,)),
     )
 
     return samples
@@ -1700,17 +1686,17 @@ def sample_inputs_lerp(op_info, device, dtype, requires_grad):
 
     samples = (
         # no broadcast
-        SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S, S)), 0.4)),
+        SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, S)), 0.4)),
         # broadcast rhs
-        SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S,)), 0.4)),
+        SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S,)), 0.4)),
         # scalar tensor
-        SampleInput((_make_tensor_helper(()), _make_tensor_helper(()), 0.4)),
+        SampleInput(_make_tensor_helper(()), args=(_make_tensor_helper(()), 0.4)),
         # broadcast rhs scalar-tensor
-        SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper(()), 0.4)),
+        SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper(()), 0.4)),
         # broadcast rhs with weight tensor
-        SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S,)), _make_tensor_helper((S, S)))),
+        SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S,)), _make_tensor_helper((S, S)))),
         # broadcast rhs and weight tensor
-        SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S, 1)), _make_tensor_helper((S,)))),
+        SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, 1)), _make_tensor_helper((S,)))),
 
         # Broadcasts `self` : Issue with inplace-variants
         # Reference: https://github.com/pytorch/pytorch/issues/50747
@@ -1723,17 +1709,17 @@ def sample_inputs_lerp(op_info, device, dtype, requires_grad):
     if dtype.is_complex:
         samples = samples + (  # type: ignore
             # no broadcast
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S, S)), 0.4j)),
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S, S)), 1.2 + 0.1j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, S)), 0.4j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, S)), 1.2 + 0.1j)),
             # broadcast rhs
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S,)), 0.4j)),
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper((S, S)), 5.4 + 9j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S,)), 0.4j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, S)), 5.4 + 9j)),
             # scalar tensor
-            SampleInput((_make_tensor_helper(()), _make_tensor_helper(()), 0.4j)),
-            SampleInput((_make_tensor_helper(()), _make_tensor_helper(()), 6.1 + 0.004j)),
+            SampleInput(_make_tensor_helper(()), args=(_make_tensor_helper(()), 0.4j)),
+            SampleInput(_make_tensor_helper(()), args=(_make_tensor_helper(()), 6.1 + 0.004j)),
             # broadcast rhs scalar-tensor
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper(()), 0.4j)),
-            SampleInput((_make_tensor_helper((S, S)), _make_tensor_helper(()), 1 + 2j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper(()), 0.4j)),
+            SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper(()), 1 + 2j)),
         )
 
     return samples
@@ -1843,21 +1829,13 @@ op_db: List[OpInfo] = [
                        # Reference: https://github.com/pytorch/pytorch/issues/49224
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
                                 dtypes=[torch.int8], active_if=TEST_WITH_ASAN),
-                       SkipInfo('TestUnaryUfuncs', 'test_variant_consistency',
-                                dtypes=[torch.cfloat, torch.cdouble]),
                        # TODO: Fix test_out_arg_all_dtypes as torch.empty_like(expected_output) where expected_output=op(input)
                        # We can break the logic of the loop over all possible types but it is OK.
                        # https://github.com/pytorch/pytorch/blob/master/test/test_unary_ufuncs.py#L440-L449
                        SkipInfo('TestUnaryUfuncs', 'test_out_arg_all_dtypes',
                                 dtypes=[torch.cfloat, torch.cdouble]),
-                       SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                                dtypes=[torch.cfloat, torch.cdouble]),
-                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                dtypes=[torch.cfloat, torch.cdouble, torch.bfloat16]),
-                       SkipInfo('TestCommon', 'test_jit_alias_remapping',
-                                dtypes=[torch.cfloat, torch.cdouble, torch.bfloat16]),
                    ),
-                   test_inplace_grad=False,
+                   supports_inplace_autograd=False,
                    assert_autodiffed=True),
     # NOTE: CPU complex acos produces incorrect outputs (https://github.com/pytorch/pytorch/issues/42952)
     UnaryUfuncInfo('acos',
@@ -1868,14 +1846,14 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and_complex_and(torch.bool),
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
-                   default_test_dtypes=[torch.long, torch.half, torch.bfloat16, torch.float32, torch.cfloat],
-                   skip_bfloat16_grad=True,
                    assert_autodiffed=True,
                    decorators=(precisionOverride({torch.float16: 1e-2,
                                                   torch.bfloat16: 1e-1,
                                                   torch.complex64: 1e-2}),),
                    safe_casts_outputs=True,
                    skips=(
+                       # "rsqrt_cpu" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
                                 device_type='cpu', dtypes=[torch.cfloat]),
                        SkipInfo('TestGradients', 'test_fn_grad',
@@ -1895,11 +1873,10 @@ op_db: List[OpInfo] = [
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 5e-2}),),
-                   test_inplace_grad=False,
+                   supports_inplace_autograd=False,
                    skips=(
-                       # RuntimeError: "rsqrt_cuda" not implemented for 'BFloat16'
-                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                device_type='cuda', dtypes=[torch.bfloat16]),
+                       # "rsqrt_cuda" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
@@ -1929,8 +1906,9 @@ op_db: List[OpInfo] = [
            assert_autodiffed=True,
            autodiff_nonfusible_nodes=['aten::add', 'aten::mm'],
            skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.bfloat16, torch.float16, torch.cfloat, torch.cdouble]),
+               # Skips unsupported bfloat16 check because above support check
+               #   doesn't work on all platforms
+               SkipInfo('TestOpInfo', 'test_unsupported_dtypes', dtypes=(torch.bfloat16,)),
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
                # addmm does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out')),
@@ -1938,10 +1916,10 @@ op_db: List[OpInfo] = [
     OpInfo('addr',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
            # Reference: https://github.com/pytorch/pytorch/issues/50747
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.float16, torch.cfloat, torch.cdouble, torch.bfloat16]),
+               # "addmv_impl_cpu" not implemented for 'Half'
+               SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.float16,)),
                # Reference: https://github.com/pytorch/pytorch/issues/50747
                SkipInfo('TestCommon', 'test_variant_consistency_eager',
                         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16)),),
@@ -1951,27 +1929,21 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_amax_amin,
            skips=(
                # amax does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-               # Reference: https://github.com/pytorch/pytorch/issues/48978
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.bfloat16]),)),
+               SkipInfo('TestCommon', 'test_out'),)),
     OpInfo('amin',
            op=torch.amin,
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_amax_amin,
            skips=(
                # amin does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-               # Reference: https://github.com/pytorch/pytorch/issues/48978
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.bfloat16]),)),
+               SkipInfo('TestCommon', 'test_out'),)),
     UnaryUfuncInfo('asin',
                    aliases=('arcsin', ),
                    ref=np.arcsin,
@@ -1983,8 +1955,9 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    skips=(
+                       # "rsqrt_cpu" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
@@ -2005,11 +1978,10 @@ op_db: List[OpInfo] = [
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 5e-2}),),
-                   test_inplace_grad=False,
+                   supports_inplace_autograd=False,
                    skips=(
-                       # RuntimeError: "rsqrt_cuda" not implemented for 'BFloat16'
-                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                device_type='cuda', dtypes=[torch.bfloat16]),
+                       # "rsqrt_cuda" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
@@ -2030,7 +2002,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    decorators=(precisionOverride({torch.bfloat16: 1e-2}),),
                    safe_casts_outputs=True,
                    skips=(
@@ -2059,7 +2030,7 @@ op_db: List[OpInfo] = [
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 1e-2}),),
-                   test_inplace_grad=False,
+                   supports_inplace_autograd=False,
                    skips=(
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
@@ -2075,7 +2046,7 @@ op_db: List[OpInfo] = [
     OpInfo('broadcast_to',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_broadcast_to),
     UnaryUfuncInfo('bitwise_not',
                    ref=np.bitwise_not,
@@ -2093,7 +2064,7 @@ op_db: List[OpInfo] = [
     HermitianOpInfo('cholesky',
                     op=torch.cholesky,
                     dtypes=floating_and_complex_types(),
-                    test_inplace_grad=False,
+                    supports_inplace_autograd=False,
                     check_batched_gradgrad=False,
                     sample_inputs_func=sample_inputs_linalg_cholesky,
                     decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -2107,13 +2078,11 @@ op_db: List[OpInfo] = [
                      dtypes=floating_and_complex_types(),
                      # TODO: RuntimeError: cholesky_inverse does not support automatic differentiation for outputs
                      # with complex dtype.
-                     test_complex_grad=False,
-                     test_inplace_grad=False,
+                     supports_complex_autograd=False,
+                     supports_inplace_autograd=False,
                      check_batched_gradgrad=False,
                      decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
                      skips=(
-                         SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                                  dtypes=[torch.complex64, torch.complex128]),
                          # cholesky_inverse does not correctly warn when resizing out= inputs
                          SkipInfo('TestCommon', 'test_out'),)),
     UnaryUfuncInfo('clamp',
@@ -2148,18 +2117,19 @@ op_db: List[OpInfo] = [
                                 dtypes=[torch.int],
                                 active_if=IS_WINDOWS),
                    ),
-                   test_inplace_grad=False),
+                   supports_inplace_autograd=False),
     UnaryUfuncInfo('cos',
                    ref=np.cos,
                    dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    handles_large_floats=False,
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 1e-2}),),
                    skips=(
+                       # "sin_cuda" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 dtypes=[torch.cfloat, torch.cdouble], active_if=IS_WINDOWS),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal', device_type='cpu',
@@ -2183,36 +2153,14 @@ op_db: List[OpInfo] = [
                                 dtypes=[torch.cfloat, torch.cdouble], active_if=IS_MACOS),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard', device_type='cpu',
                                 dtypes=[torch.cfloat, torch.cdouble], active_if=IS_MACOS),
-                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                device_type='cuda', dtypes=[torch.float16]),
                    )),
     OpInfo('cumsum',
            dtypesIfCPU=all_types_and_complex_and(torch.bool),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
            skips=(
-               # Reference: https://github.com/pytorch/pytorch/issues/53360
-               # For integer inputs,
-               # inplace variant preserves dtype of `self` while method variant
-               # always promotes it to torch.long.
-               # >>> t = torch.randint(2, 10, (3, 2), dtype=torch.int8)
-               # >>> t.cumsum(0).dtype
-               # torch.int64
-               # >>> t.cumsum_(0).dtype
-               # torch.int8
-               SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                        dtypes=[torch.uint8, torch.int8, torch.int16, torch.int32]),
-               # Reference: https://github.com/pytorch/pytorch/issues/53358
-               # >>> t = torch.tensor([False])
-               # >>> t.cumsum_(0) # Error "cumsum_out_cpu" not implemented for 'Bool'
-               # >>> t.cuda().cumsum_(0) # Error "cumsum_cuda" not implemented for 'Bool'
-               # >>> t = torch.tensor(False)
-               # >>> t.cumsum_(0) # Error "cumsum_out_cpu" not implemented for 'Bool'
-               # >>> t.cuda().cumsum_(0) # Does not fail!
-               # tensor(False, device='cuda:0')
-               SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                        dtypes=[torch.bool]),
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.bool]),
+               # "cumsum_out_{cpu,cuda}" not implemented for 'Bool'
+               SkipInfo('TestOpInfo', 'test_supported_dtypes',
+                        dtypes=(torch.bool,)),
                # cumsum does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
@@ -2221,21 +2169,11 @@ op_db: List[OpInfo] = [
     OpInfo('cumprod',
            dtypes=all_types_and_complex_and(torch.bool),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
-               # Reference: https://github.com/pytorch/pytorch/issues/53360
-               # For integer inputs,
-               # inplace variant preserves dtype of `self` while method variant
-               # always promotes it to torch.long.
-               # >>> t = torch.randint(2, 10, (3, 2), dtype=torch.int8)
-               # >>> t.cumprod(0).dtype
-               # torch.int64
-               # >>> t.cumprod_(0).dtype
-               # torch.int8
-               SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                        dtypes=[torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32]),
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.bool, torch.float16]),
+               # "cumprod_out_{cpu, cuda}" not implemented for 'Bool'
+               SkipInfo('TestOpInfo', 'test_supported_dtypes',
+                        dtypes=(torch.bool,)),
                # cumprod does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out',
                         dtypes=[torch.float32]),
@@ -2258,7 +2196,7 @@ op_db: List[OpInfo] = [
            op=torch.diff,
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_diff,
-           test_inplace_grad=False),
+           supports_inplace_autograd=False),
     OpInfo('div',
            variant_test_name='no_rounding_mode',
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
@@ -2306,7 +2244,7 @@ op_db: List[OpInfo] = [
            dtypesIfCPU=all_types_and_complex_and(torch.bool),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
            sample_inputs_func=sample_inputs_diag,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                # diag does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),)),
@@ -2325,14 +2263,14 @@ op_db: List[OpInfo] = [
                      ndimensional=False,
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.fftn',
                      aten_name='fft_fftn',
                      ref=np.fft.fftn,
                      ndimensional=True,
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
-                     test_inplace_grad=False,
+                     supports_inplace_autograd=False,
                      decorators=[precisionOverride(
                          {torch.float: 1e-4, torch.cfloat: 1e-4})],),
     SpectralFuncInfo('fft.hfft',
@@ -2342,7 +2280,7 @@ op_db: List[OpInfo] = [
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
                      check_batched_gradgrad=False,
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.rfft',
                      aten_name='fft_rfft',
                      ref=np.fft.rfft,
@@ -2351,14 +2289,14 @@ op_db: List[OpInfo] = [
                      default_test_dtypes=floating_and_complex_types(),
                      check_batched_grad=False,
                      check_batched_gradgrad=False,
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.rfftn',
                      aten_name='fft_rfftn',
                      ref=np.fft.rfftn,
                      ndimensional=True,
                      dtypes=all_types_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
-                     test_inplace_grad=False,
+                     supports_inplace_autograd=False,
                      check_batched_grad=False,
                      check_batched_gradgrad=False,
                      decorators=[precisionOverride({torch.float: 1e-4})],),
@@ -2368,14 +2306,14 @@ op_db: List[OpInfo] = [
                      ndimensional=False,
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.ifftn',
                      aten_name='fft_ifftn',
                      ref=np.fft.ifftn,
                      ndimensional=True,
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.ihfft',
                      aten_name='fft_ihfft',
                      ref=np.fft.ihfft,
@@ -2383,7 +2321,7 @@ op_db: List[OpInfo] = [
                      dtypes=all_types_and(torch.bool),
                      default_test_dtypes=floating_types(),
                      check_batched_grad=False,
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.irfft',
                      aten_name='fft_irfft',
                      ref=np.fft.irfft,
@@ -2391,7 +2329,7 @@ op_db: List[OpInfo] = [
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
                      check_batched_gradgrad=False,
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     SpectralFuncInfo('fft.irfftn',
                      aten_name='fft_irfftn',
                      ref=np.fft.irfftn,
@@ -2399,7 +2337,7 @@ op_db: List[OpInfo] = [
                      dtypes=all_types_and_complex_and(torch.bool),
                      default_test_dtypes=floating_and_complex_types(),
                      check_batched_gradgrad=False,
-                     test_inplace_grad=False,),
+                     supports_inplace_autograd=False,),
     UnaryUfuncInfo('floor',
                    ref=np.floor,
                    dtypes=floating_types_and(torch.half),
@@ -2410,19 +2348,19 @@ op_db: List[OpInfo] = [
            op=torch.flip,
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_flip,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False),
     OpInfo('fliplr',
            op=torch.fliplr,
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_fliplr_flipud,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False),
     OpInfo('flipud',
            op=torch.flipud,
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_fliplr_flipud,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False),
     UnaryUfuncInfo('i0',
                    ref=np.i0,
@@ -2449,7 +2387,7 @@ op_db: List[OpInfo] = [
                    dtypesIfCUDA=floating_types_and(torch.half),
                    # skip testing torch.frexp as it is not supported by ROCm platform yet
                    decorators=[skipCUDAIfRocm],
-                   test_inplace_grad=False,
+                   supports_inplace_autograd=False,
                    supports_out=False,
                    skips=(
                        # skips below tests as torch.frexp returns tuple-like (mantissa, exponent) as outputs,
@@ -2475,7 +2413,7 @@ op_db: List[OpInfo] = [
            op=torch.linalg.householder_product,
            aliases=('orgqr', ),
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            # TODO: backward uses in-place operations that vmap doesn't like
            check_batched_grad=False,
            check_batched_gradgrad=False,
@@ -2487,7 +2425,7 @@ op_db: List[OpInfo] = [
     OpInfo('inverse',
            op=torch.inverse,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            check_batched_gradgrad=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
            decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -2499,7 +2437,7 @@ op_db: List[OpInfo] = [
                     aten_name='linalg_cholesky',
                     op=torch.linalg.cholesky,
                     dtypes=floating_and_complex_types(),
-                    test_inplace_grad=False,
+                    supports_inplace_autograd=False,
                     # TODO: RuntimeError: While computing batched gradients,
                     # got: vmap: Calling Tensor.as_strided is not supported
                     # unless the batch dims being vmapped over are at the front of the tensor (in memory layout).
@@ -2515,7 +2453,7 @@ op_db: List[OpInfo] = [
                     aten_name='linalg_eigh',
                     op=torch.linalg.eigh,
                     dtypes=floating_and_complex_types(),
-                    test_inplace_grad=False,
+                    supports_inplace_autograd=False,
                     check_batched_gradgrad=False,
                     sample_inputs_func=sample_inputs_linalg_eigh,
                     output_func=lambda out: (out[0], abs(out[1])),  # gauge invariant loss function
@@ -2529,7 +2467,7 @@ op_db: List[OpInfo] = [
            aten_name='linalg_lstsq',
            op=torch.linalg.lstsq,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_linalg_lstsq,
            check_batched_grad=False,
@@ -2543,17 +2481,14 @@ op_db: List[OpInfo] = [
     OpInfo('linalg.norm',
            op=torch.linalg.norm,
            dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
            sample_inputs_func=sample_inputs_linalg_norm,
            aten_name='linalg_norm',
            skips=(
-               # TODO: remove this once `pow` is implemented for float16
-               #       and bfloat16 on CPU. Issue:
-               #       https://github.com/pytorch/pytorch/issues/50789
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        device_type='cpu',
-                        dtypes=[torch.float16, torch.bfloat16]),
+               # "pow" not implemented for 'BFloat16' or 'half'
+               SkipInfo('TestOpInfo', 'test_supported_backward',
+                        dtypes=(torch.bfloat16, torch.float16)),
                # linalg.norm does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
            )),
@@ -2561,7 +2496,7 @@ op_db: List[OpInfo] = [
            aten_name='linalg_qr',
            op=torch.linalg.qr,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_linalg_qr,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -2573,24 +2508,21 @@ op_db: List[OpInfo] = [
            aten_name='linalg_slogdet',
            op=torch.linalg.slogdet,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
            output_func=itemgetter(1),
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack]),
     OpInfo('linalg.vector_norm',
            op=torch.linalg.vector_norm,
            dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            decorators=[skipCUDAIfNoMagma, skipCPUIfNoLapack],
            sample_inputs_func=sample_inputs_linalg_vector_norm,
            aten_name='linalg_vector_norm',
            skips=(
-               # TODO: remove this once `pow` is implemented for float16
-               #       and bfloat16 on CPU. Issue:
-               #       https://github.com/pytorch/pytorch/issues/50789
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        device_type='cpu',
-                        dtypes=[torch.float16, torch.bfloat16]),
+               # "pow" not implemented for 'BFloat16' or 'half'
+               SkipInfo('TestOpInfo', 'test_supported_backward',
+                        dtypes=(torch.bfloat16, torch.float16)),
                # linalg.vector_norm does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
            )),
@@ -2601,7 +2533,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 5e-2}),),
                    skips=(
@@ -2616,7 +2547,6 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    safe_casts_outputs=True,
                    skips=(
@@ -2631,8 +2561,7 @@ op_db: List[OpInfo] = [
                    dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
                    decorators=(precisionOverride({torch.bfloat16: 1e-1}),),
                    safe_casts_outputs=True,
-                   assert_autodiffed=True,
-                   skip_bfloat16_grad=True),
+                   assert_autodiffed=True),
     UnaryUfuncInfo('log2',
                    ref=np.log2,
                    domain=(0, float('inf')),
@@ -2640,7 +2569,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    safe_casts_outputs=True,
                    decorators=(precisionOverride({torch.bfloat16: 1e-1}),),
                    skips=(
@@ -2688,8 +2616,6 @@ op_db: List[OpInfo] = [
                         device_type='cuda', dtypes=[torch.complex128]),
                SkipInfo('TestGradients', 'test_inplace_gradgrad',
                         device_type='cuda', dtypes=[torch.complex128]),
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.cfloat, torch.cdouble]),
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
            ),
            supports_out=False),
@@ -2698,7 +2624,7 @@ op_db: List[OpInfo] = [
            dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_masked_select,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=True,
            skips=(
                # masked_select does not correctly warn when resizing out= inputs
@@ -2710,7 +2636,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_max_min_binary,
            assert_autodiffed=True,),
     OpInfo('max',
@@ -2719,21 +2645,18 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_max_min_reduction_with_dim,
            skips=(
                # max does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-               # Reference: https://github.com/pytorch/pytorch/issues/51788#issuecomment-777625293
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        device_type='cpu', dtypes=[torch.bfloat16]),)),
+               SkipInfo('TestCommon', 'test_out'),)),
     OpInfo('max',
            op=torch.max,
            variant_test_name='reduction_no_dim',
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_max_min_reduction_no_dim,),
     OpInfo('min',
@@ -2742,7 +2665,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_max_min_binary,
            assert_autodiffed=True,),
     OpInfo('min',
@@ -2751,27 +2674,24 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_max_min_reduction_with_dim,
            skips=(
                # min does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
-               # Reference: https://github.com/pytorch/pytorch/issues/51788#issuecomment-777625293
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        device_type='cpu', dtypes=[torch.bfloat16]),)),
+           )),
     OpInfo('min',
            op=torch.min,
            variant_test_name='reduction_no_dim',
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCPU=all_types_and(torch.float16, torch.bfloat16, torch.bool),
            dtypesIfCUDA=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_max_min_reduction_no_dim,),
     UnaryUfuncInfo('neg',
                    aliases=('negative', ),
                    ref=np.negative,
-                   skip_bfloat16_grad=True,
                    dtypes=all_types_and_complex_and(torch.half, torch.bfloat16),
                    dtypesIfCPU=all_types_and_complex_and(torch.half, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.half, torch.bfloat16),
@@ -2779,10 +2699,10 @@ op_db: List[OpInfo] = [
     OpInfo('prod',
            dtypes=all_types_and_complex_and(torch.bool),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.float16, torch.bfloat16]),
+               # "cumprod_cuda" not implemented for 'BFloat16'
+               SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                # prod does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out',
                         dtypes=[torch.float32]),
@@ -2791,7 +2711,7 @@ op_db: List[OpInfo] = [
     OpInfo('qr',
            op=torch.qr,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_linalg_qr,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -2828,7 +2748,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    handles_large_floats=False,
                    handles_complex_extremals=False,
                    safe_casts_outputs=True,
@@ -2838,7 +2757,6 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
-                   skip_bfloat16_grad=True,
                    handles_large_floats=False,
                    handles_complex_extremals=False,
                    safe_casts_outputs=True,
@@ -2866,8 +2784,6 @@ op_db: List[OpInfo] = [
                        # Reference: https://github.com/pytorch/pytorch/issues/48641
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
                                 device_type='cpu', dtypes=[torch.int8]),
-                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                device_type='cuda', dtypes=[torch.float16]),
                    )),
     UnaryUfuncInfo('signbit',
                    ref=np.signbit,
@@ -2882,7 +2798,7 @@ op_db: List[OpInfo] = [
     OpInfo('solve',
            op=torch.solve,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_legacy_solve,
            check_batched_gradgrad=False,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -2895,8 +2811,8 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_std_var,
            # TODO: std does support out in some signatures
            supports_out=False,
-           test_complex_grad=False,
-           test_inplace_grad=False,
+           supports_complex_autograd=False,
+           supports_inplace_autograd=False,
            # std has only partial support for complex and half (#51127)
            skips=(SkipInfo('TestOpInfo', 'test_unsupported_dtypes',
                            dtypes=[torch.half, torch.complex64, torch.complex128]),),
@@ -2908,9 +2824,11 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    safe_casts_outputs=True,
                    skips=(
+                       # "pow" not implemented for 'BFloat16' or 'half'
+                       SkipInfo('TestOpInfo', 'test_supported_backward',
+                                dtypes=(torch.bfloat16, torch.float16)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.bfloat16]),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
@@ -2937,9 +2855,11 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    safe_casts_outputs=True,
                    skips=(
+                       # "tanh_backward_cpu" not implemented for 'BFloat16'
+                       SkipInfo('TestOpInfo', 'test_supported_backward',
+                                dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                 device_type='cpu', dtypes=[torch.cfloat, torch.cdouble],
                                 active_if=(IS_MACOS or IS_WINDOWS)),
@@ -2955,13 +2875,13 @@ op_db: List[OpInfo] = [
            dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
            supports_out=False,
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),),
            sample_inputs_func=sample_inputs_tensor_split,),
     OpInfo('triangular_solve',
            op=torch.triangular_solve,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_legacy_solve,
            check_batched_gradgrad=False,
@@ -3009,7 +2929,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=None,
                    dtypesIfCUDA=None,
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    safe_casts_outputs=True,
                    skips=(
                        # Reference: https://github.com/pytorch/pytorch/issues/45690
@@ -3041,7 +2960,6 @@ op_db: List[OpInfo] = [
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
                    assert_autodiffed=True,
-                   skip_bfloat16_grad=True,
                    decorators=(precisionOverride({torch.bfloat16: 7e-2}),),
                    skips=(
                        # Reference: https://github.com/pytorch/pytorch/issues/47358
@@ -3061,10 +2979,6 @@ op_db: List[OpInfo] = [
            dtypesIfROCM=floating_types_and(torch.half),
            sample_inputs_func=sample_inputs_lerp,
            skips=(
-               # Reference: https://github.com/pytorch/pytorch/issues/53797
-               # JIT doesn't understand complex literals
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=[torch.cfloat, torch.cdouble]),
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
            ),
            assert_autodiffed=True),
@@ -3072,7 +2986,7 @@ op_db: List[OpInfo] = [
            aten_name='linalg_inv',
            op=torch.linalg.inv,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
            check_batched_gradgrad=False,
            decorators=[skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -3090,12 +3004,12 @@ op_db: List[OpInfo] = [
                                                   torch.bfloat16: 1e-2}),),
                    safe_casts_outputs=True,
                    supports_complex_to_float=True,
-                   test_inplace_grad=False),
+                   supports_inplace_autograd=False),
     OpInfo('linalg.solve',
            aten_name='linalg_solve',
            op=torch.linalg.solve,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_linalg_solve,
            check_batched_gradgrad=False,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack],
@@ -3104,7 +3018,7 @@ op_db: List[OpInfo] = [
            aten_name='linalg_pinv',
            op=torch.linalg.pinv,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            check_batched_grad=False,
            check_batched_gradgrad=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
@@ -3118,7 +3032,7 @@ op_db: List[OpInfo] = [
                     aten_name='linalg_pinv',
                     op=torch.linalg.pinv,
                     dtypes=floating_and_complex_types(),
-                    test_inplace_grad=False,
+                    supports_inplace_autograd=False,
                     check_batched_grad=False,
                     check_batched_gradgrad=False,
                     sample_inputs_func=sample_inputs_linalg_pinv_hermitian,
@@ -3131,7 +3045,7 @@ op_db: List[OpInfo] = [
     OpInfo('eig',
            op=torch.eig,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_eig,
            decorators=[
@@ -3142,7 +3056,7 @@ op_db: List[OpInfo] = [
     OpInfo('svd',
            op=torch.svd,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_svd,
            decorators=[
                skipCUDAIfNoMagmaAndNoCusolver,
@@ -3159,7 +3073,7 @@ op_db: List[OpInfo] = [
            op=torch.linalg.svd,
            aten_name='linalg_svd',
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_linalg_svd,
            decorators=[
                skipCUDAIfNoMagmaAndNoCusolver,
@@ -3174,12 +3088,12 @@ op_db: List[OpInfo] = [
                SkipInfo('TestGradients', 'test_fn_gradgrad', device_type='cuda'),)),
     OpInfo('polar',
            dtypes=floating_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_polar),
     OpInfo('pinverse',
            op=torch.pinverse,
            dtypes=floating_and_complex_types(),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            check_batched_grad=False,
            check_batched_gradgrad=False,
            supports_out=False,
@@ -3192,7 +3106,7 @@ op_db: List[OpInfo] = [
     OpInfo('gather',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_gather,
            skips=(
                # gather does not correctly warn when resizing out= inputs
@@ -3200,13 +3114,13 @@ op_db: List[OpInfo] = [
            )),
     OpInfo('index_fill',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),),
            supports_out=False,
            sample_inputs_func=sample_inputs_index_fill),
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                # index_select does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
@@ -3221,7 +3135,7 @@ op_db: List[OpInfo] = [
            # sort on CUDA is still in the TH, no torch.bool/torch.float16 support yet
            dtypesIfCUDA=all_types_and(torch.float16),
            dtypesIfROCM=all_types_and(torch.float16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            sample_inputs_func=sample_inputs_sort,
            skips=(
                # sort does not correctly warn when resizing out= inputs
@@ -3231,7 +3145,7 @@ op_db: List[OpInfo] = [
            # gradcheck expects the input arguments as a flat list
            op=lambda *args, idx, **kwargs: torch.stack([*args], idx, **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                SkipInfo('TestCommon', 'test_variant_consistency_jit',
                         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
@@ -3243,7 +3157,7 @@ op_db: List[OpInfo] = [
            # gradcheck expects the input arguments as a flat list
            op=lambda *args, **kwargs: torch.hstack([*args], **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                SkipInfo('TestCommon', 'test_variant_consistency_jit',
                         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
@@ -3254,7 +3168,7 @@ op_db: List[OpInfo] = [
            # gradcheck expects the input arguments as a flat list
            op=lambda *args, **kwargs: torch.vstack([*args], **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                SkipInfo('TestCommon', 'test_variant_consistency_jit',
                         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
@@ -3266,7 +3180,7 @@ op_db: List[OpInfo] = [
            # gradcheck expects the input arguments as a flat list
            op=lambda *args, **kwargs: torch.dstack([*args], **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            skips=(
                SkipInfo('TestCommon', 'test_variant_consistency_jit',
                         dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
@@ -3275,12 +3189,12 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_hstack_dstack_vstack),
     OpInfo('movedim',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_movedim_moveaxis),
     OpInfo('moveaxis',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
+           supports_inplace_autograd=False,
            supports_out=False,
            sample_inputs_func=sample_movedim_moveaxis),
     ShapeFuncInfo('repeat',
@@ -3288,7 +3202,7 @@ op_db: List[OpInfo] = [
                   ref=np.tile,
                   dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
                   supports_out=False,
-                  test_inplace_grad=False,
+                  supports_inplace_autograd=False,
                   skips=(
                       # torch.repeat does not exist so we get a RuntimeError.
                       SkipInfo('TestCommon', 'test_variant_consistency_jit',
@@ -3299,7 +3213,7 @@ op_db: List[OpInfo] = [
                   ref=np.tile,
                   dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
                   supports_out=False,
-                  test_inplace_grad=False,
+                  supports_inplace_autograd=False,
                   sample_inputs_func=sample_repeat_tile),
     OpInfo('var',
            dtypes=floating_types_and(),
@@ -3307,8 +3221,8 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_std_var,
            # TODO: revisit, some var signatures do support out (see std, too)
            supports_out=False,
-           test_complex_grad=False,
-           test_inplace_grad=False,
+           supports_complex_autograd=False,
+           supports_inplace_autograd=False,
            # var has only partial support for complex and half (#51127)
            skips=(SkipInfo('TestOpInfo', 'test_unsupported_dtypes',
                            dtypes=[torch.half, torch.complex64, torch.complex128]),),
@@ -3357,30 +3271,19 @@ if TEST_SCIPY:
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
                                     device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
-                                    device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
-                           # RuntimeError: sigmoid does not support automatic differentiation for outputs with complex dtype.
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    dtypes=[torch.complex64, torch.complex128]),
-                           SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                                    dtypes=[torch.complex64, torch.complex128]),),
+                                    device_type='cpu', dtypes=[torch.cfloat, torch.cdouble])),
                        dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
                        dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
                        safe_casts_outputs=True,
                        assert_autodiffed=True,
-                       test_complex_grad=False),  # Reference: https://github.com/pytorch/pytorch/issues/48552
+                       supports_complex_autograd=False),  # Reference: https://github.com/pytorch/pytorch/issues/48552
         UnaryUfuncInfo('digamma',
                        ref=scipy.special.digamma,
                        decorators=(precisionOverride({torch.float16: 5e-1}),),
                        dtypes=all_types_and(torch.bool),
                        dtypesIfCPU=all_types_and(torch.bool),
                        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
-                       skips=(
-                           # In some cases, output is NaN (for input close to
-                           # negative integers) especially due to reduced precision
-                           # in float16 and NaN's can't be tested for equality.
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    device_type='cuda', dtypes=[torch.float16]),),
                        safe_casts_outputs=True),
         UnaryUfuncInfo('erf',
                        ref=scipy.special.erf,
@@ -3390,12 +3293,12 @@ if TEST_SCIPY:
                        dtypes=all_types_and(torch.bool),
                        dtypesIfCPU=all_types_and(torch.bool, torch.bfloat16),
                        dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
-                       skips=(
-                           # RuntimeError: "pow" not implemented for 'BFloat16'
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    dtypes=[torch.bfloat16]),),
                        assert_autodiffed=True,
-                       safe_casts_outputs=True),
+                       safe_casts_outputs=True,
+                       skips=(
+                           # "pow" not implemented for 'BFloat16'
+                           SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
+                       )),
         UnaryUfuncInfo('erfc',
                        ref=scipy.special.erfc,
                        aliases=('special.erfc', ),
@@ -3404,12 +3307,12 @@ if TEST_SCIPY:
                        dtypes=all_types_and(torch.bool),
                        dtypesIfCPU=all_types_and(torch.bool, torch.bfloat16),
                        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
-                       skips=(
-                           # RuntimeError: "pow" not implemented for 'BFloat16'
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    dtypes=[torch.bfloat16]),),
                        assert_autodiffed=True,
-                       safe_casts_outputs=True),
+                       safe_casts_outputs=True,
+                       skips=(
+                           # "pow" not implemented for 'BFloat16'
+                           SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
+                       )),
         UnaryUfuncInfo('erfinv',
                        ref=scipy.special.erfinv,
                        aliases=('special.erfinv', ),
@@ -3422,6 +3325,8 @@ if TEST_SCIPY:
                        safe_casts_outputs=True,
                        domain=(-1, 1),
                        skips=(
+                           # "pow" not implemented for 'BFloat16'
+                           SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                            # Reference: https://github.com/pytorch/pytorch/pull/49155#issuecomment-742664611
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     active_if=LooseVersion(scipy.__version__) < "1.4.0"),
@@ -3429,11 +3334,7 @@ if TEST_SCIPY:
                                     active_if=LooseVersion(scipy.__version__) < "1.4.0"),
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
                                     active_if=LooseVersion(scipy.__version__) < "1.4.0"),
-                           # RuntimeError: "pow" not implemented for 'BFloat16'
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    dtypes=[torch.bfloat16]),
-                       )
-                       ),
+                       )),
         UnaryUfuncInfo('lgamma',
                        ref=reference_lgamma,
                        aliases=('special.gammaln', ),
@@ -3442,6 +3343,8 @@ if TEST_SCIPY:
                        dtypesIfCPU=all_types_and(torch.bool, torch.bfloat16),
                        dtypesIfCUDA=all_types_and(torch.bool, torch.half),
                        skips=(
+                           # "digamma" not implemented for 'BFloat16'
+                           SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                            # Reference: https://github.com/pytorch/pytorch/pull/50140#discussion_r552615345
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
                                     dtypes=[torch.bfloat16]),
@@ -3456,12 +3359,6 @@ if TEST_SCIPY:
                                     dtypes=[torch.float32, torch.float64], active_if=IS_WINDOWS),
                            SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
                                     dtypes=[torch.float32, torch.float64], active_if=IS_WINDOWS),
-                           # Backward of `lgamma` uses `digamma` but `digamma`
-                           # is not implemented for `BFloat16`
-                           # Error Raised:
-                           #   RuntimeError: "digamma" not implemented for 'BFloat16'
-                           SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                                    dtypes=[torch.bfloat16]),
                        ),
                        safe_casts_outputs=True),
         UnaryUfuncInfo('logit',
@@ -3478,13 +3375,13 @@ if TEST_SCIPY:
                dtypes=all_types_and(torch.bool),
                dtypesIfCPU=all_types_and(torch.bool, torch.half, torch.bfloat16),
                dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
-               test_inplace_grad=True,
+               supports_inplace_autograd=True,
                safe_casts_outputs=True,
                sample_inputs_func=sample_inputs_xlogy),
         OpInfo('trace',
                dtypes=all_types_and_complex(),
                dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
-               test_inplace_grad=False,
+               supports_inplace_autograd=False,
                supports_out=False,
                sample_inputs_func=sample_inputs_trace)
     ]

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -344,6 +344,7 @@ class UnaryUfuncInfo(OpInfo):
                                              dtypesIfCPU=dtypesIfCPU,
                                              dtypesIfCUDA=dtypesIfCUDA,
                                              dtypesIfROCM=dtypesIfROCM,
+                                             default_test_dtypes=default_test_dtypes,
                                              sample_inputs_func=sample_inputs_func,
                                              supports_sparse=supports_sparse,
                                              **kwargs)
@@ -1855,7 +1856,7 @@ op_db: List[OpInfo] = [
                        # "rsqrt_cpu" not implemented for 'BFloat16'
                        SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_hard',
-                                device_type='cpu', dtypes=[torch.cfloat]),
+                                device_type='cpu', dtypes=[torch.cfloat, torch.cdouble]),
                        SkipInfo('TestGradients', 'test_fn_grad',
                                 dtypes=[torch.cdouble], active_if=IS_WINDOWS),
                        SkipInfo('TestGradients', 'test_method_grad',
@@ -1919,7 +1920,8 @@ op_db: List[OpInfo] = [
            supports_inplace_autograd=False,
            skips=(
                # "addmv_impl_cpu" not implemented for 'Half'
-               SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.float16,)),
+               # at::cuda::blas::gemv: not implemented for N3c108BFloat16E
+               SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.float16, torch.bfloat16)),
                # Reference: https://github.com/pytorch/pytorch/issues/50747
                SkipInfo('TestCommon', 'test_variant_consistency_eager',
                         dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16)),),


### PR DESCRIPTION
This PR:

- Updates the structure of the SampleInput class to require the "input" attribute be a tensor
- Limits unary ufuncs to test only the uint8, long, float16, bfloat16, float and cfloat dtypes by default
- Limits variant testing to the float dtype
- Removes test_variant_consistency from test_unary_ufuncs.py since it's now redundant with variant testing in test_ops.py
- Adds backwards supported testing to clarify failures that were coming from variant testing

This should decrease test e2e time.