### PR TITLE
Remove legacy from optional-related function names

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -44,15 +44,15 @@ bool isFwGradDefined(const c10::optional<Tensor>& t) {
   return t.has_value() && t->defined() && t->_fw_grad(/*level */ 0).defined();
 }
 
-Tensor toLegacyTensor(const c10::optional<Tensor>& t) {
+Tensor toNonOptTensor(const c10::optional<Tensor>& t) {
   return t.has_value() ? *t : Tensor();
 }
 
-Tensor toLegacyFwGrad(const c10::optional<Tensor>& t) {
+Tensor toNonOptFwGrad(const c10::optional<Tensor>& t) {
   return (t.has_value() && t->defined()) ? t->_fw_grad(/*level */ 0) : Tensor();
 }
 
-Tensor toLegacyPrimal(const c10::optional<Tensor>& t) {
+Tensor toNonOptPrimal(const c10::optional<Tensor>& t) {
   return (t.has_value() && t->defined()) ? t->_fw_primal(/*level */ 0) : Tensor();
 }
 
@@ -2740,11 +2740,11 @@ std::tuple<Tensor, Tensor, Tensor> batchnorm_double_backward(
   }
   // for half inputs, save_mean, save_invstd are float (ideally, we would cast
   // everything else, but not now)
-  auto mu = unsqueeze_dim1(training ? toLegacyTensor(save_mean).to(input.scalar_type()) : toLegacyTensor(running_mean), input);
+  auto mu = unsqueeze_dim1(training ? toNonOptTensor(save_mean).to(input.scalar_type()) : toNonOptTensor(running_mean), input);
   auto input_sub_mu = input - mu;
   auto sigma2_eps_neg_1_2 = unsqueeze_dim1(
-      training ? toLegacyTensor(save_invstd).to(input.scalar_type())
-               : toLegacyTensor(running_var).add(Scalar(eps)).pow(-0.5),
+      training ? toNonOptTensor(save_invstd).to(input.scalar_type())
+               : toNonOptTensor(running_var).add(Scalar(eps)).pow(-0.5),
       input);
   auto sigma2_eps_neg_1 = sigma2_eps_neg_1_2.pow(2);
   auto sigma2_eps_neg_3_2 = sigma2_eps_neg_1_2.pow(3);
@@ -2923,10 +2923,10 @@ infinitely_differentiable_native_layer_norm_backward(
   if (grad_input_mask[1] && dY.defined()) {
     dgamma = (dY_tensor * (X_tensor - mean_tensor) * rstd_tensor)
                  .sum(0)
-                 .reshape_as(toLegacyTensor(gamma));
+                 .reshape_as(toNonOptTensor(gamma));
   }
   if (grad_input_mask[2] && dY.defined()) {
-    dbeta = dY_tensor.sum(0).reshape_as(toLegacyTensor(gamma));
+    dbeta = dY_tensor.sum(0).reshape_as(toNonOptTensor(gamma));
   }
 
   return std::make_tuple(dX, dgamma, dbeta);
@@ -3012,10 +3012,10 @@ infinitely_differentiable_native_group_norm_backward(
     }
   }
   if (grad_input_mask[1] && dY.defined()) {
-    dgamma = ((ds - db * mean_tensor) * rstd_tensor).sum(0).reshape_as(toLegacyTensor(gamma));
+    dgamma = ((ds - db * mean_tensor) * rstd_tensor).sum(0).reshape_as(toNonOptTensor(gamma));
   }
   if (grad_input_mask[2] && dY.defined()) {
-    dbeta = db.sum(0).reshape_as(toLegacyTensor(gamma));
+    dbeta = db.sum(0).reshape_as(toNonOptTensor(gamma));
   }
 
   return std::make_tuple(dX, dgamma, dbeta);

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -32,8 +32,8 @@ struct IndexRangeGenerator {
 };
 
 bool isFwGradDefined(const c10::optional<Tensor>& t);
-Tensor toLegacyFwGrad(const c10::optional<Tensor>& t);
-Tensor toLegacyPrimal(const c10::optional<Tensor>& t);
+Tensor toNonOptFwGrad(const c10::optional<Tensor>& t);
+Tensor toNonOptPrimal(const c10::optional<Tensor>& t);
 
 bool any_variable_defined(variable_list& variables);
 void copy_range(variable_list& out, IndexRange range, const at::Tensor & t);

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -250,8 +250,8 @@ Tensor & copy_(c10::DispatchKeySet ks, Tensor & self, const Tensor & src, bool n
 
   if (isDifferentiableType(self.scalar_type()) &&
       (generated::details::isFwGradDefined(self) || generated::details::isFwGradDefined(src))) {
-    auto self_fw_grad = generated::details::toLegacyFwGrad(self);
-    auto src_fw_grad = generated::details::toLegacyFwGrad(src);
+    auto self_fw_grad = generated::details::toNonOptFwGrad(self);
+    auto src_fw_grad = generated::details::toNonOptFwGrad(src);
     Tensor new_fw_grad;
     if (self_fw_grad.defined()) {
       if (src_fw_grad.defined()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54103 cleanup static_cast of AutogradMeta
* #54102 properly make AutogradMeta/DifferentiableViewMeta attributes internal
* **#54101 Remove legacy from optional-related function names**
* #54100 Add size check for forward grads
* #54099 make internal forwardAD methods on at::Tensor internal

Differential Revision: [D27117839](https://our.internmc.facebook.com/intern/diff/D27117839)