### PR TITLE
Changes to autograd/custom functions to handle optional arguments

### DIFF
--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -121,6 +121,9 @@ struct Flatten : IterArgs<Flatten> {
   Flatten(variable_list& out) : out(out) {}
   variable_list& out;
   void operator()(const at::Tensor& x) { out.emplace_back(x); }
+  void operator()(const c10::optional<at::Tensor>& x) {
+    if (x.has_value()) out.emplace_back(x.value());
+  }
   void operator()(at::ArrayRef<at::Tensor> xs) {
     out.insert(out.end(), xs.begin(), xs.end());
   }

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -171,7 +171,7 @@ struct ExtractVariables : IterArgs<ExtractVariables> {
   variable_list& list_;
   ExtractVariables(std::vector<bool>& is_var, variable_list& list) : is_var_(is_var), list_(list) {}
   void operator()(const c10::optional<at::Tensor>& x) {
-    if (x) {
+    if (x.has_value() && x.value().defined()) {
       is_var_.push_back(true);
       list_.emplace_back(x.value());
     } else {


### PR DESCRIPTION
Small changes to autograd to support optional Tensor values.
On MLC device, we use Autograd Custom Functions to override the autograd engine for a specific operation. We do something like:

```
at::Tensor AtenMLCAutogradTypeDefault::abs(const at::Tensor & self) {
  torch_mlc::mlclogger() << "MLC bridge autograd MLC : abs" << std::endl;
  torch_mlc::AutoNonAtenMLCAutogradTypeDefault guard(true);
  return MLCAbsFunction::apply(self); 
}

TORCH_LIBRARY_IMPL(aten, AutogradMLC, m) {
  m.impl("abs", static_cast<at::Tensor (*)(const at::Tensor &)>(&AtenMLCAutogradTypeDefault::abs));
}
```
What I noticed is that the existing code does not always work for optional Tensor types. This PR fixes it. Let me know if you have a better way to deal with this issue.

