### PR TITLE
[PyTorch] Speed up Tensor::data_ptr

### DIFF
--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -195,7 +195,7 @@ bool is_quantized(Tensor self) {
         #name                                                       \
         " but found ",                                              \
         scalar_type());                                             \
-    return static_cast<T*>(this->unsafeGetTensorImpl()->data());    \
+    return this->unsafeGetTensorImpl()->data_ptr_impl<T>();         \
   }
 
 AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF(DEFINE_CAST)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53724 [PyTorch] Remove unnecessary assert in maybe_resize_storage_cpu
* **#53723 [PyTorch] Speed up Tensor::data_ptr**

We know the size of the data item at compile time. Let's take
advantage of that instead of doing a runtime multiplication by the
data type size. (Presumably, constant propagating through
`data_type.itemsize()` to optimize the `imul` away was just a bridge
too far for clang -- I checked assembly and we went from a
load-and-`imul` to a `lea` that multiplied by constant 4 for
`data_ptr<float>()`.)

Differential Revision: [D26919110](https://our.internmc.facebook.com/intern/diff/D26919110/)