### PR TITLE
Fix another incorrect native_functions.yaml dispatch entry

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8440,7 +8440,7 @@
   python_module: special
   variants: function
   dispatch:
-    CompositeExplicitAutograd: special_entr
+    CPU, CUDA: special_entr
 
 - func: special_entr.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: special


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54836 [DO NOT MERGE] Disable dtype asserts
* #53973 Restore storage on meta tensors; increase meta coverage
* #54835 Skip noarch tests on OS X and Windows
* **#54834 Fix another incorrect native_functions.yaml dispatch entry**
* #54833 Some minor doc improvements

Signed-off-by: Edward Z. Yang <ezyang@fb.com>