### PR TITLE
[5/n][torch/elastic][upstream] Move torchelastic/agent to torch/distributed/elastic/agent

### DIFF
--- a/test/distributed/elastic/agent/server/test/__init__.py
+++ b/test/distributed/elastic/agent/server/test/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+import uuid
+from typing import Any, Dict
+from unittest.mock import call, patch
+
+import torch.distributed.elastic.rendezvous.registry as rdzv_registry
+from torch.distributed.elastic.agent.server.api import (
+    RunResult,
+    SimpleElasticAgent,
+    WorkerGroup,
+    WorkerSpec,
+    WorkerState,
+    _get_fq_hostname,
+    _RoleInstanceInfo,
+)
+from torch.distributed.elastic.multiprocessing.errors import ProcessFailure
+from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+
+
+def do_nothing():
+    pass
+
+
+class WorkerStateTest(unittest.TestCase):
+    def test_is_running(self):
+        for state in WorkerState:
+            if state == WorkerState.HEALTHY or state == WorkerState.UNHEALTHY:
+                self.assertTrue(WorkerState.is_running(state))
+            else:
+                self.assertFalse(WorkerState.is_running(state))
+
+
+class WorkerGroupTest(unittest.TestCase):
+    def test_worker_group_constructor(self):
+        spec = WorkerSpec(
+            role="test_trainer",
+            local_world_size=4,
+            fn=do_nothing,
+            args=(),
+            rdzv_handler=None,
+            max_restarts=50,
+            monitor_interval=1,
+        )
+        worker_group = WorkerGroup(spec)
+
+        self.assertEqual(WorkerState.INIT, worker_group.state)
+
+        workers = worker_group.workers
+        self.assertEqual(4, len(workers))
+
+        # validate full, consecutive local ranks
+        self.assertSetEqual(set(range(4)), {w.local_rank for w in workers})
+
+        # global_rank, world_size are assigned after rdzv
+        # id is assigned after starting worker (by the agent)
+        # validate there are None
+        for w in workers:
+            self.assertEqual(-1, w.global_rank)
+            self.assertEqual(-1, w.world_size)
+            self.assertEqual(None, w.id)
+
+        # rank and store are assigned after rdzv; validate that they are None
+        self.assertIsNone(worker_group.group_rank)
+        self.assertIsNone(worker_group.store)
+
+
+class RoleInstanceInfoTest(unittest.TestCase):
+    def test_compare(self):
+        agent_role1 = _RoleInstanceInfo("role", 1, 10)
+        agent_role2 = _RoleInstanceInfo("role", 2, 10)
+        self.assertEqual(1, _RoleInstanceInfo.compare(agent_role2, agent_role1))
+        agent_role1 = _RoleInstanceInfo("role1", 1, 10)
+        agent_role2 = _RoleInstanceInfo("role2", 2, 10)
+        self.assertEqual(-1, _RoleInstanceInfo.compare(agent_role1, agent_role2))
+        agent_role1 = _RoleInstanceInfo("role1", 1, 10)
+        agent_role2 = _RoleInstanceInfo("role2", 1, 10)
+        self.assertEqual(-1, _RoleInstanceInfo.compare(agent_role1, agent_role2))
+
+    def test_serde(self):
+        agent_role = _RoleInstanceInfo("role", 1, 10)
+        str_data = agent_role.serialize()
+        actual_agent_role = _RoleInstanceInfo.deserialize(str_data)
+        self.assertEqual(agent_role.role, actual_agent_role.role)
+        self.assertEqual(agent_role.rank, actual_agent_role.rank)
+        self.assertEqual(
+            agent_role.local_world_size, actual_agent_role.local_world_size
+        )
+
+    def test_find_boundaries(self):
+        role_infos = [
+            _RoleInstanceInfo("trainer", 1, 1),
+            _RoleInstanceInfo("trainer", 2, 2),
+            _RoleInstanceInfo("trainer", 3, 3),
+            _RoleInstanceInfo("parameter_server", 4, 5),
+            _RoleInstanceInfo("parameter_server", 0, 4),
+        ]
+        start_idx, end_idx = _RoleInstanceInfo.find_role_boundaries(
+            role_infos, "trainer"
+        )
+        self.assertEqual(start_idx, 0)
+        self.assertEqual(end_idx, 2)
+
+
+class TestAgent(SimpleElasticAgent):
+    def __init__(self, spec):
+        super().__init__(spec)
+        self.stop_workers_call_count = 0
+        self.start_workers_call_count = 0
+
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
+        # workers are fake, nothing to stop; just clear the rdzv info
+        worker_group.group_rank = None
+        worker_group.group_world_size = None
+        self.stop_workers_call_count += 1
+
+    def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
+        # crate fake workers; make worker id equal to global rank
+        ids = {}
+        for worker in worker_group.workers:
+            ids[worker.local_rank] = worker.global_rank
+        self.start_workers_call_count += 1
+        return ids
+
+    def _monitor_workers(self, worker_group: WorkerGroup) -> RunResult:
+        raise NotImplementedError("mock this method")
+
+    def _shutdown(self):
+        pass
+
+
+def monres(state: WorkerState):
+    if state == WorkerState.SUCCEEDED:
+        return RunResult(state=state, return_values={0: 0}, failures={})
+    elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:
+        pf = ProcessFailure(local_rank=0, pid=999, exitcode=1, error_file="<none>")
+        return RunResult(state=state, return_values={}, failures={0: pf})
+    else:
+        return RunResult(state=state)
+
+
+class SimpleElasticAgentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # start a standalone, single process etcd server to use for all tests
+        cls._etcd_server = EtcdServer()
+        cls._etcd_server.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        # stop the standalone etcd server
+        cls._etcd_server.stop()
+
+    def _get_worker_spec(
+        self,
+        max_restarts=1,
+        monitor_interval=1.0,
+        role="test_trainer",
+        local_world_size=8,
+    ):
+        run_id = str(uuid.uuid4().int)
+        endpoint = self._etcd_server.get_endpoint()
+
+        rdzv_params = RendezvousParameters(
+            backend="etcd", endpoint=endpoint, run_id=run_id, min_nodes=1, max_nodes=1
+        )
+        rdzv_handler = rdzv_registry.get_rendezvous_handler(rdzv_params)
+        spec = WorkerSpec(
+            role=role,
+            local_world_size=local_world_size,
+            fn=do_nothing,
+            args=(),
+            rdzv_handler=rdzv_handler,
+            max_restarts=max_restarts,
+            monitor_interval=monitor_interval,
+        )
+        return spec
+
+    def test_agent_constructor(self):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        worker_group = agent.get_worker_group()
+        self.assertEquals(WorkerState.INIT, worker_group.state)
+        self.assertEquals(spec.max_restarts, agent._remaining_restarts)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_flakiness_metric(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        agent._record_flakiness_metric()
+        put_metric_mock.assert_called_with("workers.test_trainer.flakiness", 0)
+        agent._worker_group.spec.max_restarts = 10
+        agent._remaining_restarts = 3
+        agent._record_flakiness_metric()
+        put_metric_mock.assert_called_with("workers.test_trainer.flakiness", 63)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_flakiness_metric_zero_restarts(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=1)
+        spec.max_restarts = 0
+        agent = TestAgent(spec)
+        agent._record_flakiness_metric()
+        put_metric_mock.assert_called_with("workers.test_trainer.flakiness", 0)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_flakiness_metric_user_exception(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        agent._record_flakiness_metric(True)
+        put_metric_mock.assert_called_with("workers.test_trainer.flakiness", 100)
+
+    @patch.object(TestAgent, "_invoke_run")
+    @patch.object(TestAgent, "_record_metrics")
+    @patch.object(TestAgent, "_record_worker_events")
+    @patch.object(TestAgent, "_shutdown")
+    def test_invoke_run(
+        self, shutdown_mock, record_events_mock, record_metrics_mock, invoke_run_mock
+    ):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        agent.run()
+        invoke_run_mock.assert_called_once()
+        record_metrics_mock.assert_called_once()
+        record_events_mock.assert_called_once()
+        shutdown_mock.assert_called_once()
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_metrics_success_no_retries(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        group_result = RunResult({}, {})
+        agent._record_metrics(group_result)
+        calls = self._get_record_metrics_test_calls(success_no_retries=1)
+        put_metric_mock.assert_has_calls(calls, any_order=True)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_metrics_success_with_retries(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=10)
+        agent = TestAgent(spec)
+        agent._remaining_restarts = 2
+        group_result = RunResult({}, {})
+        agent._record_metrics(group_result)
+        calls = self._get_record_metrics_test_calls(success_with_retries=1)
+        put_metric_mock.assert_has_calls(calls, any_order=True)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_metrics_failed_with_retries(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=10)
+        agent = TestAgent(spec)
+        agent._remaining_restarts = 2
+        group_result = RunResult(
+            state=WorkerState.FAILED, return_values={}, failures={0: 0}
+        )
+        agent._record_metrics(group_result)
+        calls = self._get_record_metrics_test_calls(failed_with_retries=1)
+        put_metric_mock.assert_has_calls(calls, any_order=True)
+
+    @patch("torch.distributed.elastic.agent.server.api.put_metric")
+    def test_record_metrics_failed_no_retries(self, put_metric_mock):
+        spec = self._get_worker_spec(max_restarts=10)
+        agent = TestAgent(spec)
+        group_result = RunResult(
+            state=WorkerState.FAILED, return_values={}, failures={0: 0}
+        )
+        agent._record_metrics(group_result)
+        calls = self._get_record_metrics_test_calls(failed_no_retries=1)
+        put_metric_mock.assert_has_calls(calls, any_order=True)
+
+    def _get_record_metrics_test_calls(
+        self,
+        success_with_retries=0,
+        success_no_retries=0,
+        failed_with_retries=0,
+        failed_no_retries=0,
+    ):
+        calls = [
+            call("workers.test_trainer.run_success_with_retries", success_with_retries),
+            call("workers.test_trainer.run_success_no_retries", success_no_retries),
+            call("workers.test_trainer.run_failed_with_retries", failed_with_retries),
+            call("workers.test_trainer.run_failed_no_retries", failed_no_retries),
+        ]
+        return calls
+
+    def test_rendezvous(self):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        worker_group = agent.get_worker_group()
+        agent._rendezvous(worker_group)
+
+        # single agent rdzv
+        self.assertEqual(1, worker_group.group_world_size)
+        self.assertEqual(0, worker_group.group_rank)
+
+        master_addr, master_port = agent._get_master_addr_port(worker_group.store)
+
+        self.assertEqual(_get_fq_hostname(), master_addr)
+        self.assertTrue(master_port > 0)
+
+        rank_set = {w.global_rank for w in worker_group.workers}
+        for w in worker_group.workers:
+            self.assertIsNone(w.id)
+            local_world_size = spec.local_world_size
+            group_world_size = worker_group.group_world_size
+            group_rank = worker_group.group_rank
+
+            self.assertEqual(local_world_size * group_world_size, w.world_size)
+            self.assertEqual(
+                local_world_size * group_rank + w.local_rank, w.global_rank
+            )
+            self.assertSetEqual(set(range(w.world_size)), rank_set)
+
+    def test_initialize_workers(self):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        worker_group = agent.get_worker_group()
+        agent._initialize_workers(worker_group)
+
+        self.assertEqual(WorkerState.HEALTHY, worker_group.state)
+        for i in range(spec.local_world_size):
+            worker = worker_group.workers[i]
+            self.assertEqual(worker.id, worker.global_rank)
+
+    def test_restart_workers(self):
+        spec = self._get_worker_spec()
+        agent = TestAgent(spec)
+        worker_group = agent.get_worker_group()
+
+        num_restarts = 3
+        for _ in range(0, num_restarts):
+            agent._restart_workers(worker_group)
+            self.assertEqual(WorkerState.HEALTHY, worker_group.state)
+
+            # test_rendezvous and test_initialize_workers
+            # already validates the correctness of these fields
+            # simply validate that they are not None
+            # (e.g. that they get assigned)
+            self.assertIsNotNone(worker_group.group_rank)
+            self.assertIsNotNone(worker_group.group_world_size)
+            for w in worker_group.workers:
+                self.assertIsNotNone(w.id)
+                self.assertIsNotNone(w.global_rank)
+                self.assertIsNotNone(w.world_size)
+
+        self.assertEqual(num_restarts, agent.start_workers_call_count)
+        self.assertEqual(num_restarts, agent.stop_workers_call_count)
+
+    @patch.object(
+        TestAgent,
+        "_monitor_workers",
+        side_effect=[
+            monres(WorkerState.HEALTHY),
+            monres(WorkerState.HEALTHY),
+            monres(WorkerState.SUCCEEDED),
+        ],
+    )
+    @patch.object(TestAgent, "_record_worker_events")
+    def test_run_happy_path(self, record_events_mock, mock_monitor_workers):
+        # worker starts
+        # is always healthy
+        # then succeeds
+        max_restarts = 10
+        spec = self._get_worker_spec(max_restarts)
+        agent = TestAgent(spec)
+
+        agent.run()
+
+        # no failure, no membership changes -> no retries
+        self.assertEquals(max_restarts, agent._remaining_restarts)
+        record_events_mock.assert_called_once()
+
+    @patch.object(TestAgent, "_initialize_workers", side_effect=RuntimeError())
+    def test_run_initialization_failure(self, mock_initialize_workers):
+        spec = self._get_worker_spec()
+        agent = TestAgent(spec)
+        worker_group = agent._worker_group
+
+        with self.assertRaises(RuntimeError):
+            agent.run()
+
+        self.assertEqual(WorkerState.INIT, worker_group.state)
+
+    def test_run_max_retries_exceeded(self):
+        for restartable_state in [
+            monres(WorkerState.FAILED),
+            monres(WorkerState.UNHEALTHY),
+        ]:
+            with patch.object(
+                TestAgent, "_monitor_workers", return_value=restartable_state
+            ) as mock_monitor_workers:
+                spec = self._get_worker_spec(max_restarts=3, monitor_interval=0.1)
+                agent = TestAgent(spec)
+                worker_group = agent._worker_group
+
+                agent.run()
+                self.assertEqual(WorkerState.FAILED, worker_group.state)
+                self.assertEqual(0, agent._remaining_restarts)
+                # one monitor call for each retry + one to monitor the last retry
+                self.assertEqual(spec.max_restarts + 1, mock_monitor_workers.call_count)
+
+    @patch.object(
+        TestAgent,
+        "_monitor_workers",
+        side_effect=[
+            monres(WorkerState.HEALTHY),
+            monres(WorkerState.HEALTHY),
+            monres(WorkerState.HEALTHY),
+            monres(WorkerState.SUCCEEDED),
+        ],
+    )
+    @patch.object(RendezvousHandler, "num_nodes_waiting", side_effect=[1, 1, 0])
+    @patch.object(TestAgent, "_record_worker_events")
+    def test_run_membership_change(
+        self, record_events_mock, mock_num_nodes_waiting, mock_monitor_workers
+    ):
+        spec = self._get_worker_spec(max_restarts=1, monitor_interval=0.1)
+        agent = TestAgent(spec)
+        worker_group = agent._worker_group
+
+        agent.run()
+        self.assertEquals(WorkerState.SUCCEEDED, worker_group.state)
+        record_events_mock.assert_called_once()
+
+    @patch.object(
+        TestAgent, "_monitor_workers", return_value=monres(WorkerState.UNKNOWN)
+    )
+    def test_run_unknown_state(self, mock_monitor_workers):
+        # when the state is unknown we exit immediately; no retries
+        spec = self._get_worker_spec(max_restarts=100, monitor_interval=0.1)
+        agent = TestAgent(spec)
+        worker_group = agent._worker_group
+
+        with self.assertRaises(Exception):
+            agent.run()
+
+        self.assertEqual(WorkerState.UNKNOWN, worker_group.state)
+        self.assertEqual(1, mock_monitor_workers.call_count)
+        self.assertEqual(spec.max_restarts, agent._remaining_restarts)
+
+    def test_get_ranks(self):
+        role_infos = [
+            _RoleInstanceInfo("parameter_server", 0, 4),
+            _RoleInstanceInfo("trainer", 1, 1),
+            _RoleInstanceInfo("trainer", 2, 2),
+            _RoleInstanceInfo("trainer", 3, 3),
+            _RoleInstanceInfo("parameter_server", 4, 5),
+        ]
+        spec = self._get_worker_spec(
+            max_restarts=3, monitor_interval=0.1, role="not_used", local_world_size=8
+        )
+        agent = TestAgent(spec)
+        total_sum, ranks = agent._get_ranks(role_infos, 0, 0, len(role_infos))
+        self.assertEquals(15, total_sum)
+        self.assertEquals([0, 1, 2, 3], list(ranks))
+
+    def test_assign_worker_ranks(self):
+        role_infos = [
+            _RoleInstanceInfo("parameter_server", 0, 4),
+            _RoleInstanceInfo("trainer", 1, 1),
+            _RoleInstanceInfo("trainer", 2, 2),
+            _RoleInstanceInfo("trainer", 3, 3),
+            _RoleInstanceInfo("parameter_server", 4, 5),
+        ]
+        num_agents = len(role_infos)
+        with patch.object(TestAgent, "_share_and_gather", return_value=role_infos):
+            self.verify_worker_ranks(
+                role_infos[0], num_agents, [0, 1, 2, 3], [0, 1, 2, 3]
+            )
+            self.verify_worker_ranks(role_infos[1], num_agents, [4], [0])
+            self.verify_worker_ranks(role_infos[2], num_agents, [5, 6], [1, 2])
+            self.verify_worker_ranks(role_infos[3], num_agents, [7, 8, 9], [3, 4, 5])
+
+    def verify_worker_ranks(
+        self, agent_config, total_agents, expected_global_ranks, expected_role_ranks
+    ):
+        role, agent_rank, local_world_size = (
+            agent_config.role,
+            agent_config.rank,
+            agent_config.local_world_size,
+        )
+        spec = self._get_worker_spec(
+            max_restarts=3,
+            monitor_interval=0.1,
+            role=role,
+            local_world_size=local_world_size,
+        )
+        agent = TestAgent(spec)
+        workers = agent._assign_worker_ranks(None, agent_rank, total_agents, spec)
+        self.assertEqual(
+            expected_global_ranks, [worker.global_rank for worker in workers]
+        )
+        self.assertEqual(expected_role_ranks, [worker.role_rank for worker in workers])
+
+    @patch("torch.distributed.elastic.utils.store.get_all")
+    def test_share_and_gather(self, store_mock):
+        # when the state is unknown we exit immediately; no retries
+        spec = self._get_worker_spec(max_restarts=100, monitor_interval=0.1)
+        agent = TestAgent(spec)
+        expected_agent_infos = [
+            _RoleInstanceInfo("trainer", 0, 10),
+            _RoleInstanceInfo("trainer", 1, 10),
+            _RoleInstanceInfo("validator", 2, 10),
+        ]
+
+        store_mock.return_value = [obj.serialize() for obj in expected_agent_infos]
+
+        class DummyStore:
+            def __init__(self):
+                self.key = None
+                self.value = None
+
+            def set(self, key, value):
+                self.key = key
+                self.value = value
+
+            def set_timeout(self, timeout):
+                pass
+
+        store = DummyStore()
+        agent._share_and_gather(store, 1, 3, spec)
+        self.assertEquals("torchelastic/role_info1", store.key)
+        expected_info = _RoleInstanceInfo(spec.role, 1, spec.local_world_size)
+        self.assertEquals(expected_info.serialize(), store.value)
+        store_mock.assert_called_once()
+
+    def test_get_agent_status_event(self):
+        spec = self._get_worker_spec(max_restarts=1)
+        agent = TestAgent(spec)
+        actual_event = agent.get_agent_status_event(state=WorkerState.SUCCEEDED)
+        self.assertEqual("AGENT", actual_event.source)
+        self.assertEqual("etcd", actual_event.metadata["rdzv_backend"])
+        self.assertEqual(WorkerState.SUCCEEDED.value, actual_event.metadata["state"])
+        self.assertEqual(spec.role, actual_event.metadata["role"])
+
+    def test_get_worker_status_event(self):
+        spec = self._get_worker_spec(max_restarts=4)
+        agent = TestAgent(spec)
+        agent._remaining_restarts = spec.max_restarts - 2
+        actual_event = agent._construct_event(
+            state=WorkerState.SUCCEEDED.value,
+            source="WORKER",
+            worker=agent._worker_group.workers[0],
+        )
+        self.assertEqual("WORKER", actual_event.source)
+        self.assertEqual("etcd", actual_event.metadata["rdzv_backend"])
+        self.assertEqual(WorkerState.SUCCEEDED.value, actual_event.metadata["state"])
+        self.assertEqual(spec.role, actual_event.metadata["role"])
+        self.assertEqual(2, actual_event.metadata["agent_restarts"])

--- a/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
+++ b/test/distributed/elastic/agent/server/test/local_elastic_agent_test.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import json
+import multiprocessing as mp
+import os
+import shutil
+import signal
+import tempfile
+import time
+import unittest
+import uuid
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+from unittest import mock
+from unittest.mock import Mock, patch
+
+import torch
+import torch.distributed as dist
+import torch.distributed.elastic.rendezvous.registry as rdzv_registry
+import torch.distributed.rpc as rpc
+from torch.distributed.elastic.agent.server.api import (
+    RunResult,
+    WorkerSpec,
+    WorkerState,
+)
+from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent
+from torch.distributed.elastic.multiprocessing import Std
+from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, record
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.rpc.backend_registry import BackendType
+from torch.testing._internal.common_utils import (
+    TEST_WITH_ASAN,
+    TEST_WITH_TSAN,
+)
+
+
+def init_rpc(name, backend):
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    rpc.init_rpc(
+        name=name,
+        backend=backend,
+        rank=rank,
+        world_size=world_size,
+    )
+
+
+def rpc_master(msg):
+    init_rpc("master", BackendType.TENSORPIPE)
+    ret = rpc.rpc_sync(to="worker", func=_echo, args=(msg,))
+    rpc.shutdown()
+    return f"{ret} from worker"
+
+
+def rpc_worker():
+    init_rpc("worker", BackendType.TENSORPIPE)
+    rpc.shutdown()
+
+
+def _happy_function():
+    return
+
+
+def _sad_function():
+    raise RuntimeError("sad because i throw")
+
+
+def _fatal_signal_function(expected_error_index: int, sig: int):
+    rank = int(os.environ["RANK"])
+    if rank == expected_error_index:
+        os.kill(os.getpid(), sig)
+
+
+def _bipolar_function():
+    rank = int(os.environ["RANK"])
+    if rank % 2 == 0:
+        _happy_function()
+    else:
+        _sad_function()
+
+
+def _dist_sum(wait=0):
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    dist.init_process_group(backend="gloo")
+    t = torch.tensor(rank)
+
+    time.sleep(wait)
+    dist.all_reduce(t, op=dist.reduce_op.SUM)
+
+    expected_sum = sum(range(world_size))
+    actual = t.item()
+    if expected_sum != actual:
+        raise RuntimeError(f"Expected rank sum {expected_sum}, got {actual}")
+
+
+def _sleep(sleep_sec) -> int:
+    time.sleep(sleep_sec)
+    return int(os.environ["RANK"])
+
+
+@dataclass
+class RankInfo:
+    rank: int
+    role_rank: int
+    group_rank: int
+    role_world_size: int
+    world_size: int
+
+
+def _get_role_info() -> RankInfo:
+    rank = int(os.environ["RANK"])
+    role_rank = int(os.environ["ROLE_RANK"])
+    group_rank = int(os.environ["GROUP_RANK"])
+    role_world_size = int(os.environ["ROLE_WORLD_SIZE"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    return RankInfo(rank, role_rank, group_rank, role_world_size, world_size)
+
+
+def _echo(msg):
+    return msg
+
+
+def _check_env_function():
+    # just check these env vars exist, os.environ[...] will naturally throw
+    # if the variable does not exist
+    env_vars = [
+        "RANK",
+        "LOCAL_RANK",
+        "ROLE_RANK",
+        "ROLE_NAME",
+        "GROUP_RANK",
+        "LOCAL_WORLD_SIZE",
+        "ROLE_WORLD_SIZE",
+        "WORLD_SIZE",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "TORCHELASTIC_RESTART_COUNT",
+        "TORCHELASTIC_MAX_RESTARTS",
+        "TORCHELASTIC_RUN_ID",
+    ]
+    for var in env_vars:
+        _ = os.environ[var]
+
+
+@dataclass
+class Conf:
+    """
+    Holds arguments to launch an agent (e.g. simulates an agent run on a node).
+
+    """
+
+    entrypoint: Callable
+    local_world_size: int
+    args: Tuple = ()
+    role: str = "default"
+    redirects: Std = Std.NONE
+    tee: Std = Std.NONE
+
+
+class LocalElasticAgentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # start a standalone, single process etcd server to use for all tests
+        cls._etcd_server = EtcdServer()
+        cls._etcd_server.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        # stop the standalone etcd server
+        cls._etcd_server.stop()
+
+    def setUp(self):
+        self._test_dir = tempfile.mkdtemp(prefix=self.__class__.__name__)
+        self._run_id = str(uuid.uuid4()).split("-")[0]
+
+    def tearDown(self):
+        shutil.rmtree(self._test_dir)
+
+    def log_dir(self) -> str:
+        return tempfile.mkdtemp(prefix="torchelastic_", dir=self._test_dir)
+
+    def get_worker_spec(
+        self,
+        node_config: Conf,
+        min_nodes=1,
+        max_nodes=1,
+        max_restarts=0,
+        monitor_interval=0.01,
+    ):
+        rdzv_params = RendezvousParameters(
+            backend="etcd",
+            endpoint=self._etcd_server.get_endpoint(),
+            run_id=self._run_id,
+            min_nodes=min_nodes,
+            max_nodes=max_nodes,
+        )
+        rdzv_handler = rdzv_registry.get_rendezvous_handler(rdzv_params)
+        return WorkerSpec(
+            role=node_config.role,
+            local_world_size=node_config.local_world_size,
+            entrypoint=node_config.entrypoint,
+            args=node_config.args,
+            rdzv_handler=rdzv_handler,
+            max_restarts=max_restarts,
+            monitor_interval=monitor_interval,
+            redirects=node_config.redirects,
+            tee=node_config.tee,
+        )
+
+    def get_agent(
+        self, spec: WorkerSpec, start_method: str = "spawn", exit_barrier_timeout=5
+    ) -> LocalElasticAgent:
+        return LocalElasticAgent(
+            spec,
+            start_method=start_method,
+            exit_barrier_timeout=exit_barrier_timeout,
+            log_dir=self.log_dir(),
+        )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.multiprocessing.errors.record`.
+    @record
+    def run_agent(
+        self,
+        conf: Conf,
+        agent_results: Optional[mp.Queue] = None,  # (role, agent_result)
+        min_nodes=1,
+        max_nodes=1,
+        start_method: str = "spawn",
+        max_restarts: int = 0,
+        exit_barrier_timeout=5,
+    ) -> Optional[RunResult]:
+        """
+        Runs a single agent. This method can be called either on a separate process
+        or the main test process. When calling this method on a sparate process make
+        sure to pass the ``agent_results`` multiprocessing Queue so that the agent's
+        run results can be returned. If ``agent_results`` is omitted, then the
+        run result is returned from the method.
+        """
+
+        spec = self.get_worker_spec(
+            node_config=conf,
+            min_nodes=min_nodes,
+            max_nodes=max_nodes,
+            max_restarts=max_restarts,
+        )
+        agent = self.get_agent(
+            spec=spec,
+            start_method=start_method,
+            exit_barrier_timeout=exit_barrier_timeout,
+        )
+        result = agent.run()
+        if agent_results:
+            agent_results.put((conf.role, result))
+
+        if result.is_failed():
+            raise ChildFailedError(spec.get_entrypoint_name(), result.failures)
+        else:
+            if not agent_results:
+                return result
+
+    def run_job(
+        self, node_configs: List[Conf], exit_barrier_timeout: int = 5
+    ) -> Dict[str, List[RunResult]]:
+        """
+        Simulates running a distributed job by running multiple agents
+        (one on each process). Agent 0 is run on the main process for
+        test coverage and ease of debugging
+        """
+
+        nnodes = len(node_configs)
+
+        # each element in this queue holds a tuple (role, RunResult) for each agent
+        agent_results = mp.Queue()
+
+        # run first agent of first config on main process for test coverage + ease of debugging
+        # it is important we loop in reverse order b/c running fn on the main process blocks
+        procs = []
+        for node_idx in reversed(range(len(node_configs))):
+            conf = node_configs[node_idx]
+            run_agent_args = {
+                "conf": conf,
+                "agent_results": agent_results,
+                "min_nodes": nnodes,
+                "max_nodes": nnodes,
+                "start_method": "spawn",
+                "max_restarts": 0,
+                "exit_barrier_timeout": exit_barrier_timeout,
+            }
+            p = mp.Process(target=self.run_agent, kwargs=run_agent_args)
+            procs.append(p)
+            p.start()
+        for p in procs:
+            p.join()
+
+        results: Dict[str, List[RunResult]] = {}
+        while not agent_results.empty():
+            role, run_result = agent_results.get()
+            results.setdefault(role, []).append(run_result)
+        return results
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_happy_function(self):
+        res = self.run_agent(Conf(entrypoint=_happy_function, local_world_size=2))
+        self.assertFalse(res.is_failed())
+        self.assertIsNone(res.return_values[0])
+        self.assertIsNone(res.return_values[1])
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_check_env_function(self):
+        # just checks that all env vars that we need to set on the user script
+        # is actually set
+        res = self.run_agent(Conf(entrypoint=_check_env_function, local_world_size=1))
+        self.assertFalse(res.is_failed())
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_function_with_return_value(self):
+        res = self.run_agent(Conf(entrypoint=_echo, args=("foo",), local_world_size=2))
+        self.assertFalse(res.is_failed())
+        self.assertEqual("foo", res.return_values[0])
+        self.assertEqual("foo", res.return_values[1])
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_distributed_sum_homogeneous(self):
+        node_configs = [
+            Conf(role="sum", entrypoint=_dist_sum, local_world_size=4),
+            Conf(role="sum", entrypoint=_dist_sum, local_world_size=4),
+        ]
+        # When the process method is spawn, the coverage collector hangs
+        # due to getting stuck on the _dist_sum in waiting for TCPStore workers
+        # to join the cluster
+        # TODO(aivanou): t83447589 come up with the proper fix
+        res = self.run_job(node_configs)
+        self.assertEqual(2, len(res["sum"]))
+        ranks = set()
+        for run_results in res["sum"]:
+            self.assertFalse(run_results.is_failed())
+            ranks.update(run_results.return_values.keys())
+        self.assertSetEqual(set(range(4 + 4)), ranks)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_distributed_sum_heterogenous(self):
+        # sums all ranks on 3 agents; each running 1, 2, 3 workers respectively
+        # sum should be equal to 0 + (1 + 2) + (3 + 4 + 5) = 15
+        # sum asserted inside _dist_sum()
+        node_configs = [
+            Conf(role="sum", entrypoint=_dist_sum, local_world_size=1),
+            Conf(role="sum", entrypoint=_dist_sum, local_world_size=2),
+            Conf(role="sum", entrypoint=_dist_sum, local_world_size=3),
+        ]
+        # When the process method is spawn, the coverage collector hangs
+        # due to getting stuck on the _dist_sum in waiting for TCPStore workers
+        # to join the cluster
+        # TODO(aivanou): t83447589 come up with the proper fix
+        res = self.run_job(node_configs)
+        self.assertEqual(3, len(res["sum"]))
+        ranks = set()
+        for run_results in res["sum"]:
+            self.assertFalse(run_results.is_failed())
+            ranks.update(run_results.return_values.keys())
+        self.assertSetEqual(set(range(1 + 2 + 3)), ranks)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_run_sad_function(self):
+        """
+        checks error propagation logic
+        """
+        replyfile = os.path.join(self._test_dir, "error.json")
+        with mock.patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": replyfile}):
+            with self.assertRaises(ChildFailedError) as cm:
+                self.run_agent(Conf(entrypoint=_sad_function, local_world_size=2))
+
+            rank, failure = cm.exception.get_first_failure()
+            failure_data = failure.error_file_data["message"]
+            with open(replyfile, "r") as fp:
+                data = json.load(fp)["message"]
+
+                # ran two; both failed; first failure is either rank 0 or 1
+                self.assertTrue(rank in {0, 1})
+                self.assertTrue(failure.local_rank in {0, 1})
+                self.assertEqual(1, failure.exitcode)
+                self.assertEqual(data["message"], failure_data["message"])
+                self.assertEqual(int(data["extraInfo"]["timestamp"]), failure.timestamp)
+
+    def test_run_bipolar_function(self):
+        """
+        checks agent failure handling logic
+        """
+        node_conf = Conf(entrypoint=_bipolar_function, local_world_size=4)
+        spec = self.get_worker_spec(node_conf, max_restarts=2)
+        agent = self.get_agent(spec)
+        run_result = agent.run()
+        self.assertTrue(run_result.is_failed())
+        self.assertEqual(0, agent._remaining_restarts)
+        self.assertEqual(WorkerState.FAILED, agent.get_worker_group().state)
+        self.assertTrue(agent._total_execution_time > 0)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_correct_rank_assignment_heterogeneous(self):
+        node_configs = [
+            Conf(role="master", entrypoint=_get_role_info, local_world_size=8),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=1),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=2),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=3),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=4),
+            Conf(role="ps", entrypoint=_get_role_info, local_world_size=5),
+            Conf(role="ps", entrypoint=_get_role_info, local_world_size=2),
+        ]
+        results = self.run_job(node_configs)
+        print(f"heterogeneous job result: {results}")
+        self.assertEqual(1, len(results["master"]))
+        self.assertEqual(4, len(results["trainer"]))
+        self.assertEqual(2, len(results["ps"]))
+        self.assert_rank_consistency(
+            results,
+            expected_role_world_sizes={
+                "master": 8,
+                "trainer": 1 + 2 + 3 + 4,
+                "ps": 5 + 2,
+            },
+        )
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_correct_rank_assignment_homogeneous(self):
+        node_configs = [
+            Conf(role="master", entrypoint=_get_role_info, local_world_size=1),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=4),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=4),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=4),
+            Conf(role="trainer", entrypoint=_get_role_info, local_world_size=4),
+            Conf(role="ps", entrypoint=_get_role_info, local_world_size=3),
+            Conf(role="ps", entrypoint=_get_role_info, local_world_size=3),
+        ]
+        results = self.run_job(node_configs)
+        print(f"homogeneous job result: {results}")
+        self.assertEqual(1, len(results["master"]))
+        self.assertEqual(4, len(results["trainer"]))
+        self.assertEqual(2, len(results["ps"]))
+        self.assert_rank_consistency(
+            results,
+            expected_role_world_sizes={"master": 1, "trainer": 4 * 4, "ps": 3 * 2},
+        )
+
+    def assert_rank_consistency(
+        self,
+        run_results: Dict[str, List[RunResult]],
+        expected_role_world_sizes: Dict[str, int],
+    ):
+        """
+        Asserts that ranks are consecutive w.r.t role_rank. If local world sizes are 4:
+        role_rank_0 -> ranks: 0,1,2,3
+        role_rank_1 -> ranks: 4,5,6,7
+        ... etc ...
+        """
+
+        global_ranks: List[int] = []
+        # role -> [role_rank,...]
+        role_ranks: Dict[str, List[int]] = {}
+        # group rank -> [(rank, role_rank),...]
+        grouped_ranks: Dict[int, List[Tuple[int, int]]] = {}
+
+        # global world size == sum of all the role world sizes
+        expected_world_size = sum(expected_role_world_sizes.values())
+        for role, run_results in run_results.items():
+            for result in run_results:
+                res = result.return_values
+                for role_info in res.values():
+                    rank = role_info.rank
+                    role_rank = role_info.role_rank
+                    group_rank = role_info.group_rank
+                    role_world_size = role_info.role_world_size
+                    world_size = role_info.world_size
+
+                    self.assertEqual(expected_world_size, world_size)
+                    self.assertEqual(expected_role_world_sizes[role], role_world_size)
+                    grouped_ranks.setdefault(group_rank, []).append((rank, role_rank))
+                    role_ranks.setdefault(role, []).append(role_rank)
+                    global_ranks.append(rank)
+
+        global_ranks = sorted(global_ranks)
+        self.assertEqual(list(range(expected_world_size)), global_ranks)
+        for role, expected_role_world_size in expected_role_world_sizes.items():
+            self.assertEqual(
+                list(range(expected_role_world_size)), sorted(role_ranks[role])
+            )
+        # Make sure that each agent assigns consecutive ranks to workers
+        # The first argument is the global_rank and the second argument
+        # is role_rank
+        for ranks_lst in grouped_ranks.values():
+            self.assert_ranks_sequential(ranks_lst, 0)
+            self.assert_ranks_sequential(ranks_lst, 1)
+
+    def assert_ranks_sequential(self, ranks_pairs, rank_idx):
+        ranks = sorted(rank_pair[rank_idx] for rank_pair in ranks_pairs)
+        start_rank, end_rank = ranks[0], ranks[-1]
+        self.assertEqual(list(range(start_rank, end_rank + 1)), ranks)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_double_agent_fault_tolerance(self):
+        """
+        start ``nnodes`` agents, kill and restart odd ones, validate fault-tolerance works
+        """
+        nnodes = 2
+        wait = 2
+        node_conf = Conf(entrypoint=_dist_sum, args=(wait,), local_world_size=2)
+        agent_results = mp.Queue()
+        agent_args = {
+            "conf": node_conf,
+            "agent_results": agent_results,
+            "min_nodes": nnodes,
+            "max_nodes": nnodes,
+            "max_restarts": 2,
+        }
+
+        procs = []
+        for _ in range(nnodes):
+            p = mp.Process(
+                target=self.run_agent,
+                kwargs=agent_args,
+            )
+            procs.append(p)
+            p.start()
+
+        # restart odd agents
+        for i in range(nnodes):
+            if i % 2 != 0:
+                procs[i].kill()
+                p = mp.Process(
+                    target=self.run_agent,
+                    kwargs=agent_args,
+                )
+                procs[i] = p
+                p.start()
+
+        for i in range(nnodes):
+            p = procs[i]
+            p.join()
+            self.assertEqual(0, p.exitcode)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_double_agent_elastic(self):
+        """
+        start ``nnodes`` agents, kill odd ones (do not restart), validate
+        elasticity (scale-down) works. (scale-up covered in fault_tolerance test)
+        """
+        min_nodes = 1
+        max_nodes = 2
+        wait = 2
+        node_conf = Conf(entrypoint=_dist_sum, args=(wait,), local_world_size=2)
+        agent_results = mp.Queue()
+        agent_args = {
+            "conf": node_conf,
+            "agent_results": agent_results,
+            "min_nodes": min_nodes,
+            "max_nodes": max_nodes,
+            "max_restarts": 2,
+        }
+
+        procs = []
+        for _ in range(max_nodes):
+            p = mp.Process(
+                target=self.run_agent,
+                kwargs=agent_args,
+            )
+            procs.append(p)
+            p.start()
+
+        # kill odd agents
+        for i in range(max_nodes):
+            if i % 2 != 0:
+                procs[i].kill()
+
+        for i in range(max_nodes):
+            p = procs[i]
+            p.join()
+            if i % 2 == 0:
+                self.assertEqual(0, p.exitcode)
+            else:
+                self.assertEqual(-signal.SIGKILL, p.exitcode)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_torch_rpc(self):
+        """
+        Simple torch rpc example with torchelastic.
+        Creates two agents (to simulate two node job),
+        each agent runs a single worker. worker0 calls an rpc_sync on
+        worker1.
+        """
+        msg = "hello world"
+        node_configs = [
+            Conf(
+                role="master",
+                entrypoint=rpc_master,
+                args=(msg,),
+                local_world_size=1,
+                tee=Std.ALL,
+            ),
+            Conf(
+                role="worker",
+                entrypoint=rpc_worker,
+                args=(),
+                local_world_size=1,
+                tee=Std.ALL,
+            ),
+        ]
+
+        results = self.run_job(node_configs)
+        master_retvals = results["master"][0].return_values
+        # there is only one master but the global rank is not stable
+        # so compare the master return value as a collection
+        self.assertEqual([f"{msg} from worker"], list(master_retvals.values()))
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_workers_drift_success(self):
+        """
+        two agents (one worker each) finishes within ``sec`` seconds of each other,
+        exit barrier timeout set to ``sec * 2 * 2``.
+        """
+
+        sec = 1
+        node_configs = [
+            Conf(role="zzz", entrypoint=_sleep, args=(0 * sec,), local_world_size=1),
+            Conf(role="zzz", entrypoint=_sleep, args=(2 * sec,), local_world_size=1),
+        ]
+        results = self.run_job(node_configs, exit_barrier_timeout=2 * 2 * sec)
+        for i in range(2):
+            run_results = results["zzz"][i]
+            self.assertFalse(run_results.is_failed())
+            for rank, output in run_results.return_values.items():
+                # _sleep() returns its own rank
+                self.assertEqual(rank, output)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_workers_drift_fail(self):
+        """
+        two agents (one worker each) finishes within ``4 x sec`` seconds of each other,
+        exit barrier timeout set to 0. Exit barriers should NOT fail the job.
+        """
+        sec = 1
+        node_configs = [
+            Conf(role="zzz", entrypoint=_sleep, args=(0 * sec,), local_world_size=1),
+            Conf(role="zzz", entrypoint=_sleep, args=(4 * sec,), local_world_size=1),
+        ]
+        results = self.run_job(node_configs, exit_barrier_timeout=0)
+        for i in range(2):
+            run_results = results["zzz"][i]
+            self.assertFalse(run_results.is_failed())
+            for rank, output in run_results.return_values.items():
+                # _sleep() returns its own rank
+                self.assertEqual(rank, output)
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    @patch("torch.distributed.elastic.utils.store.barrier")
+    def test_barrier_failed(self, barrier_mock):
+        """
+        Failure during the barrier should NOT fail the job.
+        """
+        barrier_mock.side_effect = RuntimeError("test error")
+        res = self.run_agent(Conf(entrypoint=_happy_function, local_world_size=1))
+        self.assertFalse(res.is_failed())
+        barrier_mock.assert_called_once()
+
+    @patch("torch.distributed.elastic.agent.server.local_elastic_agent.start_processes")
+    def test_shutdown_called(self, start_processes_mock):
+        pcontext_mock = Mock()
+        pcontext_mock.pids.return_value = {0: 0}
+        start_processes_mock.return_value = pcontext_mock
+        node_conf = Conf(entrypoint=_happy_function, local_world_size=1)
+        spec = self.get_worker_spec(node_conf, max_restarts=0)
+        agent = self.get_agent(spec)
+        with patch.object(agent, "_monitor_workers") as monitor_mock:
+            monitor_mock.return_value = RunResult(
+                state=WorkerState.SUCCEEDED, return_values={0: 0}
+            )
+            agent.run("worker")
+        pcontext_mock.close.assert_called_once()

--- a/torch/distributed/elastic/agent/server/__init__.py
+++ b/torch/distributed/elastic/agent/server/__init__.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+The elastic agent is the control plane of torchelastic. It is a process
+that launches and manages underlying worker processes. The agent is
+responsible for:
+
+1. Working with distributed torch: the workers are started with all the
+   necessary information to successfully and trivially call
+   ``torch.distributed.init_process_group()``.
+
+2. Fault tolerance: monitors workers and upon detecting worker failures
+   or unhealthiness, tears down all workers and restarts everyone.
+
+3. Elasticity: Reacts to membership changes and restarts workers with the new
+   members.
+
+The simplest agents are deployed per node and works with local processes.
+A more advanced agent can launch and manage workers remotely. Agents can
+be completely decentralized, making decisions based on the workers it manages.
+Or can be coordinated, communicating to other agents (that manage workers
+in the same job) to make a collective decision.
+"""
+
+from .api import (  # noqa F401
+    ElasticAgent,
+    SimpleElasticAgent,
+    Worker,
+    WorkerGroup,
+    RunResult,
+    WorkerSpec,
+    WorkerState,
+)

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -1,0 +1,887 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import abc
+import functools
+import json
+import os
+import socket
+import time
+import traceback
+import warnings
+from contextlib import closing
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch.distributed.elastic.rendezvous as rdzv
+import torch.distributed.elastic.utils.store as store_util
+from torch.distributed.elastic.events import Event, EventSource, record
+from torch.distributed.elastic.metrics import prof, put_metric
+from torch.distributed.elastic.multiprocessing import ProcessFailure, Std
+from torch.distributed.elastic.utils.logging import get_logger
+
+
+_TERMINAL_STATE_SYNC_ID = "torchelastic/agent/terminal_state"
+
+DEFAULT_ROLE = "default"
+log = get_logger()
+
+
+@dataclass
+class WorkerSpec:
+    """
+    Contains blueprint information about a particular type of worker.
+    For a given role, there must only exist a single worker spec.
+    Worker spec is expected to be homogenous across all nodes (machine),
+    that is each node runs the same number of workers for a particular spec.
+
+    Args:
+        role: user-defined role for the workers with this spec
+        local_world_size: number local workers to run
+        fn: (deprecated use entrypoint instead)
+        entrypoint: worker function or command
+        args: arguments to pass to ``entrypoint``
+        rdzv_handler: handles rdzv for this set of workers
+        max_restarts: number of max retries for the workers
+        monitor_interval: monitor status of workers every ``n`` seconds
+        master_port: fixed port to run the c10d store on rank 0
+                     if not specified then will chose a random free port
+        redirects: redirect std streams to a file,
+                   selectively redirect for a particular
+                   local rank by passing a map
+        tee: tees the specified std stream(s) to console + file,
+             selectively tee for a particular local rank by passing a map,
+             takes precedence over ``redirects`` settings.
+
+    """
+
+    role: str
+    local_world_size: int
+    rdzv_handler: rdzv.RendezvousHandler
+    fn: Optional[Callable] = None
+    # TODO @kiuk - make entrypoint a required field
+    entrypoint: Union[Callable, str, None] = None
+    args: Tuple = ()
+    max_restarts: int = 3
+    monitor_interval: float = 30.0
+    master_port: Optional[int] = None
+    redirects: Union[Std, Dict[int, Std]] = Std.NONE
+    tee: Union[Std, Dict[int, Std]] = Std.NONE
+
+    def __post_init__(self):
+        assert self.local_world_size > 0
+        assert self.monitor_interval > 0
+
+        if self.fn:
+            warnings.warn(
+                "WorkerSpec.fn will be deprecated,"
+                " please use WorkerSpec.entrypoint instead",
+                category=DeprecationWarning,
+            )
+            self.entrypoint = self.fn
+        assert self.entrypoint
+
+    def get_entrypoint_name(self):
+        """
+        If the entrypoint is a function (e.g. ``Callable``) returns its ``__qualname__``,
+        else if the entrypoint is a binary (e.g. ``str``), returns the binary name.
+        """
+        if isinstance(self.entrypoint, str):
+            return os.path.basename(self.entrypoint)
+        else:
+            return self.entrypoint.__qualname__
+
+
+class Worker:
+    """
+    Represents a worker instance. Contrast this with ``WorkerSpec`` that
+    represents the specifications of a worker. A ``Worker`` is created from
+    a ``WorkerSpec``. A ``Worker`` is to a ``WorkerSpec`` as an object is to
+    a class.
+
+    The ``id`` of the worker is interpreted
+    by the specific implementation of ``ElasticAgent``. For a local
+    agent, it could be the ``pid (int)`` of the worker, for a remote
+    agent it could be encoded as ``host:port (string)``.
+
+    Args:
+        id (Any): uniquely identifies a worker (interpreted by the agent)
+        local_rank (int): local rank of the worker
+        global_rank (int): global rank of the worker
+        role_rank (int): rank of the worker across all workers that have the same role
+        world_size (int): number of workers (globally)
+        role_world_size (int): number of workers that have the same role
+    """
+
+    __slots__ = [
+        "id",
+        "local_rank",
+        "global_rank",
+        "role_rank",
+        "world_size",
+        "role_world_size",
+    ]
+
+    def __init__(
+        self,
+        local_rank: int,
+        global_rank: int = -1,
+        role_rank: int = -1,
+        world_size: int = -1,
+        role_world_size: int = -1,
+    ):
+        # unique identifier for this worker
+        self.id: Any = None
+
+        # rank of the worker among workers with the same role being monitored
+        # by the same ``agent`` instance.
+        self.local_rank: int = local_rank
+
+        #  rank of the worker among all the workers across all roles
+        #  across all ``agent`` instances.
+        #  Global rank is not stable between re-rendezvous.
+        self.global_rank: int = global_rank
+
+        #  rank of the worker among all the workers with the same role
+        #  across all ``agent`` instances.
+        #  Global rank is not stable between re-rendezvous.
+        self.role_rank: int = role_rank
+
+        # total number of workers (globally). Due to elasticity
+        # the world size may change between re-rendezvous.
+        self.world_size: int = world_size
+
+        # total number of workers that share the same role. Due to elasticity
+        # the role world size may change between re-rendezvous.
+        self.role_world_size: int = role_world_size
+
+    def __str__(self):
+        return (
+            f"local_rank={self.local_rank},global_rank={self.global_rank}"
+            f",role_rank={self.role_rank},world_size={self.world_size}"
+            f",role_world_size={self.role_world_size}"
+        )
+
+    def __repr__(self):
+        return str(self)
+
+
+class WorkerState(str, Enum):
+    """
+    State of the ``WorkerGroup``. Workers in a worker group change state as a unit.
+    If a single worker in a worker group fails the entire set is considered
+    failed::
+
+      UNKNOWN - agent lost track of worker group state, unrecoverable
+      INIT - worker group object created not yet started
+      HEALTHY - workers running and healthy
+      UNHEALTHY - workers running and unhealthy
+      STOPPED - workers stopped (interruped) by the agent
+      SUCCEEDED - workers finished running (exit 0)
+      FAILED - workers failed to successfully finish (exit !0)
+
+
+    A worker group starts from an initial ``INIT`` state,
+    then progresses to ``HEALTHY`` or ``UNHEALTHY`` states,
+    and finally reaches a terminal ``SUCCEEDED`` or ``FAILED`` state.
+
+    Worker groups can be interrupted and temporarily put into ``STOPPED`` state
+    by the agent. Workers in ``STOPPED`` state are scheduled to be restarted
+    in the near future by the agent. Some examples of workers being put into
+    ``STOPPED`` state are:
+
+    1. Worker group failure|unhealthy observed
+    2. Membership change detected
+
+    When actions (start, stop, rdzv, retry, etc) on worker group fails
+    and results in the action being partially applied to the worker group
+    the state will be ``UNKNOWN``. Typically this happens on uncaught/unhandled
+    exceptions during state change events on the agent. The agent is not
+    expected to recover worker groups in ``UNKNOWN`` state and is better off
+    self terminating and allowing the job manager to retry the node.
+    """
+
+    UNKNOWN = "UNKNOWN"
+    INIT = "INIT"
+    HEALTHY = "HEALTHY"
+    UNHEALTHY = "UNHEALTHY"
+    STOPPED = "STOPPED"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+    @staticmethod
+    def is_running(state: "WorkerState") -> bool:
+        """
+        Returns:
+             True if the worker state represents workers still running
+             (e.g. that the process exists but not necessarily healthy).
+        """
+        return state in {WorkerState.HEALTHY, WorkerState.UNHEALTHY}
+
+
+class WorkerGroup:
+    """
+    Represents the set of ``Worker`` instances for the given ``WorkerSpec``
+    managed by ``ElasticAgent``. Whether the worker group contains cross
+    instance workers or not depends on the implementation of the agent.
+    """
+
+    __slots__ = ["spec", "workers", "store", "group_rank", "group_world_size", "state"]
+
+    def __init__(self, spec: WorkerSpec):
+        self.spec = spec
+        self.workers = [Worker(local_rank=i) for i in range(self.spec.local_world_size)]
+
+        # assigned after rdzv
+        self.store = None
+        self.group_rank = None
+        self.group_world_size = None
+
+        self.state = WorkerState.INIT
+
+
+class _RoleInstanceInfo:
+    """
+    The class is used by the agent to exchange the information with other agents.
+    The information is used to determine the rank of the workers that agent
+    manages in heterogeneous environments, where different agents can have
+    different number of workers.
+    """
+
+    __slots__ = ["role", "rank", "local_world_size"]
+
+    def __init__(self, role: str, rank: int, local_world_size: int):
+        r"""
+
+        Args:
+            role (str): user-defined role for the workers with this spec
+            rank (int): the rank of the agent
+            local_world_size (int): number of local workers to run
+        """
+
+        self.role = role
+        self.rank = rank
+        self.local_world_size = local_world_size
+
+    def serialize(self) -> bytes:
+        dict_data = {
+            "role": self.role,
+            "rank": self.rank,
+            "local_world_size": self.local_world_size,
+        }
+        return json.dumps(dict_data).encode(encoding="UTF-8")
+
+    @staticmethod
+    def deserialize(data: bytes):
+        dict_data = json.loads(data.decode(encoding="UTF-8"))
+        return _RoleInstanceInfo(
+            dict_data["role"], dict_data["rank"], dict_data["local_world_size"]
+        )
+
+    @staticmethod
+    def compare(obj1, obj2) -> int:
+        if obj1.role == obj2.role:
+            return obj1.rank - obj2.rank
+        elif obj1.role > obj2.role:
+            return 1
+        else:
+            return -1
+
+    @staticmethod
+    def find_role_boundaries(roles_infos: List, role: str) -> Tuple[int, int]:
+        start_idx, end_idx = -1, -1
+        for idx, role_info in enumerate(roles_infos):
+            if role_info.role == role:
+                if start_idx == -1:
+                    start_idx = idx
+                end_idx = idx
+        return (start_idx, end_idx)
+
+
+@dataclass
+class RunResult:
+    """
+    Results returned by the worker executions. Run results follow an "all-or-nothing" policy
+    where the run is successful if and only if ALL local workers managed by this agent
+    complete successfully.
+
+    If the result is successful (e.g. ``is_failed() = False``) then the ``return_values``
+    field contains the outputs (return values) of the workers managed by THIS agent mapped
+    by their GLOBAL ranks. That is ``result.return_values[0]`` is the return value of
+    global rank 0.
+
+    .. note:: ``return_values`` are only meaningful for when the worker entrypoint
+              is a function. Workers specified as a binary entrypoint do not canonically
+              have a return value and the ``return_values`` field is meaningless and
+              may be empty.
+
+    If ``is_failed()`` returns ``True`` then the ``failures`` field contains the
+    failure information, again, mapped by the GLOBAL rank of the worker that failed.
+
+    The keys in ``return_values`` and ``failures`` are mutually exclusive, that is,
+    a worker's final state can only be one of: succeeded, failed. Workers intentionally
+    terminated by the agent according to the agent's restart policy, are not represented
+    in either ``return_values`` nor ``failures``.
+    """
+
+    state: WorkerState
+    return_values: Dict[int, Any] = field(default_factory=dict)
+    failures: Dict[int, ProcessFailure] = field(default_factory=dict)
+
+    def is_failed(self) -> bool:
+        return self.state == WorkerState.FAILED
+
+
+def _get_socket_with_port() -> socket.socket:
+    """
+    Returns a free port on localhost that is "reserved" by binding a temporary
+    socket on it. Close the socket before passing the port to the entity
+    that requires it. Usage example
+
+    ::
+
+    sock = _get_socket_with_port()
+    with closing(sock):
+        port = sock.getsockname()[1]
+        sock.close()
+        # there is still a race-condition that some other process
+        # may grab this port before func() runs
+        func(port)
+    """
+
+    addrs = socket.getaddrinfo(
+        host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+    )
+    for addr in addrs:
+        family, type, proto, _, _ = addr
+        s = socket.socket(family, type, proto)
+        try:
+            s.bind(("localhost", 0))
+            s.listen(0)
+            return s
+        except OSError as e:
+            s.close()
+            log.info("Socket creation attempt failed.", exc_info=e)
+    raise RuntimeError("Failed to create a socket")
+
+
+def _get_fq_hostname() -> str:
+    return socket.getfqdn(socket.gethostname())
+
+
+class ElasticAgent(abc.ABC):
+    """
+    Agent process responsible for managing one or more worker processes.
+    The worker processes are assumed to be regular distributed PyTorch scripts.
+    When the worker process is created by the agent, the agent provides the
+    necessary information for the worker processes to properly initialize
+    a torch process group.
+
+    The exact deployment topology and ratio of agent-to-worker is dependent
+    on the specific implementation of the agent and the user's job placement
+    preferences. For instance, to run a distributed training job on GPU with
+    8 trainers (one per GPU) one can:
+
+    1. Use 8 x single GPU instances, place an agent per instance, managing
+       1 worker per agent.
+    2. Use 4 x double GPU instances, place an agent per instance, managing
+       2 workers per agent.
+    3. Use 2 x quad GPU instances, place an agent per instance, managing
+       4 workers per agent.
+    4. Use 1 x 8 GPU instance, place an agent per instance, managing
+       8 workers per agent.
+
+    Usage
+    ::
+
+     group_result = agent.run()
+      if group_result.is_failed():
+        # workers failed
+        failure = group_result.failures[0]
+        log.exception(f"worker 0 failed with exit code : {failure.exit_code}")
+      else:
+        return group_result.return_values[0] # return rank 0's results
+
+    """
+
+    @abc.abstractmethod
+    def run(self, role: str = DEFAULT_ROLE) -> RunResult:
+        """
+        Runs the agent, retrying the worker group on failures up to
+        ``max_restarts``.
+
+        Returns:
+            The result of the execution, containing the return values or
+            failure details for each worker mapped by the worker's global rank.
+
+        Raises:
+            Exception - any other failures NOT related to worker process
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_worker_group(self, role: str = DEFAULT_ROLE) -> WorkerGroup:
+        """
+        Returns:
+            The ``WorkerGroup`` for the given ``role``.
+            Note that the worker group is a mutable object and hence in a
+            multi-threaded/process environment it may change state.
+            Implementors are encouraged (but not required) to return
+            a defensive read-only copy.
+        """
+        raise NotImplementedError()
+
+
+class SimpleElasticAgent(ElasticAgent):
+    """
+    An ``ElasticAgent`` that manages workers (``WorkerGroup``)
+    for a single ``WorkerSpec`` (e.g. one particular type of worker role).
+    """
+
+    def __init__(self, spec: WorkerSpec, exit_barrier_timeout: float = 300):
+        self._worker_group = WorkerGroup(spec)
+        self._remaining_restarts = self._worker_group.spec.max_restarts
+        self._store = None
+        self._exit_barrier_timeout = exit_barrier_timeout
+        self._total_execution_time = 0
+
+    def get_worker_group(self, role: str = DEFAULT_ROLE) -> WorkerGroup:
+        return self._worker_group
+
+    @abc.abstractmethod
+    def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
+        r"""
+        Starts ``worker_group.spec.local_world_size`` number of workers
+        according to worker spec for the worker group .
+
+        Returns a map of ``local_rank`` to worker ``id``.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
+        r"""
+        Stops all workers in the given worker group. Implementors
+        must deal with workers in all states defined by ``WorkerState``.
+        That is, it must gracefully handle stopping non-existent workers,
+        unhealthy (stuck) workers, etc.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _monitor_workers(self, worker_group: WorkerGroup) -> RunResult:
+        r"""
+        Checks on the workers for the ``worker_group`` and returns
+        the new state of the worker group.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _shutdown(self) -> None:
+        """
+        Cleans up any resources that were allocated during the agent's work.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def _set_master_addr_port(store, master_port):
+        if master_port is None:
+            sock = _get_socket_with_port()
+            with closing(sock):
+                master_port = sock.getsockname()[1]
+
+        store.set("MASTER_ADDR", _get_fq_hostname().encode(encoding="UTF-8"))
+        store.set("MASTER_PORT", str(master_port).encode(encoding="UTF-8"))
+
+    @staticmethod
+    def _get_master_addr_port(store) -> Tuple[str, int]:
+        master_addr = store.get("MASTER_ADDR").decode(encoding="UTF-8")
+        master_port = int(store.get("MASTER_PORT").decode(encoding="UTF-8"))
+        return (master_addr, master_port)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _rendezvous(self, worker_group: WorkerGroup) -> None:
+        r"""
+        Runs rendezvous for the workers specified by worker spec.
+        Assigns workers a new global rank and world size.
+        Updates the rendezvous store for the worker group.
+        """
+
+        spec = worker_group.spec
+
+        store, group_rank, group_world_size = spec.rdzv_handler.next_rendezvous()
+        self._store = store
+
+        workers = self._assign_worker_ranks(store, group_rank, group_world_size, spec)
+        worker_group.workers = workers
+        worker_group.store = store
+        worker_group.group_rank = group_rank
+        worker_group.group_world_size = group_world_size
+
+        if group_rank == 0:
+            self._set_master_addr_port(store, spec.master_port)
+        master_addr, master_port = self._get_master_addr_port(store)
+        restart_count = spec.max_restarts - self._remaining_restarts
+
+        log.info(
+            f"[{spec.role}] Rendezvous complete for workers. Result:\n"
+            f"  restart_count={restart_count}\n"
+            f"  master_addr={master_addr}\n"
+            f"  master_port={master_port}\n"
+            f"  group_rank={group_rank}\n"
+            f"  group_world_size={group_world_size}\n"
+            f"  local_ranks={[worker.local_rank for worker in workers]}\n"
+            f"  role_ranks={[worker.role_rank for worker in workers]}\n"
+            f"  global_ranks={[worker.global_rank for worker in workers]}\n"
+            f"  role_world_sizes={[worker.role_world_size for worker in workers]}\n"
+            f"  global_world_sizes={[worker.world_size for worker in workers]}\n"
+        )
+
+    def _get_ranks(
+        self,
+        role_infos: List[_RoleInstanceInfo],
+        role_idx: int,
+        start_idx: int = 0,
+        end_idx: int = -1,
+    ) -> Tuple[int, List[int]]:
+        if end_idx == -1:
+            end_idx = len(role_infos)
+        prefix_sum = 0
+        total_sum = 0
+        for idx in range(start_idx, end_idx):
+            if role_idx > idx:
+                prefix_sum += role_infos[idx].local_world_size
+            total_sum += role_infos[idx].local_world_size
+        return (
+            total_sum,
+            list(range(prefix_sum, prefix_sum + role_infos[role_idx].local_world_size)),
+        )
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _assign_worker_ranks(
+        self, store, group_rank: int, group_world_size: int, spec: WorkerSpec
+    ) -> List[Worker]:
+        """
+        Determines proper ranks for worker processes. The rank assignment
+        is done according to the following algorithm:
+
+        1. Each agent writes its configuration(group_rank, group_world_size
+           , num_workers) to the common store.
+        2. Each agent retrieves configuration for all agents
+           and performs two level sort using role and rank.
+        3. Determine the global rank: the global rank of the workers for the current
+           agent is the offset of the infos array up to group_rank of the agent.
+           The offset is computed as a sum of local_world_size of all agents that
+           have rank less than the group_rank. The workers would have the ranks:
+           [offset, offset+local_world_size)
+        4. Determine the role rank: The role rank is determined using the algorithms
+           in the point 3 with the exception that the offset is done from the first
+           agent that has the same role as current one and has the minimum group rank.
+        """
+
+        role_infos = self._share_and_gather(store, group_rank, group_world_size, spec)
+        my_role_info = role_infos[group_rank]
+        worker_world_size, worker_global_ranks = self._get_ranks(role_infos, group_rank)
+        role_infos = sorted(
+            role_infos, key=functools.cmp_to_key(_RoleInstanceInfo.compare)
+        )
+        role_start_idx, role_end_idx = _RoleInstanceInfo.find_role_boundaries(
+            role_infos, my_role_info.role
+        )
+        role_pos = next(
+            idx
+            for idx, role_info in enumerate(role_infos)
+            if _RoleInstanceInfo.compare(role_info, my_role_info) == 0
+        )
+        role_world_size, role_ranks = self._get_ranks(
+            role_infos, role_pos, role_start_idx, role_end_idx + 1
+        )
+        workers = []
+        for ind in range(spec.local_world_size):
+            worker = Worker(
+                local_rank=ind,
+                global_rank=worker_global_ranks[ind],
+                role_rank=role_ranks[ind],
+                world_size=worker_world_size,
+                role_world_size=role_world_size,
+            )
+            workers.append(worker)
+        return workers
+
+    def _share_and_gather(
+        self, store, group_rank: int, group_world_size: int, spec: WorkerSpec
+    ) -> List:
+        agent_role_info = _RoleInstanceInfo(
+            spec.role, group_rank, spec.local_world_size
+        )
+        key_prefix = "torchelastic/role_info"
+        agent_config_enc = agent_role_info.serialize()
+        role_infos_bytes = store_util.synchronize(
+            store, agent_config_enc, group_rank, group_world_size, key_prefix
+        )
+        role_infos = [
+            _RoleInstanceInfo.deserialize(role_info_bytes)
+            for role_info_bytes in role_infos_bytes
+        ]
+        return role_infos
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _initialize_workers(self, worker_group: WorkerGroup) -> None:
+        r"""
+        Starts a fresh set of workers for the worker_group.
+        Essentially a rendezvous followed by a start_workers.
+
+        The caller should first call ``_stop_workers()`` to stop running workers
+        prior to calling this method.
+
+        Optimistically sets the state of the worker group that
+        just started as ``HEALTHY`` and delegates the actual monitoring
+        of state to ``_monitor_workers()`` method
+        """
+        role = worker_group.spec.role
+        log.info(f"[{role}] Rendezvous'ing worker group")
+
+        # TODO after stopping workers, wait at least monitor_interval*2 for
+        # workers on different nodes to fail on a collective op before waiting
+        # on the rdzv barrier, this way we ensure that nodes enter rdzv
+        # at around the same time and reduce false positive rdzv timeout errors
+        self._rendezvous(worker_group)
+
+        log.info(f"[{role}] Starting worker group")
+        worker_ids = self._start_workers(worker_group)
+        for local_rank, w_id in worker_ids.items():
+            worker = worker_group.workers[local_rank]
+            worker.id = w_id
+
+        worker_group.state = WorkerState.HEALTHY
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _restart_workers(self, worker_group: WorkerGroup) -> None:
+        """
+        Restarts (stops, rendezvous, starts) all local workers in the group.
+        """
+
+        role = worker_group.spec.role
+        log.info(f"[{role}] Stopping worker group")
+        self._stop_workers(worker_group)
+        worker_group.state = WorkerState.STOPPED
+        self._initialize_workers(worker_group)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def run(self, role: str = DEFAULT_ROLE) -> RunResult:
+        start_time = time.monotonic()
+        try:
+            result = self._invoke_run(role)
+            self._total_execution_time = int(time.monotonic() - start_time)
+            self._record_metrics(result)
+            self._record_worker_events(result)
+            return result
+        finally:
+            # record the execution time in case there were any exceptions during run.
+            self._total_execution_time = int(time.monotonic() - start_time)
+            self._shutdown()
+
+    def get_agent_status_event(self, state: WorkerState) -> Event:
+        raw_error = traceback.format_exc() if state == WorkerState.FAILED else None
+        return self._construct_event(
+            state.value, EventSource.AGENT, raw_error=raw_error
+        )
+
+    def _record_worker_events(self, result: RunResult) -> None:
+        for worker in self._worker_group.workers:
+            failure = result.failures.get(worker.global_rank)
+            state: str = self._get_worker_state(worker, result)
+            raw_error = json.dumps(failure.error_file_data) if failure else None
+            record(self._construct_event(state, EventSource.WORKER, worker, raw_error))
+
+    def _get_worker_state(self, worker: Worker, result: RunResult) -> str:
+        failure = result.failures.get(worker.global_rank)
+        if result.state in {WorkerState.UNHEALTHY, WorkerState.FAILED} and not failure:
+            # The worker got terminated by the torchelastic agent via SIGTERM signal
+            return "TERMINATED"
+        elif failure or worker.global_rank in result.return_values:
+            return result.state.value
+        else:
+            raise ValueError(f"Unknow worker: {worker.global_rank}")
+
+    def _construct_event(
+        self,
+        state: str,
+        source: EventSource,
+        worker: Optional[Worker] = None,
+        raw_error: Optional[str] = None,
+    ) -> Event:
+        wg = self._worker_group
+        spec = wg.spec
+        md = {
+            "group_world_size": wg.group_world_size,
+            "entry_point": spec.get_entrypoint_name(),
+        }
+        if worker:
+            md["local_rank"] = (worker.local_rank,)
+            md["role_rank"] = (worker.role_rank,)
+            md["role_world_size"] = (worker.role_world_size,)
+            global_rank = worker.global_rank
+            worker_id = str(worker.id)
+        else:
+            global_rank = None
+            worker_id = None
+        md_str = json.dumps(md)
+        metadata = {
+            "run_id": spec.rdzv_handler.get_run_id(),
+            "global_rank": global_rank,
+            "group_rank": wg.group_rank,
+            "worker_id": worker_id,
+            "role": spec.role,
+            "hostname": _get_fq_hostname(),
+            "state": state,
+            "total_run_time": self._total_execution_time,
+            "rdzv_backend": spec.rdzv_handler.get_backend(),
+            "raw_error": raw_error,
+            "metadata": md_str,
+            "agent_restarts": spec.max_restarts - self._remaining_restarts,
+        }
+        return Event(
+            f"torchelastic.worker.status.{state}", source=source, metadata=metadata
+        )
+
+    def _record_metrics(self, group_results: RunResult):
+        is_failed = group_results.is_failed()
+        self._record_flakiness_metric(is_failed)
+        spec = self._worker_group.spec
+        restarts_happened = self._remaining_restarts != spec.max_restarts
+        put_metric(f"workers.{spec.role}.run_total", 1)
+        self._record_metric_with_condition(
+            "run_success_with_retries", not is_failed and restarts_happened
+        )
+        self._record_metric_with_condition(
+            "run_success_no_retries", not is_failed and not restarts_happened
+        )
+        self._record_metric_with_condition(
+            "run_failed_with_retries", is_failed and restarts_happened
+        )
+        self._record_metric_with_condition(
+            "run_failed_no_retries", is_failed and not restarts_happened
+        )
+
+    def _record_metric_with_condition(self, metric_name, condition):
+        spec = self._worker_group.spec
+        if condition:
+            put_metric(f"workers.{spec.role}.{metric_name}", 1)
+        else:
+            put_metric(f"workers.{spec.role}.{metric_name}", 0)
+
+    def _record_flakiness_metric(self, is_failed: bool = False):
+        if is_failed:
+            flakiness = 100.0
+        else:
+            spec = self._worker_group.spec
+            flakiness = 100.0 - 100.0 * (self._remaining_restarts + 1) / (
+                spec.max_restarts + 1
+            )
+        spec = self._worker_group.spec
+
+        put_metric(f"workers.{spec.role}.flakiness", int(flakiness))
+
+    def _invoke_run(self, role: str = DEFAULT_ROLE) -> RunResult:
+        # NOTE: currently only works for a single role
+
+        spec = self._worker_group.spec
+        role = spec.role
+
+        log.info(
+            f"[{role}] starting workers for entrypoint: {spec.get_entrypoint_name()}"
+        )
+
+        self._initialize_workers(self._worker_group)
+        monitor_interval = spec.monitor_interval
+        rdzv_handler = spec.rdzv_handler
+
+        while True:
+            assert self._worker_group.state != WorkerState.INIT
+            time.sleep(monitor_interval)
+            run_result = self._monitor_workers(self._worker_group)
+            state = run_result.state
+            self._worker_group.state = state
+
+            put_metric(f"workers.{role}.remaining_restarts", self._remaining_restarts)
+            put_metric(f"workers.{role}.{state.name.lower()}", 1)
+
+            if state == WorkerState.SUCCEEDED:
+                log.info(
+                    f"[{role}] worker group successfully finished."
+                    f" Waiting {self._exit_barrier_timeout} seconds for other agents to finish."
+                )
+                self._exit_barrier()
+                return run_result
+            elif state in {WorkerState.UNHEALTHY, WorkerState.FAILED}:
+                if self._remaining_restarts > 0:
+                    log.info(
+                        f"[{role}] Worker group {state.name}. "
+                        f"{self._remaining_restarts}/{spec.max_restarts} attempts left;"
+                        f" will restart worker group"
+                    )
+                    self._remaining_restarts -= 1
+                    self._restart_workers(self._worker_group)
+                else:
+                    self._stop_workers(self._worker_group)
+                    self._worker_group.state = WorkerState.FAILED
+                    self._exit_barrier()
+                    return run_result
+            elif state == WorkerState.HEALTHY:
+                # membership changes do not count as retries
+                num_nodes_waiting = rdzv_handler.num_nodes_waiting()
+                group_rank = self._worker_group.group_rank
+                if num_nodes_waiting > 0:
+                    log.info(
+                        f"[{role}] Detected {num_nodes_waiting} "
+                        f"new nodes from group_rank={group_rank}; "
+                        f"will restart worker group"
+                    )
+                    self._restart_workers(self._worker_group)
+            else:
+                raise Exception(f"[{role}] Worker group in {state.name} state")
+
+    def _exit_barrier(self):
+        """
+        Wait for ``exit_barrier_timeout`` seconds for all agents to finish
+        executing their local workers (either successfully or not). This
+        acts as a safety guard against user scripts that terminate at different
+        times. This barrier keeps the agent process alive until all workers finish.
+        """
+        log.info(
+            f"Local worker group finished ({self._worker_group.state}). "
+            f"Waiting {self._exit_barrier_timeout} seconds for other agents to finish"
+        )
+        start = time.time()
+        try:
+            store_util.barrier(
+                self._store,
+                self._worker_group.group_rank,
+                self._worker_group.group_world_size,
+                key_prefix=_TERMINAL_STATE_SYNC_ID,
+                barrier_timeout=self._exit_barrier_timeout,
+            )
+            log.info(
+                f"Done waiting for other agents. Elapsed: {time.time() - start} seconds"
+            )
+        except Exception:
+            log.exception(
+                f"Error waiting on exit barrier. Elapsed: {time.time() - start} seconds"
+            )

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import shutil
+import tempfile
+from typing import Any, Dict, Optional, Tuple
+
+from torch.distributed.elastic.agent.server.api import (
+    RunResult,
+    SimpleElasticAgent,
+    WorkerGroup,
+    WorkerSpec,
+    WorkerState,
+)
+from torch.distributed.elastic.metrics.api import prof
+from torch.distributed.elastic.multiprocessing import start_processes
+
+
+log = logging.getLogger(__name__)
+
+
+class LocalElasticAgent(SimpleElasticAgent):
+    """
+    An implementation of :py:class:`torchelastic.agent.server.ElasticAgent`
+    that handles host-local workers.
+    This agent is deployed per host and is configured to spawn ``n`` workers.
+    When using GPUs, ``n`` maps to the number of GPUs available on the host.
+
+    The local agent does not communicate to other local agents deployed on
+    other hosts, even if the workers may communicate inter-host. The worker id
+    is interpreted to be a local process. The agent starts and stops all worker
+    processes as a single unit.
+
+
+    The worker function and argument passed to the worker function must be
+    python multiprocessing compatible. To pass multiprocessing data structures
+    to the workers you may create the data structure in the same multiprocessing
+    context as the specified ``start_method`` and pass it as a function argument.
+
+    The ``exit_barrier_timeout`` specifies the amount of time (in seconds) to wait
+    for other agents to finish. This acts as a safety net to handle cases where
+    workers finish at different times, to prevent agents from viewing workers
+    that finished early as a scale-down event. It is strongly advised that the
+    user code deal with ensuring that workers are terminated in a synchronous
+    manner rather than relying on the exit_barrier_timeout.
+
+    Example launching function
+
+    ::
+
+        def trainer(args) -> str:
+            return "do train"
+
+        def main():
+            start_method="spawn"
+            shared_queue= multiprocessing.get_context(start_method).Queue()
+            spec = WorkerSpec(
+                        role="trainer",
+                        local_world_size=nproc_per_process,
+                        entrypoint=trainer,
+                        args=("foobar",),
+                        ...<OTHER_PARAMS...>)
+            agent = LocalElasticAgent(spec, start_method)
+            results = agent.run()
+
+            if results.is_failed():
+                print("trainer failed")
+            else:
+                print(f"rank 0 return value: {results.return_values[0]}")
+                # prints -> rank 0 return value: do train
+
+    Example launching binary
+
+    ::
+
+        def main():
+            spec = WorkerSpec(
+                        role="trainer",
+                        local_world_size=nproc_per_process,
+                        entrypoint="/usr/local/bin/trainer",
+                        args=("--trainer_args", "foobar"),
+                        ...<OTHER_PARAMS...>)
+            agent = LocalElasticAgent(spec)
+            results = agent.run()
+
+            if not results.is_failed():
+                print("binary launches do not have return values")
+
+    """
+
+    def __init__(
+        self,
+        spec: WorkerSpec,
+        start_method="spawn",
+        exit_barrier_timeout: float = 300,
+        log_dir: Optional[str] = None,
+    ):
+        super().__init__(spec, exit_barrier_timeout)
+        self._start_method = start_method
+        self._pcontext = None
+        rdzv_run_id = spec.rdzv_handler.get_run_id()
+        self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
+
+    def _make_log_dir(self, log_dir: Optional[str], rdzv_run_id: str):
+        base_log_dir = log_dir or tempfile.mkdtemp(prefix="torchelastic_")
+        os.makedirs(base_log_dir, exist_ok=True)
+        dir = tempfile.mkdtemp(prefix=f"{rdzv_run_id}_", dir=base_log_dir)
+        log.info(f"log directory set to: {dir}")
+        return dir
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _stop_workers(self, worker_group: WorkerGroup) -> None:
+        self._shutdown()
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
+        spec = worker_group.spec
+        store = worker_group.store
+        master_addr, master_port = super()._get_master_addr_port(store)
+        restart_count = spec.max_restarts - self._remaining_restarts
+
+        args: Dict[int, Tuple] = {}
+        envs: Dict[int, Dict[str, str]] = {}
+        for worker in worker_group.workers:
+            local_rank = worker.local_rank
+            worker_env = {
+                "LOCAL_RANK": str(local_rank),
+                "RANK": str(worker.global_rank),
+                "GROUP_RANK": str(worker_group.group_rank),
+                "ROLE_RANK": str(worker.role_rank),
+                "ROLE_NAME": spec.role,
+                "LOCAL_WORLD_SIZE": str(spec.local_world_size),
+                "WORLD_SIZE": str(worker.world_size),
+                "ROLE_WORLD_SIZE": str(worker.role_world_size),
+                "MASTER_ADDR": master_addr,
+                "MASTER_PORT": str(master_port),
+                "TORCHELASTIC_RESTART_COUNT": str(restart_count),
+                "TORCHELASTIC_MAX_RESTARTS": str(spec.max_restarts),
+                "TORCHELASTIC_RUN_ID": spec.rdzv_handler.get_run_id(),
+                "NCCL_ASYNC_ERROR_HANDLING": str(1),
+            }
+            if "OMP_NUM_THREADS" in os.environ:
+                worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]
+            envs[local_rank] = worker_env
+            args[local_rank] = spec.args
+
+        # scaling events do not count towards restarts (gets same attempt #)
+        # remove existing log dir if this restart is due to a scaling event
+        attempt_log_dir = os.path.join(self._log_dir, f"attempt_{restart_count}")
+        shutil.rmtree(attempt_log_dir, ignore_errors=True)
+        os.makedirs(attempt_log_dir)
+
+        self._pcontext = start_processes(
+            name=spec.role,
+            entrypoint=spec.entrypoint,
+            args=args,
+            envs=envs,
+            log_dir=attempt_log_dir,
+            start_method=self._start_method,
+            redirects=spec.redirects,
+            tee=spec.tee,
+        )
+
+        return self._pcontext.pids()
+
+    def _shutdown(self) -> None:
+        if self._pcontext:
+            self._pcontext.close()
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    #  `torch.distributed.elastic.metrics.prof`.
+    @prof
+    def _monitor_workers(self, worker_group: WorkerGroup) -> RunResult:
+        role = worker_group.spec.role
+        worker_pids = {w.id for w in worker_group.workers}
+        pc_pids = set(self._pcontext.pids().values())
+        if worker_pids != pc_pids:
+            log.error(
+                f"[{role}] worker pids do not match process_context pids."
+                f" Expected: {worker_pids}, actual: {pc_pids}"
+            )
+            return RunResult(state=WorkerState.UNKNOWN)
+
+        result = self._pcontext.wait(0)
+        if result:
+            if result.is_failed():
+                log.error(f"[{role}] Worker group failed")
+                # map local rank failure to global rank
+                worker_failures = {}
+                for local_rank, failure in result.failures.items():
+                    worker = worker_group.workers[local_rank]
+                    worker_failures[worker.global_rank] = failure
+                return RunResult(
+                    state=WorkerState.FAILED,
+                    failures=worker_failures,
+                )
+            else:
+                # copy ret_val_queue into a map with a global ranks
+                workers_ret_vals = {}
+                for local_rank, ret_val in result.return_values.items():
+                    worker = worker_group.workers[local_rank]
+                    workers_ret_vals[worker.global_rank] = ret_val
+                return RunResult(
+                    state=WorkerState.SUCCEEDED,
+                    return_values=workers_ret_vals,
+                )
+        else:
+            return RunResult(state=WorkerState.HEALTHY)


### PR DESCRIPTION
Summary: Move torchelastic/agent to torch/distributed/elastic/agent

Test Plan:
buck test mode/dev-nosan //pytorch/elastic/torchelastic/...
      buck test mode/dev-nosan //caffe2/test/distributed/elastic/agent/server/test/...

Differential Revision: D27173271

