### PR TITLE
make all arguments in test_history.py optional kwarg

### DIFF
--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -107,16 +107,16 @@ def get_cases(
     data: Report,
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: str,
+    test_name: Optional[str],
 ) -> List[Version2Case]:
     cases: List[Version2Case] = []
     if 'format_version' not in data:  # version 1 implicitly
         v1report = cast(Version1Report, data)
         suites = v1report['suites']
         for sname, v1suite in suites.items():
-            if sname == suite_name or not suite_name:
+            if not suite_name or sname == suite_name:
                 for v1case in v1suite['cases']:
-                    if v1case['name'] == test_name:
+                    if not test_name or v1case['name'] == test_name:
                         cases.append(newify_case(v1case))
     else:
         v_report = cast(VersionedReport, data)
@@ -127,9 +127,9 @@ def get_cases(
                 if fname == filename or not filename:
                     for sname, v2suite in v2file['suites'].items():
                         if sname == suite_name or not suite_name:
-                            v2case = v2suite['cases'].get(test_name)
-                            if v2case:
-                                cases.append(v2case)
+                            for v2case in v2suite['cases']:
+                                if not test_name or v2case['name'] == test_name:
+                                    cases.append(v2case)
         else:
             raise RuntimeError(f'Unknown format version: {version}')
     return cases

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -127,8 +127,8 @@ def get_cases(
                 if fname == filename or not filename:
                     for sname, v2suite in v2file['suites'].items():
                         if sname == suite_name or not suite_name:
-                            for v2case in v2suite['cases']:
-                                if not test_name or v2case['name'] == test_name:
+                            for cname, v2case in v2suite['cases'].items():
+                                if not test_name or cname == test_name:
                                     cases.append(v2case)
         else:
             raise RuntimeError(f'Unknown format version: {version}')

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -195,8 +195,8 @@ In multiline mode, each line next includes the name of a CircleCI job,
 followed by the time of the specified test in that job at that commit.
 Example:
 
-    $ tools/test_history.py multiline --ref=594a66 --sha-length=8 test_set_dir \
-      pytorch_linux_xenial_py3_6_gcc5_4_test pytorch_linux_xenial_py3_6_gcc7_test
+    $ tools/test_history.py --mode=multiline --ref=594a66 --sha-length=8 --test=test_set_dir \
+      --jobs=pytorch_linux_xenial_py3_6_gcc5_4_test,pytorch_linux_xenial_py3_6_gcc7_test
     2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
     2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
     2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
@@ -211,8 +211,8 @@ Example:
 
 Another multiline example, this time with the --all flag:
 
-    $ tools/test_history.py multiline --all --ref=321b9 --delta=12 --sha-length=8 \
-      test_qr_square_many_batched_complex_cuda
+    $ tools/test_history.py --mode=multiline --all --ref=321b9 --delta=12 --sha-length=8 \
+      --test=test_qr_square_many_batched_complex_cuda
     2021-01-07 10:04:56Z 321b9883 pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_test2 424.284s
     2021-01-07 10:04:56Z 321b9883 pytorch_linux_xenial_cuda10_2_cudnn7_py3_slow_test 0.006s skipped
     2021-01-07 10:04:56Z 321b9883 pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_test 402.572s
@@ -226,8 +226,8 @@ In columns mode, the name of the job isn't printed, but the order of the
 columns is guaranteed to match the order of the jobs passed on the
 command line. Example:
 
-    $ tools/test_history.py columns --ref=3cf783 --sha-length=8 test_set_dir \
-      pytorch_linux_xenial_py3_6_gcc5_4_test pytorch_linux_xenial_py3_6_gcc7_test
+    $ tools/test_history.py --mode=columns --ref=3cf783 --sha-length=8 --test=test_set_dir \
+      --jobs=pytorch_linux_xenial_py3_6_gcc5_4_test,pytorch_linux_xenial_py3_6_gcc7_test
     2021-02-10 12:18:50Z 3cf78395    0.644s    0.312s
     2021-02-10 11:13:34Z 594a66d7    0.360s  errored
     2021-02-10 10:13:25Z 9c0caf03    0.819s    0.449s
@@ -251,7 +251,7 @@ def parse_args(raw: List[str]) -> argparse.Namespace:
         formatter_class=HelpFormatter,
     )
     parser.add_argument(
-        'mode',
+        '--mode',
         choices=['columns', 'multiline'],
         help='output format',
     )
@@ -297,19 +297,18 @@ def parse_args(raw: List[str]) -> argparse.Namespace:
         help='name of the suite containing the test',
     )
     parser.add_argument(
-        'test',
+        '--test',
         help='name of the test',
     )
     parser.add_argument(
-        'job',
-        nargs='*',
+        '--jobs',
         help='names of jobs to display columns for, in order',
-        default=[],
+        default="",
     )
     args = parser.parse_args(raw)
 
