### PR TITLE
Add outer export to onnx (#53603)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5425,6 +5425,28 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(DimModel(), multi_dim_input)
 
     @skipIfUnsupportedMinOpsetVersion(12)
+    def test_outer(self):
+        class Outer(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.outer(x, y)
+
+        x = torch.arange(1, 5)
+        y = torch.arange(1, 4)
+        self.run_test(Outer(), input=(x, y))
+
+        x = torch.arange(1, 6).to(dtype=torch.float32)
+        y = torch.arange(1, 4).to(dtype=torch.long)
+        self.run_test(Outer(), input=(x, y))
+
+        x = torch.arange(2, 5).to(dtype=torch.float32)
+        y = torch.arange(2, 4).to(dtype=torch.float64)
+        self.run_test(Outer(), input=(x, y))
+
+        x = torch.arange(3, 6).to(dtype=torch.int32)
+        y = torch.arange(4, 7).to(dtype=torch.long)
+        self.run_test(Outer(), input=(x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(12)
     def test_einsum(self):
         class EinsumModelBatchDiagonal(torch.nn.Module):
             def forward(self, x):

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -14,6 +14,12 @@ def einsum(g, equation, tensor_list):
     tensors = sym_help._unpack_list(tensor_list)
     return g.op("Einsum", *tensors, equation_s=equation)
 
+@parse_args('v', 'v')
+def outer(g, input, other):
+    # make sure to cast other to self's type
+    if other.type().scalarType() != input.type().scalarType():
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[input.type().scalarType()])
+    return g.op("Einsum", input, other, equation_s='i,j->ij')
 
 @parse_args('v', 'f', 'i')
 def dropout(g, input, p, train):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54870 [ONNX] Fix export of copy_ operator (#51938)
* **#54869 Add outer export to onnx (#53603)**
* #54868 [ONNX] Update scripting docs (#54634)
* #54866 [ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)
* #54865 [ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)
* #54864 [ONNX] Support primitive type input/outputs and attributes (#53550)
* #54863 [ONNX] Improve index_put symbolic to handle singular Bool updates (#53690)

Add symbolic fuction to support torch.outer export to onnx.
Support for transfo-xl-wt103 model.

Differential Revision: [D27408978](https://our.internmc.facebook.com/intern/diff/D27408978)