### PR TITLE
construct only necessary elements in OffsetCalculator

### DIFF
--- a/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
+++ b/aten/src/ATen/cuda/detail/OffsetCalculator.cuh
@@ -28,15 +28,11 @@ struct OffsetCalculator {
   // the strides will be in # of elements.
   OffsetCalculator(int dims, const int64_t* sizes, const int64_t* const* strides, const int64_t* element_sizes=nullptr) : dims(dims) {
     TORCH_CHECK(dims <= MAX_DIMS, "tensor has too many (>", MAX_DIMS, ") dims");
-    for (int i = 0; i < MAX_DIMS; ++i) {
-      if (i < dims) {
-        sizes_[i] = IntDivider<index_t>(sizes[i]);
-      } else {
-        sizes_[i] = IntDivider<index_t>(1);
-      }
+    for (int i=0; i < dims; i++){
+      sizes_[i] = IntDivider<index_t>(sizes[i]);
       for (int arg = 0; arg < NARGS; arg++) {
         int64_t element_size = (element_sizes == nullptr ? 1LL : element_sizes[arg]);
-        strides_[i][arg] =  i < dims ? strides[arg][i] / element_size : 0;
+        strides_[i][arg] = strides[arg][i] / element_size;
       }
     }
   }


### PR DESCRIPTION
Per title. Elements beyond `dim` are never accessed because https://github.com/pytorch/pytorch/blob/646510f7028f12e8b1f3a9d3b63b8519ed80e391/aten/src/ATen/cuda/detail/OffsetCalculator.cuh#L49-L51. 
On `addmm` instruction count per 30 repetitions 1467813 -> 1452261
`add`  651522 -> 633462
`add_` 529331 -> 511271

add benchmarking snippet:
```
 timer = Timer("m1.add_(b);", setup="at::Tensor m1=torch::empty({2,2},device(at::kCUDA) ); at::Tensor b = torch::empty({2}, device(at::kCUDA));", language="c++", timer=timeit.default_timer)
 stats=timer.collect_callgrind(number=30)
 print(stats.as_standardized().stats(inclusive=False))
```

 
