### PR TITLE
Replace supports_tensor_out with supports_out

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2452,7 +2452,7 @@ op_db: List[OpInfo] = [
            op=torch.eig,
            dtypes=floating_and_complex_types(),
            test_inplace_grad=False,
-           supports_tensor_out=False,
+           supports_out=False,
            sample_inputs_func=sample_inputs_eig,
            decorators=[
                skipCUDAIfNoMagma,


### PR DESCRIPTION
#52875 introduced this bug, as `supports_tensor_out` was replaced with `supports_out` in #53259, so CI checks are failing.
