### PR TITLE
[4/n][torch/elastic][upstream] Move torchelastic/metrics to torch/distributed/elastic/metrics

### DIFF
--- a/test/distributed/elastic/metrics/__init__.py
+++ b/test/distributed/elastic/metrics/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs

--- a/test/distributed/elastic/metrics/api_test.py
+++ b/test/distributed/elastic/metrics/api_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.abs
+import abc
+import unittest
+import unittest.mock as mock
+
+from torch.distributed.elastic.metrics.api import (
+    MetricData,
+    MetricHandler,
+    MetricStream,
+    _get_metric_name,
+    prof,
+)
+
+
+def foo_1():
+    pass
+
+
+class TestMetricsHandler(MetricHandler):
+    def __init__(self):
+        self.metric_data = {}
+
+    def emit(self, metric_data: MetricData):
+        self.metric_data[metric_data.name] = metric_data
+
+
+class Parent(abc.ABC):
+    @abc.abstractmethod
+    def func(self):
+        raise NotImplementedError()
+
+    def base_func(self):
+        self.func()
+
+
+class Child(Parent):
+    # need to decorate the implementation not the abstract method!
+    @prof
+    def func(self):
+        pass
+
+
+class MetricsApiTest(unittest.TestCase):
+    def foo_2(self):
+        pass
+
+    @prof
+    def bar(self):
+        pass
+
+    @prof
+    def throw(self):
+        raise RuntimeError()
+
+    @prof(group="torchelastic")
+    def bar2(self):
+        pass
+
+    def test_get_metric_name(self):
+        self.assertEqual("api_test.foo_1", _get_metric_name(foo_1))
+        self.assertEqual("MetricsApiTest.foo_2", _get_metric_name(self.foo_2))
+
+    def test_profile(self):
+        handler = TestMetricsHandler()
+        stream = MetricStream("torchelastic", handler)
+        # patch instead of configure to avoid conflicts when running tests in parallel
+        with mock.patch(
+            "torch.distributed.elastic.metrics.api.getStream", return_value=stream
+        ):
+            self.bar()
+
+            self.assertEqual(1, handler.metric_data["MetricsApiTest.bar.success"].value)
+            self.assertNotIn("MetricsApiTest.bar.failure", handler.metric_data)
+            self.assertIn("MetricsApiTest.bar.duration.ms", handler.metric_data)
+
+            with self.assertRaises(RuntimeError):
+                self.throw()
+
+            self.assertEqual(
+                1, handler.metric_data["MetricsApiTest.throw.failure"].value
+            )
+            self.assertNotIn("MetricsApiTest.bar_raise.success", handler.metric_data)
+            self.assertIn("MetricsApiTest.throw.duration.ms", handler.metric_data)
+
+            self.bar2()
+            self.assertEqual(
+                "torchelastic",
+                handler.metric_data["MetricsApiTest.bar2.success"].group_name,
+            )
+
+    def test_inheritance(self):
+        handler = TestMetricsHandler()
+        stream = MetricStream("torchelastic", handler)
+        # patch instead of configure to avoid conflicts when running tests in parallel
+        with mock.patch(
+            "torch.distributed.elastic.metrics.api.getStream", return_value=stream
+        ):
+            c = Child()
+            c.base_func()
+
+            self.assertEqual(1, handler.metric_data["Child.func.success"].value)
+            self.assertIn("Child.func.duration.ms", handler.metric_data)

