### PR TITLE
enable bf16 for cat serial kernel

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -204,7 +204,8 @@ Tensor & _cat_out_cpu(Tensor& result, TensorList tensors, int64_t dim) {
   allContiguous = allContiguous && result.is_contiguous(first_tensor_mem_format);
   bool use_serial_kernel = result.numel() < at::internal::GRAIN_SIZE || at::get_num_threads() == 1;
   ScalarType dtype = notSkippedTensor.scalar_type();
-  if (use_serial_kernel && allContiguous && no_type_promotion && (dtype == ScalarType::Double || dtype == ScalarType::Float)) {
+  bool serial_dtype = (dtype == ScalarType::Double || dtype == ScalarType::Float || dtype == ScalarType::BFloat16);
+  if (use_serial_kernel && allContiguous && no_type_promotion && serial_dtype) {
     cat_serial_stub(kCPU, result, tensors, dim);
     return result;
   }

--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -57,7 +57,7 @@ void cat_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
 }
 
 void cat_serial_kernel(Tensor& result, TensorList tensors, int64_t dim) {
-  AT_DISPATCH_FLOATING_TYPES(result.scalar_type(), "cat_serial_kernel", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::BFloat16, result.scalar_type(), "cat_serial_kernel", [&]() {
     cat_serial_kernel_impl<scalar_t>(result, tensors, dim);
   });
 }


### PR DESCRIPTION
cat 10 2-D tensors at dim=1

|                     | shape                    | serial kernel | copy kernel | 
| ------------ | ------------- | ------------ | ------------- |
| fp32          | 1024 * 16k           |   105.45 ms    | 102.41 ms     |
| fp32          | 1024 * (100 + i)  |   324.75 us     | 448.66 us      |
| bf16          | 1024 * 16k           |   49.82 ms       | 51.39 ms       |
| bf16          | 1024 * (100 + i)  |   164.74 us      | 244.64 us      |

i = {0, ..., 9}

benchmark code
```
import torch
import torch.utils.benchmark as benchmark
def cat(*args, dim=0):
    return torch.cat(args, dim)

tensors = []
for i in range(10):
    tensors.append(torch.rand(1024, 16 *1024))
    # tensors.append(torch.rand(1024, 16 *1024).bfloat16())
    # tensors.append(torch.rand(1024, 100 + i))
    # tensors.append(torch.rand(1024, 100 + i).bfloat16())

t0 = benchmark.Timer(
    stmt='cat(*tensors, dim=1)',
    setup='from __main__ import cat',
    globals={'tensors': tensors},
    num_threads=1)
    
print(t0.blocked_autorange())

```
