### PR TITLE
Add export-historic-test-times option to dump S3 test times into a JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage.xml
 .gradle
 .hypothesis
 .mypy_cache
+.pytorch-test-times
 */*.pyc
 */*.so*
 */**/__pycache__

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -744,7 +744,7 @@ def parse_args():
         help='additional arguments passed through to unittest, e.g., '
              'python run_test.py -i sparse -- TestSparse.test_factory_size_check')
     parser.add_argument(
-        '--dump-test-times',
+        '--export-historic-test-times',
         nargs='?',
         type=str,
         const='.pytorch-test-times',
@@ -1011,20 +1011,20 @@ def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
         message += f' Received signal: {signal_name}'
     return message
 
-def dump_test_times(test_times_filename: str, test_times: Dict[str, Tuple[float, int]]) -> None:
+def export_S3_test_times(test_times_filename: str, test_times: Dict[str, Tuple[float, int]]) -> None:
     if os.path.exists(test_times_filename):
         print(f'Overwriting existent file: {test_times_filename}')
-    file = open(test_times_filename, 'w+')
-    job_times_json = get_job_times_json(test_times)
-    json.dump(job_times_json, file)
-    file.close()
+    with open(test_times_filename, 'w+') as file:
+        job_times_json = get_job_times_json(test_times)
+        json.dump(job_times_json, file)
 
 def main():
     options = parse_args()
 
-    test_times_filename = options.dump_test_times
+    test_times_filename = options.export_historic_test_times
     if test_times_filename:
-        dump_test_times(test_times_filename, pull_job_times_from_S3())
+        print(f'Exporting historic test times from S3 to {test_times_filename}, no tests will be run.')
+        export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
 
     test_directory = os.path.dirname(os.path.abspath(__file__))

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell, set_cwd,
 from torch.testing._internal.framework_utils import calculate_shards
 import torch.distributed as dist
 from typing import Dict, Optional, Tuple, List, Any
+from typing_extensions import TypedDict
 
 try:
     import boto3  # type: ignore[import]
@@ -27,6 +28,7 @@ try:
     HAVE_BOTO3 = True
 except ImportError:
     HAVE_BOTO3 = False
+
 
 TESTS = [
     'test_public_bindings',
@@ -439,6 +441,18 @@ def pull_job_times_from_S3() -> Dict[str, Tuple[float, int]]:
     return calculate_job_times(s3_reports)
 
 
+class JobTimeJSON(TypedDict):
+    commit: str
+    job_times: Dict[str, float]
+
+
+def get_job_times_json(job_times: Dict[str, Tuple[float, int]]) -> JobTimeJSON:
+    return {
+        'commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding="ascii").strip(),
+        'job_times': {job: time for job, (time, _) in job_times.items()},
+    }
+
+
 def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
     jobs_to_times = pull_job_times_from_S3()
 
@@ -730,6 +744,13 @@ def parse_args():
         help='additional arguments passed through to unittest, e.g., '
              'python run_test.py -i sparse -- TestSparse.test_factory_size_check')
     parser.add_argument(
+        '--dump-test-times',
+        nargs='?',
+        type=str,
+        const='.pytorch-test-times',
+        help='dumps test times from previous S3 stats into a file, format JSON',
+    )
+    parser.add_argument(
         '--shard',
         nargs=2,
         type=int,
@@ -990,8 +1011,22 @@ def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
         message += f' Received signal: {signal_name}'
     return message
 
+def dump_test_times(test_times_filename: str, test_times: Dict[str, Tuple[float, int]]) -> None:
+    if os.path.exists(test_times_filename):
+        print(f'Overwriting existent file: {test_times_filename}')
+    file = open(test_times_filename, 'w+')
+    job_times_json = get_job_times_json(test_times)
+    json.dump(job_times_json, file)
+    file.close()
+
 def main():
     options = parse_args()
+
+    test_times_filename = options.dump_test_times
+    if test_times_filename:
+        dump_test_times(test_times_filename, pull_job_times_from_S3())
+        return
+
     test_directory = os.path.dirname(os.path.abspath(__file__))
     selected_tests = get_selected_tests(options)
 


### PR DESCRIPTION
This will allow for future work to use the test times file (which will save computation time and also allow for more consistency). (Step one to fixing #53882)

Test plan:
export CIRCLE_JOB=your-favorite-circleci-job e.g., pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2
`python test/run_test.py --export-historic-test-times` OR 
`python test/run_test.py --export-historic-test-times .your-favorite-file`

When opening either .pytorch-test-times or .your-favorite-file, you should see something like:
```
{"commit": "2d559a09392aabb84dfb4a498010b2f01d99818c", "job_times": {"distributed/test_distributed_spawn": 583.5889999999973, "distributed/test_data_parallel": 4.866999999999997, "test_binary_ufuncs": 171.1569999999998, "test_numpy_interop": 2.5649999999999995, "test_public_bindings": 0.011,...}}
```

Note that no tests will be run when this option is specified.