### PR TITLE
[PyTorch][Mobile] Introduce kMaxSupportedBytecodeVersion

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -74,9 +74,17 @@ static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
 
 // Introduce kMinSupportedBytecodeVersion for limited backward compatibility
 // support of bytecode. If
-// kMinSupportedBytecodeVersion <= model_version <= kProducedBytecodeVersion (in loader),
+// kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion (in loader),
 // we should support this model_version. For example, we provide a wrapper to
 // handle an updated operator.
+// It is possible that kMaxSupportedBytecodeVersion is larger than kProducedBytecodeVersion
+// for a short amount of time, to better support forward compatibility. When the bytecode
+// format is updated and the version need to be bumped, kMaxSupportedBytecodeVersion can be
+// bumped first and deployed, such that runtime can support the upcoming new format. After
+// all runtime in client updates to new runtime, for example, two weeks, the new runtime can
+// support both old models and new models, then kProducedBytecodeVersion can be bumped to the same
+// kMaxSupportedBytecodeVersion.
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
+constexpr uint64_t kMaxSupportedBytecodeVersion = 0x4L;
 } // namespace serialize
 } // namespace caffe2

--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -77,13 +77,14 @@ static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
 // kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion (in loader),
 // we should support this model_version. For example, we provide a wrapper to
 // handle an updated operator.
-// It is possible that kMaxSupportedBytecodeVersion is larger than kProducedBytecodeVersion
-// for a short amount of time, to better support forward compatibility. When the bytecode
-// format is updated and the version need to be bumped, kMaxSupportedBytecodeVersion can be
-// bumped first and deployed, such that runtime can support the upcoming new format. After
-// all runtime in client updates to new runtime, for example, two weeks, the new runtime can
-// support both old models and new models, then kProducedBytecodeVersion can be bumped to the same
-// kMaxSupportedBytecodeVersion.
+// kMaxSupportedBytecodeVersion is introduced to better support forward compatibility.
+// Most of the time, kMaxSupportedBytecodeVersion should be the same as kProducedBytecodeVersion.
+// When a new model format needs to roll out, for example, update the model format from v4 to v5,
+// the process is:
+// 1. update the code to let it read model v4 and v5, bump kMaxSupportedBytecodeVersion from 4 to 5
+// 2. wait until the new code is rolling to all client device
+// 3. update the code to let it generate the new model format v5 from now on, bump kProducedBytecodeVersion
+// from 4 to 5
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
 constexpr uint64_t kMaxSupportedBytecodeVersion = 0x4L;
 } // namespace serialize

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -220,12 +220,12 @@ void BytecodeDeserializer::parseMethods(
   }
   TORCH_CHECK(
       caffe2::serialize::kMinSupportedBytecodeVersion <= model_version &&
-          model_version <= caffe2::serialize::kProducedBytecodeVersion,
+          model_version <= caffe2::serialize::kMaxSupportedBytecodeVersion,
       "Lite Interpreter verson number does not match. ",
       "The model version must be between ",
       caffe2::serialize::kMinSupportedBytecodeVersion,
       " and ",
-      caffe2::serialize::kProducedBytecodeVersion,
+      caffe2::serialize::kMaxSupportedBytecodeVersion,
       "But the model version is ",
       model_version);
 


### PR DESCRIPTION
## Summary

To better support forward compatibility when bumping model version, introduce `kMaxSupportedBytecodeVersion`. Set the `kMaxSupportedBytecodeVersion` the same as `kProducedBytecodeVersion` now, and update the check in `import.cpp` to make sure `kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion (in loader),`

How to use it to support forward compatibility? For example, when the model format is updated and the version need to be bumped from v4 to v5:

1. update the code such that it can read model v4 and v5, bump `kMaxSupportedBytecodeVersion` from 4 to 5.
2. wait until the new code is rolling to all client device
3. update the code such that it will generate the new model format v5 from now on, bump `kProducedBytecodeVersion` from 4 to 5

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54760 [PyTorch][Mobile] Introduce kMaxSupportedBytecodeVersion**

Differential Revision: [D27366421](https://our.internmc.facebook.com/intern/diff/D27366421)