### PR TITLE
SVD docs improved

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -130,7 +130,7 @@ class AbstractTestCases:
             from torch._torch_docs import __file__ as doc_file
             from torch._torch_docs import multi_dim_common, single_dim_common, factory_common_args, factory_like_common_args
 
-            with open(doc_file, "r") as f:
+            with open(doc_file, "r", encoding="utf-8") as f:
                 doc_strs = f.read()
 
             for doc_str in re.findall(r'add_docstr\((.*?),.*?("""|\'\'\')(.*?)("""|\'\'\')\)', doc_strs, re.MULTILINE | re.DOTALL):

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8481,12 +8481,13 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: Extra care needs to be taken when differentiating with respect to `U` and `V`. Such
-             operation is only well-defined when all singular values are distinct. If the distance
-             between any two singular values is close to zero, the backwards pass will be
-             unstable, as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
-             When there are repeated singular values, the gradient with respect to `U` and `V`
-             will be infinity in some directions.
+.. warning:: The gradients with respect to `U` and `V` will only be finite when the input does not
+             have zero nor repeated singular values.
+
+.. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
+             `U` and `V` will be numerically unstable, as they depends on
+             :math:`\frac{1}{\min_{i \neq j} |\sigma_i^2 - \sigma_j^2|}`. The same happens when the matrix
+             has small singular values, as these gradients also depend on `S⁻¹`.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8440,11 +8440,10 @@ value decomposition. In this case, if the last two dimensions of :attr:`input` a
 ``m`` and ``n``, then the returned ``U`` and ``V`` matrices will contain only
 ``min(n, m)`` orthonormal columns.
 
-
 If :attr:`compute_uv` is ``False``, the returned ``U`` and ``V`` will be
-zero-filled matrices of shape ``(m × m)`` and ``(n × n)``
-respectively, and the same device as :attr:`input`. The :attr:`some`
-argument has no effect when :attr:`compute_uv` is ``False``.
+zero-filled matrices of shape ``(m, m)`` and ``(n, n)``
+respectively, and the same device as :attr:`input`. The argument :attr:`some`
+has no effect when :attr:`compute_uv` is ``False``.
 
 Supports :attr:`input` of float, double, cfloat and cdouble data types.
 The dtypes of ``U`` and ``V`` are the same as :attr:`input`'s. ``S`` will
@@ -8500,7 +8499,7 @@ always be real-valued, even if :attr:`input` is complex.
 
 Args:
     input (Tensor): the input tensor of size ``(*, m, n)`` where ``*`` is zero or more
