### PR TITLE
add sndfile yum package to centos dockerfile

### DIFF
--- a/.circleci/docker/common/install_base.sh
+++ b/.circleci/docker/common/install_base.sh
@@ -77,6 +77,7 @@ install_centos() {
     glog-devel \
     hiredis-devel \
     libstdc++-devel \
+    libsndfile-devel \
     make \
     opencv-devel \
     sudo \


### PR DESCRIPTION
Fixes error when running torch test suite inside a centos CI image.  As described by https://pypi.org/project/SoundFile/0.10.3.post1/, `On Linux, you need to install libsndfile using your distribution’s package manager`.  This was missing from the centos CI image.

```
python test_spectral_ops.py -v
...
Traceback (most recent call last):
  File "test_spectral_ops.py", line 25, in <module>
    import librosa
  File "/opt/conda/lib/python3.6/site-packages/librosa/__init__.py", line 211, in <module>
    from . import core
  File "/opt/conda/lib/python3.6/site-packages/librosa/core/__init__.py", line 6, in <module>
    from .audio import *  # pylint: disable=wildcard-import
  File "/opt/conda/lib/python3.6/site-packages/librosa/core/audio.py", line 8, in <module>
    import soundfile as sf
  File "/opt/conda/lib/python3.6/site-packages/soundfile.py", line 142, in <module>
    raise OSError('sndfile library not found')
OSError: sndfile library not found
```