### PR TITLE
[ONNX] enable word_language_model GRU and LSTM scripting

### DIFF
--- a/test/onnx/model_defs/word_language_model.py
+++ b/test/onnx/model_defs/word_language_model.py
@@ -4,6 +4,7 @@
 import torch
 import torch.nn as nn
 from torch import Tensor
+from typing import Tuple, Optional
 
 class RNNModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
@@ -45,7 +46,10 @@ class RNNModel(nn.Module):
     @staticmethod
     def repackage_hidden(h):
         """Detach hidden states from their history."""
-        return h.detach()
+        if isinstance(h, torch.Tensor):
+            return h.detach()
+        else:
+            return tuple(RNNModel.repackage_hidden(v) for v in h)
 
     def init_weights(self):
         initrange = 0.1
@@ -53,7 +57,7 @@ class RNNModel(nn.Module):
         self.decoder.bias.data.fill_(0)
         self.decoder.weight.data.uniform_(-initrange, initrange)
 
-    def forward(self, input: Tensor, hidden):
+    def forward(self, input, hidden):
         emb = self.drop(self.encoder(input))
         output, hidden = self.rnn(emb, hidden)
         output = self.drop(output)
@@ -68,3 +72,33 @@ class RNNModel(nn.Module):
                     weight.new(self.nlayers, bsz, self.nhid).zero_())
         else:
             return weight.new(self.nlayers, bsz, self.nhid).zero_()
+
+class RNNModelWithTensorHidden(RNNModel):
+    """Supports GRU scripting."""
+    @staticmethod
+    def repackage_hidden(h):
+        """Detach hidden states from their history."""
+        return h.detach()
+
+    def forward(self, input: Tensor, hidden: Tensor):
+        emb = self.drop(self.encoder(input))
+        output, hidden = self.rnn(emb, hidden)
+        output = self.drop(output)
+        decoded = self.decoder(output.view(output.size(0) * output.size(1), output.size(2)))
+        self.hidden = RNNModelWithTensorHidden.repackage_hidden(hidden)
+        return decoded.view(output.size(0), output.size(1), decoded.size(1))
+
+class RNNModelWithTupleHidden(RNNModel):
+    """Supports LSTM scripting."""
+    @staticmethod
+    def repackage_hidden(h: Tuple[Tensor, Tensor]):
+        """Detach hidden states from their history."""
+        return tuple((h[0].detach(), h[1].detach()))
+
+    def forward(self, input: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):
+        emb = self.drop(self.encoder(input))
+        output, hidden = self.rnn(emb, hidden)
+        output = self.drop(output)
+        decoded = self.decoder(output.view(output.size(0) * output.size(1), output.size(2)))
+        self.hidden = self.repackage_hidden(tuple(hidden))
+        return decoded.view(output.size(0), output.size(1), decoded.size(1))

--- a/test/onnx/model_defs/word_language_model.py
+++ b/test/onnx/model_defs/word_language_model.py
@@ -93,7 +93,7 @@ class RNNModelWithTupleHidden(RNNModel):
     @staticmethod
     def repackage_hidden(h: Tuple[Tensor, Tensor]):
         """Detach hidden states from their history."""
-        return tuple((h[0].detach(), h[1].detach()))
+        return tuple(h[0].detach(), h[1].detach())
 
     def forward(self, input: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):
         emb = self.drop(self.encoder(input))

--- a/test/onnx/model_defs/word_language_model.py
+++ b/test/onnx/model_defs/word_language_model.py
@@ -3,7 +3,7 @@
 
 import torch
 import torch.nn as nn
-
+from torch import Tensor
 
 class RNNModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
@@ -45,10 +45,7 @@ class RNNModel(nn.Module):
     @staticmethod
     def repackage_hidden(h):
         """Detach hidden states from their history."""
-        if isinstance(h, torch.Tensor):
-            return h.detach()
-        else:
-            return tuple(RNNModel.repackage_hidden(v) for v in h)
+        return h.detach()
 
     def init_weights(self):
         initrange = 0.1
