### PR TITLE
[PyTorch] Use sizes indexing in addmm when known not to wrap

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -71,15 +71,16 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   TensorArg args[]{{result, "out", 0}, {self, "self", 1}, {mat1, "mat1", 2}, {mat2, "mat2", 3}};
   checkAllSameGPU("addmm", args);
 
+  IntArrayRef mat1_sizes = mat1.sizes();
+  IntArrayRef mat2_sizes = mat2.sizes();
   Tensor self_;
   if (&result != &self) {
-    std::tie(self_) = expand_size(self, {mat1.size(0), mat2.size(1)}, "addmm");
+    // TORCH_CHECK at top of function guarantees indexing into sizes() is correct.
+    std::tie(self_) = expand_size(self, {mat1_sizes[0], mat2_sizes[1]}, "addmm");
   } else {
     self_ = self;
   }
 
-  IntArrayRef mat1_sizes = mat1.sizes();
-  IntArrayRef mat2_sizes = mat2.sizes();
   IntArrayRef self__sizes = self_.sizes();
   TORCH_CHECK(
       mat1_sizes[1] == mat2_sizes[0],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55065 [PyTorch] expand_inplace_v2 with MaybeOwned<Tensor> and no 1-ary tuples
* #55061 [PyTorch] Remove outdated C++11 note on C10_DEPRECATED
* **#55020 [PyTorch] Use sizes indexing in addmm when known not to wrap**
* #55016 [PyTorch] Use DimVector for inputs to as_strided that don't grow dim

sizes()[x] is faster than size(x) because the latter does a bunch of maybe_wrap_dim calculations. We know it won't wrap in this case.

Differential Revision: [D27453123](https://our.internmc.facebook.com/intern/diff/D27453123/)