### PR TITLE
[NNC] Adding API to distribute loops

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1316,6 +1316,62 @@ void LoopNest::splitWithMask(For* f, int factor, For** outer, For** inner) {
   p->replace_stmt(f, *outer);
 }
 
+std::vector<For*> LoopNest::distributeLoop(
+    For* loop,
+    const std::unordered_set<Stmt*>& pivots) {
+  TORCH_INTERNAL_ASSERT(loop);
+  auto root = loop->get_parent();
+  if (root == nullptr) {
+    throw malformed_input("Loop without parent: ", loop);
+  }
+  auto root_block = dynamic_cast<Block*>(root);
+  if (root_block == nullptr) {
+    throw malformed_input(
+        "Loop's parent must be a Block, instead found ", root);
+  }
+
+  // Extract bodies for all the loops after distribution.
+  std::vector<Block*> new_loop_bodies;
+  auto new_loop_body = new Block({});
+  while (auto s = loop->body()->front()) {
+    loop->body()->remove_stmt(s);
+    new_loop_body->append_stmt(s);
+    if (pivots.count(s)) {
+      new_loop_bodies.push_back(new_loop_body);
+      new_loop_body = new Block({});
+    }
+  }
+  if (!new_loop_body->empty()) {
+    new_loop_bodies.push_back(new_loop_body);
+  }
+
+  // The first loop body has to be in the original loop.
+  loop->body()->splice(loop->body()->begin(), new_loop_bodies.front());
+  std::vector<For*> new_loops = {loop};
+
+  // Create loops for all the remaining blocks.
+  // Add all the new loops to the parent block.
+  for (size_t i = 1; i < new_loop_bodies.size(); ++i) {
+    auto new_loop = loop->cloneWithNewBody(new_loop_bodies[i]);
+    root_block->insert_stmt_after(new_loop, new_loops.back());
+    new_loops.push_back(new_loop);
+  }
+
+  return new_loops;
+}
+
+std::vector<For*> LoopNest::distributeLoop(For* loop) {
+  std::unordered_set<Stmt*> stmtsInBlock(
+      loop->body()->begin(), loop->body()->end());
+  return distributeLoop(loop, stmtsInBlock);
+}
+
+std::vector<For*> LoopNest::distributeLoopOverInnerLoops(For* loop) {
+  auto loops = NodeFinder<For>::find(loop);
+  std::unordered_set<Stmt*> loopsSet(loops.begin(), loops.end());
+  return distributeLoop(loop, loopsSet);
+}
+
 For* findOuterFor(For* a, For* b) {
   Stmt* s = b; // guess b is the latter.
   while (s != nullptr) {


### PR DESCRIPTION
Fixes #53864

This PR adds the following APIs that perform loop distribution to `LoopNest`:
```
static std::vector<For*> distributeLoop(For* loop, const std::unordered_set<Stmt*>& pivots);
static std::vector<For*> distributeLoop(For* loop);
static std::vector<For*> distributeLoopOverInnerLoops(For* loop);
```

* The first method distributes the given loop over its body by splitting after every given pivot stmt.
* The second method distributes the given loop over every stmt in its body.
* The last method distributes the given loop over its body by splitting after every `For` stmt in its body.
