### PR TITLE
Add CUDA arch 5.2 to Windows CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ pytorch_windows_params: &pytorch_windows_params
     VC_YEAR: <<parameters.vc_year>>
     VC_PRODUCT: <<parameters.vc_product>>
     USE_CUDA: <<parameters.use_cuda>>
-    TORCH_CUDA_ARCH_LIST: "7.5"
+    TORCH_CUDA_ARCH_LIST: "5.2 7.5"
     JOB_BASE_NAME: <<parameters.test_name>>
     JOB_EXECUTOR: <<parameters.executor>>
 binary_linux_build_params: &binary_linux_build_params

--- a/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
@@ -88,6 +88,6 @@ pytorch_windows_params: &pytorch_windows_params
     VC_YEAR: <<parameters.vc_year>>
     VC_PRODUCT: <<parameters.vc_product>>
     USE_CUDA: <<parameters.use_cuda>>
-    TORCH_CUDA_ARCH_LIST: "7.5"
+    TORCH_CUDA_ARCH_LIST: "5.2 7.5"
     JOB_BASE_NAME: <<parameters.test_name>>
     JOB_EXECUTOR: <<parameters.executor>>


### PR DESCRIPTION
To enable tests on Azure DevOps.