### PR TITLE
Add support for real and imag tensor attributes

### DIFF
--- a/test/jit/test_complex.py
+++ b/test/jit/test_complex.py
@@ -141,3 +141,14 @@ class TestComplex(JitTestCase):
         complex_consts = ['infj', 'nanj']
         for x in (float_consts + complex_consts):
             checkCmathConst(x)
+
+    def test_tensor_attributes(self):
+        def tensor_real(x):
+            return x.real
+
+        def tensor_imag(x):
+            return x.imag
+
+        t = torch.randn(2, 3, dtype=torch.cdouble)
+        self.checkScript(tensor_real, (t, ))
+        self.checkScript(tensor_imag, (t, ))

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -122,6 +122,8 @@ std::shared_ptr<SugaredValue> SimpleValue::attr(
            {"T", "prim"},
            {"ndim", "prim"},
            {"name", "prim"},
+           {"real", "prim"},
+           {"imag", "prim"},
        }},
       {TypeKind::DeviceObjType, {{"type", "prim"}, {"index", "prim"}}}};
   auto kind = value_->type()->kind();

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -1075,6 +1075,22 @@ RegisterOperators reg(
          },
          aliasAnalysisFromSchema()),
      OperatorGenerator(
+         TORCH_SELECTIVE_SCHEMA("prim::real(Tensor a) -> Tensor"),
+         [](Stack* stack) {
+           at::Tensor a;
+           pop(stack, a);
+           push(stack, at::real(a));
+         },
+         aliasAnalysisFromSchema()),
+     OperatorGenerator(
+        TORCH_SELECTIVE_SCHEMA("prim::imag(Tensor a) -> Tensor"),
+        [](Stack* stack) {
+          at::Tensor a;
+        pop(stack, a);
+          push(stack, at::imag(a));
+        },
+        aliasAnalysisFromSchema()),
+     OperatorGenerator(
          TORCH_SELECTIVE_SCHEMA("prim::is_xpu(Tensor a) -> bool"),
          [](Stack* stack) {
            at::Tensor a;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54608 Support cmath.rect in TS
* **#54611 Add support for real and imag tensor attributes**
* #54541 [TS] Add complex support for more ops
* #54328 Allow creating SugaredValue for a complex valued IValue and deserialization logic for "infj" and "nanj" global constants
* #54089 Add JIT support for cmath unary ops

