### PR TITLE
ns for fx: weight extaction for conv1d and conv3d

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -407,13 +407,42 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
     @skipIfNoFBGEMM
     def test_extract_weights_mod(self):
-        m = nn.Sequential(
-            nn.Conv2d(1, 1, 1),
-            nn.Conv2d(1, 1, 1),
-            nn.Conv2d(1, 1, 1),
-            nn.ReLU(),
-        ).eval()
-        self._test_extract_weights(m, results_len=3)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                # conv1d
+                self.conv1d_0 = nn.Conv1d(1, 1, 1)
+                # conv1d - relu
+                self.conv1d_1 = nn.Conv1d(1, 1, 1)
+                self.relu_0 = nn.ReLU()
+                # conv2d
+                self.conv2d_0 = nn.Conv2d(1, 1, 1)
+                # conv2d - relu
+                self.conv2d_1 = nn.Conv2d(1, 1, 1)
+                self.relu_1 = nn.ReLU()
+                # conv3d
+                self.conv3d_0 = nn.Conv3d(1, 1, 1)
+                # conv3d - relu
+                self.conv3d_1 = nn.Conv3d(1, 1, 1)
+                self.relu_2 = nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv1d_0(x)
+                x = self.conv1d_1(x)
+                x = self.relu_0(x)
+                x = x.reshape(1, 1, 1, 1)
+                x = self.conv2d_0(x)
+                x = self.conv2d_1(x)
+                x = self.relu_1(x)
+                x = x.reshape(1, 1, 1, 1, 1)
+                x = self.conv3d_0(x)
+                x = self.conv3d_1(x)
+                x = self.relu_2(x)
+                return x
+
+        m = M().eval()
+        self._test_extract_weights(m, results_len=6)
 
     @skipIfNoFBGEMM
     def test_extract_weights_fun(self):

--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -195,15 +195,19 @@ def _extract_weights_one_model(
             # check that A is one the modules we need
             # assume B is related (this is done by graph matcher)
             # TODO(future PR): 1d and 3d convs
+            related_to_conv1d_mod = isinstance(mod, nn.Conv1d) or \
+                (type(mod), nn.Conv1d) in type_a_related_to_b
             related_to_conv2d_mod = isinstance(mod, nn.Conv2d) or \
                 (type(mod), nn.Conv2d) in type_a_related_to_b
+            related_to_conv3d_mod = isinstance(mod, nn.Conv3d) or \
+                (type(mod), nn.Conv3d) in type_a_related_to_b
             related_to_linear_mod = isinstance(mod, nn.Linear) or \
                 (type(mod), nn.Linear) in type_a_related_to_b
             related_to_lstm_mod = isinstance(mod, nn.LSTM) or \
                 (type(mod), nn.LSTM) in type_a_related_to_b
 
             # TODO(future PR): other module types
-            if related_to_conv2d_mod:
+            if related_to_conv1d_mod or related_to_conv2d_mod or related_to_conv3d_mod:
                 weights = [get_conv_mod_weight(mod)]
             elif related_to_lstm_mod:
                 weights = get_lstm_mod_weights(mod)

--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -26,15 +26,28 @@ def _get_output_nodes(g: Graph) -> List[Node]:
 def get_base_name_to_sets_of_related_ops() -> Dict[str, Set[Callable]]:
     base_name_to_sets_of_related_ops: Dict[str, Set[Callable]] = {
         # conv modules
+        'torch.nn.Conv1d': set([
+            nn.Conv1d,
+            nnq.Conv1d,
+            nniqat.ConvBn1d,
+            nniq.ConvReLU1d,
+            nni.ConvReLU1d,
+        ]),
         'torch.nn.Conv2d': set([
             nn.Conv2d,
             nnq.Conv2d,
             nnqat.Conv2d,
-            # Note: matching weights may not work with nniqat.ConvBn2d directly
-            # leaving that as a problem for a future PR to solve.
             nniqat.ConvBn2d,
             nniq.ConvReLU2d,
             nni.ConvReLU2d,
+        ]),
+        'torch.nn.Conv3d': set([
+            nn.Conv3d,
+            nnq.Conv3d,
+            nnqat.Conv3d,
+            nniqat.ConvBn3d,
+            nniq.ConvReLU3d,
+            nni.ConvReLU3d,
         ]),
         # linear modules
         'torch.nn.Linear': set([
@@ -137,7 +150,9 @@ def get_reversed_fusions() -> Set[Tuple[NSFusionType, int]]:
     # and reuse either quantization's syntax or something else.
     return set([
         ((F.relu, F.linear), 0),
+        ((nn.ReLU, nn.Conv1d), 0),
         ((nn.ReLU, nn.Conv2d), 0),
+        ((nn.ReLU, nn.Conv3d), 0),
         # linear-relu fp16 emulation:
         # fp16_to_fp32 -> linear -> relu -> fp32_to_fp16
         ((("to", torch.float16), F.relu, F.linear, "dequantize"), 1),

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -12,10 +12,18 @@ from .utils import getattr_from_fqn
 from typing import List
 
 def get_conv_mod_weight(mod: nn.Module) -> torch.Tensor:
-    # TODO(future PR): make more generic, handle everything
-    if isinstance(mod, nn.Conv2d):
+    # TODO(future PR): handle QAT variants
+    if (
+        isinstance(mod, nn.Conv1d) or
+        isinstance(mod, nn.Conv2d) or
+        isinstance(mod, nn.Conv3d)
+    ):
         return mod.weight.detach()
-    elif isinstance(mod, nni.ConvReLU2d):
+    elif (
+        isinstance(mod, nni.ConvReLU1d) or
+        isinstance(mod, nni.ConvReLU2d) or
+        isinstance(mod, nni.ConvReLU3d)
+    ):
         return mod[0].weight.detach()
     else:
         return mod._weight_bias()[0]  # type: ignore


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55155 ns for fx: rename SugraphTypeRelationship to SubgraphTypeRelationship
* #55154 ns for fx: add allowlist for ops with same signature across dtypes
* #55080 ns for fx: add linear-relu mod weight extraction
* **#55079 ns for fx: weight extaction for conv1d and conv3d**
* #55078 ns for fx: ensure kwargs are handled when graph matching
* #55077 ns for fx: clean up debug print statements
* #55060 ns for fx: move it to top level file
* #54335 ns for fx: weight extraction for nni.ConvReLU2d
* #54327 ns for fx: make shadow input logging work for multi node subgraphs
* #54326 ns for fx: make input logging work for multi-node subgraphs
* #54280 ns for fx: refactor test cases
* #54275 ns for fx: add support for shadowing linear fp16 patterns

Summary:

Extends weight extraction to conv1d and conv3d.

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27474696](https://our.internmc.facebook.com/intern/diff/D27474696)