### PR TITLE
[sparsity] Base sparsifier class

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -77,11 +77,17 @@ EXCLUDE(native_metal_srcs "${native_metal_srcs}" ${metal_test_srcs})
 file(GLOB metal_prepack_h "native/metal/MetalPrepackOpContext.h")
 file(GLOB metal_prepack_cpp "native/metal/MetalPrepackOpRegister.cpp")
 
+file(GLOB native_mo_sparsity_cpp
+            "native/mo/sparsity/*.cpp
+            "native/mo/sparsity/cpu/*.cpp)
 file(GLOB native_sparse_cpp "native/sparse/*.cpp")
 file(GLOB native_quantized_cpp
             "native/quantized/*.cpp"
             "native/quantized/cpu/*.cpp")
 file(GLOB native_h "native/*.h")
+file(GLOB native_mo_sparsity_h
+            "native/mo/sparsity/*.h
+            "native/mo/sparsity/cpu/*.h)
 file(GLOB native_quantized_h "native/quantized/*.h" "native/quantized/cpu/*.h")
 file(GLOB native_cpu_h "native/cpu/*.h")
 
@@ -116,7 +122,7 @@ append_filelist("jit_core_sources" ATen_CORE_SRCS)
 
 add_subdirectory(quantized)
 add_subdirectory(nnapi)
-set(all_cpu_cpp ${base_cpp} ${ATen_CORE_SRCS} ${native_cpp} ${native_sparse_cpp} ${native_quantized_cpp} ${native_mkl_cpp} ${native_mkldnn_cpp} ${native_utils_cpp} ${native_xnnpack} ${generated_cpp} ${core_generated_cpp} ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${ATen_NNAPI_SRCS} ${cpu_kernel_cpp})
+set(all_cpu_cpp ${base_cpp} ${ATen_CORE_SRCS} ${native_cpp} ${native_mo_sparsity_cpp} ${native_sparse_cpp} ${native_quantized_cpp} ${native_mkl_cpp} ${native_mkldnn_cpp} ${native_utils_cpp} ${native_xnnpack} ${generated_cpp} ${core_generated_cpp} ${ATen_CPU_SRCS} ${ATen_QUANTIZED_SRCS} ${ATen_NNAPI_SRCS} ${cpu_kernel_cpp})
 if(AT_MKL_ENABLED)
   set(all_cpu_cpp ${all_cpu_cpp} ${mkl_cpp})
 endif()
@@ -405,7 +411,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake"
 
 set(INSTALL_HEADERS ${base_h} ${ATen_CORE_HEADERS})
 if(NOT INTERN_BUILD_MOBILE)
-  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
+  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_mo_sparsity_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
 else()
   if(USE_PYTORCH_METAL)
     if(IOS)

--- a/aten/src/ATen/native/mo/README
+++ b/aten/src/ATen/native/mo/README
@@ -1,0 +1,19 @@
+# Model Optimization Kernels
+
+All kernels related to the model optimization
+
+Eventually, the contents of this folder will include the following
+
+./mo
+├── pruning
+│   ├── cpu
+│   ├── cuda
+│   └── ...
+├── quantization
+│   ├── cpu
+│   ├── cuda
+│   └── ...
+└── sparsity
+    ├── cpu
+    ├── cuda
+    └── ...

--- a/aten/src/ATen/native/mo/sparsity/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/mo/sparsity/cpu/fbgemm_utils.cpp
@@ -1,0 +1,67 @@
+#include <ATen/ATen.h>
+
+#include <torch/custom_class.h>
+
+#include <ATen/native/mo/sparsity/cpu/fbgemm_utils.h>
+#include <ATen/native/mo/sparsity/cpu/qnnpack_utils.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params() {
+  static auto register_linear_params =
+      torch::class_<SparseLinearPackedParamsBase>("sparsity", "SparseLinearPackedParamsBase")
+          .def_pickle(
+              [](const c10::intrusive_ptr<SparseLinearPackedParamsBase>& params)
+                  -> SerializationTypeSparseLinearPacked { // __getstate__
+                return params->unpack();
+              },
+              [](SerializationTypeSparseLinearPacked state)
+                  -> c10::intrusive_ptr<
+                      SparseLinearPackedParamsBase> { // __setstate__
+                at::Tensor weight;
+                c10::optional<at::Tensor> bias;
+                int64_t out_features_block_size, in_features_block_size;
+                weight = std::move(std::get<0>(state));
+                bias = std::move(std::get<1>(state));
+                out_features_block_size = std::get<2>(state)[0];
+                in_features_block_size = std::get<2>(state)[1];
+
+#ifdef USE_FBGEMM
+                if (at::globalContext().qEngine() == at::QEngine::FBGEMM) {
+                  if (weight.scalar_type() == at::kQInt8) {
+                    return SparsePackedLinearWeight::prepack(
+                        weight, bias,
+                        out_features_block_size, in_features_block_size);
+                  } else {
+                    TORCH_CHECK(
+                        false,
+                        "Unsupported data type",
+                        c10::toString(weight.scalar_type()),
+                        " in serialized SparseLinearPackedParams object!");
+                  }
+                }
+#endif // USE_FBGEMM
+#ifdef USE_PYTORCH_QNNPACK
+                if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {
+                  if (weight.scalar_type() == at::kQInt8) {
+                    return SparsePackedLinearWeightQnnp::prepack(
+                        weight, bias,
+                        out_features_block_size, in_features_block_size);
+                  } else {
+                    TORCH_CHECK(
+                        false,
+                        "Unsupported data type",
+                        c10::toString(weight.scalar_type()),
+                        " in serialized LinearPackedParams object!");
+                  }
+                }
+#endif // USE_FBGEMM
+                TORCH_CHECK(false, "Unknown qengine");
+              });
+  return register_linear_params;
+}
+
+namespace {
+static auto sparse_linear_params = register_sparse_linear_params();
+}

--- a/aten/src/ATen/native/mo/sparsity/cpu/fbgemm_utils.h
+++ b/aten/src/ATen/native/mo/sparsity/cpu/fbgemm_utils.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <c10/core/QScheme.h>
+
+#ifdef USE_FBGEMM
+#include <fbgemm/Fbgemm.h>
+#include <fbgemm/FbgemmSparse.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+
+
+struct TORCH_API SparsePackedLinearWeight :
+  public SparseLinearPackedParamsBase {
+  SparsePackedLinearWeight(
+      std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w,
+      c10::optional<at::Tensor> bias,
+      std::vector<int32_t> col_offsets,
+      std::vector<float> w_scale,
+      std::vector<int32_t> w_zp,
+      c10::QScheme q_scheme,
+      const int64_t out_features_block_size /* block sparsity size across output_features */,
+      const int64_t in_features_block_size /* block sparsity size across input_features */)
+      : SparseLinearPackedParamsBase(out_features_block_size, in_features_block_size),
+        w(std::move(w)),
+        bias_(std::move(bias)),
+        col_offsets(std::move(col_offsets)),
+        w_scale(std::move(w_scale)),
+        w_zp(std::move(w_zp)),
+        q_scheme(q_scheme) {}
+  std::unique_ptr<fbgemm::BCSRMatrix<int8_t>> w;
+  c10::optional<at::Tensor> bias_;
+  std::vector<int32_t> col_offsets;
+  std::vector<float> w_scale;
+  std::vector<int32_t> w_zp;
+  c10::QScheme q_scheme;
+
+  at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override;
+  at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override;
+
+  at::Tensor apply_dynamic(const at::Tensor& input) override {
+    TORCH_INTERNAL_ASSERT(
+        false,
+        "Sparse quantized dynamic linear with fused relu is not yet "
+        "supported on qnnpack backend.");
+    return at::Tensor();
+  }
+  at::Tensor apply_dynamic_relu(const at::Tensor& input) override {
+    TORCH_INTERNAL_ASSERT(
+        false,
+        "Sparse quantized dynamic linear with fused relu is not yet "
+        "supported on qnnpack backend.");
+    return at::Tensor();
+  }
+
+  SerializationTypeSparseLinearPacked unpack() override;
+
+  c10::optional<at::Tensor> bias() override {
+    return bias_;
+  }
+
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size);
+
+ private:
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point);
+};
+
+#endif // USE_FBGEMM

--- a/aten/src/ATen/native/mo/sparsity/cpu/packed_params.h
+++ b/aten/src/ATen/native/mo/sparsity/cpu/packed_params.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+#include <ATen/core/ivalue.h>
+
+// <Weight, bias, out_features_block_size, in_features_block_size>
+using SerializationTypeSparseLinearPacked =
+  std::tuple<at::Tensor, c10::optional<at::Tensor>, std::vector<int64_t>>;
+
+struct SparseLinearPackedParamsBase : public torch::jit::CustomClassHolder {
+public:
+  SparseLinearPackedParamsBase(
+      const int64_t out_features_block_size, const int64_t in_features_block_size) :
+      out_features_block_size_(out_features_block_size), in_features_block_size_(in_features_block_size) {}
+
+  virtual at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) = 0;
+  virtual at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) = 0;
+
+  virtual at::Tensor apply_dynamic(const at::Tensor& input) = 0;
+  virtual at::Tensor apply_dynamic_relu(const at::Tensor& input) = 0;
+
+  virtual SerializationTypeSparseLinearPacked unpack() = 0;
+
+  virtual c10::optional<at::Tensor> bias() = 0;
+
+  virtual void set_bias(const c10::optional<at::Tensor>& bias) {
+    throw std::runtime_error(
+        "set_bias is not implemented for this packed "
+        "parameter type");
+  }
+
+protected:
+  const int64_t out_features_block_size_, in_features_block_size_;
+};

