### PR TITLE
add a kernel of log_softmax forward for SVE (Scalable Vector Extensions)

### DIFF
--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -10,6 +10,11 @@
 #include <ATen/cpu/vec256/vec256.h>
 #include <c10/util/Optional.h>
 
+#if defined(__ARM_FEATURE_SVE)
+#include <arm_sve.h>
+#include <sleef.h>
+#endif
+
 // [Note AVX-SSE transitions] In general we avoid calls into cmath for code
 // compiled with AVX/AVX2 This is because of SSE-AVX transitions and a bug in
 // Glibc2.23 See https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1663280
@@ -183,6 +188,60 @@ inline void _vec_host_softmax_backward_lastdim(
         }
       });
 }
+
+#if defined(__ARM_FEATURE_SVE)
+template <>
+inline void _vec_log_softmax_lastdim(
+    float* input_data_base,
+    float* output_data_base,
+    int64_t outer_size,
+    int64_t dim_size) {
+  int64_t grain_size = internal::GRAIN_SIZE / (16 * dim_size);
+  if (grain_size < 1)
+    grain_size = 1;
+
+  at::parallel_for(
+      0,
+      outer_size,
+      grain_size,
+      [&](int64_t begin, int64_t end) {
+        for (int64_t ou = begin; ou < end; ++ou) {
+          const float *src_ptr = input_data_base + ou * dim_size;
+          float *dst_ptr = output_data_base + ou * dim_size;
+          float space_max;
+          float space_denom;
+          svfloat32_t space_max_acc = svdup_n_f32(-FLT_MAX);
+          svfloat32_t space_denom_acc = svdup_n_f32(0.f);
+          for (int64_t i = 0; i < dim_size; i += svcntw()) {
+            svbool_t pg = svwhilelt_b32(i, dim_size);
+            space_max_acc = svmax_f32_m(pg, space_max_acc, svld1_f32(pg, src_ptr + i));
+          }
+          space_max = svmaxv_f32(svptrue_b32(), space_max_acc);
+
+          // sub + exp + sum
+          svfloat32_t vec_space_max = svdup_n_f32(space_max);
+          for (int64_t i = 0; i < dim_size; i += svcntw()) {
+            svbool_t pg = svwhilelt_b32(i, dim_size);
+            svfloat32_t src = svld1_f32(pg,  src_ptr + i);
+            src = svsub_f32_x(pg, src, vec_space_max);
+            space_denom_acc = svadd_f32_m(pg, space_denom_acc, Sleef_expfx_u10sve(src));
+            svst1_f32(pg, dst_ptr + i, src);
+          }
+          space_denom = svaddv_f32(svptrue_b32(), space_denom_acc);
+
+          // scal
+          space_denom = logf(space_denom);
+          svfloat32_t vec_space_denom = svdup_n_f32(space_denom);
+          for (int64_t i = 0; i < dim_size; i += svcntw()) {
+            svbool_t pg = svwhilelt_b32(i, dim_size);
+            svfloat32_t dst = svld1_f32(pg,  dst_ptr + i);
+            dst = svsub_f32_x(pg, dst, vec_space_denom);
+            svst1_f32(pg, dst_ptr + i, dst);
+          }
+        }
+      });
+}
+#endif
 
 template <typename scalar_t, bool LogSoftMax>
 struct vec_host_softmax_lastdim {


### PR DESCRIPTION
Summary
The performance of log_softmax forward on SVE(Scalable Vector Extensions)-enabled platform was not sufficient.
Therefore, in order to improve the performance of log_softmax forward on SVE-enabled platform,
I added a kernel of log_softmax forward for SVE.
When this kernel function was executed on a SVE-enabled platform, a performance improvement of about 5.3 times was confirmed(682.231ms -> 128.808ms).
Performance measurement methods and results are described below.

Environment
・CPU : Fujitsu Processor A64FX @2.0GHz
・OS : CentOS Linux release 8.1.1911
・compiler : gcc 10.2.0, clang 11.0.0
・compiler option : -march=armv8.2-a+sve
・branch : master
・commit ID: c7b1979b6bd3001e49cb95f9a189461daf74fb2c
・build Environment variable: USE_DISTRIBUTED=0, USE_MKLDNN= 1USE_LAPACK=0 USE_NNPACK=0 USE_XNNPACK=0
・Python: 3.6.8

Performance measurement methods
```
OMP_NUM_THREADS=1 python3.6 logsoftmax_bench.py
```

logsoftmax_bench.py
```
import torch
import torch.nn as nn

torch.manual_seed(1)

m = nn.LogSoftmax(dim=-1)
input = torch.randn(920, 35820)

with torch.autograd.profiler.profile(record_shapes=True) as prof:
    for i in range(100):
        output = m(input)
print(prof.key_averages().table(sort_by="self_cpu_time_total"))
```

Execution Result(Unused kernel of log_softmax forward for SVE, OMP_NUM_THREADS=1, clang-11.0.0)
```
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::_log_softmax        99.99%       68.219s       100.00%       68.223s     682.231ms           100
           aten::empty         0.01%       3.706ms         0.01%       3.706ms      37.057us           100
     aten::log_softmax         0.00%       2.363ms       100.00%       68.225s     682.255ms           100
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 68.225
```

Execution Result(Used kernel of log_softmax forward for SVE, OMP_NUM_THREADS=1, clang-11.0.0)
```
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
                  Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
    aten::_log_softmax        99.95%       12.877s        99.98%       12.881s     128.808ms           100
           aten::empty         0.03%       3.657ms         0.03%       3.657ms      36.571us           100
     aten::log_softmax         0.02%       2.253ms       100.00%       12.883s     128.831ms           100
----------------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 12.883s
```

Implementation policy for the code
The implementation is such that the kernel of log_softmax forward for SVE is generated only when this kernel is used.
Specifically, the kernel of log_softmax forward for SVE is implemented in `aten/src/ATen/native/cpu/SoftMaxKernel.cpp`,
and this is is enabled only when ` __ARM_FEATURE_SVE` is set to 1.
`__ARM_FEATURE_SVE` is the processor macro that is set to 1 when the option `-march=armv8.2-a+sve` is set to the compiler.
Therefore, if the option `-march=armv8.2-a+sve` is not set to the compiler, the behavior is the same as before this implementation.