### PR TITLE
Expose Request Devices to Python

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #include <torch/csrc/distributed/rpc/tensorpipe_agent.h>
+#include <torch/csrc/distributed/rpc/tensorpipe_utils.h>
 #include <torch/csrc/distributed/rpc/torchscript_functions.h>
 #include <torch/csrc/distributed/rpc/types.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -682,6 +683,14 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
           "_set_reverse_device_maps",
           // intentionally not releasing GIL to avoid unnecessary context switch
           &TensorPipeAgent::setReverseDeviceMaps);
+
+  module.def("_get_request_device_indices", [](){
+    auto tpAgent = std::static_pointer_cast<TensorPipeAgent>(
+        RpcAgent::getCurrentRpcAgent());
+
+    return tpAgent->getThreadLocalLazyStreamContext()->deviceIndices();
+  });
+
 
 #endif // USE_TENSORPIPE
 

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -27,6 +27,8 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 
+thread_local std::shared_ptr<LazyStreamContext> TensorPipeAgent::ctx_ = nullptr;
+
 namespace {
 
 // An environment variable along the lines of GLOO_ and NCCL_SOCKET_IFNAME that
@@ -769,6 +771,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
 
           std::shared_ptr<JitFuture> futureResponseMessage;
           try {
+            CurrentLazyStreamContextGuard guard(ctx);
             futureResponseMessage = cb_->operator()(requestMessage);
             // FIXME: The user function might use a different device than the
             // ones used in request Tensors. The agent is not aware of which

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.h
@@ -37,6 +37,7 @@ struct TORCH_API LazyStreamContext {
   virtual ~LazyStreamContext() = default;
   virtual void waitForCurrentStreams(const std::vector<torch::Tensor>& = {}) {}
   virtual void recordBarrierEvents() {}
+  virtual std::vector<c10::DeviceIndex> deviceIndices() const {return {};}
 
 #ifdef USE_CUDA_NOT_ROCM
   virtual std::vector<CUDAStream> getReservedStreams() const {
@@ -90,6 +91,15 @@ struct TORCH_CUDA_CPP_API CudaLazyStreamContext : public LazyStreamContext {
       reservedStreams.push_back(entry.second);
     }
     return reservedStreams;
+  }
+
+  std::vector<c10::DeviceIndex> deviceIndices() const override {
+    std::vector<c10::DeviceIndex> indices;
+    indices.reserve(streams_.size());
+    for (const auto& entry : streams_) {
+      indices.push_back(entry.first);
+    }
+    return indices;
   }
 
   // get a stream for the given device. If it is the first time using that

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -43,6 +43,7 @@ if is_available():
         _invoke_remote_torchscript,
         _set_rpc_timeout,
         _get_current_rpc_agent,
+        _get_request_device_indices,
         get_rpc_timeout,
         enable_gil_profiling,
         RpcBackendOptions,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53868 Expose Request Devices to Python**
* #53742 Let Tensor comm wait for CUDA ops on new devices in RPC response

This is step 1 of the following plan:

1. allow Python to read what devices are used by the current request
2. add an RPC decorator which can be used by users to specify
   involved devices in an RPC call, including both request tensors,
   comp, and response tensors. The decorator will create streams,
   synchronize streams, and use those streams as the current stream
   when running user functions.
3. add docs and examples

Differential Revision: [D27001258](https://our.internmc.facebook.com/intern/diff/D27001258)