### PR TITLE
[static runtime] fix out variant for 4bit embedding bag

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -685,33 +685,6 @@ Tensor& embedding_bag_byte_rowwise_offsets_out(
       false /* is_embedding_op */);
 }
 
-namespace {
-
-Tensor embedding_bag_byte_rowwise_offsets(
-    const Tensor& weight,
-    const Tensor& indices,
-    const c10::optional<Tensor>& offsets_in,
-    const bool /* scale_grad_by_freq */,
-    const int64_t /* mode */,
-    bool pruned_weights,
-    const c10::optional<Tensor>& per_sample_weights_,
-    const c10::optional<Tensor>& compressed_indices_mapping,
-    bool include_last_offset) {
-  auto output = at::empty({0}, weight.options().dtype(at::kFloat));
-  embedding_bag_byte_rowwise_offsets_out(
-      output,
-      weight,
-      indices,
-      offsets_in,
-      false /*unused scale_grad_by_freq*/,
-      0 /*unused mode*/,
-      pruned_weights,
-      per_sample_weights_,
-      compressed_indices_mapping,
-      include_last_offset);
-  return output;
-}
-
 Tensor& embedding_bag_4bit_rowwise_offsets_out(
     Tensor& output,
     const Tensor& weight,
@@ -745,6 +718,41 @@ Tensor& embedding_bag_4bit_rowwise_offsets_out(
       include_last_offset);
 }
 
+namespace {
+
+
+inline at::Tensor create_empty_from(
+    const at::Tensor& t,
+    c10::ScalarType dtype) {
+  return at::detail::empty_cpu(
+      {0}, dtype, t.layout(), t.device(), c10::nullopt, c10::nullopt);
+}
+
+Tensor embedding_bag_byte_rowwise_offsets(
+    const Tensor& weight,
+    const Tensor& indices,
+    const c10::optional<Tensor>& offsets_in,
+    const bool /* scale_grad_by_freq */,
+    const int64_t /* mode */,
+    bool pruned_weights,
+    const c10::optional<Tensor>& per_sample_weights_,
+    const c10::optional<Tensor>& compressed_indices_mapping,
+    bool include_last_offset) {
+  auto output = create_empty_from(weight, at::kFloat);
+  embedding_bag_byte_rowwise_offsets_out(
+      output,
+      weight,
+      indices,
+      offsets_in,
+      false /*unused scale_grad_by_freq*/,
+      0 /*unused mode*/,
+      pruned_weights,
+      per_sample_weights_,
+      compressed_indices_mapping,
+      include_last_offset);
+  return output;
+}
+
 Tensor embedding_bag_4bit_rowwise_offsets(
     const Tensor& weight,
     const Tensor& indices,
@@ -756,7 +764,7 @@ Tensor embedding_bag_4bit_rowwise_offsets(
     const c10::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset) {
 
-  auto output = at::empty({0}, weight.options().dtype(at::kFloat));
+  auto output = create_empty_from(weight, at::kFloat);
   embedding_bag_4bit_rowwise_offsets_out(
     output,
     weight,

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.h
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.h
@@ -14,7 +14,7 @@ Tensor& embedding_bag_byte_rowwise_offsets_out(
     const c10::optional<Tensor>& compressed_indices_mapping,
     bool include_last_offset);
 
-Tensor embedding_bag_4bit_rowwise_offsets_out(
+Tensor& embedding_bag_4bit_rowwise_offsets_out(
     Tensor& output,
     const Tensor& weight,
     const Tensor& indices,

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -646,7 +646,7 @@ REGISTER_OPERATOR_FUNCTOR(
         }
         auto& out_t = p_node->Output(0).toTensor();
         fastResizeToZero(out_t);
-        return at::native::embedding_bag_byte_rowwise_offsets_out(
+        return at::native::embedding_bag_4bit_rowwise_offsets_out(
             out_t,
             weight,
             indices,


### PR DESCRIPTION
Summary:
There were issues with D26138322 (https://github.com/pytorch/pytorch/commit/5b0a6482c185428c41d8772a92fa0b77174821fc) that we didn't catch the first time around.
This (rebased on top of the to_copy fixes)  fixes the converted remote_ro c2/pt output comparison

Test Plan:
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --c2_model=/data/users/ansha/tmp/adfinder/210494966_0.predictor.disagg.remote_request_only --c2_inputs=/data/users/ansha/tmp/adfinder/models/c2_remote_ro_input_data.pb --pred_net=/data/users/ansha/tmp/adfinder/models/c2_remote_ro_net2.pb --c2_sigrid_transforms_opt=1 --c2_apply_nomnigraph_passes=1 --c2_use_memonger=1 --scripted_model=/data/users/ansha/tmp/adfinder/models_dianshi/210494966_0.predictor.disagg.remote_request_only.pt --pt_inputs=/data/users/ansha/tmp/adfinder/models/remote_ro_wrapped_input_data.pt --pt_enable_static_runtime=1 --pt_cleanup_activations=1 --pt_enable_out_variant=1 --compare_results=1 --iters=1 --warmup_iters=1 --num_threads=1 --do_profile=0 --benchmark_c2_predictor=1 --do_benchmark=1
```

Differential Revision: D27477104

