### PR TITLE
[PyTorch] Remove outdated C++11 note on C10_DEPRECATED

### DIFF
--- a/c10/util/Deprecated.h
+++ b/c10/util/Deprecated.h
@@ -15,10 +15,6 @@
 //      ...
 //    };
 
-// NB: In PyTorch, this block is not actually used at the moment
-// because we are C++11.  However, aspirationally, we would like
-// to use this version, because as of C++14 it is the correct and
-// portable way to declare something deprecated.
 // NB: __cplusplus doesn't work for MSVC, so for now MSVC always uses
 // the "__declspec(deprecated)" implementation and not the C++14 "[[deprecated]]"
 // attribute. We tried enabling "[[deprecated]]" for C++14 on MSVC, but


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55065 [PyTorch] expand_inplace_v2 with MaybeOwned<Tensor> and no 1-ary tuples
* **#55061 [PyTorch] Remove outdated C++11 note on C10_DEPRECATED**
* #55020 [PyTorch] Use sizes indexing in addmm when known not to wrap
* #55016 [PyTorch] Use DimVector for inputs to as_strided that don't grow dim

We're C++14.

Differential Revision: [D27467852](https://our.internmc.facebook.com/intern/diff/D27467852/)