### PR TITLE
[torch/elastic] Expose a `silent` parameter in `EtcdServer`.

### DIFF
--- a/test/distributed/elastic/rendezvous/__init__.py
+++ b/test/distributed/elastic/rendezvous/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #

--- a/test/distributed/elastic/rendezvous/api_test.py
+++ b/test/distributed/elastic/rendezvous/api_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #

--- a/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_rendezvous_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -102,11 +102,12 @@ process:
 """
 
 from .api import (  # noqa: F401
-    RendezvousClosedException,
-    RendezvousException,
+    RendezvousClosedError,
+    RendezvousConnectionError,
+    RendezvousError,
     RendezvousHandler,
     RendezvousHandlerFactory,
-    RendezvousNonRetryableError,
     RendezvousParameters,
-    RendezvousTimeoutException,
+    RendezvousStateError,
+    RendezvousTimeoutError,
 )

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -10,42 +10,24 @@ from typing import Any, Callable, Dict, Optional, Tuple
 from torch.distributed import Store
 
 
-class RendezvousException(Exception):
-    """
-    Represents the base type for rendezvous exceptions.
-    """
-
-    pass
+class RendezvousError(Exception):
+    """Represents the base type for rendezvous errors."""
 
 
-class RendezvousClosedException(RendezvousException):
-    """
-    Raised when a rendezvous is closed.
-
-    This is used to signal completion to nodes that arrive late.
-    """
-
-    pass
+class RendezvousClosedError(RendezvousError):
+    """Raised when a rendezvous is closed."""
 
 
-class RendezvousTimeoutException(RendezvousException):
-    """
-    Raised to signal that a rendezvous did not succeed within the allocated
-    time.
-
-    This is a non-retryable type of failure.
-    """
-
-    pass
+class RendezvousTimeoutError(RendezvousError):
+    """Raised when a rendezvous did not complete on time."""
 
 
-class RendezvousNonRetryableError(RendezvousException):
-    """
-    Raised when a failure occured that should not be retried within the same
-    worker process.
-    """
+class RendezvousConnectionError(RendezvousError):
+    """Raised when the connection to a rendezvous backend has failed."""
 
-    pass
+
+class RendezvousStateError(RendezvousError):
+    """Raised when the state of a rendezvous is corrupt."""
 
 
 class RendezvousHandler(abc.ABC):
@@ -81,9 +63,8 @@ class RendezvousHandler(abc.ABC):
         Returns: a tuple of (``c10d Store``, ``rank``, ``world size``)
 
         Raises:
-            RendezvousClosedException - if rendezvous for the current
-               job is closed.
-            RendezvousTimeoutException - on timeout
+            RendezvousClosedError - if rendezvous for the current job is closed.
+            RendezvousTimeoutError - on timeout
         """
         pass
 

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -20,11 +20,11 @@ import etcd  # type: ignore[import]
 # pyre-ignore[21]: Could not find name `Store` in `torch.distributed`.
 from torch.distributed import Store
 from torch.distributed.elastic.rendezvous import (
-    RendezvousClosedException,
+    RendezvousClosedError,
+    RendezvousError,
     RendezvousHandler,
-    RendezvousNonRetryableError,
     RendezvousParameters,
-    RendezvousTimeoutException,
+    RendezvousTimeoutError,
 )
 
 from .utils import _parse_hostname_and_port
@@ -267,16 +267,15 @@ class EtcdRendezvous(object):
              ``(rdzv_version, rank, world_size)``
 
         Raises:
-            RendezvousTimeoutException - timeout waiting for rendezvous
-            RendezvousNonRetryableError - other persistent errors that
+            RendezvousTimeoutError - timeout waiting for rendezvous
+            RendezvousClosedError - rendezvous is or was closed while waiting
+            RendezvousError - other persistent errors that
              render the rendezvous non-retryable
-            RendezvousClosedException - rendezvous is or was closed while
-             waiting
         """
         self._rendezvous_deadline = time.time() + self._timeout
         while True:
             if time.time() > self._rendezvous_deadline:
-                raise RendezvousTimeoutException()
+                raise RendezvousTimeoutError()
 
             log.info("Attempting to join next rendezvous")
             try:
@@ -295,17 +294,17 @@ class EtcdRendezvous(object):
                 # to avoid spamming etcd
                 time.sleep(1)
 
-            except RendezvousTimeoutException:
+            except RendezvousTimeoutError:
                 log.info("Rendezvous timeout occured in EtcdRendezvousHandler")
                 raise
 
-            except RendezvousClosedException:
+            except RendezvousClosedError:
                 log.info(
                     f"Rendezvous for run_id={self._run_id} was observed to be closed"
                 )
                 raise
 
-            except RendezvousNonRetryableError:
+            except RendezvousError:
                 raise
 
             except Exception as e:
@@ -331,7 +330,7 @@ class EtcdRendezvous(object):
             ``(rdzv_version, rank, world_size)``
 
         Raises:
-            RendezvousClosedException - current rendezvous was/is closed
+            RendezvousClosedError - current rendezvous was/is closed
             EtcdRendezvousRetryableFailure - observed some intermediate
              state, which is best handled by retrying later
         """
@@ -346,7 +345,7 @@ class EtcdRendezvous(object):
             log.info("Observed existing rendezvous state: " + str(state))
 
         if state["status"] == "closed":
-            raise RendezvousClosedException()
+            raise RendezvousClosedError()
 
         if state["status"] == "joinable":
             return self.join_phase(state["version"])
@@ -450,7 +449,7 @@ class EtcdRendezvous(object):
         an unexpected state (e.g. already exists)
 
         Raises:
-             RendezvousNonRetryableError - on unexpected state
+             RendezvousError - on unexpected state
         """
 
         # Initially active_version is ephemeral - this is to handle the
@@ -468,7 +467,7 @@ class EtcdRendezvous(object):
             version_counter.value = str(int(version_counter.value) + 1)
             self.client.update(version_counter)
         except (etcd.EtcdKeyNotFound, etcd.EtcdCompareFailed):
-            raise RendezvousNonRetryableError(
+            raise RendezvousError(
                 "Unexpected state of EtcdRendezvousHandler, worker needs to die."
             )
 
@@ -740,7 +739,7 @@ class EtcdRendezvous(object):
                 pass
 
             if time.time() > self._rendezvous_deadline:
-                raise RendezvousTimeoutException()
+                raise RendezvousTimeoutError()
             active_version, state = self.get_rdzv_state()
 
     def handle_join_last_call(self, expected_version, deadline):
@@ -859,7 +858,7 @@ class EtcdRendezvous(object):
             pass
 
         if time.time() > self._rendezvous_deadline:
-            raise RendezvousTimeoutException()
+            raise RendezvousTimeoutError()
 
         # Unfortunately, we have to do another fetch in order to get last etcd_index.
         return self.get_rdzv_state()
@@ -1230,7 +1229,7 @@ def create_rdzv_handler(params: RendezvousParameters) -> RendezvousHandler:
         max_nodes - max number of workers allowed to join the rendezvous,
                         defaults to min_workers is not specified.
         timeout - total timeout within which next_rendezvous is expected to
-                      succeed; a RendezvousTimeoutException is raised otherwise;
+                      succeed; a RendezvousTimeoutError is raised otherwise;
                       Defaults is 600 (10 minutes).
         last_call_timeout - additional wait amount ("last call") after
                             min number of workers has been reached.

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -150,7 +150,7 @@ class EtcdServer:
         """
         return f"{self._host}:{self._port}"
 
-    def start(self, timeout: int = 60, num_retries: int = 3) -> None:
+    def start(self, timeout: int = 60, num_retries: int = 3, silent: bool = False) -> None:
         """
         Starts the server, and waits for it to be ready. When this function
         returns the sever is ready to take requests.
@@ -160,6 +160,7 @@ class EtcdServer:
                 before giving up.
             num_retries: number of retries to start the server. Each retry
                 will wait for max ``timeout`` before considering it as failed.
+            silent: Start the server without printing any progress information.
 
         Raises:
             TimeoutError: if the server is not ready within the specified timeout
@@ -169,7 +170,7 @@ class EtcdServer:
             try:
                 data_dir = os.path.join(self._base_data_dir, str(curr_retries))
                 os.makedirs(data_dir, exist_ok=True)
-                return self._start(data_dir, timeout)
+                return self._start(data_dir, timeout, silent)
             except Exception as e:
                 curr_retries += 1
                 stop_etcd(self._etcd_proc)
@@ -181,7 +182,7 @@ class EtcdServer:
                     raise
         atexit.register(stop_etcd, self._etcd_proc, self._base_data_dir)
 
-    def _start(self, data_dir: str, timeout: int = 60) -> None:
+    def _start(self, data_dir: str, timeout: int = 60, silent: bool = False) -> None:
         sock = find_free_port()
         sock_peer = find_free_port()
         self._port = sock.getsockname()[1]
@@ -206,9 +207,11 @@ class EtcdServer:
 
         log.info(f"Starting etcd server: [{etcd_cmd}]")
 
+        err_fd = subprocess.DEVNULL if silent else None
+
         sock.close()
         sock_peer.close()
-        self._etcd_proc = subprocess.Popen(etcd_cmd, close_fds=True)
+        self._etcd_proc = subprocess.Popen(etcd_cmd, close_fds=True, stderr=err_fd)
         self._wait_for_ready(timeout)
 
     def get_client(self) -> etcd.Client:


### PR DESCRIPTION
Summary: Expose a `silent` parameter to `EtcdServer` to have a clean unit test outputs.

Differential Revision: D27327495

