### PR TITLE
[1.8.1] Make ideep honor `torch.set_num_thread` changes (#53871)

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -12,6 +12,11 @@
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
 namespace at {
+#if AT_MKLDNN_ENABLED()
+namespace native { namespace mkldnn {
+void clear_computation_cache();
+}} // namespace native::mkldnn
+#endif
 
 namespace {
 // Number of threads set by the user
@@ -57,6 +62,9 @@ void set_num_threads(int nthreads) {
   caffe2::PThreadPool* const pool = caffe2::pthreadpool();
   TORCH_INTERNAL_ASSERT(pool, "Invalid thread pool!");
   pool->set_thread_count(nthreads);
+#endif
+#if AT_MKLDNN_ENABLED()
+  at::native::mkldnn::clear_computation_cache();
 #endif
 }
 

--- a/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
+++ b/aten/src/ATen/native/mkldnn/IDeepRegistration.cpp
@@ -18,4 +18,14 @@ RegisterEngineAllocator cpu_alloc(
   }
 );
 
+namespace at { namespace native { namespace mkldnn {
+
+void clear_computation_cache() {
+  // Reset computation_cache for forward convolutions
+  // As it also caches max number of OpenMP workers
+  ideep::convolution_forward::t_store().clear();
+}
+
+}}} // namespace  at::native::mkldnn
+
 #endif // AT_MKLDNN_ENALBED()

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -341,7 +341,8 @@ class ErrorTrackingProcess(mp.Process):
         set_faulthander_if_available()
         if self.disable_stderr:
             # Disable polluting stderr with errors that are supposed to happen.
-            sys.stderr = open(os.devnull, "w")
+            with open(os.devnull, 'w') as devnull:
+                os.dup2(devnull.fileno(), sys.stderr.fileno())
         try:
             super(ErrorTrackingProcess, self).run()
             self._cconn.send(None)
@@ -527,8 +528,8 @@ def disable_stderr(worker_id):
     sys.stderr.flush()  # flush library buffers that dup2 knows nothing about
     # Can't use a with-block because otherwise the fd will be closed when this
     # function ends.
-    devnull = open(os.devnull, 'w')
-    os.dup2(devnull.fileno(), sys.stderr.fileno())
+    with open(os.devnull, 'w') as devnull:
+        os.dup2(devnull.fileno(), sys.stderr.fileno())
 
 
 def _test_segfault():
@@ -2205,7 +2206,7 @@ class TestIndividualWorkerQueue(TestCase):
                 self._run_ind_worker_queue_test(batch_size=batch_size, num_workers=num_workers)
 
 
-class SetAffinityDataset(torch.utils.data.IterableDataset):
+class SetAffinityDataset(IterableDataset):
 
     def __iter__(self):
         torch.randperm(1)
@@ -2229,6 +2230,26 @@ class TestSetAffinity(TestCase):
         for sample in dataloader:
             self.assertEqual(sample, [2])
 
+class ConvDataset(Dataset):
+    def __init__(self):
+        self.x = torch.ones(1, 1, 24000)
+        # Call convolution on parent process
+        self[0]
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return torch.nn.functional.conv1d(self.x, torch.ones(1, 1, 2))
+
+
+@unittest.skipIf(IS_WINDOWS, "Needs fork")
+class TestConvAfterFork(TestCase):
+    # Tests crash reported in https://github.com/pytorch/pytorch/issues/53565
+    def test_conv_after_fork(self):
+        loader = DataLoader(ConvDataset(), num_workers=1)
+        for x in loader:
+            self.assertEqual(x.shape, (1, 1, 1, 23999))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary:
When compiled with OpenMP support `ideep`'s computational_cache would cache max number of OpenMP workers
This number could be wrong after `torch.set_num_threads` call, so clean it after the call.

Fixes https://github.com/pytorch/pytorch/issues/53565

This is a cherry-pick of  https://github.com/pytorch/pytorch/pull/53871 into release/1.8 branch

Reviewed By: albanD

Differential Revision: D27003265

Pulled By: malfet

fbshipit-source-id: 1d84c23070eafb3d444e09590d64f97f99ae9d36
