### PR TITLE
Adds the cfloat dtype to the eager and jit variant consistency tests

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2193,6 +2193,9 @@ op_db: List[OpInfo] = [
                # Skips unsupported bfloat16 check because above support check
                #   doesn't work on all platforms
                SkipInfo('TestOpInfo', 'test_unsupported_dtypes', dtypes=(torch.bfloat16,)),
+               # RuntimeError: value cannot be converted to type double without overflow: (2,3)
+               SkipInfo('TestCommon', 'test_variant_consistency_jit', dtypes=(torch.cfloat,)),
+               # TODO: remove redundant method_tests() entries
                SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
                # addmm does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out')),


### PR DESCRIPTION
Per title. One skip for addmm was needed. Either it or the jit test doesn't seem to handle a complex literal properly.