### PR TITLE
Avoid recreating thread pool upon set_num_threads()

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -43,7 +43,10 @@ void init_num_threads() {
 
 void set_num_threads(int nthreads) {
   TORCH_CHECK(nthreads > 0, "Expected positive number of threads");
-  num_threads.store(nthreads);
+  int prev_nthreads = num_threads.exchange(nthreads);
+  if (prev_nthreads == nthreads) {
+    return;
+  }
 #ifdef _OPENMP
   omp_set_num_threads(nthreads);
 #endif


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54088 Avoid recreating thread pool upon set_num_threads()**

This adds a guard to `set_num_threads()` to not call the underlying `caffe2::pthreadpool`'s `set_thread_count()`. Our code calls `set_num_threads()` repeatedly, and each time, many threads are destroyed and created. Eventually this can cause the program to fail with a bit-field overflow in ASAN.

Differential Revision: [D26767502](https://our.internmc.facebook.com/intern/diff/D26767502/)