### PR TITLE
Drop Python 2 support in common_device_type.py

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -495,13 +495,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 
         for name in generic_members:
             if name in generic_tests:  # Instantiates test member
-                # Requires tests be a function for Python2 compat
-                # (In Python2 tests are type checked methods wrapping functions)
                 test = getattr(generic_test_class, name)
-                if hasattr(test, '__func__'):
-                    test = test.__func__
-                assert inspect.isfunction(test), "Couldn't extract function from '{0}'".format(name)
-
                 # XLA-compat shim (XLA's instantiate_test takes doesn't take generic_cls)
                 sig = inspect.signature(device_type_test_class.instantiate_test)
                 if len(sig.parameters) == 3:
@@ -511,12 +505,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
                     device_type_test_class.instantiate_test(name, copy.deepcopy(test))
             else:  # Ports non-test member
                 assert name not in device_type_test_class.__dict__, "Redefinition of directly defined member {0}".format(name)
-
-                # Unwraps to functions (when available) for Python2 compat
                 nontest = getattr(generic_test_class, name)
-                if hasattr(nontest, '__func__'):
-                    nontest = nontest.__func__
-
                 setattr(device_type_test_class, name, nontest)
 
         # Mimics defining the instantiated class in the caller's file

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -770,9 +770,7 @@ class precisionOverride(object):
 # @dtypes((torch.long, torch.float32), (torch.int, torch.float64))
 class dtypes(object):
 
-    # Note: *args, **kwargs for Python2 compat.
-    # Python 3 allows (self, *args, device_type='all').
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, device_type="all"):
         if len(args) > 0 and isinstance(args[0], (list, tuple)):
             for arg in args:
                 assert isinstance(arg, (list, tuple)), \
@@ -784,7 +782,7 @@ class dtypes(object):
             assert all(isinstance(arg, torch.dtype) for arg in args), "Unknown dtype in {0}".format(str(args))
 
         self.args = args
-        self.device_type = kwargs.get('device_type', 'all')
+        self.device_type = device_type
 
     def __call__(self, fn):
         d = getattr(fn, 'dtypes', {})


### PR DESCRIPTION
Hey!

Just stumbled across these Python 2 fragments while reading the source code and thought it could be removed, since the Python 2 support has already been dropped.

@mruberry 