### PR TITLE
Improve numerical stability of GroupNorm

### DIFF
--- a/aten/src/ATen/native/SharedReduceOps.h
+++ b/aten/src/ATen/native/SharedReduceOps.h
@@ -80,8 +80,15 @@ struct WelfordData {
   scalar_t m2;
   index_t n;
   combine_t nf;
-  C10_HOST_DEVICE WelfordData() : mean(0), m2(0), n(0), nf(0)  {}
-  C10_DEVICE WelfordData(scalar_t mean, scalar_t m2, index_t n, combine_t nf) : mean(mean), m2(m2), n(n), nf(nf) {}
+
+  C10_HOST_DEVICE WelfordData() : mean(0), m2(0), n(0), nf(0) {}
+
+  C10_HOST_DEVICE WelfordData(
+      scalar_t mean,
+      scalar_t m2,
+      index_t n,
+      combine_t nf)
+      : mean(mean), m2(m2), n(n), nf(nf) {}
 };
 
 
@@ -145,7 +152,7 @@ struct WelfordOps {
     };
   }
 #endif
-  WelfordOps(index_t correction, bool take_sqrt)
+  C10_HOST_DEVICE WelfordOps(index_t correction, bool take_sqrt)
       : correction(correction), take_sqrt(take_sqrt) {}
 };
 

--- a/aten/src/ATen/native/cpu/SumKernel.cpp
+++ b/aten/src/ATen/native/cpu/SumKernel.cpp
@@ -1,11 +1,11 @@
-#include <ATen/Dispatch.h>
-#include <ATen/native/TensorIterator.h>
 #include <ATen/native/ReduceOps.h>
-#include <ATen/native/cpu/Reduce.h>
-#include <c10/util/llvmMathExtras.h>
 
 #include <algorithm>
 
