### PR TITLE
[pyper] out variant of sigrid_transforms_torch_bind + ListUnpack

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -436,8 +436,8 @@ void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   for (auto it = nodes.begin(); it != nodes.end(); ++it) {
     Node* sigrid_node = *it;
     auto kind = sigrid_node->kind();
-    // TODO: make it work the TorchBind version
-    if (strcmp(kind.toQualString(), "fb::sigrid_transforms") == 0) {
+    if (strcmp(kind.toQualString(), "fb::sigrid_transforms") == 0 ||
+        strcmp(kind.toQualString(), "fb::sigrid_transforms_torch_bind") == 0) {
       const Value* sigrid_out = sigrid_node->outputs()[0];
       if (sigrid_out->uses().size() > 1) {
         continue;


### PR DESCRIPTION
Test Plan:
Regen adindexer model that uses sigrid_transforms_torch_bind: /mnt/public/ansha/adindexer/merge20210323/adindexer_pt_traced_merge.pt

```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --scripted_model=adindexer_pt_traced_merge.pt --pt_inputs=/data/users/ansha/tmp/adindexer/merge2/container_precomputation_bs1.pt --iters=30000 --warmup_iters=300000 --num_threads=1 --pred_net=c2_net_merge.pb --pt_enable_static_runtime=1 --pt_cleanup_activations=true --pt_enable_out_variant=1 --pt_optimize_memory=1
```

Before ms/iter: 0.0647056
After ms/iter: 0.0581197

Differential Revision: D27239617

