### PR TITLE
[caffe2] add a CAFFE2_NODISCARD macro to help support old compilers

### DIFF
--- a/caffe2/core/common.h
+++ b/caffe2/core/common.h
@@ -73,6 +73,12 @@ using std::vector;
 #define NOMINMAX
 #endif
 
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard)
+#define CAFFE2_NODISCARD [[nodiscard]]
+#else
+#define CAFFE2_NODISCARD
+#endif
+
 using std::make_unique;
 
 #if defined(__ANDROID__) && !defined(__NDK_MAJOR__)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53404 [caffe2] Refactor tensor serialization function
* #53403 [caffe2] Support deserializing tensors using alternate serialization formats
* **#53754 [caffe2] add a CAFFE2_NODISCARD macro to help support old compilers**
* #53402 [caffe2] add a SerializationOptions field for the save operator
* #53401 [caffe2] update load_save_test.py to also verify the chunking behavior
* #53400 [caffe2] use AddNAlreadyReserved() when serializing blobs

Some of the PyTorch CircleCI builds still use gcc 5.4, and compile with
`-Werror=attributes` causing this old compiler to fail because it does not
understand the `[[nodiscard]]` attribute.

Let's define a `CAFFE2_NODISCARD` macro to work around this.

Differential Revision: [D26959584](https://our.internmc.facebook.com/intern/diff/D26959584/)