### PR TITLE
Enable automatic @slowTest detection based on previous nightly's S3 stats

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -410,6 +410,7 @@ def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, float]:
                 new_avg = (curr_avg * curr_count + test_file['total_seconds']) / new_count
                 jobs_to_times[name] = (new_avg, new_count)
 
+
     # if there's 'test_cpp_extensions_aot' entry in jobs_to_times, add 'test_cpp_extensions_aot_ninja'
     # and 'test_cpp_extensions_aot_no_ninja' duplicate entries to ease future computation since
     # test_cpp_extensions_aot_no_ninja and test_cpp_extensions_aot_ninja are Python test jobs that

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -11,7 +11,6 @@ import os
 import platform
 import re
 import gc
-from tools.stats_utils.s3_stat_parser import Version2Report
 import types
 import math
 from datetime import datetime, timedelta
@@ -60,7 +59,7 @@ from enum import Enum
 
 try:
     sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../.."))
-    from tools.stats_utils.s3_stat_parser import (get_S3_bucket_readonly, HAVE_BOTO3, Report)
+    from tools.stats_utils.s3_stat_parser import (get_S3_bucket_readonly, HAVE_BOTO3, Report, Version2Report)
 except ImportError:
     print("Unable to import s3_stat_parser from tools. Running without S3 stats...")
     HAVE_BOTO3 = False

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6,12 +6,15 @@ torch.testing._internal.common_cuda.py can freely initialize CUDA context when i
 """
 
 import sys
+import bz2
 import os
 import platform
 import re
 import gc
+from tools.stats_utils.s3_stat_parser import Version2Report
 import types
 import math
+from datetime import datetime, timedelta
 from functools import partial
 import inspect
 import io
@@ -38,7 +41,7 @@ import json
 from urllib.request import urlopen
 import __main__  # type: ignore[import]
 import errno
-from typing import cast, Any, Dict, Iterable, Iterator, Optional
+from typing import cast, Any, Dict, List, Iterable, Iterator, Optional, Tuple
 
 import numpy as np
 
@@ -54,6 +57,13 @@ from torch._six import string_classes
 import torch.backends.cudnn
 import torch.backends.mkl
 from enum import Enum
+
+try:
+    sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../.."))
+    from tools.stats_utils.s3_stat_parser import (get_S3_bucket_readonly, HAVE_BOTO3, Report)
+except ImportError:
+    print("Unable to import s3_stat_parser from tools. Running without S3 stats...")
+    HAVE_BOTO3 = False
 
 torch.backends.disable_global_flags()
 
@@ -792,6 +802,94 @@ try:
 except ImportError:
     print('Fail to import hypothesis in common_utils, tests are not derandomized')
 
+
+# COPIED FROM RUN_TEST.PY --> should refactor.
+# This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False
+# or the S3 bucket is somehow unavailable. Even though this function goes through ten nightly commits' reports
+# to find a non-empty report, it is still conceivable (though highly unlikely) for this function to return no reports.
+def get_test_time_reports_from_S3() -> List[Report]:
+    commit_date_ts = subprocess.check_output(
+        ['git', 'show', '-s', '--format=%ct', 'HEAD'],
+        encoding="ascii").strip()
+    commit_date = datetime.fromtimestamp(int(commit_date_ts))
+    day_before_commit = str(commit_date - timedelta(days=1)).split(' ')[0]
+    # something like git rev-list --before="2021-03-04" --max-count=10 --remotes="*origin/nightly"
+    nightly_commits = subprocess.check_output(
+        ["git", "rev-list", f"--before={day_before_commit}", "--max-count=10", "--remotes=*origin/nightly"],
+        encoding="ascii").splitlines()
+
+    job = os.environ.get("CIRCLE_JOB", "")
+    job_minus_shard_number = job.rstrip('0123456789')
+
+    bucket = get_S3_bucket_readonly('ossci-metrics')
+    reports: List[Report] = []
+    commit_index = 0
+    while len(reports) == 0 and commit_index < len(nightly_commits):
+        nightly_commit = nightly_commits[commit_index]
+        print(f'Grabbing reports from nightly commit: {nightly_commit}')
+        summaries = bucket.objects.filter(Prefix=f"test_time/{nightly_commit}/{job_minus_shard_number}")
+        for summary in summaries:
+            binary = summary.get()["Body"].read()
+            string = bz2.decompress(binary).decode("utf-8")
+            reports.append(json.loads(string))
+        commit_index += 1
+    return reports
+
+
+def calculate_test_case_times(reports: List[Report]) -> Dict[str, float]:
+    # an entry will be like ("test_doc_examples (__main__.TestTypeHints)" -> (current_avg, # values))
+    test_names_to_times: Dict[str, Tuple[float, int]] = dict()
+    for report in reports:
+        if 'format_version' not in report:  # version 1 implicitly
+            raise RuntimeError("S3 format currently handled is version 2 only")
+        else:
+            v2report = cast(Version2Report, report)
+            for _, test_file in v2report['files'].items():
+                for suitename, test_suite in test_file['suites'].items():
+                    for casename, test_case in test_suite['cases'].items():
+                        name = f'{casename} (__main__.{suitename})'
+                        succeeded: bool = test_case['status'] is None
+                        if succeeded:
+                            if name not in test_names_to_times:
+                                test_names_to_times[name] = (test_case['seconds'], 1)
+                            else:
+                                curr_avg, curr_count = test_names_to_times[name]
+                                new_count = curr_count + 1
+                                new_avg = (curr_avg * curr_count + test_case['seconds']) / new_count
+                                test_names_to_times[name] = (new_avg, new_count)
+    return {test_case: time for test_case, (time, _) in test_names_to_times.items()}
+
+
+# ALSO TAKEN FROM RUN_TEST.PY, but returns dictionaries of testMethodNames to their times
+def pull_test_times_from_S3() -> Dict[str, float]:
+    if HAVE_BOTO3:
+        s3_reports = get_test_time_reports_from_S3()
+    else:
+        print('Uh oh, boto3 is not found. Either it is not installed or we failed to import s3_stat_parser.')
+        print('If not installed, please install boto3 for automatic sharding and test categorization.')
+        s3_reports = []
+
+    if len(s3_reports) == 0:
+        print('Gathered no reports from S3. Please proceed without them.')
+        return dict()
+
+    return calculate_test_case_times(s3_reports)
+
+
+slow_tests_from_s3: Optional[Dict[str, float]] = None
+SLOW_TEST_THRESHOLD: float = 60.0
+def check_slow_test_from_S3(test):
+    global slow_tests_from_s3
+    if slow_tests_from_s3 is None and HAVE_BOTO3:
+        slow_tests_from_s3 = pull_test_times_from_S3()
+    slow_tests_from_s3 = cast(Dict[str, float], slow_tests_from_s3)
+    test_suite = str(test.__class__).split('\'')[1]
+    test_name = f'{test._testMethodName} ({test_suite})'
+
+    if test_name in slow_tests_from_s3 and slow_tests_from_s3[test_name] > SLOW_TEST_THRESHOLD:
+        getattr(test, test._testMethodName).__dict__['slow_test'] = True
+
+
 disabled_test_from_issues: Optional[Dict[str, Any]] = None
 def check_disabled(test_name):
     global disabled_test_from_issues
@@ -966,13 +1064,13 @@ class TestCase(expecttest.TestCase):
 
     def setUp(self):
 
+        check_slow_test_from_S3(self)
+        # if TEST_SKIP_FAST:
+        #     if not getattr(self, self._testMethodName).__dict__.get('slow_test', False):
+        #         raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")
+        # check_disabled(str(self))
 
-        if TEST_SKIP_FAST:
-            if not getattr(self, self._testMethodName).__dict__.get('slow_test', False):
-                raise unittest.SkipTest("test is fast; we disabled it with PYTORCH_TEST_SKIP_FAST")
-        check_disabled(str(self))
-
-        set_rng_seed(SEED)
+        # set_rng_seed(SEED)
 
     def genSparseTensor(self, size, sparse_dim, nnz, is_uncoalesced, device='cpu'):
         # Assert not given impossible combination, where the sparse dims have


### PR DESCRIPTION
This is a draft that can start discussion on how we want to automate @slowTest detection. Currently, this code just pulls nightly stats from S3 (for every test file) and uses them to detect whether a test case should be considered slow. The current requirement is that it must be a passed test case greater than 60 seconds. Pretty intuitive so far.

* The relative importing isn't working because tools is outside of torch, but the common_utils.py file getting used is in torch. I am not sure how to fix this.

There are several concerns:
1. There is duplicated code from test/run_test.py.
2. The data we use is per CI job, whereas we probably want a global bank of slow tests ALL jobs should avoid unless the job is marked as slow.
3. There is no real persistence. Consider the following situation: Run #1 reads the stats and marks test A as slow. test A is skipped for some runs. A day later, because the test was skipped, Run #100 reads the stats and does NOT mark test A as slow since it did not find a passing test A > 60s in the stats. Test A is now enabled again. And this goes on and off forever. 

My proposal/next steps: 
1. We host a list of slow tests on S3. We have a periodic master CI job (daily, let's say) that updates this list based on the test times of every CI job run on master. This would solve #2 and #3 from above. 
2. We have code to pull from this list during CI build jobs so that they can be used for spawned test jobs.
3. Oh hey wait a minute, #2 sounds like what we're doing for sharding (we generate a test-file-times file during a build job). So we can move the code for that in run_test and the code for #2 into a script in tools. The script in tools/ would export files containing S3 stats we care about. For sharding, it would be test file times. For slowTests, it would be test-case-times. This would solve problem #1. 

Any thoughts and suggestions on my proposal?
