### PR TITLE
[iOS GPU] Fix the softmax kernels

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
@@ -34,6 +34,7 @@ bool test_cat_dim1_0();
 bool test_cat_dim1_1();
 bool test_cat_dim1_nonarray_0();
 bool test_cat_dim1_nonarray_1();
+bool test_log_softmax();
 bool test_softmax();
 bool test_sigmoid();
 bool test_hardsigmoid();

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -699,14 +699,24 @@ bool test_cat_dim1_nonarray_1() {
 }
 
 bool test_softmax() {
-  __block std::vector<int64_t> size{2, 3, 1, 1};
-  return TEST(size, __PRETTY_FUNCTION__, ^bool {
-    auto X1 = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
-    auto Y1 = at::log_softmax(X1, 1);
-    auto X2 = X1.metal();
-    auto Y2 = at::log_softmax(X2, 1).cpu();
-    return almostEqual(Y1, Y2);
-  });
+    __block std::vector<int64_t> size{2,2};
+    return TEST(size, __PRETTY_FUNCTION__, ^bool {
+      auto X1 = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+      auto Y1 = at::softmax(X1, 0);
+      auto X2 = X1.metal();
+      auto Y2 = at::softmax(X2, 0).cpu();
+      return almostEqual(Y1, Y2);
+    });
+}
+bool test_log_softmax() {
+    __block std::vector<int64_t> size{2,2};
+    return TEST(size, __PRETTY_FUNCTION__, ^bool {
+      auto X1 = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+      auto Y1 = at::log_softmax(X1, 1);
+      auto X2 = X1.metal();
+      auto Y2 = at::log_softmax(X2, 1).cpu();
+      return almostEqual(Y1, Y2);
+    });
 }
 
 bool test_upsampling_nearest2d_vec() {

--- a/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
+++ b/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
@@ -6,39 +6,64 @@
 #import <ATen/native/metal/mpscnn/MPSCNNContext.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
+
+#include <ATen/ATen.h>
 #include <torch/library.h>
 
 namespace at {
 namespace native {
 namespace metal {
 
-API_AVAILABLE(ios(10.0), macos(10.13))
+template <typename T>
+Tensor mpscnn_softmax(
+    const Tensor& input,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
+  TORCH_CHECK(input.is_metal());
+  // TODO: [T87180544] Implment softmax/log_softmax in metal shaders
+  TORCH_CHECK(input.dim() == 2);
+  std::vector<int64_t> newSize(4, 1);
+  if (dim == 0) {
+    newSize[1] = input.size(0);
+    newSize[2] = input.size(1);
+  } else {
+    newSize[0] = input.size(0);
+    newSize[1] = input.size(1);
+  }
+  auto input_ = input.view(newSize);
+  MPSImage* X = imageFromTensor(input_);
+  // MPSCNNSoftmax kernels operate on feature channels
+  // https://developer.apple.com/documentation/metalperformanceshaders/mpscnnsoftmax?changes=_1&language=objc
+  T* softmax = [[T alloc] initWithDevice:[MPSCNNContext sharedInstance].device];
+  MetalTensorImplStorage mt{newSize};
+  MetalCommandBuffer* commandBuffer = getCommandBufferFromTensor(input_);
+  mt.texture()->allocateTemporaryTextureStorage(newSize, commandBuffer);
+  MPSImage* Y = mt.texture()->image();
+  [softmax encodeToCommandBuffer:commandBuffer.buffer
+                     sourceImage:X
+                destinationImage:Y];
+  // restore the original sizes
+  auto output = makeTensor(std::move(mt), input.options()).view(input.sizes());
+  return output;
+}
+
 Tensor log_softmax_int(
     const Tensor& input,
     int64_t dim,
     c10::optional<ScalarType> dtype) {
-  TORCH_CHECK(dim == 1);
-  TORCH_CHECK(input.is_metal());
-  MPSImage* X = imageFromTensor(input);
-  TORCH_CHECK(X.height == 1 && X.width == 1);
-  std::vector<int64_t> outputSize = input.sizes().vec();
-  MPSCNNLogSoftMax* logSoftmax = [[MPSCNNLogSoftMax alloc]
-      initWithDevice:[MPSCNNContext sharedInstance].device];
+  return mpscnn_softmax<MPSCNNLogSoftMax>(input, dim, dtype);
+}
 
-  MetalTensorImplStorage mt{outputSize};
-  MetalCommandBuffer* commandBuffer = getCommandBufferFromTensor(input);
-  mt.texture()->allocateTemporaryTextureStorage(
-      {outputSize[0], outputSize[1], 1, 1}, commandBuffer);
-  MPSImage* Y = mt.texture()->image();
-  [logSoftmax encodeToCommandBuffer:commandBuffer.buffer
-                        sourceImage:X
-                   destinationImage:Y];
-  auto output = makeTensor(std::move(mt), input.options());
-  return output;
+Tensor softmax_int(
+    const Tensor& input,
+    int64_t dim,
+    c10::optional<ScalarType> dtype) {
+  return mpscnn_softmax<MPSCNNSoftMax>(input, dim, dtype);
 }
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
-  m.impl("log_softmax.int", TORCH_FN(log_softmax_int));
+  m.impl("log_softmax.int", TORCH_FN(metal::log_softmax_int));
+  m.impl("softmax.int", TORCH_FN(metal::softmax_int));
 };
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54522 [iOS GPU] Implement transpose in Metal shaders
* #54521 [iOS GPU] Move the definition of `fp16_t` to MetalUtils.h
* #54520 [iOS GPU] Support multiple tensors as outputs
* **#54519 [iOS GPU] Fix the softmax kernels**
* #54518 [iOS GPU] Use function_constants to simply shader kernels

The current MPSCNNSoftmax kernels operates on tensors' feature channels. Therefore, in order to use it, we need to reshape the input tensors based on the value of `dim` . Currently, I decide to limit the input to be two dimensional. I'll remove the constraint once we have shader implementations.

Differential Revision: [D27218823](https://our.internmc.facebook.com/intern/diff/D27218823/)