### PR TITLE
Fix TCPStore wait() hang when key is previously set

### DIFF
--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -248,10 +248,15 @@ void TCPStoreDaemon::waitHandler(int socket) {
     tcputil::sendValue<WaitResponseType>(
         socket, WaitResponseType::STOP_WAITING);
   } else {
+    int numKeysToAwait = 0;
     for (auto& key : keys) {
-      waitingSockets_[key].push_back(socket);
+      // Only count keys that have not already been set
+      if (tcpStore_.find(key) == tcpStore_.end()) {
+        waitingSockets_[key].push_back(socket);
+        numKeysToAwait++;
+      }
     }
-    keysAwaited_[socket] = keys.size();
+    keysAwaited_[socket] = numKeysToAwait;
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53860 Fix TCPStore wait() hang when key is previously set**

Fixes [#53840](https://github.com/pytorch/pytorch/issues/53840)

Right now [TCPStore wait([LIST_OF_KEYS_TO_AWAIT])](https://pytorch.org/docs/master/distributed.html#torch.distributed.Store.wait) will hang if any of the keys in [LIST_OF_KEYS_TO_AWAIT] has been previously set. This change will ensure that wait() is only waiting for the keys that have not been set

Before change:
```
# Case 1: HANG
store.set("1", "1")
store.wait(["1", "2"])
store.set("2", "2")

# Case 2: SUCCEED
store.wait(["1", "2"])
store.set("1", "1")
store.set("2", "2")
```
After change:
Both cases work

TODO: working on adding a test for wait() https://github.com/pytorch/pytorch/issues/53863

Differential Revision: [D26999929](https://our.internmc.facebook.com/intern/diff/D26999929)