### PR TITLE
[ONNX] Update instance_norm2 symbolic to handle track_running_stats=True

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3109,51 +3109,51 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, x)
 
     def test_instancenorm1d_runningstats(self):
-        x = torch.randn(20, 100, 40)
-        model = torch.nn.InstanceNorm1d(100, affine=True, track_running_stats=True)
+        x = torch.randn(10, 5, 128)
+        model = torch.nn.InstanceNorm1d(5, affine=True, track_running_stats=True)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm1d(100, affine=False, track_running_stats=True)
+        model = torch.nn.InstanceNorm1d(5, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
     def test_instancenorm1d_norunningstats(self):
-        x = torch.randn(20, 100, 40)
-        model = torch.nn.InstanceNorm1d(100, affine=True, track_running_stats=False)
+        x = torch.randn(10, 5, 128)
+        model = torch.nn.InstanceNorm1d(5, affine=True, track_running_stats=False)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm1d(100, affine=False, track_running_stats=False)
+        model = torch.nn.InstanceNorm1d(5, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
     def test_instancenorm2d_runningstats(self):
-        x = torch.randn(20, 100, 35, 45)
-        model = torch.nn.InstanceNorm2d(100, affine=True, track_running_stats=True)
+        x = torch.randn(10, 3, 128, 128)
+        model = torch.nn.InstanceNorm2d(3, affine=True, track_running_stats=True)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm2d(100, affine=False, track_running_stats=True)
+        model = torch.nn.InstanceNorm2d(3, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
     def test_instancenorm2d_norunningstats(self):
-        x = torch.randn(20, 100, 35, 45)
-        model = torch.nn.InstanceNorm2d(100, affine=True, track_running_stats=False)
+        x = torch.randn(10, 3, 128, 128)
+        model = torch.nn.InstanceNorm2d(3, affine=True, track_running_stats=False)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm2d(100, affine=False, track_running_stats=False)
+        model = torch.nn.InstanceNorm2d(3, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
     def test_instancenorm3d_runningstats(self):
-        x = torch.randn(20, 100, 35, 45, 10)
-        model = torch.nn.InstanceNorm3d(100, affine=True, track_running_stats=True)
+        x = torch.randn(10, 3, 128, 128, 128)
+        model = torch.nn.InstanceNorm3d(3, affine=True, track_running_stats=True)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm3d(100, affine=False, track_running_stats=True)
+        model = torch.nn.InstanceNorm3d(3, affine=False, track_running_stats=True)
         self.run_test(model, x)
 
     def test_instancenorm3d_norunningstats(self):
-        x = torch.randn(20, 100, 35, 45, 10)
-        model = torch.nn.InstanceNorm3d(100, affine=True, track_running_stats=False)
+        x = torch.randn(10, 3, 128, 128, 128)
+        model = torch.nn.InstanceNorm3d(3, affine=True, track_running_stats=False)
         self.run_test(model, x)
 
-        model = torch.nn.InstanceNorm3d(100, affine=False, track_running_stats=False)
+        model = torch.nn.InstanceNorm3d(3, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
     @skipIfUnsupportedMinOpsetVersion(9)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -82,7 +82,6 @@ def run_ort(ort_sess, input):
 
 
 def ort_compare_with_pytorch(ort_outs, output, rtol, atol):
-    # print("pytorch output:", output, "\nort_outs:", ort_outs)
     output, _ = torch.jit._flatten(output)
     outputs = [to_numpy(outp) for outp in output]
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -82,6 +82,7 @@ def run_ort(ort_sess, input):
 
 
 def ort_compare_with_pytorch(ort_outs, output, rtol, atol):
+    # print("pytorch output:", output, "\nort_outs:", ort_outs)
     output, _ = torch.jit._flatten(output)
     outputs = [to_numpy(outp) for outp in output]
 
@@ -3106,6 +3107,54 @@ class TestONNXRuntime(unittest.TestCase):
     def test_batchnorm3d_noaffine(self):
         x = torch.randn(10, 3, 128, 128, 128)
         model = torch.nn.BatchNorm3d(3, affine=False)
+        self.run_test(model, x)
+
+    def test_instancenorm1d_runningstats(self):
+        x = torch.randn(20, 100, 40)
+        model = torch.nn.InstanceNorm1d(100, affine=True, track_running_stats=True)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm1d(100, affine=False, track_running_stats=True)
+        self.run_test(model, x)
+
+    def test_instancenorm1d_norunningstats(self):
+        x = torch.randn(20, 100, 40)
+        model = torch.nn.InstanceNorm1d(100, affine=True, track_running_stats=False)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm1d(100, affine=False, track_running_stats=False)
+        self.run_test(model, x)
+
+    def test_instancenorm2d_runningstats(self):
+        x = torch.randn(20, 100, 35, 45)
+        model = torch.nn.InstanceNorm2d(100, affine=True, track_running_stats=True)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm2d(100, affine=False, track_running_stats=True)
+        self.run_test(model, x)
+
+    def test_instancenorm2d_norunningstats(self):
+        x = torch.randn(20, 100, 35, 45)
+        model = torch.nn.InstanceNorm2d(100, affine=True, track_running_stats=False)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm2d(100, affine=False, track_running_stats=False)
+        self.run_test(model, x)
+
+    def test_instancenorm3d_runningstats(self):
+        x = torch.randn(20, 100, 35, 45, 10)
+        model = torch.nn.InstanceNorm3d(100, affine=True, track_running_stats=True)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm3d(100, affine=False, track_running_stats=True)
+        self.run_test(model, x)
+
+    def test_instancenorm3d_norunningstats(self):
+        x = torch.randn(20, 100, 35, 45, 10)
+        model = torch.nn.InstanceNorm3d(100, affine=True, track_running_stats=False)
+        self.run_test(model, x)
+
+        model = torch.nn.InstanceNorm3d(100, affine=False, track_running_stats=False)
         self.run_test(model, x)
 
     @skipIfUnsupportedMinOpsetVersion(9)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1421,6 +1421,8 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
             bias = g.op("Constant", value_t=bias_value)
         return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
     else:
+        # Now if track_running_stats is set to True it would get the same result with batchnorm. The PyTorch internal
+        # implementation of instance_norm may have a problem with running_mean and running_var repeat, will open a github issue.
         return batch_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled)
 
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1408,14 +1408,14 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
         if weight is None or sym_help._is_none(weight):
             if channel_size is None:
                 raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                                'channel size.')
+                                   'channel size.')
             weight_value = torch.tensor([1.] * channel_size).type(
                 'torch.' + input.type().scalarType() + 'Tensor')
             weight = g.op("Constant", value_t=weight_value)
         if bias is None or sym_help._is_none(bias):
             if channel_size is None:
                 raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                                'channel size.')
+                                   'channel size.')
             bias_value = torch.tensor([0.] * channel_size).type(
                 'torch.' + input.type().scalarType() + 'Tensor')
             bias = g.op("Constant", value_t=bias_value)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1403,22 +1403,25 @@ def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
 
 @parse_args('v', 'v', 'v', 'v', 'v', 'i', 'f', 'f', 'i')
 def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled):
