### PR TITLE
Resubmit: Adding parallel support for the LLVM backend.

### DIFF
--- a/benchmarks/cpp/tensorexpr/CMakeLists.txt
+++ b/benchmarks/cpp/tensorexpr/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   bench_compile.cpp
   bench_fuser_overhead.cpp
   bench_gemm.cpp
+  bench_parallel.cpp
   bench_reduce.cpp
   main.cpp)
 

--- a/benchmarks/cpp/tensorexpr/bench_parallel.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_parallel.cpp
@@ -1,0 +1,75 @@
+#include <benchmark/benchmark.h>
+#include <torch/csrc/jit/tensorexpr/analysis.h>
+#include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/torch.h>
+
+#include <immintrin.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+class ParallelAdd : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    at::set_num_threads(4);
+    torch::manual_seed(0x12345678);
+    M = state.range(0);
+    A = torch::randn({M});
+    B = torch::randn({M});
+    C = torch::zeros({M});
+  }
+
+  void TearDown(benchmark::State& state) override {
+    state.counters["tasks"] = benchmark::Counter(uint64_t(state.iterations()) * M,
+                                                 benchmark::Counter::kIsRate);
+  }
+
+  int M;
+  at::Tensor A;
+  at::Tensor B;
+  at::Tensor C;
+};
+
+BENCHMARK_DEFINE_F(ParallelAdd, Simple)(benchmark::State& state) {
+  KernelScope kernel_scope;
+  ExecutionCounter counter(llvm_codegen_parallel_dispatched);
+  Placeholder a_buf("a", kFloat, {M});
+  Placeholder b_buf("b", kFloat, {M});
+  Tensor* c_tensor = Compute(
+      "c", {{M, "m"}}, [&](const VarHandle& m) {
+        return a_buf.load(m) + b_buf.load(m);
+      });
+  LoopNest loop_nest({c_tensor});
+  auto const& loops = loop_nest.getLoopStmtsFor(c_tensor);
+  For* m = loops[0];
+  m->set_parallel();
+  loop_nest.prepareForCodegen();
+  Stmt* stmt = loop_nest.root_stmt();
+  LLVMCodeGen cg(stmt, {c_tensor, a_buf, b_buf});
+
+  float* a_ptr = A.data_ptr<float>();
+  float* b_ptr = B.data_ptr<float>();
+  float* c_ptr = C.data_ptr<float>();
+  std::vector<void*> args({c_ptr, a_ptr, b_ptr});
+  cg.value<int>(args);
+  int count = counter.elapsed_value();
+  TORCH_CHECK(count > 0);
+  for (int i = 0; i < M; i++) {
+    float diff = fabs(a_ptr[i] + b_ptr[i] - c_ptr[i]);
+    TORCH_CHECK(diff < 1e-5);
+  }
+
+  for (auto _ : state) {
+    cg.value<int>(args);
+  }
+}
+
+BENCHMARK_REGISTER_F(ParallelAdd, Simple)->Args({1 << 16});
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/benchmarks/cpp/tensorexpr/bench_reduce.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_reduce.cpp
@@ -2,6 +2,7 @@
 #include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
 #include <torch/torch.h>
 

--- a/test/cpp/tensorexpr/test_llvm.cpp
+++ b/test/cpp/tensorexpr/test_llvm.cpp
@@ -1610,6 +1610,128 @@ TEST(LLVM, RFactorVectorizedReduction) {
   ExpectAllNear(b_v, b_ref, 1e-5);
 }
 
