### PR TITLE
Update CMakeLists for frozen_conv_add_relu_fusion

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -627,6 +627,10 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_ROOT}/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
       PROPERTIES COMPILE_DEFINITIONS "NVRTC_SHORTHASH=${CUDA_NVRTC_SHORTHASH}"
     )
+    set_source_files_properties(
+      ${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
+      PROPERTIES COMPILE_DEFINITIONS "USE_CUDA"
+    )
   endif()
 
   if(USE_MLCOMPUTE)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -336,6 +336,7 @@ jit_sources_full = [
     "torch/csrc/jit/runtime/register_prim_ops.cpp",
     "torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp",
     "torch/csrc/jit/runtime/register_special_ops.cpp",
+    "torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp",
     "torch/csrc/jit/passes/remove_inplace_ops.cpp",
     "torch/csrc/jit/passes/utils/check_alias_annotation.cpp",
 ]
@@ -551,7 +552,6 @@ libtorch_python_core_sources = [
     "torch/csrc/autograd/python_variable_indexing.cpp",
     "torch/csrc/jit/backends/backend_init.cpp",
     "torch/csrc/jit/python/init.cpp",
-    "torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp",
     "torch/csrc/jit/passes/onnx/eval_peephole.cpp",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54417 Update CMakeLists for frozen_conv_add_relu_fusion**
* #52102 [JIT] Add CUDNN Conv-Add-Relu fusion for Frozen Model Optimization

Summary: Move frozen_conv_add_relu_fusion.cpp from libtorch_python_core_sources to jit_sources_full, and add USE_CUDA macro for its compilation.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: