### PR TITLE
[FX][docs] Render inherited methods in fx.Tracer API reference

### DIFF
--- a/docs/source/fx.rst
+++ b/docs/source/fx.rst
@@ -1010,6 +1010,7 @@ API Reference
 
 .. autoclass:: torch.fx.Tracer
   :members:
+  :inherited-members:
 
 .. autoclass:: torch.fx.Proxy
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53656 Convert type annotations in nn/functional.py to py3 syntax
* #53654 [FX] Make TracerBase._find_user_frame private
* **#53630 [FX][docs] Render inherited methods in fx.Tracer API reference**

![image](https://user-images.githubusercontent.com/4685384/110542181-96bc9080-80dd-11eb-8104-fa95b960b5ed.png)
![image](https://user-images.githubusercontent.com/4685384/110542196-9b814480-80dd-11eb-9b87-62dca082a506.png)
![image](https://user-images.githubusercontent.com/4685384/110542213-a1772580-80dd-11eb-80f6-8afced7e7756.png)
![image](https://user-images.githubusercontent.com/4685384/110542227-a50aac80-80dd-11eb-8707-9058e7f0ceca.png)


Differential Revision: [D26918962](https://our.internmc.facebook.com/intern/diff/D26918962)