### PR TITLE
docs: remove extra backticks in `narrow_copy`

### DIFF
--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2478,9 +2478,9 @@ narrow_copy(dimension, start, length) -> Tensor
 
 Same as :meth:`Tensor.narrow` except returning a copy rather
 than shared storage.  This is primarily for sparse tensors, which
-do not have a shared-storage narrow method.  Calling ```narrow_copy``
-with ```dimemsion > self.sparse_dim()``` will return a copy with the
-relevant dense dimension narrowed, and ```self.shape``` updated accordingly.
+do not have a shared-storage narrow method.  Calling ``narrow_copy``
+with ``dimemsion > self.sparse_dim()`` will return a copy with the
+relevant dense dimension narrowed, and ``self.shape`` updated accordingly.
 """)
 
 add_docstr_all('ndimension',


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/41590
https://11813004-65600975-gh.circle-artifacts.com/0/docs/tensors.html