### PR TITLE
Use shard file if present, improve functions used for sharding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ coverage.xml
 .gradle
 .hypothesis
 .mypy_cache
-.pytorch-test-times
+**/.pytorch-test-times
 */*.pyc
 */*.so*
 */**/__pycache__

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -308,6 +308,9 @@ TARGET_DET_LIST = [
     'distributed/pipeline/sync/test_worker',
 ]
 
+# the JSON file to store the S3 test stats
+TEST_TIMES_FILE = '.pytorch-test-times'
+
 # if a test file takes longer than 5 min, we add it to TARGET_DET_LIST
 SLOW_TEST_THRESHOLD = 300
 
@@ -392,7 +395,7 @@ def get_test_time_reports_from_S3() -> List[Dict[str, Any]]:
     return reports
 
 
-def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, Tuple[float, int]]:
+def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, float]:
     # an entry will be like ("test_file_name" -> (current_avg, # values))
     jobs_to_times: Dict[str, Tuple[float, int]] = dict()
     for report in reports:
@@ -414,13 +417,10 @@ def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, Tuple[float,
     if 'test_cpp_extensions_aot' in jobs_to_times:
         jobs_to_times['test_cpp_extensions_aot_ninja'] = jobs_to_times['test_cpp_extensions_aot']
         jobs_to_times['test_cpp_extensions_aot_no_ninja'] = jobs_to_times['test_cpp_extensions_aot']
-    return jobs_to_times
+    return {job: time for job, (time, _) in jobs_to_times.items()}
 
 
-
-
-
-def pull_job_times_from_S3() -> Dict[str, Tuple[float, int]]:
+def pull_job_times_from_S3() -> Dict[str, float]:
     if HAVE_BOTO3:
         s3_reports = get_test_time_reports_from_S3()
     else:
@@ -435,20 +435,43 @@ def pull_job_times_from_S3() -> Dict[str, Tuple[float, int]]:
     return calculate_job_times(s3_reports)
 
 
+def get_S3_job_times() -> Dict[str, float]:
+    if os.path.exists(TEST_TIMES_FILE):
+        with open(TEST_TIMES_FILE) as file:
+            test_times_json: JobTimeJSON = json.load(file)
+
+        curr_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding="ascii").strip()
+        file_commit = test_times_json.get('commit', '')
+        if curr_commit == file_commit:
+            print(f'Found stats for current commit: {curr_commit}. Proceeding with those values.')
+            return test_times_json.get('job_times', {})
+
+        # Found file, but commit in JSON doesn't match
+        print(f'Current test times file is from different commit {file_commit}.')
+        print(f'Proceeding to overwrite current file with stats based on current commit: {curr_commit}.')
+
+    job_times = pull_job_times_from_S3()
+    print(f'Exporting S3 test stats to {TEST_TIMES_FILE}.')
+    export_S3_test_times(TEST_TIMES_FILE, job_times)
+
+    return job_times
+
+
+
 class JobTimeJSON(TypedDict):
     commit: str
     job_times: Dict[str, float]
 
 
-def get_job_times_json(job_times: Dict[str, Tuple[float, int]]) -> JobTimeJSON:
+def get_job_times_json(job_times: Dict[str, float]) -> JobTimeJSON:
     return {
         'commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding="ascii").strip(),
-        'job_times': {job: time for job, (time, _) in job_times.items()},
+        'job_times': job_times,
     }
 
 
 def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
-    jobs_to_times = pull_job_times_from_S3()
+    jobs_to_times = get_S3_job_times()
 
     # Got no stats from S3, returning early to save runtime
     if len(jobs_to_times) == 0:
@@ -461,7 +484,7 @@ def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
 
 
 def get_slow_tests_based_on_S3() -> List[str]:
-    jobs_to_times = pull_job_times_from_S3()
+    jobs_to_times: Dict[str, float] = get_S3_job_times()
 
     # Got no stats from S3, returning early to save runtime
     if len(jobs_to_times) == 0:
@@ -471,8 +494,7 @@ def get_slow_tests_based_on_S3() -> List[str]:
     slow_tests: List[str] = []
     for test in TESTS:
         if test in jobs_to_times and test not in TARGET_DET_LIST:
-            test_time, _ = jobs_to_times[test]
-            if test_time > SLOW_TEST_THRESHOLD:
+            if jobs_to_times[test] > SLOW_TEST_THRESHOLD:
                 slow_tests.append(test)
     return slow_tests
 
@@ -741,7 +763,7 @@ def parse_args():
         '--export-historic-test-times',
         nargs='?',
         type=str,
-        const='.pytorch-test-times',
+        const=TEST_TIMES_FILE,
         help='dumps test times from previous S3 stats into a file, format JSON',
     )
     parser.add_argument(
@@ -1005,7 +1027,7 @@ def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
         message += f' Received signal: {signal_name}'
     return message
 
-def export_S3_test_times(test_times_filename: str, test_times: Dict[str, Tuple[float, int]]) -> None:
+def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float]) -> None:
     if os.path.exists(test_times_filename):
         print(f'Overwriting existent file: {test_times_filename}')
     with open(test_times_filename, 'w+') as file:

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -435,7 +435,7 @@ def pull_job_times_from_S3() -> Dict[str, float]:
     return calculate_job_times(s3_reports)
 
 
-def get_S3_job_times() -> Dict[str, float]:
+def get_past_job_times() -> Dict[str, float]:
     if os.path.exists(TEST_TIMES_FILE):
         with open(TEST_TIMES_FILE) as file:
             test_times_json: JobTimeJSON = json.load(file)
