### PR TITLE
<tensorexpr> Add python bindings for missing loop transformations in LoopNest

### DIFF
--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -290,6 +290,44 @@ void initTensorExprBindings(PyObject* module) {
           },
           py::return_value_policy::reference)
       .def(
+          "slice_head",
+          [](LoopNest& self, For* f, int factor) {
+            For *head = nullptr, *tail = nullptr;
+            self.sliceHead(f, factor, &head, &tail);
+            return std::make_tuple(head, tail);
+          },
+          py::return_value_policy::reference)
+      .def(
+          "slice_tail",
+          [](LoopNest& self, For* f, int factor) {
+            For *head = nullptr, *tail = nullptr;
+            self.sliceTail(f, factor, &head, &tail);
+            return std::make_tuple(head, tail);
+          },
+          py::return_value_policy::reference)
+      .def_static(
+          "normalize",
+          [](For* f) {
+            For* normalized = nullptr;
+            LoopNest::normalize(f, &normalized);
+            return normalized;
+          },
+          py::return_value_policy::reference)
+      .def_static(
+          "distribute_loop",
+          [](For* f) { return LoopNest::distributeLoop(f); },
+          py::return_value_policy::reference)
+      .def_static(
+          "distribute_loop",
+          [](For* f, const std::unordered_set<Stmt*>& pivots) {
+            return LoopNest::distributeLoop(f, pivots);
+          },
+          py::return_value_policy::reference)
+      .def_static(
+          "distribute_loop_over_inner_loops",
+          [](For* f) { return LoopNest::distributeLoopOverInnerLoops(f); },
+          py::return_value_policy::reference)
+      .def(
           "unroll",
           [](const LoopNest& self, For* f) {
             Stmt* unrolled = nullptr;
@@ -301,6 +339,18 @@ void initTensorExprBindings(PyObject* module) {
           "vectorize",
           [](const LoopNest& self, For* f) { self.vectorize(f); },
           py::return_value_policy::reference)
+      .def(
+          "cache_accesses",
+          [](LoopNest& self,
+             const Buf* producer,
+             const std::string& name,
+             Stmt* consumer) {
+            return self.cacheAccesses(producer, name, consumer);
+          },
+          py::return_value_policy::reference)
+      .def(
+          "compute_at",
+          [](LoopNest& self, Stmt* s, For* at) { self.computeAt(s, at); })
       .def(
           "compute_inline",
           [](LoopNest& self, Stmt* s) { self.computeInline(s); },
@@ -355,6 +405,14 @@ void initTensorExprBindings(PyObject* module) {
           "set_GPU_thread_index",
           &LoopNest::setGPUThreadIndex,
           py::return_value_policy::reference)
+      .def(
+          "inline_intermediate_bufs",
+          [](LoopNest& self, bool allow_duplicated_work) {
+            self.inlineIntermediateBufs(allow_duplicated_work);
+          })
+      .def(
+          "eliminate_dead_stores",
+          [](LoopNest& self) { self.eliminateDeadStores(); })
       .def(
           "__str__",
           [](const LoopNest& self) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54355 <tensorexpr> Add python bindings for missing loop transformations in LoopNest**

Differential Revision: [D27202561](https://our.internmc.facebook.com/intern/diff/D27202561)