### PR TITLE
[jit] optimize for training [wip]

### DIFF
--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -441,6 +441,9 @@ class AttributePropagator {
             if (iter2 != iter->second.end())
               paramConst = iter2->second;
           }
+          if (preserveParameters_ && name == "training") {
+            continue;
+          }
           if (!paramConst) {
             auto attr = attrModule.attr(name);
             if (!isEval || preserveParameters_) {
@@ -452,9 +455,6 @@ class AttributePropagator {
                 continue;
               } else {
                 attr = overrideGradient(attr);
-              }
-              if (!isEval && name == "training") {
-                continue;
               }
             } else {
               attr = overrideGradient(attr);


### PR DESCRIPTION
This is adding an API that will optimize your model for training. It's already being used in onnx. Parameters and buffers are preserved, so you can still update your parameters as part of the training step and move your model device and dtype. "training" is still preserved so you can still update eval/train. Additionally, any attributes that you write to are preserved so if you have any mutable state as part of inference or training that will continue to work. 

WIP i havent added tests or good docs or verified that this speeds anything up. if anyone else wants to pick this PR up LMK.

The total length of the graph string for densenet goes from 1138281 to 758054 which is a not very precise way of saying this is cleaning up the graph well.
