### PR TITLE
[Benchmark Only] Remove move/copy constructor/assignment from Scalar

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -27,49 +27,6 @@ class C10_API Scalar {
  public:
   Scalar() : Scalar(int64_t(0)) {}
 
-  Scalar(const Scalar& rhs) : tag(rhs.tag), v(rhs.v) {
-      if (isComplex()) {
-        c10::raw::intrusive_ptr::incref(v.z);
-      }
-  }
-
-  Scalar(Scalar&& rhs) noexcept : tag(rhs.tag), v(rhs.v) {}
-
-  ~Scalar() {
-    freeComplexIfNecessary();
-  }
-
-  Scalar& operator=(const Scalar& rhs) & {
-    // TODO: Note this method is implemented differently from the lvalue assignment operator of IValue
-    freeComplexIfNecessary();
-
-    tag = rhs.tag;
-    v = rhs.v;
-
-    if (isComplex()) {
-        c10::raw::intrusive_ptr::incref(v.z);
-    }
-    return *this;
-  }
-
-  C10_ALWAYS_INLINE Scalar& operator=(Scalar&& rhs) & noexcept {
-    if (&rhs == this) {
-      return *this;
-    }
-
-    freeComplexIfNecessary();
-
-    tag = rhs.tag;
-    v = rhs.v;
-
-    if (rhs.isComplex()) {
-      // Clear complex in rhs
-      rhs.tag = Tag::HAS_i;
-      rhs.v.i = 0;
-    }
-    return *this;
-  }
-
 #define DEFINE_IMPLICIT_CTOR(type, name)      \
   Scalar(type vv) : Scalar(vv, true) { }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53329 [Benchmark Only] Benchmark "almost trivial" move/copy constructor/assignment for Scalar
* **#53318 [Benchmark Only] Remove move/copy constructor/assignment from Scalar**
* #53247 Use ComplexHolder pointer in c10:Scalar
* #53246 Refactor ivalue::ComplexHolder as a top-level struct

Summary:
This will cause Scalar incorrectly handle complex value (there will be memory
leak). It's just used to see performance.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: