### PR TITLE
Workaround arm64 gcc error in `std::copysign` on Jetson platforms

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -141,7 +141,11 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
             floordiv += scalar_t(1.0);
           }
         } else {
+#if defined(__CUDA_ARCH__)
           floordiv = std::copysign(scalar_t(0), a * inv_b);
+#else
+          floordiv = (a * inv_b) & 0x8000;
+#endif
         }
         return floordiv;
       });
@@ -162,7 +166,11 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
             floordiv += scalar_t(1.0);
           }
         } else {
+#if defined(__CUDA_ARCH__)
           floordiv = std::copysign(scalar_t(0), a / b);
+#else
+          floordiv = (a / b) & 0x8000;
+#endif
         }
         return floordiv;
       });

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -172,7 +172,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
 #if defined(__CUDA_ARCH__)
           floordiv = std::copysign(scalar_t(0), a * inv_b);
 #else
-          floordiv = copysignfp16(scalar_t(0), a * inv_b);
+          floordiv = copysignfp16(scalar_t(0), scalar_t(a * inv_b));
 #endif
         }
         return floordiv;
@@ -197,7 +197,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
 #if defined(__CUDA_ARCH__)
           floordiv = std::copysign(scalar_t(0), a / b);
 #else
-          floordiv = copysignfp16(scalar_t(0), a / b);
+          floordiv = copysignfp16(scalar_t(0), scalar_t(a / b));
 #endif
         }
         return floordiv;

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -135,7 +135,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        if ((a < 0) != (b < 0)) {
+        if (!std::is_unsigned<scalar_t>::value && (a < 0) != (b < 0)) {
           // Subtracts one from the results of truncation division if the
           // divisor and dividend have different sign(bit)s and the remainder of
           // the division is nonzero

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -1,46 +1,50 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
-#include <ATen/native/DispatchStub.h>
-#include <ATen/native/cuda/Loops.cuh>
-#include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/native/TensorIterator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAMathCompat.h>
+#include <ATen/native/cuda/Loops.cuh>
 
 #include <type_traits>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at { namespace native {
+namespace at {
+namespace native {
 
-template<typename scalar_t, typename accscalar_t>
+template <typename scalar_t, typename accscalar_t>
 struct MulScalarFunctor {
-    MulScalarFunctor(accscalar_t b_): b(b_) {}
-    __device__ scalar_t operator() (scalar_t a) const {
-      return a * b;
-    }
-  private:
-    accscalar_t b;
+  MulScalarFunctor(accscalar_t b_) : b(b_) {}
+  __device__ scalar_t operator()(scalar_t a) const {
+    return a * b;
+  }
+
+ private:
+  accscalar_t b;
 };
 
-template<typename scalar_t>
+template <typename scalar_t>
 struct DivFunctor {
-  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
+  __device__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a / b;
   }
 };
 
-template<typename scalar_t>
+template <typename scalar_t>
 struct MulFunctor {
-  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
+  __device__ scalar_t operator()(scalar_t a, scalar_t b) const {
     return a * b;
   }
 };
 
-// Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
-template<>
+// Workaround for the error: '*' in boolean context, suggest '&&' instead
+// [-Werror=int-in-bool-context]
+template <>
 struct MulFunctor<bool> {
-  __device__ bool operator() (bool a, bool b) const {
+  __device__ bool operator()(bool a, bool b) const {
     return a && b;
   }
 };
@@ -51,18 +55,20 @@ void div_true_kernel_cuda(TensorIteratorBase& iter) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
-      using accscalar_t = at::acc_type<scalar_t, true>;
-      auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
-      iter.remove_operand(2);
-      MulScalarFunctor<scalar_t, decltype(inv_b)> f(inv_b);
-      gpu_kernel(iter, f);
-    });
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
+          using accscalar_t = at::acc_type<scalar_t, true>;
+          auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
+          iter.remove_operand(2);
+          MulScalarFunctor<scalar_t, decltype(inv_b)> f(inv_b);
+          gpu_kernel(iter, f);
+        });
   } else {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
-      DivFunctor<scalar_t> f;
-      gpu_kernel_with_scalars(iter, f);
-    });
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
+          DivFunctor<scalar_t> f;
+          gpu_kernel_with_scalars(iter, f);
+        });
   }
 }
 
