### PR TITLE
Prefix assert_async with underscore, fix some bugs in assert_async CUDA testing

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -193,7 +193,7 @@ bool is_nonzero(const Tensor& self) {
   TORCH_INTERNAL_ASSERT(false, "Expected non-Tensor backend scalar");
 }
 
-void assert_async_cpu(const Tensor& self) {
+void _assert_async_cpu(const Tensor& self) {
   TORCH_CHECK(native::is_nonzero(self), "Expected Tensor with single nonzero value, but got zero");
 }
 

--- a/aten/src/ATen/native/cuda/TensorCompare.cu
+++ b/aten/src/ATen/native/cuda/TensorCompare.cu
@@ -60,24 +60,24 @@ REGISTER_DISPATCH(isposinf_stub, &isposinf_kernel_impl);
 REGISTER_DISPATCH(isneginf_stub, &isneginf_kernel_impl);
 
 template <typename scalar_t>
-__global__ void assert_async_cuda_kernel(scalar_t* input) {
+__global__ void _assert_async_cuda_kernel(scalar_t* input) {
   CUDA_KERNEL_ASSERT(input[0] != 0);
 }
 
-__global__ void assert_async_cuda_kernel(c10::complex<float>* input) {
+__global__ void _assert_async_cuda_kernel(c10::complex<float>* input) {
   CUDA_KERNEL_ASSERT(input[0] != c10::complex<float>(0, 0));
 }
-__global__ void assert_async_cuda_kernel(c10::complex<double>* input) {
+__global__ void _assert_async_cuda_kernel(c10::complex<double>* input) {
   CUDA_KERNEL_ASSERT(input[0] != c10::complex<double>(0, 0));
 }
 
-void assert_async_cuda(const Tensor& self) {
+void _assert_async_cuda(const Tensor& self) {
   auto n = self.numel();
   TORCH_CHECK(n != 0, "Boolean value of Tensor with no values is ambiguous");
   TORCH_CHECK(n < 2, "Boolean value of Tensor with more than one value is ambiguous");
   auto stream = at::cuda::getCurrentCUDAStream();
-  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "assert_async_cuda", [&] {
-    assert_async_cuda_kernel<<<1, 1, 0, stream>>>(self.data_ptr<scalar_t>());
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16, self.scalar_type(), "_assert_async_cuda", [&] {
+    _assert_async_cuda_kernel<<<1, 1, 0, stream>>>(self.data_ptr<scalar_t>());
   });
 }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -121,10 +121,10 @@
 # Not assert because it's a keyword; not Assert because FX already
 # took that syntax
 # TODO: need to specify this is side-effectful somehow
-- func: assert_async(Tensor self) -> ()
+- func: _assert_async(Tensor self) -> ()
   dispatch:
-    CPU: assert_async_cpu
-    CUDA: assert_async_cuda
+    CPU: _assert_async_cpu
+    CUDA: _assert_async_cuda
 
 - func: refine_names(Tensor(a) self, Dimname[] names) -> Tensor(a)
   variants: method

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -76,6 +76,7 @@ allow_list = [
     ("aten::linalg_multi_dot", datetime.date(2021, 3, 25)),
     ("aten::empty_meta", datetime.date(2021, 4, 1)),
     ("aten::batch_norm_backward_elemt", datetime.date(2021, 5, 1)),
+    ("aten::assert_async", datetime.date(2021, 5, 1)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1825,6 +1825,8 @@ t1.start()
 t2.start()
 """])
 
+    # ROCm doesn't support device side asserts
+    @skipIfRocm
     def test_cuda_assert_async(self):
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with no values is ambiguous"):
             torch.assert_async(torch.tensor([], device="cuda"))
@@ -1841,7 +1843,7 @@ t2.start()
             "torch.assert_async(torch.tensor(0, device='cuda'))",
             "torch.assert_async(torch.tensor(0.0, device='cuda'))",
             "torch.assert_async(torch.tensor(False, device='cuda'))",
-            "torch.assert_async(torch.tensor(0+ 0 j, device='cuda'))",
+            "torch.assert_async(torch.tensor(0 + 0j, device='cuda'))",
         ]
 
         import subprocess

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1829,21 +1829,21 @@ t2.start()
     @skipIfRocm
     def test_fixed_cuda_assert_async(self):
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with no values is ambiguous"):
-            torch.assert_async(torch.tensor([], device="cuda"))
+            torch._assert_async(torch.tensor([], device="cuda"))
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with more than one value is ambiguous"):
-            torch.assert_async(torch.tensor([0, 0], device="cuda"))
+            torch._assert_async(torch.tensor([0, 0], device="cuda"))
 
-        torch.assert_async(torch.tensor(1, device="cuda"))
-        torch.assert_async(torch.tensor(0.1, device="cuda"))
-        torch.assert_async(torch.tensor(-0.1, device="cuda"))
-        torch.assert_async(torch.tensor(True, device="cuda"))
-        torch.assert_async(torch.tensor(0 + 0.1j, device="cuda"))
+        torch._assert_async(torch.tensor(1, device="cuda"))
+        torch._assert_async(torch.tensor(0.1, device="cuda"))
+        torch._assert_async(torch.tensor(-0.1, device="cuda"))
+        torch._assert_async(torch.tensor(True, device="cuda"))
+        torch._assert_async(torch.tensor(0 + 0.1j, device="cuda"))
 
         fail_stmts = [
-            "torch.assert_async(torch.tensor(0, device='cuda'))",
-            "torch.assert_async(torch.tensor(0.0, device='cuda'))",
-            "torch.assert_async(torch.tensor(False, device='cuda'))",
-            "torch.assert_async(torch.tensor(0 + 0j, device='cuda'))",
+            "torch._assert_async(torch.tensor(0, device='cuda'))",
+            "torch._assert_async(torch.tensor(0.0, device='cuda'))",
+            "torch._assert_async(torch.tensor(False, device='cuda'))",
+            "torch._assert_async(torch.tensor(0 + 0j, device='cuda'))",
         ]
 
         import subprocess

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1827,7 +1827,7 @@ t2.start()
 
     # ROCm doesn't support device side asserts
     @skipIfRocm
-    def test_cuda_assert_async(self):
+    def test_fixed_cuda_assert_async(self):
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with no values is ambiguous"):
             torch.assert_async(torch.tensor([], device="cuda"))
         with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with more than one value is ambiguous"):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2366,22 +2366,22 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
         def test_assert_async(self):
             with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with no values is ambiguous"):
-                torch.assert_async(torch.tensor([]))
+                torch._assert_async(torch.tensor([]))
             with self.assertRaisesRegex(RuntimeError, "Boolean value of Tensor with more than one value is ambiguous"):
-                torch.assert_async(torch.tensor([0, 0]))
+                torch._assert_async(torch.tensor([0, 0]))
             with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-                torch.assert_async(torch.tensor(0))
-            torch.assert_async(torch.tensor(1))
-            torch.assert_async(torch.tensor(0.1))
-            torch.assert_async(torch.tensor(-0.1))
+                torch._assert_async(torch.tensor(0))
+            torch._assert_async(torch.tensor(1))
+            torch._assert_async(torch.tensor(0.1))
+            torch._assert_async(torch.tensor(-0.1))
             with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-                torch.assert_async(torch.tensor(0.0))
-            torch.assert_async(torch.tensor(True))
+                torch._assert_async(torch.tensor(0.0))
+            torch._assert_async(torch.tensor(True))
             with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-                torch.assert_async(torch.tensor(False))
-            torch.assert_async(torch.tensor(0 + 0.1j))
+                torch._assert_async(torch.tensor(False))
+            torch._assert_async(torch.tensor(0 + 0.1j))
             with self.assertRaisesRegex(RuntimeError, "Expected Tensor with single nonzero value, but got zero"):
-                torch.assert_async(torch.tensor(0 + 0j))
+                torch._assert_async(torch.tensor(0 + 0j))
 
         # NB: we must not be built with CUDA; if we are built with CUDA but no CUDA
         # is available, we get a different error.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -10565,9 +10565,9 @@ Example::
     device(type='cpu')
 """)
 
-add_docstr(torch.assert_async,
+add_docstr(torch._assert_async,
            r"""
-assert_async(tensor) -> void
+_assert_async(tensor) -> void
 
 Asynchronously assert that the contents of tensor are nonzero.  For CPU tensors,
 this is equivalent to ``assert tensor`` or ``assert tensor.is_nonzero()``; for

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -272,7 +272,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.argmin: lambda input: -1,
         torch.argsort: lambda input, dim=None: -1,
         torch.asin: lambda input, out=None: -1,
-        torch.assert_async: lambda input: -1,
+        torch._assert_async: lambda input: -1,
         torch.arcsin: lambda input, out=None: -1,
         torch.asinh: lambda input, out=None: -1,
         torch.arcsinh: lambda input, out=None: -1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53276 Prefix assert_async with underscore, fix some bugs in assert_async CUDA testing**

- One of the tests had a syntax error (but the test
  wasn't fine grained enough to catch this; any error
  was a pass)
- Doesn't work on ROCm

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D26820048](https://our.internmc.facebook.com/intern/diff/D26820048)