### PR TITLE
Simplify convolution double backward gradInput formulas

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1217,6 +1217,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   Tensor gI;
   if (input.numel() != 0) {
     if (ggW.defined()) {
+      std::cout << "ggW defined\n";
       ConvParams gi_conv_params(params);
       gi_conv_params.transposed = !params.transposed;
 
@@ -1239,13 +1240,13 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
           }
         }
       } else {
-        auto groups = gi_conv_params.groups;
-        gi_conv_params.groups = 1;
+        //auto groups = gi_conv_params.groups;
+        //gi_conv_params.groups = 1;
         // swap stride and dilation
         std::swap(gi_conv_params.dilation, gi_conv_params.stride);
 
-        auto ggWt = ggW.transpose(0, 1);
-        auto gOt = gO.transpose(0, 1);
+        //auto ggWt = ggW.transpose(0, 1);
+        //auto gOt = gO.transpose(0, 1);
 
         // calculate output_padding
         // TODO: figure out why this needs to be computed...
@@ -1272,29 +1273,31 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
           }
         }
 
-        Tensor gIt;
-        if (params.groups == 1) {
-          if (gOt.is_cuda()) {
-            gOt = gOt.contiguous();
-          }
+//        Tensor gIt;
+//        if (true){//(params.groups == 1) {
+          // if (gOt.is_cuda()) {
+          //   gOt = gOt.contiguous();
+          // }
 
-          gIt = at::_convolution(ggWt, gOt, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
-        } else {
-          std::vector<Tensor> gIt_list(params.groups);
-          for (int g = 0; g < groups; ++g) {
-            auto ggWt_g = subvariable(ggWt, 1, groups, g);
-            auto gOt_g = subvariable(gOt, 0, groups, g);
-            if (gOt_g.is_cuda()) {
-              gOt_g = gOt_g.contiguous();
-            }
+          //gIt = at::_convolution(ggWt, gOt, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
 
-            gIt_list[g] = at::_convolution(ggWt_g, gOt_g, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
-          }
+          gI = at::_convolution(gO, ggW, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
+        // } else {
+        //   std::vector<Tensor> gIt_list(params.groups);
+        //   for (int g = 0; g < groups; ++g) {
+        //     auto ggWt_g = subvariable(ggWt, 1, groups, g);
+        //     auto gOt_g = subvariable(gOt, 0, groups, g);
+        //     if (gOt_g.is_cuda()) {
+        //       gOt_g = gOt_g.contiguous();
+        //     }
 
-          gIt = at::cat(gIt_list, 0);
-        }
+        //     gIt_list[g] = at::_convolution(ggWt_g, gOt_g, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
+        //   }
 
-        gI = gIt.transpose(0, 1);
+        //   gIt = at::cat(gIt_list, 0);
+        // }
+
+        //gI = gIt.transpose(0, 1);
       }
     }
   }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1213,7 +1213,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   }
 
   // Compute gI = convT(gO, ggW) if !transposed