--- a/aten/src/ATen/native/mo/sparsity/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/mo/sparsity/cpu/qlinear.cpp
@@ -1,0 +1,249 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/custom_class.h>
+#include <torch/library.h>
+
+#include <ATen/native/mo/sparsity/cpu/fbgemm_utils.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+
+template <bool ReluFused>
+at::Tensor SparsePackedLinearWeight::apply_impl(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  // uint8 * int8 -> uint8 (no quantization/dequantization)
+
+  // We make a strong guarantee that models using these operators will have
+  // the same numerics across different machines. Therefore, we do not provide
+  // a fallback path and rather fail loudly if we cannot run FBGEMM.
+  TORCH_CHECK(
+      fbgemm::fbgemmSupportedCPU(), "Your CPU does not support FBGEMM.");
+
+  // TODO: contiguous is called for further jit optimizations.
+  auto input_contig = input.contiguous();
+  const auto* input_ptr =
+      reinterpret_cast<uint8_t*>(input_contig.data_ptr<c10::quint8>());
+
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "The dimension of input tensor should be larger than or equal to 2");
+  int64_t batch_size = size_to_dim_(input.dim() - 1, input.sizes());
+
+  auto packW = w.get();
+
+  int64_t out_channels = static_cast<int64_t>(packW->R);
+  int64_t K = input.size(input.dim() - 1);
+  TORCH_CHECK(
+      K == static_cast<int64_t>(packW->C),
+      "The number of columns in the packW should be equal to K: " +
+          std::to_string(K));
+
+  float input_scale_float = input.q_scale();
+  int32_t input_zero_point_int32 = input.q_zero_point();
+
+  std::vector<float> output_multiplier_float(1, 0.0);
+  std::vector<float> act_times_w_scale(1, 0.0);
+  TORCH_CHECK(
+      w_scale.size() == w_zp.size(),
+      "Weight scales and zero points vectors should have the same size.");
+  if (q_scheme == c10::kPerTensorAffine) {
+    // Process the per tensor quantization.
+    act_times_w_scale[0] = (input_scale_float * w_scale[0]);
+    output_multiplier_float[0] =
+        act_times_w_scale[0] / static_cast<float>(output_scale);
+  } else if (q_scheme == c10::kPerChannelAffine) {
+    // Process the per channel quantization.
+    output_multiplier_float.resize(out_channels, 0.0);
+    act_times_w_scale.resize(out_channels, 1.0f);
+    for (int i = 0; i < out_channels; ++i) {
+      act_times_w_scale[i] = (input_scale_float * w_scale[i]);
+      output_multiplier_float[i] =
+          act_times_w_scale[i] / static_cast<float>(output_scale);
+    }
+  }
+  int32_t output_zero_point_int32 = static_cast<int32_t>(output_zero_point);
+
+  const float* bias_ptr = nullptr;
+  at::Tensor bias;
+  if (this->bias_.has_value()) {
+    bias = this->bias_.value();
+    bias = bias.contiguous();
+    TORCH_CHECK(bias.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias.size(0) == out_channels,
+        "bias should have out_channels elements: " +
+            std::to_string(out_channels));
+    bias_ptr = reinterpret_cast<float*>(bias.data_ptr<float>());
+  }
+
+  // The resulting matrix here is 2-D, let's view it with the original
+  // left hand dimensions of the input. Here are two examples:
+  // 1. If the input tensor is {batch_size, K}, the output tensor is
+  // {batch_size, out_channels}.
+  // 2. If the input tensor is {x, batch_size, K}, the output tensor is {x,
+  // batch_size, out_channels}.
+  std::vector<int64_t> out_sizes = input.sizes().vec();
+  out_sizes.back() = out_channels;  // NOLINT
+  // Allocate output Tensor and a buffer for fbgemmPacked to use
+  auto output_tr = at::_empty_affine_quantized(
+      out_sizes,
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      output_scale,
+      output_zero_point);
+  auto output = at::_empty_affine_quantized(
+      out_sizes,
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      output_scale,
+      output_zero_point);
+
+  auto buffer = at::empty(out_sizes, output.options().dtype(at::kInt));
+
+  // fbgemm kernel computes the following:
+  // C(output) = A(weight) x B(input), where C, A, B are out_channels x
+  // batch_size, out_channels x K, K x batch_size matrices, respectively.
+  // Therefore we need to transpose input
+  auto input_tr = at::_empty_affine_quantized(
+      input.sizes(),
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      input_scale_float,
+      input_zero_point_int32);
+
+  auto* input_tr_ptr =
+      reinterpret_cast<uint8_t*>(input_tr.data_ptr<c10::quint8>());
+  // TODO: Activation transpose before and after the kernel can be removed if we
+  // keep activation tensor always tranposed.
+  fbgemm::transpose_simd<uint8_t>(
+      batch_size, K, input_ptr, K, input_tr_ptr, batch_size);
+
+  int num_tasks = at::get_num_threads();
+  at::parallel_for(0, num_tasks, 1, [&](int64_t begin, int64_t end) {
+    for (int task_id = begin; task_id < end; ++task_id) {
+      fbgemm::trRequantizationParams_t reqParams = {
+          input_zero_point_int32,
+          w_zp.data(),
+          output_zero_point_int32,
+          static_cast<float>(output_scale),
+          col_offsets.data(),
+          /*activation offsets*/ nullptr,
+          bias_ptr,
+          act_times_w_scale.data()};
+
+      if (q_scheme == c10::kPerTensorAffine) {
+        // Process the per tensor quantization.
+        //
+        // After the uint8 * int8 matrix multiplication is performed, this
+        // operation does:
+        //  1) Add in row and column offsets to the rows and columns,
+        //  respectively.
+        //  2) Add in the bias term.
+
+        // Do the GEMM
+        fbgemm::fbgemmSparseDenseInt8MM<
+            ReluFused,
+            fbgemm::QuantizationGranularity::TENSOR>(
+            batch_size,
+            w,
+            input_tr_ptr,
+            /*ldb=*/ batch_size,
+            /*C_i32=*/buffer.data_ptr<int32_t>(),
+            /*C_u8=*/
+            reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+            /*ldc=*/batch_size,
+            /*rParams=*/reqParams,
+            /*accum=*/false,
+            /*thread_id=*/task_id,
+            /*num_threads=*/num_tasks);
+      } else if (q_scheme == c10::kPerChannelAffine) {
+        // Process the per channel quantization.
+        //
+        // After the uint8 * int8 matrix multiplication is performed, this
+        // operation does:
+        //  1) Add in row and column offsets to the rows and columns,
+        //  respectively.
+        //  2) Add in the bias term.
+
+        // Do the GEMM
+        fbgemm::fbgemmSparseDenseInt8MM<
+            ReluFused,
+            fbgemm::QuantizationGranularity::OUT_CHANNEL>(
+            batch_size,
+            w,
+            input_tr_ptr,
+            /*ldb=*/batch_size,
+            /*C_i32=*/buffer.data_ptr<int32_t>(),
+            /*C_u8=*/
+            reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+            /*ldc=*/batch_size,
+            /*rParams=*/reqParams,
+            /*accum*/false,
+            /*thread_id=*/task_id,
+            /*num_threads=*/num_tasks);
+      }
+    }
+  });
+
+  // transpose output_tr back to batch_size x out_channels
+  fbgemm::transpose_simd<uint8_t>(
+      out_channels,
+      batch_size,
+      reinterpret_cast<uint8_t*>(output_tr.data_ptr<c10::quint8>()),
+      batch_size,
+      reinterpret_cast<uint8_t*>(output.data_ptr<c10::quint8>()),
+      out_channels);
+
+  return output;
+}
+
+at::Tensor SparsePackedLinearWeight::apply(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<false>(input, output_scale, output_zero_point);
+}
+
+at::Tensor SparsePackedLinearWeight::apply_relu(
+    const at::Tensor& input,
+    double output_scale,
+    int64_t output_zero_point) {
+  return apply_impl<true>(input, output_scale, output_zero_point);
+}
+
+#endif // USE_FBGEMM
+
+namespace torch::mo {
+
+namespace {
+
+template <bool ReluFused>
+class SparseQLinearInt8 final {
+ public:
+  static at::Tensor run(
+      const at::Tensor& input,
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight,
+      double output_scale,
+      int64_t output_zero_point) {
+    if (ReluFused) {
+      return packed_weight->apply_relu(
+          input, output_scale, output_zero_point);
+    } else {
+      return packed_weight->apply(
+          input, output_scale, output_zero_point);
+    }
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparsity, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear"),
+      TORCH_FN(SparseQLinearInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear_relu"),
+      TORCH_FN(SparseQLinearInt8<true>::run));
+}
+
+} // namespace
+} // namespace torch::mo

--- a/aten/src/ATen/native/mo/sparsity/cpu/qlinear_dynamic.cpp
+++ b/aten/src/ATen/native/mo/sparsity/cpu/qlinear_dynamic.cpp
@@ -1,0 +1,189 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/custom_class.h>
+#include <torch/library.h>
+
+#include <ATen/native/quantized/cpu/quant_utils.h>
+#include <caffe2/utils/threadpool/pthreadpool-cpp.h>
+
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+#include <ATen/native/mo/sparsity/cpu/qnnpack_utils.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_PYTORCH_QNNPACK
+template <>
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_impl<true>(
+    const at::Tensor& input) {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "Sparse quantized dynamic linear with fused relu is not yet "
+      "supported on qnnpack backend.");
+  return at::Tensor();
+}
+
+template <>
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_impl<false>(
+    const at::Tensor& input) {
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "quantized_sparse_linear(): Input tensor rank should be >= 2");
+
+  size_t rows_input = 1;
+  size_t cols_input = input.size(input.dim() - 1);
+  for (size_t i = 0; i < input.dim() - 1; ++i) {
+    rows_input *= input.size(i);
+  }
+  TORCH_CHECK(
+      cols_input == orig_weight_.size(1),
+      "quantized_sparse_lienar: Input tensor's last and weight tensor's"
+      " second dimension must match.");
+
+  float x_min;
+  float x_max;
+  if (input.numel() > 0) {
+    x_min = input.min().item<float>();
+    x_max = input.max().item<float>();
+  } else {
+    // On empty input, no output data will be generated,
+    // so use arbitrary qparams.
+    x_min = 0;
+    x_max = 0;
+  }
+
+  auto q_params = quant_utils::ChooseQuantizationParams(
+      /*min=*/x_min,
+      /*max=*/x_max,
+      /*qmin=*/0,
+      /*qmax=*/255);
+
+  // Quantize input
+  at::Tensor q_input = at::quantize_per_tensor(
+      input, q_params.scale, q_params.zero_point, c10::kQUInt8);
+
+  auto q_input_contig = q_input.contiguous();
+  if (sparse_linear_op_ == nullptr) {
+    // We calculate requant scale here as the vector holding the requant scale
+    // is owned by this module. The pointer is then passed to qnnpack backend.
+    generate_requantization_scales(
+        w_scales_, q_input_contig.q_scale(), 1.f, requantization_scales_);
+    input_scale_ = q_input_contig.q_scale();
+    pytorch_qnnp_operator_t sparse_linear_op{nullptr};
+    pytorch_qnnp_status status =
+      pytorch_qnnp_create_fully_connected_sparse_dq_nc_q8(
+        orig_weight_.size(1),
+        orig_weight_.size(0),
+        q_input_contig.q_zero_point(),
+        w_zero_points_.data(),
+        bcsr_matrix_->col_indices.data(),
+        bcsr_matrix_->row_values.data(),
+        bcsr_matrix_->values.data(),
+        bcsr_matrix_->row_block_size,  /* out_features_block_size */
+        bcsr_matrix_->col_block_size,  /* in_features_block_size */
+        0, /* output zero point: not used */
+        std::numeric_limits<uint8_t>::min(),
+        std::numeric_limits<uint8_t>::max(),
+        0, /* flags */
+        requantization_scales_.data(),
+        true, /* use prepacking kernel */
+        &sparse_linear_op);
+    TORCH_CHECK(
+        status == pytorch_qnnp_status_success,
+        "Failed to create sparse linear operator on"
+        " qnnpack backend.");
+    sparse_linear_op_ =
+      std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter>(sparse_linear_op);
+  }
+
+  // Input on next iteration can be different, thus resulting in
+  // different input scale. This will require us to recalculate requantization scales.
+  if (input_scale_ != q_input_contig.q_scale()) {
+    generate_requantization_scales(
+        w_scales_, q_input_contig.q_scale(), 1.f, requantization_scales_);
+  }
+  // Update input related quantization params in the operator.
+  sparse_linear_op_->dynamic_conv_quantization_params.input_zero_point =
+    q_input_contig.q_zero_point();
+  sparse_linear_op_->dynamic_conv_quantization_params.multipliers =
+    requantization_scales_.data();
+
+  std::vector<int64_t> out_sizes = input.sizes().vec();
+  size_t rows_w = orig_weight_.size(0);
+  out_sizes.back() = rows_w;
+
+  auto output = at::empty(out_sizes, input.options().dtype(at::kFloat));
+
+  pytorch_qnnp_status status =
+    pytorch_qnnp_setup_fully_connected_sparse_dq_nc_q8(
+        sparse_linear_op_.get(),
+        rows_input, /* batch size */
+        reinterpret_cast<uint8_t*>(q_input_contig.data_ptr<c10::quint8>()),
+        cols_input, /* num input channels */
+        bias_.data_ptr<float>(),
+        output.data_ptr<float>(),
+        rows_w /* num output channels */);
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "Failed to setup sparse linear operator on"
+      " qnnpack backend.");
+
+  status =
+    pytorch_qnnp_run_operator(sparse_linear_op_.get(), caffe2::pthreadpool_());
+  TORCH_CHECK(
+      status == pytorch_qnnp_status_success,
+      "Failed to run sparse linear operator on"
+      " qnnpack backend.");
+
+  return output;
+}
+
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic(
+    const at::Tensor& input) {
+  return apply_dynamic_impl<false>(input);
+}
+
+at::Tensor SparsePackedLinearWeightQnnp::apply_dynamic_relu(
+    const at::Tensor& input) {
+  return apply_dynamic_impl<true>(input);
+}
+
+#endif // USE_PYTORCH_QNNPACK
+
+namespace torch::mo {
+
+namespace {
+
+template <bool ReluFused>
+class SparseQLinearDynamicInt8 final {
+ public:
+  static at::Tensor run(
+      const at::Tensor& input,
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight) {
+    auto& ctx = at::globalContext();
+#ifdef USE_PYTORCH_QNNPACK
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      if (ReluFused) {
+        return packed_weight->apply_dynamic_relu(input);
+      } else {
+        return packed_weight->apply_dynamic(input);
+      }
+    }
+#endif
+    TORCH_CHECK(
+        false,
+        "Didn't find engine for operation fb::sparse_qlinear_dynamic",
+        toString(ctx.qEngine()));
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparsity, CPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear_dynamic"),
+      TORCH_FN(SparseQLinearDynamicInt8<false>::run));
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear_relu_dynamic"),
+      TORCH_FN(SparseQLinearDynamicInt8<true>::run));
+}
+
+} // namespace
+} // namespace torch::mo

