### PR TITLE
Ensure local_used_maps_tmp is distinct from local_used_maps_[i]

### DIFF
--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -577,9 +577,11 @@ void Reducer::mark_variable_ready(VariableIndex index) {
           //
           // ** In the hoped-for case where all params are used, DDP itself won't do any
           // blocking work between now and the re-zeroing, so the danger is real.
-          auto local_used_maps_tmp = local_used_maps_[i].pin_memory();
-          // Defensively ensures a deep copy to a pinned temporary
-          TORCH_INTERNAL_ASSERT(local_used_maps_tmp.data_ptr() != local_used_maps_[i].data_ptr())
+          //
+          // Defensively ensures local_used_maps_tmp is distinct from local_used_maps_[i]
+          auto local_used_maps_tmp = at::native::empty_like(local_used_maps_[i],
+                                                            local_used_maps_[i].options().pinned_memory(true))
+          local_used_maps_tmp.copy_(local_used_maps[i]);
           local_used_maps_dev_[i].copy_(local_used_maps_tmp, true);
         } else {
           local_used_maps_dev_[i].copy_(local_used_maps_[i], true);

--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -581,7 +581,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
           // Defensively ensures local_used_maps_tmp is distinct from local_used_maps_[i]
           auto local_used_maps_tmp = at::native::empty_like(local_used_maps_[i],
                                                             local_used_maps_[i].options().pinned_memory(true));
-          local_used_maps_tmp.copy_(local_used_maps[i]);
+          local_used_maps_tmp.copy_(local_used_maps_[i]);
           local_used_maps_dev_[i].copy_(local_used_maps_tmp, true);
         } else {
           local_used_maps_dev_[i].copy_(local_used_maps_[i], true);

--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -581,6 +581,10 @@ void Reducer::mark_variable_ready(VariableIndex index) {
           // Defensively ensures local_used_maps_tmp is distinct from local_used_maps_[i]
           auto local_used_maps_tmp = at::native::empty_like(local_used_maps_[i],
                                                             local_used_maps_[i].options().pinned_memory(true));
+          // Paranoid asserts here because in some workloads, the pinned allocator behaves in a way we
+          // don't understand, and may be bugged. See https://github.com/pytorch/pytorch/pull/54474
+          TORCH_INTERNAL_ASSERT(local_used_maps_tmp.is_pinned());
+          TORCH_INTERNAL_ASSERT(local_used_maps_tmp.data_ptr() != local_used_maps_[i].data_ptr());
           local_used_maps_tmp.copy_(local_used_maps_[i]);
           local_used_maps_dev_[i].copy_(local_used_maps_tmp, true);
         } else {

--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -580,7 +580,7 @@ void Reducer::mark_variable_ready(VariableIndex index) {
           //
           // Defensively ensures local_used_maps_tmp is distinct from local_used_maps_[i]
           auto local_used_maps_tmp = at::native::empty_like(local_used_maps_[i],
-                                                            local_used_maps_[i].options().pinned_memory(true))
+                                                            local_used_maps_[i].options().pinned_memory(true));
           local_used_maps_tmp.copy_(local_used_maps[i]);
           local_used_maps_dev_[i].copy_(local_used_maps_tmp, true);
         } else {


### PR DESCRIPTION
Followup/hotfix for https://github.com/pytorch/pytorch/pull/53160. @rohan-varma and @zhaojuanmao were seeing https://github.com/pytorch/pytorch/pull/53160/files#diff-9273e5ff7b40f30d6a4444d1c7be9fe9a5c2068070c68af4e7b0ac2d4cff0923R582 fire in some internal workloads, indicating `local_used_maps_tmp` wasn't actually being created as a distinct temporary, in other words, `local_used_maps_[i]` was already pinned for some reason. This seems like a bug with the CPU allocator: [`local_used_maps_` should not have been pinned on construction](https://github.com/pytorch/pytorch/blob/9be4c75fa0399a292e95ef8f3c79457e4b5b2338/torch/lib/c10d/reducer.cpp#L180-L183). We should [investigate that separately](https://github.com/pytorch/pytorch/pull/53160/files#r599188373).

In the meantime, the present PR should ensure `local_used_maps_tmp` is always distinct from `local_used_maps_[i]` (and therefore prevents the race condition described in https://github.com/pytorch/pytorch/pull/51360) even if `local_used_maps_[i]`is already pinned.