### PR TITLE
[Gradient Compression] Introduce fp16_compress_wrapper in ddp_comm_hooks.rst

### DIFF
--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -47,8 +47,14 @@ Default communication hooks are simple **stateless** hooks, so the input state
 in ``register_comm_hook`` is either a process group or ``None``.
 The input ``bucket`` is a :class:`torch.distributed.GradBucket` object.
 
-.. automodule:: torch.distributed.algorithms.ddp_comm_hooks.default_hooks
-    :members:
+.. currentmodule:: torch.distributed.algorithms.ddp_comm_hooks.default_hooks
+.. autofunction:: allreduce_hook
+.. autofunction:: fp16_compress_hook
+
+Additionally, a communication hook wraper is provided to support :meth:`~fp16_compress_hook` as a wrapper,
+which can be combined with other communication hooks.
+
+.. autofunction:: fp16_compress_wrapper
 
 PowerSGD Communication Hook
 ---------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54052 [Gradient Compression] Introduce fp16_compress_wrapper in ddp_comm_hooks.rst**

Introduce `fp16_compress_wrapper`, which can give some speedup on top of some gradient compression algorithms like PowerSGD.

![image](https://user-images.githubusercontent.com/8884619/111277528-c8f65280-85f5-11eb-945e-ad88f7c1eb85.png)


Differential Revision: [D27076064](https://our.internmc.facebook.com/intern/diff/D27076064/)