### PR TITLE
Fix broken javadoc URL in README

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -223,4 +223,4 @@ To load torchscript model for mobile we need some special setup which is placed 
 
 ## PyTorch Android API Javadoc
 
-You can find more details about the PyTorch Android API in the [Javadoc](https://pytorch.org/docs/stable/packages.html).
+You can find more details about the PyTorch Android API in the [Javadoc](https://pytorch.org/javadoc/).


### PR DESCRIPTION
The link in the README was broken

