### PR TITLE
.github: Add workflow to build libtorch

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -115,7 +115,6 @@ def generate_libtorch_matrix(is_pr: bool) -> List[Dict[str, str]]:
     ]
     return [
         {
-            "python_version": "3.7",
             "gpu_arch_type": arch_type(arch_version),
             "gpu_arch_version": arch_version,
             "container_image": LIBTORCH_CONTAINER_IMAGES[(arch_version, abi_version)],

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -49,6 +49,16 @@ CONDA_CONTAINER_IMAGES = {
     "cpu": "pytorch/conda-builder:cpu"
 }
 
+LIBTORCH_CONTAINER_IMAGES = {
+    **{
+        # TODO: Re-do manylinux CUDA image tagging scheme to be similar to
+        #       ROCM so we don't have to do this replacement
+        gpu_arch: f"pytorch/manylinux-cuda{gpu_arch.replace('.', '')}"
+        for gpu_arch in CUDA_ARCHES
+    },
+    "cpu": "pytorch/manylinux-cpu",
+}
+
 FULL_PYTHON_VERSIONS = [
     "3.6",
     "3.7",
@@ -92,7 +102,10 @@ def generate_matrix(include_cuda=True, include_rocm=False):
             ),
             "conda_container_image": CONDA_CONTAINER_IMAGES.get(
                 arch_version, ""
-            )
+            ),
+            "libtorch_container_image": LIBTORCH_CONTAINER_IMAGES.get(
+                arch_version, ""
+            ),
         })
     return json.dumps({"include": matrix})
 

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -71,8 +71,15 @@ def is_pull_request():
     return False
     # return os.environ.get("GITHUB_HEAD_REF")
 
-def generate_matrix(include_cuda=True, include_rocm=False):
+def generate_matrix(
+    *,
+    all_pythons=True,
+    include_cuda=True,
+    include_rocm=False,
+):
     python_versions = FULL_PYTHON_VERSIONS
+    if not all_pythons:
+        python_versions = ["3.7"]
     cuda_versions = CUDA_ARCHES
     rocm_versions = ROCM_ARCHES
     arches = ["cpu"]
@@ -110,14 +117,18 @@ def generate_matrix(include_cuda=True, include_rocm=False):
     return json.dumps({"include": matrix})
 
 def main():
+    all_pythons = True
     include_cuda = True
     include_rocm = True
+    if os.environ.get("SINGLE_PYTHON", False):
+        all_pythons = False
     if os.environ.get("NO_ROCM", False):
         include_rocm = False
     if os.environ.get("NO_CUDA", False):
         include_cuda = False
     print(
         generate_matrix(
+            all_pythons=all_pythons,
             include_cuda=include_cuda,
             include_rocm=include_rocm
         )

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -117,9 +117,9 @@ def generate_libtorch_matrix(is_pr: bool) -> List[Dict[str, str]]:
         {
             "gpu_arch_type": arch_type(arch_version),
             "gpu_arch_version": arch_version,
-            "container_image": LIBTORCH_CONTAINER_IMAGES[(arch_version, abi_version)],
             "libtorch_variant": libtorch_variant,
             "devtoolset": abi_version,
+            "container_image": LIBTORCH_CONTAINER_IMAGES[(arch_version, abi_version)],
         }
         # We don't currently build libtorch for rocm
         for arch_version in ["cpu"] + snip_if(is_pr, CUDA_ARCHES)

--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -82,8 +82,11 @@ def is_pull_request() -> bool:
     # return os.environ.get("GITHUB_HEAD_REF")
 
 
-def snip_if(is_pr: bool, l: List[str]) -> List[str]:
-    return [l[-1]] if is_pr else l
+def snip_if(is_pr: bool, versions: List[str]) -> List[str]:
+    """
+    Return the full list of versions, or just the latest if on a PR.
+    """
+    return [versions[-1]] if is_pr else versions
 
 
 def generate_conda_matrix(is_pr: bool) -> List[Dict[str, str]]:

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -59,16 +59,6 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
+      fail-fast: false
     container:
       image: ${{ matrix.container_image }}
     env:

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -9,14 +9,11 @@ on:
 jobs:
   generate-build-matrix:
     if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
       image: python:3.9
-    env:
-      # We don't currently build conda packages for rocm
-      NO_ROCM: 1
     steps:
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -24,7 +21,7 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py)
+          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py conda)
           echo "${MATRIX}"
           echo "::set-output name=matrix::${MATRIX}"
   build-conda:
