### PR TITLE
Skip noarch tests on OS X and Windows

### DIFF
--- a/.jenkins/pytorch/macos-test.sh
+++ b/.jenkins/pytorch/macos-test.sh
@@ -4,6 +4,8 @@
 # shellcheck source=./macos-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/macos-common.sh"
 
+export PYTORCH_TEST_SKIP_NOARCH=1
+
 conda install -y six
 pip install -q hypothesis "librosa>=0.6.2" "numba<=0.49.1" psutil
 

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -21,6 +21,7 @@ export TEST_DIR="${PWD}/test"
 export TEST_DIR_WIN=$(cygpath -w "${TEST_DIR}")
 export PYTORCH_FINAL_PACKAGE_DIR="/c/users/circleci/workspace/build-results"
 export PYTORCH_FINAL_PACKAGE_DIR_WIN=$(cygpath -w "${PYTORCH_FINAL_PACKAGE_DIR}")
+export PYTORCH_TEST_SKIP_NOARCH=1
 
 mkdir -p $TMP_DIR/build/torch
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54836 [DO NOT MERGE] Disable dtype asserts
* #53973 Restore storage on meta tensors; increase meta coverage
* **#54835 Skip noarch tests on OS X and Windows**
* #54834 Fix another incorrect native_functions.yaml dispatch entry
* #54833 Some minor doc improvements

Signed-off-by: Edward Z. Yang <ezyang@fb.com>