### PR TITLE
Don't merge to master in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,42 +132,6 @@ commands:
       - brew_install:
           formulae: libtool
 
-  optional_merge_target_branch:
-    steps:
-      - run:
-          name: (Optional) Merge target branch
-          no_output_timeout: "10m"
-          command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && "$CIRCLE_BRANCH" != "nightly" ]]; then
-              PR_NUM=$(basename $CIRCLE_PULL_REQUEST)
-              CIRCLE_PR_BASE_BRANCH=$(curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUM | jq -r '.base.ref')
-              if [[ "${BUILD_ENVIRONMENT}" == *"xla"* || "${BUILD_ENVIRONMENT}" == *"gcc5"* ]] ; then
-                set -x
-                git config --global user.email "circleci.ossci@gmail.com"
-                git config --global user.name "CircleCI"
-                git config remote.origin.url https://github.com/pytorch/pytorch.git
-                git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
-                git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
-                # PRs generated from ghstack has format CIRCLE_PR_BASE_BRANCH=gh/xxx/1234/base
-                if [[ "${CIRCLE_PR_BASE_BRANCH}" == "gh/"* ]]; then
-                  CIRCLE_PR_BASE_BRANCH=master
-                fi
-                export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/$CIRCLE_PR_BASE_BRANCH`
-                echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-                export GIT_COMMIT=${CIRCLE_SHA1}
-                echo "GIT_COMMIT: " ${GIT_COMMIT}
-                git checkout -f ${GIT_COMMIT}
-                git reset --hard ${GIT_COMMIT}
-                git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
-                echo "Merged $CIRCLE_PR_BASE_BRANCH branch before building in environment $BUILD_ENVIRONMENT"
-                set +x
-              else
-                echo "No need to merge with $CIRCLE_PR_BASE_BRANCH, skipping..."
-              fi
-            else
-              echo "This is not a pull request, skipping..."
-            fi
-
   upload_binary_size_for_android_build:
     description: "Upload binary size data for Android build"
     parameters:
@@ -446,7 +410,6 @@ jobs:
     - checkout
     - calculate_docker_image_tag
     - setup_linux_system_environment
-    - optional_merge_target_branch
     - setup_ci_environment
     - run:
         name: Build

--- a/.circleci/verbatim-sources/commands.yml
+++ b/.circleci/verbatim-sources/commands.yml
@@ -97,42 +97,6 @@ commands:
       - brew_install:
           formulae: libtool
 
-  optional_merge_target_branch:
-    steps:
-      - run:
-          name: (Optional) Merge target branch
-          no_output_timeout: "10m"
-          command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" && "$CIRCLE_BRANCH" != "nightly" ]]; then
-              PR_NUM=$(basename $CIRCLE_PULL_REQUEST)
-              CIRCLE_PR_BASE_BRANCH=$(curl -s https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls/$PR_NUM | jq -r '.base.ref')
-              if [[ "${BUILD_ENVIRONMENT}" == *"xla"* || "${BUILD_ENVIRONMENT}" == *"gcc5"* ]] ; then
-                set -x
-                git config --global user.email "circleci.ossci@gmail.com"
-                git config --global user.name "CircleCI"
-                git config remote.origin.url https://github.com/pytorch/pytorch.git
-                git config --add remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
-                git fetch --tags --progress https://github.com/pytorch/pytorch.git +refs/heads/master:refs/remotes/origin/master --depth=100 --quiet
-                # PRs generated from ghstack has format CIRCLE_PR_BASE_BRANCH=gh/xxx/1234/base
-                if [[ "${CIRCLE_PR_BASE_BRANCH}" == "gh/"* ]]; then
-                  CIRCLE_PR_BASE_BRANCH=master
-                fi
-                export GIT_MERGE_TARGET=`git log -n 1 --pretty=format:"%H" origin/$CIRCLE_PR_BASE_BRANCH`
-                echo "GIT_MERGE_TARGET: " ${GIT_MERGE_TARGET}
-                export GIT_COMMIT=${CIRCLE_SHA1}
-                echo "GIT_COMMIT: " ${GIT_COMMIT}
-                git checkout -f ${GIT_COMMIT}
-                git reset --hard ${GIT_COMMIT}
-                git merge --allow-unrelated-histories --no-edit --no-ff ${GIT_MERGE_TARGET}
-                echo "Merged $CIRCLE_PR_BASE_BRANCH branch before building in environment $BUILD_ENVIRONMENT"
-                set +x
-              else
-                echo "No need to merge with $CIRCLE_PR_BASE_BRANCH, skipping..."
-              fi
-            else
-              echo "This is not a pull request, skipping..."
-            fi
-
   upload_binary_size_for_android_build:
     description: "Upload binary size data for Android build"
     parameters:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -8,7 +8,6 @@ jobs:
     - checkout
     - calculate_docker_image_tag
     - setup_linux_system_environment
-    - optional_merge_target_branch
     - setup_ci_environment
     - run:
         name: Build


### PR DESCRIPTION
Currently, most of our CircleCI jobs run directly on the tip of a PR, but a significant few instead merge the PR into `master` before running (the two top-level build jobs in this list do the actual merging, and their sub-items use the results of those builds, thus inheriting the merged repo state):

- pytorch_linux_xenial_py3_6_gcc5_4_build
  - pytorch_cpp_doc_build
  - pytorch_doc_test
  - pytorch_linux_backward_compatibility_check_test
  - pytorch_linux_xenial_py3_6_gcc5_4_jit_legacy_test
  - pytorch_linux_xenial_py3_6_gcc5_4_test
  - pytorch_python_doc_build
- pytorch_xla_linux_bionic_py3_6_clang9_build
  - pytorch_xla_linux_bionic_py3_6_clang9_test

This is extremely surprising and confusing: for the past few months I've been unsure whether or not our CircleCI setup merges PRs into `master` before building/testing them, and I would not have guessed (until today, when I finally dug into `.circleci/config.yml` to figure this out, leading to this PR), that the answer is "both yes and no".

Beyond the principle of least astonishment, here is a snippet from an internal doc explaining a bit more of the motivation for not merging into `master` on PRs:

> Currently, our CircleCI workflows (and some of our GitHub Actions) merge into master before building/testing/etc. ... we do not want to retain this behavior, since .... PyTorch gets many commits per day, and master is frequently broken. By merging with master before running CI, we deny people the benefit of basing their PRs off viable/strict and thus give them worse signal. See these PRs for some discussion of this behavior on the GHA side:
>
> - https://github.com/pytorch/pytorch/pull/49578
> - https://github.com/pytorch/pytorch/pull/49590

For some additional context, here's some of the Git blame timeline for the existing behavior:

- #11443 (2018-09-11) added the first instance of this behavior that I can find, but it seems to have been removed sometime in the following year? (I'm not sure how to use Git blame to find when something was removed following a commit, as opposed to changed prior to a commit)
- #26321 (2019-09-17) added the behavior again, apparently in order to serve the backward-compatibility test job (#26329), only for `gcc5_4`
- #29699 (2019-11-13) made the merging operation more permissible
- #37085 (2020-04-22) expanded the scope of the automerging, so now it happens for `xla` in addition to `gcc5_4`
- #38745 (2020-05-20) fixed a bug with the automerging when used with [`ghstack`](https://github.com/ezyang/ghstack) PRs
- #46038 (2020-10-08) narrowed the scope of the automerging, so now it no longer happens for `nightly` jobs

I've added the authors and reviewers of those PRs as reviewers of this one, to hopefully come to a consensus on what to do here. I'm guessing that this PR as initially written is not the best solution, since this automerging seems to perhaps be required for our backward-compatibility test job (and perhaps also our XLA job(s)?), so if those require automerging, we can't get rid of it entirely. However, in that case, I would much prefer to isolate the parts of our Circle `build` workflow that use automerging, and document exactly which parts of the workflow automerge and why.

**Test plan:**

PR #53639 serves as a testbed for this PR. Specifically:

- [this CircleCI workflow](https://app.circleci.com/pipelines/github/pytorch/pytorch/282946/workflows/97701e6a-1d8c-45d6-b993-9a0d4806c5ea) shows the two failing `build` jobs with the current automerging behavior when a merge conflict is introduced
- [this CircleCI workflow](https://app.circleci.com/pipelines/github/pytorch/pytorch/283005/workflows/c49c30bf-9447-47ce-8fe8-20de58649bc2) shows those jobs and their descendants succeeding when this PR is cherry-picked