@@ -70,28 +76,31 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
   if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_trunc_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        return a / b;
-      });
+      gpu_kernel_with_scalars(
+          iter,
+          [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t { return a / b; });
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
-      using accscalar_t = at::acc_type<scalar_t, true>;
-      auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
-      iter.remove_operand(2);
-      gpu_kernel(iter, [inv_b] GPU_LAMBDA (scalar_t a) -> scalar_t {
-        return std::trunc(a * inv_b);
-      });
-    });
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
+          using accscalar_t = at::acc_type<scalar_t, true>;
+          auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
+          iter.remove_operand(2);
+          gpu_kernel(iter, [inv_b] GPU_LAMBDA(scalar_t a) -> scalar_t {
+            return std::trunc(a * inv_b);
+          });
+        });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        return std::trunc(a / b);
-      });
-    });
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
+          gpu_kernel_with_scalars(
+              iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+                return std::trunc(a / b);
+              });
+        });
   }
 }
 
@@ -133,98 +142,105 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
     return div_trunc_kernel_cuda(iter);
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        if (!std::is_unsigned<scalar_t>::value && (a < 0) != (b < 0)) {
-          // Subtracts one from the results of truncation division if the
-          // divisor and dividend have different sign(bit)s and the remainder of
-          // the division is nonzero
-          const auto quot = a / b;
-          const auto rem = a % b;
-          return rem ? quot - 1 : quot;
-        }
+      gpu_kernel_with_scalars(
+          iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+            if ((a < 0) != (b < 0)) {
+              // Subtracts one from the results of truncation division if the
+              // divisor and dividend have different sign(bit)s and the
+              // remainder of the division is nonzero
+              const auto quot = a / b;
+              const auto rem = a % b;
+              return rem ? quot - 1 : quot;
+            }
 
-        return a / b;
-      });
+            return a / b;
+          });
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
-      using accscalar_t = at::acc_type<scalar_t, true>;
-      auto b = iter.scalar_value<accscalar_t>(2);
-      auto inv_b = accscalar_t(1.0) / b;
-      iter.remove_operand(2);
-      gpu_kernel(iter, [b, inv_b] GPU_LAMBDA (scalar_t a) -> scalar_t {
-        auto mod = std::fmod(a, b);
-        auto div = (a - mod) * inv_b;
-        if ((mod != 0) && (b < 0) != (mod < 0)) {
-          div -= scalar_t(1);
-        }
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
+          using accscalar_t = at::acc_type<scalar_t, true>;
+          auto b = iter.scalar_value<accscalar_t>(2);
+          auto inv_b = accscalar_t(1.0) / b;
+          iter.remove_operand(2);
+          gpu_kernel(iter, [b, inv_b] GPU_LAMBDA(scalar_t a) -> scalar_t {
+            auto mod = std::fmod(a, b);
+            auto div = (a - mod) * inv_b;
+            if ((mod != 0) && (b < 0) != (mod < 0)) {
+              div -= scalar_t(1);
+            }
 
-        scalar_t floordiv;
-        if (div != 0) {
-          floordiv = std::floor(div);
-          if (div - floordiv > scalar_t(0.5)) {
-            floordiv += scalar_t(1.0);
-          }
-        } else {
+            scalar_t floordiv;
+            if (div != 0) {
+              floordiv = std::floor(div);
+              if (div - floordiv > scalar_t(0.5)) {
+                floordiv += scalar_t(1.0);
+              }
+            } else {
 #if defined(__CUDA_ARCH__)
-          floordiv = std::copysign(scalar_t(0), a * inv_b);
+              floordiv = std::copysign(scalar_t(0), a * inv_b);
 #else
-          floordiv = copysignfp16(scalar_t(0), scalar_t(a * inv_b));
+          floordiv = c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a * inv_b));
 #endif
-        }
-        return floordiv;
-      });
-    });
+            }
+            return floordiv;
+          });
+        });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
-      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-        auto mod = std::fmod(a, b);
-        auto div = (a - mod) / b;
-        if ((mod != 0) && (b < 0) != (mod < 0)) {
-          div -= scalar_t(1);
-        }
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
+          gpu_kernel_with_scalars(
+              iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
+                auto mod = std::fmod(a, b);
+                auto div = (a - mod) / b;
+                if ((mod != 0) && (b < 0) != (mod < 0)) {
+                  div -= scalar_t(1);
+                }
 
-        scalar_t floordiv;
-        if (div != 0) {
-          floordiv = std::floor(div);
-          if (div - floordiv > scalar_t(0.5)) {
-            floordiv += scalar_t(1.0);
-          }
-        } else {
+                scalar_t floordiv;
+                if (div != 0) {
+                  floordiv = std::floor(div);
+                  if (div - floordiv > scalar_t(0.5)) {
+                    floordiv += scalar_t(1.0);
+                  }
+                } else {
 #if defined(__CUDA_ARCH__)
-          floordiv = std::copysign(scalar_t(0), a / b);
+                  floordiv = std::copysign(scalar_t(0), a / b);
 #else
-          floordiv = copysignfp16(scalar_t(0), scalar_t(a / b));
+          floordiv = c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a / b));
 #endif
-        }
-        return floordiv;
-      });
-    });
+                }
+                return floordiv;
+              });
+        });
   }
 }
 
 void mul_kernel_cuda(TensorIteratorBase& iter) {
   if (!isIntegralType(iter.common_dtype(), /*includeBool*/ true) &&
-    (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
-    //if common dtype is half the scalar constant can overflow in half precision, and yet the result can
-    //still be representable in the half dtype. Cast scalar to acc_type to have better accuracy
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
-      using accscalar_t = at::acc_type<scalar_t, true>;
-      int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
-      auto b = iter.scalar_value<accscalar_t>(scalar_arg);
-      iter.remove_operand(scalar_arg);
-      const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
-      MulScalarFunctor<scalar_t, decltype(b)> f(b);
-      gpu_kernel(iter, f);
-    });
+      (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
+    // if common dtype is half the scalar constant can overflow in half
+    // precision, and yet the result can still be representable in the half
+    // dtype. Cast scalar to acc_type to have better accuracy
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
+        kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
+          using accscalar_t = at::acc_type<scalar_t, true>;
+          int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
+          auto b = iter.scalar_value<accscalar_t>(scalar_arg);
+          iter.remove_operand(scalar_arg);
+          const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
+          MulScalarFunctor<scalar_t, decltype(b)> f(b);
+          gpu_kernel(iter, f);
+        });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
-      MulFunctor<scalar_t> f;
-      gpu_kernel_with_scalars(iter, f);
-    });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
+        kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
+          MulFunctor<scalar_t> f;
+          gpu_kernel_with_scalars(iter, f);
+        });
   }
 }
 
