### PR TITLE
[PyTorch] Don't copy vector arguments to caffe2::Tensor::Resize

### DIFF
--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1233,6 +1233,11 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
     }
   }
 
+  template <typename T>
+  void Resize(const std::vector<T>& dim_source) {
+    Resize(ArrayRef<T>(dim_source));
+  }
+
   /**
    * Resizes the tensor without touching underlying storage.
    * This requires the total size of the tensor to remains constant.

--- a/caffe2/core/tensor.h
+++ b/caffe2/core/tensor.h
@@ -227,6 +227,11 @@ class TORCH_API Tensor final {
     impl_.get()->Resize(dim_source...);
   }
 
+  template <typename T>
+  void Resize(const std::vector<T>& dim_source) const {
+    impl_.get()->Resize(ArrayRef<T>(dim_source));
+  }
+
   /**
    * Resize the tensor like the source tensor. Note that this is just a
    * sugar wrapper that essentially calls Resize(src_tensor.dims()).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53389 [PyTorch] Don't copy vector arguments to caffe2::Tensor::Resize**
* #53388 [PyTorch] Move non-template part of TensorImpl::Resize to cpp

Resize was written to take arguments by value, which was
totally fine if they were ArrayRef or a series of integers, but not so
fine if they're std::vector.

Differential Revision: [D26852105](https://our.internmc.facebook.com/intern/diff/D26852105/)