### PR TITLE
FIX make sure we import the correct object from multiprocessing

### DIFF
--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -22,11 +22,19 @@ __all__ = ['set_sharing_strategy', 'get_sharing_strategy',
            'get_all_sharing_strategies']
 
 
-from multiprocessing import *  # noqa: F403
+# Compat from older version of python to make sure we get the objects
+# compatible with the default context.
+import multiprocessing as mp
 
+_default_context = mp.get_context()
+__all__ctx = [x for x in dir(_default_context) if not x.startswith('_')]
+__all__mp = [
+    x for x in dir(mp) if x not in __all__ctx and not x.startswith('_')
+]
+globals().update((name, getattr(_default_context, name)) for name in __all__ctx)
+globals().update((name, getattr(mp, name)) for name in __all__mp)
 
-__all__ += multiprocessing.__all__  # type: ignore[attr-defined]
-
+__all__ += __all__ctx + __all__mp
 
 # This call adds a Linux specific prctl(2) wrapper function to this module.
 # See https://github.com/pytorch/pytorch/pull/14391 for more information.

--- a/torch/multiprocessing/__init__.pyi
+++ b/torch/multiprocessing/__init__.pyi
@@ -1,0 +1,9 @@
+# Get the type definitions from both multiprocessing and the local spawn module
+from multiprocessing import *
+from .spawn import *
+
+# Type annotations for the functions defined in the torch.multiprocessing module
+from typing import Set
+def set_sharing_strategy(new_strategy: str) -> None: ...
+def get_sharing_strategy() -> str: ...
+def get_all_sharing_strategies() -> Set[str]: ...


### PR DESCRIPTION
Fixes #44687.

The issue was that the Process object is not the one from the `_default_context` which should be `loky` when nesting `loky` calls.
