### PR TITLE
[nnc] Remove cached argv from LLVMCodeGen to fix race condition

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -133,7 +133,6 @@ class LLVMCodeGenImpl : public IRVisitor {
   llvm::BasicBlock* bb_;
   llvm::Value* value_{nullptr};
   llvm::JITTargetAddress kernelAddress_;
-  std::unique_ptr<void* []> argv_ { nullptr };
 
 #define LLVM_TYPE_DECLARE(_1, Name) llvm::Type* Name##Ty_;
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, LLVM_TYPE_DECLARE);
@@ -177,7 +176,6 @@ class LLVMCodeGenImpl : public IRVisitor {
   ~LLVMCodeGenImpl() = default;
 
   llvm::JITTargetAddress getKernelAddress() const;
-  void** getArgvAddress() const;
 
   void visit(const Add* v) override;
   void visit(const Sub* v) override;
@@ -284,13 +282,15 @@ void LLVMCodeGen::call(const std::vector<CallArg>& args) {
     throw malformed_input("wrong number of args in call");
   }
 
-  void** argv = impl_->getArgvAddress();
+  constexpr unsigned nargs = 8;
+  c10::SmallVector<void*, nargs> argv;
+  argv.resize(buf_args.size());
   for (size_t i = 0, e = buf_args.size(); i < e; i++) {
     auto const& bufferArg = buf_args[i];
     auto const& callArg = args[i];
     argv[i] = argToPtr(bufferArg, callArg);
   }
-  value<float>(argv);
+  value<float>(argv.data());
   USE_TRIGGER(llvm_codegen_executed);
 }
 
@@ -319,10 +319,6 @@ std::string LLVMCodeGen::getCodeText(const std::string& attr /*=""*/) {
 
 llvm::JITTargetAddress LLVMCodeGenImpl::getKernelAddress() const {
   return kernelAddress_;
-}
-
-void** LLVMCodeGenImpl::getArgvAddress() const {
-  return argv_.get();
 }
 
 LLVMCodeGenImpl::LLVMCodeGenImpl(
@@ -386,7 +382,6 @@ LLVMCodeGenImpl::LLVMCodeGenImpl(
   jit_->addModule(std::move(module_), std::move(context_));
   auto sym = jit_->findSymbol("wrapper");
   kernelAddress_ = assertSuccess(sym.getAddress());
-  argv_ = std::make_unique<void*[]>(params.size());
 
   USE_TRIGGER(llvm_codegen_created);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54286 [nnc] Remove cached argv from LLVMCodeGen to fix race condition**

A generated code object was holding not just a function pointer but a
pre-allocated argument buffer.  I assume this was a performance optimization to
avoid allocating a vector on each call?

This cached buffer makes it unsafe to call a generated function from multiple
threads, which is too severe a limitation.  This diff fixes it by locally
allocating a SmallVector to hold the args.

A better fix will be to avoid creating CallArgs, so the function can be called
directly without this packing-and-unpacking nonsense, but that's a slightly
more involved fix, possibly involving changing the kernel codegen, and this bug
needs fixing now.

Differential Revision: [D27175715](https://our.internmc.facebook.com/intern/diff/D27175715/)