### PR TITLE
[PyTorch] Don't bother with SmallVector in TensorMaker

### DIFF
--- a/aten/src/ATen/templates/Functions.cpp
+++ b/aten/src/ATen/templates/Functions.cpp
@@ -136,17 +136,18 @@ inline DataPtr TensorMaker::makeDataPtrFromContext() noexcept {
   return DataPtr{data_, ctx_.release(), ctx_.get_deleter(), *device_};
 }
 
-SmallVector<std::int64_t, 5> TensorMaker::makeTempSizes() const noexcept {
+IntArrayRef TensorMaker::makeTempSizes() const noexcept {
+  static int64_t zeros[5] = {0, 0, 0, 0, 0};
   if (opts_.has_memory_format()) {
     MemoryFormat format = *opts_.memory_format_opt();
     if (format == MemoryFormat::ChannelsLast) {
-      return {0, 0, 0, 0};
+      return IntArrayRef(zeros, 4);
     }
     if (format == MemoryFormat::ChannelsLast3d) {
-      return {0, 0, 0, 0, 0};
+      return IntArrayRef(zeros, 5);
     }
   }
-  return {0};
+  return IntArrayRef(zeros, 1);
 }
 
 inline Tensor TensorMaker::makeEmptyTensor() const {

--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -129,7 +129,7 @@ class TORCH_API TensorMaker {
 
   DataPtr makeDataPtrFromContext() noexcept;
 
-  SmallVector<std::int64_t, 5> makeTempSizes() const noexcept;
+  IntArrayRef makeTempSizes() const noexcept;
 
   Tensor makeEmptyTensor() const;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55125 [PyTorch] Don't bother with SmallVector in TensorMaker**

We can provide an ArrayRef to 1-5 zeros much more efficiently, like this.

Differential Revision: [D27494800](https://our.internmc.facebook.com/intern/diff/D27494800/)