### PR TITLE
[FX] Fix overload resolution in callsite normalization

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -34,7 +34,6 @@ except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = unittest.skipIf(not HAS_TORCHVISION, "no torchvision")
 
-
 def symbolic_trace_with_rewrite(root: Union[torch.nn.Module, Callable]) -> GraphModule:
     return GraphModule(
         root if isinstance(root, torch.nn.Module) else torch.nn.Module(),

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -856,6 +856,34 @@ class {test_classname}(torch.nn.Module):
                     if submod_class == nn_class:
                         self.assertEqual(len(node.args), 0)
 
+
+    def test_normalize_op_overloads(self):
+        # Tensor/Tensor
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.add(x, y)
+
+        traced = torch.fx.symbolic_trace(Foo())
+        normalized = NormalizeArgs(traced).transform()
+        x, y = torch.randn(3, 4), torch.randn(3, 4)
+        torch.testing.assert_allclose(normalized(x, y), traced(x, y))
+        for node in normalized.graph.nodes:
+            if node.target == torch.add:
+                assert len(node.args) == 0
+
+        # Tensor/scalar
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.add(x, 3)
+
+        traced = torch.fx.symbolic_trace(Foo())
+        normalized = NormalizeArgs(traced).transform()
+        x, y = torch.randn(3, 4), torch.randn(3, 4)
+        torch.testing.assert_allclose(normalized(x, y), traced(x, y))
+        for node in normalized.graph.nodes:
+            if node.target == torch.add:
+                assert len(node.args) == 0
+
     @skipIfNoTorchVision
     def test_annotate_returns_with_schema(self):
         m = resnet18()

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -883,6 +883,19 @@ class {test_classname}(torch.nn.Module):
             if node.target == torch.add:
                 assert len(node.args) == 0
 
+        # Tensor/scalar
+        class Foo(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.add(3, x)
+
+        traced = torch.fx.symbolic_trace(Foo())
+        normalized = NormalizeArgs(traced).transform()
+        x, y = torch.randn(3, 4), torch.randn(3, 4)
+        torch.testing.assert_allclose(normalized(x, y), traced(x, y))
+        for node in normalized.graph.nodes:
+            if node.target == torch.add:
+                assert len(node.args) == 0
+
     @skipIfNoTorchVision
     def test_annotate_returns_with_schema(self):
         m = resnet18()

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -137,6 +137,12 @@ class NormalizeArgs(Transformer):
                         if isinstance(bound_arg, torch.fx.Proxy):
                             if parameter.annotation is not torch.Tensor:
                                 raise TypeError()
+                        elif parameter.annotation is torch.Tensor:
+                            # Python arg parser accepts int, float and complex for Tensor-typed
+                            # parameters
+                            # https://github.com/pytorch/pytorch/blob/19792b45dbf30b4555c4a87512e624cdd4aa6e4c/torch/csrc/utils/python_arg_parser.cpp#L1077-L1100?  # noqa
+                            if type(bound_arg) not in {torch.Tensor, int, float, complex}:
+                                raise TypeError()
                         elif not issubclass(type(bound_arg), parameter.annotation):
                             raise TypeError()
                 found_signature = candidate_signature

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -119,6 +119,7 @@ class NormalizeArgs(Transformer):
         Perform overload resolution on a list of schema given `args` and `kwargs
         """
         found_signature = None
+        print(candidate_signatures)
         for candidate_signature in candidate_signatures:
             try:
                 bound_args = candidate_signature.bind(*args, **kwargs)
@@ -142,4 +143,5 @@ class NormalizeArgs(Transformer):
                 break
             except TypeError:
                 continue
+        print('found signature', found_signature)
         return found_signature

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -1,7 +1,6 @@
 import torch
 import torch.fx
 import inspect
-import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 from torch.fx.node import Argument, Target
 from torch._jit_internal import boolean_dispatched
@@ -128,7 +127,9 @@ class NormalizeArgs(Transformer):
                 def proxy_to_tensor(a):
                     return torch.Tensor() if isinstance(a, torch.fx.Proxy) else a
                 args_for_analysis = torch.fx.node.map_aggregate(args, proxy_to_tensor)
+                assert isinstance(args_for_analysis, tuple)
                 kwargs_for_analysis = torch.fx.node.map_aggregate(kwargs, proxy_to_tensor)
+                assert isinstance(kwargs_for_analysis, dict)
                 bound_args = candidate_signature.bind(*args_for_analysis, **kwargs_for_analysis)
                 bound_args.apply_defaults()
 

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -113,7 +113,7 @@ class NormalizeArgs(Transformer):
         return new_kwargs
 
     def _find_overload_with_type_check(
-            self, candidate_signatures : List[inspect.Signature],args : Tuple[Argument, ...],
+            self, candidate_signatures : List[inspect.Signature], args : Tuple[Argument, ...],
             kwargs : Dict[str, Any]) -> Optional[inspect.Signature]:
         """
         Perform overload resolution on a list of schema given `args` and `kwargs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54290 [FX] Fix overload resolution in callsite normalization**

I didn't realize that `inspect.Signature.bind` doesn't check the arguments against type annotations, so roll our own type checking (unfortunately)

Differential Revision: [D27177171](https://our.internmc.facebook.com/intern/diff/D27177171/)