### PR TITLE
Fix overflow issue in quantized instance_norm/layer_norm/group_norm

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -283,12 +283,20 @@ int64_t hsum_sq(const uint8_t* A, int len) {
 #ifdef CPU_CAPABILITY_AVX2
 
   int overflow_max_num = 262144;
-  if( (len / 16) > overflow_max_num){
+  //int overflow_max_num = 0;
+
+  if( len > overflow_max_num){
+
+    //TORCH_WARN("-----------LeslieDebug: LARGE uint8");
+
       __m256i sum_v_epu32[2];
     // = _mm256_setzero_si256();
     alignas(64) int32_t temp_0[8];
     alignas(64) int32_t temp_1[8];
     int loop = len/overflow_max_num;
+
+    //int loop = 16;
+
     for(int j=1; j<=loop; j++){
       sum_v_epu32[0] = _mm256_setzero_si256();
       sum_v_epu32[1] = _mm256_setzero_si256();
@@ -317,6 +325,7 @@ int64_t hsum_sq(const uint8_t* A, int len) {
       }
     }
   }else{  
+    //TORCH_WARN("-----------LeslieDebug: small uint8");
     __m256i sum_v_epu32 = _mm256_setzero_si256();
     // vectorized
     for (; i < len / 16 * 16; i += 16) {
@@ -360,15 +369,20 @@ int64_t hsum_sq(const int8_t* A, int len) {
 
 #ifdef CPU_CAPABILITY_AVX2
 
-  //int overflow_max_num = 1048576;
-  int overflow_max_num = 262144;
+  int overflow_max_num = 1048576;
+  //int overflow_max_num = 262144;
+  //int overflow_max_num = 0;
 
-  if( (len / 16) > overflow_max_num){
+  if( len > overflow_max_num){
+    //TORCH_WARN("-----------LeslieDebug: LARGE int8");
     __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();
     alignas(64) int32_t temp_0[8];
     alignas(64) int32_t temp_1[8];
 
     int loop = len/overflow_max_num;
+
+    //int loop = 16;
+
     for(int j=1; j<=loop; j++){
       sum_v_epi32[0] = _mm256_setzero_si256();
       sum_v_epi32[1] = _mm256_setzero_si256();
@@ -398,6 +412,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
       }
     }
   }else{
+    //TORCH_WARN("-----------LeslieDebug: small int8");
     __m256i sum_v_epi32 = _mm256_setzero_si256();
     // vectorized
     for (; i < len / 16 * 16; i += 16) {

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -282,11 +282,14 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   int j = 1;
 
 #ifdef CPU_CAPABILITY_AVX2
-  __m256i sum_v_epu32 = _mm256_setzero_si256();
-  alignas(64) int32_t temp[8];
+  __m256i sum_v_epu32[2];
+  // = _mm256_setzero_si256();
+  alignas(64) int32_t temp_0[8];
+  alignas(64) int32_t temp_1[8];
   // vectorized
   for (; j<=16; j +=1){
-    sum_v_epu32 = _mm256_setzero_si256();
+    sum_v_epu32[0] = _mm256_setzero_si256();
+    sum_v_epu32[1] = _mm256_setzero_si256();
     for (; i < len / 16 * j; i += 16) {
       // (i15, ..., i0)
       __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
@@ -301,13 +304,15 @@ int64_t hsum_sq(const uint8_t* A, int len) {
       __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
       __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
       // add to running sum
-      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
-      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
+      sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
+      sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
     }
 
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epu32[0]);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epu32[1]);
     for (int k = 0; k < 8; ++k) {
-      row_sum += temp[k];
+      row_sum += temp_0[k];
+      row_sum += temp_1[k];
     }
   }
 
@@ -328,11 +333,13 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int j = 1;
 
 #ifdef CPU_CAPABILITY_AVX2
-  __m256i sum_v_epi32 = _mm256_setzero_si256();
-  alignas(64) int32_t temp[8];
+  __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();
+  alignas(64) int32_t temp_0[8];
+  alignas(64) int32_t temp_1[8];
   // vectorized
   for (; j<=16; j +=1){
-    sum_v_epi32 = _mm256_setzero_si256();
+    sum_v_epi32[0] = _mm256_setzero_si256();
+    sum_v_epi32[1] = _mm256_setzero_si256();
     for (; i < len / 16 * j; i += 16) {
       // (i15, ..., i0)
       __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
@@ -347,13 +354,15 @@ int64_t hsum_sq(const int8_t* A, int len) {
       __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
       __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
       // add to running sum
-      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
-      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
+      sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epi32);
+      sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epi32);
     }
 
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epi32[0]);
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epi32[1]);
     for (int k = 0; k < 8; ++k) {
-      row_sum += temp[k];
+      row_sum += temp_0[k];
+      row_sum += temp_1[k];
     }
   }
 #endif // CPU_CAPABILITY_AVX2

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -281,26 +281,16 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   int i = 0;
 
 #ifdef CPU_CAPABILITY_AVX2
+  __m256i sum_v_epu32 = _mm256_setzero_si256();
+  alignas(64) int32_t temp[8];
 
-  int overflow_max_num = 262144;
-  //int overflow_max_num = 0;
+  int overflow_threshold = 262144; // 2147483647(max of int32)/(256*256)*8 = 262144 
+  if( len > overflow_threshold){
 
-  if( len > overflow_max_num){
-
-    //TORCH_WARN("-----------LeslieDebug: LARGE uint8");
-
-      __m256i sum_v_epu32[2];
-    // = _mm256_setzero_si256();
-    alignas(64) int32_t temp_0[8];
-    alignas(64) int32_t temp_1[8];
-    int loop = len/overflow_max_num;
-
-    //int loop = 16;
+    int loop = len / overflow_threshold;
 
     for(int j=1; j<=loop; j++){
-      sum_v_epu32[0] = _mm256_setzero_si256();
-      sum_v_epu32[1] = _mm256_setzero_si256();
-      for (; i < overflow_max_num * j; i += 16) {
+      for (; i < overflow_threshold * j; i += 16) {
         // (i15, ..., i0)
         __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
         __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
@@ -314,43 +304,38 @@ int64_t hsum_sq(const uint8_t* A, int len) {
         __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
         __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
         // add to running sum
-        sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
-        sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
+        sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
+        sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
       }
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epu32[0]);
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epu32[1]);
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
       for (int k = 0; k < 8; ++k) {
-        row_sum += temp_0[k];
-        row_sum += temp_1[k];
+        row_sum += temp[k];
       }
+      sum_v_epu32 = _mm256_setzero_si256();
     }
-  }else{  
-    //TORCH_WARN("-----------LeslieDebug: small uint8");
-    __m256i sum_v_epu32 = _mm256_setzero_si256();
-    // vectorized
-    for (; i < len / 16 * 16; i += 16) {
-      // (i15, ..., i0)
-      __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-      __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
-      // (i15 ^ 2, ..., i0 ^ 2)
-      __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
-      // (i7 ^ 2, ..., i0 ^ 2)
-      __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
-      // (i15 ^ 2, ..., i8 ^ 2)
-      __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-      // widen to epu32
-      __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-      __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
-      // add to running sum
-      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
-      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
-    }
+  }
 
-    alignas(64) int32_t temp[8];
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
-    for (int k = 0; k < 8; ++k) {
-      row_sum += temp[k];
-    }
+  for (; i < len / 16 * 16; i += 16) {
+    // (i15, ..., i0)
+    __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+    __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+    // (i15 ^ 2, ..., i0 ^ 2)
+    __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+    // (i7 ^ 2, ..., i0 ^ 2)
+    __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+    // (i15 ^ 2, ..., i8 ^ 2)
+    __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+    // widen to epu32
+    __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+    __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+    // add to running sum
+    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
+    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
+  }
+
+  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
+  for (int k = 0; k < 8; ++k) {
+    row_sum += temp[k];
   }
 
 #endif // CPU_CAPABILITY_AVX2
@@ -369,24 +354,17 @@ int64_t hsum_sq(const int8_t* A, int len) {
 
 #ifdef CPU_CAPABILITY_AVX2
 
-  int overflow_max_num = 1048576;
-  //int overflow_max_num = 262144;
-  //int overflow_max_num = 0;
+  __m256i sum_v_epi32 = _mm256_setzero_si256();
+  alignas(64) int32_t temp[8];
 
-  if( len > overflow_max_num){
-    //TORCH_WARN("-----------LeslieDebug: LARGE int8");
-    __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();
-    alignas(64) int32_t temp_0[8];
-    alignas(64) int32_t temp_1[8];
+  int overflow_threshold = 1048576; //2147483647/(128*128)*8 = 1048576
 
-    int loop = len/overflow_max_num;
+  if( len > overflow_threshold){
 
-    //int loop = 16;
+    int loop = len / overflow_threshold;
 
     for(int j=1; j<=loop; j++){
-      sum_v_epi32[0] = _mm256_setzero_si256();
-      sum_v_epi32[1] = _mm256_setzero_si256();
-      for (; i < overflow_max_num * j; i += 16) {
+      for (; i < overflow_threshold * j; i += 16) {
         // (i15, ..., i0)
         __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
         __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
@@ -400,45 +378,41 @@ int64_t hsum_sq(const int8_t* A, int len) {
         __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
         __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
         // add to running sum
-        sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epi32);
-        sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epi32);
+        sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
+        sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
       }
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epi32[0]);
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epi32[1]);
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
 
       for (int k = 0; k < 8; ++k) {
-        row_sum += temp_0[k];
-        row_sum += temp_1[k];
+        row_sum += temp[k];
       }
-    }
-  }else{
-    //TORCH_WARN("-----------LeslieDebug: small int8");
-    __m256i sum_v_epi32 = _mm256_setzero_si256();
-    // vectorized
-    for (; i < len / 16 * 16; i += 16) {
-      // (i15, ..., i0)
-      __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-      __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
-      // (i15 ^ 2, ..., i0 ^ 2)
-      __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
-      // (i7 ^ 2, ..., i0 ^ 2)
-      __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
-      // (i15 ^ 2, ..., i8 ^ 2)
-      __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
-      // widen to epi32
-      __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
-      __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
-      // add to running sum
-      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
-      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
-    }
-
-    alignas(64) int32_t temp[8];
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
-    for (int k = 0; k < 8; ++k) {
-      row_sum += temp[k];
+      sum_v_epi32 = _mm256_setzero_si256();
     }
   }
+
+  for (; i < len / 16 * 16; i += 16) {
+    // (i15, ..., i0)
+    __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+    __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
+    // (i15 ^ 2, ..., i0 ^ 2)
+    __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
+    // (i7 ^ 2, ..., i0 ^ 2)
+    __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
+    // (i15 ^ 2, ..., i8 ^ 2)
+    __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
+    // widen to epi32
+    __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
+    __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
+    // add to running sum
+    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
+    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
+  }
+
+  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
+  for (int k = 0; k < 8; ++k) {
+    row_sum += temp[k];
+  }
+
 #endif // CPU_CAPABILITY_AVX2
 
   // scalar

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -284,10 +284,10 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   // vectorized
   __m256i sum_v_epu32 = _mm256_setzero_si256();
   alignas(64) int32_t temp[8];
-  int overflow_threshold = 262144; // 2147483647(max of int32)/(256*256)*8 = 262144 
+  int overflow_threshold = 262144; // 2147483647(max of int32)/(256*256)*8 = 262144
   int loop = len / overflow_threshold + 1;
   for(int j=0; j<=loop; j++){
-    for (; ( (i < overflow_threshold * j) && (i < len / 16 * 16) ); i += 16) {
+    for (; ((i < overflow_threshold * j) && (i < len / 16 * 16)); i += 16) {
       // (i15, ..., i0)
       __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
       __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
@@ -334,7 +334,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int loop = len / overflow_threshold + 1;
 
   for(int j=0; j<=loop; j++){
-    for (; ( (i < overflow_threshold * j) && (i < len / 16 * 16) ); i += 16) {
+    for (; ((i < overflow_threshold * j) && (i < len / 16 * 16)); i += 16) {
       // (i15, ..., i0)
       __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
       __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -284,7 +284,6 @@ int64_t hsum_sq(const uint8_t* A, int len) {
 
   int overflow_max_num = 262144;
   if( (len / 16) > overflow_max_num){
-    TORCH_WARN("----------hit");
       __m256i sum_v_epu32[2];
     // = _mm256_setzero_si256();
     alignas(64) int32_t temp_0[8];
@@ -361,7 +360,8 @@ int64_t hsum_sq(const int8_t* A, int len) {
 
 #ifdef CPU_CAPABILITY_AVX2
 
-  int overflow_max_num = 1048576;
+  //int overflow_max_num = 1048576;
+  int overflow_max_num = 262144;
 
   if( (len / 16) > overflow_max_num){
     __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();
@@ -374,23 +374,24 @@ int64_t hsum_sq(const int8_t* A, int len) {
       sum_v_epi32[1] = _mm256_setzero_si256();
       for (; i < overflow_max_num * j; i += 16) {
         // (i15, ..., i0)
-        __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-        __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+        __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+        __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
         // (i15 ^ 2, ..., i0 ^ 2)
-        __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+        __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
         // (i7 ^ 2, ..., i0 ^ 2)
-        __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+        __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
         // (i15 ^ 2, ..., i8 ^ 2)
-        __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-        // widen to epu32
-        __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-        __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+        __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
+        // widen to epi32
+        __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
+        __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
         // add to running sum
-        sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epu32);
-        sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epu32);
+        sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epi32);
+        sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epi32);
       }
       _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epi32[0]);
       _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epi32[1]);
+
       for (int k = 0; k < 8; ++k) {
         row_sum += temp_0[k];
         row_sum += temp_1[k];

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -286,38 +286,62 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   // = _mm256_setzero_si256();
   alignas(64) int32_t temp_0[8];
   alignas(64) int32_t temp_1[8];
-  // vectorized
-  for (; j<=16; j +=1){
-    sum_v_epu32[0] = _mm256_setzero_si256();
-    sum_v_epu32[1] = _mm256_setzero_si256();
-    for (; i < len / 16 * j; i += 16) {
-      // (i15, ..., i0)
-      __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-      __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
-      // (i15 ^ 2, ..., i0 ^ 2)
-      __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
-      // (i7 ^ 2, ..., i0 ^ 2)
-      __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
-      // (i15 ^ 2, ..., i8 ^ 2)
-      __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-      // widen to epu32
-      __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-      __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
-      // add to running sum
-      sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
-      sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
+  
+  int overflow_max_num = 524288;
+  if( (len / 16) > overflow_max_num){
+    int loop = len/overflow_max_num;
+    for(int j=1; j<=loop; j++){
+      for (; i < overflow_max_num * j; i += 16) {
+        // (i15, ..., i0)
+        __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+        __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+        // (i15 ^ 2, ..., i0 ^ 2)
+        __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+        // (i7 ^ 2, ..., i0 ^ 2)
+        __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+        // (i15 ^ 2, ..., i8 ^ 2)
+        __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+        // widen to epu32
+        __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+        __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+        // add to running sum
+        sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
+        sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
+      }
     }
+  }else{
+    // vectorized
+    for (; j<=16; j +=1){
+      sum_v_epu32[0] = _mm256_setzero_si256();
+      sum_v_epu32[1] = _mm256_setzero_si256();
+      for (; i < len / 16 * j; i += 16) {
+        // (i15, ..., i0)
+        __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+        __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+        // (i15 ^ 2, ..., i0 ^ 2)
+        __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+        // (i7 ^ 2, ..., i0 ^ 2)
+        __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+        // (i15 ^ 2, ..., i8 ^ 2)
+        __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+        // widen to epu32
+        __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+        __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+        // add to running sum
+        sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
+        sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
+      }
 
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epu32[0]);
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epu32[1]);
-    for (int k = 0; k < 8; ++k) {
-      row_sum += temp_0[k];
-      row_sum += temp_1[k];
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epu32[0]);
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epu32[1]);
+      for (int k = 0; k < 8; ++k) {
+        row_sum += temp_0[k];
+        row_sum += temp_1[k];
+      }
     }
   }
 
 #endif // CPU_CAPABILITY_AVX2
-
   // scalar
   for (; i < len; ++i) {
     row_sum += A[i] * A[i];
@@ -336,33 +360,58 @@ int64_t hsum_sq(const int8_t* A, int len) {
   __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();
   alignas(64) int32_t temp_0[8];
   alignas(64) int32_t temp_1[8];
-  // vectorized
-  for (; j<=16; j +=1){
-    sum_v_epi32[0] = _mm256_setzero_si256();
-    sum_v_epi32[1] = _mm256_setzero_si256();
-    for (; i < len / 16 * j; i += 16) {
-      // (i15, ..., i0)
-      __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-      __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
-      // (i15 ^ 2, ..., i0 ^ 2)
-      __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
-      // (i7 ^ 2, ..., i0 ^ 2)
-      __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
-      // (i15 ^ 2, ..., i8 ^ 2)
-      __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
-      // widen to epi32
-      __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
-      __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
-      // add to running sum
-      sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epi32);
-      sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epi32);
-    }
 
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epi32[0]);
-    _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epi32[1]);
-    for (int k = 0; k < 8; ++k) {
-      row_sum += temp_0[k];
-      row_sum += temp_1[k];
+  int overflow_max_num = 2097152;
+  if( (len / 16) > overflow_max_num){
+    int loop = len/overflow_max_num;
+    for(int j=1; j<=loop; j++){
+      for (; i < overflow_max_num * j; i += 16) {
+        // (i15, ..., i0)
+        __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+        __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+        // (i15 ^ 2, ..., i0 ^ 2)
+        __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+        // (i7 ^ 2, ..., i0 ^ 2)
+        __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+        // (i15 ^ 2, ..., i8 ^ 2)
+        __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+        // widen to epu32
+        __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+        __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+        // add to running sum
+        sum_v_epu32[0] = _mm256_add_epi32(sum_v_epu32[0], sq_lo_epu32);
+        sum_v_epu32[1] = _mm256_add_epi32(sum_v_epu32[1], sq_hi_epu32);
+      }
+    }
+  }else{
+    // vectorized
+    for (; j<=16; j +=1){
+      sum_v_epi32[0] = _mm256_setzero_si256();
+      sum_v_epi32[1] = _mm256_setzero_si256();
+      for (; i < len / 16 * j; i += 16) {
+        // (i15, ..., i0)
+        __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+        __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
+        // (i15 ^ 2, ..., i0 ^ 2)
+        __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
+        // (i7 ^ 2, ..., i0 ^ 2)
+        __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
+        // (i15 ^ 2, ..., i8 ^ 2)
+        __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
+        // widen to epi32
+        __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
+        __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
+        // add to running sum
+        sum_v_epi32[0] = _mm256_add_epi32(sum_v_epi32[0], sq_lo_epi32);
+        sum_v_epi32[1] = _mm256_add_epi32(sum_v_epi32[1], sq_hi_epi32);
+      }
+
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_0), sum_v_epi32[0]);
+      _mm256_store_si256(reinterpret_cast<__m256i*>(temp_1), sum_v_epi32[1]);
+      for (int k = 0; k < 8; ++k) {
+        row_sum += temp_0[k];
+        row_sum += temp_1[k];
+      }
     }
   }
 #endif // CPU_CAPABILITY_AVX2

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -284,59 +284,31 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   // vectorized
   __m256i sum_v_epu32 = _mm256_setzero_si256();
   alignas(64) int32_t temp[8];
-
   int overflow_threshold = 262144; // 2147483647(max of int32)/(256*256)*8 = 262144 
-  if( len > overflow_threshold){
-
-    int loop = len / overflow_threshold;
-
-    for(int j=1; j<=loop; j++){
-      for (; i < overflow_threshold * j; i += 16) {
-        // (i15, ..., i0)
-        __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-        __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
-        // (i15 ^ 2, ..., i0 ^ 2)
-        __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
-        // (i7 ^ 2, ..., i0 ^ 2)
-        __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
-        // (i15 ^ 2, ..., i8 ^ 2)
-        __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-        // widen to epu32
-        __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-        __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
-        // add to running sum
-        sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
-        sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
-      }
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
-      for (int k = 0; k < 8; ++k) {
-        row_sum += temp[k];
-      }
-      sum_v_epu32 = _mm256_setzero_si256();
+  int loop = len / overflow_threshold + 1;
+  for(int j=0; j<=loop; j++){
+    for (; ( (i < overflow_threshold * j) && (i < len / 16 * 16) ); i += 16) {
+      // (i15, ..., i0)
+      __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+      __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+      // (i15 ^ 2, ..., i0 ^ 2)
+      __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+      // (i7 ^ 2, ..., i0 ^ 2)
+      __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+      // (i15 ^ 2, ..., i8 ^ 2)
+      __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+      // widen to epu32
+      __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+      __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+      // add to running sum
+      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
+      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
     }
-  }
-
-  for (; i < len / 16 * 16; i += 16) {
-    // (i15, ..., i0)
-    __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-    __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
-    // (i15 ^ 2, ..., i0 ^ 2)
-    __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
-    // (i7 ^ 2, ..., i0 ^ 2)
-    __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
-    // (i15 ^ 2, ..., i8 ^ 2)
-    __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-    // widen to epu32
-    __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-    __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
-    // add to running sum
-    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
-    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
-  }
-
-  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
-  for (int k = 0; k < 8; ++k) {
-    row_sum += temp[k];
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
+    for (int k = 0; k < 8; ++k) {
+      row_sum += temp[k];
+    }
+    sum_v_epu32 = _mm256_setzero_si256();
   }
 #endif // CPU_CAPABILITY_AVX2
 
@@ -359,59 +331,32 @@ int64_t hsum_sq(const int8_t* A, int len) {
   alignas(64) int32_t temp[8];
 
   int overflow_threshold = 1048576; //2147483647/(128*128)*8 = 1048576
+  int loop = len / overflow_threshold + 1;
 
-  if( len > overflow_threshold){
-
-    int loop = len / overflow_threshold;
-
-    for(int j=1; j<=loop; j++){
-      for (; i < overflow_threshold * j; i += 16) {
-        // (i15, ..., i0)
-        __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-        __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
-        // (i15 ^ 2, ..., i0 ^ 2)
-        __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
-        // (i7 ^ 2, ..., i0 ^ 2)
-        __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
-        // (i15 ^ 2, ..., i8 ^ 2)
-        __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
-        // widen to epi32
-        __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
-        __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
-        // add to running sum
-        sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
-        sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
-      }
-      _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
-
-      for (int k = 0; k < 8; ++k) {
-        row_sum += temp[k];
-      }
-      sum_v_epi32 = _mm256_setzero_si256();
+  for(int j=0; j<=loop; j++){
+    for (; ( (i < overflow_threshold * j) && (i < len / 16 * 16) ); i += 16) {
+      // (i15, ..., i0)
+      __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+      __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
+      // (i15 ^ 2, ..., i0 ^ 2)
+      __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
+      // (i7 ^ 2, ..., i0 ^ 2)
+      __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
+      // (i15 ^ 2, ..., i8 ^ 2)
+      __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
+      // widen to epi32
+      __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
+      __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
+      // add to running sum
+      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
+      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
     }
-  }
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
 
-  for (; i < len / 16 * 16; i += 16) {
-    // (i15, ..., i0)
-    __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-    __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
-    // (i15 ^ 2, ..., i0 ^ 2)
-    __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
-    // (i7 ^ 2, ..., i0 ^ 2)
-    __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
-    // (i15 ^ 2, ..., i8 ^ 2)
-    __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
-    // widen to epi32
-    __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
-    __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
-    // add to running sum
-    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
-    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
-  }
-
-  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
-  for (int k = 0; k < 8; ++k) {
-    row_sum += temp[k];
+    for (int k = 0; k < 8; ++k) {
+      row_sum += temp[k];
+    }
+    sum_v_epi32 = _mm256_setzero_si256();
   }
 #endif // CPU_CAPABILITY_AVX2
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -279,40 +279,45 @@ int64_t hsum(const int32_t* A, int len) {
 int64_t hsum_sq(const uint8_t* A, int len) {
   int64_t row_sum = 0;
   int i = 0;
+  int j = 1;
 
 #ifdef CPU_CAPABILITY_AVX2
   __m256i sum_v_epu32 = _mm256_setzero_si256();
+  alignas(64) int32_t temp[8];
   // vectorized
-  for (; i < len / 16 * 16; i += 16) {
-    // (i15, ..., i0)
-    __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-    __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
-    // (i15 ^ 2, ..., i0 ^ 2)
-    __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
-    // (i7 ^ 2, ..., i0 ^ 2)
-    __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
-    // (i15 ^ 2, ..., i8 ^ 2)
-    __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
-    // widen to epu32
-    __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
-    __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
-    // add to running sum
-    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
-    sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
+  for (; j<=16; j +=1){
+    sum_v_epu32 = _mm256_setzero_si256();
+    for (; i < len / 16 * j; i += 16) {
+      // (i15, ..., i0)
+      __m128i src_epu8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+      __m256i src_epu16 = _mm256_cvtepu8_epi16(src_epu8);
+      // (i15 ^ 2, ..., i0 ^ 2)
+      __m256i sq_epu16 = _mm256_mullo_epi16(src_epu16, src_epu16);
+      // (i7 ^ 2, ..., i0 ^ 2)
+      __m128i sq_lo_epu16 = _mm256_castsi256_si128(sq_epu16);
+      // (i15 ^ 2, ..., i8 ^ 2)
+      __m128i sq_hi_epu16 = _mm256_extractf128_si256(sq_epu16, 1);
+      // widen to epu32
+      __m256i sq_lo_epu32 = _mm256_cvtepu16_epi32(sq_lo_epu16);
+      __m256i sq_hi_epu32 = _mm256_cvtepu16_epi32(sq_hi_epu16);
+      // add to running sum
+      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_lo_epu32);
+      sum_v_epu32 = _mm256_add_epi32(sum_v_epu32, sq_hi_epu32);
+    }
+
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
+    for (int k = 0; k < 8; ++k) {
+      row_sum += temp[k];
+    }
   }
 
-  alignas(64) int32_t temp[8];
-  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epu32);
-  for (int k = 0; k < 8; ++k) {
-    row_sum += temp[k];
-  }
 #endif // CPU_CAPABILITY_AVX2
 
   // scalar
   for (; i < len; ++i) {
     row_sum += A[i] * A[i];
   }
-
+  
   return row_sum;
 }
 
@@ -320,32 +325,36 @@ int64_t hsum_sq(const uint8_t* A, int len) {
 int64_t hsum_sq(const int8_t* A, int len) {
   int64_t row_sum = 0;
   int i = 0;
+  int j = 1;
 
 #ifdef CPU_CAPABILITY_AVX2
   __m256i sum_v_epi32 = _mm256_setzero_si256();
-  // vectorized
-  for (; i < len / 16 * 16; i += 16) {
-    // (i15, ..., i0)
-    __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
-    __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
-    // (i15 ^ 2, ..., i0 ^ 2)
-    __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
-    // (i7 ^ 2, ..., i0 ^ 2)
-    __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
-    // (i15 ^ 2, ..., i8 ^ 2)
-    __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
-    // widen to epi32
-    __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
-    __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
-    // add to running sum
-    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
-    sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
-  }
-
   alignas(64) int32_t temp[8];
-  _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
-  for (int k = 0; k < 8; ++k) {
-    row_sum += temp[k];
+  // vectorized
+  for (; j<=16; j +=1){
+    sum_v_epi32 = _mm256_setzero_si256();
+    for (; i < len / 16 * j; i += 16) {
+      // (i15, ..., i0)
+      __m128i src_epi8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(A + i));
+      __m256i src_epi16 = _mm256_cvtepi8_epi16(src_epi8);
+      // (i15 ^ 2, ..., i0 ^ 2)
+      __m256i sq_epi16 = _mm256_mullo_epi16(src_epi16, src_epi16);
+      // (i7 ^ 2, ..., i0 ^ 2)
+      __m128i sq_lo_epi16 = _mm256_castsi256_si128(sq_epi16);
+      // (i15 ^ 2, ..., i8 ^ 2)
+      __m128i sq_hi_epi16 = _mm256_extractf128_si256(sq_epi16, 1);
+      // widen to epi32
+      __m256i sq_lo_epi32 = _mm256_cvtepi16_epi32(sq_lo_epi16);
+      __m256i sq_hi_epi32 = _mm256_cvtepi16_epi32(sq_hi_epi16);
+      // add to running sum
+      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_lo_epi32);
+      sum_v_epi32 = _mm256_add_epi32(sum_v_epi32, sq_hi_epi32);
+    }
+
+    _mm256_store_si256(reinterpret_cast<__m256i*>(temp), sum_v_epi32);
+    for (int k = 0; k < 8; ++k) {
+      row_sum += temp[k];
+    }
   }
 #endif // CPU_CAPABILITY_AVX2
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -339,11 +339,12 @@ int64_t hsum_sq(const uint8_t* A, int len) {
     row_sum += temp[k];
   }
 #endif // CPU_CAPABILITY_AVX2
+
   // scalar
   for (; i < len; ++i) {
     row_sum += A[i] * A[i];
   }
-  
+
   return row_sum;
 }
 
@@ -418,6 +419,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   for (; i < len; ++i) {
     row_sum += A[i] * A[i];
   }
+
   return row_sum;
 }
 

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -282,8 +282,9 @@ int64_t hsum_sq(const uint8_t* A, int len) {
 
 #ifdef CPU_CAPABILITY_AVX2
 
-  int overflow_max_num = 524288;
+  int overflow_max_num = 262144;
   if( (len / 16) > overflow_max_num){
+    TORCH_WARN("----------hit");
       __m256i sum_v_epu32[2];
     // = _mm256_setzero_si256();
     alignas(64) int32_t temp_0[8];
@@ -360,7 +361,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
 
 #ifdef CPU_CAPABILITY_AVX2
 
-  int overflow_max_num = 2097152;
+  int overflow_max_num = 1048576;
 
   if( (len / 16) > overflow_max_num){
     __m256i sum_v_epi32[2]; // = _mm256_setzero_si256();

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -281,6 +281,7 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   int i = 0;
 
 #ifdef CPU_CAPABILITY_AVX2
+  // vectorized
   __m256i sum_v_epu32 = _mm256_setzero_si256();
   alignas(64) int32_t temp[8];
 
@@ -337,7 +338,6 @@ int64_t hsum_sq(const uint8_t* A, int len) {
   for (int k = 0; k < 8; ++k) {
     row_sum += temp[k];
   }
-
 #endif // CPU_CAPABILITY_AVX2
   // scalar
   for (; i < len; ++i) {
@@ -353,7 +353,7 @@ int64_t hsum_sq(const int8_t* A, int len) {
   int i = 0;
 
 #ifdef CPU_CAPABILITY_AVX2
-
+  // vectorized
   __m256i sum_v_epi32 = _mm256_setzero_si256();
   alignas(64) int32_t temp[8];
 
@@ -412,14 +412,12 @@ int64_t hsum_sq(const int8_t* A, int len) {
   for (int k = 0; k < 8; ++k) {
     row_sum += temp[k];
   }
-
 #endif // CPU_CAPABILITY_AVX2
 
   // scalar
   for (; i < len; ++i) {
     row_sum += A[i] * A[i];
   }
-
   return row_sum;
 }
 

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2005,7 +2005,7 @@ class TestQuantizedOps(TestCase):
     @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
-        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 32, 224, 224, 160])
+        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 4, 224, 224, 160])
         torch_types = (torch.qint8, torch.quint8)
         y_scales = (0.1, 4.23)
         y_zero_points = (0, 1)

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2005,15 +2005,24 @@ class TestQuantizedOps(TestCase):
     @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
-        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 4, 224, 224, 160])
+        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11])
         torch_types = (torch.qint8, torch.quint8)
         y_scales = (0.1, 4.23)
         y_zero_points = (0, 1)
         channels_last_list = (True, False)
         affine_list = (True, False)
         combined = [shape_list, torch_types, y_scales, y_zero_points, channels_last_list, affine_list]
-        test_cases = itertools.product(*combined)
-
+        test_cases_product = itertools.product(*combined)
+        test_cases = list(test_case for test_case in test_cases_product)
+        # add just one test case to test overflow
+        test_cases.append([
+            [1, 4, 224, 224, 160],  # shape,
+            torch.qint8,  # torch_type
+            0.1,  # scale
+            0,  # zero_point
+            False,   # channels_last
+            True,  # affine
+        ])
         with override_quantized_engine("fbgemm"):
             for test_case in test_cases:
 

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2005,7 +2005,7 @@ class TestQuantizedOps(TestCase):
     @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
-        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 32, 224, 224, 160])
+        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 4, 224, 224, 160])
         torch_types = (torch.qint8, torch.quint8)
         y_scales = (0.1, 4.23)
         y_zero_points = (0, 1)
@@ -2066,7 +2066,7 @@ class TestQuantizedOps(TestCase):
                         ch_vals = dqX[batch_idx][ch_idx]
                         assume(
                             float(torch.unique(ch_vals).shape[0]) / ch_vals.numel() > 0.01
-                            or ch_vals.numel() < 5 or ch_vals.numel() > 25600)
+                            or ch_vals.numel() < 5)
 
                 qY = torch.ops.quantized.instance_norm(qX, weight, bias, eps, Y_scale, Y_zero_point)
 

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2005,20 +2005,22 @@ class TestQuantizedOps(TestCase):
     @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
-        side_lens = (2, 8, 11)
+        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 32, 224, 224, 160])
         torch_types = (torch.qint8, torch.quint8)
         y_scales = (0.1, 4.23)
         y_zero_points = (0, 1)
         channels_last_list = (True, False)
         affine_list = (True, False)
-        combined = [side_lens, torch_types, y_scales, y_zero_points, channels_last_list, affine_list]
+        combined = [shape_list, torch_types, y_scales, y_zero_points, channels_last_list, affine_list]
         test_cases = itertools.product(*combined)
 
         with override_quantized_engine("fbgemm"):
             for test_case in test_cases:
 
-                side_len, torch_type, Y_scale, Y_zero_point, channels_last, affine = test_case
-                shapes = [side_len] * 4
+                shapes, torch_type, Y_scale, Y_zero_point, channels_last, affine = test_case
+                if channels_last and shapes.__len__() >= 5:
+                    # required rank 4 tensor to use channels_last format
+                    continue
 
                 # In the FP kernel, sums and sums of squares are calculated in floating point.
                 # In the int8 and uint8 versions of the quantized kernel, they are
@@ -2064,7 +2066,7 @@ class TestQuantizedOps(TestCase):
                         ch_vals = dqX[batch_idx][ch_idx]
                         assume(
                             float(torch.unique(ch_vals).shape[0]) / ch_vals.numel() > 0.01
-                            or group_vals.numel() < 5)
+                            or ch_vals.numel() < 5 or ch_vals.numel() > 25600)
 
                 qY = torch.ops.quantized.instance_norm(qX, weight, bias, eps, Y_scale, Y_zero_point)
 

--- a/test/quantization/test_quantized_op.py
+++ b/test/quantization/test_quantized_op.py
@@ -2005,7 +2005,7 @@ class TestQuantizedOps(TestCase):
     @skipIfNoFBGEMM
     def test_instance_norm(self):
         max_sides = (4, 5)
-        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 4, 224, 224, 160])
+        shape_list = ([2, 2, 2, 2], [8, 8, 8, 8], [11, 11, 11, 11], [1, 32, 224, 224, 160])
         torch_types = (torch.qint8, torch.quint8)
         y_scales = (0.1, 4.23)
         y_zero_points = (0, 1)
@@ -2066,7 +2066,7 @@ class TestQuantizedOps(TestCase):
                         ch_vals = dqX[batch_idx][ch_idx]
                         assume(
                             float(torch.unique(ch_vals).shape[0]) / ch_vals.numel() > 0.01
-                            or ch_vals.numel() < 5)
+                            or ch_vals.numel() < 5 or ch_vals.numel() > 25600)
 
                 qY = torch.ops.quantized.instance_norm(qX, weight, bias, eps, Y_scale, Y_zero_point)
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/54837
`hsum_sq` has the overflow issue when the input image size is large such as (H,W,D) as (224,224,160). `hsum_sq` is used in the quantized instance_norm/layer_norm/group_norm.
