### PR TITLE
Add GitHub Actions workflow to test tools

### DIFF
--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -19,5 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install dependencies
+        run: pip install -r requirements.txt
       - name: Run tests
         run: python -m unittest discover -vs tools/test -p 'test_*.py'

--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -1,0 +1,23 @@
+name: Test tools
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+          architecture: x64
+      - name: Checkout PyTorch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run tests
+        run: python -m unittest discover -vs tools/test -p 'test_*.py'


### PR DESCRIPTION
This PR closes #52866 by adding a GitHub Actions workflow to run the tests in the dir introduced by #53755. It also uses `actions/setup-python@v2`, assuming that #54202 will be merged.

**Test plan:**

The added "Test tools" GHA workflow in CI.