### PR TITLE
[Static Runtime] Fix bug in ClipRangesGatherRangesX2SigridHash

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -437,15 +437,10 @@ PrepareForStaticModule(const torch::jit::Module& m) {
   auto module = m.copy();
   module.eval();
 
-  Method method = module.get_method("forward");
-  auto graph = method.graph();
-  // Move this pass to before running the freeze_module pass so that the
-  // sigrid_hash_compute_multipler_shift op can be precomputed and the results
-  // being folded into the module as constants. This is required to enable the
-  // ClipRangesGatherRangesX2SigridHashPrecompute pass. See D26833478
-  SplitOutPrecomputeOpsForSparseNN(graph);
   module = freeze_module(module);
-  graph = module.get_method("forward").graph();
+
+  Method method = module.get_method("forward");
+  auto graph = module.get_method("forward").graph();
   PrepareGraphForStaticModule(graph);
 
   c10::FunctionSchema s = RemoveSelfFromSchema(method.function().getSchema());


### PR DESCRIPTION
Summary:
Fix two issues with ClipRangesGatherRangesX2SigridHash and ClipRangesGatherRangesX2SigridHashPrecompute:
- The first issue is with the two step graph rewrite process. If step 2 doesn't happen after step 1, then we're stuck with a graph with a `fb::placeholder` op that can't run. Step 3 is added to revert step 1 so we restore the original graph if there's any `fb::placeholder` op left.
- The second issue is with `SigridHashPrecompute`. The coupling with `freeze_module` is not ideal and limits its use to Static Runtime only. By running `ConstantPropagation` and `ConstantPooling` after splitting SigridHash, we can move all the Constant ops to the front of the graph and fusion can happen right afterwards.

Reviewed By: ajyu

Differential Revision: D26920008

