### PR TITLE
Move mypy wrapper to tools

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -240,8 +240,4 @@ jobs:
       - name: Run mypy
         run: |
           set -eux
-          mypy --config=mypy.ini
-      - name: Run mypy strict
-        run: |
-          set -eux
-          mypy --config=mypy-strict.ini
+          for CONFIG in mypy*.ini; do mypy --config="$CONFIG"; done

--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        # mypy version copied from .circleci/docker/common/install_conda.sh
+        run: |
+          set -eux
+          pip install -r requirements.txt
+          pip install mypy==0.770
       - name: Run tests
         run: python -m unittest discover -vs tools/test -p 'test_*.py'

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -37,12 +37,12 @@ strict_equality = True
 files =
     tools/autograd/*.py,
     tools/codegen/gen.py,
+    tools/mypy_wrapper.py,
     tools/print_test_stats.py,
     tools/pyi/*.py,
     tools/stats_utils/*.py,
     tools/test_history.py,
     torch/testing/_internal/framework_utils.py,
-    torch/testing/_internal/mypy_wrapper.py,
     torch/utils/benchmark/utils/common.py,
     torch/utils/benchmark/utils/timer.py,
     torch/utils/benchmark/utils/valgrind_wrapper/*.py,

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1,7 +1,6 @@
 import torch
 
 import math
-from pathlib import PurePosixPath
 import random
 
 from torch.testing._internal.common_utils import \
@@ -9,7 +8,6 @@ from torch.testing._internal.common_utils import \
 from torch.testing._internal.framework_utils import calculate_shards
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, onlyCUDA, onlyOnCPUAndCUDA, dtypes)
-from torch.testing._internal import mypy_wrapper
 
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
@@ -589,61 +587,6 @@ if __name__ == '__main__':
 
 
 instantiate_device_type_tests(TestTesting, globals())
-
-
-class TestMypyWrapper(TestCase):
-    def test_glob(self):
-        # can match individual files
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='test/test_torch.py',
-            filename=PurePosixPath('test/test_torch.py'),
-        ))
-        self.assertFalse(mypy_wrapper.glob(
-            pattern='test/test_torch.py',
-            filename=PurePosixPath('test/test_testing.py'),
-        ))
-
-        # dir matters
-        self.assertFalse(mypy_wrapper.glob(
-            pattern='tools/codegen/utils.py',
-            filename=PurePosixPath('torch/nn/modules.py'),
-        ))
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='setup.py',
-            filename=PurePosixPath('setup.py'),
-        ))
-        self.assertFalse(mypy_wrapper.glob(
-            pattern='setup.py',
-            filename=PurePosixPath('foo/setup.py'),
-        ))
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='foo/setup.py',
-            filename=PurePosixPath('foo/setup.py'),
-        ))
-
-        # can match dirs
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='torch',
-            filename=PurePosixPath('torch/random.py'),
-        ))
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='torch',
-            filename=PurePosixPath('torch/nn/cpp.py'),
-        ))
-        self.assertFalse(mypy_wrapper.glob(
-            pattern='torch',
-            filename=PurePosixPath('tools/fast_nvcc/fast_nvcc.py'),
-        ))
-
-        # can match wildcards
-        self.assertTrue(mypy_wrapper.glob(
-            pattern='tools/autograd/*.py',
-            filename=PurePosixPath('tools/autograd/gen_autograd.py'),
-        ))
-        self.assertFalse(mypy_wrapper.glob(
-            pattern='tools/autograd/*.py',
-            filename=PurePosixPath('tools/autograd/deprecated.yaml'),
-        ))
 
 
 class TestFrameworkUtils(TestCase):

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -1,6 +1,5 @@
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, set_cwd
-from torch.testing._internal.mypy_wrapper import config_files
 import tempfile
 import torch
 import doctest
@@ -127,51 +126,6 @@ class TestTypeHints(TestCase):
             if result != 0:
                 self.fail(f"mypy failed:\n{stdout}")
 
-    @unittest.skipIf(not HAVE_MYPY, "need mypy")
-    @unittest.skipIf(os.getenv("IN_CI") is not None, "Already running in CI during lint")
-    def test_run_mypy(self):
-        """
-        Runs mypy over all files specified in our mypy configs
-        Note that our mypy configs are not shipped in an installed
-        version of PyTorch, so this test will only run mypy in a
-        development setup or in CI.
-        """
-        def is_torch_mypyini(path_to_file):
-            with open(path_to_file, 'r') as f:
-                first_line = f.readline()
-
-            name = os.path.basename(path_to_file)
-            if first_line.startswith(f'# This is the PyTorch {name} file'):
-                return True
-
-            return False
-
-        # to add more configs, edit the implementation of the
-        # config_files function rather than editing this test or adding
-        # more tests to this suite
-        for ini in config_files():
-            with self.subTest(msg=ini):
-                test_dir = os.path.dirname(os.path.realpath(__file__))
-                repo_rootdir = os.path.join(test_dir, '..')
-                mypy_inifile = os.path.join(repo_rootdir, ini)
-                if not (os.path.exists(mypy_inifile) and is_torch_mypyini(mypy_inifile)):
-                    self.skipTest("Can't find PyTorch MyPy config file")
-
-                import numpy
-                # Mypy thinks that NumPy has no attribute "__version__" even though it has
-                # Fixed in NumPy v1.20.1
-                if numpy.__version__.startswith('1.20.0.dev0'):  # type: ignore[attr-defined]
-                    self.skipTest("Typeannotations in numpy-1.20.0-dev are broken")
-
-                # TODO: Would be better not to chdir here, this affects
-                # the entire process!
-                with set_cwd(repo_rootdir):
-                    (stdout, stderr, result) = mypy.api.run([
-                        '--config', mypy_inifile,
-                    ])
-
-                if result != 0:
-                    self.fail(f"mypy failed: {stdout} {stderr}")
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -1,5 +1,5 @@
 import unittest
-from torch.testing._internal.common_utils import TestCase, run_tests, set_cwd
+from torch.testing._internal.common_utils import TestCase, run_tests
 import tempfile
 import torch
 import doctest

--- a/tools/README.md
+++ b/tools/README.md
@@ -45,6 +45,8 @@ Developer tools which you might find useful:
   can conveniently run diffs on them when working on code-generation.
   (See also [generated_dirs.txt](generated_dirs.txt) which
   specifies the list of directories with generated files.)
+* [mypy_wrapper.py](mypy_wrapper.py) - Run `mypy` on a single file using the
+  appropriate subset of our `mypy*.ini` configs.
 * [test_history.py](test_history.py) - Query S3 to display history of a single
   test across multiple jobs over time.
 

--- a/tools/test/test_mypy_wrapper.py
+++ b/tools/test/test_mypy_wrapper.py
@@ -1,0 +1,68 @@
+import unittest
+from pathlib import PurePosixPath
+
+from tools import mypy_wrapper
+
+
+class TestMypyWrapper(unittest.TestCase):
+    def test_config_files(self):
+        self.assertEqual(mypy_wrapper.config_files(), {
+            'mypy.ini',
+            'mypy-strict.ini',
+        })
+
+    def test_glob(self):
+        # can match individual files
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='test/test_torch.py',
+            filename=PurePosixPath('test/test_torch.py'),
+        ))
+        self.assertFalse(mypy_wrapper.glob(
+            pattern='test/test_torch.py',
+            filename=PurePosixPath('test/test_testing.py'),
+        ))
+
+        # dir matters
+        self.assertFalse(mypy_wrapper.glob(
+            pattern='tools/codegen/utils.py',
+            filename=PurePosixPath('torch/nn/modules.py'),
+        ))
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='setup.py',
+            filename=PurePosixPath('setup.py'),
+        ))
+        self.assertFalse(mypy_wrapper.glob(
+            pattern='setup.py',
+            filename=PurePosixPath('foo/setup.py'),
+        ))
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='foo/setup.py',
+            filename=PurePosixPath('foo/setup.py'),
+        ))
+
+        # can match dirs
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='torch',
+            filename=PurePosixPath('torch/random.py'),
+        ))
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='torch',
+            filename=PurePosixPath('torch/nn/cpp.py'),
+        ))
+        self.assertFalse(mypy_wrapper.glob(
+            pattern='torch',
+            filename=PurePosixPath('tools/fast_nvcc/fast_nvcc.py'),
+        ))
+
+        # can match wildcards
+        self.assertTrue(mypy_wrapper.glob(
+            pattern='tools/autograd/*.py',
+            filename=PurePosixPath('tools/autograd/gen_autograd.py'),
+        ))
+        self.assertFalse(mypy_wrapper.glob(
+            pattern='tools/autograd/*.py',
+            filename=PurePosixPath('tools/autograd/deprecated.yaml'),
+        ))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test/test_mypy_wrapper.py
+++ b/tools/test/test_mypy_wrapper.py
@@ -11,8 +11,7 @@ class TestMypyWrapper(unittest.TestCase):
             'mypy-strict.ini',
         })
 
-    def test_glob(self):
-        # can match individual files
+    def test_glob_can_match_individual_files(self):
         self.assertTrue(mypy_wrapper.glob(
             pattern='test/test_torch.py',
             filename=PurePosixPath('test/test_torch.py'),
@@ -22,7 +21,7 @@ class TestMypyWrapper(unittest.TestCase):
             filename=PurePosixPath('test/test_testing.py'),
         ))
 
-        # dir matters
+    def test_glob_dir_matters(self):
         self.assertFalse(mypy_wrapper.glob(
             pattern='tools/codegen/utils.py',
             filename=PurePosixPath('torch/nn/modules.py'),
@@ -40,7 +39,7 @@ class TestMypyWrapper(unittest.TestCase):
             filename=PurePosixPath('foo/setup.py'),
         ))
 
-        # can match dirs
+    def test_glob_can_match_dirs(self):
         self.assertTrue(mypy_wrapper.glob(
             pattern='torch',
             filename=PurePosixPath('torch/random.py'),
@@ -54,7 +53,7 @@ class TestMypyWrapper(unittest.TestCase):
             filename=PurePosixPath('tools/fast_nvcc/fast_nvcc.py'),
         ))
 
-        # can match wildcards
+    def test_glob_can_match_wildcards(self):
         self.assertTrue(mypy_wrapper.glob(
             pattern='tools/autograd/*.py',
             filename=PurePosixPath('tools/autograd/gen_autograd.py'),


### PR DESCRIPTION
This PR

- moves `torch/testing/_internal/mypy_wrapper.py` (and its accompanying tests from `test/test_testing.py`) to `tools`,
- removes the now-unused `test_run_mypy` from `test/test_type_hints.py`, and
- replaces the hardcoded list of `mypy` configs (previously duplicated across `mypy_wrapper.py` and `.github/workflows/lint.yml`) with a simpler glob

**Test plan:**

Should also be run in the "Test tools" GHA workflow in CI:
```
python tools/test/test_mypy_wrapper.py
```