### PR TITLE
fx quant: fix bug with fusion patterns and disabling quantization

### DIFF
--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -890,6 +890,18 @@ class Quantizer:
                     env[node.name] = result
                 continue
             elif root_node is not None:
+                if qconfig is None:
+                    # This branch is hit if all of these conditions are met:
+                    # 1. we are in a fusion pattern of multiple nodes (i.e. add-relu)
+                    # 2. the current node is not the "root_node" of the pattern
+                    # 3. quantization for this pattern is disabled
+                    #
+                    # In this case, we need to make sure to populate the env with
+                    # intermediate nodes manually, because the QuantizeHandler.convert
+                    # function will not be called.
+                    result = self.quantized_graph.node_copy(
+                        node, load_non_quantized)
+                    env[node.name] = result
                 continue
 
             # handle activation post process calls


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54654 fx quant: fix bug with fusion patterns and disabling quantization**

Summary:

Fixes a bug where disabling quantizaton on potential fusion patterns
would lead to errors in the `convert` function.  For example:
1. have a model with add-relu
2. disable quantization for the part of the model containing add-relu
3. run prepare and convert, the convert step would fail because
intermediate nodes were missing from `env`.

The fix is to add handling for this edge case.  If quantization is
disabled, we manually copy the nodes for multi-node fusion patterns.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_fusion_pattern_unquantized
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27318454](https://our.internmc.facebook.com/intern/diff/D27318454)