### PR TITLE
Move BackendSelect to default_included_set.

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -12,13 +12,6 @@ namespace c10 {
 
 namespace impl {
 
-// Some keys are ALWAYS considered for inclusion by default, so they are
-// included in the set here.  (const appears to be sufficient for
-// always_included to get inlined, constexpr not necessary)
-// Note DispatchKey::Autograd used to be in this set and it now has been
-// moved to TensorImpl constructor.
-const DispatchKeySet always_included{DispatchKey::BackendSelect};
-
 // Take a DispatchKeySet for a Tensor and determine what the actual dispatch
 // DispatchKey should be, taking into account TLS, and skipping backends which
 // fall through.
@@ -49,7 +42,7 @@ static inline DispatchKeySet computeDispatchKeySet(
   // it's a bit troublesome, because fastpath TLS access requires the type of
   // the TLS in question to be zero-initialized, so you don't actually win
   // anyting in that case.
-  return (((ks | local.included_ | always_included) - local.excluded_) & key_mask);
+  return (((ks | local.included_) - local.excluded_) & key_mask);
 }
 
 }

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -209,6 +209,7 @@ constexpr DispatchKeySet autograd_dispatch_keyset = DispatchKeySet({
 
 // See Note [TLS Initialization]
 constexpr DispatchKeySet default_included_set = DispatchKeySet({
+    DispatchKey::BackendSelect,
     DispatchKey::InplaceOrView,
 });
 

--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -8,7 +8,7 @@ namespace impl {
 // NB: POD, must be zero initialized!
 // Note [TLS Initialization]
 // We wanted raw_local_dispatch_key_set to be initialized with non-zero state
-// e.g. InplaceOrView in included set.  But certain Windows compiler (e.g the one
+// e.g. BackendSelect and InplaceOrView in included set.  But certain Windows compiler (e.g the one
 // used in ARVR tests) only allow TLS to be zero-initialized.
 // To preserve the invariant that raw TLS storage of the default state is zero,
 // we obtain the actual include keyset by XORing raw_local_dispatch_key_set.included_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55117 Move BackSelect to default_included_set.**

Differential Revision: [D27490571](https://our.internmc.facebook.com/intern/diff/D27490571)