### PR TITLE
[pytorch] use correct warning type for tracer warnings

### DIFF
--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -515,6 +515,8 @@ class TestTracer(JitTestCase):
 
         with warnings.catch_warnings(record=True) as warns:
             traced_fn = torch.jit.trace(fn, torch.tensor([1]))
+        for warn in warns:
+            self.assertIs(warn.category, torch.jit.TracerWarning)
         warns = [str(w.message) for w in warns]
         self.assertIn('a Python integer', warns[0])
         self.assertIn('a Python boolean', warns[1])

--- a/torch/tensor.py
+++ b/torch/tensor.py
@@ -593,7 +593,7 @@ class Tensor(torch._C._TensorBase):
             warnings.warn('Iterating over a tensor might cause the trace to be incorrect. '
                           'Passing a tensor of different shape won\'t change the number of '
                           'iterations executed (and might lead to errors or silently give '
-                          'incorrect results).', category=RuntimeWarning)
+                          'incorrect results).', category=torch.jit.TracerWarning, stacklevel=2)
         return iter(self.unbind(0))
 
     def __hash__(self):


### PR DESCRIPTION
Summary:
We have code to ignore this category of warnings and found this one is incorrect.

Use `stacklevel=2`, otherwise the warning is always filtered by TracerWarning.ignore_lib_warnings()

Test Plan: sandcastle

Differential Revision: D26867290

