### PR TITLE
(BE) Refactor get-test-times-from-S3 into s3_stat_parser

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -402,7 +402,7 @@ def calculate_job_times(reports: List[Report]) -> Dict[str, float]:
 def pull_job_times_from_S3() -> Dict[str, float]:
     if HAVE_BOTO3:
         ci_job_prefix = get_stripped_CI_job()
-        s3_reports: List[Report] = get_previous_reports_for_branch('upstream/nightly', ci_job_prefix)
+        s3_reports: List[Report] = get_previous_reports_for_branch('origin/nightly', ci_job_prefix)
     else:
         print('Uh oh, boto3 is not found. Either it is not installed or we failed to import s3_stat_parser.')
         print('If not installed, please install boto3 for automatic sharding and test categorization.')

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -2,7 +2,7 @@
 
 import argparse
 import copy
-from datetime import datetime, timedelta
+from datetime import datetime
 import json
 import modulefinder
 import os
@@ -22,7 +22,7 @@ from typing_extensions import TypedDict
 
 try:
     sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-    from tools.stats_utils.s3_stat_parser import (get_test_stats_summaries_for_job, HAVE_BOTO3)
+    from tools.stats_utils.s3_stat_parser import (get_previous_reports_for_branch, Report, HAVE_BOTO3)
 except ImportError:
     print("Unable to import s3_stat_parser from tools. Running without S3 stats...")
     HAVE_BOTO3 = False
@@ -374,36 +374,7 @@ def get_stripped_CI_job() -> str:
     return job
 
 
-# This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False
-# or the S3 bucket is somehow unavailable. Even though this function goes through ten nightly commits' reports
-# to find a non-empty report, it is still conceivable (though highly unlikely) for this function to return no reports.
-def get_test_time_reports_from_S3() -> List[Dict[str, Any]]:
-    commit_date_ts = subprocess.check_output(
-        ['git', 'show', '-s', '--format=%ct', 'HEAD'],
-        encoding="ascii").strip()
-    commit_date = datetime.fromtimestamp(int(commit_date_ts))
-    day_before_commit = str(commit_date - timedelta(days=1)).split(' ')[0]
-    # something like git rev-list --before="2021-03-04" --max-count=10 --remotes="*origin/nightly"
-    nightly_commits = subprocess.check_output(
-        ["git", "rev-list", f"--before={day_before_commit}", "--max-count=10", "--remotes=*origin/nightly"],
-        encoding="ascii").splitlines()
-
-    stripped_job = get_stripped_CI_job()
-    reports = []
-    commit_index = 0
-    while len(reports) == 0 and commit_index < len(nightly_commits):
-        nightly_commit = nightly_commits[commit_index]
-        print(f'Grabbing reports from nightly commit: {nightly_commit}')
-        summaries = get_test_stats_summaries_for_job(sha=nightly_commit, job_prefix=stripped_job)
-        for job_name, summary in summaries.items():
-            reports.append(summary[0])
-            if len(summary) > 1:
-                print(f'Warning: multiple summary object found for {nightly_commit}/{job_name}')
-        commit_index += 1
-    return reports
-
-
-def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, float]:
+def calculate_job_times(reports: List[Report]) -> Dict[str, float]:
     # an entry will be like ("test_file_name" -> (current_avg, # values))
     jobs_to_times: Dict[str, Tuple[float, int]] = dict()
     for report in reports:
@@ -430,7 +401,8 @@ def calculate_job_times(reports: List[Dict[str, Any]]) -> Dict[str, float]:
 
 def pull_job_times_from_S3() -> Dict[str, float]:
     if HAVE_BOTO3:
-        s3_reports = get_test_time_reports_from_S3()
+        ci_job_prefix = get_stripped_CI_job()
+        s3_reports: List[Report] = get_previous_reports_for_branch('upstream/nightly', ci_job_prefix)
     else:
         print('Uh oh, boto3 is not found. Either it is not installed or we failed to import s3_stat_parser.')
         print('If not installed, please install boto3 for automatic sharding and test categorization.')

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -1,7 +1,8 @@
 import bz2
 import json
+import subprocess
 from collections import defaultdict
-
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union, Any, cast
 from typing_extensions import Literal, TypedDict
 
