### PR TITLE
[test_c10d] Add wait in nccl high priority stream test

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -4892,7 +4892,7 @@ class CommTest(MultiProcessTestCase):
         self.assertTrue(pg.options.is_high_priority_stream)
         # test the process group works as expected
         t = torch.tensor([self.rank + 1] * 10).cuda(self.rank)
-        pg.allreduce(t)
+        pg.allreduce(t).wait()
         expected_tensor = torch.tensor([3] * 10).cuda(self.rank)
         self.assertEqual(expected_tensor, t)
 


### PR DESCRIPTION
Add wait in test_pass_nccl_options_high_priority_stream
after the all reduce operation.
Without wait, the allreduce operation might be still running and the
comparison of result might not be valid.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

