### PR TITLE
Remove nonexistent files

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/test_python.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python.bat
@@ -1,0 +1,3 @@
+call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
+cd test && python run_test.py --exclude-jit-executor --verbose --determine-from="%1" && cd ..
+if ERRORLEVEL 1 exit /b 1

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -55,8 +55,6 @@ run_tests() {
     done
 
     if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
-        $SCRIPT_HELPERS_DIR/test_python_nn.bat "$DETERMINE_FROM"
-        $SCRIPT_HELPERS_DIR/test_python_all_except_nn.bat "$DETERMINE_FROM"
         $SCRIPT_HELPERS_DIR/test_custom_script_ops.bat
         $SCRIPT_HELPERS_DIR/test_custom_backend.bat
         $SCRIPT_HELPERS_DIR/test_libtorch.bat

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -55,6 +55,7 @@ run_tests() {
     done
 
     if [ -z "${JOB_BASE_NAME}" ] || [[ "${JOB_BASE_NAME}" == *-test ]]; then
+        $SCRIPT_HELPERS_DIR/test_python.bat "$DETERMINE_FROM"
         $SCRIPT_HELPERS_DIR/test_custom_script_ops.bat
         $SCRIPT_HELPERS_DIR/test_custom_backend.bat
         $SCRIPT_HELPERS_DIR/test_libtorch.bat


### PR DESCRIPTION
Since both these files were deleted back in time, we shouldn't be running them anymore, as this was the old sharding strategy (see #50660).
```
test_python_nn.bat
test_python_all_except_nn.bat
```

I believe we intend to run all the python files, so I added a call for that instead.

Note: I don't believe there is a single unsharded test build, though, so should I instead just assume that all windows tests will be sharded?