### PR TITLE
If distributed module isn't available, don't run distributed/pipeline tests

### DIFF
--- a/test/distributed/pipeline/sync/conftest.py
+++ b/test/distributed/pipeline/sync/conftest.py
@@ -4,11 +4,11 @@
 #
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
-import pytest
 import tempfile
-import torch
-from torch.distributed import rpc
+import pytest
 
+import torch
+import torch.distributed as dist
 
 @pytest.fixture(autouse=True)
 def manual_seed_zero():
@@ -41,13 +41,17 @@ def pytest_report_header():
 @pytest.fixture
 def setup_rpc(scope="session"):
     file = tempfile.NamedTemporaryFile()
-    rpc.init_rpc(
+    dist.rpc.init_rpc(
         name="worker0",
         rank=0,
         world_size=1,
-        rpc_backend_options=rpc.TensorPipeRpcBackendOptions(
+        rpc_backend_options=dist.rpc.TensorPipeRpcBackendOptions(
             init_method="file://{}".format(file.name),
         )
     )
     yield
-    rpc.shutdown()
+    dist.rpc.shutdown()
+
+def pytest_ignore_collect(path, config):
+    "Skip this directory if distributed modules are not enabled."
+    return not dist.is_available()


### PR DESCRIPTION

Following up #52945

