### PR TITLE
Make hipified paths relative to build directory because setuptools doesn't allow absolute paths

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -903,7 +903,9 @@ def CUDAExtension(name, sources, *args, **kwargs):
         hipified_sources = set()
         for source in sources:
             s_abs = os.path.abspath(source)
-            hipified_sources.add(hipify_result[s_abs]["hipified_path"] if s_abs in hipify_result else s_abs)
+            hipified_path = os.path.relpath(hipify_result[s_abs]["hipified_path"] if s_abs in hipify_result else s_abs, build_dir)
+            hipified_sources.add(hipified_path)
+
 
         sources = list(hipified_sources)
 
@@ -1774,8 +1776,7 @@ def _write_ninja_file_to_build_library(path,
         cuda_flags += extra_cuda_cflags
         cuda_flags += _get_rocm_arch_flags(cuda_flags)
         sources = [s if not _is_cuda_file(s) else
-                   os.path.abspath(os.path.join(
-                       path, get_hip_file_path(os.path.relpath(s, path), is_pytorch_extension=True)))
+                   get_hip_file_path(os.path.relpath(s, path), is_pytorch_extension=True)
                    for s in sources]
     elif with_cuda:
         cuda_flags = common_cflags + COMMON_NVCC_FLAGS + _get_cuda_arch_flags()


### PR DESCRIPTION
Error comes from: https://github.com/pypa/setuptools/blob/a4dbe3457d89cf67ee3aa571fdb149e6eb544e88/setuptools/command/build_py.py#L263
if setup.py uses the `include_package_data=True` option.

cc @jeffdaily 