### PR TITLE
Remove legacy constructor calls from pytorch codebase.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -881,7 +881,7 @@ If you are working on the CUDA code, here are some useful CUDA debugging tips:
    nbytes_read_write = 4 # this is number of bytes read + written by a kernel. Change this to fit your kernel.
 
    for i in range(10):
-       a=torch.Tensor(size).cuda().uniform_()
+       a=torch.empty(size).cuda().uniform_()
        torch.cuda.synchronize()
        start = time.time()
        # dry run to alloc

--- a/benchmarks/overrides_benchmark/bench.py
+++ b/benchmarks/overrides_benchmark/bench.py
@@ -48,11 +48,11 @@ def main():
     NUM_REPEATS = args.nreps
     NUM_REPEAT_OF_REPEATS = args.nrepreps
 
-    types = torch.Tensor, SubTensor, WithTorchFunction, SubWithTorchFunction
+    types = torch.tensor, SubTensor, WithTorchFunction, SubWithTorchFunction
 
     for t in types:
-        tensor_1 = t(1)
-        tensor_2 = t(2)
+        tensor_1 = t([1.])
+        tensor_2 = t([2.])
 
         bench_min, bench_std = bench(tensor_1, tensor_2)
         print(

--- a/benchmarks/overrides_benchmark/bench.py
+++ b/benchmarks/overrides_benchmark/bench.py
@@ -16,8 +16,8 @@ def bench(t1, t2):
             torch.add(t1, t2)
         bench_times.append(time.time() - time_start)
 
-    bench_time = float(torch.min(torch.Tensor(bench_times))) / 1000
-    bench_std = float(torch.std(torch.Tensor(bench_times))) / 1000
+    bench_time = float(torch.min(torch.tensor(bench_times))) / 1000
+    bench_std = float(torch.std(torch.tensor(bench_times))) / 1000
 
     return bench_time, bench_std
 

--- a/benchmarks/overrides_benchmark/common.py
+++ b/benchmarks/overrides_benchmark/common.py
@@ -14,7 +14,7 @@ class WithTorchFunction:
             self._tensor = data
             return
 
-        self._tensor = torch.Tensor(data, requires_grad)
+        self._tensor = torch.empty(data, requires_grad)
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:

--- a/benchmarks/overrides_benchmark/common.py
+++ b/benchmarks/overrides_benchmark/common.py
@@ -14,7 +14,7 @@ class WithTorchFunction:
             self._tensor = data
             return
 
-        self._tensor = torch.tensor(data, requires_grad)
+        self._tensor = torch.tensor(data, requires_grad=requires_grad)
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:

--- a/benchmarks/overrides_benchmark/common.py
+++ b/benchmarks/overrides_benchmark/common.py
@@ -14,7 +14,7 @@ class WithTorchFunction:
             self._tensor = data
             return
 
-        self._tensor = torch.empty(data, requires_grad)
+        self._tensor = torch.tensor(data, requires_grad)
 
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:

--- a/benchmarks/overrides_benchmark/pyspybench.py
+++ b/benchmarks/overrides_benchmark/pyspybench.py
@@ -2,7 +2,7 @@ import torch
 import argparse
 from common import SubTensor, WithTorchFunction, SubWithTorchFunction  # noqa: F401
 
-Tensor = torch.Tensor
+Tensor = torch.tensor
 
 NUM_REPEATS = 1000000
 
@@ -21,8 +21,8 @@ if __name__ == "__main__":
     TensorClass = globals()[args.tensor_class]
     NUM_REPEATS = args.nreps
 
-    t1 = TensorClass(1)
-    t2 = TensorClass(2)
+    t1 = TensorClass([1.])
+    t2 = TensorClass([2.])
 
     for _ in range(NUM_REPEATS):
         torch.add(t1, t2)

--- a/caffe2/python/operator_test/heatmap_max_keypoint_op_test.py
+++ b/caffe2/python/operator_test/heatmap_max_keypoint_op_test.py
@@ -30,8 +30,8 @@ def heatmap_approx_keypoint_ref(maps, rois):
 
 def c10_op_ref(maps, rois):
     keypoints = torch.ops._caffe2.HeatmapMaxKeypoint(
-        torch.Tensor(maps),
-        torch.Tensor(rois),
+        torch.tensor(maps),
+        torch.tensor(rois),
         should_output_softmax=True,
     )
     return [keypoints.numpy()]

--- a/caffe2/python/operator_test/layer_norm_op_test.py
+++ b/caffe2/python/operator_test/layer_norm_op_test.py
@@ -344,7 +344,7 @@ class TestLayerNormOp(serial.SerializedTestCase):
             expected_norm, expected_mean, expected_std = \
                 _layer_norm_with_affine_ref(axis, eps, X, gamma, beta)
             actual_norm, actual_mean, actual_std = jit_layer_norm(
-                torch.Tensor(X), torch.tensor(gamma), torch.tensor(beta),
+                torch.tensor(X), torch.tensor(gamma), torch.tensor(beta),
                 axis, eps, elementwise_affine)
         else:
             expected_norm, expected_mean, expected_std = _layer_norm_ref(

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -842,12 +842,12 @@ class TorchIntegration(hu.HypothesisTestCase):
 
     def test_alias_with_name_is_in_place(self):
         device = "cuda" if workspace.has_cuda_support else "cpu"
-        x = torch.tensor([3, 42], device=device)
+        x = torch.tensor([3, 42]).to(device=device)
         y = torch.ops._caffe2.AliasWithName(x, "new_name")
         x[1] = 6
-        torch.testing.assert_allclose(x, torch.tensor([3, 6], device=device))
+        torch.testing.assert_allclose(x, torch.tensor([3, 6]).to(device=device))
         # y should also change because y is alias of x
-        torch.testing.assert_allclose(y, torch.tensor([3, 6], device=device))
+        torch.testing.assert_allclose(y, torch.tensor([3, 6]).to(device=device))
 
     @unittest.skipIf(not workspace.has_cuda_support, "No cuda support")
     def test_copy_between_cpu_and_gpu(self):
@@ -924,7 +924,7 @@ class TorchIntegration(hu.HypothesisTestCase):
         actual_output = torch.ops._caffe2.Percentile(
             torch.tensor(original_values),
             torch.tensor(value_to_pct),
-            torch.tensor(lengths).int(),
+            torch.tensor(lengths),
         )
         torch.testing.assert_allclose(expected_output, actual_output.cpu())
 

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -558,8 +558,8 @@ class TorchIntegration(hu.HypothesisTestCase):
 
         roi_feature_ref = roi_align_ref(feature, rois)
         roi_feature = torch.ops._caffe2.RoIAlign(
-            torch.Tensor(feature).to(device),
-            torch.Tensor(rois).to(device),
+            torch.tensor(feature).to(device),
+            torch.tensor(rois).to(device),
             order="NCHW",
             spatial_scale=1.0,
             pooled_h=3,
@@ -615,8 +615,8 @@ class TorchIntegration(hu.HypothesisTestCase):
 
         roi_feature_ref = roi_align_ref(feature, rois)
         roi_feature = torch.ops._caffe2.RoIAlignRotated(
-            torch.Tensor(feature).to(device),
-            torch.Tensor(rois).to(device),
+            torch.tensor(feature).to(device),
+            torch.tensor(rois).to(device),
             order="NCHW",
             spatial_scale=1.0,
             pooled_h=3,
@@ -639,7 +639,7 @@ class TorchIntegration(hu.HypothesisTestCase):
         im_dims = np.random.randint(100, 600, batch_size)
         rpn_rois_and_scores = []
         for i in range(5):
-            rpn_rois_and_scores.append(torch.Tensor(generate_rois(roi_counts, im_dims)))
+            rpn_rois_and_scores.append(torch.tensor(generate_rois(roi_counts, im_dims)))
         for i in range(5):
             rpn_rois_and_scores.append(torch.rand(sum(roi_counts)))
 
@@ -842,16 +842,16 @@ class TorchIntegration(hu.HypothesisTestCase):
 
     def test_alias_with_name_is_in_place(self):
         device = "cuda" if workspace.has_cuda_support else "cpu"
-        x = torch.Tensor([3, 42]).to(device)
+        x = torch.tensor([3, 42], device=device)
         y = torch.ops._caffe2.AliasWithName(x, "new_name")
         x[1] = 6
-        torch.testing.assert_allclose(x, torch.Tensor([3, 6]).to(device))
+        torch.testing.assert_allclose(x, torch.tensor([3, 6], device=device))
         # y should also change because y is alias of x
-        torch.testing.assert_allclose(y, torch.Tensor([3, 6]).to(device))
+        torch.testing.assert_allclose(y, torch.tensor([3, 6], device=device))
 
     @unittest.skipIf(not workspace.has_cuda_support, "No cuda support")
     def test_copy_between_cpu_and_gpu(self):
-        x_cpu_ref = torch.Tensor([1, 2, 3])
+        x_cpu_ref = torch.tensor([1, 2, 3])
         x_gpu_ref = x_cpu_ref.to("cuda")
 
         x_gpu = torch.ops._caffe2.CopyCPUToGPU(x_cpu_ref)
@@ -923,8 +923,8 @@ class TorchIntegration(hu.HypothesisTestCase):
         expected_output = _percentile_ref(original_values, value_to_pct, lengths)
         actual_output = torch.ops._caffe2.Percentile(
             torch.tensor(original_values),
-            torch.Tensor(value_to_pct),
-            torch.Tensor(lengths).int(),
+            torch.tensor(value_to_pct),
+            torch.tensor(lengths).int(),
         )
         torch.testing.assert_allclose(expected_output, actual_output.cpu())
 
@@ -945,7 +945,7 @@ class TorchIntegration(hu.HypothesisTestCase):
 
         expected_output = _batch_bucket_one_hot_ref(data, lengths, boundaries)
         actual_output = torch.ops._caffe2.BatchBucketOneHot(
-            torch.tensor(data), torch.Tensor(lengths).int(), torch.Tensor(boundaries)
+            torch.tensor(data), torch.tensor(lengths), torch.tensor(boundaries)
         )
         torch.testing.assert_allclose(expected_output, actual_output.cpu())
 

--- a/caffe2/python/operator_test/torch_integration_test.py
+++ b/caffe2/python/operator_test/torch_integration_test.py
@@ -842,16 +842,16 @@ class TorchIntegration(hu.HypothesisTestCase):
 
     def test_alias_with_name_is_in_place(self):
         device = "cuda" if workspace.has_cuda_support else "cpu"
-        x = torch.tensor([3, 42]).to(device=device)
+        x = torch.tensor([3., 42.]).to(device=device)
         y = torch.ops._caffe2.AliasWithName(x, "new_name")
         x[1] = 6
-        torch.testing.assert_allclose(x, torch.tensor([3, 6]).to(device=device))
+        torch.testing.assert_allclose(x, torch.tensor([3., 6.]).to(device=device))
         # y should also change because y is alias of x
-        torch.testing.assert_allclose(y, torch.tensor([3, 6]).to(device=device))
+        torch.testing.assert_allclose(y, torch.tensor([3., 6.]).to(device=device))
 
     @unittest.skipIf(not workspace.has_cuda_support, "No cuda support")
     def test_copy_between_cpu_and_gpu(self):
-        x_cpu_ref = torch.tensor([1, 2, 3])
+        x_cpu_ref = torch.tensor([1., 2., 3.])
         x_gpu_ref = x_cpu_ref.to("cuda")
 
         x_gpu = torch.ops._caffe2.CopyCPUToGPU(x_cpu_ref)

--- a/docs/source/jit_language_reference_v2.rst
+++ b/docs/source/jit_language_reference_v2.rst
@@ -1333,7 +1333,7 @@ The above code results in the below RuntimeError
     a : torch.jit.final[Bool] = True
 
     if a:
-        return torch.Tensor(2,3)
+        return torch.empty(2,3)
     else:
         return []
 

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -223,9 +223,9 @@ This is how a ``Linear`` module can be implemented::
             # won't be converted when e.g. .cuda() is called. You can use
             # .register_buffer() to register buffers.
             # nn.Parameters require gradients by default.
-            self.weight = nn.Parameter(torch.Tensor(output_features, input_features))
+            self.weight = nn.Parameter(torch.empty(output_features, input_features))
             if bias:
-                self.bias = nn.Parameter(torch.Tensor(output_features))
+                self.bias = nn.Parameter(torch.empty(output_features))
             else:
                 # You should always register all possible parameters, but the
                 # optional ones can be None if you want.
@@ -494,7 +494,7 @@ will return subclass instances instead of ``torch.Tensor`` instances::
   ...     pass
   >>> type(torch.add(SubTensor([0]), SubTensor([1]))).__name__
   'SubTensor'
-  >>> type(torch.add(SubTensor([0]), torch.Tensor([1]))).__name__
+  >>> type(torch.add(SubTensor([0]), torch.tensor([1]))).__name__
   'SubTensor'
 
 If multiple subclasses exist, the lowest one in the hierarchy will be chosen by
@@ -503,7 +503,7 @@ default. If there is no unique way to determine such a case, then a
 
   >>> type(torch.add(SubTensor2([0]), SubTensor([1]))).__name__
   'SubTensor2'
-  >>> type(torch.add(SubTensor2([0]), torch.Tensor([1]))).__name__
+  >>> type(torch.add(SubTensor2([0]), torch.tensor([1]))).__name__
   'SubTensor2'
   >>> torch.add(SubTensor([0]), OtherSubTensor([1]))
   Traceback (most recent call last):

--- a/docs/source/tensor_attributes.rst
+++ b/docs/source/tensor_attributes.rst
@@ -224,7 +224,7 @@ to perform many tensor operations efficiently.
 
 Example::
 
-    >>> x = torch.Tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+    >>> x = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
     >>> x.stride()
     (5, 1)
 

--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -990,7 +990,7 @@ class TestBenchmarkUtils(TestCase):
         for i, (tensors, _, _) in enumerate(fuzzer.take(2)):
             x = tensors["x"]
             self.assertEqual(
-                x, torch.Tensor(expected_results[i]), rtol=1e-3, atol=1e-3)
+                x, torch.tensor(expected_results[i]), rtol=1e-3, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/test/cpp/api/optim_baseline.py
+++ b/test/cpp/api/optim_baseline.py
@@ -75,7 +75,7 @@ def run(optimizer_name, iterations, sample_every):
         loss.backward()
 
         def closure():
-            return torch.tensor([10])
+            return torch.tensor([10.])
         optimizer.step(closure)
 
         if i % sample_every == 0:

--- a/test/cpp/api/optim_baseline.py
+++ b/test/cpp/api/optim_baseline.py
@@ -75,7 +75,7 @@ def run(optimizer_name, iterations, sample_every):
         loss.backward()
 
         def closure():
-            return torch.Tensor([10])
+            return torch.tensor([10])
         optimizer.step(closure)
 
         if i % sample_every == 0:

--- a/test/jit/test_isinstance.py
+++ b/test/jit/test_isinstance.py
@@ -56,7 +56,7 @@ class TestIsinstance(JitTestCase):
             assert torch.jit.isinstance(x, List[torch.Tensor])
             assert not torch.jit.isinstance(x, Tuple[int])
 
-        x = [torch.Tensor([1]), torch.Tensor([2]), torch.Tensor([3])]
+        x = [torch.tensor([1]), torch.tensor([2]), torch.tensor([3])]
         self.checkScript(list_tensor_test, (x,))
 
     def test_dict(self):

--- a/test/jit/test_tracer.py
+++ b/test/jit/test_tracer.py
@@ -2108,7 +2108,7 @@ class TestMixTracingScripting(JitTestCase):
         class Param(nn.Module):
             def __init__(self):
                 super(Param, self).__init__()
-                self.register_parameter("bias", nn.Parameter(torch.Tensor(4, 4)))
+                self.register_parameter("bias", nn.Parameter(torch.empty(4, 4)))
 
             def forward(self, x):
                 return x

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -166,14 +166,14 @@ class TestModels(TestCase):
     def test_dcgan_netD(self):
         netD = _netD(1)
         netD.apply(weights_init)
-        input = Variable(torch.Tensor(bsz, 3, imgsz, imgsz).normal_(0, 1))
+        input = Variable(torch.empty(bsz, 3, imgsz, imgsz).normal_(0, 1))
         self.exportTest(toC(netD), toC(input))
 
     @disableScriptTest()
     def test_dcgan_netG(self):
         netG = _netG(1)
         netG.apply(weights_init)
-        input = Variable(torch.Tensor(bsz, nz, 1, 1).normal_(0, 1))
+        input = Variable(torch.empty(bsz, nz, 1, 1).normal_(0, 1))
         self.exportTest(toC(netG), toC(input))
 
     @skipIfUnsupportedMinOpsetVersion(10)

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -1779,7 +1779,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 )
                 return output
 
-        feature = torch.Tensor(img_count, A, H, W)
+        feature = torch.empty(img_count, A, H, W)
         im_info = torch.ones(img_count, 3, dtype=torch.float32)
         anchors = torch.ones(A, 4, dtype=torch.float32)
         inputs = (feature, im_info, anchors)

--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -49,7 +49,7 @@ from torch.quantization._numeric_suite_fx import (
 class LinearReluFunctional(nn.Module):
     def __init__(self):
         super().__init__()
-        self.w1 = nn.Parameter(torch.Tensor(4, 4))
+        self.w1 = nn.Parameter(torch.empty(4, 4))
         self.b1 = nn.Parameter(torch.zeros(4))
         torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
 
@@ -82,7 +82,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
         class M(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.w = nn.Parameter(torch.Tensor(1, 4))
+                self.w = nn.Parameter(torch.empty(1, 4))
                 self.b = nn.Parameter(torch.zeros(1))
                 torch.nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
 
@@ -449,7 +449,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         class M(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.w = nn.Parameter(torch.Tensor(4, 4))
+                self.w = nn.Parameter(torch.empty(4, 4))
                 self.b = nn.Parameter(torch.zeros(4))
                 torch.nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
 
@@ -482,9 +482,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         class M(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.w1 = nn.Parameter(torch.Tensor(4, 4))
+                self.w1 = nn.Parameter(torch.empty(4, 4))
                 self.b1 = nn.Parameter(torch.zeros(4))
-                self.w2 = nn.Parameter(torch.Tensor(4, 4))
+                self.w2 = nn.Parameter(torch.empty(4, 4))
                 self.b2 = nn.Parameter(torch.zeros(4))
                 torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
                 torch.nn.init.kaiming_uniform_(self.w2, a=math.sqrt(5))
@@ -518,9 +518,9 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         class M(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.w1 = nn.Parameter(torch.Tensor(4, 4))
+                self.w1 = nn.Parameter(torch.empty(4, 4))
                 self.b1 = nn.Parameter(torch.zeros(4))
-                self.w2 = nn.Parameter(torch.Tensor(4, 4))
+                self.w2 = nn.Parameter(torch.empty(4, 4))
                 self.b2 = nn.Parameter(torch.zeros(4))
                 torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
                 torch.nn.init.kaiming_uniform_(self.w2, a=math.sqrt(5))

--- a/test/quantization/test_qat_module.py
+++ b/test/quantization/test_qat_module.py
@@ -43,8 +43,8 @@ class _ReferenceConvBnNd(torch.nn.Conv2d, torch.nn.modules.conv._ConvNd):
         self.momentum = momentum
         self.freeze_bn = freeze_bn if self.training else True
         self.num_features = out_channels
-        self.gamma = nn.Parameter(torch.Tensor(out_channels))
-        self.beta = nn.Parameter(torch.Tensor(out_channels))
+        self.gamma = nn.Parameter(torch.empty(out_channels))
+        self.beta = nn.Parameter(torch.empty(out_channels))
         self.affine = True
         self.track_running_stats = True
         self.register_buffer('running_mean', torch.zeros(out_channels))
@@ -53,7 +53,7 @@ class _ReferenceConvBnNd(torch.nn.Conv2d, torch.nn.modules.conv._ConvNd):
         self.activation_post_process = self.qconfig.activation()
         self.weight_fake_quant = self.qconfig.weight()
         if bias:
-            self.bias = nn.Parameter(torch.Tensor(out_channels))
+            self.bias = nn.Parameter(torch.empty(out_channels))
         else:
             self.register_parameter('bias', None)
         self.reset_bn_parameters()

--- a/test/quantization/test_workflow_module.py
+++ b/test/quantization/test_workflow_module.py
@@ -519,7 +519,7 @@ class TestObserver(QuantizationTestCase):
                 obs = obs_cls(0.1, 0)
             else:
                 obs = obs_cls()
-            x = torch.Tensor()
+            x = torch.tensor([])
             # verify no crash
             x = obs(x)
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1595,10 +1595,10 @@ class TestAutograd(TestCase):
         y = Variable(x, requires_grad=True)
         idx = [[[1, 2], [0, 0]], [[0, 1], [1, 1]]]
         y[idx].sum().backward()
-        expected_grad = torch.tensor([[0, 2, 0, 0],
-                                      [1, 0, 0, 0],
-                                      [0, 1, 0, 0],
-                                      [0, 0, 0, 0]])
+        expected_grad = torch.tensor([[0., 2., 0., 0.],
+                                      [1., 0., 0., 0.],
+                                      [0., 1., 0., 0.],
+                                      [0., 0., 0., 0.]])
         self.assertEqual(y.grad, expected_grad)
 
         x = torch.arange(1., 65).view(4, 4, 4)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1497,7 +1497,7 @@ class TestAutograd(TestCase):
             self.assertEqual(indexed_tensor, indexed_var_t)
 
             indexed_var.sum().backward()
-            expected_grad = torch.Tensor(x.size()).fill_(0)
+            expected_grad = torch.empty(x.size()).fill_(0)
             expected_grad[idx] = 1
             self.assertEqual(y.grad, expected_grad)
 
@@ -1595,7 +1595,7 @@ class TestAutograd(TestCase):
         y = Variable(x, requires_grad=True)
         idx = [[[1, 2], [0, 0]], [[0, 1], [1, 1]]]
         y[idx].sum().backward()
-        expected_grad = torch.Tensor([[0, 2, 0, 0],
+        expected_grad = torch.tensor([[0, 2, 0, 0],
                                       [1, 0, 0, 0],
                                       [0, 1, 0, 0],
                                       [0, 0, 0, 0]])
@@ -1606,7 +1606,7 @@ class TestAutograd(TestCase):
 
         idx = [[1, 1, 1], slice(None), slice(None)]
         y[idx].sum().backward()
-        expected_grad = torch.Tensor(4, 4, 4).zero_()
+        expected_grad = torch.empty(4, 4, 4).zero_()
         expected_grad[1].fill_(3)
         self.assertEqual(y.grad, expected_grad)
 
@@ -1849,7 +1849,7 @@ class TestAutograd(TestCase):
         r.backward(torch.ones(5, 5), retain_graph=True)
         self.assertEqual(x.grad, torch.ones(5, 5) / 2)
         w.backward(torch.ones(5, 5), retain_graph=True)
-        self.assertEqual(x.grad, torch.Tensor(5, 5).fill_((1 + math.e) / 2))
+        self.assertEqual(x.grad, torch.empty(5, 5).fill_((1 + math.e) / 2))
         self.assertRaises(RuntimeError, lambda: q.backward(torch.ones(5, 5)))
 
         leaf = torch.ones(5, 5, requires_grad=True)
@@ -4309,7 +4309,7 @@ for shape in [(1,), ()]:
 
         feat_combined = []
         for r in range(num_inp):
-            data_r = torch.Tensor(1, nz_inp)
+            data_r = torch.empty(1, nz_inp)
             data_r.uniform_()
             data_r.requires_grad = True
             feat_r = checkpoint(module, data_r)

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1483,10 +1483,10 @@ class TestCuda(TestCase):
     @skipIfRocm
     def test_multinomial_invalid_probs_cuda(self):
         test_method = TestCuda._test_multinomial_invalid_probs_cuda
-        self._spawn_method(test_method, torch.tensor([1, -1, 1]))
-        self._spawn_method(test_method, torch.tensor([1, inf, 1]))
-        self._spawn_method(test_method, torch.tensor([1, -inf, 1]))
-        self._spawn_method(test_method, torch.tensor([1, 1, nan]))
+        self._spawn_method(test_method, torch.tensor([1., -1., 1.]))
+        self._spawn_method(test_method, torch.tensor([1., inf, 1.]))
+        self._spawn_method(test_method, torch.tensor([1., -inf, 1.]))
+        self._spawn_method(test_method, torch.tensor([1., 1., nan]))
 
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1483,10 +1483,10 @@ class TestCuda(TestCase):
     @skipIfRocm
     def test_multinomial_invalid_probs_cuda(self):
         test_method = TestCuda._test_multinomial_invalid_probs_cuda
-        self._spawn_method(test_method, torch.Tensor([1, -1, 1]))
-        self._spawn_method(test_method, torch.Tensor([1, inf, 1]))
-        self._spawn_method(test_method, torch.Tensor([1, -inf, 1]))
-        self._spawn_method(test_method, torch.Tensor([1, 1, nan]))
+        self._spawn_method(test_method, torch.tensor([1, -1, 1]))
+        self._spawn_method(test_method, torch.tensor([1, inf, 1]))
+        self._spawn_method(test_method, torch.tensor([1, -inf, 1]))
+        self._spawn_method(test_method, torch.tensor([1, 1, nan]))
 
     @slowTest
     @unittest.skipIf(not TEST_LARGE_TENSOR, "not enough memory")

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1911,7 +1911,7 @@ class DictDataset(Dataset):
 
     def __getitem__(self, ndx):
         return {
-            'a_tensor': torch.Tensor(4, 2).fill_(ndx),
+            'a_tensor': torch.empty(4, 2).fill_(ndx),
             'another_dict': {
                 'a_number': ndx,
             },

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -469,7 +469,7 @@ class TestFX(JitTestCase):
                             # Pull out constants. These constants will later be
                             # fed to the interpreter C++ object via add_constant()
                             arg_name = f'constant_{constant_idx}'
-                            constants[arg_name] = torch.Tensor(
+                            constants[arg_name] = torch.tensor(
                                 [arg] if isinstance(arg, numbers.Number) else arg)
                             arg_names.append(arg_name)
                             constant_idx += 1

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1094,7 +1094,7 @@ class {test_classname}(torch.nn.Module):
                 self.rhs = rhs
 
             def forward(self, a, b, c, d, e):
-                s = torch.Tensor((0))
+                s = torch.tensor([])
                 matmuls = []
 
                 # For some reason using a list comprehension or for-loop for this

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -18,7 +18,7 @@ class TestIndexing(TestCase):
     def test_index(self, device):
 
         def consec(size, start=1):
-            sequence = torch.ones(int(torch.Tensor(size).prod(0))).cumsum(0)
+            sequence = torch.ones(torch.tensor(size).prod(0)).cumsum(0)
             sequence.add_(start - 1)
             return sequence.view(*size)
 
@@ -36,10 +36,10 @@ class TestIndexing(TestCase):
         self.assertEqual(reference[:], consec((3, 3, 3)), atol=0, rtol=0)
 
         # indexing with Ellipsis
-        self.assertEqual(reference[..., 2], torch.Tensor([[3, 6, 9],
+        self.assertEqual(reference[..., 2], torch.tensor([[3, 6, 9],
                                                           [12, 15, 18],
                                                           [21, 24, 27]]), atol=0, rtol=0)
-        self.assertEqual(reference[0, ..., 2], torch.Tensor([3, 6, 9]), atol=0, rtol=0)
+        self.assertEqual(reference[0, ..., 2], torch.tensor([3, 6, 9]), atol=0, rtol=0)
         self.assertEqual(reference[..., 2], reference[:, :, 2], atol=0, rtol=0)
         self.assertEqual(reference[0, ..., 2], reference[0, :, 2], atol=0, rtol=0)
         self.assertEqual(reference[0, 2, ...], reference[0, 2], atol=0, rtol=0)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -36,10 +36,10 @@ class TestIndexing(TestCase):
         self.assertEqual(reference[:], consec((3, 3, 3)), atol=0, rtol=0)
 
         # indexing with Ellipsis
-        self.assertEqual(reference[..., 2], torch.tensor([[3, 6, 9],
-                                                          [12, 15, 18],
-                                                          [21, 24, 27]]), atol=0, rtol=0)
-        self.assertEqual(reference[0, ..., 2], torch.tensor([3, 6, 9]), atol=0, rtol=0)
+        self.assertEqual(reference[..., 2], torch.tensor([[3., 6., 9.],
+                                                          [12., 15., 18.],
+                                                          [21., 24., 27.]]), atol=0, rtol=0)
+        self.assertEqual(reference[0, ..., 2], torch.tensor([3., 6., 9.]), atol=0, rtol=0)
         self.assertEqual(reference[..., 2], reference[:, :, 2], atol=0, rtol=0)
         self.assertEqual(reference[0, ..., 2], reference[0, :, 2], atol=0, rtol=0)
         self.assertEqual(reference[0, 2, ...], reference[0, 2], atol=0, rtol=0)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9115,7 +9115,7 @@ dedent """
                 return v
 
         with torch.jit.optimized_execution(False):
-            i = torch.Tensor(2)
+            i = torch.empty(2)
             m = M()
             o = m(i)
             v = i
@@ -9513,7 +9513,7 @@ dedent """
                 return self.mods(v)
 
         with torch.jit.optimized_execution(False):
-            i = torch.Tensor(2)
+            i = torch.empty(2)
             m = M()
             o = m(i)
             v = i
@@ -9592,7 +9592,7 @@ dedent """
         with self.assertRaisesRegex(RuntimeError, "(Tensor, Tensor, Tensor)"):
             with torch.jit.optimized_execution(False):
                 hs = HaveSequential()
-                i = torch.Tensor(2)
+                i = torch.empty(2)
                 hs(i)
 
     @_tmp_donotuse_dont_inline_everything
@@ -11248,8 +11248,8 @@ dedent """
         class M(torch.nn.Module):
             def __init__(self):
                 super(M, self).__init__()
-                self.weight_0 = torch.nn.Parameter(torch.Tensor(torch.rand(weight_0_shape)))
-                self.weight_1 = torch.nn.Parameter(torch.Tensor(torch.rand(weight_1_shape)))
+                self.weight_0 = torch.nn.Parameter(torch.rand(weight_0_shape))
+                self.weight_1 = torch.nn.Parameter(torch.rand(weight_1_shape))
 
             def forward(self, x):
                 o = F.linear(x, self.weight_0)
@@ -13288,8 +13288,8 @@ dedent """
                 super(TestLinear, self).__init__()
                 self.in_features = in_features
                 self.out_features = out_features
-                self.weight = torch.nn.Parameter(torch.Tensor(out_features, in_features))
-                self.bias = torch.nn.Parameter(torch.Tensor(out_features))
+                self.weight = torch.nn.Parameter(torch.empty(out_features, in_features))
+                self.bias = torch.nn.Parameter(torch.empty(out_features))
                 self.register_buffer('counter', torch.ones(out_features))
                 self.reset_parameters()
 

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -9296,7 +9296,7 @@ dedent """
 
         a = torch.arange(120.).reshape(2, 3, 4, 5)
         b = torch.arange(840.).reshape(4, 5, 6, 7)
-        dims = torch.Tensor([2])
+        dims = torch.tensor([2])
         self.checkScript(tensordot_dims_tensor, (a, b, dims))
 
         a = torch.arange(60.).reshape(3, 4, 5)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1209,7 +1209,7 @@ class TestLinalg(TestCase):
                 for ord in ord_settings:
                     for dtype, out_dtype in dtype_pairs:
                         input = torch.rand(*input_size)
-                        result = torch.Tensor().to(out_dtype)
+                        result = torch.tensor([]).to(out_dtype)
                         with self.assertRaisesRegex(RuntimeError, r'provided dtype must match dtype of result'):
                             torch.linalg.norm(input, ord=ord, keepdim=keepdim, dtype=dtype, out=result)
 
@@ -1609,7 +1609,7 @@ class TestLinalg(TestCase):
                 self.assertEqual(res.shape, expected.shape, msg=msg)
                 self.assertEqual(res, expected, msg=msg)
 
-                res_out = torch.Tensor().to(device)
+                res_out = torch.tensor([]).to(device)
                 torch.linalg.norm(x, ord, keepdim=keepdim, out=res_out)
                 self.assertEqual(res_out.shape, expected.shape, msg=msg)
                 self.assertEqual(res_out.cpu(), expected, msg=msg)
@@ -1624,7 +1624,7 @@ class TestLinalg(TestCase):
                 self.assertEqual(res.shape, expected.shape, msg=msg)
                 self.assertEqual(res, expected, msg=msg)
 
-                res_out = torch.Tensor().to(device)
+                res_out = torch.tensor([]).to(device)
                 torch.linalg.norm(x, ord, keepdim=keepdim, out=res_out)
                 self.assertEqual(res_out.shape, expected.shape, msg=msg)
                 self.assertEqual(res_out.cpu(), expected, msg=msg)

--- a/test/test_metal.py
+++ b/test/test_metal.py
@@ -63,8 +63,8 @@ class TestMetalRewritePass(TestCase):
         class Conv2D(torch.nn.Module):
             def __init__(self):
                 super(Conv2D, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -83,8 +83,8 @@ class TestMetalRewritePass(TestCase):
         class Conv2DRelu(torch.nn.Module):
             def __init__(self):
                 super(Conv2DRelu, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -122,8 +122,8 @@ class TestMetalRewritePass(TestCase):
         class Conv2DHardtanh(torch.nn.Module):
             def __init__(self):
                 super(Conv2DHardtanh, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations

--- a/test/test_mobile_optimizer.py
+++ b/test/test_mobile_optimizer.py
@@ -54,10 +54,10 @@ class TestOptimizer(TestCase):
         class MyTestModule(torch.nn.Module):
             def __init__(self):
                 super(MyTestModule, self).__init__()
-                self.conv_weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)))
-                self.conv_bias = torch.nn.Parameter(torch.Tensor(torch.rand((conv_bias_shape))))
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)))
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))))
+                self.conv_weight = torch.nn.Parameter(torch.rand(conv_weight_shape))
+                self.conv_bias = torch.nn.Parameter(torch.rand((conv_bias_shape)))
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape))
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)))
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -142,8 +142,8 @@ class TestOptimizer(TestCase):
         class MyMobileOptimizedTagTest(torch.nn.Module):
             def __init__(self):
                 super(MyMobileOptimizedTagTest, self).__init__()
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)))
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))))
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape))
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)))
 
             def forward(self, x):
                 o = F.linear(x, self.linear_weight, self.linear_bias)
