### PR TITLE
[PyTorch] TensorIterator::output should return const reference

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -204,7 +204,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   const Tensor& tensor(int arg) const { return operands_[arg].tensor; }
   Tensor& tensor(int arg) { return operands_[arg].tensor; }
 
-  Tensor output(int arg=0) const {
+  const Tensor& output(int arg=0) const {
     AT_ASSERT(arg < num_outputs_);
     return operands_[arg].tensor;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54811 [PyTorch] TensorIterator::output should return const reference**
* #54880 [PyTorch][easy] Missing std::move in TensorIterator
* #54806 [PyTorch] Inline Tensor keyset-checking methods & similar getters

Callers can make a refcount bump themselves if they need one.

Differential Revision: [D27377210](https://our.internmc.facebook.com/intern/diff/D27377210/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27377210/)!