### PR TITLE
[iOS GPU][BE][1/n] - Remove unused headers + improve error message

### DIFF
--- a/aten/src/ATen/native/metal/MetalAten.mm
+++ b/aten/src/ATen/native/metal/MetalAten.mm
@@ -1,6 +1,5 @@
 #import <ATen/native/metal/MetalTensor.h>
 #import <ATen/native/metal/MetalTensorImpl.h>
-#import <ATen/native/metal/MetalUtils.h>
 #import <ATen/native/metal/mpscnn/MPSCNNContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNOps.h>
 

--- a/aten/src/ATen/native/metal/MetalCommandBuffer.h
+++ b/aten/src/ATen/native/metal/MetalCommandBuffer.h
@@ -3,7 +3,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
 @interface MetalCommandBuffer : NSObject
-@property(nonatomic, strong, readonly) NSThread* thread;
+@property(nonatomic, weak, readonly) NSThread* thread;
 @property(nonatomic, strong, readonly) id<MTLCommandBuffer> buffer;
 
 + (MetalCommandBuffer*)newBuffer;

--- a/aten/src/ATen/native/metal/MetalConvolution.h
+++ b/aten/src/ATen/native/metal/MetalConvolution.h
@@ -1,6 +1,6 @@
 #import <ATen/native/metal/MetalPrepackOpContext.h>
 
-#include <torch/script.h>
+#include <c10/util/ArrayRef.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/metal/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/MetalConvolution.mm
@@ -1,6 +1,4 @@
 #import <ATen/native/metal/MetalConvolution.h>
-#import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNOps.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/metal/MetalShaders.h
+++ b/aten/src/ATen/native/metal/MetalShaders.h
@@ -1,7 +1,7 @@
 #ifndef MPSCNNShaders_h
 #define MPSCNNShaders_h
 
-static const char* METAL_SHADERS = R"METAL_SHADERS(
+static const char* PT_METAL_SHADERS = R"PT_METAL_SHADERS(
 #include <metal_stdlib>
 using namespace metal;
 
@@ -98,8 +98,6 @@ kernel void copy_nchw_to_metal(constant float* in[[buffer(0)]],
     }
     const ushort n = gid.z / divRoundUp(C, 4);
     const ushort c = gid.z - n * divRoundUp(C, 4);
