### PR TITLE
[iOS GPU] Support multiple tensors as outputs

### DIFF
--- a/aten/src/ATen/native/metal/MetalCommandBuffer.h
+++ b/aten/src/ATen/native/metal/MetalCommandBuffer.h
@@ -2,14 +2,20 @@
 #import <Metal/Metal.h>
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
+@protocol PTMetalCommandBufferDelegate<NSObject>
+@optional
+- (void)prepareForSynchronization;
+@end
+
 @interface MetalCommandBuffer : NSObject
 @property(nonatomic, weak, readonly) NSThread* thread;
 @property(nonatomic, strong, readonly) id<MTLCommandBuffer> buffer;
 
 + (MetalCommandBuffer*)newBuffer;
 + (MetalCommandBuffer*)currentBuffer;
+- (void)addDelegate:(id<PTMetalCommandBufferDelegate>)delegate;
+- (void)removeDelegate:(id<PTMetalCommandBufferDelegate>)delegate;
 - (void)synchronize;
-
 - (void)add:(MPSTemporaryImage*)image;
 - (void)remove:(MPSTemporaryImage*)image;
 

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
@@ -12,6 +12,7 @@ namespace metal {
 class API_AVAILABLE(ios(10.0), macos(10.13)) MPSImageWrapper {
  public:
   MPSImageWrapper(IntArrayRef sizes);
+  ~MPSImageWrapper();
   operator bool() const {
     return _image;
   }
@@ -28,11 +29,13 @@ class API_AVAILABLE(ios(10.0), macos(10.13)) MPSImageWrapper {
   MPSImage* image() const;
   void recycleImage();
   void synchronize();
+  void prepareForSynchronization();
 
  private:
   std::vector<int64_t> _textureSizes;
   MPSImage* _image = nullptr;
   MetalCommandBuffer* _commandBuffer;
+  id<PTMetalCommandBufferDelegate> _delegate;
 };
 
 } // namespace metal

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -1,10 +1,37 @@
 #import <ATen/native/metal/MetalCommandBuffer.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImageWrapper.h>
+
+using namespace at::native::metal;
+@interface MPSImageWrapperTrampoline : NSObject<PTMetalCommandBufferDelegate>
++ (instancetype)newWithMPSImageWrapper:(MPSImageWrapper*)wrapper;
+@end
+
+@implementation MPSImageWrapperTrampoline {
+  MPSImageWrapper* _imageWrapper;
+}
+
++ (instancetype)newWithMPSImageWrapper:(MPSImageWrapper*)wrapper {
+  MPSImageWrapperTrampoline* trampoline = [MPSImageWrapperTrampoline new];
+  trampoline->_imageWrapper = wrapper;
+  return trampoline;
+}
+
+- (void)dealloc {
+  _imageWrapper = nil;
+}
+
+- (void)prepareForSynchronization {
+  if (_imageWrapper) {
+    _imageWrapper->prepareForSynchronization();
+  }
+}
+
+@end
 
 namespace at {
 namespace native {
@@ -12,17 +39,25 @@ namespace metal {
 
 MPSImageWrapper::MPSImageWrapper(IntArrayRef sizes) {
   _textureSizes = computeTextureSize(sizes);
+  _delegate = [MPSImageWrapperTrampoline newWithMPSImageWrapper:this];
+}
+
+MPSImageWrapper::~MPSImageWrapper() {
+  _delegate = nil;
+  _commandBuffer = nil;
+  _image = nil;
 }
 
 void MPSImageWrapper::copyDataFromHost(const float* inputData) {
   TORCH_CHECK(inputData);
   _commandBuffer = [MetalCommandBuffer currentBuffer];
+  [_commandBuffer addDelegate:_delegate];
   _image = createTemporaryImage(_commandBuffer, _textureSizes, inputData);
 }
 
 void MPSImageWrapper::copyDataToHost(float* hostData) {
-  TORCH_CHECK(_image);
   synchronize();
+  TORCH_CHECK(_image && ![_image isTemporaryImage]);
   copyToHost(hostData, _image);
 }
 
@@ -34,11 +69,14 @@ void MPSImageWrapper::recycleImage() {
   if ([_image isTemporaryImage]) {
     [_image recycle];
     [_commandBuffer remove:(MPSTemporaryImage*)_image];
+    [_commandBuffer removeDelegate:_delegate];
+    _image = nil;
   }
 }
 
 void MPSImageWrapper::setCommandBuffer(MetalCommandBuffer* cb) {
   _commandBuffer = cb;
+  [_commandBuffer addDelegate:_delegate];
 }
 MetalCommandBuffer* MPSImageWrapper::commandBuffer() const {
   return _commandBuffer;
@@ -57,8 +95,8 @@ void MPSImageWrapper::allocateTemporaryTextureStorage(
     IntArrayRef sizes,
     MetalCommandBuffer* commandBuffer) {
   TORCH_CHECK(commandBuffer)
+  setCommandBuffer(commandBuffer);
   _textureSizes = computeTextureSize(sizes);
-  _commandBuffer = commandBuffer;
   _image = createTemporaryImage(commandBuffer, _textureSizes);
 }
 
@@ -70,13 +108,26 @@ void MPSImageWrapper::copyFromTexture(MPSImage* image) {
   }
 }
 
-void MPSImageWrapper::synchronize() {
-  if ([_image isTemporaryImage]) {
+void MPSImageWrapper::prepareForSynchronization() {
+  // If the temporary image is still alive in the current command buffer,
+  // make it a static image.
+  if ([_image isTemporaryImage] && _image.readCount != 0) {
+#if DEBUG
+    NSLog(
+        @"[MPSImageWrapper] Found a temporary image: [%lld, %lld, %lld, %lld]",
+        (int64_t)_image.numberOfImages,
+        (int64_t)_image.featureChannels,
+        (int64_t)_image.height,
+        (int64_t)_image.width);
+#endif
     _image =
         createStaticImage((MPSTemporaryImage*)_image, _commandBuffer, false);
   }
-  [_commandBuffer synchronize];
-  _commandBuffer = nil;
+}
+
+void MPSImageWrapper::synchronize() {
+  TORCH_CHECK(commandBuffer());
+  [commandBuffer() synchronize];
 }
 
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54522 [iOS GPU] Implement transpose in Metal shaders
* #54521 [iOS GPU] Move the definition of `fp16_t` to MetalUtils.h
* **#54520 [iOS GPU] Support multiple tensors as outputs**
* #54519 [iOS GPU] Fix the softmax kernels
* #54518 [iOS GPU] Use function_constants to simply shader kernels

Currently, we don't support output more than one tensor on GPU. For example, if you do

```
auto x = at::rand(1,4,2,2).metal();
auto y = at::chunk(x,2,1);  //y is a tuple
auto output1 = y[0].cpu();
auto output2 = y[1].cpu();
```
In the example above, when it hits `y[1].cpu()`, the command buffer has already become invalid, thus the temporary image that lives `output2` has been recycled.

The way we address it is using the observer pattern
1. Before we flush the command buffer, we'll notify its the observers(a.k.a MPSImageWrapper objects) who hold the temporary images.
2. When observers receive the notice through callback, they'll turn the current temporary images into a static images.
3. Now, when `.cpu()` happens, the output tensor can just read the data directly from the static image generated in the above step.

You may be wondering does that have a hidden cost where all the intermediate tensors have now hold unused static images? The answers is no. All intermediate tensors will be dealloced once their reference counts become zero. Since the MetalTensorImpl is subclassing from the TensorImpl, we're overriding the release_resource method  which gives us a chance to release the underlying storage (textures and buffers) and remove observers from the command buffer. Therefore, once the intermediate tensors go away, the temporary images will be recycled immediately.

Differential Revision: [D27165886](https://our.internmc.facebook.com/intern/diff/D27165886/)