### PR TITLE
[PyTorch] Check is_same instead of data_ptr in addmm_out_cuda_impl

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -165,7 +165,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
       result_ptr, result_ld
     );
   });
-  if (result.data_ptr() != result_->data_ptr()) {
+  if (!result.is_same(*result_)) {
     result.copy_(*result_);
   }
   return result;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55111 [PyTorch] Check is_same instead of data_ptr in addmm_out_cuda_impl**

I don't see how we could have ended up with !is_same but also identical data_ptr, and is_same is cheaper.

Differential Revision: [D27484914](https://our.internmc.facebook.com/intern/diff/D27484914/)