### PR TITLE
[2/n][torch/elastic][upstream] Move torchelastic/timer torchelastic/multiprocessing to torch/distributed/elastic

### DIFF
--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -1,0 +1,707 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import ctypes
+import multiprocessing
+import os
+import shutil
+import signal
+import sys
+import tempfile
+import time
+import unittest
+from itertools import product
+from typing import Dict, List
+from unittest import mock
+
+import torch.multiprocessing as mp
+from torch.distributed.elastic.multiprocessing import ProcessFailure, start_processes
+from torch.distributed.elastic.multiprocessing.api import (
+    MultiprocessContext,
+    RunProcsResult,
+    Std,
+    _validate_full_rank,
+    _wrap,
+    to_map,
+)
+from torch.distributed.elastic.multiprocessing.errors.error_handler import _write_error
+from torch.testing._internal.common_utils import (
+    NO_MULTIPROCESSING_SPAWN,
+    TEST_WITH_ASAN,
+    TEST_WITH_TSAN,
+)
+
+
+class RunProcResultsTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_is_failed(self):
+        pr_success = RunProcsResult(return_values={0: "a", 1: "b"})
+        self.assertFalse(pr_success.is_failed())
+
+        fail0 = ProcessFailure(
+            local_rank=0, pid=998, exitcode=1, error_file="ignored.json"
+        )
+        pr_fail = RunProcsResult(failures={0: fail0})
+        self.assertTrue(pr_fail.is_failed())
+
+    def test_get_failures(self):
+        with mock.patch("time.time", side_effect=[3, 2, 1]):
+            error_file0 = os.path.join(self.test_dir, "error0.json")
+            error_file1 = os.path.join(self.test_dir, "error1.json")
+            _write_error(RuntimeError("error 0"), error_file0)
+            _write_error(RuntimeError("error 1"), error_file1)
+
+            fail0 = ProcessFailure(
+                local_rank=0, pid=997, exitcode=1, error_file=error_file0
+            )
+            fail1 = ProcessFailure(
+                local_rank=1, pid=998, exitcode=3, error_file=error_file1
+            )
+            fail2 = ProcessFailure(
+                local_rank=2, pid=999, exitcode=15, error_file="no_exist.json"
+            )
+
+            self.assertEqual(3, fail0.timestamp)
+            self.assertEqual(2, fail1.timestamp)
+            self.assertEqual(1, fail2.timestamp)
+
+
+class StdTest(unittest.TestCase):
+    def test_from_value(self):
+        self.assertEqual(Std.NONE, Std.from_str("0"))
+        self.assertEqual(Std.OUT, Std.from_str("1"))
+        self.assertEqual(Std.ERR, Std.from_str("2"))
+        self.assertEqual(Std.ALL, Std.from_str("3"))
+
+    def test_from_value_map(self):
+        self.assertEqual({0: Std.OUT}, Std.from_str("0:1"))
+        self.assertEqual({0: Std.OUT, 1: Std.OUT}, Std.from_str("0:1,1:1"))
+
+    def test_from_str_bad_input(self):
+        bad_inputs = ["0:1,", "11", "0:1,1", "1,0:1"]
+        for bad in bad_inputs:
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    Std.from_str(bad)
+
+
+def echo0(msg: str) -> None:
+    """
+    void function
+    """
+    print(msg)
+
+
+def echo1(msg: str, exitcode: int = 0) -> str:
+    """
+    returns ``msg`` or exits with the given exitcode (if nonzero)
+    """
+
+    rank = int(os.environ["RANK"])
+    if exitcode != 0:
+        print(f"exit {exitcode} from {rank}", file=sys.stderr)
+        sys.exit(exitcode)
+    else:
+        print(f"{msg} stdout from {rank}")
+        print(f"{msg} stderr from {rank}", file=sys.stderr)
+        return f"{msg}_{rank}"
+
+
+def echo2(msg: str, fail: bool = False) -> str:
+    """
+    returns ``msg`` or raises a RuntimeError if ``fail`` is set
+    """
+    if fail:
+        raise RuntimeError(msg)
+    return msg
+
+
+def echo3(msg: str, fail: bool = False) -> str:
+    """
+    returns ``msg`` or induces a SIGSEGV if ``fail`` is set
+    """
+    if fail:
+        ctypes.string_at(0)
+    return msg
+
+
+def echo_large(size: int) -> Dict[int, str]:
+    """
+    returns a large output ({0: test0", 1: "test1", ..., (size-1):f"test{size-1}"})
+    """
+    out = {}
+    for idx in range(0, size):
+        out[idx] = f"test{idx}"
+    return out
+
+
+def redirects() -> List[Std]:
+    return [
+        Std.NONE,
+        Std.OUT,
+        Std.ERR,
+        Std.ALL,
+    ]
+
+
+class StartProcessesTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")
+
+        if NO_MULTIPROCESSING_SPAWN:  # python 2.7 doesn't have spawn
+            self._start_methods = ["fork", "forkserver"]
+        else:
+            self._start_methods = ["fork", "forkserver", "spawn"]
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def log_dir(self):
+        return tempfile.mkdtemp(dir=self.test_dir)
+
+    def assert_in_file(self, expected: List[str], filename: str) -> None:
+        expected = [f"{line.rstrip()}\n" for line in expected]
+        with open(filename, "r") as fp:
+            actual = fp.readlines()
+            for line in expected:
+                self.assertIn(line, actual)
+
+    def assert_pids_noexist(self, pids: Dict[int, int]):
+        for local_rank, pid in pids.items():
+            with self.assertRaises(
+                OSError, msg=f"local_rank: {local_rank} pid: {pid} should not exist"
+            ):
+                os.kill(pid, 0)
+
+    def test_to_map(self):
+        local_world_size = 2
+        self.assertEqual({0: Std.OUT, 1: Std.OUT}, to_map(Std.OUT, local_world_size))
+        self.assertEqual(
+            {0: Std.NONE, 1: Std.OUT}, to_map({1: Std.OUT}, local_world_size)
+        )
+        self.assertEqual(
+            {0: Std.ERR, 1: Std.OUT}, to_map({0: Std.ERR, 1: Std.OUT}, local_world_size)
+        )
+
+    def test_wrap(self):
+        none = ""
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+        stderr_log = os.path.join(self.test_dir, "stderr.log")
+        redirs = [
+            (none, none),
+            (none, stderr_log),
+            (stdout_log, none),
+            (stdout_log, stderr_log),
+        ]
+
+        for stdout_redir, stderr_redir in redirs:
+            queue = multiprocessing.SimpleQueue()
+            _wrap(
+                local_rank=0,
+                fn=echo1,
+                args={0: ("hello",)},
+                envs={0: {"RANK": "0"}},
+                stdout_redirects={0: stdout_redir},
+                stderr_redirects={0: stderr_redir},
+                ret_vals={0: queue},
+            )
+            self.assertEqual("hello_0", queue.get())
+            if stdout_redir:
+                self.assert_in_file(["hello stdout from 0"], stdout_log)
+            if stderr_redir:
+                self.assert_in_file(["hello stderr from 0"], stderr_log)
+
+    def test_invalid_log_dir(self):
+        with tempfile.NamedTemporaryFile(dir=self.test_dir) as not_a_dir:
+            cases = {
+                "does_not_exist": FileNotFoundError,
+                not_a_dir.name: NotADirectoryError,
+                # test_dir is not empty since we touched not_a_dir file
+                self.test_dir: RuntimeError,
+            }
+
+            for (log_dir, expected_error) in cases.items():
+                with self.subTest(log_dir=log_dir, expected_error=expected_error):
+                    with self.assertRaises(expected_error):
+                        start_processes(
+                            name="echo",
+                            entrypoint=echo1,
+                            args={0: ("hello",)},
+                            envs={0: {"RANK": "0"}},
+                            log_dir=log_dir,
+                        )
+
+    def test_args_env_len_mismatch(self):
+        cases = [
+            # 1 x args; 2 x envs
+            {
+                "args": {0: ("hello",)},
+                "envs": {0: {"RANK": "0"}, 1: {"RANK": "1"}},
+            },
+            # 2 x args; 1 x envs
+            {
+                "args": {0: ("hello",), 1: ("world",)},
+                "envs": {0: {"RANK": "0"}},
+            },
+        ]
+
+        for kwds in cases:
+            args = kwds["args"]
+            envs = kwds["envs"]
+            with self.subTest(args=args, envs=envs):
+                with self.assertRaises(RuntimeError):
+                    start_processes(
+                        name="echo",
+                        entrypoint=echo1,
+                        args=args,
+                        envs=envs,
+                        log_dir=self.log_dir(),
+                    )
+
+    def test_pcontext_wait(self):
+        pc = start_processes(
+            name="sleep",
+            entrypoint=time.sleep,
+            args={0: (1,)},
+            envs={0: {}},
+            log_dir=self.log_dir(),
+            start_method="fork",
+        )
+
+        self.assertIsNone(pc.wait(timeout=0.1, period=0.01))
+        self.assertIsNotNone(pc.wait(period=0.1))
+        self.assertTrue(pc._stderr_tail.stopped())
+        self.assertTrue(pc._stdout_tail.stopped())
+
+    def test_multiprocess_context_close(self):
+        pc = start_processes(
+            name="sleep",
+            entrypoint=time.sleep,
+            args={0: (1,)},
+            envs={0: {}},
+            log_dir=self.log_dir(),
+            start_method="fork",
+        )
+
+        pids = pc.pids()
+        pc.close()
+        self.assert_pids_noexist(pids)
+        self.assertTrue(pc._stderr_tail.stopped())
+        self.assertTrue(pc._stdout_tail.stopped())
+
+    ########################################
+    # start_processes as binary tests
+    ########################################
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function(self):
+        for start_method, redirs in product(self._start_methods, redirects()):
+            with self.subTest(start_method=start_method, redirs=redirs):
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo1,
+                    args={0: ("hello",), 1: ("hello",)},
+                    envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+                    log_dir=self.log_dir(),
+                    start_method=start_method,
+                    redirects=redirs,
+                )
+
+                results = pc.wait(period=0.1)
+                nprocs = pc.nprocs
+
+                self.assert_pids_noexist(pc.pids())
+                self.assertEqual(
+                    {i: f"hello_{i}" for i in range(nprocs)}, results.return_values
+                )
+
+                for i in range(nprocs):
+                    if redirs & Std.OUT != Std.OUT:
+                        self.assertFalse(results.stdouts[i])
+                    if redirs & Std.ERR != Std.ERR:
+                        self.assertFalse(results.stderrs[i])
+                    if redirs & Std.OUT == Std.OUT:
+                        self.assert_in_file(
+                            [f"hello stdout from {i}"], results.stdouts[i]
+                        )
+                    if redirs & Std.ERR == Std.ERR:
+                        self.assert_in_file(
+                            [f"hello stderr from {i}"], results.stderrs[i]
+                        )
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function_exit(self):
+        """
+        run 2x copies of echo1 fail (exit) the first
+        functions that exit from python do not generate an error file
+        (even if they are decorated with @record)
+        """
+
+        FAIL = 138
+        for start_method in self._start_methods:
+            with self.subTest(start_method=start_method):
+                log_dir = self.log_dir()
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo1,
+                    args={0: ("hello", FAIL), 1: ("hello",)},
+                    envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+                    log_dir=log_dir,
+                    start_method=start_method,
+                    redirects={0: Std.ERR},
+                )
+
+                results = pc.wait(period=0.1)
+
+                self.assert_pids_noexist(pc.pids())
+                self.assertTrue(results.is_failed())
+                self.assertEqual(1, len(results.failures))
+                self.assertFalse(results.return_values)
+
+                failure = results.failures[0]
+                error_file = failure.error_file
+
+                self.assertEqual(FAIL, failure.exitcode)
+                self.assertEqual("<N/A>", failure.signal_name())
+                self.assertEqual(pc.pids()[0], failure.pid)
+                self.assertEqual("<N/A>", error_file)
+                self.assertEqual(
+                    f"Process failed with exitcode {FAIL}", failure.message
+                )
+                self.assertLessEqual(failure.timestamp, int(time.time()))
+
+                self.assert_in_file([f"exit {FAIL} from 0"], results.stderrs[0])
+                self.assertFalse(results.stdouts[0])
+                self.assertFalse(results.stderrs[1])
+                self.assertFalse(results.stdouts[1])
+                self.assertTrue(pc._stderr_tail.stopped())
+                self.assertTrue(pc._stdout_tail.stopped())
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function_signal(self):
+        """
+        run 2x copies of echo3, induce a segfault on first
+        """
+        SEGFAULT = True
+        for start_method, redirs in product(self._start_methods, redirects()):
+            with self.subTest(start_method=start_method):
+                log_dir = self.log_dir()
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo3,
+                    args={0: ("hello", SEGFAULT), 1: ("world",)},
+                    envs={0: {}, 1: {}},
+                    log_dir=log_dir,
+                    start_method=start_method,
+                    redirects=redirs,
+                )
+
+                results = pc.wait(period=0.1)
+
+                self.assert_pids_noexist(pc.pids())
+                self.assertEqual(1, len(results.failures))
+                self.assertFalse(results.return_values)
+
+                failure = results.failures[0]
+                error_file = failure.error_file
+
+                self.assertEqual(-signal.SIGSEGV, failure.exitcode)
+                self.assertEqual("SIGSEGV", failure.signal_name())
+                self.assertEqual(pc.pids()[0], failure.pid)
+                self.assertEqual(os.path.join(log_dir, "0", "error.json"), error_file)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_void_function(self):
+        for start_method in self._start_methods:
+            with self.subTest(start_method=start_method):
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo0,
+                    args={0: ("hello",), 1: ("world",)},
+                    envs={0: {}, 1: {}},
+                    log_dir=self.log_dir(),
+                    start_method=start_method,
+                )
+
+                results = pc.wait(period=0.1)
+                self.assertEqual({0: None, 1: None}, results.return_values)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function_large_ret_val(self):
+        # python multiprocessing.queue module uses pipes and actually PipedQueues
+        # This means that if a single object is greater than a pipe size
+        # the writer process will block until reader process will start
+        # reading the pipe.
+        # This test makes a worker fn to return huge output, around ~10 MB
+
+        size = 200000
+        for start_method in self._start_methods:
+            with self.subTest(start_method=start_method):
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo_large,
+                    args={0: (size,), 1: (size,), 2: (size,), 3: (size,)},
+                    envs={0: {}, 1: {}, 2: {}, 3: {}},
+                    log_dir=self.log_dir(),
+                    start_method=start_method,
+                )
+
+                results = pc.wait(period=0.1)
+                for i in range(pc.nprocs):
+                    self.assertEqual(size, len(results.return_values[i]))
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function_raise(self):
+        """
+        run 2x copies of echo2, raise an exception on the first
+        """
+        RAISE = True
+
+        for start_method in self._start_methods:
+            with self.subTest(start_method=start_method):
+                log_dir = self.log_dir()
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=echo2,
+                    args={0: ("hello", RAISE), 1: ("world",)},
+                    envs={0: {}, 1: {}},
+                    log_dir=log_dir,
+                    start_method=start_method,
+                )
+
+                results = pc.wait(period=0.1)
+
+                self.assert_pids_noexist(pc.pids())
+                self.assertEqual(1, len(results.failures))
+                self.assertFalse(results.return_values)
+
+                failure = results.failures[0]
+                error_file = failure.error_file
+                error_file_data = failure.error_file_data
+
+                self.assertEqual(1, failure.exitcode)
+                self.assertEqual("<N/A>", failure.signal_name())
+                self.assertEqual(pc.pids()[0], failure.pid)
+                self.assertEqual(os.path.join(log_dir, "0", "error.json"), error_file)
+                self.assertEqual(
+                    int(error_file_data["message"]["extraInfo"]["timestamp"]),
+                    int(failure.timestamp),
+                )
+                self.assertTrue(pc._stderr_tail.stopped())
+                self.assertTrue(pc._stdout_tail.stopped())
+
+    def test_function_redirect_and_tee(self):
+        for start_method in self._start_methods:
+            with self.subTest(start_method=start_method):
+                log_dir = self.log_dir()
+                pc = start_processes(
+                    name="trainer",
+                    entrypoint=echo1,
+                    args={0: ("hello",), 1: ("world",)},
+                    envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+                    log_dir=log_dir,
+                    start_method="fork",
+                    redirects={0: Std.ERR, 1: Std.NONE},
+                    tee={0: Std.OUT, 1: Std.ERR},
+                )
+
+                result = pc.wait()
+
+                self.assertFalse(result.is_failed())
+                self.assert_in_file(["hello stdout from 0"], pc.stdouts[0])
+                self.assert_in_file(["hello stderr from 0"], pc.stderrs[0])
+                self.assert_in_file(["world stderr from 1"], pc.stderrs[1])
+                self.assertFalse(pc.stdouts[1])
+                self.assertTrue(pc._stderr_tail.stopped())
+                self.assertTrue(pc._stdout_tail.stopped())
+
+    ########################################
+    # start_processes as binary tests
+    ########################################
+
+    def bin(self, name: str):
+        dir = os.path.dirname(__file__)
+        return os.path.join(dir, "bin", name)
+
+    def test_binary(self):
+        for redirs in redirects():
+            with self.subTest(redirs=redirs):
+                pc = start_processes(
+                    name="echo",
+                    entrypoint=self.bin("echo1.py"),
+                    args={0: ("hello",), 1: ("hello",)},
+                    envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+                    log_dir=self.log_dir(),
+                    redirects=redirs,
+                )
+
+                results = pc.wait(period=0.1)
+
+                self.assert_pids_noexist(pc.pids())
+                # currently binaries return {rank: None}
+                self.assertEqual(2, len(results.return_values))
+                self.assertFalse(results.is_failed())
+
+                nprocs = pc.nprocs
+                for i in range(nprocs):
+                    if redirs & Std.OUT != Std.OUT:
+                        self.assertFalse(results.stdouts[i])
+                    if redirs & Std.ERR != Std.ERR:
+                        self.assertFalse(results.stderrs[i])
+                    if redirs & Std.OUT == Std.OUT:
+                        self.assert_in_file(
+                            [f"hello stdout from {i}"], results.stdouts[i]
+                        )
+                    if redirs & Std.ERR == Std.ERR:
+                        self.assert_in_file(
+                            [f"hello stderr from {i}"], results.stderrs[i]
+                        )
+
+    def test_binary_exit(self):
+        FAIL = 138
+        pc = start_processes(
+            name="echo",
+            entrypoint=self.bin("echo1.py"),
+            args={0: ("--exitcode", FAIL, "foo"), 1: ("--exitcode", 0, "bar")},
+            envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+            log_dir=self.log_dir(),
+            redirects={0: Std.ALL},
+        )
+
+        results = pc.wait(period=0.1)
+
+        self.assertTrue(results.is_failed())
+        self.assertEqual(1, len(results.failures))
+
+        failure = results.failures[0]
+        self.assertEqual(138, failure.exitcode)
+        self.assertEqual("<N/A>", failure.signal_name())
+        self.assertEqual("<NONE>", failure.error_file_data["message"])
+        self.assert_in_file([f"exit {FAIL} from 0"], results.stderrs[0])
+        self.assert_in_file([], results.stdouts[0])
+        self.assertFalse(results.stderrs[1])
+        self.assertFalse(results.stdouts[1])
+        self.assertTrue(pc._stderr_tail.stopped())
+        self.assertTrue(pc._stdout_tail.stopped())
+
+    def test_binary_raises(self):
+        pc = start_processes(
+            name="echo",
+            entrypoint=self.bin("echo2.py"),
+            args={0: ("--raises", "true", "foo"), 1: ("bar",)},
+            envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+            log_dir=self.log_dir(),
+        )
+
+        results = pc.wait(period=0.1)
+
+        self.assert_pids_noexist(pc.pids())
+        self.assertTrue(results.is_failed())
+        self.assertEqual(1, len(results.failures))
+
+        failure = results.failures[0]
+        self.assertEqual(1, failure.exitcode)
+        self.assertEqual("<NONE>", failure.error_file_data["message"])
+        self.assertEqual("<N/A>", failure.signal_name())
+
+    def test_binary_incorrect_entrypoint(self):
+        with self.assertRaises(FileNotFoundError):
+            start_processes(
+                name="echo",
+                entrypoint="does_not_exist.py",
+                args={0: ("foo"), 1: ("bar",)},
+                envs={0: {}, 1: {}},
+                log_dir=self.log_dir(),
+            )
+
+    def test_binary_signal(self):
+        pc = start_processes(
+            name="echo",
+            entrypoint=self.bin("echo3.py"),
+            args={0: ("--segfault", "true", "foo"), 1: ("bar",)},
+            envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+            log_dir=self.log_dir(),
+        )
+
+        results = pc.wait(period=0.1)
+
+        self.assert_pids_noexist(pc.pids())
+        self.assertTrue(results.is_failed())
+        self.assertEqual(1, len(results.failures))
+
+        failure = results.failures[0]
+        self.assertNotEqual(signal.SIGSEGV, failure.exitcode)
+        self.assertEqual("SIGSEGV", failure.signal_name())
+        self.assertEqual("<NONE>", failure.error_file_data["message"])
+
+    def test_binary_redirect_and_tee(self):
+        pc = start_processes(
+            name="trainer",
+            entrypoint=self.bin("echo1.py"),
+            args={0: ("hello",), 1: ("world",)},
+            envs={0: {"RANK": "0"}, 1: {"RANK": "1"}},
+            log_dir=self.log_dir(),
+            start_method="fork",
+            redirects={0: Std.ERR, 1: Std.NONE},
+            tee={0: Std.OUT, 1: Std.ERR},
+        )
+
+        result = pc.wait()
+
+        self.assertFalse(result.is_failed())
+        self.assert_in_file(["hello stdout from 0"], pc.stdouts[0])
+        self.assert_in_file(["hello stderr from 0"], pc.stderrs[0])
+        self.assert_in_file(["world stderr from 1"], pc.stderrs[1])
+        self.assertFalse(pc.stdouts[1])
+        self.assertTrue(pc._stderr_tail.stopped())
+        self.assertTrue(pc._stdout_tail.stopped())
+
+    def test_validate_full_rank(self):
+        with self.assertRaises(RuntimeError):
+            _validate_full_rank({}, 10, "")
+
+    def test_multiprocessing_context_poll_raises_exception(self):
+        mp_context = MultiprocessContext(
+            name="test_mp",
+            entrypoint=echo0,
+            args={0: (0, 1)},
+            envs={},
+            stdouts={0: {}},
+            stderrs={0: {}},
+            tee_stdouts={0: "tee_stdout"},
+            tee_stderrs={0: "tee_stderr"},
+            error_files={0: "test_file"},
+            start_method="spawn",
+        )
+        mp_context._pc = mock.Mock()
+        # Using mock since we cannot just set exitcode on process
+        mock_process = mock.Mock()
+        mock_process.exitcode = -1
+        mp_context._pc.processes = [mock_process]
+        e = mp.ProcessRaisedException(msg="test msg", error_index=0, error_pid=123)
+        mp_context._pc.join.side_effect = e
+        with mock.patch.object(mp_context, "close"):
+            run_result = mp_context._poll()
+            self.assertEqual(1, len(run_result.failures))
+            failure = run_result.failures[0]
+            self.assertEqual("Signal 1 (SIGHUP) received by PID 123", failure.message)

