### PR TITLE
[3/n][torch/elastic][upstream] Move torchelastic/events to torch/distributed/events (#143)

### DIFF
--- a/test/distributed/elastic/events/lib_test.py
+++ b/test/distributed/elastic/events/lib_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs
+import logging
+import unittest
+from unittest.mock import patch
+
+from torch.distributed.elastic.events import _get_or_create_logger, Event, EventSource
+
+
+class EventLibTest(unittest.TestCase):
+    def assert_event(self, actual_event, expected_event):
+        self.assertEqual(actual_event.name, expected_event.name)
+        self.assertEqual(actual_event.source, expected_event.source)
+        self.assertEqual(actual_event.timestamp, expected_event.timestamp)
+        self.assertDictEqual(actual_event.metadata, expected_event.metadata)
+
+    @patch("torch.distributed.elastic.events.get_logging_handler")
+    def test_get_or_create_logger(self, logging_handler_mock):
+        logging_handler_mock.return_value = logging.NullHandler()
+        logger = _get_or_create_logger("test_destination")
+        self.assertIsNotNone(logger)
+        self.assertEqual(1, len(logger.handlers))
+        self.assertIsInstance(logger.handlers[0], logging.NullHandler)
+
+    def test_event_created(self):
+        event = Event(
+            name="test_event",
+            source=EventSource.AGENT,
+            metadata={"key1": "value1", "key2": 2},
+        )
+        self.assertEqual("test_event", event.name)
+        self.assertEqual(EventSource.AGENT, event.source)
+        self.assertDictEqual({"key1": "value1", "key2": 2}, event.metadata)
+
+    def test_event_deser(self):
+        event = Event(
+            name="test_event",
+            source=EventSource.AGENT,
+            metadata={"key1": "value1", "key2": 2, "key3": 1.0},
+        )
+        json_event = event.serialize()
+        deser_event = Event.deserialize(json_event)
+        self.assert_event(event, deser_event)

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -173,6 +173,7 @@ USE_PYTEST_LIST = [
     'distributions/test_transforms',
     'distributions/test_utils',
     'test_typing',
+    "distributed/elastic/events/lib_test",
 ]
 
 WINDOWS_BLOCKLIST = [

--- a/torch/distributed/elastic/events/__init__.py
+++ b/torch/distributed/elastic/events/__init__.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env/python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Module contains events processing mechanisms that are integrated with the standard python logging.
+
+Example of usage:
+
+::
+
+  from torch.distributed.elastic import events
+  event = Event(name="test_event", source=EventSource.WORKER, metadata={...})
+  events.get_events_logger(destination="default").info(event)
+
+"""
+
+import logging
+
+from torch.distributed.elastic.events.handlers import get_logging_handler
+
+from .api import Event, EventSource, EventMetadataValue  # noqa F401
+
+_events_logger = None
+
+
+def _get_or_create_logger(destination: str = "null") -> logging.Logger:
+    """
+    Constructs python logger based on the destination type or extends if provided.
+    Available destination could be found in ``handlers.py`` file.
+    The constructed logger does not propagate messages to the upper level loggers,
+    e.g. root logger. This makes sure that a single event can be processed once.
+
+    Args:
+        destination: The string representation of the event handler.
+            Available handlers found in ``handlers`` module
+        logger: Logger to be extended with the events handler. Method constructs
+            a new logger if None provided.
+    """
+    global _events_logger
+    if _events_logger:
+        return _events_logger
+    logging_handler = get_logging_handler(destination)
+    _events_logger = logging.getLogger(f"torchelastic-events-{destination}")
+    _events_logger.setLevel(logging.DEBUG)
+    # Do not propagate message to the root logger
+    _events_logger.propagate = False
+    _events_logger.addHandler(logging_handler)
+    return _events_logger
+
+
+def record(event: Event, destination: str = "console") -> None:
+    _get_or_create_logger(destination).info(event.serialize())

--- a/torch/distributed/elastic/events/api.py
+++ b/torch/distributed/elastic/events/api.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Dict, Union
+
+
+EventMetadataValue = Union[str, int, float, bool, None]
+
+
+class EventSource(str, Enum):
+    """
+    Known identifiers of the event producers.
+    """
+
+    AGENT = "AGENT"
+    WORKER = "WORKER"
+
+
+@dataclass
+class Event:
+    """
+    The class represents the generic event that occurs during the torchelastic
+    job execution. The event can be any kind of meaningful action.
+
+    Args:
+        name: event name.
+        source: the event producer, e.g. agent or worker
+        timestamp: timestamp in milliseconds when event occured.
+        metadata: additional data that is associated with the event.
+    """
+
+    name: str
+    source: EventSource
+    timestamp: int = 0
+    metadata: Dict[str, EventMetadataValue] = field(default_factory=dict)
+
+    def __str__(self):
+        return self.serialize()
+
+    @staticmethod
+    def deserialize(data: Union[str, "Event"]) -> "Event":
+        if isinstance(data, Event):
+            return data
+        if isinstance(data, str):
+            data_dict = json.loads(data)
+        data_dict["source"] = EventSource[data_dict["source"]]
+        return Event(**data_dict)
+
+    def serialize(self) -> str:
+        return json.dumps(asdict(self))

--- a/torch/distributed/elastic/events/handlers.py
+++ b/torch/distributed/elastic/events/handlers.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from typing import Dict
+
+
+_log_handlers: Dict[str, logging.Handler] = {
+    "console": logging.StreamHandler(),
+}
+
+
+def get_logging_handler(destination: str = "console") -> logging.Handler:
+    return _log_handlers[destination]


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/elastic/pull/143

The diff upsteams torchelastic/events to the torch.

Test Plan:
buck test mode/dev-nosan //pytorch/elastic/torchelastic/agent/...
    buck test mode/dev-nosan //caffe2/test/distributed/elastic/events/fb/...

Reviewed By: kiukchung

Differential Revision: D26932830

