### PR TITLE
enable bf16 vec copy

### DIFF
--- a/aten/src/ATen/native/cpu/CopyKernel.cpp
+++ b/aten/src/ATen/native/cpu/CopyKernel.cpp
@@ -15,8 +15,6 @@ static void copy_kernel(TensorIterator& iter, bool non_blocking) {
   if (dtype == iter.dtype(1)) {
     if (dtype == ScalarType::Half) {
       cpu_kernel(iter, [=](at::Half a) -> at::Half { return a; });
-    } else if (dtype == ScalarType::BFloat16) {
-      cpu_kernel(iter, [=](at::BFloat16 a) -> at::BFloat16 { return a; });
     } else if (dtype == ScalarType::ComplexHalf) {
       cpu_kernel(iter, [=](c10::complex<at::Half> a) -> c10::complex<at::Half> { return a; });
     } else if (isQIntType(dtype)) {
@@ -34,8 +32,8 @@ static void copy_kernel(TensorIterator& iter, bool non_blocking) {
             [=](Vec256<scalar_t> a) -> Vec256<scalar_t> { return a; });
         });
     } else {
-      AT_DISPATCH_ALL_TYPES_AND(
-          ScalarType::Bool, dtype, "copy_kernel", [&] {
+      AT_DISPATCH_ALL_TYPES_AND2(
+          ScalarType::Bool, ScalarType::BFloat16,dtype, "copy_kernel", [&] {
             cpu_kernel_vec(
                 iter,
                 [=](scalar_t a) -> scalar_t { return a; },


### PR DESCRIPTION
Enable bf16 vectorized copy.

BFloat16's copy get 2x performance for fp32 as our expectation.

BFloat16's vec copy dose not show performance gain compare with scalar version with op benchmark. This should caused by the memory system of operator. The system will really "read/write" a scalar at one time, although the code is written in scalar version.

benchmarks code:
```
import torch
import torch.utils.benchmark as benchmark

# x = torch.empty(10 * 18304 * 1024 * 16, dtype=torch.bfloat16)
x = torch.empty(10 * 18304 * 1024 * 16, dtype=torch.float)
def copy(tensors):
    for t in tensors:
        x.copy_(t)

tensors = []
for i in range(2):
    # l3 cache size 36608k = 18304 bfloat16 * 2 byte(per bfloat16)
    # tensors.append(torch.rand(10 * 18304 * 1024 * 16).bfloat16())
    tensors.append(torch.rand(10 * 18304 * 1024 * 16))

t0 = benchmark.Timer(
    stmt='copy(tensors)',
    setup='from __main__ import copy',
    globals={'tensors': tensors},
    num_threads=1)
    
print(t0.timeit(20))
```

Before this comit:
fp32:
  3.84 s
  1 measurement, 20 runs , 1 thread
bf16:
  1.89 s
  1 measurement, 20 runs , 1 thread

After:
fp32:
  3.71 s
  1 measurement, 20 runs , 1 thread
bf16:
  1.85 s
  1 measurement, 20 runs , 1 thread
