### PR TITLE
[Static Runtime] Add TORCH_API to functions in static/passes.h

### DIFF
--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -3,12 +3,16 @@
 namespace torch {
 namespace jit {
 
-void FuseInferenceOpsForSparseNN(std::shared_ptr<torch::jit::Graph>& graph);
-void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void FuseInferenceOpsForSparseNN(
+    std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void FuseSigridTransformsListUnpack(
+    std::shared_ptr<torch::jit::Graph>& graph);
 
-void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 
-bool HasInplaceOp(std::shared_ptr<Graph>& graph, const AliasDb& alias_db);
+TORCH_API bool HasInplaceOp(
+    std::shared_ptr<Graph>& graph,
+    const AliasDb& alias_db);
 
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Add TORCH_API macro to make functions visible from tests.

Test Plan: CI

Differential Revision: D27495331

