### PR TITLE
Some minor doc improvements

### DIFF
--- a/aten/src/ATen/native/README.md
+++ b/aten/src/ATen/native/README.md
@@ -274,6 +274,8 @@ dispatch:
     CompositeImplicitAutograd: func
 
 # overload is ignored, but out functions get suffixed with _out in their name
+# (NB: no out functions in PyTorch today actually support autograd, but if they
+# did, you could call them here and autograd would be inferred)
 func: func.out_overload(...) -> ...
 dispatch:
     CompositeImplicitAutograd: func_out

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -7,6 +7,29 @@
 
 namespace c10 {
 
+// A storage represents the underlying backing data buffer for a
+// tensor.  This concept was inherited from the original Torch7
+// codebase; we'd kind of like to get rid of the concept
+// (see https://github.com/pytorch/pytorch/issues/14797) but
+// it's hard work and no one has gotten around to doing it.
+//
+// NB: storage is supposed to uniquely own a data pointer; e.g.,
+// two non-null data pointers alias if and only if they are from
+// the same storage.  Technically you can violate this invariant
+// (e.g., you can create a non-owning StorageImpl with at::from_blob)
+// but a lot of things won't work correctly, including:
+//
+// - An ordinary deleter on such a storage is wrong, because normal deleters
+//   assume unique ownership, but if you have two storages at the same data, that
+//   implies there is some sort of shared ownership. So your deleter would have to
+//   actually be internally doing some sort of refcount thing
+// - Deepcopy in Python side relies on storage equality and not data pointer
+//   equality; so if there are two separate storages pointing to the same data,
+//   the data will actually get duplicated in that case (one data ptr before, two
+//   data ptrs after)
+// - Version counts won't work correctly, because we do all VC tracking at the
+//   level of storages (unless you explicitly disconnect the VC with detach);
+//   mutation because data pointers are the same are totally untracked
 struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
  public:
   struct use_byte_size_t {};


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54836 [DO NOT MERGE] Disable dtype asserts
* #53973 Restore storage on meta tensors; increase meta coverage
* #54835 Skip noarch tests on OS X and Windows
* #54834 Fix another incorrect native_functions.yaml dispatch entry
* **#54833 Some minor doc improvements**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>