### PR TITLE
Add a missing sys import in test/distributed/rpc/test_tensorpipe_agent.py

### DIFF
--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import sys
+
 import torch.distributed as dist
 
 if not dist.is_available():


### PR DESCRIPTION

`sys` is used a couple of lines below.


