### PR TITLE
[caffe2] Fix shape inference for LpNorm

### DIFF
--- a/caffe2/opt/bound_shape_inference_test.cc
+++ b/caffe2/opt/bound_shape_inference_test.cc
@@ -1008,3 +1008,29 @@ TEST(BoundShapeInference, Softmax) {
       {TensorBoundShape_DimType_CONSTANT, TensorBoundShape_DimType_CONSTANT},
       {1, 16});
 }
+
+TEST(BoundShapeInference, LpNorm) {
+  NetDef net;
+  net.add_op()->CopyFrom(CreateOperatorDef(
+      "LpNorm",
+      "",
+      {"input"},
+      {"output"},
+      {MakeArgument<int>("p", 1)}));
+  ShapeInfoMap shape_map;
+  shape_map.emplace(
+      "input",
+      makeTensorInfo(
+          {TensorBoundShape_DimType_CONSTANT,
+           TensorBoundShape_DimType_CONSTANT},
+          {1, 16}));
+  BoundShapeSpec spec(32, 1000);
+  BoundShapeInferencer eng(spec);
+  eng.InferBoundShapeAndType(net, shape_map, nullptr);
+  const auto& out_shape = eng.shape_info();
+  verifyShapeInfo(
+      out_shape,
+      "output",
+      {TensorBoundShape_DimType_CONSTANT},
+      {1});
+}

--- a/caffe2/opt/bound_shape_inferencer.cc
+++ b/caffe2/opt/bound_shape_inferencer.cc
@@ -171,6 +171,8 @@ void BoundShapeInferencer::InferOps(
     InferSparseLengthsSumSparseLookup(op);
   } else if (op.type() == "Softmax") {
     InferSoftmax(op);
+  } else if (op.type() == "LpNorm") {
+    InferLpNorm(op);
   } else {
     InferCommonOp(op);
   }
@@ -919,6 +921,16 @@ void BoundShapeInferencer::InferSoftmax(const OperatorDef& op) {
       ConvertToVec(it->second.shape.dims()),
       it->second.shape.data_type(),
       false);
+}
+
+void BoundShapeInferencer::InferLpNorm(const OperatorDef& op) {
+  CAFFE_ENFORCE_EQ(op.output_size(), 1, op.type(), " must have 1 output");
+  InferCommonOp(op);
+  auto it = shape_info_.find(op.output(0));
+  if (it != shape_info_.end()) {
+    it->second.setDimType(std::vector<TensorBoundShape::DimType>(
+        it->second.shape.dims_size(), TensorBoundShape_DimType_CONSTANT));
+  }
 }
 
 void BoundShapeInferencer::InferCommonOp(

--- a/caffe2/opt/bound_shape_inferencer.h
+++ b/caffe2/opt/bound_shape_inferencer.h
@@ -136,6 +136,7 @@ class TORCH_API BoundShapeInferencer : public BoundShapeInferencerBase {
   void InferTile(const OperatorDef& op);
   void InferSparseLengthsSumSparseLookup(const OperatorDef& op);
   void InferSoftmax(const OperatorDef& op);
+  void InferLpNorm(const OperatorDef& op);
 
   // Standard shape/type inference using op schema registered shape inference
   // function


### PR DESCRIPTION
Summary: This is to make sure we don't get `BATCH` dim type for the output.

Differential Revision: D26836902

