### PR TITLE
Optimize alias_analysis node lookup

### DIFF
--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -1327,6 +1327,7 @@ class AliasDb::WorkingSet {
   // Add `n` to the working set
   void add(Node* n) {
     nodes_.push_back(n);
+    node_to_index_[n] = nodes_.size() - 1;
     for (const auto user : getUsersSameBlock(n)) {
       users_.insert(user);
     }
@@ -1406,8 +1407,9 @@ class AliasDb::WorkingSet {
     if (mover_ && users.count(mover_)) {
       return true;
     }
-    return std::any_of(nodes_.begin(), nodes_.end(), [&](Node* node) {
-      return users.count(node) != 0;
+
+    return std::any_of(users.begin(), users.end(), [&](Node* node) {
+      return node_to_index_.find(node) != node_to_index_.end();
     });
   }
 
@@ -1452,6 +1454,10 @@ class AliasDb::WorkingSet {
 
   const AliasDb& aliasDb_;
   std::vector<Node*> nodes_;
+  // Extra data structure for nodes for faster look up
+  // Since the tryMove method is used a lot, we want to
+  // make it as fast as possible.
+  std::unordered_map<Node*, int64_t> node_to_index_;
 
   // Mover dependencies. We track these separately since we may erase the mover
   // from the working set.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54115 Optimize alias_analysis node lookup**

By using this optimization, we were able to reduce the one round of tracing time for some internal models from 20 mins to under 1 min now. Including the extra time for check tracing, we can now trace models that take one hour to trace to within couple minutes. 

Differential Revision: [D27104047](https://our.internmc.facebook.com/intern/diff/D27104047)