### PR TITLE
[ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)

### DIFF
--- a/test/onnx/expect/TestOperators.test_transpose.expect
+++ b/test/onnx/expect/TestOperators.test_transpose.expect
@@ -2,6 +2,12 @@ ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
+  node {
+    input: "0"
+    output: "1"
+    name: "Identity_0"
+    op_type: "Identity"
+  }
   name: "torch-jit-export"
   input {
     name: "0"
@@ -20,7 +26,7 @@ graph {
     }
   }
   output {
-    name: "0"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/expect/TestOperators.test_type_as.expect
+++ b/test/onnx/expect/TestOperators.test_type_as.expect
@@ -2,6 +2,12 @@ ir_version: 6
 producer_name: "pytorch"
 producer_version: "CURRENT_VERSION"
 graph {
+  node {
+    input: "0"
+    output: "1"
+    name: "Identity_0"
+    op_type: "Identity"
+  }
   name: "torch-jit-export"
   input {
     name: "0"
@@ -17,7 +23,7 @@ graph {
     }
   }
   output {
-    name: "0"
+    name: "1"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -236,7 +236,7 @@ class TestONNXOpset(TestCase):
         check_onnx_opsets_operator(MyModule(), x, ops, opset_versions=[9, 10], training=torch.onnx.TrainingMode.TRAINING)
 
         # test eval mode
-        ops = []
+        ops = [{"op_name" : "Identity"}]
         ops = {9 : ops, 10 : ops}
         check_onnx_opsets_operator(MyModule(), x, ops, opset_versions=[9, 10], training=torch.onnx.TrainingMode.EVAL)
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -825,6 +825,15 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(AllOptionalModel(), {'y': y, 'z': None}, input_names=['input_y'])
         self.run_test(AllOptionalModel(), {'y': None, 'z': z}, input_names=['input_z'])
 
+    def test_input_as_output(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                return x, y
+
+        x = torch.randn(2, 3)
+        y = torch.randn(3, 4)
+        self.run_test(Model(), (x, y), input_names=['x', 'y'], output_names=['x_out', 'y_out'])
+
     @disableScriptTest()
     def test_none_as_input(self):
         class Model(torch.nn.Module):
@@ -6127,6 +6136,24 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(3, 3)
         cond = torch.tensor(1, dtype=torch.bool)
         self.run_test(torch.jit.script(IfModel()), (x, y, cond))
+
+    @skipIfUnsupportedMinOpsetVersion(13)
+    def test_if_view(self):
+        class IfModel(torch.nn.Module):
+            def forward(self, x, y, cond):
+                bs, seq = y.shape[:2]
+                if cond:
+                    res = x.view(bs, seq, -1)
+                else:
+                    res = y
+                return res.transpose(1, 2)
+
+        x = torch.randn(2, 16, 2, 2)
+        y = torch.randn(2, 16, 8)
+        cond = torch.tensor(1, dtype=torch.bool)
+        self.run_test(torch.jit.script(IfModel()), (x, y, cond),
+                      output_names=['output_1'],
+                      dynamic_axes={'output_1': [1]})
 
     def test_onnx_proto_checker(self):
         class Model(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -851,6 +851,28 @@ static void removeSequenceSplitConcat(Block* b) {
   }
 }
 
+static void insertIdentityForInputUsedAsOutput(Block* b) {
+  // Resolving limitation from ONNX that the block input cannot be used directly
+  // as block output. Inserting an Identity node inside
+  // the block, linking with the value as workaround.
+  for (auto out : b->outputs()) {
+    auto n = out->node();
+    if (nullptr != n && n->kind() == prim::Param) {
+      Node* id_node = b->owningGraph()->create(onnx::Identity);
+      id_node->insertBefore(b->return_node());
+      id_node->addInput(out);
+      id_node->output()->setType(out->type());
+      b->return_node()->replaceInputWith(out, id_node->output());
+    }
+  }
+
+  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
+    for (auto* child_block : it->blocks()) {
+      insertIdentityForInputUsedAsOutput(child_block);
+    }
+  }
+}
+
 // This optimization does ONNX-specific peephole optimizations.
 //
 // At the moment, here are the optimizations it does:
@@ -894,6 +916,7 @@ void PeepholeOptimizeONNX(
   eraseListConstruct(graph->block(), opset_version);
   removeMaxPoolUnusedOutput(graph->block());
   removeSequenceSplitConcat(graph->block());
+  insertIdentityForInputUsedAsOutput(graph->block());
 }
 
 } // namespace jit


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54870 [ONNX] Fix export of copy_ operator (#51938)
* #54869 Add outer export to onnx (#53603)
* #54868 [ONNX] Update scripting docs (#54634)
* #54866 [ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)
* **#54865 [ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)**
* #54864 [ONNX] Support primitive type input/outputs and attributes (#53550)
* #54863 [ONNX] Improve index_put symbolic to handle singular Bool updates (#53690)

Fix if output shape mismatch error & Fix graph input directly used as output

Differential Revision: [D27408979](https://our.internmc.facebook.com/intern/diff/D27408979)