### PR TITLE
MAGMA: Initialize ipiv data to avoid internal memory access violation (#53064)

### DIFF
--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1414,6 +1414,9 @@ AT_ERROR("inverse: MAGMA library not found in "
     self_inv_array[i] = &self_inv_data[i * self_inv_mat_stride];
     ipiv_array[i] = &ipiv_data[i * n];
   }
+  // magmaLuBatched leaves ipiv_data values unwritten for singular matrices.
+  // Initialize to avoid memory access violations inside magma kernels (gh-51930).
+  std::fill_n(ipiv_data, batch_size * n, 1);
 
   MAGMAQueue magma_queue(self.get_device());
   magmaLuBatched<scalar_t>(

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2382,6 +2382,19 @@ class TestLinalg(TestCase):
         for params in [(1, 0), (2, 0), (2, 1), (4, 0), (4, 2), (10, 2)]:
             run_test_singular_input(*params)
 
+    @skipCUDAIfNoMagmaAndNoCusolver
+    @skipCPUIfNoLapack
+    @onlyOnCPUAndCUDA   # TODO: XLA doesn't raise exception
+    @skipCUDAIfRocm
+    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+    def test_inverse_errors_large(self, device, dtype):
+        # Test batched inverse of singular matrices reports errors without crashing (gh-51930)
+        x = torch.empty((8, 10, 616, 616), dtype=dtype, device=device)
+        x[:] = torch.eye(616, dtype=dtype, device=device)
+        x[..., 10, 10] = 0
+        with self.assertRaisesRegex(RuntimeError, r'For batch 0: U\(11,11\) is zero'):
+            torch.inverse(x)
+
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3, torch.float64: 1e-7, torch.complex128: 1e-7})
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53376 MAGMA: Initialize ipiv data to avoid internal memory access violation (#53064)**
* #53375 Automated submodule update: tensorpipe (#53353)
* #53374 fixes #38775 #38779: complex support for linspace and logspace (#38875)
* #53161 Change cuda namespace to _cuda

Summary:
Fixes https://github.com/pytorch/pytorch/issues/51930

Running the reproducer under `cuda-gdb`, I see access violations in either [`zswap_kernel_batched`](https://bitbucket.org/icl/magma/src/4fd4634f35020e315b05689c277899dbd09749ed/magmablas/zgetf2_kernels.cu?at=master#lines-276) (part of the LU factorization) and other times in [`zlaswp_columnserial_kernel`](https://bitbucket.org/icl/magma/src/4fd4634f35020e315b05689c277899dbd09749ed/magmablas/zlaswp_batched.cu?at=master#lines-335) (part of the inverse).

The common factor between both of these is they use `ipiv` to index into the matrix. My best guess is the `ipiv` indices aren't written when the factorization fails, hence garbage data is used as matrix indices and we get an access violation. Initializing `ipiv` to a known-good value before the  factorization fixes the issue.

Reviewed By: zhangguanheng66

Differential Revision: D26829053

Pulled By: heitorschueroff

fbshipit-source-id: 842854a6ee182f20b2acad0d76d32d27cb51b061