### PR TITLE
Backup .circleci/config.yml before regenerating

### DIFF
--- a/.circleci/regenerate.sh
+++ b/.circleci/regenerate.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -xe
 
 # Allows this script to be invoked from any directory:
-cd $(dirname "$0")
+cd "$(dirname "$0")"
 
+OLD_FILE=$(mktemp)
+cp config.yml "$OLD_FILE"
 NEW_FILE=$(mktemp)
-./generate_config_yml.py > $NEW_FILE
-cp $NEW_FILE config.yml
+./generate_config_yml.py > "$NEW_FILE"
+cp "$NEW_FILE" config.yml


### PR DESCRIPTION
If you accidentally modify `.circleci/config.yml` directly and then run `.circleci/regenerate.sh`, it clobbers your changes. This PR saves the previous contents of `.circleci/config.yml` to a temporary file, whose name is printed to the console due to the `-x` already present in the script.

**Test plan:**

```
$ echo "418 I'm a teapot" > .circleci/config.yml
$ .circleci/regenerate.sh
```

Before:
```
++ dirname .circleci/regenerate.sh
+ cd .circleci
++ mktemp
+ NEW_FILE=/var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.vW7yBQT2
+ ./generate_config_yml.py
+ cp /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.vW7yBQT2 config.yml
```
```
$ echo ':('
:(
```

After:
```
++ dirname .circleci/regenerate.sh
+ cd .circleci
++ mktemp
+ OLD_FILE=/var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.54GhUh7w
+ cp config.yml /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.54GhUh7w
++ mktemp
+ NEW_FILE=/var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.aV87RTvQ
+ ./generate_config_yml.py
+ cp /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.aV87RTvQ config.yml
```
```
$ cat /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.54GhUh7w
418 I'm a teapot
$ echo ':D'
:D
```