### PR TITLE
Test tools/test_history.py

### DIFF
--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -21,6 +21,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # deep clone, to allow us to use git log
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        # boto3 version copied from .circleci/docker/common/install_conda.sh
+        run: |
+          set -eux
+          pip install -r requirements.txt
+          pip install boto3==1.16.34
       - name: Run tests
         run: python -m unittest discover -vs tools/test -p 'test_*.py'

--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # deep clone, to allow us to use git log
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -41,6 +41,7 @@ files =
     tools/pyi/*.py,
     tools/stats_utils/*.py,
     tools/test_history.py,
+    tools/test/test_test_history.py,
     torch/testing/_internal/framework_utils.py,
     torch/testing/_internal/mypy_wrapper.py,
     torch/utils/benchmark/utils/common.py,

--- a/tools/test/test_test_history.py
+++ b/tools/test/test_test_history.py
@@ -1,0 +1,74 @@
+import itertools
+import re
+import shlex
+import unittest
+from typing import List, Optional
+
+from tools import test_history
+from typing_extensions import TypedDict
+
+
+class Example(TypedDict):
+    cmd: str
+    args: List[str]
+    lines: List[str]
+
+
+def parse_block(block: List[str]) -> Optional[Example]:
+    if block:
+        match = re.match(r'^\$ ([^ ]+) (.*)$', block[0])
+        if match:
+            cmd, first = match.groups()
+            args = []
+            for i, line in enumerate([first] + block[1:]):
+                if line.endswith('\\'):
+                    args.append(line[:-1])
+                else:
+                    args.append(line)
+                    break
+            return {
+                'cmd': cmd,
+                'args': shlex.split(''.join(args)),
+                'lines': block[i + 1:]
+            }
+    return None
+
+
+def parse_description(description: str) -> List[Example]:
+    examples: List[Example] = []
+    for block in description.split('\n\n'):
+        matches = [
+            re.match(r'^    (.*)$', line)
+            for line in block.splitlines()
+        ]
+        if all(matches):
+            lines = []
+            for match in matches:
+                assert match
+                line, = match.groups()
+                lines.append(line)
+            example = parse_block(lines)
+            if example:
+                examples.append(example)
+    return examples
+
+
+class TestTestHistory(unittest.TestCase):
+    maxDiff = None
+
+    def test_help_examples(self) -> None:
+        examples = parse_description(test_history.description())
+        self.assertEqual(len(examples), 3)
+        for i, example in enumerate(examples):
+            with self.subTest(i=i):
+                self.assertTrue(test_history.__file__.endswith(example['cmd']))
+                expected = example['lines']
+                actual = list(itertools.islice(
+                    test_history.run(example['args']),
+                    len(expected),
+                ))
+                self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Question for reviewers: the [test logs](https://github.com/pytorch/pytorch/runs/2142297972) are showing these `ResourceWarning`s:
```
/home/runner/work/pytorch/pytorch/tools/test/test_test_history.py:66: ResourceWarning: unclosed <ssl.SSLSocket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('10.1.0.4', 39106), raddr=('52.216.111.19', 443)>
  actual = list(itertools.islice(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
Should these be addressed in this PR, or in a followup?

**Test plan:**

The main point of this is to be run in our "Test tools" GitHub Actions workflow. To test locally:
```
mypy --config=mypy-strict.ini
python tools/test/test_test_history.py
```