### PR TITLE
[torch.Package/TorchScript] TS serialization unified format exporter (alternate implementation of #54892)

### DIFF
--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -946,6 +946,12 @@ void initJitScriptBindings(PyObject* module) {
             pyIValueDeepcopy(IValue(self._ivalue()), memo).toObject());
       });
 
+  // Used by torch.Package to save TS objects in unified format
+  py::class_<ScriptModuleSerializerUniversal>(m, "TorchScriptSerializer")
+      .def(py::init<caffe2::serialize::PyTorchStreamWriter&, py::object>())
+      .def("serialize", &ScriptModuleSerializerUniversal::serialize)
+      .def("write_files", &ScriptModuleSerializerUniversal::writeFiles);
+
   // torch.jit.ScriptModule is a subclass of this C++ object.
   // Methods here are prefixed with _ since they should not be
   // public.

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -81,6 +81,25 @@ class ScriptModuleSerializerBase {
   OrderedDict<std::string, PythonPrint> file_streams_;
 };
 
+// Implementation of ScriptModuleSerializerBase to export unified format 
+struct TORCH_API ScriptModuleSerializerUniversal : public ScriptModuleSerializerBase {
+  explicit ScriptModuleSerializerUniversal(caffe2::serialize::PyTorchStreamWriter& export_writer, py::object exporter)
+      : ScriptModuleSerializerBase(export_writer), package_exporter(exporter) {}
+
+  void serialize(Module& module, const std::string& ts_id);
+  void writeFiles(const std::string& code_dir = ".data/ts_code/code/");
+
+ private:
+  void writeArchive(
+      const std::string& archive_name, 
+      const IValue& value,
+      const std::string& pickle_dir_ext);
+
+  // function calls into package_exporter to get next storage id 
+  std::string getNextStorageID();
+  py::object package_exporter; 
+}; 
+
 // For testing purposes
 TORCH_API std::string pretty_print_onnx(
     const std::shared_ptr<Graph>& graph,

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -294,7 +294,8 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
       std::string(toString(tensor.scalar_type())).append("Storage");
   pushGlobal("torch", data_type);
   // root_key
-  pushString(c10::to_string(tensor_data_.size()));
+  std::string root_key = (get_tensor_id_ == nullptr) ? c10::to_string(tensor_data_.size()) : get_tensor_id_();
+  pushString(root_key);
   // location
   pushString(tensor.device().str());
   // size

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -127,11 +127,13 @@ class TORCH_API Pickler {
       std::function<void(const char*, size_t)> writer,
       std::vector<at::Tensor>* tensor_table,
       std::function<c10::QualifiedName(const c10::ClassTypePtr&)> type_renamer,
-      std::vector<c10::ClassTypePtr>* memoized_class_types)
+      std::vector<c10::ClassTypePtr>* memoized_class_types,
+      std::function<std::string()> get_tensor_id = nullptr)
       : writer_(std::move(writer)),
         tensor_table_(tensor_table),
         type_renamer_(std::move(type_renamer)),
-        memoized_class_types_(memoized_class_types) {}
+        memoized_class_types_(memoized_class_types),
+        get_tensor_id_(std::move(get_tensor_id)) {}
   ~Pickler();
 
   // Push protocol onto the stack
@@ -255,6 +257,9 @@ class TORCH_API Pickler {
 
   // List of all the types that it wrote, inspect from the IValues it wrote.
   std::vector<c10::ClassTypePtr>* memoized_class_types_;
+  // Function to grab next id_name for tensor storage, function is responsible
+  // for returning unique ids 
+  std::function<std::string()> get_tensor_id_;
 
   // List of tensor storages to serialize in the same binary as the pickle data
   // similar to ivalues, they are memoized using BINPUT


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#54903 [torch.Package/TorchScript] TS serialization unified format exporter (alternate implementation of #54892)**
* #54902 [torch.Package/TorchScript] refactor shared code for TS old file format and (new) unified file formats into Base class

Alternate implementation of #54892. I can't get this PR to compile on my devvm due to linker errors. I'm assuming that I need to edit the tools/build_variables.bzl file, but I can't figure out what to change ... 