### PR TITLE
Upgrade onednn to v2.1.2

### DIFF
--- a/third_party/mkl-dnn.BUILD
+++ b/third_party/mkl-dnn.BUILD
@@ -1,28 +1,32 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@//third_party:substitution.bzl", "template_rule")
 
+_DNNL_RUNTIME_OMP = {
+    "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
+    "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
+    "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
+    "#cmakedefine DNNL_WITH_SYCL": "/* #undef DNNL_WITH_SYCL */",
+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "/* #undef DNNL_WITH_LEVEL_ZERO */",
+    "#cmakedefine DNNL_SYCL_CUDA": "/* #undef DNNL_SYCL_CUDA */",
+}
+
 template_rule(
     name = "include_dnnl_version",
-    src = "include/dnnl_version.h.in",
-    out = "include/dnnl_version.h",
+    src = "include/oneapi/dnnl/dnnl_version.h.in",
+    out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
-        "@DNNL_VERSION_MAJOR@": "1",
-        "@DNNL_VERSION_MINOR@": "7",
-        "@DNNL_VERSION_PATCH@": "0",
-        "@DNNL_VERSION_HASH@": "2e4732679f0211bb311780d0f383cf2dce9baca7",
+        "@DNNL_VERSION_MAJOR@": "2",
+        "@DNNL_VERSION_MINOR@": "1",
+        "@DNNL_VERSION_PATCH@": "2",
+        "@DNNL_VERSION_HASH@": "98be7e8afa711dc9b66c8ff3504129cb82013cdb",
     },
 )
 
 template_rule(
     name = "include_dnnl_config",
-    src = "include/dnnl_config.h.in",
-    out = "include/dnnl_config.h",
-    substitutions = {
-        "cmakedefine": "define",
-        "${DNNL_CPU_THREADING_RUNTIME}": "OMP",
-        "${DNNL_CPU_RUNTIME}": "OMP",
-        "${DNNL_GPU_RUNTIME}": "NONE",
-    },
+    src = "include/oneapi/dnnl/dnnl_config.h.in",
+    out = "include/oneapi/dnnl/dnnl_config.h",
+    substitutions = _DNNL_RUNTIME_OMP,
 )
 
 cc_library(
@@ -31,20 +35,22 @@ cc_library(
         "src/common/*.cpp",
         "src/cpu/**/*.cpp",
     ], exclude=[
-        "src/cpu/aarch64/*.cpp",
+        "src/cpu/aarch64/**/*.cpp",
     ]),
     hdrs = glob([
+        "include/oneapi/dnnl/*.h",
+        "include/oneapi/dnnl/*.hpp",
         "include/*.h",
         "include/*.hpp",
-        "src/*.hpp",
         "src/cpu/**/*.hpp",
         "src/cpu/**/*.h",
         "src/common/*.hpp",
     ], exclude=[
-        "src/cpu/aarch64/*.hpp",
+        "src/cpu/aarch64/**/*.hpp",
+        "src/cpu/aarch64/**/*.h",
     ]) + [
-        "include/dnnl_version.h",
-        "include/dnnl_config.h",
+        "include/oneapi/dnnl/dnnl_config.h",
+        "include/oneapi/dnnl/dnnl_version.h",
     ],
     copts = [
         "-DUSE_AVX",
@@ -63,6 +69,8 @@ cc_library(
     }),
     includes = [
         "include/",
+        "include/oneapi/",
+        "include/oneapi/dnnl/",
         "src/",
         "src/common/",
         "src/cpu/",


### PR DESCRIPTION
This PR is to upgrade onednn to v2.1.2 which has the following main changes about cpu:

- Improved performance of forward convolution with plain activations for processors with Intel AVX-512 support

- Improved performance of fp32 depthwise convolution with plain activations on CPU.

more changes can be found in https://github.com/oneapi-src/oneDNN/releases.

Ideep used version is [pytorch-rls-v2.1.2](https://github.com/intel/ideep/tree/pytorch-rls-v2.1.2).
OneDNN used version is  [v2.1.2](https://github.com/oneapi-src/oneDNN/tree/v2.1.2).
