### PR TITLE
make internal forwardAD methods on at::Tensor internal

### DIFF
--- a/aten/src/ATen/core/Formatting.cpp
+++ b/aten/src/ATen/core/Formatting.cpp
@@ -296,7 +296,7 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
       }
     }
 
-    auto& fw_grad = tensor.fw_grad(/* level */ 0);
+    auto& fw_grad = tensor._fw_grad(/* level */ 0);
     if (fw_grad.defined()) {
       stream << ", tangent:" << std::endl << fw_grad;
     }

--- a/aten/src/ATen/native/AutogradComposite.cpp
+++ b/aten/src/ATen/native/AutogradComposite.cpp
@@ -7,11 +7,11 @@ namespace native {
 /// Note that the dual Tensor's primal is a view of the given primal and the given tangent is used as-is.
 /// This function is backward differentiable.
 at::Tensor _make_dual(const at::Tensor& primal, const at::Tensor& tangent, int64_t level) {
-  TORCH_CHECK(!primal.fw_grad(level).defined(), "Making a dual Tensor based on a Tensor that "
+  TORCH_CHECK(!primal._fw_grad(level).defined(), "Making a dual Tensor based on a Tensor that "
               "already has a forward gradient at the same level ", level, " is not supported.");
 
   auto dual_tensor = primal.view(primal.sizes());
-  dual_tensor.set_fw_grad(tangent, level, /* is_inplace_op */ false);
+  dual_tensor._set_fw_grad(tangent, level, /* is_inplace_op */ false);
   return dual_tensor;
 }
 
@@ -19,7 +19,7 @@ at::Tensor _make_dual(const at::Tensor& primal, const at::Tensor& tangent, int64
 /// is a view of the dual and the tangent is returned as is.
 /// This function is backward differentiable.
 std::tuple<at::Tensor, at::Tensor> _unpack_dual(const at::Tensor& tensor, int64_t level) {
-  return std::tuple<at::Tensor, at::Tensor>(tensor._fw_primal(level), tensor.fw_grad(level));
+  return std::tuple<at::Tensor, at::Tensor>(tensor._fw_primal(level), tensor._fw_grad(level));
 }
 
 } // namespace native

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -646,16 +646,16 @@ class TORCH_API Tensor {
   // users who should use the API provided in torch/csrc/autograd.h
 
   /// This function returns the forward gradient for this Tensor at the given level.
-  const Tensor& fw_grad(uint64_t level) const {
-    return impl_->fw_grad(level, *this);
+  const Tensor& _fw_grad(uint64_t level) const {
+    return impl_->_fw_grad(level, *this);
   }
 
   /// This function can be used to set the value of the forward grad.
   /// Note that the given new_grad might not be used directly if it has different
   /// metadata (size/stride/storage offset) compared to this Tensor. In that case,
   /// new_grad content will be copied into a new Tensor
-  void set_fw_grad(const Tensor& new_grad, uint64_t level, bool is_inplace_op) {
-    impl_->set_fw_grad(new_grad, *this, level, is_inplace_op);
+  void _set_fw_grad(const Tensor& new_grad, uint64_t level, bool is_inplace_op) {
+    impl_->_set_fw_grad(new_grad, *this, level, is_inplace_op);
   }
 
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -44,13 +44,13 @@ const at::Tensor& TensorImpl::grad() const {
   return autograd_meta_->grad();
 }
 
-const at::Tensor& TensorImpl::fw_grad(uint64_t level, const at::Tensor& self) const {
+const at::Tensor& TensorImpl::_fw_grad(uint64_t level, const at::Tensor& self) const {
   // See TensorImpl::grad() above for explanation about the line below
   if (!autograd_meta_) return impl::GetAutogradMetaFactory()->undefined_tensor();
   return autograd_meta_->fw_grad(level, self);
 }
 
-void TensorImpl::set_fw_grad(const at::Tensor& new_grad, const at::Tensor& self, uint64_t level, bool is_inplace_op) {
+void TensorImpl::_set_fw_grad(const at::Tensor& new_grad, const at::Tensor& self, uint64_t level, bool is_inplace_op) {
   if (!autograd_meta_) autograd_meta_ = impl::GetAutogradMetaFactory()->make();
   autograd_meta_->set_fw_grad(new_grad, self, level, is_inplace_op);
 }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -674,7 +674,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    *   - "self" should represent the Tensor whose forward grad is accessed. It is
    *     required when dealing with view.
    */
-  const at::Tensor& fw_grad(uint64_t level, const at::Tensor& self) const;
+  const at::Tensor& _fw_grad(uint64_t level, const at::Tensor& self) const;
 
   /**
    * Sets the forward gradient for this Tensor.
@@ -694,7 +694,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    *   - "is_inplace_op" is a boolean flag that tells if this gradient was generated
    *     by an inplace operation or an out of place one. This allows better error checking.
    */
-  void set_fw_grad(const at::Tensor& new_grad, const at::Tensor& self, uint64_t level, bool is_inplace_op);
+  void _set_fw_grad(const at::Tensor& new_grad, const at::Tensor& self, uint64_t level, bool is_inplace_op);
 
   /**
    * Return a typed data pointer to the actual data which this tensor refers to.

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -41,7 +41,7 @@ bool isDefined(const c10::optional<Tensor>& t) {
 }
 
 bool isFwGradDefined(const c10::optional<Tensor>& t) {
-  return t.has_value() && t->defined() && t->fw_grad(/*level */ 0).defined();
+  return t.has_value() && t->defined() && t->_fw_grad(/*level */ 0).defined();
 }
 
 Tensor toLegacyTensor(const c10::optional<Tensor>& t) {
@@ -49,7 +49,7 @@ Tensor toLegacyTensor(const c10::optional<Tensor>& t) {
 }
 
 Tensor toLegacyFwGrad(const c10::optional<Tensor>& t) {
-  return (t.has_value() && t->defined()) ? t->fw_grad(/*level */ 0) : Tensor();
+  return (t.has_value() && t->defined()) ? t->_fw_grad(/*level */ 0) : Tensor();
 }
 
 Tensor toLegacyPrimal(const c10::optional<Tensor>& t) {

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -262,7 +262,7 @@ Tensor & copy_(c10::DispatchKeySet ks, Tensor & self, const Tensor & src, bool n
     } else {
       new_fw_grad = src_fw_grad;
     }
-    self.set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ true);
+    self._set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ true);
   }
 
   return self;
@@ -282,7 +282,7 @@ Tensor& resize_(
     at::redispatch::resize_(ks & c10::after_autograd_keyset, self_, size, optional_memory_format);
   }
 
-  if (self.fw_grad(/* level */ 0).defined()) {
+  if (self._fw_grad(/* level */ 0).defined()) {
     AT_ERROR("cannot resize variables that has a forward grad");
   }
 
@@ -305,7 +305,7 @@ Tensor& resize_as_(
   }
 
   // Handle fw grad
-  if (self.fw_grad(/* level */ 0).defined()) {
+  if (self._fw_grad(/* level */ 0).defined()) {
     AT_ERROR("cannot resize variables that has a forward grad");
   }
   return self;
@@ -320,9 +320,9 @@ Tensor detach(const Tensor & self) {
   namedinference::propagate_names(result, self);
 
   // detach only backward gradients for both primal and tangent
-  if (self.fw_grad(/* level */ 0).defined()) {
-    auto new_fw_grad = self.fw_grad(/* level */ 0).detach();
-    result.set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
+  if (self._fw_grad(/* level */ 0).defined()) {
+    auto new_fw_grad = self._fw_grad(/* level */ 0).detach();
+    result._set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
   }
 
   return result;
@@ -363,8 +363,8 @@ Tensor & detach_(Tensor & self) {
   autograd_meta->output_nr_ = 0;
 
   // detach only backward gradients for both primal and tangent
-  if (self.fw_grad(/* level */ 0).defined()) {
-    self.fw_grad(/* level */ 0).detach_();
+  if (self._fw_grad(/* level */ 0).defined()) {
+    self._fw_grad(/* level */ 0).detach_();
   }
 
   return self;

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -139,7 +139,7 @@ void AutogradMeta::set_fw_grad(const Variable& new_grad_, const Variable& self, 
         auto view_info = this_view_meta->get_forward_view();
         auto& base = view_info.base_;
 
-        if (!base.fw_grad(level).defined()) {
+        if (!base._fw_grad(level).defined()) {
           // Enforce same meta here to make sure that the view op below is always valid
           Tensor new_base_fw_grad;
           if (has_same_meta(new_grad, base)) {
@@ -161,7 +161,7 @@ void AutogradMeta::set_fw_grad(const Variable& new_grad_, const Variable& self, 
             new_grad = new_fw_grad_value;
           }
 
-          base.set_fw_grad(new_base_fw_grad, level, /* is_inplace_op */ false);
+          base._set_fw_grad(new_base_fw_grad, level, /* is_inplace_op */ false);
         }
       }
     }
@@ -195,7 +195,7 @@ const Variable& AutogradMeta::fw_grad(uint64_t level, const Variable& self) cons
       const auto& view_info = this_view_meta->get_forward_view();
       const auto& base = view_info.base_;
 
-      const auto& base_val = base.fw_grad(level);
+      const auto& base_val = base._fw_grad(level);
       if (base_val.defined()) {
         // Lazy initialization of fw_grad_
         this_view_meta->fw_grad_ = std::make_shared<ForwardGrad>();

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -25,7 +25,7 @@ SavedVariable::SavedVariable(const Variable& variable, bool is_output, bool is_i
     // Do them here instead of in the init list in case data is undefined.
     data_ = variable.tensor_data();
     // TODO(albanD) This needs to be updated when moving to multiple levels
-    const auto& fw_grad = variable.fw_grad(/* level */ 0);
+    const auto& fw_grad = variable._fw_grad(/* level */ 0);
     if (fw_grad.defined()) {
       fw_grad_ = std::make_shared<ForwardGrad>();
       fw_grad_->set_value(fw_grad, /* level */ 0);
@@ -113,7 +113,7 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
   if (fw_grad_ && !fw_grad_->empty()) {
     // TODO(albanD) This needs to be updated when moving to multiple levels
     auto new_fw_grad = fw_grad_->value(/* level */ 0);
-    var.set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
+    var._set_fw_grad(new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
   }
 
   return var;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54103 cleanup static_cast of AutogradMeta
* #54102 properly make AutogradMeta/DifferentiableViewMeta attributes internal
* #54101 Remove legacy from optional-related function names
* #54100 Add size check for forward grads
* **#54099 make internal forwardAD methods on at::Tensor internal**

Differential Revision: [D27117838](https://our.internmc.facebook.com/intern/diff/D27117838)