### PR TITLE
[torch.Package/TorchScript] refactor shared code for TS old file format and (new) unified file formats into Base class

### DIFF
--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -3,7 +3,10 @@
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/csrc/jit/serialization/pickler.h>
+#include <torch/csrc/jit/serialization/python_print.h>
+#include <torch/csrc/jit/serialization/type_name_uniquer.h>
 #include <torch/csrc/onnx/onnx.h>
 
 #include <ostream>
@@ -52,6 +55,31 @@ TORCH_API std::string serialize_model_proto_to_string(
     const std::shared_ptr<::ONNX_NAMESPACE::ModelProto>& model_proto);
 
 TORCH_API void check_onnx_proto(const std::string& proto_string);
+
+// Base serializer to hold shared serialization logic for original TS
+// format and unified serialization format 
+class ScriptModuleSerializerBase {
+ public:
+  explicit ScriptModuleSerializerBase(
+      caffe2::serialize::PyTorchStreamWriter& export_writer
+    ) : writer_(export_writer) {}
+    virtual void writeFiles(const std::string& code_dir);
+  
+  virtual ~ScriptModuleSerializerBase() = default;
+  
+ protected:
+  void convertNamedType(const c10::NamedTypePtr& class_type);
+  void convertTypes(const at::NamedTypePtr &root_type);
+
+  caffe2::serialize::PyTorchStreamWriter& writer_;
+  std::vector<at::IValue> constant_table_;
+  std::unordered_set<c10::NamedTypePtr> converted_types_;
+  PrintDepsTable class_deps_;
+  TypeNameUniquer type_name_uniquer_;
+  // qualifier, e.g. '__torch__.Bar' -> PythonPrint for the file that will be
+  // created
+  OrderedDict<std::string, PythonPrint> file_streams_;
+};
 
 // For testing purposes
 TORCH_API std::string pretty_print_onnx(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54903 [torch.Package/TorchScript] TS serialization unified format exporter (alternate implementation of #54892)
* **#54902 [torch.Package/TorchScript] refactor shared code for TS old file format and (new) unified file formats into Base class**

PR to refactor existing TorchScript exporter serialization code to allow for code sharing between original TS serialization format logic and new unified format 