### PR TITLE
[GraphModule] Improve buffer registration during init

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -895,11 +895,10 @@ class {test_classname}(torch.nn.Module):
                 self.W = torch.nn.Parameter(torch.randn(2))
                 self.seq = torch.nn.Sequential(torch.nn.BatchNorm1d(2, 2))
                 self.linear = torch.nn.Linear(2, 2)
-                self.attr = torch.randn(2)
-                self.register_buffer('attr2', torch.randn(2))
+                self.register_buffer('attr', torch.randn(2))
 
             def forward(self, x):
-                return self.linear(self.seq(self.W + self.attr + self.attr2 + x))
+                return self.linear(self.seq(self.W + self.attr + x))
 
         mod = symbolic_trace(Test())
         module_name = 'Foo'

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -124,9 +124,8 @@ def _copy_attr(from_module: torch.nn.Module, to_module: torch.nn.Module, target:
         from_module, to_module = f, t
 
     orig = getattr(from_module, field)
-    # If it is a tensor and not a parameter attribute of a module, it should be a named buffer.
-    # So, we register it as a named buffer in the target module.
-    if isinstance(orig, torch.Tensor) and not isinstance(orig, torch.nn.Parameter):
+    # Register it as a named buffer in to_module if it was a buffer in from_module.
+    if field in from_module._buffers.keys():
         to_module.register_buffer(field, orig)
     else:
         setattr(to_module, field, orig)
@@ -143,7 +142,12 @@ def _assign_attr(from_obj: Any, to_module: torch.nn.Module, target: str):
             setattr(to_module, item, t)
         to_module = t
 
-    setattr(to_module, field, from_obj)
+    # If it is a tensor and not a parameter attribute of a module, it should be a named buffer.
+    # So, we register it as a named buffer in the target module.
+    if isinstance(from_obj, torch.Tensor) and not isinstance(from_obj, torch.nn.Parameter):
+        to_module.register_buffer(field, from_obj)
+    else:
+        setattr(to_module, field, from_obj)
 
 class GraphModule(torch.nn.Module):
     """


### PR DESCRIPTION
Summary:
GraphModule construction has two options when constructing the base nn.Module: a dict of names to attrs to assign to the GraphModule, or another nn.Module to copy attrs from.

- For the dict case, add logic to explicitly register `nn.Tensors` that are not `nn.Parameter` as buffers on the GraphModule, else fall back to `__setattr__`.
- For the other `nn.Module` case, update so that it checks in the other module whether the attr to copy in is a buffer, and register it as such, else fall back to `__setattr__`.

Test Plan: Added tests for fetching params and buffers from a GraphModule using both dict and module `__init__`s

Differential Revision: D26860055

