### PR TITLE
[Static Runtime] remove redundant gather_ranges when fusing

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -222,6 +222,43 @@ void PrecomputeMultiplierShiftForSigridHash(
   fuse.runOnGraph(graph);
 }
 
+void ClipRangesGatherRangesX2SigridHash(
+    std::shared_ptr<torch::jit::Graph>& graph) {
+  // Placeholder is a dummy op used to capture the first subgraph
+  std::string pattern = R"IR(
+    graph(%ranges, %values, %max_length, %salt, %max_value, %hash_into_int32):
+        %clipped : Tensor = fb::clip_ranges(%ranges, %max_length)
+        %output : Tensor, %unused : Tensor = fb::gather_ranges(%values, %clipped)
+        %sigrid_hash_out : Tensor = fb::sigrid_hash(%output, %salt, %max_value, %hash_into_int32)
+        return (%sigrid_hash_out, %clipped))IR";
+  std::string fused_pattern = R"IR(
+    graph(%ranges, %values, %max_length, %salt, %max_value, %hash_into_int32):
+        %sigrid_hash_out : Tensor, %clipped : Tensor = fb::placeholder(%ranges, %values, %max_length, %salt, %max_value, %hash_into_int32)
+        return (%sigrid_hash_out, %clipped))IR";
+
+  // the second gather_ranges can be eliminated because the `lengths` is
+  // produces is identical to the lengths produced by
+  // clip_ranges_gather_sigrid_hash_v3 (caveat, the fused ops makes some
+  // simplifying assumptions about the ranges input)
+  std::string pattern2 = R"IR(
+    graph(%gather2_values, %ranges, %values, %max_length, %salt, %max_value, %hash_into_int32):
+        %sigrid_hash_out : Tensor, %clipped : Tensor = fb::placeholder(%ranges, %values, %max_length, %salt, %max_value, %hash_into_int32)
+        %unused : Tensor, %lengths : Tensor = fb::gather_ranges(%gather2_values, %clipped)
+        return (%lengths, %sigrid_hash_out))IR";
+
+  std::string fused_pattern2 = R"IR(
+    graph(%gather2_values, %ranges, %values, %max_length, %salt, %max_value, %hash_into_int32):
+        %lengths : Tensor, %sigrid_hash_out : Tensor = fb::clip_ranges_gather_sigrid_hash_v3(%ranges, %values, %max_length, %salt, %max_value, %hash_into_int32)
+        return (%lengths, %sigrid_hash_out))IR";
+
+  SubgraphRewriter fuse;
+  fuse.RegisterRewritePattern(pattern, fused_pattern);
+  fuse.runOnGraph(graph);
+
+  fuse.RegisterRewritePattern(pattern2, fused_pattern2);
+  fuse.runOnGraph(graph);
+}
+
 void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 #ifdef FBCODE_CAFFE2
   ConcatAddMulReplaceNaNClip(graph);
@@ -231,6 +268,7 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
   ClipRangesGatherRangesLengthsToOffsets(graph);
   ClipRangesGatherSigridHash(graph);
   ClipRangesGatherRangesSigridHash(graph);
+  ClipRangesGatherRangesX2SigridHash(graph);
 
   // prioritize clip_ranges+gather_ranges+sigrid_hash fusion over
   // clip_ranges+gather_ranges


### PR DESCRIPTION
Summary: Whilst optimizing inline cvr local ro, found a pattern where gather_ranges is used redundantly. Fuse this pattern to remove unnecessary gather_ranges.

Reviewed By: hlu1

Differential Revision: D26659824

