### PR TITLE
add api to export some version

### DIFF
--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -222,11 +222,13 @@ struct TORCH_API Module : public Object {
   void _save_for_mobile(
       std::ostream& out,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
+      at::optional<uint64_t> version = at::optional<uint64_t>(),
       bool save_mobile_debug_info = false) const;
 
   void _save_for_mobile(
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
+      at::optional<uint64_t> version = at::optional<uint64_t>(),
       bool save_mobile_debug_info = false) const;
 
   Module copy() const;

--- a/torch/csrc/jit/api/module_save.cpp
+++ b/torch/csrc/jit/api/module_save.cpp
@@ -16,24 +16,26 @@ void Module::save(const std::string& filename, const ExtraFilesMap& extra_files)
 void Module::_save_for_mobile(
     std::ostream& out,
     const ExtraFilesMap& extra_files,
+    at::optional<uint64_t> version,
     bool save_mobile_debug_info) const {
   ExportModule(
       *this,
       out,
       extra_files,
-      true /* bytecode_format */,
+      version /* bytecode_format version */,
       save_mobile_debug_info);
 }
 
 void Module::_save_for_mobile(
     const std::string& filename,
     const ExtraFilesMap& extra_files,
+    at::optional<uint64_t> version,
     bool save_mobile_debug_info) const {
   ExportModule(
       *this,
       filename,
       extra_files,
-      true /* bytecode_format */,
+      version /* bytecode_format version*/,
       save_mobile_debug_info);
 }
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -973,6 +973,7 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& m,
              const std::string& filename,
              const ExtraFilesMap& _extra_files = ExtraFilesMap(),
+             uint64_t _version = caffe2::serialize::kProducedBytecodeVersion,
              bool _save_mobile_debug_info = false) {
             m._save_for_mobile(filename, _extra_files, _save_mobile_debug_info);
           },
@@ -983,6 +984,7 @@ void initJitScriptBindings(PyObject* module) {
           "_save_to_buffer_for_mobile",
           [](Module& m,
              const ExtraFilesMap& _extra_files = ExtraFilesMap(),
+             uint64_t _version = caffe2::serialize::kProducedBytecodeVersion,
              bool _save_mobile_debug_info = false) {
             std::ostringstream buf;
             m._save_for_mobile(buf, _extra_files, _save_mobile_debug_info);

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -70,21 +70,21 @@ TORCH_API void ExportModule(
     const Module& module,
     std::ostream& out,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::string& filename,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::function<size_t(const void*, size_t)>& writer_func,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 // Write the bytes of a pickle archive and the tensors referenced inside that


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54930 change to bytecode format to version
* **#54929 add api to export some version**
* #54306 [Review only] Reuse cosntant table from jit (including read and write)