--- a/aten/src/ATen/native/mo/sparsity/cpu/qlinear_prepack.cpp
+++ b/aten/src/ATen/native/mo/sparsity/cpu/qlinear_prepack.cpp
@@ -1,0 +1,225 @@
+#include <ATen/ATen.h>
+#include <torch/custom_class.h>
+
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/native/quantized/cpu/init_qnnpack.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+#include <ATen/native/mo/sparsity/cpu/fbgemm_utils.h>
+#include <ATen/native/mo/sparsity/cpu/qnnpack_utils.h>
+
+#include <algorithm>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+namespace {
+// Calculate the column offsets.
+// Note this includes the sum of the columns as well as the scalar term
+// B_zero_point * K, whereas the row_offsets created by
+// packing of activation is only the sum of the A rows.
+void calc_col_offsets_transpose(
+    int K,
+    int N,
+    const int8_t* Bint8,
+    int32_t* B_zero_point,
+    int32_t* col_offsets,
+    c10::QScheme qtype) {
+  for (size_t i = 0; i < N; ++i) {
+    int32_t sum = 0;
+    for (size_t j = 0; j < K; ++j) {
+      sum += Bint8[i * K + j];
+    }
+    if (qtype == c10::kPerTensorAffine) {
+      col_offsets[i] = sum - B_zero_point[0] * K;
+    } else {
+      col_offsets[i] = sum - B_zero_point[i] * K;
+    }
+  }
+}
+} // namespace
+
+c10::intrusive_ptr<SparseLinearPackedParamsBase> SparsePackedLinearWeight::prepack(
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias,
+    const int64_t out_features_block_size,
+    const int64_t in_features_block_size) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "The weight tensor for fb::sparse_qlinear_prepack (fbgemm) should"
+      " be 2-dimensional.");
+
+  auto N = weight.size(0);
+  auto K = weight.size(1);
+
+  auto weight_contig = weight.contiguous();
+  const auto qtype = weight.qscheme();
+  std::vector<int32_t> weight_zero_points_int32(1, 0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_zero_points_int32[0] = weight.q_zero_point();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_zero_points_int32.resize(N, 0);
+    for (int i = 0; i < N; ++i) {
+      weight_zero_points_int32[i] =
+          weight.q_per_channel_zero_points()[i].item<int32_t>();
+    }
+  }
+  TORCH_CHECK(
+      std::all_of(
+          weight_zero_points_int32.cbegin(),
+          weight_zero_points_int32.cend(),
+          [](int32_t i) { return i == 0; }),
+      "zero point(s) should be 0 for the weight tensor of sparse qlinear op");
+  std::vector<float> weight_scales_float(1, 0.0);
+  if (qtype == c10::kPerTensorAffine) {
+    weight_scales_float[0] = weight.q_scale();
+  } else if (qtype == c10::kPerChannelAffine) {
+    weight_scales_float.resize(N, 0.0);
+    for (int i = 0; i < N; ++i) {
+      weight_scales_float[i] = weight.q_per_channel_scales()[i].item<float>();
+    }
+  }
+
+  int8_t* weight_ptr_int8 =
+      reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+
+  std::vector<int32_t> col_offsets(N);
+  calc_col_offsets_transpose(
+      /*K=*/K,
+      /*N=*/N,
+      /*Bint8=*/weight_ptr_int8,
+      /*B_zero_point=*/weight_zero_points_int32.data(),
+      /*col_offsets=*/col_offsets.data(),
+      /*qtype=*/qtype);
+
+  c10::optional<at::Tensor> bias_contig;
+  if (bias.has_value()) {
+    const at::Tensor& bias_vec = bias.value();
+    TORCH_CHECK(bias_vec.dim() == 1, "bias should be a vector (1D Tensor)");
+    TORCH_CHECK(
+        bias_vec.size(0) == N,
+        "bias should have N elements: " + std::to_string(N));
+    bias_contig = bias->contiguous();
+  }
+
+  auto bcsr = fbgemm::fbgemmDenseToBCSR<int8_t>(N, K, weight_ptr_int8);
+  auto ret_ptr = c10::make_intrusive<SparsePackedLinearWeight>(
+      std::move(bcsr),
+      bias_contig,
+      col_offsets,
+      weight_scales_float,
+      weight_zero_points_int32,
+      qtype,
+      out_features_block_size,
+      in_features_block_size);
+  return ret_ptr;
+}
+
+#endif // USE_FBGEMM
+
+#ifdef USE_PYTORCH_QNNPACK
+c10::intrusive_ptr<SparseLinearPackedParamsBase> SparsePackedLinearWeightQnnp::prepack(
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias,
+    const int64_t out_features_block_size,
+    const int64_t in_features_block_size) {
+  at::native::initQNNPACK();
+  return c10::make_intrusive<SparsePackedLinearWeightQnnp>(
+      weight, bias, out_features_block_size, in_features_block_size);
+}
+
+SparsePackedLinearWeightQnnp::SparsePackedLinearWeightQnnp(
+    const at::Tensor& weight,
+    const c10::optional<at::Tensor>& bias,
+    const int64_t out_features_block_size,
+    const int64_t in_features_block_size
+    ) : SparseLinearPackedParamsBase(out_features_block_size, in_features_block_size),
+        orig_weight_(weight), orig_bias_(bias) {
+  TORCH_CHECK(
+      weight.dim() == 2,
+      "sparse_qlinear (qnnpack): Weight tensor rank should be == 2");
+  TORCH_CHECK(out_features_block_size > 0, "Row block size must be > 0.");
+  TORCH_CHECK(in_features_block_size > 0, "Row block size must be > 0.");
+
+  int64_t rows_w = weight.size(0);
+  if (bias.has_value()) {
+    bias_ = bias.value();
+  } else {
+    bias_ = at::zeros(rows_w, weight.options().dtype(at::kFloat));
+  }
+  TORCH_CHECK(
+       (bias_.ndimension() == 1 && bias_.size(0) == rows_w),
+      "sparse_qlinear_prepack (qnnpack): Given weight of size ",
+      weight.sizes(),
+      ", expected bias to be 1-dimensional with ",
+      rows_w,
+      " elements",
+      ", but got bias of size ",
+      bias_.sizes(),
+      " instead");
+
+  // Given bias is supposed to be 1 dim, it is already contiguous,
+  // but the weight might be non-contiguous.
+  at::Tensor weight_contig = orig_weight_.contiguous();
+
+  q_scheme_ = orig_weight_.qscheme();
+  std::tie(w_zero_points_, w_scales_) =
+      make_zero_points_and_scales_tensor(weight_contig);
+  const float* weight_scales_data = w_scales_.data_ptr<float>();
+  at::Tensor qnnp_weight = at::_empty_affine_quantized(
+      weight_contig.sizes(),
+      at::device(c10::kCPU).dtype(c10::kQUInt8),
+      weight_scales_data[0],
+      w_zero_points_[0]);
+  auto* qnnp_w_data = qnnp_weight.data_ptr<c10::quint8>();
+  auto wt_numel = weight_contig.numel();
+  int8_t* w_data =
+    reinterpret_cast<int8_t*>(weight_contig.data_ptr<c10::qint8>());
+  for (int i = 0; i < wt_numel; ++i) {
+    qnnp_w_data[i] = static_cast<c10::quint8>(w_data[i] + 128);
+  }
+  bcsr_matrix_ = qnnpack::generateBlockCSRMatrix(
+      reinterpret_cast<uint8_t*>(qnnp_w_data),
+      orig_weight_.size(0), /* output_channels */
+      orig_weight_.size(1), /* input_channels */
+      out_features_block_size,
+      in_features_block_size,
+      w_zero_points_.data());
+}
+#endif // USE_PYTORCH_QNNPACK
+
+namespace {
+
+class SparseQLinearPackWeightInt8 final {
+ public:
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> run(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size) {
+    auto& ctx = at::globalContext();
+
+#ifdef USE_FBGEMM
+    if (ctx.qEngine() == at::QEngine::FBGEMM) {
+      return SparsePackedLinearWeight::prepack(
+          weight, bias, out_features_block_size, in_features_block_size);
+    }
+#endif
+#ifdef USE_PYTORCH_QNNPACK
+    if (ctx.qEngine() == at::QEngine::QNNPACK) {
+      return SparsePackedLinearWeightQnnp::prepack(
+          weight, bias, out_features_block_size, in_features_block_size);
+    }
+#endif
+    TORCH_CHECK(
+        false,
+        "Didn't find engine for operation fb::sparse_qlinear_prepack ",
+        toString(ctx.qEngine()));
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparsity, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear_prepack"),
+      TORCH_FN(SparseQLinearPackWeightInt8::run));
+}
+} // namespace

