### PR TITLE
[ONNX] Redesign inplace conversion

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -170,7 +170,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   # JIT C++ extensions require ninja, so put it into PATH.
   export PATH="/var/lib/jenkins/.local/bin:$PATH"
   if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
-    pip install -q --user onnxruntime==1.6.0
+    pip install -q --user onnxruntime==1.7.0
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4271,6 +4271,8 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(4, 5)
         self.run_test(model, (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(14)  # Need onnx::identity of sequence in opset 14
+    def test_list_append_nested_2(self):
         class ListModel(torch.nn.Module):
             def forward(self, x):
                 res = []
@@ -4659,7 +4661,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.zeros(12,)
         self.run_test(torch.jit.script(M()), (x))
 
-    @unittest.skip("Skip til ONNX opset 14 for Sequence Identity. Pass locally.")
+    @skipIfUnsupportedMinOpsetVersion(14)  # Need onnx::identity of sequence in opset 14
     def test_inplace_sequence_with_loop(self):
         class M(torch.nn.Module):
             def process(self, beam_hyps: List[torch.Tensor], done: torch.Tensor, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4271,6 +4271,22 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(4, 5)
         self.run_test(model, (x, y))
 
+        class ListModel(torch.nn.Module):
+            def forward(self, x):
+                res = []
+                res_replicate = []
+                for i in range(x.size(0)):
+                    if len(res) > 2:
+                        for j in range(x.size(1)):
+                            res.append(x[i][j])
+                        res_replicate.append(res[-1])
+                        res.append(res_replicate[-1])
+                return res, res_replicate
+
+        model = torch.jit.script(ListModel())
+        x = torch.randn(4, 4, 3, 4)
+        self.run_test(model, (x, ))
+
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_list_pop(self):
         class ListModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7550,7 +7550,6 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (random_data, empty_tensor))
 
     @skipIfUnsupportedMinOpsetVersion(11)
-    # TODO: test input size with (0, 0, 0, 0, 0) doesn't work with current ort rel (1.7)
     def test_index_put_if_2(self):
         @torch.jit.script
         def check_init(input_data, hidden_size, prev_state):
@@ -7584,8 +7583,12 @@ class TestONNXRuntime(unittest.TestCase):
 
         model = Example(10)
         random_data = torch.rand((1, 5, 30, 30))
-        empty_tensor = torch.tensor([0], dtype=torch.float).view(1, 1, 1, 1, 1)
-        self.run_test(model, (random_data, empty_tensor))
+        empty_tensor = torch.tensor([], dtype=torch.float).view(0, 0, 0, 0, 0)
+        random_state = torch.rand((1, 1, 10, 30, 30))
+        self.run_test(model, (random_data, empty_tensor),
+                      input_names=['data', 'state'],
+                      dynamic_axes={'state': [0, 1, 2, 3, 4]},
+                      test_with_inputs=[(random_data, random_state)])
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_index_put_if_3(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4539,7 +4539,7 @@ class TestONNXRuntime(unittest.TestCase):
                 a = torch.ones(12,)
                 for i in range(10):
                     a.add_(torch.ones(12,))
-                return a+x
+                return a + x
 
         m = M()
         x = torch.randn(12,)
@@ -4616,7 +4616,7 @@ class TestONNXRuntime(unittest.TestCase):
     @unittest.skip("Skip til ONNX opset 14 for Sequence Identity. Pass locally.")
     def test_inplace_sequence_with_loop(self):
         class M(torch.nn.Module):
-            def process(self, beam_hyps: List[torch.Tensor], done:torch.Tensor, x):
+            def process(self, beam_hyps: List[torch.Tensor], done: torch.Tensor, x):
                 batch_size = x.shape[0]
                 for i in range(batch_size):
                     if done[i]:

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4353,6 +4353,36 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(4, 5)
         self.run_test(model, (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_list_set(self):
+        class ListModel(torch.nn.Module):
+            def forward(self, x, y):
+                res = []
+                for i in range(x.size(0)):
+                    res.append(x[i])
+                res[y] = x[y]
+                return res
+
+        model = torch.jit.script(ListModel())
+        x = torch.randn(12, 4)
+        y = torch.tensor(2, dtype=torch.long)
+        self.run_test(model, (x, y))
+
+    @skipIfUnsupportedMinOpsetVersion(13)
+    def test_list_idx_sum(self):
+        class ListModel(torch.nn.Module):
+            def forward(self, x, y):
+                indices = torch.arange(x.size(0))
+                res = []
+                for i in range(x.size(0)):
+                    res.append(x[i])
+                return res[torch.sum(indices[:y])]
+
+        model = torch.jit.script(ListModel())
+        x = torch.randn(12, 4)
+        y = torch.tensor(2, dtype=torch.long)
+        self.run_test(model, (x, y))
+
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_tensor_factories(self):
         class TensorFactory(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4532,6 +4532,127 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(InplaceAddModel(), (x, y), rtol=1e-2, atol=1e-2)
         self.run_test(InplaceMulModel(), (x, y), rtol=1e-2, atol=1e-2)
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_inplace_with_loop(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                a = torch.ones(12,)
+                for i in range(10):
+                    a.add_(torch.ones(12,))
+                return a+x
+
+        m = M()
+        x = torch.randn(12,)
+        self.run_test(torch.jit.script(M()), (x))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_inplace_with_loop_2(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                _bias = torch.ones(12,)
+                a = torch.ones(12,)  # used in loop, altered.
+                a_ref = a  # not used in loop, should be altered.
+                b = x.clone()  # used in loop, not be altered.
+                b_ref = b  # not used in loop, should not be altered.
+                for i in range(10):
+                    if i == 3:
+                        for j in range(5):
+                            a += _bias
+                            _bias.add_(torch.ones(12,))
+                            b = b + torch.ones(12,)
+
+                    _bias.add_(torch.ones(12,))
+                    a += _bias
+                # TODO: value for a_ref is incorrect.
+                # a_ref += torch.ones(12,)
+                b_ref += torch.ones(12,)
+                return _bias + x, a, b, b_ref
+
+        m = M()
+        x = torch.zeros(12,)
+        self.run_test(torch.jit.script(M()), (x))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_inplace_attr_with_loop(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._bias = torch.arange(12,)
+
+            def forward(self, x):
+                self._bias = torch.arange(12,)
+                for i in range(10):
+                    if i == 3:
+                        for j in range(5):
+                            self._bias += torch.arange(12,)
+                return self._bias + x
+
+        m = M()
+        x = torch.zeros(12,)
+        self.run_test(torch.jit.script(M()), (x))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_inplace_attr_copy_with_loop(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._bias = torch.arange(12,)
+
+            def forward(self, x):
+                self._bias = torch.arange(12,)
+                for i in range(10):
+                    if i == 3:
+                        for j in range(5):
+                            self._bias.copy_(torch.arange(12,))
+                        self._bias.copy_(self._bias + torch.arange(12,))
+
+                    self._bias.copy_(self._bias + torch.arange(12,))
+                return self._bias + x
+
+        m = M()
+        x = torch.zeros(12,)
+        self.run_test(torch.jit.script(M()), (x))
+
+    @unittest.skip("Skip til ONNX opset 14 for Sequence Identity. Pass locally.")
+    def test_inplace_sequence_with_loop(self):
+        class M(torch.nn.Module):
+            def process(self, beam_hyps: List[torch.Tensor], done:torch.Tensor, x):
+                batch_size = x.shape[0]
+                for i in range(batch_size):
+                    if done[i]:
+                        continue
+
+                    beam_idx = 0
+                    for _, token in enumerate(x[i]):
+                        beam_hyps.append(token)
+                        beam_idx += 1
+
+                        if beam_idx == 6:
+                            break
+
+                    done[i] = len(beam_hyps) > 4
+
+                return beam_hyps, done
+
+            def forward(self, x):
+                beam_hyps: List[torch.Tensor] = []
+                batch_size = x.shape[0]
+                cur_len = 0
+                max_len = x.shape[1]
+                # TODO: fix this
+                # done = torch.tensor([False for _ in range(batch_size)], dtype=torch.bool)
+                done = torch.zeros(batch_size, dtype=torch.bool)
+                while cur_len < max_len:
+                    beam_hyps, done = self.process(beam_hyps, done, x[:, 0, :])
+                    cur_len = cur_len + 1
+
+                return beam_hyps
+
+        m = torch.jit.script(M())
+        x = torch.randn(8, 4, 3)
+        self.run_test(torch.jit.script(M()), (x))
+
+
     @disableScriptTest()  # Sort with dynamic dim not supported in ONNX
     def test_sort(self):
         class SortModel(torch.nn.Module):
@@ -7290,6 +7411,37 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (x, anchors))
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    def test_set_attr_5(self):
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super(MyModule, self).__init__()
+                self.conv = torch.nn.Conv1d(10, 3, 3)
+                self.conv.bias = torch.nn.Parameter(torch.zeros(3, 10, 3))
+
+            def set_cell_anchors(self, anchors):
+                self.conv.weight = torch.arange(10)
+                for i in range(10):
+                    if i == 3:
+                        for j in range(10):
+                            w = self.conv.weight
+                            self.conv.weight = torch.arange(10) + w
+
+                    self.conv.weight = self.conv.weight + torch.arange(10)
+                    # NOTE: `is not None` and `assert` is for passing torchscript.
+                    if self.conv.bias is not None:
+                        a = self.conv.bias
+                        assert a is not None
+                        self.conv.bias = anchors + a
+
+            def forward(self, anchors):
+                self.set_cell_anchors(anchors)
+                return self.conv.weight, self.conv.bias
+
+        model = torch.jit.script(MyModule())
+        anchors = torch.ones(3, 10, 3)
+        self.run_test(model, (anchors))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_set_attr_in_loop(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7352,6 +7504,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (random_data, empty_tensor))
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    # TODO: test input size with (0, 0, 0, 0, 0) doesn't work with current ort rel
     def test_index_put_if_2(self):
         @torch.jit.script
         def check_init(input_data, hidden_size, prev_state):
@@ -7385,7 +7538,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         model = Example(10)
         random_data = torch.rand((1, 5, 30, 30))
-        empty_tensor = torch.tensor([], dtype=torch.float).view(0, 0, 0, 0, 0)
+        empty_tensor = torch.tensor([0], dtype=torch.float).view(1, 1, 1, 1, 1)
         self.run_test(model, (random_data, empty_tensor))
 
     @skipIfUnsupportedMinOpsetVersion(11)
@@ -7450,6 +7603,41 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, input_data, prev_state):
                 prev_state = check_init(input_data, self.hidden_size, prev_state)
                 return prev_state
+
+        model = Example(4)
+        random_data = torch.rand((1, 5, 4, 4))
+        empty_tensor = torch.tensor([], dtype=torch.float).view(0, 0, 0, 0, 0)
+        self.run_test(model, (random_data, empty_tensor))
+
+
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_index_put_if_5(self):
+        @torch.jit.script
+        def check_init(input_data, hidden_size, prev_state):
+            # type: (torch.Tensor, int, torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]
+            batch_size = input_data.size(0)
+            spatial_size_0 = input_data.size(2)
+            spatial_size_1 = input_data.size(3)
+            # generate empty prev_state, if None is provided
+            state_size = (2, batch_size, hidden_size, spatial_size_0, spatial_size_1)
+            state = torch.zeros(state_size, device=input_data.device)
+            state_ref = state
+            if prev_state.size(0) == 0:
+                state[:] = torch.ones(batch_size, hidden_size, spatial_size_0, spatial_size_1) * 3
+                state = state + 3
+                state[:] = torch.ones(batch_size, hidden_size, spatial_size_0, spatial_size_1) * 4
+            else:
+                state = state + 2
+            return state, state_ref
+
+        class Example(torch.nn.Module):
+            def __init__(self, hidden_size):
+                super().__init__()
+                self.hidden_size = hidden_size
+
+            def forward(self, input_data, prev_state):
+                prev_state, state_ref = check_init(input_data, self.hidden_size, prev_state)
+                return prev_state, state_ref
 
         model = Example(4)
         random_data = torch.rand((1, 5, 4, 4))

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -4669,8 +4669,6 @@ class TestONNXRuntime(unittest.TestCase):
                 batch_size = x.shape[0]
                 cur_len = 0
                 max_len = x.shape[1]
-                # TODO: fix this
-                # done = torch.tensor([False for _ in range(batch_size)], dtype=torch.bool)
                 done = torch.zeros(batch_size, dtype=torch.bool)
                 while cur_len < max_len:
                     beam_hyps, done = self.process(beam_hyps, done, x[:, 0, :])
@@ -7534,7 +7532,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (random_data, empty_tensor))
 
     @skipIfUnsupportedMinOpsetVersion(11)
-    # TODO: test input size with (0, 0, 0, 0, 0) doesn't work with current ort rel
+    # TODO: test input size with (0, 0, 0, 0, 0) doesn't work with current ort rel (1.7)
     def test_index_put_if_2(self):
         @torch.jit.script
         def check_init(input_data, hidden_size, prev_state):

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -237,7 +237,7 @@ std::vector<Value*> FixupONNXLoopNode(Node* node, int opset_version) {
   //       since onnx loop requires scan outputs to be the last outputs.
   auto new_outputs = ConvertSequenceDependencies(node, opset_version);
 
-  // TODO: fix node output metadata based on block output metadata.
+  // Copy type of block output to node output.
   for (size_t i = 0; i < node->outputs().size(); ++i) {
     node->output(i)->setType(node->blocks().at(0)->outputs().at(i + 1)->type());
   }
@@ -380,7 +380,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   auto* graph = if_node->owningGraph();
   FixupONNXSubblockOutputs(node);
   ONNXFixupUninitializedOutput(if_node);
-  // TODO: fix node output metadata based on block output metadata.
+  // Copy type of block output to node output.
   for (size_t i = 0; i < node->outputs().size(); ++i) {
     node->output(i)->setType(node->blocks().at(0)->outputs().at(i)->type());
   }

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -238,8 +238,8 @@ std::vector<Value*> FixupONNXLoopNode(Node* node, int opset_version) {
   auto new_outputs = ConvertSequenceDependencies(node, opset_version);
 
   // TODO: fix node output metadata based on block output metadata.
-  for (size_t i=0; i < node->outputs().size(); ++i) {
-    node->output(i)->setType(node->blocks().at(0)->outputs().at(i+1)->type());
+  for (size_t i = 0; i < node->outputs().size(); ++i) {
+    node->output(i)->setType(node->blocks().at(0)->outputs().at(i + 1)->type());
   }
   TORCH_INTERNAL_ASSERT(output_size == new_outputs.size());
   return new_outputs;
@@ -381,7 +381,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   FixupONNXSubblockOutputs(node);
   ONNXFixupUninitializedOutput(if_node);
   // TODO: fix node output metadata based on block output metadata.
-  for (size_t i=0; i < node->outputs().size(); ++i) {
+  for (size_t i = 0; i < node->outputs().size(); ++i) {
     node->output(i)->setType(node->blocks().at(0)->outputs().at(i)->type());
   }
 

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -236,6 +236,11 @@ std::vector<Value*> FixupONNXLoopNode(Node* node, int opset_version) {
   // NOTE: the output order is deliberately changed to match expected order
   //       since onnx loop requires scan outputs to be the last outputs.
   auto new_outputs = ConvertSequenceDependencies(node, opset_version);
+
+  // TODO: fix node output metadata based on block output metadata.
+  for (size_t i=0; i < node->outputs().size(); ++i) {
+    node->output(i)->setType(node->blocks().at(0)->outputs().at(i+1)->type());
+  }
   TORCH_INTERNAL_ASSERT(output_size == new_outputs.size());
   return new_outputs;
 }
@@ -375,6 +380,11 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   auto* graph = if_node->owningGraph();
   FixupONNXSubblockOutputs(node);
   ONNXFixupUninitializedOutput(if_node);
+  // TODO: fix node output metadata based on block output metadata.
+  for (size_t i=0; i < node->outputs().size(); ++i) {
+    node->output(i)->setType(node->blocks().at(0)->outputs().at(i)->type());
+  }
+
   GRAPH_DUMP("Graph after fixing controlflow: ", node->owningGraph());
   return if_node->outputs().vec();
 }

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -72,8 +72,10 @@ struct InplaceConverter {
     std::unordered_map<Value*, Value*> alias_to_value_;
 
     // Sort the alias based on their order in graph.
-    // A tie can happen when two aliases belong to different blocks, while having the same ancestor node.
-    // The unique id is used as tie breaker.
+    // A tie can happen when two distinct aliases belong to different blocks,
+    // while having the same ancestor node. The unique id is used as tie
+    // breaker, otherwise the two aliases will be considered equal to each
+    // other. aliasComp must satisfy strict weak ordering.
     struct aliasComp {
       bool operator()(const Value* a, const Value* b) const {
         auto* n_a = a->node();

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -614,6 +614,7 @@ void InplaceConverter::gatherAttrNameInitialValueMap(
         paramConst = findArgumentAsInputParam(graph_, fullName, attr);
         attr_name_value_map.insert({fullName, paramConst});
       } else if (auto attrVal = tryInsertConstant(*graph_, attr)) {
+        // TODO: Extend support for attribute of type List[Tensor] etc.
         for (size_t i = 0; i < type->getAttributes().size(); i++) {
           if (type->getAttributeName(i) == name) {
             paramConst = *attrVal;
@@ -621,6 +622,8 @@ void InplaceConverter::gatherAttrNameInitialValueMap(
           }
         }
       } else {
+        // If attribute is a custom class object, instead of primitive types,
+        // Tensor, or List/Tuple/Dict of Tensors.
         GRAPH_DEBUG(
             attr.type()->cast<ClassType>() ? "" : "attribute: ",
             name,
@@ -628,7 +631,8 @@ void InplaceConverter::gatherAttrNameInitialValueMap(
       }
     }
 
-    // Create dummy initial value.
+    // Create dummy initial value, if initial value does not exist for this
+    // attribute.
     if (attr_name_value_map.find(fullName) == attr_name_value_map.end()) {
       auto* noneNode = graph_->create(prim::Constant);
       noneNode->output()->setType(NoneType::get());

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -21,7 +21,7 @@ const std::set<c10::Symbol> inplace_ops =
 
 struct InplaceConverter {
   InplaceConverter(
-      const std::shared_ptr<Graph>& graph,
+      std::shared_ptr<Graph> graph,
       MutationRemover* mr,
       Module* model = nullptr)
       : graph_(graph), mr_(mr), module_(model) {}
@@ -68,7 +68,6 @@ struct InplaceConverter {
     // root value.
     std::unordered_map<Value*, Value*> alias_to_value_;
 
-    // TODO: order might be useless, could potentially remove this.
     struct aliasComp {
       bool operator()(const Value* a, const Value* b) {
         auto* n_a = a->node();
@@ -370,7 +369,7 @@ std::string InplaceConverter::ValueTracker::toString() const {
      << std::endl;
   ss << "value_to_sorted_aliases_: " << std::endl;
   size_t idx = 0;
-  for (auto it : value_to_sorted_aliases_) {
+  for (const auto& it : value_to_sorted_aliases_) {
     ss << "Value[" << idx << "]: " << it.first->debugName() << std::endl;
     ss << "  Mapping to ";
     for (auto v : it.second) {
@@ -640,7 +639,7 @@ void InplaceConverter::replaceAttrWithInplaceOps(
     Block* block,
     const std::unordered_map<std::string, Value*>& attr_name_value_map,
     const std::unordered_map<Node*, std::string>& attr_node_fullname_map) {
-  for (auto pair : attr_node_fullname_map) {
+  for (const auto& pair : attr_node_fullname_map) {
     auto* n = pair.first;
     auto fullName = pair.second;
     auto find_init_val = attr_name_value_map.find(fullName);
@@ -764,7 +763,7 @@ void RemoveInplaceOpsForONNX(
   PrepareForRemoveMutations(mr, graph->block());
   RemoveTensorMutation(graph);
   RemoveListMutation(graph);
-  InplaceConverter ic(graph, &mr, model);
+  InplaceConverter ic(std::move(graph), &mr, model);
   ic.convertMutationForONNX();
 }
 

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -69,7 +69,7 @@ struct InplaceConverter {
     std::unordered_map<Value*, Value*> alias_to_value_;
 
     struct aliasComp {
-      bool operator()(const Value* a, const Value* b) {
+      bool operator()(const Value* a, const Value* b) const {
         auto* n_a = a->node();
         auto* n_b = b->node();
         if (n_a == n_b) {

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -24,7 +24,7 @@ struct InplaceConverter {
       std::shared_ptr<Graph> graph,
       MutationRemover* mr,
       Module* model = nullptr)
-      : graph_(graph), mr_(mr), module_(model) {}
+      : graph_(std::move(graph)), mr_(mr), module_(model) {}
 
   void convertMutationForONNX();
 
@@ -763,7 +763,7 @@ void RemoveInplaceOpsForONNX(
   PrepareForRemoveMutations(mr, graph->block());
   RemoveTensorMutation(graph);
   RemoveListMutation(graph);
-  InplaceConverter ic(std::move(graph), &mr, model);
+  InplaceConverter ic(graph, &mr, model);
   ic.convertMutationForONNX();
 }
 

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -49,7 +49,7 @@ struct InplaceConverter {
 
     void init(const std::shared_ptr<Graph>& graph);
     void registerSetValue(Value* old_v, Value* new_v);
-    void updateInputsWithAlias(Node* n);
+    void correctAliasReferenceForInputs(Node* n);
 
     std::string toString() const;
 
@@ -470,7 +470,7 @@ void InplaceConverter::correctAliasReferences(Block* block) {
     Node* n = *it;
     it++; // node n can be destroyed
 
-    vt_.updateInputsWithAlias(n);
+    vt_.correctAliasReferenceForInputs(n);
 
     auto nkind = n->kind();
     if (nkind == prim::If || nkind == prim::Loop) {
@@ -479,10 +479,10 @@ void InplaceConverter::correctAliasReferences(Block* block) {
       }
     }
   }
-  vt_.updateInputsWithAlias(block->return_node());
+  vt_.correctAliasReferenceForInputs(block->return_node());
 }
 
-void InplaceConverter::ValueTracker::updateInputsWithAlias(Node* n) {
+void InplaceConverter::ValueTracker::correctAliasReferenceForInputs(Node* n) {
   for (size_t i = 0; i < n->inputs().size(); ++i) {
     auto* in = n->input(i);
     auto* alias = findAliasForValueAtNode(in, n);

--- a/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
+++ b/torch/csrc/jit/passes/onnx/remove_inplace_ops_for_onnx.cpp
@@ -26,38 +26,46 @@ struct InplaceConverter {
       Module* model = nullptr)
       : graph_(graph), mr_(mr), module_(model) {}
 
-  // new api
   void convertMutationForONNX();
 
-  // old api
-  void RegisterInplaceOpAsBlockOutputs();
-
-  // old code
-  void RegisterInplaceNodeInBlocks(Value* orig_data, Value* new_data);
-  bool isInplaceNode(const Node* n) const;
-
  private:
+  void gatherAttrNameInitialValueMap(Block* block,
+      std::unordered_map<std::string, Value*>& attr_name_value_map,
+      std::unordered_map<Node*, std::string>& attr_node_fullname_map);
+  void replaceAttrWithInplaceOps(Block* block,
+      const std::unordered_map<std::string, Value*>& attr_name_value_map,
+      const std::unordered_map<Node*, std::string>& attr_node_fullname_map);
+
+  void convertInplaceOps();
+  void convertInplaceOps(Block* block);
+
+  void correctAliasReferences();
+  void correctAliasReferences(Block* block);
+
+  void convertGetSetAttrToInplaceOps(Block* block);
 
   struct ValueTracker {
     ValueTracker() : graph_(nullptr), root_block_(nullptr) {}
 
     void init(const std::shared_ptr<Graph>& graph);
     void registerSetValue(Value* old_v, Value* new_v);
-    Value* findAliasForValueAtNode(Value* v, const Node* n) const;
-    void passUpdateValueUse(Block* block);
+    void updateInputsWithAlias(Node* n);
+
     std::string toString() const;
 
    private:
-    std::vector<std::tuple<Value*, Node*, Block*>> sortAliasOfValue(const Value* v) const;
+    Value* findAliasForValueAtNode(Value* v, const Node* n) const;
 
     std::shared_ptr<Graph> graph_;
     Block* root_block_;
 
-    // Map from aliases to ground truth value.
+    // Map from aliases to root value.
     // A single value can have multiple aliases throughout the graph,
     // created by inplace operators, and preserved through loop carried input/output.
+    // For each such value, its first occurance will be set as root value.
     std::unordered_map<Value*, Value*> alias_to_value_;
 
+    // TODO: order might be useless, could potentially remove this.
     struct aliasComp {
       bool operator() (const Value* a, const Value* b) {
         auto* n_a = a->node();
@@ -73,93 +81,15 @@ struct InplaceConverter {
         return a_b;
       }
     };
-    // Map from ground truth value to aliases sorted by their order in graph.
+    // Map from root value to aliases sorted by their order in graph.
     std::unordered_map<Value*, std::set<Value*, aliasComp>> value_to_sorted_aliases_;
   };
-
-  // new code
-  void gatherAttrNameInitialValueMap(Block* block,
-      std::unordered_map<std::string, Value*>& attr_name_value_map,
-      std::unordered_map<Node*, std::string>& attr_node_fullname_map);
-  void replaceAttrWithInplaceOps(Block* block,
-      const std::unordered_map<std::string, Value*>& attr_name_value_map,
-      const std::unordered_map<Node*, std::string>& attr_node_fullname_map);
-
-  void convertInplaceOps();
-  void convertInplaceOps(Block* block);
-
-  // old code
-  Value* MatchIfBlocksOutputForValue(
-      Value* orig_data,
-      Block* outer_block,
-      Value* origOutput);
-
-  void RegisterInplaceNodeInIfBlocks(
-      Value* orig_data,
-      Value* new_data,
-      const std::string& output_name);
-
-  void RegisterInplaceNodeInLoopBlocks(Value* orig_data, Value* new_data);
-
-  void convertGetSetAttrToInplaceOps(Block* block);
-  std::unordered_map<std::string, Value*> registerInplaceOpAsBlockOutputs(Block* block);
-
-  void trackAndRegisterAttributesInBlocks(
-      Node* n,
-      const Module& module_,
-      std::unordered_map<std::string, Value*>& nextSetAttrValues);
-
-  Value* registerSetAttrInBlocks(
-      Block* block,
-      Node* cloneNode,
-      Value* origValue,
-      const std::string& output_name);
-
-  void PrintSnapshotForDebug(const Node* n) {
-    GRAPH_UPDATE("Print Snapshot for debugging.\nGraph: ", graph_->toString());
-    GRAPH_UPDATE("Current node: ", *n);
-
-    auto print_map = [](const std::unordered_map<std::string, Value*>& map) {
-      for (auto iter : map) {
-        GRAPH_UPDATE("Key: ", iter.first);
-        GRAPH_UPDATE("Value: ", iter.second->debugName());
-      }
-    };
-
-    GRAPH_UPDATE("All attribute values map:");
-    print_map(allAttrValues_);
-
-    GRAPH_UPDATE("Set attribute values map:");
-    print_map(setAttrValues_);
-
-    GRAPH_UPDATE("All attribute modules map:");
-    print_map(allAttrModules_);
-  }
 
   std::shared_ptr<Graph> graph_;
   MutationRemover* mr_;
   Module* module_;
   ValueTracker vt_;
-  // A map of names and values of referenced attributes, to avoid duplicates.
-  std::unordered_map<std::string, Value*> allAttrValues_ = {};
-  // A map of names and values of set attributes, to track mutations.
-  std::unordered_map<std::string, Value*> setAttrValues_ = {};
-  // A map of names and values of attribute modules, to create SetAttr node.
-  std::unordered_map<std::string, Value*> allAttrModules_ = {};
 };
-
-bool InplaceConverter::isInplaceNode(const Node* n) const {
-  if (inplace_ops.find(n->kind()) != inplace_ops.end()) {
-    return true;
-  }
-
-  if (n->kind() == Symbol::fromQualString("onnx::Placeholder") &&
-      n->s(attr::name) == "index_put_") {
-    return true;
-  }
-
-  return false;
-}
 
 Node* addDummyClone(
     Graph* graph,
@@ -193,362 +123,6 @@ Node* addDummyClone(
     noneNode->insertBefore(newNode);
   }
   return newNode;
-}
-
-// Check If then/else blocks to match the number of outputs.
-// If the number of block outputs do not match, insert a dummy
-// constant of corresponding shape and type.
-Value* InplaceConverter::MatchIfBlocksOutputForValue(
-    Value* orig_data,
-    Block* outer_block,
-    Value* origOutput) {
-  if (outer_block->owningNode()->kind() == prim::Loop)
-    return outer_block->owningNode()->outputs().at(
-        outer_block->owningNode()->outputs().size() - 1);
-
-  if (outer_block->owningNode()->kind() != prim::If)
-    return nullptr;
-  size_t output_size = outer_block->outputs().size();
-
-  for (size_t i = 0; i < output_size - 1; i++) {
-    if (outer_block->outputs().at(i)->debugNameBase() ==
-        origOutput->debugNameBase()) { // Check debug names
-      outer_block->replaceOutput(i, outer_block->outputs().at(output_size - 1));
-      outer_block->eraseOutput(output_size - 1);
-      outer_block->owningNode()->eraseOutput(output_size - 1);
-      return outer_block->owningNode()->outputs().at(i);
-    }
-  }
-
-  for (Block* b : outer_block->owningNode()->blocks()) {
-    if (b->outputs().size() < output_size) {
-      auto clone_node =
-          addDummyClone(graph_.get(), orig_data, false, b->return_node());
-      b->registerOutput(clone_node->output());
-      b->outputs()
-          .at(b->outputs().size() - 1)
-          ->copyMetadata(
-              outer_block->outputs().at(output_size - 1)); // Copy debug names
-    }
-  }
-  return outer_block->owningNode()->outputs().at(output_size - 1);
-}
-
-// clang-format off
-// Register inplace op node inputs/outputs through the blocks.
-// Eg. The IR before updating:
-//%23 : bool = aten::eq(%22, %13)
-// = prim::If(%23)
-//  block0():
-//    %24 : int[] = prim::ListConstruct(%batch_size.1, %6, %spatial_size_0.1, %spatial_size_1.1)
-//    %25 : Tensor = aten::ones(%24, %12, %12, %12, %12)
-//    %26 : Tensor = aten::slice(%state.1, %13, %13, %10, %11)
-//    %27 : Tensor = aten::copy_(%26, %25, %9)
-//    -> ()
-//  block1():
-//    %28 : int[] = prim::ListConstruct(%batch_size.1, %6, %spatial_size_0.1, %spatial_size_1.1)
-//    %29 : Tensor = aten::randn(%28, %12, %12, %12, %12)
-//    %30: Tensor = aten::slice(%state.1, %13, %13, %10, %11)
-//    %31 : Tensor = aten::copy_(%30, %29, %9)
-//    -> ()
-// After updating:
-//%23 : bool = aten::eq(%22, %13)
-//%51 : Tensor = prim::If(%23)
-//  block0():
-//    %24 : int[] = prim::ListConstruct(%batch_size.1, %6, %spatial_size_0.1, %spatial_size_1.1)
-//    %25 : Tensor = aten::ones(%24, %12, %12, %12, %12)
-//    %26 : Tensor = aten::slice(%state.1, %13, %13, %10, %11)
-//    %32 : Tensor?[] = prim::ListConstruct()
-//    %33 : Tensor = aten::expand_as(%25, %26)
-//    %38 : int = prim::Constant[value=0]()
-//    %39 : int = aten::size(%state.1, %38)
-//    %40 : int = prim::Constant[value=4]()
-//    %41 : None = prim::Constant()
-//    %42 : None = prim::Constant()
-//    %43 : None = prim::Constant()
-//    %44 : Tensor = aten::arange(%39, %40, %41, %42, %43)
-//    %45 : int = prim::Constant[value=0]()
-//    %46 : Tensor = aten::slice(%44, %45, %13, %10, %11)
-//    %47 : int[] = prim::Constant[value=[-1]]()
-//    %48 : Tensor = aten::view(%46, %47)
-//    %49 : Tensor?[] = prim::ListConstruct(%48)
-//    %50 : Tensor = aten::index_put(%state.1, %49, %33, %9)
-//    -> (%50)
-//  block1():
-//    %28 : int[] = prim::ListConstruct(%batch_size.1, %6, %spatial_size_0.1, %spatial_size_1.1)
-//    %29 : Tensor = aten::randn(%28, %12, %12, %12, %12)
-//    %30 : Tensor = aten::slice(%state.1, %13, %13, %10, %11)
-//    %35 : Tensor?[] = prim::ListConstruct()
-//    %36 : Tensor = aten::expand_as(%29, %30)
-//    %52 : int = prim::Constant[value=0]()
-//    %53 : int = aten::size(%state.1, %52)
-//    %54 : int = prim::Constant[value=4]()
-//    %55 : None = prim::Constant()
-//    %56 : None = prim::Constant()
-//    %57 : None = prim::Constant()
-//    %58 : Tensor = aten::arange(%53, %54, %55, %56, %57)
-//    %59 : int = prim::Constant[value=0]()
-//    %60 : Tensor = aten::slice(%58, %59, %13, %10, %11)
-//    %61 : int[] = prim::Constant[value=[-1]]()
-//    %62 : Tensor = aten::view(%60, %61)
-//    %63 : Tensor?[] = prim::ListConstruct(%62)
-//    %64 : Tensor = aten::index_put(%state.1, %63, %36, %9)
-//    -> (%64)
-// clang-format on
-void InplaceConverter::RegisterInplaceNodeInIfBlocks(
-    Value* orig_data,
-    Value* new_data,
-    const std::string& output_name) {
-  auto outer_block = new_data->node()->owningBlock();
-  auto initial_block_node = outer_block->owningNode();
-
-  if ((nullptr == initial_block_node) ||
-      (initial_block_node->kind() != prim::If)) {
-    return;
-  }
-
-  auto next_block_node = initial_block_node;
-  new_data->setDebugName("_output_" + output_name);
-  outer_block->registerOutput(new_data);
-  // Block has a new output. Add the output for the prim::If node.
-  if (next_block_node->outputs().size() < outer_block->outputs().size())
-    next_block_node->addOutput()->copyMetadata(new_data);
-
-  auto next_block = next_block_node->owningBlock();
-  while (nullptr != next_block->owningNode() &&
-         next_block != orig_data->node()->owningBlock()) {
-    // TODO:
-    //    1. output(0): 0 is wrong, should be -1, since the last output is the one added,
-    //       but should use a better way of keeping track of this output.
-    //    2. This is recursively updating outer block, if and loop should be handled differently.
-    next_block->registerOutput(next_block_node->output(0));
-    next_block_node = next_block->owningNode();
-    // Block has a new output. Add the output for the prim::If node.
-    if (next_block_node->outputs().size() < next_block->outputs().size())
-      next_block_node->addOutput()->setType(new_data->type());
-    next_block = next_block_node->owningBlock();
-  }
-  orig_data->replaceAllUsesAfterNodeWith(
-      next_block_node,
-      next_block_node->outputs().at(next_block_node->outputs().size() - 1));
-}
-
-// clang-format off
-// Register inplace op node inputs/outputs through the blocks.
-// Eg. The IR before updating:
-//   = prim::Loop(%10, %27)
-//    block0(%stream_idx.1 : int):
-//       = prim::Loop(%9, %27)
-//        block0(%i.1 : int):
-//          %36 : Tensor = aten::select(%bias.1, %26, %stream_idx.1)
-//          %41 : Tensor = aten::copy_(%37, %40, %25)
-//          -> (%27)
-//      -> (%27)
-//  After updating:
-// %62 : Tensor = prim::Loop(%10, %27, %bias.2)
-//    block0(%stream_idx.1 : int, %bias.3 : Tensor):
-//      %61 : Tensor = prim::Loop(%9, %27, %bias.3)
-//        block0(%i.1 : int, %bias.1 : Tensor):
-//          %36 : Tensor = aten::select(%bias.1, %26, %stream_idx.1)
-//          %59 : Tensor?[] = prim::ListConstruct(%55, %58)
-//          %60 : Tensor = aten::index_put(%bias.1, %59, %45, %25)
-//          -> (%27, %60)
-//      -> (%27, %61)
-// clang-format on
-void InplaceConverter::RegisterInplaceNodeInLoopBlocks(Value* orig_data, Value* new_data) {
-  Node* inplace_node = new_data->node();
-  Block* outer_block = inplace_node->owningBlock();
-  Node* outer_block_node = outer_block->owningNode();
-
-  if (nullptr == outer_block_node) {
-    return;
-  }
-
-  if (outer_block_node->kind() != prim::Loop)
-    return;
-
-  outer_block->registerOutput(new_data);
-  std::vector<std::pair<Block*, Node*>> node_list = {
-      std::make_pair(outer_block, outer_block_node)};
-
-  outer_block_node->addOutput()->setType(new_data->type());
-  auto next_block = outer_block_node->owningBlock();
-  auto next_node = outer_block_node;
-
-  while (nullptr != next_block->owningNode() &&
-         next_block != orig_data->node()->owningBlock()) {
-    outer_block = next_block;
-    outer_block->registerOutput(
-        next_node->outputs().at(next_node->outputs().size() - 1));
-    next_node = outer_block->owningNode();
-    next_node->addOutput()->setType(new_data->type());
-    next_block = next_node->owningBlock();
-    if (next_node->kind() == prim::Loop) // Do not register input if nested in
-                                         // If block. Register in Loop blocks.
-      node_list.emplace_back(std::make_pair(outer_block, next_node));
-  }
-
-  // Register inplace node inputs through the blocks.
-  auto next_data = orig_data;
-  while (!node_list.empty()) {
-    auto cur_pair = node_list.back();
-    // Add input to current node.
-    cur_pair.second->addInput(next_data);
-    // Add input to current block.
-    auto cur_input = cur_pair.first->addInput();
-    cur_input->setType(next_data->type());
-    next_data = cur_input;
-    node_list.pop_back();
-  }
-
-  // Update inplace node inputs inside the outer most block.
-  outer_block_node = outer_block->owningNode();
-  auto prev_data =
-      outer_block_node->inputs().at(outer_block_node->inputs().size() - 1);
-  for (auto node : inplace_node->owningBlock()->nodes()) {
-    size_t idx = 0;
-    for (auto inputs_ : node->inputs()) {
-      if (inputs_ == prev_data) {
-        node->replaceInput(idx, next_data);
-        break;
-      }
-      idx++;
-    }
-  }
-
-  orig_data->replaceAllUsesAfterNodeWith(
-      next_node->outputs().at(0)->node(),
-      next_node->outputs().at(next_node->outputs().size() - 1));
-}
-
-// void RegisterInplaceNodeThroughBlocks
-//     Value* orig_data,
-//     Value* new_data,
-//     const std::string& output_name) {
-//   Node* inplace_node = new_data->node();
-//   Block* outer_block = inplace_node->owningBlock();
-//   Node* outer_block_node = outer_block->owningNode();
-
-//   if (nullptr == outer_block_node) {
-//     return;
-//   }
-
-//   new_data->setDebugName("_output_" + output_name);
-//   outer_block->registerOutput(new_data);
-
-
-// }
-
-// Register inplace op node inputs/outputs through the blocks.
-void InplaceConverter::RegisterInplaceNodeInBlocks(Value* orig_data, Value* new_data) {
-  Node* inplace_node = new_data->node();
-  Block* outer_block = inplace_node->owningBlock();
-  Node* outer_block_node = outer_block->owningNode();
-
-  if (outer_block_node == nullptr)
-    return;
-
-  // Check if the value is already registered in the block
-  bool registered = false;
-  while (isInplaceNode(orig_data->node())) {
-    // TODO: another edge case. will overtrace orig_data
-    //    eg.
-    //        a = tensor
-    //        b = a.inplace_op()
-    //        loop
-    //          c = a.inplace_op()
-    //          loop
-    //            d = a.inplace_op()
-    //        return a
-    //
-    //  In code handling "b = a.inplace_op()", all later usage of a are
-    //  converted to b. So the below code will use `a` as `orig_data`, while
-    //  in the graph, all the rest of inplace ops actually uses `b`.
-    orig_data = orig_data->node()->inputs().at(0);
-  }
-  for (auto use : orig_data->uses()) {
-    if ((use.user->owningBlock() == outer_block) &&
-        (use.user->isAfter(inplace_node))) {
-      size_t idx = 0;
-      // TODO: GetAttr afterwards are not counted as use of same orig_data.
-      for (auto input_ : use.user->inputs()) {
-        if (input_ == orig_data) {
-          use.user->replaceInput(idx, new_data);
-          registered = true;
-        }
-        idx++;
-      }
-    }
-  }
-  if (registered)
-    return;
-
-  // Register inplace node outputs through the blocks.
-  // RegisterInplaceNodeThroughBlocks(orig_data, new_data, orig_data->debugName());
-
-  RegisterInplaceNodeInLoopBlocks(orig_data, new_data);
-
-  RegisterInplaceNodeInIfBlocks(orig_data, new_data, orig_data->debugName());
-
-  while (nullptr != outer_block->owningNode() &&
-         outer_block != orig_data->node()->owningBlock()) {
-    MatchIfBlocksOutputForValue(orig_data, outer_block, new_data);
-    outer_block = outer_block->owningNode()->owningBlock();
-  }
-}
-
-void PrepareIndexPutForONNX(Node* node, InplaceConverter* ic) {
-  TORCH_INTERNAL_ASSERT(
-      node->kind() == aten::index_put || node->kind() == aten::index_put_);
-  auto placeholder_node = EncapsulatePatternIntoSubblock(node).value();
-  if (node->kind() == aten::index_put_) {
-    auto orig_data = placeholder_node->input();
-    auto new_data = placeholder_node->output();
-
-    // avoid confusing "registered" logic
-    node->removeAllInputs();
-
-    if (nullptr == placeholder_node->owningBlock()->owningNode()) {
-      orig_data->replaceAllUsesAfterNodeWith(placeholder_node, new_data);
-      return;
-    }
-    ic->RegisterInplaceNodeInBlocks(orig_data, new_data);
-  }
-}
-
-void PrepareCopyForONNX(Node* node, InplaceConverter* ic) {
-  if (node->kind() == aten::copy_) {
-    // aten::copy_ can be viewed as a special case of index_put, where the
-    // tensor indices input is empty.
-    // Remove aten::copy_, and replace it with index_put.
-    // 1. create an empty listConstruct node as indices input for index_put.
-    // 2. create index_put node.
-
-    // Tracing aten::copy_ broadcasts the rhs values.
-    // 3. Apply broadcasting for scripting.
-    WithInsertPoint guard(node);
-    auto graph = node->owningGraph();
-    auto dummy_list =
-        graph->insertNode(graph->createList(OptionalType::ofTensor(), {}))
-            ->output();
-
-    auto expanded_value =
-        graph->insert(aten::expand_as, {node->input(1), node->input(0)});
-    expanded_value->node()->setSourceRange(node->sourceRange());
-    expanded_value->copyMetadata(node->input(1));
-
-    auto index_put = graph->insert(
-        aten::index_put_,
-        {node->input(0), dummy_list, expanded_value, node->input(2)});
-    index_put->node()->setSourceRange(node->sourceRange());
-    index_put->copyMetadata(node->output());
-    node->output()->replaceAllUsesWith(index_put);
-
-    // avoid confusing "registered" logic
-    node->removeAllInputs();
-
-    PrepareIndexPutForONNX(index_put->node(), ic);
-  }
 }
 
 std::pair<Value*, Value*> PrepareIndexPutForONNX(Node* node) {
@@ -591,42 +165,6 @@ std::pair<Value*, Value*> PrepareCopyForONNX(Node* node) {
   node->destroy();
 
   return PrepareIndexPutForONNX(index_put->node());
-}
-
-void PrepareInplaceOpsInBlocksForONNX(Node* node, InplaceConverter* ic) {
-  if (!node->kind().is_aten())
-    return;
-
-  auto name = node->schema().name();
-  bool inplace_op = name.at(name.size() - 1) == '_';
-  if (!inplace_op)
-    return;
-
-  auto new_schema = name.substr(0, name.size() - 1);
-
-  Node* input_node = node->inputs().at(0)->node();
-  // if (input_node->kind() != aten::select && input_node->kind() != aten::slice)
-  //   return;
-
-  auto graph = node->owningGraph();
-  auto new_node = graph->create(Symbol::fromQualString(new_schema), 1);
-  for (Value* input : node->inputs()) {
-    new_node->addInput(input);
-  }
-  new_node->output()->setType(node->output()->type());
-  new_node->insertBefore(node);
-  new_node->setSourceRange(node->sourceRange());
-
-  auto false_val_ = graph->insertConstant(false);
-
-  auto new_copy = graph->create(aten::copy_, 1);
-  new_copy->addInput(node->inputs().at(0));
-  new_copy->addInput(new_node->output());
-  new_copy->addInput(false_val_);
-  new_copy->insertBefore(node);
-  new_copy->setSourceRange(node->sourceRange());
-
-  PrepareCopyForONNX(new_copy, ic);
 }
 
 std::pair<Value*, Value*> PrepareInplaceOpsInBlocksForONNX(Node* node) {
@@ -814,289 +352,6 @@ Value* findArgumentAsInputParam(
       name);
 }
 
-Value* InplaceConverter::registerSetAttrInBlocks(
-    Block* block,
-    Node* cloneNode,
-    Value* origValue,
-    const std::string& output_name) {
-  // TODO: add check for registered
-  auto orig_data = origValue;
-  auto new_data = cloneNode->output();
-
-  // Check if the value is already registered in the block
-  bool registered = false;
-  while (isInplaceNode(orig_data->node())) {
-    orig_data = orig_data->node()->inputs().at(0);
-  }
-  for (auto use : orig_data->uses()) {
-    if ((use.user->owningBlock() == block) &&
-        (use.user->isAfter(cloneNode))) {
-      size_t idx = 0;
-      for (auto input_ : use.user->inputs()) {
-        if (input_ == orig_data) {
-          use.user->replaceInput(idx, new_data);
-          registered = true;
-        }
-        idx++;
-      }
-    }
-  }
-
-  for (auto n : block->nodes()) {
-    if (n->isAfter(cloneNode) && n->kind() == prim::SetAttr) {
-      // Check if it is SetAttr node on this value, if so, postpone registration till then.
-      // if (n->) {
-      //   registered = true;
-      // }
-    }
-  }
-
-  if (registered)
-    return nullptr;
-
-  RegisterInplaceNodeInLoopBlocks(origValue, cloneNode->output());
-  RegisterInplaceNodeInIfBlocks(origValue, cloneNode->output(), output_name);
-
-  Value* output = nullptr;
-  while (nullptr != block->owningNode() &&
-         block != origValue->node()->owningBlock()) {
-    output = MatchIfBlocksOutputForValue(origValue, block, cloneNode->output());
-    block = block->owningNode()->owningBlock();
-  }
-  return output;
-}
-
-// clang-format off
-// The trackAndRegisterAttributesInBlocks function tracks any instances
-// of getAttr and setAttr in a sub-block and capture these nodes as inpalce
-// read/write ops. This pass captures the output of setAttr in sub-block outputs
-// so that it gets reflected into the outer block.
-// Also, the pass matched the number of If sub-block outputs
-// if a value is updated in one branch, but no updated on the other branch.
-// For example:
-//= prim::If(%12)
-//    block0():
-//      %13 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %b.1 : Tensor? = prim::GetAttr[name="bias"](%13)
-//      ...
-//      %18 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %19 : Tensor = aten::add(%anchors.1, %b, %6)
-//       = prim::SetAttr[name="bias"](%18, %19)
-//     -> ()
-//    block1():
-//      %20 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %21 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %22 : Tensor = prim::GetAttr[name="weight"](%21)
-//      %23 : Tensor = aten::slice(%22, %7, %7, %8, %6)
-//       = prim::SetAttr[name="bias"](%20, %23)
-//     -> ()
-// After the pass
-//%_output_conv.bias.3 : Tensor = prim::If(%12)
-//    block0():
-//     ...
-//      %18 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %19 : Tensor = aten::add(%anchors.1, %b, %6)
-//      %_output_conv.bias.2 : Tensor = aten::clone(%19, %26)
-//     -> (%_output_conv.bias.2)
-//    block1():
-//      %20 : __torch__.torch.nn.modules.conv.___torch_mangle_9.Conv1d = prim::GetAttr[name="conv"](%3)
-//      %23 : Tensor = aten::slice(%conv.weight, %7, %7, %8, %6)
-//      %31 : None = prim::Constant()
-//      %_output_conv.bias.4 : Tensor = aten::clone(%23, %31)
-//     -> (%_output_conv.bias.4)
-// clang-format on
-void InplaceConverter::trackAndRegisterAttributesInBlocks(
-    Node* n,
-    const Module& module_,
-    std::unordered_map<std::string, Value*>& nextSetAttrValues) {
-  if (n->kind() != prim::GetAttr && n->kind() != prim::SetAttr)
-    return;
-
-  auto name = n->s(attr::name);
-  auto attrModule = module_;
-  Value* paramConst = nullptr;
-
-  auto moduleNames =
-      findSubModuleAttr(n->inputs().at(0), name, attrModule, graph_);
-
-  std::string fullName("");
-  for (auto& name : moduleNames) {
-    fullName += name + '.';
-  }
-  fullName += name;
-
-  if (allAttrValues_.find(fullName) == allAttrValues_.end() &&
-      attrModule.hasattr(name)) {
-    auto attr = attrModule.attr(name);
-    auto type = attrModule.type();
-    auto slot = *type->findAttributeSlot(name);
-
-    // Add model_parameters and model_buffers as model inputs. Order is
-    // preserved based on the appearance in the graph.
-    if (type->is_parameter(slot) || type->is_buffer(slot) ||
-        (attr.isObject() && !attr.toObjectRef().type()->is_module())) {
-      if (allAttrValues_.find(fullName) == allAttrValues_.end()) {
-        paramConst = findArgumentAsInputParam(graph_, fullName, attr);
-        allAttrValues_.insert({fullName, paramConst});
-      }
-    } else if (auto attrVal = tryInsertConstant(*graph_, attr)) {
-      for (size_t i = 0; i < type->getAttributes().size(); i++) {
-        if (type->getAttributeName(i) == name) {
-          paramConst = *attrVal;
-          allAttrValues_.insert({fullName, paramConst});
-        }
-      }
-    } else {
-      GRAPH_DEBUG(
-          attr.type()->cast<ClassType>() ? "" : "attribute: ",
-          name,
-          " is not materializable.");
-      return;
-    }
-  }
-
-  if (n->kind() == prim::SetAttr) { // Handle SetAttr node
-    if (attrModule.hasattr(name)) {
-      // If inside a block, keep the output value to register in block
-      // output.
-      auto block_ = n->owningBlock();
-      Node* cloneNode =
-          addDummyClone(graph_.get(), n->inputs().at(1), true, n);
-      if (block_->owningNode() &&
-          (block_->owningNode()->kind() == prim::If ||
-           block_->owningNode()->kind() == prim::Loop)) {
-        auto attrValue = (setAttrValues_.find(fullName) != setAttrValues_.end())
-            ? setAttrValues_[fullName]
-            : allAttrValues_[fullName];
-
-        auto blockOutput = registerSetAttrInBlocks(
-            block_, cloneNode, attrValue, fullName);
-
-        if (nullptr != blockOutput) {
-          nextSetAttrValues[fullName] = blockOutput;
-        }
-      }
-      // SetAttr writes a value to an attr. Keep this
-      // in the setAttrValues map.
-      setAttrValues_[fullName] = cloneNode->output();
-    }
-  } else if (n->kind() == prim::GetAttr) { // Handle GetAttr node
-    allAttrModules_[fullName] = n->input(0);
-    if (setAttrValues_.find(fullName) != setAttrValues_.end()) {
-      // Attr has been set earlier in the graph.
-      // Read its value from setAttrValues map.
-      auto set_attr_node_input = setAttrValues_[fullName];
-      // Clone SetAttr input
-      n->output()->replaceAllUsesAfterNodeWith(n, set_attr_node_input);
-    } else if (allAttrValues_.find(fullName) != allAttrValues_.end()) {
-      // Attr has not been set earlier in the graph. Replace it with the
-      // graph parameter if exists.
-      n->output()->replaceAllUsesWith(allAttrValues_[fullName]);
-      n->removeAllInputs();
-    }
-  }
-}
-
-// clang-format off
-// The registerInplaceOpAsBlockOutputs function tracks inplace op
-// (like aten::copy_ or aten::append) outputs as sub-block output.
-// Also, match the number of If sub-block outputs
-// if a value is updated in one branch, but no updated on the other branch.
-// For example:
-// = prim::If(%30)
-//    block0():
-//      ...
-//      %35 : Tensor = aten::copy_(%state_copy.1, %33, %12)
-//      -> ()
-//    block1():
-//      ...
-//      %40 : Tensor = aten::copy_(%state.1, %38, %12)
-//      -> ()
-//
-// After the pass
-//%_output_state_copy.1 : Tensor, %_output_state.1 : Tensor = prim::If(%30)
-//    block0():
-//      %_output_state.2 : Tensor = aten::clone(%state.1, %59)
-//      ...
-//      %_output_state_copy.3 : Tensor = onnx::Placeholder[name="index_put_"](%state_copy.1)...
-//      ...
-//      -> (%_output_state_copy.3, %_output_state.2)
-//    block1():
-//      %50 : None = prim::Constant()
-//      %_output_state_copy.2 : Tensor = aten::clone(%state_copy.1, %50)
-//      ...
-//      %_output_state.3 : Tensor = onnx::Placeholder[name="index_put_"](%state.1)...
-//       ...
-//      -> (%_output_state_copy.2, %_output_state.3)
-std::unordered_map<std::string, Value*> InplaceConverter::registerInplaceOpAsBlockOutputs(Block* block) {
-  Node* m = *block->nodes().begin();
-  WithInsertPoint guard(m);
-  std::unordered_map<std::string, Value*> nextSetAttrValues = {};
-
-  for (auto it = block->nodes().begin(); it != block->nodes().end();) {
-    Node* n = *it;
-    it++; // node n can be destroyed
-    // printf("before node: ");
-    // n->dump();
-    // printf("pre graph: %s\n", n->owningGraph()->toString().c_str());
-    if (nullptr != module_ &&
-        (n->kind() == prim::GetAttr || n->kind() == prim::SetAttr)) {
-      Module moduleClone = (*module_);
-      trackAndRegisterAttributesInBlocks(
-          n,
-          moduleClone,
-          nextSetAttrValues);
-    } else if (n->kind() == aten::copy_) {
-      PrepareCopyForONNX(n, this);
-      GRAPH_UPDATE("After copy:", graph_->toString());
-    } else if (n->kind() == aten::index_put || n->kind() == aten::index_put_) {
-      PrepareIndexPutForONNX(n, this);
-    } else if (mr_->inplaceOpVariant(n)) {
-      // TODO: not sure the effectiveness of this.
-      //       Since aliasDb is not out of sync with current graph.
-      PrepareInplaceOpsInBlocksForONNX(n, this);
-      GRAPH_UPDATE("After inplace op:", graph_->toString());
-    } else if (n->kind() == aten::pop) {
-      PrepareListPopForONNX(n, this);
-    } else if (n->kind() == aten::insert || n->kind() == aten::append) {
-      GRAPH_UPDATE("Before registering inplace node in blocks");
-      PrintSnapshotForDebug(n);
-      PrepareListAppendAndInsertForONNX(n, this);
-      // Check if input of n is something in setAttrValues, and update it.
-      auto orig_data = n->input(0);
-      GRAPH_UPDATE("orig_data for list append: ", orig_data->debugName());
-      PrintSnapshotForDebug(n);
-      for (auto iter : allAttrValues_) {
-        if (iter.second == orig_data) {
-          auto attr_full_name = iter.first;
-          auto attr_name = attr_full_name.substr(attr_full_name.rfind('.') + 1);
-          // TODO: find module of this value.
-          //       need to create a map for this.
-          auto set_attr_node = graph_->create(prim::SetAttr, {allAttrModules_[attr_full_name], n->output()}, 0);
-          set_attr_node->s_(attr::name, attr_name);
-          set_attr_node->insertAfter(n);
-          break;
-        }
-      }
-    } else if (n->kind() == aten::Delete) {
-      PrepareListDeleteForONNX(n, this);
-    } else if (n->kind() == aten::_set_item) {
-      PrepareListSetItemForONNX(n, this);
-    } else { // for prim::If and prim::Loop nodes with blocks.
-      for (Block* sub_block : n->blocks()) {
-        std::unordered_map<std::string, Value*> map_ =
-            registerInplaceOpAsBlockOutputs(sub_block);
-        std::unordered_map<std::string, Value*>::iterator mapIt;
-        for (mapIt = map_.begin(); mapIt != map_.end(); mapIt++) {
-          setAttrValues_[mapIt->first] = mapIt->second;
-        }
-      }
-    }
-    // printf("after graph: %s\n", n->owningGraph()->toString().c_str());
-  }
-  return nextSetAttrValues;
-}
-
 void InplaceConverter::ValueTracker::init(const std::shared_ptr<Graph>& graph) {
   alias_to_value_ = {};
   value_to_sorted_aliases_ = {};
@@ -1130,18 +385,6 @@ std::string InplaceConverter::ValueTracker::toString() const {
   return ss.str();
 }
 
-std::vector<std::tuple<Value*, Node*, Block*>> InplaceConverter::ValueTracker::sortAliasOfValue(const Value* v) const {
-  std::vector<std::tuple<Value*, Node*, Block*>> res = {};
-
-  // TORCH_INTERNAL_ASSERT(value_to_sorted_aliases_.find(v) != value_to_sorted_aliases.end());
-  // for (auto v : value_to_aliases_[v]) {
-
-  // }
-
-  return res;
-}
-
-// TODO: maybe don't need n, is it true that for all cases n should be just new_v->node()?
 void InplaceConverter::ValueTracker::registerSetValue(Value* old_v, Value* new_v) {
   GRAPH_UPDATE("Calling registerSetValue with old_v: ", old_v->debugName(), " new_v: ", new_v->debugName());
   GRAPH_UPDATE(this->toString());
@@ -1218,32 +461,36 @@ void InplaceConverter::ValueTracker::registerSetValue(Value* old_v, Value* new_v
   GRAPH_UPDATE(this->toString());
 }
 
-void InplaceConverter::ValueTracker::passUpdateValueUse(Block* block) {
-  auto updateValueUse = [this](Node* n) {
-    for (size_t i = 0; i < n->inputs().size(); ++i) {
-      auto* in = n->input(i);
-      auto* alias = this->findAliasForValueAtNode(in, n);
-      if (alias != in) {
-        n->replaceInput(i, alias);
-        GRAPH_UPDATE("Replacing ", in->debugName(), " with ", alias->debugName(), " for ", *n);
-      }
-    }
-  };
+void InplaceConverter::correctAliasReferences() {
+  correctAliasReferences(graph_->block());
+}
 
+void InplaceConverter::correctAliasReferences(Block* block) {
   for (auto it = block->nodes().begin(); it != block->nodes().end();) {
     Node* n = *it;
     it++; // node n can be destroyed
 
-    updateValueUse(n);
+    vt_.updateInputsWithAlias(n);
 
     auto nkind = n->kind();
     if (nkind == prim::If || nkind == prim::Loop) {
       for (auto* sub_block : n->blocks()) {
-        passUpdateValueUse(sub_block);
+        correctAliasReferences(sub_block);
       }
     }
   }
-  updateValueUse(block->return_node());
+  vt_.updateInputsWithAlias(block->return_node());
+}
+
+void InplaceConverter::ValueTracker::updateInputsWithAlias(Node* n) {
+  for (size_t i = 0; i < n->inputs().size(); ++i) {
+    auto* in = n->input(i);
+    auto* alias = findAliasForValueAtNode(in, n);
+    if (alias != in) {
+      n->replaceInput(i, alias);
+      GRAPH_UPDATE("Replacing ", in->debugName(), " with ", alias->debugName(), " for ", *n);
+    }
+  }
 }
 
 Value* InplaceConverter::ValueTracker::findAliasForValueAtNode(Value* v, const Node* n) const {
@@ -1278,6 +525,7 @@ Value* InplaceConverter::ValueTracker::findAliasForValueAtNode(Value* v, const N
     }
   }
 
+  // TODO: add error & exception handling.
   TORCH_INTERNAL_ASSERT(nullptr != found_alias);
 
   return found_alias;
@@ -1343,6 +591,7 @@ void InplaceConverter::gatherAttrNameInitialValueMap(
     }
 
     // Create dummy initial value.
+    // TODO: Add error and exception handling for these cases. Not repro-ed yet.
     if (attr_name_value_map.find(fullName) == attr_name_value_map.end()) {
       auto* noneNode = graph_->create(prim::Constant);
       noneNode->output()->setType(NoneType::get());
@@ -1365,11 +614,8 @@ void InplaceConverter::replaceAttrWithInplaceOps(Block* block,
 
     TORCH_INTERNAL_ASSERT(n->kind() == prim::GetAttr || n->kind() == prim::SetAttr);
     if (n->kind() == prim::SetAttr) {
-      // auto* copyNode = graph_->create(aten::copy_, 1);
-      // WithInsertPoint guard(graph_->nodes().front());
-      // auto false_val_ = graph_->insertConstant(false);
-
-      // NOTE: directly create index_put_ to avoid expanding for copy_.
+      // Convert SetAttr to inplace op.
+      // Directly convert to index_put_ instead of copy_, since we know expand is not required for value.
       WithInsertPoint guard(n);
       auto false_val_ = graph_->insertConstant(false);
       auto dummy_list =
@@ -1382,17 +628,10 @@ void InplaceConverter::replaceAttrWithInplaceOps(Block* block,
       index_put_node->addInput(n->input(1));
       index_put_node->addInput(false_val_);
       index_put_node->setSourceRange(n->sourceRange());
-
       index_put_node->insertBefore(n);
-
-
-      // copyNode->addInput(find_init_val->second);
-      // copyNode->addInput(n->input(1));
-      // copyNode->addInput(false_val_);
-      // copyNode->insertBefore(n);
-      // copyNode->setSourceRange(n->sourceRange());
-    } else {
-      // prim::GetAttr
+    } else if (n->kind() == prim::GetAttr) {
+      // Replace use of GetAttr with first seen alias (usually initial value) of that particular value.
+      // Correct alias at point of this node will be discovered and assigned in later pass.
       n->output()->replaceAllUsesWith(find_init_val->second);
     }
 
@@ -1413,24 +652,9 @@ void InplaceConverter::convertGetSetAttrToInplaceOps(Block* block) {
   GRAPH_UPDATE("Graph after gatherAttrNameInitialValueMap", graph_->toString());
 
   // Second pass over graph,
-  // replace GetAttr with initial value,
-  // and replace SetAttr with aten::copy_(initial_value, new_value)
+  // replace GetAttr with first seen alias (usually initial value),
+  // and replace SetAttr with inplace op, updating new value onto first seen alias.
   replaceAttrWithInplaceOps(block, attr_name_value_map, attr_node_fullname_map);
-}
-
-
-
-// Register Inplace Ops As Block Outputs
-// Inplace operations like aten::copy_ or aten::append that are inside
-// sub-blocks would require the output of the operation to be captured
-// as sub-block output, so that the inplace operation would be visible
-// to the outer block.
-// We also consider setAttr node an inplace op, and handle those
-// similarly by tracking the output as sub-block outputs.
-void InplaceConverter::RegisterInplaceOpAsBlockOutputs() {
-  convertGetSetAttrToInplaceOps(graph_->block());
-  GRAPH_UPDATE("Graph after convertGetSetAttrToInplaceOps", graph_->toString());
-  registerInplaceOpAsBlockOutputs(graph_->block());
 }
 
 void InplaceConverter::convertInplaceOps(Block* block) {
@@ -1472,8 +696,6 @@ void InplaceConverter::convertInplaceOps(Block* block) {
       std::tie(orig_data, new_out) = PrepareListSetItemForONNX(n);
       vt_.registerSetValue(orig_data, new_out);
     } else { // for prim::If and prim::Loop nodes with blocks.
-      // All outputs are replacing some outer values.
-      // For those already captured, it implies that new values are assigned to the alias.
       for (Block* sub_block : n->blocks()) {
         convertInplaceOps(sub_block);
       }
@@ -1492,7 +714,7 @@ void InplaceConverter::convertMutationForONNX() {
   GRAPH_UPDATE("Graph after convertGetSetAttrToInplaceOps", graph_->toString());
   vt_.init(graph_);
   convertInplaceOps();
-  vt_.passUpdateValueUse(graph_->block());
+  correctAliasReferences();
 }
 
 } // namespace

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -256,6 +256,9 @@ def __getitem_(g, self, i):
         from torch.onnx.symbolic_opset9 import __getitem_ as getitem
         return getitem(g, self, i)
 
+def _set_item(g, tensor_list, i, v):
+    tensor_list = g.op("SequenceErase", tensor_list, i)
+    return g.op("SequenceInsert", tensor_list, v, i)
 
 def append(g, self, tensor):
     return g.op("SequenceInsert", self, tensor)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1611,11 +1611,6 @@ def min(g, self, dim_or_y=None, keepdim=None):
         return min, indices
 
 
-def prim_min(g, self):
-    ten = stack(g, self, g.op("Constant", value_t=torch.tensor([0])))
-    return min(g, ten)
-
-
 def exp(g, self):
     return g.op("Exp", self)
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1111,6 +1111,10 @@ def wrap_logical_op_with_negation(func):
     return wrap_with_not
 
 
+def __not_(g, self):
+    return g.op("Not", self)
+
+
 def eq(g, self, other):
     return g.op("Equal", self, other)
 
@@ -1594,6 +1598,11 @@ def min(g, self, dim_or_y=None, keepdim=None):
         min = g.op("ReduceMin", self, axes_i=[dim], keepdims_i=keepdim)
         indices = g.op('ArgMin', self, axis_i=dim, keepdims_i=keepdim)
         return min, indices
+
+
+def prim_min(g, self):
+    ten = stack(g, self, g.op("Constant", value_t=torch.tensor([0])))
+    return min(g, ten)
 
 
 def exp(g, self):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1463,10 +1463,21 @@ def index_select(g, self, dim, index):
 
 
 def index_put(g, self, indices_list_value, values, accumulate):
-    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
+    if sym_help._is_packed_list(indices_list_value):
         indices_list = sym_help._unpack_list(indices_list_value)
+    else:
+        indices_list = [indices_list_value]
+    if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         args = [self] + indices_list + [values, accumulate]
         return g.op("ATen", *args, operator_s='index_put')
+
+    accumulate = sym_help._parse_arg(accumulate, 'b')
+
+    if len(indices_list) == 0:
+        if accumulate:
+            return add(g, self, values)
+        else:
+            return values
     else:
         sym_help._onnx_opset_unsupported('index_put', 9, 11)
 


### PR DESCRIPTION
* Create `InplaceConverter` and `ValueTracker` to keep track of aliases of values throughout the graph. For a given value, a new alias is created every time when there is an inplace operation, SetAttr, or through nested blocks owned by If/Loop nodes.
* Fix bug where controlflow node output types are not set, when the complete node is unable to run ONNX shape inference due to containing non-onnx node. 
* Add symbolic for `__not__` ~~and `prim_min`~~(update: moved to a separate PR), and update `index_put` opset9 to support case of assignment without providing indices. 
* Bump ORT version in CI test.