-                    batch dimensions consisting of ``(m × n)`` matrices.
+                    batch dimensions consisting of ``(m, n)`` matrices.
     some (bool, optional): controls whether to compute the reduced or full decomposition, and
                            consequently the shape of returned ``U`` and ``V``. Default: ``True``.
     compute_uv (bool, optional): option whether to compute ``U`` and ``V`` or not. Default: ``True``.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -2060,7 +2060,7 @@ add_docstr(torch.conj,
            r"""
 conj(input, *, out=None) -> Tensor
 
-Computes the element-wise conjugate of the given :attr:`input` tensor. If :attr`input` has a non-complex dtype,
+Computes the element-wise conjugate of the given :attr:`input` tensor. If :attr:`input` has a non-complex dtype,
 this function just returns :attr:`input`.
 
 .. warning:: In the future, :func:`torch.conj` may return a non-writeable view for an :attr:`input` of

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8486,7 +8486,7 @@ always be real-valued, even if :attr:`input` is complex.
 
 .. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
              `U` and `V` will be numerically unstable, as they depends on
-             :math:`\frac{1}{\min_{i \neq j} |\sigma_i^2 - \sigma_j^2|}`. The same happens when the matrix
+             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when the matrix
              has small singular values, as these gradients also depend on `S⁻¹`.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8482,8 +8482,9 @@ always be real-valued, even if :attr:`input` is complex.
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
 .. warning:: Extra care needs to be taken when differentiating with respect to `U` and `V`. Such
-             operation is only well-defined when all singular values are distinct. The backwards
-             pass becomes less stable as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`r
+             operation is only well-defined when all singular values are distinct. If the distance
+             between any two singular values is close to zero, the backwards pass will be
+             unstable, as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
              When there are repeated singular values, the gradient with respect to `U` and `V`
              will be infinity in some directions.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8499,8 +8499,8 @@ Args:
     input (Tensor): the input tensor of size `(*, m, n)` where `*` is zero or more
                     batch dimensions consisting of `(m, n)` matrices.
     some (bool, optional): controls whether to compute the reduced or full decomposition, and
-                           consequently the shape of returned `U` and `V`. Default: `True`.
-    compute_uv (bool, optional): option whether to compute `U` and `V` or not. Default: `True`.
+                           consequently, the shape of returned `U` and `V`. Default: `True`.
+    compute_uv (bool, optional): controls whether to compute `U` and `V`. Default: `True`.
 
 Keyword args:
     out (tuple, optional): the output tuple of tensors

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8491,7 +8491,7 @@ always be real-valued, even if :attr:`input` is complex.
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
-             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.  # noqa: E501
+             and `the resulting vectors will span the same subspace`_.
              Different platforms, like NumPy, or inputs on different device types,
              may produce different `U` and `V` tensors.
 
@@ -8534,6 +8534,9 @@ Example::
     >>> torch.dist(a_big, torch.matmul(torch.matmul(u, torch.diag_embed(s)), v.transpose(-2, -1)))
     tensor(2.6503e-06)
 
+.. _the resulting vectors will span the same subspace:
+    (https://en.wikipedia.org/wiki/Singular_value_decomposition\
+            #Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
 """)
 
 add_docstr(torch.symeig, r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8474,7 +8474,7 @@ always be real-valued, even if :attr:`input` is complex.
           and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
 
 .. note:: The returned matrix ``U`` will not be contiguous. It will be represented as a
-          column-major (i.e. fortran-contiguous) matrix.
+          column-major matrix (i.e. fortran-contiguous).
 
 .. note:: Gradients computed using ``U`` and ``V`` may be unstable if :attr:`input` has
           repeated non-unique singular values, e.g., when it is not full-rank.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8491,7 +8491,7 @@ always be real-valued, even if :attr:`input` is complex.
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
-             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.
+             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.  # noqa: E501
              Different platforms, like NumPy, or inputs on different device types,
              may produce different `U` and `V` tensors.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8535,8 +8535,7 @@ Example::
     tensor(2.6503e-06)
 
 .. _the resulting vectors will span the same subspace:
-    (https://en.wikipedia.org/wiki/Singular_value_decomposition\
-            #Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
+       (https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
 """)
 
 add_docstr(torch.symeig, r"""

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8428,9 +8428,8 @@ svd(input, some=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
 Computes the singular value decomposition of either a matrix or batch of
 matrices :attr:`input`. The singular value decomposition is represented as a
-namedtuple ``(U, S, V)``, such that
-:math:`\texttt{input} = \texttt{U} \operatorname{diag}(\texttt{S}) \texttt{V}^{\text{H}}`
-where :math:`\texttt{V}^{\text{H}}` is the transpose of ``V`` for real inputs,
+namedtuple ``(U, S, V)``, such that ``input = U diag(S) Vᴴ``.
+where ``Vᴴ`` is the transpose of ``V`` for real inputs,
 and the conjugate transpose of ``V`` for complex inputs.
 If :attr:`input` is a batch of matrices, then ``U``, ``S``, and ``V`` are also
 batched with the same batch dimensions as :attr:`input`.
@@ -8468,17 +8467,17 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
           then the singular values of each matrix in the batch are returned in descending order.
 
-.. note:: The implementation of SVD on CPU uses the LAPACK routine ``?gesdd`` (a divide-and-conquer
-          algorithm) instead of ``?gesvd`` for speed. Analogously, the SVD on GPU uses the
-          cuSOLVER routines ``gesvdj`` and ``gesvdjBatched`` on CUDA 10.1.243 and later,
-          and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
+.. note:: The implementation of :func:`torch.svd` on CPU uses the LAPACK routine ``?gesdd``
+          (a divide-and-conquer algorithm) instead of ``?gesvd`` for speed. Analogously,
+          :func:`torch.svd` on GPU uses the cuSOLVER routines ``gesvdj`` and ``gesvdjBatched``
+          on CUDA 10.1.243 and later, and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
 
 .. note:: The returned matrix ``U`` will not be contiguous. It will be represented as a
-          column-major matrix (i.e. fortran-contiguous).
+          column-major matrix (i.e. Fortran-contiguous).
 
 .. note:: Gradients computed using ``U`` and ``V`` may be unstable if :attr:`input` has
           repeated non-unique singular values, e.g., when it is not full-rank.
-          See also the last note in this list.
+          See also the note below on complex gradients.
 
 .. note:: When :attr:`some` is ``False``, the gradients on ``U[..., :, min(m, n):]``
           and ``V[..., :, min(m, n):]`` will be ignored in backward as those vectors
@@ -8486,14 +8485,14 @@ always be real-valued, even if :attr:`input` is complex.
 
 .. note:: The ``S`` tensor can only be used to compute gradients if :attr:`compute_uv` is ``True``.
 
-.. note:: For complex-valued :attr:`input` the SVD is not unique, as ``U`` and ``V`` may
-          be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
+.. note:: For complex-valued :attr:`input` the singular value decomposition is not unique,
+          as ``U`` and ``V`` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
           The same happens when :attr:`input` has repeated singular values, where one may multiply
           the columns of the spanning subspace in ``U`` and ``V`` by a rotation matrix
           and the resulting vectors will span the same subspace.
-          Different platforms, like Numpy, or inputs on different device types,
+          Different platforms, like NumPy, or inputs on different device types,
           may produce different ``U`` and ``V`` tensors.
-          In these cases, the backward operation is only well-defined when the cost-function
+          In these cases, the gradient is only well-defined when the cost-function
           is invariant under these transformations, i.e., when it just depends on the spanned
           subspaces and not on the particular basis.
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8483,7 +8483,9 @@ always be real-valued, even if :attr:`input` is complex.
 
 .. warning:: Extra care needs to be taken when differentiating with respect to `U` and `V`. Such
              operation is only well-defined when all singular values are distinct. The backwards
-             pass becomes less stable the smaller :math:`\min_{i \neq j} |\sigma_i - \sigma_j|` is.
+             pass becomes less stable as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`r
+             When there are repeated singular values, the gradient with respect to `U` and `V`
+             will be infinity in some directions.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
@@ -8492,8 +8494,6 @@ always be real-valued, even if :attr:`input` is complex.
              and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.
              Different platforms, like NumPy, or inputs on different device types,
              may produce different `U` and `V` tensors.
-             In these cases, the gradient with respect to `U` and `V` will be infinity in some
-             directions.
 
 Args:
     input (Tensor): the input tensor of size `(*, m, n)` where `*` is zero or more

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -830,60 +830,69 @@ linalg.svd(input, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, 
 
 Computes the singular value decomposition of either a matrix or batch of
 matrices :attr:`input`." The singular value decomposition is represented as a
-namedtuple ``(U, S, Vh)``, such that :math:`input = U \mathbin{@} diag(S) \times
-Vh`. If :attr:`input` is a batch of tensors, then ``U``, ``S``, and ``Vh`` are
+namedtuple ``(U, S, Vh)``, such that
+:math:`\texttt{input} = \texttt{U} \operatorname{diag}(\texttt{S}) \texttt{Vh}`.
+If :attr:`input` is a batch of matrices, then ``U``, ``S``, and ``Vh`` are
 also batched with the same batch dimensions as :attr:`input`.
 
-If :attr:`full_matrices` is ``False`` (default), the method returns the reduced singular
-value decomposition i.e., if the last two dimensions of :attr:`input` are
-``m`` and ``n``, then the returned `U` and `V` matrices will contain only
-:math:`min(n, m)` orthonormal columns.
+If :attr:`full_matrices` is ``False``, the method returns the reduced singular
+value decomposition. In this case, if the last two dimensions of :attr:`input` are
+``m`` and ``n``, then the returned ``U`` and ``Vh`` matrices will contain only
+``min(n, m)`` orthonormal columns.
 
-If :attr:`compute_uv` is ``False``, the returned `U` and `Vh` will be empy
+If :attr:`compute_uv` is ``False``, the returned ``U`` and ``Vh`` will be empty
 tensors with no elements and the same device as :attr:`input`. The
 :attr:`full_matrices` argument has no effect when :attr:`compute_uv` is False.
 
-The dtypes of ``U`` and ``V`` are the same as :attr:`input`'s. ``S`` will
+The dtypes of ``U`` and ``Vh`` are the same as :attr:`input`'s. ``S`` will
 always be real-valued, even if :attr:`input` is complex.
 
 .. note:: Unlike NumPy's ``linalg.svd``, this always returns a namedtuple of
-          three tensors, even when :attr:`compute_uv=False`. This behavior may
+          three tensors, even when :attr:`compute_uv` is ``False``. This behavior may
           change in a future PyTorch release.
 
 .. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
           then the singular values of each matrix in the batch is returned in descending order.
 
-.. note:: The implementation of SVD on CPU uses the LAPACK routine `?gesdd` (a divide-and-conquer
-          algorithm) instead of `?gesvd` for speed. Analogously, the SVD on GPU uses the cuSOLVER routines
-          `gesvdj` and `gesvdjBatched` on CUDA 10.1.243 and later, and uses the MAGMA routine `gesdd`
-          on earlier versions of CUDA.
+.. note:: The implementation of SVD on CPU uses the LAPACK routine ``?gesdd`` (a divide-and-conquer
+          algorithm) instead of ``?gesvd`` for speed. Analogously, the SVD on GPU uses the
+          cuSOLVER routines ``gesvdj`` and ``gesvdjBatched`` on CUDA 10.1.243 and later,
+          and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
 
-.. note:: The returned matrix `U` will be transposed, i.e. with strides
-          :code:`U.contiguous().transpose(-2, -1).stride()`.
+.. note:: The returned matrix ``U`` will not be contiguous. It will be represented as a
+          column-major (i.e. fortran-contiguous) matrix.
 
-.. note:: Gradients computed using `U` and `Vh` may be unstable if
-          :attr:`input` is not full rank or has non-unique singular values.
+.. note:: Gradients computed using ``U`` and ``V`` may be unstable if :attr:`input` has
+          repeated non-unique singular values, e.g., when it is not full-rank.
+          See also the last note in this list.
 
-.. note:: When :attr:`full_matrices` = ``True``, the gradients on :code:`U[..., :, min(m, n):]`
-          and :code:`V[..., :, min(m, n):]` will be ignored in backward as those vectors
+.. note:: When :attr:`full_matrices` is ``True``, the gradients on ``U[..., :, min(m, n):]``
+          and ``V[..., :, min(m, n):]`` will be ignored in backward as those vectors
           can be arbitrary bases of the subspaces.
 
-.. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv` is True.
+.. note:: The ``S`` tensor can only be used to compute gradients if :attr:`compute_uv` is ``True``.
 
-.. note:: Since `U` and `V` of an SVD is not unique, each vector can be multiplied by
-          an arbitrary phase factor :math:`e^{i \phi}` while the SVD result is still correct.
-          Different platforms, like Numpy, or inputs on different device types, may produce different
-          `U` and `V` tensors.
+.. note:: For complex-valued :attr:`input` the SVD is not unique, as ``U`` and ``V`` may
+          be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
+          The same happens when :attr:`input` has repeated singular values, where one may multiply
+          the columns of the spanning subspace in ``U`` and ``Vh`` by a rotation matrix
+          and the resulting vectors will span the same subspace.
+          Different platforms, like Numpy, or inputs on different device types,
+          may produce different ``U`` and ``Vh`` tensors.
+          In these cases, the backward operation is only well-defined when the cost-function
+          is invariant under these transformations, i.e., when it just depends on the spanned
+          subspaces and not on the particular basis.
+
 
 Args:
-    input (Tensor): the input tensor of size :math:`(*, m, n)` where `*` is zero or more
+    input (Tensor): the input tensor of size :math:`(*, m, n)` where ``*`` is zero or more
                     batch dimensions consisting of :math:`m \times n` matrices.
     full_matrices (bool, optional): controls whether to compute the full or reduced decomposition, and
-                                    consequently the shape of returned ``U`` and ``V``. Defaults to True.
-    compute_uv (bool, optional): whether to compute `U` and `V` or not. Defaults to True.
-    out (tuple, optional): a tuple of three tensors to use for the outputs. If compute_uv=False,
-                           the 1st and 3rd arguments must be tensors, but they are ignored. E.g. you can
-                           pass `(torch.tensor([]), out_S, torch.tensor([]))`
+                                    consequently the shape of returned ``U`` and ``Vh``. Default: ``True``.
+    compute_uv (bool, optional): whether to compute ``U`` and ``Vh`` or not. Default: ``True``.
+    out (tuple, optional): a tuple of three tensors to use for the outputs. If ``compute_uv=False``,
+                           the 1st and 3rd arguments must be tensors, but they are ignored.
+                           For example, you can pass `(torch.tensor([]), out_S, torch.tensor([]))`
 
 Example::
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -885,9 +885,9 @@ always be real-valued, even if :attr:`input` is complex.
 Args:
     input (Tensor): the input tensor of size `(*, m, n)` where `*` is zero or more
                     batch dimensions consisting of `(m, n)` matrices.
-    full_matrices (bool, optional): controls whether to compute the full or reduced decomposition. and
-                                    consequently the shape of returned `U` and `Vh`. Default: `True`.
-    compute_uv (bool, optional): whether to compute `U` and `Vh` or not. Default: `True`.
+    full_matrices (bool, optional): controls whether to compute the full or reduced decomposition, and
+                                    consequently, the shape of returned `U` and `Vh`. Default: `True`.
+    compute_uv (bool, optional): controls whether to compute `U` and `Vh`. Default: `True`.
     out (tuple, optional): a tuple of three tensors to use for the outputs.
                            If :attr`compute_uv` is `False`, the 1st and 3rd arguments must be tensors,
                            but they are ignored.  For example, you can pass

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -867,12 +867,13 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: Extra care needs to be taken when differentiating with respect to `U` and `Vh`. Such
-             operation is only well-defined when all singular values are distinct. If the distance
-             between any two singular values is close to zero, the backwards pass will be
-             unstable, as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
-             When there are repeated singular values, the gradient with respect to `U` and `Vh`
-             will be infinity in some directions.
+.. warning:: The gradients with respect to `U` and `Vh` will only be finite when the input does not
+             have zero nor repeated singular values.
+
+.. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
+             `U` and `Vh` will be numerically unstable, as they depends on
+             :math:`\frac{1}{\min_{i \neq j} |\sigma_i^2 - \sigma_j^2|}`. The same happens when the matrix
+             has small singular values, as these gradients also depend on `S⁻¹`.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -852,7 +852,7 @@ always be real-valued, even if :attr:`input` is complex.
           change in a future PyTorch release.
 
 .. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-          then the singular values of each matrix in the batch is returned in descending order.
+          then the singular values of each matrix in the batch are returned in descending order.
 
 .. note:: The implementation of SVD on CPU uses the LAPACK routine ``?gesdd`` (a divide-and-conquer
           algorithm) instead of ``?gesvd`` for speed. Analogously, the SVD on GPU uses the
@@ -860,7 +860,7 @@ always be real-valued, even if :attr:`input` is complex.
           and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
 
 .. note:: The returned matrix ``U`` will not be contiguous. It will be represented as a
-          column-major (i.e. fortran-contiguous) matrix.
+          column-major matrix (i.e. fortran-contiguous).
 
 .. note:: Gradients computed using ``U`` and ``V`` may be unstable if :attr:`input` has
           repeated non-unique singular values, e.g., when it is not full-rank.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -926,8 +926,7 @@ Example::
     tensor(3.0957e-06)
 
 .. _the resulting vectors will span the same subspace:
-    (https://en.wikipedia.org/wiki/Singular_value_decomposition\
-            #Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
+       (https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
 """)
 
 cond = _add_docstr(_linalg.linalg_cond, r"""

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -889,7 +889,7 @@ Args:
                                     consequently, the shape of returned `U` and `Vh`. Default: `True`.
     compute_uv (bool, optional): controls whether to compute `U` and `Vh`. Default: `True`.
     out (tuple, optional): a tuple of three tensors to use for the outputs.
-                           If :attr`compute_uv` is `False`, the 1st and 3rd arguments must be tensors,
+                           If :attr:`compute_uv` is `False`, the 1st and 3rd arguments must be tensors,
                            but they are ignored.  For example, you can pass
                            ``(torch.tensor([]), out_S, torch.tensor([]))``
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -877,7 +877,7 @@ always be real-valued, even if :attr:`input` is complex.
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
-             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.  # noqa: E501
+             and `the resulting vectors will span the same subspace`_.
              Different platforms, like NumPy, or inputs on different device types,
              may produce different `U` and `Vh` tensors.
 
@@ -924,6 +924,10 @@ Example::
     >>> u, s, vh = torch.linalg.svd(a_big, full_matrices=False)
     >>> torch.dist(a_big, u @ torch.diag_embed(s) @ vh)
     tensor(3.0957e-06)
+
+.. _the resulting vectors will span the same subspace:
+    (https://en.wikipedia.org/wiki/Singular_value_decomposition\
+            #Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
 """)
 
 cond = _add_docstr(_linalg.linalg_cond, r"""

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -868,8 +868,9 @@ always be real-valued, even if :attr:`input` is complex.
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
 .. warning:: Extra care needs to be taken when differentiating with respect to `U` and `Vh`. Such
-             operation is only well-defined when all singular values are distinct. The backwards
-             pass becomes less stable as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
+             operation is only well-defined when all singular values are distinct. If the distance
+             between any two singular values is close to zero, the backwards pass will be
+             unstable, as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
              When there are repeated singular values, the gradient with respect to `U` and `Vh`
              will be infinity in some directions.
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -872,7 +872,7 @@ always be real-valued, even if :attr:`input` is complex.
 
 .. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
              `U` and `Vh` will be numerically unstable, as they depends on
-             :math:`\frac{1}{\min_{i \neq j} |\sigma_i^2 - \sigma_j^2|}`. The same happens when the matrix
+             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when the matrix
              has small singular values, as these gradients also depend on `S⁻¹`.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -830,8 +830,7 @@ linalg.svd(input, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, 
 
 Computes the singular value decomposition of either a matrix or batch of
 matrices :attr:`input`." The singular value decomposition is represented as a
-namedtuple ``(U, S, Vh)``, such that
-:math:`\texttt{input} = \texttt{U} \operatorname{diag}(\texttt{S}) \texttt{Vh}`.
+namedtuple ``(U, S, Vh)``, such that ``input = U diag(S) Vh``.
 If :attr:`input` is a batch of matrices, then ``U``, ``S``, and ``Vh`` are
 also batched with the same batch dimensions as :attr:`input`.
 
@@ -854,17 +853,17 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
           then the singular values of each matrix in the batch are returned in descending order.
 
-.. note:: The implementation of SVD on CPU uses the LAPACK routine ``?gesdd`` (a divide-and-conquer
-          algorithm) instead of ``?gesvd`` for speed. Analogously, the SVD on GPU uses the
-          cuSOLVER routines ``gesvdj`` and ``gesvdjBatched`` on CUDA 10.1.243 and later,
-          and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
+.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses the LAPACK routine ``?gesdd``
+          (a divide-and-conquer algorithm) instead of ``?gesvd`` for speed. Analogously,
+          :func:`torch.linalg.svd` on GPU uses the cuSOLVER routines ``gesvdj`` and ``gesvdjBatched``
+          on CUDA 10.1.243 and later, and uses the MAGMA routine ``gesdd`` on earlier versions of CUDA.
 
 .. note:: The returned matrix ``U`` will not be contiguous. It will be represented as a
-          column-major matrix (i.e. fortran-contiguous).
+          column-major matrix (i.e. Fortran-contiguous).
 
 .. note:: Gradients computed using ``U`` and ``V`` may be unstable if :attr:`input` has
           repeated non-unique singular values, e.g., when it is not full-rank.
-          See also the last note in this list.
+          See also the note below on complex gradients.
 
 .. note:: When :attr:`full_matrices` is ``True``, the gradients on ``U[..., :, min(m, n):]``
           and ``V[..., :, min(m, n):]`` will be ignored in backward as those vectors
@@ -872,27 +871,26 @@ always be real-valued, even if :attr:`input` is complex.
 
 .. note:: The ``S`` tensor can only be used to compute gradients if :attr:`compute_uv` is ``True``.
 
-.. note:: For complex-valued :attr:`input` the SVD is not unique, as ``U`` and ``V`` may
-          be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
+.. note:: For complex-valued :attr:`input` the singular value decomposition is not unique,
+          as ``U`` and ``V`` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
           The same happens when :attr:`input` has repeated singular values, where one may multiply
-          the columns of the spanning subspace in ``U`` and ``Vh`` by a rotation matrix
+          the columns of the spanning subspace in ``U`` and ``V`` by a rotation matrix
           and the resulting vectors will span the same subspace.
-          Different platforms, like Numpy, or inputs on different device types,
-          may produce different ``U`` and ``Vh`` tensors.
-          In these cases, the backward operation is only well-defined when the cost-function
+          Different platforms, like NumPy, or inputs on different device types,
+          may produce different ``U`` and ``V`` tensors.
+          In these cases, the gradient is only well-defined when the cost-function
           is invariant under these transformations, i.e., when it just depends on the spanned
           subspaces and not on the particular basis.
 
-
 Args:
-    input (Tensor): the input tensor of size :math:`(*, m, n)` where ``*`` is zero or more
-                    batch dimensions consisting of :math:`m \times n` matrices.
+    input (Tensor): the input tensor of size ``(*, m, n)`` where ``*`` is zero or more
+                    batch dimensions consisting of ``(m, n)`` matrices.
     full_matrices (bool, optional): controls whether to compute the full or reduced decomposition, and
                                     consequently the shape of returned ``U`` and ``Vh``. Default: ``True``.
     compute_uv (bool, optional): whether to compute ``U`` and ``Vh`` or not. Default: ``True``.
     out (tuple, optional): a tuple of three tensors to use for the outputs. If ``compute_uv=False``,
                            the 1st and 3rd arguments must be tensors, but they are ignored.
-                           For example, you can pass `(torch.tensor([]), out_S, torch.tensor([]))`
+                           For example, you can pass ``(torch.tensor([]), out_S, torch.tensor([]))``
 
 Example::
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -856,7 +856,7 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv` is `True`.
 
 .. note:: When :attr:`full_matrices` is `True`, the gradients on `U[..., :, min(m, n):]`
-          and `V[..., :, min(m, n):]` will be ignored in the backwards pass, as those vectors
+          and `Vh[..., min(m, n):, :]` will be ignored in the backwards pass, as those vectors
           can be arbitrary bases of the corresponding subspaces.
 
 .. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `?gesdd`
@@ -867,10 +867,10 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: Extra care needs to be taken when differentiating with respect to `U` and `V`. Such
+.. warning:: Extra care needs to be taken when differentiating with respect to `U` and `Vh`. Such
              operation is only well-defined when all singular values are distinct. The backwards
              pass becomes less stable as it depends on :math:`\frac{1}{\min_{i \neq j} |\sigma_i - \sigma_j|}`.
-             When there are repeated singular values, the gradient with respect to `U` and `V`
+             When there are repeated singular values, the gradient with respect to `U` and `Vh`
              will be infinity in some directions.
 
 .. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
@@ -879,7 +879,7 @@ always be real-valued, even if :attr:`input` is complex.
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
              and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.
              Different platforms, like NumPy, or inputs on different device types,
-             may produce different `U` and `V` tensors.
+             may produce different `U` and `Vh` tensors.
 
 
 Args:

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -877,7 +877,7 @@ always be real-valued, even if :attr:`input` is complex.
              as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
-             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.
+             and `the resulting vectors will span the same subspace <https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD>`_.  # noqa: E501
              Different platforms, like NumPy, or inputs on different device types,
              may produce different `U` and `Vh` tensors.
 


### PR DESCRIPTION
- Corrected a few errata in the SVD docs
- Made the notation more uniform (refer to `Vh` in `linalg.svd`, always use double tilts...)
- Wrote a better explanation about why the gradients of `U` and `V` are not well-defined when the input is complex or real but has repeated singular values. The previous one pointed to a somewhat obscure post on gauge theory.