+#include <ATen/Dispatch.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/cpu/Reduce.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at {
 namespace native {
@@ -46,17 +46,6 @@ void accumulate_result(char * C10_RESTRICT data, int64_t stride, int64_t index,
   for (int64_t k = 0; k < numel; ++k) {
     accumulate_result(base_ptr, stride, k, values[k]);
   }
-}
-
-int64_t ceil_log2(int64_t x) {
-  if (x <= 2) {
-    return 1;
-  }
-
-  auto ux = static_cast<uint64_t>(x);
-  // Last set bit is floor(log2(x)), floor + 1 is ceil
-  // except when x is an exact powers of 2, so subtract 1 first
-  return static_cast<int64_t>(llvm::findLastSet(ux - 1)) + 1;
 }
 
 /** Simultaneously sum over n rows at once
@@ -101,7 +90,7 @@ std::array<scalar_t, nrows> multi_row_sum(
   constexpr int64_t num_levels = 4;
 
   const int64_t level_power =
-      std::max(int64_t(4), ceil_log2(size) / num_levels);
+      std::max(int64_t(4), utils::CeilLog2(size) / num_levels);
   const int64_t level_step = (1 << level_power);
   const int64_t level_mask = level_step - 1;
 

--- a/aten/src/ATen/native/cpu/moments_utils.h
+++ b/aten/src/ATen/native/cpu/moments_utils.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <array>
+#include <cstring>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include <ATen/cpu/vec/vec.h>
+#include <ATen/native/cpu/utils.h>
+#include <c10/util/SmallVector.h>
+
+namespace at {
+namespace native {
+namespace utils {
+
+constexpr int64_t kChunkSize = 16;
+
+template <typename T>
+void AddMoments(
+    int64_t m0_add,
+    const T& m1_add,
+    const T& m2_add,
+    int64_t& m0,
+    T& m1,
+    T& m2) {
+  const int64_t n = m0 + m0_add;
+  const T c = n == 0 ? 0 : static_cast<T>(m0_add) / static_cast<T>(n);
+  const T delta = m1_add - m1;
+  m1 += c * delta;
+  m2 += m2_add + delta * delta * c * static_cast<T>(m0);
+  m0 = n;
+}
+
+template <typename T>
+void AddMomentsVec(
+    int64_t m0_add,
+    const vec::Vectorized<T>& m1_add,
+    const vec::Vectorized<T>& m2_add,
+    int64_t& m0,
+    vec::Vectorized<T>& m1,
+    vec::Vectorized<T>& m2) {
+  using Vec = vec::Vectorized<T>;
+  const int64_t n = m0 + m0_add;
+  const T c = n == 0 ? 0 : static_cast<T>(m0_add) / static_cast<T>(n);
+  const Vec c_vec(c);
+  const Vec delta = m1_add - m1;
+  m1 += c_vec * delta;
+  m2 += m2_add + delta * delta * c_vec * Vec(static_cast<T>(m0));
+  m0 = n;
+}
+
+// Compute rowwise moments by Welford algorithm and cascade sum to improve
+// numerical stability.
+// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+// https://en.wikipedia.org/wiki/Pairwise_summation
+template <typename T, int64_t kMaxDepth>
+std::pair<T, T> RowwiseMomentsImpl(const T* X, int64_t N) {
+  using Vec = vec::Vectorized<T>;
+
+  constexpr int64_t kVecSize = Vec::size();
+  const int64_t n = N / kVecSize;
+  const int64_t m = divup(n, kChunkSize);
+  const int64_t depth = CeilLog2(m);
+
+  const Vec kZeroVec(T(0));
+  c10::SmallVector<int64_t, kMaxDepth> m0_stk(depth, 0);
+  c10::SmallVector<Vec, kMaxDepth> m1_stk(depth, kZeroVec);
+  c10::SmallVector<Vec, kMaxDepth> m2_stk(depth, kZeroVec);
+
+  for (int64_t i = 0; i < m; ++i) {
+    const T* X_ptr = X + i * kChunkSize * kVecSize;
+    const int64_t m0 = std::min(kChunkSize, n - i * kChunkSize);
+    Vec m1_vec(0);
+    Vec m2_vec(0);
+    for (int64_t j = 0; j < m0; ++j) {
+      const Vec x_vec = Vec::loadu(X_ptr + j * kVecSize);
+      const Vec delta_vec = x_vec - m1_vec;
+      const Vec c_vec = Vec(T(1) / static_cast<T>(j + 1));
+      m1_vec += delta_vec * c_vec;
+      m2_vec += delta_vec * (x_vec - m1_vec);
+    }
+    AddMomentsVec(m0, m1_vec, m2_vec, m0_stk[0], m1_stk[0], m2_stk[0]);
+    int64_t mask = i + 1;
+    for (int64_t j = 1; j < depth && (mask & 1) == 0; ++j) {
+      AddMomentsVec(
+          m0_stk[j - 1],
+          m1_stk[j - 1],
+          m2_stk[j - 1],
+          m0_stk[j],
+          m1_stk[j],
+          m2_stk[j]);
+      m0_stk[j - 1] = 0;
+      m1_stk[j - 1] = kZeroVec;
+      m2_stk[j - 1] = kZeroVec;
+      mask >>= 1;
+    }
+  }
+  for (int64_t i = 1; i < depth; ++i) {
+    AddMomentsVec(
+        m0_stk[i], m1_stk[i], m2_stk[i], m0_stk[0], m1_stk[0], m2_stk[0]);
+  }
+
+  std::array<T, kVecSize> m1_arr{};
+  std::array<T, kVecSize> m2_arr{};
+  m1_stk[0].store(m1_arr.data());
+  m2_stk[0].store(m2_arr.data());
+
+  int64_t m0 = 0;
+  T m1 = 0;
+  T m2 = 0;
+  for (int64_t i = n * kVecSize; i < N; ++i) {
+    const T delta = X[i] - m1;
+    ++m0;
+    m1 += delta / static_cast<T>(m0);
+    m2 += delta * (X[i] - m1);
+  }
+  for (int64_t i = 0; i < kVecSize; ++i) {
+    AddMoments(n, m1_arr[i], m2_arr[i], m0, m1, m2);
+  }
+
+  return std::make_pair(m1, m2 / static_cast<T>(N));
+}
+
+template <typename T>
+std::pair<T, T> RowwiseMoments(const T* X, int64_t N) {
+  using Vec = vec::Vectorized<T>;
+  constexpr int64_t kVecSize = Vec::size();
+  const int64_t n = N / kVecSize;
+  const int64_t m = divup(n, kChunkSize);
+  const int64_t depth = CeilLog2(m);
+  if (depth <= 4) {
+    return RowwiseMomentsImpl<T, 4>(X, N);
+  } else if (depth <= 8) {
+    return RowwiseMomentsImpl<T, 8>(X, N);
+  } else if (depth <= 16) {
+    return RowwiseMomentsImpl<T, 16>(X, N);
+  } else if (depth <= 32) {
+    return RowwiseMomentsImpl<T, 32>(X, N);
+  } else {
+    return RowwiseMomentsImpl<T, 64>(X, N);
+  }
+}
+
+} // namespace utils
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -3,7 +3,10 @@
 #include <ATen/cpu/vec/vec.h>
 #include <c10/util/llvmMathExtras.h>
 
-namespace at { namespace native { namespace {
+namespace at {
+namespace native {
+
+namespace {
 
 template <typename T>
 inline T data_index_init(T offset) {
@@ -11,7 +14,7 @@ inline T data_index_init(T offset) {
 }
 
 template <typename T, typename... Args>
-inline T data_index_init(T offset, T &x, const T &X, Args &&... args) {
+inline T data_index_init(T offset, T& x, const T& X, Args&&... args) {
   offset = data_index_init(offset, std::forward<Args>(args)...);
   x = offset % X;
   return offset / X;
@@ -22,7 +25,7 @@ inline bool data_index_step() {
 }
 
 template <typename T, typename... Args>
-inline bool data_index_step(T &x, const T &X, Args &&... args) {
+inline bool data_index_step(T& x, const T& X, Args&&... args) {
   if (data_index_step(std::forward<Args>(args)...)) {
     x = ((x + 1) == X) ? 0 : (x + 1);
     return x == 0;
@@ -47,4 +50,4 @@ T CeilLog2(const T& x) {
 } // namespace utils
 
 } // namespace native
-} // namespace at// namespace at::native::<anonymous>
+} // namespace at

--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -1,10 +1,10 @@
-#include <ATen/AccumulateType.h>
 #include <ATen/ATen.h>
-#include <ATen/Config.h>
+#include <ATen/AccumulateType.h>
 #include <ATen/CPUApplyUtils.h>
-#include <ATen/native/group_norm.h>
+#include <ATen/Config.h>
 #include <ATen/NativeFunctions.h>
 #include <ATen/Parallel.h>
+#include <ATen/native/group_norm.h>
 #include <c10/util/accumulate.h>
 
 #include <array>
@@ -13,21 +13,25 @@
 #include <tuple>
 #include <vector>
 
-
 namespace at {
 namespace native {
 
 std::tuple<Tensor, Tensor, Tensor> native_group_norm(
-    const Tensor& X, const c10::optional<Tensor>& gamma_opt /* optional */, const c10::optional<Tensor>& beta_opt /* optional */,
+    const Tensor& X,
+    const c10::optional<Tensor>& gamma_opt /* optional */,
+    const c10::optional<Tensor>& beta_opt /* optional */,
     int64_t N,
     int64_t C,
     int64_t HxW,
     int64_t group,
     double eps) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> gamma_maybe_owned = at::borrow_from_optional_tensor(gamma_opt);
