### PR TITLE
Introduce a fluent API to construct tensors from external data.

### DIFF
--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -13,7 +13,7 @@ Tensor var(const Tensor& self, int dim) {
   return at::var(self, IntArrayRef{dim});
 }
 
-std::tuple<Tensor,Tensor> var_mean(const Tensor& self, int dim) {
+std::tuple<Tensor, Tensor> var_mean(const Tensor& self, int dim) {
   return at::var_mean(self, IntArrayRef{dim});
 }
 
@@ -21,31 +21,138 @@ Tensor std(const Tensor& self, int dim) {
   return at::std(self, IntArrayRef{dim});
 }
 
-std::tuple<Tensor,Tensor> std_mean(const Tensor& self, int dim) {
+std::tuple<Tensor, Tensor> std_mean(const Tensor& self, int dim) {
   return at::std_mean(self, IntArrayRef{dim});
 }
 
 at::Tensor conv1d(
-    const Tensor& input, const Tensor& weight, const Tensor& bias, IntArrayRef stride,
-    std::initializer_list<int64_t> padding_, IntArrayRef dilation, int64_t groups) {
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef stride,
+    std::initializer_list<int64_t> padding_,
+    IntArrayRef dilation,
+    int64_t groups) {
   auto padding = IntArrayRef(padding_);
   return at::conv1d(input, weight, bias, stride, padding, dilation, groups);
 }
 
 at::Tensor conv2d(
-    const Tensor& input, const Tensor& weight, const Tensor& bias, IntArrayRef stride,
-    std::initializer_list<int64_t> padding_, IntArrayRef dilation, int64_t groups) {
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef stride,
+    std::initializer_list<int64_t> padding_,
+    IntArrayRef dilation,
+    int64_t groups) {
   auto padding = IntArrayRef(padding_);
   return at::conv2d(input, weight, bias, stride, padding, dilation, groups);
 }
 
 at::Tensor conv3d(
-    const Tensor& input, const Tensor& weight, const Tensor& bias, IntArrayRef stride,
-    std::initializer_list<int64_t> padding_, IntArrayRef dilation, int64_t groups) {
+    const Tensor& input,
+    const Tensor& weight,
+    const Tensor& bias,
+    IntArrayRef stride,
+    std::initializer_list<int64_t> padding_,
+    IntArrayRef dilation,
+    int64_t groups) {
   auto padding = IntArrayRef(padding_);
   return at::conv3d(input, weight, bias, stride, padding, dilation, groups);
 }
 
+namespace detail {
+
+void noopDelete(void*)
+{}
+
+}  // namespace detail
+
+Tensor TensorMaker::make_tensor() {
+  AutoNonVariableTypeMode guard{}; // TODO: Remove.
+  tracer::impl::NoTracerDispatchMode tracer_guard{};
+
+  TORCH_CHECK_VALUE(
+      !deleter_ || !ctx_,
+      "The deleter and context arguments are mutually exclusive.");
+
+  if (device_ == nullopt) {
+    device_ = globalContext().getDeviceFromPtr(data_, opts_.device().type());
+  }
+
+  if (opts_.device().has_index()) {
+    // clang-format off
+    TORCH_CHECK_VALUE(
+        opts_.device() == *device_,
+        "Specified device ", opts_.device(), " does not match device of data ", *device_);
+    // clang-format on
+  }
+
+  std::size_t size_bytes = computeStorageSize();
+
+  DataPtr data_ptr{};
+  if (deleter_) {
+    data_ptr = makeDataPtrFromDeleter();
+  } else {
+    data_ptr = makeDataPtrFromContext();
+  }
+
+  Storage storage{Storage::use_byte_size_t{}, size_bytes, std::move(data_ptr)};
+
+  at::Tensor tensor = makeEmptyTensor();
+
+  c10::TensorImpl* tensor_impl = tensor.unsafeGetTensorImpl();
+
+  tensor_impl->set_storage_keep_dtype(std::move(storage));
+
+  if (strides_) {
+    tensor_impl->set_sizes_and_strides(sizes_, *strides_);
+  } else {
+    tensor_impl->set_sizes_contiguous(sizes_);
+  }
+
+  return tensor;
+}
+
+std::size_t TensorMaker::computeStorageSize() const noexcept {
+  std::size_t itemsize = opts_.dtype().itemsize();
+
+  if (strides_) {
+    return detail::computeStorageNbytes(sizes_, *strides_, itemsize);
+  }
+
+  std::size_t size = 1;
+  for (std::size_t s : sizes_) {
+    size *= s;
+  }
+  return size * itemsize;
+}
+
+inline DataPtr TensorMaker::makeDataPtrFromDeleter() const {
+  return InefficientStdFunctionContext::makeDataPtr(data_, deleter_, *device_);
+}
+
+inline DataPtr TensorMaker::makeDataPtrFromContext() noexcept {
+  return DataPtr{data_, ctx_.release(), ctx_.get_deleter(), *device_};
+}
+
+SmallVector<std::int64_t, 5> TensorMaker::makeTempSizes() const noexcept {
+  if (opts_.has_memory_format()) {
+    MemoryFormat format = *opts_.memory_format_opt();
+    if (format == MemoryFormat::ChannelsLast) {
+      return {0, 0, 0, 0};
+    }
+    if (format == MemoryFormat::ChannelsLast3d) {
+      return {0, 0, 0, 0, 0};
+    }
+  }
+  return {0};
+}
+
+inline Tensor TensorMaker::makeEmptyTensor() const {
+  return empty(makeTempSizes(), opts_);
+}
+
 ${function_definitions}
 
-}
+} // namespace at

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -64,19 +64,87 @@ TORCH_API at::Tensor conv3d(
     const Tensor& input, const Tensor& weight, const Tensor& bias, IntArrayRef stride,
     std::initializer_list<int64_t> padding, IntArrayRef dilation = 1, int64_t groups = 1);
 
