### PR TITLE
Pass PyTorch's architectures to the rest of ROCm

### DIFF
--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -127,6 +127,9 @@ if(NOT DEFINED ENV{PYTORCH_ROCM_ARCH})
 else()
   set(PYTORCH_ROCM_ARCH $ENV{PYTORCH_ROCM_ARCH})
 endif()
+# Copy to other ROCm architecture control variables in the build
+set(GPU_TARGETS ${PYTORCH_ROCM_ARCH} CACHE STRING "GPU targets to compile for")
+set(AMDGPU_TARGETS ${PYTORCH_ROCM_ARCH} CACHE STRING "AMD GPU targets to compile for")
 
 # Add HIP to the CMAKE Module Path
 set(CMAKE_MODULE_PATH ${HIP_PATH}/cmake ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
When I run a build of current master, I don't get binaries for `gfx803`, and I see a different, shorter list of architectures in `CMakeCache.txt`, stored in `GPU_TARGETS` and `AMDGPU_TARGETS`. It isn't coming from the default PYTORCH_ROCM_ARCH or from my environment variables. So this change overrides it.

The [AMD docs](https://rocmdocs.amd.com/en/latest/Installation_Guide/Using-CMake-with-AMD-ROCm.html#using-hip-in-cmake) say we need to set `GPU_TARGETS` before we find the `hip` package if we want to control what architectures are built.

This patch, and having a development version of `rocrand` 2.10.9 installed that itself supports `gfx803`, allowed me to build PyTorch with `gfx803` support and work around #53738.

Fixes #53738 (at least in conjunction with sufficiently new `rocrand`).
