### PR TITLE
Also strip slow_test

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -366,7 +366,9 @@ def print_to_stderr(message):
 # Convert something like pytorch_windows_vs2019_py36_cuda10.1_build to pytorch_windows_vs2019_py36_cuda10.1
 def get_stripped_CI_job() -> str:
     job = os.environ.get("CIRCLE_JOB", "").rstrip('0123456789')
-    if job.endswith('_test'):
+    if job.endswith('_slow_test'):
+        job = job[:len(job) - len('_slow_test')]
+    elif job.endswith('_test'):
         job = job[:len(job) - len('_test')]
     elif job.endswith('_build'):
         job = job[:len(job) - len('_build')]


### PR DESCRIPTION
Since `_test1`, `_test2` and `_build` and `test` are all stripped, `slow_test` should be stripped as well. This way, the _slow_test stats will be considered as a part of all stats relating to a particular build job, though currently, it doesn't do much because the jobs don't share a common stemmed name--the build has `_gcc7` while the slow_test CI job does not.

This makes me think...do we omit the `gcc7` intentionally? Are there other things I should strip, e.g., `multigpu_test`?

See:
ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test
ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test1
ci/circleci: pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2