### PR TITLE
fix torch.testing._internal.common_distributed.skip_if_not_multigpu decorator

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -3591,7 +3591,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
     def test_resnet18_ddp(self):
         from torchvision import models
         from torchvision.models import quantization as quantized_models
+        name = "resnet18_ddp"
         eager_quantizable_model = quantized_models.__dict__[name](pretrained=True, quantize=False).eval().float()
         model = models.__dict__[name](pretrained=True).eval().float()
-        self._test_model_impl(
-            'ddp', 'resnet18', model, eager_quantizable_model)
+        self._test_model_impl('ddp', name, model, eager_quantizable_model)

--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -3591,7 +3591,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
     def test_resnet18_ddp(self):
         from torchvision import models
         from torchvision.models import quantization as quantized_models
-        name = "resnet18_ddp"
+        name = "resnet18"
         eager_quantizable_model = quantized_models.__dict__[name](pretrained=True, quantize=False).eval().float()
         model = models.__dict__[name](pretrained=True).eval().float()
         self._test_model_impl('ddp', name, model, eager_quantizable_model)

--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -6,6 +6,7 @@ import torch.nn.quantized.dynamic as nnqd
 import torch.nn.intrinsic as nni
 import torch.nn.intrinsic.quantized as nniq
 import torch.multiprocessing as mp
+import torch.distributed
 
 # graph mode quantization based on fx
 from torch.quantization.quantize_fx import (
@@ -3381,6 +3382,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
         prepared = prepare_fx_fn(model, qconfig_dict)
 
         if mode == 'ddp':
+            world_size = torch.distributed.get_world_size()
             mp.spawn(run_ddp,
                      args=(world_size, prepared),
                      nprocs=world_size,

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -65,17 +65,15 @@ def skip_if_small_worldsize(func):
 
 def skip_if_not_multigpu(func):
     """Multi-GPU tests requires at least 2 GPUS. Skip if this is not met."""
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if torch.cuda.is_available() and torch.cuda.device_count() >= 2:
-                return func(*args, **kwargs)
-            message = "Need at least {} CUDA devices".format(2)
-            TEST_SKIPS["multi-gpu"] = TestSkip(75, message)
-            sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
-        return wrapper
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if torch.cuda.is_available() and torch.cuda.device_count() >= 2:
+            return func(*args, **kwargs)
+        message = "Need at least {} CUDA devices".format(2)
+        TEST_SKIPS["multi-gpu"] = TestSkip(75, message)
+        sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
+    return wrapper
 
-    return decorator
 
 def require_n_gpus_for_nccl_backend(n, backend):
     def decorator(func):


### PR DESCRIPTION
`torch.testing._internal.common_distributed.skip_if_not_multigpu decorator` is not correctly set up:

https://github.com/pytorch/pytorch/blob/d3cde6c23c1a7d184f38d4e5fb797257e39d3376/torch/testing/_internal/common_distributed.py#L66-L78

The double wrapper structure (`decorator` / `wrapper`) is used if the decorator itself has parameters. Since this is not the case this silently passes tests that should have been skipped or run otherwise.

## Reproduction

```python
import unittest
import unittest.mock

from torch.testing._internal.common_distributed import skip_if_not_multigpu


patcher = unittest.mock.patch("torch.cuda.device_count", return_value=1)
patcher.start()


class TestCase(unittest.TestCase):
    @skip_if_not_multigpu
    def test_foo(self):
        assert False
```

Without the patch:

```
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

With the patch:

```
E
======================================================================
ERROR: test_foo (test_decorator.TestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/philip/git/pytorch/torch/torch/testing/_internal/common_distributed.py", line 74, in wrapper
    sys.exit(TEST_SKIPS['multi-gpu'].exit_code)
SystemExit: 75

----------------------------------------------------------------------
Ran 1 test in 0.009s

FAILED (errors=1)
```
