### PR TITLE
[Gradient Compression] Remove cuda.syncrhonize in batched powerSGD

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -624,8 +624,6 @@ def batched_powerSGD_hook(
         if state.use_error_feedback:
             # Memorize the local errors.
             state.error_dict[bucket_index] = input_tensor_cp - input_tensor
-        if torch.cuda.is_available():
-            torch.cuda.synchronize(device)
         if not state.warm_start:
             state.p_memory_dict.clear()
             state.q_memory_dict.clear()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54482 [Gradient Compression] Remove cuda.syncrhonize in batched powerSGD**

`cuda.synchronize` is unnecessary for `batched_powerSGD_hook`.

Differential Revision: [D27254314](https://our.internmc.facebook.com/intern/diff/D27254314/)