### PR TITLE
Replace torch.chain_matmul calls to torch.linalg.multi_dot

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -465,7 +465,7 @@ class TestAutograd(TestCase):
         s.abs_().clamp_(0.0001)
         for sign in (-1, 1):
             s[-1] = sign
-            mat = torch.chain_matmul(u, s.diag(), v.t()).requires_grad_()
+            mat = torch.linalg.multi_dot([u, s.diag(), v.t()]).requires_grad_()
             gradcheck(sign_mul_logdet, mat)
             gradgradcheck(sign_mul_logdet, mat)
 

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -108,7 +108,7 @@ class SpectralNorm:
         # Tries to returns a vector `v` s.t. `u = normalize(W @ v)`
         # (the invariant at top of this class) and `u @ W @ v = sigma`.
         # This uses pinverse in case W^T W is not invertible.
-        v = torch.chain_matmul(weight_mat.t().mm(weight_mat).pinverse(), weight_mat.t(), u.unsqueeze(1)).squeeze(1)
+        v = torch.linalg.multi_dot([weight_mat.t().mm(weight_mat).pinverse(), weight_mat.t(), u.unsqueeze(1)]).squeeze(1)
         return v.mul_(target_sigma / torch.dot(u, torch.mv(weight_mat, v)))
 
     @staticmethod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55064 Replace torch.chain_matmul calls to torch.linalg.multi_dot**
* #53453 Deprecate torch.chain_matmul in favor of torch.linalg.multi_dot
* #52859 [Relanding] Implemented torch.linalg.multi_dot

Differential Revision: [D27469261](https://our.internmc.facebook.com/intern/diff/D27469261)