### PR TITLE
Change sharding in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
 
           docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-          export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "sudo chown -R jenkins workspace && export CIRCLE_JOB="$CIRCLE_JOB" && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -603,6 +603,7 @@ jobs:
           # =================== The following code will be executed inside Docker container ===================
           set -ex
           export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
+          export CIRCLE_JOB="$CIRCLE_JOB"
           ${PARALLEL_FLAGS}
           cd workspace
           EOL

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -34,7 +34,7 @@ jobs:
 
           docker cp /home/circleci/project/. $id:/var/lib/jenkins/workspace
 
-          export COMMAND='((echo "sudo chown -R jenkins workspace && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
+          export COMMAND='((echo "sudo chown -R jenkins workspace && export CIRCLE_JOB="$CIRCLE_JOB" && cd workspace && .jenkins/pytorch/build.sh && find ${BUILD_ROOT} -type f -name "*.a" -or -name "*.o" -delete") | docker exec -u jenkins -i "$id" bash) 2>&1'
 
           echo ${COMMAND} > ./command.sh && unbuffer bash ./command.sh | ts
 
@@ -165,6 +165,7 @@ jobs:
           # =================== The following code will be executed inside Docker container ===================
           set -ex
           export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
+          export CIRCLE_JOB="$CIRCLE_JOB"
           ${PARALLEL_FLAGS}
           cd workspace
           EOL

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -37,9 +37,6 @@ CC="clang" CXX="clang++" LDSHARED="clang --shared" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py install
 
-# export test times so that potential sharded tests that'll branch off this build will use consistent data
-python test/run_test.py --export-past-test-times
-
 # Test building via the sdist source tarball
 python setup.py sdist
 mkdir -p /tmp/tmp

--- a/.jenkins/pytorch/build-asan.sh
+++ b/.jenkins/pytorch/build-asan.sh
@@ -37,6 +37,8 @@ CC="clang" CXX="clang++" LDSHARED="clang --shared" \
   USE_ASAN=1 USE_CUDA=0 USE_MKLDNN=0 \
   python setup.py install
 
+# export test times so that potential sharded tests that'll branch off this build will use consistent data
+python test/run_test.py --export-past-test-times
 
 # Test building via the sdist source tarball
 python setup.py sdist

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -206,7 +206,7 @@ else
     # ppc64le build fails when WERROR=1
     # set only when building other architectures
     # only use for "python setup.py install" line