+  c10::MaybeOwned<Tensor> gamma_maybe_owned =
+      at::borrow_from_optional_tensor(gamma_opt);
   const Tensor& gamma = *gamma_maybe_owned;
-  const Tensor& beta = c10::value_or_else(beta_opt, [] {return Tensor();});
+  const Tensor& beta = c10::value_or_else(beta_opt, [] { return Tensor(); });
+
+  TORCH_CHECK(X.is_contiguous());
 
   Tensor Y = at::native::empty_like(
       X,
@@ -47,14 +51,16 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
     const Tensor& dY,
     const Tensor& X,
     const Tensor& mean,
-    const Tensor& rstd, const c10::optional<Tensor>& gamma_opt,
+    const Tensor& rstd,
+    const c10::optional<Tensor>& gamma_opt,
     int64_t N,
     int64_t C,
     int64_t HxW,
     int64_t group,
     std::array<bool, 3> grad_input_mask) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> gamma_maybe_owned = at::borrow_from_optional_tensor(gamma_opt);
+  c10::MaybeOwned<Tensor> gamma_maybe_owned =
+      at::borrow_from_optional_tensor(gamma_opt);
   const Tensor& gamma = *gamma_maybe_owned;
 
   Tensor dX;
@@ -106,13 +112,16 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
 
 Tensor group_norm(
     const Tensor& input,
-    int64_t num_groups, const c10::optional<Tensor>& weight_opt /* optional */, const c10::optional<Tensor>& bias_opt /* optional */,
+    int64_t num_groups,
+    const c10::optional<Tensor>& weight_opt /* optional */,
+    const c10::optional<Tensor>& bias_opt /* optional */,
     double eps,
     bool /* cudnn_enabled, deprecated */) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> weight_maybe_owned =
