### PR TITLE
[fix] Dimension out of range in pixel_shuffle / pixel_unshuffle

### DIFF
--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -46,7 +46,7 @@ Tensor pixel_shuffle(const Tensor& self, int64_t upscale_factor) {
   std::vector<int64_t> permutation(self.sizes().begin(), self_sizes_batch_end);
   // std::iota is used to maintain the batch dims within the permutation.
   std::iota(permutation.begin(), permutation.end(), 0);
-  const auto NUM_BATCH_DIMS = self.sizes().size() - NUM_NON_BATCH_DIMS;
+  const auto NUM_BATCH_DIMS = self.dim() - NUM_NON_BATCH_DIMS;
   permutation.insert(permutation.end(), {NUM_BATCH_DIMS /* oc */, NUM_BATCH_DIMS + 3 /* h */,
     NUM_BATCH_DIMS + 1 /* 1st upscale factor */, NUM_BATCH_DIMS + 4 /* w */,
     NUM_BATCH_DIMS + 2 /* 2nd upscale factor */});
@@ -99,7 +99,7 @@ Tensor pixel_unshuffle(const Tensor& self, int64_t downscale_factor) {
   std::vector<int64_t> permutation(self.sizes().begin(), self_sizes_batch_end);
   // std::iota is used to maintain the batch dims within the permutation.
   std::iota(permutation.begin(), permutation.end(), 0);
-  const auto NUM_BATCH_DIMS = self.sizes().size() - NUM_NON_BATCH_DIMS;
+  const auto NUM_BATCH_DIMS = self.dim() - NUM_NON_BATCH_DIMS;
   permutation.insert(permutation.end(), {NUM_BATCH_DIMS /* c */, NUM_BATCH_DIMS + 2 /* 1st downscale factor */,
     NUM_BATCH_DIMS + 4 /* 2nd upscale factor */, NUM_BATCH_DIMS + 1 /* oh */,
     NUM_BATCH_DIMS + 3 /* ow */});

--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -101,7 +101,7 @@ Tensor pixel_unshuffle(const Tensor& self, int64_t downscale_factor) {
   std::iota(permutation.begin(), permutation.end(), 0);
   const auto NUM_BATCH_DIMS = self.dim() - NUM_NON_BATCH_DIMS;
   permutation.insert(permutation.end(), {NUM_BATCH_DIMS /* c */, NUM_BATCH_DIMS + 2 /* 1st downscale factor */,
-    NUM_BATCH_DIMS + 4 /* 2nd upscale factor */, NUM_BATCH_DIMS + 1 /* oh */,
+    NUM_BATCH_DIMS + 4 /* 2nd downscale factor */, NUM_BATCH_DIMS + 1 /* oh */,
     NUM_BATCH_DIMS + 3 /* ow */});
   const auto input_permuted = input_reshaped.permute(permutation);
 

--- a/aten/src/ATen/native/PixelShuffle.cpp
+++ b/aten/src/ATen/native/PixelShuffle.cpp
@@ -46,10 +46,8 @@ Tensor pixel_shuffle(const Tensor& self, int64_t upscale_factor) {
   std::vector<int64_t> permutation(self.sizes().begin(), self_sizes_batch_end);
   // std::iota is used to maintain the batch dims within the permutation.
   std::iota(permutation.begin(), permutation.end(), 0);
-  const auto NUM_BATCH_DIMS = self.dim() - NUM_NON_BATCH_DIMS;
-  permutation.insert(permutation.end(), {NUM_BATCH_DIMS /* oc */, NUM_BATCH_DIMS + 3 /* h */,
-    NUM_BATCH_DIMS + 1 /* 1st upscale factor */, NUM_BATCH_DIMS + 4 /* w */,
-    NUM_BATCH_DIMS + 2 /* 2nd upscale factor */});
+  permutation.insert(permutation.end(), {-5 /* oc */, -2 /* h */, -4 /* 1st upscale_factor */, -1 /* w */,
+                                         -3 /* 2nd upscale_factor */});
   const auto input_permuted = input_reshaped.permute(permutation);
 
   // Finally, upscale by collapsing (h, upscale_factor) -> a single dim (oh)
@@ -99,10 +97,8 @@ Tensor pixel_unshuffle(const Tensor& self, int64_t downscale_factor) {
   std::vector<int64_t> permutation(self.sizes().begin(), self_sizes_batch_end);
   // std::iota is used to maintain the batch dims within the permutation.
   std::iota(permutation.begin(), permutation.end(), 0);
-  const auto NUM_BATCH_DIMS = self.dim() - NUM_NON_BATCH_DIMS;
-  permutation.insert(permutation.end(), {NUM_BATCH_DIMS /* c */, NUM_BATCH_DIMS + 2 /* 1st downscale factor */,
-    NUM_BATCH_DIMS + 4 /* 2nd downscale factor */, NUM_BATCH_DIMS + 1 /* oh */,
-    NUM_BATCH_DIMS + 3 /* ow */});
+  permutation.insert(permutation.end(), {-5 /* c */, -3 /* 1st downscale_factor */, -1 /*2nd downscale_factor */,
+                                         -4 /* oh */, -2 /* ow */});
   const auto input_permuted = input_reshaped.permute(permutation);
 
   // Finally, downscale by collapsing (c, downscale_factor, downscale_factor) -> a single dim (oc),


### PR DESCRIPTION
Fixes #54051

Problem was application of the unary minus operator to an unsigned type. Positive indices are now used to build the permutation array for both `pixel_shuffle` and `pixel_unshuffle`.