### PR TITLE
[pytorch] disable static dispatch for RedispatchFunctions

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1005,14 +1005,15 @@ def main() -> None:
         'function_definitions': list(mapMaybe(ComputeFunction(
             Target.DEFINITION, static_dispatch_backend=static_dispatch_backend, is_redispatching_fn=False), native_functions)),
     })
+    # NB: no static dispatch support for RedispatchFunctions.
     cpu_fm.write('RedispatchFunctions.h', lambda: {
         'function_redispatch_declarations': list(mapMaybe(ComputeFunction(
-            Target.DECLARATION, static_dispatch_backend=static_dispatch_backend, is_redispatching_fn=True), native_functions)),
+            Target.DECLARATION, static_dispatch_backend=None, is_redispatching_fn=True), native_functions)),
     })
     cpu_fm.write('RedispatchFunctions.cpp', lambda: {
-        'static_dispatch_extra_headers': static_dispatch_extra_headers(static_dispatch_backend),
+        'static_dispatch_extra_headers': '',
         'function_redispatch_definitions': list(mapMaybe(ComputeFunction(
-            Target.DEFINITION, static_dispatch_backend=static_dispatch_backend, is_redispatching_fn=True), native_functions)),
+            Target.DEFINITION, static_dispatch_backend=None, is_redispatching_fn=True), native_functions)),
     })
     core_fm.write('TensorBody.h', lambda: {
         'tensor_method_declarations': list(mapMaybe(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53869 [pytorch] disable static dispatch for RedispatchFunctions**

Redispatch APIs have the DispatchKeySet passed in as the first argument - static dispatch codegen
doesn't support this yet. It breaks the compile for TraceType / VariableType when static dispatch
is enabled.

This doesn't break OSS static dispatch CI because the OSS CI uses mobile build config which doesn't
include TraceType / VariableType sources.

This breaks internal BUCK build with static dispatch mode enabled because internal targets compile
TraceType / VariableType - although they are not really used by the inference-only binary.

An alternative fix is to exclude TraceType / VariableType from the BUCK targets when static dispatch
mode is enabled - but it's considerably more involved change, so the simple fix is to ignore static
dispatch flag when generating the redispatch APIs.

Differential Revision: [D27001359](https://our.internmc.facebook.com/intern/diff/D27001359/)