### PR TITLE
fixes #38775 #38779: complex support for linspace and logspace (#38875)

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -62,7 +62,11 @@ Tensor& logspace_cpu_out(Tensor& result, Scalar start, Scalar end, c10::optional
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
-    r.fill_(std::pow(base, start.to<double>()));
+    if (isComplexType(r.scalar_type())){
+      r.fill_(std::pow(base, start.to<c10::complex<double>>()));
+    } else {
+      r.fill_(std::pow(base, start.to<double>()));
+    }
   } else if (isComplexType(r.scalar_type())) {
     AT_DISPATCH_COMPLEX_TYPES(r.scalar_type(), "logspace_cpu", [&]() {
       scalar_t scalar_base = static_cast<scalar_t>(base);

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -451,6 +451,31 @@ Tensor new_full(
   return at::full(size, fill_value, self.options().merge_in(options));
 }
 
+namespace {
+TensorOptions linspace_logspace_infer_options(
+    Scalar start,
+    Scalar end,
+    const TensorOptions& options) {
+  auto result_options = options;
+  if (start.isComplex() || end.isComplex()) {
+    // Since result_options.has_dtype() returns true (dtype is default type),
+    // even if the user hasn't specified the dtype.
+    // We just check to see if either `start` or `end` is complex,
+    // and if the `result_dtype` is not complex (be it default float type or
+    // user provided), we cast it to default complex dtype with a Warning!.
+    auto result_dtype = c10::typeMetaToScalarType(options.dtype());
+    if (!at::isComplexType(result_dtype)) {
+      TORCH_WARN(
+          "As either `start` or `stop` is complex, return type will be the complex dtype corresponding to default dtype.",
+          "In future, this may throw an error when a non-complex dtype arg is passed as input along ",
+          "with complex valued start or end value.");
+      result_options = result_options.dtype(c10::get_default_complex_dtype());
+    }
+  }
+
+  return result_options;
+}
+} // anonymous namespace
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ linspace ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -461,7 +486,8 @@ Tensor linspace(
     const TensorOptions& options) {
   const auto steps_ = steps.value_or(100);
   TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
-  Tensor result = at::empty({steps_}, options);
+  auto result_options = linspace_logspace_infer_options(start, end, options);
+  Tensor result = at::empty({steps_}, result_options);
   return at::linspace_out(result, start, end, steps);
 }
 
@@ -475,7 +501,8 @@ Tensor logspace(
     const TensorOptions& options) {
   const auto steps_ = steps.value_or(100);
   TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
-  Tensor result = at::empty({steps_}, options);
+  auto result_options = linspace_logspace_infer_options(start, end, options);
+  Tensor result = at::empty({steps_}, result_options);
   return at::logspace_out(result, start, end, steps, base);
 }
 

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -130,7 +130,11 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, c10::optiona
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
-    r.fill_(std::pow(base, start.to<double>()));
+    if (isComplexType(r.scalar_type())){
+      r.fill_(std::pow(base, start.to<c10::complex<double>>()));
+    } else {
+      r.fill_(std::pow(base, start.to<double>()));
+    }
   } else if (isIntegralType(r.scalar_type(), 0)) {
     AT_DISPATCH_INTEGRAL_TYPES(r.scalar_type(), "logspace_cuda", [&]() {
       float scalar_base = static_cast<float>(base); // Use float to avoid promotion to double
@@ -146,7 +150,7 @@ Tensor& logspace_cuda_out(Tensor& result, Scalar start, Scalar end, c10::optiona
       });
     });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, r.scalar_type(), "logspace_cuda", [&]() {
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, r.scalar_type(), "logspace_cuda", [&]() {
       scalar_t scalar_base = static_cast<scalar_t>(base);
       scalar_t scalar_start = start.to<scalar_t>();
       scalar_t scalar_end = end.to<scalar_t>();

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2359,6 +2359,29 @@ class TestTensorCreation(TestCase):
             self.assertTrue(t[0].item() == a[0])
             self.assertTrue(t[steps - 1].item() == a[steps - 1])
 
+    def _test_linspace_logspace_complex_helper(self, torch_fn, np_fn, device, dtype):
+        start = torch.randn(1, dtype=dtype).item()
+        end = (start + torch.randn(1, dtype=dtype) + random.randint(5, 15)).item()
+
+        def test_fn(torch_fn, numpy_fn, steps):
+            t = torch_fn(start, end, steps, device=device)
+            a = numpy_fn(start, end, steps, dtype=torch_to_numpy_dtype_dict[dtype])
+            t = t.cpu()
+            self.assertEqual(t, torch.from_numpy(a))
+
+        for steps in [1, 2, 3, 5, 11, 256, 257, 2**22]:
+            test_fn(torch.linspace, np.linspace, steps)
+
+    @dtypes(torch.complex64)
+    def test_linspace_vs_numpy_complex(self, device, dtype):
+        self._test_linspace_logspace_complex_helper(torch.linspace, np.linspace,
+                                                    device, dtype)
+
+    @dtypes(torch.complex64)
+    def test_logspace_vs_numpy_complex(self, device, dtype):
+        self._test_linspace_logspace_complex_helper(torch.logspace, np.logspace,
+                                                    device, dtype)
+
     @precisionOverride({torch.float: 1e-6, torch.double: 1e-10})
     @dtypes(*torch.testing.get_all_fp_dtypes(include_half=False, include_bfloat16=False))
     def test_logspace_vs_numpy(self, device, dtype):
@@ -2610,10 +2633,6 @@ class TestTensorCreation(TestCase):
                          torch.tensor((2, 1, 0), device=device, dtype=dtype),
                          atol=0, rtol=0)
 
-        # Create non-complex tensor from complex numbers
-        if not dtype.is_complex:
-            self.assertRaises(RuntimeError, lambda: torch.linspace(1j, 2j, 3, device=device, dtype=dtype))
-
         # Check for race condition (correctness when applied on a large tensor).
         if dtype not in (torch.int8, torch.uint8, torch.int16, torch.half, torch.bfloat16):
             y = torch.linspace(0, 999999 + (999999j if dtype.is_complex else 0),
@@ -2630,14 +2649,28 @@ class TestTensorCreation(TestCase):
         y = torch.linspace(0, 3, 4, out=x.narrow(1, 1, 2), dtype=dtype)
         self.assertEqual(x, torch.tensor(((0, 0, 1), (0, 2, 3)), device=device, dtype=dtype), atol=0, rtol=0)
 
+    def _test_linspace_logspace_deduction_helper(self, fn, device):
+        for start, end in [(1, 2), (1., 2), (1., -2.), (1j, 2j), (0., 2j), (1j, 2)]:
+            dtype = torch.float32
+            if isinstance(start, complex) or isinstance(end, complex):
+                dtype = torch.cfloat
+
+            if dtype == torch.cfloat:
+                # TODO(kshitij12345): Fix unnecessary warning
+                # Reference: https://github.com/pytorch/pytorch/issues/53171
+                with self.assertWarnsRegex(UserWarning,
+                                           "As either `start` or `stop` is complex"):
+                    self.assertEqual(fn(start, end, steps=100, device=device).dtype, dtype)
+            else:
+                self.assertEqual(fn(start, end, steps=100, device=device).dtype, dtype)
+
     def test_linspace_deduction(self, device):
         # Test deduction from input parameters.
-        self.assertEqual(torch.linspace(1, 2, device=device).dtype, torch.float32)
-        self.assertEqual(torch.linspace(1., 2, device=device).dtype, torch.float32)
-        self.assertEqual(torch.linspace(1., -2., device=device).dtype, torch.float32)
-        # TODO: Need fix
-        with self.assertRaises(RuntimeError):
-            torch.linspace(1j, -2j, device=device)
+        self._test_linspace_logspace_deduction_helper(torch.linspace, device)
+
+    def test_logspace_deduction(self, device):
+        # Test deduction from input parameters.
+        self._test_linspace_logspace_deduction_helper(torch.logspace, device)
 
     # The implementation of linspace+logspace goes through a different path
     # when the steps arg is equal to 0 or 1. For other values of `steps`

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4404,7 +4404,10 @@ Args:
 
 Keyword arguments:
     {out}
-    {dtype}
+    dtype (torch.dtype, optional): the data type to perform the computation in.
+        Default: if None, uses the global default dtype (see torch.get_default_dtype())
+        when both :attr:`start` and :attr:`end` are real,
+        and corresponding complex dtype when either is complex.
     {layout}
     {device}
     {requires_grad}
@@ -4773,7 +4776,10 @@ Args:
 
 Keyword arguments:
     {out}
-    {dtype}
+    dtype (torch.dtype, optional): the data type to perform the computation in.
+        Default: if None, uses the global default dtype (see torch.get_default_dtype())
+        when both :attr:`start` and :attr:`end` are real,
+        and corresponding complex dtype when either is complex.
     {layout}
     {device}
     {requires_grad}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53376 MAGMA: Initialize ipiv data to avoid internal memory access violation (#53064)
* #53375 Automated submodule update: tensorpipe (#53353)
* **#53374 fixes #38775 #38779: complex support for linspace and logspace (#38875)**
* #53161 Change cuda namespace to _cuda

Summary:
Closes https://github.com/pytorch/pytorch/issues/38775, Closes https://github.com/pytorch/pytorch/issues/38779

TO-DO:
* [x] Add Tests

Quansight Tracking : q-38775, q-38779

Reviewed By: malfet

Differential Revision: D26628530

Pulled By: anjali411

fbshipit-source-id: ca4259b9f6725c4a4350f944465327169d12122e