@@ -56,7 +53,7 @@ class RNNModel(nn.Module):
         self.decoder.bias.data.fill_(0)
         self.decoder.weight.data.uniform_(-initrange, initrange)
 
-    def forward(self, input, hidden):
+    def forward(self, input: Tensor, hidden):
         emb = self.drop(self.encoder(input))
         output, hidden = self.rnn(emb, hidden)
         output = self.drop(output)

--- a/test/onnx/model_defs/word_language_model.py
+++ b/test/onnx/model_defs/word_language_model.py
@@ -93,7 +93,7 @@ class RNNModelWithTupleHidden(RNNModel):
     @staticmethod
     def repackage_hidden(h: Tuple[Tensor, Tensor]):
         """Detach hidden states from their history."""
-        return tuple(h[0].detach(), h[1].detach())
+        return (h[0].detach(), h[1].detach())
 
     def forward(self, input: Tensor, hidden: Optional[Tuple[Tensor, Tensor]] = None):
         emb = self.drop(self.encoder(input))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -415,9 +415,18 @@ class TestONNXRuntime(unittest.TestCase):
         dropout = 0.2
         tied = False
         batchsize = 5
-        model = word_language_model.RNNModel(model_name, ntokens, emsize,
-                                             nhid, nlayers, dropout, tied,
-                                             batchsize)
+        if model_name == "GRU":
+            model = word_language_model.RNNModelWithTensorHidden(model_name, ntokens, emsize,
+                                                nhid, nlayers, dropout, tied,
+                                                batchsize)
+        elif model_name == "LSTM":
+            model = word_language_model.RNNModelWithTupleHidden(model_name, ntokens, emsize,
+                                                nhid, nlayers, dropout, tied,
+                                                batchsize)
+        else:
+            model = word_language_model.RNNModel(model_name, ntokens, emsize,
+                                                nhid, nlayers, dropout, tied,
+                                                batchsize)
         x = torch.arange(0, ntokens).long().view(-1, batchsize)
         # Only support CPU version, since tracer is not working in GPU RNN.
         self.run_test(model, (x, model.hidden))
@@ -586,7 +595,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_word_language_model_RNN_RELU(self):
         self.run_word_language_model("RNN_RELU")
 
-    @disableScriptTest()
+    @disableScriptTest()  # scripting prim::unchecked_cast prim::setattr
     def test_word_language_model_LSTM(self):
         self.run_word_language_model("LSTM")
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -417,16 +417,16 @@ class TestONNXRuntime(unittest.TestCase):
         batchsize = 5
         if model_name == "GRU":
             model = word_language_model.RNNModelWithTensorHidden(model_name, ntokens, emsize,
-                                                nhid, nlayers, dropout, tied,
-                                                batchsize)
+                                                                 nhid, nlayers, dropout, tied,
+                                                                 batchsize)
         elif model_name == "LSTM":
             model = word_language_model.RNNModelWithTupleHidden(model_name, ntokens, emsize,
-                                                nhid, nlayers, dropout, tied,
-                                                batchsize)
+                                                                nhid, nlayers, dropout, tied,
+                                                                batchsize)
         else:
             model = word_language_model.RNNModel(model_name, ntokens, emsize,
-                                                nhid, nlayers, dropout, tied,
-                                                batchsize)
+                                                 nhid, nlayers, dropout, tied,
+                                                 batchsize)
         x = torch.arange(0, ntokens).long().view(-1, batchsize)
         # Only support CPU version, since tracer is not working in GPU RNN.
         self.run_test(model, (x, model.hidden))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -590,7 +590,6 @@ class TestONNXRuntime(unittest.TestCase):
     def test_word_language_model_LSTM(self):
         self.run_word_language_model("LSTM")
 
-    @disableScriptTest()
     def test_word_language_model_GRU(self):
         self.run_word_language_model("GRU")
 


### PR DESCRIPTION
Enable word_language_model GRU and LSTM scripting.
Scripting of LSTM are struck in prim::unchecked_cast prim::setattr.