@@ -159,8 +159,8 @@ class TestOptimizer(TestCase):
         class MyPreserveMethodsTest(torch.nn.Module):
             def __init__(self):
                 super(MyPreserveMethodsTest, self).__init__()
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)))
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))))
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape))
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)))
 
             def forward(self, x):
                 o = F.linear(x, self.linear_weight, self.linear_bias)

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -841,7 +841,7 @@ if __name__ == "__main__":
         p.join()
 
     def test_empty_shared(self):
-        t = torch.Tensor()
+        t = torch.tensor([])
         t.share_memory_()
 
     def _test_is_shared(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -377,14 +377,14 @@ class TestNN(NNTestCase):
         class Layer(nn.Module):
             def __init__(self):
                 super(Layer, self).__init__()
-                self.layer_dummy_param = Parameter(torch.Tensor(3, 5))
+                self.layer_dummy_param = Parameter(torch.empty(3, 5))
                 self.register_buffer('layer_dummy_buf', torch.zeros(1, 3, 3, 7))
 
         class Net(nn.Module):
             def __init__(self):
                 super(Net, self).__init__()
                 self.l1 = Layer()
-                self.dummy_param = Parameter(torch.Tensor(3, 5))
+                self.dummy_param = Parameter(torch.empty(3, 5))
                 self.register_buffer('dummy_buf', torch.zeros(7, 3, 3, 1))
 
         l = Layer()
@@ -469,7 +469,7 @@ class TestNN(NNTestCase):
             self.assertTrue(isinstance(output, torch.Tensor))
             self.assertTrue(h_module is module)
             self.assertEqual(input[0], torch.ones(5, 5))
-            self.assertEqual(output, torch.Tensor(5, 5).fill_(1 / (1 + 1 / math.e)))
+            self.assertEqual(output, torch.empty(5, 5).fill_(1 / (1 + 1 / math.e)))
             counter['forwards'] += inc
 
         def bw_hook(inc, h_module, grad_input, grad_output):
@@ -1087,8 +1087,8 @@ class TestNN(NNTestCase):
     def test_dir(self):
         linear = nn.Linear(2, 2)
         linear._test_submodule = nn.Linear(2, 2)
-        linear._test_parameter = Parameter(torch.Tensor(2, 2))
-        linear.register_buffer('_test_buffer', torch.Tensor(2, 2))
+        linear._test_parameter = Parameter(torch.empty(2, 2))
+        linear.register_buffer('_test_buffer', torch.empty(2, 2))
         keys = dir(linear)
         self.assertIn('_test_submodule', keys)
         self.assertIn('_test_parameter', keys)
@@ -2932,7 +2932,7 @@ class TestNN(NNTestCase):
         r"""Check Ln structured pruning by hand.
         """
         m = nn.Conv2d(3, 1, 2)
-        m.weight.data = torch.Tensor(
+        m.weight.data = torch.tensor(
             [[[[1., 2.], [1., 2.5]],
              [[0.5, 1.], [0.1, 0.1]],
              [[-3., -5.], [0.1, -1.]]]]
@@ -2955,12 +2955,12 @@ class TestNN(NNTestCase):
         r"""Check Ln structured pruning by hand.
         """
         m = nn.Conv2d(3, 1, 2)
-        m.weight.data = torch.Tensor(
+        m.weight.data = torch.tensor(
             [[[[1., 2.], [1., 2.5]],
              [[0.5, 1.], [0.1, 0.1]],
              [[-3., -5.], [0.1, -1.]]]]
         )
-        importance_scores = torch.Tensor(
+        importance_scores = torch.tensor(
             [[[[10., 1.], [10., 1.]],
              [[30., 3.], [30., 3.]],
              [[-20., -2.], [-20., -2.]]]]
@@ -3802,7 +3802,7 @@ class TestNN(NNTestCase):
         self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
 
     def test_embedding_from_pretrained(self):
-        a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
+        a = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
         embedding = nn.Embedding.from_pretrained(a)
         self.assertEqual(a, embedding.weight.data)
 
@@ -3820,7 +3820,7 @@ class TestNN(NNTestCase):
         self.assertEqual(embedding_nn.weight[padding_idx], padding_vec)
 
     def test_embedding_from_pretrained_options(self):
-        a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
+        a = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
         opts = {
             "max_norm": 2.,
             "norm_type": .5,
@@ -3876,7 +3876,7 @@ class TestNN(NNTestCase):
         torch.testing.assert_allclose(expected_output, actual_output.cpu(), atol=1e-3, rtol=1e-3)
 
     def test_embeddingbag_from_pretrained(self):
-        a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
+        a = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
         embeddingbag = nn.EmbeddingBag.from_pretrained(a)
         self.assertEqual(a, embeddingbag.weight.data)
 
@@ -3885,7 +3885,7 @@ class TestNN(NNTestCase):
         self.assertEqual(a.mean(0, keepdim=True), output)
 
     def test_embeddingbag_from_pretrained_options(self):
-        a = torch.Tensor([[1, 2, 3], [4, 5, 6]])
+        a = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
         opts = {
             "max_norm": 2.,
             "norm_type": .5,
@@ -5802,45 +5802,45 @@ class TestNN(NNTestCase):
             p.data.copy_(x)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[20, 30, 40, 50]]])
+        encoder_input = torch.tensor([[[20., 30., 40., 50.]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.258703, 0.127985, -0.697881, 0.170862]]])
+        ref_output = torch.tensor([[[2.258703, 0.127985, -0.697881, 0.170862]]])
         result = result.detach().numpy()
         ref_output = ref_output.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
         # 0 values are NOT masked. This shouldn't mask anything.
-        mask = torch.Tensor([[0]]) == 1
+        mask = torch.tensor([[0]]) == 1
         result = model(encoder_input, src_key_padding_mask=mask)
         result = result.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
         # 1 values are masked. Since there is only 1 input embedding this
         # will result in nan.
-        mask = torch.Tensor([[1]]) == 1
+        mask = torch.tensor([[1]]) == 1
         result = model(encoder_input, src_key_padding_mask=mask)
         result = result.detach().numpy()
         self.assertTrue(np.isnan(result).all())
 
         # deterministic input
-        encoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]])
+        encoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.272644, 0.119035, -0.691669, 0.153486]],
+        ref_output = torch.tensor([[[2.272644, 0.119035, -0.691669, 0.153486]],
                                    [[2.272644, 0.119035, -0.691669, 0.153486]]])
         result = result.detach().numpy()
         ref_output = ref_output.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
         # all 0 which is no masking
