### PR TITLE
ns for fx: clean up debug print statements

### DIFF
--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -7,7 +7,6 @@ from torch.quantization.fx.utils import get_new_attr_name_with_prefix
 from .utils import (
     get_node_first_input_and_output_type,
     getattr_from_fqn,
-    print_node,
     NodeInputOrOutputType,
     return_first_non_observer_node,
     get_number_of_non_param_args,
@@ -44,7 +43,6 @@ def _insert_logger_after_node(
     # create new name
     logger_node_name = \
         get_new_attr_name_with_prefix(node.name + logger_node_name_suffix)(gm)
-    # print('node.name', node.name, 'suffix', logger_node_name_suffix, 'new name', logger_node_name)
     # create a string representation of the node's target type
     target_type = ''
     if node.op == 'call_function':
@@ -458,13 +456,6 @@ def create_a_shadows_b(
                 assert node_b_is_end_node
                 subgraph_a, ref_name = \
                     end_node_b_to_matched_subgraph_a_and_name[node_b]
-
-            if False:
-                print('b')
-                print_node(node_b)
-                print('a')
-                print_node(subgraph_a.start_node)
-                print_node(subgraph_a.end_node)
 
             if node_b_is_start_node:
 

--- a/torch/quantization/ns/utils.py
+++ b/torch/quantization/ns/utils.py
@@ -6,16 +6,7 @@ from torch.fx import GraphModule
 from torch.fx.graph import Node
 from torch.quantization.fx.quantize import is_activation_post_process
 
-from typing import Optional, Any, Tuple, Callable
-
-# TODO(future PR): delete this after FX has a util for it
-def print_node(node: Optional[Node]) -> None:
-    if node is None:
-        print(None)
-    else:
-        print(
-            node, ', target:', node.target, ', op:', node.op,
-            ', args:', node.args, ', kwargs:', node.kwargs)
+from typing import Any, Tuple, Callable
 
 def getattr_from_fqn(gm: GraphModule, fqn: str) -> Any:
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55155 ns for fx: rename SugraphTypeRelationship to SubgraphTypeRelationship
* #55154 ns for fx: add allowlist for ops with same signature across dtypes
* #55080 ns for fx: add linear-relu mod weight extraction
* #55079 ns for fx: weight extaction for conv1d and conv3d
* #55078 ns for fx: ensure kwargs are handled when graph matching
* **#55077 ns for fx: clean up debug print statements**
* #55060 ns for fx: move it to top level file
* #54335 ns for fx: weight extraction for nni.ConvReLU2d
* #54327 ns for fx: make shadow input logging work for multi node subgraphs
* #54326 ns for fx: make input logging work for multi-node subgraphs
* #54280 ns for fx: refactor test cases
* #54275 ns for fx: add support for shadowing linear fp16 patterns

Summary:

Deletes debugging prints from the code, no logic change.

Test Plan:

CI

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27474700](https://our.internmc.facebook.com/intern/diff/D27474700)