--- a/aten/src/ATen/native/mo/sparsity/cpu/qlinear_unpack.cpp
+++ b/aten/src/ATen/native/mo/sparsity/cpu/qlinear_unpack.cpp
@@ -1,0 +1,72 @@
+#include <ATen/ATen.h>
+#include <torch/custom_class.h>
+
+#include <ATen/cpp_custom_type_hack.h>
+#include <ATen/native/mo/sparsity/cpu/fbgemm_utils.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+#include <ATen/native/mo/sparsity/cpu/qnnpack_utils.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+#ifdef USE_FBGEMM
+
+SerializationTypeSparseLinearPacked SparsePackedLinearWeight::unpack() {
+  auto packW = w.get();
+
+  int64_t N = static_cast<int64_t>(packW->R);
+  int64_t K = static_cast<int64_t>(packW->C);
+
+  at::Tensor weight_origin;
+  if (q_scheme == c10::kPerTensorAffine) {
+    weight_origin = at::_empty_affine_quantized(
+        {N, K}, at::device(c10::kCPU).dtype(c10::kQInt8), w_scale[0], w_zp[0]);
+  } else if (q_scheme == c10::kPerChannelAffine) {
+    auto scales = at::from_blob(
+        w_scale.data(), w_scale.size(), device(c10::kCPU).dtype(c10::kFloat));
+    auto zero_points = at::from_blob(
+        w_zp.data(), w_zp.size(), device(c10::kCPU).dtype(c10::kInt));
+
+    weight_origin = at::_empty_per_channel_affine_quantized(
+        {N, K},
+        scales.toType(c10::kDouble),
+        zero_points.toType(c10::kLong),
+        0, // The output channel axis is 0
+        device(c10::kCPU).dtype(c10::kQInt8));
+  }
+
+  // TODO: uncomment once unpack is implemented for BCSRMatrix
+  // int8_t* weight_ptr_int8 =
+  //     reinterpret_cast<int8_t*>(weight_origin.data_ptr<c10::qint8>());
+  // packW->unpack(weight_ptr_int8);
+  std::vector<int64_t> block_pattern({out_features_block_size_, in_features_block_size_});
+
+  return std::make_tuple(weight_origin, bias_, std::move(block_pattern));
+}
+
+#endif // USE_FBGEMM
+
+#ifdef USE_PYTORCH_QNNPACK
+
+SerializationTypeSparseLinearPacked SparsePackedLinearWeightQnnp::unpack() {
+  std::vector<int64_t> block_pattern({out_features_block_size_, in_features_block_size_});
+  return std::make_tuple(orig_weight_, orig_bias_, std::move(block_pattern));
+}
+
+#endif // USE_FBGEMM
+
+namespace {
+
+class SparseQLinearUnpackWeightInt8 final {
+ public:
+  static SerializationTypeSparseLinearPacked run(
+      const c10::intrusive_ptr<SparseLinearPackedParamsBase>& packed_weight) {
+    return packed_weight->unpack();
+  }
+};
+
+TORCH_LIBRARY_IMPL(sparsity, QuantizedCPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("sparsity::sparse_qlinear_unpack"),
+      TORCH_FN(SparseQLinearUnpackWeightInt8::run));
+}
+} // namespace

--- a/aten/src/ATen/native/mo/sparsity/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/mo/sparsity/cpu/qnnpack_utils.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <c10/core/QScheme.h>
+
+#ifdef USE_PYTORCH_QNNPACK
+// TODO: Refacto qnnpack_utils.h so as to separate code
+// needed for quantized op from the generic qnnpack specific
+// quantization utilities.
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+#include <ATen/native/quantized/cpu/qnnpack_utils.h>
+#include <pack_block_sparse.h>
+
+struct TORCH_API SparsePackedLinearWeightQnnp :
+  public SparseLinearPackedParamsBase {
+  SparsePackedLinearWeightQnnp(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size /* block sparsity size across output_features */,
+      const int64_t in_features_block_size /* block sparsity size across input_features */);
+  at::Tensor orig_weight_;
+  c10::optional<at::Tensor> orig_bias_;
+  // Seperate copy of bias exist so that we can fill in zeros when
+  // optional bias does not exist. This is to compy with qnnpack operator that
+  // expects bias to be present.
+  // In case bias is present bias_ is just a reference to orig_bias_
+  at::Tensor bias_;
+  c10::QScheme q_scheme_;
+  double input_scale_;
+  std::unique_ptr<qnnpack::BCSRMatrix> bcsr_matrix_;
+  at::Tensor w_scales_;
+  std::vector<uint8_t> w_zero_points_;
+  std::vector<float> requantization_scales_;
+  std::unique_ptr<pytorch_qnnp_operator, QnnpackOperatorDeleter> sparse_linear_op_{nullptr};
+
+  at::Tensor apply(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override {
+    TORCH_CHECK(
+        false, "Static quantized sparse linear unimplemented on QNNPACK");
+  }
+  at::Tensor apply_relu(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point) override {
+    TORCH_CHECK(
+        false, "Static quantized sparse linear unimplemented on QNNPACK");
+  }
+
+  at::Tensor apply_dynamic(const at::Tensor& input) override;
+  at::Tensor apply_dynamic_relu(const at::Tensor& input) override;
+
+  SerializationTypeSparseLinearPacked unpack() override;
+
+  c10::optional<at::Tensor> bias() override {
+    return orig_bias_;
+  }
+
+  static c10::intrusive_ptr<SparseLinearPackedParamsBase> prepack(
+      const at::Tensor& weight,
+      const c10::optional<at::Tensor>& bias,
+      const int64_t out_features_block_size,
+      const int64_t in_features_block_size);
+
+ private:
+  template <bool ReluFused>
+  at::Tensor apply_impl(
+      const at::Tensor& input,
+      double output_scale,
+      int64_t output_zero_point);
+  template <bool ReluFused>
+  at::Tensor apply_dynamic_impl(const at::Tensor& input);
+};
+
+#endif // USE_PYTORCH_QNNPACK

--- a/aten/src/ATen/native/mo/sparsity/library.cpp
+++ b/aten/src/ATen/native/mo/sparsity/library.cpp
@@ -1,0 +1,27 @@
+#include <torch/library.h>
+
+#include <torch/custom_class.h>
+#include <ATen/native/mo/sparsity/cpu/packed_params.h>
+
+torch::class_<SparseLinearPackedParamsBase> register_sparse_linear_params();
+
+// Register operators
+TORCH_LIBRARY(sparsity, m) {
+  register_sparse_linear_params();
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear(Tensor X, __torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear_relu(Tensor X, __torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear_dynamic(Tensor X, __torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear_relu_dynamic(Tensor X, __torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack) -> Tensor Y"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear_prepack(Tensor W, Tensor? B, int out_features_block_size, int in_features_block_size) -> __torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack"));
+
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "sparsity::sparse_qlinear_unpack(__torch__.torch.classes.sparsity.SparseLinearPackedParamsBase W_prepack) -> (Tensor W_origin, Tensor? B_origin, int[] block_pattern)"));
+}

