### PR TITLE
Set requires_gradient to help autodiff to prune unneeded gradients

### DIFF
--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -58,14 +58,15 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             return torch.nn.functional.relu(input + bias)
         input = torch.randn(2, 8, requires_grad=True)
         bias = torch.randn(8, requires_grad=False)    # bias does NOT require grad
-        NUM_PROFILED_RUNS  = 1
+        NUM_PROFILED_RUNS = 1
         with num_profiled_runs(NUM_PROFILED_RUNS):
-            WARMUP = 3 # 2 runs to reach backward + 1 to optimize it
+            WARMUP = 3 #  2 runs to reach backward + 1 to optimize it
             for x in range(WARMUP):
                 o = t(input, bias)
                 o.sum().backward()
 
-            bwd_graph = list(list(t.get_debug_state().execution_plans.values())[0].code.grad_executor_states()[0].execution_plans.values())[0].graph
+            fwd_plan = list(t.get_debug_state().execution_plans.values())[0]
+            bwd_graph = list(fwd_plan.code.grad_executor_states()[0].execution_plans.values())[0].graph
             tup = next(bwd_graph.outputs())
             self.assertEqual(len(list(tup.node().inputs())), 1)
 

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -60,7 +60,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
         bias = torch.randn(8, requires_grad=False)    # bias does NOT require grad
         NUM_PROFILED_RUNS = 1
         with num_profiled_runs(NUM_PROFILED_RUNS):
-            WARMUP = 3 #  2 runs to reach backward + 1 to optimize it
+            WARMUP = 3    # 2 runs to reach backward + 1 to optimize it
             for x in range(WARMUP):
                 o = t(input, bias)
                 o.sum().backward()

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -49,12 +49,12 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
                 output = func(input, profile_and_replay=True)
                 self.assertAutodiffNode(func.graph_for(input), True, ['prim::ConstantChunk'], [])
 
-    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    #@unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     def test_differentiable_graph_ops_requires_grad(self):
-        x = torch.randn(8, 2, dtype=torch.float, device="cuda").requires_grad_()
-        y = torch.randn(8, 2, dtype=torch.float, device="cuda")
+        x = torch.randn(8, 2, dtype=torch.float).requires_grad_()
+        y = torch.randn(8, 2, dtype=torch.float)
 
         def t(x : torch.Tensor, y : torch.Tensor):
             o = x + 1.0
@@ -64,22 +64,23 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             o3 = o1 + o2
             return o1, o2, o3
 
-        t_jit = torch.jit.script(t)
-        jit_o = t_jit(x, y)
-        jit_o = t_jit(x, y)
-        o = t(x, y)
+        with enable_profiling_mode_for_profiling_tests():
 
-        # validate the differentiableGraphOps are marking proper requires_grad
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
-            self.assertEqual(oo, jit_oo)
-        # one more runs to trigger fusion
-        jit_o = t_jit(x, y)
-        for oo, jit_oo in zip(o, jit_o):
-            self.assertEqual(oo.dtype, jit_oo.dtype)
-            self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
-            self.assertEqual(oo, jit_oo)
-        self.assertGraphContainsExactly(t_jit.graph_for(x, y), FUSION_GUARD, 1, True)
+            t_jit = torch.jit.script(t)
+            jit_o = t_jit(x, y)
+            jit_o = t_jit(x, y)
+            o = t(x, y)
+
+            # validate the differentiableGraphOps are marking proper requires_grad
+            for oo, jit_oo in zip(o, jit_o):
+                self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
+                self.assertEqual(oo, jit_oo)
+            # one more runs to trigger fusion
+            jit_o = t_jit(x, y)
+            for oo, jit_oo in zip(o, jit_o):
+                self.assertEqual(oo.dtype, jit_oo.dtype)
+                self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
+                self.assertEqual(oo, jit_oo)
 
     @unittest.skipIf(GRAPH_EXECUTOR == ProfilingMode.PROFILING, "Simple Executor doesn't support gradients")
     def test_prune_grad(self):

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -69,7 +69,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             jit_o = t_jit(x, y)
             jit_o = t_jit(x, y)
             o = t(x, y)
- 
+
             FileCheck().check("prim::DifferentiableGraph").run(t_jit.graph_for(x, y))
             # validate the differentiableGraphOps are marking proper requires_grad
             for oo, jit_oo in zip(o, jit_o):

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -69,7 +69,8 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             jit_o = t_jit(x, y)
             jit_o = t_jit(x, y)
             o = t(x, y)
-
+            
+            FileCheck().check("prim::DifferentiableGraph").run(t_jit.graph_for(x, y))
             # validate the differentiableGraphOps are marking proper requires_grad
             for oo, jit_oo in zip(o, jit_o):
                 self.assertEqual(oo.requires_grad, jit_oo.requires_grad)

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -69,7 +69,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             jit_o = t_jit(x, y)
             jit_o = t_jit(x, y)
             o = t(x, y)
-            
+ 
             FileCheck().check("prim::DifferentiableGraph").run(t_jit.graph_for(x, y))
             # validate the differentiableGraphOps are marking proper requires_grad
             for oo, jit_oo in zip(o, jit_o):

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -49,7 +49,6 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
                 output = func(input, profile_and_replay=True)
                 self.assertAutodiffNode(func.graph_for(input), True, ['prim::ConstantChunk'], [])
 
-    #@unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")
     def test_differentiable_graph_ops_requires_grad(self):

