### PR TITLE
Remove ops from the complex_list for which the method_tests have been ported

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5298,7 +5298,7 @@ def run_functional_checks(test_case, test_name, name, apply_fn, run_grad_checks,
 # the tests for these ops which do not have 'complex' in variant should not run for complex
 # and only run for floating point
 
-separate_complex_tests = ['view_as_real', 'real', 'imag', 'div', 'pow', 'rsqrt', '__rdiv__', 'add', 'sub']
+separate_complex_tests = ['view_as_real', 'real', 'imag', 'div', 'pow', '__rdiv__', 'add', 'sub']
 
 # NOTE: Some non-holomorphic are separately tested in TestAutogradComplex until gradcheck works properly
 # for non-holomorphic functions
@@ -5312,15 +5312,15 @@ if _get_torch_cuda_version() != (11, 2):
 
 # allow list for complex
 complex_list = ['t', 'view', 'reshape', 'reshape_as', 'view_as', 'roll', 'clone',
-                'repeat', 'expand', 'rot90', 'transpose',
+                'expand', 'rot90', 'transpose',
                 'permute', 'squeeze', 'unsqueeze', 'resize', 'resize_as', 'tril', 'triu',
-                'chunk', 'split', 'split_with_sizes', 'repeat', 'expand', 'zero_',
-                'eq_', 'ne_', 'add', '__radd__', 'sum', 'conj', 'mul',
-                '__rmul__', 'abs', 'dot', 'vdot', 'tensor_split', 'matmul',
+                'chunk', 'split', 'split_with_sizes', 'zero_',
+                'eq_', 'ne_', 'add', '__radd__', 'sum', 'mul',
+                '__rmul__', 'dot', 'vdot', 'matmul',
                 'bmm', 'mv', 'ger', 'diagonal', 'fill_', 'sub',
-                'mean', 'inverse', 'solve', 'addcmul',
-                'addcdiv', 'linalg.tensorinv', 'matrix_exp', 'qr',
-                'narrow', 'swapaxes', 'swapdims', 'tensor_split', 'tile',
+                'mean', 'inverse', 'addcmul',
+                'addcdiv', 'linalg.tensorinv', 'matrix_exp',
+                'narrow', 'swapaxes', 'swapdims', 'tensor_split',
                 'baddbmm', 'addbmm', 'addmv'] + complex_list_filter + separate_complex_tests
 
 # deny list for batched grad computation


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54754 Remove ops from the complex_list for which the method_tests have been ported**

Differential Revision: [D27354326](https://our.internmc.facebook.com/intern/diff/D27354326)