### PR TITLE
Fix bug in assertRaises NotImplemented handling when no exception is thrown

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -858,7 +858,7 @@ def get_comparison_dtype(a, b):
 # 2010, seems low risk to inherit from.
 class AssertRaisesContextIgnoreNotImplementedError(unittest.case._AssertRaisesContext):
     def __exit__(self, exc_type, exc_value, tb):
-        if issubclass(exc_type, NotImplementedError):
+        if exc_type is not None and issubclass(exc_type, NotImplementedError):
             self.test_case.skipTest("not_implemented: {exc_value}")  # type: ignore[attr-defined]
         return super().__exit__(exc_type, exc_value, tb)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53973 Add some trivial meta functions for commonly used inplace operations
* #54127 Fix inaccurate dispatch tables
* #54079 Add Tensor::is_cpu, genericize TensorIterator
* #54034 Refactor tensor_new.cpp to use TensorOptions instead of DispatchKey
* **#54126 Fix bug in assertRaises NotImplemented handling when no exception is thrown**
* #54016 Delete denseTypeIdWithDefault and toDense

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27109510](https://our.internmc.facebook.com/intern/diff/D27109510)