@@ -35,7 +32,7 @@ jobs:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
     container:
-      image: ${{ matrix.conda_container_image }}
+      image: ${{ matrix.container_image }}
     env:
       DESIRED_PYTHON: ${{ matrix.python_version }}
       # TODO: This is a legacy variable that we eventually want to get rid of in

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -57,6 +57,8 @@ jobs:
       PYTORCH_BUILD_NUMBER: 1
       SKIP_ALL_TESTS: 1
     steps:
+      - name: Clean runner workspace
+        run: rm -rf "${{ github.workspace }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Generating build matrix
         id: set-matrix
         run: |

--- a/.github/workflows/build_linux_conda.yml
+++ b/.github/workflows/build_linux_conda.yml
@@ -59,6 +59,16 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
+      - name: Checkout PR tip
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # We are on a PR, so actions/checkout leaves us on a merge commit.
+            # Check out the actual tip of the branch.
+            git checkout ${{ github.event.pull_request.head.sha }}
+          fi
+          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Generating build matrix
         id: set-matrix
         run: |

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -1,0 +1,90 @@
+name: Build Linux libtorch
+
+on:
+  # TODO: These are only runnable from workflow_dispatch, we need to eventually add
+  #       a cron
+  # TODO: Add an on_release trigger to build on tags
+  workflow_dispatch:
+
+jobs:
+  generate-build-matrix:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    runs-on: ubuntu-18.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    container:
+      image: python:3.9
+    env:
+      # We don't currently build libtorch for rocm
+      NO_ROCM: 1
+    steps:
+      - name: Clone pytorch/pytorch
+        uses: actions/checkout@v2
+      - name: Generating build matrix
+        id: set-matrix
+        run: |
+          # outputting for debugging purposes
+          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py)
+          echo "${MATRIX}"
+          echo "::set-output name=matrix::${MATRIX}"
+  build-libtorch:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    needs: generate-build-matrix
+    runs-on: linux.2xlarge
+    strategy:
+      matrix:
+        ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
+    container:
+      image: ${{ matrix.libtorch_container_image }}
+    env:
+      DESIRED_PYTHON: ${{ matrix.python_version }}
+      # TODO: This is a legacy variable that we eventually want to get rid of in
+      #       favor of GPU_ARCH_VERSION
+      DESIRED_CUDA: ${{ matrix.gpu_arch_version }}
+      GPU_ARCH_VERSION: ${{ matrix.GPU_ARCH_VERSION }}
+      GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
+      BUILD_PYTHONLESS: 1
+      PYTORCH_BUILD_NUMBER: 1
+      SKIP_ALL_TESTS: 1
+    steps:
+      - name: Clone pytorch/pytorch
+        uses: actions/checkout@v2
+        with:
+          path: pytorch
+          submodules: recursive
+      - name: Clone pytorch/builder
+        uses: actions/checkout@v2
+        with:
+          repository: pytorch/builder
+          path: builder
+      - name: Generate version string
+        working-directory: pytorch/
+        run: |
+          version=$(.github/scripts/generate_pytorch_version.py)
+          echo "Generated version: ${version}"
+          echo "PYTORCH_BUILD_VERSION=${version}" >> $GITHUB_ENV
+      - name: Set BUILD_SPLIT_CUDA
+        if: ${{ matrix.gpu_arch_type == 'cuda' && matrix.gpu_arch_version == '11.1' }}
+        run: |
+          echo "BUILD_SPLIT_CUDA=1" >> $GITHUB_ENV
+      # TODO: Remove this once we remove the need for the directories to be
+      #       in specific locations
+      - name: Symlink repositories to root directory (for legacy scripts purposes)
+        run: |
+          ln -s $(pwd)/pytorch /pytorch
+          ln -s $(pwd)/builder /builder
+      # TODO: Bundle the correct build script in the base container image so
+      #       that we don't have to do this type of specification
+      - name: Build PyTorch binary (CUDA specific)
+        if: ${{ matrix.gpu_arch_type == 'cuda' }}
+        run: |
+          /builder/manywheel/build.sh
+      - name: Build PyTorch binary (CPU specific)
+        if: ${{ matrix.gpu_arch_type == 'cpu' }}
+        run: |
+          /builder/manywheel/build_cpu.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pytorch-libtorch-py${{ matrix.python_version }}-${{matrix.gpu_arch_type}}-${{ matrix.gpu_arch_version }}
+          path: /remote/**/*.bz2
+      # TODO: Add a step here for uploading binaries

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -5,6 +5,7 @@ on:
   #       a cron
   # TODO: Add an on_release trigger to build on tags
   workflow_dispatch:
