### PR TITLE
Fix raw_deleter() bug with PYTORCH_NO_CUDA_MEMORY_CACHING=1

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1199,7 +1199,11 @@ struct CudaCachingAllocator : public Allocator {
     return {r, r, &raw_delete, Device(DeviceType::CUDA, device)};
   }
   DeleterFnPtr raw_deleter() const override {
-    return &raw_delete;
+    if (forceUncachedAllocator()) {
+      return &uncached_delete;
+    } else {
+      return &raw_delete;
+    }
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54775 Fix raw_deleter() bug with PYTORCH_NO_CUDA_MEMORY_CACHING=1**

Thanks danpovey for reporting. Fixes https://github.com/pytorch/pytorch/issues/54770

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27363730](https://our.internmc.facebook.com/intern/diff/D27363730)