### PR TITLE
Deprecate legacy constructor `torch.Tensor()`

### DIFF
--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -162,9 +162,8 @@ view of a storage and defines numeric operations on it.
 
    .. warning::
       The :class:`torch.Tensor` constructor is deprecated. Instead, consider using:
-      :func:`torch.tensor` for creating tensors out of tensor-like objects (e.g. lists and tuples);
-      or :func:`torch.empty` for creating uninitialized tensors out of a set of dimension
-      sizes (e.g. int).
+      :func:`torch.tensor` for creating tensors from tensor-like objects (e.g. lists and tuples);
+      or :func:`torch.empty` for creating uninitialized tensors with specific sizes (e.g. int).
 
    .. automethod:: new_tensor
    .. automethod:: new_full

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -160,6 +160,12 @@ view of a storage and defines numeric operations on it.
    - To create a tensor with similar type but different size as another tensor,
      use ``tensor.new_*`` creation ops.
 
+   .. warning::
+      The :class:`torch.Tensor` constructor is deprecated. Instead, consider using:
+      :func:`torch.tensor` for creating tensors out of tensor-like objects (e.g. lists and tuples);
+      or :func:`torch.empty` for creating uninitialized tensors out of a set of dimension
+      sizes (e.g. int).
+
    .. automethod:: new_tensor
    .. automethod:: new_full
    .. automethod:: new_empty

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -470,6 +470,11 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
     return legacy_sparse_tensor_ctor(dispatch_key, scalar_type, args, kwargs);
   }
 
+  TORCH_WARN_ONCE(
+      "Legacy tensor constructor is deprecated. "
+      "Use: torch.tensor(...) for creating a tensor out of a tensor-like object; "
+      "or torch.empty(...) for creating an uninitialized tensor out of dimension sizes.");
+
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);
   if (r.idx == 0) {

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -472,8 +472,8 @@ Tensor legacy_tensor_ctor(c10::DispatchKey dispatch_key, at::ScalarType scalar_t
 
   TORCH_WARN_ONCE(
       "Legacy tensor constructor is deprecated. "
-      "Use: torch.tensor(...) for creating a tensor out of a tensor-like object; "
-      "or torch.empty(...) for creating an uninitialized tensor out of dimension sizes.");
+      "Use: torch.tensor(...) for creating tensors from tensor-like objects; "
+      "or torch.empty(...) for creating an uninitialized tensor with specific sizes.");
 
   ParsedArgs<2> parsed_args;
   auto r = parser.parse(args, kwargs, parsed_args);


### PR DESCRIPTION
Fixes #47112

This pull request is the final step in [the proposed plan](https://github.com/pytorch/pytorch/issues/47112#issuecomment-789972007) for deprecating `torch.Tensor()` constructor. Specifically, it **updates the docs and throws `TORCH_WARN_ONCE` if someone uses `torch.Tensor()`**.