### PR TITLE
Adding workflow to daily update slow tests

### DIFF
--- a/.github/workflows/update_slow_tests.yml
+++ b/.github/workflows/update_slow_tests.yml
@@ -1,0 +1,38 @@
+name: Update slow tests
+on:
+  # This is for testing purposes so that I could run this on my PR.
+  workflow_run:
+    types:
+      - requested
+    workflows:
+      - Lint
+  # schedule:
+  #   # Every day at noon
+  #   - cron: "0 12 * * *"
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+
+jobs:
+  update-slow-list:
+    runs-on: ubuntu-18.04
+    if: ${{ github.repository_owner == 'pytorch' }}
+    steps:
+      - name: Checkout PyTorch
+        uses: actions/checkout@v2
+
+      - name: Generate new slow test stats
+        run: |
+          pip install typing_extensions boto3
+          python tools/export_slow_tests.py -f .pytorch-slow-tests
+
+      - name: Push file to test-infra repository
+        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
+        env:
+           API_TOKEN_GITHUB: ${{ secrets.TEST_INFRA_TOKEN }}
+        with:
+          source_file: '.pytorch-slow-tests'
+          destination_repo: 'janeyx99/test-infra'
+          destination_folder: 'stats'
+          user_email: 'janeyx@fb.com'
+          user_name: 'janeyx99'
+          commit_message: 'Updating slow tests stats'

--- a/.github/workflows/update_slow_tests.yml
+++ b/.github/workflows/update_slow_tests.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   update-slow-list:
     runs-on: ubuntu-18.04
-    if: ${{ github.repository_owner == 'pytorch' }}
+    # if: ${{ github.repository_owner == 'pytorch' }}
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2

--- a/.github/workflows/update_slow_tests.yml
+++ b/.github/workflows/update_slow_tests.yml
@@ -1,30 +1,36 @@
 name: Update slow tests
+
 on:
-  # This is for testing purposes so that I could run this on my PR.
-  workflow_run:
-    types:
-      - requested
-    workflows:
-      - Lint
-  # schedule:
-  #   # Every day at noon
-  #   - cron: "0 12 * * *"
+  schedule:
+    # Every day at noon
+    - cron: "0 12 * * *"
   # Have the ability to trigger this job manually through the API
   workflow_dispatch:
 
 jobs:
   update-slow-list:
     runs-on: ubuntu-18.04
-    # if: ${{ github.repository_owner == 'pytorch' }}
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+          architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v2
-
+        with:
+          fetch-depth: 0 # deep clone, to allow us to use git log
+      - name: Install dependencies
+        # mypy and boto3 versions copied from
+        # .circleci/docker/common/install_conda.sh
+        run: |
+          set -eux
+          pip install -r requirements.txt
+          pip install boto3==1.16.34 mypy==0.770
       - name: Generate new slow test stats
         run: |
-          pip install typing_extensions boto3
+          export PYTHONPATH=$PWD
           python tools/export_slow_tests.py -f .pytorch-slow-tests
-
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:


### PR DESCRIPTION
This GHA exports a new JSON of slow tests and their times and pushes it to the test-infra repo at path `stats/.pytorch-slow-tests`.

Test plan: 
Testing right now with my own GHA experiments repo.
File: https://github.com/janeyx99/gha-experiments/blob/main/.github/update_slow_tests.yml
Successful run: https://github.com/janeyx99/gha-experiments/actions/runs/702449227