### PR TITLE
check for torch.distributed.is_available() first

### DIFF
--- a/test/distributed/test_c10d_spawn.py
+++ b/test/distributed/test_c10d_spawn.py
@@ -6,6 +6,10 @@ import unittest
 
 import torch
 import torch.distributed as c10d
+if not c10d.is_available():
+    print('c10d not available, skipping tests', file=sys.stderr)
+    sys.exit(0)
+
 import torch.multiprocessing as mp
 import torch.nn as nn
 
@@ -29,10 +33,6 @@ except ImportError:
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
-
-if not c10d.is_available():
-    print('c10d not available, skipping tests', file=sys.stderr)
-    sys.exit(0)
 
 
 if NO_MULTIPROCESSING_SPAWN:

--- a/test/distributed/test_distributed_fork.py
+++ b/test/distributed/test_distributed_fork.py
@@ -5,6 +5,10 @@ from functools import wraps
 import torch
 import torch.cuda
 import torch.distributed as dist
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
 from torch.testing._internal.common_utils import TestCase, find_free_port, run_tests
 from torch.distributed.distributed_c10d import _get_default_group
 from torch.testing._internal.distributed.distributed_test import (
@@ -16,10 +20,6 @@ Ninja (https://ninja-build.org) must be available to run C++ extensions tests,
 but it could not be found. Install ninja with `pip install ninja`
 or `conda install ninja`.
 """
-
-if not dist.is_available():
-    print("Distributed not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
 
 BACKEND = os.environ["BACKEND"]
 INIT_METHOD = os.getenv("INIT_METHOD", "env://")

--- a/test/distributed/test_distributed_spawn.py
+++ b/test/distributed/test_distributed_spawn.py
@@ -4,14 +4,14 @@ import sys
 import unittest
 
 import torch.distributed as dist
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
 from torch.testing._internal.common_utils import run_tests, TEST_WITH_ASAN, NO_MULTIPROCESSING_SPAWN
 from torch.testing._internal.distributed.distributed_test import (
     DistributedTest, TestDistBackend
 )
-
-if not dist.is_available():
-    print("Distributed not available, skipping tests", file=sys.stderr)
-    sys.exit(0)
 
 BACKEND = os.environ["BACKEND"]
 

--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -3,6 +3,10 @@ import tempfile
 from sys import platform
 import torch
 import torch.distributed as c10d
+if not c10d.is_available():
+    print('c10d not available, skipping tests', file=sys.stderr)
+    sys.exit(0)
+
 import time
 from datetime import timedelta
 from typing import List
@@ -15,10 +19,6 @@ from torch.testing._internal.jit_utils import JitTestCase
 # load_tests from common_utils is used to automatically filter tests for
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
-
-if not c10d.is_available():
-    print('c10d not available, skipping tests', file=sys.stderr)
-    sys.exit(0)
 
 if platform == 'darwin':
     LOOPBACK = 'lo0'


### PR DESCRIPTION
Currently test/distributed/test_* import torch.distributed.distributed_c10d first before even checking distributed is available. 

changing the order to exit before importing c10d