### PR TITLE
Dispatcher: split OperatorHandle in two: OperatorCleanup & OperatorHandle

### DIFF
--- a/aten/src/ATen/core/dispatch/OperatorEntry.h
+++ b/aten/src/ATen/core/dispatch/OperatorEntry.h
@@ -150,7 +150,7 @@ public:
 
   // Asserts that the given FuncType is correct for calling this operator in an unboxed way.
   template<class FuncType>
-  void assertSignatureIsCorrect() {
+  void assertSignatureIsCorrect() const {
     if (C10_UNLIKELY(cpp_signature_.has_value() && (CppSignature::make<FuncType>() != cpp_signature_->signature))) {
       reportSignatureError(CppSignature::make<FuncType>().name());
     }


### PR DESCRIPTION
Dispatcher: split OperatorHandle in two:
 - OperatorCleanup that enables quick deregister
 - OperatorHandle for dispatching

This makes us 1) save memory by specializing the classes to the user's needs
and 2) faster dispatch by removing an indirection through OperatorDef

Once this PR and #53893 are merged, I'll create a new to optimize the dispatching further by removing the optional<>, further reducing memory consumption & improve speed (one less load in the fast path).

cc @swolchok @bhosmer @smessmer