### PR TITLE
Remove reference to 9.2 as it's been removed from nightlies

### DIFF
--- a/.circleci/cimodel/data/binary_build_data.py
+++ b/.circleci/cimodel/data/binary_build_data.py
@@ -60,9 +60,8 @@ CONFIG_TREE_DATA = OrderedDict(
             "3.8",
         ],
     )),
-    # Skip CUDA-9.2 builds on Windows
     windows=(
-        [v for v in dimensions.GPU_VERSIONS if v not in ['cuda92'] + dimensions.ROCM_VERSION_LABELS],
+        [v for v in dimensions.GPU_VERSIONS if v not in dimensions.ROCM_VERSION_LABELS],
         OrderedDict(
             wheel=dimensions.STANDARD_PYTHON_VERSIONS,
             conda=dimensions.STANDARD_PYTHON_VERSIONS,


### PR DESCRIPTION
Removing a tiny bit of unneeded reference to cuda92 for windows binary. Note that the config.yml did not change.