### PR TITLE
Modify assert order to correct the error message when nan appears in multinomial on cuda

### DIFF
--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -194,9 +194,9 @@ sampleMultinomialOnce(int64_t* dest,
     scalar_t val;
     for (int cat = threadIdx.x; cat < categories; cat += blockDim.x) {
       val = dist[curDist * stride_dist + cat * stride_categories];
-      CUDA_KERNEL_ASSERT(val >= zero);
-      CUDA_KERNEL_ASSERT(!THCNumerics<scalar_t>::isinf(val));
       CUDA_KERNEL_ASSERT(!THCNumerics<scalar_t>::isnan(val));
+      CUDA_KERNEL_ASSERT(!THCNumerics<scalar_t>::isinf(val));
+      CUDA_KERNEL_ASSERT(val >= zero);
       sum = sum + static_cast<accscalar_t>(val);
     }
 


### PR DESCRIPTION
Summary: Modify assert order to correct the error message when nan appears in multinomial on cuda.

Previously if there is nan in the prob tensor, it will also assert fail for val >= zero, so there will be no nan error log.

Test Plan: unittest

Differential Revision: D26824353

