### PR TITLE
[PyTorch] Add DimVector variant of infer_size

### DIFF
--- a/aten/src/ATen/ExpandUtils.cpp
+++ b/aten/src/ATen/ExpandUtils.cpp
@@ -4,12 +4,14 @@
 
 namespace at {
 
+namespace {
 // NOTE: are_expandable did a similar check, please keep them sync if change is needed
-std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
+template <typename Container>
+Container infer_size_impl(IntArrayRef a, IntArrayRef b) {
   size_t dimsA = a.size();
   size_t dimsB = b.size();
   size_t ndim = dimsA > dimsB ? dimsA : dimsB;
-  std::vector<int64_t> expandedSizes(ndim);
+  Container expandedSizes(ndim);
 
   // Use ptrdiff_t to ensure signed comparison.
   for (ptrdiff_t i = (ptrdiff_t)ndim - 1; i >= 0; --i) {
@@ -30,6 +32,15 @@ std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
   }
 
   return expandedSizes;
+}
+}
+
+std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b) {
+  return infer_size_impl<std::vector<int64_t>>(a, b);
+}
+
+DimVector infer_size_dimvector(IntArrayRef a, IntArrayRef b) {
+  return infer_size_impl<DimVector>(a, b);
 }
 
 std::tuple<std::vector<int64_t>, std::vector<int64_t>> inferExpandGeometry(

--- a/aten/src/ATen/ExpandUtils.h
+++ b/aten/src/ATen/ExpandUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/DimVector.h>
 #include <ATen/Tensor.h>
 #include <c10/util/Exception.h>
 
@@ -10,6 +11,7 @@
 namespace at {
 
 TORCH_API std::vector<int64_t> infer_size(IntArrayRef a, IntArrayRef b);
+TORCH_API DimVector infer_size_dimvector(IntArrayRef a, IntArrayRef b);
 TORCH_API std::tuple<std::vector<int64_t>, std::vector<int64_t>>
 inferExpandGeometry(
     IntArrayRef tensor_sizes,

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -986,7 +986,7 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
       shape_ = shape;
     } else if (!shape.equals(shape_)) {
       all_ops_same_shape_ = false;
-      shape_ = DimVector(infer_size(shape_, shape));
+      shape_ = infer_size_dimvector(shape_, shape);
     }
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/qmul.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qmul.cpp
@@ -105,7 +105,7 @@ class QMul final {
   static Tensor run(Tensor qa, Tensor qb, double scale, int64_t zero_point) {
     check_inputs(qa, qb);
     auto qc = at::_empty_affine_quantized(
-        DimVector(infer_size(qa.sizes(), qb.sizes())),
+        infer_size_dimvector(qa.sizes(), qb.sizes()),
         at::device(kCPU).dtype(qa.scalar_type()),
         scale,
         zero_point,

--- a/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
+++ b/aten/src/ATen/native/quantized/cpu/tensor_operators.cpp
@@ -32,7 +32,7 @@ Tensor at_op##_quantized_cpu(const Tensor& self, const Scalar& other) { \
 Tensor& at_op##_out_quantized_cpu(const Tensor& self, \
                                 const Tensor& other, Tensor& out) { \
   /* We infer size to make sure the tensors are compatible. */\
-  infer_size(self.sizes(), other.sizes()); \
+  infer_size_dimvector(self.sizes(), other.sizes()); \
   TORCH_CHECK(out.dtype() == at::ScalarType::Bool, \
               "The 'out' tensor must have dtype 'torch.bool'"); \
   auto self_dq = self.dequantize(); \
@@ -41,7 +41,7 @@ Tensor& at_op##_out_quantized_cpu(const Tensor& self, \
 } \
 Tensor at_op##_quantized_cpu(const Tensor& self, const Tensor& other) { \
   /* We infer size to make sure the tensors are compatible. */\
-  infer_size(self.sizes(), other.sizes()); \
+  infer_size_dimvector(self.sizes(), other.sizes()); \
   auto self_dq = self.dequantize(); \
   auto other_dq = other.dequantize(); \
   return at:: at_op(self_dq, other_dq); \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54882 [PyTorch] Add DimVector variant of infer_size**

Sometimes we have no reason to think that the output of `infer_size` won't be within the range of typical tensor sizes. In those cases, we can use a DimVector.

Differential Revision: [D27400387](https://our.internmc.facebook.com/intern/diff/D27400387/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27400387/)!