### PR TITLE
[ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)

### DIFF
--- a/test/jit/test_onnx_export.py
+++ b/test/jit/test_onnx_export.py
@@ -11,7 +11,6 @@ sys.path.append(pytorch_test_dir)
 from torch.testing._internal.common_utils import suppress_warnings
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.onnx import OperatorExportTypes
-from torch.testing import FileCheck
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
@@ -334,32 +333,6 @@ class TestONNXExport(JitTestCase):
             f2,
             (torch.ones(1, 10, dtype=torch.float), ),
             None, verbose=False, example_outputs=outputs_f2)
-
-    def test_onnx_export_preprocess_decompose_linear(self):
-        def t(x, weight, bias):
-            return torch.nn.functional.linear(x, weight, bias)
-
-        foo = torch.jit.script(t)
-        foo(torch.zeros(2, 4), torch.randn(3, 4), torch.randn(3))
-        # run it twice in case we need to remove profiling nodes
-        graph = foo.graph_for(
-            torch.zeros(2, 4), torch.randn(3, 4), torch.randn(3))
-
-        nodes = []
-        for n in graph.nodes():
-            nodes.append(n.kind())
-        self.assertEqual(nodes, ['aten::linear'])
-        torch._C._jit_pass_onnx_preprocess(graph)
-
-        nodes = []
-        for n in graph.nodes():
-            nodes.append(n.kind())
-            for b in n.blocks():
-                nodes_b = []
-                for n_n in b.nodes():
-                    nodes_b.append(n_n.kind())
-                nodes.append(nodes_b)
-        FileCheck().check("aten::t").check_next("aten::matmul").check_next("aten::add").run(graph)
 
     def test_onnx_export_shape_reshape(self):
         class Foo(torch.nn.Module):

--- a/test/onnx/expect/TestOperators.test_linear.expect
+++ b/test/onnx/expect/TestOperators.test_linear.expect
@@ -1,34 +1,43 @@
 ir_version: 6
 producer_name: "pytorch"