-    // TODO: are the `else` branches needed?
-    // TODO: trick the optimizer for case where C == 4?
 #define CHW_TO_CHWP4(idx, n, c_, h, w)                                     \
 if ((c_) < C) {                                                          \
 trns[idx] = in[n * H * W * C + int(c_) * H * W + int(h) * W + int(w)]; \
@@ -125,8 +123,6 @@ kernel void copy_nchw_to_metal_nonarray(constant float* in[[buffer(0)]],
         return;
     }
     half4 trns;
-    // TODO: are the `else` branches needed?
-    // TODO: trick the optimizer for case where C % 4 == 0?
 #define CHW_TO_CHWP4(idx, c, h, w)                        \
 if ((c) < C) {                                          \
 trns[idx] = in[int(c) * H * W + int(h) * W + int(w)]; \
@@ -516,6 +512,6 @@ kernel void resize_nearest_nonarray(texture2d<half, access::sample> in[[texture(
     out.write(in.sample(s, float2(in_x, in_y)), gid.xy);
 }
 
-)METAL_SHADERS";
+)PT_METAL_SHADERS";
 
 #endif /* MPSCNNShaders_h */

--- a/aten/src/ATen/native/metal/MetalTensor.h
+++ b/aten/src/ATen/native/metal/MetalTensor.h
@@ -1,4 +1,5 @@
-#include <torch/script.h>
+#include <ATen/Tensor.h>
+#include <c10/util/ArrayRef.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/metal/MetalTensorImpl.h
+++ b/aten/src/ATen/native/metal/MetalTensorImpl.h
@@ -2,7 +2,6 @@
 #define MetalTensorImpl_h
 
 #include <ATen/OpaqueTensorImpl.h>
-#include <ATen/Tensor.h>
 #include <ATen/WrapDimUtils.h>
 #import <ATen/native/metal/MetalTensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageWrapper.h>

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNN.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNN.mm
@@ -21,8 +21,8 @@ int computeMPSAlignOffset(int kernel, int pad) {
   // For 3x3s1p0, offset should be (1, 1)
   // For 3x3s1p2, offset should be (-1, -1)
   const int mps_offset = kernel / 2;
-  const int c2_offset = pad;
-  return mps_offset - c2_offset;
+  const int pt_offset = pad;
+  return mps_offset - pt_offset;
 }
 
 NSString* kernelFor(

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.h
@@ -1,8 +1,5 @@
-#import <ATen/native/metal/MetalConvolution.h>
-#import <Foundation/Foundation.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
-using namespace at::native::metal;
 @interface MPSCNNNeuronOp : NSObject
 
 + (MPSCNNNeuronReLU*)relu;

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNOp.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNOp.h
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
@@ -44,7 +44,7 @@ static inline MetalCommandBuffer* commandBufferFromInputTensor(
   MetalTensorImpl* impl = (MetalTensorImpl*)tensor.unsafeGetTensorImpl();
   MetalTensor& metalTensor = impl->unsafe_opaque_handle();
   MetalCommandBuffer* cmdBuffer = metalTensor.texture()->commandBuffer();
-  TORCH_CHECK(cmdBuffer, @"Command Buffer can't be nil!");
+  TORCH_CHECK(cmdBuffer, @"The Metal command buffer can't be nil!");
   return cmdBuffer;
 }
 
@@ -340,28 +340,6 @@ Tensor& hardswish_(Tensor& input) {
   return input;
 }
 
-/*
- A fully connected layer takes an MPSImage object with dimensions source.width x
- source.height x Ni, convolves it with
- Weights[No][source.width][source.height][Ni],and produces a 1 x 1 x No output.
-
- Thus, the following conditions must be true:
- kernelWidth == source.width
- kernelHeight == source.height
- clipRect.size.width == 1
- clipRect.size.height == 1
-
- You can think of a fully connected layer as a matrix multiplication
- where the image is flattened into a vector of length
- source.width*source.height*Ni, and the weights are arranged in a matrix of
- dimension No x (source.width*source.height*Ni) to produce an output vector of
- length No
-
- The value of the strideInPixelsX, strideInPixelsY, and groups properties must
- be 1. The offset property is not applicable and it is ignored. Because the clip
- rectangle is clamped to the destination image bounds, if the destination is 1 x
- 1, you do not need to set the clipRect property.
- */
 API_AVAILABLE(ios(10.0), macos(10.13))
 Tensor addmm(const Tensor& bias, const Tensor& input, const Tensor& weight) {
   MPSImage* X = imageFromTensor(input);
@@ -441,7 +419,7 @@ Tensor binaryElementwiseShaderKernel(
   MetalTensor mt{outputSize};
   MetalCommandBuffer* cb1 = commandBufferFromInputTensor(input1);
   MetalCommandBuffer* cb2 = commandBufferFromInputTensor(input2);
-  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different command buffer");
+  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   mt.texture()->allocateTemporaryTextureStorage(outputSize, cb1);
   MPSImage* Y = imageFromMetalTensor(mt);
   id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
@@ -475,7 +453,7 @@ Tensor& binaryElementwiseShaderKernel_(
   }
   MetalCommandBuffer* cb1 = commandBufferFromInputTensor(input1);
   MetalCommandBuffer* cb2 = commandBufferFromInputTensor(input2);
-  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different command buffer");
+  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   MPSImage* Y = [MPSImage temporaryImageFromSize:outputSize commandBuffer:cb1];
   id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
       pipelineState:kernelFor(X1, arrayKernel, nonarrayKernel)];
@@ -510,7 +488,7 @@ Tensor binaryElementwiseMPSCNNKernel(
   MetalTensor mt{outputSize};
   MetalCommandBuffer* cb1 = commandBufferFromInputTensor(input1);
   MetalCommandBuffer* cb2 = commandBufferFromInputTensor(input2);
-  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different command buffer");
+  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   mt.texture()->allocateTemporaryTextureStorage(outputSize, cb1);
   MPSImage* Y = imageFromMetalTensor(mt);
   T* kernel = [[T alloc]
@@ -541,7 +519,7 @@ Tensor& binaryElementwiseMPSCNNKernel_(
   MetalTensor mt{outputSize};
   MetalCommandBuffer* cb1 = commandBufferFromInputTensor(input1);
   MetalCommandBuffer* cb2 = commandBufferFromInputTensor(input2);
-  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different command buffer");
+  TORCH_CHECK([cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   mt.texture()->allocateTemporaryTextureStorage(outputSize, cb1);
   MPSImage* Y = imageFromMetalTensor(mt);
   T* kernel = [[T alloc]
@@ -766,7 +744,7 @@ Tensor cat_batch(const TensorList tensors, MetalTensor& mt) {
     const auto& t = tensors[i];
     MPSImage* X = imageFromTensor(t);
     MetalCommandBuffer* Xcb = commandBufferFromInputTensor(t);
-    TORCH_CHECK([commandBuffer isEqual:Xcb], @"inputs have different command buffer");
+    TORCH_CHECK([commandBuffer isEqual:Xcb], @"inputs have different Metal command buffers");
     id<MTLComputeCommandEncoder> encoder = [commandBuffer.buffer computeCommandEncoder];
     id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
         pipelineState:metal::mpscnn::kernelFor(
@@ -807,7 +785,7 @@ Tensor cat_feature(const TensorList tensors, MetalTensor& mt) {
     const auto& t = tensors[i];
     MPSImage* X = imageFromTensor(t);
     MetalCommandBuffer* Xcb = commandBufferFromInputTensor(t);
-    TORCH_CHECK([commandBuffer isEqual:Xcb], @"inputs have different command buffer");
+    TORCH_CHECK([commandBuffer isEqual:Xcb], @"inputs have different Metal command buffers");
     id<MTLComputeCommandEncoder> encoder = [commandBuffer.buffer computeCommandEncoder];
     auto kernelString = metal::mpscnn::kernelFor(
                          X, @"append_features_off0", @"append_features_off0_nonarray");

--- a/aten/src/ATen/native/metal/mpscnn/MPSImage+Tensor.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImage+Tensor.h
@@ -1,6 +1,5 @@
 #include <ATen/Tensor.h>
 #import <ATen/native/metal/MetalCommandBuffer.h>
-#import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
 @interface MPSImage (Tensor)

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
@@ -3,7 +3,7 @@
 
 #import <ATen/native/metal/MetalCommandBuffer.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
-#include <torch/script.h>
+#include <c10/util/ArrayRef.h>
 
 namespace at {
 namespace native {

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -5,8 +5,6 @@
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageWrapper.h>
 
-#include <numeric>
-
 namespace at {
 namespace native {
 namespace metal {

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -3,16 +3,10 @@
 #import <ATen/native/metal/mpscnn/MPSCNNOps.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/tests/MPSCNNTests.h>
+
 #import <Foundation/Foundation.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
-#include <ATen/ATen.h>
-#include <ATen/Utils.h>
-#include <c10/util/accumulate.h>
-#import <ATen/native/metal/mpscnn/tests/MPSCNNTests.h>
-
-#include <stdlib.h>
-#include <torch/script.h>
 #include <sstream>
 
 #define ITER_COUNT 5


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53432 [iOS GPU][BE][5/n] Remove indirection calls from MPSCNNOps.mm and MetalAten.mm
* #53431 [iOS GPU][BE][4/n] - Convert Objective-C class methods to C functions
* #53430 [iOS GPU][BE][3/n] - Rename MetalTensor to MetalTensorImplStorage
* #53429 [iOS GPU][BE][2/n] - Use dispatcher in MPSCNNTests.mm
* **#53428 [iOS GPU][BE][1/n] - Remove unused headers + improve error message**

Start to do some code clean up work.

Differential Revision: [D26681115](https://our.internmc.facebook.com/intern/diff/D26681115/)