### PR TITLE
[DDP] Fix wrong call to dist.get_rank()

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -1254,7 +1254,9 @@ class DistributedDataParallel(Module):
                 # upon a rank to sync module buffers from, since rank 0 may
                 # already have been joined and have stale module buffers.
                 if self.ddp_uneven_inputs_config.ddp_join_enabled:
-                    authoritative_rank = self._find_common_rank(dist.get_rank(), True)
+                    authoritative_rank = self._find_common_rank(
+                        dist.get_rank(self.process_group), True
+                    )
                 else:
                     # The process with rank 0 is considered the authoritative copy.
                     authoritative_rank = 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53795 [DDP] add _distributed_rank helper function
* **#53793 [DDP] Fix wrong call to dist.get_rank()**

This call should pass in the process group so it works appropriately
for subgroups instead of whole world being passed into DDP.

Aside: This wasn't caught by tests since we don't have good testing around
passing subgroups into DDP, I believe nearly all tests use the entire world.
Should we add better testing for subgroups which may potentially bring up more
subtle bugs?

Differential Revision: [D26972367](https://our.internmc.facebook.com/intern/diff/D26972367/)