### PR TITLE
[PyTorch] Skip TI::mark_resize_outputs if shapes match

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -922,6 +922,12 @@ void TensorIteratorBase::mark_resize_outputs(const TensorIteratorConfig& config)
   if (config.static_shape_.has_value()) {
     return;
   }
+  // Optimization: if all_ops_same_shape_, the
+  // `!output.sizes().equals(shape_)` condition below will never be
+  // true, so just skip the loop entirely.
+  if (all_ops_same_shape_) {
+    return;
+  }
   for (int i = 0; i < num_outputs_; i++) {
     const auto& output = operands_[i].tensor;
     if (output.defined() && !output.sizes().equals(shape_)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54811 [PyTorch] TensorIterator::output should return const reference
* **#54810 [PyTorch] Skip TI::mark_resize_outputs if shapes match**
* #54806 [PyTorch] Inline Tensor keyset-checking methods & similar getters

See code comment.

Differential Revision: [D27376729](https://our.internmc.facebook.com/intern/diff/D27376729/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27376729/)!