### PR TITLE
[DDP logging] Prefer use of c10::Join

### DIFF
--- a/c10/util/Logging.h
+++ b/c10/util/Logging.h
@@ -376,24 +376,10 @@ struct DDPLoggingData {
     std::ostream& output,
     const DDPLoggingData& ddp_logging_data
   ) {
-    std::stringstream deviceIdsStream, bucketSizesStream;
-    auto toString = [](std::stringstream& ss, const std::vector<int>& vec ) -> std::string {
-      for (size_t i = 0; i < vec.size(); ++i) {
-        if (i != 0) {
-          ss << ",";
-        }
-        ss << vec[i];
-      }
-      return ss.str();
-    };
 
-    std::string devicesStr = toString(deviceIdsStream, ddp_logging_data.device_ids);
-    std::string bucketSizesStr = toString(bucketSizesStream, ddp_logging_data.bucket_sizes);
-    std::string dtypesStr;
-    for (const auto & dtype : ddp_logging_data.dtypes) {
-      dtypesStr += dtype;
-      dtypesStr += " ";
-    }
+    std::string devicesStr = c10::Join(", ", ddp_logging_data.device_ids);
+    std::string bucketSizesStr = c10::Join(", ", ddp_logging_data.bucket_sizes);
+    std::string dtypesStr = c10::Join(" ", ddp_logging_data.dtypes);
 
     std::string ddpLoggingDataInfo = c10::str(
       "world_size: ", ddp_logging_data.world_size, ", module_name: ",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54649 [DDP logging] Prefer use of c10::Join**

Some operator<< code manually implemented string join in C++, turns
out there is a c10 util for this. Use the util instead of rolling our own.

Differential Revision: [D27316705](https://our.internmc.facebook.com/intern/diff/D27316705/)