### PR TITLE
Add 'remote_parameters' and 'get_module_rref' to RemoteModule docs.

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -266,7 +266,7 @@ The invocation however incurs RPC calls to the remote end and can be performed
 asynchronously if needed via additional APIs supported by RemoteModule.
 
 .. autoclass:: torch.distributed.nn.api.remote_module.RemoteModule
-    :members:
+    :members: remote_parameters, get_module_rref
 
 
 Distributed Autograd Framework

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -196,9 +196,11 @@ class _RemoteModule(nn.Module):
             method = torch.jit.export(method)
             setattr(self, method_name, types.MethodType(method, self))
 
-    def remote_parameters(self, recurse: bool = True) -> List[rpc.RRef[Parameter]]:
-        r"""Returns a list of RRefs of remote module parameters.
+    def remote_parameters(self, recurse: bool = True) -> List[rpc.RRef]:
+        """
+        Returns a list of RRefs of remote module parameters.
         This is typically passed to a distributed optimizer.
+
         Args:
             recurse (bool): if True, then returns parameters of the remote module
                 and all submodules of the remote module.
@@ -209,7 +211,7 @@ class _RemoteModule(nn.Module):
         """
         return rpc.rpc_sync(self.on, _param_rrefs, args=(self.module_rref, recurse))
 
-    def get_module_rref(self) -> rpc.RRef[nn.Module]:
+    def get_module_rref(self) -> rpc.RRef:
         """Returns the RRef to remote module."""
         return self.module_rref
 

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -198,21 +198,27 @@ class _RemoteModule(nn.Module):
 
     def remote_parameters(self, recurse: bool = True) -> List[rpc.RRef]:
         """
-        Returns a list of RRefs of remote module parameters.
-        This is typically passed to a distributed optimizer.
+        Returns a list of :class:`~torch.distributed.rpc.RRef` pointing to the
+        remote module's parameters. This can typically be used in conjuction
+        with :class:`~torch.distributed.optim.DistributedOptimizer`.
 
         Args:
-            recurse (bool): if True, then returns parameters of the remote module
-                and all submodules of the remote module.
-                Otherwise, returns only parameters that are direct members of the remote module.
+            recurse (bool): if True, then returns parameters of the remote
+                module and all submodules of the remote module. Otherwise,
+                returns only parameters that are direct members of the
+                remote module.
 
         Returns:
-            A list of RRefs to remote module parameters.
+            A list of :class:`~torch.distributed.rpc.RRef` (``List[RRef[nn.Parameter]]``)
+            to remote module's parameters.
         """
         return rpc.rpc_sync(self.on, _param_rrefs, args=(self.module_rref, recurse))
 
     def get_module_rref(self) -> rpc.RRef:
-        """Returns the RRef to remote module."""
+        """
+        Returns an :class:`~torch.distributed.rpc.RRef` (``RRef[nn.Module]``)
+        pointing to the remote module.
+        """
         return self.module_rref
 
     def register_buffer(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54645 Add 'remote_parameters' and 'get_module_rref' to RemoteModule docs.**

Had to replace RRef[..] with just RRef in the return signature since
sphynx seemed to completely mess up rendering RRef[..]

![Screen Shot 2021-03-24 at 5 42 34 PM](https://user-images.githubusercontent.com/9958665/112401761-75a49400-8cc8-11eb-9d8b-95ff7b2b330b.png)

Differential Revision: [D27314609](https://our.internmc.facebook.com/intern/diff/D27314609/)