### PR TITLE
Fix ConvTranspose with padding as a list of values

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10152,6 +10152,15 @@ class TestNN(NNTestCase):
 
             self.assertTrue(torch.allclose(grads1, grads2, rtol, atol))
 
+    def test_padding_list(self):
+        # Padding can be a list, or tuple (regression test for gh-54452)
+        x = torch.randn(4, 8, 32, 32)
+        net = torch.nn.ConvTranspose2d(8, 16, kernel_size=3, padding=[3, 3])
+        y = net(x)
+
+        net = torch.nn.ConvTranspose2d(8, 16, kernel_size=3, padding=(3, 3))
+        y = net(x)
+
 
 class TestNNInit(TestCase):
     def setUp(self):

--- a/torch/nn/modules/utils.py
+++ b/torch/nn/modules/utils.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Any
 def _ntuple(n):
     def parse(x):
         if isinstance(x, collections.abc.Iterable):
-            return x
+            return tuple(x)
         return tuple(repeat(x, n))
     return parse
 


### PR DESCRIPTION
Fixes #54452

The assertion that fails in the issue is necessary to appease mypy. Instead, I fix `_ntuple` to always return a `tuple`.