### PR TITLE
[WIP] Optimized ragged token -> padded batch function for pytext

### DIFF
--- a/aten/src/ATen/native/PackedSequence.cpp
+++ b/aten/src/ATen/native/PackedSequence.cpp
@@ -224,7 +224,7 @@ std::tuple<Tensor, Tensor> ragged_indices_to_padded_tensor_and_mask(
     }
   }
 
-  return {padded_tensor, mask_tensor};
+  return std::tuple<Tensor, Tensor>{padded_tensor, mask_tensor};
 }
 
 TORCH_LIBRARY(padded, m) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54380 [WIP] Optimized ragged token -> padded batch function for pytext**

This gives us a 1000x speedup over the original implementation: https://gist.github.com/jamesr66a/e8145b58f37542072bb9af383d744701

Differential Revision: [D27218002](https://our.internmc.facebook.com/intern/diff/D27218002)