### PR TITLE
[ONNX] Improve index_put symbolic to handle singular Bool updates

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1755,24 +1755,24 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(IndexPutModel(), (x, ind, update))
 
     @skipIfUnsupportedMinOpsetVersion(11)
-    def test_index_put_bool(self):
-        class IndexPutModel(torch.nn.Module):
+    def test_index_put_singular(self):
+        class IndexPutBoolModel(torch.nn.Module):
             def forward(self, mask, indices):
                 mask[indices] = True
                 return mask
 
         mask = torch.zeros(100, dtype=torch.bool)
         indices = (torch.rand(25) * mask.shape[0]).to(torch.int64)
-        self.run_test(IndexPutModel(), (mask, indices))
+        self.run_test(IndexPutBoolModel(), (mask, indices))
 
-        class IndexPutModel2(torch.nn.Module):
+        class IndexPutFloatModel(torch.nn.Module):
             def forward(self, mask, indices):
                 mask[indices] = torch.tensor(5.5)
                 return mask
 
         mask = torch.rand(100, dtype=torch.float)
         indices = (torch.rand(50) * mask.shape[0]).to(torch.int64)
-        self.run_test(IndexPutModel2(), (mask, indices))
+        self.run_test(IndexPutFloatModel(), (mask, indices))
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_accumulate(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1765,6 +1765,15 @@ class TestONNXRuntime(unittest.TestCase):
         indices = (torch.rand(25) * mask.shape[0]).to(torch.int64)
         self.run_test(IndexPutModel(), (mask, indices))
 
+        class IndexPutModel2(torch.nn.Module):
+            def forward(self, mask, indices):
+                mask[indices] = torch.tensor(5.5)
+                return mask
+
+        mask = torch.rand(100, dtype=torch.float)
+        indices = (torch.rand(50) * mask.shape[0]).to(torch.int64)
+        self.run_test(IndexPutModel2(), (mask, indices))
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_accumulate(self):
         class IndexPutModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1755,6 +1755,17 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(IndexPutModel(), (x, ind, update))
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put_bool(self):
+        class IndexPutModel(torch.nn.Module):
+            def forward(self, mask, indices):
+                mask[indices] = True
+                return mask
+
+        mask = torch.zeros(100, dtype=torch.bool)
+        indices = (torch.rand(25) * mask.shape[0]).to(torch.int64)
+        self.run_test(IndexPutModel(), (mask, indices))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_accumulate(self):
         class IndexPutModel(torch.nn.Module):
             def forward(self, x, ind, update):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -136,6 +136,10 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
     sub_data_shape = sym_help._slice_helper(
         g, g.op("Shape", self), axes=[0], starts=[len(indices_list)], ends=[maxsize])
     values_shape = g.op("Concat", broadcast_index_shape, sub_data_shape, axis_i=0)
+    # Check if values is a singular value and expand accordingly
+    rank = sym_help._get_tensor_rank(values)
+    if rank is not None and rank == 0:
+        values = expand(g, values, values_shape, None)
     values = g.op("Reshape", values, values_shape)
 
     if accumulate:


### PR DESCRIPTION
Adds support for cases where the updates to the index_put node is a single Bool value, such as the case shown below

```
mask[indices] = True
```

Fixes #53507 