### PR TITLE
[Benchmark Only] Benchmark "almost trivial" move/copy constructor/assignment for Scalar

### DIFF
--- a/c10/core/Scalar.h
+++ b/c10/core/Scalar.h
@@ -27,6 +27,24 @@ class C10_API Scalar {
  public:
   Scalar() : Scalar(int64_t(0)) {}
 
+  Scalar(const Scalar& rhs) : tag(rhs.tag), v(rhs.v) {}
+
+  Scalar(Scalar&& rhs) noexcept : tag(rhs.tag), v(rhs.v) {}
+
+  ~Scalar() {}
+
+  Scalar& operator=(const Scalar& rhs) & {
+    tag = rhs.tag;
+    v = rhs.v;
+    return *this;
+  }
+
+  Scalar& operator=(Scalar&& rhs) & noexcept {
+    tag = rhs.tag;
+    v = rhs.v;
+    return *this;
+  }
+
 #define DEFINE_IMPLICIT_CTOR(type, name)      \
   Scalar(type vv) : Scalar(vv, true) { }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53329 [Benchmark Only] Benchmark "almost trivial" move/copy constructor/assignment for Scalar**
* #53318 [Benchmark Only] Remove move/copy constructor/assignment from Scalar
* #53247 Use ComplexHolder pointer in c10:Scalar
* #53246 Refactor ivalue::ComplexHolder as a top-level struct

Summary:
The "almost trivial" move/copy constructor/assignment
mechaniscally copy the underlying data:

```
  Scalar(const Scalar& rhs) : tag(rhs.tag), v(rhs.v) {}
```

However, the difference with default (compiler-generated)
constructor/assignment is it breaks the POD property of Scalar.
(https://stackoverflow.com/a/36088134)

This measures the performance upperbound for ComplexHolder in Scalar.

For the benchmark:
Baseline: 28,707,818
ComplexHolder + "almost trivial" constructor/assignment: 28,684,612

This almost offset the 6.2% benefits provided by reducing Scalar size,
and only result in ~0.08% performance improvement.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: