### PR TITLE
[TensorExpr] Reland: "Simplify index expressions constructed in loop flattening. Fixes #51173"

### DIFF
--- a/test/cpp/tensorexpr/test_simplify.cpp
+++ b/test/cpp/tensorexpr/test_simplify.cpp
@@ -2595,7 +2595,7 @@ TEST(Simplify, SimplifyRoundModPatternFactorization) {
 
   {
     // Partial Factorization.
-    // 32 * (x/y) + 4 * (x % y) => 4 * x.
+    // 32 * (x/8) + 4 * (x % 8) => 4 * x.
     VarHandle x("x", kInt);
     VarHandle y("y", kInt);
     ExprHandle body = ExprHandle(32) * (x / 8) + ExprHandle(4) * (x % 8);
@@ -2675,8 +2675,8 @@ TEST(Simplify, SimplifyRoundModPatternMultivar) {
 
   {
     // Compound.
-    // (x + (z + 512 * y) % 16) + 16 * ((z + 512 * y) / 16)  => x + (z + 512 *
-    // y).
+    // (x + (z + 512 * y) % 16) + 16 * ((z + 512 * y) / 16)
+    // => (z + 512 * y) + x
     VarHandle x("x", kInt);
     VarHandle y("y", kInt);
     VarHandle z("z", kInt);
@@ -2685,12 +2685,297 @@ TEST(Simplify, SimplifyRoundModPatternMultivar) {
         ExprHandle(16) * ((z + ExprHandle(512) * y) / ExprHandle(16));
     ExprHandle simplified = IRSimplifier::simplify(body);
     IS_NODE_WITH_NAME(Add, simplified.node(), add);
-    IS_VAR_WITH_NAME(add->lhs(), "x");
-    IS_NODE_WITH_NAME(Add, add->rhs(), add2);
+    IS_VAR_WITH_NAME(add->rhs(), "x");
+    IS_NODE_WITH_NAME(Add, add->lhs(), add2);
     IS_VAR_WITH_NAME(add2->lhs(), "z");
     IS_NODE_WITH_NAME(Mul, add2->rhs(), mul);
     IS_IMM_WITH_VAL(Int, mul->lhs(), 512);
     IS_VAR_WITH_NAME(mul->rhs(), "y");
+  }
+}
+
+TEST(Simplify, SimplifyModRoundModPattern) {
+  KernelScope kernel_scope;
+
+  {
+    // t/7 % 9 * 7 + t % 7 => t%63
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / 7 % 9) * 7 + t % 7;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+  }
+
+  {
+    // 2*t/7 % 9 * 7 + 2*t % 7 => 2*t % 63
+    VarHandle t("t", kInt);
+    ExprHandle body = (ExprHandle(2) * t / 7 % 9) * 7 + ExprHandle(2) * t % 7;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_NODE_WITH_NAME(Mul, mod->lhs(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_VAR_WITH_NAME(mul->rhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+  }
+
+  {
+    // t/x % y * x + t % x => t%(x*y)
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body = (t / x % y) * x + t % x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul);
+    IS_VAR_WITH_NAME(mul->lhs(), "x");
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
+  }
+
+  {
+    // k*t/x % y * x + k*t % x => k*t%(x*y)
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle k("k", kInt);
+    ExprHandle body = (k * t / x % y) * x + k * t % x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_NODE_WITH_NAME(Mul, mod->lhs(), mul1);
+    IS_VAR_WITH_NAME(mul1->lhs(), "t");
+    IS_VAR_WITH_NAME(mul1->rhs(), "k");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul2);
+    IS_VAR_WITH_NAME(mul2->lhs(), "x");
+    IS_VAR_WITH_NAME(mul2->rhs(), "y");
+  }
+
+  {
+    // t/k/x % y * x + t/k % x => t/k%(x*y)
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle k("k", kInt);
+    ExprHandle body = (t / k / x % y) * x + t / k % x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_NODE_WITH_NAME(Div, mod->lhs(), div);
+    IS_VAR_WITH_NAME(div->lhs(), "t");
+    IS_VAR_WITH_NAME(div->rhs(), "k");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul);
+    IS_VAR_WITH_NAME(mul->lhs(), "x");
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
+  }
+
+  {
+    // Sanity checking we wont do the optimization on floats.
+    VarHandle x("x", kFloat);
+    VarHandle y("y", kFloat);
+    VarHandle z("z", kFloat);
+    ExprHandle body = ((x / y % z) * y) + (x % y);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_NODE_WITH_NAME(Mul, add->lhs(), mul);
+    IS_NODE_WITH_NAME(Mod, mul->lhs(), mod);
+    IS_NODE_WITH_NAME(Div, mod->lhs(), div);
+    IS_VAR_WITH_NAME(div->lhs(), "x");
+    IS_VAR_WITH_NAME(div->rhs(), "y");
+    IS_VAR_WITH_NAME(mod->rhs(), "z");
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
+    IS_NODE_WITH_NAME(Mod, add->rhs(), mod2);
+    IS_VAR_WITH_NAME(mod2->lhs(), "x");
+    IS_VAR_WITH_NAME(mod2->rhs(), "y");
+  }
+}
+
+TEST(Simplify, SimplifyModRoundModPatternFactorization) {
+  KernelScope kernel_scope;
+
+  {
+    // 2 * (t /7 % 9 * 7) + 2 * (t % 7) => 2 * (t % 63)
+    VarHandle t("t", kInt);
+    ExprHandle body =
+        ExprHandle(2) * ((t / 7 % 9) * 7) + ExprHandle(2) * (t % 7);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_NODE_WITH_NAME(Mod, mul->rhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+  }
+
+  {
+    // t /7 % 9 * 14 + 2* (t % 7) => 2* (t % 63)
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / 7 % 9) * 14 + ExprHandle(2) * (t % 7);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_NODE_WITH_NAME(Mod, mul->rhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+  }
+
+  {
+    // t/14 % 9 * 7 + t/2 % 7 => t/2 % 63
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / 14 % 9) * 7 + t / 2 % 7;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_NODE_WITH_NAME(Div, mod->lhs(), div);
+    IS_VAR_WITH_NAME(div->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, div->rhs(), 2);
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+  }
+
+  {
+    // t/(7*3) % 9 * 7*3 + t % (7*3) => t % 189
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / (ExprHandle(7) * ExprHandle(3)) % 9) * 7 * 3 +
+        t % (ExprHandle(7) * ExprHandle(3));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mod, simplified.node(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 189);
+  }
+
+  {
+    // 2*(t/x % y * x) + 2*(t % x) => 2*(t%(x*y))
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    ExprHandle body =
+        ExprHandle(2) * ((t / x % y) * x) + ExprHandle(2) * (t % x);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Mul, simplified.node(), mul);
+    IS_IMM_WITH_VAL(Int, mul->lhs(), 2);
+    IS_NODE_WITH_NAME(Mod, mul->rhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul2);
+    IS_VAR_WITH_NAME(mul2->lhs(), "x");
+    IS_VAR_WITH_NAME(mul2->rhs(), "y");
+  }
+}
+
+TEST(Simplify, SimplifyModRoundModPatternMultivar) {
+  KernelScope kernel_scope;
+
+  {
+    // t/7 % 9 * 7 + t % 7 + t => t % 63 + t
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / 7 % 9) * 7 + t % 7 + t;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_NODE_WITH_NAME(Mod, add->rhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod->rhs(), 63);
+    IS_VAR_WITH_NAME(add->lhs(), "t");
+  }
+
+  {
+    // t/7 % 9 * 7 + t/8 % 9 * 8 + t % 7 + t % 8  => t % 63 + t % 72
+    VarHandle t("t", kInt);
+    ExprHandle body = (t / 7 % 9) * 7 + (t / 8 % 9) * 8 + t % 7 + t % 8;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_NODE_WITH_NAME(Mod, add->lhs(), mod1);
+    IS_VAR_WITH_NAME(mod1->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod1->rhs(), 63);
+    IS_NODE_WITH_NAME(Mod, add->rhs(), mod2);
+    IS_VAR_WITH_NAME(mod2->lhs(), "t");
+    IS_IMM_WITH_VAL(Int, mod2->rhs(), 72);
+  }
+
+  {
+    // k + t/x % y * x + t % x => k + t%(x*y)
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle k("k", kInt);
+    ExprHandle body = k + (t / x % y) * x + t % x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_VAR_WITH_NAME(add->lhs(), "k");
+    IS_NODE_WITH_NAME(Mod, add->rhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul);
+    IS_VAR_WITH_NAME(mul->lhs(), "x");
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
+  }
+
+  {
+    // t/x % y * x + t % x + (t/k / x % y) * x + t/k % x
+    // => t%(x*y) + t/k % (x*y)
+    VarHandle t("t", kInt);
+    VarHandle x("x", kInt);
+    VarHandle y("y", kInt);
+    VarHandle k("k", kInt);
+    ExprHandle body = (t / x % y) * x + t % x + (t / k / x % y) * x + t / k % x;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_NODE_WITH_NAME(Add, simplified.node(), add);
+    IS_NODE_WITH_NAME(Mod, add->lhs(), mod);
+    IS_VAR_WITH_NAME(mod->lhs(), "t");
+    IS_NODE_WITH_NAME(Mul, mod->rhs(), mul);
+    IS_VAR_WITH_NAME(mul->lhs(), "x");
+    IS_VAR_WITH_NAME(mul->rhs(), "y");
+    IS_NODE_WITH_NAME(Mod, add->rhs(), mod2);
+    IS_NODE_WITH_NAME(Div, mod2->lhs(), div);
+    IS_VAR_WITH_NAME(div->lhs(), "t");
+    IS_VAR_WITH_NAME(div->rhs(), "k");
+    IS_NODE_WITH_NAME(Mul, mod2->rhs(), mul2);
+    IS_VAR_WITH_NAME(mul2->lhs(), "x");
+    IS_VAR_WITH_NAME(mul2->rhs(), "y");
+  }
+
+  {
+    // 3D: (7 * ((i0_flat / 7) % 9) + i0_flat % 7) + 63 * (i0_flat / 63)
+    // => io_flat
+    VarHandle t("io_flat", kInt);
+    ExprHandle body =
+        ExprHandle(7) * (t / 7 % 9) + t % 7 + ExprHandle(63) * (t / 63);
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "io_flat");
+  }
+
+  { // 5D: i0_flat / (11 * 10 * 9 * 7)  * (7 * 9 * 10 * 11) +
+    // (i0_flat / (10 * 9 * 7) % 11)  * 7 * 9 * 10 +
+    // (i0_flat / (9 * 7) % 10) * 7 * 9 +
+    // (i0_flat / 7 % 9)  * 7 +
+    // i0_flat % 7 => io_flat
+    VarHandle t("io_flat", kInt);
+    ExprHandle body = (t / (ExprHandle(11) * 10 * 9 * 7)) * (7 * 9 * 10 * 11) +
+        (t / (ExprHandle(10) * 9 * 7) % 11) * 7 * 9 * 10 +
+        (t / (ExprHandle(9) * 7) % 10) * 7 * 9 + (t / 7 % 9) * 7 + t % 7;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "io_flat");
+  }
+
+  {
+    // 3D: (m * ((i0_flat / m) % n) + i0_flat % m) + (m * n) *
+    // (i0_flat / (m * n)) => io_flat
+    VarHandle t("io_flat", kInt);
+    VarHandle m("m", kInt);
+    VarHandle n("n", kInt);
+    ExprHandle body = m * (t / m % n) + t % m + (m * n) * (t / (m * n));
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "io_flat");
+  }
+
+  { // 5D: i0_flat / (k * l * n * m)  * (m * n * l * k) +
+    // (i0_flat / (l * n * m) % k)  * m * n * l +
+    // (i0_flat / (n * m) % l) * m * n +
+    // (i0_flat / m % n)  * m +
+    // i0_flat % m => io_flat
+    VarHandle t("io_flat", kInt);
+    VarHandle m("m", kInt);
+    VarHandle n("n", kInt);
+    VarHandle l("l", kInt);
+    VarHandle k("k", kInt);
+    ExprHandle body = (t / (k * l * n * m)) * (m * n * l * k) +
+        (t / (l * n * m) % k) * m * n * l + (t / (n * m) % l) * m * n +
+        (t / m % n) * m + t % m;
+    ExprHandle simplified = IRSimplifier::simplify(body);
+    IS_VAR_WITH_NAME(simplified.node(), "io_flat");
   }
 }
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1717,80 +1717,279 @@ const Expr* polyGCD(const Polynomial* poly) {
   return getImmediateByType(poly->dtype(), GCD);
 }
 
-// Searches the polynomial for Terms that can be merged in the Round + Mod
-// pattern: (x/y) * y + x % y => RoundOff(x,y) + Mod(x, y) => x.
+// A ModRound is a div-mod-mul in which the divisor in div and multiplier in mul
+// are identical and not equal to 1.
+// In a ModRound x/y%z*y*c (c is constant), 'scalar' denotes c, 'denominator'
+// denotes x, 'divisor' denotes y and 'mod_divisor' denotes z.
+class ModRound {
+ public:
+  ModRound(
+      const Expr* scalar,
+      const Expr* denom,
+      const Expr* divisor,
+      const Expr* mod_divisor)
+      : scalar(scalar),
+        denom(denom),
+        divisor(divisor),
+        mod_divisor(mod_divisor) {}
+  const Expr* scalar;
+  const Expr* denom;
+  const Expr* divisor;
+  const Expr* mod_divisor;
+};
+
+c10::optional<class ModRound*> isModRound(const Term* e) {
+  const Div* div{nullptr};
+  const Mod* mod{nullptr};
+  const Expr* denom{nullptr};
+  const Expr* divisor{nullptr};
+  const Expr* mod_divisor{nullptr};
+  const Expr* multiplier = e->scalar();
+  const Expr* scalar{nullptr};
+  const Expr* other{nullptr};
+
+  for (auto* m : e->variables()) {
+    if (m->expr_type() == IRNodeType::kMod) {
+      // TODO: currently only identify terms with one variable being mod; it is
+      // possible to extend this if we have to handle terms like (t/(x%2 * y) %
+      // z) * (x%2 *y).
+      if (!mod) {
+        mod = dynamic_cast<const Mod*>(m);
+      } else {
+        return c10::nullopt;
+      }
+    } else {
+      // Take care of special cases before multiplying the scalar and variable.
+      if (multiplier->isConstant()) {
+        // Take care of lane mismatch first.
+        if (multiplier->dtype().lanes() != m->dtype().lanes()) {
+          multiplier = new Broadcast(multiplier, m->dtype().lanes());
+        }
+        // Take care of scalar type mismatch.
+        if (multiplier->dtype().scalar_type() != m->dtype().scalar_type()) {
+          multiplier = new Cast(m->dtype(), multiplier);
+          if (m->dtype().lanes() == 1) {
+            multiplier = evaluateOp(multiplier);
+          }
+        }
+      }
+
+      // All non-mod vairables are considered as part of the multiplier.
+      multiplier = new Mul(multiplier, m);
+    }
+  }
+  multiplier = IRSimplifier::simplify(multiplier);
+
+  if (!mod) {
+    return c10::nullopt;
+  }
+
+  mod_divisor = IRSimplifier::simplify(mod->rhs());
+  other = mod->lhs();
+
+  if (!(div = dynamic_cast<const Div*>(other))) {
+    return c10::nullopt;
+  }
+
+  divisor = IRSimplifier::simplify(div->rhs());
+  other = div->lhs();
+
+  denom = IRSimplifier::simplify(other);
+
+  // Deny cases in which divisor!=multiplier.
+  HashProvider& hasher = e->hasher();
+  if (hasher.hash(divisor) != hasher.hash(multiplier)) {
+    // TODO: currently we do not extract a common factor if divisor and
+    // multiplier are not constants. The extraction is not supported (e.g.,
+    // x*2/x -> 2) in IRSimplifier.simplify because x could be 0. As future
+    // work, we can extend division to 2 versions: 1) division for customers
+    // that has to be strictly simplified and 2) division we introduced in our
+    // transformations which can be simplified without considering 0s, e.g.,
+    // Div_nonzero. The second division will be only used to facilitate our
+    // transformations.
+    if (divisor->isConstant() && multiplier->isConstant()) {
+      // If both are scalar we may be able to find a common factor.
+      if (immediateEquals(evaluateOp(new Mod(multiplier, divisor)), 0)) {
+        // The common factor becomes 'scalar' of the term, e.g.,in t/3%7*6,
+        // divisor=multiplier=3, scalar=2.
+        Expr* c = evaluateOp(new Div(multiplier, divisor));
+        scalar = c;
+      } else if (immediateEquals(evaluateOp(new Mod(divisor, multiplier)), 0)) {
+        // The common factor becomes part of 'denom', e.g., in t/14%7*2,
+        // divisor=multiplier=2, denom=t/7.
+        Expr* c = evaluateOp(new Div(divisor, multiplier));
+        divisor = multiplier;
+        denom = IRSimplifier::simplify(new Div(other, c));
+      } else {
+        return c10::nullopt;
+      }
+    } else {
+      return c10::nullopt;
+    }
+  }
+
+  // Deny cases in which divisor=1. Such cases are considered as Mods.
+  if (divisor->isConstant() && immediateEquals(divisor, 1)) {
+    return c10::nullopt;
+  }
+
+  if (!scalar) {
+    scalar = getImmediateByType(multiplier->dtype(), 1);
+  }
+
+  return new ModRound(scalar, denom, divisor, mod_divisor);
+}
+
+// Search the polynomial for Terms that can be merged in
+// (1) Round + Mod pattern: (x/y) * y + x % y => RoundOff(x,y) + Mod(x, y) => x
+// (2) Mod round + Mod pattern: (x/y % z)*y + x%y => ModRound(x, y, z) + Mod(x,
+// y) => x % (y*z)
 const Expr* simplifyRoundModPattern(const Polynomial* poly) {
-  std::set<const Term*> rounds;
-  std::set<const Term*> mods;
+  std::vector<const Term*> rounds;
+  std::vector<const Term*> mods;
+  std::vector<const Term*> mod_rounds;
   std::vector<const Term*> others;
 
-  // Split out the RoundOffs and Mod operations so we can inspect.
+  // Split out the Mod, ModRounds and RoundOffs operations so we can inspect.
   for (auto* c : poly->variables()) {
     if (c->variables().size() > 1) {
-      others.push_back(c);
+      if (auto a = isModRound(c)) {
+        mod_rounds.push_back(c);
+      } else {
+        others.push_back(c);
+      }
       continue;
     }
 
     const Expr* e = c->variables()[0];
 
     if (e->expr_type() == IRNodeType::kRoundOff) {
-      rounds.insert(c);
+      rounds.push_back(c);
     } else if (e->expr_type() == IRNodeType::kMod) {
-      mods.insert(c);
+      if (auto a = isModRound(c)) {
+        mod_rounds.push_back(c);
+      } else {
+        mods.push_back(c);
+      }
     } else {
       others.push_back(c);
     }
   }
 
-  // Can't continue without at least one RoundOff and one Mod.
-  if (rounds.empty() || mods.empty()) {
+  // Can't continue without at least one RoundOff/ModRound and one Mod.
+  if ((rounds.empty() && mod_rounds.empty()) || mods.empty()) {
     return nullptr;
   }
 
   HashProvider& hasher = poly->hasher();
   bool didAnything = false;
+  std::vector<const Term*> mods_merged;
+  bool repeat = true;
+  // Repeat merging terms till there are no Mods or the terms cannot be merged
+  // any further.
+  while (!mods.empty() && repeat) {
+    repeat = false;
+    for (int i = mods.size() - 1; i >= 0; i--) {
+      const Term* m = mods[i];
+      const Mod* mod = dynamic_cast<const Mod*>(m->variables()[0]);
+      CHECK(mod);
+      const Expr* mod_lhs = IRSimplifier::simplify(mod->lhs());
+      const Expr* mod_rhs = IRSimplifier::simplify(mod->rhs());
+      bool merged = false;
+      for (int j = mod_rounds.size() - 1; j >= 0; j--) {
+        const Term* mr = mod_rounds[j];
+        auto a = isModRound(mr);
+        CHECK(a);
+        const ModRound* mod_round = dynamic_cast<const ModRound*>(*a);
 
-  for (auto* r : rounds) {
-    bool merged = false;
-    const RoundOff* roundoff = dynamic_cast<const RoundOff*>(r->variables()[0]);
-    CHECK(roundoff);
+        // TODO: for now don't attempt partial factorization of this
+        // optimization. E.g. it's possible to do: 2 * (x/y%z) * y + (x%y) =>
+        // x%(y*z) + (x/y%z) * y
+        if (!immediateEquals(
+                evaluateOp(new Sub(mod_round->scalar, m->scalar())), 0)) {
+          continue;
+        }
+        // Valid optimization if mod LHS matches denom and mod RHS matches
+        // divisor.
+        if (hasher.hash(mod_round->denom) == hasher.hash(mod_lhs) &&
+            hasher.hash(mod_round->divisor) == hasher.hash(mod_rhs)) {
+          const Term* merged_m = new Term(
+              hasher,
+              mod_round->scalar,
+              IRSimplifier::simplify(new Mod(
+                  mod_round->denom,
+                  new Mul(mod_round->divisor, mod_round->mod_divisor))));
+          mods_merged.push_back(merged_m);
+          merged = true;
+          repeat = true;
+          didAnything = true;
+          mods.erase(mods.begin() + i);
+          mod_rounds.erase(mod_rounds.begin() + j);
+          break;
+        }
+      }
 
-    for (auto* m : mods) {
-      // TODO: for now don't attempt partial factorization of this optimization.
-      // E.g. it's possible to do: 2 * (x/y) * y + (x%y) => x + (x/y) * y but
-      // unsure thats actually much better, particulary with CSE.
-      if (!immediateEquals(evaluateOp(new Sub(r->scalar(), m->scalar())), 0)) {
+      if (merged) {
         continue;
       }
 
-      const Mod* mod = dynamic_cast<const Mod*>(m->variables()[0]);
-      CHECK(mod);
+      for (int k = rounds.size() - 1; k >= 0; k--) {
+        const Term* r = rounds[k];
+        const RoundOff* roundoff =
+            dynamic_cast<const RoundOff*>(r->variables()[0]);
+        CHECK(roundoff);
 
-      // Valid optimization if LHS and RHS are equal for both.
-      if (hasher.hash(roundoff->lhs()) == hasher.hash(mod->lhs()) &&
-          hasher.hash(roundoff->rhs()) == hasher.hash(mod->rhs())) {
-        others.push_back(new Term(hasher, r->scalar(), roundoff->lhs()));
-        merged = true;
-        didAnything = true;
-        mods.erase(m);
-        break;
+        // TODO: for now don't attempt partial factorization of this
+        // optimization. E.g. it's possible to do: 2 * (x/y) * y + (x%y) => x +
+        // (x/y) * y but unsure thats actually much better, particulary with
+        // CSE.
+        if (!immediateEquals(
+                evaluateOp(new Sub(r->scalar(), m->scalar())), 0)) {
+          continue;
+        }
+        const Expr* round_lhs = IRSimplifier::simplify(roundoff->lhs());
+        const Expr* round_rhs = IRSimplifier::simplify(roundoff->rhs());
+        // Valid optimization if LHS and RHS are equal for both.
+        if (hasher.hash(round_lhs) == hasher.hash(mod_lhs) &&
+            hasher.hash(round_rhs) == hasher.hash(mod_rhs)) {
+          const Term* merged_r = new Term(hasher, r->scalar(), round_lhs);
+          others.push_back(merged_r);
+          merged = true;
+          didAnything = true;
+          mods.erase(mods.begin() + i);
+          rounds.erase(rounds.begin() + k);
+          break;
+        }
       }
+
+      // If we didn't merge, move out the Mod.
+      if (!merged) {
+        others.push_back(m);
+        mods.erase(mods.begin() + i);
+      }
+
+    } // end of for-loop
+
+    // Add newly generated Mods for merging opportunities in the next iteration.
+    if (!mods_merged.empty()) {
+      mods.insert(mods.end(), mods_merged.begin(), mods_merged.end());
+      mods_merged.clear();
     }
 
-    // If we didn't merge, keep the roundoff.
-    if (!merged) {
-      others.push_back(r);
-    }
-  }
+  } // end of while-loop
 
   // If we made no changes, just exit.
   if (!didAnything) {
     return nullptr;
   }
 
-  // Keep remaining Mods.
-  for (auto* m : mods) {
-    others.push_back(m);
+  // Keep remaining ModRounds and RoundOffs.
+  if (!mod_rounds.empty()) {
+    others.insert(others.end(), mod_rounds.begin(), mod_rounds.end());
+  }
+
+  if (!rounds.empty()) {
+    others.insert(others.end(), rounds.begin(), rounds.end());
   }
 
   return new Polynomial(hasher, poly->scalar(), others);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53861 [TensorExpr] Reland: "Simplify index expressions constructed in loop flattening. Fixes #51173"**

Replaced the iterators in the for-loops with integer index variables due to
overflow when handling empty vectors.

Differential Revision: [D26998894](https://our.internmc.facebook.com/intern/diff/D26998894)