### PR TITLE
[TensorPipe] Merge channel hierarchies. (#326)

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -135,16 +135,16 @@ constexpr int64_t kMultiplexedUvChannelPriority = 100;
 constexpr int64_t kBasicChannelPriority = 0;
 
 #if TENSORPIPE_HAS_CUDA_IPC_CHANNEL && defined(USE_CUDA_NOT_ROCM)
-constexpr int64_t kCudaIpcChannelPriority = 300;
+constexpr int64_t kCudaIpcChannelPriority = 301;
 #endif
 
 #if TENSORPIPE_HAS_CUDA_GDR_CHANNEL && defined(USE_CUDA_NOT_ROCM)
-constexpr int64_t kCudaGdrChannelPriority = 200;
+constexpr int64_t kCudaGdrChannelPriority = 201;
 #endif
 
 #ifdef USE_CUDA_NOT_ROCM
-constexpr int64_t kCudaXthChannelPriority = 400;
-constexpr int64_t kCudaBasicChannelPriority = 100;
+constexpr int64_t kCudaXthChannelPriority = 401;
+constexpr int64_t kCudaBasicChannelPriority = 101;
 #endif
 
 std::unique_ptr<TransportRegistration> makeUvTransport() {

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -38,12 +38,11 @@ class Context;
 } // namespace transport
 
 namespace channel {
-template <typename TBuffer>
 class Context;
-using CpuContext = Context<CpuBuffer>;
+using CpuContext = Context;
 
 #ifdef USE_CUDA_NOT_ROCM
-using CudaContext = Context<CudaBuffer>;
+using CudaContext = Context;
 #endif
 
 } // namespace channel


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/tensorpipe/pull/326

Pull Request resolved: https://github.com/pytorch/tensorpipe/pull/312

This is a first step towards cross-device type transfers: eventually,
channels will not connect devices of a given type between two hosts,
but possibly heterogeneous pairs of devices. Hence, the distinction
between CPU-to-CPU and GPU-to-GPU channels will not make much sense
anymore, and we can afford to simplify the Pipe's code quite bit.

The main change here is that the `channel::Channel` and
`channel::Context` classes are not templated (on the buffer type)
anymore. Instead, a channel's `send`/`recv` methods act on generic
`Buffer`s and the actual unpacking is done in the
`ChannelBoilerplate`. The
`channel::CpuContext`/`channel::CudaContext` (respectively
`channel::CudaContext`/`channel::CudaChannel`) aliases now simply
resolve to `channel::Context` (respectively `channel::Channel`). A
subsequent diff will get rid of the aliases altogether.

The Pipe is being simplified: all the duplication due to having
separate hierarchies is gone, which gets rid of a lot of boiler plate
template code. Note that previously, two channels with the same name
could potentially coexist, provided one was a CPU channel and the
other a GPU channel. This is not the case anymore, though it should
not matter.
In its current state, the Pipe still needs to pick a channel based on
whether that channel acts on CPU or GPU buffers. This is solved by
introducing the temporary method
`bool channel::Context::supportsDeviceType(DeviceType t)`. When
iterating through available channels to select one for a given tensor,
the Pipe now discards channels that do not support the tensor's
`DeviceType`. This leads to having a single ordered list of channels,
which in practice is two separate lists (one for CPU, one for GPU)
merged together. This will change soon as we initialize only one
channel per `DeviceType`.

Test Plan: Imported from OSS

Reviewed By: lw

Differential Revision: D26958187

Pulled By: beauby

