### PR TITLE
[static runtime] support DictConstruct

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -1130,7 +1130,7 @@ ProcessedNode::ProcessedNode(
   } else if (
       node->kind() != prim::ListConstruct &&
       node->kind() != prim::TupleConstruct &&
-      node->kind() != prim::ListUnpack) {
+      node->kind() != prim::DictConstruct && node->kind() != prim::ListUnpack) {
     const Operator& op = node->getOperator();
     TORCH_CHECK(op.hasOperation());
     op_ = op.getOperation(node);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -129,7 +129,8 @@ bool canRunNatively(Node* n) {
       "aten::to",
       "prim::ListConstruct",
       "prim::ListUnpack",
-      "prim::TupleConstruct"};
+      "prim::TupleConstruct",
+      "prim::DictConstruct"};
   auto str = std::string(n->kind().toQualString());
   if (!native_nodes.count(str)) {
     return false;
@@ -872,6 +873,24 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       } else {
         tupleConstruct(stack, node->inputs().size());
       }
+      // put output back
+      p_node->Output(0) = std::move(stack[0]);
+    };
+  } else if (n->kind() == prim::DictConstruct) {
+    return [](ProcessedNode* p_node) {
+      // prepare inputs
+      std::vector<IValue> stack;
+      const size_t size = p_node->inputs().size();
+      stack.reserve(size);
+      for (size_t i = 0; i < size; i++) {
+        stack.emplace_back(p_node->Input(i));
+      }
+      // run op
+      auto* node = p_node->node();
+      dictConstruct(
+          stack,
+          node->output()->type()->expectRef<DictType>(),
+          node->inputs().size());
       // put output back
       p_node->Output(0) = std::move(stack[0]);
     };


### PR DESCRIPTION
Summary:
August 1x model has DictConstruct in the graph (P331168321)
These can be easily removed with jit pass, but to easily measure the improvement
and run replayer with the model in the meantime, enable DictConstruct in static runtime

Test Plan:
```
./sigrid/predictor/scripts/pytorch/pyper_inference_e2e_local_replayer_test.sh \
    cpu 218841466_0 7449 /data/users/ansha/tmp/adfinder/august_1x/ /data/users/ansha/tmp/adfinder/august_1x/filtered_requests_inline_cvr_100
```

```
TEST trace
Total num requests                                   100
Num exceptions                                         0
Latency us avg                                    180965
Latency us p25                                     89785
Latency us p50                                    131240
Latency us p75                                    146621
Latency us p90                                    158378
Latency us p95                                    166628
Latency us p99                                   1886680
Latency us p100                                  3803252
Server latency us avg                              91554
Server latency us p25                              51447
Server latency us p50                              86371
Server latency us p75                              95229
Server latency us p90                             102706
Server latency us p95                             116023
Server latency us p99                             557017
Server latency us p100                            716319
Num rankUnits avg                                     28
```

Differential Revision: D27236682

