### PR TITLE
Adding print_test_stats.py job to Windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,6 +801,7 @@ jobs:
             export CIRCLE_BRANCH="$CIRCLE_BRANCH"
             export CIRCLE_JOB="$CIRCLE_JOB"
             export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            pip install typing_extensions boto3
             python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
           when: always
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,6 +788,21 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-test.sh
+      - run:
+          name: Report results
+          no_output_timeout: "5m"
+          command: |
+            set -ex
+            export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}
+            export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
+            export CIRCLE_TAG="${CIRCLE_TAG:-}"
+            export CIRCLE_SHA1="$CIRCLE_SHA1"
+            export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-}"
+            export CIRCLE_BRANCH="$CIRCLE_BRANCH"
+            export CIRCLE_JOB="$CIRCLE_JOB"
+            export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
+          when: always
       - store_test_results:
           path: test/test-reports
   binary_linux_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,6 +801,8 @@ jobs:
             export CIRCLE_BRANCH="$CIRCLE_BRANCH"
             export CIRCLE_JOB="$CIRCLE_JOB"
             export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             pip install typing_extensions boto3
             python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
           when: always

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -363,6 +363,8 @@ jobs:
             export CIRCLE_BRANCH="$CIRCLE_BRANCH"
             export CIRCLE_JOB="$CIRCLE_JOB"
             export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             pip install typing_extensions boto3
             python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
           when: always

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -363,6 +363,7 @@ jobs:
             export CIRCLE_BRANCH="$CIRCLE_BRANCH"
             export CIRCLE_JOB="$CIRCLE_JOB"
             export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            pip install typing_extensions boto3
             python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
           when: always
       - store_test_results:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -350,5 +350,20 @@ jobs:
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             set -x
             .jenkins/pytorch/win-test.sh
+      - run:
+          name: Report results
+          no_output_timeout: "5m"
+          command: |
+            set -ex
+            export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}
+            export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
+            export CIRCLE_TAG="${CIRCLE_TAG:-}"
+            export CIRCLE_SHA1="$CIRCLE_SHA1"
+            export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-}"
+            export CIRCLE_BRANCH="$CIRCLE_BRANCH"
+            export CIRCLE_JOB="$CIRCLE_JOB"
+            export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
+            python torch/testing/_internal/print_test_stats.py --upload-to-s3 --compare-with-s3 test
+          when: always
       - store_test_results:
           path: test/test-reports

--- a/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_libtorch.bat
@@ -10,7 +10,9 @@ set TEST_OUT_DIR=%~dp0\..\..\..\test\test-reports\cpp-unittest
 md %TEST_OUT_DIR%
 set PATH=C:\Program Files\NVIDIA Corporation\NvToolsExt\bin\x64;%TMP_DIR_WIN%\build\torch\lib;%PATH%
 
-test_api.exe --gtest_filter="-IntegrationTest.MNIST*" --gtest_output=xml:%TEST_OUT_DIR%\test_api.xml
+set TEST_API_OUT_DIR=%TEST_OUT_DIR%\test_api
+md %TEST_API_OUT_DIR%
+test_api.exe --gtest_filter="-IntegrationTest.MNIST*" --gtest_output=xml:%TEST_API_OUT_DIR%\test_api.xml
 if errorlevel 1 exit /b 1
 if not errorlevel 0 exit /b 1
 
@@ -43,7 +45,9 @@ if "%~1" == "c10_intrusive_ptr_benchmark" (
   call "%~2"
   goto :eof
 )
-call "%~2" --gtest_output=xml:%TEST_OUT_DIR%\%~1.xml
+:: Differentiating the test report directories is crucial for test time reporting.
+md %TEST_OUT_DIR%\%~n2
+call "%~2" --gtest_output=xml:%TEST_OUT_DIR%\%~n2\%~1.xml
 if errorlevel 1 (
   echo %1 failed with exit code %errorlevel%
   exit /b 1


### PR DESCRIPTION
This way, we can get S3 test time stats for windows tests as well.