### PR TITLE
[1.8.1] Explicitly export submodules and variables from torch module

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -26,7 +26,7 @@ from ._utils_internal import get_file_path, prepare_multiprocessing_environment,
 if sys.executable == 'torch_deploy':
     __version__ = "torch-deploy-1.8"
 else:
-    from .version import __version__
+    from .version import __version__ as __version__
 from ._six import string_classes as _string_classes
 
 from typing import Set, Type, TYPE_CHECKING
@@ -597,37 +597,45 @@ def _assert(condition, message):
 # Import most common subpackages
 ################################################################################
 
-import torch.cuda
-import torch.autograd
-from torch.autograd import no_grad, enable_grad, set_grad_enabled
-import torch.fft
-import torch.futures
-import torch.nn
+# Use the redundant form so that type checkers know that these are a part of
+# the public API. The "regular" import lines are there solely for the runtime
+# side effect of adding to the imported module's members for other users.
+
+from torch import cuda as cuda
+from torch import autograd as autograd
+from torch.autograd import (
+    no_grad as no_grad,
+    enable_grad as enable_grad,
+    set_grad_enabled as set_grad_enabled,
+)
+from torch import fft as fft
+from torch import futures as futures
+from torch import nn as nn
 import torch.nn.intrinsic
 import torch.nn.quantizable
 import torch.nn.quantized
-import torch.optim
+from torch import optim as optim
 import torch.optim._multi_tensor
-import torch.multiprocessing
-import torch.sparse
+from torch import multiprocessing as multiprocessing
+from torch import sparse as sparse
 import torch.utils.backcompat
-import torch.onnx
-import torch.jit
-import torch.linalg
-import torch.hub
-import torch.random
-import torch.distributions
-import torch.testing
+from torch import onnx as onnx
+from torch import jit as jit
+from torch import linalg as linalg
+from torch import hub as hub
+from torch import random as random
+from torch import distributions as distributions
+from torch import testing as testing
 import torch.backends.cuda
 import torch.backends.mkl
 import torch.backends.mkldnn
 import torch.backends.openmp
 import torch.backends.quantized
-import torch.quantization
+from torch import quantization as quantization
 import torch.utils.data
-import torch.__config__
-import torch.__future__
-import torch.profiler
+from torch import __config__ as __config__
+from torch import __future__ as __future__
+from torch import profiler as profiler
 
 _C._init_names(list(torch._storage_classes))
 
@@ -642,11 +650,11 @@ def compiled_with_cxx11_abi():
 
 
 # Import the ops "namespace"
-from torch._ops import ops
-from torch._classes import classes
+from torch._ops import ops as ops
+from torch._classes import classes as classes
 
 # Import the quasi random sampler
-import torch.quasirandom
+from torch import quasirandom as quasirandom
 
 # If you are seeing this, it means that this call site was not checked if
 # the memory format could be preserved, and it was switched to old default
@@ -660,7 +668,7 @@ del register_after_fork
 
 # Import tools that require fully imported torch (for applying
 # torch.jit.script as a decorator, for instance):
-from ._lobpcg import lobpcg
+from ._lobpcg import lobpcg as lobpcg
 
 # These were previously defined in native_functions.yaml and appeared on the
 # `torch` namespace, but we moved them to c10 dispatch to facilitate custom


### PR DESCRIPTION
Summary:
For https://github.com/pytorch/pytorch/issues/47027.

Some progress has been made in https://github.com/pytorch/pytorch/issues/50665, but in my testing trying to unwrap the circular dependencies is turning into a neverending quest.

This PR explicitly exports things in the top-level torch module without any semantic effect, in accordance with this py.typed library guidance: https://github.com/microsoft/pyright/blob/master/docs/typed-libraries.md#library-interface

It may be possible to do some of the other fixes just using `__all__` where needed, but `__all__` has a semantic effect I would like to further review. This PR at least fixes simple completions like `torch.nn` in Pylance/pyright.

This is a cherry-pick of  https://github.com/pytorch/pytorch/pull/52339 into release/1.8

Reviewed By: smessmer

Differential Revision: D26694909

Pulled By: malfet

fbshipit-source-id: 99f2c6d0bf972afd4036df988e3acae857dde3e1
