### PR TITLE
Don't actually print anomalies in TTRR

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1188,22 +1188,6 @@ Commit graph (base is most recent master ancestor with at least one S3 report):
     job: foo_job
     commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-
-  class Foo:
-      # was   42.50s ±   2.12s
-      # now    3.02s
-
-    - def test_bar: ...
-    -     # was   1.000s
-
-    ! def test_foo: ...
-    !     # was  41.500s ±  2.121s
-    !     # now   0.020s           (skipped)
-
-    + def test_baz: ...
-    +     # now   3.000s
-
-
 Commit graph (base is most recent master ancestor with at least one S3 report):
 
     : (master)
@@ -1257,17 +1241,6 @@ Added    (across    1 suite)      1 test,  totaling +   3.00s
 
     job: foo_job
     commit: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-
-
-+ class Foo:
-+     # now    3.02s
-+
-+     def test_baz: ...
-+         # now   3.000s
-+
-+     def test_foo: ...
-+         # now   0.020s           (skipped)
-
 
 Commit graph (base is most recent master ancestor with at least one S3 report):
 

--- a/torch/testing/_internal/print_test_stats.py
+++ b/torch/testing/_internal/print_test_stats.py
@@ -622,7 +622,12 @@ def regression_info(
             f'    job: {job_name}',
             f'    commit: {head_sha}',
         ]),
-        anomalies(analysis),
+
+        # don't print anomalies, because sometimes due to sharding, the
+        # output from this would be very long and obscure better signal
+
+        # anomalies(analysis),
+
         graph(
             head_sha=head_sha,
             head_seconds=head_report['total_seconds'],


### PR DESCRIPTION
This PR disables the bulk of the output for test time regression reporting, since it's obscuring more important signal (especially in cases where shards are shifting around).

**Test plan:**

```
python test/test_testing.py
```