### PR TITLE
[quant][fx] store dtype, axis as literals in the graph

### DIFF
--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -158,10 +158,8 @@ def quantize_node(quantizer, in_node, obs_module, obs_node, is_input):
             qparam_node = create_getattr_from_value(root_module, graph, module_path + prefix + key, value)
             inputs.append(qparam_node)
         else:
-            get_new_attr_name = get_new_attr_name_with_prefix(module_path + prefix + key)
-            qparam_full_path = get_new_attr_name(root_module)
-            setattr(root_module, qparam_full_path, value)
-            inputs.append(graph.create_node('get_attr', qparam_full_path))
+            # for qparams that are not scale/zero_point (like axis, dtype) we store them as literals in the graph.
+            inputs.append(value)
     return graph.create_node(node_type, quantize_op, tuple(inputs), {})
 
 def get_custom_module_class_keys(custom_config_dict, custom_config_dict_key) -> List[Any]:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54860 [quant][fx] Add pass in convert to fold quant-dequant sequence
* #54859 [quant][fx][pyper] Get first linear use of quantize_per_tensor for FQN
* **#54624 [quant][fx] store dtype, axis as literals in the graph**

Summary:
previously we were creating setattr nodes for dtype and axis.
The FX convention is that primitive types are embedded as literals in args/kwargs.

With this change we won't see getattr nodes in the graph anymore for dtype/axis

Test Plan:
python test/test_quantization.py TestQuantizeFx

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27306898](https://our.internmc.facebook.com/intern/diff/D27306898)