### PR TITLE
[DDP] remove dedupe check in reducer

### DIFF
--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -130,19 +130,11 @@ Reducer::Reducer(
         // This is used later on when the autograd graph is traversed
         // to check for parameters for which no gradient is computed, if
         // find_unused_parameters=True.
-        // We maintain a mapping of gradient accumulator to vector of variables,
-        // since multiple parameters may share the same grad accumulator.
+        // Note that the mapping of gradient accumulator to variable should be
+        // one to one as we deduplicate shared parameters before constructing
+        // Reducer.
         if (find_unused_parameters_) {
-          auto gradAcc = gradAccToVariablesMap_.find(grad_accumulator.get());
-          if (gradAcc == gradAccToVariablesMap_.end()) {
-            std::vector<VariableIndex> indexVec{index};
-            gradAccToVariablesMap_[grad_accumulator.get()] =
-                std::move(indexVec);
-          } else {
-            // Scenario where we have indices whose corresponding parameters
-            // share the same grad accumulator.
-            gradAcc->second.push_back(index);
-          }
+          gradAccToVariableMap_[grad_accumulator.get()] = index;
         }
 
         // The gradient accumulator is stored as weak_ptr in the autograd
@@ -959,14 +951,11 @@ void Reducer::prepare_for_backward(
   }
 
   // Find accumulator functions that don't show up in this graph.
-  for (const auto& it : gradAccToVariablesMap_) {
+  for (const auto& it : gradAccToVariableMap_) {
     // If the accumulator function is present in the graph, we know
     // a gradient will be computed for the corresponding parameter.
     if (seen.count(it.first) == 0) {
-      auto& indices = it.second;
-      unused_parameters_.reserve(unused_parameters_.size() + indices.size());
-      unused_parameters_.insert(
-          unused_parameters_.end(), indices.begin(), indices.end());
+      unused_parameters_.push_back(it.second);
     }
   }
 

--- a/torch/lib/c10d/reducer.hpp
+++ b/torch/lib/c10d/reducer.hpp
@@ -148,8 +148,8 @@ class Reducer {
 
   std::vector<std::vector<std::shared_ptr<torch::autograd::Node>>>
       grad_accumulators_;
-  std::unordered_map<torch::autograd::Node*, std::vector<VariableIndex>>
-      gradAccToVariablesMap_;
+  std::unordered_map<torch::autograd::Node*, VariableIndex>
+      gradAccToVariableMap_;
   std::vector<std::pair<uintptr_t, std::shared_ptr<torch::autograd::Node>>>
       hooks_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

https://github.com/pytorch/pytorch/pull/53279/files has landed
deduplicating the shared params in python before constructing reducer. Because
of this, we no longer need the changes in
https://github.com/pytorch/pytorch/pull/46755/files.

This is already tested by `test_ddp_shared_grad_acc_unused_params` and
`test_ddp_weight_sharing`

Differential Revision: [D27015466](https://our.internmc.facebook.com/intern/diff/D27015466/)