-    args.jobs = None if args.all else args.job
-    if args.jobs == []:  # no jobs, and not None (which would mean all jobs)
+    args.jobs = None if args.all else args.jobs.split(',')
+    if args.jobs == "":  # no jobs, and not None (which would mean all jobs)
         parser.error('No jobs specified.')
 
     return args

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -29,7 +29,7 @@ def make_column(
     data: Optional[Report],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: str,
+    test_name: Optional[str],
     digits: int,
 ) -> Tuple[str, int]:
     decimals = 3
@@ -62,7 +62,7 @@ def make_columns(
     omitted: Dict[str, int],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: str,
+    test_name: Optional[str],
     digits: int,
 ) -> str:
     columns = []
@@ -95,7 +95,7 @@ def make_lines(
     omitted: Dict[str, int],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: str,
+    test_name: Optional[str],
 ) -> List[str]:
     lines = []
     for job, data in jsons.items():
@@ -128,7 +128,7 @@ def history_lines(
     jobs: Optional[List[str]],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: str,
+    test_name: Optional[str],
     delta: int,
     sha_length: int,
     mode: str,
@@ -254,6 +254,7 @@ def parse_args(raw: List[str]) -> argparse.Namespace:
         '--mode',
         choices=['columns', 'multiline'],
         help='output format',
+        default='columns',
     )
     parser.add_argument(
         '--pytorch',
@@ -303,12 +304,13 @@ def parse_args(raw: List[str]) -> argparse.Namespace:
     parser.add_argument(
         '--jobs',
         help='names of jobs to display columns for, in order',
-        default="",
+        default='',
     )
     args = parser.parse_args(raw)
 
     args.jobs = None if args.all else args.jobs.split(',')
-    if args.jobs == "":  # no jobs, and not None (which would mean all jobs)
+    # We dont allow implicit or empty "--jobs", unless "--all" is specified.
+    if args.jobs and (args.jobs == [] or args.jobs[0] == ''):  
         parser.error('No jobs specified.')
 
     return args

--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -29,7 +29,7 @@ def make_column(
     data: Optional[Report],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: Optional[str],
+    test_name: str,
     digits: int,
 ) -> Tuple[str, int]:
     decimals = 3
@@ -62,7 +62,7 @@ def make_columns(
     omitted: Dict[str, int],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: Optional[str],
+    test_name: str,
     digits: int,
 ) -> str:
     columns = []
@@ -95,7 +95,7 @@ def make_lines(
     omitted: Dict[str, int],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: Optional[str],
+    test_name: str,
 ) -> List[str]:
     lines = []
     for job, data in jsons.items():
@@ -128,7 +128,7 @@ def history_lines(
     jobs: Optional[List[str]],
     filename: Optional[str],
     suite_name: Optional[str],
-    test_name: Optional[str],
+    test_name: str,
     delta: int,
     sha_length: int,
     mode: str,
@@ -196,7 +196,7 @@ followed by the time of the specified test in that job at that commit.
 Example:
 
     $ tools/test_history.py --mode=multiline --ref=594a66 --sha-length=8 --test=test_set_dir \
-      --jobs=pytorch_linux_xenial_py3_6_gcc5_4_test,pytorch_linux_xenial_py3_6_gcc7_test
+      --job pytorch_linux_xenial_py3_6_gcc5_4_test --job pytorch_linux_xenial_py3_6_gcc7_test
     2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
     2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
     2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
@@ -227,7 +227,7 @@ columns is guaranteed to match the order of the jobs passed on the
 command line. Example:
 
     $ tools/test_history.py --mode=columns --ref=3cf783 --sha-length=8 --test=test_set_dir \
-      --jobs=pytorch_linux_xenial_py3_6_gcc5_4_test,pytorch_linux_xenial_py3_6_gcc7_test
+      --job pytorch_linux_xenial_py3_6_gcc5_4_test --job pytorch_linux_xenial_py3_6_gcc7_test
     2021-02-10 12:18:50Z 3cf78395    0.644s    0.312s
     2021-02-10 11:13:34Z 594a66d7    0.360s  errored
     2021-02-10 10:13:25Z 9c0caf03    0.819s    0.449s
@@ -300,17 +300,19 @@ def parse_args(raw: List[str]) -> argparse.Namespace:
     parser.add_argument(
         '--test',
         help='name of the test',
+        required=True
     )
     parser.add_argument(
-        '--jobs',
+        '--job',
         help='names of jobs to display columns for, in order',
-        default='',
+        action='append',
+        default=[],
     )
     args = parser.parse_args(raw)
 
-    args.jobs = None if args.all else args.jobs.split(',')
+    args.jobs = None if args.all else args.job
     # We dont allow implicit or empty "--jobs", unless "--all" is specified.
-    if args.jobs and (args.jobs == [] or args.jobs[0] == ''):  
+    if args.jobs == []:
         parser.error('No jobs specified.')
 
     return args


### PR DESCRIPTION
This is to make it more flexible to be reused when pulling test stats other than by-test-case. 
Also it makes it less likely to use it wrong with positional arguments. 

Test Plan
see the updated tools/test/test_test_history.py examples.

