### PR TITLE
[caffe2] increase deadline of test_dnnlowp_batch_matmul_int_constant_B

### DIFF
--- a/caffe2/quantization/server/batch_matmul_dnnlowp_op_test.py
+++ b/caffe2/quantization/server/batch_matmul_dnnlowp_op_test.py
@@ -124,7 +124,7 @@ class DNNLowPBatchMatMulOpTest(hu.HypothesisTestCase):
         out_quantized=st.booleans(),
         **hu.gcs_cpu_only
     )
-    @settings(deadline=1000)
+    @settings(deadline=2000)
     def test_dnnlowp_batch_matmul_int_constant_B(
         self, m, n, k, C_1, C_2, A_quantized, B_quantized, out_quantized, gc, dc
     ):


### PR DESCRIPTION
Summary: As title

Test Plan: buck test //caffe2/caffe2/quantization/server:batch_matmul_dnnlowp_op_test -- test_dnnlowp_batch_matmul_int_constant_B -[jongsoo@devbig279.ftw3 ~/server] buck test :batch_matmul_dnnlowp_op_test -- test_dnnlowp_batch_matmul_int_constant_B --run-disabled --stress-runs 10 --jobs 18

Differential Revision: D27150098

