### PR TITLE
Fix typo in tools/test_history.py

### DIFF
--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -229,7 +229,7 @@ def make_columns(
     if total_omitted > 0:
         columns.append(f'({total_omitted} S3 reports omitted)')
     if total_suites > 0:
-        columns.append(f'({total_suites}) matching suites omitted)')
+        columns.append(f'({total_suites} matching suites omitted)')
     return ' '.join(columns)
 
 


### PR DESCRIPTION
**Test plan:**

```
tools/test_history.py columns --ref=0ca029b22d17d236d34bcecad44b94b35b1af4bb test_common_errors pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test1
```