### PR TITLE
Declare NamedTuple at top level

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -126,6 +126,12 @@ ddp_find_unused_params_enabled_str = "Since `find_unused_parameters=True` is ena
 ddp_outputs_not_used_in_loss_str = "`forward` function outputs participate in calculating loss"
 
 
+class DDPUnevenTestInput(NamedTuple):
+    name: str
+    model: nn.Module
+    inp: Union[torch.tensor, tuple]
+    sync_interval: int
+
 
 class _FC2(nn.Module):
     def __init__(self):
@@ -4090,12 +4096,6 @@ class DistributedTest:
         @require_backends_available({"gloo", "nccl"})
         @skip_if_lt_x_gpu(2)
         def test_ddp_uneven_inputs(self):
-            class DDPUnevenTestInput(NamedTuple):
-                name: str
-                model: nn.Module
-                inp: Union[torch.tensor, tuple]
-                sync_interval: int
-
             dim = 1000
             batch = 1
             # Create a variety of models to run uneven input tests on.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53273 Declare NamedTuple at top level**

This prevents a mypy bug.  Fixes #53272

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D26819428](https://our.internmc.facebook.com/intern/diff/D26819428)