### PR TITLE
[PyTorch] Enable test_lite_interpreter_runtime running in android

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -36,7 +36,9 @@ endif()
 # NB: If you edit these globs, you'll have to update setup.py package_data as well
 file(GLOB_RECURSE ATen_CORE_HEADERS  "core/*.h")
 file(GLOB_RECURSE ATen_CORE_SRCS "core/*.cpp")
-file(GLOB_RECURSE ATen_CORE_TEST_SRCS "core/*_test.cpp")
+if (NOT BUILD_LITE_INTERPRETER)
+  file(GLOB_RECURSE ATen_CORE_TEST_SRCS "core/*_test.cpp")
+endif()
 EXCLUDE(ATen_CORE_SRCS "${ATen_CORE_SRCS}" ${ATen_CORE_TEST_SRCS})
 
 file(GLOB base_h "*.h" "detail/*.h" "cpu/*.h" "cpu/vec256/*.h" "quantized/*.h")

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # NB: If you edit these globs, you'll have to update setup.py package_data as well
 file(GLOB_RECURSE ATen_CORE_HEADERS  "core/*.h")
 file(GLOB_RECURSE ATen_CORE_SRCS "core/*.cpp")
-if (NOT BUILD_LITE_INTERPRETER)
+if(NOT BUILD_LITE_INTERPRETER)
   file(GLOB_RECURSE ATen_CORE_TEST_SRCS "core/*_test.cpp")
 endif()
 EXCLUDE(ATen_CORE_SRCS "${ATen_CORE_SRCS}" ${ATen_CORE_TEST_SRCS})

--- a/modules/module_test/CMakeLists.txt
+++ b/modules/module_test/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
   option(BUILD_SHARED_LIBS "Build shared libs." ON)
 endif()
 
-if(BUILD_TEST)
+if(BUILD_TEST AND NOT BUILD_LITE_INTERPRETER)
   add_library(
       caffe2_module_test_dynamic
       ${CMAKE_CURRENT_SOURCE_DIR}/module_test_dynamic.cc)

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -101,7 +101,7 @@ if [ -z "$BUILD_MOBILE_TEST" ]; then
   BUILD_MOBILE_TEST=0
 fi
 # Don't build artifacts we don't need
-CMAKE_ARGS+=("-DBUILD_TEST=OFF")
+CMAKE_ARGS+=("-DBUILD_TEST=ON")
 CMAKE_ARGS+=("-DBUILD_BINARY=OFF")
 
 # If there exists env variable and it equals to 1, build lite interpreter.

--- a/scripts/build_android.sh
+++ b/scripts/build_android.sh
@@ -101,7 +101,7 @@ if [ -z "$BUILD_MOBILE_TEST" ]; then
   BUILD_MOBILE_TEST=0
 fi
 # Don't build artifacts we don't need
-CMAKE_ARGS+=("-DBUILD_TEST=ON")
+CMAKE_ARGS+=("-DBUILD_TEST=OFF")
 CMAKE_ARGS+=("-DBUILD_BINARY=OFF")
 
 # If there exists env variable and it equals to 1, build lite interpreter.

--- a/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
@@ -4,7 +4,7 @@
 #include <torch/csrc/jit/frontend/resolver.h>
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
-#include <torch/torch.h>
+// #include <torch/torch.h>
 
 #include <unordered_set>
 

--- a/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
+++ b/test/cpp/lite_interpreter_runtime/test_lite_interpreter_runtime.cpp
@@ -4,7 +4,6 @@
 #include <torch/csrc/jit/frontend/resolver.h>
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
-// #include <torch/torch.h>
 
 #include <unordered_set>
 


### PR DESCRIPTION
## Summary

1. Eliminate a few more tests when BUILD_LITE_INTERPRETER is on, such that test_lite_interpreter_runtime can build and run on device.
2. Remove `#include <torch/torch.h>`, because it's not needed.


## Test plan

Set the BUILD_TEST=ON `in build_android.sh`, then run
` BUILD_LITE_INTERPRETER=1 ./scripts/build_pytorch_android.sh x86`

push binary to android device:
```
 adb push ./build_android_x86/bin/test_lite_interpreter_runtime /data/local/tmp
```

Reorganize the folder in `/data/local/tmp` so the test binary and model file is like following:
```
/data/local/tmp/test_bin/test_lite_interpreter_runtime
/data/local/tmp/test/cpp/lite_interpreter_runtime/sequence.ptl
```
such that the model file is in the correct path and can be found by the test_lite_interpreter_runtime.

![image](https://user-images.githubusercontent.com/16430979/112276332-d89d1900-8c3d-11eb-91de-7bf10d1e418d.png)


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54579 [PyTorch] Enable test_lite_interpreter_runtime running in android**

Differential Revision: [D27300720](https://our.internmc.facebook.com/intern/diff/D27300720)