--- a/test/mo/sparsity/test_quantized.py
+++ b/test/mo/sparsity/test_quantized.py
@@ -1,0 +1,316 @@
+import copy
+import numpy as np
+import io
+import logging
+from itertools import product
+
+import torch
+import torch.quantization as tq
+
+from torch import nn
+from torch.nn import mo
+from torch.nn.mo.sparsity.utils import QNNPACKLinearBlockSparsePattern
+
+from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_quantized import (
+    override_cpu_allocator_for_qnnpack,
+    override_qengines,
+    qengine_is_qnnpack,
+    qengine_is_fbgemm,
+)
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+class TestQuantizedSparseKernels(TestCase):
+    @override_qengines
+    def test_sparse_qlinear(self):
+        batch_size = 12
+        input_channels = 16
+        output_channels = 4
+        decimal_val = 4
+        row_block_size = 1
+        col_block_size = 4
+
+        # X86 implementation of sparse ops in qnnpack only support
+        # block pattern 1x4.
+        # arm kernels have support for both 1x4 and 8x1.
+        # This distinction is only because x86 implementations exist
+        # only to enable testing of integration path.
+        # We do plan to add 8x1 as well so that testing does not have to
+        # special case like this. At the moment it is deprioritized due
+        # to other higher priority works.
+        if qengine_is_qnnpack() and not (row_block_size == 1 and col_block_size == 4):
+            return
+
+        dense_prepack = torch.ops.quantized.linear_prepack
+        dense_qlinear = torch.ops.quantized.linear
+        dense_qlinear_dynamic = torch.ops.quantized.linear_dynamic
+
+        sparse_prepack = torch.ops.sparsity.sparse_qlinear_prepack
+        sparse_qlinear = torch.ops.sparsity.sparse_qlinear
+        sparse_qlinear_dynamic = torch.ops.sparsity.sparse_qlinear_dynamic
+
+        X_scale = 0.2
+        X_zp = 2
+        X_fp32 = torch.randn(batch_size, input_channels, dtype=torch.float32)
+        float_bias = torch.randn(output_channels, dtype=torch.float32)
+
+        W_scales = torch.rand(output_channels, dtype=torch.float32)
+        W_zps = torch.zeros(output_channels, dtype=torch.int32)
+        W_fp32 = torch.randn(output_channels, input_channels, dtype=torch.float32)
+
+        with override_cpu_allocator_for_qnnpack(qengine_is_qnnpack()):
+            X_q = torch.quantize_per_tensor(
+                X_fp32, scale=X_scale, zero_point=X_zp, dtype=torch.quint8
+            )
+
+            for use_channelwise, dynamic_mode in product([True, False], [True, False]):
+                if qengine_is_fbgemm() and dynamic_mode:
+                    logging.info("dynamic sparse_qlinear is only available in qnnpack")
+                    continue
+                if qengine_is_qnnpack() and not dynamic_mode:
+                    logging.info("static sparse_qlinear is only available in fbgemm")
+                    continue
+                if use_channelwise:
+                    W_q = torch.quantize_per_channel(
+                        W_fp32, scales=W_scales, zero_points=W_zps, axis=0, dtype=torch.qint8
+                    )
+                else:
+                    W_q = torch.quantize_per_tensor(
+                        W_fp32, scale=W_scales[0], zero_point=W_zps[0], dtype=torch.qint8
+                    )
+
+                Y_scale = 1.1234
+                Y_zp = 5
+                W_prepack_dense = dense_prepack(W_q, float_bias)
+                W_prepack_sparse = sparse_prepack(W_q, float_bias, row_block_size, col_block_size)
+
+                if dynamic_mode:
+                    Y = sparse_qlinear_dynamic(X_fp32, W_prepack_sparse)
+                    Y_ref = dense_qlinear_dynamic(X_fp32, W_prepack_dense)
+
+                    np.testing.assert_array_almost_equal(Y_ref.numpy(), Y.numpy(), decimal=decimal_val)
+                else:
+                    Y_q = sparse_qlinear(X_q, W_prepack_sparse, Y_scale, Y_zp)
+                    Y_q_ref = dense_qlinear(X_q, W_prepack_dense, Y_scale, Y_zp)
+
+                    np.testing.assert_array_almost_equal(
+                        Y_q_ref.int_repr().numpy(), Y_q.int_repr().numpy(), decimal=decimal_val
+                    )
+
+
+class TestQuantizedSparseLayers(TestCase):
+    class SparseQuantizedModel(nn.Module):
+        def __init__(self, in_channels, out_channels):
+            super().__init__()
+            self.linear = nn.Linear(in_channels, out_channels)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    @override_qengines
+    def test_sparse_qlinear(self):
+        batch_size = 12
+        input_channels = 4
+        output_channels = 7
+        model = self.SparseQuantizedModel(input_channels, output_channels)
+
+        # For sparse kernels both the activation and weight ZP = 0
+        X_scale = 0.2
+        X_zp = 2
+        W_scale = 1e-2
+        W_zp = 0
+
+        X_fp32 = torch.randn(batch_size, input_channels, dtype=torch.float32)
+        float_bias = torch.randn(output_channels, dtype=torch.float32)
+
+        W_fp32 = torch.randn(output_channels, input_channels, dtype=torch.float32)
+        mask = torch.randint(0, 2, W_fp32.shape)
+        W_fp32 *= mask
+
+        with override_cpu_allocator_for_qnnpack(qengine_is_qnnpack()):
+            X_q = torch.quantize_per_tensor(
+                X_fp32, scale=X_scale, zero_point=X_zp, dtype=torch.quint8
+            )
+            X_fp32 = X_q.dequantize()
+
+            W_q = torch.quantize_per_tensor(W_fp32, W_scale, W_zp, torch.qint8)
+
+            model.weight = nn.Parameter(W_q.dequantize())
+            model.eval()
+
+            # Note: At the moment, for sparse kernels
+            # fbgemm supports only static quantized sparse linear
+            # qnnpack supports only dynamically quantized sparse linear
+            # Hence we have two different tests.
+            # fbgemm tests static flow, qnnpack tests dynamic.
+            # Should be unified later on and tests should be fixed
+            # appropriately.
+            if qengine_is_fbgemm():
+                model.qconfig = tq.get_default_qconfig('fbgemm')
+                qmodel = copy.deepcopy(model)
+                sqmodel = copy.deepcopy(model)
+
+                tq.prepare(qmodel, inplace=True)
+                tq.prepare(sqmodel, inplace=True)
+
+                with torch.no_grad():
+                    qmodel(X_fp32)
+                    sqmodel(X_fp32)
+
+                # Make sure the quantization parameters are computed the same way
+                qparams = qmodel.linear.qconfig.weight().calculate_qparams()
+                sqparams = sqmodel.linear.qconfig.weight().calculate_qparams()
+                self.assertEqual(qparams, sqparams)
+
+                # Make sure mapping of sparse kernels does not affect the non-sparse
+                sparse_mapping = tq.get_default_static_quant_module_mappings()
+                sparse_mapping[nn.Linear] = mo.sparsity.Linear
+                tq.convert(sqmodel, inplace=True, mapping=sparse_mapping)
+                tq.convert(qmodel, inplace=True)
+
+                assert isinstance(sqmodel.linear, mo.sparsity.Linear), "Convert failed"
+                assert isinstance(qmodel.linear, nn.quantized.Linear), "Mapping failed"
+
+                # Make sure numerics are right
+                Y_ref = qmodel(X_q)
+                Y_hat = sqmodel(X_q)
+                self.assertEqual(Y_ref.dequantize(), Y_hat.dequantize())
+
+            if qengine_is_qnnpack():
+                qconfig = {nn.Linear : tq.qconfig.default_dynamic_qconfig}
+                dqmodel = copy.deepcopy(model)
+                sdqmodel = copy.deepcopy(model)
+
+                tq.propagate_qconfig_(dqmodel, qconfig)
+                tq.propagate_qconfig_(sdqmodel, qconfig)
+
+                # Make sure the quantization parameters are computed the same way
+                qparams = dqmodel.linear.qconfig.weight().calculate_qparams()
+                sqparams = sdqmodel.linear.qconfig.weight().calculate_qparams()
+                self.assertEqual(qparams, sqparams)
+
+                # Make sure mapping of sparse kernels does not affect the non-sparse
+                sparse_mapping = copy.deepcopy(tq.get_default_dynamic_quant_module_mappings())
+                sparse_mapping[nn.Linear] = mo.sparsity.dynamic.Linear
+                with QNNPACKLinearBlockSparsePattern(1, 4):
+                    tq.convert(sdqmodel, inplace=True, mapping=sparse_mapping)
+                tq.convert(dqmodel, mapping=tq.get_default_dynamic_quant_module_mappings(), inplace=True)
+
+                assert isinstance(sdqmodel.linear, mo.sparsity.dynamic.Linear), "Convert failed"
+                assert isinstance(dqmodel.linear, nn.quantized.dynamic.Linear), "Mapping failed"
+
+                # Make sure numerics are right
+                Y_ref = dqmodel(X_fp32)
+                Y_hat = sdqmodel(X_fp32)
+                self.assertEqual(Y_ref, Y_hat)
+
+    @override_qengines
+    def test_sparse_qlinear_serdes(self):
+        batch_size = 12
+        input_channels = 4
+        output_channels = 7
+        model = self.SparseQuantizedModel(input_channels, output_channels)
+
+        # For sparse kernels both the activation and weight ZP = 0
+        X_scale = 0.2
+        X_zp = 0
+        W_scale = 1e-2
+        W_zp = 0
+
+        with override_cpu_allocator_for_qnnpack(qengine_is_qnnpack()):
+            X_fp32 = torch.randn(batch_size, input_channels, dtype=torch.float32)
+            float_bias = torch.randn(output_channels, dtype=torch.float32)
+
+            X_q = torch.quantize_per_tensor(
+                X_fp32, scale=X_scale, zero_point=X_zp, dtype=torch.quint8
+            )
+            X_fp32 = X_q.dequantize()
+
+            W_fp32 = torch.randn(output_channels, input_channels, dtype=torch.float32)
+            mask = torch.randint(0, 2, W_fp32.shape)
+            W_fp32 *= mask
+            W_q = torch.quantize_per_tensor(W_fp32, W_scale, W_zp, torch.qint8)
+
+            model.weight = nn.Parameter(W_q.dequantize())
+            model.eval()
+
+            # Note: At the moment, for sparse kernels
+            # fbgemm supports only static quantized sparse linear
+            # qnnpack supports only dynamically quantized sparse linear
+            # Hence we have two different tests.
+            # fbgemm tests static flow, qnnpack tests dynamic.
+            # Should be unified later on and tests should be fixed
+            # appropriately.
+            if qengine_is_fbgemm():
+                model.qconfig = tq.get_default_qconfig('fbgemm')
+                qmodel = copy.deepcopy(model)
+                sqmodel = copy.deepcopy(model)
+
+                tq.prepare(qmodel, inplace=True)
+                tq.prepare(sqmodel, inplace=True)
+
+                with torch.no_grad():
+                    qmodel(X_fp32)
+                    sqmodel(X_fp32)
+
+                # Make sure the quantization parameters are computed the same way
+                qparams = qmodel.linear.qconfig.weight().calculate_qparams()
+                sqparams = sqmodel.linear.qconfig.weight().calculate_qparams()
+                self.assertEqual(qparams, sqparams)
+
+                # Make sure mapping of sparse kernels does not affect the non-sparse
+                sparse_mapping = tq.get_default_static_quant_module_mappings()
+                sparse_mapping[nn.Linear] = mo.sparsity.Linear
+                tq.convert(sqmodel, inplace=True, mapping=sparse_mapping)
+                tq.convert(qmodel, inplace=True)
+
+                assert isinstance(sqmodel.linear, mo.sparsity.Linear), "Convert failed"
+                assert isinstance(qmodel.linear, nn.quantized.Linear), "Mapping failed"
+
+                scripted_sqmodel = torch.jit.script(sqmodel)
+                scripted_sqmodel.eval()
+                buffer = io.BytesIO()
+                torch.jit.save(scripted_sqmodel, buffer)
+                buffer.seek(0)
+                sqmodel = torch.jit.load(buffer)
+
+                # Make sure numerics are right
+                Y_ref = qmodel(X_q)
+                Y_hat = sqmodel(X_q)
+                self.assertEqual(Y_ref.dequantize(), Y_hat.dequantize())
+
+            if qengine_is_qnnpack():
+                qconfig = {nn.Linear : tq.qconfig.default_dynamic_qconfig}
+                dqmodel = copy.deepcopy(model)
+                sdqmodel = copy.deepcopy(model)
+
+                tq.propagate_qconfig_(dqmodel, qconfig)
+                tq.propagate_qconfig_(sdqmodel, qconfig)
+
+                # Make sure the quantization parameters are computed the same way
+                qparams = dqmodel.linear.qconfig.weight().calculate_qparams()
+                sqparams = sdqmodel.linear.qconfig.weight().calculate_qparams()
+                self.assertEqual(qparams, sqparams)
+
+                # Make sure mapping of sparse kernels does not affect the non-sparse
+                sparse_mapping = copy.deepcopy(tq.get_default_dynamic_quant_module_mappings())
+                sparse_mapping[nn.Linear] = mo.sparsity.dynamic.Linear
+                with QNNPACKLinearBlockSparsePattern(1, 4):
+                    tq.convert(sdqmodel, inplace=True, mapping=sparse_mapping)
+                tq.convert(dqmodel, mapping=tq.get_default_dynamic_quant_module_mappings(), inplace=True)
+
+                assert isinstance(sdqmodel.linear, mo.sparsity.dynamic.Linear), "Convert failed"
+                assert isinstance(dqmodel.linear, nn.quantized.dynamic.Linear), "Mapping failed"
+
+                scripted_sdqmodel = torch.jit.script(sdqmodel)
+                scripted_sdqmodel.eval()
+                buffer = io.BytesIO()
+                torch.jit.save(scripted_sdqmodel, buffer)
+                buffer.seek(0)
+                sdqmodel = torch.jit.load(buffer)
+
+                # Make sure numerics are right
+                Y_ref = dqmodel(X_fp32)
+                Y_hat = sdqmodel(X_fp32)
+                self.assertEqual(Y_ref, Y_hat)

