### PR TITLE
Avoid of creating a copy of statusString every inference time

### DIFF
--- a/caffe2/opt/onnxifi_op.cc
+++ b/caffe2/opt/onnxifi_op.cc
@@ -684,12 +684,11 @@ bool OnnxifiOp<CPUContext>::RunOnDevice() {
         output_desc_.data(),
         &output_fence,
         traces_.get());
-    const string statusString = mapOnnxStatusToString(status);
     CAFFE_ENFORCE_EQ(
         status,
         ONNXIFI_STATUS_SUCCESS,
         "Reason: onnxSetIOAndRunGraph returned status code ",
-        statusString);
+        mapOnnxStatusToString(status));
 
     current_batch_size = extractOutputBatchSizes();
     onnxEventState eventState;


### PR DESCRIPTION
Summary: as title

Reviewed By: yinghai

Differential Revision: D26949450