--- a/torch/distributed/elastic/metrics/__init__.py
+++ b/torch/distributed/elastic/metrics/__init__.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env/python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Metrics API
+
+**Overview**:
+
+The metrics API in torchelastic is used to publish telemetry metrics.
+It is designed to be used by torchelastic's internal modules to
+publish metrics for the end user with the goal of increasing visibility
+and helping with debugging. However you may use the same API in your
+jobs to publish metrics to the same metrics ``sink``.
+
+A ``metric`` can be thought of as timeseries data
+and is uniquely identified by the string-valued tuple
+``(metric_group, metric_name)``.
+
+torchelastic makes no assumptions about what a ``metric_group`` is
+and what relationship it has with ``metric_name``. It is totally up
+to the user to use these two fields to uniquely identify a metric.
+
+.. note:: The metric group ``torchelastic`` is reserved by torchelastic for
+          platform level metrics that it produces.
+          For instance torchelastic may output the latency (in milliseconds)
+          of a re-rendezvous operation from the agent as
+          ``(torchelastic, agent.rendezvous.duration.ms)``
+
+A sensible way to use metric groups is to map them to a stage or module
+in your job. You may also encode certain high level properties
+the job such as the region or stage (dev vs prod).
+
+**Publish Metrics**:
+
+Using torchelastic’s metrics API is similar to using python’s logging
+framework. You first have to configure a metrics handler before
+trying to add metric data.
+
+The example below measures the latency for the ``calculate()`` function.
+
+::
+
+  import time
+  import torch.distributed.elastic.metrics as metrics
+
+  # makes all metrics other than the one from "my_module" to go /dev/null
+  metrics.configure(metrics.NullMetricsHandler())
+  metrics.configure(metrics.ConsoleMetricsHandler(), "my_module")
+
+  def my_method():
+    start = time.time()
+    calculate()
+    end = time.time()
+    metrics.put_metric("calculate_latency", int(end-start), "my_module")
+
+You may also use the torch.distributed.elastic.metrics.prof` decorator
+to conveniently and succinctly profile functions
+
+::
+
+  # -- in module examples.foobar --
+
+  import torch.distributed.elastic.metrics as metrics
+
+  metrics.configure(metrics.ConsoleMetricsHandler(), "foobar")
+  metrics.configure(metrics.ConsoleMetricsHandler(), "Bar")
+
+  @metrics.prof
+  def foo():
+    pass
+
+  class Bar():
+
+    @metrics.prof
+    def baz():
+        pass
+
+``@metrics.prof`` will publish the following metrics
+::
+
+  <leaf_module or classname>.success - 1 if the function finished successfully
+  <leaf_module or classname>.failure - 1 if the function threw an exception
+  <leaf_module or classname>.duration.ms - function duration in milliseconds
+
+**Configuring Metrics Handler**:
+
+`torch.distributed.elastic.metrics.MetricHandler` is responsible for emitting
+the added metric values to a particular destination. Metric groups can be
+configured with different metric handlers.
+
+By default torchelastic emits all metrics to ``/dev/null``.
+By adding the following configuration metrics,
+``torchelastic`` and ``my_app`` metric groups will be printed out to
+console.
+
+::
+
+  import torch.distributed.elastic.metrics as metrics
+
+  metrics.configure(metrics.ConsoleMetricHandler(), group = "torchelastic")
+  metrics.configure(metrics.ConsoleMetricHandler(), group = "my_app")
+
+**Writing a Custom Metric Handler**:
+
+If you want your metrics to be emitted to a custom location, implement
+the `torch.distributed.elastic.metrics.MetricHandler` interface
+and configure your job to use your custom metric handler.
+
+Below is a toy example that prints the metrics to ``stdout``
+
+::
+
+  import torch.distributed.elastic.metrics as metrics
+
+  class StdoutMetricHandler(metrics.MetricHandler):
+     def emit(self, metric_data):
+         ts = metric_data.timestamp
+         group = metric_data.group_name
+         name = metric_data.name
+         value = metric_data.value
+         print(f"[{ts}][{group}]: {name}={value}")
+
+  metrics.configure(StdoutMetricHandler(), group="my_app")
+
+Now all metrics in the group ``my_app`` will be printed to stdout as:
+
+::
+
+  [1574213883.4182858][my_app]: my_metric=<value>
+  [1574213940.5237644][my_app]: my_metric=<value>
+
+"""
+
+from typing import Optional
+
+from .api import (  # noqa F401
+    ConsoleMetricHandler,
+    MetricData,
+    MetricHandler,
+    MetricsConfig,
+    NullMetricHandler,
+    configure,
+    get_elapsed_time_ms,
+    getStream,
+    prof,
+    profile,
+    publish_metric,
+    put_metric,
+)
+
+
+def initialize_metrics(cfg: Optional[MetricsConfig] = None):
+    pass
+
+
+try:
+    from torch.distributed.elastic.metrics.static_init import *  # type: ignore # noqa: F401 F403
+except ModuleNotFoundError:
+    pass

--- a/torch/distributed/elastic/metrics/api.py
+++ b/torch/distributed/elastic/metrics/api.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import time
+import warnings
+from collections import namedtuple
+from functools import wraps
+from typing import Dict, Optional
+
+
+MetricData = namedtuple("MetricData", ["timestamp", "group_name", "name", "value"])
+
+
+class MetricsConfig:
+    __slots__ = ["params"]
+
+    def __init__(self, params: Optional[Dict[str, str]] = None):
+        self.params = params
+        if self.params is None:
+            self.params = {}
+
+
+class MetricHandler(abc.ABC):
+    @abc.abstractmethod
+    def emit(self, metric_data: MetricData):
+        pass
+
+
+class ConsoleMetricHandler(MetricHandler):
+    def emit(self, metric_data: MetricData):
+        print(
+            "[{}][{}]: {}={}".format(
+                metric_data.timestamp,
+                metric_data.group_name,
+                metric_data.name,
+                metric_data.value,
+            )
+        )
+
+
+class NullMetricHandler(MetricHandler):
+    def emit(self, metric_data: MetricData):
+        pass
+
+
+class MetricStream:
+    def __init__(self, group_name: str, handler: MetricHandler):
+        self.group_name = group_name
+        self.handler = handler
+
+    def add_value(self, metric_name: str, metric_value: int):
+        self.handler.emit(
+            MetricData(time.time(), self.group_name, metric_name, metric_value)
+        )
+
+
+_metrics_map = {}
+_default_metrics_handler = NullMetricHandler()  # type: MetricHandler
+
+
+# pyre-fixme[9]: group has type `str`; used as `None`.
+def configure(handler: MetricHandler, group: str = None):
+    if group is None:
+        global _default_metrics_handler
+        # pyre-fixme[9]: _default_metrics_handler has type `NullMetricHandler`; used
+        #  as `MetricHandler`.
+        _default_metrics_handler = handler
+    else:
+        _metrics_map[group] = handler
+
+
+def getStream(group: str):
+    if group in _metrics_map:
+        handler = _metrics_map[group]
+    else:
+        handler = _default_metrics_handler
+    return MetricStream(group, handler)
+
+
+def _get_metric_name(fn):
+    qualname = fn.__qualname__
+    split = qualname.split(".")
+    if len(split) == 1:
+        module = fn.__module__
+        if module:
+            return module.split(".")[-1] + "." + split[0]
+        else:
+            return split[0]
+    else:
+        return qualname
+
+
+def prof(fn=None, group: str = "torchelastic"):
+    r"""
+    @profile decorator publishes duration.ms, count, success, failure
+    metrics for the function that it decorates. The metric name defaults
+    to the qualified name (``class_name.def_name``) of the function.
+    If the function does not belong to a class, it uses the leaf module name
+    instead.
+
+    Usage
+
+    ::
+
+     @metrics.prof
+     def x():
+         pass
+
+     @metrics.prof(group="agent")
+     def y():
+         pass
+    """
+
+    def wrap(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            key = _get_metric_name(f)
+            try:
+                start = time.time()
+                result = f(*args, **kwargs)
+                put_metric(f"{key}.success", 1, group)
+            except Exception:
+                put_metric(f"{key}.failure", 1, group)
+                raise
+            finally:
+                put_metric(f"{key}.duration.ms", get_elapsed_time_ms(start), group)
+            return result
+
+        return wrapper
+
+    if fn:
+        return wrap(fn)
+    else:
+        return wrap
+
+
+def profile(group=None):
+    """
+    @profile decorator adds latency and success/failure metrics to any given function.
+
+    Usage
+
+    ::
+
+     @metrics.profile("my_metric_group")
+     def some_function(<arguments>):
+    """
+    warnings.warn("Deprecated, use @prof instead", DeprecationWarning)
+
+    def wrap(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                start_time = time.time()
+                result = func(*args, **kwargs)
+                publish_metric(group, "{}.success".format(func.__name__), 1)
+            except Exception:
+                publish_metric(group, "{}.failure".format(func.__name__), 1)
+                raise
+            finally:
+                publish_metric(
+                    group,
+                    "{}.duration.ms".format(func.__name__),
+                    get_elapsed_time_ms(start_time),
+                )
+            return result
+
+        return wrapper
+
+    return wrap
+
+
+def put_metric(metric_name: str, metric_value: int, metric_group: str = "torchelastic"):
+    """
+    Publishes a metric data point.
+
+    Usage
+
+    ::
+
+     put_metric("metric_name", 1)
+     put_metric("metric_name", 1, "metric_group_name")
+    """
+
+    getStream(metric_group).add_value(metric_name, metric_value)
+
+
+def publish_metric(metric_group: str, metric_name: str, metric_value: int):
+    warnings.warn(
+        "Deprecated, use put_metric(metric_group)(metric_name, metric_value) instead"
+    )
+    metric_stream = getStream(metric_group)
+    metric_stream.add_value(metric_name, metric_value)
+
+
+def get_elapsed_time_ms(start_time_in_seconds: float):
+    """
+    Returns the elapsed time in millis from the given start time.
+    """
+    end_time = time.time()
+    return int((end_time - start_time_in_seconds) * 1000)


### PR DESCRIPTION
Summary: Move torchelastic/metrics to torch/distributed/elastic/metrics

Test Plan: buck test mode/dev-nosan //pytorch/elastic/torchelastic/...

Differential Revision: D26970901

