### PR TITLE
ns for fx: ensure kwargs are handled when graph matching

### DIFF
--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -284,8 +284,7 @@ class _NSGraphMatchableSubgraphsIterator:
 
             self.seen_nodes.add(cur_start_node)
             # add args of previous nodes to stack
-            # TODO(future PR): handle kwargs as needed
-            for arg in cur_start_node.args:
+            for arg in cur_start_node.all_input_nodes:
                 self._recursively_add_node_arg_to_stack(arg)
 
             # skip observers, etc


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55155 ns for fx: rename SugraphTypeRelationship to SubgraphTypeRelationship
* #55154 ns for fx: add allowlist for ops with same signature across dtypes
* #55080 ns for fx: add linear-relu mod weight extraction
* #55079 ns for fx: weight extaction for conv1d and conv3d
* **#55078 ns for fx: ensure kwargs are handled when graph matching**
* #55077 ns for fx: clean up debug print statements
* #55060 ns for fx: move it to top level file
* #54335 ns for fx: weight extraction for nni.ConvReLU2d
* #54327 ns for fx: make shadow input logging work for multi node subgraphs
* #54326 ns for fx: make input logging work for multi-node subgraphs
* #54280 ns for fx: refactor test cases
* #54275 ns for fx: add support for shadowing linear fp16 patterns

Summary:

Fixes a TODO, make sure we iterate through kwargs as well as args
when navigating graphs.  We can use `node.all_input_nodes` convenience
property to accomplish this.

Test Plan:

```
python test/test_quantization.py TestFXGraphMatcher
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27474699](https://our.internmc.facebook.com/intern/diff/D27474699)