### PR TITLE
Add dependency of libnccl_static.a when do libtorch static build

### DIFF
--- a/cmake/TorchConfig.cmake.in
+++ b/cmake/TorchConfig.cmake.in
@@ -154,8 +154,10 @@ if(@USE_CUDA@)
   if(@BUILD_SHARED_LIBS@)
     find_library(C10_CUDA_LIBRARY c10_cuda PATHS "${TORCH_INSTALL_PREFIX}/lib")
     list(APPEND TORCH_CUDA_LIBRARIES ${C10_CUDA_LIBRARY})
+    list(APPEND TORCH_LIBRARIES ${TORCH_CUDA_LIBRARIES})
+  else()
+    append_torchlib_if_found(nccl_static)
   endif()
-  list(APPEND TORCH_LIBRARIES ${TORCH_CUDA_LIBRARIES})
 endif()
 
 # When we build libtorch with the old GCC ABI, dependent libraries must too.


### PR DESCRIPTION
Add dependency of libnccl_static.a when do libtorch static build.
