### PR TITLE
Tensor::register_hook: Avoid wrapping hook in two levels of std::function

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -881,8 +881,9 @@ template <typename T>
 auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_void_t<T> {
   // Return the grad argument in case of a hook with void return type to have an
   // std::function with Tensor return type
-  std::function<void(Tensor)> fn(hook);
-  return _register_hook([fn](const Tensor& grad) {
+  static_assert(std::is_same<decltype(hook(Tensor())), void>::value,
+                "Expected hook to return void");
+  return _register_hook([fn=std::forward<T>(hook)](const Tensor& grad) {
     fn(grad);
     return Tensor();
   });
@@ -890,7 +891,7 @@ auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_void_t<T> {
 
 template <typename T>
 auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_var_t<T> {
-  return _register_hook(hook);
+  return _register_hook(std::forward<T>(hook));
 }
 
 namespace detail {


### PR DESCRIPTION
The void overload of `register_hook` puts the user's callable into a `std::function` which is used in a lambda, then `_register_hook` wraps that lambda in another `std::function`. This is bad because each call goes through two indirections and also it requires more heap allocations.

Instead, the lambda can capture the original callable without wrapping it in an `std::function` first.