### PR TITLE
[Pyper] resize_as_ -> resize_

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -512,7 +512,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::relu, aten_relu, [](Node* n) -> SROperator {
       fastResizeToZero(out_t);
       at::native::threshold_out(in0_t, 0, 0, out_t);
     } else {
-      at::native::resize_as_(out_t, in0_t, c10::nullopt);
+      at::native::resize_(out_t, in0_t.sizes(), c10::nullopt);
       (*te)(out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
     }
   };
@@ -530,7 +530,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
       fastResizeToZero(out_t);
       at::native::tanh_out(in0_t, out_t);
     } else {
-      at::native::resize_as_(out_t, in0_t, c10::nullopt);
+      at::native::resize_(out_t, in0_t.sizes(), c10::nullopt);
       (*te)(out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
     }
   };
@@ -551,7 +551,7 @@ REGISTER_OPERATOR_FUNCTOR(
           fastResizeToZero(out_t);
           at::native::sigmoid_out(in0_t, out_t);
         } else {
-          at::native::resize_as_(out_t, in0_t, c10::nullopt);
+          at::native::resize_(out_t, in0_t.sizes(), c10::nullopt);
           (*te)(
               out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
         }
@@ -578,7 +578,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
       fastResizeToZero(out_t);
       at::native::logit_out(in0_t, in1_d, out_t);
     } else {
-      at::native::resize_as_(out_t, in0_t, c10::nullopt);
+      at::native::resize_(out_t, in0_t.sizes(), c10::nullopt);
       (*te)(out_t.data_ptr<float>(), in0_t.data_ptr<float>(), in0_t.numel());
     }
   };
@@ -591,7 +591,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::clone, aten_clone, [](Node* n) -> SROperator {
       p_node->Output(0) = create_empty_from(in0_t);
     }
     auto& out_t = p_node->Output(0).toTensor();
-    at::native::resize_as_(out_t, in0_t, c10::nullopt);
+    at::native::resize_(out_t, in0_t.sizes(), c10::nullopt);
     at::native::copy_(out_t, in0_t, false);
   };
 });


### PR DESCRIPTION
Summary: resize_as_ still goes through the dispatcher because it calls tensor.resize_. We can easily call resize_ directly while bypassing the dispatcher.

Reviewed By: swolchok

Differential Revision: D27457894

