### PR TITLE
Enable helper functions for accessing quantized weights for quantized Linear

### DIFF
--- a/torch/nn/quantized/modules/linear.py
+++ b/torch/nn/quantized/modules/linear.py
@@ -228,15 +228,19 @@ class Linear(torch.nn.Module):
 
     # Function rather than property to make sure that JIT serialization doesn't
     # register this as an attribute
+
     def _weight_bias(self):
         return self._packed_params._weight_bias()
 
+    @torch.jit.export
     def weight(self):
         return self._weight_bias()[0]
 
+    @torch.jit.export
     def bias(self):
         return self._weight_bias()[1]
 
+    @torch.jit.export
     def set_weight_bias(self, w: torch.Tensor, b: Optional[torch.Tensor]) -> None:
         self._packed_params.set_weight_bias(w, b)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53541 Enable helper functions for accessing quantized weights for quantized Linear**

Currently, to access quantized parameters of a scripted linear model, one needs to do:
(wt,bias) = m._packed_params._weight_bias()

With this fix, one can do:
wt = m.weight()
bias = m.bias()

Differential Revision: [D26892055](https://our.internmc.facebook.com/intern/diff/D26892055/)