### PR TITLE
[DDP] Remove data_ptr assert check after pin_memory

### DIFF
--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -578,8 +578,6 @@ void Reducer::mark_variable_ready(VariableIndex index) {
           // ** In the hoped-for case where all params are used, DDP itself won't do any
           // blocking work between now and the re-zeroing, so the danger is real.
           auto local_used_maps_tmp = local_used_maps_[i].pin_memory();
-          // Defensively ensures a deep copy to a pinned temporary
-          TORCH_INTERNAL_ASSERT(local_used_maps_tmp.data_ptr() != local_used_maps_[i].data_ptr())
           local_used_maps_dev_[i].copy_(local_used_maps_tmp, true);
         } else {
           local_used_maps_dev_[i].copy_(local_used_maps_[i], true);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54453 [DDP] Remove data_ptr assert check after pin_memory**

It seems like this assert is not always necessarily true, such as if
the tensor being pinned was already somehow pinned, or if cuda is run with UVM
enabled. This check was added in
https://github.com/pytorch/pytorch/pull/53160/files but should not be necessary
to fix the race condition that the PR fixed.

Differential Revision: [D27243485](https://our.internmc.facebook.com/intern/diff/D27243485/)