+      at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& bias = c10::value_or_else(bias_opt, [] {return Tensor();});
+  const Tensor& bias = c10::value_or_else(bias_opt, [] { return Tensor(); });
 
   const int64_t N = input.size(0);
   const int64_t C = input.size(1);
@@ -160,16 +169,19 @@ DEFINE_DISPATCH(GroupNormBackwardKernel);
 
 // Ported from pytorch/xla repo
 std::tuple<at::Tensor, at::Tensor, at::Tensor> math_group_norm(
-    const Tensor& input, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& bias_opt,
+    const Tensor& input,
+    const c10::optional<Tensor>& weight_opt,
+    const c10::optional<Tensor>& bias_opt,
     int64_t N,
     int64_t C,
     int64_t HxW,
     int64_t group,
     double eps) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> weight_maybe_owned =
+      at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& bias = c10::value_or_else(bias_opt, [] {return Tensor();});
+  const Tensor& bias = c10::value_or_else(bias_opt, [] { return Tensor(); });
 
   auto input_shape = input.sizes();
   at::Tensor input_reshaped = input.view({1, N * group, N ? -1 : 1});

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -1649,6 +1649,17 @@ new_module_tests = [
     ),
     dict(
         module_name='GroupNorm',
+        constructor_args=(3, 51, 1e-5, False),
+        cpp_constructor_args='torch::nn::GroupNormOptions(3, 51).eps(1e-5).affine(false)',
+        input_size=(2, 51, 28, 28),
+        cudnn=True,
+        check_eval=True,
+        check_bfloat16=True,
+        desc='2d_no_affine_large_feature',
+        test_cpu=False,
+    ),
+    dict(
+        module_name='GroupNorm',
         constructor_args=(3, 3, 1e-3, False),
         cpp_constructor_args='torch::nn::GroupNormOptions(3, 3).eps(1e-3).affine(false)',
         input_size=(4, 3, 2, 3),


### PR DESCRIPTION
Summary: Improve numerical stability of GroupNorm

Test Plan: buck test mode/dev-nosan //caffe2/test:nn -- "GroupNorm"

Differential Revision: D27414438

There are two main changes in this PR:
1. Use Welford algorithm to compute main and variance.
2. Use cascade summation when computing sum over input for both mean and variance.

Some benchmark results.

input_size = [256, 1024, 28, 28], group = 8

for single thread CPU run average time change is 510.91ms -> 602.70ms.
for CUDA run average time change is 12.20ms -> 12.47ms.