--- a/test/mo/sparsity/test_sparsifier.py
+++ b/test/mo/sparsity/test_sparsifier.py
@@ -1,0 +1,62 @@
+from torch.testing._internal.common_utils import TestCase
+
+from torch import mo
+from torch import nn
+
+import copy
+
+class ModelUnderTest(nn.Module):
+    def __init__(self, iC, oC):
+        super().__init__()
+        self.linear1 = nn.Linear(iC, 16)
+        self.linear2 = nn.Linear(16, oC)
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.lienar2(x)
+        return x
+
+class TestBaseSparsifierClass(TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.model = ModelUnderTest(8, 16)
+        self.config = [
+            {'params': self.model.linear1},
+            {'params': self.model.linear2, 'target_ratio': 0.99, 'block_pattern': (1, 4)}
+        ]
+        self.kwargs = {
+            'target_ratio': 0.7,
+            'block_pattern': (1, 1),
+            'scheme': 'inplace'
+        }
+
+    def test_getstate_setstate(self):
+        r"""Tests the correctness of the __getstate__ and __setstate__."""
+        sparsifier = mo.sparsity.Sparsifier(self.config)
+        sparsifier.state['test_arg'] = 'abc.def'
+
+        defaults = sparsifier.defaults
+        state = copy.deepcopy(sparsifier.state)
+        print(state)
+        config = sparsifier.config_groups
+
+        getstate = sparsifier.__getstate__()
+        sparsifier.__setstate__(getstate)
+
+        assert state == sparsifier.state
+        assert config == sparsifier.config_groups
+        assert defaults == sparsifier.defaults
+
+        # TODO : Check this test -- it is failing
+        # sparsifier.state['test_arg'] = 123.456
+        # assert state != sparsifier.state, str(state)
+        # sparsifier.__setstate__(state)
+        # assert state == sparsifier.state, str(sparsifier.state) + ' ' + str(state)
+
+    def test_add_group(self):
+        r"""Tests if the default args are propagated throughout"""
+        sparsifier = mo.sparsity.Sparsifier(self.config, **self.kwargs)
+
+        for config in sparsifier.config_groups:
+            for key in self.kwargs.keys():
+                assert key in config

--- a/test/test_mo.py
+++ b/test/test_mo.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+r"""Tests related to the model optimization"""
+
+from torch.testing._internal.common_utils import run_tests
+
+# Sparsity tests
+from mo.sparsity.test_quantized import TestQuantizedSparseKernels  # noqa: F401
+from mo.sparsity.test_quantized import TestQuantizedSparseLayers  # noqa: F401
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/test_mo.py
+++ b/test/test_mo.py
@@ -4,9 +4,16 @@ r"""Tests related to the model optimization"""
 
 from torch.testing._internal.common_utils import run_tests
 
-# Sparsity tests
+###############################################################################
+# Sparsity
+
+# Kernels, ops, and layers
 from mo.sparsity.test_quantized import TestQuantizedSparseKernels  # noqa: F401
 from mo.sparsity.test_quantized import TestQuantizedSparseLayers  # noqa: F401
 
+# Utilities
+from mo.sparsity.test_sparsifier import TestBaseSparsifierClass  # noqa: F401
+
+###############################################################################
 if __name__ == '__main__':
     run_tests()

--- a/torch/mo/README
+++ b/torch/mo/README
@@ -1,0 +1,17 @@
+# Model Optimization Utilities
+
+All utilities used by the model optimization
+
+## Package structure
+./mo
+├── common  # TBD
+├── pruning  # TBD
+│   └── ...
+├── quantization  # TBD
+│   ├── fx
+│   ├── ns
+│   └── ...
+└── sparsity
+    └── ...
+
+The `common` package holds any utilities used by all model optimization frameworks.

--- a/torch/mo/__init__.py
+++ b/torch/mo/__init__.py
@@ -1,0 +1,1 @@
+from . import sparsity

--- a/torch/mo/sparsity/__init__.py
+++ b/torch/mo/sparsity/__init__.py
@@ -1,0 +1,6 @@
+
+from .sparsifier import Sparsifier
+
+__all__ = [
+    'Sparsifier'
+]

--- a/torch/mo/sparsity/sparsifier/__init__.py
+++ b/torch/mo/sparsity/sparsifier/__init__.py
@@ -1,0 +1,6 @@
+
+from .sparsifier import Sparsifier
+
+__all__ = [
+    'Sparsifier'
+]

--- a/torch/mo/sparsity/sparsifier/sparsifier.py
+++ b/torch/mo/sparsity/sparsifier/sparsifier.py
@@ -1,0 +1,109 @@
+from collections import defaultdict
+
+import torch
+
+class Sparsifier(object):
+    r"""Base class for all sparsifiers.
+
+    Args:
+        config: sparsification configuration. The exact configuration
+                depends on the implementation of the sparsifier.
+        kwargs: a dict containing default values of sparsification
+                  options. These are only used if the `config` does not
+                  specify them.
+
+    Members:
+        state: holds the current state of the sparsification. The implemented
+               sparsifiers must store their state in this dict.
+        config_groups: list of configurations that are applied to the model
+
+    TODO:
+        - hook for profiler
+        - What to do if the config is empty?
+        - __repr__ should conform with the design doc
+        - `config_groups` checks
+            - Need to add behavior for different types of configs (list, dict)
+        - Add check for the required/optional arguments
+    """
+    def __init__(self, config, **kwargs):
+        torch._C._log_api_usage_once("python.mo.sparsifier")
+        self.defaults = kwargs
+
+        if not isinstance(config, (dict, list, tuple)):
+            raise TypeError("config argument given to sparsifier must be "
+                            "a dict, a list, or a tuple, got " +
+                            torch.typename(config))
+
+        self.state = defaultdict(dict)
+        self.config_groups = []
+
+        config_groups = list(config)
+        if len(config_groups) == 0:
+            raise ValueError("Sparsifier for an ampty configuration")
+        self._add_config_groups(config_groups)
+
+    def _add_config_groups(self, config_groups):
+        config_set = set()
+        for config_group in config_groups:
+            assert isinstance(config_group, dict), \
+                   "config group must be a dict"
+            assert 'params' in config_group, \
+                   "config group must have a target to sparsify"
+            if config_group['params'] in config_set:
+                raise ValueError("some sparsification targets appear in more "
+                                 "than one configuration group")
+            else:
+                config_set.add(config_group['params'])
+            self._add_config_group(config_group)
+
+    def _add_config_group(self, config_group):
+        for name, default in self.defaults.items():
+            config_group.setdefault(name, default)
+
+    def __getstate__(self):
+        return {
+            'defaults': self.defaults,
+            'state': self.state,
+            'config_groups': self.config_groups
+        }
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+    def __repr__(self):
+        format_string = self.__class__.__name__ + ' ('
+        for i, group in enumerate(self.config_groups):
+            format_string += '\n'
+            format_string += 'Sparsity Group {0}\n'.format(i)
+            for key in sorted(group.keys()):
+                if key != 'params':
+                    format_string += '    {0}: {1}\n'.format(key, group[key])
+        format_string += ')'
+        return format_string
+
+    def state_dict(self):
+        r"""Returns the state of the sparsifier as a :class:`dict`.
+
+        Keys:
+            state: a dict holding the current state. Depends on the
+                   implementation
+            config_groups: a dict containing the sparsification configs
+        """
+        state = self.__getstate__()
+        del state['defaults']
+        return state
+
+    def load_state_dict(self, state):
+        self.__setstate__(state)
+
+    def step(self):
+        r"""Performs a single sparsification step."""
+        raise NotImplementedError
+
+    def prepare(self):
+        r"""Prepares the model for sparsification."""
+        raise NotImplementedError
+
+    def convert(self):
+        r"""Converts the model."""
+        raise NotImplementedError

--- a/torch/nn/mo/README
+++ b/torch/nn/mo/README
@@ -1,0 +1,20 @@
+# Model Optimization nn
+
+All layers related to model optimization
+
+Eventually, the contents of this folder will include the following
+
+./nn/mo
+├── commonm
+├── pruning
+│   ├── dynamic
+│   └── ...
+├── quantization
+│   ├── intrinsic
+│   ├── qat
+│   ├── quantizable
+│   ├── quantized
+│   └── ...
+└── sparsity
+    ├── dynamic
+    └── ...

--- a/torch/nn/mo/__init__.py
+++ b/torch/nn/mo/__init__.py
@@ -1,0 +1,2 @@
+
+from . import sparsity

--- a/torch/nn/mo/sparsity/__init__.py
+++ b/torch/nn/mo/sparsity/__init__.py
@@ -1,0 +1,3 @@
+from . import dynamic
+from .linear import Linear
+from .linear import LinearPackedParams

--- a/torch/nn/mo/sparsity/dynamic/__init__.py
+++ b/torch/nn/mo/sparsity/dynamic/__init__.py
@@ -1,0 +1,1 @@
+from .linear import Linear

--- a/torch/nn/mo/sparsity/dynamic/linear.py
+++ b/torch/nn/mo/sparsity/dynamic/linear.py
@@ -1,0 +1,139 @@
+from typing import Optional
+
+import torch
+from torch import nn
+import torch.nn.intrinsic as nni
+from torch.nn.quantized.modules.utils import _quantize_weight, hide_packed_params_repr
+from torch.nn.mo.sparsity import linear
+from torch.nn.mo.sparsity.utils import QNNPACKLinearBlockSparsePattern
+
+# torch.ops.load_library("//caffe2/torch/fb/model_optimization:sparsity")
+
+class Linear(torch.nn.Module):
+    r"""
+    A dynamically quantized sparse linear module with float tensor as inputs and outputs.
+    """
+    _version = 1
+    _op_type = "sparse_dynamic"
+    _FLOAT_MODULE = nn.Linear
+
+    def __init__(self, in_features, out_features, row_block_size, col_block_size, bias=True, dtype=torch.qint8):
+        super().__init__()
+
+        if dtype != torch.qint8:
+            raise NotImplementedError("Only QINT8 is supported for Sparse Quantized Linear Dynamic")
+
+        self.in_features = in_features
+        self.out_features = out_features
+
+        if bias:
+            bias = torch.zeros(self.out_features, dtype=torch.float)
+        else:
+            bias = None
+
+        qweight = torch._empty_affine_quantized([out_features, in_features],
+                                                scale=1, zero_point=0, dtype=torch.qint8)
+        self._packed_params = linear.LinearPackedParams(dtype)
+        self._packed_params.set_weight_bias(qweight, bias, row_block_size, col_block_size)
+
+    def _get_name(self):
+        return 'SparseQuantizedDynamicLinear'
+
+    def extra_repr(self):
+        return 'in_features={}, out_features={}, qscheme={}'.format(
+            self.in_features, self.out_features, self.weight().qscheme()
+        )
+
+    def __repr__(self):
+        return hide_packed_params_repr(self, linear.LinearPackedParams)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.sparsity.sparse_qlinear_dynamic(x, self._packed_params._packed_params)
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        super()._save_to_state_dict(destination, prefix, keep_vars)
+        destination[prefix + 'op_type'] = self._op_type
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        op_type = int(state_dict[prefix + 'op_type'])
+        assert op_type == 'sparse', \
+               "Cannot load from op_type [{}], expecting [{}]".format(op_type, self._op_type)
+        state_dict.pop(prefix + 'op_type')
+
+        version = local_metadata.get('version', None)
+        assert version <= self._version
+
+        # Is this code valid? In old quantization it seemed to be used to load
+        # older model
+        weight = state_dict.pop(prefix + 'weight')
+        bias = state_dict.pop(prefix + 'bias')
+        state_dict.update({prefix + '_packed_params.weight': weight,
+                           prefix + '_packed_params.bias': bias})
+
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, False,
+            missing_keys, unexpected_keys, error_msgs)
+
+    def _weight_bias(self):
+        return self._packed_params._weight_bias()
+
+    def weight(self):
+        return self._weight_bias()[0]
+
+    def bias(self):
+        return self._weight_bias()[1]
+
+    def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor],
+                        row_block_size: Optional[int], col_block_size: Optional[int]) -> None:
+        assert row_block_size is not None and col_block_size is not None
+        self._packed_params.set_weight_bias(w, b, row_block_size, col_block_size)
+
+    @classmethod
+    def from_float(cls, mod):
+        r"""Create a quantized sparse dynamic module from a float module.
+
+        We only care about the convert at this stage, no need for observers just yet.
+        """
+        assert type(mod) == cls._FLOAT_MODULE, ' nnq.' + cls.__name__ + '.from_float only works for ' + \
+            cls._FLOAT_MODULE.__name__
+        # TODO: Need to add options to qconfig to avoid the calibration.
+        # TODO: Add calibration for the sparsity
+        assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
+        if type(mod) == nni.LinearReLU:
+            mod = mod[0]
+        if mod.qconfig is not None and mod.qconfig.weight is not None:
+            weight_observer = mod.qconfig.weight()
+        else:
+            # We have the circular import issues if we import the qconfig in the beginning of this file:
+            # https://github.com/pytorch/pytorch/pull/24231. The current workaround is to postpone the
+            # import until we need it.
+            from torch.quantization.qconfig import default_dynamic_qconfig
+            weight_observer = default_dynamic_qconfig.weight()
+
+        # It is important to multiply by the mask BEFORE calling the `weight_observer`
+        # TODO (zaf): Mask might not be part of the qconfig (T83295194)
+        weight = mod.weight
+        if getattr(mod.qconfig, 'mask', False):
+            weight = mod.qconfig.mask * mod.weight
+
+        weight_observer(weight)
+        dtype = weight_observer.dtype
+        assert dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
+        w_sc, w_zp = weight_observer.calculate_qparams()
+        if isinstance(w_zp, torch.Tensor):
+            assert not torch.any(w_zp.bool()), "All weight zero points must map to 0"
+        else:
+            assert w_zp == 0, 'Weight zero point must map to 0'
+        qweight = _quantize_weight(weight.float(), weight_observer)
+
+        # Use these default values until we figure out how to augment
+        # `mod` to contain sparse config
+        row_block_size, col_block_size = QNNPACKLinearBlockSparsePattern.block_size()
+        qlinear = cls(mod.in_features,
+                      mod.out_features,
+                      row_block_size,
+                      col_block_size,
+                      dtype=dtype)
+        qlinear.set_weight_bias(qweight, mod.bias, row_block_size, col_block_size)
+        return qlinear

