### PR TITLE
Lowering NLLLoss/CrossEntropyLoss to ATen Dispatch

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -393,6 +393,15 @@ Tensor nll_loss_backward_cpu(
   return grad_input;
 }
 
+Tensor cross_entropy_loss(const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
+  return at::nll_loss_nd(
+    at::log_softmax(self, 1, c10::nullopt),
+    target,
+    weight,
+    ignore_index,
+    reduction);
+}
+
 Tensor & nll_loss_out(Tensor & output, const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
   Tensor total_weight = at::empty({0}, self.options());
   return std::get<0>(at::nll_loss_forward_out(output, total_weight, self, target, weight, reduction, ignore_index));
@@ -400,6 +409,64 @@ Tensor & nll_loss_out(Tensor & output, const Tensor & self, const Tensor & targe
 
 Tensor nll_loss(const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
   return std::get<0>(at::nll_loss_forward(self, target, weight, reduction, ignore_index));
+}
+
+Tensor nll_loss_nd(const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
+  if (self.dim() < 2){
+    TORCH_CHECK(false, "Expected 2 or more dimensions (got ", self.dim(), ")");
+  }
+
+  if (self.sizes()[0] != target.sizes()[0]) {
+    TORCH_CHECK(false, "Expected input batch_size (", self.sizes()[0], ") to match target batch_size (", target.sizes()[0], ").");
+  }
+
+  Tensor ret;
+  Tensor input_ = self;
+  Tensor target_ = target;
+  if (input_.dim() == 2) {
+    ret = at::nll_loss(
+          input_,
+          target_,
+          weight,
+          reduction,
+          ignore_index);
+  } else if (input_.dim() == 4) {
+    ret = at::nll_loss2d(
+          input_,
+          target_,
+          weight,
+          reduction,
+          ignore_index);
+  } else {
+    // dim == 3 or dim > 4
+    auto n = input_.sizes()[0];
+    auto c = input_.sizes()[1];
+    auto out_size = input_.sizes().slice(2).vec();
+    out_size.insert(out_size.begin(), n);
+    if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
+      TORCH_CHECK(false, "Expected target size ", IntArrayRef(out_size), ", got ", target_.sizes());
+    }
+    input_ = input_.contiguous();
+    target_ = target_.contiguous();
+    // support empty batches, see #15870
+    if (input_.numel() > 0) {
+      input_ = input_.view({n, c, 1, -1});
+    } else {
+      input_ = input_.view({n, c, 0, 0});
+    }
+    if (target_.numel() > 0) {
+      target_ = target_.view({n, 1, -1});
+    } else {
+      target_ = target_.view({n, 0, 0});
+    }
+    if (reduction == Reduction::None) {
+      ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+    } else {
+      auto out = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+      ret = out.view(out_size);
+    }
+  }
+  return ret;
 }
 
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5834,6 +5834,10 @@
   dispatch:
     DefaultBackend: addcdiv
 
+- func: cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
+  use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
+  python_module: nn
+
 - func: lstsq.X(Tensor self, Tensor A, *, Tensor(a!) X, Tensor(b!) qr) -> (Tensor(a!) solution, Tensor(b!) QR)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
   dispatch:
@@ -7370,6 +7374,10 @@
     CUDA: legacy::cuda::_thnn_multilabel_margin_loss_backward
 
 - func: nll_loss.out(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100, *, Tensor(a!) out) -> Tensor(a!)
+  use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
+  python_module: nn
+
+- func: nll_loss_nd(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
   python_module: nn
 

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -781,54 +781,7 @@ inline Tensor nll_loss(
     TORCH_CHECK(false, "Expected input batch_size (", input.sizes()[0], ") to match target batch_size (", target.sizes()[0], ").");
   }
 
-  torch::Tensor ret;
-  torch::Tensor input_ = input;
-  torch::Tensor target_ = target;
-  if (input_.dim() == 2) {
-    ret = torch::nll_loss(
-          input_,
-          target_,
-          weight,
-          enumtype::reduction_get_enum(reduction),
-          ignore_index);
-  } else if (input_.dim() == 4) {
-    ret = torch::nll_loss2d(
-          input_,
-          target_,
-          weight,
-          enumtype::reduction_get_enum(reduction),
-          ignore_index);
-  } else {
-    // dim == 3 or dim > 4
-    auto n = input_.sizes()[0];
-    auto c = input_.sizes()[1];
-    auto out_size = input_.sizes().slice(2).vec();
-    out_size.insert(out_size.begin(), n);
-    if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
-      TORCH_CHECK(false, "Expected target size ", at::IntArrayRef(out_size), ", got ", target_.sizes());
-    }
-    input_ = input_.contiguous();
-    target_ = target_.contiguous();
-    // support empty batches, see #15870
-    if (input_.numel() > 0) {
-      input_ = input_.view({n, c, 1, -1});
-    } else {
-      input_ = input_.view({n, c, 0, 0});
-    }
-    if (target_.numel() > 0) {
-      target_ = target_.view({n, 1, -1});
-    } else {
-      target_ = target_.view({n, 0, 0});
-    }
-    auto reduction_enum = enumtype::reduction_get_enum(reduction);
-    if (!c10::get_if<enumtype::kNone>(&reduction)) {
-      ret = torch::nll_loss2d(input_, target_, weight, reduction_enum, ignore_index);
-    } else {
-      auto out = torch::nll_loss2d(input_, target_, weight, reduction_enum, ignore_index);
-      ret = out.view(out_size);
-    }
-  }
-  return ret;
+  return torch::nll_loss_nd(input, target, weight, enumtype::reduction_get_enum(reduction), ignore_index);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -866,25 +819,12 @@ inline Tensor cross_entropy(
     const Tensor& weight,
     int64_t ignore_index,
     CrossEntropyFuncOptions::reduction_t reduction) {
-  NLLLossFuncOptions::reduction_t reduction_;
-  if (c10::get_if<enumtype::kNone>(&reduction)) {
-    reduction_ = torch::kNone;
-  } else if (c10::get_if<enumtype::kMean>(&reduction)) {
-    reduction_ = torch::kMean;
-  } else if (c10::get_if<enumtype::kSum>(&reduction)) {
-    reduction_ = torch::kSum;
-  } else {
-    TORCH_INTERNAL_ASSERT(
-      false,
-      enumtype::get_enum_name(reduction),
-      " is not valid");
-  }
-  return torch::nn::functional::detail::nll_loss(
-    torch::nn::functional::detail::log_softmax(input, 1, c10::nullopt),
+  return torch::cross_entropy_loss(
+    input,
     target,
     weight,
     ignore_index,
-    reduction_);
+    enumtype::reduction_get_enum(reduction));
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */


### PR DESCRIPTION
- Lowering NLLLoss/CrossEntropyLoss to ATen dispatch
- This allows the MLC device to override these ops
- Reduce code duplication between the Python and C++ APIs.