### PR TITLE
[torch] make StreamContext nop (and doesn't call cuda lazy init) when stream is None

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -339,8 +339,12 @@ class StreamContext(object):
     def __init__(self, stream: Optional['torch.cuda.Stream']):  # type: ignore
         self.stream = stream
         # Initialize the below streams to default stream on the current device
-        self.src_prev_stream = torch.cuda.default_stream(None)
-        self.dst_prev_stream = torch.cuda.default_stream(None)
+        self.src_prev_stream = (
+            None if stream is None else torch.cuda.default_stream(None)
+        )
+        self.dst_prev_stream = (
+            None if stream is None else torch.cuda.default_stream(None)
+        )
 
     def __enter__(self):
         # Local cur_stream variable for type refinement


### PR DESCRIPTION
Summary: Make it really nop.

Test Plan: buck run mode/opt -c fbcode.nvcc_arch=v100 //hpc/models/ads:ads_10x_launcher +launcher=local +data_loader=random +mode=local_cpu optimizer.sparse_optim=ROWWISE_ADAGRAD data_loader.batch_size=16384 launcher.inactive_timeout_sec=null model.jit=True model.ne_opt_level=1

Differential Revision: D27433887

