### PR TITLE
Update repo name for add-annotations-github-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -201,7 +201,7 @@ jobs:
 
           cat ${GITHUB_WORKSPACE}/clang-tidy-output.txt
       - name: Add annotations
-        uses: suo/add-annotations-github-action@master
+        uses: pytorch/add-annotations-github-action@master
         with:
           check_name: 'clang-tidy'
           linter_output_path: 'clang-tidy-output.txt'


### PR DESCRIPTION
It looks like https://github.com/suo/add-annotations-github-action redirects to https://github.com/pytorch/add-annotations-github-action, so this is a bit less confusing.

**Test plan:**

The clang-tidy CI job should pass on this PR.