### PR TITLE
ghstack test

### DIFF
--- a/aten/src/ATen/LegacyTHFunctionsCPU.cpp
+++ b/aten/src/ATen/LegacyTHFunctionsCPU.cpp
@@ -99,6 +99,18 @@ Tensor & _th_nonzero_out(Tensor & result, const Tensor & self) {
             THBFloat16Tensor_nonzero(result_, self_);
             break;
         }
+        case ScalarType::ComplexDouble: {
+            auto result_ = checked_dense_tensor_unwrap(result, "result", 0, "_th_nonzero_out", false, DeviceType::CPU, ScalarType::Long);
+            auto self_ = checked_dense_tensor_unwrap(self, "self", 1, "_th_nonzero_out", false, DeviceType::CPU, dispatch_scalar_type);
+            THComplexDoubleTensor_nonzero(result_, self_);
+            break;
+        }
+        case ScalarType::ComplexFloat: {
+            auto result_ = checked_dense_tensor_unwrap(result, "result", 0, "_th_nonzero_out", false, DeviceType::CPU, ScalarType::Long);
+            auto self_ = checked_dense_tensor_unwrap(self, "self", 1, "_th_nonzero_out", false, DeviceType::CPU, dispatch_scalar_type);
+            THComplexFloatTensor_nonzero(result_, self_);
+            break;
+        }
         default:
             AT_ERROR("_th_nonzero_out not supported on CPUType for ", dispatch_scalar_type);
     }
