### PR TITLE
[android] fbjni from prefab dependency 0.2.2

### DIFF
--- a/.circleci/docker/android/build.gradle
+++ b/.circleci/docker/android/build.gradle
@@ -51,7 +51,8 @@ android {
 dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
+    implementation 'com.facebook.fbjni:fbjni-java-only:0.2.2'
+    implementation 'com.facebook.fbjni:fbjni:0.2.2'
     implementation 'com.google.code.findbugs:jsr305:3.0.1'
     implementation 'com.facebook.soloader:nativeloader:0.8.0'
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ allprojects {
             junitVersion = "4.12"
 
             androidSupportAppCompatV7Version = "28.0.0"
-            fbjniJavaOnlyVersion = "0.0.3"
-            soLoaderNativeLoaderVersion = "0.8.0"
+            fbjniVersion = "0.2.2"
+            soLoaderNativeLoaderVersion = "0.10.1"
         }
 
         repositories {

--- a/android/pytorch_android/CMakeLists.txt
+++ b/android/pytorch_android/CMakeLists.txt
@@ -86,10 +86,6 @@ target_compile_options(${PYTORCH_JNI_TARGET} PRIVATE
 target_include_directories(${PYTORCH_JNI_TARGET} BEFORE
 PUBLIC $<BUILD_INTERFACE:${libtorch_include_DIR}>)
 
-set(fbjni_DIR ${CMAKE_CURRENT_LIST_DIR}/../libs/fbjni/)
-set(fbjni_BUILD_DIR ${CMAKE_BINARY_DIR}/fbjni/${BUILD_SUBDIR})
-
-add_subdirectory(${fbjni_DIR} ${fbjni_BUILD_DIR})
 
 # ---[ Vulkan deps
 if(USE_VULKAN)
@@ -99,6 +95,9 @@ if(USE_VULKAN)
 endif()
 
 if(ANDROID_ABI)
+  set(build_DIR ${CMAKE_SOURCE_DIR}/build)
+  find_package(fbjni REQUIRED CONFIG)
+
   function(import_static_lib name)
     add_library(${name} STATIC IMPORTED)
     set_property(
@@ -120,7 +119,7 @@ if(ANDROID_ABI)
 
   # Link most things statically on Android.
   set(pytorch_jni_LIBS
-      fbjni
+      fbjni::fbjni
       -Wl,--gc-sections
       -Wl,--whole-archive
       libtorch
@@ -134,8 +133,14 @@ if(ANDROID_ABI)
       libeigen_blas
       libcpuinfo
       libclog
+      android
+      log
   )
 else()
+  set(fbjni_DIR ${CMAKE_CURRENT_LIST_DIR}/../libs/fbjni/)
+  set(fbjni_BUILD_DIR ${CMAKE_BINARY_DIR}/fbjni/${BUILD_SUBDIR})
+  add_subdirectory(${fbjni_DIR} ${fbjni_BUILD_DIR})
+
   # Prefer dynamic linking on the host
   set(pytorch_jni_LIBS
       fbjni

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -34,6 +34,9 @@ android {
             minifyEnabled false
         }
     }
+    buildFeatures {
+        prefab true
+    }
     sourceSets {
         main {
             java {
@@ -73,7 +76,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.fbjni:fbjni-java-only:' + rootProject.fbjniJavaOnlyVersion
+    implementation 'com.facebook.fbjni:fbjni:' + rootProject.fbjniVersion
     implementation 'com.android.support:appcompat-v7:' + rootProject.androidSupportAppCompatV7Version
     implementation 'com.facebook.soloader:nativeloader:' + rootProject.soLoaderNativeLoaderVersion
 

--- a/android/pytorch_android/host/build.gradle
+++ b/android/pytorch_android/host/build.gradle
@@ -32,8 +32,8 @@ sourceSets {
 
 dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
-    implementation 'com.facebook.soloader:nativeloader:0.8.0'
-    implementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
+    implementation 'com.facebook.soloader:nativeloader:0.10.1'
+    implementation 'com.facebook.fbjni:fbjni-java-only:0.2.2'
     testImplementation 'junit:junit:4.12'
 }
 

--- a/android/test_app/app/build.gradle
+++ b/android/test_app/app/build.gradle
@@ -112,6 +112,7 @@ android {
         }
     }
     packagingOptions {
+        pickFirst '**/*.so'
         doNotStrip '**.so'
     }
 
@@ -139,7 +140,7 @@ tasks.all { task ->
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.facebook.soloader:nativeloader:0.8.0'
+    implementation 'com.facebook.soloader:nativeloader:0.10.1'
 
     localImplementation project(':pytorch_android')
     localImplementation project(':pytorch_android_torchvision')
@@ -154,8 +155,7 @@ dependencies {
 
     aarImplementation(name:'pytorch_android', ext:'aar')
     aarImplementation(name:'pytorch_android_torchvision', ext:'aar')
-    aarImplementation 'com.facebook.soloader:nativeloader:0.8.0'
-    aarImplementation 'com.facebook.fbjni:fbjni-java-only:0.0.3'
+    aarImplementation 'com.facebook.fbjni:fbjni-java-only:0.2.2'
 
     def camerax_version = "1.0.0-alpha05"
     cameraImplementation "androidx.camera:camera-core:$camerax_version"


### PR DESCRIPTION
Switching pytorch android to use fbjni from prefab dependencies
Bumping version of fbjni to 0.2.2
soloader version to 0.10.1