### PR TITLE
[Static Runtime] Fix bug in reshape_copy

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -108,6 +108,15 @@ const auto reshape_inplace_script = R"JIT(
       return (d, e, f)
 )JIT";
 
+// b is in_contiguous
+const auto reshape_incontiguous_script = R"JIT(
+  def forward(self, a: Tensor, shape: List[int]):
+      b = a.transpose(0, 1)
+      c = b.reshape(shape)
+      c = c.relu()
+      return (c)
+)JIT";
+
 // exercise flatten_copy
 const auto flatten_script_1 = R"JIT(
   def forward(self, a: Tensor, start_dim: int, end_dim: int):

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -149,6 +149,7 @@ TEST(StaticRuntime, IndividualOps_Reshape) {
   testStaticRuntime(reshape_script_4, args);
   testStaticRuntime(reshape_script_5, args);
   testStaticRuntime(reshape_inplace_script, args);
+  testStaticRuntime(reshape_incontiguous_script, args);
 }
 
 TEST(StaticRuntime, IndividualOps_flatten) {

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -28,17 +28,14 @@ at::Tensor& reshape_copy_out(
                           : proposed_shape;
   at::native::resize_(out, shape, c10::nullopt);
 
-  if (!self.is_contiguous()) {
-    at::native::copy_(out, self, false /* non_blocking */);
-    return out;
-  }
+  auto self_contig = self.expect_contiguous();
 
   size_t nbytes = self.nbytes();
   if (nbytes == 0) {
     return out;
   }
 
-  const void* self_data = self.data_ptr();
+  const void* self_data = self_contig->data_ptr();
   void* out_data = out.data_ptr();
   memcpy(out_data, self_data, nbytes);
 


### PR DESCRIPTION
Summary: `at::native::copy_` requires src/dest to have the same sizes, which isn't true in reshape.

Test Plan: Added new test cases to cover this case.

Differential Revision: D27249617

