### PR TITLE
Update embedding op signature

### DIFF
--- a/aten/src/ATen/native/Embedding.cpp
+++ b/aten/src/ATen/native/Embedding.cpp
@@ -1,7 +1,8 @@
 #include <ATen/ATen.h>
+#include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
-#include <ATen/NativeFunctions.h>
+#include <ATen/core/grad_mode.h>
 
 #include <c10/util/irange.h>
 
@@ -13,8 +14,58 @@
 
 namespace at { namespace native {
 
-Tensor embedding(const Tensor & weight, const Tensor & indices,
-                 int64_t padding_idx, bool scale_grad_by_freq, bool sparse) {
+inline void _no_grad_embedding_renorm_(
+    Tensor weight,
+    const Tensor& input,
+    float max_norm,
+    float norm_type) {
+  at::NoGradGuard no_grad;
+  at::embedding_renorm_(weight, input, max_norm, norm_type);
+}
+
+Tensor embedding(
+    const Tensor& weight,
+    const Tensor& indices,
+    c10::optional<int64_t> padding_idx,
+    bool scale_grad_by_freq,
+    bool sparse,
+    c10::optional<double> max_norm,
+    double norm_type) {
+  auto input_ = indices;
+
+  if (padding_idx != c10::nullopt) {
+    if (*padding_idx > 0) {
+      TORCH_CHECK(
+          *padding_idx < weight.size(0),
+          "Padding_idx must be within num_embeddings");
+    } else if (*padding_idx < 0) {
+      TORCH_CHECK(
+          *padding_idx >= -weight.size(0),
+          "Padding_idx must be within num_embedding");
+      padding_idx = weight.size(0) + *padding_idx;
+    }
+  } else {
+    padding_idx = -1;
+  }
+
+  if (max_norm != c10::nullopt) {
+    // Note [embedding_renorm contiguous]
+    // `embedding_renorm_` will call .contiguous() on input anyways, so we
+    // call it here and take advantage of the improved locality in the
+    // `embedding` call below too.
+    input_ = input_.contiguous();
+    _no_grad_embedding_renorm_(weight, input_, *max_norm, norm_type);
+  }
+  return at::_embedding(
+      weight, input_, *padding_idx, scale_grad_by_freq, sparse);
+}
+
+Tensor _embedding(
+    const Tensor& weight,
+    const Tensor& indices,
+    int64_t padding_idx,
+    bool scale_grad_by_freq,
+    bool sparse) {
   TORCH_CHECK(weight.dim() >= 1, "'weight' must be at least 1-D");
   auto indices_arg = TensorArg(indices, "indices", 1);
   checkScalarTypes("embedding", indices_arg, {kLong, kInt});

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1432,9 +1432,11 @@
 
 - func: einsum(str equation, Tensor[] tensors) -> Tensor
 
-- func: embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
+- func: embedding(Tensor weight, Tensor indices, int? padding_idx=None, bool scale_grad_by_freq=False, bool sparse=False, float? max_norm=None, float norm_type=2) -> Tensor
+
+- func: _embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
   dispatch:
-    DefaultBackend: embedding
+    DefaultBackend: _embedding
 
 - func: embedding_backward(Tensor grad, Tensor indices, int num_weights, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1266,7 +1266,7 @@
   self: binary_cross_entropy_with_logits_backward(grad, self, target, weight, pos_weight, reduction)
   target: binary_cross_entropy_with_logits_target_backward(grad, self, target, weight, pos_weight, reduction)
 
-- name: embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
+- name: _embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> Tensor
   indices: non_differentiable
   weight: embedding_backward(grad, indices, weight.size(0), padding_idx, scale_grad_by_freq, sparse)
 

--- a/torch/csrc/api/include/torch/nn/functional/embedding.h
+++ b/torch/csrc/api/include/torch/nn/functional/embedding.h
@@ -24,25 +24,14 @@ inline Tensor embedding(const Tensor& input,
                         double norm_type,
                         bool scale_grad_by_freq,
                         bool sparse) {
-  auto input_ = input;
-
-  if (padding_idx != c10::nullopt) {
-    if (*padding_idx > 0) {
-      TORCH_CHECK(*padding_idx < weight.size(0), "Padding_idx must be within num_embeddings");
-    }
-    else if (*padding_idx < 0) {
-      TORCH_CHECK(*padding_idx >= -weight.size(0), "Padding_idx must be within num_embedding");
-      padding_idx = weight.size(0) + *padding_idx;
-    }
-  } else {
-    padding_idx = -1;
-  }
-
-  if (max_norm != c10::nullopt) {
-    input_ = input_.contiguous();
-    _no_grad_embedding_renorm_(weight, input_, *max_norm, norm_type);
-  }
-  return torch::embedding(weight, input_, *padding_idx, scale_grad_by_freq, sparse);
+  return torch::embedding(
+      weight,
+      input,
+      padding_idx,
+      scale_grad_by_freq,
+      sparse,
+      max_norm,
+      norm_type);
 }
 } // namespace detail
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1701,7 +1701,7 @@ class ShapePropagator {
       }
     } else if (
         node->matches(
-            "aten::embedding(Tensor weight, Tensor indices, int padding_idx, bool scale_grad_by_freq, bool sparse) -> Tensor")) {
+            "aten::embedding(Tensor weight, Tensor indices, int? padding_idx=None, bool scale_grad_by_freq=False, bool sparse=False, float? max_norm=None, float norm_type=2) -> Tensor")) {
       auto weight_type = input_type(0);
       auto indices_type = input_type(1);
       if (weight_type && indices_type && indices_type->dim()) {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2000,34 +2000,13 @@ def embedding(
                  [ 0.0000,  0.0000,  0.0000],
                  [ 0.6262,  0.2438,  0.7471]]])
     """
-
     if has_torch_function_variadic(input, weight):
         return handle_torch_function(
             embedding, (input, weight),
             input, weight, padding_idx, max_norm, norm_type,
             scale_grad_by_freq, sparse
         )
-    if padding_idx is not None:
-        if padding_idx > 0:
-            assert padding_idx < weight.size(0), "Padding_idx must be within num_embeddings"
-        elif padding_idx < 0:
-            assert padding_idx >= -weight.size(0), "Padding_idx must be within num_embeddings"
-            padding_idx = weight.size(0) + padding_idx
-    else:
-        padding_idx = -1
-    if max_norm is not None:
-        # Note [embedding_renorm contiguous]
-        # `embedding_renorm_` will call .contiguous() on input anyways, so we
-        # call it here and take advantage of the improved locality in the
-        # `embedding` call below too.
-        input = input.contiguous()
-        # Note [embedding_renorm set_grad_enabled]
-        # XXX: equivalent to
-        # with torch.no_grad():
-        #   torch.embedding_renorm_
-        # remove once script supports set_grad_enabled
-        _no_grad_embedding_renorm_(weight, input, max_norm, norm_type)
-    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
+    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse, max_norm, norm_type)
 
 
 def embedding_bag(

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -106,7 +106,7 @@ nn_functional_tests = [
     ('linear', (S, S), ((M, S),), '', (True, ['aten::linear'])),
     ('linear', (S, S), ((M, S), (M,)), 'addmm', (True, ['aten::linear'])),
     ('bilinear', (S, S, S), ((S, S, M), torch.zeros(M, S, M),),),
-    ('embedding', torch.tensor([[1, 2, 4, 5], [4, 3, 2, 5]]), (torch.rand(6, 3), ), '', (True,)),
+    ('embedding', torch.tensor([[1, 2, 4, 5], [4, 3, 2, 5]]), (torch.rand(6, 3), ), '', (False, ['aten::embedding'])),
     ('embedding_bag', torch.tensor([1, 2, 4, 2]), (torch.rand(5, 3), torch.tensor([0, 4]),),),
     ('batch_norm', (S, S), (non_differentiable(torch.randn(S)), non_differentiable(torch.ones(S)), ),
         '', (False, 'aten::_batch_norm_impl_index')),


### PR DESCRIPTION
- Change embedding op signature which should be a DefaultDispatch operation. This is called both by C++ and Python APIs. This reduces code duplication between the two.
- This allows devices like MLC which needs to override Embedding with norm to be able to do so while keeping the current behavior.