### PR TITLE
[PyPer] Port c2 add to pt

### DIFF
--- a/caffe2/operators/elementwise_ops_utils.cc
+++ b/caffe2/operators/elementwise_ops_utils.cc
@@ -43,8 +43,8 @@ ComputeLegacyBroadcastSizes(const Tensor& A, const Tensor& B, int axis) {
 }
 
 std::vector<int> ComputeBinaryBroadcastForwardDims(
-    const std::vector<int>& A_dims,
-    const std::vector<int>& B_dims) {
+    const c10::ArrayRef<int>& A_dims,
+    const c10::ArrayRef<int>& B_dims) {
   const int ndim = std::max(A_dims.size(), B_dims.size());
   std::vector<int> C_dims(ndim);
   int i = A_dims.size() - 1;
@@ -54,9 +54,11 @@ std::vector<int> ComputeBinaryBroadcastForwardDims(
     const int A_dim = A_dims[i];
     const int B_dim = B_dims[j];
     CAFFE_ENFORCE(
-      A_dim == B_dim || A_dim == 1 || B_dim == 1,
-      "A_dim: ", A_dim , ",B_dim: ", B_dim
-    );
+        A_dim == B_dim || A_dim == 1 || B_dim == 1,
+        "A_dim: ",
+        A_dim,
+        ",B_dim: ",
+        B_dim);
     if (A_dim == 0 || B_dim == 0) {
       C_dims[k] = 0;
     } else {

--- a/caffe2/operators/elementwise_ops_utils.h
+++ b/caffe2/operators/elementwise_ops_utils.h
@@ -14,8 +14,8 @@ TORCH_API std::tuple<size_t, size_t, size_t>
 ComputeLegacyBroadcastSizes(const Tensor& A, const Tensor& B, int axis);
 
 TORCH_API std::vector<int> ComputeBinaryBroadcastForwardDims(
-    const std::vector<int>& A_dims,
-    const std::vector<int>& B_dims);
+    const c10::ArrayRef<int>& A_dims,
+    const c10::ArrayRef<int>& B_dims);
 
 TORCH_API void ComputeBinaryBroadcastBackwardAxes(
     const std::vector<int>& A_dims,

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -231,20 +231,6 @@ REGISTER_OPERATOR_FUNCTOR(
       };
     });
 
-REGISTER_OPERATOR_FUNCTOR(aten::add, aten_add, [](Node* n) -> SROperator {
-  return [](ProcessedNode* p_node) {
-    const auto& in0_t = p_node->Input(0).toTensor();
-    const auto& in1_t = p_node->Input(1).toTensor();
-    const auto in2_s = p_node->Input(2).toScalar();
-    if (p_node->Output(0).isNone()) {
-      p_node->Output(0) = create_empty_from(in0_t);
-    }
-    auto& out_t = p_node->Output(0).toTensor();
-    fastResizeToZero(out_t);
-    at::cpu::add_out(out_t, in0_t, in1_t, in2_s);
-  };
-});
-
 REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
   return [](ProcessedNode* p_node) {
     const auto& in0_t = p_node->Input(0).toTensor();


### PR DESCRIPTION
Summary: Because caffe2 add uses Eigen for add with broadcasting which is not well supported by OSS PyTorch, it's easier to just keep the `c2_add_out` internal for now. Caffe2 does use mkl add when the input dims of A and B are the same and there is no broadcasting needed.

Reviewed By: bertmaher

Differential Revision: D27036279

