### PR TITLE
[caffe2] don't use static for template declarations in headers

### DIFF
--- a/aten/src/ATen/core/boxing/impl/boxing.h
+++ b/aten/src/ATen/core/boxing/impl/boxing.h
@@ -74,7 +74,7 @@ using can_unbox =
 // boxArgs - utility for pushing unboxed args onto IValue stack
 //
 template <class... Args>
-static torch::jit::Stack boxArgs(Args... args) {
+torch::jit::Stack boxArgs(Args... args) {
   // TODO Reuse stack vector instead of allocating?
   torch::jit::Stack stack;
   stack.reserve(sizeof...(Args));

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -908,7 +908,7 @@ static std::vector<T> createVectorFromList(const c10::detail::ListImpl* impl) {
 }
 
 template <typename T>
-static std::vector<T> createVectorFromList(const c10::List<T>& impl) {
+std::vector<T> createVectorFromList(const c10::List<T>& impl) {
   std::vector<T> result;
   result.reserve(impl.size());
   for (size_t i = 0, N = impl.size(); i < N; ++i) {


### PR DESCRIPTION
Summary: Using static in headers causes code bloat. Remove the unnecessary `static` qualifiers.

Test Plan: sandcastle

Reviewed By: asp2insp

Differential Revision: D26886180

