### PR TITLE
[JIT] Fix backward compatibility test broken by #53410

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -29,6 +29,7 @@ allow_list = [
     ("c10_experimental", datetime.date(2222, 1, 1)),
     # Internal
     ("static", datetime.date(9999, 1, 1)),
+    ("prim::ModuleDictIndex", datetime.date(9999, 1, 1)),
     # Internal, profiler-specific ops
     ("profiler::_call_end_callbacks_on_jit_fut*", datetime.date(9999, 1, 1)),
     ("profiler::_record_function_enter", datetime.date(9999, 1, 1)),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53683 [JIT] Fix backward compatibility test broken by #53410**

**Summary**
This commit fixes the BC test broken by #53410. There are no promises
about operator-level BC with the operators added and modified by that
PR, so this test failure does not represent a real backward
compatibility issue.

**Test Plan**
Ran the BC test locally by runniing `dump_all_schemas.py` and then
`check_backward_compatibility.py`.

Differential Revision: [D26936505](https://our.internmc.facebook.com/intern/diff/D26936505)