@@ -158,6 +170,16 @@ Tensor _th_nonzero(const Tensor & self) {
         case ScalarType::BFloat16: {
             auto self_ = checked_dense_tensor_unwrap(self, "self", 1, "_th_nonzero", false, DeviceType::CPU, dispatch_scalar_type);
             THBFloat16Tensor_nonzero(result_, self_);
+            break;
+        }
+        case ScalarType::ComplexDouble: {
+            auto self_ = checked_dense_tensor_unwrap(self, "self", 1, "_th_nonzero", false, DeviceType::CPU, dispatch_scalar_type);
+            THComplexDoubleTensor_nonzero(result_, self_);
+            break;
+        }
+        case ScalarType::ComplexFloat: {
+            auto self_ = checked_dense_tensor_unwrap(self, "self", 1, "_th_nonzero", false, DeviceType::CPU, dispatch_scalar_type);
+            THComplexFloatTensor_nonzero(result_, self_);
             break;
         }
         default:

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -924,7 +924,7 @@ Tensor& nonzero_out_cuda(Tensor& out, const Tensor& self){
   TORCH_CHECK(out.dtype() == at::kLong, "Expected object of scalar type ", at::kLong, " as out, but got ", out.dtype());
   TORCH_CHECK(self.device() == out.device(), "expected self and out to be on the same device, but got out on ",
   out.device(), " and self on ", self.device());
-  AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half,
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(at::ScalarType::Bool, at::ScalarType::BFloat16, at::ScalarType::Half,
     self.scalar_type(), "nonzero_cuda",
     [&] {nonzero_cuda_out_impl<scalar_t>(self, out);});
   return out;

--- a/aten/src/ATen/native/sparse/SparseTensor.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensor.cpp
@@ -402,7 +402,7 @@ SparseTensor coalesce_sparse_cpu(const SparseTensor& self) {
   auto indicesBufferAccessor = indicesBuffer.accessor<int64_t, 1>();
 
   int64_t i = -1;
-  AT_DISPATCH_ALL_TYPES(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX(
       values.scalar_type(), "coalesce", [&] {
         int64_t prev = -1;
         int64_t blockSize = values.stride(0);
@@ -510,7 +510,7 @@ SparseTensor& sparse_mask_out_cpu(SparseTensor& r, const Tensor& t, const Sparse
     // TODO: Re-audit this; it used to be an indexSelect directly into r_values
     at::index_select_out(r_values, t_view, 0, indices);
   } else {
-    AT_DISPATCH_ALL_TYPES(r_values.scalar_type(), "sparse_mask", [&] {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(r_values.scalar_type(), "sparse_mask", [&] {
       sparse_mask_out_cpu_kernel<scalar_t>(
         r_values,
         t,

--- a/aten/src/ATen/native/sparse/SparseTensorMath.cpp
+++ b/aten/src/ATen/native/sparse/SparseTensorMath.cpp
@@ -479,7 +479,7 @@ SparseTensor& add_out_sparse_contiguous(SparseTensor& r, const SparseTensor& t, 
     auto r_indices_accessor = r_indices.accessor<int64_t, 2>();
     auto src_indices_accessor = src_indices.accessor<int64_t, 2>();
 
-    AT_DISPATCH_ALL_TYPES(
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(
         commonDtype, "cadd_sparse", [&] {
           scalar_t* t_values_ptr = t_values.data_ptr<scalar_t>();
           scalar_t* s_values_ptr = s_values.data_ptr<scalar_t>();
@@ -549,7 +549,7 @@ SparseTensor& add_out_sparse_non_contiguous(SparseTensor& r, const SparseTensor&
 
     // If `t` or `src` contains non-contiguous `values`, `at::native::cpublas::axpy` doesn't work
     // and we concat the indices and values tensors instead.
-    AT_DISPATCH_ALL_TYPES(
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX(
       commonDtype, "add_out_sparse_cpu", [&] {
           if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
             s_values = s_values.mul(value);
@@ -678,7 +678,7 @@ Tensor& add_out_dense_sparse_cpu(Tensor& r, const Tensor& dense, const SparseTen
       dstBuffer.add_(srcBuffer, value);
     }
   } else {
-    AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::Bool,
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(at::ScalarType::Bool,
         commonDtype, "add_dense_sparse", [&] {
           add_dense_sparse_worker_cpu<scalar_t>(resultBuffer, value, sparse, indices, valuesBuffer);
         });

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -137,7 +137,7 @@ SparseTensor coalesce_sparse_cuda(const SparseTensor& self) {
     int64_t stride = c10::multiply_integers(values.sizes().slice(1));
     dim3 grid(THCCeilDiv(newNnz, (int64_t) SZ), THCCeilDiv(stride, (int64_t) C10_WARP_SIZE*SZ));
     dim3 block(C10_WARP_SIZE, SZ);
-    AT_DISPATCH_ALL_TYPES_AND2(
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16, values.scalar_type(), "coalesce_sparse_cuda", [&] {
         using cuda_accscalar_t = acc_type<scalar_t, /* is_cuda */ true>;
         apply::coalesceValuesKernel<scalar_t, cuda_accscalar_t><<<grid, block, 0, stream>>>(
@@ -272,7 +272,7 @@ Tensor sparse_mask_helper_cuda(
     auto t_indices_pos_ti =
         getTensorInfo<int64_t, int64_t>(t_indices_pos);
 
-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND1(kHalf,
         r_values.scalar_type(), "sparse_mask_helper_cuda", [&] {
           auto t_values_ti = getTensorInfo<scalar_t, int64_t>(t_values);
           auto r_values_ti =

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensorMath.cu
@@ -338,7 +338,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
     if (sparse.dense_dim() == 0) {
       TORCH_CHECK(cuda::getApplyGrid(nnz, grid, curDevice), "add: Argument #0: tensor too large or too many dimensions");
 
-      AT_DISPATCH_ALL_TYPES_AND3(
+      AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
         at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
           apply::sparseElementwiseKernelScalar<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
             <<<grid, block, 0, stream>>>(
@@ -353,7 +353,7 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
       // sparseElementwiseKernel needs values to be contiguous too
       values = values.contiguous();
 
-      AT_DISPATCH_ALL_TYPES_AND2(
+      AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
         at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
           apply::sparseElementwiseKernel<TensorCAddOp<scalar_t>, uint64_t, scalar_t>
             <<<grid, block, 0, stream>>>(
@@ -369,9 +369,9 @@ Tensor& add_out_dense_sparse_cuda(Tensor& r_, const Tensor& dense, const SparseT
 
     // FIXME: at some point we can wrap the scale into indexAdd
     // NB: Purposely not inplace!
-    AT_DISPATCH_ALL_TYPES_AND2(
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_dense_sparse_cuda", [&] {
-        if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
+        if (value.to<scalar_t>() != scalar_t(1)) {
           values = values.mul(value);
         }
       });
@@ -438,10 +438,9 @@ SparseTensor& add_out_sparse_cuda(const SparseTensor& t, const SparseTensor& src
 
   Tensor t_values_ = t._values().to(commonDtype);
   Tensor s_values_ = src._values().to(commonDtype);
-
-  AT_DISPATCH_ALL_TYPES_AND2(
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
     at::ScalarType::Half, at::ScalarType::BFloat16, commonDtype, "add_out_sparse_cuda", [&] {
-      if (value.to<scalar_t>() != static_cast<scalar_t>(1)) {
+      if (value.to<scalar_t>() != scalar_t(1)) {
         s_values_ = s_values_.mul(value);
       }
     });

--- a/aten/src/TH/THTensor.h
+++ b/aten/src/TH/THTensor.h
@@ -35,6 +35,9 @@
 #include <TH/generic/THTensorMath.h>
 #include <TH/THGenerateBFloat16Type.h>
 
+#include <TH/generic/THTensorMath.h>
+#include <TH/THGenerateComplexTypes.h>
+
 /* lapack support */
 #include <TH/generic/THTensorLapack.h>
 #include <TH/THGenerateFloatTypes.h>

--- a/aten/src/TH/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/THTensorEvenMoreMath.cpp
@@ -14,3 +14,6 @@
 
 #include <TH/generic/THTensorEvenMoreMath.cpp>
 #include <TH/THGenerateBFloat16Type.h>
+
+#include <TH/generic/THTensorEvenMoreMath.cpp>
+#include <TH/THGenerateComplexTypes.h>

--- a/aten/src/TH/THVector.h
+++ b/aten/src/TH/THVector.h
@@ -18,4 +18,6 @@
 #include <TH/generic/THVector.h>
 #include <TH/THGenerateBFloat16Type.h>
 
+#include <TH/generic/THVector.h>
+#include <TH/THGenerateComplexTypes.h>
 #endif // TH_VECTOR_INC

--- a/aten/src/TH/generic/THTensorEvenMoreMath.cpp
+++ b/aten/src/TH/generic/THTensorEvenMoreMath.cpp
@@ -18,7 +18,7 @@ void THTensor_(nonzero)(THLongTensor *subscript, THTensor *tensor)
 #elif defined(TH_REAL_IS_BFLOAT16)
 #define IS_NONZERO(val) (c10::BFloat16(0)!=val)
 #else
-#define IS_NONZERO(val) ((val)!=0)
+#define IS_NONZERO(val) ((val)!=scalar_t(0))
 #endif
 
   /* First Pass to determine size of subscripts */

--- a/test/expect/TestSparseCPU.test_print_cpu_float64.expect
+++ b/test/expect/TestSparseCPU.test_print_cpu_float64.expect
@@ -46,25 +46,23 @@ tensor(indices=tensor([], size=(0, 10)),
 tensor([], size=(0, 10), dtype=torch.int64)
 # _values
 tensor([], size=(10, 0), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(0,), nnz=10, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(0,), nnz=10, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(0,), nnz=10, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], size=(0, 10), dtype=torch.int64)
 # _values
-tensor([], size=(10, 0), dtype=torch.float32)
+tensor([], size=(10, 0))
 
 # shape: torch.Size([2])
 # nnz: 3
@@ -130,33 +128,31 @@ tensor([[0, 1, 2]])
 tensor([[0, 0, 0],
         [0, 0, 1],
         [1, 1, 1]], dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([[0, 1, 2]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([[0, 1, 2]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([[0, 1, 2]]),
        values=tensor([[0.0000, 0.4444, 0.8889],
                       [1.3333, 1.7778, 2.2222],
                       [2.6667, 3.1111, 3.5556]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([[0, 1, 2]])
 # _values
 tensor([[0.0000, 0.2222, 0.4444],
         [0.6667, 0.8889, 1.1111],
-        [1.3333, 1.5556, 1.7778]], dtype=torch.float32)
+        [1.3333, 1.5556, 1.7778]])
 
 # shape: torch.Size([100, 20, 3])
 # nnz: 0
@@ -206,25 +202,23 @@ tensor(indices=tensor([], size=(0, 3)),
 tensor([], size=(0, 3), dtype=torch.int64)
 # _values
 tensor([], size=(3, 10, 0, 3), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], size=(0, 3), dtype=torch.int64)
 # _values
-tensor([], size=(3, 10, 0, 3), dtype=torch.float32)
+tensor([], size=(3, 10, 0, 3))
 
 # shape: torch.Size([10, 0, 3])
 # nnz: 0

--- a/test/expect/TestSparseCPUUncoalesced.test_print_cpu_float64.expect
+++ b/test/expect/TestSparseCPUUncoalesced.test_print_cpu_float64.expect
@@ -46,25 +46,23 @@ tensor(indices=tensor([], size=(0, 10)),
 tensor([], size=(0, 10), dtype=torch.int64)
 # _values
 tensor([], size=(10, 0), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(0,), nnz=10, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(0,), nnz=10, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       size=(0,), nnz=10, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(0,), nnz=10, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], size=(0, 10), dtype=torch.int64)
 # _values
-tensor([], size=(10, 0), dtype=torch.float32)
+tensor([], size=(10, 0))
 
 # shape: torch.Size([2])
 # nnz: 3
@@ -130,33 +128,31 @@ tensor([[0, 1, 0]])
 tensor([[0, 0, 0],
         [0, 0, 1],
         [1, 1, 1]], dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([[0, 1, 0]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([[0, 1, 0]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([[0, 1, 0]]),
        values=tensor([[0.0000, 0.4444, 0.8889],
                       [1.3333, 1.7778, 2.2222],
                       [2.6667, 3.1111, 3.5556]]),
-       size=(100, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(100, 3), nnz=3, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([[0, 1, 0]])
 # _values
 tensor([[0.0000, 0.2222, 0.4444],
         [0.6667, 0.8889, 1.1111],
-        [1.3333, 1.5556, 1.7778]], dtype=torch.float32)
+        [1.3333, 1.5556, 1.7778]])
 
 # shape: torch.Size([100, 20, 3])
 # nnz: 0
@@ -206,25 +202,23 @@ tensor(indices=tensor([], size=(0, 3)),
 tensor([], size=(0, 3), dtype=torch.int64)
 # _values
 tensor([], size=(3, 10, 0, 3), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       requires_grad=True)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo, requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       size=(10, 0, 3), nnz=3, dtype=torch.float32, layout=torch.sparse_coo,
-       grad_fn=<AddBackward0>)
+       size=(10, 0, 3), nnz=3, layout=torch.sparse_coo, grad_fn=<AddBackward0>)
 # _indices
 tensor([], size=(0, 3), dtype=torch.int64)
 # _values
-tensor([], size=(3, 10, 0, 3), dtype=torch.float32)
+tensor([], size=(3, 10, 0, 3))
 
 # shape: torch.Size([10, 0, 3])
 # nnz: 0

--- a/test/expect/TestSparseCUDA.test_print_cuda_float64.expect
+++ b/test/expect/TestSparseCUDA.test_print_cuda_float64.expect
@@ -49,26 +49,25 @@ tensor(indices=tensor([], size=(0, 10)),
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
 # _values
 tensor([], device='cuda:0', size=(10, 0), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(0,), nnz=10, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(0,), nnz=10, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 1)),
        values=tensor([], size=(1, 0)),
-       device='cuda:0', size=(0,), nnz=1, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(0,), nnz=1, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
 # _values
-tensor([], device='cuda:0', size=(10, 0), dtype=torch.float32)
+tensor([], device='cuda:0', size=(10, 0))
 
 # shape: torch.Size([2])
 # nnz: 3
@@ -135,21 +134,20 @@ tensor([[0, 1, 2]], device='cuda:0')
 tensor([[0, 0, 0],
         [0, 0, 1],
         [1, 1, 1]], device='cuda:0', dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([[0, 1, 2]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(100, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([[0, 1, 2]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(100, 3), nnz=3, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([[0, 1, 2, 0, 1, 2]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
@@ -158,14 +156,14 @@ tensor(indices=tensor([[0, 1, 2, 0, 1, 2]]),
                       [0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=6, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(100, 3), nnz=6, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([[0, 1, 2]], device='cuda:0')
 # _values
 tensor([[0.0000, 0.2222, 0.4444],
         [0.6667, 0.8889, 1.1111],
-        [1.3333, 1.5556, 1.7778]], device='cuda:0', dtype=torch.float32)
+        [1.3333, 1.5556, 1.7778]], device='cuda:0')
 
 # shape: torch.Size([100, 20, 3])
 # nnz: 0
@@ -218,26 +216,25 @@ tensor(indices=tensor([], size=(0, 3)),
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
 # _values
 tensor([], device='cuda:0', size=(3, 10, 0, 3), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(10, 0, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(10, 0, 3), nnz=3, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 1)),
        values=tensor([], size=(1, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=1, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(10, 0, 3), nnz=1, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
 # _values
-tensor([], device='cuda:0', size=(3, 10, 0, 3), dtype=torch.float32)
+tensor([], device='cuda:0', size=(3, 10, 0, 3))
 
 # shape: torch.Size([10, 0, 3])
 # nnz: 0

--- a/test/expect/TestSparseCUDAUncoalesced.test_print_cuda_float64.expect
+++ b/test/expect/TestSparseCUDAUncoalesced.test_print_cuda_float64.expect
@@ -49,26 +49,25 @@ tensor(indices=tensor([], size=(0, 10)),
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
 # _values
 tensor([], device='cuda:0', size=(10, 0), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(0,), nnz=10, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 10)),
        values=tensor([], size=(10, 0)),
-       device='cuda:0', size=(0,), nnz=10, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(0,), nnz=10, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 1)),
        values=tensor([], size=(1, 0)),
-       device='cuda:0', size=(0,), nnz=1, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(0,), nnz=1, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 10), dtype=torch.int64)
 # _values
-tensor([], device='cuda:0', size=(10, 0), dtype=torch.float32)
+tensor([], device='cuda:0', size=(10, 0))
 
 # shape: torch.Size([2])
 # nnz: 3
@@ -135,21 +134,20 @@ tensor([[0, 1, 0]], device='cuda:0')
 tensor([[0, 0, 0],
         [0, 0, 1],
         [1, 1, 1]], device='cuda:0', dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([[0, 1, 0]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(100, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([[0, 1, 0]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(100, 3), nnz=3, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([[0, 1, 0, 0, 1, 0]]),
        values=tensor([[0.0000, 0.2222, 0.4444],
@@ -158,14 +156,14 @@ tensor(indices=tensor([[0, 1, 0, 0, 1, 0]]),
                       [0.0000, 0.2222, 0.4444],
                       [0.6667, 0.8889, 1.1111],
                       [1.3333, 1.5556, 1.7778]]),
-       device='cuda:0', size=(100, 3), nnz=6, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(100, 3), nnz=6, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([[0, 1, 0]], device='cuda:0')
 # _values
 tensor([[0.0000, 0.2222, 0.4444],
         [0.6667, 0.8889, 1.1111],
-        [1.3333, 1.5556, 1.7778]], device='cuda:0', dtype=torch.float32)
+        [1.3333, 1.5556, 1.7778]], device='cuda:0')
 
 # shape: torch.Size([100, 20, 3])
 # nnz: 0
@@ -218,26 +216,25 @@ tensor(indices=tensor([], size=(0, 3)),
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
 # _values
 tensor([], device='cuda:0', size=(3, 10, 0, 3), dtype=torch.int32)
-########## torch.float32 ##########
+########## torch.float64 ##########
 # sparse tensor
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo)
+       device='cuda:0', size=(10, 0, 3), nnz=3, layout=torch.sparse_coo)
 # after requires_grad_
 tensor(indices=tensor([], size=(0, 3)),
        values=tensor([], size=(3, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=3, dtype=torch.float32,
-       layout=torch.sparse_coo, requires_grad=True)
+       device='cuda:0', size=(10, 0, 3), nnz=3, layout=torch.sparse_coo,
+       requires_grad=True)
 # after addition
 tensor(indices=tensor([], size=(0, 1)),
        values=tensor([], size=(1, 10, 0, 3)),
-       device='cuda:0', size=(10, 0, 3), nnz=1, dtype=torch.float32,
-       layout=torch.sparse_coo, grad_fn=<AddBackward0>)
+       device='cuda:0', size=(10, 0, 3), nnz=1, layout=torch.sparse_coo,
+       grad_fn=<AddBackward0>)
 # _indices
 tensor([], device='cuda:0', size=(0, 3), dtype=torch.int64)
 # _values
-tensor([], device='cuda:0', size=(3, 10, 0, 3), dtype=torch.float32)
+tensor([], device='cuda:0', size=(3, 10, 0, 3))
 
 # shape: torch.Size([10, 0, 3])
 # nnz: 0

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -518,10 +518,6 @@ class TestTypePromotion(TestCase):
                         v = torch.tensor([2], dtype=dt2, device=device)
                         self.assertRaises(RuntimeError, lambda: torch.tensor([op["compare_op"](u, v)], dtype=torch.bool))
 
-        for dtype in [torch.complex64, torch.complex128]:
-            t = self._get_test_tensor(device, dtype, False)
-            self.assertRaises(RuntimeError, lambda: t.to_sparse())
-
     @float_double_default_dtype
     def test_lt_with_type_promotion(self, device):
         for dt in torch.testing.get_all_math_dtypes(device):

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -91,7 +91,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'replication_pad1d', 'replication_pad2d', 'replication_pad3d',
     'replication_pad1d_backward', 'replication_pad2d_backward', 'replication_pad3d_backward',
     'diag', 'masked_scatter', 'masked_select', 'index_fill', 'trace', 'polar', 'cumsum',
-    'eig', 'lerp'
+    'eig', 'lerp', 'to_dense', 'coalesce', 'values', '_sparse_coo_tensor_with_dims_and_tensors', 'sparse_mask_helper_cuda'
 }
 
 # Some operators invalidate the grad_accumulator. Let's reset it.

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -452,7 +452,7 @@ PYTORCH_CUDA_MEMCHECK = os.getenv('PYTORCH_CUDA_MEMCHECK', '0') == '1'
 # The tests in these test cases are derived from the generic tests in
 # generic_test_class.
 # See note "Generic Device Type Testing."
-def instantiate_device_type_tests(generic_test_class, scope, except_for=None, only_for=None):
+def instantiate_device_type_tests(generic_test_class, scope, except_for=None, only_for=None, add_uncoalesced_tests=False):
     # Removes the generic test class from its enclosing scope so its tests
     # are not discoverable.
     del scope[generic_test_class.__name__]
@@ -484,42 +484,48 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
 
-        # type set to Any and suppressed due to unsupport runtime class:
-        # https://github.com/python/mypy/wiki/Unsupported-Python-Features
-        device_type_test_class: Any = type(class_name, (base, empty_class), {})
 
-        for name in generic_members:
-            if name in generic_tests:  # Instantiates test member
-                # Requires tests be a function for Python2 compat
-                # (In Python2 tests are type checked methods wrapping functions)
-                test = getattr(generic_test_class, name)
-                if hasattr(test, '__func__'):
-                    test = test.__func__
-                assert inspect.isfunction(test), "Couldn't extract function from '{0}'".format(name)
+        for is_uncoalesced in set([add_uncoalesced_tests, False]):
+            class_name += ('Uncoalesced' if is_uncoalesced else '')
+            # type set to Any and suppressed due to unsupport runtime class:
+            # https://github.com/python/mypy/wiki/Unsupported-Python-Features
+            device_type_test_class: Any = type(class_name, (base, empty_class), {})
 
-                # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)
-                sig = inspect.signature(device_type_test_class.instantiate_test)
-                if len(sig.parameters) == 3:
-                    # Instantiates the device-specific tests
-                    device_type_test_class.instantiate_test(name, copy.deepcopy(test), generic_cls=generic_test_class)
-                else:
-                    device_type_test_class.instantiate_test(name, copy.deepcopy(test))
-            else:  # Ports non-test member
-                assert name not in device_type_test_class.__dict__, "Redefinition of directly defined member {0}".format(name)
+            for name in generic_members:
+                if name in generic_tests:  # Instantiates test member
+                    # Requires tests be a function for Python2 compat
+                    # (In Python2 tests are type checked methods wrapping functions)
+                    test = getattr(generic_test_class, name)
+                    if hasattr(test, '__func__'):
+                        test = test.__func__
+                    assert inspect.isfunction(test), "Couldn't extract function from '{0}'".format(name)
 
-                # Unwraps to functions (when available) for Python2 compat
-                nontest = getattr(generic_test_class, name)
-                if hasattr(nontest, '__func__'):
-                    nontest = nontest.__func__
+                    # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)
+                    sig = inspect.signature(device_type_test_class.instantiate_test)
+                    if len(sig.parameters) == 3:
+                        # Instantiates the device-specific tests
+                        device_type_test_class.instantiate_test(name, copy.deepcopy(test), generic_cls=generic_test_class)
+                    else:
+                        device_type_test_class.instantiate_test(name, copy.deepcopy(test))
+                else:  # Ports non-test member
+                    assert name not in device_type_test_class.__dict__, "Redefinition of directly defined member {0}".format(name)
 
-                setattr(device_type_test_class, name, nontest)
+                    # Unwraps to functions (when available) for Python2 compat
+                    nontest = getattr(generic_test_class, name)
+                    if hasattr(nontest, '__func__'):
+                        nontest = nontest.__func__
 
-        # Mimics defining the instantiated class in the caller's file
-        # by setting its module to the given class's and adding
-        # the module to the given scope.
-        # This lets the instantiated class be discovered by unittest.
-        device_type_test_class.__module__ = generic_test_class.__module__
-        scope[class_name] = device_type_test_class
+                    setattr(device_type_test_class, name, nontest)
+
+            attr_name = "is_uncoalesced"
+            setattr(device_type_test_class, attr_name, is_uncoalesced)
+
+            # Mimics defining the instantiated class in the caller's file
+            # by setting its module to the given class's and adding
+            # the module to the given scope.
+            # This lets the instantiated class be discovered by unittest.
+            device_type_test_class.__module__ = generic_test_class.__module__
+            scope[class_name] = device_type_test_class
 
 
 # Category of dtypes to run an OpInfo-based test for

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -974,20 +974,20 @@ class TestCase(expecttest.TestCase):
 
         set_rng_seed(SEED)
 
-    def genSparseTensor(self, size, sparse_dim, nnz, is_uncoalesced, device='cpu'):
+    def genSparseTensor(self, size, sparse_dim, nnz, is_uncoalesced, device='cpu', dtype=torch.double):
         # Assert not given impossible combination, where the sparse dims have
         # empty numel, but nnz > 0 makes the indices containing values.
         assert all(size[d] > 0 for d in range(sparse_dim)) or nnz == 0, 'invalid arguments'
 
         v_size = [nnz] + list(size[sparse_dim:])
-        v = torch.randn(*v_size, device=device)
+        v = torch.randn(*v_size, dtype=dtype, device=device)
         i = torch.rand(sparse_dim, nnz, device=device)
         i.mul_(torch.tensor(size[:sparse_dim]).unsqueeze(1).to(i))
         i = i.to(torch.long)
         if is_uncoalesced:
             v = torch.cat([v, torch.randn_like(v)], 0)
             i = torch.cat([i, i], 1)
-        x = torch.sparse_coo_tensor(i, v, torch.Size(size))
+        x = torch.sparse_coo_tensor(i, v, torch.Size(size), dtype=dtype, device=device)
 
         if not is_uncoalesced:
             x = x.coalesce()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54148 before rebase**

complex type factory tests for sparse tensors


to_dense support


to_sparse support


minor fixes for add_out_sparse


sparse_mask complex support


 complex  support for to_dense backward


Update unit tests to support complex tensors

minor updates


minor typo fix


minor fix for _test_spadd_shape


minor update


minor fixes


minor fix


update: review addressed

new forward complex support tests:
- test_is_nonzero
- test_sparse_add_coalesce

new backward complex support  tests:
- test_sparse_backward
- test_sparse_ctor_getter_backward
minor update


minor fix


minor update


use @dtypes decorator.


revert use @dtypes.


minor fix


revert


fix test issues


update test_autograd


add device generic test framework


minor fix


remove blank space


minor fixes


fix test_pickle on rocm


minor fix


minor fix for static_cast<scalart_t>(1) for cpp code
skip test_pickle for rocm


enable cuda test for test_sparse_sum and test_sparse_matmul


redo

rebase


rebase step 2


rebase


nonzero complex


minor fix after rebase


changes after rebase

remove trailing spaces


minor change