### PR TITLE
[Gradient Compression] Update the comment on fp16_compress_hook

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -41,7 +41,7 @@ def fp16_compress_hook(
     This DDP communication hook implements a simple gradient compression
     approach that casts ``GradBucket`` tensors to half-precision floating-point format (``torch.float16``).
     It allreduces those ``float16`` gradient tensors. Once compressed gradient
-    tensors are allreduced, the chained callback ``decompress`` computes the average
+    tensors are allreduced, the chained callback ``decompress`` first averages the aggregate result on all the processes,
     and then casts it back to the input data type (such as ``float32``).
 
     Example::

--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -41,8 +41,8 @@ def fp16_compress_hook(
     This DDP communication hook implements a simple gradient compression
     approach that casts ``GradBucket`` tensors to half-precision floating-point format (``torch.float16``).
     It allreduces those ``float16`` gradient tensors. Once compressed gradient
-    tensors are allreduced, its then callback called ``decompress`` casts the
-    aggregated result back to the input data type (such as ``float32``) and takes the mean.
+    tensors are allreduced, the chained callback ``decompress`` computes the average
+    and then casts it back to the input data type (such as ``float32``).
 
     Example::
         >>> ddp_model.register_comm_hook(process_group, fp16_compress_hook)

--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -39,11 +39,10 @@ def fp16_compress_hook(
 ) -> torch.futures.Future:
     """
     This DDP communication hook implements a simple gradient compression
-    approach that converts ``GradBucket`` tensors whose type is assumed to be
-    ``torch.float32`` to half-precision floating point format (``torch.float16``).
+    approach that casts ``GradBucket`` tensors to half-precision floating-point format (``torch.float16``).
     It allreduces those ``float16`` gradient tensors. Once compressed gradient
-    tensors are allreduced, its then callback called ``decompress`` converts the
-    aggregated result back to ``float32`` and takes the mean.
+    tensors are allreduced, its then callback called ``decompress`` casts the
+    aggregated result back to the input data type (such as ``float32``) and takes the mean.
 
     Example::
         >>> ddp_model.register_comm_hook(process_group, fp16_compress_hook)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53780 [Gradient Compression] Update the comment on fp16_compress_hook**

Update the comment, because the input data type of `fp16_compress_hook` does not have to be FP32. For example, the input dtype can also be FP64, as long as it can be casted into FP16.

Differential Revision: [D26967224](https://our.internmc.facebook.com/intern/diff/D26967224/)