### PR TITLE
Added verbosity to C++ learning rate schedulers

### DIFF
--- a/torch/csrc/api/include/torch/optim/schedulers/lr_scheduler.h
+++ b/torch/csrc/api/include/torch/optim/schedulers/lr_scheduler.h
@@ -11,8 +11,9 @@ class TORCH_API LRScheduler {
 public:
 
   //This class needs to take a reference of an optimizer from outside such that it can
-  //modify its learning rates; due to this the lifetime of said optimizer must be maintained
-  LRScheduler(torch::optim::Optimizer& optimizer);
+  //modify its learning rates; due to this the lifetime of said optimizer must be
+  //maintained
+  LRScheduler(torch::optim::Optimizer& optimizer, const bool verbose = false);
 
   virtual ~LRScheduler() = default;
 
@@ -28,12 +29,18 @@ protected:
   //Get current learning rates from the optimizer
   std::vector<double> get_current_lrs() const;
 
-  unsigned step_count_;
+  unsigned get_step_count() const;
 
 private:
   void set_optimizer_lrs(const std::vector<double>& learning_rates);
 
+  void print_lrs(const std::vector<double>& learning_rates) const;
+
   torch::optim::Optimizer& optimizer_;
+
+  unsigned step_count_;
+
+  const bool verbose_;
 
 };
 } // namespace optim

--- a/torch/csrc/api/include/torch/optim/schedulers/step_lr.h
+++ b/torch/csrc/api/include/torch/optim/schedulers/step_lr.h
@@ -1,5 +1,9 @@
 #pragma once
 
+/*
+ * Decays the learning rate of each parameter group by gamma every step_size epochs.
+ */
+
 #include <torch/optim/schedulers/lr_scheduler.h>
 
 namespace torch {
@@ -10,7 +14,8 @@ public:
 
   StepLR(torch::optim::Optimizer& optimizer,
          const unsigned step_size,
-         const double gamma = 0.1);
+         const double gamma = 0.1,
+         const bool verbose = false);
 
 private:
   std::vector<double> get_lrs() override;

--- a/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
+++ b/torch/csrc/api/src/optim/schedulers/lr_scheduler.cpp
@@ -3,19 +3,23 @@
 namespace torch {
 namespace optim {
 
-LRScheduler::LRScheduler(torch::optim::Optimizer& optimizer) :
+LRScheduler::LRScheduler(torch::optim::Optimizer& optimizer, const bool verbose) :
+  optimizer_(optimizer),
   step_count_(0),
-  optimizer_(optimizer) {}
+  verbose_(verbose) {}
 
 void LRScheduler::step() {
+  //Get learning rates from subclass
   std::vector<double> learning_rates = get_lrs();
+  if(verbose_)
+    print_lrs(learning_rates);
   set_optimizer_lrs(learning_rates);
   step_count_++;
 }
 
 void LRScheduler::set_optimizer_lrs(const std::vector<double>& learning_rates) {
-  //Check the number of learning rates is equal to the number of parameters groups in the
-  //optimizer
+  //Check the number of learning rates is equal to the number of parameters groups in
+  //the optimizer
   TORCH_CHECK(learning_rates.size() == optimizer_.param_groups().size(),
               "Number of learning rates not equal to the number of param groups\n",
               "Number of learning rates given: ", learning_rates.size(),
@@ -30,6 +34,26 @@ std::vector<double> LRScheduler::get_current_lrs() const {
   for(std::size_t i = 0; i < optimizer_.param_groups().size(); i++)
       learnings_rates[i] = optimizer_.param_groups()[i].options().get_lr();
   return learnings_rates;
+}
+
+unsigned LRScheduler::get_step_count() const {
+  return step_count_;
+}
+
+void LRScheduler::print_lrs(const std::vector<double>& learning_rates) const {
+  //Store current cout state
+  std::ios previous_cout_state(nullptr);
+  previous_cout_state.copyfmt(std::cout);
+  //Modify cout to format floats in scientific notation with 4dp precision
+  std::cout << std::scientific;
+  std::cout.precision(4);
+
+  for(std::size_t i = 0; i < learning_rates.size(); i++)
+    std::cout << "Adjusting learning rate of group " << i << " to " <<
+      learning_rates[i] << std::endl;
+
+  //Restore previous cout state
+  std::cout.copyfmt(previous_cout_state);
 }
 
 } // namespace optim

--- a/torch/csrc/api/src/optim/schedulers/step_lr.cpp
+++ b/torch/csrc/api/src/optim/schedulers/step_lr.cpp
@@ -5,16 +5,19 @@ namespace optim {
 
 StepLR::StepLR(torch::optim::Optimizer& optimizer,
                const unsigned step_size,
-               const double gamma) :
-  LRScheduler(optimizer),
+               const double gamma,
+               const bool verbose) :
+  LRScheduler(optimizer, verbose),
   step_size_(step_size),
   gamma_(gamma) {}
 
 std::vector<double> StepLR::get_lrs() {
-  if(step_count_ == 0 || step_count_ % step_size_ != 0)
+  const unsigned step_count = get_step_count();
+  if(step_count == 0 || step_count % step_size_ != 0)
     return get_current_lrs();
   else {
     std::vector<double> lrs = get_current_lrs();
+    //Multiply all learning rates by gamma
     std::transform(lrs.begin(), lrs.end(), lrs.begin(),
                    [this](const double& v){ return this->gamma_ * v; });
     return lrs;


### PR DESCRIPTION
This is a small feature that mimics the functionality in the python learning rate schedulers whereby one can set the verbosity of the learning rate scheduler in order to get informative printouts.
