### PR TITLE
Hide module paths leaking in the documentation.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,6 +195,8 @@ autodoc_inherit_docstrings = False
 # Disable displaying type annotations, these can be very verbose
 autodoc_typehints = 'none'
 
+# Enable overriding of function signatures in the first line of the docstring.
+autodoc_docstring_signature = True
 
 # -- katex javascript in header
 #

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -88,7 +88,7 @@ class _CPatchManager(object):
         sys.setprofile(None)
 
 class Tracer(TracerBase):
-    """Tracer(self, autowrap_modules = (math, ), enable_cpatching = False)
+    """Tracer(autowrap_modules=(math,), enable_cpatching=False)
 
     ``Tracer`` is the class that implements the symbolic tracing functionality
     of ``torch.fx.symbolic_trace``. A call to ``symbolic_trace(m)`` is equivalent

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -117,6 +117,8 @@ class Tracer(TracerBase):
                 Turning this on is likely to slow down tracing by 1.5-3x.
 
         """
+        modules_dict: Dict[str, ModuleType] = {'math': math}
+        autowrap_modules = tuple(modules_dict[m] if isinstance(m, str) else m for m in autowrap_modules)
 
         super().__init__()
 

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -88,7 +88,8 @@ class _CPatchManager(object):
         sys.setprofile(None)
 
 class Tracer(TracerBase):
-    """
+    """Tracer(self, autowrap_modules = (math, ), enable_cpatching = False)
+
     ``Tracer`` is the class that implements the symbolic tracing functionality
     of ``torch.fx.symbolic_trace``. A call to ``symbolic_trace(m)`` is equivalent
     to ``Tracer().trace(m)``.
@@ -117,8 +118,6 @@ class Tracer(TracerBase):
                 Turning this on is likely to slow down tracing by 1.5-3x.
 
         """
-        modules_dict: Dict[str, ModuleType] = {'math': math}
-        autowrap_modules = tuple(modules_dict[m] if isinstance(m, str) else m for m in autowrap_modules)
 
         super().__init__()
 

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -88,6 +88,11 @@ class _CPatchManager(object):
         sys.setprofile(None)
 
 class Tracer(TracerBase):
+    # Reference: https://github.com/pytorch/pytorch/issues/54354
+    # The first line of this docstring overrides the one Sphinx generates for the
+    # documentation. We need it so that Sphinx doesn't leak `math`s path from the
+    # build environment (e.g. `<module 'math' from '/leaked/path').
+
     """Tracer(autowrap_modules=(math,), enable_cpatching=False)
 
     ``Tracer`` is the class that implements the symbolic tracing functionality
@@ -99,6 +104,10 @@ class Tracer(TracerBase):
     in the docstrings of the methods on this class.
     """
     def __init__(self, autowrap_modules: Tuple[ModuleType] = (math, ), enable_cpatching: bool = False) -> None:
+        # This method's signature is overridden by the first line of this class'
+        # docstring. If this method's signature is modified, the signature that
+        # overrides it also should be modified accordingly.
+
         """
         Construct a Tracer object.
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -331,8 +331,10 @@ def _check_dill_version(pickle_module) -> None:
             ))
 
 def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
-         pickle_module='pickle', pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
-    """Saves an object to a disk file.
+         pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
+    """save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True)
+
+    Saves an object to a disk file.
 
     See also: :ref:`saving-loading-tensors`
 
@@ -364,7 +366,6 @@ def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
         >>> buffer = io.BytesIO()
         >>> torch.save(x, buffer)
     """
-    pickle_module = pickle if pickle_module == 'pickle' else pickle_module
     _check_dill_version(pickle_module)
 
     with _open_file_like(f, 'wb') as opened_file:
@@ -493,7 +494,9 @@ def _save(obj, zip_file, pickle_module, pickle_protocol):
 
 
 def load(f, map_location=None, pickle_module='pickle', **pickle_load_args):
-    """Loads an object saved with :func:`torch.save` from a file.
+    """load(f, map_location=None, pickle_module=pickle, **pickle_load_args)
+
+    Loads an object saved with :func:`torch.save` from a file.
 
     :func:`torch.load` uses Python's unpickling facilities but treats storages,
     which underlie tensors, specially. They are first deserialized on the
@@ -572,7 +575,6 @@ def load(f, map_location=None, pickle_module='pickle', **pickle_load_args):
         # Load a module with 'ascii' encoding for unpickling
         >>> torch.load('module.pt', encoding='ascii')
     """
-    pickle_module = pickle if pickle_module == 'pickle' else pickle_module
     _check_dill_version(pickle_module)
 
     if 'encoding' not in pickle_load_args.keys():

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -332,6 +332,11 @@ def _check_dill_version(pickle_module) -> None:
 
 def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
          pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
+    # Reference: https://github.com/pytorch/pytorch/issues/54354
+    # The first line of this docstring overrides the one Sphinx generates for the
+    # documentation. We need it so that Sphinx doesn't leak `pickle`s path from
+    # the build environment (e.g. `<module 'pickle' from '/leaked/path').
+
     """save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True)
 
     Saves an object to a disk file.
@@ -494,6 +499,11 @@ def _save(obj, zip_file, pickle_module, pickle_protocol):
 
 
 def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
+    # Reference: https://github.com/pytorch/pytorch/issues/54354
+    # The first line of this docstring overrides the one Sphinx generates for the
+    # documentation. We need it so that Sphinx doesn't leak `pickle`s path from
+    # the build environment (e.g. `<module 'pickle' from '/leaked/path').
+
     """load(f, map_location=None, pickle_module=pickle, **pickle_load_args)
 
     Loads an object saved with :func:`torch.save` from a file.

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -493,7 +493,7 @@ def _save(obj, zip_file, pickle_module, pickle_protocol):
         zip_file.write_record(name, storage.data_ptr(), num_bytes)
 
 
-def load(f, map_location=None, pickle_module='pickle', **pickle_load_args):
+def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
     """load(f, map_location=None, pickle_module=pickle, **pickle_load_args)
 
     Loads an object saved with :func:`torch.save` from a file.

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -331,7 +331,7 @@ def _check_dill_version(pickle_module) -> None:
             ))
 
 def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
-         pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
+         pickle_module='pickle', pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
     """Saves an object to a disk file.
 
     See also: :ref:`saving-loading-tensors`
@@ -364,6 +364,7 @@ def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
         >>> buffer = io.BytesIO()
         >>> torch.save(x, buffer)
     """
+    pickle_module = pickle if pickle_module == 'pickle' else pickle_module
     _check_dill_version(pickle_module)
 
     with _open_file_like(f, 'wb') as opened_file:
@@ -491,7 +492,7 @@ def _save(obj, zip_file, pickle_module, pickle_protocol):
         zip_file.write_record(name, storage.data_ptr(), num_bytes)
 
 
-def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
+def load(f, map_location=None, pickle_module='pickle', **pickle_load_args):
     """Loads an object saved with :func:`torch.save` from a file.
 
     :func:`torch.load` uses Python's unpickling facilities but treats storages,
@@ -571,6 +572,7 @@ def load(f, map_location=None, pickle_module=pickle, **pickle_load_args):
         # Load a module with 'ascii' encoding for unpickling
         >>> torch.load('module.pt', encoding='ascii')
     """
+    pickle_module = pickle if pickle_module == 'pickle' else pickle_module
     _check_dill_version(pickle_module)
 
     if 'encoding' not in pickle_load_args.keys():


### PR DESCRIPTION
Fixes #54354