@@ -233,4 +249,5 @@ REGISTER_DISPATCH(div_trunc_stub, &div_trunc_kernel_cuda);
 REGISTER_DISPATCH(div_floor_stub, &div_floor_kernel_cuda);
 REGISTER_DISPATCH(mul_stub, &mul_kernel_cuda);
 
-}} // namespace at::native
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -96,34 +96,6 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
   }
 }
 
-namespace{
-
-template<typename scalar_t>
-scalar_t fp16_from_bits(uint16_t w) {
-    union {
-      uint32_t as_bits;
-      scalar_t as_value;
-    } fp16 = {w};
-    return fp16.as_value;
-}
-
-template<typename scalar_t>
-uint32_t fp16_to_bits(scalar_t f) {
-    union {
-      scalar_t as_value;
-      uint16_t as_bits;
-    } fp16 = {f};
-    return fp16.as_bits;
-}
-
-template<typename scalar_t>
-scalar_t copysignfp16(scalar_t x, scalar_t y){
-  return fp16_from_bits<scalar_t>(
-    (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
-}
-
-}// namespace
-
 void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   // See NOTE: [Floor Division in Python]
   const auto dtype = iter.common_dtype();

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -117,7 +117,7 @@ uint32_t fp16_to_bits(scalar_t f) {
 
 template<typename scalar_t>
 scalar_t copysignfp16(scalar_t x, scalar_t y){
-  return return fp16_from_bits(
+  return fp16_from_bits(
     (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
 } 
 

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -120,7 +120,7 @@ template<typename scalar_t>
 scalar_t copysignfp16(scalar_t x, scalar_t y){
   return fp16_from_bits<scalar_t>(
     (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
-} 
+}
 
 }// namespace
 

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -170,11 +170,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
             floordiv += scalar_t(1.0);
           }
         } else {
-#if defined(__CUDA_ARCH__)
-          floordiv = std::copysign(scalar_t(0), a * inv_b);
-#else
           floordiv = ::c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a * inv_b));
-#endif
         }
         return floordiv;
       });
