### PR TITLE
Pass commit_sha to add-annotations-github-action again

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get HEAD commit SHA
+        run: echo ::set-output name=commit-sha::$(git rev-parse HEAD)
+        id: get-commit-sha
       - name: Run flake8
         run: |
           set -eux
@@ -79,7 +82,7 @@ jobs:
         with:
           check_name: 'flake8-py3'
           linter_output_path: 'flake8-output.txt'
-          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
+          commit_sha: ${{ steps.get-commit-sha.outputs.commit-sha }}
           regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorCode>\w+\d+) (?<errorDesc>.*)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -101,6 +104,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # deep clone, to allow us to use git merge-base
+      - name: Get HEAD commit SHA
+        run: echo ::set-output name=commit-sha::$(git rev-parse HEAD)
+        id: get-commit-sha
       - name: Install dependencies
         run: |
           set -eux
@@ -182,7 +188,7 @@ jobs:
         with:
           check_name: 'clang-tidy'
           linter_output_path: 'clang-tidy-output.txt'
-          commit_sha: ${{ steps.get_pr_tip.outputs.commit_sha }}
+          commit_sha: ${{ steps.get-commit-sha.outputs.commit-sha }}
           regex: '^(?<filename>.*?):(?<lineNumber>\d+):(?<columnNumber>\d+): (?<errorDesc>.*?) \[(?<errorCode>.*)\]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #53833.

**Test plan:**

The CI logs for flake8-py3 and clang-tidy on this PR should show `commit_sha` being set to the PR tip in their respective "Add annotations" steps.