### PR TITLE
Pin autocanceling GHA repo to specific commit

### DIFF
--- a/.github/workflows/cancel_redundant_workflows.yml
+++ b/.github/workflows/cancel_redundant_workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Cancel duplicate workflow runs
-        uses: potiuk/cancel-workflow-runs@v4_8
+        uses: potiuk/cancel-workflow-runs@a81b3c4d59c61e27484cfacdc13897dd908419c9
         with:
           cancelMode: duplicates
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This way, if malicious code gets committed and the tag moves forward, we would be at risk. This does mean that we would have to manually update the SHA if there are desirable upgrades to the repository.

We are pinning it to this commit: https://github.com/potiuk/cancel-workflow-runs/commit/a81b3c4d59c61e27484cfacdc13897dd908419c9