### PR TITLE
Temporary disable TestNumbaIntegration.test_from_cuda_array_interface*

### DIFF
--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -229,6 +229,7 @@ class TestNumbaIntegration(common.TestCase):
                 numba.cuda.as_cuda_array(cudat), numba.cuda.devicearray.DeviceNDArray
             )
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -314,6 +315,7 @@ class TestNumbaIntegration(common.TestCase):
             torch_ary = torch.as_tensor(numba_ary, device="cuda")
             self.assertTrue(torch_ary.is_contiguous())
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -325,6 +327,7 @@ class TestNumbaIntegration(common.TestCase):
         del numba_ary
         self.assertEqual(torch_ary.cpu().data.numpy(), numpy.arange(6))  # `torch_ary` is still alive
 
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")

--- a/test/test_numba_integration.py
+++ b/test/test_numba_integration.py
@@ -229,7 +229,7 @@ class TestNumbaIntegration(common.TestCase):
                 numba.cuda.as_cuda_array(cudat), numba.cuda.devicearray.DeviceNDArray
             )
 
-    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -315,7 +315,7 @@ class TestNumbaIntegration(common.TestCase):
             torch_ary = torch.as_tensor(numba_ary, device="cuda")
             self.assertTrue(torch_ary.is_contiguous())
 
-    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")
@@ -327,7 +327,7 @@ class TestNumbaIntegration(common.TestCase):
         del numba_ary
         self.assertEqual(torch_ary.cpu().data.numpy(), numpy.arange(6))  # `torch_ary` is still alive
 
-    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54429")
+    @unittest.skip("Test is temporary disabled, see https://github.com/pytorch/pytorch/issues/54418")
     @unittest.skipIf(not TEST_NUMPY, "No numpy")
     @unittest.skipIf(not TEST_CUDA, "No cuda")
     @unittest.skipIf(not TEST_NUMBA_CUDA, "No numba.cuda")


### PR DESCRIPTION
see https://github.com/pytorch/pytorch/issues/54418
see https://github.com/pytorch/pytorch/issues/54429

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54430 Temporary disable TestNumbaIntegration.test_from_cuda_array_interface***

Differential Revision: [D27232636](https://our.internmc.facebook.com/intern/diff/D27232636)