@@ -195,11 +191,7 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
             floordiv += scalar_t(1.0);
           }
         } else {
-#if defined(__CUDA_ARCH__)
-          floordiv = std::copysign(scalar_t(0), a / b);
-#else
           floordiv = ::c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a / b));
-#endif
         }
         return floordiv;
       });

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -5,6 +5,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAMathCompat.h>
 
 #include <type_traits>
 

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -117,7 +117,7 @@ uint32_t fp16_to_bits(scalar_t f) {
 
 template<typename scalar_t>
 scalar_t copysignfp16(scalar_t x, scalar_t y){
-  return fp16_from_bits(
+  return fp16_from_bits<scalar_t>(
     (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
 } 
 

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -1,50 +1,46 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
-#include <ATen/native/BinaryOps.h>
 #include <ATen/native/DispatchStub.h>
-#include <ATen/native/TensorIterator.h>
-#include <c10/cuda/CUDAGuard.h>
-#include <c10/cuda/CUDAMathCompat.h>
 #include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+#include <c10/cuda/CUDAGuard.h>
 
 #include <type_traits>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 
-namespace at {
-namespace native {
+namespace at { namespace native {
 
-template <typename scalar_t, typename accscalar_t>
+template<typename scalar_t, typename accscalar_t>
 struct MulScalarFunctor {
-  MulScalarFunctor(accscalar_t b_) : b(b_) {}
-  __device__ scalar_t operator()(scalar_t a) const {
-    return a * b;
-  }
-
- private:
-  accscalar_t b;
+    MulScalarFunctor(accscalar_t b_): b(b_) {}
+    __device__ scalar_t operator() (scalar_t a) const {
+      return a * b;
+    }
+  private:
+    accscalar_t b;
 };
 
-template <typename scalar_t>
+template<typename scalar_t>
 struct DivFunctor {
-  __device__ scalar_t operator()(scalar_t a, scalar_t b) const {
+  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
     return a / b;
   }
 };
 
-template <typename scalar_t>
+template<typename scalar_t>
 struct MulFunctor {
-  __device__ scalar_t operator()(scalar_t a, scalar_t b) const {
+  __device__ scalar_t operator() (scalar_t a, scalar_t b) const {
     return a * b;
   }
 };
 
-// Workaround for the error: '*' in boolean context, suggest '&&' instead
-// [-Werror=int-in-bool-context]
-template <>
+// Workaround for the error: '*' in boolean context, suggest '&&' instead [-Werror=int-in-bool-context]
+template<>
 struct MulFunctor<bool> {
-  __device__ bool operator()(bool a, bool b) const {
+  __device__ bool operator() (bool a, bool b) const {
     return a && b;
   }
 };
@@ -55,20 +51,18 @@ void div_true_kernel_cuda(TensorIteratorBase& iter) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-        kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
-          using accscalar_t = at::acc_type<scalar_t, true>;
-          auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
-          iter.remove_operand(2);
-          MulScalarFunctor<scalar_t, decltype(inv_b)> f(inv_b);
-          gpu_kernel(iter, f);
-        });
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
+      iter.remove_operand(2);
+      MulScalarFunctor<scalar_t, decltype(inv_b)> f(inv_b);
+      gpu_kernel(iter, f);
+    });
   } else {
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-        kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
-          DivFunctor<scalar_t> f;
-          gpu_kernel_with_scalars(iter, f);
-        });
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "div_true_cuda", [&]() {
+      DivFunctor<scalar_t> f;
+      gpu_kernel_with_scalars(iter, f);
+    });
   }
 }
 
@@ -76,31 +70,28 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
   auto dtype = iter.common_dtype();
   if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_trunc_cuda", [&]() {
-      gpu_kernel_with_scalars(
-          iter,
-          [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t { return a / b; });
+      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+        return a / b;
+      });
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
-          using accscalar_t = at::acc_type<scalar_t, true>;
-          auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
-          iter.remove_operand(2);
-          gpu_kernel(iter, [inv_b] GPU_LAMBDA(scalar_t a) -> scalar_t {
-            return std::trunc(a * inv_b);
-          });
-        });
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto inv_b = accscalar_t(1.0) / iter.scalar_value<accscalar_t>(2);
+      iter.remove_operand(2);
+      gpu_kernel(iter, [inv_b] GPU_LAMBDA (scalar_t a) -> scalar_t {
+        return std::trunc(a * inv_b);
+      });
+    });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
-          gpu_kernel_with_scalars(
-              iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-                return std::trunc(a / b);
-              });
-        });
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_trunc_cuda", [&]() {
+      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+        return std::trunc(a / b);
+      });
+    });
   }
 }
 
