### PR TITLE
[caffe2] expose whether FBGEMM is available to the Python code

### DIFF
--- a/caffe2/python/_import_c_extension.pyi
+++ b/caffe2/python/_import_c_extension.pyi
@@ -157,6 +157,7 @@ class Annotation:
 is_asan: bool
 has_mkldnn: bool
 use_mkldnn: bool
+has_fbgemm: bool
 use_rocm: bool
 use_trt: bool
 define_caffe2_no_operator_schema: bool

--- a/caffe2/python/pybind_state.cc
+++ b/caffe2/python/pybind_state.cc
@@ -1031,6 +1031,13 @@ void addObjectMethods(py::module& m) {
 
 void addGlobalMethods(py::module& m) {
   m.attr("is_asan") = py::bool_(C10_ASAN_ENABLED);
+  m.attr("has_fbgemm") = py::bool_(
+#ifdef USE_FBGEMM
+      true
+#else
+      false
+#endif
+  );
   m.def("get_build_options", []() { return GetBuildOptions(); });
 
   // The old mkl backend has been removed permanently, but we

--- a/caffe2/python/workspace.py
+++ b/caffe2/python/workspace.py
@@ -45,6 +45,7 @@ CreateOfflineTensor = C.create_offline_tensor
 operator_tracebacks = defaultdict(dict)
 
 is_asan = C.is_asan
+has_fbgemm = C.has_fbgemm
 has_cuda_support = C.has_cuda_support
 has_hip_support = C.has_hip_support
 has_gpu_support = C.has_gpu_support


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53735 [caffe2] support serializing float data as bfloat16
* **#54274 [caffe2] expose whether FBGEMM is available to the Python code**

Some of the Python tests need to be aware of whether or not FBGEMM is
available, so expose this setting in the pybind extension.

Differential Revision: [D27171780](https://our.internmc.facebook.com/intern/diff/D27171780/)