### PR TITLE
fix channels_last bug in upsample kernels

### DIFF
--- a/aten/src/ATen/native/UpSampleBilinear2d.cpp
+++ b/aten/src/ATen/native/UpSampleBilinear2d.cpp
@@ -19,7 +19,7 @@ TORCH_META_FUNC(upsample_bilinear2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output(full_output_size, input.options());
+  set_output(full_output_size, input.options().memory_format(input.suggest_memory_format()));
 }
 
 TORCH_META_FUNC(upsample_bilinear2d_backward) (

--- a/aten/src/ATen/native/UpSampleNearest2d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest2d.cpp
@@ -17,7 +17,7 @@ TORCH_META_FUNC(upsample_nearest2d) (
       "Non-empty 4D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output(full_output_size, input.options());
+  set_output(full_output_size, input.options().memory_format(input.suggest_memory_format()));
 }
 
 TORCH_META_FUNC(upsample_nearest2d_backward) (

--- a/aten/src/ATen/native/UpSampleNearest3d.cpp
+++ b/aten/src/ATen/native/UpSampleNearest3d.cpp
@@ -20,7 +20,7 @@ TORCH_META_FUNC(upsample_nearest3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output(full_output_size, input.options());
+  set_output(full_output_size, input.options().memory_format(input.suggest_memory_format()));
 }
 
 TORCH_META_FUNC(upsample_nearest3d_backward) (

--- a/aten/src/ATen/native/UpSampleTrilinear3d.cpp
+++ b/aten/src/ATen/native/UpSampleTrilinear3d.cpp
@@ -24,7 +24,7 @@ TORCH_META_FUNC(upsample_trilinear3d) (
       "Non-empty 5D data tensor expected but got a tensor with sizes ",
       input.sizes());
 
-  set_output(full_output_size, input.options());
+  set_output(full_output_size, input.options().memory_format(input.suggest_memory_format()));
 }
 
 TORCH_META_FUNC(upsample_trilinear3d_backward) (

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5547,6 +5547,27 @@ class TestTorchDeviceType(TestCase):
         y = ndhwc.permute(0, 1, 4, 3, 2).permute(0, 1, 4, 3, 2)
         self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
 
+    def test_memory_format_preserved_after_upsample(self, device):
+        x = torch.randn(4, 3, 8, 8, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last)
+        y = torch._C._nn.upsample_nearest2d(nhwc, (2, 2))
+        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
+
+        x = torch.randn(4, 3, 8, 8, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last)
+        y = torch._C._nn.upsample_bilinear2d(nhwc, (2, 2), True)
+        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
+
+        x = torch.randn(4, 3, 8, 8, 8, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last_3d)
+        y = torch._C._nn.upsample_nearest3d(nhwc, (2, 2, 2))
+        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
+
+        x = torch.randn(4, 3, 8, 8, 8, device=device)
+        nhwc = x.contiguous(memory_format=torch.channels_last_3d)
+        y = torch._C._nn.upsample_trilinear3d(nhwc, (2, 2, 2), True)
+        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
+
     def test_memory_format_propagation_rules(self, device):
 
         contiguous = torch.rand(10, 3, 5, 5, device=device)


### PR DESCRIPTION
During the port to structured kernels for upsample kernels, I missed that a subset of them explicitly pass `memory_format` information from the input to the output tensors.

Note 1:
I added the logic into the `meta` function of each op, which feels morally correct since this logic affects the output shape/metadata. One consequence is that all backend implementations will get the logic. I synced with @fmassa that this seems reasonable.


Note 2:
This logic used to happen in the following operators, which this PR fixes:
- upsample_nearest3d
- upsample_trilinear3d
- upsample_nearest2d
- upsample_bilinear2d

I explicitly didn't patch the other upsample kernels, which look like they never forwarded memory_format information:
- `upsample_bicubic2d` (maybe this should though? `UpSampleBicubic2d.cpp` isn't currently written to do anything different for `channels_last` tensors)
- All of the `upsample_{mode}1d` operators. Probably because, afaik, channels_last isn't supported for 3d tensors
- The corresponding backwards operator for every upsample op.

Note 3:
I'm also wondering why memory_format isn't just directly a part of the `tensor::options()` method, which would cause all ops to universally forward memory_format information from input to output tensors, rather than just the upsample ops. My guess is:
- BC-breakage. I'm not sure whether this would really *break* people, but it's an API change
- performance. `tensor::options()` is called everywhere, and adding a call to `suggest_memory_format()` would probably noticeably hit microbenchmarks. We could probably deal with that by making `memory_format` a precomputed field on the tensor?


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53535 fix channels_last bug in upsample kernels**

Differential Revision: [D26891540](https://our.internmc.facebook.com/intern/diff/D26891540)