### PR TITLE
[caffe2] Support Log1p operator

### DIFF
--- a/caffe2/operators/log1p_op.cc
+++ b/caffe2/operators/log1p_op.cc
@@ -1,0 +1,29 @@
+#include "caffe2/operators/log1p_op.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(
+    Log1p,
+    UnaryElementwiseOp<TensorTypes<float>, CPUContext, Log1pFunctor<CPUContext>>);
+
+OPERATOR_SCHEMA(Log1p)
+    .NumInputs(1)
+    .NumOutputs(1)
+    .AllowInplace({{0, 0}})
+    .IdenticalTypeAndShape()
+    .SetDoc(R"DOC(
+Calculates log1p of the given input tensor element-wise. This
+operation can be done in an in-place fashion too, by providing the same input
+and output blobs.
+
+Github Link:
+- https://github.com/pytorch/pytorch/blob/master/caffe2/operators/log1p_op.cc
+)DOC")
+    .Input(0, "X", "*(type: Tensor`<float>`)* Input tensor.")
+    .Output(
+        0,
+        "Y",
+        "*(type: Tensor`<float>`)* Output tensor computed as log1p of the input tensor computed, element-wise.")
+    .InheritOnnxSchema();
+
+} // namespace caffe2

--- a/caffe2/operators/log1p_op.h
+++ b/caffe2/operators/log1p_op.h
@@ -1,0 +1,21 @@
+#ifndef CAFFE2_OPERATORS_LOG1P_OP_H_
+#define CAFFE2_OPERATORS_LOG1P_OP_H_
+
+#include "caffe2/operators/elementwise_ops.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+template <class Context>
+struct Log1pFunctor {
+  template <typename T>
+  bool operator()(const int N, const T* X, T* Y, Context* context) const {
+    math::Log1p(N, X, Y, context);
+    return true;
+  }
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_LOG1P_OP_H_
+

--- a/caffe2/python/operator_test/log1p_op_test.py
+++ b/caffe2/python/operator_test/log1p_op_test.py
@@ -1,0 +1,16 @@
+from caffe2.python import core
+from hypothesis import given
+import caffe2.python.hypothesis_test_util as hu
+import numpy as np
+
+class TestLog1pOp(hu.HypothesisTestCase):
+
+    @given(data=hu.tensor(dtype=np.float32), **hu.gcs)
+    def test_log1p(self, data, gc, dc):
+        op = core.CreateOperator("Log1p", ["input"], ["output"])
+
+        def ref_log1p(input):
+            result = np.log1p(input)
+            return (result,)
+
+        self.assertReferenceChecks(gc, op, [data], ref_log1p)


### PR DESCRIPTION
Summary:
Support Log1p operator to add feature parity with PyTorch.

NumPy doc https://numpy.org/doc/stable/reference/generated/numpy.log1p.html
PyTorch doc https://pytorch.org/docs/stable/generated/torch.log1p.html

Differential Revision: D27422219