--- a/test/distributed/elastic/multiprocessing/bin/echo1.py
+++ b/test/distributed/elastic/multiprocessing/bin/echo1.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import sys
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="test binary, exits with exitcode")
+    parser.add_argument("--exitcode", type=int, default=0)
+    parser.add_argument("msg", type=str)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+    exitcode = args.exitcode
+    if exitcode != 0:
+        print(f"exit {exitcode} from {rank}", file=sys.stderr)
+        sys.exit(exitcode)
+    else:
+        print(f"{args.msg} stdout from {rank}")
+        print(f"{args.msg} stderr from {rank}", file=sys.stderr)

--- a/test/distributed/elastic/multiprocessing/bin/echo2.py
+++ b/test/distributed/elastic/multiprocessing/bin/echo2.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="test binary, raises a RuntimeError")
+    parser.add_argument("--raises", type=bool, default=False)
+    parser.add_argument("msg", type=str)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+
+    if args.raises:
+        raise RuntimeError(f"raised from {rank}")
+    else:
+        print(f"{args.msg} from {rank}")

--- a/test/distributed/elastic/multiprocessing/bin/echo3.py
+++ b/test/distributed/elastic/multiprocessing/bin/echo3.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import ctypes
+import os
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="test binary, triggers a segfault (SIGSEGV)"
+    )
+    parser.add_argument("--segfault", type=bool, default=False)
+    parser.add_argument("msg", type=str)
+    args = parser.parse_args()
+
+    rank = int(os.environ["RANK"])
+
+    if args.segfault:
+        ctypes.string_at(0)
+    else:
+
+        print(f"{args.msg} from {rank}")

--- a/test/distributed/elastic/multiprocessing/bin/test_script.py
+++ b/test/distributed/elastic/multiprocessing/bin/test_script.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# TODO <DELETE_ME>

--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+import filecmp
+import json
+import os
+import shutil
+import signal
+import tempfile
+import unittest
+from unittest import mock
+
+from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, ProcessFailure, record
+from torch.distributed.elastic.multiprocessing.errors.error_handler import _write_error
+from torch.testing._internal.common_utils import TEST_WITH_TSAN
+
+
+class SentinelError(Exception):
+    # exists so that we can validate that
+    # the correct error is raised and propagated
+    pass
+
+
+@record
+def raise_exception_fn():
+    raise SentinelError("foobar")
+
+
+@record
+def good_fn():
+    print("hello world")
+
+
+@record
+def raise_child_failure_error_fn(name, child_error_file=""):
+    if child_error_file:
+        _write_error(SentinelError("foobar"), child_error_file)
+    pf = ProcessFailure(local_rank=0, pid=997, exitcode=1, error_file=child_error_file)
+    raise ChildFailedError(name, {0: pf})
+
+
+def read_resource_file(resource_file: str) -> str:
+    with open(os.path.join(os.path.dirname(__file__), resource_file), "r") as fp:
+        return "".join(fp.readlines())
+
+
+@unittest.skipIf(TEST_WITH_TSAN, "test incompatible with tsan")
+class ApiTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
+        self.test_error_file = os.path.join(self.test_dir, "error.json")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def failure_with_error_file(self, exception):
+        _write_error(exception, self.test_error_file)
+        return ProcessFailure(
+            local_rank=0, pid=997, exitcode=1, error_file=self.test_error_file
+        )
+
+    def failure_without_error_file(self, exitcode):
+        return ProcessFailure(
+            local_rank=0, pid=997, exitcode=exitcode, error_file="ignored.json"
+        )
+
+    def test_process_failure(self):
+        pf = self.failure_with_error_file(exception=SentinelError("foobar"))
+        self.assertEqual(0, pf.local_rank)
+        self.assertEqual(997, pf.pid)
+        self.assertEqual(1, pf.exitcode)
+        self.assertEqual(self.test_error_file, pf.error_file)
+        self.assertEqual(
+            pf.error_file_data["message"]["extraInfo"]["timestamp"], str(pf.timestamp)
+        )
+        self.assertTrue(pf.message)  # check not None and not "" (empty string)
+        self.assertEqual("<N/A>", pf.signal_name())
+
+    def test_process_failure_signal(self):
+        pf = self.failure_without_error_file(exitcode=-signal.SIGSEGV)
+        self.assertEqual("SIGSEGV", pf.signal_name())
+        self.assertEqual(
+            f"Signal {signal.SIGSEGV} (SIGSEGV) received by PID {pf.pid}", pf.message
+        )
+
+    def test_process_failure_no_error_file(self):
+        pf = self.failure_without_error_file(exitcode=138)
+        self.assertEqual("<N/A>", pf.signal_name())
+        self.assertEqual("<N/A>", pf.error_file)
+        self.assertEqual("Process failed with exitcode 138", pf.message)
+
+    def test_child_failed_error(self):
+        pf0 = self.failure_with_error_file(exception=SentinelError("rank 0"))
+        pf1 = self.failure_with_error_file(exception=SentinelError("rank 1"))
+        pf2 = self.failure_without_error_file(exitcode=138)
+        ex = ChildFailedError("trainer.par", {0: pf0, 1: pf1, 2: pf2})
+        self.assertEqual(pf0, ex.get_first_failure()[1])
+        # print is intentional and should prints something like this:
+        """
+        *********************************************
+              trainer.par FAILED
+        =============================================
+        Root Cause:
+        [0]:
+          time: 2020-11-25_21:22:31
+          rank: 0 (local_rank: 0)
+          exitcode: 1 (pid: 997)
+          error_file: /tmp/ApiTesttbb37ier/error.json
+          msg: "SentinelError: rank 0"
+        =============================================
+        Other Failures:
+        [1]:
+          time: 2020-11-25_21:22:31
+          rank: 1 (local_rank: 0)
+          exitcode: 1 (pid: 997)
+          error_file: /tmp/ApiTesttbb37ier/error.json
+          msg: "SentinelError: rank 1"
+        [2]:
+          time: 2020-11-25_21:22:31
+          rank: 2 (local_rank: 0)
+          exitcode: 138 (pid: 997)
+          error_file: <N/A>
+          msg: "Process failed with exitcode 138"
+        *********************************************
+        """
+        print(ex)
+
+    def test_record(self):
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            with self.assertRaises(SentinelError):
+                raise_exception_fn()
+
+        with open(self.test_error_file, "r") as fp:
+            err = json.load(fp)
+            self.assertIsNotNone(err["message"]["message"])
+            self.assertIsNotNone(err["message"]["extraInfo"]["py_callstack"])
+            self.assertIsNotNone(err["message"]["extraInfo"]["timestamp"])
+
+    def test_record_no_error_file(self):
+        with mock.patch.dict(os.environ, {}):
+            with self.assertRaises(SentinelError):
+                raise_exception_fn()
+
+        # no error file should have been generated
+        self.assertFalse(os.path.isfile(self.test_error_file))
+
+    def test_record_good_fn(self):
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            good_fn()
+            # function did not error; no error file should be produced
+            self.assertFalse(os.path.isfile(self.test_error_file))
+
+    def test_record_child_failure(self):
+        trainer_log_dir = os.path.join(self.test_dir, "trainer", "0")
+        os.makedirs(trainer_log_dir)
+        trainer_error_file = os.path.join(trainer_log_dir, "error.json")
+
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            with self.assertRaises(ChildFailedError) as cm:
+                raise_child_failure_error_fn("trainer", trainer_error_file)
+
+            self.assertTrue(
+                filecmp.cmp(
+                    self.test_error_file, cm.exception.get_first_failure()[1].error_file
+                )
+            )
+
+    def test_record_child_failure_no_child_error_file(self):
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            with self.assertRaises(ChildFailedError):
+                raise_child_failure_error_fn("trainer")
+
+            # @record should only copy child error file when ChildFailedError
+            # is raised - it should NOT record ChildFailedError itself
+            # it SHOULD re-raise ChildFailedError for any upstream system
+            # to handle it.
+            self.assertFalse(os.path.isfile(self.test_error_file))

