### PR TITLE
Add size check for forward grads

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6765,6 +6765,17 @@ class TestAutogradForwardMode(TestCase):
             del dual
             self.assertIsNone(tangent_ref())
 
+    def test_size_check(self):
+        foo = torch.rand(2)
+        tangent = torch.rand(3)
+
+        with fwAD.dual_level():
+            with self.assertRaisesRegex(RuntimeError, "Trying to set a forward gradient that has a different size"):
+                dual = fwAD.make_dual(foo, tangent)
+
+            dual = fwAD.make_dual(foo, tangent[1:])
+
+
 # Generic device type autograd tests.
 class TestAutogradDeviceType(TestCase):
 

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -123,9 +123,9 @@ void AutogradMeta::set_fw_grad(const Variable& new_grad_, const Variable& self, 
     // TODO(alband) remove this spurious version counter bump
     auto new_grad = new_grad_;
 
-    TORCH_CHECK(self.is_same_size(new_grad_), "Trying to set a forward gradient that has a different size than the "
-                "original Tensor, this is not supported. Tensor is of size ", self.sizes(), " while the given forward "
-                "gradient is of size ", new_grad_.sizes(), ".");
+    TORCH_CHECK(self.is_same_size(new_grad_), "Trying to set a forward gradient that has a different size than that "
+                "of the original Tensor, this is not supported. Tensor is of size ", self.sizes(), " while the given "
+                "forward gradient is of size ", new_grad_.sizes(), ".");
 
     if (is_inplace_op && is_view_) {
       auto this_view_meta = static_cast<DifferentiableViewMeta*>(this);

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -123,6 +123,10 @@ void AutogradMeta::set_fw_grad(const Variable& new_grad_, const Variable& self, 
     // TODO(alband) remove this spurious version counter bump
     auto new_grad = new_grad_;
 
+    TORCH_CHECK(self.is_same_size(new_grad_), "Trying to set a forward gradient that has a different size than the "
+                "original Tensor, this is not supported. Tensor is of size ", self.sizes(), " while the given forward "
+                "gradient is of size ", new_grad_.sizes(), ".");
+
     if (is_inplace_op && is_view_) {
       auto this_view_meta = static_cast<DifferentiableViewMeta*>(this);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54103 cleanup static_cast of AutogradMeta
* #54102 properly make AutogradMeta/DifferentiableViewMeta attributes internal
* #54101 Remove legacy from optional-related function names
* **#54100 Add size check for forward grads**
* #54099 make internal forwardAD methods on at::Tensor internal

Differential Revision: [D27117842](https://our.internmc.facebook.com/intern/diff/D27117842)