### PR TITLE
Make ideep honor `torch.set_num_thread` changes

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -12,6 +12,11 @@
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 namespace at {
+#if AT_MKLDNN_ENABLED()
+namespace native { namespace mkldnn {
+void clear_computation_cache();
+}} // namespace native::mkldnn
+#endif
 
 namespace {
 // Number of threads set by the user
@@ -57,6 +62,9 @@ void set_num_threads(int nthreads) {
   caffe2::PThreadPool* const pool = caffe2::pthreadpool();
   TORCH_INTERNAL_ASSERT(pool, "Invalid thread pool!");
   pool->set_thread_count(nthreads);
+#endif
+#if AT_MKLDNN_ENABLED()
+  at::native::mkldnn::clear_computation_cache();
 #endif
 }
 

--- a/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
+++ b/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
@@ -18,4 +18,14 @@ RegisterEngineAllocator cpu_alloc(
   }
 );
 
+namespace at { namespace native { namespace mkldnn {
+
+void computation_cache() {
+  // Reset computation_cache for forward convolutions
+  // As it also caches max number of OpenMP workers
+  ideep::convolution_forward::t_store().clear();
+}
+
+}}} // namespace  at::native::mkldnn
+
 #endif // AT_MKLDNN_ENALBED()

--- a/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
+++ b/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
@@ -20,7 +20,7 @@ RegisterEngineAllocator cpu_alloc(
 
 namespace at { namespace native { namespace mkldnn {
 
-void computation_cache() {
+void clear_computation_cache() {
   // Reset computation_cache for forward convolutions
   // As it also caches max number of OpenMP workers
   ideep::convolution_forward::t_store().clear();

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -339,7 +339,8 @@ class ErrorTrackingProcess(mp.Process):
         set_faulthander_if_available()
         if self.disable_stderr:
             # Disable polluting stderr with errors that are supposed to happen.
-            sys.stderr = open(os.devnull, "w")
+            with open(os.devnull, 'w') as devnull:
+                os.dup2(devnull.fileno(), sys.stderr.fileno())
         try:
             super(ErrorTrackingProcess, self).run()
             self._cconn.send(None)
@@ -525,8 +526,8 @@ def disable_stderr(worker_id):
     sys.stderr.flush()  # flush library buffers that dup2 knows nothing about
     # Can't use a with-block because otherwise the fd will be closed when this
     # function ends.
-    devnull = open(os.devnull, 'w')
-    os.dup2(devnull.fileno(), sys.stderr.fileno())
+    with open(os.devnull, 'w') as devnull:
+        os.dup2(devnull.fileno(), sys.stderr.fileno())
 
 
 def _test_segfault():


### PR DESCRIPTION
When compiled with OpenMP support `ideep`'s computational_cache would cache max number of OpenMP workers
This number could be wrong after `torch.set_num_threads` call, so clean it after the call.

Fixes #53565
