### PR TITLE
[PyTorch][easy] Missing std::move in TensorIterator

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -983,7 +983,7 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
       all_ops_same_shape_ = false;
     }
     if (shape_.empty()) {
-      shape_ = shape;
+      shape_ = std::move(shape);
     } else if (!shape.equals(shape_)) {
       all_ops_same_shape_ = false;
       shape_ = DimVector(infer_size(shape_, shape));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54811 [PyTorch] TensorIterator::output should return const reference
* **#54880 [PyTorch][easy] Missing std::move in TensorIterator**
* #54806 [PyTorch] Inline Tensor keyset-checking methods & similar getters

Just noticed we failed to move here.

Differential Revision: [D27399999](https://our.internmc.facebook.com/intern/diff/D27399999/)