--- a/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import filecmp
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler, _write_error
+from torch.distributed.elastic.multiprocessing.errors.handlers import get_error_handler
+
+
+def raise_exception_fn():
+    raise RuntimeError("foobar")
+
+
+class GetErrorHandlerTest(unittest.TestCase):
+    def test_get_error_handler(self):
+        self.assertTrue(isinstance(get_error_handler(), ErrorHandler))
+
+
+class ErrorHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
+        self.test_error_file = os.path.join(self.test_dir, "error.json")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    @patch("faulthandler.enable")
+    def test_initialize(self, fh_enable_mock):
+        ErrorHandler().initialize()
+        fh_enable_mock.assert_called_once()
+
+    @patch("faulthandler.enable", side_effect=RuntimeError)
+    def test_initialize_error(self, fh_enable_mock):
+        # makes sure that initialize handles errors gracefully
+        ErrorHandler().initialize()
+        fh_enable_mock.assert_called_once()
+
+    def test_record_exception(self):
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}):
+            eh = ErrorHandler()
+            eh.initialize()
+
+            try:
+                raise_exception_fn()
+            except Exception as e:
+                eh.record_exception(e)
+
+            with open(self.test_error_file, "r") as fp:
+                err = json.load(fp)
+                # error file content example:
+                # {
+                #   "message": {
+                #     "message": "RuntimeError: foobar",
+                #     "extraInfo": {
+                #       "py_callstack": "Traceback (most recent call last):\n  <... OMITTED ...>",
+                #       "timestamp": "1605774851"
+                #     }
+                #   }
+            self.assertIsNotNone(err["message"]["message"])
+            self.assertIsNotNone(err["message"]["extraInfo"]["py_callstack"])
+            self.assertIsNotNone(err["message"]["extraInfo"]["timestamp"])
+
+    def test_record_exception_no_error_file(self):
+        # make sure record does not fail when no error file is specified in env vars
+        with patch.dict(os.environ, {}):
+            eh = ErrorHandler()
+            eh.initialize()
+            try:
+                raise_exception_fn()
+            except Exception as e:
+                eh.record_exception(e)
+
+    def test_copy_error_file(self):
+        src_error_file = os.path.join(self.test_dir, "src_error.json")
+        _write_error(RuntimeError("foobar"), src_error_file)
+
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}):
+            eh = ErrorHandler()
+            eh.copy_error_file(src_error_file)
+            self.assertTrue(filecmp.cmp(src_error_file, self.test_error_file))
+
+        with patch.dict(os.environ, {}):
+            eh = ErrorHandler()
+            eh.copy_error_file(src_error_file)
+            # just validate that copy_error_file works when
+            # my error file is not set
+            # should just log an error with src_error_file pretty printed
+
+    def test_copy_error_file_overwrite_existing(self):
+        dst_error_file = os.path.join(self.test_dir, "dst_error.json")
+        src_error_file = os.path.join(self.test_dir, "src_error.json")
+        _write_error(RuntimeError("foo"), dst_error_file)
+        _write_error(RuntimeError("bar"), src_error_file)
+
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": dst_error_file}):
+            eh = ErrorHandler()
+            eh.copy_error_file(src_error_file)
+            self.assertTrue(filecmp.cmp(src_error_file, dst_error_file))

--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import ctypes
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+from torch.distributed.elastic.multiprocessing.redirects import (
+    redirect,
+    redirect_stderr,
+    redirect_stdout,
+)
+
+
+libc = ctypes.CDLL("libc.so.6")
+c_stderr = ctypes.c_void_p.in_dll(libc, "stderr")
+
+
+class RedirectsTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_redirect_invalid_std(self):
+        with self.assertRaises(ValueError):
+            with redirect("stdfoo", os.path.join(self.test_dir, "stdfoo.log")):
+                pass
+
+    def test_redirect_stdout(self):
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+
+        # printing to stdout before redirect should go to console not stdout.log
+        print("foo first from python")
+        libc.printf(b"foo first from c\n")
+        os.system("echo foo first from cmd")
+
+        with redirect_stdout(stdout_log):
+            print("foo from python")
+            libc.printf(b"foo from c\n")
+            os.system("echo foo from cmd")
+
+        # make sure stdout is restored
+        print("foo again from python")
+        libc.printf(b"foo again from c\n")
+        os.system("echo foo again from cmd")
+
+        with open(stdout_log, "r") as f:
+            # since we print from python, c, cmd -> the stream is not ordered
+            # do a set comparison
+            lines = set(f.readlines())
+            self.assertEqual(
+                {"foo from python\n", "foo from c\n", "foo from cmd\n"}, lines
+            )
+
+    def test_redirect_stderr(self):
+        stderr_log = os.path.join(self.test_dir, "stderr.log")
+
+        print("bar first from python")
+        libc.fprintf(c_stderr, b"bar first from c\n")
+        os.system("echo bar first from cmd 1>&2")
+
+        with redirect_stderr(stderr_log):
+            print("bar from python", file=sys.stderr)
+            libc.fprintf(c_stderr, b"bar from c\n")
+            os.system("echo bar from cmd 1>&2")
+
+        print("bar again from python")
+        libc.fprintf(c_stderr, b"bar again from c\n")
+        os.system("echo bar again from cmd 1>&2")
+
+        with open(stderr_log, "r") as f:
+            lines = set(f.readlines())
+            self.assertEqual(
+                {"bar from python\n", "bar from c\n", "bar from cmd\n"}, lines
+            )
+
+    def test_redirect_both(self):
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+        stderr_log = os.path.join(self.test_dir, "stderr.log")
+
+        print("first stdout from python")
+        libc.printf(b"first stdout from c\n")
+
+        print("first stderr from python", file=sys.stderr)
+        libc.fprintf(c_stderr, b"first stderr from c\n")
+
+        with redirect_stdout(stdout_log), redirect_stderr(stderr_log):
+            print("redir stdout from python")
+            print("redir stderr from python", file=sys.stderr)
+            libc.printf(b"redir stdout from c\n")
+            libc.fprintf(c_stderr, b"redir stderr from c\n")
+
+        print("again stdout from python")
+        libc.fprintf(c_stderr, b"again stderr from c\n")
+
+        with open(stdout_log, "r") as f:
+            lines = set(f.readlines())
+            self.assertEqual(
+                {"redir stdout from python\n", "redir stdout from c\n"}, lines
+            )
+
+        with open(stderr_log, "r") as f:
+            lines = set(f.readlines())
+            self.assertEqual(
+                {"redir stderr from python\n", "redir stderr from c\n"}, lines
+            )
+
+    def _redirect_large_buffer(self, print_fn, num_lines=500_000):
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+
+        with redirect_stdout(stdout_log):
+            for i in range(num_lines):
+                print_fn(i)
+
+        with open(stdout_log) as fp:
+            actual = {int(line.split(":")[1]) for line in fp.readlines()}
+            expected = set(range(num_lines))
+            self.assertSetEqual(expected, actual)
+
+    def test_redirect_large_buffer_py(self):
+        def py_print(i):
+            print(f"py:{i}")
+
+        self._redirect_large_buffer(py_print)
+
+    def test_redirect_large_buffer_c(self):
+        def c_print(i):
+            libc.printf(bytes(f"c:{i}\n", "utf-8"))
+
+        self._redirect_large_buffer(c_print)

--- a/test/distributed/elastic/multiprocessing/tail_log_test.py
+++ b/test/distributed/elastic/multiprocessing/tail_log_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import io
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from concurrent.futures import wait
+from concurrent.futures._base import ALL_COMPLETED
+from concurrent.futures.thread import ThreadPoolExecutor
+from typing import Dict, Set
+from unittest import mock
+
+from torch.distributed.elastic.multiprocessing.tail_log import TailLog
+
+
+def write(max: int, sleep: float, file: str):
+    with open(file, "w") as fp:
+        for i in range(max):
+            print(i, file=fp, flush=True)
+            time.sleep(sleep)
+
+
+class TailLogTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix=f"{self.__class__.__name__}_")
+        self.threadpool = ThreadPoolExecutor()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_tail(self):
+        """
+        writer() writes 0 - max (on number on each line) to a log file.
+        Run nprocs such writers and tail the log files into an IOString
+        and validate that all lines are accounted for.
+        """
+        nprocs = 32
+        max = 1000
+        interval_sec = 0.0001
+
+        log_files = {
+            local_rank: os.path.join(self.test_dir, f"{local_rank}_stdout.log")
+            for local_rank in range(nprocs)
+        }
+
+        dst = io.StringIO()
+        tail = TailLog("writer", log_files, dst, interval_sec).start()
+        # sleep here is intentional to ensure that the log tail
+        # can gracefully handle and wait for non-existent log files
+        time.sleep(interval_sec * 10)
+
+        futs = []
+        for local_rank, file in log_files.items():
+            f = self.threadpool.submit(
+                write, max=max, sleep=interval_sec * local_rank, file=file
+            )
+            futs.append(f)
+
+        wait(futs, return_when=ALL_COMPLETED)
+        self.assertFalse(tail.stopped())
+        tail.stop()
+
+        dst.seek(0)
+        actual: Dict[int, Set[int]] = {}
+
+        for line in dst.readlines():
+            header, num = line.split(":")
+            nums = actual.setdefault(header, set())
+            nums.add(int(num))
+
+        self.assertEqual(nprocs, len(actual))
+        self.assertEqual(
+            {f"[writer{i}]": set(range(max)) for i in range(nprocs)}, actual
+        )
+        self.assertTrue(tail.stopped())
+
+    def test_tail_no_files(self):
+        """
+        Ensures that the log tail can gracefully handle no log files
+        in which case it does nothing.
+        """
+        tail = TailLog("writer", log_files={}, dst=sys.stdout).start()
+        self.assertFalse(tail.stopped())
+        tail.stop()
+        self.assertTrue(tail.stopped())
+
+    def test_tail_logfile_never_generates(self):
+        """
+        Ensures that we properly shutdown the threadpool
+        even when the logfile never generates.
+        """
+
+        tail = TailLog("writer", log_files={0: "foobar.log"}, dst=sys.stdout).start()
+        tail.stop()
+        self.assertTrue(tail.stopped())
+        self.assertTrue(tail._threadpool._shutdown)
+
+    @mock.patch("torch.distributed.elastic.multiprocessing.tail_log.log")
+    def test_tail_logfile_error_in_tail_fn(self, mock_logger):
+        """
+        Ensures that when there is an error in the tail_fn (the one that runs in the
+        threadpool), it is dealt with and raised properly.
+        """
+
+        # try giving tail log a directory (should fail with an IsADirectoryError
+        tail = TailLog("writer", log_files={0: self.test_dir}, dst=sys.stdout).start()
+        tail.stop()
+
+        mock_logger.error.assert_called_once()

--- a/test/distributed/elastic/timer/__init__.py
+++ b/test/distributed/elastic/timer/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/distributed/elastic/timer/api_test.py
+++ b/test/distributed/elastic/timer/api_test.py
@@ -1,0 +1,74 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+import unittest.mock as mock
+
+from torch.distributed.elastic.timer import TimerServer
+from torch.distributed.elastic.timer.api import RequestQueue, TimerRequest
+
+
+class MockRequestQueue(RequestQueue):
+    def size(self):
+        return 2
+
+    def get(self, size, timeout):
+        return [TimerRequest(1, "test_1", 0), TimerRequest(2, "test_2", 0)]
+
+
+class MockTimerServer(TimerServer):
+    """
+     Mock implementation of TimerServer for testing purposes.
+     This mock has the following behavior:
+
+     1. reaping worker 1 throws
+     2. reaping worker 2 succeeds
+     3. reaping worker 3 fails (caught exception)
+
+    For each workers 1 - 3 returns 2 expired timers
+    """
+
+    def __init__(self, request_queue, max_interval):
+        super().__init__(request_queue, max_interval)
+
+    def register_timers(self, timer_requests):
+        pass
+
+    def clear_timers(self, worker_ids):
+        pass
+
+    def get_expired_timers(self, deadline):
+        return {
+            i: [TimerRequest(i, f"test_{i}_0", 0), TimerRequest(i, f"test_{i}_1", 0)]
+            for i in range(1, 4)
+        }
+
+    def _reap_worker(self, worker_id):
+        if worker_id == 1:
+            raise RuntimeError("test error")
+        elif worker_id == 2:
+            return True
+        elif worker_id == 3:
+            return False
+
+
+class TimerApiTest(unittest.TestCase):
+    @mock.patch.object(MockTimerServer, "register_timers")
+    @mock.patch.object(MockTimerServer, "clear_timers")
+    def test_run_watchdog(self, mock_clear_timers, mock_register_timers):
+        """
+        tests that when a ``_reap_worker()`` method throws an exception
+        for a particular worker_id, the timers for successfully reaped workers
+        are cleared properly
+        """
+        max_interval = 1
+        request_queue = mock.Mock(wraps=MockRequestQueue())
+        timer_server = MockTimerServer(request_queue, max_interval)
+        timer_server._run_watchdog()
+
+        request_queue.size.assert_called_once()
+        request_queue.get.assert_called_with(request_queue.size(), max_interval)
+        mock_register_timers.assert_called_with(request_queue.get(2, 1))
+        mock_clear_timers.assert_called_with({1, 2})

