### PR TITLE
[PyTorch] Update Bazel build for TensorPipe

### DIFF
--- a/third_party/tensorpipe.BUILD
+++ b/third_party/tensorpipe.BUILD
@@ -78,6 +78,7 @@ header_template_rule(
         "#cmakedefine01 TENSORPIPE_HAS_SHM_TRANSPORT": "",
         "#cmakedefine01 TENSORPIPE_HAS_CMA_CHANNEL": "",
         "#cmakedefine01 TENSORPIPE_HAS_CUDA_IPC_CHANNEL": "",
+        "#cmakedefine01 TENSORPIPE_HAS_CUDA_GDR_CHANNEL": "",
         "#cmakedefine01 TENSORPIPE_HAS_IBV_TRANSPORT": "",
         "#cmakedefine01 TENSORPIPE_SUPPORTS_CUDA": "",
     },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54416 [PyTorch] Update Bazel build for TensorPipe**

Once D27230990 lands, we'll need this for TensorPipe to be built with Bazel.

Differential Revision: [D27231000](https://our.internmc.facebook.com/intern/diff/D27231000/)