### PR TITLE
[Static Runtime] Only run ReplaceWithCopy pass when enable_out_variant is true

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -340,24 +340,9 @@ TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
   m.def("static_runtime::pure_inputs() -> Tensor", []() -> at::Tensor {
     return at::randn({1});
   });
+  m.def("static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor");
   m.def(
-      "static_runtime::permute_copy(Tensor self, int[] dims) -> Tensor",
-      [](const at::Tensor& self, ArrayRef<int64_t> dims) -> at::Tensor {
-        at::Tensor out = at::empty_like(self);
-        at::native::copy_(out, self);
-        return out.permute(dims);
-      });
-  m.def(
-      "static_runtime::to_copy(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor",
-      [](const at::Tensor& self,
-         at::ScalarType dtype,
-         bool non_blocking,
-         bool copy,
-         c10::optional<c10::MemoryFormat> format) -> at::Tensor {
-        at::Tensor out = at::empty_like(self);
-        at::native::copy_(out, self);
-        return out.to(dtype, non_blocking, copy, format);
-      });
+      "static_runtime::to_copy(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor");
 }
 
 void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {


### PR DESCRIPTION
Summary: If we only run the ReplaceWithCopy pass when enable_out_variant is true, there is no need register a default op implementation.

Reviewed By: edvgha

Differential Revision: D27036077

