### PR TITLE
[Static Runtime] Remove dead code

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -14,12 +14,6 @@ struct SROperatorFunctor {
     std::function<void(ProcessedNode*)> out;
     return out;
   }
-  virtual bool CanReuseInput() {
-    return false;
-  }
-  virtual bool CanReuseOutput() {
-    return false;
-  }
   virtual ~SROperatorFunctor() = default;
 };
 
@@ -35,17 +29,6 @@ C10_DECLARE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
     }                                                        \
   };                                                         \
   C10_REGISTER_CLASS(SROperatorRegistry, name, SROperatorFunctor_##id);
-
-#define REGISTER_VIEW_OPERATOR_FUNCTOR(name, id, ...)        \
-  struct SROperatorFunctor_##id : public SROperatorFunctor { \
-    const SROpFunctor fn = __VA_ARGS__;                      \
-    SROperator Generate(Node* n) override {                  \
-      return fn(n);                                          \
-    }                                                        \
-  };                                                         \
-  C10_REGISTER_CLASS(SRViewOperatorRegistry, name, SROperatorFunctor_##id);
-
-C10_DECLARE_REGISTRY(SRViewOperatorRegistry, SROperatorFunctor);
 
 inline at::Tensor create_empty_from(const at::Tensor& t) {
   return at::detail::empty_cpu(
@@ -102,10 +85,7 @@ inline void fastResizeToZero(at::Tensor& t) {
 
 bool canRunOutOfPlace(Node* n);
 bool canReuseInputsOutputs(Node* n);
-bool canReuseInputs(Node* n);
-bool canReuseOutputs(Node* n);
 bool canOptimizeConstruct(Node* n);
-bool isViewOp(Node* n);
 
 std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);
 


### PR DESCRIPTION
Summary: Remove `SRViewOperatorRegistry` and related code now that it's no longer needed.

Differential Revision: D26901367