-        mask = torch.Tensor([[0, 0]]) == 1
+        mask = torch.tensor([[0, 0]]) == 1
         result = model(encoder_input, src_key_padding_mask=mask)
         result = result.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
-        mask = torch.Tensor([[1, 0]]) == 1
+        mask = torch.tensor([[1, 0]]) == 1
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor([[[2.301516, 0.092249, -0.679101, 0.103088]],
+        ref_output = torch.tensor([[[2.301516, 0.092249, -0.679101, 0.103088]],
                                    [[2.301516, 0.092249, -0.679101, 0.103088]]])
         result = result.detach().numpy()
         ref_output = ref_output.detach().numpy()
@@ -5848,7 +5848,7 @@ class TestNN(NNTestCase):
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        encoder_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                        [0.5387, 0.1655, 0.3565, 0.0471]],
                                       [[0.8335, 0.2799, 0.5031, 0.2947],
                                        [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -5859,7 +5859,7 @@ class TestNN(NNTestCase):
                                       [[0.8117, 0.2366, 0.4838, 0.7881],
                                        [0.3718, 0.4945, 0.9511, 0.0864]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.428589, 0.020835, -0.602055, -0.085249],
+        ref_output = torch.tensor([[[2.428589, 0.020835, -0.602055, -0.085249],
                                     [2.427987, 0.021213, -0.602496, -0.084103]],
                                    [[2.424689, 0.019155, -0.604793, -0.085672],
                                     [2.413863, 0.022211, -0.612486, -0.072490]],
@@ -5883,7 +5883,7 @@ class TestNN(NNTestCase):
         mask[1, 3] = 1
         mask[1, 4] = 1
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
+        ref_output = torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                     [2.428811, 0.021445, -0.601912, -0.084252]],
                                    [[2.425009, 0.019155, -0.604566, -0.085899],
                                     [2.415408, 0.02249 , -0.611415, -0.073]],
@@ -5918,23 +5918,23 @@ class TestNN(NNTestCase):
             p.data.copy_(x)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[20, 30, 40, 50]]])
+        encoder_input = torch.tensor([[[20., 30., 40., 50.]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.249815, 0.131006, -0.702199, 0.177868]]])
+        ref_output = torch.tensor([[[2.249815, 0.131006, -0.702199, 0.177868]]])
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]])
+        encoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.264103, 0.121417, -0.696012, 0.159724]],
+        ref_output = torch.tensor([[[2.264103, 0.121417, -0.696012, 0.159724]],
                                    [[2.264103, 0.121417, -0.696012, 0.159724]]])
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        encoder_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                        [0.5387, 0.1655, 0.3565, 0.0471]],
                                       [[0.8335, 0.2799, 0.5031, 0.2947],
                                        [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -5945,7 +5945,7 @@ class TestNN(NNTestCase):
                                       [[0.8117, 0.2366, 0.4838, 0.7881],
                                        [0.3718, 0.4945, 0.9511, 0.0864]]])
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.42163188, 0.03227153, -0.60714219, -0.05908082],
+        ref_output = torch.tensor([[[2.42163188, 0.03227153, -0.60714219, -0.05908082],
                                     [2.42151276, 0.03302179, -0.60722523, -0.05762651]],
                                    [[2.41926761, 0.02974034, -0.60879519, -0.0621269],
                                     [2.41626395, 0.03539356, -0.61087842, -0.04978623]],
@@ -5979,34 +5979,34 @@ class TestNN(NNTestCase):
             p.data.copy_(x)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]])
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]])
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]])
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.314351, 0.094805, -0.671322, 0.101977]]])
+        ref_output = torch.tensor([[[2.314351, 0.094805, -0.671322, 0.101977]]])
         result = result.detach().numpy()
         ref_output = ref_output.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]])
