### PR TITLE
update build tutorial - choose the correct VS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Choose Correct Visual Studio Version.
 
 Visual Studio upgrades are very often. Sometimes, there're regressions in some new versions.
 It'd best to use the same Visual Studio Version as [PyTorch CI's](https://github.com/pytorch/pytorch/blob/a1bd7918cc5a06cbef6c5178259bf0a7b5ab1ce3/.circleci/scripts/vs_install.ps1#L4). 
-You can use Visual Stuido Enterprise, Professional or Community though PyTorch CI uses VS BuildTools.
+You can use Visual Studio Enterprise, Professional or Community though PyTorch CI uses Visual Studio BuildTools.
 
 Build with CPU
 

--- a/README.md
+++ b/README.md
@@ -248,12 +248,12 @@ On Windows
 Choose Correct Visual Studio Version.
 
 Visual Studio upgrades are very often. Sometimes, there're regressions in some new versions.
-It'd best to use the same Visual Studio Version as [PyTorch CI's](https://github.com/pytorch/pytorch/blob/a1bd7918cc5a06cbef6c5178259bf0a7b5ab1ce3/.circleci/scripts/vs_install.ps1#L4). 
+It'd best to use the same Visual Studio Version as [PyTorch CI's](https://github.com/pytorch/pytorch/blob/a1bd7918cc5a06cbef6c5178259bf0a7b5ab1ce3/.circleci/scripts/vs_install.ps1#L4).
 You can use Visual Studio Enterprise, Professional or Community though PyTorch CI uses Visual Studio BuildTools.
 
 Build with CPU
 
-It's fairly easy to build with CPU. 
+It's fairly easy to build with CPU.
 
 Note on OpenMP: The desired OpenMP implementation is Intel OpenMP (iomp). In order to link against iomp, you'll need to manually download the library and set up the buliding environment by tweaking `CMAKE_INCLUDE_PATH` and `LIB`. The instruction [here](https://github.com/pytorch/pytorch/blob/master/docs/source/notes/windows.rst#building-from-source) is an example for setting up both MKL and Intel OpenMP. Without these configuraions for CMake, Microsoft Visual C OpenMP runtime (vcomp) will be used.
 

--- a/README.md
+++ b/README.md
@@ -245,9 +245,15 @@ Each CUDA version only supports one particular XCode version. The following comb
 
 On Windows
 
+Choose Correct Visual Studio Version.
+
+Visual Studio upgrades are very often. Sometimes, there're regressions in some new versions.
+It'd best to use the same Visual Studio Version as [PyTorch CI's](https://github.com/pytorch/pytorch/blob/a1bd7918cc5a06cbef6c5178259bf0a7b5ab1ce3/.circleci/scripts/vs_install.ps1#L4). 
+You can use Visual Stuido Enterprise, Professional or Community though PyTorch CI uses VS BuildTools.
+
 Build with CPU
 
-It's fairly easy to build with CPU. Visual Studio 2019 version 16.7.6 (MSVC toolchain version 14.27) or higher is recommended.
+It's fairly easy to build with CPU. 
 
 Note on OpenMP: The desired OpenMP implementation is Intel OpenMP (iomp). In order to link against iomp, you'll need to manually download the library and set up the buliding environment by tweaking `CMAKE_INCLUDE_PATH` and `LIB`. The instruction [here](https://github.com/pytorch/pytorch/blob/master/docs/source/notes/windows.rst#building-from-source) is an example for setting up both MKL and Intel OpenMP. Without these configuraions for CMake, Microsoft Visual C OpenMP runtime (vcomp) will be used.
 


### PR DESCRIPTION
There might be regressions in newest VS. 
Remind users to choose the stable VC version as our CI's
