### PR TITLE
Pin ShellCheck version to v0.7.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,9 @@ jobs:
           pip install -r requirements.txt
           cd .circleci && ./ensure-consistency.py
       - name: Shellcheck Jenkins scripts
-        # https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary
+        # https://github.com/koalaman/shellcheck/tree/v0.7.1#installing-a-pre-compiled-binary
         run: |
-          scversion="stable"
+          scversion="v0.7.1"
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
           sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
           rm -r "shellcheck-${scversion}"


### PR DESCRIPTION
Not sure why I didn't do this in #47786. Version 0.7.1 (the latest `"stable"` version of ShellCheck) was released [almost a year ago](https://github.com/koalaman/shellcheck/releases/tag/v0.7.1), but even if releases are infrequent, it's better to just get rid of the nondeterminism that caused #47786 in the first place.

**Test plan:**

The "Lint / quick-checks" job in GitHub Actions.