### PR TITLE
Add install for libCaffe2_perfkernels_avx*.a

### DIFF
--- a/caffe2/perfkernels/CMakeLists.txt
+++ b/caffe2/perfkernels/CMakeLists.txt
@@ -28,6 +28,9 @@ if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
   add_dependencies(Caffe2_perfkernels_avx2 Caffe2_PROTO)
   target_link_libraries(Caffe2_perfkernels_avx PRIVATE c10)
   target_link_libraries(Caffe2_perfkernels_avx2 PRIVATE c10)
+  install(TARGETS Caffe2_perfkernels_avx Caffe2_perfkernels_avx2
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
   if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     target_compile_options(Caffe2_perfkernels_avx
         PRIVATE "/arch:AVX"
@@ -61,6 +64,9 @@ if(CAFFE2_COMPILER_SUPPORTS_AVX2_EXTENSIONS)
     add_library(Caffe2_perfkernels_avx512 STATIC ${avx512_srcs})
     add_dependencies(Caffe2_perfkernels_avx512 Caffe2_PROTO)
     target_link_libraries(Caffe2_perfkernels_avx512 PRIVATE c10)
+    install(TARGETS Caffe2_perfkernels_avx512
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
     if(MSVC AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       target_compile_options(Caffe2_perfkernels_avx512
           PRIVATE "/D__AVX512F__"


### PR DESCRIPTION
When build libtorch static library, these three static libraries will be generated but won't be installed to CMAKE_INSTALL_LIBDIR:
- libCaffe2_perfkernels_avx2.a
- libCaffe2_perfkernels_avx512.a
- libCaffe2_perfkernels_avx.a

This PR will fix this issue.

Please be noted that after this fix there still have static libraries missing in CMAKE_INSTALL_LIBDIR, but they belong to third_party repo, and we need to fix in the corresponding repo:
- libfoxi_loader.a
- libonnx.a
- libonnx_proto.a
- libfmt.a
- libnccl_static.a