### PR TITLE
Allow inlining of more Tensor methods

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -477,8 +477,13 @@ class TORCH_API Tensor {
   }
 
   /// Returns a `Tensor`'s dimension names data structure
-  const NamedTensorMeta* get_named_tensor_meta() const;
-  NamedTensorMeta* get_named_tensor_meta();
+  const NamedTensorMeta* get_named_tensor_meta() const {
+    return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
+  }
+
+  NamedTensorMeta* get_named_tensor_meta() {
+    return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
+  }
 
   /// Returns the `TensorOptions` corresponding to this `Tensor`. Defined in
   /// TensorOptions.h.

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -57,14 +57,6 @@ TensorOptions Tensor::options() const {
 
 ${tensor_method_definitions}
 
-NamedTensorMeta* Tensor::get_named_tensor_meta() {
-  return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
-}
-
-const NamedTensorMeta* Tensor::get_named_tensor_meta() const {
-  return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
-}
-
 #define DEFINE_CAST(T, name)                                        \
   template <>                                                       \
   TORCH_API T* Tensor::data_ptr() const {                           \


### PR DESCRIPTION
This `is_meta` call in `TensorIterator` shows up in profiling as around 4-5% of fast setup time:
https://github.com/pytorch/pytorch/blob/49a5f99440bde6a2f214e9c0b64c3ae0fdfb5a59/aten/src/ATen/TensorIterator.cpp#L886

After inlining, `is_meta()` compiles to a single `test` instruction. Saving 20-30 ns per operator call. The functions I'm moving into the header here are all similar, in that they inline away to almost nothing.