### PR TITLE
[nnc] Test for using int64 dimensions

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -4035,6 +4035,7 @@ TEST(LoopNest, DISABLED_Int64Direct) {
   Placeholder b("b", kLong, {N});
   VarHandle n("n", kLong);
   Stmt* s = For::make(n, 0, N, b.store({n}, a.load({n}) + 1l));
+  s = IRSimplifier::simplify(s);
   std::ostringstream oss;
   oss << *s;
   ASSERT_EQ(oss.str(), int64Loop);

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -4030,7 +4030,7 @@ const char* int64Loop = R"IR(
 TEST(LoopNest, DISABLED_Int64Direct) {
   KernelScope kernel_scope;
 
-  int64_t N = 12;
+  constexpr int64_t N = 12;
   Placeholder a("a", kLong, {N});
   Placeholder b("b", kLong, {N});
   VarHandle n("n", kLong);
@@ -4044,7 +4044,7 @@ TEST(LoopNest, DISABLED_Int64Direct) {
 TEST(LoopNest, DISABLED_Int64Compute) {
   KernelScope kernel_scope;
 
-  int64_t N = 12;
+  constexpr int64_t N = 12;
   Placeholder a("a", kLong, {N});
   Tensor* b = Compute("b", {{N, "n"}}, [&](const VarHandle& n) {
     return a.load(n) + LongImm::make(1l);

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -4034,7 +4034,7 @@ TEST(LoopNest, DISABLED_Int64Direct) {
   Placeholder a("a", kLong, {N});
   Placeholder b("b", kLong, {N});
   VarHandle n("n", kLong);
-  Stmt* s = For::make(n, 0, N, b.store({n}, a.load({n}) + 1l));
+  Stmt* s = For::make(n, 0, N, b.store({n}, a.load({n}) + LongImm::make(1l)));
   s = IRSimplifier::simplify(s);
   std::ostringstream oss;
   oss << *s;
@@ -4046,8 +4046,9 @@ TEST(LoopNest, DISABLED_Int64Compute) {
 
   int64_t N = 12;
   Placeholder a("a", kLong, {N});
-  Tensor* b = Compute(
-      "b", {{N, "n"}}, [&](const VarHandle& n) { return a.load(n) + 1l; });
+  Tensor* b = Compute("b", {{N, "n"}}, [&](const VarHandle& n) {
+    return a.load(n) + LongImm::make(1l);
+  });
   LoopNest nest({b});
   nest.prepareForCodegen();
   nest.simplify();

--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -4019,5 +4019,41 @@ TEST(LoopNest, DISABLED_VectorizeUse) {
       oss.str());
 }
 
+const char* int64Loop = R"IR(
+{
+  for (int64_t n = 0; n < 12; n++) {
+    b[n] = (a[n]) + 1;
+  }
+}
+)IR";
+
+TEST(LoopNest, DISABLED_Int64Direct) {
+  KernelScope kernel_scope;
+
+  int64_t N = 12;
+  Placeholder a("a", kLong, {N});
+  Placeholder b("b", kLong, {N});
+  VarHandle n("n", kLong);
+  Stmt* s = For::make(n, 0, N, b.store({n}, a.load({n}) + 1l));
+  std::ostringstream oss;
+  oss << *s;
+  ASSERT_EQ(oss.str(), int64Loop);
+}
+
+TEST(LoopNest, DISABLED_Int64Compute) {
+  KernelScope kernel_scope;
+
+  int64_t N = 12;
+  Placeholder a("a", kLong, {N});
+  Tensor* b = Compute(
+      "b", {{N, "n"}}, [&](const VarHandle& n) { return a.load(n) + 1l; });
+  LoopNest nest({b});
+  nest.prepareForCodegen();
+  nest.simplify();
+  std::ostringstream oss;
+  oss << *nest.root_stmt();
+  ASSERT_EQ(oss.str(), int64Loop);
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -105,6 +105,8 @@ class Placeholder {
   template <typename T>
   inline ExprHandle load(const std::vector<T>& args) const;
 
+  inline ExprHandle load(const std::vector<ExprHandle>& args) const;
+
   inline ExprHandle loadWithMask(
       const std::vector<ExprHandle>& args,
       const ExprHandle& mask) const {
@@ -323,6 +325,10 @@ inline ExprHandle Placeholder::load(const std::vector<T>& args) const {
   std::vector<ExprHandle> params(args.begin(), args.end());
   return ExprHandle(
       new Load(data(), ExprHandleVectorToExprVector(params), new IntImm(1)));
+}
+
+inline ExprHandle Placeholder::load(const std::vector<ExprHandle>& args) const {
+  return this->template load<ExprHandle>(args);
 }
 
 template <typename... Ts>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54121 [nnc] Tests for proposed feature: loop bounds conditional simplification
* **#54094 [nnc] Test for using int64 dimensions**

We should be able to use 64-bit integers for loop boundaries and
buffer/tensor indexing.

Differential Revision: [D27094934](https://our.internmc.facebook.com/intern/diff/D27094934/)