### PR TITLE
[PyTorch] Move non-template part of TensorImpl::Resize to cpp

### DIFF
--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -103,6 +103,29 @@ IntArrayRef TensorImpl::strides() const {
   return sizes_and_strides_.strides_arrayref();
 }
 
+void TensorImpl::HandleResize() {
+  // If needed, we will free the data. the next mutable_data() call
+  // will create the data storage.
+  bool reset_tensor = false;
+  if (reserved_) {
+    // If tensor is reserved then don't claim its memeory unless nbytes()
+    // is smaller than new size
+    reset_tensor = storage_.nbytes() <
+      (storage_offset_ + numel_) * data_type_.itemsize();
+  } else {
+    reset_tensor = storage_.nbytes() <
+      (storage_offset_ + numel_) * data_type_.itemsize() ||
+      !FLAGS_caffe2_keep_on_shrink ||
+      storage_.nbytes() -
+      (storage_offset_ + numel_) * data_type_.itemsize() >
+      static_cast<size_t>(FLAGS_caffe2_max_keep_on_shrink_memory);
+  }
+
+  if (reset_tensor && storage_initialized()) {
+    FreeMemory();
+  }
+}
+
 bool TensorImpl::compute_contiguous() const {
   bool is_contiguous = true;
   if (is_empty())

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1229,26 +1229,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   void Resize(Ts... dim_source) {
     bool size_changed = SetDims(dim_source...);
     if (size_changed) {
-      // If needed, we will free the data. the next mutable_data() call
-      // will create the data storage.
-      bool reset_tensor = false;
-      if (reserved_) {
-        // If tensor is reserved then don't claim its memeory unless nbytes()
-        // is smaller than new size
-        reset_tensor = storage_.nbytes() <
-            (storage_offset_ + numel_) * data_type_.itemsize();
-      } else {
-        reset_tensor = storage_.nbytes() <
-                (storage_offset_ + numel_) * data_type_.itemsize() ||
-            !FLAGS_caffe2_keep_on_shrink ||
-            storage_.nbytes() -
-                    (storage_offset_ + numel_) * data_type_.itemsize() >
-                static_cast<size_t>(FLAGS_caffe2_max_keep_on_shrink_memory);
-      }
-
-      if (reset_tensor && storage_initialized()) {
-        FreeMemory();
-      }
+      HandleResize();
     }
   }
 
@@ -1537,6 +1518,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   }
 
 private:
+  void HandleResize();
 
   // The Caffe2 Resize() method supports being called both as Resize({2,2}) as
   // well as variadic with Resize(2, 2).  These overloads provide all of the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53389 [PyTorch] Don't copy vector arguments to caffe2::Tensor::Resize
* **#53388 [PyTorch] Move non-template part of TensorImpl::Resize to cpp**

Most of this method did not depend on the template parameter. No need to include it in the .h file or duplicate it in the generated code.

Differential Revision: [D26851985](https://our.internmc.facebook.com/intern/diff/D26851985/)