-namespace {
-  inline std::vector<int64_t> zero_sizes(const TensorOptions& options) {
-    if (options.has_memory_format()) {
-      auto memory_format = *options.memory_format_opt();
-      if (at::MemoryFormat::ChannelsLast == memory_format) {
-        return {0, 0, 0, 0};
-      }
-      if (at::MemoryFormat::ChannelsLast3d == memory_format) {
-        return {0, 0, 0, 0, 0};
-      }
-    }
-    return {0};
+namespace detail {
+
+TORCH_API void noopDelete(void*);
+
+} // namespace detail
+
+/// Provides a fluent API to construct tensors from external data.
+///
+/// The fluent API can be used instead of `from_blob` functions in case the
+/// required set of parameters does not align with the existing overloads.
+///
+///     at::Tensor tensor = at::for_blob(data, sizes)
+///             .strides(strides)
+///             .context(context, [](void *ctx) { delete static_cast<Ctx*>(ctx); })
+///             .options(...)
+///             .make_tensor();
+///
+class TORCH_API TensorMaker {
+  friend TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept;
+
+ public:
+  using ContextDeleter = DeleterFnPtr;
+
+  TensorMaker& strides(optional<IntArrayRef> value) noexcept {
+    strides_ = value;
+
+    return *this;
   }
+
+  TensorMaker& deleter(std::function<void(void*)> value) noexcept {
+    deleter_ = std::move(value);
+
+    return *this;
+  }
+
+  TensorMaker& context(void* value, ContextDeleter deleter = nullptr) noexcept {
+    ctx_ = std::unique_ptr<void, ContextDeleter>{
+        value, deleter ? deleter : detail::noopDelete};
+
+    return *this;
+  }
+
+  TensorMaker& target_device(optional<Device> value) noexcept {
+    device_ = value;
+
+    return *this;
+  }
+
+  TensorMaker& options(TensorOptions value) noexcept {
+    opts_ = value;
+
+    return *this;
+  }
+
+  Tensor make_tensor();
+
+ private:
+  explicit TensorMaker(void* data, IntArrayRef sizes) noexcept
+      : data_{data}, sizes_{sizes} {}
+
+  std::size_t computeStorageSize() const noexcept;
+
+  DataPtr makeDataPtrFromDeleter() const;
+
+  DataPtr makeDataPtrFromContext() noexcept;
+
+  SmallVector<std::int64_t, 5> makeTempSizes() const noexcept;
+
+  Tensor makeEmptyTensor() const;
+
+  void* data_;
+  IntArrayRef sizes_;
+  optional<IntArrayRef> strides_{};
+  std::function<void(void*)> deleter_{};
+  std::unique_ptr<void, ContextDeleter> ctx_{nullptr, detail::noopDelete};
+  optional<Device> device_{};
+  TensorOptions opts_{};
+};
+
+inline TensorMaker for_blob(void* data, IntArrayRef sizes) noexcept {
+  return TensorMaker{data, sizes};
 }
 
 inline Tensor from_blob(
@@ -86,23 +154,12 @@ inline Tensor from_blob(
     const std::function<void(void*)>& deleter,
     const TensorOptions& options = {},
     const c10::optional<Device> target_device = c10::nullopt) {
-  AutoNonVariableTypeMode guard;  // TODO: remove
-  tracer::impl::NoTracerDispatchMode tracer_guard;
-  auto device = (target_device.has_value()?
-    target_device.value() : globalContext().getDeviceFromPtr(data, options.device().type()));
-  if (options.device().has_index()) {
-    TORCH_CHECK(
-        options.device() == device,
-        "Specified device ", options.device(),
-        " does not match device of data ", device);
-  }
-  auto storage = Storage(
-      Storage::use_byte_size_t(),
-      detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
-      InefficientStdFunctionContext::makeDataPtr(data, deleter, device),
-      /*allocator=*/nullptr,
-      /*resizable=*/false);
-  return empty(IntArrayRef(zero_sizes(options)), options).set_(storage, 0, sizes, strides);
+  return for_blob(data, sizes)
+      .strides(strides)
+      .deleter(deleter)
+      .options(options)
+      .target_device(target_device)
+      .make_tensor();
 }
 
 inline Tensor from_blob(
@@ -110,7 +167,10 @@ inline Tensor from_blob(
     IntArrayRef sizes,
     const std::function<void(void*)>& deleter,
     const TensorOptions& options = {}) {
-  return from_blob(data, sizes, detail::defaultStrides(sizes), deleter, options);
+  return for_blob(data, sizes)
+      .deleter(deleter)
+      .options(options)
+      .make_tensor();
 }
 
 inline Tensor from_blob(
@@ -118,29 +178,17 @@ inline Tensor from_blob(
     IntArrayRef sizes,
     IntArrayRef strides,
     const TensorOptions& options = {}) {
-  AutoNonVariableTypeMode guard;  // TODO: remove
-  tracer::impl::NoTracerDispatchMode tracer_guard;
-  auto device = globalContext().getDeviceFromPtr(data, options.device().type());
-  if (options.device().has_index()) {
-    TORCH_CHECK(
-        options.device() == device,
-        "Specified device ", options.device(),
-        " does not match device of data ", device);
-  }
-  auto storage = Storage(
-      Storage::use_byte_size_t(),
-      detail::computeStorageNbytes(sizes, strides, options.dtype().itemsize()),
-      DataPtr(data, nullptr, [](void*) {}, device),
-      /*allocator=*/nullptr,
-      /*resizable=*/false);
-  return empty(IntArrayRef(zero_sizes(options)), options).set_(storage, 0, sizes, strides);
+  return for_blob(data, sizes)
+      .strides(strides)
+      .options(options)
+      .make_tensor();
 }
 
 inline Tensor from_blob(
     void* data,
     IntArrayRef sizes,
     const TensorOptions& options = {}) {
-  return from_blob(data, sizes, detail::defaultStrides(sizes), options);
+  return for_blob(data, sizes).options(options).make_tensor();
 }
 
 inline int64_t numel(const Tensor& tensor) {

--- a/c10/core/Storage.h
+++ b/c10/core/Storage.h
@@ -15,8 +15,8 @@ struct C10_API Storage {
   Storage(
       use_byte_size_t use_byte_size,
       size_t size_bytes,
-      Allocator* allocator,
-      bool resizable)
+      Allocator* allocator = nullptr,
+      bool resizable = false)
       : storage_impl_(c10::make_intrusive<StorageImpl>(
             StorageImpl::use_byte_size_t(),
             size_bytes,
@@ -30,8 +30,8 @@ struct C10_API Storage {
       use_byte_size_t use_byte_size,
       size_t size_bytes,
       at::DataPtr data_ptr,
-      at::Allocator* allocator,
-      bool resizable)
+      at::Allocator* allocator = nullptr,
+      bool resizable = false)
       : storage_impl_(c10::make_intrusive<StorageImpl>(
             StorageImpl::use_byte_size_t(),
             size_bytes,


### PR DESCRIPTION
Summary:
This diff introduces the following changes and improvements:

- Introduces a new fluent API to construct tensors from external data as an alternative to `from_blob` overloads. See below for an example.
- Leverages several small-buffer optimizations which result in %50 reduction in tensor construction times.
- Exposes a new (lightweight) way to construct tensors by passing a naked `context` and `context_deleter` pair as an alternative to the existing `deleter` parameter.
- Updates the existing `from_blob` overloads to internally use the fluent API.

```
// Example 1
at::Tensor tensor = at::for_blob(data, sizes)
  .strides(strides)
  .context(context, [](void *ctx) { delete static_cast<Ctx*>(ctx); })
  .options(...)
  .target_device(...)
  .make_tensor();

// Example 2
at::Tensor tensor = at::for_blob(data, sizes).make_tensor();

// Example 3
at::Tensor tensor = at::for_blob(data, sizes)
  .deleter(...)
  .make_tensor();
```

Test Plan:
Below are the folly Benchmark results for the following two equivalent operations:

```
// The fluent API
at::Tensor tensor = at::for_blob(data, sizes)
  .deleter([buffer](void*) mutable { buffer.reset(); })
  .options(dtype(c10::ScalarType::Float))
  .make_tensor();

// The original `from_blob` overload
at::Tensor tensor = at::from_blob(
  data,
  sizes,
  [buffer](void*) mutable { buffer.reset(); },
  dtype(c10::ScalarType::Float));
```

```
============================================================================
scripts/balioglu/from_blob_exp/main.cpp         relative  time/iter  iters/s
============================================================================
fluent                                                     298.34ns    3.35M
from_blob                                         55.19%   540.51ns    1.85M
============================================================================
```

Various similar experiments show an approximate %50 reduction in tensor construction times.

Differential Revision: D27269344

