### PR TITLE
cleanup static_cast of AutogradMeta

### DIFF
--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -122,8 +122,7 @@ variable_list _wrap_outputs(const variable_list &input_vars,
     // return and input that is a view as is).
     // See NOTE [ View + Inplace detection ] for why we replace everything by a warning.
     if (!(is_input && is_modified) && var.is_view()) {
-      // NB: is_view() ==> get_autograd_meta()
-      auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
+      auto diff_view_meta = impl::get_view_autograd_meta(var);
       diff_view_meta->set_creation_meta(CreationMeta::IN_CUSTOM_FUNCTION);
     }
 
@@ -140,8 +139,7 @@ variable_list _wrap_outputs(const variable_list &input_vars,
   if (num_diff_outputs > 1) {
     for (auto& var: outputs) {
       if (var.is_view()) {
-        // NB: is_view() ==> get_autograd_meta()
-        auto diff_view_meta = static_cast<DifferentiableViewMeta*>(impl::get_autograd_meta(var));
+        auto diff_view_meta = impl::get_view_autograd_meta(var);
         diff_view_meta->set_creation_meta(CreationMeta::MULTI_OUTPUT_NODE);
       }
     }

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -109,6 +109,10 @@ namespace impl {
   // a materialized structure, use materialize_autograd_meta instead.
   TORCH_API AutogradMeta* get_autograd_meta(const Variable&);
 
+  // WARNING: This function should only be called for view Tensors.
+  // This function always returns a valid DifferentiableViewMeta.
+  TORCH_API DifferentiableViewMeta* get_view_autograd_meta(const Variable&);
+
   // Returns the current autograd meta, materializing it if it was previously
   // none.  This counts as a *mutating* operation, so do not call it on
   // "read-only" operators; in particular, this is NOT thread safe


### PR DESCRIPTION
The goal is to reduce the spread of static casts in the autograd code as per the comment in https://github.com/pytorch/pytorch/pull/49097#discussion_r543695091
I wasn't sure how to use a virtual method here but a simple method in impl clean it up quite nicely.


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54103 cleanup static_cast of AutogradMeta**
* #54102 properly make AutogradMeta/DifferentiableViewMeta attributes internal
* #54101 Remove legacy from optional-related function names
* #54100 Add size check for forward grads
* #54099 make internal forwardAD methods on at::Tensor internal

Differential Revision: [D27117840](https://our.internmc.facebook.com/intern/diff/D27117840)