### PR TITLE
Revert "Revert D26907093: Add repeats to Timer.collect_callgrind(...)"

### DIFF
--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -511,6 +511,20 @@ class TestBenchmarkUtils(TestCase):
         self.assertIsInstance(counts, int)
         self.assertGreater(counts, 0)
 
+        # There is some jitter with the allocator, so we use a simpler task to
+        # test reproducibility.
+        timer = benchmark_utils.Timer(
+            "x += 1",
+            setup="x = torch.ones((1,))",
+        )
+
+        stats = timer.collect_callgrind(number=1000, repeats=20)
+        assert isinstance(stats, tuple)
+
+        # Check that the repeats are at least somewhat repeatable. (within 10 instructions per iter)
+        counts = collections.Counter([s.counts(denoise=True) // 10_000 * 10_000 for s in stats])
+        self.assertGreater(max(counts.values()), 1, f"Every instruction count total was unique: {counts}")
+
         from torch.utils.benchmark.utils.valgrind_wrapper.timer_interface import wrapper_singleton
         self.assertIsNone(
             wrapper_singleton()._bindings_module,
@@ -548,7 +562,7 @@ class TestBenchmarkUtils(TestCase):
 
         # NB: Unlike the example above, there is no expectation that all
         #     repeats will be identical.
-        counts = collections.Counter([s.counts(denoise=True) for s in stats])
+        counts = collections.Counter([s.counts(denoise=True) // 10_000 * 10_000 for s in stats])
         self.assertGreater(max(counts.values()), 1, repr(counts))
 
     def test_manipulate_callgrind_stats(self):

--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -511,20 +511,6 @@ class TestBenchmarkUtils(TestCase):
         self.assertIsInstance(counts, int)
         self.assertGreater(counts, 0)
 
-        # There is some jitter with the allocator, so we use a simpler task to
-        # test reproducibility.
-        timer = benchmark_utils.Timer(
-            "x += 1",
-            setup="x = torch.ones((1,))",
-        )
-
-        stats = timer.collect_callgrind(number=1000, repeats=20)
-        assert isinstance(stats, tuple)
-
-        # Check that the repeats are at least somewhat repeatable.
-        counts = collections.Counter([s.counts(denoise=True) for s in stats])
-        self.assertGreater(max(counts.values()), 1, f"Every instruction count total was unique: {counts}")
-
         from torch.utils.benchmark.utils.valgrind_wrapper.timer_interface import wrapper_singleton
         self.assertIsNone(
             wrapper_singleton()._bindings_module,

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -550,6 +550,7 @@ def _disabled_torch_function_impl(func: Callable, types: Iterable[Type], args: T
 # Defined in `valgrind.h` and `callgrind.h` respecitively.
 def _valgrind_supported_platform() -> _bool: ...  # NVALGRIND
 def _valgrind_toggle() -> None: ...  # CALLGRIND_TOGGLE_COLLECT
+def _valgrind_toggle_and_dump_stats() -> None: ...  # CALLGRIND_TOGGLE_COLLECT and CALLGRIND_DUMP_STATS
 
 has_openmp: _bool
 has_mkl: _bool

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -954,6 +954,20 @@ Call this whenever a new thread is created in order to propagate values from
     }
   );
 
+  py_module.def(
+    "_valgrind_toggle_and_dump_stats", [](){
+      #if defined(USE_VALGRIND)
+      // NB: If we don't toggle collect around dump stats, callgrind_annotate
+      //     won't process the results correctly. Specifically,
+      //     `callgrind_annotate --inclusive=no` will be almost completely empty.
+      CALLGRIND_TOGGLE_COLLECT;
+      CALLGRIND_DUMP_STATS;
+      #else
+      TORCH_CHECK(false, "Valgrind is not supported.");
+      #endif
+    }
+  );
+
 #ifdef USE_CUDA
   PyObject *has_cuda = Py_True;
 #else

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -2,7 +2,7 @@
 import enum
 import timeit
 import textwrap
-from typing import Any, Callable, Dict, List, NoReturn, Optional, Type, Union
+from typing import overload, Any, Callable, Dict, List, NoReturn, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -403,13 +403,36 @@ class Timer(object):
             task_spec=self._task_spec
         )
 
+    @overload
+    def collect_callgrind(
+        self,
+        number: int,
+        *,
+        repeats: None,
+        collect_baseline: bool,
+        retain_out_file: bool,
+    ) -> valgrind_timer_interface.CallgrindStats:
+        ...
+
+    @overload
+    def collect_callgrind(
+        self,
+        number: int,
+        *,
+        repeats: int,
+        collect_baseline: bool,
+        retain_out_file: bool,
+    ) -> Tuple[valgrind_timer_interface.CallgrindStats, ...]:
+        ...
+
     def collect_callgrind(
         self,
         number: int = 100,
         *,
+        repeats: Optional[int] = None,
         collect_baseline: bool = True,
         retain_out_file: bool = False,
-    ) -> valgrind_timer_interface.CallgrindStats:
+    ) -> Any:
         """Collect instruction counts using Callgrind.
 
         Unlike wall times, instruction counts are deterministic
@@ -444,17 +467,23 @@ class Timer(object):
         if not isinstance(self._task_spec.stmt, str):
             raise ValueError("`collect_callgrind` currently only supports string `stmt`")
 
+        if repeats is not None and repeats < 1:
+            raise ValueError("If specified, `repeats` must be >= 1")
+
         # Check that the statement is valid. It doesn't guarantee success, but it's much
         # simpler and quicker to raise an exception for a faulty `stmt` or `setup` in
         # the parent process rather than the valgrind subprocess.
         self._timer.timeit(1)
         is_python = (self._language == Language.PYTHON)
         assert is_python or not self._globals
-        return valgrind_timer_interface.wrapper_singleton().collect_callgrind(
+        result = valgrind_timer_interface.wrapper_singleton().collect_callgrind(
             task_spec=self._task_spec,
             globals=self._globals,
             number=number,
+            repeats=repeats or 1,
             collect_baseline=collect_baseline and is_python,
             is_python=is_python,
             retain_out_file=retain_out_file,
         )
+
+        return (result[0] if repeats is None else result)

--- a/torch/utils/benchmark/utils/valgrind_wrapper/compat_bindings.cpp
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/compat_bindings.cpp
@@ -19,7 +19,18 @@ void _valgrind_toggle() {
     #endif
 }
 
+void _valgrind_toggle_and_dump_stats() {
+    #if defined(NVALGRIND)
+    TORCH_CHECK(false, "Valgrind is not supported.");
+    #else
+    // NB: See note in Module.cpp
+    CALLGRIND_TOGGLE_COLLECT;
+    CALLGRIND_DUMP_STATS;
+    #endif
+}
+
 PYBIND11_MODULE(callgrind_bindings, m) {
     m.def("_valgrind_supported_platform", &_valgrind_supported_platform);
     m.def("_valgrind_toggle", &_valgrind_toggle);
+    m.def("_valgrind_toggle_and_dump_stats", &_valgrind_dump_stats);
 }

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
@@ -24,15 +24,18 @@ static_assert(false);
 int main(int argc, char* argv[]) {
     // This file should only be called inside of `Timer`, so we can adopt a
     // very simple and rigid argument parsing scheme.
-    TORCH_CHECK(argc == 7);
+    TORCH_CHECK(argc == 9);
     TORCH_CHECK(std::string(argv[1]) == "--number");
     auto number = std::stoi(argv[2]);
 
     TORCH_CHECK(std::string(argv[3]) == "--number_warmup");
     auto number_warmup = std::stoi(argv[4]);
 
-    TORCH_CHECK(std::string(argv[5]) == "--number_threads");
-    auto number_threads = std::stoi(argv[6]);
+    TORCH_CHECK(std::string(argv[5]) == "--repeats");
+    auto repeats = std::stoi(argv[6]);
+
+    TORCH_CHECK(std::string(argv[7]) == "--number_threads");
+    auto number_threads = std::stoi(argv[8]);
     torch::set_num_threads(number_threads);
 
     // Setup
@@ -44,9 +47,15 @@ int main(int argc, char* argv[]) {
     }
 
     // Main loop
-    CALLGRIND_TOGGLE_COLLECT;
-    for (int i = 0; i < number; i++) {
+    for (int repeat = 0; repeat < repeats; repeat++) {
+        CALLGRIND_TOGGLE_COLLECT;
+
+        for (int i = 0; i < number; i++) {
         // STMT_TEMPLATE_LOCATION
+        }
+
+        // NB: See note in Module.cpp
+        CALLGRIND_TOGGLE_COLLECT;
+        CALLGRIND_DUMP_STATS;
     }
-    CALLGRIND_TOGGLE_COLLECT;
 }

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.py
@@ -475,12 +475,18 @@ class GlobalsBridge:
 class _ValgrindWrapper(object):
     def __init__(self) -> None:
         self._bindings_module: Optional[CallgrindModuleType] = None
-        if hasattr(torch._C, "_valgrind_supported_platform"):
+        valgrind_symbols = (
+            "_valgrind_supported_platform",
+            "_valgrind_toggle",
+            "_valgrind_toggle_and_dump_stats",
+        )
+        if all(hasattr(torch._C, symbol) for symbol in valgrind_symbols):
             self._supported_platform: bool = torch._C._valgrind_supported_platform()
 
         else:
             print("Callgrind bindings are not present in `torch._C`. JIT-ing bindings.")
             self._bindings_module = cpp_jit.get_compat_bindings()
+            assert all(hasattr(self._bindings_module, symbol) for symbol in valgrind_symbols)
             self._supported_platform = self._bindings_module._valgrind_supported_platform()
 
         self._commands_available: Dict[str, bool] = {}
@@ -498,8 +504,6 @@ class _ValgrindWrapper(object):
         if build_search is not None:
             self._build_type = build_search.groups()[0].split(",")[0]
 
-        self._baseline_cache: Dict[Tuple[int, int], Tuple[FunctionCounts, FunctionCounts, Optional[str]]] = {}
-
     def _validate(self) -> None:
         if not self._supported_platform:
             raise OSError("Valgrind is not supported on this platform.")
@@ -512,55 +516,53 @@ class _ValgrindWrapper(object):
         self,
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
+        *,
         number: int,
+        repeats: int,
         collect_baseline: bool,
         is_python: bool,
         retain_out_file: bool,
-    ) -> CallgrindStats:
+    ) -> Tuple[CallgrindStats, ...]:
         """Collect stats, and attach a reference run which can be used to filter interpreter overhead."""
         self._validate()
         assert is_python or not collect_baseline
 
-        baseline_inclusive_stats = FunctionCounts((), inclusive=True)
-        baseline_exclusive_stats = FunctionCounts((), inclusive=False)
-        if collect_baseline:
-            cache_key = (number, task_spec.num_threads)
-            if cache_key not in self._baseline_cache:
-                self._baseline_cache[cache_key] = self._invoke(
-                    common.TaskSpec(
-                        stmt="pass",
-                        setup="pass",
-                        num_threads=task_spec.num_threads,
-                    ),
-                    globals={},
-                    number=number,
-                    is_python=True,
-                    retain_out_file=False,
-                )
-            baseline_inclusive_stats, baseline_exclusive_stats, _ = \
-                self._baseline_cache[cache_key]
-
-        stmt_inclusive_stats, stmt_exclusive_stats, out_contents = self._invoke(
-            task_spec, globals, number, is_python, retain_out_file)
-        return CallgrindStats(
+        *task_stats, baseline_stats = self._invoke(
             task_spec=task_spec,
-            number_per_run=number,
-            built_with_debug_symbols=self._build_type == "RelWithDebInfo",
-            baseline_inclusive_stats=baseline_inclusive_stats,
-            baseline_exclusive_stats=baseline_exclusive_stats,
-            stmt_inclusive_stats=stmt_inclusive_stats,
-            stmt_exclusive_stats=stmt_exclusive_stats,
-            stmt_callgrind_out=out_contents,
+            globals=globals,
+            number=number,
+            repeats=repeats,
+            collect_baseline=collect_baseline,
+            is_python=is_python,
+            retain_out_file=retain_out_file,
+        )
+        assert len(task_stats) == repeats
+
+        return tuple(
+            CallgrindStats(
+                task_spec=task_spec,
+                number_per_run=number,
+                built_with_debug_symbols=self._build_type == "RelWithDebInfo",
+                baseline_inclusive_stats=baseline_stats[0],
+                baseline_exclusive_stats=baseline_stats[1],
+                stmt_inclusive_stats=stmt_inclusive_stats,
+                stmt_exclusive_stats=stmt_exclusive_stats,
+                stmt_callgrind_out=out_contents,
+            )
+            for stmt_inclusive_stats, stmt_exclusive_stats, out_contents in task_stats
         )
 
     def _invoke(
         self,
+        *,
         task_spec: common.TaskSpec,
         globals: Dict[str, Any],
         number: int,
+        repeats: int,
+        collect_baseline: bool,
         is_python: bool,
         retain_out_file: bool,
-    ) -> Tuple[FunctionCounts, FunctionCounts, Optional[str]]:
+    ) -> Tuple[Tuple[FunctionCounts, FunctionCounts, Optional[str]], ...]:
         """Core invocation method for Callgrind collection.
 
         Valgrind operates by effectively replacing the CPU with an emulated
@@ -618,11 +620,15 @@ class _ValgrindWrapper(object):
                         task_spec,
                         globals=GlobalsBridge(globals, data_dir),
                         number=number,
+                        repeats=repeats,
+                        collect_baseline=collect_baseline,
                         error_log=error_log,
                         stat_log=stat_log,
                         bindings=self._bindings_module))
+
                 run_loop_cmd = ["python", script_file]
             else:
+                assert not collect_baseline
                 run_loop_exec = cpp_jit.compile_callgrind_template(
                     stmt=task_spec.stmt,
                     setup=task_spec.setup,
@@ -632,6 +638,7 @@ class _ValgrindWrapper(object):
                     run_loop_exec,
                     "--number", str(number),
                     "--number_warmup", str(min(number, 10)),
+                    "--repeats", str(repeats),
                     "--number_threads", str(task_spec.num_threads),
                 ]
 
@@ -655,46 +662,81 @@ class _ValgrindWrapper(object):
 
                 raise OSError(f"Failed to collect callgrind profile:\n{error_report}")
 
-            def parse_output(inclusive: bool) -> FunctionCounts:
+            def parse_output(fpath: str, inclusive: bool) -> FunctionCounts:
                 annotate_invocation, annotate_invocation_output = run([
                     "callgrind_annotate",
                     f"--inclusive={'yes' if inclusive else 'no'}",
                     "--threshold=100",
                     "--show-percs=no",
-                    callgrind_out
+                    fpath
                 ], check=True)
 
-                begin_collecting = False
+                total_pattern = re.compile(r"^([0-9,]+)\s+PROGRAM TOTALS")
+                begin_pattern = re.compile(r"Ir\s+file:function")
+                function_pattern = re.compile(r"^\s*([0-9,]+)\s+(.+:.+)$")
+
+                class ScanState(enum.Enum):
+                    SCANNING_FOR_TOTAL = 0
+                    SCANNING_FOR_START = 1
+                    PARSING = 2
+
+                scan_state = ScanState.SCANNING_FOR_TOTAL
                 fn_counts = []
                 for l in annotate_invocation_output.splitlines(keepends=False):
-                    if not begin_collecting and re.match(r"Ir\s+file:function", l):
-                        begin_collecting = True
-                        continue
+                    if scan_state == ScanState.SCANNING_FOR_TOTAL:
+                        total_match = total_pattern.match(l)
+                        if total_match:
+                            program_totals = int(total_match.groups()[0].replace(",", ""))
+                            scan_state = ScanState.SCANNING_FOR_START
 
-                    count_match = re.match(r"^\s*([0-9,]+)\s+(.+:.+)$", l)
-                    if count_match:
-                        ir_str, file_function = count_match.groups()
-                        ir = int(ir_str.replace(",", ""))
-                        fn_counts.append(FunctionCount(ir, file_function))
-                        continue
+                    elif scan_state == ScanState.SCANNING_FOR_START:
+                        if begin_pattern.match(l):
+                            scan_state = ScanState.PARSING
 
-                    if begin_collecting and re.match(r"-+", l):
-                        continue
+                    else:
+                        assert scan_state == ScanState.PARSING
+                        fn_match = function_pattern.match(l)
+                        if fn_match:
+                            ir_str, file_function = fn_match.groups()
+                            ir = int(ir_str.replace(",", ""))
+                            if ir == program_totals:
+                                # Callgrind includes some top level red herring symbols when
+                                # a program dumps multiple profiles.
+                                continue
+                            fn_counts.append(FunctionCount(ir, file_function))
 
-                    begin_collecting = False
+                        elif re.match(r"-+", l):
+                            # Ignore heading separator lines.
+                            continue
 
+                        else:
+                            break
+
+                assert scan_state == ScanState.PARSING, f"Failed to parse {fpath}"
                 return FunctionCounts(tuple(sorted(fn_counts, reverse=True)), inclusive=inclusive)
 
-            callgrind_out_contents: Optional[str] = None
-            if retain_out_file:
-                with open(callgrind_out, "rt") as f:
-                    callgrind_out_contents = f.read()
+            def read_results(i: int) -> Tuple[FunctionCounts, FunctionCounts, Optional[str]]:
+                if i == repeats and not collect_baseline:
+                    # Null baseline.
+                    return (
+                        FunctionCounts((), inclusive=True),
+                        FunctionCounts((), inclusive=False),
+                        None,
+                    )
 
-            return (
-                parse_output(inclusive=True),
-                parse_output(inclusive=False),
-                callgrind_out_contents,
-            )
+                fpath = f"{callgrind_out}.{i + 1}"  # Callgrind one-indexes files.
+                callgrind_out_contents: Optional[str] = None
+                if retain_out_file:
+                    with open(fpath, "rt") as f:
+                        callgrind_out_contents = f.read()
+
+                return (
+                    parse_output(fpath, inclusive=True),
+                    parse_output(fpath, inclusive=False),
+                    callgrind_out_contents
+                )
+
+            return tuple(read_results(i) for i in range(repeats + 1))
         finally:
             shutil.rmtree(working_dir)
 
@@ -702,27 +744,50 @@ class _ValgrindWrapper(object):
     def _construct_script(
         task_spec: common.TaskSpec,
         globals: GlobalsBridge,
+        *,
         number: int,
+        repeats: int,
+        collect_baseline: bool,
         error_log: str,
         stat_log: str,
         bindings: Optional[CallgrindModuleType],
     ) -> str:
-        # The naive template looks something like:
-        #   "for _ in range({number}): {stmt}"
-        # However a loop in Python is surprisingly expensive, and significantly
-        # increases the number of background Python instructions. So instead we
-        # partially unroll the loops, with a block size of 100 chosen to keep
-        # the instruction overhead from `range` low while also not ballooning
-        # the size of the generated file.
-        block_size = 100
-        loop_count = number // block_size
-        remainder = number - block_size * loop_count
-        blocked_stmt = ""
-        if loop_count:
-            unrolled_stmts = textwrap.indent("\n".join([task_spec.stmt] * block_size), " " * 4)
-            blocked_stmt += f"for _ in range({loop_count}):\n{unrolled_stmts}\n"
-        if remainder:
-            blocked_stmt += "\n".join([task_spec.stmt] * remainder)
+        def block_stmt(stmt: str, indent: int = 0) -> str:
+            """Partially unroll benchmark loop.
+
+            The naive template looks something like:
+                "for _ in range({number}): {stmt}"
+
+            However a loop in Python is surprisingly expensive, and significantly
+            increases the number of background Python instructions. So instead we
+            partially unroll the loops, with a block size of 100 chosen to keep
+            the instruction overhead from `range` low while also not ballooning
+            the size of the generated file.
+            """
+            block_size = 100
+            loop_count = number // block_size
+            if loop_count == 1:
+                # There is no point in having `for _ in range(1): ...` rather
+                # than just `...`, and this lets us save shave a few background
+                # instructions.
+                loop_count = 0
+            remainder = number - block_size * loop_count
+            blocked_stmt = ""
+
+            if loop_count:
+                unrolled_stmts = textwrap.indent("\n".join([stmt] * block_size), " " * 4)
+                blocked_stmt += f"for _ in range({loop_count}):\n{unrolled_stmts}\n"
+
+            if remainder:
+                blocked_stmt += "\n".join([stmt] * remainder)
+
+            return textwrap.indent(blocked_stmt, " " * indent)
+
+        pass_baseline = (
+            "callgrind_bindings._valgrind_toggle()\n"
+            f"{block_stmt('pass')}\n"
+            "callgrind_bindings._valgrind_toggle_and_dump_stats()"
+        )
 
         return textwrap.dedent(r"""
             import gc
@@ -805,17 +870,19 @@ class _ValgrindWrapper(object):
             # =============================================================================
             # == User code block ==========================================================
             # =============================================================================
-            callgrind_bindings._valgrind_toggle()
+            for _ in range({repeats}):
+                callgrind_bindings._valgrind_toggle()
             {blocked_stmt}
+                callgrind_bindings._valgrind_toggle_and_dump_stats()
+                gc.collect()
 
-            # Sleep is to allow the interpreter to catch up before we stop collecting in
-            # order to reduce jitter.
-            time.sleep(0.01)
-            callgrind_bindings._valgrind_toggle()
+            {baseline}
         """).strip().format(
             indented_stmt=textwrap.indent(task_spec.stmt, " " * 4),
-            blocked_stmt=blocked_stmt,
+            blocked_stmt=block_stmt(task_spec.stmt, indent=4),
+            baseline=(pass_baseline if collect_baseline else ""),
             number=number,
+            repeats=repeats,
             load_globals=globals.construct(),
             setup=task_spec.setup,
             warmup_number=min(number, 10),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #53296 Definition infrastructure for instruction count ubenchmarks
* **#54484 Revert "Revert D26907093: Add repeats to Timer.collect_callgrind(...)"**

Re-land of https://github.com/pytorch/pytorch/pull/53295. (With fixed unit tests.)

This reverts commit 0dc5abfaa9cac9266791788839d896b14600d123.

Differential Revision: [D27255201](https://our.internmc.facebook.com/intern/diff/D27255201)