### PR TITLE
[docs] Add updated TorchScript language reference section for types

### DIFF
--- a/docs/source/jit_language_reference_v2.rst
+++ b/docs/source/jit_language_reference_v2.rst
@@ -29,6 +29,215 @@
 TorchScript Language Reference
 ==============================
 
+.. _type_annotation:
+
+
+Type Annotation
+~~~~~~~~~~~~~~~
+Since TorchScript is statically typed, programmers need to annotate types at *strategic points* of TorchScript code so that every local variable or
+instance data attribute has a static type, and every function and method has a statically typed signature.
+
+When to annotate types
+^^^^^^^^^^^^^^^^^^^^^^
+In general, type annotations are only needed in places where static types cannot be automatically inferred, such as parameters or sometimes return types to
+methods or functions. Types of local variables and data attributes are often automatically inferred from their assignment statements. Sometimes, an inferred type
+may be too restrictive, e.g., ``x`` being inferred as ``NoneType`` through assignment ``x = None``, whereas ``x`` is actually used as an ``Optional``. In such
+cases, type annotations may be needed to overwrite auto inference, e.g., ``x: Optional[int] = None``. Note that it is always safe to type annotate a local variable
+or data attribute even if its type can be automatically inferred. But the annotated type must be congruent with TorchScript’s type checking.
+
+When a parameter, local variable, or data attribute is not type annotated and its type cannot be automatically inferred, TorchScript assumes it to be a
+default type of ``TensorType``, ``List[TensorType]``, or ``Dict[str, TensorType]``.
+
+Annotate function signature
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Since parameter may not be automatically inferred from the body of the function (including both functions and methods), they need to be type annotated,
+otherwise they assume the default type ``TensorType``.
+
+TorchScript supports two styles for method and function signature type annotation:
+
+* **Python3-style** annotates types directly on the signature. As such, it allows individual parameters be left unannotated (whose type will be the default type of ``TensorType``) , or the return type be left unannotated (whose type will be automatically inferred).
+
+
+::
+
+    Python3Annotation := "def" Identifier [ "(" ParamAnnot* ")" ] [ReturnAnnot] ":"
+                         FuncOrMethodBody
+    ParamAnnot := Identifier [ ":" TSType ] ","
+    ReturnAnnot := "->" TSType
+
+Note that using Python3 style, the type of ``self`` is automatically inferred and should not be annotated.
+
+* **Mypy style** annotates types as a comment right below the function/method declaration. In the My-Py style, since parameter names do not appear in the annotation, all parameters have to be annotated.
+
+
+::
+
+    MyPyAnnotation := "# type:" "(" ParamAnnot* ")" [ ReturnAnnot ]
+    ParamAnnot := TSType ","
+    ReturnAnnot := "->" TSType
+
+**Example 1**
+
+In this example, ``a`` is not annotated and assumes the default type of ``TensorType``, ``b`` is annotated as type ``int``, and the return type is not
+annotated and is automatically inferred as type ``TensorType`` (based on the type of the value being returned).
+
+::
+
+    import torch
+
+    def f(a, b: int):
+        return a+b
+
+    m = torch.jit.script(f)
+    print("TorchScript:", m(torch.ones([6]), 100))
+
+**Example 2**
+
+The following code snippet gives an example of using mypy style annotation. Note that parameters or return values must be annotated even if some of
+them assume the default type.
+
+::
+
+    import torch
+
+    def f(a, b):
+        # type: (torch.Tensor, int) → torch.Tensor
+        return a+b
+
+    m = torch.jit.script(f)
+    print("TorchScript:", m(torch.ones([6]), 100))
+
+
+Annotate variables and data attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In general, types of data attributes (including class and instance data attributes) and local variables can be automatically inferred from assignment statements.
+Sometimes, however, if a variable or attribute is associated with values of different types (e.g., as ``None`` or ``TensorType``), then they may need to be explicitly
+type annotated as a *wider* type such as ``Optional[int]`` or ``Any``.
+
+Local variables
+"""""""""""""""
+Local variables can be annotated according to Python3 typing module annotation rule, i.e.,
+
+::
+
+    LocalVarAnnotation := Identifier [":" TSType] "=" Expr
+
+In general, types of local variables can be automatically inferred. In some cases, however, programmers may need to annotate a multi-type for local variables
+that may be associated with different concrete types. Typical multi-types include ``Optional[T]`` and ``Any``.
+
+**Example**
+
+::
+
+    import torch
+
+    def f(a, setVal: bool):
+        value: Optional[torch.Tensor] = None
+        if setVal:
+            value = a
+        return value
+
+    ones = torch.ones([6])
+    m = torch.jit.script(f)
+    print("TorchScript:", m(ones, True), m(ones, False))
+
+Instance data attributes
+""""""""""""""""""""""""
+For ``ModuleType`` classes, instance data attributes can be annotated according to Python3 typing module annotation rules. Instance data attributes can be annotated (optionally) as final
+via ``Final``.
+
+::
+
+    "class" ClassIdentifier "(torch.nn.Module):"
+    InstanceAttrIdentifier ":" ["Final("] TSType [")"]
+    ...
+
+where ``InstanceAttrIdentifier`` is the name of an instance attribute and ``Final`` indicates that the attribute cannot be re-assigned outside
+of ``__init__`` or overridden in subclasses.
+
+**Example**
+
+In this example, ``a`` is not annotated and assumes the default type of ``TensorType``, ``b`` is annotated as type ``int``, and the return type is not
+annotated and is automatically inferred as type ``TensorType`` (based on the type of the value being returned).
+
+::
+
+    import torch
+
+    class MyModule(torch.nn.Module):
+        offset_: int
+
+    def __init__(self, offset):
+        self.offset_ = offset
+
+    ...
+
+
+
+Type Annotation APIs
+^^^^^^^^^^^^^^^^^^^^
+
+``torch.jit.annotate(T, expr)``
+"""""""""""""""""""""""""""""""
+This API annotates type ``T`` to an expression ``expr``. This is often used when the default type of an expression is not the type intended by the programmer.
+For instance, an empty list (dictionary) has the default type of ``List[TensorType]`` (``Dict[TensorType, TensorType]``) but sometimes it may be used to initialize
+a list of some other types. Another common use case is for annotating the return type of ``tensor.tolist()``. Note, however that it cannot be used to annotate
+the type of a module attribute in `__init__`; ``torch.jit.Attribute`` should be used for this instead.
+
+**Example**
+
+In this example, ``[]`` is declared as a list of integers via ``torch.jit.annotate`` (instead of assuming ``[]`` to be the default type of ``List[TensorType]``).
+
+::
+
+    import torch
+    from typing import List
+
+    def g(l: List[int], val: int):
+        l.append(val)
+        return l
+
+    def f(val: int):
+        l = g(torch.jit.annotate(List[int], []), val)
+        return l
+
+    m = torch.jit.script(f)
+    print("Eager:", f(3))
+    print("TorchScript:", m(3))
+
+
+See :meth:`torch.jit.annotate` for more information.
+
+
+Appendix
+^^^^^^^^
+
+Unsupported Typing Constructs
+"""""""""""""""""""""""""""""
+TorchScript does not support all features and types of the Python3 `typing <https://docs.python.org/3/library/typing.html#module-typing>`_ module.
+Any functionality from the typing `typing <https://docs.python.org/3/library/typing.html#module-typing>`_ module not explicitly specified in this
+documentation is unsupported. The following table summarizes ``typing`` constructs that are either unsupported or supported with restrictions in TorchScript.
+
+=============================  ================
+ Item                           Description
+-----------------------------  ----------------
+``typing.Any``                  In development
+``typing.NoReturn``             Not supported
+``typing.Union``                In development
+``typing.Callable``             Not supported
+``typing.Literal``              Not supported
+``typing.ClassVar``             Not supported
+``typing.Final``                Supported for module attributes, class attribute, and annotations but not for functions
+``typing.AnyStr``               Not supported
+``typing.overload``             In development
+Type aliases                    Not supported
+Nominal typing                  In development
+Structural typing               Not supported
+NewType                         Not supported
+Generics                        Not supported
+=============================  ================
+
+
 .. _expressions:
 
 


### PR DESCRIPTION
**Summary**
This commit adds information about type annotation and inference to
the updated language specification. It will be rebased on top of #52494
after it lands.

**Test Plan**
Continuous integration.

Screen capture:
https://user-images.githubusercontent.com/4392003/110560184-66371f80-80fa-11eb-803a-923cf8de25ff.mov

