### PR TITLE
docs: add `unsafe_chunk` and `unsafe_split` in torch.rst

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -110,6 +110,8 @@ Indexing, Slicing, Joining, Mutating Ops
     tile
     transpose
     unbind
+    unsafe_chunk
+    unsafe_split
     unsqueeze
     vstack
     where


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/53642
https://11809959-65600975-gh.circle-artifacts.com/0/docs/generated/torch.unsafe_chunk.html#torch.unsafe_chunk
https://11809959-65600975-gh.circle-artifacts.com/0/docs/generated/torch.unsafe_split.html#torch.unsafe_split