### PR TITLE
Improved aten::to performance from inline cvr remote_request_only

### DIFF
--- a/aten/src/ATen/native/Copy.cpp
+++ b/aten/src/ATen/native/Copy.cpp
@@ -114,28 +114,36 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
       if (src.dtype() == at::kFloat && self.dtype() == at::kHalf) {
         auto* output_ptr =
             reinterpret_cast<fbgemm::float16*>(self.data_ptr<at::Half>());
-        at::parallel_for(
-            0,
-            self.numel(),
-            at::internal::GRAIN_SIZE,
-            [&](int64_t begin, int64_t end) {
-              fbgemm::FloatToFloat16_simd(
-                  src.data_ptr<float>() + begin,
-                  output_ptr + begin,
+        if (self.numel() < at::internal::GRAIN_SIZE) {
+          fbgemm::FloatToFloat16_simd(src.data_ptr<float>(), output_ptr, self.numel());
+        } else {
+          at::parallel_for(
+              0,
+              self.numel(),
+              at::internal::GRAIN_SIZE,
+              [&](int64_t begin, int64_t end) {
+                fbgemm::FloatToFloat16_simd(
+                    src.data_ptr<float>() + begin,
+                    output_ptr + begin,
                   end - begin);
-            });
+              });
+        }
       } else {
         auto in_data = reinterpret_cast<fbgemm::float16*>(
             src.data_ptr<at::Half>());
         auto* output_ptr = self.data_ptr<float>();
-        at::parallel_for(
-            0,
-            self.numel(),
-            at::internal::GRAIN_SIZE,
-            [&](int64_t begin, int64_t end) {
-              fbgemm::Float16ToFloat_simd(
-                  in_data + begin, output_ptr + begin, end - begin);
-            });
+        if (self.numel() < at::internal::GRAIN_SIZE) {
+          fbgemm::Float16ToFloat_simd(in_data, output_ptr, self.numel());
+        } else {
+          at::parallel_for(
+              0,
+              self.numel(),
+              at::internal::GRAIN_SIZE,
+              [&](int64_t begin, int64_t end) {
+                fbgemm::Float16ToFloat_simd(
+                    in_data + begin, output_ptr + begin, end - begin);
+              });
+        }
       }
       return self;
     }
@@ -218,7 +226,6 @@ static Tensor & copy_impl(Tensor & self, const Tensor & src, bool non_blocking) 
   if(!self.is_complex() && src.is_complex()) {
     TORCH_WARN_ONCE("Casting complex values to real discards the imaginary part");
   }
-
   copy_stub(device_type, iter, non_blocking);
   return self;
 }


### PR DESCRIPTION
Summary:
copy_impl improvement:

Before: 1732 ns
After:.    1159 ns

remote_request_only

Before: Milliseconds per iter: 1.22971. Iters per second: 813.2
             0.169993 ms.    13.9123%. aten::to (155 nodes)

After:    Milliseconds per iter: 1.18376. Iters per second: 844.765
             0.119433 ms.    10.3746%. aten::to (155 nodes)

Test Plan: buck test caffe2:ATen-core-test

Differential Revision: D26967349