-        memory_input = torch.Tensor([[[1, 2, 3, 4]]])
+        decoder_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]])
+        memory_input = torch.tensor([[[1., 2., 3., 4.]]])
         result = model(decoder_input, memory_input)
         result = result.detach().numpy()
-        ref_output = torch.Tensor([[[2.422245, 0.051716, -0.606338, -0.024756]],
+        ref_output = torch.tensor([[[2.422245, 0.051716, -0.606338, -0.024756]],
                                    [[2.422245, 0.051716, -0.606338, -0.024756]]])
         ref_output = ref_output.detach().numpy()
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]])
-        memory_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]])
+        decoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]])
+        memory_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.343536, 0.085561, -0.654954, 0.074991]],
+        ref_output = torch.tensor([[[2.343536, 0.085561, -0.654954, 0.074991]],
                                    [[2.343536, 0.085561, -0.654954, 0.074991]]])
         result = result.detach().numpy()
         ref_output = ref_output.detach().numpy()
@@ -6014,13 +6014,13 @@ class TestNN(NNTestCase):
         np.testing.assert_allclose(result, ref_output, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                        [0.2678, 0.3677, 0.4459, 0.7166]],
                                       [[0.8100, 0.3716, 0.4096, 0.1976],
                                        [0.6958, 0.8844, 0.6081, 0.8315]],
                                       [[0.0494, 0.9343, 0.5955, 0.3830],
                                        [0.5404, 0.3464, 0.9378, 0.6200]]])
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6031,7 +6031,7 @@ class TestNN(NNTestCase):
                                      [[0.8117, 0.2366, 0.4838, 0.7881],
                                       [0.3718, 0.4945, 0.9511, 0.0864]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6045,7 +6045,7 @@ class TestNN(NNTestCase):
         # key_padding_mask
         key_padding_mask = torch.zeros(2, 3) == 1
         result = model(decoder_input, memory_input, tgt_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6061,7 +6061,7 @@ class TestNN(NNTestCase):
         key_padding_mask[1, 1] = 1
         key_padding_mask[1, 2] = 1
         result = model(decoder_input, memory_input, tgt_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430025, 0.027643, -0.601164, -0.073476],
+        ref_output = torch.tensor([[[2.430025, 0.027643, -0.601164, -0.073476],
                                     [2.4323, 0.029375, -0.599553, -0.071881]],
                                    [[2.428523, 0.026838, -0.602226, -0.07391],
                                     [2.432634, 0.029842, -0.599318, -0.071253]],
@@ -6075,7 +6075,7 @@ class TestNN(NNTestCase):
         # memory_key_padding_mask
         key_padding_mask = torch.zeros(2, 5) == 1
         result = model(decoder_input, memory_input, memory_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6091,7 +6091,7 @@ class TestNN(NNTestCase):
         key_padding_mask[1, 3] = 1
         key_padding_mask[1, 4] = 1
         result = model(decoder_input, memory_input, memory_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.429757, 0.027358, -0.601351, -0.073816],
+        ref_output = torch.tensor([[[2.429757, 0.027358, -0.601351, -0.073816],
                                     [2.432692, 0.028583, -0.599263, -0.073634]],
                                    [[2.428247, 0.02662, -0.602419, -0.074123],
                                     [2.432657, 0.029055, -0.599293, -0.072732]],
@@ -6124,42 +6124,42 @@ class TestNN(NNTestCase):
             p.data.copy_(x)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]])
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]])
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]])
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.306435, 0.095946, -0.675796, 0.10687]]])
+        ref_output = torch.tensor([[[2.306435, 0.095946, -0.675796, 0.10687]]])
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]])
-        memory_input = torch.Tensor([[[1, 2, 3, 4]]])
+        decoder_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]])
+        memory_input = torch.tensor([[[1., 2., 3., 4.]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.415448, 0.054389, -0.610932, -0.0156613]],
+        ref_output = torch.tensor([[[2.415448, 0.054389, -0.610932, -0.0156613]],
                                    [[2.415448, 0.054389, -0.610932, -0.0156613]]])
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]])
-        memory_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]])
+        decoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]])
+        memory_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.338531, 0.087709, -0.65776, 0.080646]],
+        ref_output = torch.tensor([[[2.338531, 0.087709, -0.65776, 0.080646]],
                                    [[2.338531, 0.087709, -0.65776, 0.080646]]])
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                        [0.2678, 0.3677, 0.4459, 0.7166]],
                                       [[0.8100, 0.3716, 0.4096, 0.1976],
                                        [0.6958, 0.8844, 0.6081, 0.8315]],
                                       [[0.0494, 0.9343, 0.5955, 0.3830],
                                        [0.5404, 0.3464, 0.9378, 0.6200]]])
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6170,7 +6170,7 @@ class TestNN(NNTestCase):
                                      [[0.8117, 0.2366, 0.4838, 0.7881],
                                       [0.3718, 0.4945, 0.9511, 0.0864]]])
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.42049104, 0.03443088, -0.60793706, -0.05436271],
+        ref_output = torch.tensor([[[2.42049104, 0.03443088, -0.60793706, -0.05436271],
                                     [2.42210631, 0.03546578, -0.60679895, -0.05357488]],
                                    [[2.41907674, 0.0336104, -0.60892977, -0.05490462],
                                     [2.42216881, 0.03586554, -0.6067524, -0.05289126]],
@@ -6215,7 +6215,7 @@ class TestNN(NNTestCase):
         model = nn.TransformerEncoder(encoder_layer, 1).to(device)
 
         # deterministic input
-        encoder_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        encoder_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                        [0.5387, 0.1655, 0.3565, 0.0471]],
                                       [[0.8335, 0.2799, 0.5031, 0.2947],
                                        [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6227,7 +6227,7 @@ class TestNN(NNTestCase):
                                        [0.3718, 0.4945, 0.9511, 0.0864]]]
                                      ).to(device)
         result = model(encoder_input)
