### PR TITLE
Leak Caffe2 threadpool in child processes right after fork to prevent segfault

### DIFF
--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -72,7 +72,8 @@ void PThreadPool::run(
 size_t getDefaultNumThreads();
 
 PThreadPool* pthreadpool() {
-  static auto threadpool = std::make_unique<PThreadPool>(getDefaultNumThreads());
+  static auto threadpool =
+    std::make_unique<PThreadPool>(getDefaultNumThreads());
 #ifndef WIN32
   static std::once_flag flag;
   std::call_once(flag, []() {
@@ -80,8 +81,7 @@ PThreadPool* pthreadpool() {
   });
 #endif
   static auto true_bool = true;
-  static auto false_bool = false;
-  if (leak_corrupted_threadpool.compare_exchange_strong(true_bool, false_bool)) {
+  if (leak_corrupted_threadpool.compare_exchange_strong(true_bool, false)) {
     if (auto leaked = threadpool.release()) {
       auto num_threads = leaked->get_thread_count();
       threadpool.reset(new PThreadPool(num_threads));

--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -80,7 +80,7 @@ PThreadPool* pthreadpool() {
     pthread_atfork(nullptr, nullptr, child_atfork);
   });
 #endif
-  static auto true_bool = true;
+  auto true_bool = true;
   if (leak_corrupted_threadpool.compare_exchange_strong(true_bool, false)) {
     if (auto leaked = threadpool.release()) {
       auto num_threads = leaked->get_thread_count();

--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -7,10 +7,7 @@
 namespace {
 // After fork, the child process inherits the data-structures of the parent
 // process' thread-pool, but since those threads don't exist, the thread-pool
-// is corrupt. It's done in order to prevent segfaults in worker processes,
-// which otherwise segfault, as they try to handle inherited data-structures of
-// parent's Caffe2 thread-pool, although those threads don't exist in child
-// processes.
+// is corrupt. It's leaked in order to prevent segfaults.
 // Ref: https://github.com/pytorch/pytorch/issues/54752#issuecomment-810315302
 std::atomic<bool> leak_corrupted_threadpool(false);
 

--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -85,7 +85,7 @@ PThreadPool* pthreadpool() {
     if (auto leaked = threadpool.release()) {
       auto num_threads = leaked->get_thread_count();
       threadpool.reset(new PThreadPool(num_threads));
-      TORCH_WARN("Leaking thread pool before fork.");
+      TORCH_WARN("Leaking Caffe2 thread-pool after fork.");
     }
   }
   return threadpool.get();

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -536,6 +536,19 @@ def _test_segfault():
     _ = next(iter(dataloader))
 
 
+def _test_no_segfault():
+    dataset = [1, 2, 3]
+    num_threads = torch.get_num_threads()
+    if num_threads < 4:
+        torch.set_num_threads(4)
+    else:
+        torch.set_num_threads(num_threads)
+    mp_ctx = torch.multiprocessing.get_context(method='fork')
+    dataloader = DataLoader(dataset, num_workers=1, worker_init_fn=disable_stderr,
+                            multiprocessing_context=mp_ctx)
+    _ = next(iter(dataloader))
+
+
 class TestProperExitDataset(Dataset):
     def __init__(self, size, error_event):
         self.size = size
@@ -948,7 +961,6 @@ except RuntimeError as e:
             next(loader1_it)
             next(loader2_it)
 
-    @unittest.skip("temporarily disable until flaky failures are fixed")
     def test_segfault(self):
         p = ErrorTrackingProcess(target=_test_segfault)
         p.start()
@@ -962,6 +974,25 @@ except RuntimeError as e:
             else:
                 self.assertIsInstance(p.exception, RuntimeError)
                 self.assertRegex(str(p.exception), r'DataLoader worker \(pid \d+\) is killed by signal: ')
+        finally:
+            p.terminate()
+
+    # Tests if the child process forked by the DataLoader segfaults due to having more than 3 threads
+    # in the parent process after at least one set_num_threads invocation in the parent process.
+    # After forking, set_num_threads(1) in the child process entails handling some inherited data-structures
+    # of the Caffe2 thread-pool of the parent process, culminating in a segfault.
+    # Reference: https://github.com/pytorch/pytorch/issues/54752
+    @unittest.skipIf(IS_WINDOWS, "Needs fork")
+    def test_no_segfault(self):
+        p = ErrorTrackingProcess(target=_test_no_segfault)
+        p.start()
+        p.join(JOIN_TIMEOUT)
+        try:
+            self.assertFalse(p.is_alive())
+            if p.exception:
+                self.assertIsInstance(p.exception, RuntimeError)
+                self.assertRegex(str(p.exception), r'DataLoader worker \(pid \d+\) is killed by signal: ')
+                self.fail("Segfault occurred in worker process after fork")
         finally:
             p.terminate()
 


### PR DESCRIPTION
## Problem summary
Fixes #54752 - when the number of threads is more than 3 and at least one `set_num_threads` invocation has taken place before forking child processes by the dataloader, `set_num_threads(1)` in the child process causes a segfault, as during its invocation, the child process is made to handle the data structures of the Caffe2 thread-pool of the parent process, whose data structures it inherits from the parent process (these threads don't exist in the child process, but some of its data structures do, due to the copy-on-write technique used by `fork`).


## Solution
@malfet [advised](https://github.com/pytorch/pytorch/issues/54752#issuecomment-810315302) & [authored code](https://github.com/pytorch/pytorch/pull/54895#pullrequestreview-625670122) for adding a `pthread_atfork` handler in `pytorch/caffe2/utils/threadpool/pthreadpool-cpp.cc`, that's invoked in the child process right after fork, to leak the Caffe2 thread-pool (the child inherits the thread-pool's data structures from its parent process, but doesn't actually have those threads, since after `fork` , a child process only has one thread).


## Additional changes
Added unittest `test_no_segfault` to test for this issue in `test_dataloader.py` 
Also enabled `test_segfault` (which actually makes sure that segfaults happen in worker processes in a particular case).