--- a/test/distributed/elastic/timer/local_timer_example.py
+++ b/test/distributed/elastic/timer/local_timer_example.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import logging
+import multiprocessing as mp
+import signal
+import time
+import unittest
+
+import torch.distributed.elastic.timer as timer
+import torch.multiprocessing as torch_mp
+from torch.testing._internal.common_utils import TEST_WITH_ASAN, TEST_WITH_TSAN
+
+
+logging.basicConfig(
+    level=logging.INFO, format="[%(levelname)s] %(asctime)s %(module)s: %(message)s"
+)
+
+
+def _happy_function(rank, mp_queue):
+    timer.configure(timer.LocalTimerClient(mp_queue))
+    with timer.expires(after=1):
+        time.sleep(0.5)
+
+
+def _stuck_function(rank, mp_queue):
+    timer.configure(timer.LocalTimerClient(mp_queue))
+    with timer.expires(after=1):
+        time.sleep(5)
+
+
+class LocalTimerExample(unittest.TestCase):
+    """
+    Demonstrates how to use LocalTimerServer and LocalTimerClient
+    to enforce expiration of code-blocks.
+
+    Since torch multiprocessing's ``start_process`` method currently
+    does not take the multiprocessing context as parameter argument
+    there is no way to create the mp.Queue in the correct
+    context BEFORE spawning child processes. Once the ``start_process``
+    API is changed in torch, then re-enable ``test_torch_mp_example``
+    unittest. As of now this will SIGSEGV.
+    """
+
+    @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test is a/tsan incompatible")
+    def test_torch_mp_example(self):
+        # in practice set the max_interval to a larger value (e.g. 60 seconds)
+        mp_queue = mp.get_context("spawn").Queue()
+        server = timer.LocalTimerServer(mp_queue, max_interval=0.01)
+        server.start()
+
+        world_size = 8
+
+        # all processes should complete successfully
+        # since start_process does NOT take context as parameter argument yet
+        # this method WILL FAIL (hence the test is disabled)
+        torch_mp.spawn(
+            fn=_happy_function, args=(mp_queue,), nprocs=world_size, join=True
+        )
+
+        with self.assertRaises(Exception):
+            # torch.multiprocessing.spawn kills all sub-procs
+            # if one of them gets killed
+            torch_mp.spawn(
+                fn=_stuck_function, args=(mp_queue,), nprocs=world_size, join=True
+            )
+
+        server.stop()
+
+    @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test is a/tsan incompatible")
+    def test_example_start_method_spawn(self):
+        self._run_example_with(start_method="spawn")
+
+    @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test is a/tsan incompatible")
+    def test_example_start_method_forkserver(self):
+        self._run_example_with(start_method="forkserver")
+
+    @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
+    def test_example_start_method_fork(self):
+        self._run_example_with(start_method="fork")
+
+    def _run_example_with(self, start_method):
+        spawn_ctx = mp.get_context(start_method)
+        mp_queue = spawn_ctx.Queue()
+        server = timer.LocalTimerServer(mp_queue, max_interval=0.01)
+        server.start()
+
+        world_size = 8
+        processes = []
+        for i in range(0, world_size):
+            if i % 2 == 0:
+                p = spawn_ctx.Process(target=_stuck_function, args=(i, mp_queue))
+            else:
+                p = spawn_ctx.Process(target=_happy_function, args=(i, mp_queue))
+            p.start()
+            processes.append(p)
+
+        for i in range(0, world_size):
+            p = processes[i]
+            p.join()
+            if i % 2 == 0:
+                self.assertEqual(-signal.SIGKILL, p.exitcode)
+            else:
+                self.assertEqual(0, p.exitcode)
+
+        server.stop()

