### PR TITLE
optimizer exploration - v1 and v2 + fix position_weighted optimizer + decoupled weight decay (#53881)

### DIFF
--- a/caffe2/python/operator_test/decay_adagrad_test.py
+++ b/caffe2/python/operator_test/decay_adagrad_test.py
@@ -1,0 +1,68 @@
+import functools
+
+from hypothesis import given
+import hypothesis.strategies as st
+import numpy as np
+
+from caffe2.python import core
+import caffe2.python.hypothesis_test_util as hu
+
+
+class TestDecayAdagrad(hu.HypothesisTestCase):
+
+    @staticmethod
+    def ref_decay_adagrad(param, mom1, mom2, grad, LR, ITER,
+                 beta1, beta2, epsilon, weight_decay, bias_correction_first, output_grad=False):
+        t = ITER + 1
+        mom1_out = (beta1 * mom1) + (1 - beta1) * grad
+        mom2_out = mom2 + np.square(grad)
+        if bias_correction_first:
+            c = 1 - np.power(beta1, t)
+        else:
+            c = 1.0
+        grad_out = mom1_out / c / (np.sqrt(mom2_out) + epsilon) + weight_decay * param
+        param_out = param + LR * grad_out
+
+        return param_out, mom1_out, mom2_out
+
+    @given(inputs=hu.tensors(n=4),
+           ITER=st.integers(min_value=0, max_value=10000),
+           LR=st.floats(min_value=0.01, max_value=0.99,
+                        allow_nan=False, allow_infinity=False),
+           beta1=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           beta2=st.floats(min_value=0.01, max_value=0.99,
+                           allow_nan=False, allow_infinity=False),
+           epsilon=st.floats(min_value=0.01, max_value=0.99,
+                             allow_nan=False, allow_infinity=False),
+           weight_decay=st.floats(min_value=0.01, max_value=0.99,
+                             allow_nan=False, allow_infinity=False),
+           **hu.gcs_cpu_only)
+    def test_decay_adagrad(self, inputs, ITER, LR, beta1, beta2, epsilon, weight_decay, gc, dc):
+        bias_correction_first = True
+
+        param, mom1, mom2, grad = inputs
+        mom2 = np.abs(mom2)
+        ITER = np.array([ITER], dtype=np.int64)
+        LR = np.array([LR], dtype=np.float32)
+
+        op = core.CreateOperator(
+            "DecayAdagrad",
+            ["param", "mom1", "mom2", "grad", "lr", "iter"],
+            ["output_param", "output_mom1", "output_mom2"],
+            beta1=beta1, beta2=beta2, epsilon=epsilon, weight_decay=weight_decay, bias_correction_first=bias_correction_first)
+
+        # Iter lives on the CPU
+        input_device_options = {'iter': hu.cpu_do}
+
+        self.assertReferenceChecks(
+            gc, op,
+            [param, mom1, mom2, grad, LR, ITER],
+            functools.partial(
+                self.ref_decay_adagrad,
+                beta1=beta1, beta2=beta2, epsilon=epsilon, weight_decay=weight_decay, bias_correction_first=bias_correction_first),
+            input_device_options=input_device_options)
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/caffe2/python/optimizer.py
+++ b/caffe2/python/optimizer.py
@@ -1620,6 +1620,75 @@ class AdamOptimizer(Optimizer):
         self.alpha *= scale
         return
 
+class DecayAdagradOptimizer(Optimizer):
+    def __init__(
+        self,
+        alpha=0.01,
+        beta1=0.0,
+        beta2=0.999,
+        epsilon=0.1,
+        weight_decay=0.0,
+        bias_correction_first=True,
+        policy="fixed",
+        engine="",
+        **kwargs
+    ):
+        super(DecayAdagradOptimizer, self).__init__()
+        self.alpha = alpha
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+        self.weight_decay = weight_decay
+        self.bias_correction_first = bias_correction_first
+        self.policy = policy
+        self.engine = engine
+        self.init_kwargs = kwargs
+
+    def _run(self, net, param_init_net, param_info):
+        param = param_info.blob
+        grad = param_info.grad
+
+        if self.alpha <= 0:
+            return
+
+        lr, iteration = self.build_lr(
+            net,
+            param_init_net,
+            base_learning_rate=self.alpha,
+            policy=self.policy,
+            **(self.init_kwargs)
+        )
+
+        if isinstance(grad, core.GradientSlice):
+            # hack for position weighted.
+            param_squared_sum = param_init_net.ConstantFill([param], param + "_squared_sum", value=0.0)
+            self._aux_params.local.append(param_squared_sum)
+            output_blobs = [param, param_squared_sum]
+            net.SparseAdagrad(
+                [param, param_squared_sum, grad.indices, grad.values, lr],
+                output_blobs,
+                epsilon=self.epsilon,
+            )
+        else:
+            m1 = param_init_net.ConstantFill([param], param + "_first_mo1ment", value=0.0)
+            m2 = param_init_net.ConstantFill([param], param + "_second_moment", value=0.0)
+            self._aux_params.shared.append(iteration)
+            self._aux_params.local.append(m1)
+            self._aux_params.local.append(m2)
+            output_blobs = [param, m1, m2]
+            net.DecayAdagrad(
+                [param, m1, m2, grad, lr, iteration],
+                output_blobs,
+                beta1=self.beta1,
+                beta2=self.beta2,
+                epsilon=self.epsilon,
+                weight_decay=self.weight_decay,
+                bias_correction_first=self.bias_correction_first,
+            )
+
+    def scale_learning_rate(self, scale):
+        self.alpha *= scale
+        return
 
 class YellowFinOptimizer(Optimizer):
     """YellowFin: An automatic tuner for momentum SGD
@@ -2086,6 +2155,20 @@ def build_adam(
         allow_lr_injection=allow_lr_injection,
     )
 
+def build_decay_adagrad(
+    model,
+    base_learning_rate,
+    max_gradient_norm=None,
+    allow_lr_injection=False,
+    **kwargs
+):
+    decay_adagrad_optimizer = DecayAdagradOptimizer(alpha=base_learning_rate, **kwargs)
+    return _build(
+        model,
+        decay_adagrad_optimizer,
+        max_gradient_norm=max_gradient_norm,
+        allow_lr_injection=allow_lr_injection,
+    )
 
 def build_yellowfin(model, base_learning_rate=0.1, **kwargs):
     yellowfin_optimizer = YellowFinOptimizer(alpha=base_learning_rate, **kwargs)

--- a/caffe2/python/optimizer_test.py
+++ b/caffe2/python/optimizer_test.py
@@ -6,7 +6,7 @@ import caffe2.python.optimizer as optimizer
 from caffe2.python.optimizer import (
     build_sgd, build_multi_precision_sgd, build_ftrl, build_gftrl, build_wngrad,
     build_adagrad, build_adadelta, build_adam, build_yellowfin, build_rms_prop,
-    build_storm, add_weight_decay, SgdOptimizer)
+    build_storm, build_decay_adagrad, add_weight_decay, SgdOptimizer)
 from caffe2.python.optimizer_context import UseOptimizer
 from caffe2.python.optimizer_test_util import (
     OptimizerTestBase, LRModificationTestBase
@@ -241,6 +241,26 @@ class TestAdam(OptimizerTestBase, LRModificationTestBase, TestCase):
         for param in optimizer.get_auxiliary_parameters().local:
             workspace.FetchBlob(param)
 
+class TestDecayAdagrad(OptimizerTestBase, LRModificationTestBase, TestCase):
+    def build_optimizer(self, model, **kwargs):
+        self._skip_gpu = True
+        return build_decay_adagrad(model, base_learning_rate=1.0, **kwargs)
+
+    def check_optimizer(self, optimizer):
+        self.assertTrue(optimizer.get_auxiliary_parameters().shared)
+        self.assertTrue(optimizer.get_auxiliary_parameters().local)
+        self.assertTrue(workspace.HasBlob("optimizer_iteration"))
+        iteration_tensor = workspace.FetchBlob("optimizer_iteration")
+        np.testing.assert_allclose(np.array([2000]),
+                                   iteration_tensor,
+                                   atol=1e-5)
+        for param in optimizer.get_auxiliary_parameters().shared:
+            workspace.FetchBlob(param)
+        for param in optimizer.get_auxiliary_parameters().local:
+            workspace.FetchBlob(param)
+
+    def testSparse(self):
+        raise unittest.SkipTest("no sparse support")
 
 class TestSparseRAdam(OptimizerTestBase, LRModificationTestBase, TestCase):
     def build_optimizer(self, model, **kwargs):

--- a/caffe2/sgd/decay_adagrad_op.cc
+++ b/caffe2/sgd/decay_adagrad_op.cc
@@ -1,0 +1,52 @@
+#include "caffe2/sgd/decay_adagrad_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(DecayAdagrad, DecayAdagradOp<float, CPUContext>);
+OPERATOR_SCHEMA(DecayAdagrad)
+    .NumInputs(6)
+    .NumOutputs(3)
+    .AllowInplace({{0, 0}, {1, 1}, {2, 2}})
+    .DeviceInferenceFunction([](const OperatorDef& def) {
+      auto op_device =
+          def.has_device_option() ? def.device_option() : DeviceOption();
+      vector<DeviceOption> in_dev(def.input_size(), op_device);
+      vector<DeviceOption> out_dev(def.output_size(), op_device);
+      // ITER input lives on CPU
+      in_dev[5] = DeviceOption();
+      return std::make_pair(in_dev, out_dev);
+    })
+    .SetDoc(R"DOC(
+
+Computes the DecayAdagrad update for an
+input gradient and momentum parameters. Concretely, given inputs
+(param, m1, m2, c, grad, lr, iters),
+
+    t = iters + 1
+    m1_o = (beta1 * m1) + (1 - beta1) * grad
+    m2_o = m2 + np.square(grad)
+    c = 1.0 or (1 - power(beta1, t))
+    grad_o = m1_o / c / (sqrt(m2_o) + epsilon)
+    param_o = param + lr * (grad_o + weight_decay * param)
+
+and returns (param_o, m1_o, m2_o)
+
+)DOC")
+    .Input(0, "param", "Parameters to be updated")
+    .Input(1, "moment_1", "First moment history")
+    .Input(2, "moment_2", "Second moment history")
+    .Input(3, "grad", "Gradient computed")
+    .Input(4, "lr", "learning rate")
+    .Input(5, "iter", "iteration number")
+    .Output(0, "output_param", "Updated parameters")
+    .Output(1, "output_moment_1", "Updated first moment")
+    .Output(2, "output_moment_2", "Updated second moment")
+    .Arg("beta1", "Default 0.9")
+    .Arg("beta2", "Default 0.999")
+    .Arg("epsilon", "Default 1e-5")
+    .Arg("weight_decay", "Default 0.0")
+    .Arg("bias_correction_first", "Default True");
+
+
+SHOULD_NOT_DO_GRADIENT(DecayAdagrad);
+} // namespace caffe2

--- a/caffe2/sgd/decay_adagrad_op.h
+++ b/caffe2/sgd/decay_adagrad_op.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/eigen_utils.h"
+
+namespace caffe2 {
+
+template <typename Context>
+void decay_adagrad_compute(
+    int N,
+    const float* w,
+    const float* g,
+    const float* m,
+    const float* v,
+    float* nw,
+    float* nm,
+    float* nv,
+    float beta1,
+    float beta2,
+    float eps_hat,
+    float weight_decay,
+    float c,
+    const float* lr,
+    Context* /*context*/) {
+    ConstEigenVectorArrayMap<float> w_arr(w, N);
+    ConstEigenVectorArrayMap<float> g_arr(g, N);
+    ConstEigenVectorArrayMap<float> m_arr(m, N);
+    ConstEigenVectorArrayMap<float> v_arr(v, N);
+    EigenVectorArrayMap<float> nw_arr(nw, N);
+    EigenVectorArrayMap<float> nm_arr(nm, N);
+    EigenVectorArrayMap<float> nv_arr(nv, N);
+    nm_arr = m_arr * beta1 + g_arr * (1.0f - beta1);
+    nv_arr = v_arr + g_arr.square();
+    nw_arr = w_arr + *lr * (nm_arr / c / (nv_arr.sqrt() + eps_hat) + weight_decay * w_arr);
+}
+
+template <typename T, class Context>
+class DecayAdagradOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  DecayAdagradOp(const OperatorDef& operator_def, Workspace* ws)
+      : Operator<Context>(operator_def, ws),
+        beta1_(this->template GetSingleArgument<float>("beta1", 0.9f)),
+        beta2_(this->template GetSingleArgument<float>("beta2", 0.999f)),
+        epsilon_(this->template GetSingleArgument<float>("epsilon", 1e-5f)),
+        weight_decay_(this->template GetSingleArgument<float>("weight_decay", 0.0f)),
+        bias_correction_first_(this->template GetSingleArgument<bool>("bias_correction_first", true)) {}
+
+  bool RunOnDevice() override {
+    // Iter live on the CPU
+    CAFFE_ENFORCE(OperatorBase::InputIsTensorType(ITER, CPU));
+    CAFFE_ENFORCE(Input(LR).numel() == 1);
+    CAFFE_ENFORCE(Input(GRAD).numel() == Input(PARAM).numel());
+    CAFFE_ENFORCE(Input(GRAD).numel() == Input(MOMENT_1).numel());
+    CAFFE_ENFORCE(Input(GRAD).numel() == Input(MOMENT_2).numel());
+    Output(OUTPUT_PARAM)->ResizeLike(Input(PARAM));
+    Output(OUTPUT_MOMENT_1)->ResizeLike(Input(MOMENT_1));
+    Output(OUTPUT_MOMENT_2)->ResizeLike(Input(MOMENT_2));
+
+    const auto iter =
+        OperatorBase::Input<Tensor>(ITER, CPU).template data<int64_t>()[0];
+
+    const auto t = iter + 1;
+    const auto c = (bias_correction_first_)? (T(1.) - std::pow(beta1_, t)) : 1.0;
+    decay_adagrad_compute<Context>(
+        Input(GRAD).numel(),
+        Input(PARAM).template data<T>(),
+        Input(GRAD).template data<T>(),
+        Input(MOMENT_1).template data<T>(),
+        Input(MOMENT_2).template data<T>(),
+        Output(OUTPUT_PARAM)->template mutable_data<T>(),
+        Output(OUTPUT_MOMENT_1)->template mutable_data<T>(),
+        Output(OUTPUT_MOMENT_2)->template mutable_data<T>(),
+        beta1_,
+        beta2_,
+        epsilon_,
+        weight_decay_,
+        c,
+        Input(LR).template data<T>(),
+        &context_);
+
+    return true;
+  }
+
+ protected:
+  T beta1_{0.9};
+  T beta2_{0.999};
+  T epsilon_{1e-8};
+  T weight_decay_{0.0};
+  bool bias_correction_first_{true};
+  INPUT_TAGS(PARAM, MOMENT_1, MOMENT_2, GRAD, LR, ITER);
+  OUTPUT_TAGS(OUTPUT_PARAM, OUTPUT_MOMENT_1, OUTPUT_MOMENT_2);
+};
+
+} // namespace caffe2


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/53881

1. Fix position_weighted optimizer: Position weighted layer uses default optimizer but is actually gradient_slice, which will cause problem if we do not handle it properly in the new optimizier. The solution is to use sparseadagrad when it is gradient_slices.
2. Optimizer implementation of v1 and v2: using 1st momentum with/without bias_correction.
3. also implemented decoupled weight decay in the new optimizer.

Test Plan:
buck test //caffe2/caffe2/fb/dper/layer_models/tests/split_1:sparse_nn_test_2 -- test_mlp_optimization

buck test //caffe2/caffe2/python:optimizer_test -- TestDecayAdagrad

buck test //caffe2/caffe2/python/operator_test:decay_adagrad_test

ctr_mbl_feed work flow: f255731660
oc work flow: f255739503

Reviewed By: 0x10cxR1

Differential Revision: D26839668

