### PR TITLE
[PyTorch] Avoid refcount bump in TensorArg

### DIFF
--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -14,11 +14,13 @@ namespace at {
 // which do NO argument checking by default.
 
 struct TORCH_API TensorArg {
-  Tensor tensor;
+  const Tensor& tensor;
   const char* name;
   int pos; // 1-indexed
-  TensorArg(Tensor tensor, const char* name, int pos)
-    : tensor(std::move(tensor)), name(name), pos(pos) {}
+  TensorArg(const Tensor& tensor, const char* name, int pos)
+    : tensor(tensor), name(name), pos(pos) {}
+  // Try to mitigate any possibility of dangling reference to temporaries.
+  TensorArg(Tensor&& tensor, const char* name, int pos) = delete;
   const Tensor* operator->() const { return &tensor; }
   const Tensor& operator*() const { return tensor; }
 };

--- a/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
+++ b/aten/src/ATen/native/cudnn/AffineGridGenerator.cpp
@@ -52,7 +52,8 @@ Tensor cudnn_affine_grid_generator_forward(
     const Tensor& theta_t,
     int64_t N, int64_t C, int64_t H, int64_t W)
 {
-  TensorArg theta{ theta_t.contiguous(), "theta", 1 };
+  auto theta_t_contig = theta_t.contiguous();
+  TensorArg theta{ theta_t_contig, "theta", 1 };
   CheckedFrom c = "cudnn_affine_grid_generator_forward";
   checkContiguous(c, theta);
   checkSize(c, theta, {N, 2, 3});
@@ -73,7 +74,8 @@ Tensor cudnn_affine_grid_generator_backward(
     const Tensor& grad_grid_t,
     int64_t N, int64_t C, int64_t H, int64_t W)
 {
-  TensorArg grad_grid{ grad_grid_t.contiguous(), "grad_grid", 1 };
+  auto grad_grid_contig = grad_grid_t.contiguous();
+  TensorArg grad_grid{ grad_grid_contig, "grad_grid", 1 };
   CheckedFrom c = "cudnn_affine_grid_generator_backward";
   checkContiguous(c, grad_grid);
   checkSize(c, grad_grid, {N, H, W, 2});

--- a/aten/src/ATen/native/cudnn/BatchNorm.cpp
+++ b/aten/src/ATen/native/cudnn/BatchNorm.cpp
@@ -240,8 +240,9 @@ std::tuple<Tensor, Tensor, Tensor> cudnn_batch_norm_backward(
   // TODO: Is it worth it to have a contiguous call or maybe we should go with
   // whatever format is given here.
 
+  auto grad_output_contig = grad_output_t.contiguous(input_t.suggest_memory_format());
   TensorArg input{ input_t, "input", 1 },
-            grad_output{ grad_output_t.contiguous(input_t.suggest_memory_format()), "grad_output", 2 },
+            grad_output{ grad_output_contig, "grad_output", 2 },
             weight{ weight_t, "weight", 3 },
             save_mean{ save_mean_t, "save_mean", 4 },
             save_var{ save_var_t, "save_var", 5 },

--- a/aten/src/ATen/native/cudnn/GridSampler.cpp
+++ b/aten/src/ATen/native/cudnn/GridSampler.cpp
@@ -66,8 +66,10 @@ void checkGridSize(CheckedFrom c, TensorArg grid, TensorArg input)
 Tensor cudnn_grid_sampler_forward(
     const Tensor& input_t, const Tensor& grid_t)
 {
-  TensorArg input{ contiguousIfZeroInStrides(input_t), "input", 1 },
-            grid{ grid_t.contiguous(), "grid", 2 };
+  auto input_contig = contiguousIfZeroInStrides(input_t);
+  auto grid_contig = grid_t.contiguous();
+  TensorArg input{ input_contig, "input", 1 },
+            grid{ grid_contig, "grid", 2 };
   CheckedFrom c = "cudnn_grid_sampler_forward";
   checkAllSameGPU(c, {input, grid});
   checkAllSameType(c, {input, grid});
@@ -103,9 +105,12 @@ std::tuple<Tensor, Tensor> cudnn_grid_sampler_backward(
     const Tensor& input_t, const Tensor& grid_t,
     const Tensor& grad_output_t)
 {
-  TensorArg input{ contiguousIfZeroInStrides(input_t), "input", 1 },
-            grid{ grid_t.contiguous(), "grid", 2 },
-            grad_output{ contiguousIfZeroInStrides(grad_output_t), "grad_output", 3 };
+  auto input_contig = contiguousIfZeroInStrides(input_t);
+  auto grid_contig = grid_t.contiguous();
+  auto grad_output_contig = contiguousIfZeroInStrides(grad_output_t);
+  TensorArg input{ input_contig, "input", 1 },
+            grid{ grid_contig, "grid", 2 },
+            grad_output{ grad_output_contig, "grad_output", 3 };
   CheckedFrom c = "cudnn_grid_sampler_backward";
   checkAllSameGPU(c, {input, grad_output, grid});
   checkGridSize(c, grid, input);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #54936 [PyTorch] One less refcount bump in linear()
* #54935 [PyTorch] Avoid refcount bumps in addmm_out_cuda_impl
* **#54934 [PyTorch] Avoid refcount bump in TensorArg**

It looks like the vast majority of usage is just borrowing a pre-existing Tensor.

Differential Revision: [D27415131](https://our.internmc.facebook.com/intern/diff/D27415131/)