-producer_version: "1.9"
+producer_version: "CURRENT_VERSION"
 graph {
   node {
     input: "input"
-    input: "6"
-    output: "4"
-    name: "MatMul_0"
-    op_type: "MatMul"
-  }
-  node {
-    input: "4"
+    input: "weight"
     input: "bias"
-    output: "5"
-    name: "Add_1"
-    op_type: "Add"
+    output: "3"
+    name: "Gemm_0"
+    op_type: "Gemm"
+    attribute {
+      name: "alpha"
+      f: 1
+      type: FLOAT
+    }
+    attribute {
+      name: "beta"
+      f: 1
+      type: FLOAT
+    }
+    attribute {
+      name: "transB"
+      i: 1
+      type: INT
+    }
   }
   name: "torch-jit-export"
+  initializer {
+    dims: 5
+    dims: 4
+    data_type: 1
+    name: "weight"
+    raw_data: "\212\332\356>@\265u>p\303E\275 \320\306\274\354\201\221>\004\354\261\276\2746*>8\247)\276\340\035\224>\024\2446\276\200\211\312<\224\344,>D\356\257>\320\202\226\275\364\213\351>z\226\330\276\310\250\266\275\352F\377\276\000\250)=\244K\021>"
+  }
   initializer {
     dims: 5
     data_type: 1
     name: "bias"
     raw_data: "\324BO\276@\245T>\350\377\245\275\374u\336\276&\212\304>"
-  }
-  initializer {
-    dims: 4
-    dims: 5
-    data_type: 1
-    name: "6"
-    raw_data: "\212\332\356>\354\201\221>\340\035\224>D\356\257>\310\250\266\275@\265u>\004\354\261\276\024\2446\276\320\202\226\275\352F\377\276p\303E\275\2746*>\200\211\312<\364\213\351>\000\250)= \320\306\2748\247)\276\224\344,>z\226\330\276\244K\021>"
   }
   input {
     name: "input"
@@ -47,6 +56,22 @@ graph {
     }
   }
   input {
+    name: "weight"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
     name: "bias"
     type {
       tensor_type {
@@ -59,24 +84,8 @@ graph {
       }
     }
   }
-  input {
-    name: "6"
-    type {
-      tensor_type {
-        elem_type: 1
-        shape {
-          dim {
-            dim_value: 4
-          }
-          dim {
-            dim_value: 5
-          }
-        }
-      }
-    }
-  }
   output {
-    name: "5"
+    name: "3"
     type {
       tensor_type {
         elem_type: 1

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3787,6 +3787,22 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(3, 16)
         self.run_test(LinearModel(), (x,))
 
+        class LinearModel(torch.nn.Module):
+            def forward(self, input, weight, bias):
+                return torch.nn.functional.linear(input, weight, bias)
+
+        # input of rank 2
+        x = torch.randn(2, 2)
+        y = torch.randn(2, 2)
+        z = torch.randn(1)
+        self.run_test(LinearModel(), (x, y, z))
+
+        # input of rank 3
+        x = torch.randn(3, 3, 3)
+        y = torch.randn(3, 3)
+        z = torch.randn(1)
+        self.run_test(LinearModel(), (x, y, z))
+
     @disableScriptTest()
     def test_weight_norm(self):
         # addmm for 3-d inputs converts to onnx::MatMul

--- a/torch/csrc/jit/passes/onnx/preprocess_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/preprocess_for_onnx.cpp
@@ -217,48 +217,9 @@ static void fuseListAndListUnpack(Block* b) {
   }
 }
 
-static void decomposeLinear(Block* b) {
-  std::vector<Node*> linear_nodes;
-  for (auto it = b->nodes().begin(), end = b->nodes().end(); it != end; ++it) {
-    for (auto* child_block : it->blocks()) {
-      decomposeLinear(child_block);
-    }
-    if (it->kind() == aten::linear) {
-      linear_nodes.push_back(*it);
-    }
-  }
-  for (Node* node : linear_nodes) {
-    auto g = b->owningGraph();
-
-    if (node->inputs()[2]->mustBeNone()) {
-      auto t_weight_n =
-          g->create(aten::t, {node->inputs()[1]}, 1)->insertBefore(node);
-      auto matmul_n =
-          g->create(aten::matmul, {node->inputs()[0], t_weight_n->output()}, 1)
-              ->insertBefore(node);
-      node->output()->replaceAllUsesWith(matmul_n->output());
-      node->destroy();
-    } else {
-      WithInsertPoint guard(node);
-      auto const_1 = g->insertConstant(IValue(1.0));
-      auto t_weight_n =
-          g->insertNode(g->create(aten::t, {node->inputs()[1]}, 1));
-      auto matmul_n = g->insertNode(g->create(
-          aten::matmul, {node->inputs()[0], t_weight_n->output()}, 1));
-      auto add_n = g->insertNode(g->create(
-          aten::add, {matmul_n->output(), node->inputs()[2], const_1}, 1));
-      node->output()->replaceAllUsesWith(add_n->output());
-      node->destroy();
-    }
-  }
-}
-
 } // namespace
 
 void PreprocessForONNX(std::shared_ptr<Graph>& graph) {
-  GRAPH_DEBUG("priot to decompose linear", graph);
-  decomposeLinear(graph->block());
-  GRAPH_DEBUG("after decompose linear", graph);
   FuseWithListUnpack(graph->block());
   ReplaceAddWithConcat(graph->block());
   fuseListAndListUnpack(graph->block());

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2999,3 +2999,18 @@ def __range_length(g, lo, hi, step):
     sub = g.op("Sub", hi, lo)
     div = g.op("Ceil", true_divide(g, sub, step))
     return g.op("Cast", div, to_i=sym_help.cast_pytorch_to_onnx['Long'])
+
+
+def linear(g, input, weight, bias):
+    rank = sym_help._get_tensor_rank(input)
+    weight = t(g, weight)
+    if rank == 2 and not bias.node().mustBeNone():
+        alpha = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
+        beta = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
+        output = addmm(g, bias, input, weight, alpha, beta)
+    else:
+        output = matmul(g, input, weight)
+        if not bias.node().mustBeNone():
+            output = add(g, bias, output)
+
+    return output


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54870 [ONNX] Fix export of copy_ operator (#51938)
* #54869 Add outer export to onnx (#53603)
* #54868 [ONNX] Update scripting docs (#54634)
* **#54866 [ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)**
* #54865 [ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)
* #54864 [ONNX] Support primitive type input/outputs and attributes (#53550)
* #54863 [ONNX] Improve index_put symbolic to handle singular Bool updates (#53690)

Replace decomposeLinear pre process pass with a symbolic

Differential Revision: [D27408981](https://our.internmc.facebook.com/intern/diff/D27408981)