### PR TITLE
[ONNX] Support primitive type input/outputs and attributes (#53550)

### DIFF
--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -32,26 +32,37 @@ bool IsInplaceNode(const Node* n) {
   return false;
 }
 
-Node* addDummyCloneToBlock(Block* b, Value* orig_data) {
-  auto graph = b->owningGraph();
-
+Node* addDummyClone(
+    Graph* graph,
+    Value* orig_data,
+    bool insertBefore,
+    Node* referenceNode) {
   Node* newNode = nullptr;
   if (orig_data->type()->kind() == TypeKind::ListType) {
     newNode = graph->create(aten::list, /*num_outputs =*/1);
     newNode->addInput(orig_data);
     newNode->output()->setType(orig_data->type());
-    b->prependNode(newNode);
-  } else if (orig_data->type()->kind() == TypeKind::TensorType) {
-    newNode = graph->create(aten::clone, /*num_outputs =*/1);
-    newNode->addInput(orig_data);
+    if (insertBefore)
+      newNode->insertBefore(referenceNode);
+    else
+      referenceNode->owningBlock()->prependNode(newNode);
+  } else if (
+      orig_data->type()->kind() == TypeKind::TensorType ||
+      orig_data->type()->kind() == TypeKind::IntType ||
+      orig_data->type()->kind() == TypeKind::FloatType ||
+      orig_data->type()->kind() == TypeKind::BoolType) {
     auto* noneNode = graph->create(prim::Constant);
     noneNode->output()->setType(NoneType::get());
+    newNode = graph->create(aten::clone, /*num_outputs =*/1);
+    newNode->addInput(orig_data);
     newNode->addInput(noneNode->output());
     newNode->output()->setType(orig_data->type());
-    b->prependNode(newNode);
+    if (insertBefore)
+      newNode->insertBefore(referenceNode);
+    else
+      referenceNode->owningBlock()->prependNode(newNode);
     noneNode->insertBefore(newNode);
-  } // TODO: Handle float/int attributes
-
+  }
   return newNode;
 }
 
@@ -82,7 +93,8 @@ Value* MatchIfBlocksOutputForValue(
 
   for (Block* b : outer_block->owningNode()->blocks()) {
     if (b->outputs().size() < output_size) {
-      auto clone_node = addDummyCloneToBlock(b, orig_data);
+      auto clone_node =
+          addDummyClone(b->owningGraph(), orig_data, false, b->return_node());
       b->registerOutput(clone_node->output());
       b->outputs()
           .at(b->outputs().size() - 1)
@@ -492,7 +504,8 @@ static void PrepareForRemoveMutations(MutationRemover& mr, Block* b) {
                   << (*it)->debugName() << "'. This changes graph semantics."
                   << std::endl;
 
-        Node* newNode = addDummyCloneToBlock(b, input);
+        Node* newNode =
+            addDummyClone(b->owningGraph(), input, false, b->return_node());
         TORCH_INTERNAL_ASSERT(nullptr != newNode);
         node->replaceInput(index, newNode->output());
         input->replaceAllUsesAfterNodeWith(node, newNode->output());
@@ -531,7 +544,7 @@ std::deque<std::string> findSubModuleAttr(
       moduleNames.push_front(node->s(attr::name));
       node = node->inputs()[0]->node();
     } else {
-      return moduleNames;
+      break;
     }
   }
   // Assign the inner module to attrModule.
@@ -552,31 +565,6 @@ Value* findArgumentAsInputParam(
   throw std::runtime_error(
       "Attribute is not part of model parameters. Cannot handle SetAttr and GetAttr nodes for : " +
       name);
-}
-
-Node* insertCloneBeforeNode(
-    const std::shared_ptr<Graph>& graph,
-    Value* orig_data,
-    Node* node) {
-  Node* newNode = nullptr;
-  if (orig_data->type()->kind() == TypeKind::ListType) {
-    // Create an aten::list to clone the list in graph inputs
-    newNode = graph->create(aten::list, /*num_outputs =*/1);
-    newNode->addInput(orig_data);
-    newNode->output()->setType(orig_data->type());
-    newNode->insertBefore(node);
-  } else if (orig_data->type()->kind() == TypeKind::TensorType) {
-    auto* noneNode = graph->create(prim::Constant);
-    noneNode->output()->setType(NoneType::get());
-    newNode = graph->create(aten::clone, /*num_outputs =*/1);
-    newNode->addInput(orig_data);
-
-    newNode->addInput(noneNode->output());
-    newNode->output()->setType(orig_data->type());
-    newNode->insertBefore(node);
-    noneNode->insertBefore(newNode);
-  } // TODO: Handle float/int attributes
-  return newNode;
 }
 
 Value* registerSetAttrInBlocks(
@@ -694,7 +682,8 @@ void trackAndRegisterAttributesInBlocks(
       // If inside a block, keep the output value to register in block
       // output.
       auto block_ = n->owningBlock();
-      Node* cloneNode = insertCloneBeforeNode(graph, n->inputs().at(1), n);
+      Node* cloneNode =
+          addDummyClone(block_->owningGraph(), n->inputs().at(1), true, n);
       if (block_->owningNode() &&
           (block_->owningNode()->kind() == prim::If ||
            block_->owningNode()->kind() == prim::Loop)) {

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -436,10 +436,10 @@ def _model_to_graph(model, args, verbose=False,
                     training=None, dynamic_axes=None):
     from torch.onnx.symbolic_helper import _export_onnx_opset_version
     # Special case for common case of passing a single Tensor
-    if isinstance(args, torch.Tensor):
+    if isinstance(args, (torch.Tensor, int, float, bool)):
         args = (args, )
 
-    if isinstance(example_outputs, torch.Tensor):
+    if isinstance(example_outputs, (torch.Tensor, int, float, bool)):
         example_outputs = (example_outputs,)
 
     graph, params, torch_out, module = _create_jit_graph(model, args,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54870 [ONNX] Fix export of copy_ operator (#51938)
* #54869 Add outer export to onnx (#53603)
* #54868 [ONNX] Update scripting docs (#54634)
* #54866 [ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)
* #54865 [ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)
* **#54864 [ONNX] Support primitive type input/outputs and attributes (#53550)**
* #54863 [ONNX] Improve index_put symbolic to handle singular Bool updates (#53690)

Support primitive type attributes. Needed for Silero model.

Differential Revision: [D27408982](https://our.internmc.facebook.com/intern/diff/D27408982)