### PR TITLE
Fix caffe2/operators/log1p_op.h file ending

### DIFF
--- a/caffe2/operators/log1p_op.h
+++ b/caffe2/operators/log1p_op.h
@@ -18,4 +18,3 @@ struct Log1pFunctor {
 } // namespace caffe2
 
 #endif // CAFFE2_OPERATORS_LOG1P_OP_H_
-


### PR DESCRIPTION
#54968 added `caffe2/operators/log1p_op.h` with an extra trailing newline, ran CI before #54737 was merged (so the lint job passed), and then landed after #54737 was merged (breaking `master`). This PR fixes the lint.

**Test plan:**

The "Lint / quick-checks" GitHub Actions job should succeed on this PR.