### PR TITLE
[fx]Allow rewrite a symbolic traced module

### DIFF
--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -37,11 +37,14 @@ def patched_getline(*args, **kwargs):
     return _orig_getlines(*args, **kwargs)
 linecache.getlines = patched_getline
 
+
 def _forward_from_src(src: str, globals: Dict[str, Any]):
     # avoid mutating the passed in dict
-    globals = globals.copy()
-    exec_with_source(src, globals)
-    return globals['forward']
+    globals_copy = globals.copy()
+    exec_with_source(src, globals_copy)
+    forward_fn = globals_copy['forward']
+    del globals_copy['forward']
+    return forward_fn
 
 
 def _format_import_statement(name: str, obj: Any, importer: Importer) -> str:


### PR DESCRIPTION
Summary: After symbolic tracing, `fn` seems to already have "forward" in its globals. In this case, `new_keys` would have length of 0 and we take "forward" from `global_dict` directly as `fn_compiled`.

Test Plan: Added a new test in test_fx_experimental.

Differential Revision: D27049012

