### PR TITLE
Fix prefix store timeout bug

### DIFF
--- a/torch/lib/c10d/PrefixStore.cpp
+++ b/torch/lib/c10d/PrefixStore.cpp
@@ -67,4 +67,12 @@ void PrefixStore::wait(
   store_->wait(joinedKeys, timeout);
 }
 
+const std::chrono::milliseconds& PrefixStore::getTimeout() const noexcept {
+  return store_->getTimeout();
+}
+
+void PrefixStore::setTimeout(const std::chrono::milliseconds& timeout) {
+  store_->setTimeout(timeout);
+}
+
 } // namespace c10d

--- a/torch/lib/c10d/PrefixStore.hpp
+++ b/torch/lib/c10d/PrefixStore.hpp
@@ -36,6 +36,10 @@ class PrefixStore : public Store {
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) override;
 
+  const std::chrono::milliseconds& getTimeout() const noexcept override;
+
+  void setTimeout(const std::chrono::milliseconds& timeout) override;
+
  protected:
   std::string prefix_;
   c10::intrusive_ptr<Store> store_;

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -17,7 +17,7 @@ class Store : public torch::CustomClassHolder {
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 
-  Store() {}
+  Store() : timeout_(kDefaultTimeout) {}
 
   explicit Store(const std::chrono::milliseconds& timeout)
       : timeout_(timeout) {}

--- a/torch/lib/c10d/Store.hpp
+++ b/torch/lib/c10d/Store.hpp
@@ -17,7 +17,7 @@ class Store : public torch::CustomClassHolder {
   static constexpr std::chrono::milliseconds kNoTimeout =
       std::chrono::milliseconds::zero();
 
-  Store() : timeout_(kDefaultTimeout) {}
+  Store() {}
 
   explicit Store(const std::chrono::milliseconds& timeout)
       : timeout_(timeout) {}
@@ -51,9 +51,9 @@ class Store : public torch::CustomClassHolder {
       const std::vector<std::string>& keys,
       const std::chrono::milliseconds& timeout) = 0;
 
-  const std::chrono::milliseconds& getTimeout() const noexcept;
+  virtual const std::chrono::milliseconds& getTimeout() const noexcept;
 
-  void setTimeout(const std::chrono::milliseconds& timeout);
+  virtual void setTimeout(const std::chrono::milliseconds& timeout);
 
  protected:
   std::chrono::milliseconds timeout_;

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -8,6 +8,8 @@
 #include <c10d/HashStore.hpp>
 #include <c10d/PrefixStore.hpp>
 
+constexpr int64_t kShortStoreTimeoutMillis = 100;
+
 void testGetSet(std::string prefix = "") {
   // Basic set/get
   {
@@ -27,6 +29,8 @@ void testGetSet(std::string prefix = "") {
     EXPECT_EQ(numKeys, 2);
     auto delFailure = store.deleteKey("badKeyName");
     EXPECT_FALSE(delFailure);
+    auto timeout = std::chrono::milliseconds(kShortStoreTimeoutMillis);
+    store.setTimeout(timeout);
     EXPECT_THROW(store.get("key0"), std::runtime_error);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53928 Fix prefix store timeout bug**

HashStoreTest was taking forever to run. Turns out it was because a default timeout is set when creating Store() and setTimeout for prefixStore is not actually able to change the timeout of the underlying store.

After removing the default timeout and updating setTimeout, this will save ~10 minutes for all of the [gcc_test CI runs](https://app.circleci.com/pipelines/github/pytorch/pytorch/285205/workflows/1d171e45-8ff2-4c99-a5d6-969069ace2e9/jobs/11536097).

Differential Revision: [D27025275](https://our.internmc.facebook.com/intern/diff/D27025275)