### PR TITLE
Raise error in clip_grad_norm_ if norm is non-finite

### DIFF
--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <random>
+#include <string>
+#include <sstream>
 
 using namespace torch::nn;
 
@@ -101,6 +103,172 @@ TEST_F(NNUtilsTest, ClipGradNorm) {
     utils::clip_grad_norm_(p1, max_norm, norm_type);
     utils::clip_grad_norm_({p2}, max_norm, norm_type);
     ASSERT_TRUE(torch::allclose(p1.grad(), p2.grad()));
+  }
+}
+
+// Check that clip_grad_norm_ raises an error if the norm of a gradient
+// is non-finite
+TEST_F(NNUtilsTest, ClipGradNormErrorIfNonfinite) {
+  double inf = std::numeric_limits<double>::infinity();
+  double nan = std::numeric_limits<double>::quiet_NaN();
+
+  using Vector = std::vector<double>;
+
+  Vector norms_pos = {0.1, 1, 2, 3.5, inf};
+  Vector norms_neg = {-0.1, -1, -2, -3.5};
+  Vector norms_neg_plus_0 = {0, -0.1, -1, -2, -3.5};
+  Vector norms_except_0 = {0.1, 1, 2, 3.5, inf, -0.1, -1, -2, -3.5};
+  Vector norms_all = {0, 0.1, 1, 2, 3.5, inf, -0.1, -1, -2, -3.5};
+
+  // Each entry in test_cases has the following values, in this order:
+  //
+  // grad_only_one_elem    If True, only one element of the parameter's
+  //                       gradient is set to the scalar grad, and the
+  //                       rest of the elements are 0. If False, all grad
+  //                       elements are equal to the scalar.
+  //
+  // prefix_finite_grad_param  If True, prefix a parameter that has a grad
+  //                           of 1.
+  //
+  // scalars           Scalars to use as the parameter's grad, through
+  //                   multiplication
+  //
+  // norms_nonfinite   Norm types that should produce nonfinite total norm
+  //
+  // norms_finite      Norm types that should produce finite total norm
+  std::vector<std::tuple<bool, bool, Vector, Vector, Vector>> test_cases({
+    // Test errors from an infinite grad
+    std::make_tuple(false, false, Vector({inf, -inf}), norms_except_0, Vector({0})),
+    std::make_tuple(false, true, Vector({inf, -inf}), norms_pos, norms_neg_plus_0),
+    std::make_tuple(true, false, Vector({inf, -inf}), norms_pos, norms_neg_plus_0),
+    std::make_tuple(false, true, Vector({inf, -inf}), norms_pos, norms_neg_plus_0),
+
+    // Test errors from a NaN grad
+    std::make_tuple(false, false, Vector({nan}), norms_except_0, Vector({0})),
+    std::make_tuple(false, true, Vector({nan}), norms_except_0, Vector({0})),
+    std::make_tuple(true, false, Vector({nan}), norms_except_0, Vector({0})),
+    std::make_tuple(true, true, Vector({nan}), norms_except_0, Vector({0})),
+
+    // Test a grad that should never error
+    std::make_tuple(false, false, Vector({2e22, -2e22}), Vector(), norms_all),
+    std::make_tuple(false, true, Vector({2e22, -2e22}), Vector(), norms_all),
+    std::make_tuple(true, false, Vector({2e22, -2e22}), Vector(), norms_all),
+    std::make_tuple(true, true, Vector({2e22, -2e22}), Vector(), norms_all),
+
+    // Test a grad that will overflow to inf for only some norm orders
+    std::make_tuple(
+      false, false, Vector({2e200, -2e200}), Vector({3.5, 2, -2, -3.5}),
+      Vector({inf, 1, 0.1, 0, -1, -0.1})),
+    std::make_tuple(
+      false, true, Vector({2e200, -2e200}), Vector({3.5, 2}),
+      Vector({inf, 1, 0.1, 0, -1, -0.1, -2, -3.5})),
+    std::make_tuple(
+      true, false, Vector({2e200, -2e200}), Vector({3.5, 2}),
+      Vector({inf, 1, 0.1, 0, -1, -0.1, -2, -3.5})),
+    std::make_tuple(
+      false, true, Vector({2e200, -2e200}), Vector({3.5, 2}),
+      Vector({inf, 1, 0.1, 0, -1, -0.1, -2, -3.5})),
+  });
+
+  auto gen_parameters = [](
+      double scalar,
+      bool grad_only_one_elem,
+      bool prefix_finite_grad_param,
+      torch::DeviceType device_type) {
+    auto param = torch::ones(10, torch::TensorOptions().dtype(torch::kDouble).device(device_type).requires_grad(true));
+    if (grad_only_one_elem) {
+      param[1].mul(scalar).sum().backward();
+    } else {
+      param.mul(scalar).sum().backward();
+    }
+
+    std::vector<torch::Tensor> parameters;
+    if (prefix_finite_grad_param) {
+      auto prefix_param = torch::ones(1, torch::TensorOptions().dtype(torch::kDouble).device(device_type).requires_grad(true));
+      prefix_param.mul(1).sum().backward();
+      parameters.push_back(prefix_param);
+    }
+    parameters.push_back(param);
+
+    return parameters;
+  };
+
+  auto run_test_case = [&gen_parameters](
+      double norm_type,
+      bool error_if_nonfinite,
+      double scalar,
+      bool grad_only_one_elem,
+      bool prefix_finite_grad_param,
+      bool is_norm_nonfinite,
+      torch::DeviceType device_type) {
+    std::stringstream ss;
+    ss << "device: " << device_type
+       << ", norm_type: " << norm_type
+       << ", error_if_nonfinite: " << error_if_nonfinite
+       << ", scalar: " << scalar
+       << ", grad_only_one_elem: " << grad_only_one_elem
+       << ", prefix_finite_grad_param: " << prefix_finite_grad_param
+       << ", is_norm_nonfinite: " << is_norm_nonfinite;
+    std::string msg = ss.str();
+
+    auto parameters = gen_parameters(
+      scalar,
+      grad_only_one_elem,
+      prefix_finite_grad_param,
+      device_type);
+
+    if (is_norm_nonfinite && error_if_nonfinite) {
+      std::vector<torch::Tensor> grads_before;
+      for (auto p : parameters) {
+        grads_before.push_back(p.grad().clone());
+      }
+      EXPECT_THROW(utils::clip_grad_norm_(parameters, 1., norm_type), std::exception) << msg;
+      // Grads should not change if error is thrown
+      for (int64_t p_idx = 0; p_idx < parameters.size(); p_idx++) {
+        ASSERT_TRUE(torch::allclose(parameters[p_idx].grad(), grads_before[p_idx], 1.0, 0.0, /*equal_nan*/ true)) << msg;
+      }
+    } else {
+      EXPECT_NO_THROW(utils::clip_grad_norm_(parameters, 1., norm_type, error_if_nonfinite)) << msg;
+    }
+  };
+
+  for (auto device_type : {torch::kCPU, torch::kCUDA}) {
+    if (device_type == torch::kCUDA && !torch::cuda::is_available()) {
+      continue;
+    }
+    for (auto test_case : test_cases) {
+      auto grad_only_one_elem = std::get<0>(test_case);
+      auto prefix_finite_grad_param = std::get<1>(test_case);
+      auto scalars = std::get<2>(test_case);
+      auto norms_nonfinite = std::get<3>(test_case);
+      auto norms_finite = std::get<4>(test_case);
+
+      for (auto error_if_nonfinite : {false, true}) {
+        for (auto scalar : scalars) {
+          for (auto norm_type : norms_nonfinite) {
+            run_test_case(
+              norm_type,
+              error_if_nonfinite,
+              scalar,
+              grad_only_one_elem,
+              prefix_finite_grad_param,
+              true,
+              device_type);
+          }
+
+          for (auto norm_type : norms_finite) {
+            run_test_case(
+              norm_type,
+              error_if_nonfinite,
+              scalar,
+              grad_only_one_elem,
+              prefix_finite_grad_param,
+              false,
+              device_type);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2217,7 +2217,7 @@ torch.cuda.synchronize()
                     if i == skip_iter and scaler.is_enabled():
                         model[1].weight.grad.data.fill_(float('inf'))
                     scaler.unscale_(optimizer)
-                    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+                    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm, error_if_nonfinite=False)
                     scaler.step(optimizer)
                     scaler.update()
                 else:

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -13,7 +13,8 @@ namespace utils {
 inline double clip_grad_norm_(
     std::vector<Tensor> parameters,
     double max_norm,
-    double norm_type = 2.0) {
+    double norm_type = 2.0,
+    bool error_if_nonfinite = true) {
   std::vector<Tensor> params_with_grad;
 
   for (const auto& param : parameters) {
@@ -26,16 +27,25 @@ inline double clip_grad_norm_(
   if (norm_type == std::numeric_limits<double>::infinity()) {
     for (const auto& param : params_with_grad) {
       auto param_max = param.grad().data().abs().max().item().toDouble();
-      if (param_max > total_norm) {
+      if (param_max > total_norm || std::isnan(param_max)) {
         total_norm = param_max;
       }
     }
+  } else if (norm_type == 0) {
+    total_norm = static_cast<double>(params_with_grad.size());
   } else {
     for (const auto& param : params_with_grad) {
       auto param_norm = param.grad().data().norm(norm_type);
       total_norm += std::pow(param_norm.item().toDouble(), norm_type);
     }
     total_norm = std::pow(total_norm, 1.0 / norm_type);
+  }
+  if (error_if_nonfinite) {
+    TORCH_CHECK(std::isfinite(total_norm),
+      "The total norm of order ", norm_type, " for gradients from `parameters` ",
+      "is non-finite, so it cannot be clipped. To disable this error and scale ",
+      "the gradients with the non-finite norm anyway, set ",
+      "`error_if_nonfinite=false`");
   }
 
   auto clip_coef = max_norm / (total_norm + 1e-6);
@@ -52,8 +62,9 @@ inline double clip_grad_norm_(
 inline double clip_grad_norm_(
     std::initializer_list<Tensor> parameters,
     double max_norm,
-    double norm_type = 2.0) {
-  return clip_grad_norm_(std::vector<Tensor>(parameters), max_norm, norm_type);
+    double norm_type = 2.0,
+    bool error_if_nonfinite = true) {
+  return clip_grad_norm_(std::vector<Tensor>(parameters), max_norm, norm_type, error_if_nonfinite);
 }
 
 // A wrapper around clip_grad_norm_ that allows us to call the function with a
@@ -61,9 +72,10 @@ inline double clip_grad_norm_(
 inline double clip_grad_norm_(
     Tensor parameter,
     double max_norm,
-    double norm_type = 2.0) {
+    double norm_type = 2.0,
+    bool error_if_nonfinite = true) {
   std::vector<Tensor> params = {parameter};
-  return clip_grad_norm_(params, max_norm, norm_type);
+  return clip_grad_norm_(params, max_norm, norm_type, error_if_nonfinite);
 }
 
 // Clips gradient of an iterable of parameters at specified value.

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -6,7 +6,9 @@ from typing import Union, Iterable
 _tensor_or_tensors = Union[torch.Tensor, Iterable[torch.Tensor]]
 
 
-def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.0) -> torch.Tensor:
+def clip_grad_norm_(
+        parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.0,
+        error_if_nonfinite: bool = True) -> torch.Tensor:
     r"""Clips gradient norm of an iterable of parameters.
 
     The norm is computed over all gradients together, as if they were
@@ -18,6 +20,9 @@ def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: 
         max_norm (float or int): max norm of the gradients
         norm_type (float or int): type of the used p-norm. Can be ``'inf'`` for
             infinity norm.
+        error_if_nonfinite (bool): if True, an error is thrown if the total
+            norm of the gradients from :attr:``parameters`` is ``nan``,
+            ``inf``, or ``-inf``. Default: True
 
     Returns:
         Total norm of the parameters (viewed as a single vector).
@@ -31,9 +36,16 @@ def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: 
         return torch.tensor(0.)
     device = parameters[0].grad.device
     if norm_type == inf:
-        total_norm = max(p.grad.detach().abs().max().to(device) for p in parameters)
+        norms = [p.grad.detach().abs().max().to(device) for p in parameters]
+        total_norm = norms[0] if len(norms) == 1 else torch.max(torch.stack(norms))
     else:
         total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(), norm_type).to(device) for p in parameters]), norm_type)
+    if error_if_nonfinite and (total_norm.isnan() or total_norm.isinf()):
+        raise RuntimeError(
+            f'The total norm of order {norm_type} for gradients from '
+            '`parameters` is non-finite, so it cannot be clipped. To disable '
+            'this error and scale the gradients by the non-finite norm anyway, '
+            'set `error_if_nonfinite=False`')
     clip_coef = max_norm / (total_norm + 1e-6)
     if clip_coef < 1:
         for p in parameters:
@@ -41,7 +53,9 @@ def clip_grad_norm_(parameters: _tensor_or_tensors, max_norm: float, norm_type: 
     return total_norm
 
 
-def clip_grad_norm(parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.) -> torch.Tensor:
+def clip_grad_norm(
+        parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.,
+        error_if_nonfinite: bool = True) -> torch.Tensor:
     r"""Clips gradient norm of an iterable of parameters.
 
     .. warning::
@@ -50,7 +64,7 @@ def clip_grad_norm(parameters: _tensor_or_tensors, max_norm: float, norm_type: f
     """
     warnings.warn("torch.nn.utils.clip_grad_norm is now deprecated in favor "
                   "of torch.nn.utils.clip_grad_norm_.", stacklevel=2)
-    return clip_grad_norm_(parameters, max_norm, norm_type)
+    return clip_grad_norm_(parameters, max_norm, norm_type, error_if_nonfinite)
 
 
 def clip_grad_value_(parameters: _tensor_or_tensors, clip_value: float) -> None:


### PR DESCRIPTION
**BC-breaking note**: This change throws errors for cases that used to silently pass. The old behavior can be obtained by setting `error_if_nonfinite=False`

Fixes #46849