@@ -135,7 +136,7 @@ def get_cases(
     return cases
 
 
-def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Any]]:
+def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Report]]:
     summary_dict = defaultdict(list)
     for summary in summaries:
         summary_job = summary.key.split('/')[2]
@@ -148,13 +149,42 @@ def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Any]]
 # Collect and decompress S3 test stats summaries into JSON.
 # data stored on S3 buckets are pathed by {sha}/{job} so we also allow
 # optional jobs filter
-def get_test_stats_summaries(*, sha: str, jobs: Optional[List[str]] = None) -> Dict[str, List[Any]]:
+def get_test_stats_summaries(*, sha: str, jobs: Optional[List[str]] = None) -> Dict[str, List[Report]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
     summaries = bucket.objects.filter(Prefix=f"test_time/{sha}")
     return _parse_s3_summaries(summaries, jobs=list(jobs or []))
 
 
-def get_test_stats_summaries_for_job(*, sha: str, job_prefix: str) -> Dict[str, List[Any]]:
+def get_test_stats_summaries_for_job(*, sha: str, job_prefix: str) -> Dict[str, List[Report]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
     summaries = bucket.objects.filter(Prefix=f"test_time/{sha}/{job_prefix}")
     return _parse_s3_summaries(summaries, jobs=list())
+
+
+# This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False
+# or the S3 bucket is somehow unavailable. Even though this function goes through ten commits' reports to find a
+# non-empty report, it is still conceivable (though highly unlikely) for this function to return no reports.
+def get_previous_reports_for_branch(branch: str, ci_job_prefix: str = "") -> List[Report]:
+    commit_date_ts = subprocess.check_output(
+        ['git', 'show', '-s', '--format=%ct', 'HEAD'],
+        encoding="ascii").strip()
+    commit_date = datetime.fromtimestamp(int(commit_date_ts))
+    # We go a day before this current commit to avoiding pulling incomplete reports
+    day_before_commit = str(commit_date - timedelta(days=1)).split(' ')[0]
+    # something like git rev-list --before="2021-03-04" --max-count=10 --remotes="*origin/nightly"
+    commits = subprocess.check_output(
+        ["git", "rev-list", f"--before={day_before_commit}", "--max-count=10", f"--remotes=*{branch}"],
+        encoding="ascii").splitlines()
+
+    reports: List[Report] = []
+    commit_index = 0
+    while len(reports) == 0 and commit_index < len(commits):
+        commit = commits[commit_index]
+        print(f'Grabbing reports from commit: {commit}')
+        summaries = get_test_stats_summaries_for_job(sha=commit, job_prefix=ci_job_prefix)
+        for job_name, summary in summaries.items():
+            reports.append(summary[0])
+            if len(summary) > 1:
+                print(f'Warning: multiple summary objects found for {commit}/{job_name}')
+        commit_index += 1
+    return reports

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -1,5 +1,6 @@
 import bz2
 import json
+import logging
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -12,6 +13,9 @@ try:
     HAVE_BOTO3 = True
 except ImportError:
     HAVE_BOTO3 = False
+
+
+logger = logging.getLogger(__name__)
 
 
 OSSCI_METRICS_BUCKET = 'ossci-metrics'
@@ -180,11 +184,11 @@ def get_previous_reports_for_branch(branch: str, ci_job_prefix: str = "") -> Lis
     commit_index = 0
     while len(reports) == 0 and commit_index < len(commits):
         commit = commits[commit_index]
-        print(f'Grabbing reports from commit: {commit}')
+        logger.info(f'Grabbing reports from commit: {commit}')
         summaries = get_test_stats_summaries_for_job(sha=commit, job_prefix=ci_job_prefix)
         for job_name, summary in summaries.items():
             reports.append(summary[0])
             if len(summary) > 1:
-                print(f'Warning: multiple summary objects found for {commit}/{job_name}')
+                logger.info(f'Warning: multiple summary objects found for {commit}/{job_name}')
         commit_index += 1
     return reports


### PR DESCRIPTION
Moves more s3 parsing code to s3_stat_parser.py. This is another step in modularizing the parsing code more correctly. I will also be using this exact function in future slowTest code.

Also replaces some Any's in the code to be Report.

Test plan:
.pytorch-test-times generated before the code and after this code is the same.
CI should pass, specifically the test tools GHA.