### PR TITLE
Make the DDP reducer to support more device types.

### DIFF
--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -277,7 +277,7 @@ void Reducer::copy_grad_to_bucket(
     auto wrapped = c10::scalar_to_tensor(double(1.) / divFactor_);
     wrapped.unsafeGetTensorImpl()->set_wrapped_number(true);
     // Divides while copying into the bucket view.
-    at::native::mul_out(bucket_view, grad, wrapped);
+    at::mul_out(bucket_view, grad, wrapped);
   } else {
     bucket_view.copy_(grad);
   }


### PR DESCRIPTION
Use the at::mul_out instead of at::native::mul_out in DDP to dispatch the operator based on device other than CPU or CUDA.
