### PR TITLE
Support needsOutputs for RecordFunction and ObserverUtil improvements (#54442)

### DIFF
--- a/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
+++ b/aten/src/ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h
@@ -377,6 +377,10 @@ namespace impl {
       assert_is_valid_output_type<T, AllowDeprecatedTypes>();
       return c10::ivalue::from(std::move(v));
     }
+    static IValue copy(const T& v) {
+      assert_is_valid_output_type<T, AllowDeprecatedTypes>();
+      return IValue(v);
+    }
   };
 
   // Special case to allow kernels to return `Tensor&`.
@@ -385,6 +389,9 @@ namespace impl {
   struct return_to_ivalue<at::Tensor&, AllowDeprecatedTypes, void> final {
     static IValue call(at::Tensor& v) {
       return c10::ivalue::from(v);
+    }
+    static IValue copy(at::Tensor& v) {
+      return IValue(v);
     }
   };
 
@@ -477,11 +484,17 @@ namespace impl {
     static void call(OutputType&& output, Stack* stack) {
       torch::jit::push(*stack, return_to_ivalue<OutputType, AllowDeprecatedTypes>::call(std::forward<OutputType>(output)));
     }
+    static void copy(const OutputType& output, Stack* stack) {
+      torch::jit::push(*stack, return_to_ivalue<OutputType, AllowDeprecatedTypes>::copy(output));
+    }
   };
   template<class... OutputTypes, bool AllowDeprecatedTypes>
   struct push_outputs<std::tuple<OutputTypes...>, AllowDeprecatedTypes> final {
     static void call(std::tuple<OutputTypes...>&& output, Stack* stack) {
       call_(std::move(output), stack, std::make_index_sequence<sizeof...(OutputTypes)>());
+    }
+    static void copy(const std::tuple<OutputTypes...>& output, Stack* stack) {
+      copy_(output, stack, std::make_index_sequence<sizeof...(OutputTypes)>());
     }
 
   private:
@@ -489,10 +502,16 @@ namespace impl {
     static void call_(std::tuple<OutputTypes...>&& output, Stack* stack, std::index_sequence<indices...>) {
       torch::jit::push(*stack, return_to_ivalue<OutputTypes, AllowDeprecatedTypes>::call(std::forward<OutputTypes>(std::get<indices>(output)))...);
     }
+    template<size_t... indices>
+    static void copy_(const std::tuple<OutputTypes...>& output, Stack* stack, std::index_sequence<indices...>) {
+      torch::jit::push(*stack, return_to_ivalue<OutputTypes, AllowDeprecatedTypes>::copy(std::get<indices>(output))...);
+    }
   };
   template<bool AllowDeprecatedTypes>
   struct push_outputs<void, AllowDeprecatedTypes> final {
     static void call(int /*dummy*/, Stack* /*stack*/) {
+    }
+    static void copy(int /*dummy*/, Stack* /*stack*/) {
     }
   };
 

--- a/test/cpp/jit/test_misc.cpp
+++ b/test/cpp/jit/test_misc.cpp
@@ -691,10 +691,10 @@ at::Tensor invokeTestRecordFunctionJIT(at::Tensor& t) {
   return module->forward({t}).toTensor();
 }
 
-using TracedTestInputs =
+using TracedTestValues =
     std::vector<std::tuple<std::string, std::vector<std::vector<int64_t>>>>;
 
-void checkTracedInputs(const TracedTestInputs& inputs) {
+void checkTracedInputs(const TracedTestValues& inputs) {
   bool found_test = false;
   bool found_pow = false;
   bool found_mul = false;
@@ -714,6 +714,32 @@ void checkTracedInputs(const TracedTestInputs& inputs) {
     } else if (fn == "aten::mul") {
       found_mul = true;
       TORCH_CHECK(sizes.size() > 1);
+      TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
+    }
+  }
+  TORCH_CHECK(found_test);
+  TORCH_CHECK(found_pow);
+  TORCH_CHECK(found_mul);
+}
+
+void checkTracedOutputs(const TracedTestValues& outputs) {
+  bool found_test = false;
+  bool found_pow = false;
+  bool found_mul = false;
+  for (const auto& output : outputs) {
+    const auto& fn = std::get<0>(output);
+    const auto& sizes = std::get<1>(output);
+
+    if (fn == "test") {
+      found_test = true;
+      TORCH_CHECK(sizes.empty());
+    } else if (fn == "aten::pow") {
+      found_pow = true;
+      TORCH_CHECK(sizes.size() == 1);
+      TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
+    } else if (fn == "aten::mul") {
+      found_mul = true;
+      TORCH_CHECK(sizes.size() == 1);
       TORCH_CHECK(sizes[0] == std::vector<int64_t>({1, 2, 3}));
     }
   }
@@ -803,8 +829,10 @@ static bool shouldRunCallback(const RecordFunctionCallback&) {
   return should_run;
 }
 
-static TracedTestInputs traced_inputs;
-static std::unordered_set<std::string> ts_names;
+static TracedTestValues traced_inputs;
+static TracedTestValues traced_outputs;
+static std::unordered_set<std::string> ts_input_names;
+static std::unordered_set<std::string> ts_output_names;
 
 std::unique_ptr<at::ObserverContext> tracedInputsCallback(
     const RecordFunction& fn) {
@@ -820,43 +848,71 @@ std::unique_ptr<at::ObserverContext> tracedInputsCallback(
     }
     traced_inputs.push_back(std::make_tuple(fn.name().str(), sizes));
   } else if (fn.scope() == RecordScope::TORCHSCRIPT_FUNCTION) {
-    ts_names.insert(fn.name().str());
+    ts_input_names.insert(fn.name().str());
   }
   return nullptr;
 }
 
-TEST(RecordFunctionTest, TracedTestInputs) {
+void tracedOutputsCallback(const RecordFunction& fn, ObserverContext* ctx_ptr) {
+  if (fn.scope() == RecordScope::FUNCTION) {
+    auto outputs = fn.outputs();
+    std::vector<std::vector<int64_t>> sizes;
+    for (const auto& output : outputs) {
+      if (output.isTensor()) {
+        sizes.push_back(output.toTensor().sizes().vec());
+      } else if (output.isScalar()) {
+        sizes.emplace_back();
+      }
+    }
+    traced_outputs.push_back(std::make_tuple(fn.name().str(), sizes));
+  } else if (fn.scope() == RecordScope::TORCHSCRIPT_FUNCTION) {
+    ts_output_names.insert(fn.name().str());
+  }
+}
+
+TEST(RecordFunctionTest, TracedTestInputsOutputs) {
   // disabling the inlining of method calls
   GraphOptimizerEnabledGuard opt_guard(false);
 
   // [(fn, [[sizes], [sizes], ...]), ...]
   addGlobalCallback(
-      RecordFunctionCallback(tracedInputsCallback).needsInputs(true));
+      RecordFunctionCallback(tracedInputsCallback, tracedOutputsCallback)
+          .needsInputs(true)
+          .needsOutputs(true));
 
-  TracedTestInputs eager_inputs, jit_inputs;
+  TracedTestValues eager_inputs, eager_outputs, jit_inputs, jit_outputs;
   {
     auto t = torch::randn({1, 2, 3}, at::kCPU);
     t.set_requires_grad(true);
     auto t2 = invokeTestRecordFunction(t);
     t2.backward(torch::ones_like(t2, at::MemoryFormat::Preserve));
     eager_inputs = traced_inputs;
+    eager_outputs = traced_outputs;
     traced_inputs.clear();
+    traced_outputs.clear();
 
-    TORCH_CHECK(ts_names.empty());
+    TORCH_CHECK(ts_input_names.empty());
+    TORCH_CHECK(ts_output_names.empty());
 
     t = torch::randn({1, 2, 3}, at::kCPU);
     t.set_requires_grad(true);
     t2 = invokeTestRecordFunctionJIT(t);
     t2.backward(torch::ones_like(t2, at::MemoryFormat::Preserve));
     jit_inputs = traced_inputs;
+    jit_outputs = traced_outputs;
     traced_inputs.clear();
+    traced_outputs.clear();
   }
 
-  TORCH_CHECK(ts_names.find("forward") != ts_names.end());
-  TORCH_CHECK(ts_names.find("foo") != ts_names.end());
+  TORCH_CHECK(ts_input_names.find("forward") != ts_input_names.end());
+  TORCH_CHECK(ts_input_names.find("foo") != ts_input_names.end());
+  TORCH_CHECK(ts_output_names.find("forward") != ts_output_names.end());
+  TORCH_CHECK(ts_output_names.find("foo") != ts_output_names.end());
 
   checkTracedInputs(eager_inputs);
+  checkTracedOutputs(eager_outputs);
   checkTracedInputs(jit_inputs);
+  checkTracedOutputs(jit_outputs);
   at::clearCallbacks();
 }
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/54442

Added needsOutputs support to RecordFunction, improved ObserverUtil functions to handle list data. Minor refactor names to be consistent.

To get output data from kernel calls, we need to temporarily capture them before passing them to the record function. Then the results are released to function return. We handle two cases, for unboxed and boxed kernels. The boxed version is fairly simple since all outputs are stored in the stack object. For unboxed kernel calls, we added a `ReturnValue` utility class to properly handle the different return values of unboxed kernels.

For optimization, this intermediate capture is only enabled for observers that request `needsOutputs(true)` and should not affect other observers or when the observer is not enabled.

Test Plan:
```
=> buck build //caffe2/test/cpp/jit: --show-output
=> buck-out/gen/caffe2/test/cpp/jit/jit --gtest_filter=RecordFunctionTest*
CUDA not available. Disabling CUDA and MultiCUDA tests
Note: Google Test filter = RecordFunctionTest*-*_CUDA:*_MultiCUDA
[==========] Running 7 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 7 tests from RecordFunctionTest
[ RUN      ] RecordFunctionTest.TracedTestInputsOutputs
[       OK ] RecordFunctionTest.TracedTestInputsOutputs (226 ms)
[ RUN      ] RecordFunctionTest.SampledCallbacks
[       OK ] RecordFunctionTest.SampledCallbacks (771 ms)
[ RUN      ] RecordFunctionTest.RecordFunctionGuard
[       OK ] RecordFunctionTest.RecordFunctionGuard (0 ms)
[ RUN      ] RecordFunctionTest.Callbacks
[       OK ] RecordFunctionTest.Callbacks (2 ms)
[ RUN      ] RecordFunctionTest.ShouldRun
[       OK ] RecordFunctionTest.ShouldRun (0 ms)
[ RUN      ] RecordFunctionTest.Basic
[       OK ] RecordFunctionTest.Basic (1 ms)
[ RUN      ] RecordFunctionTest.OperatorNameOverload
[       OK ] RecordFunctionTest.OperatorNameOverload (1 ms)
[----------] 7 tests from RecordFunctionTest (1001 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test case ran. (1002 ms total)
[  PASSED  ] 7 tests.

```

Differential Revision: D27449877

