### PR TITLE
Disable the fusion group which is not supported by XPU device.

### DIFF
--- a/torch/csrc/jit/codegen/fuser/executor.cpp
+++ b/torch/csrc/jit/codegen/fuser/executor.cpp
@@ -362,6 +362,8 @@ bool runFusion(const int64_t key, Stack& stack, std::string* code_out) {
     return false;
   if (device.is_cpu() && !canFuseOnCPU())
     return false;
+  if (device.is_xpu())
+    return false;
 
   // Validates sizes and expands inputs as needed
   auto maybe_map_size = canRunKernel(spec, inputs);

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -850,6 +850,8 @@ class TensorExprFuser {
       return canFuseOnCPU();
     } else if (device->is_cuda()) {
       return canFuseOnGPU();
+    } else if (device->is_xpu()) {
+      return false;
     }
     throw std::runtime_error("Unknown device");
   }


### PR DESCRIPTION
The XPU device doesn't support the fusion group. Disable it for XPU devices.
