### PR TITLE
Get rid of {Cpu,Cuda}{Channel,Context} in tensorpipe_agent.

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -39,12 +39,6 @@ class Context;
 
 namespace channel {
 class Context;
-using CpuContext = Context;
-
-#ifdef USE_CUDA_NOT_ROCM
-using CudaContext = Context;
-#endif
-
 } // namespace channel
 
 using DeviceMap = std::unordered_map<c10::DeviceIndex, c10::DeviceIndex>;
@@ -70,7 +64,7 @@ struct TransportRegistration {
 C10_DECLARE_REGISTRY(TensorPipeTransportRegistry, TransportRegistration);
 
 struct CpuChannelRegistration {
-  std::shared_ptr<tensorpipe::channel::CpuContext> channel;
+  std::shared_ptr<tensorpipe::channel::Context> channel;
   int64_t priority;
 };
 
@@ -79,7 +73,7 @@ C10_DECLARE_REGISTRY(TensorPipeCpuChannelRegistry, CpuChannelRegistration);
 
 struct CudaChannelRegistration {
 #ifdef USE_CUDA_NOT_ROCM
-  std::shared_ptr<tensorpipe::channel::CudaContext> channel;
+  std::shared_ptr<tensorpipe::channel::Context> channel;
   int64_t priority;
 #endif
 };


### PR DESCRIPTION
Summary:
Following the merge of channel hierarchies, here comes the promised
clean up.

Test Plan: CI

Reviewed By: lw

Differential Revision: D27232442

