### PR TITLE
c10/util/thread_name.cpp: pthread_setname_np requires Glibc 2.12

### DIFF
--- a/c10/util/thread_name.cpp
+++ b/c10/util/thread_name.cpp
@@ -2,7 +2,11 @@
 
 #include <algorithm>
 
-#if defined(__GLIBC__) && !defined(__APPLE__) && !defined(__ANDROID__)
+#ifndef __GLIBC_PREREQ
+# define __GLIBC_PREREQ(x,y) 0
+#endif
+
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 12) && !defined(__APPLE__) && !defined(__ANDROID__)
 #define C10_HAS_PTHREAD_SETNAME_NP
 #endif
 


### PR DESCRIPTION
`pthread_setname_np` requires Glibc 2.12. The patch reproduces what numactl does: https://github.com/numactl/numactl/blob/93867c59b0bb29470873a427dc7f06ebaf305221/syscall.c#L132-L136

Related to issue #23482 and the `pthread_setname_np.patch` patch that @adamjstewart shared.