### PR TITLE
[Gradient Compression] Update a warning in ddp_comm_hooks.rst

### DIFF
--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -81,7 +81,9 @@ PowerSGD Hooks
     compressed communication and improve accuracy.
 
 .. warning ::
-    The current implementation may cause gradient overflow for FP16 input.
+    PowerSGD hooks may conflict with `Apex automatic mixed precision package <https://github.com/NVIDIA/apex>`_.
+    Please use PyTorch `native automatic mixed precision package <https://pytorch.org/docs/stable/amp.html>`_
+    instead.
 
 .. autofunction:: powerSGD_hook
 .. autofunction:: batched_powerSGD_hook


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55031 [Gradient Compression] Update a warning in ddp_comm_hooks.rst**

It turns out that PowerSGD hooks can work on PyTorch native AMP package, but not Apex AMP package, which can somehow mutate gradients during the execution of communication hooks.

![image](https://user-images.githubusercontent.com/8884619/113112430-0514e000-91be-11eb-9aa6-18c4bd7952af.png)

Facebook:
Used native amp backend for the same pytext model and worked:
f261564342
f261561664

Differential Revision: [D27436484](https://our.internmc.facebook.com/intern/diff/D27436484/)