### PR TITLE
[PyTorch] Reduce size of register_symbols.cpp

### DIFF
--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -23,6 +23,14 @@ std::string qual_name_for_entry(const Entry& entry) {
   return s;
 }
 
+// NOTE: we could save even more space by packing the string data as follows:
+// constexpr char namespaces[] = "namespaces\0prim\0aten\0...";
+// constexpr char unqual_names[] = "prim\0aten\0cuda\0...";
+// and then storing two uint16_t (or uint32_t if needed) offsets into
+// the raw string tables in Entry instead of 8-byte pointers.
+// I haven't implemented that because it's not clear to me how to
+// dedupe the namespaces array at compile-time, particularly in C++14,
+// but it would be straightforward if we switched to codegen.
 constexpr Entry entries[] = {
 #define SYMBOL_ENTRY(n, s) {#n, #s, n::s, namespaces::n},
 

--- a/aten/src/ATen/core/register_symbols.cpp
+++ b/aten/src/ATen/core/register_symbols.cpp
@@ -12,14 +12,15 @@ struct Entry {
 };
 
 std::string qual_name_for_entry(const Entry& entry) {
+  const char *const sep = "::";
   const auto namespace_len = strlen(entry.namespace_);
+  const auto sep_len = strlen(sep);
   const auto unqual_name_len = strlen(entry.unqual_name);
   std::string s;
-  s.reserve(namespace_len + strlen("::") + unqual_name_len);
-  s.append(entry.namespace_);
-  s.push_back(':');
-  s.push_back(':');
-  s.append(entry.unqual_name);
+  s.reserve(namespace_len + sep_len + unqual_name_len);
+  s.append(entry.namespace_, namespace_len);
+  s.append(sep, sep_len);
+  s.append(entry.unqual_name, unqual_name_len);
   return s;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53278 [PyTorch] Reduce size of register_symbols.cpp**

We can avoid duplicating the string data for the namespaces
by assembling qualified names ourselves as needed.

Differential Revision: [D26820648](https://our.internmc.facebook.com/intern/diff/D26820648/)