@@ -142,105 +133,98 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
     return div_trunc_kernel_cuda(iter);
   } else if (isIntegralType(dtype, /*includeBool*/ false)) {
     AT_DISPATCH_INTEGRAL_TYPES(dtype, "div_floor_cuda", [&]() {
-      gpu_kernel_with_scalars(
-          iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-            if ((a < 0) != (b < 0)) {
-              // Subtracts one from the results of truncation division if the
-              // divisor and dividend have different sign(bit)s and the
-              // remainder of the division is nonzero
-              const auto quot = a / b;
-              const auto rem = a % b;
-              return rem ? quot - 1 : quot;
-            }
+      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+        if ((a < 0) != (b < 0)) {
+          // Subtracts one from the results of truncation division if the
+          // divisor and dividend have different sign(bit)s and the remainder of
+          // the division is nonzero
+          const auto quot = a / b;
+          const auto rem = a % b;
+          return rem ? quot - 1 : quot;
+        }
 
-            return a / b;
-          });
+        return a / b;
+      });
     });
   } else if (iter.is_cpu_scalar(2)) {
     // optimization for floating-point types: if the second operand is a CPU
     // scalar, compute a * reciprocal(b). Note that this may lose one bit of
     // precision compared to computing the division.
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
-          using accscalar_t = at::acc_type<scalar_t, true>;
-          auto b = iter.scalar_value<accscalar_t>(2);
-          auto inv_b = accscalar_t(1.0) / b;
-          iter.remove_operand(2);
-          gpu_kernel(iter, [b, inv_b] GPU_LAMBDA(scalar_t a) -> scalar_t {
-            auto mod = std::fmod(a, b);
-            auto div = (a - mod) * inv_b;
-            if ((mod != 0) && (b < 0) != (mod < 0)) {
-              div -= scalar_t(1);
-            }
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto b = iter.scalar_value<accscalar_t>(2);
+      auto inv_b = accscalar_t(1.0) / b;
+      iter.remove_operand(2);
+      gpu_kernel(iter, [b, inv_b] GPU_LAMBDA (scalar_t a) -> scalar_t {
+        auto mod = std::fmod(a, b);
+        auto div = (a - mod) * inv_b;
+        if ((mod != 0) && (b < 0) != (mod < 0)) {
+          div -= scalar_t(1);
+        }
 
-            scalar_t floordiv;
-            if (div != 0) {
-              floordiv = std::floor(div);
-              if (div - floordiv > scalar_t(0.5)) {
-                floordiv += scalar_t(1.0);
-              }
-            } else {
+        scalar_t floordiv;
+        if (div != 0) {
+          floordiv = std::floor(div);
+          if (div - floordiv > scalar_t(0.5)) {
+            floordiv += scalar_t(1.0);
+          }
+        } else {
 #if defined(__CUDA_ARCH__)
-              floordiv = std::copysign(scalar_t(0), a * inv_b);
+          floordiv = std::copysign(scalar_t(0), a * inv_b);
 #else
-          floordiv = c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a * inv_b));
+          floordiv = ::c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a * inv_b));
 #endif
-            }
-            return floordiv;
-          });
-        });
+        }
+        return floordiv;
+      });
+    });
   } else {
-    AT_DISPATCH_FLOATING_TYPES_AND2(
-        kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
-          gpu_kernel_with_scalars(
-              iter, [] GPU_LAMBDA(scalar_t a, scalar_t b) -> scalar_t {
-                auto mod = std::fmod(a, b);
-                auto div = (a - mod) / b;
-                if ((mod != 0) && (b < 0) != (mod < 0)) {
-                  div -= scalar_t(1);
-                }
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
+      gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+        auto mod = std::fmod(a, b);
+        auto div = (a - mod) / b;
+        if ((mod != 0) && (b < 0) != (mod < 0)) {
+          div -= scalar_t(1);
+        }
 
-                scalar_t floordiv;
-                if (div != 0) {
-                  floordiv = std::floor(div);
-                  if (div - floordiv > scalar_t(0.5)) {
-                    floordiv += scalar_t(1.0);
-                  }
-                } else {
+        scalar_t floordiv;
+        if (div != 0) {
+          floordiv = std::floor(div);
+          if (div - floordiv > scalar_t(0.5)) {
+            floordiv += scalar_t(1.0);
+          }
+        } else {
 #if defined(__CUDA_ARCH__)
-                  floordiv = std::copysign(scalar_t(0), a / b);
+          floordiv = std::copysign(scalar_t(0), a / b);
 #else
-          floordiv = c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a / b));
+          floordiv = ::c10::cuda::compat::copysignfp16(scalar_t(0), scalar_t(a / b));
 #endif
-                }
-                return floordiv;
-              });
-        });
+        }
+        return floordiv;
+      });
+    });
   }
 }
 
 void mul_kernel_cuda(TensorIteratorBase& iter) {
   if (!isIntegralType(iter.common_dtype(), /*includeBool*/ true) &&
-      (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
-    // if common dtype is half the scalar constant can overflow in half
-    // precision, and yet the result can still be representable in the half
-    // dtype. Cast scalar to acc_type to have better accuracy
-    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(
-        kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
-          using accscalar_t = at::acc_type<scalar_t, true>;
-          int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
-          auto b = iter.scalar_value<accscalar_t>(scalar_arg);
-          iter.remove_operand(scalar_arg);
-          const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
-          MulScalarFunctor<scalar_t, decltype(b)> f(b);
-          gpu_kernel(iter, f);
-        });
+    (iter.is_cpu_scalar(1) || iter.is_cpu_scalar(2))) {
+    //if common dtype is half the scalar constant can overflow in half precision, and yet the result can
+    //still be representable in the half dtype. Cast scalar to acc_type to have better accuracy
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(kHalf, kBFloat16, iter.common_dtype(), "mul_cuda", [&]() {
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      int scalar_arg = iter.is_cpu_scalar(1) ? 1 : 2;
+      auto b = iter.scalar_value<accscalar_t>(scalar_arg);
+      iter.remove_operand(scalar_arg);
+      const cuda::OptionalCUDAGuard device_guard(device_of(iter.tensor(1)));
+      MulScalarFunctor<scalar_t, decltype(b)> f(b);
+      gpu_kernel(iter, f);
+    });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
-        kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
-          MulFunctor<scalar_t> f;
-          gpu_kernel_with_scalars(iter, f);
-        });
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBFloat16, kBool, iter.common_dtype(), "mul_cuda", [&]() {
+      MulFunctor<scalar_t> f;
+      gpu_kernel_with_scalars(iter, f);
+    });
   }
 }
 
