### PR TITLE
[PyTorch] Fix typo in QNNPACK

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qnnpack/src/fully-connected.c
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack/src/fully-connected.c
@@ -92,7 +92,7 @@ enum pytorch_qnnp_status pytorch_qnnp_create_fully_connected_nc_q8(
       kr,
 #if !PYTORCH_QNNPACK_RUNTIME_QUANTIZATION
       input_zero_point,
-      kernel_zero_point[0],
+      kernel_zero_points[0],
 #endif
       kernel,
       bias,


### PR DESCRIPTION
Summary: Build failed when `PYTORCH_QNNPACK_RUNTIME_QUANTIZATION` is unset. According to D21339044 (https://github.com/pytorch/pytorch/commit/622f5b68f08eda6dd7eb6210494ea164d04ab399) it seems like a typo.

Test Plan: buck build //xplat/caffe2/aten/src/ATen/native/quantized/cpu/qnnpack:pytorch_qnnpackWindows xplat/mode/windows-msvc-15.9

Reviewed By: kimishpatel

Differential Revision: D26907439

