### PR TITLE
Fix link to an example of an analogous function

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -589,7 +589,7 @@ This function checks if all :attr:`input` and :attr:`other` satisfy the conditio
     \lvert \text{input} - \text{other} \rvert \leq \texttt{atol} + \texttt{rtol} \times \lvert \text{other} \rvert
 """ + r"""
 elementwise, for all elements of :attr:`input` and :attr:`other`. The behaviour of this function is analogous to
-`numpy.allclose <https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html>`_
+`numpy.allclose <https://numpy.org/doc/stable/reference/generated/numpy.allclose.html>`_
 
 Args:
     input (Tensor): first tensor to compare


### PR DESCRIPTION
The link "https://docs.scipy.org/doc/numpy/reference/generated/numpy.allclose.html" seems to lead nowhere and "https://numpy.org/doc/stable/reference/generated/numpy.allclose.html" is probably the correct URL it should point to.
