### PR TITLE
[PyTorch] Fix string copy in WARN path for both interpreters

### DIFF
--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -215,8 +215,9 @@ bool InterpreterState::run(Stack& stack) {
         // STRIP_ERROR_MESSAGES is defined (which happens for production
         // mobile builds). This will cause the stack to be in an inconsistent
         // state. It has previously resulted in a SEV (S22350).
-        auto sref = pop(stack).toStringRef();
+        const auto& sref = stack.back().toStringRef();
         TORCH_WARN(sref);
+        stack.pop_back();
         ++pc;
       } break;
       default:

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1559,7 +1559,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             auto range = node->sourceRange().source();
             if (range->filename()) {
               drop(stack, 1);
-              const auto msg = pop(stack).toStringRef();
+              const auto& msg = stack.back().toStringRef();
               if (need_warn) {
                 auto line = range->starting_line_no() +
                     range->lineno_for_offset(node->sourceRange().start());
@@ -1570,11 +1570,13 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
                 // will print the exception as configured.
                 c10::Warning::warn(location, msg, /*verbatim=*/true);
               }
+              stack.pop_back();
             } else {
-              const auto msg = pop(stack).toStringRef();
+              const auto& msg = stack.back().toStringRef();
               if (need_warn) {
                 TORCH_WARN(msg);
               }
+              stack.pop_back();
             }
             ++frame.pc;
           } break;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54076 [PyTorch] Fix string copy in WARN path for both interpreters**
* #54031 [PyTorch][mobile] Audit mobile interpreter for extra copies

If we don't constrain ourselves to use `torch::jit::pop`, we can avoid copying a string or moving IValues around.

Differential Revision: [D27087204](https://our.internmc.facebook.com/intern/diff/D27087204/)