--- a/torch/nn/mo/sparsity/linear.py
+++ b/torch/nn/mo/sparsity/linear.py
@@ -1,0 +1,223 @@
+from typing import Optional
+
+import torch
+from torch import nn
+import torch.nn.intrinsic as nni
+from torch.nn.quantized.modules.utils import _quantize_weight, hide_packed_params_repr
+
+# torch.ops.load_library("//caffe2/torch/fb/model_optimization:sparsity")
+
+# TODO (zaf): Inherit from `quantized.LinearPackedParams` (T83294430)
+class LinearPackedParams(torch.nn.Module):
+    _version = 1
+    _op_type = "sparse"
+
+    def __init__(self, row_block_size=1, col_block_size=4, dtype=torch.qint8):
+        super().__init__()
+        self.prepack_op = torch.ops.sparsity.sparse_qlinear_prepack
+        self.unpack_op = torch.ops.sparsity.sparse_qlinear_unpack
+
+        if dtype != torch.qint8:
+            raise NotImplementedError("Linear prepacking only supports QINT8")
+        self.dtype = dtype
+        wq = torch._empty_affine_quantized([1, 1], scale=1.0, zero_point=0, dtype=torch.qint8)
+        self.set_weight_bias(wq, None, row_block_size, col_block_size)
+        # Hack to make torch.jit.script/torch.jit.load work
+        # Once we have self.unpack_op working we wont need this.
+        self.__annotations__['bias'] = Optional[torch.Tensor]
+
+    def _get_name(self):
+        return "SparseQuantizedLinearPackedParams"
+
+    @torch.jit.export
+    def set_weight_bias(self, weight: torch.Tensor, bias: Optional[torch.Tensor],
+                        row_block_size: Optional[int], col_block_size: Optional[int]) -> None:
+        assert row_block_size is not None and col_block_size is not None
+        self._packed_params = self.prepack_op(weight, bias, row_block_size, col_block_size)
+        # TODO: We will save the original weight and bias, because the unpacking is not yet there.
+        self.weight = weight
+        self.bias = bias
+        self.row_block_size = row_block_size
+        self.col_block_size = col_block_size
+
+    @torch.jit.export
+    def _weight_bias(self):
+        # TODO: The unpacking is not yet implemented
+        # return self.unpack_op(self._packed_params)
+        return self.weight, self.bias, self.row_block_size, self.col_block_size
+
+    def forward(self, x):
+        return x
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        super()._save_to_state_dict(destination, prefix, keep_vars)
+        destination[prefix + 'dtype'] = self.dtype
+        destination[prefix + '_packed_params'] = self._weight_bias()
+        destination[prefix + 'op_type'] = self._op_type
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        version = local_metadata.get('version', None)
+        assert version <= self._version
+
+        op_type = state_dict.pop(prefix + 'op_type')
+        assert op_type == self._op_type, \
+               "Cannot load from op_type [{}], expecting [{}]".format(op_type, self._op_type)
+        self.dtype = state_dict.pop(prefix + 'dtype')
+        weight, bias, row_block_size, col_block_size = state_dict.pop(prefix + '_packed_params')
+        self.set_weight_bias(weight, bias, row_block_size, col_block_size)
+
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, False,
+                                      missing_keys, unexpected_keys, error_msgs)
+
+    @torch.jit.export
+    def __getstate__(self):
+        qweight, bias, row_block_size, col_block_size = self._weight_bias()
+        return qweight, bias, row_block_size, col_block_size, self.training, self.dtype
+
+    @torch.jit.export
+    def __setstate__(self, state):
+        self.set_weight_bias(state[0], state[1], state[2], state[3])
+        self.training = state[4]
+        self.dtype = state[5]
+
+    def __repr__(self):
+        return self._weight_bias().__repr__()
+
+# TODO (zaf): Inherit from `quantized.Linear` (T83294430)
+class Linear(torch.nn.Module):
+    r"""
+    A quantized sparse linear module with quantized tensor as inputs and outputs.
+    """
+    _version = 1
+    _op_type = "sparse"
+    _FLOAT_MODULE = nn.Linear
+
+    def __init__(self, in_features, out_features, row_block_size, col_block_size, bias=True, dtype=torch.qint8):
+        super().__init__()
+
+        if dtype != torch.qint8:
+            raise NotImplementedError("Only QINT8 is supported for Sparse Quantized Linear")
+
+        self.in_features = in_features
+        self.out_features = out_features
+
+        if bias:
+            bias = torch.zeros(self.out_features, dtype=torch.float)
+        else:
+            bias = None
+
+        qweight = torch._empty_affine_quantized([out_features, in_features],
+                                                scale=1, zero_point=0, dtype=torch.qint8)
+        self._packed_params = LinearPackedParams(dtype)
+        self._packed_params.set_weight_bias(qweight, bias, row_block_size, col_block_size)
+        self.scale = 1.0
+        self.zero_point = 0
+
+    def _get_name(self):
+        return 'SparseQuantizedLinear'
+
+    def extra_repr(self):
+        return 'in_features={}, out_features={}, scale={}, zero_point={}, qscheme={}'.format(
+            self.in_features, self.out_features, self.scale, self.zero_point, self.weight().qscheme()
+        )
+
+    def __repr__(self):
+        return hide_packed_params_repr(self, LinearPackedParams)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.sparsity.sparse_qlinear(x, self._packed_params._packed_params, self.scale, self.zero_point)
+
+    def _save_to_state_dict(self, destination, prefix, keep_vars):
+        super()._save_to_state_dict(destination, prefix, keep_vars)
+        destination[prefix + 'scale'] = torch.tensor(self.scale)
+        destination[prefix + 'zero_point'] = torch.tensor(self.zero_point)
+        destination[prefix + 'op_type'] = self._op_type
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        self.scale = float(state_dict[prefix + 'scale'])
+        state_dict.pop(prefix + 'scale')
+
+        self.zero_point = int(state_dict[prefix + 'zero_point'])
+        state_dict.pop(prefix + 'zero_point')
+
+        op_type = int(state_dict[prefix + 'op_type'])
+        assert op_type == 'sparse', \
+               "Cannot load from op_type [{}], expecting [{}]".format(op_type, self._op_type)
+        state_dict.pop(prefix + 'op_type')
+
+        version = local_metadata.get('version', None)
+        assert version <= self._version
+
+        # Is this code valid? In old quantization it seemed to be used to load
+        # older model
+        weight = state_dict.pop(prefix + 'weight')
+        bias = state_dict.pop(prefix + 'bias')
+        state_dict.update({prefix + '_packed_params.weight': weight,
+                           prefix + '_packed_params.bias': bias})
+
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, False,
+            missing_keys, unexpected_keys, error_msgs)
+
+    def _weight_bias(self):
+        return self._packed_params._weight_bias()
+
+    def weight(self):
+        return self._weight_bias()[0]
+
+    def bias(self):
+        return self._weight_bias()[1]
+
+    def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor],
+                        row_block_size: Optional[int], col_block_size: Optional[int]) -> None:
+        assert row_block_size is not None and col_block_size is not None
+        self._packed_params.set_weight_bias(w, b, row_block_size, col_block_size)
+
+    @classmethod
+    def from_float(cls, mod):
+        r"""Create a quantized sparse module from a float module.
+
+        We only care about the convert at this stage, no need for observers just yet.
+        """
+        assert type(mod) == cls._FLOAT_MODULE, ' nnq.' + cls.__name__ + '.from_float only works for ' + \
+            cls._FLOAT_MODULE.__name__
+        # TODO: Need to add options to qconfig to avoid the calibration.
+        # TODO: Add calibration for the sparsity
+        assert hasattr(mod, 'qconfig'), 'Input float module must have qconfig defined'
+        activation_post_process = mod.activation_post_process
+        if type(mod) == nni.LinearReLU:
+            mod = mod[0]
+        weight_post_process = mod.qconfig.weight()
+
+        # It is important to multiply by the mask BEFORE calling the `weight_post_process`
+        # TODO (zaf): Mask might not be part of the qconfig (T83295194)
+        weight = mod.weight
+        if getattr(mod.qconfig, 'mask', False):
+            weight = mod.qconfig.mask * mod.weight
+
+        weight_post_process(weight)
+        dtype = weight_post_process.dtype
+        act_scale, act_zp = activation_post_process.calculate_qparams()
+        assert dtype == torch.qint8, 'Weight observer must have dtype torch.qint8'
+        w_sc, w_zp = weight_post_process.calculate_qparams()
+        if isinstance(w_zp, torch.Tensor):
+            assert not torch.any(w_zp.bool()), "All weight zero points must map to 0"
+        else:
+            assert w_zp == 0, 'Weight zero point must map to 0'
+        qweight = _quantize_weight(weight.float(), weight_post_process)
+
+        # Use these default values until we figure out how to augment
+        # `mod` to contain sparse config
+        row_block_size = 1
+        col_block_size = 4
+        qlinear = cls(mod.in_features,
+                      mod.out_features,
+                      row_block_size,
+                      col_block_size,
+                      dtype=dtype)
+        qlinear.set_weight_bias(qweight, mod.bias, row_block_size, col_block_size)
+        qlinear.scale = float(act_scale)
+        qlinear.zero_point = int(act_zp)
+        return qlinear

