### PR TITLE
Simplify init._calculate_fan_in_and_fan_out

### DIFF
--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -4,6 +4,7 @@ import warnings
 from torch import Tensor
 import torch
 
+
 # These no_grad_* functions are necessary as wrappers around the parts of these
 # functions that use `with torch.no_grad()`. The JIT doesn't support context
 # managers, so these need to be implemented as builtins. Using these wrappers
@@ -275,7 +276,7 @@ def _calculate_fan_in_and_fan_out(tensor):
     if tensor.dim() > 2:
         # math.prod is not always available, accumulate the product manually
         for s in tensor.shape[2:]:
-            receptive_field_size = receptive_field_size*s
+            receptive_field_size = receptive_field_size * s
     fan_in = num_input_fmaps * receptive_field_size
     fan_out = num_output_fmaps * receptive_field_size
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -275,8 +275,9 @@ def _calculate_fan_in_and_fan_out(tensor):
     receptive_field_size = 1
     if tensor.dim() > 2:
         # math.prod is not always available, accumulate the product manually
+        # we could use functools.reduce but that is not supported by TorchScript
         for s in tensor.shape[2:]:
-            receptive_field_size = receptive_field_size * s
+            receptive_field_size *= s
     fan_in = num_input_fmaps * receptive_field_size
     fan_out = num_output_fmaps * receptive_field_size
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -274,7 +274,7 @@ def _calculate_fan_in_and_fan_out(tensor):
     num_output_fmaps = tensor.size(0)
     receptive_field_size = 1
     if tensor.dim() > 2:
-        receptive_field_size = tensor[0][0].numel()
+        receptive_field_size = math.prod(tensor.shape[2:])
     fan_in = num_input_fmaps * receptive_field_size
     fan_out = num_output_fmaps * receptive_field_size
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -4,6 +4,13 @@ import warnings
 from torch import Tensor
 import torch
 
+# Provide prod for older versions of math (prod was added in 3.8)
+if hasattr(math, 'prod'):
+    prod = math.prod
+else:
+    from functools import reduce
+    import operator
+    prod = lambda x: reduce(operator.mul, x, 1)
 
 # These no_grad_* functions are necessary as wrappers around the parts of these
 # functions that use `with torch.no_grad()`. The JIT doesn't support context
@@ -274,7 +281,7 @@ def _calculate_fan_in_and_fan_out(tensor):
     num_output_fmaps = tensor.size(0)
     receptive_field_size = 1
     if tensor.dim() > 2:
-        receptive_field_size = math.prod(tensor.shape[2:])
+        receptive_field_size = prod(tensor.shape[2:])
     fan_in = num_input_fmaps * receptive_field_size
     fan_out = num_output_fmaps * receptive_field_size
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -12,7 +12,7 @@ else:
     import operator
     from typing import Tuple
 
-    def prod(shape: Tuple[int] ) -> int:
+    def prod(shape: Tuple[int]) -> int:
         return reduce(operator.mul, shape, 1)
 
 

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -10,7 +10,11 @@ if hasattr(math, 'prod'):
 else:
     from functools import reduce
     import operator
-    prod = lambda x: reduce(operator.mul, x, 1)
+    from typing import Tuple
+
+    def prod(shape: Tuple[int] ) -> int:
+        return reduce(operator.mul, shape, 1)
+
 
 # These no_grad_* functions are necessary as wrappers around the parts of these
 # functions that use `with torch.no_grad()`. The JIT doesn't support context


### PR DESCRIPTION
This uses the shape of the tensor instead of directly indexing it. This is useful when extending PyTorch's tensor class, e.g. for lazy access. Since the `init` sub-module doesn't check for `torch_function`, it is not possibly to override its functions. Explicitly indexing the tensor will force a call to tensor() and reconstruct the full tensor/explicitly access the elements. Simply using the shape allows to avoid that.

Fixes #53540