### PR TITLE
[Doc]fix torch.ceil formula issue(pytorch#54948)

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1550,7 +1550,7 @@ Returns a new tensor with the ceil of the elements of :attr:`input`,
 the smallest integer greater than or equal to each element.
 
 .. math::
-    \text{out}_{i} = \left\lceil \text{input}_{i} \right\rceil = \left\lfloor \text{input}_{i} \right\rfloor + 1
+    \text{out}_{i} = \left\lceil \text{input}_{i} \right\rceil
 """ + r"""
 Args:
     {input}


### PR DESCRIPTION
Fixes wrong formula #54948
The new one is
<img width="157" alt="截屏2021-03-31 下午5 25 59" src="https://user-images.githubusercontent.com/32546978/113124411-14407000-9248-11eb-92f6-7b47b4cfd5e4.png">