-  //         gI = conv(go, ggw)      if transposed
+  //         gI = conv(gO, ggw)  if transposed
   Tensor gI;
   if (input.numel() != 0) {
     if (ggW.defined()) {

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1217,7 +1217,6 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
   Tensor gI;
   if (input.numel() != 0) {
     if (ggW.defined()) {
-      std::cout << "ggW defined\n";
       ConvParams gi_conv_params(params);
       gi_conv_params.transposed = !params.transposed;
 
@@ -1267,6 +1266,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
             auto expected_input_shape = (kernel_size[i] - 1) * gi_conv_params.stride[i]
               - 2 * gi_conv_params.padding[i]
               + (gi_conv_params.dilation[i] * (grad_output_shape[i] - 1) + 1);
+            std::cout << input_shape[i] - expected_input_shape << "\n";
             if (expected_input_shape != input_shape[i]) {
               gi_conv_params.output_padding[i] = input_shape[i] - expected_input_shape;
             }

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -1212,7 +1212,7 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
     }
   }
 
-  // Compute gI = convT(ggW, gO.t()) if !transposed
+  // Compute gI = convT(gO, ggW) if !transposed
   //         gI = conv(go, ggw)      if transposed
   Tensor gI;
   if (input.numel() != 0) {
@@ -1239,14 +1239,6 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
           }
         }
       } else {
-        //auto groups = gi_conv_params.groups;
-        //gi_conv_params.groups = 1;
-        // swap stride and dilation
-        std::swap(gi_conv_params.dilation, gi_conv_params.stride);
-
-        //auto ggWt = ggW.transpose(0, 1);
-        //auto gOt = gO.transpose(0, 1);
-
         // calculate output_padding
         // TODO: figure out why this needs to be computed...
         auto kernel_size = weight.sizes().slice(2);
@@ -1254,50 +1246,28 @@ std::tuple<Tensor,Tensor,Tensor> _convolution_double_backward( const c10::option
         auto grad_output_shape = gO.sizes().slice(2);
 
         if (kernel_size.size() == 1) {
-          auto expected_input_shape = (kernel_size[0] - 1) * gi_conv_params.stride[1]
+          auto expected_input_shape = (kernel_size[0] - 1) * gi_conv_params.dilation[1]
             - 2 * gi_conv_params.padding[1]
-            + (gi_conv_params.dilation[1] * (grad_output_shape[0] - 1) + 1);
+            + (gi_conv_params.stride[1] * (grad_output_shape[0] - 1) + 1);
           if (expected_input_shape != input_shape[0]) {
             gi_conv_params.output_padding[1] = input_shape[0] - expected_input_shape;
           }
         } else {
           for(size_t i = 0; i < kernel_size.size(); ++i) {
             // Check if whole input has been used or not
-            auto expected_input_shape = (kernel_size[i] - 1) * gi_conv_params.stride[i]
+            auto expected_input_shape = (kernel_size[i] - 1) * gi_conv_params.dilation[i]
               - 2 * gi_conv_params.padding[i]
-              + (gi_conv_params.dilation[i] * (grad_output_shape[i] - 1) + 1);
-            std::cout << input_shape[i] - expected_input_shape << "\n";
+              + (gi_conv_params.stride[i] * (grad_output_shape[i] - 1) + 1);
             if (expected_input_shape != input_shape[i]) {
               gi_conv_params.output_padding[i] = input_shape[i] - expected_input_shape;
             }
           }
         }
 
-//        Tensor gIt;
-//        if (true){//(params.groups == 1) {
-          // if (gOt.is_cuda()) {
-          //   gOt = gOt.contiguous();
-          // }
-
-          //gIt = at::_convolution(ggWt, gOt, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
-
-          gI = at::_convolution(gO, ggW, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
-        // } else {
-        //   std::vector<Tensor> gIt_list(params.groups);
-        //   for (int g = 0; g < groups; ++g) {
-        //     auto ggWt_g = subvariable(ggWt, 1, groups, g);
-        //     auto gOt_g = subvariable(gOt, 0, groups, g);
-        //     if (gOt_g.is_cuda()) {
-        //       gOt_g = gOt_g.contiguous();
-        //     }
-
-        //     gIt_list[g] = at::_convolution(ggWt_g, gOt_g, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
-        //   }
-
-        //   gIt = at::cat(gIt_list, 0);
-        // }
-
-        //gI = gIt.transpose(0, 1);
+        if (gO.is_cuda()) {
+          gO = gO.contiguous();
+        }
+        gI = at::_convolution(gO, ggW, Tensor(), gi_conv_params.stride, gi_conv_params.padding, gi_conv_params.dilation, gi_conv_params.transposed, gi_conv_params.output_padding, gi_conv_params.groups, gi_conv_params.benchmark, gi_conv_params.deterministic, gi_conv_params.cudnn_enabled, params.allow_tf32);
       }
     }
   }


### PR DESCRIPTION
Currently in convolution double backward grad of input is computed as `convT(ggW, gO.T)`. Notice how first argument is, in fact, of the size that convolution weight has, and second is of the size of gradOutput, which is an inverse order compared to how convolutions are regularly called, and sizes are far from what cudnn heuristics is trained for and what cudnn is guaranteed to have efficient kernels for. This takes cudnn 8 to some dark places, calling  kernels that take 20-100 s. But, luckily for us, convT is a commutative operation (unlike conv), so convT(ggW, gO) is actually the same as  convT(gO, ggW), modulo some transposes because of conventions around the weight size, so we  can use convT(gO, ggW). As an added bonus, we don't need a special branch for groups with this formulation. 
For the following pretty standard convolution, 
 - cudnn 7.6+old formulation takes 7.5 ms for double backward,
 - cudnn 8 + old formulation takes ~40 s, 
 - cudnn 8 + new formulation is 1.8 ms with benchmark enabled, 
 - cudnn 8 + new formulation is 4 ms with benchmark disabled, 
 benchmarking script is below:
```
import torch
import time

#torch.backends.cudnn.benchmark=True

def ggI(conv, inp):
    out = conv(inp)
    grads = torch.autograd.grad(out, conv.weight, torch.rand_like(out), create_graph=True, retain_graph=True)
    torch.cuda.synchronize()
    start = time.time()
    grads[0].backward(torch.rand_like(grads[0]))
    torch.cuda.synchronize()
    print("db time: ", time.time()-start)
    return inp.grad

conv = torch.nn.Conv2d(512,256,kernel_size=3, padding=1, groups=2).cuda()
inp = torch.randn(1,512,128,128, device="cuda", requires_grad=True)
for _ in range(20):
    ggI(conv, inp)
torch.cuda.synchronize()
```