-        ref_output = torch.Tensor([[[2.428589, 0.020835, -0.602055, -0.085249],
+        ref_output = torch.tensor([[[2.428589, 0.020835, -0.602055, -0.085249],
                                     [2.427987, 0.021213, -0.602496, -0.084103]],
                                    [[2.424689, 0.019155, -0.604793, -0.085672],
                                     [2.413863, 0.022211, -0.612486, -0.072490]],
@@ -6250,7 +6250,7 @@ class TestNN(NNTestCase):
         mask[1, 3] = 1
         mask[1, 4] = 1
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
+        ref_output = torch.tensor([[[2.429026, 0.020793, -0.601741, -0.085642],
                                     [2.428811, 0.021445, -0.601912, -0.084252]],
                                    [[2.425009, 0.019155, -0.604566, -0.085899],
                                     [2.415408, 0.02249, -0.611415, -0.073]],
@@ -6267,7 +6267,7 @@ class TestNN(NNTestCase):
         # test case 2, multiple layers no norm
         model = nn.TransformerEncoder(encoder_layer, 2).to(device)
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.419051, 0.017446, -0.608738, -0.085003],
               [2.419102, 0.017452, -0.608703, -0.085026]],
              [[2.419043, 0.017445, -0.608744, -0.084999],
@@ -6284,7 +6284,7 @@ class TestNN(NNTestCase):
 
         model = nn.TransformerEncoder(encoder_layer, 6).to(device)
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.419101, 0.017453, -0.608703, -0.085025],
               [2.419101, 0.017453, -0.608704, -0.085025]],
              [[2.419101, 0.017453, -0.608703, -0.085025],
@@ -6304,7 +6304,7 @@ class TestNN(NNTestCase):
         norm = nn.LayerNorm(4)
         model = nn.TransformerEncoder(encoder_layer, 2, norm=norm).to(device)
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[1.695949, -0.357635, -0.893077, -0.445238],
               [1.695955, -0.357639, -0.893050, -0.445266]],
              [[1.695948, -0.357634, -0.893082, -0.445233],
@@ -6321,7 +6321,7 @@ class TestNN(NNTestCase):
 
         model = nn.TransformerEncoder(encoder_layer, 6, norm=norm).to(device)
         result = model(encoder_input, src_key_padding_mask=mask)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[1.695955, -0.357639, -0.893051, -0.445265],
               [1.695955, -0.357639, -0.893051, -0.445265]],
              [[1.695955, -0.357639, -0.893051, -0.445265],
@@ -6373,20 +6373,20 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 1).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]]).to(device)
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]]).to(device)
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]]).to(device)
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.314351, 0.094805, -0.671322, 0.101977]]]).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output, rtol=1e-7, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]]).to(device)
-        memory_input = torch.Tensor([[[1, 2, 3, 4]]]).to(device)
+        decoder_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]]).to(device)
+        memory_input = torch.tensor([[[1., 2., 3., 4.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.422245, 0.051716, -0.606338, -0.024756]],
              [[2.422245, 0.051716, -0.606338, -0.024756]]]
         ).to(device)
@@ -6394,12 +6394,12 @@ class TestNN(NNTestCase):
         torch.testing.assert_allclose(result, ref_output, rtol=1e-7, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]]).to(device)
-        memory_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]]).to(device)
+        decoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]]).to(device)
+        memory_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.343536, 0.085561, -0.654954, 0.074991]],
              [[2.343536, 0.085561, -0.654954, 0.074991]]]
         ).to(device)
@@ -6407,14 +6407,14 @@ class TestNN(NNTestCase):
         torch.testing.assert_allclose(result, ref_output, rtol=1e-7, atol=1e-5)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                        [0.2678, 0.3677, 0.4459, 0.7166]],
                                       [[0.8100, 0.3716, 0.4096, 0.1976],
                                        [0.6958, 0.8844, 0.6081, 0.8315]],
                                       [[0.0494, 0.9343, 0.5955, 0.3830],
                                        [0.5404, 0.3464, 0.9378, 0.6200]]]
                                      ).to(device)
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6426,7 +6426,7 @@ class TestNN(NNTestCase):
                                       [0.3718, 0.4945, 0.9511, 0.0864]]]
                                     ).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6441,7 +6441,7 @@ class TestNN(NNTestCase):
         result = model(decoder_input,
                        memory_input,
                        tgt_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6458,7 +6458,7 @@ class TestNN(NNTestCase):
         result = model(decoder_input,
                        memory_input,
                        tgt_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430025, 0.027643, -0.601164, -0.073476],
+        ref_output = torch.tensor([[[2.430025, 0.027643, -0.601164, -0.073476],
                                     [2.4323, 0.029375, -0.599553, -0.071881]],
                                    [[2.428523, 0.026838, -0.602226, -0.07391],
                                     [2.432634, 0.029842, -0.599318, -0.071253]],
@@ -6473,7 +6473,7 @@ class TestNN(NNTestCase):
         result = model(decoder_input,
                        memory_input,
                        memory_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
+        ref_output = torch.tensor([[[2.430065, 0.027862, -0.601136, -0.073096],
                                     [2.431935, 0.028907, -0.599809, -0.072488]],
                                    [[2.428457, 0.027053, -0.602275, -0.073462],
                                     [2.431970, 0.029387, -0.599789, -0.071621]],
@@ -6490,7 +6490,7 @@ class TestNN(NNTestCase):
         result = model(decoder_input,
                        memory_input,
                        memory_key_padding_mask=key_padding_mask)
-        ref_output = torch.Tensor([[[2.429757, 0.027358, -0.601351, -0.073816],
+        ref_output = torch.tensor([[[2.429757, 0.027358, -0.601351, -0.073816],
                                     [2.432692, 0.028583, -0.599263, -0.073634]],
                                    [[2.428247, 0.02662, -0.602419, -0.074123],
                                     [2.432657, 0.029055, -0.599293, -0.072732]],
@@ -6504,10 +6504,10 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 2).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]]).to(device)
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]]).to(device)
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]]).to(device)
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.31316, 0.0950293, -0.671995, 0.102802]]]).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output, rtol=1e-7, atol=1e-5)
@@ -6516,14 +6516,14 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 6).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                       [0.2678, 0.3677, 0.4459, 0.7166]],
                                      [[0.8100, 0.3716, 0.4096, 0.1976],
                                       [0.6958, 0.8844, 0.6081, 0.8315]],
                                      [[0.0494, 0.9343, 0.5955, 0.3830],
                                       [0.5404, 0.3464, 0.9378, 0.6200]]]
                                      ).to(device)
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6535,7 +6535,7 @@ class TestNN(NNTestCase):
                                       [0.3718, 0.4945, 0.9511, 0.0864]]]
                                     ).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.42794, 0.026164, -0.60263, -0.0747591],
               [2.43113, 0.0279516, -0.600376, -0.0736896]],
              [[2.42794, 0.026164, -0.60263, -0.0747591],
@@ -6552,10 +6552,10 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 2, norm=norm).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]]).to(device)
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]]).to(device)
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]]).to(device)
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[1.66166, -0.326986, -1.01466, -0.320017]]]).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output, rtol=1e-7, atol=1e-5)
@@ -6564,14 +6564,14 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 6, norm=norm).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                        [0.2678, 0.3677, 0.4459, 0.7166]],
                                       [[0.8100, 0.3716, 0.4096, 0.1976],
                                        [0.6958, 0.8844, 0.6081, 0.8315]],
                                       [[0.0494, 0.9343, 0.5955, 0.3830],
                                        [0.5404, 0.3464, 0.9378, 0.6200]]]
                                      ).to(device)
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6583,7 +6583,7 @@ class TestNN(NNTestCase):
                                       [0.3718, 0.4945, 0.9511, 0.0864]]]
                                     ).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[1.69559, -0.357291, -0.894741, -0.443553],
               [1.69571, -0.357363, -0.894154, -0.444196]],
              [[1.69559, -0.357291, -0.894741, -0.443553],
@@ -6604,46 +6604,46 @@ class TestNN(NNTestCase):
         model = nn.TransformerDecoder(decoder_layer, 1).to(device)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[20, 30, 40, 50]]]).to(device)
-        memory_input = torch.Tensor([[[60, 70, 80, 90]]]).to(device)
+        decoder_input = torch.tensor([[[20., 30., 40., 50.]]]).to(device)
+        memory_input = torch.tensor([[[60., 70., 80., 90.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor([[[2.306435, 0.095946, -0.675796, 0.10687]]]
+        ref_output = torch.tensor([[[2.306435, 0.095946, -0.675796, 0.10687]]]
                                   ).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[9, 10, 11, 12]],
-                                      [[11, 12, 13, 14]]]).to(device)
-        memory_input = torch.Tensor([[[1, 2, 3, 4]]]).to(device)
+        decoder_input = torch.tensor([[[9., 10., 11., 12.]],
+                                      [[11., 12., 13., 14.]]]).to(device)
+        memory_input = torch.tensor([[[1., 2., 3., 4.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.415448, 0.054389, -0.610932, -0.0156613]],
              [[2.415448, 0.054389, -0.610932, -0.0156613]]]).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[1, 2, 3, 4]],
-                                      [[5, 6, 7, 8]]]).to(device)
-        memory_input = torch.Tensor([[[9, 10, 11, 12]],
-                                     [[11, 12, 13, 14]]]).to(device)
+        decoder_input = torch.tensor([[[1., 2., 3., 4.]],
+                                      [[5., 6., 7., 8.]]]).to(device)
+        memory_input = torch.tensor([[[9., 10., 11., 12.]],
+                                     [[11., 12., 13., 14.]]]).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.338531, 0.087709, -0.65776, 0.080646]],
              [[2.338531, 0.087709, -0.65776, 0.080646]]]).to(device)
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_allclose(result, ref_output)
 
         # deterministic input
-        decoder_input = torch.Tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
+        decoder_input = torch.tensor([[[0.4517, 0.6793, 0.5313, 0.0034],
                                        [0.2678, 0.3677, 0.4459, 0.7166]],
                                       [[0.8100, 0.3716, 0.4096, 0.1976],
                                        [0.6958, 0.8844, 0.6081, 0.8315]],
                                       [[0.0494, 0.9343, 0.5955, 0.3830],
                                        [0.5404, 0.3464, 0.9378, 0.6200]]]
                                      ).to(device)
-        memory_input = torch.Tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
+        memory_input = torch.tensor([[[0.7462, 0.6653, 0.5679, 0.4891],
                                       [0.5387, 0.1655, 0.3565, 0.0471]],
                                      [[0.8335, 0.2799, 0.5031, 0.2947],
                                       [0.1402, 0.0318, 0.7636, 0.1346]],
@@ -6655,7 +6655,7 @@ class TestNN(NNTestCase):
                                       [0.3718, 0.4945, 0.9511, 0.0864]]]
                                     ).to(device)
         result = model(decoder_input, memory_input)
