### PR TITLE
Use the conda channel defined in docker.Makefile to install cudatoolkit

### DIFF
--- a/.github/scripts/build_publish_nightly_docker.sh
+++ b/.github/scripts/build_publish_nightly_docker.sh
@@ -3,14 +3,13 @@
 set -xeuo pipefail
 
 PYTORCH_DOCKER_TAG=$(git describe --tags --always)-devel
-CUDA_VERSION=11.1.1
+CUDA_VERSION=11.1
 
 # Build PyTorch nightly docker
 make -f docker.Makefile \
      DOCKER_REGISTRY=ghcr.io \
      DOCKER_ORG=pytorch \
      CUDA_VERSION=${CUDA_VERSION} \
-     CUDA_CHANNEL=conda-forge \
      DOCKER_IMAGE=pytorch-nightly \
      DOCKER_TAG=${PYTORCH_DOCKER_TAG} \
      INSTALL_CHANNEL=pytorch-nightly BUILD_TYPE=official devel-image

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -14,7 +14,7 @@ BASE_RUNTIME              = ubuntu:18.04
 BASE_DEVEL                = nvidia/cuda:$(CUDA_VERSION)-cudnn$(CUDNN_VERSION)-devel-ubuntu18.04
 
 # The conda channel to use to install cudatoolkit
-CUDA_CHANNEL              = defaults
+CUDA_CHANNEL              = nvidia
 # The conda channel to use to install pytorch / torchvision
 INSTALL_CHANNEL           = pytorch
 


### PR DESCRIPTION
Test Plan:
Nightly Docker build CI

This is a follow-up PR after docker moved default CUDA => 11.1. Only merge this after #53299 is committed.
