### PR TITLE
[ONNX] Support torch.isinf, torch.any and torch.all export to ONNX

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5791,12 +5791,31 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2, float('inf')], [2, float('nan'), float('inf')]])
         self.run_test(M(), (x, ))
 
+    @skipIfUnsupportedMinOpsetVersion(9)  # ONNX IsNaN op is added in opset 9.
     def test_isnan(self):
         class M(torch.nn.Module):
             def forward(self, x):
                 return x.isnan()
 
         x = torch.tensor([[1, 2, float('inf')], [2, float('nan'), float('inf')]])
+        self.run_test(M(), (x, ))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_any(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x.any()
+
+        x = torch.tensor([[True, False], [False, False]])
+        self.run_test(M(), (x, ))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_all(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x.all()
+
+        x = torch.tensor([[True, False], [False, False]])
         self.run_test(M(), (x, ))
 
     def test_dropout(self):

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -298,5 +298,5 @@ def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128
     return g.op("DequantizeLinear", g.op("QuantizeLinear", inputs, scale, zero_point), scale, zero_point)
 
 def isinf(g, input):
-    from torch.onnx.symbolic_opset9 import _cast_Double
-    return g.op("IsInf", _cast_Double(g, input, False))
+    from torch.onnx.symbolic_opset9 import _cast_Double  # type: ignore
+    return g.op("IsInf", _cast_Double(g, input, False))  # type: ignore

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -296,3 +296,6 @@ def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128
     zero_point_dtype = torch.int8 if quant_min == -128 else torch.uint8
     zero_point = torch.tensor(zero_point, dtype=zero_point_dtype)  # ONNX requires zero_point to be tensor
     return g.op("DequantizeLinear", g.op("QuantizeLinear", inputs, scale, zero_point), scale, zero_point)
+
+def isinf(g, input):
+    return g.op("IsInf", input)

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -298,4 +298,5 @@ def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128
     return g.op("DequantizeLinear", g.op("QuantizeLinear", inputs, scale, zero_point), scale, zero_point)
 
 def isinf(g, input):
-    return g.op("IsInf", input)
+    from torch.onnx.symbolic_opset9 import _cast_Double
+    return g.op("IsInf", _cast_Double(g, input, False))

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -42,7 +42,9 @@ import warnings
 block_listed_operators = [
     "nonzero", "where", "scatter", "scatter_add", "erf", "sign", "isnan", "gather",
     "arange", "masked_fill",
-    "index_fill", "index_copy", "repeat_interleave"
+    "index_fill", "index_copy", "repeat_interleave",
+    "isnan",
+    "any", "all"
 ]
 
 for block_listed_op in block_listed_operators:

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2005,8 +2005,8 @@ def repeat_interleave(g, self, repeats, dim=None):
     input_sizes[dim], input_sizes_temp[dim] = -1, 1
     for idx, r_split in enumerate(r_splits):
         i_split = unsqueeze(g, i_splits[idx], dim + 1)
-        r_concat = [g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[:dim + 1])), 
-                    r_split, 
+        r_concat = [g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[:dim + 1])),
+                    r_split,
                     g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[dim + 1:]))]
         r_concat = g.op("Concat", *r_concat, axis_i=0)
         i_split = expand(g, i_split, r_concat, None)
@@ -2378,6 +2378,14 @@ def nonzero_numpy(g, input, _outputs=None):
 def isnan(g, input):
     output = g.op('IsNaN', input)
     return output
+
+def _any(g, input):
+    input = _cast_Long(g, input, False)  # type: ignore
+    input_sum = sym_help._reducesum_helper(g, input, keepdims_i=0)
+    return gt(g, input_sum, g.op("Constant", value_t=torch.LongTensor([0])))
+
+def _all(g, input):
+    return g.op("Not", _any(g, g.op("Not", input)))
 
 
 @parse_args('v', 'i', 'i', 'i')

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -32,6 +32,10 @@ def register_ops_helper(domain, version, iter_version):
             op = ('len', op[1])
         if op[0] == '_list':
             op = ('list', op[1])
+        if op[0] == '_any':
+            op = ('any', op[1])
+        if op[0] == '_all':
+            op = ('all', op[1])
         if isfunction(op[1]) and not is_registered_op(op[0], domain, version):
             register_op(op[0], op[1], domain, version)
 


### PR DESCRIPTION
Supported for ONNX export after opset 10.
This is not exportable to opsets < 10 due to
1. onnx::IsInf is introduced in opset 10
2. onnx::Equal does not accept float tensor prior to opset 11