### PR TITLE
[ONNX] Fix export of copy_ operator (#51938)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1936,6 +1936,17 @@ class TestONNXRuntime(unittest.TestCase):
         update = torch.arange(3 * 5).to(torch.float).view(3, 5)
         self.run_test(IndexPutModel8(), (x, update))
 
+        class IndexPutModel9(torch.nn.Module):
+            def forward(self, poses):
+                w = 32
+                x = poses[:, :, 0] - (w - 1) // 2
+                boxes = torch.zeros([poses.shape[0], 17, 4])
+                boxes[:, :, 0] = x
+                return boxes
+
+        x = torch.zeros([2, 17, 3], dtype=torch.int64)
+        self.run_test(IndexPutModel9(), (x,))
+
     @skipIfUnsupportedMinOpsetVersion(11)
     @disableScriptTest()  # Ellipses followed by tensor indexing not scriptable
     def test_index_put_ellipsis(self):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -142,10 +142,13 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         values = expand(g, values, values_shape, None)
     values = g.op("Reshape", values, values_shape)
 
+    dtype = self.type().scalarType()
+    if dtype is not None and dtype != values.type().scalarType():
+        values = g.op("Cast", values, to_i=sym_help.cast_pytorch_to_onnx[dtype])
+    dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
+    dtype = sym_help.scalar_type_to_pytorch_type[dtype]
+
     if accumulate:
-        dtype = self.type().scalarType()
-        dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
-        dtype = sym_help.scalar_type_to_pytorch_type[dtype]
         zeros = g.op("ConstantOfShape", g.op("Shape", self), value_t=torch.tensor([0], dtype=dtype))
         result = g.op("ScatterND", zeros, index, values)
         result = add(g, self, result)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54870 [ONNX] Fix export of copy_ operator (#51938)**
* #54869 Add outer export to onnx (#53603)
* #54868 [ONNX] Update scripting docs (#54634)
* #54866 [ONNX] Replace decomposeLinear pre process pass with a symbolic (#53077)
* #54865 [ONNX] Fix if output shape mismatch error & Fix graph input directly used as output (#53219)
* #54864 [ONNX] Support primitive type input/outputs and attributes (#53550)
* #54863 [ONNX] Improve index_put symbolic to handle singular Bool updates (#53690)

copy_operator before going into onnx exporter is being decomposed into aten::expand_as and aten::index_put.
There is a scenario where inputs to copy are not of the same type, but copy op in torch does implicit casting that is not currently reflected inside onnx exporter. This PR is adding casting inside index_put symbolic in case when tensor self is not of the same type as values.

Differential Revision: [D27408975](https://our.internmc.facebook.com/intern/diff/D27408975)