### PR TITLE
Skip test_variant_consistency_eager for masked_scatter on Windows CUDA

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2721,6 +2721,9 @@ op_db: List[OpInfo] = [
                SkipInfo('TestGradients', 'test_inplace_gradgrad',
                         device_type='cuda', dtypes=[torch.complex128]),
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
+               # RuntimeError: CUDA error: misaligned address
+               SkipInfo('TestCommon', 'test_variant_consistency_eager',
+                        device_type='cuda', dtypes=[torch.cfloat, torch.cdouble], active_if=IS_WINDOWS),
            ),
            supports_out=False),
     OpInfo('masked_select',


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54505 Skip  for masked_scatter on Windows CUDA**

Fixes master.
Reference: https://app.circleci.com/pipelines/github/pytorch/pytorch/287971/workflows/3566b7af-c730-40f3-bbe9-81062df4eb35/jobs/11692255

Differential Revision: [D27262444](https://our.internmc.facebook.com/intern/diff/D27262444)