### PR TITLE
skip dispatch trip for CPU in resize_

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -1302,7 +1302,12 @@ void TensorIteratorBase::set_output(int64_t output_idx, IntArrayRef sizes, IntAr
       // for the is_meta_ test.
       TORCH_INTERNAL_ASSERT(op.original_tensor.is_same(t));
       TORCH_INTERNAL_ASSERT(!op.tensor.is_same(t));
-      at::native::resize_output(op.tensor, sizes);
+      // fastpath CPU to skip a dispatcher trip
+      if (op.tensor.device().is_cpu()) {
+        at::native::resize_output_cpu(op.tensor, sizes);
+      } else {
+        at::native::resize_output(op.tensor, sizes);
+      }
       if (!strides.empty()) {
         TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
         op.tensor.as_strided_(sizes, strides);
@@ -1328,7 +1333,12 @@ void TensorIterator::set_output(int64_t output_idx, IntArrayRef sizes, IntArrayR
       }
       op.current_dtype = op.target_dtype;
   } else if (op.will_resize) {
-      at::native::resize_output(op.tensor, sizes);
+      // fastpath CPU to skip a dispatcher trip
+      if (op.tensor.device().is_cpu()) {
+        at::native::resize_output_cpu(op.tensor, sizes);
+      } else {
+        at::native::resize_output(op.tensor, sizes);
+      }
       if (!strides.empty()) {
         TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
         op.tensor.as_strided_(sizes, strides);

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -19,7 +19,7 @@ void resize_output(Tensor& output, IntArrayRef shape) {
       "t.resize_(0).");
   }
 
-  output.resize_(shape);
+  at::native::resize_(output, shape);
 }
 
 // Call the sparse implementation in SparseTensor.cpp directly.

--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -30,7 +30,7 @@ void resize_output(Tensor& output, IntArrayRef shape) {
 // Ideally, once external backends have access to meta functions
 // We can write one for resize_ and get rid of this.
 void resize_output_cpu(Tensor& output, IntArrayRef shape) {
-  at::detail::resize_output_check(output, shape);
+  resize_output_check(output, shape);
   at::native::resize_(output, shape);
 }
 

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -18,6 +18,8 @@ namespace at { namespace native {
 // NOTE: In the future the warning will become an error
 TORCH_API void resize_output(Tensor& output, IntArrayRef shape);
 
+TORCH_API void resize_output_cpu(Tensor& output, IntArrayRef shape);
+
 // These functions are called by native::resize_ as well as (legacy) TH resize.
 // They are not in TH/THTensor.cpp because the at namespace is easier
 // to benchmark than TH; I can't get gbenchmark to call fns from THTensor.cpp

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -277,9 +277,16 @@ if (strides.empty()) {{
         elif k is SchemaKind.inplace:
             return maybe_set_guard
         elif k is SchemaKind.out:
+            if self.dispatch_key == DispatchKey.CPU:
+                resize_impl = "resize_output_cpu"
+            else:
+                # Only bothering to include a resize_output fastpath for CPU for now.
+                # We can add one in if for the perf if we need to. But it'll be easier when external backends
+                # have access to meta functions, and we can write one for resize_.
+                resize_impl = "resize_output"
             return f"""
 {maybe_set_guard}
-at::native::resize_output(outputs_[output_idx], sizes);
+at::native::{resize_impl}(outputs_[output_idx], sizes);
 if (!strides.empty()) {{
     TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
     at::native::as_strided_(outputs_[output_idx], sizes, strides);


### PR DESCRIPTION
This PR skips a dispatcher trip, giving a 2-3% perf win for the following ops:
- `out` variants of all structured kernels (just `add_out` for now)
- `at::eq` (functional variant)

Both the structured kernel codegen and TensorIterator call out to `at::native::resize_output`. It turns out that even though that function is in the native namespace, it works for all backends and re-invokes the dispatcher:
```
void resize_output(Tensor& output, IntArrayRef shape) {
  // Just wraps `resize_`. Runs a deprecating warning first.
  TORCH_WARN(....);
  output.resize_(shape); // method invocation- invokes dispatcher!
}
```

`resize_output` is just a wrapper around `resize_`, but it's backend agnostic. We can't just update the codegen to call the backend-specific kernels for `resize_`, since then we'd miss the deprecating warning contained in the wrapper. For context, the wrapper was originally added [here](https://github.com/pytorch/pytorch/pull/42079).

This seems like a good example of where structured kernels + a Common dispatch key would be useful. We can't just move the deprecation warning from the wrapper into the CPU/CUDA variants of `resize_`, since that would prevent external backends from getting it. But if `resize_` had a meta function and external backends knew how to codegen/dispatch into it, we could stick the warning there.

For now, I just wrote a CPU-specific version of `resize_output` that I call from structured kernel codegen + TensorIterator.

I'm actually starting to think that I should take out the special-case in TensorIterator, but lmk what you think. In general, we hit that special case within TensorIterator in a small number of ops, which will drop further as more ops are ported to structured. We hit the code that sees the performance improvement when the following is true:
* We're calling an `out` op that uses TensorIterator
* The `out` tensor argument is defined, and needs to be resized

This happens to be the case for `at::eq`, because the functional variant calls the out variant, passing in a zero-sized `out` tensor. That will not longer be true once at::eq` gets ported to be structured, since the codegen resizes the output to the correct size already before calling into TensorIteratorBase. I'll confirm this, but I think it'll get the perf win through the codegen'd call to `resize_output` instead.


**Structured kernel wins**
This gives a nice perf bump for structured `out` variants of kernels. Which, currently, is only `add_out` 😛. I saw a 3.3% decrease in benchmarks. I have the `callgrind_annotate` output. Before: P281594980, and After: P281590209.


**Tensor Iterator wins**
The only microbenchmark that I saw the win for was `at::eq`, with a ~2% win. Full output from Taylor's tool is here: P281574928 (I added an `at::add_out` benchmark to the suite in that run).

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53575 skip dispatch in resize_**

Differential Revision: [D26902348](https://our.internmc.facebook.com/intern/diff/D26902348)