### PR TITLE
[ROCm] add 4.1 docker image

### DIFF
--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -26,6 +26,7 @@ IMAGE_NAMES = [
     "pytorch-linux-bionic-rocm3.9-py3.6",
     "pytorch-linux-bionic-rocm3.10-py3.6",
     "pytorch-linux-bionic-rocm4.0.1-py3.6",
+    "pytorch-linux-bionic-rocm4.1-py3.6",
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6793,6 +6793,9 @@ workflows:
       - docker_build_job:
           name: "docker-pytorch-linux-bionic-rocm4.0.1-py3.6"
           image_name: "pytorch-linux-bionic-rocm4.0.1-py3.6"
+      - docker_build_job:
+          name: "docker-pytorch-linux-bionic-rocm4.1-py3.6"
+          image_name: "pytorch-linux-bionic-rocm4.1-py3.6"
       - pytorch_linux_build:
           name: pytorch_linux_xenial_py3_6_gcc5_4_build
           requires:

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -240,6 +240,14 @@ case "$image" in
     VISION=yes
     ROCM_VERSION=4.0.1
     ;;
+  pytorch-linux-bionic-rocm4.1-py3.6)
+    ANACONDA_PYTHON_VERSION=3.6
+    GCC_VERSION=9
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
+    ROCM_VERSION=4.1
+    ;;
   *)
     # Catch-all for builds that are not hardcoded.
     PROTOBUF=yes


### PR DESCRIPTION
Add a ROCm 4.1 docker image for CI.  Plan is to keep two ROCm versions at a time, however we still need the 3.9 image due to some CI jobs depending on it.  Keep the 4.0.1 and 3.10 images, in addition to the 3.9 image until the 3.9 image is no longer needed.