-        ref_output = torch.Tensor(
+        ref_output = torch.tensor(
             [[[2.42049104, 0.03443088, -0.60793706, -0.05436271],
               [2.42210631, 0.03546578, -0.60679895, -0.05357488]],
              [[2.41907674, 0.0336104, -0.60892977, -0.05490462],
@@ -8990,11 +8990,11 @@ class TestNN(NNTestCase):
         # test known input on CPU
         input = torch.arange(1., 7).view(1, 2, 3)
         output = F.affine_grid(input, torch.Size([1, 1, 2, 2]), align_corners=True)
-        groundtruth = torch.Tensor(
-            [[[0, -3], [2, 5]], [[4, 7], [6, 15]]]).view(1, 2, 2, 2)
+        groundtruth = torch.tensor(
+            [[[0., -3.], [2., 5.]], [[4., 7.], [6., 15.]]]).view(1, 2, 2, 2)
         self.assertEqual(output, groundtruth)
         output = F.affine_grid(input, torch.Size([1, 1, 2, 2]), align_corners=False)
-        groundtruth = torch.Tensor(
+        groundtruth = torch.tensor(
             [[[1.5, 1.5], [2.5, 5.5]], [[3.5, 6.5], [4.5, 10.5]]]).view(1, 2, 2, 2)
         self.assertEqual(output, groundtruth)
 
@@ -9038,14 +9038,14 @@ class TestNN(NNTestCase):
         # test known input on CPU
         input = torch.arange(1., 13).view(1, 3, 4)
         output = F.affine_grid(input, torch.Size([1, 1, 2, 2, 2]), align_corners=True)
-        groundtruth = torch.Tensor(
-            [[[[[-2, -10, -18], [0, 0, 0]], [[2, 2, 2], [4, 12, 20]]],
-              [[[4, 4, 4], [6, 14, 22]], [[8, 16, 24], [10, 26, 42]]]]]).view(1, 2, 2, 2, 3)
+        groundtruth = torch.tensor(
+            [[[[[-2., -10., -18.], [0., 0., 0.]], [[2., 2., 2.], [4., 12., 20.]]],
+              [[[4., 4., 4.], [6., 14., 22.]], [[8., 16., 24.], [10., 26., 42.]]]]]).view(1, 2, 2, 2, 3)
         self.assertEqual(output, groundtruth)
         output = F.affine_grid(input, torch.Size([1, 1, 2, 2, 2]), align_corners=False)
-        groundtruth = torch.Tensor(
-            [[[[[1, -1, -3], [2, 4, 6]], [[3, 5, 7], [4, 10, 16]]],
-              [[[4, 6, 8], [5, 11, 17]], [[6, 12, 18], [7, 17, 27]]]]]).view(1, 2, 2, 2, 3)
+        groundtruth = torch.tensor(
+            [[[[[1., -1., -3.], [2., 4., 6.]], [[3., 5., 7.], [4., 10., 16.]]],
+              [[[4., 6., 8.], [5., 11., 17.]], [[6., 12., 18.], [7., 17., 27.]]]]]).view(1, 2, 2, 2, 3)
         self.assertEqual(output, groundtruth)
 
         for align_corners in (True, False):
@@ -9281,7 +9281,7 @@ class TestNN(NNTestCase):
     def test_upsamplingBicubic2d(self):
         # test output against known input: align_corners=False result must match opencv
         in_t = torch.arange(8.).view(1, 2, 2, 2)
-        expected_out_t = torch.Tensor(
+        expected_out_t = torch.tensor(
             [[[[-0.31641, 0.01562, 0.56250, 0.89453],
               [0.34766, 0.67969, 1.22656, 1.55859],
               [1.44141, 1.77344, 2.32031, 2.65234],
@@ -9318,7 +9318,7 @@ class TestNN(NNTestCase):
     def test_upsampling_not_recompute_scale_factor(self):
         # test output against known input: result must match opencv
         in_t = torch.arange(8.).view(1, 2, 2, 2)
-        expected_out_t = torch.Tensor(
+        expected_out_t = torch.tensor(
             [[[[-0.32725, -0.08843, 0.37933, 0.79744],
               [0.15039, 0.38921, 0.85697, 1.27508],
               [1.08591, 1.32473, 1.79249, 2.21060],
@@ -9330,7 +9330,7 @@ class TestNN(NNTestCase):
               [5.92213, 6.16095, 6.62871, 7.04682]]]])
         if IS_PPC:
             # Both OpenCV and PyTorch give a slightly different result on PPC
-            expected_out_t = torch.Tensor(
+            expected_out_t = torch.tensor(
                 [[[[-0.32725, -0.08843, 0.37933, 0.79744],
                   [0.15039, 0.38921, 0.85697, 1.27508],
                   [1.08591, 1.32473, 1.79249, 2.21060],
@@ -13640,7 +13640,7 @@ class TestNNDeviceType(NNTestCase):
                 length = next_offset - offset
                 if length == 0:
                     bags.append(
-                        torch.Tensor([0] * weight.size(1)).to(
+                        torch.tensor([0] * weight.size(1)).to(
                             dtype=embeddings.dtype, device=embeddings.device
                         )
                     )
@@ -13661,7 +13661,7 @@ class TestNNDeviceType(NNTestCase):
                 length = next_offset - offset
                 if length == 0:
                     bags.append(
-                        torch.Tensor([0] * weight.size(1)).to(
+                        torch.tensor([0] * weight.size(1)).to(
                             dtype=embeddings.dtype, device=embeddings.device
                         )
                     )
@@ -14543,7 +14543,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(-log_probs.sum(0)[[0, 2], 0], loss[[0, 2]])
 
     def test_empty_dropout(self, device):
-        x = torch.Tensor([]).to(device)
+        x = torch.tensor([]).to(device)
         out = torch.nn.functional.dropout(x)
         self.assertEqual(out.size(), x.size())
 
@@ -15258,7 +15258,7 @@ class TestModuleGlobalHooks(TestCase):
             self.assertTrue(isinstance(output, torch.Tensor))
             self.assertTrue(isinstance(h_module, module))
             self.assertEqual(input[0], torch.ones(5, 5))
-            self.assertEqual(output, torch.Tensor(5, 5).fill_(1 / (1 + 1 / math.e)))
+            self.assertEqual(output, torch.empty(5, 5).fill_(1 / (1 + 1 / math.e)))
             counter['forwards'] += inc
 
         def bw_hook(inc, h_module, grad_input, grad_output):

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -85,7 +85,7 @@ class TestNumPyInterop(TestCase):
                         self.assertEqual(x[i][j], y[i][j])
 
             # empty
-            x = torch.Tensor().to(dtp)
+            x = torch.tensor([]).to(dtp)
             y = x.numpy()
             self.assertEqual(y.size, 0)
 
@@ -273,10 +273,10 @@ class TestNumPyInterop(TestCase):
             if np.dtype(dtype).kind == 'u':  # type: ignore[misc]
                 # .type expects a XxxTensor, which have no type hints on
                 # purpose, so ignore during mypy type checking
-                x = torch.Tensor([1, 2, 3, 4]).type(tp)  # type: ignore
+                x = torch.tensor([1, 2, 3, 4]).type(tp)  # type: ignore
                 array = np.array([1, 2, 3, 4], dtype=dtype)
             else:
-                x = torch.Tensor([1, -2, 3, -4]).type(tp)  # type: ignore
+                x = torch.tensor([1, -2, 3, -4]).type(tp)  # type: ignore
                 array = np.array([1, -2, 3, -4], dtype=dtype)
 
             # Test __array__ w/o dtype argument
@@ -311,7 +311,7 @@ class TestNumPyInterop(TestCase):
         float_types = [torch.DoubleTensor, torch.FloatTensor]
         float_dtypes = [np.float64, np.float32]
         for tp, dtype in zip(float_types, float_dtypes):
-            x = torch.Tensor([1, 2, 3, 4]).type(tp)  # type: ignore
+            x = torch.tensor([1, 2, 3, 4]).type(tp)  # type: ignore
             array = np.array([1, 2, 3, 4], dtype=dtype)
             for func in ['sin', 'sqrt', 'ceil']:
                 ufunc = getattr(np, func)
@@ -323,7 +323,7 @@ class TestNumPyInterop(TestCase):
 
         # Test functions with boolean return value
         for tp, dtype in zip(types, dtypes):
-            x = torch.Tensor([1, 2, 3, 4]).type(tp)  # type: ignore
+            x = torch.tensor([1, 2, 3, 4]).type(tp)  # type: ignore
             array = np.array([1, 2, 3, 4], dtype=dtype)
             geq2_x = np.greater_equal(x, 2)
             geq2_array = np.greater_equal(array, 2).astype('uint8')

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -30,7 +30,7 @@ def rosenbrock(tensor):
 
 def drosenbrock(tensor):
     x, y = tensor
-    return torch.Tensor((-400 * x * (y - x ** 2) - 2 * (1 - x), 200 * (y - x ** 2)))
+    return torch.tensor((-400 * x * (y - x ** 2) - 2 * (1 - x), 200 * (y - x ** 2)))
 
 
 class TestOptim(TestCase):
@@ -40,7 +40,7 @@ class TestOptim(TestCase):
                                 sparse_only=False):
         if scheduler_constructors is None:
             scheduler_constructors = []
-        params_t = torch.Tensor([1.5, 1.5])
+        params_t = torch.tensor([1.5, 1.5])
 
         params = Variable(params_t, requires_grad=True)
         optimizer = constructor([params])
@@ -52,7 +52,7 @@ class TestOptim(TestCase):
             params_c = Variable(params_t.clone(), requires_grad=True)
             optimizer_c = constructor([params_c])
 
-        solution = torch.Tensor([1, 1])
+        solution = torch.tensor([1, 1])
         initial_dist = params.data.dist(solution)
 
         def eval(params, sparse_grad, w):
@@ -66,11 +66,11 @@ class TestOptim(TestCase):
             if w:
                 i = torch.LongTensor([[0, 0]])
                 x = grad[0]
-                v = torch.Tensor([x / 4., x - x / 4.])
+                v = torch.tensor([x / 4., x - x / 4.])
             else:
                 i = torch.LongTensor([[1, 1]])
                 y = grad[1]
-                v = torch.Tensor([y - y / 4., y / 4.])
+                v = torch.tensor([y - y / 4., y / 4.])
             x = sparse.DoubleTensor(i, v, torch.Size([2])).to(dtype=v.dtype)
             with torch.no_grad():
                 if sparse_grad:
@@ -614,7 +614,7 @@ class TestOptim(TestCase):
         opt2 = optim.LBFGS(params, 0.01, tolerance_grad=-inf)
 
         def closure():
-            return torch.Tensor([10])
+            return torch.tensor([10])
 
         res1 = opt1.step(closure)
         res2 = opt2.step(closure)
@@ -707,7 +707,7 @@ class TestLRScheduler(TestCase):
 
     def test_no_cyclic_references(self):
         import gc
-        param = Variable(torch.Tensor(10), requires_grad=True)
+        param = Variable(torch.empty(10), requires_grad=True)
         optim = SGD([param], lr=0.5)
         scheduler = LambdaLR(optim, lambda epoch: 1.0)
         del scheduler

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -63,11 +63,11 @@ class TestShapeOps(TestCase):
     @onlyCPU
     def test_tolist(self, device):
         list0D = []
-        tensor0D = torch.Tensor(list0D)
+        tensor0D = torch.tensor(list0D)
         self.assertEqual(tensor0D.tolist(), list0D)
 
-        table1D = [1, 2, 3]
-        tensor1D = torch.Tensor(table1D)
+        table1D = [1., 2., 3.]
+        tensor1D = torch.tensor(table1D)
         storage = torch.Storage(table1D)
         self.assertEqual(tensor1D.tolist(), table1D)
         self.assertEqual(storage.tolist(), table1D)
@@ -75,10 +75,10 @@ class TestShapeOps(TestCase):
         self.assertEqual(storage.tolist(), table1D)
 
         table2D = [[1, 2], [3, 4]]
-        tensor2D = torch.Tensor(table2D)
+        tensor2D = torch.tensor(table2D)
         self.assertEqual(tensor2D.tolist(), table2D)
 
-        tensor3D = torch.Tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        tensor3D = torch.tensor([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
         tensorNonContig = tensor3D.select(1, 1)
         self.assertFalse(tensorNonContig.is_contiguous())
         self.assertEqual(tensorNonContig.tolist(), [[3, 4], [7, 8]])

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1239,13 +1239,13 @@ class TestTensorCreation(TestCase):
         bad_mock_seq = MockSequence([1.0, 2.0, 3.0])
         good_mock_seq = GoodMockSequence([1.0, 2.0, 3.0])
         with self.assertRaisesRegex(ValueError, 'could not determine the shape'):
-            torch.Tensor(bad_mock_seq)
-        self.assertEqual(torch.Tensor([1.0, 2.0, 3.0]), torch.Tensor(good_mock_seq))
+            torch.tensor(bad_mock_seq)
+        self.assertEqual(torch.tensor([1.0, 2.0, 3.0]), torch.tensor(good_mock_seq))
 
     # TODO: update to work on CUDA, too?
     @onlyCPU
     def test_simple_scalar_cast(self, device):
-        ok = [torch.Tensor([1.5]), torch.zeros(1, 1, 1, 1)]
+        ok = [torch.tensor([1.5]), torch.zeros(1, 1, 1, 1)]
         ok_values = [1.5, 0]
 
         not_ok = map(torch.Tensor, [[], [1, 2], [[1, 2], [3, 4]]])
@@ -1268,7 +1268,7 @@ class TestTensorCreation(TestCase):
     # TODO: update to work on CUDA, too?
     @onlyCPU
     def test_offset_scalar_cast(self, device):
-        x = torch.Tensor([1, 2, 3])
+        x = torch.tensor([1., 2., 3.])
         y = x[2:]
         self.assertEqual(int(y), 3)
 
@@ -1806,8 +1806,8 @@ class TestTensorCreation(TestCase):
     # TODO: this test should be updated
     @onlyCPU
     def test_constructor_dtypes(self, device):
-        default_type = torch.Tensor().type()
-        self.assertIs(torch.Tensor().dtype, torch.get_default_dtype())
+        default_type = torch.tensor([]).type()
+        self.assertIs(torch.tensor([]).dtype, torch.get_default_dtype())
 
         self.assertIs(torch.uint8, torch.ByteTensor.dtype)
         self.assertIs(torch.float32, torch.FloatTensor.dtype)
@@ -2171,18 +2171,18 @@ class TestTensorCreation(TestCase):
         # Check arange for non-contiguous tensors.
         x = torch.zeros(2, 3)
         torch.arange(0, 4, out=x.narrow(1, 1, 2))
-        res2 = torch.Tensor(((0, 0, 1), (0, 2, 3)))
+        res2 = torch.tensor(((0, 0, 1), (0, 2, 3)))
         self.assertEqual(x, res2, atol=1e-16, rtol=0)
 
         # Check negative
-        res1 = torch.Tensor((1, 0))
-        res2 = torch.Tensor()
+        res1 = torch.tensor((1, 0))
+        res2 = torch.tensor([])
         torch.arange(1, -1, -1, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)
 
         # Equal bounds
         res1 = torch.ones(1)
-        res2 = torch.Tensor()
+        res2 = torch.tensor([])
         torch.arange(1, 0, -1, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)
         torch.arange(1, 2, 1, out=res2)
@@ -2583,7 +2583,7 @@ class TestTensorCreation(TestCase):
 
     @onlyCUDA
     def test_tensor_factory_gpu_type_inference(self, device):
-        saved_type = torch.Tensor().type()
+        saved_type = torch.tensor([]).type()
         torch.set_default_tensor_type(torch.cuda.DoubleTensor)
         torch.set_default_dtype(torch.float32)
         self.assertIs(torch.float32, torch.tensor(0.).dtype)
@@ -2595,7 +2595,7 @@ class TestTensorCreation(TestCase):
 
     @onlyCUDA
     def test_tensor_factory_gpu_type(self, device):
-        saved_type = torch.Tensor().type()
+        saved_type = torch.tensor([]).type()
         torch.set_default_tensor_type(torch.cuda.FloatTensor)
         x = torch.zeros((5, 5))
         self.assertIs(torch.float32, x.dtype)
@@ -3257,7 +3257,7 @@ class TestLikeTensorCreation(TestCase):
     # TODO: this test should be updated
     @onlyCPU
     def test_empty_like(self, device):
-        x = torch.autograd.Variable(torch.Tensor())
+        x = torch.autograd.Variable(torch.tensor([]))
         y = torch.autograd.Variable(torch.randn(4, 4))
         z = torch.autograd.Variable(torch.IntTensor([1, 2, 3]))
         for a in (x, y, z):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2171,11 +2171,11 @@ class TestTensorCreation(TestCase):
         # Check arange for non-contiguous tensors.
         x = torch.zeros(2, 3)
         torch.arange(0, 4, out=x.narrow(1, 1, 2))
-        res2 = torch.tensor(((0, 0, 1), (0, 2, 3)))
+        res2 = torch.tensor(((0., 0., 1.), (0., 2., 3.)))
         self.assertEqual(x, res2, atol=1e-16, rtol=0)
 
         # Check negative
-        res1 = torch.tensor((1, 0))
+        res1 = torch.tensor((1., 0.))
         res2 = torch.tensor([])
         torch.arange(1, -1, -1, out=res2)
         self.assertEqual(res1, res2, atol=0, rtol=0)

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -289,8 +289,8 @@ class TestTensorBoardSummaryWriter(BaseTestCase):
 class TestTensorBoardEmbedding(BaseTestCase):
     def test_embedding(self):
         w = self.createSummaryWriter()
-        all_features = torch.tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
-        all_labels = torch.tensor([33, 44, 55])
+        all_features = torch.tensor([[1., 2., 3.], [5., 4., 1.], [3., 7., 7.]])
+        all_labels = torch.tensor([33., 44., 55.])
         all_images = torch.zeros(3, 3, 5, 5)
 
         w.add_embedding(all_features,
@@ -309,8 +309,8 @@ class TestTensorBoardEmbedding(BaseTestCase):
 
     def test_embedding_64(self):
         w = self.createSummaryWriter()
-        all_features = torch.tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
-        all_labels = torch.tensor([33, 44, 55])
+        all_features = torch.tensor([[1., 2., 3.], [5., 4., 1.], [3., 7., 7.]])
+        all_labels = torch.tensor([33., 44., 55.])
         all_images = torch.zeros((3, 3, 5, 5), dtype=torch.float64)
 
         w.add_embedding(all_features,

--- a/test/test_tensorboard.py
+++ b/test/test_tensorboard.py
@@ -99,7 +99,7 @@ class TestTensorBoardPyTorchNumpy(BaseTestCase):
         self.assertIsInstance(make_np(0.1), np.ndarray)
 
     def test_pytorch_autograd_np(self):
-        x = torch.autograd.Variable(torch.Tensor(1))
+        x = torch.autograd.Variable(torch.empty(1))
         self.assertIsInstance(make_np(x), np.ndarray)
 
     def test_pytorch_write(self):
@@ -289,8 +289,8 @@ class TestTensorBoardSummaryWriter(BaseTestCase):
 class TestTensorBoardEmbedding(BaseTestCase):
     def test_embedding(self):
         w = self.createSummaryWriter()
-        all_features = torch.Tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
-        all_labels = torch.Tensor([33, 44, 55])
+        all_features = torch.tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
+        all_labels = torch.tensor([33, 44, 55])
         all_images = torch.zeros(3, 3, 5, 5)
 
         w.add_embedding(all_features,
@@ -309,8 +309,8 @@ class TestTensorBoardEmbedding(BaseTestCase):
 
     def test_embedding_64(self):
         w = self.createSummaryWriter()
-        all_features = torch.Tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
-        all_labels = torch.Tensor([33, 44, 55])
+        all_features = torch.tensor([[1, 2, 3], [5, 4, 1], [3, 7, 7]])
+        all_labels = torch.tensor([33, 44, 55])
         all_images = torch.zeros((3, 3, 5, 5), dtype=torch.float64)
 
         w.add_embedding(all_features,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -209,12 +209,11 @@ class AbstractTestCases:
                 torch.zeros(1, device=torch.device('msnpu'))
 
         def test_has_storage(self):
-            self.assertIsNotNone(torch.Tensor().storage())
-            self.assertIsNotNone(torch.Tensor(0).storage())
-            self.assertIsNotNone(torch.Tensor([]).storage())
-            self.assertIsNotNone(torch.Tensor().clone().storage())
-            self.assertIsNotNone(torch.Tensor([0, 0, 0]).nonzero().storage())
-            self.assertIsNotNone(torch.Tensor().new().storage())
+            self.assertIsNotNone(torch.tensor([]).storage())
+            self.assertIsNotNone(torch.empty(0).storage())
+            self.assertIsNotNone(torch.tensor([]).clone().storage())
+            self.assertIsNotNone(torch.tensor([0, 0, 0]).nonzero().storage())
+            self.assertIsNotNone(torch.tensor([]).new().storage())
 
         def test_where_invalid_device(self):
             if torch.cuda.is_available():
@@ -529,10 +528,10 @@ class AbstractTestCases:
         @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
         def test_multinomial_invalid_probs(self):
             test_method = AbstractTestCases._TestTorchMixin._test_multinomial_invalid_probs
-            self._spawn_method(test_method, torch.Tensor([1, -1, 1]))
-            self._spawn_method(test_method, torch.Tensor([1, inf, 1]))
-            self._spawn_method(test_method, torch.Tensor([1, -inf, 1]))
-            self._spawn_method(test_method, torch.Tensor([1, 1, nan]))
+            self._spawn_method(test_method, torch.tensor([1, -1, 1]))
+            self._spawn_method(test_method, torch.tensor([1, inf, 1]))
+            self._spawn_method(test_method, torch.tensor([1, -inf, 1]))
+            self._spawn_method(test_method, torch.tensor([1, 1, nan]))
 
         def test_copy_broadcast(self):
             torch.zeros(5, 6).copy_(torch.zeros(6))
@@ -585,10 +584,10 @@ class AbstractTestCases:
             self.assertEqual(imfc, imfx, atol=0, rtol=0, msg='torch.conv2')
             self.assertLessEqual(math.abs(x.dot(x) - torch.xcorr2(x, x)[0][0]), 1e-10, 'torch.conv2')
 
-            xx = torch.Tensor(2, x.size(1), x.size(2))
+            xx = torch.empty(2, x.size(1), x.size(2))
             xx[1].copy_(x)
             xx[2].copy_(x)
-            kk = torch.Tensor(2, k.size(1), k.size(2))
+            kk = torch.empty(2, k.size(1), k.size(2))
             kk[1].copy_(k)
             kk[2].copy_(k)
 
@@ -629,10 +628,10 @@ class AbstractTestCases:
             self.assertEqual(imfc, imfx, atol=0, rtol=0, msg='torch.conv3')
             self.assertLessEqual(math.abs(x.dot(x) - torch.xcorr3(x, x)[0][0][0]), 4e-10, 'torch.conv3')
 
-            xx = torch.Tensor(2, x.size(1), x.size(2), x.size(3))
+            xx = torch.empty(2, x.size(1), x.size(2), x.size(3))
             xx[1].copy_(x)
             xx[2].copy_(x)
-            kk = torch.Tensor(2, k.size(1), k.size(2), k.size(3))
+            kk = torch.empty(2, k.size(1), k.size(2), k.size(3))
             kk[1].copy_(k)
             kk[2].copy_(k)
 
@@ -732,7 +731,7 @@ class AbstractTestCases:
 
             torch.random.manual_seed(100)
             buf = io.BytesIO()
-            tensor = torch.Tensor([1, 2, 3])
+            tensor = torch.tensor([1, 2, 3])
             ForkingPickler(buf, pickle.HIGHEST_PROTOCOL).dump(tensor)
             after = torch.rand(10)
 
@@ -858,7 +857,7 @@ class AbstractTestCases:
                 run_test(x, *case)
 
         def _consecutive(self, size, start=1):
-            sequence = torch.ones(int(torch.Tensor(size).prod(0))).cumsum(0)
+            sequence = torch.ones(torch.tensor(size).prod(0)).cumsum(0)
             sequence.add_(start - 1)
             return sequence.resize_(*size)
 
@@ -1200,18 +1199,18 @@ class AbstractTestCases:
             self.assertEqual(repr(a.max(1)), textwrap.dedent(expected).strip())
 
         def test_is_same_size(self):
-            t1 = torch.Tensor(3, 4, 9, 10)
-            t2 = torch.Tensor(3, 4)
-            t3 = torch.Tensor(1, 9, 3, 3)
-            t4 = torch.Tensor(3, 4, 9, 10)
+            t1 = torch.empty(3, 4, 9, 10)
+            t2 = torch.empty(3, 4)
+            t3 = torch.empty(1, 9, 3, 3)
+            t4 = torch.empty(3, 4, 9, 10)
 
             self.assertFalse(t1.is_same_size(t2))
             self.assertFalse(t1.is_same_size(t3))
             self.assertTrue(t1.is_same_size(t4))
 
         def test_tensor_set(self):
-            t1 = torch.Tensor()
-            t2 = torch.Tensor(3, 4, 9, 10).uniform_()
+            t1 = torch.tensor([])
+            t2 = torch.empty(3, 4, 9, 10).uniform_()
             t1.set_(t2)
             self.assertEqual(t1.storage()._cdata, t2.storage()._cdata)
             size = torch.Size([9, 3, 4, 10])
@@ -1228,7 +1227,7 @@ class AbstractTestCases:
             self.assertEqual(t1.stride(), stride)
 
             # test argument names
-            t1 = torch.Tensor()
+            t1 = torch.tensor([])
             # 1. case when source is tensor
             t1.set_(source=t2)
             self.assertEqual(t1.storage()._cdata, t2.storage()._cdata)
@@ -1273,11 +1272,11 @@ class AbstractTestCases:
 
         def test_equal(self):
             # Contiguous, 1D
-            t1 = torch.Tensor((3, 4, 9, 10))
+            t1 = torch.tensor((3, 4, 9, 10))
             t2 = t1.contiguous()
-            t3 = torch.Tensor((1, 9, 3, 10))
-            t4 = torch.Tensor((3, 4, 9))
-            t5 = torch.Tensor()
+            t3 = torch.tensor((1, 9, 3, 10))
+            t4 = torch.tensor((3, 4, 9))
+            t5 = torch.tensor([])
             self.assertTrue(t1.equal(t2))
             self.assertFalse(t1.equal(t3))
             self.assertFalse(t1.equal(t4))
@@ -1288,11 +1287,11 @@ class AbstractTestCases:
             self.assertFalse(torch.equal(t1, t5))
 
             # Non contiguous, 2D
-            s = torch.Tensor(((1, 2, 3, 4), (5, 6, 7, 8)))
+            s = torch.tensor(((1, 2, 3, 4), (5, 6, 7, 8)))
             s1 = s[:, 1:3]
             s2 = s1.clone()
-            s3 = torch.Tensor(((2, 3), (6, 7)))
-            s4 = torch.Tensor(((0, 0), (0, 0)))
+            s3 = torch.tensor(((2, 3), (6, 7)))
+            s4 = torch.tensor(((0, 0), (0, 0)))
 
             self.assertFalse(s1.is_contiguous())
             self.assertTrue(s1.equal(s2))
@@ -1353,7 +1352,7 @@ class AbstractTestCases:
         def test_permute(self):
             orig = [1, 2, 3, 4, 5, 6, 7]
             perm = torch.randperm(7).tolist()
-            x = torch.Tensor(*orig).fill_(0)
+            x = torch.empty(*orig).fill_(0)
             new = [i - 1 for i in x.permute(*perm).size()]
             self.assertEqual(perm, new)
             self.assertEqual(x.size(), orig)
@@ -1469,7 +1468,7 @@ class AbstractTestCases:
             self.assertEqual(g1_randn, g2_randn)
 
             default_state = torch.default_generator.get_state()
-            q = torch.Tensor(100)
+            q = torch.empty(100)
             g1_normal = q.normal_()
             g2 = torch.Generator()
             g2.set_state(default_state)
@@ -1884,7 +1883,7 @@ class AbstractTestCases:
                     assert_with_filename(fname)
 
         def test_print(self):
-            default_type = torch.Tensor().type()
+            default_type = torch.tensor([]).type()
             for t in torch._tensor_classes:
                 if t == torch.HalfTensor:
                     continue  # HalfTensor does not support fill
@@ -2152,7 +2151,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
             for i, sub in enumerate(x):
                 self.assertEqual(sub, x[i])
 
-            x = torch.Tensor()
+            x = torch.tensor([])
             self.assertEqual(list(x), [])
 
         def test_assertEqual(self) -> None:
@@ -2173,7 +2172,7 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
                                    lambda: self.assertEqual(x, xv, "", 1.0))  # type: ignore
 
         def test_new(self) -> None:
-            x = torch.autograd.Variable(torch.Tensor())
+            x = torch.autograd.Variable(torch.tensor([]))
             y = torch.autograd.Variable(torch.randn(4, 4))
             z = torch.autograd.Variable(torch.IntTensor([1, 2, 3]))
             self.assertEqual(x.new().shape, [0])
@@ -3422,7 +3421,7 @@ class TestTorchDeviceType(TestCase):
         self.assertTrue(t1.is_set_to(t3))
         self.assertTrue(t3.is_set_to(t1), "is_set_to should be symmetric")
         self.assertFalse(t1.is_set_to(t4))
-        self.assertFalse(torch.Tensor().is_set_to(torch.Tensor()),
+        self.assertFalse(torch.tensor([]).is_set_to(torch.tensor([])),
                          "Tensors with no storages should not appear to be set "
                          "to each other")
 
@@ -4058,7 +4057,7 @@ class TestTorchDeviceType(TestCase):
     def test_cumsum(self, device):
         x = torch.rand(100, 100, device=device)
         res1 = torch.cumsum(x, 1)
-        res2 = torch.Tensor().to(device)
+        res2 = torch.tensor([]).to(device)
         torch.cumsum(x, 1, out=res2)
         self.assertEqual(res1, res2)
         x.cumsum_(1)
@@ -4108,7 +4107,7 @@ class TestTorchDeviceType(TestCase):
     def test_cumprod(self, device):
         x = torch.rand(100, 100, device=device)
         res1 = torch.cumprod(x, 1)
-        res2 = torch.Tensor().to(device)
+        res2 = torch.tensor([]).to(device)
         torch.cumprod(x, 1, out=res2)
         self.assertEqual(res1, res2)
         x.cumprod_(1)
@@ -6544,10 +6543,10 @@ class TestTorchDeviceType(TestCase):
                 torch.multinomial(probs.to(device), 2)
                 torch.cuda.synchronize()
 
-        test(torch.Tensor([1, -1, 1]))
-        test(torch.Tensor([1, inf, 1]))
-        test(torch.Tensor([1, -inf, 1]))
-        test(torch.Tensor([1, 1, nan]))
+        test(torch.tensor([1, -1, 1]))
+        test(torch.tensor([1, inf, 1]))
+        test(torch.tensor([1, -inf, 1]))
+        test(torch.tensor([1, 1, nan]))
 
     def test_multinomial_invalid_distribution(self, device):
         def test(probs, replacement):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6543,10 +6543,10 @@ class TestTorchDeviceType(TestCase):
                 torch.multinomial(probs.to(device), 2)
                 torch.cuda.synchronize()
 
-        test(torch.tensor([1, -1, 1]))
-        test(torch.tensor([1, inf, 1]))
-        test(torch.tensor([1, -inf, 1]))
-        test(torch.tensor([1, 1, nan]))
+        test(torch.tensor([1., -1., 1.]))
+        test(torch.tensor([1., inf, 1.]))
+        test(torch.tensor([1., -inf, 1.]))
+        test(torch.tensor([1., 1., nan]))
 
     def test_multinomial_invalid_distribution(self, device):
         def test(probs, replacement):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -528,10 +528,10 @@ class AbstractTestCases:
         @unittest.skipIf(IS_WINDOWS, 'FIXME: CUDA OOM error on Windows')
         def test_multinomial_invalid_probs(self):
             test_method = AbstractTestCases._TestTorchMixin._test_multinomial_invalid_probs
-            self._spawn_method(test_method, torch.tensor([1, -1, 1]))
-            self._spawn_method(test_method, torch.tensor([1, inf, 1]))
-            self._spawn_method(test_method, torch.tensor([1, -inf, 1]))
-            self._spawn_method(test_method, torch.tensor([1, 1, nan]))
+            self._spawn_method(test_method, torch.tensor([1., -1., 1.]))
+            self._spawn_method(test_method, torch.tensor([1., inf, 1.]))
+            self._spawn_method(test_method, torch.tensor([1., -inf, 1.]))
+            self._spawn_method(test_method, torch.tensor([1., 1., nan]))
 
         def test_copy_broadcast(self):
             torch.zeros(5, 6).copy_(torch.zeros(6))
@@ -1272,10 +1272,10 @@ class AbstractTestCases:
 
         def test_equal(self):
             # Contiguous, 1D
-            t1 = torch.tensor((3, 4, 9, 10))
+            t1 = torch.tensor((3., 4., 9., 10.))
             t2 = t1.contiguous()
-            t3 = torch.tensor((1, 9, 3, 10))
-            t4 = torch.tensor((3, 4, 9))
+            t3 = torch.tensor((1., 9., 3., 10.))
+            t4 = torch.tensor((3., 4., 9.))
             t5 = torch.tensor([])
             self.assertTrue(t1.equal(t2))
             self.assertFalse(t1.equal(t3))

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -861,21 +861,21 @@ class TestOldViewOps(TestCase):
     # TODO: update to work on CUDA, too
     @onlyCPU
     def test_narrow(self, device):
-        x = torch.Tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-        self.assertEqual(x.narrow(0, 0, 1), torch.Tensor([[0, 1, 2]]))
-        self.assertEqual(x.narrow(0, 0, 2), torch.Tensor([[0, 1, 2], [3, 4, 5]]))
-        self.assertEqual(x.narrow(0, 1, 1), torch.Tensor([[3, 4, 5]]))
-        self.assertEqual(x.narrow(0, -1, 1), torch.Tensor([[6, 7, 8]]))
-        self.assertEqual(x.narrow(0, -2, 2), torch.Tensor([[3, 4, 5], [6, 7, 8]]))
-        self.assertEqual(x.narrow(0, -3, 3), torch.Tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
-        self.assertEqual(x.narrow(-1, -1, 1), torch.Tensor([[2], [5], [8]]))
-        self.assertEqual(x.narrow(-2, -1, 1), torch.Tensor([[6, 7, 8]]))
+        x = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+        self.assertEqual(x.narrow(0, 0, 1), torch.tensor([[0, 1, 2]]))
+        self.assertEqual(x.narrow(0, 0, 2), torch.tensor([[0, 1, 2], [3, 4, 5]]))
+        self.assertEqual(x.narrow(0, 1, 1), torch.tensor([[3, 4, 5]]))
+        self.assertEqual(x.narrow(0, -1, 1), torch.tensor([[6, 7, 8]]))
+        self.assertEqual(x.narrow(0, -2, 2), torch.tensor([[3, 4, 5], [6, 7, 8]]))
+        self.assertEqual(x.narrow(0, -3, 3), torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
+        self.assertEqual(x.narrow(-1, -1, 1), torch.tensor([[2], [5], [8]]))
+        self.assertEqual(x.narrow(-2, -1, 1), torch.tensor([[6, 7, 8]]))
 
     # TODO: update to work on CUDA, too
     @onlyCPU
     def test_narrow_tensor(self, device):
-        x = torch.Tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-        self.assertEqual(x.narrow(0, torch.tensor(0), 1), torch.Tensor([[0, 1, 2]]))
+        x = torch.tensor([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+        self.assertEqual(x.narrow(0, torch.tensor(0), 1), torch.tensor([[0, 1, 2]]))
         with self.assertRaises(Exception):
             x.narrow(0, torch.tensor(0.), 1)
         with self.assertRaises(Exception):

--- a/test/test_vulkan.py
+++ b/test/test_vulkan.py
@@ -66,8 +66,8 @@ class TestVulkanRewritePass(TestCase):
         class Conv2D(torch.nn.Module):
             def __init__(self):
                 super(Conv2D, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -86,8 +86,8 @@ class TestVulkanRewritePass(TestCase):
         class Conv2DRelu(torch.nn.Module):
             def __init__(self):
                 super(Conv2DRelu, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -125,8 +125,8 @@ class TestVulkanRewritePass(TestCase):
         class Conv2DHardtanh(torch.nn.Module):
             def __init__(self):
                 super(Conv2DHardtanh, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations

--- a/test/test_xnnpack_integration.py
+++ b/test/test_xnnpack_integration.py
@@ -620,8 +620,8 @@ class TestXNNPACKRewritePass(TestCase):
         class Linear(torch.nn.Module):
             def __init__(self):
                 super(Linear, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
 
             def forward(self, x):
                 return F.linear(x, self.weight, self.bias)
@@ -629,7 +629,7 @@ class TestXNNPACKRewritePass(TestCase):
         class LinearNoBias(torch.nn.Module):
             def __init__(self):
                 super(LinearNoBias, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(weight_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(weight_shape), requires_grad=False)
 
             def forward(self, x):
                 return F.linear(x, self.weight, None)
@@ -667,8 +667,8 @@ class TestXNNPACKRewritePass(TestCase):
         class Conv2D(torch.nn.Module):
             def __init__(self):
                 super(Conv2D, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -681,8 +681,8 @@ class TestXNNPACKRewritePass(TestCase):
         class Conv2DT(torch.nn.Module):
             def __init__(self):
                 super(Conv2DT, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_transpose_weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(conv_transpose_weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.output_paddings = output_paddings
@@ -717,10 +717,10 @@ class TestXNNPACKRewritePass(TestCase):
         class M(torch.nn.Module):
             def __init__(self, activation_fn=F.relu):
                 super(M, self).__init__()
-                self.conv_weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                self.conv_bias = torch.nn.Parameter(torch.Tensor(torch.rand((conv_bias_shape))), requires_grad=False)
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)), requires_grad=False)
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.conv_weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                self.conv_bias = torch.nn.Parameter(torch.rand((conv_bias_shape)), requires_grad=False)
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape), requires_grad=False)
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -829,8 +829,8 @@ class TestXNNPACKRewritePass(TestCase):
         class MFusionAntiPattern(torch.nn.Module):
             def __init__(self):
                 super(MFusionAntiPattern, self).__init__()
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)), requires_grad=False)
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape), requires_grad=False)
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -857,8 +857,8 @@ class TestXNNPACKRewritePass(TestCase):
         class MFusionAntiPatternParamMinMax(torch.nn.Module):
             def __init__(self):
                 super(MFusionAntiPatternParamMinMax, self).__init__()
-                self.linear_weight = torch.nn.Parameter(torch.Tensor(torch.rand(linear_weight_shape)), requires_grad=False)
-                self.linear_bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.linear_weight = torch.nn.Parameter(torch.rand(linear_weight_shape), requires_grad=False)
+                self.linear_bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
                 self.strides = strides
                 self.paddings = paddings
                 self.dilations = dilations
@@ -890,8 +890,8 @@ class TestXNNPACKRewritePass(TestCase):
         class DecomposedLinearAddmm(torch.nn.Module):
             def __init__(self):
                 super(DecomposedLinearAddmm, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
 
             def forward(self, x):
                 weight_t = self.weight.t()
@@ -900,8 +900,8 @@ class TestXNNPACKRewritePass(TestCase):
         class DecomposedLinearMatmulAdd(torch.nn.Module):
             def __init__(self):
                 super(DecomposedLinearMatmulAdd, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
 
             def forward(self, x):
                 weight_t = self.weight.t()
@@ -912,8 +912,8 @@ class TestXNNPACKRewritePass(TestCase):
         class DecomposedLinearMatmul(torch.nn.Module):
             def __init__(self):
                 super(DecomposedLinearMatmul, self).__init__()
-                self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(weight_shape)), requires_grad=False)
-                self.bias = torch.nn.Parameter(torch.Tensor(torch.rand((weight_output_dim))), requires_grad=False)
+                self.weight = torch.nn.Parameter(torch.rand(weight_shape), requires_grad=False)
+                self.bias = torch.nn.Parameter(torch.rand((weight_output_dim)), requires_grad=False)
 
             def forward(self, x):
                 weight_t = self.weight.t()
@@ -1014,8 +1014,8 @@ class TestXNNPACKConv1dTransformPass(TestCase):
             class Conv1D(torch.nn.Module):
                 def __init__(self):
                     super(Conv1D, self).__init__()
-                    self.weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                    self.bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                    self.weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                    self.bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                     self.stride = stride
                     self.padding = padding
                     self.dilation = dilation
@@ -1076,15 +1076,15 @@ class TestXNNPACKConv1dTransformPass(TestCase):
             class Net(torch.nn.Module):
                 def __init__(self):
                     super(Net, self).__init__()
-                    self.conv_weight = torch.nn.Parameter(torch.Tensor(torch.rand(conv_weight_shape)), requires_grad=False)
-                    self.conv_bias = torch.nn.Parameter(torch.Tensor(torch.rand(conv_bias_shape)), requires_grad=False)
+                    self.conv_weight = torch.nn.Parameter(torch.rand(conv_weight_shape), requires_grad=False)
+                    self.conv_bias = torch.nn.Parameter(torch.rand(conv_bias_shape), requires_grad=False)
                     self.stride = stride
                     self.padding = padding
                     self.dilation = dilation
                     self.groups = groups
 
-                    self.fc_weight = torch.nn.Parameter(torch.Tensor(torch.rand(fc_weight_shape)), requires_grad=False)
-                    self.fc_bias = torch.nn.Parameter(torch.Tensor(torch.rand(fc_bias_shape)), requires_grad=False)
+                    self.fc_weight = torch.nn.Parameter(torch.rand(fc_weight_shape), requires_grad=False)
+                    self.fc_bias = torch.nn.Parameter(torch.rand(fc_bias_shape), requires_grad=False)
 
                 def forward(self, x):
                     x = F.conv1d(x, self.conv_weight, self.conv_bias,


### PR DESCRIPTION
Follow up from #53889 
Related to #47112

Removing every occurrence of the legacy constructor call present in PyTorch at:
- _docs_
- _benchmarks_
- _test_
- _caffe2_
- _CONTRIBUTING.md_