### PR TITLE
Skips test_linalg_lstsq on ROCm

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6900,11 +6900,11 @@ else:
         self.assertEqual(b, b_placeholder)
         self.assertEqual(c, c_placeholder)
 
-    # https://github.com/pytorch/pytorch/issues/53976 tracks ROCm skip
-    @skipCUDAIfRocm
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.double)
+    # https://github.com/pytorch/pytorch/issues/53976 tracks ROCm skip
+    @skipCUDAIfRocm
     def test_lstsq(self, device, dtype):
         def _test_underdetermined(a, b, expectedNorm):
             # underdetermined systems are only supported on CPU

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -117,6 +117,8 @@ class TestLinalg(TestCase):
         run_test_case(zero_strided, b)
         run_test_case(a, zero_strided)
 
+    # https://github.com/pytorch/pytorch/issues/53976 tracks ROCm skip
+    @skipCUDAIfRocm
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.float, torch.double, torch.cfloat, torch.cdouble)
@@ -6903,8 +6905,6 @@ else:
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.double)
-    # https://github.com/pytorch/pytorch/issues/53976 tracks ROCm skip
-    @skipCUDAIfRocm
     def test_lstsq(self, device, dtype):
         def _test_underdetermined(a, b, expectedNorm):
             # underdetermined systems are only supported on CPU

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6900,6 +6900,8 @@ else:
         self.assertEqual(b, b_placeholder)
         self.assertEqual(c, c_placeholder)
 
+    # https://github.com/pytorch/pytorch/issues/53976 tracks ROCm skip
+    @skipCUDAIfRocm
     @skipCUDAIfNoMagma
     @skipCPUIfNoLapack
     @dtypes(torch.double)


### PR DESCRIPTION
This test is flaky (tracked in https://github.com/pytorch/pytorch/issues/53976). This PR skips it to let the rest of the ROCm CI run.

cc @nikitaved 