### PR TITLE
[StaticRuntime] Fuse SigridTransforms + ListUnpack

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -4,6 +4,8 @@ namespace torch {
 namespace jit {
 
 void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph);
+void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+
 void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 
 void SplitOutPrecomputeOpsForSparseNN(


### PR DESCRIPTION
Summary:
Fusing SigridTransforms + ListUnpack allows for enabling out variant for SigridTransforms so that the output tensors can be managed by the MemoryPlanner in Static Runtime.

The speedup comes from three parts 1) get rid of memory allocation inside SigridTransforms itself, 2) memory deallocation cost (outside SigridTransforms, inside MemoryPlanner), 3) get rid of ListUnpack. However, in 3) we still need to pay the cost of constructing `vector<Tensor>` for outputs and a round of refcount bumps for all the output TensorImpls.

Differential Revision: D26220546

