### PR TITLE
[PyTorch][JIT] Full pass at push/pop fixes in interpreter

### DIFF
--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -1258,7 +1258,8 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             break;
           case STOREN:
             for (size_t i = inst.N; i > 0; --i) {
-              reg(inst.X + i - 1) = std::move(*(stack.end() - (inst.N - i + 1)));
+              reg(inst.X + i - 1) =
+                  std::move(*(stack.end() - (inst.N - i + 1)));
             }
             drop(stack, inst.N);
             ++pc;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54197 [PyTorch][JIT] Full pass at push/pop fixes in interpreter**
* #54196 [PyTorch][JIT] Put `pc` in a register during the interpreter loop
* #54195 [PyTorch][JIT] RFC: Store function return_pc & unify current pc
* #54110 [PyTorch][JIT] Less shared_ptr use in dictConstruct
* #54124 [PyTorch] Avoid extra intrusive_ptr copy in IValue::toIntrusivePtr

`torch::jit::pop` (and sometimes `push`) are known efficiency
problems.

Differential Revision: [D27128055](https://our.internmc.facebook.com/intern/diff/D27128055/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27128055/)!