### PR TITLE
[Benchmark] Benchmark perormance with smaller Scalar

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -51,19 +51,6 @@ struct GenericDict;
 struct Object;
 struct PyObjectHolder;
 struct EnumHolder;
-// We need a ComplexHolder because currently the payloads in the Union
-// only take 64 bits. Since ComplexDouble takes up 128 bits, and is too big
-// to fit in the IValue directly, we indirect complex numbers through an intrusive
-// pointer to ComplexHolder (which contains a c10::complex).
-struct ComplexHolder : c10::intrusive_ptr_target {
-  public:
-    template <typename T>
-    ComplexHolder(c10::complex<T> c) {
-      val = convert<decltype(val), c10::complex<T>>(c);
-    }
-    ComplexHolder() {}
-    c10::complex<double> val;
-};
 } // namespace ivalue
 
 // This is an owning wrapper for a c10::optional<std::vector<T>>

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -15,6 +15,7 @@
 #include <c10/core/UndefinedTensorImpl.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/hash.h>
+#include <c10/util/ComplexHolder.h>
 
 namespace torch {
 namespace jit {
@@ -135,7 +136,7 @@ inline c10::intrusive_ptr<ivalue::EnumHolder> IValue::toEnumHolder() const& {
 }
 inline c10::complex<double> IValue::toComplexDouble() const {
   TORCH_INTERNAL_ASSERT(isComplexDouble(), "Expected ComplexDouble but got ", tagKind());
-  auto ptr = toIntrusivePtr<ivalue::ComplexHolder>();
+  auto ptr = toIntrusivePtr<c10::ComplexHolder>();
   return (*ptr).val;
 }
 inline at::Tensor IValue::toTensor() && {
@@ -1271,7 +1272,7 @@ inline IValue::IValue(c10::intrusive_ptr<at::Quantizer> v)
 template <typename T>
 inline IValue::IValue(c10::complex<T> c)
     : tag(Tag::ComplexDouble), is_intrusive_ptr(true) {
-  auto v = c10::make_intrusive<ivalue::ComplexHolder>(c);
+  auto v = c10::make_intrusive<c10::ComplexHolder>(c);
   payload.u.as_intrusive_ptr = v.release();
 }
 

--- a/c10/core/Scalar.cpp
+++ b/c10/core/Scalar.cpp
@@ -7,7 +7,7 @@ Scalar Scalar::operator-() const {
   if (isFloatingPoint()) {
     return Scalar(-v.d);
   } else if (isComplex()) {
-    return Scalar(-v.z);
+    return Scalar(-(*v.z).val);
   } else {
     return Scalar(-v.i);
   }
@@ -15,7 +15,7 @@ Scalar Scalar::operator-() const {
 
 Scalar Scalar::conj() const {
   if (isComplex()) {
-    return Scalar(std::conj(v.z));
+    return Scalar(std::conj((*v.z).val));
   } else {
     return *this;
   }
@@ -23,7 +23,7 @@ Scalar Scalar::conj() const {
 
 Scalar Scalar::log() const {
   if (isComplex()) {
-    return std::log(v.z);
+    return std::log((*v.z).val);
   } else if (isFloatingPoint()) {
     return std::log(v.d);
   } else {

--- a/c10/util/ComplexHolder.h
+++ b/c10/util/ComplexHolder.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <c10/util/intrusive_ptr.h>
+
+namespace c10 {
+
+// TODO: Revise Comment...
+//
+// We need a ComplexHolder because currently the payloads in the Union
+// only take 64 bits. Since ComplexDouble takes up 128 bits, and is too big
+// to fit in the IValue directly, we indirect complex numbers through an intrusive
+// pointer to ComplexHolder (which contains a c10::complex).
+struct C10_API ComplexHolder : intrusive_ptr_target {
+  public:
+    template <typename T>
+    ComplexHolder(c10::complex<T> c) {
+      val = convert<decltype(val), c10::complex<T>>(c);
+    }
+    ComplexHolder() {}
+    c10::complex<double> val;
+};
+
+} // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53289 [Benchmark] Benchmark perormance with smaller Scalar**

Summary:
This is done by holding (potential) complex data on heap, instead of in struct.
This PR doesn't contain necessary copy/move constructor/assignment implementation
to handle complex value correctly.

Test Plan:
USE_CUDA=0 BUILD_TEST=0 python setup.py install

Reviewers:

Subscribers:

Tasks:

Tags: