### PR TITLE
[PyTorch Edge] Provide a method ObservedOperators::getUnobservedOperatorList() so that model tracer can empty it out during tracing

### DIFF
--- a/aten/src/ATen/core/dispatch/ObservedOperators.cpp
+++ b/aten/src/ATen/core/dispatch/ObservedOperators.cpp
@@ -6,9 +6,9 @@
 namespace c10 {
 
 /* static */
-bool ObservedOperators::isObserved(const OperatorName& name) {
+std::unordered_set<std::string>& ObservedOperators::getUnobservedOperatorList() {
   // names of the operators that should not be observed
-  std::unordered_set<std::string> not_observed_ops = {
+  static std::unordered_set<std::string> not_observed_ops = {
     "aten::size",
     "aten::is_leaf",
     "aten::output_nr",
@@ -17,7 +17,12 @@ bool ObservedOperators::isObserved(const OperatorName& name) {
     "profiler::_record_function_enter",
     "profiler::_record_function_exit",
   };
-  return !not_observed_ops.count(name.name);
+  return not_observed_ops;
+}
+
+/* static */
+bool ObservedOperators::isObserved(const OperatorName& name) {
+  return !ObservedOperators::getUnobservedOperatorList().count(name.name);
 }
 
 } // namespace c10

--- a/aten/src/ATen/core/dispatch/ObservedOperators.h
+++ b/aten/src/ATen/core/dispatch/ObservedOperators.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_set>
+#include <string>
 #include <ATen/core/operator_name.h>
 
 namespace c10 {
@@ -8,6 +10,8 @@ struct TORCH_API ObservedOperators {
   ObservedOperators() = delete;
 
   static bool isObserved(const OperatorName& name);
+
+  static std::unordered_set<std::string>& getUnobservedOperatorList();
 };
 
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55017 [PyTorch Edge] Provide a method ObservedOperators::getUnobservedOperatorList() so that model tracer can empty it out during tracing**

@jakeszwe in D26678637 found the mis-alignment between the operator list that the YAML file claimed and the dispatcher claimed. After some digging thorough investigation by @jakeszwe, we have come to the conclusion that the non-traced operators are more trouble than they are worth since it will result in phantom operators which every user of the capabilities API needs to be aware of (or every language implementation needs to be aware of). Instead, with this change, we can reliably trace all operators called via the dispatcher by clearing the list of un-observed operators during model tracing.

Also another thing to note is that the ignore-list in the observer is a list of base operator names, and not full operator names (with overload), which is whaat tracing based selective build needs. If we use the ignore-list, then we would need to include every overload on un-traced operators.

Latency isn't an issue during model tracing, so this should be generally okay.

Ran the following command to re-generate all the YAML files: `buck run caffe2/torch/fb/mobile/cli:cli -- --gen_all_model_configs`

Differential Revision: [D27452855](https://our.internmc.facebook.com/intern/diff/D27452855/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27452855/)!