### PR TITLE
Ability to export pixel_unshuffle to ONNX

### DIFF
--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -817,7 +817,7 @@ class TestOperators(TestCase):
     def test_pixel_unshuffle(self):
         x = torch.randn(2, 2, 6, 8).float()
         self.assertONNX(lambda x: torch.pixel_unshuffle(x, downscale_factor=2), x, opset_version=11)
-    
+
     def test_frobenius_norm(self):
         x = torch.randn(2, 3, 4).float()
         self.assertONNX(lambda x: torch.norm(x, p="fro", dim=(0, 1), keepdim=True), x)

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -814,7 +814,7 @@ class TestOperators(TestCase):
         x = torch.randn(2, 8, 3, 4).float()
         self.assertONNX(lambda x: torch.pixel_shuffle(x, upscale_factor=2), x, opset_version=11)
 
-    def test_pixel_shuffle(self):
+    def test_pixel_unshuffle(self):
         x = torch.randn(2, 2, 6, 8).float()
         self.assertONNX(lambda x: torch.pixel_unshuffle(x, downscale_factor=2), x, opset_version=11)
     

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -814,6 +814,10 @@ class TestOperators(TestCase):
         x = torch.randn(2, 8, 3, 4).float()
         self.assertONNX(lambda x: torch.pixel_shuffle(x, upscale_factor=2), x, opset_version=11)
 
+    def test_pixel_shuffle(self):
+        x = torch.randn(2, 2, 6, 8).float()
+        self.assertONNX(lambda x: torch.pixel_unshuffle(x, downscale_factor=2), x, opset_version=11)
+    
     def test_frobenius_norm(self):
         x = torch.randn(2, 3, 4).float()
         self.assertONNX(lambda x: torch.norm(x, p="fro", dim=(0, 1), keepdim=True), x)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4421,7 +4421,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 16, 4, 3, requires_grad=True)
         self.run_test(PixelShuffle(), x)
-        
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_pixel_unshuffle(self):
         class PixelUnshuffle(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4421,6 +4421,15 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 16, 4, 3, requires_grad=True)
         self.run_test(PixelShuffle(), x)
+        
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_pixel_unshuffle(self):
+        class PixelUnshuffle(torch.nn.Module):
+            def forward(self, x):
+                return torch.pixel_unshuffle(x, downscale_factor=2)
+
+        x = torch.randn(2, 4, 8, 6, requires_grad=True)
+        self.run_test(PixelUnshuffle(), x)
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_scalar_type(self):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -207,6 +207,14 @@ def pixel_shuffle(g, self, upscale_factor):
     return g.op("DepthToSpace", self, blocksize_i=upscale_factor, mode_s="CRD")
 
 
+@parse_args('v', 'i')
+def pixel_unshuffle(g, self, downscale_factor):
+    rank = sym_help._get_tensor_rank(self)
+    if rank is not None and rank != 4:
+        return _unimplemented("pixel_unshuffle", "only support 4d input")
+    return g.op("SpaceToDepth", self, blocksize_i=downscale_factor)
+
+
 def _interpolate(name, dim, interpolate_mode):
     return sym_help._interpolate_helper(name, dim, interpolate_mode)
 


### PR DESCRIPTION
Fixes #51181 by registering torch's `pixel_unshuffle` op with ONNX's `SpaceToDepth` op. Also adds 2 ONNX tests that mirror existing tests for `pixel_shuffle` (the inverse op). 
