### PR TITLE
Handle stride > 1 with im2col in CUDA thnn conv2d

### DIFF
--- a/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose2d.cpp
@@ -453,7 +453,9 @@ static void slow_conv_transpose2d_backward_out_cpu_template(
           grad_input_n = grad_input.select(0, elt);
           grad_output_n = grad_output.select(0, elt);
 
-          if (kernel_height != 1 || kernel_width != 1) {
+          if (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+              stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+              dilation_height != 1 || dilation_width != 1) {
             // Extract columns:
             im2col<scalar_t>(
                   grad_output_n.data_ptr<scalar_t>(),
@@ -481,8 +483,12 @@ static void slow_conv_transpose2d_backward_out_cpu_template(
 
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
-          auto gemm_in_ptr = (kernel_height != 1 || kernel_width != 1) ?
-              grad_columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr =
+              (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+               stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+               dilation_height != 1 || dilation_width != 1)
+              ? grad_columns.data_ptr<scalar_t>()
+              : grad_output_n.data_ptr<scalar_t>();
           cpublas::gemm(
               cpublas::NoTranspose,
               cpublas::NoTranspose,
@@ -648,7 +654,9 @@ void slow_conv_transpose2d_acc_grad_parameters_cpu(
             // Matrix mulitply per output:
             input_n = input.select(0, elt);
 
-            if (kernel_height != 1 || kernel_width != 1) {
+            if (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+                stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+                dilation_height != 1 || dilation_width != 1) {
               // Extract columns:
               im2col<scalar_t>(
                   grad_output_n.data_ptr<scalar_t>(),
@@ -676,8 +684,12 @@ void slow_conv_transpose2d_acc_grad_parameters_cpu(
 
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
-            auto gemm_in_ptr = (kernel_height != 1 || kernel_width != 1) ?
-                columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr =
+                (kernel_height != 1 || kernel_width != 1 ||
+                 stride_height != 1 || stride_width != 1 || pad_height != 0 ||
+                 pad_width != 0 || dilation_height != 1 || dilation_width != 1)
+                ? columns.data_ptr<scalar_t>()
+                : grad_output_n.data_ptr<scalar_t>();
             cpublas::gemm(
                 cpublas::Transpose,
                 cpublas::NoTranspose,

--- a/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
+++ b/aten/src/ATen/native/NaiveConvolutionTranspose3d.cpp
@@ -531,7 +531,11 @@ void slow_conv_transpose3d_backward_out_cpu_template(
           grad_input_n = grad_input.select(0, elt);
           grad_output_n = grad_output.select(0, elt);
 
-          if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) {
+          if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+              stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+              dilation_depth != 1 || dilation_height != 1 ||
+              dilation_width != 1 || padding_depth != 0 ||
+              padding_height != 0 || padding_width != 0) {
             // Extract columns:
             at::native::vol2col<scalar_t>(
                 grad_output_n.data_ptr<scalar_t>(),
@@ -566,8 +570,14 @@ void slow_conv_transpose3d_backward_out_cpu_template(
 
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
-          auto gemm_in_ptr = (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) ?
-              grad_columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr =
+              (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+               stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+               dilation_depth != 1 || dilation_height != 1 ||
+               dilation_width != 1 || padding_depth != 0 ||
+               padding_height != 0 || padding_width != 0)
+              ? grad_columns.data_ptr<scalar_t>()
+              : grad_output_n.data_ptr<scalar_t>();
           cpublas::gemm(
               cpublas::NoTranspose,
               cpublas::NoTranspose,
@@ -761,7 +771,11 @@ void slow_conv_transpose3d_acc_grad_parameters_cpu(
             // Matrix mulitply per output:
             input_n = input.select(0, elt);
 
-            if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) {
+            if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+                stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+                dilation_depth != 1 || dilation_height != 1 ||
+                dilation_width != 1 || padding_depth != 0 ||
+                padding_height != 0 || padding_width != 0) {
               // Extract columns:
               at::native::vol2col<scalar_t>(
                   grad_output_n.data_ptr<scalar_t>(),
@@ -795,8 +809,14 @@ void slow_conv_transpose3d_acc_grad_parameters_cpu(
 
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
-            auto gemm_in_ptr = (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) ?
-                columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr =
+                (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+                 stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+                 dilation_depth != 1 || dilation_height != 1 ||
+                 dilation_width != 1 || padding_depth != 0 ||
+                 padding_height != 0 || padding_width != 0)
+                ? columns.data_ptr<scalar_t>()
+                : grad_output_n.data_ptr<scalar_t>();
             cpublas::gemm(
                 cpublas::Transpose,
                 cpublas::NoTranspose,

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -472,7 +472,9 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
           grad_input_n = grad_input.select(0, elt);
           grad_output_n = grad_output.select(0, elt);
 
-          if (kernel_height != 1 || kernel_width != 1) {
+          if (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+              stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+              dilation_height != 1 || dilation_width != 1) {
             im2col<scalar_t>(
                 at::cuda::getCurrentCUDAStream(),
                 grad_output_n.data_ptr<scalar_t>(),
@@ -500,8 +502,12 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
 
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
-          auto gemm_in_ptr = (kernel_height != 1 || kernel_width != 1) ?
-              grad_columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr =
+              (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+               stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+               dilation_height != 1 || dilation_width != 1)
+              ? grad_columns.data_ptr<scalar_t>()
+              : grad_output_n.data_ptr<scalar_t>();
           at::cuda::blas::gemm<scalar_t>(
               'n',
               'n',
@@ -684,7 +690,9 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
             // Matrix mulitply per output:
             input_n = input.select(0, elt);
 
-            if (kernel_height != 1 || kernel_width != 1) {
+            if (kernel_height != 1 || kernel_width != 1 || stride_height != 1 ||
+                stride_width != 1 || pad_height != 0 || pad_width != 0 ||
+                dilation_height != 1 || dilation_width != 1) {
               // Extract columns:
               im2col<scalar_t>(
                   at::cuda::getCurrentCUDAStream(),
@@ -713,8 +721,12 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
 
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
-            auto gemm_in_ptr = (kernel_height != 1 || kernel_width != 1) ?
-                columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr =
+                (kernel_height != 1 || kernel_width != 1 ||
+                 stride_height != 1 || stride_width != 1 || pad_height != 0 ||
+                 pad_width != 0 || dilation_height != 1 || dilation_width != 1)
+                ? columns.data_ptr<scalar_t>()
+                : grad_output_n.data_ptr<scalar_t>();
             at::cuda::blas::gemm<scalar_t>(
                 't',
                 'n',

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose3d.cu
@@ -543,7 +543,11 @@ void slow_conv_transpose3d_backward_out_cuda_template(
           grad_input_n = grad_input.select(0, elt);
           grad_output_n = grad_output.select(0, elt);
 
-          if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) {
+          if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+              stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+              dilation_depth != 1 || dilation_height != 1 ||
+              dilation_width != 1 || padding_depth != 0 ||
+              padding_height != 0 || padding_width != 0) {
             // Extract columns:
             at::native::vol2col<scalar_t>(
                 at::cuda::getCurrentCUDAStream(),
@@ -579,8 +583,14 @@ void slow_conv_transpose3d_backward_out_cuda_template(
 
           // Do GEMM (note: this is a bit confusing because gemm assumes
           // column-major matrices)
-          auto gemm_in_ptr = (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) ?
-              grad_columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+          auto gemm_in_ptr =
+              (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+               stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+               dilation_depth != 1 || dilation_height != 1 ||
+               dilation_width != 1 || padding_depth != 0 ||
+               padding_height != 0 || padding_width != 0)
+              ? grad_columns.data_ptr<scalar_t>()
+              : grad_output_n.data_ptr<scalar_t>();
           at::cuda::blas::gemm<scalar_t>(
               'n',
               'n',
@@ -785,7 +795,11 @@ void slow_conv_transpose3d_acc_grad_parameters_cuda(
             // Matrix mulitply per output:
             input_n = input.select(0, elt);
 
-            if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) {
+            if (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+                stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+                dilation_depth != 1 || dilation_height != 1 ||
+                dilation_width != 1 || padding_depth != 0 ||
+                padding_height != 0 || padding_width != 0) {
               // Extract columns:
               at::native::vol2col<scalar_t>(
                   at::cuda::getCurrentCUDAStream(),
@@ -820,8 +834,14 @@ void slow_conv_transpose3d_acc_grad_parameters_cuda(
 
             // Do GEMM (note: this is a bit confusing because gemm assumes
             // column-major matrices)
-            auto gemm_in_ptr = (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1) ?
-                columns.data_ptr<scalar_t>() : grad_output_n.data_ptr<scalar_t>();
+            auto gemm_in_ptr =
+                (kernel_depth != 1 || kernel_height != 1 || kernel_width != 1 ||
+                 stride_depth != 1 || stride_height != 1 || stride_width != 1 ||
+                 dilation_depth != 1 || dilation_height != 1 ||
+                 dilation_width != 1 || padding_depth != 0 ||
+                 padding_height != 0 || padding_width != 0)
+                ? columns.data_ptr<scalar_t>()
+                : grad_output_n.data_ptr<scalar_t>();
             at::cuda::blas::gemm<scalar_t>(
                 't',
                 'n',

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -203,7 +203,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
       THCTensor_(zero)(state, output_n);
     }
 
-    if (kW != 1 || kH != 1) {
+    if (kW != 1 || kH != 1 || dW != 1 || dH != 1) {
       // Extract columns:
       at::native::im2col<scalar_t>(
         c10::cuda::getCurrentCUDAStream(),
@@ -223,8 +223,9 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     int64_t k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    auto gemm_in_ptr = (kW != 1 || kH != 1) ?
-        THCTensor_(data)(state, columns) : THCTensor_(data)(state, input_n);
+    auto gemm_in_ptr = (kW != 1 || kH != 1 || dW != 1 || dH != 1)
+        ? THCTensor_(data)(state, columns)
+        : THCTensor_(data)(state, input_n);
     at::cuda::blas::gemm<scalar_t>(
         'n', 'n',
         n, m, k,
@@ -422,7 +423,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       // Matrix mulitply per output:
       THCTensor_(select)(state, input_n, input, 0, elt);
 
-      if (kW != 1 || kH != 1) {
+      if (kW != 1 || kH != 1 || dW != 1 || dH != 1) {
         // Extract columns:
         at::native::im2col<scalar_t>(
           c10::cuda::getCurrentCUDAStream(),
@@ -442,8 +443,9 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       int64_t k = columns->size(1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-      auto gemm_in_ptr = (kW != 1 || kH != 1) ?
-          THCTensor_(data)(state, columns) : THCTensor_(data)(state, input_n);
+      auto gemm_in_ptr = (kW != 1 || kH != 1 || dW != 1 || dH != 1)
+          ? THCTensor_(data)(state, columns)
+          : THCTensor_(data)(state, input_n);
       at::cuda::blas::gemm<scalar_t>(
           't', 'n',
           n, m, k,

--- a/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
+++ b/aten/src/THCUNN/generic/SpatialConvolutionMM.cu
@@ -203,7 +203,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
       THCTensor_(zero)(state, output_n);
     }
 
-    if (kW != 1 || kH != 1 || dW != 1 || dH != 1) {
+    if (kW != 1 || kH != 1 || dW != 1 || dH != 1 || padH != 0 || padW != 0) {
       // Extract columns:
       at::native::im2col<scalar_t>(
         c10::cuda::getCurrentCUDAStream(),
@@ -223,7 +223,8 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     int64_t k = nInputPlane*kH*kW;
 
     // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-    auto gemm_in_ptr = (kW != 1 || kH != 1 || dW != 1 || dH != 1)
+    auto gemm_in_ptr =
+        (kW != 1 || kH != 1 || dW != 1 || dH != 1 || padH != 0 || padW != 0)
         ? THCTensor_(data)(state, columns)
         : THCTensor_(data)(state, input_n);
     at::cuda::blas::gemm<scalar_t>(
@@ -423,7 +424,7 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       // Matrix mulitply per output:
       THCTensor_(select)(state, input_n, input, 0, elt);
 
-      if (kW != 1 || kH != 1 || dW != 1 || dH != 1) {
+      if (kW != 1 || kH != 1 || dW != 1 || dH != 1 || padH != 0 || padW != 0) {
         // Extract columns:
         at::native::im2col<scalar_t>(
           c10::cuda::getCurrentCUDAStream(),
@@ -443,7 +444,8 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       int64_t k = columns->size(1);
 
       // Do GEMM (note: this is a bit confusing because gemm assumes column-major matrices)
-      auto gemm_in_ptr = (kW != 1 || kH != 1 || dW != 1 || dH != 1)
+      auto gemm_in_ptr =
+          (kW != 1 || kH != 1 || dW != 1 || dH != 1 || padH != 0 || padW != 0)
           ? THCTensor_(data)(state, columns)
           : THCTensor_(data)(state, input_n);
       at::cuda::blas::gemm<scalar_t>(

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4606,19 +4606,21 @@ class TestNN(NNTestCase):
         self.assertEqual(l.state_dict()['buf'], buf)
 
     @unittest.skipIf(not TEST_CUDA, 'CUDA not available')
-    def test_thnn_conv2d_strided(self):
-        inputs = torch.randn(1, 4, 8, 8, dtype=torch.double, device="cuda", requires_grad=True)
-        weight = torch.randn(8, 4, 1, 1, dtype=torch.double, device="cuda", requires_grad=True)
-        bias = torch.randn(8, dtype=torch.double, device="cuda", requires_grad=True)
-        with torch.backends.cudnn.flags(enabled=False):
-            res = torch.nn.functional.conv2d(inputs, weight, bias, stride=2)
-        res_cpu = torch.nn.functional.conv2d(inputs.cpu(), weight.cpu(), bias.cpu(), stride=2)
-        self.assertEqual(res, res_cpu)
-        with torch.backends.cudnn.flags(enabled=False):
-            torch.autograd.gradcheck(
-                lambda x, w, b: torch.nn.functional.conv2d(x, w, b, stride=2),
-                (inputs, weight, bias)
-            )
+    def test_thnn_conv2d_strided_padded(self):
+        for stride, padding in ((2, 0), (1, 1), (2, 1)):
+            kwargs = {"stride": stride, "padding": padding}
+            inputs = torch.randn(1, 4, 8, 8, dtype=torch.double, device="cuda", requires_grad=True)
+            weight = torch.randn(8, 4, 1, 1, dtype=torch.double, device="cuda", requires_grad=True)
+            bias = torch.randn(8, dtype=torch.double, device="cuda", requires_grad=True)
+            with torch.backends.cudnn.flags(enabled=False):
+                res = torch.nn.functional.conv2d(inputs, weight, bias, **kwargs)
+            res_cpu = torch.nn.functional.conv2d(inputs.cpu(), weight.cpu(), bias.cpu(), **kwargs)
+            self.assertEqual(res, res_cpu)
+            with torch.backends.cudnn.flags(enabled=False):
+                torch.autograd.gradcheck(
+                    lambda x, w, b: torch.nn.functional.conv2d(x, w, b, **kwargs),
+                    (inputs, weight, bias)
+                )
 
     def test_Conv2d_inconsistent_types(self):
         inputs = torch.randn(4, 1, 7, 7, dtype=torch.float)


### PR DESCRIPTION
The fallback thnn 2d convolution uses `im2col` to get patches and `gemm` to implement convolution .
I has a shortcut to use `gemm` directly for kernel size 1, but this only works for stride == 1 and padding == 0. 
This PR adds checks for stride == 1 and padding == 0 to determining whether `im2col` can be skipped.

Fixes #54036
