### PR TITLE
Fix run_test_module logic

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -992,7 +992,7 @@ def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
 
     # Printing the date here can help diagnose which tests are slow
     print_to_stderr('Running {} ... [{}]'.format(test, datetime.now()))
-    handler = CUSTOM_HANDLERS.get(test, run_test)
+    handler = CUSTOM_HANDLERS.get(test_module, run_test)
     return_code = handler(test_module, test_directory, options)
     assert isinstance(return_code, int) and not isinstance(
         return_code, bool), 'Return code should be an integer'


### PR DESCRIPTION
First argument is either file name or test module name, but key to `CUSTOM_HANDLERS` is test module name.

Test plan: Run `python3 run_test.py -i distributed/test_distributed_spawn.py`