-    channel_size = sym_help._get_tensor_dim_size(input, 1)
-    if weight is None or sym_help._is_none(weight):
-        if channel_size is None:
-            raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                               'channel size.')
-        weight_value = torch.tensor([1.] * channel_size).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
-        weight = g.op("Constant", value_t=weight_value)
-    if bias is None or sym_help._is_none(bias):
-        if channel_size is None:
-            raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                               'channel size.')
-        bias_value = torch.tensor([0.] * channel_size).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
-        bias = g.op("Constant", value_t=bias_value)
-    return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
+    if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
+        channel_size = sym_help._get_tensor_dim_size(input, 1)
+        if weight is None or sym_help._is_none(weight):
+            if channel_size is None:
+                raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
+                                'channel size.')
+            weight_value = torch.tensor([1.] * channel_size).type(
+                'torch.' + input.type().scalarType() + 'Tensor')
+            weight = g.op("Constant", value_t=weight_value)
+        if bias is None or sym_help._is_none(bias):
+            if channel_size is None:
+                raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
+                                'channel size.')
+            bias_value = torch.tensor([0.] * channel_size).type(
+                'torch.' + input.type().scalarType() + 'Tensor')
+            bias = g.op("Constant", value_t=bias_value)
+        return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
+    else:
+        return batch_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled)
 
 
 @parse_args('v', 'i', 'i', 'i')


### PR DESCRIPTION
Fixes [#53887](https://github.com/pytorch/pytorch/issues/53887)
Not input calling running_mean and running_var when track_running_stats=True
