### PR TITLE
[PyTorch] Move std::strings in dispatch when possible

### DIFF
--- a/tools/codegen/api/translate.py
+++ b/tools/codegen/api/translate.py
@@ -54,7 +54,7 @@ class UnsatError(RuntimeError):
 def translate(
     bindings: Sequence[Union[Expr, Binding]],
     goals: Sequence[Union[CType, Binding]],
-    *, method: bool = False
+    *, method: bool = False, move_ok: bool = False
 ) -> List[Expr]:
 
     binding_exprs: List[Expr] = []
@@ -120,6 +120,8 @@ Check this module for more information.
             return solve(goal, direct=True)
 
         if goal in ctx:
+            if move_ok and goal.cpp_type() == "std::string":
+                return f"std::move({ctx[goal]})"
             # Trivial
             return ctx[goal]
 

--- a/tools/codegen/api/types.py
+++ b/tools/codegen/api/types.py
@@ -280,8 +280,5 @@ class NativeSignature:
     def returns_type(self) -> str:
         return native.returns_type(self.func.returns)
 
-    def dispatcher_exprs(self) -> List[Expr]:
-        return translate.translate(self.arguments(), dispatcher.arguments(self.func), method=False)
-
 # Functions only, no types
 from tools.codegen.api import cpp, dispatcher, native, translate

--- a/tools/codegen/api/types.py
+++ b/tools/codegen/api/types.py
@@ -281,4 +281,4 @@ class NativeSignature:
         return native.returns_type(self.func.returns)
 
 # Functions only, no types
-from tools.codegen.api import cpp, dispatcher, native, translate
+from tools.codegen.api import cpp, dispatcher, native

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -111,7 +111,7 @@ class RegisterDispatchKey:
             def generate_defn(cpp_sig: CppSignature) -> str:
                 return f"""
 {cpp_sig.defn()} {{
-return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments()))});
+return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments(), move_ok=True))});
 }}
 """
             result = generate_defn(cpp_sig_group.signature)
@@ -382,7 +382,7 @@ struct {class_name} final : public {parent_class} {{
             def generate_defn(cpp_sig: CppSignature) -> str:
                 return f"""
 {cpp_sig.defn()} {{
-return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments()))});
+return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), sig.arguments(), move_ok=True))});
 }}
 """
             result = generate_defn(cpp_sig_group.signature)
@@ -428,7 +428,8 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 e.expr for e in translate(
                     context,
                     structured.meta_arguments(self.g),
-                    method=False
+                    method=False,
+                    move_ok=False
                 )
             )
             sig_body.append(f"op.meta({meta_exprs});")
@@ -458,7 +459,8 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                     e.expr for e in translate(
                         context,
                         out_sig.arguments(),
-                        method=False
+                        method=False,
+                        move_ok=True
                     )
                 )
                 # TODO: I think this means structured won't work with method
@@ -477,7 +479,8 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                     e.expr for e in translate(
                         context,
                         structured.impl_arguments(self.g),
-                        method=False
+                        method=False,
+                        move_ok=True
                     )
                 )
                 sig_body.append(f"op.impl({impl_exprs});")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53285 [PyTorch] Move std::strings in dispatch when possible**

When we have a `std::string` by-value argument and we're
forwarding that to another function by value, we need to use
`std::move` to avoid copying the string.

Differential Revision: [D26822649](https://our.internmc.facebook.com/intern/diff/D26822649/)