### PR TITLE
Add PyTorchDeploy predictor model type

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -19,12 +19,16 @@ Package InterpreterManager::load_package(const std::string& uri) {
   return Package(uri, this);
 }
 
+Package InterpreterManager::load_package(std::shared_ptr<caffe2::serialize::ReadAdapterInterface> reader) {
+  return Package(reader, this);
+}
+
 Obj InterpreterSession::from_movable(const ReplicatedObj& obj) {
   return impl_->unpickle_or_get(obj.pImpl_->object_id_, obj.pImpl_->data_);
 }
 
 InterpreterSession ReplicatedObj::acquire_session(
-    const Interpreter* on_this_interpreter) {
+    const Interpreter* on_this_interpreter) const {
   InterpreterSession I = on_this_interpreter
       ? on_this_interpreter->acquire_session()
       : pImpl_->manager_->acquire_one();

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -121,6 +121,7 @@ struct TORCH_API InterpreterManager {
     resources_.setResourceLimit(N);
   }
   Package load_package(const std::string& uri);
+  Package load_package(std::shared_ptr<caffe2::serialize::ReadAdapterInterface> reader);
   InterpreterManager(const InterpreterManager&) = delete;
   InterpreterManager& operator=(const InterpreterManager&) = delete;
   InterpreterManager& operator=(InterpreterManager&&) = delete;
@@ -149,11 +150,17 @@ struct TORCH_API ReplicatedObjImpl {
 struct TORCH_API ReplicatedObj {
   ReplicatedObj() : pImpl_(nullptr) {}
   InterpreterSession acquire_session(
-      const Interpreter* on_this_interpreter = nullptr);
-  at::IValue operator()(at::ArrayRef<at::IValue> args) {
+      const Interpreter* on_this_interpreter = nullptr) const;
+  at::IValue operator()(at::ArrayRef<at::IValue> args) const {
     auto I = acquire_session();
     return I.self(args).toIValue();
   }
+
+  at::IValue call_kwargs(std::vector<std::tuple<std::string, at::IValue>> kwargs) const {
+    auto I = acquire_session();
+    return I.self.call_kwargs(std::move(kwargs)).toIValue();
+  }
+
   void unload(const Interpreter* on_this_interpreter = nullptr);
 
  private:
@@ -174,6 +181,16 @@ struct TORCH_API Package {
     return I.create_movable(loaded);
   }
 
+  std::string load_text(
+      const std::string& module,
+      const std::string& file) {
+    auto I = acquire_session();
+    auto loaded = I.self.attr("load_text")({module, file});
+    // What should the behavior be if file doesn't exist? (same Q for load_pickle)
+    // Should I assert isString first?
+    return loaded.toIValue().toStringRef();
+  }
+
   InterpreterSession acquire_session() {
     auto I = manager_->acquire_one();
     I.self = I.impl_->create_or_get_package_importer_from_container_file(
@@ -189,6 +206,13 @@ struct TORCH_API Package {
       : manager_(pm),
         container_file_(
             std::make_shared<caffe2::serialize::PyTorchStreamReader>(uri)) {}
+    Package(
+      std::shared_ptr<caffe2::serialize::ReadAdapterInterface> reader,
+      InterpreterManager*
+          pm) // or really any of the constructors to our zip file format
+      : manager_(pm),
+        container_file_(
+            std::make_shared<caffe2::serialize::PyTorchStreamReader>(reader)) {}
   friend struct ReplicatedObj;
   friend struct InterpreterManager;
   InterpreterManager* manager_;

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -32,8 +32,6 @@ using namespace py::literals;
 #define PYOBJ_ASSERT(obj) assert(NULL != obj);
 #endif
 
-static wchar_t* program;
-
 #define FOREACH_LIBRARY(_) \
   _(array)                 \
   _(_asyncio)              \
@@ -316,6 +314,7 @@ struct ConcreteInterpreterImpl : public torch::deploy::InterpreterImpl {
     // Release the GIL that PyInitialize acquires
     PyEval_SaveThread();
   }
+
   ~ConcreteInterpreterImpl() override {
     PyGILState_Ensure();
     // make sure pybind11 doesn't try to decref after we have destroyed python
@@ -329,8 +328,8 @@ struct ConcreteInterpreterImpl : public torch::deploy::InterpreterImpl {
       exit(1); // can't use TORCH_INTERNAL_ASSERT because we are in a
                // non-throwing destructor.
     }
-    PyMem_RawFree(program);
   }
+
   torch::deploy::InterpreterSessionImpl* acquire_session() override;
   py::object save_storage;
   py::object load_storage;
@@ -432,12 +431,27 @@ struct ConcreteInterpreterSessionImpl
     return wrap(call(unwrap(obj), m_args));
   }
 
+  Obj call_kwargs(Obj obj, std::vector<std::tuple<std::string, at::IValue>> kwargs) override {
+    std::vector<std::tuple<std::string, py::object>> kwargs_list;
+    kwargs_list.reserve(kwargs.size());
+    for (auto& kv: kwargs) {
+      kwargs_list.emplace_back(std::get<0>(kv), torch::jit::toPyObject(std::get<1>(kv)));
+    }
+    py::object o = py::cast(kwargs_list);
+    if(!o) {
+      throw py::error_already_set();
+    }
+    py::dict py_kwargs(o);
+    py::list py_args;
+    return wrap(call(unwrap(obj), py_args, py_kwargs));
+  }
+
   Obj attr(Obj obj, const char* attr) override {
     return wrap(unwrap(obj).attr(attr));
   }
 
-  static py::object call(py::handle object, py::handle args) {
-    PyObject* result = PyObject_CallObject(object.ptr(), args.ptr());
+  static py::object call(py::handle object, py::handle args, py::handle kwargs = nullptr) {
+    PyObject* result = PyObject_Call(object.ptr(), args.ptr(), kwargs.ptr());
     if (!result) {
       throw py::error_already_set();
     }
@@ -447,10 +461,12 @@ struct ConcreteInterpreterSessionImpl
   py::handle unwrap(Obj obj) const {
     return objects_.at(ID(obj));
   }
+
   Obj wrap(py::object obj) {
     objects_.emplace_back(std::move(obj));
     return Obj(this, objects_.size() - 1);
   }
+
   ~ConcreteInterpreterSessionImpl() override {
     objects_.clear();
   }

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -33,6 +33,7 @@ struct Obj {
   at::IValue toIValue() const;
   Obj operator()(at::ArrayRef<Obj> args);
   Obj operator()(at::ArrayRef<at::IValue> args);
+  Obj call_kwargs(std::vector<std::tuple<std::string, at::IValue>> kwargs);
   Obj attr(const char* attr);
 
  private:
@@ -64,7 +65,11 @@ struct InterpreterSessionImpl {
 
   virtual Obj call(Obj obj, at::ArrayRef<Obj> args) = 0;
   virtual Obj call(Obj obj, at::ArrayRef<at::IValue> args) = 0;
+  virtual Obj call_kwargs(
+      Obj obj,
+      std::vector<std::tuple<std::string, at::IValue>> kwargs) = 0;
   virtual Obj attr(Obj obj, const char* attr) = 0;
+
 
  protected:
   int64_t ID(Obj obj) const {
@@ -77,7 +82,7 @@ struct InterpreterImpl {
   virtual ~InterpreterImpl() = default; // this will uninitialize python
 };
 
-// inline definitions for PythonObject are necessary to avoid introducing a
+// inline definitions for Objs are necessary to avoid introducing a
 // source file that would need to exist it both the libinterpreter.so and then
 // the libtorchpy library.
 inline at::IValue Obj::toIValue() const {
@@ -92,6 +97,9 @@ inline Obj Obj::operator()(at::ArrayRef<at::IValue> args) {
   return interaction_->call(*this, args);
 }
 
+inline Obj Obj::call_kwargs(std::vector<std::tuple<std::string, at::IValue>> kwargs) {
+  return interaction_->call_kwargs(*this, std::move(kwargs));
+}
 inline Obj Obj::attr(const char* attr) {
   return interaction_->attr(*this, attr);
 }


### PR DESCRIPTION
Summary:
Construct InterpreterManager inside PyTorchDeployModel
 - add ReadAdapterInterface to deploy::Package
Basic test of loading and executing 'simple' model
 - skip Example/IValue/schema logic for now

Implement PyTorchDeployModel::makePrediction for FeatureStore Examples
- WIP still but have passed a simple e2e test

Runs locally in opt and dbg, but not dev
- debugging LSAN issue in dev mode

needs -c=python.package_style=inplace currently or generate_packages fails,

e.g.
buck test mode/opt -c=python.package_style=inplace //fblearner/predictor/model/tests:pytorch_deploy_model_test
should pass

Differential Revision: D26961744

