### PR TITLE
[ROCm] if TEST_WITH_ROCM, only instantiate GPU device tests

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -486,6 +486,9 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
             continue
         if only_for is not None and base.device_type not in only_for:
             continue
+        # Special-case for ROCm testing -- only test for 'cuda' i.e. ROCm device by default
+        if TEST_WITH_ROCM and except_for is None and only_for is None and base.device_type != 'cuda':
+            continue
 
         class_name = generic_test_class.__name__ + base.device_type.upper()
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -487,7 +487,8 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
         if only_for is not None and base.device_type not in only_for:
             continue
         # Special-case for ROCm testing -- only test for 'cuda' i.e. ROCm device by default
-        if TEST_WITH_ROCM and except_for is None and only_for is None and base.device_type != 'cuda':
+        # The except_for and only_for cases were already checked above. At this point we only need to check 'cuda'.
+        if TEST_WITH_ROCM and base.device_type != 'cuda':
             continue
 
         class_name = generic_test_class.__name__ + base.device_type.upper()


### PR DESCRIPTION
Improves ROCm CI throughput by instantiating only for device tests that exercise the AMD GPU devices.