### PR TITLE
Delete defunct ComplexCPU/ComplexCUDA dispatch keys

### DIFF
--- a/c10/core/DispatchKey.cpp
+++ b/c10/core/DispatchKey.cpp
@@ -42,11 +42,6 @@ const char* toString(DispatchKey t) {
     case DispatchKey::QuantizedXPU:
       return "QuantizedXPU";
 
-    case DispatchKey::ComplexCPU:
-      return "ComplexCPU";
-    case DispatchKey::ComplexCUDA:
-      return "ComplexCUDA";
-
     case DispatchKey::CustomRNGKeyId:
       return "CustomRNGKeyId";
 

--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -88,12 +88,6 @@ enum class DispatchKey : uint8_t {
   QuantizedCPU, // registered at build/aten/src/ATen/RegisterQuantizedCPU.cpp
   QuantizedCUDA, // registered at build/aten/src/ATen/RegisterQuantizedCUDA.cpp
   QuantizedXPU, // For out of tree Intel's heterogeneous computing plug-in
-  ComplexCPU, // lives out of tree at
-  // https://gitlab.com/pytorch-complex/pytorch-cpu-strided-complex
-  ComplexCUDA, // and
-  // https://gitlab.com/pytorch-complex/pytorch-cuda-strided-complex
-  // tested at test/cpp_extensions/complex_registration_extension.cpp
-  // TODO: Remove Complex dispatch keys when Complex is moved in tree
 
   // This backend is to support custom RNGs; it lets you go
   // to a different kernel if you pass in a generator that is not a

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -217,8 +217,6 @@ constexpr DispatchKeySet autogradother_backends = DispatchKeySet({
   DispatchKey::IDEEP,
   DispatchKey::QuantizedCPU,
   DispatchKey::QuantizedCUDA,
-  DispatchKey::ComplexCPU,
-  DispatchKey::ComplexCUDA,
   DispatchKey::CustomRNGKeyId,
   DispatchKey::MkldnnCPU,
   DispatchKey::SparseCPU,

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -70,8 +70,6 @@ class DispatchKey(Enum):
     QuantizedCPU = auto()
     QuantizedCUDA = auto()
     QuantizedXPU = auto()
-    ComplexCPU = auto()
-    ComplexCUDA = auto()
     CustomRNGKeyId = auto()
     MkldnnCPU = auto()
     SparseCPU = auto()
@@ -143,7 +141,6 @@ def is_cuda_dispatch_key(dk: DispatchKey) -> bool:
     return dk in {
         DispatchKey.CUDA,
         DispatchKey.QuantizedCUDA,
-        DispatchKey.ComplexCUDA,
         DispatchKey.SparseCUDA,
         DispatchKey.AutogradCUDA,
         DispatchKey.CUDATensorId,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54079 Add Tensor::is_cpu, genericize TensorIterator
* #54034 Refactor tensor_new.cpp to use TensorOptions instead of DispatchKey
* #54016 Delete denseTypeIdWithDefault and toDense
* **#54013 Delete defunct ComplexCPU/ComplexCUDA dispatch keys**
* #53972 Make storage access error NotImplementedError
* #53823 Compute type_equal() without reference to backend()
* #53816 Also propagate storage_access_should_throw_ when copying tensor metadata

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27051837](https://our.internmc.facebook.com/intern/diff/D27051837)