### PR TITLE
add uncommit change detector

### DIFF
--- a/.circleci/regenerate.sh
+++ b/.circleci/regenerate.sh
@@ -1,10 +1,17 @@
-#!/bin/bash -xe
+#!/bin/bash -e
 
 # Allows this script to be invoked from any directory:
 cd "$(dirname "$0")"
 
-OLD_FILE=$(mktemp)
-cp config.yml "$OLD_FILE"
+UNCOMMIT_CHANGE=$(git status -s | grep " config.yml" | wc -l | xargs)
+if [[ $UNCOMMIT_CHANGE != 0 ]]; then
+    OLD_FILE=$(mktemp)
+    cp config.yml "$OLD_FILE"
+    echo "Uncommitted change detected in .circleci/config.yml"
+    echo "It has been backed up to $OLD_FILE"
+fi
+
 NEW_FILE=$(mktemp)
 ./generate_config_yml.py > "$NEW_FILE"
 cp "$NEW_FILE" config.yml
+echo "New config generated in .circleci/config.yml"

--- a/.circleci/regenerate.sh
+++ b/.circleci/regenerate.sh
@@ -3,7 +3,7 @@
 # Allows this script to be invoked from any directory:
 cd "$(dirname "$0")"
 
-UNCOMMIT_CHANGE=$(git status -s | grep " config.yml" | wc -l | xargs)
+UNCOMMIT_CHANGE=$(git status -s | grep -c " config.yml")
 if [[ $UNCOMMIT_CHANGE != 0 ]]; then
     OLD_FILE=$(mktemp)
     cp config.yml "$OLD_FILE"


### PR DESCRIPTION
warn if uncommit changes exists in .circleci/config.yml, unlike other generated code, .circleci/config.yml actually commits to the repo. (this is a follow up of #54345)

two options I am open to
1. abort regenerate if detected 
2. print out backed up temp filename  

Also remove the `-x` since it is currently very verbose
```
++ dirname .circleci/regenerate.sh
+ cd .circleci
++ mktemp
+ OLD_FILE=/var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.54GhUh7w
+ cp config.yml /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.54GhUh7w
++ mktemp
+ NEW_FILE=/var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.aV87RTvQ
+ ./generate_config_yml.py
+ cp /var/folders/vw/ryb6j4d97xs1t_14024b710h0000gn/T/tmp.aV87RTvQ config.yml
```

Test Plan
1. 
```
$ echo "418 I'm a teapot" > .circleci/config.yml
$ .circleci/regenerate.sh
$ .circleci/regenerate.sh
```
Result:
```
$ .circleci/regenerate.sh
Uncommitted change detected in .circleci/config.yml
It has been backed up to /var/folders/89/brnr1wt970130lk0m52605mw0000gn/T/tmp.2VOp4BPo
New config generated in .circleci/config.yml
$ .circleci/regenerate.sh  #-- second time there's no uncommitted changes
New config generated in .circleci/config.yml
```

2. 
```
$ echo "418 I'm a teapot" > .circleci/config.yml
$ git add .circleci/config.yml
$ .circleci/regenerate.sh
$ .circleci/regenerate.sh
```
Result:
```
$ .circleci/regenerate.sh
Uncommitted change detected in .circleci/config.yml
It has been backed up to /var/folders/89/brnr1wt970130lk0m52605mw0000gn/T/tmp.2VOp4BPo
New config generated in .circleci/config.yml
$ .circleci/regenerate.sh #-- second time there's still uncommitted changes b/c git split staged vs unstaged changes
Uncommitted change detected in .circleci/config.yml
It has been backed up to /var/folders/89/brnr1wt970130lk0m52605mw0000gn/T/tmp.2ruMAynI
New config generated in .circleci/config.yml
```