### PR TITLE
[ROCm] add MAGMA_HOME env var hint to cmake, centos-rocm Dockerfile

### DIFF
--- a/.circleci/docker/centos-rocm/Dockerfile
+++ b/.circleci/docker/centos-rocm/Dockerfile
@@ -64,6 +64,7 @@ ENV PATH /opt/rocm/hcc/bin:$PATH
 ENV PATH /opt/rocm/hip/bin:$PATH
 ENV PATH /opt/rocm/opencl/bin:$PATH
 ENV PATH /opt/rocm/llvm/bin:$PATH
+ENV MAGMA_HOME /opt/rocm/magma
 ENV LANG en_US.utf8
 ENV LC_ALL en_US.utf8
 

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -122,6 +122,14 @@ else()
   set(ROCTRACER_PATH $ENV{ROCTRACER_PATH})
 endif()
 
+# MAGMA_HOME
+if(NOT DEFINED ENV{MAGMA_HOME})
+  set(MAGMA_HOME ${ROCM_PATH}/magma)
+  set(ENV{MAGMA_HOME} ${ROCM_PATH}/magma)
+else()
+  set(MAGMA_HOME $ENV{MAGMA_HOME})
+endif()
+
 if(NOT DEFINED ENV{PYTORCH_ROCM_ARCH})
   set(PYTORCH_ROCM_ARCH gfx803;gfx900;gfx906;gfx908)
 else()


### PR DESCRIPTION
MAGMA_HOME was previously set for the ubuntu-rocm/Dockerfile.  However, this missed centos builds as well as any builds that do not use the CI image environments.