### PR TITLE
fix libfmt.a installation when build static pytorch library

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1784,6 +1784,11 @@ endif()
 #
 # End ATen checks
 #
+
+# Only install libfmt.a when do static build.
+if(NOT BUILD_SHARED_LIBS)
+  set(FMT_INSTALL ON CACHE BOOL "install libfmt.a when build static pytorch library")
+endif()
 set(TEMP_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/fmt)


### PR DESCRIPTION
After https://github.com/pytorch/pytorch/pull/53825 got merged, there still have following static libraries missing in CMAKE_INSTALL_LIBDIR (they belong to third_party repo):

- [ ] libfoxi_loader.a
- [ ] libonnx.a
- [ ] libonnx_proto.a
- [ ] libfmt.a
- [ ] libnccl_static.a

And after [discuss](https://github.com/fmtlib/fmt/issues/2182) with FMT owner, I create this PR to fix libfmt.a installation.

