### PR TITLE
initial commit to refactor all s3 access codes to s3_stats_parser

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -395,10 +395,10 @@ def get_test_time_reports_from_S3() -> List[Dict[str, Any]]:
         nightly_commit = nightly_commits[commit_index]
         print(f'Grabbing reports from nightly commit: {nightly_commit}')
         summaries = get_test_stats_summaries_for_job(sha=nightly_commit, job_prefix=stripped_job)
-        for _, summary in summaries.items():
+        for job_name, summary in summaries.items():
             reports.append(summary[0])
             if len(summary) > 1:
-                print(f'Warning: multiple summary object found for {nightly_commit}/{stripped_job}')
+                print(f'Warning: multiple summary object found for {nightly_commit}/{job_name}')
         commit_index += 1
     return reports
 

--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -18,7 +18,7 @@ from xml.dom import minidom  # type: ignore[import]
 
 import requests
 from typing_extensions import TypedDict
-from tools.stats_utils.s3_stat_parser import (newify_case, get_S3_object_from_bucket, get_S3_bucket_readonly,
+from tools.stats_utils.s3_stat_parser import (newify_case, get_S3_object_from_bucket, get_test_stats_summaries_for_job,
                                               Report, Status, Commit, HAVE_BOTO3, Version2Case, VersionedReport,
                                               Version1Report, Version2Report, ReportMetaMeta)
 
@@ -805,20 +805,13 @@ def print_regressions(head_report: Report, *, num_prev_commits: int) -> None:
         commits = commits[:-1]
 
     job = os.environ.get("CIRCLE_JOB", "")
-    bucket = get_S3_bucket_readonly('ossci-metrics')
-    index = {}
-    for commit in commits:
-        summaries = bucket.objects.filter(Prefix=f"test_time/{commit}/{job}/")
-        index[commit] = list(summaries)
+    objects: Dict[Commit, List[Report]] = defaultdict(list)
 
-    objects: Dict[Commit, List[Report]] = {}
-    # should we do these in parallel?
-    for commit, summaries in index.items():
-        objects[commit] = []
-        for summary in summaries:
-            binary = summary.get()["Body"].read()
-            string = bz2.decompress(binary).decode("utf-8")
-            objects[commit].append(json.loads(string))
+    for commit in commits:
+        objects[commit]
+        summaries = get_test_stats_summaries_for_job(sha=commit, job_prefix=job)
+        for _, summary in summaries.items():
+            objects[commit].extend(summary)
 
     print()
     print(regression_info(

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -150,11 +150,11 @@ def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Any]]
 # optional jobs filter
 def get_test_stats_summaries(*, sha: str, jobs: Optional[List[str]] = None) -> Dict[str, List[Any]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
-    summaries = list(bucket.objects.filter(Prefix=f"test_time/{sha}"))
+    summaries = bucket.objects.filter(Prefix=f"test_time/{sha}")
     return _parse_s3_summaries(summaries, jobs=list(jobs or []))
 
 
 def get_test_stats_summaries_for_job(*, sha: str, job_prefix: str) -> Dict[str, List[Any]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
-    summaries = list(bucket.objects.filter(Prefix=f"test_time/{sha}/{job_prefix}"))
+    summaries = bucket.objects.filter(Prefix=f"test_time/{sha}/{job_prefix}")
     return _parse_s3_summaries(summaries, jobs=list())


### PR DESCRIPTION
First step to move all S3 related operations into S3 parser utils.
in the end we provide APIs from s3_stats_parser:
1. downloading data as reports and uploading data as reports
2. filter by job name

and handle all compression, formatting inside. 

TODO
- [ ] Refactor out upload into s3_stats_parser 
- [ ] Remove all S3/BOTO related checkers and try/catch blocks outside of s3_stats_parser 

Test Plan
1. Running tools/test/* covers the refactoring logic (test_test_history.py and test_stats.py as entrypoint and both using the 2 new APIs in s3_stats_parser after the refactoring.
2. print_test_stats.py's main argparse entrypoint is covered by CI step Report Test Result step.
3. run `python test/run_test.py --export-past-test-times` before and after this PR should result in the same file content in .pytorch-test-times