--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -49,7 +49,37 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
                 output = func(input, profile_and_replay=True)
                 self.assertAutodiffNode(func.graph_for(input), True, ['prim::ConstantChunk'], [])
 
+    @unittest.skipIf(not RUN_CUDA, "requires CUDA")
+    @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
+                     "Requires fusion optimization pass to be effective")
+    def test_differentiable_graph_ops_requires_grad(self):
+        x = torch.randn(8, 2, dtype=torch.float, device="cuda").requires_grad_()
+        y = torch.randn(8, 2, dtype=torch.float, device="cuda")
 
+        def t(x : torch.Tensor, y : torch.Tensor):
+            o = x + 1.0
+            o1 = torch.relu(o)
+            o = y + 1.5
+            o2 = torch.relu(o)
+            o3 = o1 + o2
+            return o1, o2, o3
+
+        t_jit = torch.jit.script(t)
+        jit_o = t_jit(x, y)
+        jit_o = t_jit(x, y)
+        o = t(x, y)
+
+        # validate the differentiableGraphOps are marking proper requires_grad
+        for oo, jit_oo in zip(o, jit_o):
+            self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
+            self.assertEqual(oo, jit_oo)
+        # one more runs to trigger fusion
+        jit_o = t_jit(x, y)
+        for oo, jit_oo in zip(o, jit_o):
+            self.assertEqual(oo.dtype, jit_oo.dtype)
+            self.assertEqual(oo.requires_grad, jit_oo.requires_grad)
+            self.assertEqual(oo, jit_oo)
+        self.assertGraphContainsExactly(t_jit.graph_for(x, y), FUSION_GUARD, 1, True)
 
     @unittest.skipIf(GRAPH_EXECUTOR == ProfilingMode.PROFILING, "Simple Executor doesn't support gradients")
     def test_prune_grad(self):

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -136,6 +136,7 @@ static bool needsGradientInProfilingMode(Block* b) {
 // properties from inputs to the `prim::DifferentiableGraph` onto inputs to the
 // differentiable graph. Autodiff will inspect these properties and prune
 // off gradients that aren't required
+// `requires_grad` properties from `dnode->outputs()` will also be transferred
 static void setRequiresGradOnDiffGraph(Node* dnode) {
   auto gi = dnode->g(attr::Subgraph)->inputs();
   for (size_t i = 0; i < dnode->inputs().size(); i++) {
@@ -149,6 +150,41 @@ static void setRequiresGradOnDiffGraph(Node* dnode) {
           gi[i],
           " ",
           gi[i]->debugName());
+    }
+  }
+
+  // We also need to put requires_grad on outputs within subgraph, so autodiff
+  // can  set df_input_vjps and DifferentiableGraphOp can set `requires_grad=`
+  // properly
+  auto go = dnode->g(attr::Subgraph)->outputs();
+  for (size_t i = 0; i < go.size(); i++) {
+    auto ty = go[i]->type()->cast<TensorType>();
+    if (ty) {
+      auto n = go[i]->node();
+      auto dno = dnode->outputs().at(i);
+      auto dno_use0 = dno->uses().at(0);
+      GRAPH_DEBUG("found first user of ", i, " as ", *dno_use0.user);
+      if (n->kind() == prim::profile) {
+        GRAPH_DEBUG(
+            "setting output ", i, " to type ", *n->ty(attr::profiled_type));
+        go[i]->setType(n->ty(attr::profiled_type));
+      } else if (dno_use0.user->kind() == prim::profile) {
+        GRAPH_DEBUG(
+            "setting output ",
+            i,
+            " to type ",
+            *dno_use0.user->ty(attr::profiled_type));
+        go[i]->setType(dno_use0.user->ty(attr::profiled_type));
+      } else if (dno_use0.user->kind() == prim::DifferentiableGraph) {
+        Value* o =
+            dno_use0.user->g(attr::Subgraph)->inputs().at(dno_use0.offset);
+        auto nn = o->uses().at(0).user;
+        if (nn->kind() == prim::profile) {
+          GRAPH_DEBUG(
+              "setting output ", i, " to type ", *nn->ty(attr::profiled_type));
+          go[i]->setType(nn->ty(attr::profiled_type));
+        }
+      }
     }
   }
 }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -129,6 +129,13 @@ static bool needsGradientInProfilingMode(Block* b) {
   return false;
 }
 
+// `prim::RequiresGradCheck` guarantees that requires_grad properties
+// of input tensors will match the profiled, otherwise a fallback path
+// will be triggered. This allow us to prune off gradients in backward
+// graph for inputs that don't need gradients. We transfer requires_grad
+// properties from inputs to the `prim::DifferentiableGraph` onto inputs to the
+// differentiable graph. Autodiff will inspect these properties and prune
+// off gradients that aren't required
 static void setRequiresGradOnDiffGraph(Node* dnode) {
   auto gi = dnode->g(attr::Subgraph)->inputs();
   for (size_t i = 0; i < dnode->inputs().size(); i++) {


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/54040
`prim::RequiresGradCheck` guarantees that requires_grad properties
of input tensors will match the profiled, otherwise a fallback path
will be triggered. This allow us to prune off gradients in backward
graph for inputs that don't need gradients. We transfer requires_grad
properties from inputs to the `prim::DifferentiableGraph` onto inputs to the
differentiable graph. Autodiff will inspect these properties and prune
off gradients that aren't required