### PR TITLE
[PyTorch] Remove unnecessary assert in maybe_resize_storage_cpu

### DIFF
--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -36,9 +36,11 @@ static inline void maybe_resize_storage_cpu(TensorImpl* self, uint64_t new_size)
     caffe2::TypeMeta dtype = self->dtype();
 #endif
     THTensor_stealAndSetStoragePtr(self, THStorage_new());
+#ifndef NDEBUG
     // THTensor_stealAndSetStoragePtr guarantees this. Leave debug
     // assert in case of code changes.
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dtype == self->dtype());
+#endif
   }
   uint64_t new_size_bytes =
       (new_size + self->storage_offset()) * self->dtype().itemsize();

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -32,9 +32,13 @@ static inline void maybe_resize_storage_cpu(TensorImpl* self, uint64_t new_size)
     return;
   }
   if (!THTensor_getStoragePtr(self)) {
+#ifndef NDEBUG
     caffe2::TypeMeta dtype = self->dtype();
+#endif
     THTensor_stealAndSetStoragePtr(self, THStorage_new());
-    TORCH_INTERNAL_ASSERT(dtype == self->dtype());
+    // THTensor_stealAndSetStoragePtr guarantees this. Leave debug
+    // assert in case of code changes.
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(dtype == self->dtype());
   }
   uint64_t new_size_bytes =
       (new_size + self->storage_offset()) * self->dtype().itemsize();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53724 [PyTorch] Remove unnecessary assert in maybe_resize_storage_cpu**
* #53723 [PyTorch] Speed up Tensor::data_ptr

See new code comment -- stealAndSetStoragePtr calls set_storage_keep_dtype.

Differential Revision: [D26922164](https://our.internmc.facebook.com/intern/diff/D26922164/)