--- a/torch/nn/mo/sparsity/utils.py
+++ b/torch/nn/mo/sparsity/utils.py
@@ -1,0 +1,38 @@
+import threading
+
+def is_valid_linear_block_sparse_pattern(row_block_size, col_block_size):
+    return (row_block_size == 1 and col_block_size == 4) or \
+           (row_block_size == 8 and col_block_size == 1)
+
+# This is a stop-gap measure as current flow does not allow module
+# specific block sparse pattern.
+# Infact there is no way to convey sparse pattern via module config
+# of quantization flow. Thus using the global context to convey
+# sparsity pattern.
+# Once the flow supports it, this should be removed.
+class QNNPACKLinearBlockSparsePattern:
+    rlock = threading.RLock()
+    row_block_size = 1
+    col_block_size = 4
+    prev_row_block_size = 1
+    prev_col_block_size = 4
+
+    def __init__(self, row_block_size=1, col_block_size=4):
+        assert(is_valid_linear_block_sparse_pattern(row_block_size, col_block_size))
+        QNNPACKLinearBlockSparsePattern.rlock.acquire()
+        QNNPACKLinearBlockSparsePattern.prev_row_block_size = QNNPACKLinearBlockSparsePattern.row_block_size
+        QNNPACKLinearBlockSparsePattern.prev_col_block_size = QNNPACKLinearBlockSparsePattern.col_block_size
+        QNNPACKLinearBlockSparsePattern.row_block_size = row_block_size
+        QNNPACKLinearBlockSparsePattern.col_block_size = col_block_size
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, backtrace):
+        QNNPACKLinearBlockSparsePattern.row_block_size = QNNPACKLinearBlockSparsePattern.prev_row_block_size
+        QNNPACKLinearBlockSparsePattern.col_block_size = QNNPACKLinearBlockSparsePattern.prev_col_block_size
+        QNNPACKLinearBlockSparsePattern.rlock.release()
+
+    @staticmethod
+    def block_size():
+        return QNNPACKLinearBlockSparsePattern.row_block_size, QNNPACKLinearBlockSparsePattern.col_block_size


### PR DESCRIPTION
Summary: Introducing the base sparsifier class as described in https://docs.google.com/document/d/1Tr3OYnv7RdTDmnLNxUF_8cwpBofPTGY7cTrROXKA_yw/edit?usp=sharing

Test Plan:
`buck test mode/opt //caffe2/test:mo -- TestBaseSparsifierClass`

```
Building: finished in 4.8 sec (100%) 7385/7385 jobs, 0 updated
  Total time: 5.2 sec
More details at https://www.internalfb.com/intern/buck/build/11697063-377e-456d-a072-bb5f99cbca5b
Tpx test run coordinator for Facebook. See https://fburl.com/tpx for details.
Running with tpx session id: 89ba2d03-b789-4a64-a4a9-af8f2f433f45
Trace available for this run at /tmp/tpx-20210304-032515.471916/trace.log
Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/562950135301094
    ✓ ListingSuccess: caffe2/test:mo - main (0.850)
    ✓ Pass: caffe2/test:mo - test_add_group (mo.sparsity.test_sparsifier.TestBaseSparsifierClass) (0.883)
    ✓ Pass: caffe2/test:mo - test_getstate_setstate (mo.sparsity.test_sparsifier.TestBaseSparsifierClass) (1.036)
Summary
  Pass: 2
  ListingSuccess: 1
Finished test run: https://www.internalfb.com/intern/testinfra/testrun/562950135301094
```

Differential Revision: D26814581

