### PR TITLE
Use c10::ArrayRef instead of std::vector for the jit::unpickle's tensor_table.

### DIFF
--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<CleanupAutogradContextReq> CleanupAutogradContextReq::
       payload,
       payload_size,
       *rpc::RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
 
   // convert ivalue to int and construct request
   int64_t context_id = ivalue_context_id.toInt();

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<PropagateGradientsReq> PropagateGradientsReq::fromMessage(
       payload,
       payload_size,
       *rpc::RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   std::vector<at::IValue> tupleElements = tuple.toTuple()->elements();
 
   // Build PropagateGradientsReq.

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<RRefBackwardReq> RRefBackwardReq::fromMessage(
       payload,
       payload_size,
       *rpc::RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   std::vector<at::IValue> tupleElements = tuple.toTuple()->elements();
 
   // Build RRefBackwardReq.

--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -41,7 +41,7 @@ std::unique_ptr<PythonRemoteCall> PythonRemoteCall::fromMessage(
       payload,
       payload_size,
       *RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   auto values = value.toTuple()->elements();
 
   // remove the last elements from values and convert it back to an RRef

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -24,7 +24,7 @@ std::vector<IValue> toIValues(const Message& message, MessageType type) {
       payload,
       payload_size,
       *RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   return value.toTuple()->elements();
 }
 

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -127,7 +127,7 @@ std::unique_ptr<ScriptCall> ScriptCall::fromMessage(const Message& message) {
       payload,
       payload_size,
       *RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
 
   auto values = value.toTuple()->elements();
   return fromIValues(values);

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromMessage(
       payload,
       payload_size,
       *RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   auto values = value.toTuple()->elements();
   return fromIValues(values);
 }

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<ScriptResp> ScriptResp::fromMessage(const Message& message) {
       payload,
       payload_size,
       *RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &message.tensors());
+      message.tensors());
   return std::make_unique<ScriptResp>(std::move(value));
 }
 

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -512,7 +512,7 @@ std::vector<at::IValue> readWrappedPayload(
       wrappedPayloadBegin,
       additionalPayloadSize,
       *rpc::RpcAgent::getCurrentRpcAgent()->getTypeResolver(),
-      &tensorTable);
+      tensorTable);
   std::vector<at::IValue> tupleElements = tuple.toTuple()->elements();
   payload.resize(payload.size() - additionalPayloadSize);
   return tupleElements;

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -152,7 +152,7 @@ IValue ScriptModuleDeserializer::LEGACY_loadPickleArchive(
         auto cls = source_importer_.loadType(qn)->expect<ClassType>();
         return c10::StrongTypePtr(compilation_unit_, std::move(cls));
       },
-      &tensor_table_);
+      tensor_table_);
   return ivalue;
 }
 

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -118,7 +118,7 @@ IValue pickle_load(const std::vector<char>& data) {
 IValue unpickle(
     std::function<size_t(char*, size_t)> reader,
     TypeResolver type_resolver,
-    const std::vector<at::Tensor>* tensor_table) {
+    c10::ArrayRef<at::Tensor> tensor_table) {
   Unpickler unpickler(
       std::move(reader), std::move(type_resolver), tensor_table);
   return unpickler.parse_ivalue();
@@ -128,7 +128,7 @@ IValue unpickle(
     const char* data,
     size_t size,
     TypeResolver type_resolver,
-    const std::vector<at::Tensor>* tensor_table) {
+    c10::ArrayRef<at::Tensor> tensor_table) {
   size_t bytes_read = 0;
   return unpickle(
       [&](char* buffer, size_t len) -> size_t {

--- a/torch/csrc/jit/serialization/pickle.h
+++ b/torch/csrc/jit/serialization/pickle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <c10/util/ArrayRef.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/serialization/pickler.h>
@@ -68,7 +69,7 @@ TORCH_API IValue pickle_load(const std::vector<char>& data);
 TORCH_API IValue unpickle(
     std::function<size_t(char*, size_t)> reader,
     TypeResolver type_resolver,
-    const std::vector<at::Tensor>* tensor_table);
+    c10::ArrayRef<at::Tensor> tensor_table);
 
 /// Decode a chunk of memory containing pickled data into its `torch::IValue`s.
 ///
@@ -80,7 +81,7 @@ TORCH_API IValue unpickle(
     const char* data,
     size_t size,
     TypeResolver type_resolver = nullptr,
-    const std::vector<at::Tensor>* tensor_table = nullptr);
+    c10::ArrayRef<at::Tensor> tensor_table = {});
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -461,9 +461,9 @@ void Unpickler::readGlobal(
         auto setitem_data = stack_.back();
         stack_.pop_back();
         TORCH_INTERNAL_ASSERT(
-            tensor_table_,
+            !tensor_table_.empty(),
             "Pickler tried to write a tensor but had no tensor table to write to");
-        stack_.emplace_back(tensor_table_->at(setitem_data.toInt()));
+        stack_.emplace_back(tensor_table_.at(setitem_data.toInt()));
       });
     } else if (class_name == "IntList") {
       globals_.emplace_back([this] {
@@ -479,10 +479,10 @@ void Unpickler::readGlobal(
         auto data = stack_.back().toTuple()->elements().at(0);
         stack_.pop_back();
         TORCH_CHECK(
-            tensor_table_,
+            !tensor_table_.empty(),
             "Found a tensor table reference but Unpickler"
             " has no tensor table\n");
-        stack_.emplace_back(tensor_table_->at(data.toInt()));
+        stack_.emplace_back(tensor_table_.at(data.toInt()));
       });
     } else if (class_name == "restore_type_tag") {
       globals_.emplace_back([this] {
@@ -787,7 +787,7 @@ void Unpickler::readList(IValue list_ivalue) {
   size_t start = marks_.back();
   marks_.pop_back();
   auto num_elements = stack_.size() - start;
-  auto elements = at::ArrayRef<IValue>(stack_).slice(start);
+  auto elements = c10::ArrayRef<IValue>(stack_).slice(start);
   if (list_ivalue.isIntList()) {
     auto list = std::move(list_ivalue).toIntList();
     list.reserve(num_elements);

--- a/torch/csrc/jit/serialization/unpickler.h
+++ b/torch/csrc/jit/serialization/unpickler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/core/ivalue.h>
+#include <c10/util/ArrayRef.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/serialization/pickler.h>
@@ -30,7 +31,7 @@ class TORCH_API Unpickler {
   Unpickler(
       std::function<size_t(char*, size_t)> reader,
       TypeResolver type_resolver,
-      const std::vector<at::Tensor>* tensor_table)
+      c10::ArrayRef<at::Tensor> tensor_table)
       : reader_(std::move(reader)),
         tensor_table_(tensor_table),
         type_resolver_(std::move(type_resolver)),
@@ -47,7 +48,7 @@ class TORCH_API Unpickler {
       c10::optional<at::Device> device,
       bool use_storage_device = false)
       : reader_(std::move(reader)),
-        tensor_table_(nullptr),
+        tensor_table_(),
         type_resolver_(std::move(type_resolver)),
         obj_loader_(std::move(obj_loader)),
         read_record_(std::move(read_record)),
@@ -127,7 +128,7 @@ class TORCH_API Unpickler {
   std::vector<std::function<void(void)>> globals_;
   std::vector<IValue> memo_table_;
   std::vector<size_t> marks_;
-  const std::vector<at::Tensor>* tensor_table_;
+  c10::ArrayRef<at::Tensor> tensor_table_;
 
   // When deserializing types on lists and dicts, cache the type here
   // so we don't have to parse the same type multiple times. Strings


### PR DESCRIPTION
Summary: Using c10::ArrayRef as the parameter type makes the API more flexible and allows the caller to leverage small-buffer optimizations (e.g. c10::SmallVector, std::array) for performance critical cases.

Test Plan: No behavioral changes. Run the existing unit and integration tests.

Differential Revision: D27232222