+  pull_request: # TODO: remove before undrafting
 
 jobs:
   generate-build-matrix:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -15,10 +15,6 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
       image: python:3.9
-    env:
-      SINGLE_PYTHON: 1
-      # We don't currently build libtorch for rocm
-      NO_ROCM: 1
     steps:
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
@@ -26,7 +22,7 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py)
+          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py libtorch)
           echo "${MATRIX}"
           echo "::set-output name=matrix::${MATRIX}"
   build-libtorch:
@@ -37,7 +33,7 @@ jobs:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
     container:
-      image: ${{ matrix.libtorch_container_image }}
+      image: ${{ matrix.container_image }}
     env:
       DESIRED_PYTHON: ${{ matrix.python_version }}
       # TODO: This is a legacy variable that we eventually want to get rid of in
@@ -46,6 +42,7 @@ jobs:
       GPU_ARCH_VERSION: ${{ matrix.GPU_ARCH_VERSION }}
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       BUILD_PYTHONLESS: 1
+      LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
       PYTORCH_BUILD_NUMBER: 1
       SKIP_ALL_TESTS: 1
     steps:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -16,6 +16,7 @@ jobs:
     container:
       image: python:3.9
     env:
+      SINGLE_PYTHON: 1
       # We don't currently build libtorch for rocm
       NO_ROCM: 1
     steps:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -54,16 +54,6 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -54,6 +54,16 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
+      - name: Checkout PR tip
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # We are on a PR, so actions/checkout leaves us on a merge commit.
+            # Check out the actual tip of the branch.
+            git checkout ${{ github.event.pull_request.head.sha }}
+          fi
+          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -5,7 +5,6 @@ on:
   #       a cron
   # TODO: Add an on_release trigger to build on tags
   workflow_dispatch:
-  pull_request: # TODO: remove before undrafting
 
 jobs:
   generate-build-matrix:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -43,6 +43,8 @@ jobs:
       GPU_ARCH_TYPE: ${{ matrix.gpu_arch_type }}
       BUILD_PYTHONLESS: 1
       LIBTORCH_VARIANT: ${{ matrix.libtorch_variant }}
+      # TODO: remove this and bake env var into the Docker image
+      DESIRED_DEVTOOLSET: ${{ matrix.devtoolset }}
       PYTORCH_BUILD_NUMBER: 1
       SKIP_ALL_TESTS: 1
     steps:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -85,5 +85,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: pytorch-libtorch-py${{ matrix.python_version }}-${{matrix.gpu_arch_type}}-${{ matrix.gpu_arch_version }}
-          path: /remote/**/*.bz2
+          path: /remote/**/*.zip
       # TODO: Add a step here for uploading binaries

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
+      fail-fast: false
     container:
       image: ${{ matrix.container_image }}
     env:

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -35,7 +35,8 @@ jobs:
     container:
       image: ${{ matrix.container_image }}
     env:
-      DESIRED_PYTHON: ${{ matrix.python_version }}
+      # TODO: remove this var from the libtorch builder script(s)
+      DESIRED_PYTHON: '3.7'
       # TODO: This is a legacy variable that we eventually want to get rid of in
       #       favor of GPU_ARCH_VERSION
       DESIRED_CUDA: ${{ matrix.gpu_arch_version }}
@@ -86,6 +87,6 @@ jobs:
           /builder/manywheel/build_cpu.sh
       - uses: actions/upload-artifact@v2
         with:
-          name: pytorch-libtorch-py${{ matrix.python_version }}-${{matrix.gpu_arch_type}}-${{ matrix.gpu_arch_version }}
+          name: pytorch-libtorch-${{ matrix.libtorch_variant }}-${{ matrix.devtoolset }}-${{matrix.gpu_arch_type}}-${{ matrix.gpu_arch_version }}
           path: /remote/**/*.zip
       # TODO: Add a step here for uploading binaries

--- a/.github/workflows/build_linux_libtorch.yml
+++ b/.github/workflows/build_linux_libtorch.yml
@@ -52,6 +52,8 @@ jobs:
       PYTORCH_BUILD_NUMBER: 1
       SKIP_ALL_TESTS: 1
     steps:
+      - name: Clean runner workspace
+        run: rm -rf "${{ github.workspace }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -46,6 +46,8 @@ jobs:
       PYTORCH_BUILD_NUMBER: 1
       SKIP_ALL_TESTS: 1
     steps:
+      - name: Clean runner workspace
+        run: rm -rf "${{ github.workspace }}"
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -48,6 +48,16 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
+      - name: Checkout PR tip
+        run: |
+          set -eux
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # We are on a PR, so actions/checkout leaves us on a merge commit.
+            # Check out the actual tip of the branch.
+            git checkout ${{ github.event.pull_request.head.sha }}
+          fi
+          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
+        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -33,6 +33,7 @@ jobs:
     strategy:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
+      fail-fast: false
     container:
       image: ${{ matrix.container_image }}
     env:

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -48,16 +48,6 @@ jobs:
         with:
           path: pytorch
           submodules: recursive
-      - name: Checkout PR tip
-        run: |
-          set -eux
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # We are on a PR, so actions/checkout leaves us on a merge commit.
-            # Check out the actual tip of the branch.
-            git checkout ${{ github.event.pull_request.head.sha }}
-          fi
-          echo ::set-output name=commit_sha::$(git rev-parse HEAD)
-        id: get_pr_tip
       - name: Clone pytorch/builder
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -21,7 +21,7 @@ jobs:
         id: set-matrix
         run: |
           # outputting for debugging purposes
-          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py)
+          MATRIX=$(python .github/scripts/generate_binary_build_matrix.py wheels)
           echo "${MATRIX}"
           echo "::set-output name=matrix::${MATRIX}"
   build-wheel:
@@ -32,7 +32,7 @@ jobs:
       matrix:
         ${{ fromJson(needs.generate-build-matrix.outputs.matrix) }}
     container:
-      image: ${{ matrix.wheel_container_image }}
+      image: ${{ matrix.container_image }}
     env:
       DESIRED_PYTHON: ${{ matrix.python_version }}
       # TODO: This is a legacy variable that we eventually want to get rid of in

--- a/.github/workflows/build_linux_wheels.yml
+++ b/.github/workflows/build_linux_wheels.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Clone pytorch/pytorch
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Generating build matrix
         id: set-matrix
         run: |

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -38,7 +38,6 @@ files =
     .github/scripts/generate_binary_build_matrix.py,
     tools/autograd/*.py,
     tools/codegen/gen.py,
-    tools/codegen/gen.py,
     tools/print_test_stats.py,
     tools/pyi/*.py,
     tools/stats_utils/*.py,

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -35,7 +35,9 @@ implicit_reexport = False
 strict_equality = True
 
 files =
+    .github/scripts/generate_binary_build_matrix.py,
     tools/autograd/*.py,
+    tools/codegen/gen.py,
     tools/codegen/gen.py,
     tools/print_test_stats.py,
     tools/pyi/*.py,


### PR DESCRIPTION
Based on #50633 and #51243.

Things left to do:

- [x] modify `.github/scripts/generate_binary_build_matrix.py` further
  - [x] add option for not iterating over Python version
  - [x] add `LIBTORCH_VARIANT`
  - [x] add option for cxx11
  - [x] fix the artifact uploading
  - [x] remove `pull_request` hook before merging

**Test plan:**

[CI](https://github.com/pytorch/pytorch/actions/runs/665781075).