### PR TITLE
fixed grad function of sinc

### DIFF
--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1020,6 +1020,17 @@ class TestUnaryUfuncs(TestCase):
         out.backward(torch.ones_like(inputTensor))
         self.assertEqual(inputTensor.grad, expetedTensor)
 
+    @dtypesIfCUDA(torch.float, torch.double, torch.bfloat16)
+    @dtypes(torch.float, torch.double)
+    def test_sinc_backward(self, device, dtype):
+        inputValues = [-1.0, 0.0, 1.0]
+        expectedValues = [1.0, 0.0, -1.0]
+        inputTensor = torch.tensor(inputValues, dtype=dtype, device=device).requires_grad_()
+        expectedTensor = torch.tensor(expectedValues, dtype=dtype, device=device)
+        out = torch.sinc(inputTensor)
+        out.backward(torch.ones_like(inputTensor))
+        self.assertEqual(inputTensor.grad, expectedTensor)
+
     @skipIfNoSciPy
     @dtypes(torch.float, torch.double)
     def test_silu(self, device, dtype):

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -984,7 +984,7 @@
   self: grad * self.cos().conj()
 
 - name: sinc(Tensor self) -> Tensor
-  self: grad * ((M_PI * self * (M_PI * self).cos() - (M_PI * self).sin()) / (M_PI * self * self)).conj()
+  self: sinc_backward(grad, self)
 
 - name: sinh(Tensor self) -> Tensor
   self: grad * self.cosh().conj()

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1970,6 +1970,17 @@ Tensor elu_double_backward(
     }
 }
 
+Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
+  Tensor self_scaled = at::ones_like(self);
+  Tensor scale_v;
+  Tensor pi = wrapped_scalar_tensor(Scalar(M_PI));
+  scale_v = grad *
+      ((pi * self * (pi * self).cos() - (pi * self).sin()) / (pi * self * self))
+          .conj();
+  scale_v.masked_fill_(self == 0, 0);
+  return self_scaled * scale_v;
+}
+
 Tensor slice_backward_wrapper(
     const at::Tensor& grad,
     const c10::IntArrayRef& input_sizes,

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1971,14 +1971,11 @@ Tensor elu_double_backward(
 }
 
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
-  Tensor self_scaled = at::ones_like(self);
-  Tensor scale_v;
-  Tensor pi = wrapped_scalar_tensor(Scalar(M_PI));
-  scale_v = grad *
-      ((pi * self * (pi * self).cos() - (pi * self).sin()) / (pi * self * self))
-          .conj();
-  scale_v.masked_fill_(self == 0, 0);
-  return self_scaled * scale_v;
+  Tensor pi_self = wrapped_scalar_tensor(Scalar(M_PI)) * self;
+  Tensor vals = grad *
+      ((pi_self * pi_self.cos() - pi_self.sin()) / (pi_self * self)).conj();
+  Tensor out = at::zeros_like(self, self.options());
+  return at::where(self == 0, out, vals);
 }
 
 Tensor slice_backward_wrapper(

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -135,6 +135,7 @@ at::Tensor embedding_dense_double_backward(const at::Tensor & grad, const at::Te
 at::Tensor index_backward(at::Tensor zeros_like_self, const torch::List<c10::optional<Tensor>>& indices, const at::Tensor& grad);
 at::Tensor _cudnn_ctc_loss_backward(const at::Tensor& grad_out, const at::Tensor& loss, const at::Tensor& raw_grad, bool zero_infinity);
 at::Tensor elu_double_backward(const Tensor& grad, const Tensor& grad_output, Scalar alpha, Scalar scale, Scalar input_scale, bool is_result, const Tensor& self_or_result);
+at::Tensor sinc_backward(const at::Tensor& grad, const at::Tensor& self);
 
 Tensor svd_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
           bool some, bool compute_uv, const Tensor& raw_u, const Tensor& sigma, const Tensor& raw_v);


### PR DESCRIPTION
Summary:
Fixes #53989
Adds a special case for the sinc gradient formula to account for the case of input = 0

