### PR TITLE
[Static Runtime] Call native resize_/resize_as_ as much as possible

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -172,7 +172,7 @@ at::Tensor& embedding_bag_4bit_impl(
   }
 
   const std::vector<int64_t> shape = {output_size, D};
-  output.resize_(shape);
+  at::native::resize_(output, shape, c10::nullopt);
   auto* output_data = output.data_ptr<float>();
 
   const int64_t block_size = D;
@@ -314,7 +314,7 @@ at::Tensor& embedding_bag_byte_impl(
   } else {
     shape = {output_size, D};
   }
-  output.resize_(shape);
+  at::native::resize_(output, shape, c10::nullopt);
   auto* output_data = output.data_ptr<float>();
 
   const int index_size = indices.numel();

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -575,10 +575,10 @@ REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
     }
     auto& out_t = p_node->Output(0).toTensor();
     if (!te->supports(in0_t)) {
-      out_t.resize_({0});
+      fastResizeToZero(out_t);
       at::native::tanh_out(out_t, in0_t);
     } else {
-      out_t.resize_as_(in0_t);
+      at::native::resize_as_(out_t, in0_t, c10::nullopt);
       (*te)(out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
     }
   };
@@ -596,10 +596,10 @@ REGISTER_OPERATOR_FUNCTOR(
         }
         auto& out_t = p_node->Output(0).toTensor();
         if (!te->supports(in0_t)) {
-          out_t.resize_({0});
+          fastResizeToZero(out_t);
           at::native::sigmoid_out(out_t, in0_t);
         } else {
-          out_t.resize_as_(in0_t);
+          at::native::resize_as_(out_t, in0_t, c10::nullopt);
           (*te)(
               out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
         }
@@ -626,7 +626,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
       fastResizeToZero(out_t);
       at::native::logit_out(out_t, in0_t, in1_d);
     } else {
-      out_t.resize_as_(in0_t);
+      at::native::resize_as_(out_t, in0_t, c10::nullopt);
       (*te)(out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
     }
   };


### PR DESCRIPTION
Summary:
t.resize_ goes through the dispatcher. Replace with direct native calls
- t.resize_/resize_as_ -> at::native::resize_/resize_as_
- t.resize_({0}) -> fastResizeToZero(t)

Reviewed By: ajyu, edvgha

Differential Revision: D26836278

