### PR TITLE
[Static Runtime] Check for number of uses of op inputs > 1 in ReplaceWithCopy

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -95,6 +95,17 @@ const auto reshape_script_5 = R"JIT(
       return g
 )JIT";
 
+const auto reshape_inplace_script = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = a.reshape(shape)
+      c = b.sigmoid_()
+      d = c + c
+      e = a + a
+      f = b + b
+      return (d, e, f)
+)JIT";
+
 const auto flatten_script_1 = R"JIT(
   def forward(self, a: Tensor, start_dim: int, end_dim: int):
       b = torch.flatten(a, start_dim, end_dim)

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -148,6 +148,7 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
   testStaticRuntime(reshape_script_3, args);
   testStaticRuntime(reshape_script_4, args);
   testStaticRuntime(reshape_script_5, args);
+  testStaticRuntime(reshape_inplace_script, args);
 }
 
 TEST(StaticRuntime, IndividualOps_flatten) {


### PR DESCRIPTION
Summary: The comments in the code explained why this change is needed.

Differential Revision: D27145406

