### PR TITLE
Support for Half / bfloat16 / index_select and better testing

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -473,7 +473,8 @@ Tensor& index_add_cpu_(Tensor & self, int64_t dim, const Tensor & index, const T
 
     // explicitly capture all required variables to work around windows build
     // TODO: fix this when windows can correctly capture variables in nested lambda
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(self.scalar_type(), "index_add_", [&self, &source, &dim, &index_contig, &numel] {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16,
+      self.scalar_type(), "index_add_", [&self, &source, &dim, &index_contig, &numel] {
       auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
       auto source_stride = source.dim() == 0 ? 1 : source.stride(dim);
       // TODO: Maybe TensorAccessor can beused here?
@@ -684,8 +685,8 @@ Tensor & index_select_out_cpu_(Tensor & result, const Tensor & self, int64_t dim
     TORCH_CHECK(result.dim() <= 1, "result.dim() (", result.dim(), ") must one or zero for given self.dim() (", self.dim(), ")");
     // explicitly capture all required variables to work around windows build
     // TODO: fix this when windows can correctly capture variables in nested lambda
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(at::ScalarType::Bool, self.scalar_type(), "index_select",
-      [&index_contig, &self, &result, &dim, &numel] {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(ScalarType::Half, ScalarType::Bool, ScalarType::BFloat16,
+      self.scalar_type(), "index_select", [&index_contig, &self, &result, &dim, &numel] {
       auto self_stride = self.dim() == 0 ? 1 : self.stride(dim);
       auto result_stride = result.dim() == 0 ? 1 : result.stride(dim);
 

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -507,7 +507,7 @@ Tensor& index_add_cuda_(Tensor & self, int64_t dim, const Tensor & index, const 
   if (cuda::detail::canUse32BitIndexMath(self) &&
       cuda::detail::canUse32BitIndexMath(source) &&
       cuda::detail::canUse32BitIndexMath(index)) {
-    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
       cuda::detail::TensorInfo<scalar_t, unsigned int> selfInfo =
           cuda::detail::getTensorInfo<scalar_t, unsigned int>(self_);
       int selfAddDim = selfInfo.collapseDims(dim);
@@ -558,7 +558,7 @@ Tensor& index_add_cuda_(Tensor & self, int64_t dim, const Tensor & index, const 
       });
     });
   } else {
-    AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "index_add", [&] {
       cuda::detail::TensorInfo<scalar_t, uint64_t> selfInfo =
         cuda::detail::getTensorInfo<scalar_t, uint64_t>(self_);
       int selfAddDim = selfInfo.collapseDims(dim);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4588,7 +4588,7 @@ class TestTorchDeviceType(TestCase):
                     dest = torch.index_select(src, dim, idx, out=out)
                     dest2 = ref_index_select(src, dim, idx)
                     self.assertEqual(dest, dest2)
-                    if self.device.type != 'xla':
+                    if device.type != 'xla':
                         self.assertEqual(out.data_ptr(), dest.data_ptr())
                     else:
                         # XLA does not have data_ptr()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4572,7 +4572,6 @@ class TestTorchDeviceType(TestCase):
                 dest[idx_dest] = src[idx_src]
             return dest
 
-        # More thorough testing as in index_add
         for src_contig, idx_contig, out_contig in product([True, False], repeat=3):
             for other_sizes in ((), (4, 5)):
                 for dim in range(len(other_sizes)):
@@ -4607,7 +4606,6 @@ class TestTorchDeviceType(TestCase):
         for source, idx in scalars:
             out = source.index_select(0, idx)
             self.assertEqual(out.item(), source.item())
-
 
     def test_take_empty(self, device):
         for input_shape in [(0,), (0, 1, 2, 0), (1, 2, 3)]:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4588,7 +4588,7 @@ class TestTorchDeviceType(TestCase):
                     dest = torch.index_select(src, dim, idx, out=out)
                     dest2 = ref_index_select(src, dim, idx)
                     self.assertEqual(dest, dest2)
-                    self.assertEqual(out.storage().data_ptr(), dest.storage().data_ptr())
+                    self.assertEqual(out.data_ptr(), dest.data_ptr())
 
         for idx_type in (torch.int32, torch.int64):
             other_sizes = (3, 2)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4554,6 +4554,8 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(0, x.index_fill(0, index, -1).dim())
         self.assertEqual(0, x.index_fill_(0, index, -1).dim())
 
+    # The test fails for zero-dimensional tensors on XLA
+    @onlyOnCPUAndCUDA
     @dtypes(*torch.testing.get_all_dtypes())
     def test_index_select(self, device, dtype):
         num_src, num_out = 3, 5

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -4588,11 +4588,11 @@ class TestTorchDeviceType(TestCase):
                     dest = torch.index_select(src, dim, idx, out=out)
                     dest2 = ref_index_select(src, dim, idx)
                     self.assertEqual(dest, dest2)
-                    try:
+                    if self.device.type != 'xla':
                         self.assertEqual(out.data_ptr(), dest.data_ptr())
-                    except RuntimeError:
+                    else:
                         # XLA does not have data_ptr()
-                        out.fill_(99)
+                        out.fill_(13)
                         self.assertEqual(out, dest)
 
         for idx_type in (torch.int32, torch.int64):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -560,7 +560,10 @@
 
 - name: index_add_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)
   self: grad
-  source: grad.index_select(dim, index).expand_as(source)
+  # The case source.dim() == 0  is necessary to support scalar tensors of the form
+  # source.dim() == 0 and index.dim() == 1 and index.size() == (1,),
+  # This is because source is not broadcastable to index, as source.dim() < index.dim()
+  source: "source.dim() > 0 ? grad.index_select(dim, index).expand_as(source) : grad.index_select(dim, index.squeeze(0))"
   index: non_differentiable
 
 - name: index_copy_(Tensor(a!) self, int dim, Tensor index, Tensor source) -> Tensor(a!)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2952,7 +2952,7 @@ op_db: List[OpInfo] = [
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            test_inplace_grad=False,
-           supports_out=False,
+           supports_out=False,  # index_select does not correctly warn when resizing out=
            sample_inputs_func=sample_inputs_index_select),
     OpInfo('sort',
            dtypes=all_types_and(torch.bool, torch.float16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2952,14 +2952,7 @@ op_db: List[OpInfo] = [
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            test_inplace_grad=False,
-           skips=(
-               # https://github.com/pytorch/pytorch/issues/49707
-               SkipInfo('TestCommon', 'test_variant_consistency_eager',
-                        dtypes=[torch.float16, torch.bfloat16]),
-               SkipInfo('TestCommon', 'test_variant_consistency_jit', dtypes=[torch.float16, torch.bfloat16]),
-               # index_select does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out')
-           ),
+           supports_out=False,
            sample_inputs_func=sample_inputs_index_select),
     OpInfo('sort',
            dtypes=all_types_and(torch.bool, torch.float16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2985,7 +2985,10 @@ op_db: List[OpInfo] = [
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            test_inplace_grad=False,
-           supports_out=False,  # index_select does not correctly warn when resizing out=
+           skips=(
+               # index_select does not correctly warn when resizing out= inputs
+               SkipInfo('TestCommon', 'test_out')
+           ),
            sample_inputs_func=sample_inputs_index_select),
     OpInfo('index_add',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2989,7 +2989,6 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_index_select),
     OpInfo('index_add',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           test_inplace_grad=False,
            supports_out=False,
            sample_inputs_func=sample_inputs_index_add),
     OpInfo('sort',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -738,6 +738,39 @@ def sample_inputs_index_select(op_info, device, dtype, requires_grad):
                         0, torch.tensor(0, dtype=torch.int64, device=device))),
             )
 
+# Missing to test the nondeterminism of the operation
+# https://github.com/pytorch/pytorch/issues/53352
+def sample_inputs_index_add(op_info, device, dtype, requires_grad):
+    # These testa are pretty much the same as those from index_copy.
+    # Perhaps merge?
+    def make_arg(shape, low=None, high=None, dtype=dtype, device=device, contiguous=True):
+        return make_tensor(shape, device=device, dtype=dtype,
+                           low=low, high=high,
+                           discontiguous=not contiguous,
+                           requires_grad=requires_grad)
+
+    t = make_arg((S, S))
+    s = make_arg((S, S))
+    # non-contiguous target
+    t_nonctg = t.transpose(0, 1)
+    # non-contiguous source
+    s_nonctg = s.transpose(0, 1)
+
+    idx = make_arg((S,), dtype=torch.int64, low=0, high=S)
+    idx_nonctg = make_arg((S,), dtype=torch.int64, low=0, high=S, contiguous=False)
+    idx_neg = -idx - 1
+    samples = [SampleInput((tensor, 1, idx, source))
+               for tensor, idx, source in product([t, t_nonctg], [idx, idx_nonctg], [s, s_nonctg])]
+
+    # Add scalar cases
+    scalar_sizes = [(), (1,)]
+    ts = (make_arg(size) for size in scalar_sizes)
+    idxs = (make_arg(size, dtype=torch.int64, low=0, high=1) for size in scalar_sizes)
+    ss = (make_arg(size) for size in scalar_sizes)
+
+    samples.extend(SampleInput((t, 0, idx, s)) for t, idx, s in product(ts, idxs, ss))
+    return samples
+
 def sample_inputs_sort(op_info, device, dtype, requires_grad):
     def apply_grad(t):
         if dtype in floating_types_and(torch.float16, torch.bfloat16):
@@ -2954,6 +2987,11 @@ op_db: List[OpInfo] = [
            test_inplace_grad=False,
            supports_out=False,  # index_select does not correctly warn when resizing out=
            sample_inputs_func=sample_inputs_index_select),
+    OpInfo('index_add',
+           dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
+           test_inplace_grad=False,
+           supports_out=False,
+           sample_inputs_func=sample_inputs_index_add),
     OpInfo('sort',
            dtypes=all_types_and(torch.bool, torch.float16),
            # sort on CUDA is still in the TH, no torch.bool/torch.float16 support yet
@@ -3836,11 +3874,6 @@ def method_tests():
         ('triu', (3, 3, S, S), NO_ARGS, 'more_batched'),
         ('cross', (S, 3), ((S, 3),)),
         ('cross', (S, 3, S), ((S, 3, S), 1), 'dim'),
-        ('index_add', (S, S), (0, index_variable(2, S), (2, S)), 'dim', (), [0]),
-        ('index_add', (), (0, torch.tensor([0], dtype=torch.int64), (1,)), 'scalar_input_dim', (), [0]),
-        ('index_add', (), (0, torch.tensor(0, dtype=torch.int64), ()), 'scalar_all_dim', (), [0]),
-        ('index_add', (S, S), (0, index_variable(2, S), (2, S)), 'alert_nondeterministic', (), [0],
-            [expectedAlertNondeterministic('index_add_cuda_', 'cuda')]),
         ('index_copy', (S, S), (0, index_perm_variable(2, S), (2, S)), 'dim', (), [0]),
         ('index_copy', (S, S), (0, index_perm_variable(2, S), (2, S)), 'dim_alert_nondeterministic', (), [0],
             [skipMeta, expectedAlertNondeterministic('index_copy')]),


### PR DESCRIPTION
Added the support for half / bfloat / bool for `index_select`, as suggested by @ngimel in
https://github.com/pytorch/pytorch/issues/49707#issuecomment-788140578

For the tests to pass, I also added the support for `index_add`.

I added `OpInfo` tests for `index_add` and more thorough forward tests for `index_select` to test these changes. 

While doing so, I found that the support for scalar types in the derivative of `index_add` was not correct, so I corrected it.

Resolves https://github.com/pytorch/pytorch/issues/49707

It should also resolve similar issues that I encountered when porting `index_copy`, `take` and `put`. 