### PR TITLE
[ZeroRedundancyOptimizer] bounding the multiple gpus unit test to 4 gpus, hardcoded values

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -14,6 +14,7 @@ from typing import List, Any, Type, cast
 import numpy as np
 import torch
 import torch.distributed as dist
+
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
@@ -206,7 +207,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
 class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     @property
     def world_size(self):
-        return max(2, torch.cuda.device_count())
+        return min(4, max(2, torch.cuda.device_count()))
 
     @common_distributed.skip_if_rocm
     def test_step(self):
@@ -494,7 +495,9 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
                 model.register_buffer("test_buffer", torch.ones((1)) * self.rank)
                 model.to(self.device)
 
-                sharded_optimizer = ZeroRedundancyOptimizer(params=model.parameters(), optimizer_class=optimizer, lr=1e-3)
+                sharded_optimizer = ZeroRedundancyOptimizer(
+                    params=model.parameters(), optimizer_class=optimizer, lr=1e-3
+                )
                 sharded_ddp_model = DDP(
                     module=model, device_ids=[self.rank], broadcast_buffers=True, find_unused_parameters=True
                 )


### PR DESCRIPTION
Fixes #53322, the test has some hardcoded values to check that the sharding works as expected, and was not used beyond 4 gpus prior