--- a/test/distributed/elastic/timer/local_timer_test.py
+++ b/test/distributed/elastic/timer/local_timer_test.py
@@ -1,0 +1,267 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import multiprocessing as mp
+import signal
+import time
+import unittest
+import unittest.mock as mock
+
+import torch.distributed.elastic.timer as timer
+from torch.distributed.elastic.timer.api import TimerRequest
+from torch.distributed.elastic.timer.local_timer import MultiprocessingRequestQueue
+from torch.testing._internal.common_utils import TEST_WITH_TSAN
+
+
+class LocalTimerTest(unittest.TestCase):
+    def setUp(self):
+        self.mp_queue = mp.Queue()
+        self.max_interval = 0.01
+        self.server = timer.LocalTimerServer(self.mp_queue, self.max_interval)
+        self.server.start()
+
+    def tearDown(self):
+        self.server.stop()
+
+    def test_exception_propagation(self):
+        with self.assertRaises(Exception, msg="foobar"):
+            with timer.expires(after=1):
+                raise Exception("foobar")
+
+    def test_no_client(self):
+        # no timer client configured; exception expected
+        timer.configure(None)
+        with self.assertRaises(RuntimeError):
+            with timer.expires(after=1):
+                pass
+
+    def test_client_interaction(self):
+        # no timer client configured but one passed in explicitly
+        # no exception expected
+        timer_client = timer.LocalTimerClient(self.mp_queue)
+        timer_client.acquire = mock.MagicMock(wraps=timer_client.acquire)
+        timer_client.release = mock.MagicMock(wraps=timer_client.release)
+        with timer.expires(after=1, scope="test", client=timer_client):
+            pass
+
+        timer_client.acquire.assert_called_once_with("test", mock.ANY)
+        timer_client.release.assert_called_once_with("test")
+
+    def test_happy_path(self):
+        timer.configure(timer.LocalTimerClient(self.mp_queue))
+        with timer.expires(after=0.5):
+            time.sleep(0.1)
+
+    @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
+    def test_get_timer_recursive(self):
+        """
+        If a function acquires a countdown timer with default scope,
+        then recursive calls to the function should re-acquire the
+        timer rather than creating a new one. That is only the last
+        recursive call's timer will take effect.
+        """
+        self.server.start()
+        timer.configure(timer.LocalTimerClient(self.mp_queue))
+
+        # func should not time out
+        def func(n):
+            if n > 0:
+                with timer.expires(after=0.1):
+                    func(n - 1)
+                    time.sleep(0.05)
+
+        func(4)
+
+        # func2 should time out
+        def func2(n):
+            if n > 0:
+                with timer.expires(after=0.1):
+                    func2(n - 1)
+                    time.sleep(0.2)
+
+        p = mp.Process(target=func2, args=(2,))
+        p.start()
+        p.join()
+        self.assertEqual(-signal.SIGKILL, p.exitcode)
+
+    @staticmethod
+    def _run(mp_queue, timeout, duration):
+        client = timer.LocalTimerClient(mp_queue)
+        timer.configure(client)
+
+        with timer.expires(after=timeout):
+            time.sleep(duration)
+
+    @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
+    def test_timer(self):
+        timeout = 0.1
+        duration = 1
+        p = mp.Process(target=self._run, args=(self.mp_queue, timeout, duration))
+        p.start()
+        p.join()
+        self.assertEqual(-signal.SIGKILL, p.exitcode)
+
+
+def _enqueue_on_interval(mp_queue, n, interval, sem):
+    """
+    enqueues ``n`` timer requests into ``mp_queue`` one element per
+    interval seconds. Releases the given semaphore once before going to work.
+    """
+    sem.release()
+    for i in range(0, n):
+        mp_queue.put(TimerRequest(i, "test_scope", 0))
+        time.sleep(interval)
+
+
+class MultiprocessingRequestQueueTest(unittest.TestCase):
+    def test_get(self):
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+
+        requests = request_queue.get(1, timeout=0.01)
+        self.assertEqual(0, len(requests))
+
+        request = TimerRequest(1, "test_scope", 0)
+        mp_queue.put(request)
+        requests = request_queue.get(2, timeout=0.01)
+        self.assertEqual(1, len(requests))
+        self.assertIn(request, requests)
+
+    def test_get_size(self):
+        """
+        Creates a "producer" process that enqueues ``n`` elements
+        every ``interval`` seconds. Asserts that a ``get(n, timeout=n*interval+delta)``
+        yields all ``n`` elements.
+        """
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+        n = 10
+        interval = 0.1
+        sem = mp.Semaphore(0)
+
+        p = mp.Process(target=_enqueue_on_interval, args=(mp_queue, n, interval, sem))
+        p.start()
+
+        sem.acquire()  # blocks until the process has started to run the function
+        timeout = interval * (n + 1)
+        start = time.time()
+        requests = request_queue.get(n, timeout=timeout)
+        self.assertLessEqual(time.time() - start, timeout + interval)
+        self.assertEqual(n, len(requests))
+
+    def test_get_less_than_size(self):
+        """
+        Tests slow producer.
+        Creates a "producer" process that enqueues ``n`` elements
+        every ``interval`` seconds. Asserts that a ``get(n, timeout=(interval * n/2))``
+        yields at most ``n/2`` elements.
+        """
+        mp_queue = mp.Queue()
+        request_queue = MultiprocessingRequestQueue(mp_queue)
+        n = 10
+        interval = 0.1
+        sem = mp.Semaphore(0)
+
+        p = mp.Process(target=_enqueue_on_interval, args=(mp_queue, n, interval, sem))
+        p.start()
+
+        sem.acquire()  # blocks until the process has started to run the function
+        requests = request_queue.get(n, timeout=(interval * (n / 2)))
+        self.assertLessEqual(n / 2, len(requests))
+
+
+class LocalTimerServerTest(unittest.TestCase):
+    def setUp(self):
+        self.mp_queue = mp.Queue()
+        self.max_interval = 0.01
+        self.server = timer.LocalTimerServer(self.mp_queue, self.max_interval)
+
+    def tearDown(self):
+        self.server.stop()
+
+    @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
+    def test_watchdog_call_count(self):
+        """
+        checks that the watchdog function ran wait/interval +- 1 times
+        """
+        self.server._run_watchdog = mock.MagicMock(wraps=self.server._run_watchdog)
+
+        wait = 0.1
+
+        self.server.start()
+        time.sleep(wait)
+        self.server.stop()
+        watchdog_call_count = self.server._run_watchdog.call_count
+        self.assertGreaterEqual(watchdog_call_count, int(wait / self.max_interval) - 1)
+        self.assertLessEqual(watchdog_call_count, int(wait / self.max_interval) + 1)
+
+    def test_watchdog_empty_queue(self):
+        """
+        checks that the watchdog can run on an empty queue
+        """
+        self.server._run_watchdog()
+
+    def _expired_timer(self, pid, scope):
+        expired = time.time() - 60
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=expired)
+
+    def _valid_timer(self, pid, scope):
+        valid = time.time() + 60
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=valid)
+
+    def _release_timer(self, pid, scope):
+        return TimerRequest(worker_id=pid, scope_id=scope, expiration_time=-1)
+
+    @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
+    @mock.patch("os.kill")
+    def test_expired_timers(self, mock_os_kill):
+        """
+        tests that a single expired timer on a process should terminate
+        the process and clean up all pending timers that was owned by the process
+        """
+        test_pid = -3
+        self.mp_queue.put(self._expired_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=test_pid, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(0, len(self.server._timers))
+        mock_os_kill.assert_called_once_with(test_pid, signal.SIGKILL)
+
+    @mock.patch("os.kill")
+    def test_acquire_release(self, mock_os_kill):
+        """
+        tests that:
+          1. a timer can be acquired then released (should not terminate process)
+          2. a timer can be vacuously released (e.g. no-op)
+        """
+        test_pid = -3
+        self.mp_queue.put(self._valid_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._release_timer(pid=test_pid, scope="test1"))
+        self.mp_queue.put(self._release_timer(pid=test_pid, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(0, len(self.server._timers))
+        mock_os_kill.assert_not_called()
+
+    @mock.patch("os.kill")
+    def test_valid_timers(self, mock_os_kill):
+        """
+        tests that valid timers are processed correctly and the process is left alone
+        """
+        self.mp_queue.put(self._valid_timer(pid=-3, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=-3, scope="test2"))
+        self.mp_queue.put(self._valid_timer(pid=-2, scope="test1"))
+        self.mp_queue.put(self._valid_timer(pid=-2, scope="test2"))
+
+        self.server._run_watchdog()
+
+        self.assertEqual(4, len(self.server._timers))
+        self.assertTrue((-3, "test1") in self.server._timers)
+        self.assertTrue((-3, "test2") in self.server._timers)
+        self.assertTrue((-2, "test1") in self.server._timers)
+        self.assertTrue((-2, "test2") in self.server._timers)
+        mock_os_kill.assert_not_called()

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Library that launches and manages ``n`` copies of worker subprocesses
+either specified by a function or a binary.
+
+For functions, it uses ``torch.multiprocessing`` (and therefore python
+``multiprocessing``) to spawn/fork worker processes. For binaries it uses python
+``subprocessing.Popen`` to create worker processes.
+
+
+Usage 1: Launching two trainers as a function
+
+::
+
+ from torch.distributed.elastic.multiprocessing import Redirect, start_processes
+
+ def trainer(a, b, c):
+     pass # train
+
+
+ # runs two trainers
+ # LOCAL_RANK=0 trainer(1,2,3)
+ # LOCAL_RANK=1 trainer(4,5,6)
+ ctx = start_processes(
+         name="trainer",
+         entrypoint=trainer,
+         args={0: (1,2,3), 1: (4,5,6)},
+         envs={0: {"LOCAL_RANK": 0}, 1: {"LOCAL_RANK": 1}},
+         log_dir="/tmp/foobar",
+         redirects=Std.ALL, # write all worker stdout/stderr to a log file
+         tee={0: Std.ERR}, # tee only local rank 0's stderr to console
+       )
+
+ # waits for all copies of trainer to finish
+ ctx.wait()
+
+Usage 2: Launching 2 echo workers as a binary
+
+::
+
+ # same as invoking
+ # echo hello
+ # echo world > stdout.log
+ ctx = start_processes(
+         name="echo"
+         entrypoint="echo",
+         log_dir="/tmp/foobar",
+         args={0: "hello", 1: "world"},
+         redirects={1: Std:OUT},
+        )
+
+Just like ``torch.multiprocessing``, the return value of the function
+:func:`start_processes` is a process context (:class:`api.PContext`). If a function
+was launched, a :class:`api.MultiprocessContext` is returned and if a binary
+was launched a :class:`api.SubprocessContext` is returned. Both are specific
+implementations of the parent :class:`api.PContext` class.
+"""
+
+import os
+from typing import Callable, Dict, Tuple, Union
+
+from torch.distributed.elastic.multiprocessing.api import (  # noqa F401
+    MultiprocessContext,
+    PContext,
+    ProcessFailure,
+    RunProcsResult,
+    Std,
+    SubprocessContext,
+    _validate_full_rank,
+    to_map,
+)
+
+
+def start_processes(
+    name: str,
+    entrypoint: Union[Callable, str],
+    args: Dict[int, Tuple],
+    envs: Dict[int, Dict[str, str]],
+    log_dir: str,
+    start_method: str = "spawn",
+    redirects: Union[Std, Dict[int, Std]] = Std.NONE,
+    tee: Union[Std, Dict[int, Std]] = Std.NONE,
+) -> PContext:
+    """
+    Starts ``n`` copies of ``entrypoint`` processes with the provided options.
+    ``entrypoint`` is either a ``Callable`` (function) or a ``str`` (binary).
+    The number of copies is determined by the number of entries for ``args`` and
+    ``envs`` arguments, which need to have the same key set.
+
+    ``args`` and ``env`` parameters are the arguments and environment variables
+    to pass down to the entrypoint mapped by the replica index (local rank).
+    All local ranks must be accounted for.
+    That is, the keyset should be ``{0,1,...,(nprocs-1)}``.
+
+    .. note:: When the ``entrypoint`` is a binary (``str``), ``args`` can only be strings.
+              If any other type is given, then it is casted to a string representation
+              (e.g. ``str(arg1)``). Furthermore, a binary failure will only write
+              an ``error.json`` error file if the main function is annotated with
+              ``torch.distributed.elastic.multiprocessing.errors.record``. For function launches,
+              this is done by default and there is no need to manually annotate
+              with the ``@record`` annotation.
+
+    ``redirects`` and ``tees`` are bitmasks specifying which std stream(s) to redirect
+    to a log file in the ``log_dir``. Valid mask values are defined in ``Std``.
+    To redirect/tee only certain local ranks, pass ``redirects`` as a map with the key as
+    the local rank to specify the redirect behavior for.
+    Any missing local ranks will default to ``Redirect.NONE``.
+
+    ``tee`` acts like the unix "tee" command in that it redirects + prints to console.
+    To avoid worker stdout/stderr from printing to console, use the ``redirects`` parameter.
+
+    For each process, the ``log_dir`` will contain:
+
+    #. ``{local_rank}/error.json``: if the process failed, a file with the error info
+    #. ``{local_rank}/stdout.json``: if ``redirect & STDOUT == STDOUT``
+    #. ``{local_rank}/stderr.json``: if ``redirect & STDERR == STDERR``
+
+    .. note:: It is expected that the ``log_dir`` exists, is empty, and is a directory.
+
+    Example:
+
+    ::
+
+     log_dir = "/tmp/test"
+
+     # ok; two copies of foo: foo("bar0"), foo("bar1")
+     start_processes(
+        name="trainer",
+        entrypoint=foo,
+        args:{0:("bar0",), 1:("bar1",),
+        envs:{0:{}, 1:{}},
+        log_dir=log_dir
+     )
+
+     # invalid; envs missing for local rank 1
+     start_processes(
+        name="trainer",
+        entrypoint=foo,
+        args:{0:("bar0",), 1:("bar1",),
+        envs:{0:{}},
+        log_dir=log_dir
+     )
+
+     # ok; two copies of /usr/bin/touch: touch file1, touch file2
+     start_processes(
+        name="trainer",
+        entrypoint="/usr/bin/touch",
+        args:{0:("file1",), 1:("file2",),
+        envs:{0:{}, 1:{}},
+        log_dir=log_dir
+      )
+
+     # caution; arguments casted to string, runs:
+     # echo "1" "2" "3" and echo "[1, 2, 3]"
+     start_processes(
+        name="trainer",
+        entrypoint="/usr/bin/echo",
+        args:{0:(1,2,3), 1:([1,2,3],),
+        envs:{0:{}, 1:{}},
+        log_dir=log_dir
+      )
+
+    Args:
+        name: a human readable short name that describes what the processes are
+              (used as header when tee'ing stdout/stderr outputs)
+        entrypoint: either a ``Callable`` (function) or ``cmd`` (binary)
+        args: arguments to each replica
+        envs: env vars to each replica
+        log_dir: directory used to write log files
+        nprocs: number of copies to create (one on each process)
+        start_method: multiprocessing start method (spawn, fork, forkserver)
+                      ignored for binaries
+        redirects: which std streams to redirect to a log file
+        tees: which std streams to redirect + print to console
+
+    """
+
+    # listdir raises FileNotFound or NotADirectoryError so no need to check manually
+    if os.listdir(log_dir):
+        raise RuntimeError(
+            f"log_dir: {log_dir} is not empty, please provide an empty log_dir"
+        )
+
+    nprocs = len(args)
+    _validate_full_rank(args, nprocs, "args")
+    _validate_full_rank(envs, nprocs, "envs")
+
+    # create subdirs for each local rank in the logs_dir
+    # logs_dir
+    #       |- 0
+    #          |- error.json
+    #          |- stdout.log
+    #          |- stderr.log
+    #       |- ...
+    #       |- (nprocs-1)
+    redirs = to_map(redirects, nprocs)
+    ts = to_map(tee, nprocs)
+
+    # to tee stdout/stderr we first redirect into a file
+    # then tail -f stdout.log/stderr.log so add tee settings to redirects
+    for local_rank, tee_std in ts.items():
+        redirect_std = redirs[local_rank]
+        redirs[local_rank] = redirect_std | tee_std
+
+    stdouts = {local_rank: "" for local_rank in range(nprocs)}
+    stderrs = {local_rank: "" for local_rank in range(nprocs)}
+    tee_stdouts: Dict[int, str] = {}
+    tee_stderrs: Dict[int, str] = {}
+    error_files = {}
+
+    for local_rank in range(nprocs):
+        clogdir = os.path.join(log_dir, str(local_rank))
+        os.mkdir(clogdir)
+
+        rd = redirs[local_rank]
+        if (rd & Std.OUT) == Std.OUT:
+            stdouts[local_rank] = os.path.join(clogdir, "stdout.log")
+        if (rd & Std.ERR) == Std.ERR:
+            stderrs[local_rank] = os.path.join(clogdir, "stderr.log")
+
+        t = ts[local_rank]
+        if t & Std.OUT == Std.OUT:
+            tee_stdouts[local_rank] = stdouts[local_rank]
+        if t & Std.ERR == Std.ERR:
+            tee_stderrs[local_rank] = stderrs[local_rank]
+
+        error_file = os.path.join(clogdir, "error.json")
+        error_files[local_rank] = error_file
+        envs[local_rank]["TORCHELASTIC_ERROR_FILE"] = error_file
+
+    context: PContext
+    if isinstance(entrypoint, str):
+        context = SubprocessContext(
+            name=name,
+            entrypoint=entrypoint,
+            args=args,
+            envs=envs,
+            stdouts=stdouts,
+            stderrs=stderrs,
+            tee_stdouts=tee_stdouts,
+            tee_stderrs=tee_stderrs,
+            error_files=error_files,
+        )
+    else:
+        context = MultiprocessContext(
+            name=name,
+            entrypoint=entrypoint,
+            args=args,
+            envs=envs,
+            stdouts=stdouts,
+            stderrs=stderrs,
+            tee_stdouts=tee_stdouts,
+            tee_stderrs=tee_stderrs,
+            error_files=error_files,
+            start_method=start_method,
+        )
+
+    try:
+        context.start()
+        return context
+    except Exception:
+        context.close()
+        raise

--- a/torch/distributed/elastic/multiprocessing/api.py
+++ b/torch/distributed/elastic/multiprocessing/api.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from enum import IntFlag
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Union
+
+import torch.multiprocessing as mp
+from torch.distributed.elastic.multiprocessing.errors import ProcessFailure, record
+from torch.distributed.elastic.multiprocessing.redirects import (
+    redirect_stderr,
+    redirect_stdout,
+)
+from torch.distributed.elastic.multiprocessing.tail_log import TailLog
+
+
+log = logging.getLogger(__name__)
+
+
+def _validate_full_rank(d: Dict[int, Any], nprocs: int, what: str):
+    actual_keys = set(d.keys())
+    expected_keys = set(range(nprocs))
+
+    if actual_keys != expected_keys:
+        raise RuntimeError(
+            f"{what}, local rank mapping mismatch,"
+            f" expected: {expected_keys}, actual: {actual_keys}"
+        )
+
+
+_MAPPING_REGEX = r"^(\d:[0123],)*(\d:[0123])$"
+_VALUE_REGEX = r"^[0123]$"
+
+
+class Std(IntFlag):
+    NONE = 0
+    OUT = 1
+    ERR = 2
+    ALL = OUT | ERR
+
+    @classmethod
+    def from_str(cls, vm: str) -> Union["Std", Dict[int, "Std"]]:
+        """
+        Example:
+
+        ::
+
+         from_str("0") -> Std.NONE
+         from_str("1") -> Std.OUT
+         from_str("0:3,1:0,2:1,3:2") -> {0: Std.ALL, 1: Std.NONE, 2: Std.OUT, 3: Std.ERR}
+
+        Any other input raises an exception
+        """
+
+        def to_std(v):
+            v = int(v)
+            for s in Std:
+                if s == v:
+                    return s
+            # return None -> should NEVER reach here since we regex check input
+
+        if re.match(_VALUE_REGEX, vm):  # vm is a number (e.g. 0)
+            return to_std(vm)
+        elif re.match(_MAPPING_REGEX, vm):  # vm is a mapping (e.g. 0:1,1:2)
+            d: Dict[int, Std] = {}
+            for m in vm.split(","):
+                i, v = m.split(":")
+                d[int(i)] = to_std(v)
+            return d
+        else:
+            raise ValueError(
+                f"{vm} does not match: <{_VALUE_REGEX}> or <{_MAPPING_REGEX}>"
+            )
+
+
+def to_map(
+    val_or_map: Union[Std, Dict[int, Std]], local_world_size: int
+) -> Dict[int, Std]:
+    """
+    Certain APIs take redirect settings either as a single value (e.g. apply to all
+    local ranks) or as an explicit user-provided mapping. This method is a convenience
+    method that converts a value or mapping into a mapping.
+
+    Example:
+
+    ::
+
+     to_map(Std.OUT, local_world_size=2) # returns: {0: Std.OUT, 1: Std.OUT}
+     to_map({1: Std.OUT}, local_world_size=2) # returns: {0: Std.NONE, 1: Std.OUT}
+     to_map({0: Std.OUT, 1: Std.OUT}, local_world_size=2) # returns: {0: Std.OUT, 1: Std.OUT}
+    """
+    if isinstance(val_or_map, Std):
+        return {i: val_or_map for i in range(local_world_size)}
+    else:
+        map = {}
+        for i in range(local_world_size):
+            map[i] = val_or_map.get(i, Std.NONE)
+        return map
+
+
+@dataclass
+class RunProcsResult:
+    """
+    Results of a completed run of processes started with ``start_processes()``.
+    Returned by ``PContext``.
+
+    Note the following:
+
+    1. All fields are mapped by local rank
+    2. ``return_values`` - only populated for functions (not the binaries).
+    3. ``stdouts`` - path to stdout.log (empty string if no redirect)
+    4. ``stderrs`` - path to stderr.log (empty string if no redirect)
+
+    """
+
+    return_values: Dict[int, Any] = field(default_factory=dict)
+    failures: Dict[int, ProcessFailure] = field(default_factory=dict)
+    stdouts: Dict[int, str] = field(default_factory=dict)
+    stderrs: Dict[int, str] = field(default_factory=dict)
+
+    def is_failed(self) -> bool:
+        return len(self.failures) > 0
+
+
+class PContext(abc.ABC):
+    """
+    The base class that standardizes operations over a set of processes
+    that are launched via different mechanisms. The name ``PContext``
+    is intentional to disambiguate with ``torch.multiprocessing.ProcessContext``.
+
+    .. warning:: stdouts and stderrs should ALWAYS be a superset of
+                 tee_stdouts and tee_stderrs (respectively) this is b/c
+                 tee is implemented as a redirect + tail -f <stdout/stderr.log>
+    """
+
+    def __init__(
+        self,
+        name: str,
+        entrypoint: Union[Callable, str],
+        args: Dict[int, Tuple],
+        envs: Dict[int, Dict[str, str]],
+        stdouts: Dict[int, str],
+        stderrs: Dict[int, str],
+        tee_stdouts: Dict[int, str],
+        tee_stderrs: Dict[int, str],
+        error_files: Dict[int, str],
+    ):
+        self.name = name
+        # validate that all mappings have the same number of keys and
+        # all local ranks are accounted for
+        nprocs = len(args)
+        _validate_full_rank(stdouts, nprocs, "stdouts")
+        _validate_full_rank(stderrs, nprocs, "stderrs")
+
+        self.entrypoint = entrypoint
+        self.args = args
+        self.envs = envs
+        self.stdouts = stdouts
+        self.stderrs = stderrs
+        self.error_files = error_files
+        self.nprocs = nprocs
+
+        self._stdout_tail = TailLog(name, tee_stdouts, sys.stdout)
+        self._stderr_tail = TailLog(name, tee_stderrs, sys.stderr)
+
+    def start(self) -> None:
+        """
+        Start processes using parameters defined in the constructor.
+        """
+        self._start()
+        self._stdout_tail.start()
+        self._stderr_tail.start()
+
+    @abc.abstractmethod
+    def _start(self) -> None:
+        """
+        Start processes using strategy defined in a particular context.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _poll(self) -> Optional[RunProcsResult]:
+        """
+        Polls the run status of the processes running under this context.
+        This method follows an "all-or-nothing" policy and returns
+        a ``RunProcessResults`` object if either all processes complete
+        successfully or any process fails. Returns ``None`` if
+        all processes are still running.
+        """
+        raise NotImplementedError()
+
+    def wait(self, timeout: float = -1, period: float = 1) -> Optional[RunProcsResult]:
+        """
+        Waits for the specified ``timeout`` seconds, polling every ``period`` seconds
+        for the processes to be done. Returns ``None`` if the processes are still running
+        on timeout expiry. Negative timeout values are interpreted as "wait-forever".
+        A timeout value of zero simply queries the status of the processes (e.g. equivalent
+        to a poll).
+        """
+
+        if timeout == 0:
+            return self._poll()
+
+        if timeout < 0:
+            timeout = sys.maxsize
+
+        expiry = time.time() + timeout
+        while time.time() < expiry:
+            pr = self._poll()
+            if pr:
+                return pr
+            time.sleep(period)
+
+        return None
+
+    @abc.abstractmethod
+    def pids(self) -> Dict[int, int]:
+        """
+        Returns pids of processes mapped by their respective local_ranks
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _close(self) -> None:
+        r"""
+        Terminates all processes managed by this context and cleans up any
+        meta resources (e.g. redirect, error_file files).
+        """
+        raise NotImplementedError()
+
+    def close(self) -> None:
+        self._close()
+        if self._stdout_tail:
+            self._stdout_tail.stop()
+        if self._stderr_tail:
+            self._stderr_tail.stop()
+
+
+class _nullcontext(AbstractContextManager):
+    # TODO remove and replace in favor of contextlib.nullcontext
+    # when torch drops support for python3.6
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *excinfo):
+        pass
+
+
+def _wrap(
+    local_rank: int,
+    fn: Callable,
+    args: Dict[int, Tuple],
+    envs: Dict[int, Dict[str, str]],
+    stdout_redirects: Dict[int, str],  # redirect file for stdout (to console if None)
+    stderr_redirects: Dict[int, str],  # redirect file for stderr (to console if None)
+    ret_vals: Dict[int, mp.SimpleQueue],
+) -> None:
+    # get the per-rank params up front so we fail fast if no mapping is found
+    args_ = args[local_rank]
+    env_ = envs[local_rank]
+    ret_val_ = ret_vals[local_rank]
+
+    stdout_rd = stdout_redirects[local_rank]
+    stderr_rd = stderr_redirects[local_rank]
+
+    stdout_cm = redirect_stdout(stdout_rd) if stdout_rd else _nullcontext()
+    stderr_cm = redirect_stderr(stderr_rd) if stderr_rd else _nullcontext()
+
+    for k, v in env_.items():
+        os.environ[k] = v
+
+    with stdout_cm, stderr_cm:
+        ret = record(fn)(*args_)
+    ret_val_.put(ret)
+
+
+class MultiprocessContext(PContext):
+    """
+    ``PContext`` holding worker processes invoked as a function.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        entrypoint: Callable,
+        args: Dict[int, Tuple],
+        envs: Dict[int, Dict[str, str]],
+        stdouts: Dict[int, str],
+        stderrs: Dict[int, str],
+        tee_stdouts: Dict[int, str],
+        tee_stderrs: Dict[int, str],
+        error_files: Dict[int, str],
+        start_method: str,
+    ):
+        super().__init__(
+            name,
+            entrypoint,
+            args,
+            envs,
+            stdouts,
+            stderrs,
+            tee_stdouts,
+            tee_stderrs,
+            error_files,
+        )
+
+        self.start_method = start_method
+        # each ret_val queue will always contain a single element.
+        self._ret_vals = {
+            local_rank: mp.get_context(self.start_method).SimpleQueue()
+            for local_rank in range(self.nprocs)
+        }
+
+        # see comments in ``join()`` for what this is
+        self._return_values: Dict[int, Any] = {}
+        self._pc: Optional[mp.ProcessContext] = None
+
+    def _start(self):
+        if self._pc:
+            raise ValueError(
+                "The process context already initialized."
+                " Most likely the start method got called twice."
+            )
+        self._pc = mp.start_processes(
+            fn=_wrap,
+            args=(
+                self.entrypoint,
+                self.args,
+                self.envs,
+                self.stdouts,
+                self.stderrs,
+                self._ret_vals,
+            ),
+            nprocs=self.nprocs,
+            join=False,
+            daemon=False,
+            start_method=self.start_method,
+        )
+
+    def _poll(self) -> Optional[RunProcsResult]:
+        assert self._pc is not None  # assertion for mypy type checker
+
+        try:
+            # torch.mp.ProcessContext returns True if all the workers have
+            # successfully finished, False if some/all are still running
+            # and throws an Exception if some/all of them failed
+            # timeout < 0 checks worker status and return immediately
+            done = self._pc.join(-1)
+
+            # IMPORTANT: we use multiprocessing.Queue to carry worker return values
+            # back to the parent, the worker process will wait before terminating
+            # until all the buffered items are fed by the feeder thread to the underlying
+            # pipe. Hence to prevent deadlocks on large return values,
+            # we opportunistically try queue.get on each join call
+            # See: https://docs.python.org/2/library/multiprocessing.html#all-platforms
+            for local_rank in range(0, self.nprocs):
+                return_queue = self._ret_vals[local_rank]
+                if not return_queue.empty():
+                    # save the return values temporarily into a member var
+                    self._return_values[local_rank] = return_queue.get()
+
+            if done:
+                # we should ALWAYS have ALL the return values when all the processes are done
+                _validate_full_rank(
+                    self._return_values, self.nprocs, "return_value queue"
+                )
+                self.close()
+                return RunProcsResult(
+                    return_values=self._return_values,
+                    stdouts=self.stdouts,
+                    stderrs=self.stderrs,
+                )
+            else:
+                return None
+        except (mp.ProcessRaisedException, mp.ProcessExitedException) as e:
+            failed_local_rank = e.error_index
+
+            # entrypoint for MultiprocessContext will always be a Callable
+            fn_name = self.entrypoint.__qualname__  # type: ignore[union-attr]
+            failed_proc = self._pc.processes[failed_local_rank]
+            error_filepath = self.error_files[failed_local_rank]
+
+            log.error(
+                f"failed (exitcode: {failed_proc.exitcode})"
+                f" local_rank: {failed_local_rank} (pid: {e.pid})"
+                f" of fn: {fn_name} (start_method: {self.start_method})",
+                exc_info=True,
+            )
+
+            self.close()
+            return RunProcsResult(
+                failures={
+                    failed_local_rank: ProcessFailure(
+                        local_rank=failed_local_rank,
+                        pid=e.pid,
+                        exitcode=failed_proc.exitcode,
+                        error_file=error_filepath,
+                    )
+                },
+                stdouts=self.stdouts,
+                stderrs=self.stderrs,
+            )
+
+    def pids(self) -> Dict[int, int]:
+        assert self._pc is not None  # assertion for mypy type checking
+        return {local_rank: pid for local_rank, pid in enumerate(self._pc.pids())}
+
+    def _close(self) -> None:
+        if self._pc:
+            for proc in self._pc.processes:
+                proc.terminate()
+                proc.join()
+
+
+class SubprocessHandler:
+    """
+    Convenience wrapper around python's ``subprocess.Popen``. Keeps track of
+    meta-objects associated to the process (e.g. stdout and stderr redirect fds).
+    """
+
+    def __init__(
+        self,
+        entrypoint: str,
+        args: Tuple,
+        env: Dict[str, str],
+        preexec_fn: Callable,
+        stdout: str,
+        stderr: str,
+    ):
+        self._stdout = open(stdout, "w") if stdout else None
+        self._stderr = open(stderr, "w") if stderr else None
+        args_str = [str(e) for e in args]
+
+        # inherit parent environment vars
+        env_vars = os.environ.copy()
+        env_vars.update(env)
+
+        self.proc: subprocess.Popen = subprocess.Popen(
+            # pyre-fixme[6]: Expected `Union[typing.Sequence[Union[_PathLike[bytes],
+            #  _PathLike[str], bytes, str]], bytes, str]` for 1st param but got
+            #  `Tuple[str, *Tuple[Any, ...]]`.
+            args=(entrypoint, *args_str),
+            env=env_vars,
+            preexec_fn=preexec_fn,
+            stdout=self._stdout,
+            stderr=self._stderr,
+        )
+
+    def close(self):
+        self.proc.terminate()
+        self.proc.wait()
+        if self._stdout:
+            self._stdout.close()
+        if self._stderr:
+            self._stderr.close()
+
+
+class SubprocessContext(PContext):
+    """
+    ``PContext`` holding worker processes invoked as a binary.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        entrypoint: str,
+        args: Dict[int, Tuple],
+        envs: Dict[int, Dict[str, str]],
+        stdouts: Dict[int, str],
+        stderrs: Dict[int, str],
+        tee_stdouts: Dict[int, str],
+        tee_stderrs: Dict[int, str],
+        error_files: Dict[int, str],
+    ):
+        super().__init__(
+            name,
+            entrypoint,
+            args,
+            envs,
+            stdouts,
+            stderrs,
+            tee_stdouts,
+            tee_stderrs,
+            error_files,
+        )
+
+        # state vector; _vdone[local_rank] -> is local_rank finished or not
+        self._running_local_ranks: Set[int] = set(range(self.nprocs))
+        self._failures: Dict[int, ProcessFailure] = {}
+        self.subprocess_handlers: Dict[int, SubprocessHandler] = {}
+
+    def _start(self):
+        if self.subprocess_handlers:
+            raise ValueError(
+                "The subprocess handlers already initialized. Most likely the start method got called twice."
+            )
+        self.subprocess_handlers = {
+            local_rank: SubprocessHandler(
+                entrypoint=self.entrypoint,  # type: ignore[arg-type] # entrypoint is always a str
+                args=self.args[local_rank],
+                env=self.envs[local_rank],
+                preexec_fn=mp._prctl_pr_set_pdeathsig(signal.SIGTERM),  # type: ignore[attr-defined]
+                stdout=self.stdouts[local_rank],
+                stderr=self.stderrs[local_rank],
+            )
+            for local_rank in range(self.nprocs)
+        }
+
+    def _poll(self) -> Optional[RunProcsResult]:
+        done_local_ranks = set()
+        for local_rank in self._running_local_ranks:
+            handler = self.subprocess_handlers[local_rank]
+            exitcode = handler.proc.poll()
+            if exitcode is not None:
+                done_local_ranks.add(local_rank)
+                if exitcode != 0:  # failed or signaled
+                    self._failures[local_rank] = ProcessFailure(
+                        local_rank=local_rank,
+                        pid=handler.proc.pid,
+                        exitcode=exitcode,
+                        error_file=self.error_files[local_rank],
+                    )
+                # else: --> succeeded; nothing to do
+
+        self._running_local_ranks.difference_update(done_local_ranks)
+
+        # if ALL procs are finished or ANY have failed
+        if not self._running_local_ranks or self._failures:
+            self.close()  # terminate all running procs
+            result = RunProcsResult(
+                failures=self._failures,
+                stdouts=self.stdouts,
+                stderrs=self.stderrs,
+            )
+            if result.is_failed():
+                first_failure = min(result.failures.values(), key=lambda f: f.timestamp)
+                log.error(
+                    f"failed (exitcode: {first_failure.exitcode})"
+                    f" local_rank: {first_failure.local_rank} (pid: {first_failure.pid})"
+                    f" of binary: {self.entrypoint}"
+                )
+            else:
+                # Populate return with dummy values. This provides consistency with MultiprocessingHandler
+                result.return_values = {
+                    local_rank: None for local_rank in range(self.nprocs)
+                }
+
+            return result
+        else:  # there are no failures and procs still running
+            return None
+
+    def pids(self) -> Dict[int, int]:
+        return {
+            local_rank: sh.proc.pid
+            for local_rank, sh in self.subprocess_handlers.items()
+        }
+
+    def _close(self) -> None:
+        if self.subprocess_handlers:
+            for handler in self.subprocess_handlers.values():
+                handler.close()

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Each host in a distributed PyTorch job runs with a single TorchElastic agent,
+and multiple workers (as children processes of the TorchElastic agent).
+Since the workers are user-provided (your PyTorch script/job), TorchElastic
+has a way to propagate errors on the trainers through the agent and up to the
+scheduler, which ultimately informs the end-user about the state of the job
+and applies any retry policies.
+
+TorchElastic categorizes errors into 3 categories:
+
++----------------+----------------+--------------------------------------------------------------+
+| Category       | Sub-Category   |  Description                                                 |
++================+================+==============================================================+
+| User Error     | Input Error    | invalid inputs to TorchElastic APIs (e.g. min > max nodes)   |
+|                +----------------+--------------------------------------------------------------+
+|                | Worker Failure | any failures on the worker child process                     |
++----------------+----------------+--------------------------------------------------------------+
+| Platform Error |      n/a       | failures caused by the agent                                 |
++----------------+----------------+--------------------------------------------------------------+
+| Infra Error    |      n/a       | failures outside the domain of the agent and workers         |
+|                |                | (e.g. host failures)                                         |
++----------------+----------------+--------------------------------------------------------------+
+
+All errors other than "Worker Failure" are either raised canonically from the
+agent process or implicitly or explicitly crash the agent process. So the
+standard language (python) provided exception handling strategies apply.
+
+Worker Failures are special because the exception/failure originates on a different
+process from the agent so the error needs to be propagated inter-process
+(e.g. the agent cannot simply ``try-catch`` an exception raised on the worker process).
+
+TorchElastic agents use :func:`torch.distributed.elastic.multiprocessing.start_processes`
+to launch the workers which has a simple file based inter-process error propagation
+built-in.
+
+Any function or binary entrypoint decorated with :func:`record`
+will write uncaught exceptions (with the trace information) to a file specified by the
+environment variable ``TORCHELASTIC_ERROR_FILE``. The parent process (e.g. agent)
+sets this env var on each child it launches, then aggregates the error files for all
+children, and propagates the one with the **smallest** timestamp (e.g. the **first** error).
+"""
+
+import json
+import os
+import signal
+import time
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime
+from functools import wraps
+from string import Template
+from typing import Callable, Dict, List, Optional, Tuple
+
+from .error_handler import ErrorHandler  # noqa F401
+from .handlers import get_error_handler  # noqa F401
+
+
+JSON = Dict
+
+_EMPTY_ERROR_DATA = {"message": "<NONE>"}
+_NOT_AVAILABLE = "<N/A>"
+
+
+@dataclass
+class ProcessFailure:
+    """
+    Represents the failed process result. When the worker process fails,
+    it may record failure root cause into the file.
+    Tries to read the failure timestamp from the provided ``error_file``,
+    if the ``error_file`` does not exist, the timestamp is the current
+    timestamp (seconds since epoch).
+
+    The ``message`` field is a concise explanation of the failure. If
+    the error file exists then the message is obtained from the error file.
+    Otherwise one is generated based on the failure signature.
+
+    .. note:: It is assumed that the ``error_file`` is written by
+              ``torch.distributed.elastic.multiprocessing.errors.error_handler.ErrorHandler``.
+              Otherwise the behavior is undefined.
+
+    """
+
+    local_rank: int
+    pid: int
+    exitcode: int
+    error_file: str
+    error_file_data: JSON = field(init=False)
+    message: str = field(init=False)
+    timestamp: int = field(init=False)
+
+    def __post_init__(self):
+        if os.path.isfile(self.error_file):
+            with open(self.error_file, "r") as fp:
+                self.error_file_data = json.load(fp)
+                self.message = self.error_file_data["message"]["message"]
+                self.timestamp = int(
+                    self.error_file_data["message"]["extraInfo"]["timestamp"]
+                )
+        else:
+            self.error_file = _NOT_AVAILABLE
+            self.error_file_data = _EMPTY_ERROR_DATA
+            self.message = ""
+            self.timestamp = int(time.time())
+
+        # make up an informative message if not already present
+        if not self.message:
+            # signals typically do not generate an error file message
+            if self.exitcode < 0:
+                self.message = (
+                    f"Signal {-self.exitcode} ({self.signal_name()})"
+                    f" received by PID {self.pid}"
+                )
+            else:
+                self.message = f"Process failed with exitcode {self.exitcode}"
+
+    def signal_name(self) -> str:
+        if self.exitcode < 0:
+            return signal.Signals(-self.exitcode).name
+        else:
+            return _NOT_AVAILABLE
+
+    def timestamp_isoformat(self):
+        """
+        Returns timestamp in ISO format (YYYY-MM-DD_HH:MM:SS)
+        """
+        return datetime.fromtimestamp(self.timestamp).isoformat(sep="_")
+
+
+GlobalRank = int
+
+_FAILURE_FORMAT_TEMPLATE = """[${idx}]:
+  time: ${time}
+  rank: ${rank} (local_rank: ${local_rank})
+  exitcode: ${exitcode} (pid: ${pid})
+  error_file: ${error_file}
+  msg: \"${message}\""""
+
+# extra new lines before and after are intentional
+_MSG_FORMAT_TEMPLATE = """
+${boarder}
+${title}
+${section}
+Root Cause:
+${root_failure}
+${section}
+Other Failures:
+${other_failures}
+${boarder}
+"""
+
+
+class ChildFailedError(Exception):
+    """
+    Special exception type that can be raised from a function annotated with the
+    ``@record`` decorator to have the child process' (root exception) propagate
+    up the stack as-is (e.g. without being wrapped in the parent's traceback).
+
+    Useful in cases where the parent is a simple nanny process
+    and the child (worker) processes are actually doing meaningful compute.
+    In this case, errors typically occur on the child process as the parent
+    is not doing anything non-trivial, and child errors should be propagated
+    to the scheduler for accurate root cause diagnostics.
+
+    .. note:: The propagation relies on error files rather than exception handling to
+              support both function and binary launches.
+
+    Example:
+
+    ::
+
+     # process tree on a host (container)
+     0: scheduler-init-process:
+                |- 1: torchelastic_agent:
+                         |- 2: trainer_0 (ok)
+                         |- 3: trainer_1 (fail) -> error.json
+                         |- ...
+                         |- n+2: trainer_n (ok)
+                |- n+3: other processes
+                |- ...
+
+    In the example above, trainer 1's failure (written into error.json) is
+    the root cause and should be reported to the scheduler's init process.
+    The torchelastic agent raises a ``ChildFailedError("trainer", {1: "trainer_1/error.json"})``
+    upon detecting trainer 1's failure which would propagate the contents
+    of trainer 1's error file to the scheduler's init process.
+    """
+
+    def __init__(self, name: str, failures: Dict[GlobalRank, ProcessFailure]):
+        self.name = name
+        self.failures = failures
+        assert (
+            self.failures
+        )  # does not make sense to create a ChildFaileError with no failures
+        super().__init__(self.format_msg())
+
+    def get_first_failure(self) -> Tuple[GlobalRank, ProcessFailure]:
+        rank = min(self.failures.keys(), key=lambda r: self.failures[r].timestamp)
+        return rank, self.failures[rank]
+
+    def format_msg(self, boarder_delim="*", section_delim="="):
+        title = f"  {self.name} FAILED  "
+        root_rank, root_failure = self.get_first_failure()
+
+        root_failure_fmt: str = ""
+        other_failures_fmt: List[str] = []
+        width = len(title)
+        for idx, (rank, failure) in enumerate(self.failures.items()):
+            fmt, w = self._format_failure(idx, rank, failure)
+            width = max(width, w)
+            if rank == root_rank:
+                root_failure_fmt = fmt
+            else:
+                other_failures_fmt.append(fmt)
+
+        return Template(_MSG_FORMAT_TEMPLATE).substitute(
+            boarder=boarder_delim * width,
+            title=title.center(width),
+            section=section_delim * width,
+            root_failure=root_failure_fmt,
+            other_failures="\n".join(other_failures_fmt or ["  <NO_OTHER_FAILURES>"]),
+        )
+
+    def _format_failure(
+        self, idx: int, rank: int, failure: ProcessFailure
+    ) -> Tuple[str, int]:
+        fmt = Template(_FAILURE_FORMAT_TEMPLATE).substitute(
+            idx=idx,
+            time=failure.timestamp_isoformat(),
+            rank=rank,
+            local_rank=failure.local_rank,
+            exitcode=failure.exitcode,
+            pid=failure.pid,
+            error_file=failure.error_file,
+            message=failure.message,
+        )
+        width = 0
+        for line in fmt.split("\n"):
+            width = max(width, len(line))
+        return fmt, width
+
+
+def _no_error_file_warning_msg(rank: int, failure: ProcessFailure) -> str:
+    msg = [
+        "CHILD PROCESS FAILED WITH NO ERROR_FILE"
+        f"Child process {failure.pid} (local_rank {rank}) FAILED (exitcode {failure.exitcode})"
+        f"Error msg: {failure.message}",
+        f"Without writing an error file to {failure.error_file}.",
+        "While this DOES NOT affect the correctness of your application,",
+        "no trace information about the error will be available for inspection.",
+        "Consider decorating your top level entrypoint function with",
+        "torch.distributed.elastic.multiprocessing.errors.record. Example:",
+        "",
+        r"  from torch.distributed.elastic.multiprocessing.errors import record",
+        "",
+        r"  @record",
+        r"  def trainer_main(args):",
+        r"     # do train",
+    ]
+    width = 0
+    for line in msg:
+        width = max(width, len(line))
+
+    boarder = "*" * width
+    header = "CHILD PROCESS FAILED WITH NO ERROR_FILE".center(width)
+    return "\n".join(["\n", boarder, header, boarder, *msg, boarder])
+
+
+def record(fn, error_handler: Optional[ErrorHandler] = None) -> Callable:
+    """
+    Syntactic sugar to record errors/exceptions that happened in the decorated
+    function using the provided ``error_handler``.
+
+    Using this decorator is equivalent to:
+
+    ::
+
+     error_handler = get_error_handler()
+     error_handler.initialize()
+     try:
+        foobar()
+     except ChildFailedError as e:
+        error_handler.copy_error_file(e.get_first_failure())
+        raise
+     except Exception as e:
+        error_handler.record(e)
+        raise
+
+    .. important:: use this decorator once per process at the top level method,
+                   typically this is the main method.
+
+    Example
+
+    ::
+
+     @record
+     def main():
+         pass
+
+     if __name__=="__main__":
+        main()
+
+    """
+
+    if not error_handler:
+        error_handler = get_error_handler()
+
+    def wrap(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            assert error_handler is not None  # assertion for mypy type checker
+            error_handler.initialize()
+            try:
+                return f(*args, **kwargs)
+            except ChildFailedError as e:
+                rank, failure = e.get_first_failure()
+                if failure.error_file != _NOT_AVAILABLE:
+                    error_handler.copy_error_file(failure.error_file)
+                else:
+                    warnings.warn(_no_error_file_warning_msg(rank, failure))
+                raise
+            except Exception as e:
+                error_handler.record_exception(e)
+                raise
+
+        return wrapper
+
+    return wrap(fn)

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import faulthandler
+import json
+import logging
+import os
+import shutil
+import time
+import traceback
+import warnings
+from typing import Optional
+
+
+log = logging.getLogger(__name__)
+
+
+def _write_error(e: BaseException, error_file: Optional[str]):
+    data = {
+        "message": {
+            "message": f"{type(e).__name__}: {e}",
+            "extraInfo": {
+                "py_callstack": traceback.format_exc(),
+                "timestamp": str(int(time.time())),
+            },
+        }
+    }
+
+    if error_file:
+        with open(error_file, "w") as fp:
+            json.dump(data, fp)
+    else:
+        log.error(json.dumps(data, indent=2))
+
+
+class ErrorHandler:
+    """
+    Writes the provided exception object along with some other metadata about
+    the error in a structured way in JSON format to an error file specified by the
+    environment variable: ``TORCHELASTIC_ERROR_FILE``. If this environment
+    variable is not set, then simply logs the contents of what would have been
+    written to the error file.
+
+    This handler may be subclassed to customize the handling of the error.
+    Subclasses should override ``initialize()`` and ``record_exception()``.
+    """
+
+    def _get_error_file_path(self) -> Optional[str]:
+        """
+        Returns the error file path. May return ``None`` to have the
+        structured error be logged only.
+        """
+        return os.environ.get("TORCHELASTIC_ERROR_FILE", None)
+
+    def initialize(self) -> None:
+        """
+        Called prior to running code that we wish to capture errors/exceptions.
+        Typically registers signal/fault handlers. Users can override this
+        function to add custom initialization/registrations that aid in
+        propagation/information of errors/signals/exceptions/faults.
+        """
+        try:
+            faulthandler.enable(all_threads=True)
+        except Exception as e:
+            warnings.warn(f"Unable to enable fault handler. {type(e).__name__}: {e}")
+
+    def record_exception(self, e: BaseException) -> None:
+        """
+        Writes a structured information about the exception into an error file in
+        JSON format. If the error file cannot be determined, then logs the content
+        that would have been written to the error file.
+        """
+        _write_error(e, self._get_error_file_path())
+
+    def copy_error_file(self, rootcause_error_file: str):
+        with open(rootcause_error_file, "r") as fp:
+            log.info(
+                f"child error file ({rootcause_error_file}) contents:\n"
+                f"{json.dumps(json.load(fp), indent=2)}"
+            )
+
+        my_error_file = self._get_error_file_path()
+        if my_error_file:
+            # Guard against existing error files
+            # This can happen when the child is created using multiprocessing
+            # and the same env var (TORCHELASTIC_ERROR_FILE) is used on the
+            # parent and child to specify the error files (respectively)
+            # because the env vars on the child is set in the wrapper function
+            # and by default the child inherits the parent's env vars, if the child
+            # process receives a signal before the wrapper function kicks in
+            # and the signal handler writes to the error file, then the child
+            # will write to the parent's error file. In this case just log the
+            # original error file contents and overwrite the error file.
+            self._rm(my_error_file)
+            shutil.copyfile(rootcause_error_file, my_error_file)
+            log.info(
+                f"copied child error file to parent's ({rootcause_error_file} -> {my_error_file}"
+            )
+        else:
+            log.error(
+                f"no error file defined for parent, to copy child error file ({rootcause_error_file})"
+            )
+
+    def _rm(self, my_error_file):
+        if os.path.isfile(my_error_file):
+            with open(my_error_file, "r") as fp:
+                original = json.dumps(json.load(fp), indent=2)
+                log.warning(
+                    f"{my_error_file} already exists"
+                    f" and will be overwritten."
+                    f" Original contents:\n{original}"
+                )
+            os.remove(my_error_file)

--- a/torch/distributed/elastic/multiprocessing/errors/handlers.py
+++ b/torch/distributed/elastic/multiprocessing/errors/handlers.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+# Multiprocessing error-reporting module
+
+
+from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
+
+
+def get_error_handler():
+    return ErrorHandler()

--- a/torch/distributed/elastic/multiprocessing/redirects.py
+++ b/torch/distributed/elastic/multiprocessing/redirects.py
@@ -1,0 +1,85 @@
+# !/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Taken and modified from original source:
+# https://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/
+
+import ctypes
+import os
+import sys
+from contextlib import contextmanager
+from functools import partial
+
+
+libc = ctypes.CDLL("libc.so.6")
+
+
+def _c_std(stream: str):
+    return ctypes.c_void_p.in_dll(libc, stream)
+
+
+def _python_std(stream: str):
+    return {"stdout": sys.stdout, "stderr": sys.stderr}[stream]
+
+
+_VALID_STD = {"stdout", "stderr"}
+
+
+@contextmanager
+def redirect(std: str, to_file: str):
+    """
+    Redirects ``std`` (one of ``"stdout"`` or ``"stderr"``) to a file
+    in the path specified by ``to_file``. This method redirects the
+    underlying std file descriptor (not just pyton's ``sys.stdout|stderr``).
+    See usage for details.
+
+    Directory of ``dst_filename`` is assumed to exist and the destination file
+    is overwritten if it already exists.
+
+    .. note:: Due to buffering cross source writes are not guaranteed to
+              appear in wall-clock order. For instance in the example below
+              it is possible for the C-outputs to appear before the python
+              outputs in the log file.
+
+    Usage:
+
+    ::
+
+     # syntactic-sugar for redirect("stdout", "tmp/stdout.log")
+     with redirect_stdout("/tmp/stdout.log"):
+        print("python stdouts are redirected")
+        libc = ctypes.CDLL("libc.so.6")
+        libc.printf(b"c stdouts are also redirected"
+        os.system("echo system stdouts are also redirected")
+
+     print("stdout restored")
+
+    """
+
+    if std not in _VALID_STD:
+        raise ValueError(
+            f"unknown standard stream <{std}>, must be one of {_VALID_STD}"
+        )
+
+    c_std = _c_std(std)
+    python_std = _python_std(std)
+    std_fd = python_std.fileno()
+
+    def _redirect(dst):
+        libc.fflush(c_std)
+        python_std.flush()
+        os.dup2(dst.fileno(), std_fd)
+
+    with os.fdopen(os.dup(std_fd)) as orig_std, open(to_file, mode="w+b") as dst:
+        _redirect(dst)
+        yield
+        _redirect(orig_std)
+
+
+redirect_stdout = partial(redirect, "stdout")
+redirect_stderr = partial(redirect, "stderr")

--- a/torch/distributed/elastic/multiprocessing/tail_log.py
+++ b/torch/distributed/elastic/multiprocessing/tail_log.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import time
+from concurrent.futures._base import Future
+from concurrent.futures.thread import ThreadPoolExecutor
+from threading import Event
+from typing import Dict, List, TextIO
+
+
+log = logging.getLogger(__name__)
+
+
+def tail_logfile(
+    header: str, file: str, dst: TextIO, finished: Event, interval_sec: float
+):
+
+    while not os.path.exists(file):
+        if finished.is_set():
+            return
+        time.sleep(interval_sec)
+
+    with open(file, "r") as fp:
+        while True:
+            line = fp.readline()
+
+            if line:
+                dst.write(f"{header}{line}")
+            else:  # reached EOF
+                if finished.is_set():
+                    # log line producer is finished
+                    break
+                else:
+                    # log line producer is still going
+                    # wait for a bit before looping again
+                    time.sleep(interval_sec)
+
+
+class TailLog:
+    """
+    Tails the given log files. The log files do not have to exist when the
+    ``start()`` method is called. The tail-er will gracefully wait until the
+    log files are created by the producer and will tail the contents of the
+    log files until the ``stop()`` method is called.
+
+    .. warning:: ``TailLog`` will wait indefinitely for the log file to be created!
+
+    Each log file's line will be suffixed with a header of the form: ``[{name}{idx}]:``,
+    where the ``name`` is user-provided and ``idx`` is the index of the log file
+    in the ``log_files`` mapping.
+
+    Usage:
+
+    ::
+
+     log_files = {0: "/tmp/0_stdout.log", 1: "/tmp/1_stdout.log"}
+     tailer = TailLog("trainer", log_files, sys.stdout).start()
+     # actually run the trainers to produce 0_stdout.log and 1_stdout.log
+     run_trainers()
+     tailer.stop()
+
+     # once run_trainers() start writing the ##_stdout.log files
+     # the tailer will print to sys.stdout:
+     # >>> [trainer0]:log_line1
+     # >>> [trainer1]:log_line1
+     # >>> [trainer0]:log_line2
+     # >>> [trainer0]:log_line3
+     # >>> [trainer1]:log_line2
+
+    .. note:: Due to buffering log lines between files may not necessarily
+              be printed out in order. You should configure your application's
+              logger to suffix each log line with a proper timestamp.
+
+    """
+
+    def __init__(
+        self,
+        name: str,
+        log_files: Dict[int, str],
+        dst: TextIO,
+        interval_sec: float = 0.1,
+    ):
+        n = len(log_files)
+        self._threadpool = None
+        if n > 0:
+            self._threadpool = ThreadPoolExecutor(
+                max_workers=n,
+                thread_name_prefix=f"{self.__class__.__qualname__}_{name}",
+            )
+
+        self._name = name
+        self._dst = dst
+        self._log_files = log_files
+        self._finished_events: Dict[int, Event] = {
+            local_rank: Event() for local_rank in log_files.keys()
+        }
+        self._futs: List[Future] = []
+        self._interval_sec = interval_sec
+        self._stopped = False
+
+    def start(self) -> "TailLog":
+        if not self._threadpool:
+            return self
+
+        for local_rank, file in self._log_files.items():
+            self._futs.append(
+                self._threadpool.submit(
+                    tail_logfile,
+                    header=f"[{self._name}{local_rank}]:",
+                    file=file,
+                    dst=self._dst,
+                    finished=self._finished_events[local_rank],
+                    interval_sec=self._interval_sec,
+                )
+            )
+        return self
+
+    def stop(self) -> None:
+        for finished in self._finished_events.values():
+            finished.set()
+
+        for local_rank, f in enumerate(self._futs):
+            try:
+                f.result()
+            except Exception as e:
+                log.error(
+                    f"error in log tailor for {self._name}{local_rank}."
+                    f" {e.__class__.__qualname__}: {e}",
+                )
+
+        if self._threadpool:
+            self._threadpool.shutdown(wait=True)
+
+        self._stopped = True
+
+    def stopped(self) -> bool:
+        return self._stopped

--- a/torch/distributed/elastic/timer/__init__.py
+++ b/torch/distributed/elastic/timer/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Expiration timers are set up on the same process as the agent and
+used from your script to deal with stuck workers. When you go into
+a code-block that has the potential to get stuck you can acquire
+an expiration timer, which instructs the timer server to kill the
+process if it does not release the timer by the self-imposed expiration
+deadline.
+
+Usage::
+
+    import torchelastic.timer as timer
+    import torchelastic.agent.server as agent
+
+    def main():
+        start_method = "spawn"
+        message_queue = mp.get_context(start_method).Queue()
+        server = timer.LocalTimerServer(message, max_interval=0.01)
+        server.start() # non-blocking
+
+        spec = WorkerSpec(
+                    fn=trainer_func,
+                    args=(message_queue,),
+                    ...<OTHER_PARAMS...>)
+        agent = agent.LocalElasticAgent(spec, start_method)
+        agent.run()
+
+    def trainer_func(message_queue):
+        timer.configure(timer.LocalTimerClient(message_queue))
+        with timer.expires(after=60): # 60 second expiry
+            # do some work
+
+In the example above if ``trainer_func`` takes more than 60 seconds to
+complete, then the worker process is killed and the agent retries the worker group.
+"""
+
+from .api import TimerClient, TimerRequest, TimerServer, configure, expires  # noqa F401
+from .local_timer import LocalTimerClient, LocalTimerServer  # noqa F401

--- a/torch/distributed/elastic/timer/api.py
+++ b/torch/distributed/elastic/timer/api.py
@@ -1,0 +1,276 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import abc
+import logging
+import threading
+import time
+from contextlib import contextmanager
+from inspect import getframeinfo, stack
+from typing import Any, Dict, List, Optional, Set
+
+
+class TimerRequest:
+    """
+    Data object representing a countdown timer acquisition and release
+    that is used between the ``TimerClient`` and ``TimerServer``.
+    A negative ``expiration_time`` should be interpreted as a "release"
+    request.
+
+    .. note:: the type of ``worker_id`` is implementation specific.
+              It is whatever the TimerServer and TimerClient implementations
+              have on to uniquely identify a worker.
+    """
+
+    __slots__ = ["worker_id", "scope_id", "expiration_time"]
+
+    def __init__(self, worker_id: Any, scope_id: str, expiration_time: float):
+        self.worker_id = worker_id
+        self.scope_id = scope_id
+        self.expiration_time = expiration_time
+
+    def __eq__(self, other):
+        if isinstance(other, TimerRequest):
+            return (
+                self.worker_id == other.worker_id
+                and self.scope_id == other.scope_id
+                and self.expiration_time == other.expiration_time
+            )
+        return False
+
+
+class TimerClient(abc.ABC):
+    """
+    Client library to acquire and release countdown timers by communicating
+    with the TimerServer.
+    """
+
+    @abc.abstractmethod
+    def acquire(self, scope_id: str, expiration_time: float) -> None:
+        """
+        Acquires a timer for the worker that holds this client object
+        given the scope_id and expiration_time. Typically registers
+        the timer with the TimerServer.
+        """
+        pass
+
+    @abc.abstractmethod
+    def release(self, scope_id: str):
+        """
+        Releases the timer for the ``scope_id`` on the worker this
+        client represents. After this method is
+        called, the countdown timer on the scope is no longer in effect.
+        """
+        pass
+
+
+class RequestQueue(abc.ABC):
+    """
+    Consumer queue holding timer acquisition/release requests
+    """
+
+    @abc.abstractmethod
+    def size(self) -> int:
+        """
+        Returns the size of the queue at the time this method is called.
+        Note that by the time ``get`` is called the size of the queue
+        may have increased. The size of the queue should not decrease
+        until the ``get`` method is called. That is, the following assertion
+        should hold:
+
+        size = q.size()
+        res = q.get(size, timeout=0)
+        assert size == len(res)
+
+        -- or --
+
+        size = q.size()
+        res = q.get(size * 2, timeout=1)
+        assert size <= len(res) <= size * 2
+        """
+        pass
+
+    @abc.abstractmethod
+    def get(self, size: int, timeout: float) -> List[TimerRequest]:
+        """
+        Gets up to ``size`` number of timer requests in a blocking fashion
+        (no more than ``timeout`` seconds).
+        """
+        pass
+
+
+class TimerServer(abc.ABC):
+    """
+    Entity that monitors active timers and expires them
+    in a timely fashion. This server is responsible for
+    reaping workers that have expired timers.
+    """
+
+    def __init__(
+        self, request_queue: RequestQueue, max_interval: float, daemon: bool = True
+    ):
+        """
+        :param request_queue: Consumer ``RequestQueue``
+        :param max_interval: max time (in seconds) to wait
+                             for an item in the request_queue
+        :param daemon: whether to run the watchdog thread as a daemon
+        """
+        super().__init__()
+        self._request_queue = request_queue
+        self._max_interval = max_interval
+        self._daemon = daemon
+        self._watchdog_thread: Optional[threading.Thread] = None
+        self._stop_signaled = False
+
+    @abc.abstractmethod
+    def register_timers(self, timer_requests: List[TimerRequest]) -> None:
+        """
+        Processes the incoming timer requests and registers them with the server.
+        The timer request can either be a acquire-timer or release-timer request.
+        Timer requests with a negative expiration_time should be interpreted
+        as a release-timer request.
+        """
+        pass
+
+    @abc.abstractmethod
+    def clear_timers(self, worker_ids: Set[Any]) -> None:
+        """
+        Clears all timers for the given ``worker_ids``.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_expired_timers(self, deadline: float) -> Dict[str, List[TimerRequest]]:
+        """
+        Returns all expired timers for each worker_id. An expired timer
+        is a timer for which the expiration_time is less than or equal to
+        the provided deadline.
+        """
+        pass
+
+    @abc.abstractmethod
+    def _reap_worker(self, worker_id: Any) -> bool:
+        """
+        Reaps the given worker. Returns True if the worker has been
+        successfully reaped, False otherwise. If any uncaught exception
+        is thrown from this method, the worker is considered reaped
+        and all associated timers will be removed.
+        """
+
+    def _reap_worker_no_throw(self, worker_id: Any) -> bool:
+        """
+        Wraps ``_reap_worker(worker_id)``, if an uncaught exception is
+        thrown, then it considers the worker as reaped.
+        """
+        try:
+            return self._reap_worker(worker_id)
+        except Exception as e:
+            logging.error(
+                "Uncaught exception thrown from _reap_worker(), "
+                "check that the implementation correctly catches exceptions",
+                exc_info=e,
+            )
+            return True
+
+    def _watchdog_loop(self):
+        while not self._stop_signaled:
+            try:
+                self._run_watchdog()
+            except Exception as e:
+                logging.error("Error running watchdog", exc_info=e)
+
+    def _run_watchdog(self):
+        batch_size = max(1, self._request_queue.size())
+        timer_requests = self._request_queue.get(batch_size, self._max_interval)
+        self.register_timers(timer_requests)
+        now = time.time()
+        reaped_worker_ids = set()
+        for worker_id, expired_timers in self.get_expired_timers(now).items():
+            logging.info(
+                f"Reaping worker_id=[{worker_id}]."
+                f" Expired timers: {self._get_scopes(expired_timers)}"
+            )
+            if self._reap_worker_no_throw(worker_id):
+                logging.info(f"Successfully reaped worker=[{worker_id}]")
+                reaped_worker_ids.add(worker_id)
+            else:
+                logging.error(
+                    f"Error reaping worker=[{worker_id}]. Will retry on next watchdog."
+                )
+        self.clear_timers(reaped_worker_ids)
+
+    def _get_scopes(self, timer_requests):
+        return [r.scope_id for r in timer_requests]
+
+    def start(self) -> None:
+        logging.info(
+            f"Starting {type(self).__name__}..."
+            f" max_interval={self._max_interval},"
+            f" daemon={self._daemon}"
+        )
+        self._watchdog_thread = threading.Thread(
+            target=self._watchdog_loop, daemon=self._daemon
+        )
+        logging.info("Starting watchdog thread...")
+        self._watchdog_thread.start()
+
+    def stop(self) -> None:
+        logging.info(f"Stopping {type(self).__name__}")
+        self._stop_signaled = True
+        if self._watchdog_thread:
+            logging.info("Stopping watchdog thread...")
+            self._watchdog_thread.join(self._max_interval)
+            self._watchdog_thread = None
+        else:
+            logging.info("No watchdog thread running, doing nothing")
+
+
+_timer_client = None
+
+
+def configure(timer_client: TimerClient):
+    """
+    Configures a timer client. Must be called before using ``expires``.
+    """
+    global _timer_client
+    _timer_client = timer_client
+    logging.info(f"Timer client configured to: {type(_timer_client).__name__}")
+
+
+@contextmanager
+def expires(
+    after: float, scope: Optional[str] = None, client: Optional[TimerClient] = None
+):
+    """
+    Acquires a countdown timer that expires in ``after`` seconds from now,
+    unless the code-block that it wraps is finished within the timeframe.
+    When the timer expires, this worker is eligible to be reaped. The
+    exact meaning of "reaped" depends on the client implementation. In
+    most cases, reaping means to terminate the worker process.
+    Note that the worker is NOT guaranteed to be reaped at exactly
+    ``time.now() + after``, but rather the worker is "eligible" for being
+    reaped and the ``TimerServer`` that the client talks to will ultimately
+    make the decision when and how to reap the workers with expired timers.
+
+    Usage::
+
+        torch.distributed.elastic.timer.configure(LocalTimerClient())
+        with expires(after=10):
+            torch.distributed.all_reduce(...)
+    """
+    if client is None:
+        if _timer_client is None:
+            raise RuntimeError("Configure timer client before using coundown timers.")
+        client = _timer_client
+    if scope is None:
+        # grab the caller file + lineno
+        caller = getframeinfo(stack()[1][0])
+        scope = f"{caller.filename}#{caller.lineno}"
+    expiration = time.time() + after
+    client.acquire(scope, expiration)
+    try:
+        yield
+    finally:
+        client.release(scope)

--- a/torch/distributed/elastic/timer/local_timer.py
+++ b/torch/distributed/elastic/timer/local_timer.py
@@ -1,0 +1,122 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import logging
+import multiprocessing as mp
+import os
+import signal
+import time
+from queue import Empty
+from typing import Any, Dict, List, Set, Tuple
+
+from .api import RequestQueue, TimerClient, TimerRequest, TimerServer
+
+
+class LocalTimerClient(TimerClient):
+    """
+    Client side of ``LocalTimerServer``. This client is meant to be used
+    on the same host that the ``LocalTimerServer`` is running on and uses
+    pid to uniquely identify a worker. This is particularly useful in situations
+    where one spawns a subprocess (trainer) per GPU on a host with multiple
+    GPU devices.
+    """
+
+    def __init__(self, mp_queue):
+        super().__init__()
+        self._mp_queue = mp_queue
+
+    def acquire(self, scope_id, expiration_time):
+        pid = os.getpid()
+        acquire_request = TimerRequest(pid, scope_id, expiration_time)
+        self._mp_queue.put(acquire_request)
+
+    def release(self, scope_id):
+        pid = os.getpid()
+        release_request = TimerRequest(pid, scope_id, -1)
+        self._mp_queue.put(release_request)
+
+
+class MultiprocessingRequestQueue(RequestQueue):
+    """
+    A ``RequestQueue`` backed by python ``multiprocessing.Queue``
+    """
+
+    def __init__(self, mp_queue: mp.Queue):
+        super().__init__()
+        self._mp_queue = mp_queue
+
+    def size(self) -> int:
+        return self._mp_queue.qsize()
+
+    def get(self, size, timeout: float) -> List[TimerRequest]:
+        requests = []
+        wait = timeout
+        for _ in range(0, size):
+            start = time.time()
+
+            try:
+                r = self._mp_queue.get(block=True, timeout=wait)
+            except Empty:
+                break
+
+            requests.append(r)
+            wait = wait - (time.time() - start)
+            if wait <= 0:
+                break
+
+        return requests
+
+
+class LocalTimerServer(TimerServer):
+    """
+    Server that works with ``LocalTimerClient``. Clients are expected to be
+    subprocesses to the parent process that is running this server. Each host
+    in the job is expected to start its own timer server locally and each
+    server instance manages timers for local workers (running on processes
+    on the same host).
+    """
+
+    def __init__(
+        self, mp_queue: mp.Queue, max_interval: float = 60, daemon: bool = True
+    ):
+        super().__init__(MultiprocessingRequestQueue(mp_queue), max_interval, daemon)
+        self._timers: Dict[Tuple[Any, str], TimerRequest] = {}
+
+    def register_timers(self, timer_requests: List[TimerRequest]) -> None:
+        for request in timer_requests:
+            pid = request.worker_id
+            scope_id = request.scope_id
+            expiration_time = request.expiration_time
+
+            # negative expiration is a proxy for a release call
+            if expiration_time < 0:
+                self._timers.pop((pid, scope_id), None)
+            else:
+                self._timers[(pid, scope_id)] = request
+
+    def clear_timers(self, worker_ids: Set[int]) -> None:
+        for (pid, scope_id) in list(self._timers.keys()):
+            if pid in worker_ids:
+                self._timers.pop((pid, scope_id))
+
+    def get_expired_timers(self, deadline: float) -> Dict[Any, List[TimerRequest]]:
+        # pid -> [timer_requests...]
+        expired_timers: Dict[Any, List[TimerRequest]] = {}
+        for request in self._timers.values():
+            if request.expiration_time <= deadline:
+                expired_scopes = expired_timers.setdefault(request.worker_id, [])
+                expired_scopes.append(request)
+        return expired_timers
+
+    def _reap_worker(self, worker_id: int) -> bool:
+        try:
+            os.kill(worker_id, signal.SIGKILL)
+            return True
+        except ProcessLookupError:
+            logging.info(f"Process with pid={worker_id} does not exist. Skipping")
+            return True
+        except Exception as e:
+            logging.error(f"Error terminating pid={worker_id}", exc_info=e)
+        return False


### PR DESCRIPTION
Summary: Upstreams `torchelastic/timer|multiprocessing` to `torch/distributed/elastic/timer|multiprocessing`

Test Plan:
```
buck test mode/dev-nosan //caffe2/torch/distributed/elastic/...
buck test mode/dev-nosan //caffe2/test/distributed/elastic/...
buck test mode/dev-nosan //pytorch/elastic/torchelastic/...
buck test mode/dev-nosan //hpc/...
buck test mode/dev-nosan //caffe2/torch/fb/training_toolkit/...
```

Differential Revision: D26899809

