### PR TITLE
Lowering NLLLoss/CrossEntropyLoss to ATen code

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -397,6 +397,21 @@ Tensor nll_loss_backward_cpu(
   return grad_input;
 }
 
+Tensor cross_entropy_loss(
+    const Tensor& self,
+    const Tensor& target,
+    const c10::optional<Tensor>& weight,
+    int64_t reduction,
+    int64_t ignore_index) {
+  return at::nll_loss_nd(
+      at::log_softmax(
+          self, 1, optTypeMetaToScalarType(self.options().dtype_opt())),
+      target,
+      weight,
+      reduction,
+      ignore_index);
+}
+
 Tensor & nll_loss_out(Tensor & output, const Tensor & self, const Tensor & target, const Tensor & weight, int64_t reduction, int64_t ignore_index) {
   Tensor total_weight = at::empty({0}, self.options());
   return std::get<0>(at::nll_loss_forward_out(output, total_weight, self, target, weight, reduction, ignore_index));
@@ -409,6 +424,71 @@ Tensor nll_loss(const Tensor & self, const Tensor & target, const c10::optional<
   return std::get<0>(at::nll_loss_forward(self, target, weight, reduction, ignore_index));
 }
 
+Tensor nll_loss_nd(
+    const Tensor& self,
+    const Tensor& target,
+    const c10::optional<Tensor>& weight,
+    int64_t reduction,
+    int64_t ignore_index) {
+  if (self.dim() < 2) {
+    TORCH_CHECK_VALUE(
+        false, "Expected 2 or more dimensions (got ", self.dim(), ")");
+  }
+
+  if (self.sizes()[0] != target.sizes()[0]) {
+    TORCH_CHECK_VALUE(
+        false,
+        "Expected input batch_size (",
+        self.sizes()[0],
+        ") to match target batch_size (",
+        target.sizes()[0],
+        ").");
+  }
+
+  Tensor ret;
+  Tensor input_ = self;
+  Tensor target_ = target;
+  if (input_.dim() == 2) {
+    ret = at::nll_loss(input_, target_, weight, reduction, ignore_index);
+  } else if (input_.dim() == 4) {
+    ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+  } else {
+    // dim == 3 or dim > 4
+    auto n = input_.sizes()[0];
+    auto c = input_.sizes()[1];
+    auto out_size = input_.sizes().slice(2).vec();
+    out_size.insert(out_size.begin(), n);
+    if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
+      TORCH_CHECK(
+          false,
+          "Expected target size ",
+          IntArrayRef(out_size),
+          ", got ",
+          target_.sizes());
+    }
+    input_ = input_.contiguous();
+    target_ = target_.contiguous();
+    // support empty batches, see #15870
+    if (input_.numel() > 0) {
+      input_ = input_.view({n, c, 1, -1});
+    } else {
+      input_ = input_.view({n, c, 0, 0});
+    }
+    if (target_.numel() > 0) {
+      target_ = target_.view({n, 1, -1});
+    } else {
+      target_ = target_.view({n, 0, 0});
+    }
+    if (!(reduction == Reduction::None)) {
+      ret = at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+    } else {
+      auto out =
+          at::nll_loss2d(input_, target_, weight, reduction, ignore_index);
+      ret = out.view(out_size);
+    }
+  }
+  return ret;
+}
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5691,6 +5691,9 @@
   dispatch:
     DefaultBackend: addcdiv
 
+- func: cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
+  python_module: nn
+
 - func: lstsq.X(Tensor self, Tensor A, *, Tensor(a!) X, Tensor(b!) qr) -> (Tensor(a!) solution, Tensor(b!) QR)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
   dispatch:
@@ -7186,6 +7189,9 @@
 
 - func: nll_loss.out(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100, *, Tensor(a!) out) -> Tensor(a!)
   use_c10_dispatcher: hacky_wrapper_for_legacy_signatures
+  python_module: nn
+
+- func: nll_loss_nd(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   python_module: nn
 
 - func: nll_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     input: "input"
-    input: "target.1"
+    input: "target"
     output: "2"
     name: "SoftmaxCrossEntropyLoss_0"
     op_type: "SoftmaxCrossEntropyLoss"
@@ -40,7 +40,7 @@ graph {
     }
   }
   input {
-    name: "target.1"
+    name: "target"
     type {
       tensor_type {
         elem_type: 7

--- a/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
+++ b/test/onnx/expect/TestOperators.test_softmaxcrossentropy_3d_none.expect
@@ -4,7 +4,7 @@ producer_version: "CURRENT_VERSION"
 graph {
   node {
     input: "input"
-    input: "target.1"
+    input: "target"
     output: "2"
     name: "SoftmaxCrossEntropyLoss_0"
     op_type: "SoftmaxCrossEntropyLoss"
@@ -40,7 +40,7 @@ graph {
     }
   }
   input {
-    name: "target.1"
+    name: "target"
     type {
       tensor_type {
         elem_type: 7

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -781,54 +781,12 @@ inline Tensor nll_loss(
     TORCH_CHECK(false, "Expected input batch_size (", input.sizes()[0], ") to match target batch_size (", target.sizes()[0], ").");
   }
 
-  torch::Tensor ret;
-  torch::Tensor input_ = input;
-  torch::Tensor target_ = target;
-  if (input_.dim() == 2) {
-    ret = torch::nll_loss(
-          input_,
-          target_,
-          weight,
-          enumtype::reduction_get_enum(reduction),
-          ignore_index);
-  } else if (input_.dim() == 4) {
-    ret = torch::nll_loss2d(
-          input_,
-          target_,
-          weight,
-          enumtype::reduction_get_enum(reduction),
-          ignore_index);
-  } else {
-    // dim == 3 or dim > 4
-    auto n = input_.sizes()[0];
-    auto c = input_.sizes()[1];
-    auto out_size = input_.sizes().slice(2).vec();
-    out_size.insert(out_size.begin(), n);
-    if (target_.sizes().slice(1) != input_.sizes().slice(2)) {
-      TORCH_CHECK(false, "Expected target size ", at::IntArrayRef(out_size), ", got ", target_.sizes());
-    }
-    input_ = input_.contiguous();
-    target_ = target_.contiguous();
-    // support empty batches, see #15870
-    if (input_.numel() > 0) {
-      input_ = input_.view({n, c, 1, -1});
-    } else {
-      input_ = input_.view({n, c, 0, 0});
-    }
-    if (target_.numel() > 0) {
-      target_ = target_.view({n, 1, -1});
-    } else {
-      target_ = target_.view({n, 0, 0});
-    }
-    auto reduction_enum = enumtype::reduction_get_enum(reduction);
-    if (!c10::get_if<enumtype::kNone>(&reduction)) {
-      ret = torch::nll_loss2d(input_, target_, weight, reduction_enum, ignore_index);
-    } else {
-      auto out = torch::nll_loss2d(input_, target_, weight, reduction_enum, ignore_index);
-      ret = out.view(out_size);
-    }
-  }
-  return ret;
+  return torch::nll_loss_nd(
+      input,
+      target,
+      weight,
+      enumtype::reduction_get_enum(reduction),
+      ignore_index);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
@@ -866,25 +824,12 @@ inline Tensor cross_entropy(
     const Tensor& weight,
     int64_t ignore_index,
     CrossEntropyFuncOptions::reduction_t reduction) {
-  NLLLossFuncOptions::reduction_t reduction_;
-  if (c10::get_if<enumtype::kNone>(&reduction)) {
-    reduction_ = torch::kNone;
-  } else if (c10::get_if<enumtype::kMean>(&reduction)) {
-    reduction_ = torch::kMean;
-  } else if (c10::get_if<enumtype::kSum>(&reduction)) {
-    reduction_ = torch::kSum;
-  } else {
-    TORCH_INTERNAL_ASSERT(
-      false,
-      enumtype::get_enum_name(reduction),
-      " is not valid");
-  }
-  return torch::nn::functional::detail::nll_loss(
-    torch::nn::functional::detail::log_softmax(input, 1, c10::nullopt),
-    target,
-    weight,
-    ignore_index,
-    reduction_);
+  return torch::cross_entropy_loss(
+      input,
+      target,
+      weight,
+      enumtype::reduction_get_enum(reduction),
+      ignore_index);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -51,6 +51,29 @@ def nll_loss2d(g, self, target, weight, reduction, ignore_index):
     return nll_loss(g, self, target, weight, reduction, ignore_index)
 
 
+def nll_loss_nd(g, self, target, weight, reduction, ignore_index):
+    return nll_loss(g, self, target, weight, reduction, ignore_index)
+
+
+def cross_entropy_loss(g, self, target, weight, reduction, ignore_index):
+    # none reduction : onnx::Constant[value={0}]
+    # mean reduction : onnx::Constant[value={1}]
+    # sum reduction : onnx::Constant[value={2}]
+    reduction = sym_help._maybe_get_const(reduction, 'i')
+    reduction_vals = ['none', 'mean', 'sum']
+    reduction = reduction_vals[reduction]
+
+    # in onnx SoftmaxCrossEntropyLoss specification, ignore_index is optional without default value.
+    # therefore we need to set ignore_index attribute even if it is not specified (e.g. ignore_index=-100).
+    ignore_index = sym_help._maybe_get_const(ignore_index, 'i')
+    if weight.node().mustBeNone():
+        celoss = g.op("SoftmaxCrossEntropyLoss", self, target, reduction_s=reduction, ignore_index_i=ignore_index)
+    else:
+        celoss = g.op("SoftmaxCrossEntropyLoss", self, target, weight, reduction_s=reduction, ignore_index_i=ignore_index)
+
+    return celoss
+
+
 @parse_args('v', 'v', 'v', 'v', 'i')
 def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduction):
     from torch.onnx.symbolic_opset9 import sigmoid, log, sub, neg, mul, add

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -122,7 +122,7 @@ nn_functional_tests = [
      (False, ['aten::contiguous', 'aten::_batch_norm_impl_index', 'aten::addcmul'])),
     ('group_norm', (S, S, S), (1, torch.rand(5),),),
     ('local_response_norm', (S, S, S), (2, ),),
-    ('nll_loss', F.log_softmax(torch.randn(3, 5), dim=0), (torch.tensor([1, 0, 4]),), '', (True, 'aten::nll_loss_forward')),
+    ('nll_loss', F.log_softmax(torch.randn(3, 5), dim=0), (torch.tensor([1, 0, 4]),), '',),
     ('poisson_nll_loss', torch.rand(S, 2), (torch.rand(S, 2),),),
     ('poisson_nll_loss', torch.rand(S, 2), (torch.rand(S, 2), True, True), 'full'),
     ('kl_div', F.log_softmax(torch.randn(S, 10), 1), (F.softmax(torch.randn(S, 10), 1),),),


### PR DESCRIPTION
* Lowering NLLLoss/CrossEntropyLoss to ATen dispatch
* This allows the MLC device to override these ops
* Reduce code duplication between the Python and C++ APIs.
