### PR TITLE
Cancel redundant GHA workflows

### DIFF
--- a/.github/workflows/cancel_redundant_workflows.yml
+++ b/.github/workflows/cancel_redundant_workflows.yml
@@ -1,0 +1,20 @@
+name: Cancel redundant workflows
+on:
+  workflow_run:
+    types:
+      - requested
+    workflows:
+      - clang-format
+      - Lint
+      - Test tools
+
+jobs:
+  cancel:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Cancel duplicate workflow runs
+        uses: potiuk/cancel-workflow-runs@v4_8
+        with:
+          cancelMode: duplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
This PR adds a lightweight workflow which runs when any of our GitHub Actions lint or test workflows start (currently just the three listed in the YAML in this PR's diff), and cancels redundant ones (e.g. if a PR author pushes several commits in rapid succession). Currently this isn't particularly impactful, but it would become more so if/when we add heavier workflows that run on PRs.

Initially we tried using [`technote-space/auto-cancel-redundant-workflow`](https://github.com/technote-space/auto-cancel-redundant-workflow) instead of [`potiuk/cancel-workflow-runs`](https://github.com/potiuk/cancel-workflow-runs), but for some reason it the former doesn't seem to work even if triggered by `workflow_run` with the `TARGET_RUN_ID` input set appropriately.

**Test plan:**

@janeyx99 and I tested this in a separate GitHub repo, and confirmed that it successfully cancels redundant `push`-triggered workflows on the source repo and `pull_request`-triggered workflows from forks.