### PR TITLE
[iOS GPU][BE][2/n] - Use dispatcher in MPSCNNTests.mm

### DIFF
--- a/aten/src/ATen/native/metal/MetalAten.mm
+++ b/aten/src/ATen/native/metal/MetalAten.mm
@@ -207,30 +207,24 @@ Tensor upsample_nearest2d_vec(
 Tensor add_Tensor(const Tensor& input1, const Tensor& input2, Scalar alpha) {
   TORCH_CHECK(input1.is_metal());
   TORCH_CHECK(input1.dim() == input2.dim());
-  TORCH_CHECK(input1.sizes()[2] == input2.sizes()[2]);
-  TORCH_CHECK(input1.sizes()[3] == input2.sizes()[3]);
   return mpscnn::add(input1, input2.is_metal() ? input2 : input2.metal());
 }
 
 Tensor& add__Tensor(Tensor& input1, const Tensor& input2, Scalar alpha) {
   TORCH_CHECK(input1.is_metal());
   TORCH_CHECK(input1.dim() == input2.dim());
-  TORCH_CHECK(input1.sizes()[2] == input2.sizes()[2]);
-  TORCH_CHECK(input1.sizes()[3] == input2.sizes()[3]);
   return mpscnn::add_(input1, input2.is_metal() ? input2 : input2.metal());
 }
 
 Tensor sub_Tensor(const Tensor& input1, const Tensor& input2, Scalar alpha) {
   TORCH_CHECK(input1.is_metal());
   TORCH_CHECK(input1.dim() == input2.dim());
-  TORCH_CHECK(input2.sizes()[2] == input2.sizes()[3] == 1);
   return mpscnn::sub(input1, input2.is_metal() ? input2 : input2.metal());
 }
 
 Tensor mul_Tensor(const Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(input1.is_metal());
   TORCH_CHECK(input1.dim() == input2.dim());
-  TORCH_CHECK(input2.sizes()[2] == input2.sizes()[3] == 1);
   return mpscnn::mul(input1, input2.is_metal() ? input2 : input2.metal());
 }
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNOps.mm
@@ -538,36 +538,50 @@ API_AVAILABLE(ios(10.0), macos(10.13))
 Tensor add(const Tensor& input1, const Tensor& input2) {
   if (@available(iOS 11.3, *)) {
     return binaryElementwiseMPSCNNKernel<MPSCNNAdd>(input1, input2);
+  } else {
+    // TODO: support broadcast in shader functions for iOS 10 users
+    TORCH_CHECK(input1.sizes()[2] == input2.sizes()[2]);
+    TORCH_CHECK(input1.sizes()[3] == input2.sizes()[3]);
+    return binaryElementwiseShaderKernel(
+        input1, input2, @"elementwise_add", @"elementwise_add_nonarray");
   }
-  return binaryElementwiseShaderKernel(
-      input1, input2, @"elementwise_add", @"elementwise_add_nonarray");
 }
 
 API_AVAILABLE(ios(10.0), macos(10.13))
 Tensor& add_(Tensor& input1, const Tensor& input2) {
   if (@available(iOS 11.3, *)) {
     return binaryElementwiseMPSCNNKernel_<MPSCNNAdd>(input1, input2);
+  } else {
+    // TODO: support broadcast in for iOS 10 users
+    TORCH_CHECK(input1.sizes()[2] == input2.sizes()[2]);
+    TORCH_CHECK(input1.sizes()[3] == input2.sizes()[3]);
+    return binaryElementwiseShaderKernel_(
+        input1, input2, @"elementwise_add", @"elementwise_add_nonarray");
   }
-  return binaryElementwiseShaderKernel_(
-      input1, input2, @"elementwise_add", @"elementwise_add_nonarray");
 }
 
 API_AVAILABLE(ios(10.0), macos(10.13))
 Tensor sub(const Tensor& input1, const Tensor& input2) {
   if (@available(iOS 11.3, *)) {
     return binaryElementwiseMPSCNNKernel<MPSCNNSubtract>(input1, input2);
+  } else {
+    // TODO: support non-broadcast for iOS 10 users
+    TORCH_CHECK(input2.sizes()[2] == input2.sizes()[3] == 1);
+    return binaryElementwiseShaderKernel(
+        input1, input2, @"elementwise_sub", @"elementwise_sub_nonarray");
   }
-  return binaryElementwiseShaderKernel(
-      input1, input2, @"elementwise_sub", @"elementwise_sub_nonarray");
 }
 
 API_AVAILABLE(ios(10.0), macos(10.13))
 Tensor mul(const Tensor& input1, const Tensor& input2) {
   if (@available(iOS 11.3, *)) {
     return binaryElementwiseMPSCNNKernel<MPSCNNMultiply>(input1, input2);
+  } else {
+    // TODO: support non-broadcast for iOS 10 users
+    TORCH_CHECK(input2.sizes()[2] == input2.sizes()[3] == 1);
+    return binaryElementwiseShaderKernel(
+        input1, input2, @"elementwise_mul", @"elementwise_mul_nonarray");
   }
-  return binaryElementwiseShaderKernel(
-      input1, input2, @"elementwise_mul", @"elementwise_mul_nonarray");
 }
 
 API_AVAILABLE(ios(10.0), macos(10.13))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53432 [iOS GPU][BE][5/n] Remove indirection calls from MPSCNNOps.mm and MetalAten.mm
* #53431 [iOS GPU][BE][4/n] - Convert Objective-C class methods to C functions
* #53430 [iOS GPU][BE][3/n] - Rename MetalTensor to MetalTensorImplStorage
* **#53429 [iOS GPU][BE][2/n] - Use dispatcher in MPSCNNTests.mm**
* #53428 [iOS GPU][BE][1/n] - Remove unused headers + improve error message

Call the testing ops through dispatcher instead of calling them through `at::native`. Some metal ops can't be called through dispatcher yet. For example, `at::t` will call `at::as_strided` which hasn't been implemented on metal yet. For those ops, we'll skip and call `mpscnn::`directly. We'll convert those ops once we have implemented the missing ops.

Differential Revision: [D26683366](https://our.internmc.facebook.com/intern/diff/D26683366/)