### PR TITLE
[deploy] namespace and rename

### DIFF
--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -226,8 +226,8 @@ static py::object global_impl(const char* module, const char* name) {
 }
 
 using at::IValue;
-using torch::PickledObject;
-using torch::PythonObject;
+using torch::deploy::Obj;
+using torch::deploy::PickledObject;
 
 // Ensure GIL is held while this object is live,
 // note: we are not use py::gil_scoped_acquire here because
@@ -263,7 +263,7 @@ struct InitLockAcquire {
   std::mutex& init_lock_;
 };
 
-struct ConcreteInterpreterImpl : public torch::InterpreterImpl {
+struct ConcreteInterpreterImpl : public torch::deploy::InterpreterImpl {
   ConcreteInterpreterImpl() {
 #define APPEND_INIT(name) PyImport_AppendInittab(#name, PyInit_##name);
     FOREACH_LIBRARY(APPEND_INIT)
@@ -331,7 +331,7 @@ struct ConcreteInterpreterImpl : public torch::InterpreterImpl {
     }
     PyMem_RawFree(program);
   }
-  torch::InterpreterSessionImpl* acquire_session() override;
+  torch::deploy::InterpreterSessionImpl* acquire_session() override;
   py::object save_storage;
   py::object load_storage;
   py::object get_package;
@@ -339,24 +339,25 @@ struct ConcreteInterpreterImpl : public torch::InterpreterImpl {
   std::mutex init_lock_;
 };
 
-struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
+struct ConcreteInterpreterSessionImpl
+    : public torch::deploy::InterpreterSessionImpl {
   ConcreteInterpreterSessionImpl(ConcreteInterpreterImpl* interp)
       : interp_(interp) {}
-  PythonObject global(const char* module, const char* name) override {
+  Obj global(const char* module, const char* name) override {
     return wrap(global_impl(module, name));
   }
 
-  PythonObject from_ivalue(IValue value) override {
+  Obj from_ivalue(IValue value) override {
     return wrap(torch::jit::toPyObject(value));
   }
-  PythonObject create_or_get_package_importer_from_container_file(
+  Obj create_or_get_package_importer_from_container_file(
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
           container_file_) override {
     InitLockAcquire guard(interp_->init_lock_);
     return wrap(interp_->get_package(container_file_));
   }
 
-  PickledObject pickle(PythonObject container, PythonObject obj) override {
+  PickledObject pickle(Obj container, Obj obj) override {
     py::tuple result = interp_->save_storage(unwrap(container), unwrap(obj));
     py::bytes bytes = py::cast<py::bytes>(result[0]);
     py::list storages = py::cast<py::list>(result[1]);
@@ -378,7 +379,7 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
         std::move(dtypes_c),
         std::move(container_file)};
   }
-  PythonObject unpickle_or_get(int64_t id, const PickledObject& obj) override {
+  Obj unpickle_or_get(int64_t id, const PickledObject& obj) override {
     py::dict objects = interp_->objects;
     py::object id_p = py::cast(id);
     if (objects.contains(id_p)) {
@@ -411,12 +412,11 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
     }
   }
 
-  IValue toIValue(PythonObject obj) const override {
+  IValue toIValue(Obj obj) const override {
     return torch::jit::toTypeInferredIValue(unwrap(obj));
   }
 
-  PythonObject call(PythonObject obj, at::ArrayRef<PythonObject> args)
-      override {
+  Obj call(Obj obj, at::ArrayRef<Obj> args) override {
     py::tuple m_args(args.size());
     for (size_t i = 0, N = args.size(); i != N; ++i) {
       m_args[i] = unwrap(args[i]);
@@ -424,7 +424,7 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
     return wrap(call(unwrap(obj), m_args));
   }
 
-  PythonObject call(PythonObject obj, at::ArrayRef<IValue> args) override {
+  Obj call(Obj obj, at::ArrayRef<IValue> args) override {
     py::tuple m_args(args.size());
     for (size_t i = 0, N = args.size(); i != N; ++i) {
       m_args[i] = torch::jit::toPyObject(args[i]);
@@ -432,7 +432,7 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
     return wrap(call(unwrap(obj), m_args));
   }
 
-  PythonObject attr(PythonObject obj, const char* attr) override {
+  Obj attr(Obj obj, const char* attr) override {
     return wrap(unwrap(obj).attr(attr));
   }
 
@@ -444,12 +444,12 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
     return py::reinterpret_steal<py::object>(result);
   }
 
-  py::handle unwrap(PythonObject obj) const {
+  py::handle unwrap(Obj obj) const {
     return objects_.at(ID(obj));
   }
-  PythonObject wrap(py::object obj) {
+  Obj wrap(py::object obj) {
     objects_.emplace_back(std::move(obj));
-    return PythonObject(this, objects_.size() - 1);
+    return Obj(this, objects_.size() - 1);
   }
   ~ConcreteInterpreterSessionImpl() override {
     objects_.clear();
@@ -459,11 +459,13 @@ struct ConcreteInterpreterSessionImpl : public torch::InterpreterSessionImpl {
   std::vector<py::object> objects_;
 };
 
-torch::InterpreterSessionImpl* ConcreteInterpreterImpl::acquire_session() {
+torch::deploy::InterpreterSessionImpl* ConcreteInterpreterImpl::
+    acquire_session() {
   return new ConcreteInterpreterSessionImpl(this);
 }
 
-extern "C" __attribute__((visibility("default"))) torch::InterpreterImpl*
+extern "C" __attribute__((visibility("default")))
+torch::deploy::InterpreterImpl*
 new_interpreter_impl(void) {
   return new ConcreteInterpreterImpl();
 }

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -5,6 +5,7 @@
 #include <caffe2/serialize/inline_container.h>
 
 namespace torch {
+namespace deploy {
 
 struct InterpreterSessionImpl;
 
@@ -23,16 +24,16 @@ struct PickledObject {
 // link against libpython. Instead all interaction with the Python state in each
 // interpreter is done via this wrapper class, and methods on
 // InterpreterSession.
-struct PythonObject {
+struct Obj {
   friend struct InterpreterSessionImpl;
-  PythonObject() : interaction_(nullptr), id_(0) {}
-  PythonObject(InterpreterSessionImpl* interaction, int64_t id)
+  Obj() : interaction_(nullptr), id_(0) {}
+  Obj(InterpreterSessionImpl* interaction, int64_t id)
       : interaction_(interaction), id_(id) {}
 
   at::IValue toIValue() const;
-  PythonObject operator()(at::ArrayRef<PythonObject> args);
-  PythonObject operator()(at::ArrayRef<at::IValue> args);
-  PythonObject attr(const char* attr);
+  Obj operator()(at::ArrayRef<Obj> args);
+  Obj operator()(at::ArrayRef<at::IValue> args);
+  Obj attr(const char* attr);
 
  private:
   InterpreterSessionImpl* interaction_;
@@ -41,38 +42,32 @@ struct PythonObject {
 
 struct InterpreterSessionImpl {
   friend struct Package;
-  friend struct MovableObject;
-  friend struct PythonObject;
+  friend struct ReplicatedObj;
+  friend struct Obj;
   friend struct InterpreterSession;
-  friend struct MovableObjectImpl;
+  friend struct ReplicatedObjImpl;
 
   virtual ~InterpreterSessionImpl() = default;
 
  private:
-  virtual PythonObject global(const char* module, const char* name) = 0;
-  virtual PythonObject from_ivalue(at::IValue value) = 0;
-  virtual PythonObject create_or_get_package_importer_from_container_file(
+  virtual Obj global(const char* module, const char* name) = 0;
+  virtual Obj from_ivalue(at::IValue value) = 0;
+  virtual Obj create_or_get_package_importer_from_container_file(
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
           container_file_) = 0;
 
-  virtual PickledObject pickle(PythonObject container, PythonObject obj) = 0;
-  virtual PythonObject unpickle_or_get(
-      int64_t id,
-      const PickledObject& obj) = 0;
+  virtual PickledObject pickle(Obj container, Obj obj) = 0;
+  virtual Obj unpickle_or_get(int64_t id, const PickledObject& obj) = 0;
   virtual void unload(int64_t id) = 0;
 
-  virtual at::IValue toIValue(PythonObject obj) const = 0;
+  virtual at::IValue toIValue(Obj obj) const = 0;
 
-  virtual PythonObject call(
-      PythonObject obj,
-      at::ArrayRef<PythonObject> args) = 0;
-  virtual PythonObject call(
-      PythonObject obj,
-      at::ArrayRef<at::IValue> args) = 0;
-  virtual PythonObject attr(PythonObject obj, const char* attr) = 0;
+  virtual Obj call(Obj obj, at::ArrayRef<Obj> args) = 0;
+  virtual Obj call(Obj obj, at::ArrayRef<at::IValue> args) = 0;
+  virtual Obj attr(Obj obj, const char* attr) = 0;
 
  protected:
-  int64_t ID(PythonObject obj) const {
+  int64_t ID(Obj obj) const {
     return obj.id_;
   }
 };
@@ -85,20 +80,21 @@ struct InterpreterImpl {
 // inline definitions for PythonObject are necessary to avoid introducing a
 // source file that would need to exist it both the libinterpreter.so and then
 // the libtorchpy library.
-inline at::IValue PythonObject::toIValue() const {
+inline at::IValue Obj::toIValue() const {
   return interaction_->toIValue(*this);
 }
 
-inline PythonObject PythonObject::operator()(at::ArrayRef<PythonObject> args) {
+inline Obj Obj::operator()(at::ArrayRef<Obj> args) {
   return interaction_->call(*this, args);
 }
 
-inline PythonObject PythonObject::operator()(at::ArrayRef<at::IValue> args) {
+inline Obj Obj::operator()(at::ArrayRef<at::IValue> args) {
   return interaction_->call(*this, args);
 }
 
-inline PythonObject PythonObject::attr(const char* attr) {
+inline Obj Obj::attr(const char* attr) {
   return interaction_->attr(*this, attr);
 }
 
+} // namespace deploy
 } // namespace torch

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -14,8 +14,8 @@ int main(int argc, char* argv[]) {
 
 void compare_torchpy_jit(const char* model_filename, const char* jit_filename) {
   // Test
-  torch::InterpreterManager m(1);
-  torch::Package p = m.load_package(model_filename);
+  torch::deploy::InterpreterManager m(1);
+  torch::deploy::Package p = m.load_package(model_filename);
   auto model = p.load_pickle("model", "model.pkl");
   at::IValue eg;
   {
@@ -52,20 +52,20 @@ TEST(TorchpyTest, ResNet) {
 }
 
 TEST(TorchpyTest, Movable) {
-  torch::InterpreterManager m(1);
-  torch::MovableObject obj;
+  torch::deploy::InterpreterManager m(1);
+  torch::deploy::ReplicatedObj obj;
   {
     auto I = m.acquire_one();
     auto model =
-        I.global("torch.nn", "Module")(std::vector<torch::PythonObject>());
+        I.global("torch.nn", "Module")(std::vector<torch::deploy::Obj>());
     obj = I.create_movable(model);
   }
   obj.acquire_session();
 }
 
 TEST(TorchpyTest, MultiSerialSimpleModel) {
-  torch::InterpreterManager manager(3);
-  torch::Package p = manager.load_package(path("SIMPLE", simple));
+  torch::deploy::InterpreterManager manager(3);
+  torch::deploy::Package p = manager.load_package(path("SIMPLE", simple));
   auto model = p.load_pickle("model", "model.pkl");
   auto ref_model = torch::jit::load(path("SIMPLE_JIT", simple_jit));
 
@@ -88,9 +88,9 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
 
 TEST(TorchpyTest, ThreadedSimpleModel) {
   size_t nthreads = 3;
-  torch::InterpreterManager manager(nthreads);
+  torch::deploy::InterpreterManager manager(nthreads);
 
-  torch::Package p = manager.load_package(path("SIMPLE", simple));
+  torch::deploy::Package p = manager.load_package(path("SIMPLE", simple));
   auto model = p.load_pickle("model", "model.pkl");
   auto ref_model = torch::jit::load(path("SIMPLE_JIT", simple_jit));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53670 [deploy] namespace and rename**

This puts deploy into the torch::deploy namespace. It also renames some
objects to better match their behavior:

PythonObject -> Obj, in the future it will refer to either a python object or a handle to a script obj, so rename it torch::deploy::Obj to be generic
MovableObject -> ReplicatedObj, to prevent confusion with "std::move" which is unrelated, and to note that we are replicating this object across interpreters.

Differential Revision: [D26932131](https://our.internmc.facebook.com/intern/diff/D26932131)