### PR TITLE
fx quant: remove unnecessary dequants for getattr

### DIFF
--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -905,6 +905,11 @@ class Quantizer:
                 else:
                     env[node.name] = \
                         self.quantized_graph.node_copy(node, load_non_quantized)
+            elif node.op == 'call_function' and node.target is getattr:
+                # getattr nodes can work on quantized or non-quantized
+                # tensors
+                env[node.name] = \
+                    self.quantized_graph.node_copy(node, load_x)
             else:
                 # copy quantized or non-quantized node
                 env[node.name] = \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53875 fx quant: remove unnecessary dequants for getattr**
* #53614 fx quant: clean up names of quantize handlers
* #53196 fx quant: ensure fp32 sum works correctly with quantized layers
* #53187 fx quant: fix using size of quant layer in torch._assert
* #53120 fx quant: support for ndim followed by binary op

Summary:

Ensures that we do not insert unnecessary dequants for `getattr`
nodes.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_ndim_of_quant_tensor
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27003504](https://our.internmc.facebook.com/intern/diff/D27003504)