### PR TITLE
[StaticRuntime] Copy version of reshape/flatten

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -74,6 +74,7 @@ const auto reshape_script_3 = R"JIT(
       return b.reshape(shape), g
 )JIT";
 
+// exercise reshape_copy and flatten_copy
 const auto reshape_script_4 = R"JIT(
   def forward(self, inp: Tensor, shape: List[int]):
       k = inp + inp
@@ -83,11 +84,12 @@ const auto reshape_script_4 = R"JIT(
       return b + c
 )JIT";
 
+// exercise reshape_copy
 const auto reshape_script_5 = R"JIT(
   def forward(self, inp: Tensor, shape: List[int]):
       a = inp + inp
       b = a.reshape(shape)
-      c = a.reshape(shape)
+      c = a.reshape(shape).relu()
       d = c + c
       e = d + d
       f = e * e
@@ -106,10 +108,13 @@ const auto reshape_inplace_script = R"JIT(
       return (d, e, f)
 )JIT";
 
+// exercise flatten_copy
 const auto flatten_script_1 = R"JIT(
   def forward(self, a: Tensor, start_dim: int, end_dim: int):
-      b = torch.flatten(a, start_dim, end_dim)
-      return b + b
+      b = a * a
+      c = torch.flatten(b, start_dim, end_dim)
+      d = torch.relu(c)
+      return d
 )JIT";
 
 const auto flatten_script_2 = R"JIT(

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -34,8 +34,8 @@ void compareTensorLists(
   for (int i = 0; i < l.size(); ++i) {
     ASSERT_TRUE(l[i].isTensor());
     ASSERT_TRUE(r[i].isTensor());
-    LOG(INFO) << "expect " << i << ": \n" << l[i] << std::endl;
-    LOG(INFO) << "output " << i << ": \n" << r[i] << std::endl;
+    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
+    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
     if (! l[i].toTensor().defined()) {
       EXPECT_TRUE(! r[i].toTensor().defined());
     } else {
@@ -49,8 +49,8 @@ void compareTensorLists(
     const std::vector<at::Tensor>& r /* values */) {
   EXPECT_TRUE(l.size() == r.size());
   for (int i = 0; i < l.size(); ++i) {
-    LOG(INFO) << "expect " << i << ": \n" << l[i] << std::endl;
-    LOG(INFO) << "output " << i << ": \n" << r[i] << std::endl;
+    VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
+    VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
     if (! l[i].defined()) {
       EXPECT_TRUE(! r[i].defined());
     } else {

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -11,6 +11,7 @@
 #include <torch/csrc/jit/runtime/custom_operator.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/ops.h>
+#include <torch/csrc/jit/runtime/static/passes.h>
 
 namespace torch {
 namespace jit {
@@ -19,6 +20,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size);
 
 void fuseStaticSubgraphs(std::shared_ptr<Graph> graph, size_t min_size) {
   Inline(*graph);
+  ReplaceWithCopy(graph);
   ConstantPropagation(graph);
   Canonicalize(graph);
   ConstantPropagation(graph);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -18,48 +18,34 @@
 
 namespace at {
 namespace native {
-// The out variants of view ops can't be moved to aten because they don't
-// exactly follow the semantics of the aten ops. aten::reshape/flatten create
-// views, t, that are tracked by autograd and t.is_view() returns true. Here
-// t.is_view() would return false instead.
-at::Tensor& reshape_out(
+// copy version of view ops
+at::Tensor& reshape_copy_out(
     at::Tensor& out,
     const at::Tensor& self,
     const std::vector<int64_t>& proposed_shape,
     bool infer_size = true) {
   auto shape = infer_size ? at::infer_size(proposed_shape, self.numel())
                           : proposed_shape;
-  auto stride = at::detail::computeStride(self.sizes(), self.strides(), shape);
+  at::native::resize_(out, shape, c10::nullopt);
 
-  if (stride.has_value()) {
-    // create view
-    if (!out.defined() || !out.storage().is_alias_of(self.storage())) {
-      auto impl = c10::make_intrusive<c10::TensorImpl>(
-          c10::Storage(self.storage()), self.key_set(), self.dtype());
-      out = at::Tensor(std::move(impl));
-    }
-
-    c10::TensorImpl* impl = out.unsafeGetTensorImpl();
-    impl->set_storage_offset(self.storage_offset());
-    impl->set_sizes_and_strides(shape, *stride);
-  } else {
-    // copy over tensor
-    if (!out.defined()) {
-      out = at::native::empty_like(
-          self, self.options(), at::MemoryFormat::Contiguous);
-    }
-    // copy first and set shape/strides later. It doesn't work the other way
-    // around.
-    at::native::copy_(out, self);
-    stride = at::detail::computeStride(out.sizes(), out.strides(), shape);
-    c10::TensorImpl* impl = out.unsafeGetTensorImpl();
-    impl->set_sizes_and_strides(shape, *stride);
+  if (!self.is_contiguous()) {
+    at::native::copy_(out, self, false /* non_blocking */);
+    return out;
   }
-  // namedinference::propagate_names(output, self);
+
+  size_t nbytes = self.nbytes();
+  if (nbytes == 0) {
+    return out;
+  }
+
+  const void* self_data = self.data_ptr();
+  void* out_data = out.data_ptr();
+  memcpy(out_data, self_data, nbytes);
+
   return out;
 }
 
-at::Tensor& flatten_out(
+at::Tensor& flatten_copy_out(
     at::Tensor& out,
     const at::Tensor& self,
     int64_t start_dim,
@@ -72,12 +58,12 @@ at::Tensor& flatten_out(
       "flatten() has invalid args: start_dim cannot come after end_dim");
 
   if (self.dim() == 0) {
-    return reshape_out(out, self, {1}, false);
+    return reshape_copy_out(out, self, {1}, false);
   }
 
   if (start_dim == end_dim) {
-    out = self;
-    return out;
+    auto shape = self.sizes().vec();
+    return reshape_copy_out(out, self, shape, false);
   }
 
   // We don't want to infer_size on the entire shape, because that can give us
@@ -101,7 +87,7 @@ at::Tensor& flatten_out(
   for (int64_t i = end_dim + 1; i < self.dim(); i++) {
     shape.push_back(self.sizes()[i]);
   }
-  return reshape_out(out, self, shape, false);
+  return reshape_copy_out(out, self, shape, false);
 }
 
 at::Tensor& to_copy_out(Tensor& out, const Tensor& self, bool non_blocking) {
@@ -789,7 +775,7 @@ REGISTER_OPERATOR_FUNCTOR(
 // Out variants for view ops are registered to a separate registry because
 // their outputs (views) can't participate in memory reuse.
 REGISTER_OPERATOR_FUNCTOR(
-    aten::reshape,
+    static_runtime::reshape_copy,
     aten_reshape,
     [](Node* n) -> SROperator {
       return [](ProcessedNode* p_node) {
@@ -797,15 +783,15 @@ REGISTER_OPERATOR_FUNCTOR(
         const auto proposed_shape = p_node->Input(1).toIntVector(); // shape
 
         if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = at::Tensor();
+          p_node->Output(0) = create_empty_from(self);
         }
         auto& out = p_node->Output(0).toTensor();
-        at::native::reshape_out(out, self, proposed_shape, true);
+        at::native::reshape_copy_out(out, self, proposed_shape, true);
       };
     });
 
 REGISTER_OPERATOR_FUNCTOR(
-    aten::flatten,
+    static_runtime::flatten_copy,
     aten_flatten,
     [](Node* n) -> SROperator {
       return [](ProcessedNode* p_node) {
@@ -815,10 +801,10 @@ REGISTER_OPERATOR_FUNCTOR(
         const auto end_dim = p_node->Input(2).toInt();
 
         if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = at::Tensor();
+          p_node->Output(0) = create_empty_from(self);
         }
         auto& out = p_node->Output(0).toTensor();
-        at::native::flatten_out(out, self, start_dim, end_dim);
+        at::native::flatten_copy_out(out, self, start_dim, end_dim);
       };
     });
 


### PR DESCRIPTION
Summary: The current implementation of reshape/flatten is problematic because whether the output is sometimes a tensor view and sometimes not. It entirely depends on the graph ir and input shapes. Replacing them with the copy version makes it deterministic and the output is always a tensor.

Reviewed By: ajyu, edvgha

Differential Revision: D26358525

