### PR TITLE
Remove set_default_dtype from test_datapipe.py

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -500,7 +500,6 @@ class TestFunctionalIterDataPipe(TestCase):
 
     @skipIfNoTorchVision
     def test_transforms_datapipe(self):
-        torch.set_default_dtype(torch.float)
         # A sequence of numpy random numbers representing 3-channel images
         w = h = 32
         inputs = [np.random.randint(0, 255, (h, w, 3), dtype=np.uint8) for i in range(10)]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53620 Remove set_default_dtype from test_datapipe.py**
* #53617 Marginally improve pytest collection for top-level test files
* #53611 Fix inaccurate dispatch table for fill_
* #53610 Convert a few more checks to raise NotImplementedError
* #53397 Add Meta support for empty_strided
* #53396 Add debug only layout assert for empty_cpu
* #53377 Add TORCH_CHECK_NOT_IMPLEMENTED/c10::NotImplementedError; make dispatch use it

The default dtype is float so this shouldn't be necessary.  If the
default dtype is not float we got other problems.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>