### PR TITLE
[PyTorch][easy] Move strings into class_::defineMethod

### DIFF
--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -247,7 +247,7 @@ class class_ {
 
     auto wrapped_setter =
         detail::wrap_func<CurClass, SetterFunc>(std::move(setter_func));
-    setter = defineMethod(name + "_setter", setter_name, wrapped_setter, doc_string);
+    setter = defineMethod(name + "_setter", wrapped_setter, doc_string);
 
     classTypePtr->addProperty(name, getter, setter);
     return *this;

--- a/torch/custom_class.h
+++ b/torch/custom_class.h
@@ -241,15 +241,13 @@ class class_ {
     torch::jit::Function* getter;
     torch::jit::Function* setter;
 
-    auto getter_name = name + "_getter";
     auto wrapped_getter =
         detail::wrap_func<CurClass, GetterFunc>(std::move(getter_func));
-    getter = defineMethod(getter_name, wrapped_getter, doc_string);
+    getter = defineMethod(name + "_getter", wrapped_getter, doc_string);
 
-    auto setter_name = name + "_setter";
     auto wrapped_setter =
         detail::wrap_func<CurClass, SetterFunc>(std::move(setter_func));
-    setter = defineMethod(setter_name, wrapped_setter, doc_string);
+    setter = defineMethod(name + "_setter", setter_name, wrapped_setter, doc_string);
 
     classTypePtr->addProperty(name, getter, setter);
     return *this;
@@ -263,10 +261,9 @@ class class_ {
       std::string doc_string = "") {
     torch::jit::Function* getter;
 
-    auto getter_name = name + "_getter";
     auto wrapped_getter =
         detail::wrap_func<CurClass, GetterFunc>(std::move(getter_func));
-    getter = defineMethod(getter_name, wrapped_getter, doc_string);
+    getter = defineMethod(name + "_getter", wrapped_getter, doc_string);
 
     classTypePtr->addProperty(name, getter, nullptr);
     return *this;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54548 [PyTorch] Extract non-template parts of torch::class_
* #54547 [PyTorch][easy] Move more strings in torch::class_
* **#54533 [PyTorch][easy] Move strings into class_::defineMethod**

There were some forgotten moves here. Since the values are
not otherwise used, let's just not give them names.

Differential Revision: [D27271991](https://our.internmc.facebook.com/intern/diff/D27271991/)