### PR TITLE
[CI]Install older cmath during Windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,6 +697,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: _HACK_ Install CUDA compatible cmath
+          no_output_timeout: 1m
+          command: |
+              powershell .circleci/scripts/vs_install_cmath.ps1
+      - run:
           name: Install Cuda
           no_output_timeout: 30m
           command: |

--- a/.circleci/scripts/vs_install_cmath.ps1
+++ b/.circleci/scripts/vs_install_cmath.ps1
@@ -1,0 +1,5 @@
+$CMATH_DOWNLOAD_LINK = "https://raw.githubusercontent.com/microsoft/STL/12c684bba78f9b032050526abdebf14f58ca26a3/stl/inc/cmath"
+$VC14_28_INSTALL_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include"
+curl.exe --retry 3 -kL $CMATH_DOWNLOAD_LINK --output cmath
+
+Copy-Item -Path "cmath" -Destination "$VC14_28_INSTALL_PATH"

--- a/.circleci/scripts/vs_install_cmath.ps1
+++ b/.circleci/scripts/vs_install_cmath.ps1
@@ -1,5 +1,5 @@
 $CMATH_DOWNLOAD_LINK = "https://raw.githubusercontent.com/microsoft/STL/12c684bba78f9b032050526abdebf14f58ca26a3/stl/inc/cmath"
 $VC14_28_INSTALL_PATH="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\include"
-curl.exe --retry 3 -kL $CMATH_DOWNLOAD_LINK --output cmath
 
-Copy-Item -Path "cmath" -Destination "$VC14_28_INSTALL_PATH"
+curl.exe --retry 3 -kL $CMATH_DOWNLOAD_LINK --output "$home\cmath"
+Move-Item -Path "$home\cmath" -Destination "$VC14_28_INSTALL_PATH" -Force

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -259,6 +259,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: _HACK_ Install CUDA compatible cmath
+          no_output_timeout: 1m
+          command: |
+              powershell .circleci/scripts/vs_install_cmath.ps1
+      - run:
           name: Install Cuda
           no_output_timeout: 30m
           command: |


### PR DESCRIPTION
Based on @peterjc123 analysis, `cmath` after https://github.com/microsoft/STL/commit/26bbe2ad50cd7003b8220cfec2bff16dbc032ca8#diff-3fa97ceb95d524432661f01d4b34509c6d261a2f7f45ddcf26f79f55b3eec88a renders a lot of CUDA fail to compile with:
```
error: calling a __host__ function("__copysignf") from a __host__ __device__ function("c10::guts::detail::apply_impl< ::at::native::AUnaryFunctor< ::>  &,     ::std::tuple<float >  &, (unsigned long long)0ull > ") is not allowed
```
Workaround for #54382