### PR TITLE
Generate no-op meta functions for all inplace operations

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -45,7 +45,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, onlyOnCPUAndCUDA, \
-    deviceCountAtLeast, expectedAlertNondeterministic, largeTensorTest
+    deviceCountAtLeast, expectedAlertNondeterministic, largeTensorTest, expectedFailureMeta
 from torch.nn import MultiheadAttention
 
 from hypothesis import given
@@ -15094,6 +15094,7 @@ class TestNNDeviceType(NNTestCase):
             for p, pe in zip(test_model.parameters(), ref_model.parameters()):
                 self.assertEqual(p.grad.to(devices[0]), pe.grad)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_elu_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
@@ -15101,26 +15102,31 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.elu_(x)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_hardswish_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.hardswish(x, inplace=True)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_silu_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.silu(x, inplace=True)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_softplus_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.softplus(x, out=x)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_softshrink_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):
             F.softshrink(x, out=x)
 
+    @expectedFailureMeta  # https://github.com/pytorch/pytorch/issues/54897
     def test_leaky_relu_inplace_overlap(self, device):
         x = torch.randn((1, 6), device=device).expand((6, 6))
         with self.assertRaisesRegex(RuntimeError, 'unsupported operation'):

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -7,7 +7,7 @@ import torch
 from torch.testing._internal.common_utils import (TestCase, run_tests, load_tests,
                                                   TEST_NUMPY, torch_to_numpy_dtype_dict)
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, onlyOnCPUAndCUDA,
-                                                        dtypes, dtypesIfCUDA, onlyCPU)
+                                                        dtypes, dtypesIfCUDA, onlyCPU, expectedFailureMeta)
 
 if TEST_NUMPY:
     import numpy as np
@@ -560,14 +560,17 @@ class TestTypePromotion(TestCase):
         for dtype in torch.testing.get_all_dtypes():
             self.assertEqual(torch.promote_types(dtype, dtype), dtype)
 
+    @expectedFailureMeta
     @float_double_default_dtype
-    def test_indexing(self, device):
+    def test_indexing_fail(self, device):
         # https://github.com/pytorch/pytorch/issues/28010
         a = torch.ones(5, 2, dtype=torch.double, device=device)
         b = torch.zeros(5, dtype=torch.int, device=device)
         with self.assertRaises(RuntimeError):
             a[:, [1]] = b.unsqueeze(-1)
 
+    @float_double_default_dtype
+    def test_indexing(self, device):
         x = torch.ones(5, 2, dtype=torch.double, device=device)
         y = torch.zeros(5, dtype=torch.double, device=device)
         x[:, [1]] = y.unsqueeze(-1)

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -92,8 +92,8 @@ class RegisterDispatchKey:
             if (self.dispatch_key == DispatchKey.Meta and
                     f.func.kind() is SchemaKind.inplace and
                     # Defer to composites for meta implementation
-                    self.dispatch_key.CompositeImplicitAutograd not in f.dispatch and
-                    self.dispatch_key.CompositeExplicitAutograd not in f.dispatch and
+                    DispatchKey.CompositeImplicitAutograd not in f.dispatch and
+                    DispatchKey.CompositeExplicitAutograd not in f.dispatch and
                     # Inplace list operations are not supported
                     len(f.func.returns) == 1):
                 inplace_meta = True
@@ -135,12 +135,13 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
             # short circuit for inplace_meta
             if inplace_meta:
                 assert f.func.arguments.self_arg is not None
-                self_arg = f.func.arguments.self_arg.argument.name
+                self_arg_name = f.func.arguments.self_arg.argument.name
                 # TODO: handle in place on tensor list
                 return f"""
 {returns_type} {name}({args_str}) {{
-   TORCH_CHECK_NOT_IMPLEMENTED({self_arg}.is_meta(), "Cannot inplace into non-meta tensor with meta tensor argument");
-   return {self_arg};
+  TORCH_CHECK_NOT_IMPLEMENTED({self_arg_name}.is_meta(),
+    "Cannot inplace into non-meta tensor with meta tensor argument");
+  return {self_arg_name};
 }}
 """
 

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -87,8 +87,18 @@ class RegisterDispatchKey:
 
     @method_with_native_function
     def gen_unstructured(self, f: NativeFunction) -> Optional[str]:
+        inplace_meta = False
         if self.dispatch_key not in f.dispatch:
-            return None
+            if (self.dispatch_key == DispatchKey.Meta and
+                    f.func.kind() is SchemaKind.inplace and
+                    # Defer to composites for meta implementation
+                    self.dispatch_key.CompositeImplicitAutograd not in f.dispatch and
+                    self.dispatch_key.CompositeExplicitAutograd not in f.dispatch and
+                    # Inplace list operations are not supported
+                    len(f.func.returns) == 1):
+                inplace_meta = True
+            else:
+                return None
         if f.manual_kernel_registration:
             return None
 
@@ -122,6 +132,18 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 result += generate_defn(cpp_sig_group.faithful_signature)
             return result
         elif self.target is Target.ANONYMOUS_DEFINITION:
+            # short circuit for inplace_meta
+            if inplace_meta:
+                assert f.func.arguments.self_arg is not None
+                self_arg = f.func.arguments.self_arg.argument.name
+                # TODO: handle in place on tensor list
+                return f"""
+{returns_type} {name}({args_str}) {{
+   TORCH_CHECK_NOT_IMPLEMENTED({self_arg}.is_meta(), "Cannot inplace into non-meta tensor with meta tensor argument");
+   return {self_arg};
+}}
+"""
+
             impl_name = f"at::native::{f.dispatch[self.dispatch_key]}"
 
             args_exprs_str = ', '.join(a.name for a in args)

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -817,6 +817,9 @@ def onlyCUDA(fn):
 def expectedFailureCUDA(fn):
     return expectedFailure('cuda')(fn)
 
+def expectedFailureMeta(fn):
+    return expectedFailure('meta')(fn)
+
 class expectedAlertNondeterministic:
     def __init__(self, caller_name, device_type=None, fn_has_device_arg=True):
         self.device_type = device_type


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54901 Generate no-op meta functions for all inplace operations**

Some subtleties:
- Need to make sure not to clobber composite definitions when
  deciding when to generate
- I was lazy and so I didn't make inplace on TensorList work,
  nor did I make inplace functions that returned void work
- A few tests started complaining that these noop meta functions
  weren't raising the errors they needed.  This is tracked
  in https://github.com/pytorch/pytorch/issues/54897

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27407232](https://our.internmc.facebook.com/intern/diff/D27407232)