### PR TITLE
[JIT] Add recursive scripting for class type module attributes (#45234)

### DIFF
--- a/test/jit/test_module_containers.py
+++ b/test/jit/test_module_containers.py
@@ -422,29 +422,6 @@ class TestModuleContainers(JitTestCase):
         with self.assertRaisesRegex(RuntimeError, error_msg):
             torch.jit.script(Mod())
 
-    def test_unannotated_module_attribute_error(self):
-        """
-        Test that an attempt to script a module with an unannotated attribute
-        whose type cannot be inferred fails with a relevant error message
-        suggesting annotating the attribute.
-        """
-        class JitClass:  # noqa: B903
-            def __init__(self, v: int):
-                self.v = v
-
-        class Mod(torch.nn.Module):
-            # Adding following line makes the case pass
-            # v: JitClass
-            def __init__(self):
-                super().__init__()
-                self.v = JitClass(2)
-
-            def forward(self):
-                return self.v
-
-        with self.assertRaisesRegex(RuntimeError, "try adding a type annotation for the attribute"):
-            torch.jit.script(Mod())
-
     def test_empty_dict_override_contains(self):
         class CustomModuleInterface(torch.nn.Module):
             def __init__(self):

--- a/test/jit/test_type_sharing.py
+++ b/test/jit/test_type_sharing.py
@@ -242,14 +242,11 @@ class TestTypeSharing(JitTestCase):
         """
         Attributes whose type cannot be inferred should fail cleanly with nice hints
         """
-        class NotScriptable(object):
-            pass
-
         class M(torch.nn.Module):
             def __init__(self):
                 super(M, self).__init__()
                 # assign a type we know can't be converted to TorchScript
-                self.foo = NotScriptable()
+                self.foo = object
 
             def forward(self):
                 # try to use it in forward

--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -226,6 +226,12 @@ def can_compile_class(cls):
     # be compiled and is probably a builtin / bound from C
     if is_ignored_fn(cls):
         return False
+
+    # Ignore the following list of built-in classes.
+    ignored_builtin_classes = (torch.nn.Module, tuple, list, Exception)
+    if issubclass(cls, ignored_builtin_classes):
+        return False
+
     names = cls.__dict__
     fns = [getattr(cls, name) for name in names if inspect.isroutine(getattr(cls, name, None))]
     has_code = [hasattr(fn, '__code__') for fn in fns]

--- a/torch/csrc/distributed/rpc/py_rref.cpp
+++ b/torch/csrc/distributed/rpc/py_rref.cpp
@@ -85,6 +85,20 @@ TypePtr tryInferTypeWithTypeHint(
         "type_hint should only be specified when the RRef being created contains a ScriptModule.");
   }
 
+  // Check if value is an instance of a ScriptClass. If not, skip type inference
+  // because it will try to script the class that value is in instance of, and
+  // this should be avoided.
+  py::bool_ can_compile = py::module::import("torch._jit_internal").attr("can_compile_class")(value.get_type());
+
+  if (py::cast<bool>(can_compile)) {
+    py::str qualified_name = py::module::import("torch._jit_internal").attr("_qualified_name")(value.get_type());
+    py::object existing_ty = py::module::import("torch.jit._state").attr("_get_script_class")(qualified_name);
+
+    if (existing_ty.is_none()) {
+      return PyObjectType::get();
+    }
+  }
+
   // NB: `jit::tryToInferType(..)` infers types including ScriptClass, but
   // excluding ScripModule.
   jit::InferredType type_inferred = jit::tryToInferType(value);

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -334,12 +334,49 @@ inline InferredType tryToInferType(py::handle input) {
   py::bool_ isClass =
       py::module::import("inspect").attr("isclass")(input.get_type());
   if (py::cast<bool>(isClass)) {
-    auto scriptClass = py::module::import("torch.jit._state")
+    // Assume that the class is compiled already or will compile. Invalidate
+    // this later if needed.
+    bool class_compiled = true;
+
+    // Check if the type is already compiled.
+    py::object existing_ty = py::module::import("torch.jit._state")
+                                 .attr("_get_script_class")(input.get_type());
+
+    if (existing_ty.is_none()) {
+      // If not, try to compile it.
+      py::bool_ can_compile = py::module::import("torch._jit_internal")
+                                  .attr("can_compile_class")(input.get_type());
+
+      if (py::cast<bool>(can_compile)) {
+        // Try to compile the class. This is wrapped in a try-catch because
+        // compilation of class types can raise an Exception and in that case,
+        // we want to defer to other attempts at type inference below rather
+        // than fail compilation altogether.
+        try {
+          py::module::import("torch.jit._script")
+              .attr("_recursive_compile_class")(
+                  input.get_type(), SourceRange());
+        } catch (...) {
+          // Invalidate the assumption that the class compiled so that we don't
+          // look up and return its JIT type as the type for the input.
+          class_compiled = false;
+        }
+      }
+    }
+
+    // If the class compiled successfully, look up the existing JIT type by
+    // qualified name and return it.
+    if (class_compiled) {
+      auto script_class = py::module::import("torch.jit._state")
                            .attr("_get_script_class")(input.get_type());
-    if (!scriptClass.is_none()) {
-      auto classType = py::cast<ClassTypePtr>(scriptClass);
-      TORCH_INTERNAL_ASSERT(classType);
-      return InferredType(classType);
+
+      if (!script_class.is_none()) {
+        auto class_type = py::cast<ClassTypePtr>(script_class);
+
+        if (class_type && !class_type->is_module()) {
+          return InferredType(class_type);
+        }
+      }
     }
   }
 

--- a/torch/jit/annotations.py
+++ b/torch/jit/annotations.py
@@ -342,8 +342,7 @@ def try_ann_to_type(ann, loc):
         maybe_script_class = _get_script_class(ann)
         if maybe_script_class is not None:
             return maybe_script_class
-        ignored_builtin_classes = (torch.nn.Module, tuple, list, Exception)
-        if torch._jit_internal.can_compile_class(ann) and not issubclass(ann, ignored_builtin_classes):
+        if torch._jit_internal.can_compile_class(ann):
             return torch.jit._script._recursive_compile_class(ann, loc)
 
     # Maybe resolve a NamedTuple to a Tuple Type


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/45234

**Summary**
This commit modifies type inference (used by the module scripting code)
so that it tries to script the type of any class instances that it
encounters. This enables recursive, automatic scripting of class type
module attributes.

**Test Plan**
This commit adds a test case for this to `TestClassType`.

Test Plan: Imported from OSS

Reviewed By: gmagogsfm

Differential Revision: D23971883

Pulled By: SplitInfinity