@@ -471,7 +471,7 @@ def get_job_times_json(job_times: Dict[str, float]) -> JobTimeJSON:
 
 
 def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
-    jobs_to_times = get_S3_job_times()
+    jobs_to_times = get_past_job_times()
 
     # Got no stats from S3, returning early to save runtime
     if len(jobs_to_times) == 0:
@@ -484,7 +484,7 @@ def get_shard(which_shard: int, num_shards: int, tests: List[str]) -> List[str]:
 
 
 def get_slow_tests_based_on_S3() -> List[str]:
-    jobs_to_times: Dict[str, float] = get_S3_job_times()
+    jobs_to_times: Dict[str, float] = get_past_job_times()
 
     # Got no stats from S3, returning early to save runtime
     if len(jobs_to_times) == 0:
@@ -760,7 +760,7 @@ def parse_args():
         help='additional arguments passed through to unittest, e.g., '
              'python run_test.py -i sparse -- TestSparse.test_factory_size_check')
     parser.add_argument(
-        '--export-historic-test-times',
+        '--export-past-test-times',
         nargs='?',
         type=str,
         const=TEST_TIMES_FILE,
@@ -1037,9 +1037,9 @@ def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float])
 def main():
     options = parse_args()
 
-    test_times_filename = options.export_historic_test_times
+    test_times_filename = options.export_past_test_times
     if test_times_filename:
-        print(f'Exporting historic test times from S3 to {test_times_filename}, no tests will be run.')
+        print(f'Exporting past test times from S3 to {test_times_filename}, no tests will be run.')
         export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -662,17 +662,17 @@ class TestFrameworkUtils(TestCase):
     ]
 
     test_times = {
-        'super_long_test': (55, 1),
-        'long_test1': (22, 2),
-        'long_test2': (18, 2),
-        'normal_test1': (9, 2),
-        'normal_test2': (7, 2),
-        'normal_test3': (5, 2),
-        'short_test1': (1, 2),
-        'short_test2': (0.6, 3),
-        'short_test3': (0.4, 5),
-        'short_test4': (0.3, 1),
-        'short_test5': (0.01, 2),
+        'super_long_test': 55,
+        'long_test1': 22,
+        'long_test2': 18,
+        'normal_test1': 9,
+        'normal_test2': 7,
+        'normal_test3': 5,
+        'short_test1': 1,
+        'short_test2': 0.6,
+        'short_test3': 0.4,
+        'short_test4': 0.3,
+        'short_test5': 0.01,
     }
 
     def test_calculate_2_shards_with_complete_test_times(self):
@@ -718,12 +718,12 @@ class TestFrameworkUtils(TestCase):
     def test_calculate_2_shards_against_optimal_shards(self):
         for _ in range(100):
             random.seed(120)
-            random_times = {k: (random.random() * 10, 1) for k in self.tests}
+            random_times = {k: random.random() * 10 for k in self.tests}
             # all test times except first two
-            rest_of_tests = [i for (k, (i, _)) in random_times.items() if k != 'super_long_test' and k != 'long_test1']
+            rest_of_tests = [i for k, i in random_times.items() if k != 'super_long_test' and k != 'long_test1']
             sum_of_rest = sum(rest_of_tests)
-            random_times['super_long_test'] = (max(sum_of_rest / 2, max(rest_of_tests)), 1)
-            random_times['long_test1'] = (sum_of_rest - random_times['super_long_test'][0], 1)
+            random_times['super_long_test'] = max(sum_of_rest / 2, max(rest_of_tests))
+            random_times['long_test1'] = sum_of_rest - random_times['super_long_test']
             # An optimal sharding would look like the below, but we don't need to compute this for the test:
             # optimal_shards = [
             #     (sum_of_rest, ['super_long_test', 'long_test1']),

--- a/torch/testing/_internal/framework_utils.py
+++ b/torch/testing/_internal/framework_utils.py
@@ -1,12 +1,11 @@
 from typing import Dict, Tuple, List
 
-def calculate_shards(num_shards: int, tests: List[str], job_times: Dict[str, Tuple[float, int]]) -> List[Tuple[float, List[str]]]:
+def calculate_shards(num_shards: int, tests: List[str], job_times: Dict[str, float]) -> List[Tuple[float, List[str]]]:
     filtered_job_times: Dict[str, float] = dict()
     unknown_jobs : List[str] = []
     for test in tests:
         if test in job_times:
-            avg_time, _ = job_times[test]
-            filtered_job_times[test] = avg_time
+            filtered_job_times[test] = job_times[test]
         else:
             unknown_jobs.append(test)
 


### PR DESCRIPTION
Step 2 to fixing #53882 :) 

This changes TARGET_DET_LIST and sharding automation by checking if there's already cached data from the commit in `.pytorch-test-times`. If not, it pulls data from S3 and updates the file to have the stats. This way, S3 pulling does not need to happen more than once for the same commit.

Test plan: the following methods should run the same set of tests.
First `export CIRCLE_JOB=pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2` or your favorite CIRCLE JOB.

1. Pull data first and use it:
Download the data from S3 and write it to the cache file with `python test/run_test.py --export-historic-test-times .pytorch-test-times`
Now run `python test/run_test.py --shard 1 10` 

2. Make the sharding job pull data:
Delete the file you just created: `rm .pytorch-test-times`
Now run `python test/run_test.py --shard 1 10` 
