### PR TITLE
Change ScatterGather kernel names on dtype dispatch. 

### DIFF
--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -145,7 +145,7 @@ struct cpu_scatter_gather_base_kernel {
 
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Bool, ScalarType::Half, iter.dtype(),
-      "method_name", [&] {
+      "scatter_gather_scalar", [&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 1;
 
@@ -240,7 +240,7 @@ struct cpu_scatter_gather_base_kernel {
 
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Bool, ScalarType::Half, iter.dtype(),
-      "method_name", [&] {
+      "scatter_gather_tensor", [&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 2;
         constexpr auto SRC_ITER_STRIDE_IDX = 1;

--- a/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
+++ b/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp
@@ -145,7 +145,7 @@ struct cpu_scatter_gather_base_kernel {
 
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Bool, ScalarType::Half, iter.dtype(),
-      "scatter_gather_scalar", [&] {
+      "scatter_gather_scalar_cpu", [&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 1;
 
@@ -240,7 +240,7 @@ struct cpu_scatter_gather_base_kernel {
 
     AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
       ScalarType::Bool, ScalarType::Half, iter.dtype(),
-      "scatter_gather_tensor", [&] {
+      "scatter_gather_tensor_cpu", [&] {
         constexpr auto SELF_ITER_STRIDE_IDX = 0;
         constexpr auto INDEX_ITER_STRIDE_IDX = 2;
         constexpr auto SRC_ITER_STRIDE_IDX = 1;


### PR DESCRIPTION
Changed `ScatterGather` kernel name when `dtype` dispatching to a more meaningful name than `"method_name"`.    

https://github.com/pytorch/pytorch/blob/2a53897114e984f5433e9e495cccb1417b86a8d3/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp#L146-L148

https://github.com/pytorch/pytorch/blob/2a53897114e984f5433e9e495cccb1417b86a8d3/aten/src/ATen/native/cpu/ScatterGatherKernel.cpp#L241-L243

Maybe, a more specific name, based on who is calling (e.g. `gather_cpu_kernel`, `scatter_cpu_kernel`), would be better. Any thoughts?