### PR TITLE
[caffe2] Add an optimization to avoid extra fp32->fp16 conversions in Onnxifi

### DIFF
--- a/caffe2/opt/custom/in_batch_broadcast.cc
+++ b/caffe2/opt/custom/in_batch_broadcast.cc
@@ -5,6 +5,8 @@
 namespace caffe2 {
 namespace opt {
 
+const std::string kFP16_SUFFIX = "_fp16";
+const std::string kFP32_SUFFIX = "_fp32";
 const std::string kTILE_SUFFIX = "_tile";
 
 void inBatchBroadcast(
@@ -97,20 +99,62 @@ void inBatchBroadcast(
     shape.shape.set_dims(0, shape.shape.dims(0) / batch_size);
     shape.setDimType(0, TensorBoundShape_DimType_CONSTANT);
   };
+
   for (const auto& blob : to_broadcast_copy) {
-    auto new_blob = blob + kTILE_SUFFIX;
-    auto* op = broadcast_net.add_op();
-    op->CopyFrom(CreateOperatorDef(
+    auto it = shape_hints.find(blob);
+    CAFFE_ENFORCE(it != shape_hints.end(), "Cannot find shape info for ", blob);
+    const auto& shape = it->second;
+    CAFFE_ENFORCE_GT(shape.shape.dims_size(), 0, "Dim size for ", blob, " is 0");
+
+    // If an op like Fused8BitRowwiseQuantizedToFloat ends up on CPU and
+    // Tile ends up on an accelerator and only FP16 is supported, then we want
+    // to make sure conversion from FP32 to FP16 is done on CPU to save cycles
+    // on accelerator.
+    const std::string blob_fp16 = blob + kFP16_SUFFIX;
+    const std::string blob_fp32 = blob + kFP32_SUFFIX;
+    const bool isFp32Optimization =
+        (shape.shape.data_type() == TensorProto_DataType_FLOAT);
+    if (isFp32Optimization) {
+      auto* op_fp16 = broadcast_net.add_op();
+      op_fp16->CopyFrom(CreateOperatorDef(
+          "FloatToHalf",
+          "",
+          {blob},
+          {blob_fp16},
+          {MakeArgument<int>("net_pos", current_pos++)}));
+      auto* op_fp32 = broadcast_net.add_op();
+      op_fp32->CopyFrom(CreateOperatorDef(
+          "HalfToFloat",
+          "",
+          {blob_fp16},
+          {blob_fp32},
+          {MakeArgument<int>("net_pos", current_pos++)}));
+    }
+
+    std::string blob_tile = blob + kTILE_SUFFIX;
+    auto* op_tile = broadcast_net.add_op();
+    op_tile->CopyFrom(CreateOperatorDef(
         "Tile",
         "",
-        {blob},
-        {new_blob},
+        {isFp32Optimization ? blob_fp32 : blob},
+        {blob_tile},
         {MakeArgument<int>("tiles", batch_size),
          MakeArgument<int>("axis", 0),
          // Indicating that we are tiling to max_batch_size
          MakeArgument<int>("dynamic", 1),
          MakeArgument<int>("net_pos", current_pos++)}));
-    setShape(blob, new_blob);
+
+    setShape(blob, blob_tile);
+    if (isFp32Optimization) {
+      const auto adjusted_shape = shape_hints[blob];
+
+      auto shape_fp16 = adjusted_shape;
+      shape_fp16.shape.set_data_type(TensorProto_DataType_FLOAT16);
+      shape_hints.emplace(blob_fp16, shape_fp16);
+
+      shape_hints.emplace(blob_fp32, adjusted_shape);
+    }
+
     const auto rit = reversed.find(blob);
     if (rit != reversed.end()) {
       const auto& original_input = rit->second;


### PR DESCRIPTION
Summary: If an op like Fused8BitRowwiseQuantizedToFloat ends up on CPU and Tile ends up on an accelerator and only FP16 is supported, then we want to make sure conversion from FP32 to FP16 is done on CPU to save cycles on accelerator.

Differential Revision: D26862322

