### PR TITLE
[Static Runtime] Check for inplace ops explicitly in ReplaceWithCopy

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -108,6 +108,19 @@ const auto reshape_inplace_script = R"JIT(
       return (d, e, f)
 )JIT";
 
+const auto sigmoid_inplace_script = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = torch.sigmoid(inp, out=inp)
+      return (a)
+)JIT";
+
+const auto sigmoid_out_script = R"JIT(
+  def forward(self, inp: Tensor, shape: List[int]):
+      a = inp + inp
+      b = torch.sigmoid(inp, out=a)
+      return (b)
+)JIT";
+
 // b is in_contiguous
 const auto reshape_incontiguous_script = R"JIT(
   def forward(self, a: Tensor, shape: List[int]):

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -7,6 +7,22 @@
 
 namespace torch {
 namespace jit {
+namespace {
+bool HasInplaceOp(Block* block, const AliasDb& alias_db) {
+  for (auto* node : block->nodes()) {
+    for (Block* sub_block : node->blocks()) {
+      return HasInplaceOp(sub_block, alias_db);
+    }
+    auto inputs = node->inputs();
+    // check if node modifies inputs (both inplace ops and certain out variants
+    // would qualify). For example: c = torch.sigmoid(b, out=b) is essentially
+    // the same as c = b.sigmoid_()
+    if (inputs.size() > 0 && alias_db.writesToAlias(node, {inputs[0]})) {
+      return true;
+    }
+  }
+  return false;
+}
 
 void ConcatAddMulReplaceNaNClip(std::shared_ptr<torch::jit::Graph>& graph) {
   // TODO:: check restrictions for inputs; outputs not used elsewhere
@@ -306,6 +322,16 @@ void ClipRangesGatherRangesX2SigridHashPrecompute(
   fuse.runOnGraph(graph);
 }
 
+void SplitOutPrecomputeOpsForSparseNN(
+    std::shared_ptr<torch::jit::Graph>& graph) {
+#ifdef FBCODE_CAFFE2
+  PrecomputeMultiplierShiftForSigridHash(graph);
+  ConstantPropagation(graph);
+  ConstantPooling(graph);
+#endif
+}
+} // namespace
+
 void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 #ifdef FBCODE_CAFFE2
   SplitOutPrecomputeOpsForSparseNN(graph);
@@ -327,15 +353,6 @@ void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph) {
 #endif
 }
 
-void SplitOutPrecomputeOpsForSparseNN(
-    std::shared_ptr<torch::jit::Graph>& graph) {
-#ifdef FBCODE_CAFFE2
-  PrecomputeMultiplierShiftForSigridHash(graph);
-  ConstantPropagation(graph);
-  ConstantPooling(graph);
-#endif
-}
-
 TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
   m.def("static_runtime::pure_inputs() -> Tensor", []() -> at::Tensor {
     return at::randn({1});
@@ -347,6 +364,10 @@ TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
       "static_runtime::reshape_copy(Tensor(a) self, int[] shape) -> Tensor(a)");
   m.def(
       "static_runtime::flatten_copy.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)");
+}
+
+bool HasInplaceOp(std::shared_ptr<Graph>& graph, const AliasDb& alias_db) {
+  return HasInplaceOp(graph->block(), alias_db);
 }
 
 void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
@@ -381,6 +402,8 @@ void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
        c10::Symbol::fromQualString("static_runtime::flatten_copy")},
       {c10::Symbol::fromQualString("aten::to"),
        c10::Symbol::fromQualString("static_runtime::to_copy")}};
+
+  bool has_inplace_ops = HasInplaceOp(graph, db);
   std::vector<std::pair<Node*, Node*>> replacement;
   for (auto* n : graph->nodes()) {
     if (!supported.count(n->kind())) {
@@ -406,7 +429,7 @@ void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
     // result. To keep static runtime consistent with the jit interpreter, here
     // we choose not to replace reshape with the copy version
     auto* in = n->input(0);
-    if (in->uses().size() > 1) {
+    if (has_inplace_ops && in->uses().size() > 1) {
       continue;
     }
 

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -8,8 +8,7 @@ void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
 
 void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 
-void SplitOutPrecomputeOpsForSparseNN(
-    std::shared_ptr<torch::jit::Graph>& graph);
+bool HasInplaceOp(std::shared_ptr<Graph>& graph, const AliasDb& alias_db);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: The constraint checked in D27145406 (https://github.com/pytorch/pytorch/commit/acf03b13f157f8f0190d7ef70591490a2e8585b4) is too tight for the adindexer model and as a result, 5 ops (4 aten::narrow + 1 aten::premute) are not replaced with the copy version and resulted in perf regression. This diff checks for inplace ops explicitly and only applies the input constraint to graphs with inplace ops.

Test Plan: Contbuild

Differential Revision: D27253145

