### PR TITLE
Add outer export to onnx

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5312,6 +5312,16 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(DimModel(), multi_dim_input)
 
     @skipIfUnsupportedMinOpsetVersion(12)
+    def test_outer(self):
+        class Outer(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.outer(x, y)
+
+        x = torch.arange(1, 5)
+        y = torch.arange(1, 4)
+        self.run_test(Outer(), input=(x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(12)
     def test_einsum(self):
         class EinsumModelBatchDiagonal(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5321,6 +5321,18 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.arange(1, 4)
         self.run_test(Outer(), input=(x, y))
 
+        x = torch.arange(1, 6).to(dtype=torch.float32)
+        y = torch.arange(1, 4).to(dtype=torch.long)
+        self.run_test(Outer(), input=(x, y))
+
+        x = torch.arange(2, 5).to(dtype=torch.float32)
+        y = torch.arange(2, 4).to(dtype=torch.float64)
+        self.run_test(Outer(), input=(x, y))
+
+        x = torch.arange(3, 6).to(dtype=torch.int32)
+        y = torch.arange(4, 7).to(dtype=torch.long)
+        self.run_test(Outer(), input=(x, y))
+
     @skipIfUnsupportedMinOpsetVersion(12)
     def test_einsum(self):
         class EinsumModelBatchDiagonal(torch.nn.Module):

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -16,6 +16,9 @@ def einsum(g, equation, tensor_list):
 
 @parse_args('v', 'v')
 def outer(g, input, other):
+    # make sure to cast other to self's type
+    if other.type().scalarType() != input.type().scalarType():
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[input.type().scalarType()])
     return g.op("Einsum", input, other, equation_s='i,j->ij')
 
 @parse_args('v', 'f', 'i')

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -14,6 +14,9 @@ def einsum(g, equation, tensor_list):
     tensors = sym_help._unpack_list(tensor_list)
     return g.op("Einsum", *tensors, equation_s=equation)
 
+@parse_args('v', 'v')
+def outer(g, input, other):
+    return g.op("Einsum", input, other, equation_s='i,j->ij')
 
 @parse_args('v', 'f', 'i')
 def dropout(g, input, p, train):


### PR DESCRIPTION
Add symbolic fuction to support torch.outer export to onnx.
Support for transfo-xl-wt103 model.