### PR TITLE
Support int32 indices in torch.repeat_interleave

### DIFF
--- a/aten/src/ATen/native/Repeat.cpp
+++ b/aten/src/ATen/native/Repeat.cpp
@@ -2,42 +2,50 @@
 #include <ATen/native/Repeat.h>
 #include <ATen/Parallel.h>
 
-static void compute_cpu(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
-    at::parallel_for(0, size, 1, [&](int64_t i_begin, int64_t i_end) {
-        for(int64_t i = i_begin; i < i_end; i++) {
-            int64_t end = cumsum_ptr[i];
-            int64_t size = repeat_ptr[i];
-            int64_t start = end - size;
-            for(int64_t j = start; j < end; j++) {
-                result_ptr[j] = i;
-            }
-        }
-    });
+template <typename index_t>
+static void compute_cpu(index_t *repeat_ptr, int64_t *cumsum_ptr, index_t *result_ptr, int64_t size) {
+  at::parallel_for(0, size, 1, [&](int64_t i_begin, int64_t i_end) {
+    for (int64_t i = i_begin; i < i_end; i++) {
+      int64_t end = cumsum_ptr[i];
+      index_t size = repeat_ptr[i];
+      int64_t start = end - size;
+      for (int64_t j = start; j < end; j++) {
+        result_ptr[j] = i;
+      }
+    }
+  });
 }
 
 namespace at { namespace native {
 
 Tensor repeat_interleave_cpu(const Tensor &repeat) {
-    return repeat_interleave_common<compute_cpu>(repeat);
+  Tensor output;
+  AT_DISPATCH_INDEX_TYPES(repeat.scalar_type(), "repeat_interleave_cpu", [&]() {
+    output = repeat_interleave_common<index_t, compute_cpu<index_t>>(repeat);
+  });
+
+  return output;
 }
 
 Tensor repeat_interleave(const Tensor &self, const Tensor &repeats, c10::optional<int64_t> dim) {
-    Tensor input = self;
-    if(!dim) {
-        input = self.flatten();
-        dim = 0;
-    }
+  Tensor input = self;
+  if(!dim) {
+    input = self.flatten();
+    dim = 0;
+  }
 
-    Tensor repeats_ = repeats;
-    if (repeats.dim() == 0 || (repeats.dim() == 1 && repeats.size(0) == 1)) {
-        repeats_ = repeats.reshape({1}).expand({input.size(dim.value())});
-    } else if (repeats.dim() == 1) {
-        TORCH_CHECK(repeats.size(0) == input.size(dim.value()), "repeats must have the same size as input along dim")
-    } else {
-        AT_ERROR("repeats must be 0-dim or 1-dim tensor");
-    }
+  Tensor repeats_ = repeats;
+  if (repeats.dim() == 0 || (repeats.dim() == 1 && repeats.size(0) == 1)) {
+    repeats_ = repeats.reshape({1}).expand({input.size(dim.value())});
+  } else if (repeats.dim() == 1) {
+    TORCH_CHECK(
+        repeats.size(0) == input.size(dim.value()),
+        "repeats must have the same size as input along dim")
+  } else {
+    AT_ERROR("repeats must be 0-dim or 1-dim tensor");
+  }
 
-    return input.index_select(dim.value(), at::repeat_interleave(repeats_));
+  return input.index_select(dim.value(), at::repeat_interleave(repeats_));
 }
 
 Tensor repeat_interleave(const Tensor &self, int64_t repeats, c10::optional<int64_t> dim) {

--- a/aten/src/ATen/native/Repeat.h
+++ b/aten/src/ATen/native/Repeat.h
@@ -4,23 +4,25 @@
 
 namespace at { namespace native {
 
-template <void compute(int64_t *, int64_t *, int64_t *, int64_t)>
+template <typename index_t, void compute(index_t*, int64_t*, index_t*, int64_t)>
 static inline Tensor repeat_interleave_common(const Tensor &repeats) {
-    TORCH_CHECK(repeats.dim() == 1, "repeat_interleave only accept 1D vector as repeat");
-    TORCH_CHECK(repeats.scalar_type() == at::kLong, "repeats has to be Long tensor");
-    TORCH_CHECK((repeats >= 0).all().item<uint8_t>(), "repeats can not be negative");
-    if (repeats.size(0) == 0) {
-        return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-    }
-    Tensor repeats_ = repeats.contiguous();
-    Tensor cumsum = repeats.cumsum(0);
-    int64_t total = cumsum[-1].item<int64_t>();
-    Tensor result = at::empty({total}, repeats.options());
-    int64_t *repeat_ptr = repeats_.data_ptr<int64_t>();
-    int64_t *cumsum_ptr = cumsum.data_ptr<int64_t>();
-    int64_t *result_ptr = result.data_ptr<int64_t>();
-    compute(repeat_ptr, cumsum_ptr, result_ptr, repeats.size(0));
-    return result;
+  TORCH_CHECK(repeats.dim() == 1, "repeat_interleave only accept 1D vector as repeat");
+  TORCH_CHECK(
+      repeats.scalar_type() == at::kLong || repeats.scalar_type() == at::kInt,
+      "repeats has to be Long or Int tensor");
+  TORCH_CHECK((repeats >= 0).all().item<uint8_t>(), "repeats can not be negative");
+  if (repeats.size(0) == 0) {
+    return at::empty_like(repeats, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+  }
+  Tensor repeats_ = repeats.contiguous();
+  Tensor cumsum = repeats.cumsum(0);
+  int64_t total = cumsum[-1].item<int64_t>();
+  Tensor result = at::empty({total}, repeats.options());
+  index_t* repeat_ptr = repeats_.data_ptr<index_t>();
+  int64_t* cumsum_ptr = cumsum.data_ptr<int64_t>();
+  index_t* result_ptr = result.data_ptr<index_t>();
+  compute(repeat_ptr, cumsum_ptr, result_ptr, repeats.size(0));
+  return result;
 }
 
 }}

--- a/aten/src/ATen/native/cuda/Repeat.cu
+++ b/aten/src/ATen/native/cuda/Repeat.cu
@@ -2,14 +2,15 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/native/Repeat.h>
 
-__global__ static void compute_cuda_kernel(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
+template <typename index_t>
+__global__ static void compute_cuda_kernel(index_t *repeat_ptr, int64_t *cumsum_ptr, index_t *result_ptr, int64_t size) {
     int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     int64_t stride = (blockDim.x * gridDim.x) / C10_WARP_SIZE;
     int warp_id = idx / C10_WARP_SIZE;
     int tid_in_warp = idx % C10_WARP_SIZE;
     for (int64_t i = warp_id; i < size; i += stride) {
         int64_t end = cumsum_ptr[i];
-        int64_t repeat = repeat_ptr[i];
+        index_t repeat = repeat_ptr[i];
         int64_t start = end - repeat;
         for(int64_t j = start + tid_in_warp; j < end; j += C10_WARP_SIZE) {
             result_ptr[j] = i;
@@ -17,7 +18,8 @@ __global__ static void compute_cuda_kernel(int64_t *repeat_ptr, int64_t *cumsum_
     }
 }
 
-static void compute_cuda(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *result_ptr, int64_t size) {
+template <typename index_t>
+static void compute_cuda(index_t *repeat_ptr, int64_t *cumsum_ptr, index_t *result_ptr, int64_t size) {
     int64_t block = 512;
     int64_t warps_per_block = block / C10_WARP_SIZE;
     int64_t grid = std::min<int64_t>((size + warps_per_block - 1) / warps_per_block, 2048L);
@@ -29,7 +31,11 @@ static void compute_cuda(int64_t *repeat_ptr, int64_t *cumsum_ptr, int64_t *resu
 namespace at { namespace native {
 
 Tensor repeat_interleave_cuda(const Tensor &repeat) {
-    return repeat_interleave_common<compute_cuda>(repeat);
+    Tensor output;
+    AT_DISPATCH_INDEX_TYPES(repeat.scalar_type(), "repeat_interleave_cuda", [&]() {
+        output = repeat_interleave_common<index_t, compute_cuda<index_t>>(repeat);
+    });
+    return output;
 }
 
 }}

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3732,6 +3732,17 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(a.dtype, dtype)
         self.assertEqual(a.size(), torch.Size([1]))
 
+    def test_repeat_interleave(self, device):
+        y = torch.tensor([[1, 2], [3, 4]], device=device)
+        for dtype in [torch.int, torch.long]:
+            a = torch.repeat_interleave(
+                y,
+                torch.tensor([1, 2], dtype=dtype, device=device),
+                dim=0,
+            )
+            self.assertEqual(a.dtype, y.dtype)
+            self.assertEqual(a.size(), torch.Size([3, 2]))
+
     @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=False, include_bfloat16=False)))
     @dtypesIfCUDA(*(torch.testing.get_all_fp_dtypes(include_bfloat16=False)))
     def test_bernoulli_p(self, device, dtype):


### PR DESCRIPTION
Summary: To avoid casting a tensor to `.long()`, we introduce support for int32 in `torch.repeat_interleave`.

Differential Revision: D27478235

