### PR TITLE
[PyTorch] RFC: Add C10_DISABLE_AUTOGRAD flag for performance

### DIFF
--- a/aten/src/ATen/core/LegacyTypeDispatch.h
+++ b/aten/src/ATen/core/LegacyTypeDispatch.h
@@ -44,6 +44,11 @@ namespace at {
 // out of VariableType.
 
 struct TORCH_API AutoNonVariableTypeMode {
+#ifdef C10_DISABLE_AUTOGRAD
+  AutoNonVariableTypeMode(bool enabled = true) {
+    TORCH_INTERNAL_ASSERT(enabled);
+  }
+#else
   // NB: The enabled parameter must ALWAYS be black, as Henry Ford used to say.
   // TODO: Eliminate this parameter entirely
   AutoNonVariableTypeMode(bool enabled = true) :
@@ -54,6 +59,7 @@ struct TORCH_API AutoNonVariableTypeMode {
 
   // disable all autograd dispatch keys
   c10::impl::ExcludeDispatchKeyGuard autograd_guard_;
+#endif
 };
 
 } // namespace at

--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -19,6 +19,13 @@ namespace impl {
 // moved to TensorImpl constructor.
 const DispatchKeySet always_included{DispatchKey::BackendSelect};
 
+#ifdef C10_DISABLE_AUTOGRAD
+constexpr DispatchKeySet always_excluded{c10::autograd_dispatch_keyset};
+#else
+// TODO: inspect dispatcher, make sure this is optimized out
+constexpr DispatchKeySet always_excluded;
+#endif
+
 // Take a DispatchKeySet for a Tensor and determine what the actual dispatch
 // DispatchKey should be, taking into account TLS, and skipping backends which
 // fall through.
@@ -49,7 +56,7 @@ static inline DispatchKeySet computeDispatchKeySet(
   // it's a bit troublesome, because fastpath TLS access requires the type of
   // the TLS in question to be zero-initialized, so you don't actually win
   // anyting in that case.
-  return (((ks | local.included_ | always_included) - local.excluded_) & key_mask);
+  return (((ks | local.included_ | always_included) - local.excluded_ - always_excluded) & key_mask);
 }
 
 }

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -394,7 +394,9 @@ void TensorImpl::copy_tensor_metadata(
     const c10::VariableVersion& version_counter,
     bool allow_tensor_metadata_change) {
   copy_tensor_metadata_except_version_counter(src_impl, dest_impl, allow_tensor_metadata_change);
+#ifndef C10_DISABLE_AUTOGRAD
   dest_impl->set_version_counter(version_counter);
+#endif
 }
 
 void TensorImpl::copy_tensor_metadata(
@@ -403,7 +405,9 @@ void TensorImpl::copy_tensor_metadata(
     c10::VariableVersion&& version_counter,
     bool allow_tensor_metadata_change) {
   copy_tensor_metadata_except_version_counter(src_impl, dest_impl, allow_tensor_metadata_change);
+#ifndef C10_DISABLE_AUTOGRAD
   dest_impl->set_version_counter(std::move(version_counter));
+#endif
 }
 
 namespace impl {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#53939 [PyTorch] RFC: Add C10_DISABLE_AUTOGRAD flag for performance**

Most (all?) inference workloads don't need autograd by
definition. We don't need to allocate a version counter for these
workloads or even reserve space for it in TensorImpl.

Open issues:
- Proliferating flags like this will blow up our testing matrix
  (though we don't seem to worry too much about that with the flags we
  have already)

Differential Revision: [D27026970](https://our.internmc.facebook.com/intern/diff/D27026970/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27026970/)!