### PR TITLE
automate sharding using S3 test time stats

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -890,7 +890,7 @@ def get_dep_modules(test):
     )
     # HACK: some platforms default to ascii, so we can't just run_script :(
     with open(test_location, 'r', encoding='utf-8') as fp:
-        finder.load_module('__main__', fp, test_location, ('', 'r', '1'))
+        finder.load_module('__main__', fp, test_location, ('', 'r', 1))
 
     dep_modules = set(finder.modules.keys())
     _DEP_MODULES_CACHE[test] = dep_modules

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 import argparse
+import bz2
 import copy
-from datetime import datetime
+from datetime import datetime, timedelta
+import json
 import modulefinder
 import os
 import shutil
@@ -15,7 +17,14 @@ import torch
 from torch.utils import cpp_extension
 from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell, set_cwd, FILE_SCHEMA
 import torch.distributed as dist
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple, List
+
+try:
+    import boto3  # type: ignore[import]
+    import botocore  # type: ignore[import]
+    HAVE_BOTO3 = True
+except ImportError:
+    HAVE_BOTO3 = False
 
 TESTS = [
     'test_public_bindings',
@@ -338,6 +347,82 @@ JIT_EXECUTOR_TESTS = [
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)
+
+
+def get_test_time_reports_from_S3():
+    commit_date_str = subprocess.check_output(
+        ['git', 'show', '-s', '--format=%ci', 'HEAD'],
+        encoding="ascii").splitlines()[0]
+    commit_date = datetime.strptime(commit_date_str, '%Y-%m-%d %H:%M:%S %z')
+    day_before_commit = str(commit_date - timedelta(days=1)).split(' ')[0]
+    # something like git rev-list --before="2021-02-24" --max-count=1 --remotes="*upstream/nightly"
+    nightly_commit = subprocess.check_output(
+        ["git", "rev-list", f"--before={day_before_commit}", "--max-count=1", "--remotes=*upstream/nightly"],
+        encoding="ascii").splitlines()[0]
+
+    job = os.environ.get("CIRCLE_JOB", "")
+    job_minus_shard_number = job.rstrip('0123456789')
+    s3 = boto3.resource("s3", config=botocore.config.Config(signature_version=botocore.UNSIGNED))
+    bucket = s3.Bucket(name="ossci-metrics")
+    summaries = bucket.objects.filter(Prefix=f"test_time/{nightly_commit}/{job_minus_shard_number}")
+
+    reports = []
+    for summary in summaries:
+        binary = summary.get()["Body"].read()
+        string = bz2.decompress(binary).decode("utf-8")
+        reports.append(json.loads(string))
+    return reports
+
+
+def calculate_job_times(reports) -> Dict[str, Tuple[float, int]]:
+    # an entry will be like ("test_file_name" -> (current_avg, # values))
+    jobs_to_times: Dict[str, Tuple[float, int]] = dict()
+    for report in reports:
+        assert report['format_version'] == 2, "S3 format currently handled is version 2 only"
+        files = report['files']
+        for name, test_file in files.items():
+            if name != jobs_to_times:
+                jobs_to_times[name] = (test_file['total_seconds'], 1)
+            else:
+                curr_avg, curr_count = jobs_to_times[name]
+                new_count = curr_count + 1
+                new_avg = (curr_avg * curr_count + test_file['total_seconds']) / new_count
+                jobs_to_times[name] = (new_avg, new_count)
+    return jobs_to_times
+
+
+def calculate_shards(num_shards: int, tests: List[str], job_times: Dict[str, Tuple[float, int]]) -> List[Tuple[float, List[str]]]:
+    # if there's 'test_cpp_extensions_aot' entry in job_times, add 'test_cpp_extensions_aot_ninja' 
+    # and 'test_cpp_extensions_aot_no_ninja' duplicate entries to ease future computation since 
+    # test_cpp_extensions_aot_no_ninja and test_cpp_extensions_aot_ninja are Python test jobs that 
+    # both use the test_cpp_extensions_aot.py file.
+    if 'test_cpp_extensions_aot' in job_times:
+        job_times['test_cpp_extensions_aot_ninja'] = job_times['test_cpp_extensions_aot']
+        job_times['test_cpp_extensions_aot_no_ninja'] = job_times['test_cpp_extensions_aot']
+    filtered_job_times = {job: avg_time for job, (avg_time, _) in job_times.items() if job in tests}
+    sorted_jobs = sorted(filtered_job_times, key=lambda j: job_times[j], reverse=True)
+    unknown_jobs = [job for job in tests if job not in sorted_jobs]
+
+    sharded_jobs: List[Tuple[float, List[str]]] = [(0.0, []) for i in range(num_shards)]
+    for job in sorted_jobs:
+        min_shard_index = sorted(range(num_shards), key=lambda i: sharded_jobs[i][0])[0]
+        curr_shard_time, curr_shard_jobs = sharded_jobs[min_shard_index]
+        curr_shard_jobs.append(job)
+        sharded_jobs[min_shard_index] = (curr_shard_time + filtered_job_times[job], curr_shard_jobs)
+
+    index = sorted(range(num_shards), key=lambda i: sharded_jobs[i][0])[0]
+    for job in unknown_jobs:
+        sharded_jobs[index][1].append(job)
+        index = (index + 1) % num_shards
+    return sharded_jobs
+
+
+def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
+    s3_reports = get_test_time_reports_from_S3()
+    jobs_to_times = calculate_job_times(s3_reports)
+    shards = calculate_shards(num_shards, tests, jobs_to_times)
+    _, tests_from_shard = shards[which_shard]
+    return tests_from_shard
 
 
 def get_executable_command(options, allow_pytest, disable_coverage=False):
@@ -686,7 +771,7 @@ def get_selected_tests(options):
         which_shard, num_shards = options.shard
         assert which_shard <= num_shards, "Selected shard must be less or equal that total number of shards"
         assert num_shards <= len(selected_tests), f"Number of shards must be less than {len(selected_tests)}"
-        selected_tests = selected_tests[which_shard - 1 :: num_shards]
+        selected_tests = get_shard(which_shard, num_shards, selected_tests)
 
     if options.exclude_jit_executor:
         options.exclude.extend(JIT_EXECUTOR_TESTS)
@@ -786,7 +871,7 @@ def get_dep_modules(test):
     )
     # HACK: some platforms default to ascii, so we can't just run_script :(
     with open(test_location, 'r', encoding='utf-8') as fp:
-        finder.load_module('__main__', fp, test_location, ('', 'r', 1))
+        finder.load_module('__main__', fp, test_location, ('', 'r', '1'))
 
     dep_modules = set(finder.modules.keys())
     _DEP_MODULES_CACHE[test] = dep_modules


### PR DESCRIPTION
Uses nightly commit stats to automatically shard tests based on execution time.

Test plan:
set CIRCLE_JOB to an existing job, like `pytorch_linux_bionic_py3_6_clang9_test`
Then you can run something like: `python test/run_test.py --shard 1 10`