### PR TITLE
[PyTorch] Rename XPLAT_MOBILE_BUILD to TEMPLATE_SELECTIVE_BUILD

### DIFF
--- a/aten/src/ATen/Dispatch.h
+++ b/aten/src/ATen/Dispatch.h
@@ -10,7 +10,7 @@
 #include <c10/util/complex.h>
 #include <c10/util/string_view.h>
 
-#ifdef XPLAT_MOBILE_BUILD
+#ifdef TEMPLATE_SELECTIVE_BUILD
 #include <ATen/selected_mobile_ops.h>
 #else
 namespace at {

--- a/aten/src/ATen/core/op_registration/op_allowlist.h
+++ b/aten/src/ATen/core/op_registration/op_allowlist.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // TODO: unify to C10_MOBILE. In theory this header could be used in OSS.
-#ifdef XPLAT_MOBILE_BUILD
+#ifdef TEMPLATE_SELECTIVE_BUILD
 #include <ATen/selected_mobile_ops.h>
 #endif
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54217 [PyTorch] Rename XPLAT_MOBILE_BUILD to TEMPLATE_SELECTIVE_BUILD**

As title. Find all XPLAT_MOBILE_BUILD usage: [search result](https://www.internalfb.com/intern/codesearch/?bunny_arg=XPLAT_MOBILE_BUILD&bunny_command=fbgs&lucky=0&q=repo%3Afbcode%20case%3Ainsensitive%20regex%3Aoff%20XPLAT_MOBILE_BUILD&source=redirect) and replace.

 Since template selective build is added in OSS, rename the macro to make it clearer.

T86478520 to follow up to unify XPLAT_MOBILE_BUILD (rename to TEMPLATE_SELECTIVE_BUILD), C10_MOBILE and BUILD_LITE_INTERPRETER macros.

Differential Revision: [D27112046](https://our.internmc.facebook.com/intern/diff/D27112046/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27112046/)!