-    if [[ "$BUILD_ENVIRONMENT" != *ppc64le*  && "$BUILD_ENVIRONMENT" != *clang* ]]; then
+    if [[ "$BUILD_ENVIRONMENT" != *ppc64le* && "$BUILD_ENVIRONMENT" != *clang* ]]; then
       WERROR=1 python setup.py bdist_wheel
       python -mpip install dist/*.whl
     else
@@ -318,4 +318,10 @@ if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
   python setup.py install
   popd
   assert_git_not_dirty
+fi
+
+if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; then
+  # export test times so that potential sharded tests that'll branch off this build will use consistent data
+  # don't do this for libtorch as libtorch is C++ only and thus won't have python tests run on its build
+  python test/run_test.py --export-past-test-times
 fi

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -117,5 +117,8 @@ python setup.py install --cmake && sccache --show-stats && (
     echo NOTE: To run `import torch`, please make sure to activate the conda environment by running `call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3` in Command Prompt before running Git Bash.
   ) else (
     7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && copy /Y "%TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z" "%PYTORCH_FINAL_PACKAGE_DIR%\"
+
+    :: export test times so that potential sharded tests that'll branch off this build will use consistent data
+    python test/run_test.py --export-past-test-times %PYTORCH_FINAL_PACKAGE_DIR%/.pytorch-test-times
   )
 )

--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -1,5 +1,7 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
+echo Copying over test times file
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
 
 pushd test
 

--- a/.jenkins/pytorch/win-test-helpers/test_python_jit_legacy.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_jit_legacy.bat
@@ -1,5 +1,8 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
+echo Copying over test times file
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
+
 pushd test
 
 echo Run jit_profiling tests

--- a/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
@@ -1,3 +1,8 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+
+echo Copying over test times file
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
+
 cd test && python run_test.py --exclude-jit-executor --shard 2 2 --verbose --determine-from="%1" && cd ..
+
 if ERRORLEVEL 1 exit /b 1

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -365,8 +365,12 @@ def print_to_stderr(message):
 
 # Convert something like pytorch_windows_vs2019_py36_cuda10.1_build to pytorch_windows_vs2019_py36_cuda10.1
 def get_stripped_CI_job() -> str:
-    job = os.environ.get("CIRCLE_JOB", "")
-    return job.rstrip('0123456789').rstrip('_test').rstrip('_build')
+    job = os.environ.get("CIRCLE_JOB", "").rstrip('0123456789')
+    if job.endswith('_test'):
+        job = job[:len(job) - len('_test')]
+    elif job.endswith('_build'):
+        job = job[:len(job) - len('_build')]
+    return job
 
 
 # This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -363,6 +363,12 @@ def print_to_stderr(message):
     print(message, file=sys.stderr)
 
 
+# Convert something like pytorch_windows_vs2019_py36_cuda10.1_build to pytorch_windows_vs2019_py36_cuda10.1
+def get_stripped_CI_job() -> str:
+    job = os.environ.get("CIRCLE_JOB", "")
+    return job.rstrip('0123456789').rstrip('_test').rstrip('_build')
+
+
 # This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False
 # or the S3 bucket is somehow unavailable. Even though this function goes through ten nightly commits' reports
 # to find a non-empty report, it is still conceivable (though highly unlikely) for this function to return no reports.
@@ -377,16 +383,14 @@ def get_test_time_reports_from_S3() -> List[Dict[str, Any]]:
         ["git", "rev-list", f"--before={day_before_commit}", "--max-count=10", "--remotes=*origin/nightly"],
         encoding="ascii").splitlines()
 
-    job = os.environ.get("CIRCLE_JOB", "")
-    job_minus_shard_number = job.rstrip('0123456789')
-
+    stripped_job = get_stripped_CI_job()
     bucket = get_S3_bucket_readonly('ossci-metrics')
     reports = []
     commit_index = 0
     while len(reports) == 0 and commit_index < len(nightly_commits):
         nightly_commit = nightly_commits[commit_index]
         print(f'Grabbing reports from nightly commit: {nightly_commit}')
-        summaries = bucket.objects.filter(Prefix=f"test_time/{nightly_commit}/{job_minus_shard_number}")
+        summaries = bucket.objects.filter(Prefix=f"test_time/{nightly_commit}/{stripped_job}")
         for summary in summaries:
             binary = summary.get()["Body"].read()
             string = bz2.decompress(binary).decode("utf-8")
@@ -442,20 +446,24 @@ def get_past_job_times() -> Dict[str, float]:
 
         curr_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding="ascii").strip()
         file_commit = test_times_json.get('commit', '')
-        if curr_commit == file_commit:
-            print(f'Found stats for current commit: {curr_commit}. Proceeding with those values.')
+        curr_ci_job = get_stripped_CI_job()
+        file_ci_job = test_times_json.get('CIRCLE_JOB', 'N/A')
+        if curr_commit != file_commit:
+            print(f'Current test times file is from different commit {file_commit}.')
+        elif curr_ci_job != file_ci_job:
+            print(f'Current test times file is for different CI job {file_ci_job}.')
+        else:
+            print(f'Found stats for current commit: {curr_commit} and job: {curr_ci_job}. Proceeding with those values.')
             return test_times_json.get('job_times', {})
 
-        # Found file, but commit in JSON doesn't match
-        print(f'Current test times file is from different commit {file_commit}.')
-        print(f'Proceeding to overwrite current file with stats based on current commit: {curr_commit}.')
+        # Found file, but commit or CI job in JSON doesn't match
+        print(f'Overwriting current file with stats based on current commit: {curr_commit} and CI job: {curr_ci_job}')
 
     job_times = pull_job_times_from_S3()
     print(f'Exporting S3 test stats to {TEST_TIMES_FILE}.')
     export_S3_test_times(TEST_TIMES_FILE, job_times)
 
     return job_times
-
 
 
 class JobTimeJSON(TypedDict):
@@ -466,6 +474,7 @@ class JobTimeJSON(TypedDict):
 def get_job_times_json(job_times: Dict[str, float]) -> JobTimeJSON:
     return {
         'commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding="ascii").strip(),
+        'CIRCLE_JOB': get_stripped_CI_job(),
         'job_times': job_times,
     }
 


### PR DESCRIPTION
Step three (landing this should fix #53882)!

Modifying CI to compute job times during build so that the exported job times can be used for sharding future test jobs. 
The builds that are exempted from this:
- `bazel` (no python tests so no need)
- `libtorch` (no python stuff so no need)
- `onnx` (the test shards are not calculated the same way)
- `asan` (runs into error I don't know how to debug/we can debug later: [logs](https://app.circleci.com/pipelines/github/pytorch/pytorch/288019/workflows/57f95f67-1a1b-44a0-9b02-9652b57f2a5f/jobs/11693962)

Test plan:
CI