### PR TITLE
update upsample tests in test_nn.py to test for memory_format

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9020,8 +9020,8 @@ class TestNN(NNTestCase):
             with warnings.catch_warnings(record=True) as w:
                 out_t = m(in_t)
                 out_uint8_t = m(in_uint8_t)
-            self.assertEqual(torch.ones(1, 2, 4, 4).contiguous(memory_format=memory_format), out_t.data)
-            self.assertEqual(torch.ones(1, 2, 4, 4, dtype=torch.uint8).contiguous(memory_format=memory_format), out_uint8_t.data)
+            self.assertEqual(torch.ones(1, 2, 4, 4), out_t)
+            self.assertEqual(torch.ones(1, 2, 4, 4, dtype=torch.uint8), out_uint8_t)
             # Assert that memory format is carried through to the output
             self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
@@ -9030,7 +9030,8 @@ class TestNN(NNTestCase):
             in_t = torch.ones(1, 2, 2, 1).contiguous(memory_format=memory_format)
             with warnings.catch_warnings(record=True) as w:
                 out_t = m(in_t)
-            self.assertEqual(torch.ones(1, 2, 4, 2).contiguous(memory_format=memory_format), out_t.data)
+            self.assertEqual(torch.ones(1, 2, 4, 2), out_t)
+            self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
             # test backward when input's height is not same as width
             input = torch.ones(1, 2, 2, 1, requires_grad=True).contiguous(memory_format=memory_format)
@@ -9165,8 +9166,8 @@ class TestNN(NNTestCase):
             with warnings.catch_warnings(record=True) as w:
                 out_t = m(in_t)
                 out_uint8_t = m(in_uint8_t)
-            self.assertEqual(torch.ones(1, 2, 4, 4, 4).contiguous(memory_format=memory_format), out_t.data)
-            self.assertEqual(torch.ones(1, 2, 4, 4, 4, dtype=torch.uint8).contiguous(memory_format=memory_format), out_uint8_t.data)
+            self.assertEqual(torch.ones(1, 2, 4, 4, 4), out_t)
+            self.assertEqual(torch.ones(1, 2, 4, 4, 4, dtype=torch.uint8), out_uint8_t)
             # Assert that memory format is carried through to the output
             self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9057,7 +9057,7 @@ class TestNN(NNTestCase):
                     out_size = int(math.floor(in_t.shape[-1] * scale_factor))
                     with warnings.catch_warnings(record=True) as w:
                         out_t = m(in_t)
-                    self.assertEqual(torch.ones(1, 2, out_size, out_size).contiguous(memory_format=memory_format), out_t.data)
+                    self.assertEqual(torch.ones(1, 2, out_size, out_size), out_t.data)
                     # Assert that memory format is carried through to the output
                     self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 
@@ -9185,7 +9185,7 @@ class TestNN(NNTestCase):
                     out_size = int(math.floor(in_t.shape[-1] * scale_factor))
                     with warnings.catch_warnings(record=True) as w:
                         out_t = m(in_t)
-                    self.assertEqual(torch.ones(1, 2, out_size, out_size, out_size).contiguous(memory_format=memory_format), out_t.data)
+                    self.assertEqual(torch.ones(1, 2, out_size, out_size, out_size), out_t.data)
                     # Assert that memory format is carried through to the output
                     self.assertTrue(out_t.is_contiguous(memory_format=memory_format))
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5547,27 +5547,6 @@ class TestTorchDeviceType(TestCase):
         y = ndhwc.permute(0, 1, 4, 3, 2).permute(0, 1, 4, 3, 2)
         self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
 
-    def test_memory_format_preserved_after_upsample(self, device):
-        x = torch.randn(4, 3, 8, 8, device=device)
-        nhwc = x.contiguous(memory_format=torch.channels_last)
-        y = torch._C._nn.upsample_nearest2d(nhwc, (2, 2))
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
-
-        x = torch.randn(4, 3, 8, 8, device=device)
-        nhwc = x.contiguous(memory_format=torch.channels_last)
-        y = torch._C._nn.upsample_bilinear2d(nhwc, (2, 2), True)
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last))
-
-        x = torch.randn(4, 3, 8, 8, 8, device=device)
-        nhwc = x.contiguous(memory_format=torch.channels_last_3d)
-        y = torch._C._nn.upsample_nearest3d(nhwc, (2, 2, 2))
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
-
-        x = torch.randn(4, 3, 8, 8, 8, device=device)
-        nhwc = x.contiguous(memory_format=torch.channels_last_3d)
-        y = torch._C._nn.upsample_trilinear3d(nhwc, (2, 2, 2), True)
-        self.assertTrue(y.is_contiguous(memory_format=torch.channels_last_3d))
-
     def test_memory_format_propagation_rules(self, device):
 
         contiguous = torch.rand(10, 3, 5, 5, device=device)


### PR DESCRIPTION
@ngimel pointed out to me where we already test the behavior of the `Upsample` ops in `test_nn.py`. This PR deleting my bespoke tests in `test_torch.py` and updates those in `test_nn.py` to test memory format properly.

There were two reasons the original test didn't pick up on a memory format regression:
- They didn't test the memory format of the output tensor explicitly, i.e. `output.is_contiguous(memory_format=...)`
- Even with that change, the test tensors were to simple to fail the tests. From some trial and error, it looks like one of the first two dimensions in the inputs needs to be > 1 in order for the `channels_last` memory format to actually re-order the strides.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53665 update upsample tests in test_nn.py to test for memory_format**
* #53535 fix channels_last bug in upsample kernels

Differential Revision: [D26929683](https://our.internmc.facebook.com/intern/diff/D26929683)