### PR TITLE
removing warning from optimizer::size() method

### DIFF
--- a/torch/csrc/api/src/optim/optimizer.cpp
+++ b/torch/csrc/api/src/optim/optimizer.cpp
@@ -129,7 +129,6 @@ std::vector<Tensor>& Optimizer::parameters() noexcept {
 }
 
 size_t Optimizer::size() const noexcept {
-  TORCH_WARN("Optimizer::size() will be removed in PyTorch 1.6");
   size_t count = 0;
   for (const auto& group : param_groups_) {
     count += group.params().size();


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/46822

When optimizer groups were implemented in the c++ api,
warnings were placed on Optimizer methods that did not extend to multiple parameter groups,
e.g. in api/src/optim/optimizer.cpp

```
std::vector<Tensor>& Optimizer::parameters() noexcept {
   TORCH_WARN("Optimizer::parameters() will be removed in PyTorch 1.6");
   return param_groups_.at(0).params();
}
```
The warning makes sense since the returned vector of parameters omits any additional parameter groups.
But for the size() method, the count of parameters is accurate in the case of multiple parameter groups:

```
size_t Optimizer::size() const noexcept {
  TORCH_WARN("Optimizer::size() will be removed in PyTorch 1.6");
  size_t count = 0;
  for (const auto& group : param_groups_) {
    count += group.params().size();
  }
  return count;
}
```