### PR TITLE
Update CMakeLists for frozen_conv_add_relu_fusion

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -627,10 +627,12 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_ROOT}/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
       PROPERTIES COMPILE_DEFINITIONS "NVRTC_SHORTHASH=${CUDA_NVRTC_SHORTHASH}"
     )
-    set_source_files_properties(
-      ${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
-      PROPERTIES COMPILE_DEFINITIONS "USE_CUDA"
-    )
+    if(USE_CUDNN)
+      set_source_files_properties(
+        ${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
+        PROPERTIES COMPILE_DEFINITIONS "USE_CUDA"
+      )
+    endif()
   endif()
 
   if(USE_MLCOMPUTE)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -630,7 +630,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
     if(USE_CUDNN)
       set_source_files_properties(
         ${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
-        PROPERTIES COMPILE_DEFINITIONS "USE_CUDA"
+        PROPERTIES COMPILE_DEFINITIONS "USE_CUDNN"
       )
     endif()
   endif()

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -627,6 +627,10 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
       ${TORCH_ROOT}/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
       PROPERTIES COMPILE_DEFINITIONS "NVRTC_SHORTHASH=${CUDA_NVRTC_SHORTHASH}"
     )
+    set_source_files_properties(
+      ${TORCH_SRC_DIR}/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
+      PROPERTIES COMPILE_DEFINITIONS "USE_CUDA"
+    )
   endif()
 
   if(USE_MLCOMPUTE)

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -336,6 +336,7 @@ jit_sources_full = [
     "torch/csrc/jit/runtime/register_prim_ops.cpp",
     "torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp",
     "torch/csrc/jit/runtime/register_special_ops.cpp",
+    "torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp",
     "torch/csrc/jit/passes/remove_inplace_ops.cpp",
     "torch/csrc/jit/passes/utils/check_alias_annotation.cpp",
 ]
@@ -551,7 +552,6 @@ libtorch_python_core_sources = [
     "torch/csrc/autograd/python_variable_indexing.cpp",
     "torch/csrc/jit/backends/backend_init.cpp",
     "torch/csrc/jit/python/init.cpp",
-    "torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp",
     "torch/csrc/jit/passes/onnx.cpp",
     "torch/csrc/jit/passes/onnx/cast_all_constant_to_floating.cpp",
     "torch/csrc/jit/passes/onnx/eval_peephole.cpp",

--- a/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_add_relu_fusion.cpp
@@ -8,17 +8,13 @@
 #include <torch/csrc/jit/passes/graph_rewrite_helper.h>
 #include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
-#ifdef USE_CUDA
-#include <ATen/cuda/CUDAConfig.h>
-#endif
 
 namespace torch {
 namespace jit {
 
 namespace {
 void fuseFrozenConvAddReluImpl(std::shared_ptr<Graph>& graph) {
-#ifdef USE_CUDA
-#if AT_CUDNN_ENABLED()
+#ifdef USE_CUDNN
   SubgraphRewriter rewriter;
 
   // TODO: fix CUDNN conv1d and conv3d failure
@@ -102,7 +98,6 @@ void fuseFrozenConvAddReluImpl(std::shared_ptr<Graph>& graph) {
   });
 
   rewriter.runOnGraph(graph, filter);
-#endif
 #endif
 }
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54423 Update CMakeLists for frozen_conv_add_relu_fusion**

Summary: Move frozen_conv_add_relu_fusion.cpp from libtorch_python_core_sources to jit_sources_full, and add USE_CUDA macro for its compilation.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27231899](https://our.internmc.facebook.com/intern/diff/D27231899)