### PR TITLE
[PyTorch] Inline Tensor keyset-checking methods & similar getters

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -360,10 +360,14 @@ class TORCH_API Tensor {
   }
 
   /// Returns a `Tensor`'s layout. Defined in Type.h
-  Layout layout() const noexcept;
+  Layout layout() const noexcept {
+    return impl_->layout();
+  }
 
   /// Returns a `Tensor`'s dtype (`TypeMeta`). Defined in TensorMethods.cpp
-  caffe2::TypeMeta dtype() const noexcept;
+  caffe2::TypeMeta dtype() const noexcept {
+    return impl_->dtype();
+  }
 
   /// Returns a `Tensor`'s device.
   inline Device device() const {

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -371,44 +371,82 @@ class TORCH_API Tensor {
   }
 
   /// Returns a `Tensor`'s device index.
-  int64_t get_device() const;
+  int64_t get_device() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->get_device();
+  }
+
 
   /// Returns if a `Tensor` has CPU backend.
-  bool is_cpu() const;
+  bool is_cpu() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_cpu();
+  }
 
   /// Returns if a `Tensor` has CUDA backend.
-  bool is_cuda() const;
+  bool is_cuda() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_cuda();
+  }
 
   /// Returns if a `Tensor` has XPU backend.
-  bool is_xpu() const;
+  bool is_xpu() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_xpu();
+  }
 
   /// Returns if a `Tensor` has XLA backend.
-  bool is_xla() const;
+  bool is_xla() const {
+    return impl_->is_xla();
+  }
 
   /// Returns if a `Tensor` has HIP backend.
-  bool is_hip() const;
+  bool is_hip() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_hip();
+  }
 
   /// Returns if a `Tensor` has sparse backend.
-  bool is_sparse() const;
+  bool is_sparse() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_sparse();
+  }
 
   /// Returns if a `Tensor` is mkldnn tensor.
-  bool is_mkldnn() const;
+  bool is_mkldnn() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_mkldnn();
+  }
 
   /// Returns if a `Tensor` is mlc tensor.
-  bool is_mlc() const;
+  bool is_mlc() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_mlc();
+  }
 
   /// Returns if a `Tensor` is vulkan tensor.
-  bool is_vulkan() const;
+  bool is_vulkan() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_vulkan();
+  }
 
   /// Returns if a `Tensor` is metal tensor.
-  bool is_metal() const;
+  bool is_metal() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_metal();
+  }
 
   /// Returns if a `Tensor` has quantized backend.
-  bool is_quantized() const;
+  bool is_quantized() const {
+    // NB: this is not a native function to avoid dispatching overhead.
+    return impl_->is_quantized();
+  }
 
   /// Returns if a `Tensor` is a meta tensor.  Meta tensors can
   /// also have other designations.
-  bool is_meta() const;
+  bool is_meta() const {
+    return impl_->is_meta();
+  }
 
   /// If a tensor is a quantized tensor, returns its quantizer
   /// TODO: it's not in native_functions.yaml yet as it's not exposed to python
@@ -812,7 +850,9 @@ protected:
 #pragma warning( pop )
 #endif
 
-int64_t get_device(Tensor self);
+inline int64_t get_device(const Tensor& self) {
+  return self.get_device();
+}
 
 template <typename T>
 auto Tensor::register_hook(T&& hook) const -> Tensor::hook_return_void_t<T> {

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -57,23 +57,6 @@ TensorOptions Tensor::options() const {
 
 ${tensor_method_definitions}
 
-caffe2::TypeMeta Tensor::dtype() const noexcept {
-  return impl_->dtype();
-}
-
-Layout Tensor::layout() const noexcept {
-  return impl_->layout();
-}
-
-int64_t Tensor::get_device() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->get_device();
-}
-
-int64_t get_device(Tensor self) {
-  return self.get_device();
-}
-
 NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }

--- a/aten/src/ATen/templates/TensorMethods.cpp
+++ b/aten/src/ATen/templates/TensorMethods.cpp
@@ -74,30 +74,6 @@ int64_t get_device(Tensor self) {
   return self.get_device();
 }
 
-bool Tensor::is_cpu() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_cpu();
-}
-
-bool Tensor::is_cuda() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_cuda();
-}
-
-bool Tensor::is_xpu() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_xpu();
-}
-
-bool is_xpu(Tensor self) {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return self.is_xpu();
-}
-
-bool Tensor::is_xla() const {
-    return impl_->is_xla();
-}
-
 NamedTensorMeta* Tensor::get_named_tensor_meta() {
   return static_cast<NamedTensorMeta*>(impl_->named_tensor_meta());
 }
@@ -113,82 +89,6 @@ bool Tensor::has_names() const {
     return false;
   }
   return impl::has_names(unsafeGetTensorImpl());
-}
-
-bool is_cuda(Tensor self) {
-  return self.is_cuda();
-}
-
-bool is_xla(Tensor self) {
-    return self.is_xla();
-}
-
-bool Tensor::is_hip() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_hip();
-}
-
-bool is_hip(Tensor self) {
-  return self.is_hip();
-}
-
-bool Tensor::is_sparse() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_sparse();
-}
-
-bool is_sparse(Tensor self) {
-  return self.is_sparse();
-}
-
-bool Tensor::is_mkldnn() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_mkldnn();
-}
-
-bool is_mkldnn(Tensor self) {
-  return self.is_mkldnn();
-}
-
-bool Tensor::is_mlc() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_mlc();
-}
-
-bool is_mlc(Tensor self) {
-  return self.is_mlc();
-}
-
-bool Tensor::is_vulkan() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_vulkan();
-}
-
-bool Tensor::is_metal() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_metal();
-}
-
-
-bool is_vulkan(Tensor self) {
-  return self.is_vulkan();
-}
-
-bool is_metal(Tensor self) {
-  return self.is_metal();
-}
-
-bool Tensor::is_quantized() const {
-  // NB: this is not a native function to avoid dispatching overhead.
-  return impl_->is_quantized();
-}
-
-bool Tensor::is_meta() const {
-  return impl_->is_meta();
-}
-
-bool is_quantized(Tensor self) {
-  return self.is_quantized();
 }
 
 #define DEFINE_CAST(T, name)                                        \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54811 [PyTorch] TensorIterator::output should return const reference
* #54880 [PyTorch][easy] Missing std::move in TensorIterator
* **#54806 [PyTorch] Inline Tensor keyset-checking methods & similar getters**

These are all very small key set checks (or similar getters
like `dtype()`, and we clearly want them to be inlinable -- we've even
made them non-virtual for perf in TensorImpl and said so in
comments. Don't make LTO work to figure that out.

Differential Revision: [D27375016](https://our.internmc.facebook.com/intern/diff/D27375016/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27375016/)!