+TEST(LLVM, SimpleParallel) {
+  for (int test_cfg = 0; test_cfg < 4; test_cfg++) {
+    // Compute a simple operation, and try all loop-axis combination to be
+    // parallel or sequential.
+    ExecutionCounter counter(llvm_codegen_parallel_dispatched);
+    KernelScope kernel_scope;
+    const int M = 4;
+    const int N = 6;
+    Tensor* f = Compute(
+        "f", {{M, "m"}, {N, "n"}}, [](const VarHandle& m, const VarHandle& n) {
+          return cast<float>(m + n);
+        });
+    LoopNest loop_nest({f});
+    auto const& loops = loop_nest.getLoopStmtsFor(f);
+    For* m = loops[0];
+    For* n = loops[1];
+    if (test_cfg & 0x1) {
+      m->set_parallel();
+    }
+    if (test_cfg & 0x2) {
+      n->set_parallel();
+    }
+    loop_nest.prepareForCodegen();
+    Stmt* stmt = loop_nest.root_stmt();
+    LLVMCodeGen cg(stmt, {f});
+
+    PaddedBuffer<float> f_v(M, N, "f_v");
+    std::vector<void*> args({f_v.data()});
+    int value = cg.value<int>(args);
+    ASSERT_EQ(value, 0);
+    PaddedBuffer<float> f_ref(M, N, "f_ref");
+    for (int m = 0; m < M; m++) {
+      for (int n = 0; n < N; n++) {
+        f_ref(m, n) = m + n;
+      }
+    }
+    ExpectAllNear(f_v, f_ref, 1e-5);
+    int count = counter.elapsed_value();
+    if (test_cfg == 0) {
+      ASSERT_EQ(count, 0);
+    } else {
+      ASSERT_GT(count, 0);
+    }
+  }
+}
+
+TEST(LLVM, CompositeParallel) {
+  int loop_count = 6;
+  int test_count = 1 << loop_count;
+  // Compute a composite operation, and try all loop-axis combination to be
+  // parallel or sequential.
+  for (int test_cfg = 0; test_cfg < test_count; test_cfg++) {
+    ExecutionCounter counter(llvm_codegen_parallel_dispatched);
+    KernelScope kernel_scope;
+    int M = 5;
+    int N = 7;
+    Tensor* t1 =
+        Compute("t1", {{M, "M"}}, [](const VarHandle& m) { return m + 1.f; });
+    Tensor* t2 =
+        Compute("t2", {{N, "N"}}, [](const VarHandle& n) { return n + 2.f; });
+    Tensor* t3 = Compute(
+        "t3",
+        {{M, "M"}, {N, "N"}},
+        [=](const VarHandle& m, const VarHandle& n) {
+          return t1->call(m) * t2->call(n);
+        });
+    Tensor* t4 = Compute(
+        "t4",
+        {{M, "M"}, {N, "N"}},
+        [=](const VarHandle& m, const VarHandle& n) {
+          return t3->call(m, n) + m + n;
+        });
+    LoopNest loop_nest({t4});
+    std::vector<For*> loop_list;
+    {
+      auto const& loops = loop_nest.getLoopStmtsFor(t1);
+      loop_list.push_back(loops[0]);
+    }
+    {
+      auto const& loops = loop_nest.getLoopStmtsFor(t2);
+      loop_list.push_back(loops[0]);
+    }
+    {
+      auto const& loops = loop_nest.getLoopStmtsFor(t3);
+      loop_list.push_back(loops[0]);
+      loop_list.push_back(loops[1]);
+    }
+    {
+      auto const& loops = loop_nest.getLoopStmtsFor(t4);
+      loop_list.push_back(loops[0]);
+      loop_list.push_back(loops[1]);
+    }
+    ASSERT_EQ(loop_list.size(), loop_count);
+    for (int i = 0; i < loop_count; i++) {
+      if (test_cfg & (1 << i)) {
+        loop_list[i]->set_parallel();
+      }
+    }
+    loop_nest.prepareForCodegen();
+    Stmt* stmt = loop_nest.root_stmt();
+    LLVMCodeGen cg(stmt, {t4});
+
+    PaddedBuffer<float> t4_v(M, N, "t4_v");
+    std::vector<void*> args({t4_v.data()});
+    int value = cg.value<int>(args);
+    ASSERT_EQ(value, 0);
+    PaddedBuffer<float> t4_ref(M, N, "t4_ref");
+    for (int m = 0; m < M; m++) {
+      for (int n = 0; n < N; n++) {
+        t4_ref(m, n) = (m + 1) * (n + 2) + m + n;
+      }
+    }
+    ExpectAllNear(t4_v, t4_ref, 1e-5);
+    int count = counter.elapsed_value();
+    if (test_cfg == 0) {
+      ASSERT_EQ(count, 0);
+    } else {
+      ASSERT_GT(count, 0);
+    }
+  }
+}
+
 TEST(LLVM, VectorizedGEMM) {
   KernelScope ks;
 

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -2,7 +2,9 @@
 
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 
+#include <aten/src/ATen/Parallel.h>
 #include <c10/util/Exception.h>
+#include <torch/csrc/jit/tensorexpr/analysis.h>
 #include <torch/csrc/jit/tensorexpr/llvm_jit.h>
 
 #include <memory>
@@ -56,6 +58,7 @@ DEFINE_TRIGGER(llvm_codegen_executed);
 namespace torch {
 namespace jit {
 namespace tensorexpr {
+DEFINE_TRIGGER(llvm_codegen_parallel_dispatched);
 namespace {
 
 llvm::CmpInst::Predicate llvm_comparison_predicate(
@@ -121,6 +124,34 @@ llvm::ElementCount ElementCount(int lanes) {
 }
 #endif
 
+#if LLVM_VERSION_MAJOR >= 9
+
+using FunctionCallee = llvm::FunctionCallee;
+
+#elif LLVM_VERSION_MAJOR == 8 && LLVM_VERSION_PATCH == 20181009
+
+struct FunctionCallee {
+  FunctionCallee() {}
+
+  FunctionCallee(llvm::Constant* fn)
+      : v_(fn), ft_(cast<llvm::Function>(v_)->getFunctionType()) {}
+
+  llvm::FunctionType* getFunctionType() {
+    return ft_;
+  }
+
+  llvm::Value* getCallee() {
+    return v_;
+  }
+
+ private:
+  llvm::Value* v_{nullptr};
+  llvm::FunctionType* ft_{nullptr};
+};
+
+#else
+#error Only LLVM versions 8 and above are supported.
+#endif
 } // namespace
 
 class LLVMCodeGenImpl : public IRVisitor {
@@ -139,6 +170,7 @@ class LLVMCodeGenImpl : public IRVisitor {
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, LLVM_TYPE_DECLARE);
 #undef LLVM_TYPE_DECLARE
   llvm::Type* Int8PtrTy_;
+  llvm::Type* VoidTy_;
 
   std::unordered_map<const Var*, int> varToArg_;
   std::unordered_map<const Var*, llvm::Value*> varToVal_;
@@ -167,6 +199,14 @@ class LLVMCodeGenImpl : public IRVisitor {
       llvm::Type* type,
       Arity arity,
       int lanes);
+
+  llvm::Value* varToValue(const Var* var);
+  void replaceVarMapping(
+      const std::vector<const Var*>& vars,
+      const std::vector<llvm::Value*>& vals);
+  llvm::Value* packFuncArgs(const std::vector<llvm::Value*>& func_args);
+  std::vector<llvm::Value*> unpackFuncArgs(llvm::Value* packed, int arg_count);
+  void processParallelFor(const For* v);
 
  public:
   LLVMCodeGenImpl(
@@ -238,6 +278,19 @@ class LLVMCodeGenImpl : public IRVisitor {
     return asmCode;
   }
 };
+
+typedef void (*ParallelCallee)(int index, int8_t* packed_data);
+void DispatchParallel(int8_t* func, int start, int stop, int8_t* packed_data) {
+  // TODO: preserve the func type.
+  ParallelCallee callee = reinterpret_cast<ParallelCallee>(func);
+  at::parallel_for(start, stop, 1, [&](int64_t f_begin, int64_t f_end) {
+    for (int index = f_begin; index < f_end; index++) {
+      callee(index, packed_data);
+    }
+  });
+  USE_TRIGGER(llvm_codegen_parallel_dispatched);
+}
+
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch
@@ -341,6 +394,7 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   FloatTy_ = llvm::Type::getFloatTy(getContext());
   DoubleTy_ = llvm::Type::getDoubleTy(getContext());
   Int8PtrTy_ = llvm::Type::getInt8PtrTy(getContext());
+  VoidTy_ = llvm::Type::getVoidTy(getContext());
   BoolTy_ = ByteTy_;
 
   llvm::InitializeNativeTarget();
@@ -955,12 +1009,35 @@ void LLVMCodeGenImpl::visit(const BitCast* v) {
 }
 
 void LLVMCodeGenImpl::visit(const Var* v) {
-  if (varToArg_.count(v)) {
+  value_ = varToValue(v);
+}
+
+llvm::Value* LLVMCodeGenImpl::varToValue(const Var* v) {
+  // It is possible for v to be in both varToVal_ and varToArgs.
+  // In that case, varToVal_ takes precedence.
+  if (varToVal_.count(v)) {
+    return varToVal_.at(v);
+  } else if (varToArg_.count(v)) {
     auto idx = varToArg_.at(v);
     auto arg = fn_->arg_begin() + idx;
-    value_ = arg;
-  } else if (varToVal_.count(v)) {
-    value_ = varToVal_.at(v);
+    return arg;
+  }
+  return nullptr;
+}
+
+void LLVMCodeGenImpl::replaceVarMapping(
+    const std::vector<const Var*>& vars,
+    const std::vector<llvm::Value*>& vals) {
+  TORCH_CHECK(vars.size() == vals.size());
+  int i = 0;
+  for (int i = 0; i < vars.size(); i++) {
+    const Var* var = vars[i];
+    llvm::Value* val = vals[i];
+    if (val) {
+      varToVal_[var] = val;
+    } else {
+      varToVal_.erase(var);
+    }
   }
 }
 
@@ -1128,7 +1205,132 @@ void LLVMCodeGenImpl::visit(const Load* v) {
   value_ = load;
 }
 
+// Pack the arguments into an aggregate struct for forwarding.
+llvm::Value* LLVMCodeGenImpl::packFuncArgs(
+    const std::vector<llvm::Value*>& func_args) {
+  if (func_args.empty()) {
+    llvm::PointerType* VoidPtrType = llvm::Type::getInt8PtrTy(getContext());
+    llvm::Constant* NullPtr = llvm::ConstantPointerNull::get(VoidPtrType);
+    return NullPtr;
+  }
+  std::vector<llvm::Type*> arg_types(func_args.size());
+  for (int i = 0; i < func_args.size(); i++) {
+    arg_types[i] = func_args[i]->getType();
+  }
+  llvm::StructType* packed_type = llvm::StructType::create(arg_types);
+  llvm::Value* zero = llvm::ConstantInt::get(IntTy_, 0);
+  llvm::Value* one = llvm::ConstantInt::get(IntTy_, 1);
+  llvm::Value* packed = irb_.CreateAlloca(packed_type, one);
+  for (int i = 0; i < func_args.size(); i++) {
+    llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
+        packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
+    irb_.CreateStore(func_args[i], dst_ptr);
+  }
+  return packed;
+}
+
+// Unpack the aggregate struct into individual arguments.
+std::vector<llvm::Value*> LLVMCodeGenImpl::unpackFuncArgs(
+    llvm::Value* packed,
+    int arg_count) {
+  // TODO: extract arg_count from packed.
+  std::vector<llvm::Value*> func_args(arg_count);
+  llvm::Value* zero = llvm::ConstantInt::get(IntTy_, 0);
+  for (int i = 0; i < arg_count; i++) {
+    llvm::Value* dst_ptr = irb_.CreateInBoundsGEP(
+        packed, {zero, llvm::ConstantInt::get(IntTy_, i)});
+    func_args[i] = irb_.CreateLoad(dst_ptr);
+  }
+  return func_args;
+}
+
+// Lower the parallel for-loop.
+// * Move the body into its own closure.
+// * Identify var across the boundary into arguments and forward them.
+// * Send the closure and range to the dispatcher for execution.
+void LLVMCodeGenImpl::processParallelFor(const For* v) {
+  // Create "start" and "stop" values.
+  v->start()->accept(this);
+  auto start = this->value_;
+  v->stop()->accept(this);
+  auto stop = this->value_;
+
+  // The Vars that need to be forward in the body closure.
+  std::vector<const Var*> body_arg_vars;
+  // Corresponding Value* that was used in the old body for the caller.
+  std::vector<llvm::Value*> body_caller_vals;
+  // Corresponding Value* that will be used in the new body closure.
+  std::vector<llvm::Value*> body_closure_args;
+
+  // Identify the Var* used in the body, and generated outside.
+  VarFinder var_finder;
+  v->body()->accept(&var_finder);
+  const auto& vars = var_finder.vars();
+  for (auto& var : vars) {
+    if (llvm::Value* value = varToValue(var)) {
+      body_arg_vars.push_back(var);
+      body_caller_vals.push_back(value);
+    }
+  }
+
+  // Pack the arguments in an automatic variable for forwarding.
+  llvm::Value* packed_caller_args = packFuncArgs(body_caller_vals);
+
+  // Remember where we are before moving to the new function.
+  llvm::BasicBlock* old_insert_block = irb_.GetInsertBlock();
+
+  // Create the new body closure code.
+  auto func_type =
+      llvm::FunctionType::get(VoidTy_, {IntTy_, Int8PtrTy_}, false);
+  llvm::Function* func = llvm::Function::Create(
+      func_type, llvm::Function::PrivateLinkage, "func", module_.get());
+  auto func_body = llvm::BasicBlock::Create(getContext(), "func_body", func);
+  irb_.SetInsertPoint(func_body);
+  auto args = func->arg_begin();
+  llvm::Value* index = args++;
+  llvm::Value* packed_func_args_raw = args++;
+  llvm::Value* packed_func_args = irb_.CreatePointerCast(
+      packed_func_args_raw, packed_caller_args->getType());
+
+  // Unpack the arguments from the opaque buffer.
+  body_closure_args = unpackFuncArgs(packed_func_args, body_arg_vars.size());
+  // Set the codegen to the new func.
+  // TODO: this should be replaced by RAII wrappers.
+  varToVal_[v->var()] = index;
+  replaceVarMapping(body_arg_vars, body_closure_args);
+  llvm::Function* old_fn = fn_;
+  fn_ = func;
+  if (v->body()) {
+    v->body()->accept(this);
+  }
+  // Restore back to the previous fn_
+  fn_ = old_fn;
+  irb_.CreateRet(nullptr);
+  replaceVarMapping(body_arg_vars, body_caller_vals);
+  varToVal_.erase(v->var());
+
+  // Points back to the original block and generate the callee code.
+  irb_.SetInsertPoint(old_insert_block);
+  llvm::Value* packed_caller_args_ptr =
+      irb_.CreatePointerCast(packed_caller_args, Int8PtrTy_);
+  llvm::Value* func_value = irb_.CreatePointerCast(func, Int8PtrTy_);
+  llvm::FunctionType* dispatcher_fntype = llvm::FunctionType::get(
+      VoidTy_, {Int8PtrTy_, IntTy_, IntTy_, Int8PtrTy_}, false);
+  FunctionCallee dispatcher_callee =
+      module_->getOrInsertFunction("DispatchParallel", dispatcher_fntype);
+  llvm::Function* dispatcher =
+      llvm::cast<llvm::Function>(dispatcher_callee.getCallee());
+  irb_.CreateCall(
+      dispatcher, {func_value, start, stop, packed_caller_args_ptr});
+  value_ = llvm::ConstantInt::get(IntTy_, 0);
+}
+
 void LLVMCodeGenImpl::visit(const For* v) {
+  if (v->is_parallel()) {
+    processParallelFor(v);
+    return;
+  }
+
   // Create "start" and "stop" values.
   v->start()->accept(this);
   auto start = this->value_;
@@ -1360,38 +1562,6 @@ static void applyMathFunctionAttributes(llvm::Function* f) {
   f->addFnAttr(llvm::Attribute::WillReturn);
 #endif
 }
-
-namespace {
-#if LLVM_VERSION_MAJOR >= 9
-
-using FunctionCallee = llvm::FunctionCallee;
-
-#elif LLVM_VERSION_MAJOR == 8 && LLVM_VERSION_PATCH == 20181009
-
-struct FunctionCallee {
-  FunctionCallee() {}
-
-  FunctionCallee(llvm::Constant* fn)
-      : v_(fn), ft_(cast<llvm::Function>(v_)->getFunctionType()) {}
-
-  llvm::FunctionType* getFunctionType() {
-    return ft_;
-  }
-
-  llvm::Value* getCallee() {
-    return v_;
-  }
-
- private:
-  llvm::Value* v_{nullptr};
-  llvm::FunctionType* ft_{nullptr};
-};
-
-#else
-#error Only LLVM versions 8 and above are supported.
-#endif
-
-} // namespace
 
 llvm::Value* LLVMCodeGenImpl::toVec(llvm::Value* v, int lanes) {
   if (lanes > 1) {

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.h
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <torch/csrc/jit/tensorexpr/codegen.h>
+#include <torch/csrc/jit/tensorexpr/execution_counter.h>
 #include <torch/csrc/jit/tensorexpr/ir.h>
 #include <torch/csrc/jit/tensorexpr/ir_visitor.h>
 
@@ -13,6 +14,8 @@
 namespace torch {
 namespace jit {
 namespace tensorexpr {
+
+DECLARE_TRIGGER(llvm_codegen_parallel_dispatched);
 
 class LLVMCodeGenImpl;
 

--- a/torch/csrc/jit/tensorexpr/llvm_jit.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.cpp
@@ -88,6 +88,8 @@ static void registerIntrinsics(
     assertSuccess(
         JD.define(absoluteSymbols({entry(kv.first.c_str(), kv.second)})));
   }
+  assertSuccess(JD.define(
+      absoluteSymbols({entry("DispatchParallel", DispatchParallel)})));
 }
 
 namespace llvm {

--- a/torch/csrc/jit/tensorexpr/llvm_jit.h
+++ b/torch/csrc/jit/tensorexpr/llvm_jit.h
@@ -16,6 +16,8 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+void DispatchParallel(int8_t* func, int start, int stop, int8_t* packed_data);
+
 inline std::string formatError(llvm::Error&& err, const char* msg) {
   static constexpr char* defaultErrorMsg = "Unexpected failure in LLVM JIT";
   std::string errorMsg(msg ? msg : defaultErrorMsg);

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -538,17 +538,28 @@ class TORCH_API LoopOptions {
     gpu_thread_index_ = index;
   }
 
+  void set_parallel() {
+    is_parallel_ = true;
+  }
+
+  bool is_parallel() const {
+    return is_parallel_;
+  }
+
   std::string ToString() const {
     if (is_gpu_block_index()) {
       return gpu_block_index_str();
     } else if (is_gpu_thread_index()) {
       return gpu_thread_index_str();
+    } else if (is_parallel()) {
+      return "parallel";
     }
     return "";
   }
 
   bool isDefault() const {
-    return gpu_block_index_ == IDX_UNSET && gpu_thread_index_ == IDX_UNSET;
+    return gpu_block_index_ == IDX_UNSET && gpu_thread_index_ == IDX_UNSET &&
+        !is_parallel_;
   }
 
   void set_buffer_mapping(
@@ -563,6 +574,7 @@ class TORCH_API LoopOptions {
  private:
   int gpu_block_index_{IDX_UNSET};
   int gpu_thread_index_{IDX_UNSET};
+  bool is_parallel_{false};
   std::unordered_map<std::string, const Buf*> map_input_to_tensor_bufs_;
 };
 
@@ -645,6 +657,14 @@ class TORCH_API For : public StmtNode<For> {
 
   void set_gpu_thread_index(int thread_index) {
     loop_options_.set_gpu_thread_index(thread_index);
+  }
+
+  void set_parallel() {
+    loop_options_.set_parallel();
+  }
+
+  bool is_parallel() const {
+    return loop_options_.is_parallel();
   }
 
   void set_buffer_map(const std::unordered_map<std::string, const Buf*>& map) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54122 Resubmit: Adding parallel support for the LLVM backend.**

Test plan:
  * USE_TBB=1 ATEN_THREADING=TBB python setup.py develop --cmake
  * USE_TBB=1 ATEN_THREADING=NATIVE python setup.py develop --cmake
  * USE_TBB=1 ATEN_THREADING=OMP python setup.py develop --cmake
  * cd build; ninja bin/tensorexpr_bench
  * bin/test_tensorexpr --gtest_filter="*Parallel*"

Differential Revision: [D27109802](https://our.internmc.facebook.com/intern/diff/D27109802)