### PR TITLE
Added support for TensorList inputs in OpInfo

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -6,7 +6,7 @@ import torch
 from torch.testing import \
     (FileCheck, floating_and_complex_types_and)
 from torch.testing._internal.common_utils import \
-    (TestCase, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor)
+    (TestCase, is_iterable_of_tensors, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor)
 from torch.testing._internal.common_methods_invocations import \
     (op_db, method_tests)
 from torch.testing._internal.common_device_type import \
@@ -113,19 +113,25 @@ class TestGradients(TestCase):
                 variant_out_fn = variant
 
             def fn(*inputs):
+                if not isinstance(sample.input, torch.Tensor):
+                    inputs = (inputs[:len(sample.input)], *inputs[len(sample.input):])
                 output = variant_out_fn(*inputs, **sample.kwargs)
                 return op.output_func(output)
 
+            # Gradcheck does not support TensorList so we splat it with the remaining args
+            gradcheck_args = (sample.input,) if isinstance(sample.input, torch.Tensor) else sample.input
+            gradcheck_args += sample.args
+
             if check == 'gradcheck':
-                self.assertTrue(gradcheck(fn, (sample.input,) + sample.args,
+                self.assertTrue(gradcheck(fn, gradcheck_args,
                                           check_batched_grad=op.check_batched_grad,
                                           check_grad_dtypes=True))
             elif check == 'gradgradcheck':
-                self.assertTrue(gradgradcheck(fn, (sample.input,) + sample.args,
+                self.assertTrue(gradgradcheck(fn, gradcheck_args,
                                               gen_non_contig_grad_outputs=False,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True))
-                self.assertTrue(gradgradcheck(fn, (sample.input,) + sample.args,
+                self.assertTrue(gradgradcheck(fn, gradcheck_args,
                                               gen_non_contig_grad_outputs=True,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True))
@@ -229,8 +235,11 @@ class TestCommon(JitCommonTestCase):
                           (dtype.is_floating_point or op.supports_complex_autograd))
         samples = op.sample_inputs(device, dtype, requires_grad=_requires_grad)
         for sample in samples:
+            # Check grad only on the first input Tensor
+            tensor = sample.input if isinstance(sample.input, torch.Tensor) else sample.input[0]
+
             # Computes function forward and backward values
-            sample.input.grad = None
+            tensor.grad = None
             expected_forward = op(sample.input, *sample.args, **sample.kwargs)
             expected_grad = None
 
@@ -238,18 +247,17 @@ class TestCommon(JitCommonTestCase):
             #   the input dtype
             skip_inplace = False
             if (isinstance(expected_forward, torch.Tensor) and
-                    expected_forward.dtype is not sample.input.dtype):
+                    expected_forward.dtype is not tensor.dtype):
                 skip_inplace = True
 
             # TODO: backward consistency only supported for single tensor outputs
-            # TODO: backward consistency only checked on sample.input, not all
-            #   tensor inputs
+            # TODO: backward consistency only checked on first input Tensor
             # TODO: update to handle checking grads of all tensor inputs as
             #   derived from each tensor output
             if (op.supports_autograd and isinstance(expected_forward, torch.Tensor)
                     and (dtype.is_floating_point or op.supports_complex_autograd)):
                 expected_forward.sum().backward()
-                expected_grad = sample.input.grad
+                expected_grad = tensor.grad
 
             # Test eager consistency
             for variant in variants:
@@ -259,7 +267,7 @@ class TestCommon(JitCommonTestCase):
 
                 # Compares variant's forward
                 # Note: copies the to-be-modified input when testing the inplace variant
-                sample.input.grad = None
+                tensor.grad = None
                 cloned = clone_input_helper(sample.input) if variant in inplace_ops else sample.input
                 variant_forward = variant(cloned,
                                           *sample.args,
@@ -269,7 +277,7 @@ class TestCommon(JitCommonTestCase):
                 # Compares variant's backward
                 if expected_grad is not None and (variant not in inplace_ops or op.supports_inplace_autograd):
                     variant_forward.sum().backward()
-                    self.assertEqual(expected_grad, sample.input.grad)
+                    self.assertEqual(expected_grad, tensor.grad)
 
     # Tests that the forward and backward passes of operations produce the
     #   same values for the cross-product of op variants (function, method, inplace)
@@ -469,19 +477,7 @@ class TestCommon(JitCommonTestCase):
         # Short-circuits if output is not a single tensor or an
         #   iterable of tensors
 
-        # Returns True if iterable is an iterable of tensors (includes empty iterables)
-        #   and False o.w.
-        def _is_iterable_of_tensors(iterable):
-            try:
-                for t in iter(iterable):
-                    if not isinstance(t, torch.Tensor):
-                        return False
-            except TypeError as te:
-                return False
-
-            return True
-
-        if not isinstance(expected, torch.Tensor) and not _is_iterable_of_tensors(expected):
+        if not isinstance(expected, torch.Tensor) and not is_iterable_of_tensors(expected, include_empty=True):
             self.skipTest("Skipped! Only supports single tensor or iterable of tensor outputs.")
 
         # A wrapper around map that works with single tensors and always

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -114,7 +114,7 @@ class TestGradients(TestCase):
 
             def fn(*inputs):
                 # Pack input back into TensorList since we splat it when passing to gradcheck
-                if not isinstance(sample.input, torch.Tensor):
+                if is_iterable_of_tensors(sample.input):
                     n = len(sample.input)
                     inputs = (inputs[:n], *inputs[n:])
                 output = variant_out_fn(*inputs, **sample.kwargs)
@@ -237,7 +237,7 @@ class TestCommon(JitCommonTestCase):
                           (dtype.is_floating_point or op.supports_complex_autograd))
         samples = op.sample_inputs(device, dtype, requires_grad=_requires_grad)
         for sample in samples:
-            # Check grad only on the first input Tensor
+            # TODO: Check grad for all Tensors requiring grad if sample.input is TensorList
             tensor = sample.input if isinstance(sample.input, torch.Tensor) else sample.input[0]
 
             # Computes function forward and backward values

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -113,13 +113,15 @@ class TestGradients(TestCase):
                 variant_out_fn = variant
 
             def fn(*inputs):
+                # Pack input back into TensorList since we splat it when passing to gradcheck
                 if not isinstance(sample.input, torch.Tensor):
-                    inputs = (inputs[:len(sample.input)], *inputs[len(sample.input):])
+                    n = len(sample.input)
+                    inputs = (inputs[:n], *inputs[n:])
                 output = variant_out_fn(*inputs, **sample.kwargs)
                 return op.output_func(output)
 
             # Gradcheck does not support TensorList so we splat it with the remaining args
-            gradcheck_args = (sample.input,) if isinstance(sample.input, torch.Tensor) else sample.input
+            gradcheck_args = (sample.input,) if isinstance(sample.input, torch.Tensor) else tuple(sample.input)
             gradcheck_args += sample.args
 
             if check == 'gradcheck':

--- a/test/test_shape_ops.py
+++ b/test/test_shape_ops.py
@@ -620,6 +620,7 @@ class TestShapeFuncs(TestCase):
     def test_repeat_tile_vs_numpy(self, device, dtype, op):
         samples = op.sample_inputs(device, dtype, requires_grad=False)
         for sample in samples:
+            assert isinstance(sample.input, torch.Tensor)
             expected = op.ref(sample.input.cpu().numpy(), *sample.args, **sample.kwargs)
             result = op(sample.input, *sample.args, **sample.kwargs).cpu().numpy()
             self.assertEqual(expected, result)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -3272,13 +3272,11 @@ class TestSparseUnaryUfuncs(TestCase):
 
         sample = samples[0]
 
-        if len(sample.input) > 1:
-            self.skipTest("Skipped! Testing unary ops, one input is expected")
-        sample = sample.input[0]
+        assert isinstance(sample.input, torch.Tensor)
 
-        expected = op(sample)
+        expected = op(sample.input)
         assert torch.is_tensor(expected)
-        output = op(sample.to_sparse())
+        output = op(sample.input.to_sparse())
         assert torch.is_tensor(output)
         self.assertEqual(output.to_dense(), expected)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -93,7 +93,7 @@ class SampleInput(object):
 
     def __repr__(self):
         arguments = [
-            'input=Tensor' if isinstance(self.input, torch.Tensor) else f'input[{len(self.input)}]',
+            'input=Tensor' if isinstance(self.input, torch.Tensor) else f'input=TensorList[{len(self.input)}]',
             f'args={self.args}' if len(self.args) > 0 else None,
             f'kwargs={self.kwargs}' if len(self.kwargs) > 0 else None,
             (f'output_process_fn_grad={self.output_process_fn_grad}'
@@ -3643,7 +3643,6 @@ op_db: List[OpInfo] = [
                # stack does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),),),
     OpInfo('hstack',
-           # gradcheck expects the input arguments as a flat list
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            skips=(
@@ -3651,7 +3650,6 @@ op_db: List[OpInfo] = [
                # hstack does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),),),
     OpInfo('vstack',
-           # gradcheck expects the input arguments as a flat list
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            skips=(
@@ -3659,7 +3657,6 @@ op_db: List[OpInfo] = [
                # vstack does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),),),
     OpInfo('dstack',
-           # gradcheck expects the input arguments as a flat list
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            skips=(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11,7 +11,7 @@ from torch._six import inf
 from torch.autograd import Variable
 import collections.abc
 
-from typing import List, Tuple, Dict, Any
+from typing import List, Sequence, Tuple, Dict, Any, Union
 
 from torch.testing import \
     (make_non_contiguous, _dispatch_dtypes, floating_types, floating_types_and,
@@ -86,7 +86,7 @@ class SampleInput(object):
         # This follows the typical pattern where for Tensor inputs op(t, ...) = t.op(...).
         # op with TensorList inputs do not support method or inplace variants.
         assert isinstance(input, torch.Tensor) or is_iterable_of_tensors(input)
-        self.input = input if isinstance(input, torch.Tensor) else tuple(input)
+        self.input: Union[torch.Tensor, Sequence] = input
         self.args = args
         self.kwargs = kwargs if kwargs is not None else {}
         self.output_process_fn_grad = output_process_fn_grad

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -24,7 +24,7 @@ from torch.testing._internal.common_device_type import \
      skipCUDAIfRocm, expectedAlertNondeterministic, precisionOverride,)
 from torch.testing._internal.common_cuda import CUDA11OrLater
 from torch.testing._internal.common_utils import \
-    (random_square_matrix_of_rank,
+    (is_iterable_of_tensors, random_square_matrix_of_rank,
      random_symmetric_matrix, random_symmetric_psd_matrix,
      random_symmetric_pd_matrix, make_nonzero_det,
      random_fullrank_matrix_distinct_singular_value, set_rng_seed, SEED,
@@ -82,17 +82,18 @@ class SampleInput(object):
     __slots__ = ['input', 'args', 'kwargs', 'output_process_fn_grad']
 
     def __init__(self, input, *, args=tuple(), kwargs=None, output_process_fn_grad=None):
-        # input must be a single tensor, and will be the first argument to the op
-        #   this follows the typical pattern where op(t, ...) = t.op(...)
-        assert isinstance(input, torch.Tensor)
-        self.input = input
+        # input is the first input to the op and must be either a Tensor or TensorList (Sequence[Tensor]).
+        # This follows the typical pattern where for Tensor inputs op(t, ...) = t.op(...).
+        # op with TensorList inputs do not support method or inplace variants.
+        assert isinstance(input, torch.Tensor) or is_iterable_of_tensors(input)
+        self.input = input if isinstance(input, torch.Tensor) else tuple(input)
         self.args = args
         self.kwargs = kwargs if kwargs is not None else {}
         self.output_process_fn_grad = output_process_fn_grad
 
     def __repr__(self):
         arguments = [
-            f'input[{len(self.input)}]',
+            'input=Tensor' if isinstance(self.input, torch.Tensor) else f'input[{len(self.input)}]',
             f'args={self.args}' if len(self.args) > 0 else None,
             f'kwargs={self.kwargs}' if len(self.kwargs) > 0 else None,
             (f'output_process_fn_grad={self.output_process_fn_grad}'
@@ -659,21 +660,22 @@ def sample_inputs_div(self, device, dtype, requires_grad, rounding_mode=None):
     )
 
 def sample_inputs_stack(op_info, device, dtype, requires_grad):
-    return (
-        SampleInput(
-            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-            args=(
-                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-                make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad)),
-            kwargs=dict(idx=0)),
-    )
+    tensors = [
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+    ]
+
+    return (SampleInput(tensors, args=(0,)),)
 
 def sample_inputs_hstack_dstack_vstack(op_info, device, dtype, requires_grad):
-    return (SampleInput(
-        make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-        args=(
-            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad),
-            make_tensor((S, S), device, dtype, low=None, high=None, requires_grad=requires_grad))),)
+    tensors = [
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+        make_tensor((S, S), device, dtype, requires_grad=requires_grad),
+    ]
+
+    return (SampleInput(tensors),)
 
 def sample_inputs_gather(op_info, device, dtype, requires_grad):
     return (
@@ -3634,26 +3636,36 @@ op_db: List[OpInfo] = [
                SkipInfo('TestCommon', 'test_out'),
            )),
     OpInfo('stack',
-           # gradcheck expects the input arguments as a flat list
-           op=lambda *args, idx, **kwargs: torch.stack([*args], idx, **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
+           sample_inputs_func=sample_inputs_stack,
            skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
+               SkipInfo('TestCommon', 'test_variant_consistency_jit'),
                # stack does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-           ),
-           sample_inputs_func=sample_inputs_stack),
+               SkipInfo('TestCommon', 'test_out'),),),
     OpInfo('hstack',
            # gradcheck expects the input arguments as a flat list
-           op=lambda *args, **kwargs: torch.hstack([*args], **kwargs),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
+           sample_inputs_func=sample_inputs_hstack_dstack_vstack,
            skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
+               SkipInfo('TestCommon', 'test_variant_consistency_jit'),
                # hstack does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out')),
-           sample_inputs_func=sample_inputs_hstack_dstack_vstack),
+               SkipInfo('TestCommon', 'test_out'),),),
+    OpInfo('vstack',
+           # gradcheck expects the input arguments as a flat list
+           dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
+           sample_inputs_func=sample_inputs_hstack_dstack_vstack,
+           skips=(
+               SkipInfo('TestCommon', 'test_variant_consistency_jit'),
+               # vstack does not correctly warn when resizing out= inputs
+               SkipInfo('TestCommon', 'test_out'),),),
+    OpInfo('dstack',
+           # gradcheck expects the input arguments as a flat list
+           dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
+           sample_inputs_func=sample_inputs_hstack_dstack_vstack,
+           skips=(
+               SkipInfo('TestCommon', 'test_variant_consistency_jit'),
+               # dstack does not correctly warn when resizing out= inputs
+               SkipInfo('TestCommon', 'test_out'),),),
     OpInfo('unfold',
            op=lambda x, *args: x.unfold(*args),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
@@ -3667,27 +3679,6 @@ op_db: List[OpInfo] = [
                SkipInfo('TestOperatorSignatures', 'test_get_torch_func_signature_exhaustive'),
            ),
            sample_inputs_func=sample_inputs_unfold),
-    OpInfo('vstack',
-           # gradcheck expects the input arguments as a flat list
-           op=lambda *args, **kwargs: torch.vstack([*args], **kwargs),
-           dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
-               # vstack does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-           ),
-           sample_inputs_func=sample_inputs_hstack_dstack_vstack),
-    OpInfo('dstack',
-           # gradcheck expects the input arguments as a flat list
-           op=lambda *args, **kwargs: torch.dstack([*args], **kwargs),
-           dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           skips=(
-               SkipInfo('TestCommon', 'test_variant_consistency_jit',
-                        dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16)),
-               # dstack does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),),
-           sample_inputs_func=sample_inputs_hstack_dstack_vstack),
     OpInfo('movedim',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -692,7 +692,7 @@ def is_iterable(obj):
 
 
 def is_iterable_of_tensors(iterable, include_empty=False):
-    """ Returns True if iterable is an iterable of tensors and False o.w. 
+    """ Returns True if iterable is an iterable of tensors and False o.w.
 
         If the iterable is empty, the return value is :attr:`include_empty`
     """

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -690,6 +690,30 @@ def is_iterable(obj):
     except TypeError:
         return False
 
+
+def is_iterable_of_tensors(iterable, include_empty=False):
+    """ Returns True if iterable is an iterable of tensors and False o.w. 
+
+        If the iterable is empty, the return value is :attr:`include_empty`
+    """
+    # Tensor itself is iterable so we check this first
+    if isinstance(iterable, torch.Tensor):
+        return False
+
+    try:
+        if len(iterable) == 0:
+            return include_empty
+
+        for t in iter(iterable):
+            if not isinstance(t, torch.Tensor):
+                return False
+
+    except TypeError as te:
+        return False
+
+    return True
+
+
 class CudaNonDefaultStream():
     def __enter__(self):
         # Before starting CUDA test save currently active streams on all


### PR DESCRIPTION
Stack:
* #54954 Fixed OpInfo jit tests failing for TensorList inputs 
* __#54922 Added support for TensorList inputs in OpInfo__

Updated OpInfo to accept either a `Tensor` or `TensorList` as `sample.input` and added workarounds to make this work with gradcheck.

Note: JIT testing support for TensorList inputs will be added in a follow up PR.

Fixes https://github.com/pytorch/pytorch/issues/51996