@@ -249,5 +233,4 @@ REGISTER_DISPATCH(div_trunc_stub, &div_trunc_kernel_cuda);
 REGISTER_DISPATCH(div_floor_stub, &div_floor_kernel_cuda);
 REGISTER_DISPATCH(mul_stub, &mul_kernel_cuda);
 
-} // namespace native
-} // namespace at
+}} // namespace at::native

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -97,7 +97,7 @@ void div_trunc_kernel_cuda(TensorIteratorBase& iter) {
 
 namespace{
 
-  template<typename scalar_t>
+template<typename scalar_t>
 scalar_t fp16_from_bits(uint16_t w) {
     union {
       uint32_t as_bits;

--- a/c10/cuda/CUDAMathCompat.h
+++ b/c10/cuda/CUDAMathCompat.h
@@ -43,8 +43,13 @@ __MATH_FUNCTIONS_DECL__ double ceil(double x) {
 }
 
 __MATH_FUNCTIONS_DECL__ float copysign(float x, float y) {
+#if defined(__CUDA_ARCH__)
   return ::copysignf(x, y);
+#else
+  return (x & 0x7fff'ffff) | (y & 0x8000'0000);
+#endif
 }
+
 __MATH_FUNCTIONS_DECL__ double copysign(double x, double y) {
   return ::copysign(x, y);
 }

--- a/c10/cuda/CUDAMathCompat.h
+++ b/c10/cuda/CUDAMathCompat.h
@@ -67,7 +67,7 @@ __MATH_FUNCTIONS_DECL__ float copysign(float x, float y) {
   return ::copysignf(x, y);
 #else
   return fp32_from_bits(
-      (fp32_to_bits(x) & 0x7fffffffu) | (fp32_to_bits(y) & 0x80000000u))
+      (fp32_to_bits(x) & 0x7fffffffu) | (fp32_to_bits(y) & 0x80000000u));
 #endif
 }
 

--- a/c10/cuda/CUDAMathCompat.h
+++ b/c10/cuda/CUDAMathCompat.h
@@ -76,11 +76,6 @@ __MATH_FUNCTIONS_DECL__ uint16_t fp16_to_bits(scalar_t f) {
   return fp16.as_bits;
 }
 
-template <typename scalar_t>
-__MATH_FUNCTIONS_DECL__ scalar_t copysignfp16(scalar_t x, scalar_t y) {
-  return fp16_from_bits<scalar_t>(
-      (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
-}
 
 template <typename scalar_t>
 __MATH_FUNCTIONS_DECL__ scalar_t copysignfp32(scalar_t x, scalar_t y) {
@@ -94,6 +89,16 @@ __MATH_FUNCTIONS_DECL__ float copysign(float x, float y) {
 #else
   return copysignfp32(x, y);
 #endif
+}
+
+template <typename scalar_t>
+__MATH_FUNCTIONS_DECL__ scalar_t copysignfp16(scalar_t x, scalar_t y) {
+  #if defined(__CUDA_ARCH__)
+    return copysign(x,y);
+  #else
+    return fp16_from_bits<scalar_t>(
+      (fp16_to_bits(x) & 0x7fffu) | (fp16_to_bits(y) & 0x8000u));
+  #endif
 }
 
 __MATH_FUNCTIONS_DECL__ double copysign(double x, double y) {


### PR DESCRIPTION
This is a continuation of #52049, but on the CUDA side. 

Jetson platforms need this PR as well as #52049 to build without gcc ICE. Tested on Jetson Xavier NX. 

See #51834 for more detailed discussion.