### PR TITLE
Avoid aggregate initialization for tensorpipe::{Cpu,Cuda}Buffer and tensorpipe::Message::Tensor.

### DIFF
--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -42,9 +42,12 @@ TEST(TensorpipeSerialize, Base) {
   EXPECT_EQ(recvingTpMessage.payloads.size(), sendingTpMessage.payloads.size());
   recvingTpMessage.tensors.reserve(sendingTpMessage.tensors.size());
   for (auto& tpTensor : sendingTpMessage.tensors) {
+    tensorpipe::CpuBuffer buffer;
+    buffer.ptr = nullptr;
+    buffer.length = tpTensor.buffer.unwrap<tensorpipe::CpuBuffer>().length;
+
     tensorpipe::Message::Tensor t;
-    t.buffer = tensorpipe::CpuBuffer{
-        nullptr, tpTensor.buffer.unwrap<tensorpipe::CpuBuffer>().length};
+    t.buffer = buffer;
     t.metadata = tpTensor.metadata;
     recvingTpMessage.tensors.push_back(std::move(t));
   }

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
@@ -96,9 +96,15 @@ std::tuple<tensorpipe::Message, TensorpipeWriteBuffers> tensorpipeSerialize(
     if (!tensorData.storageHasDeleter()) {
       std::vector<char> storageData(
           tensorData.data(), tensorData.data() + tensorData.sizeInBytes());
-      tpMessage.tensors.push_back(tensorpipe::Message::Tensor{
-          tensorpipe::CpuBuffer{storageData.data(), storageData.size()},
-          std::move(metadata)});
+      tensorpipe::CpuBuffer buffer;
+      buffer.ptr = storageData.data();
+      buffer.length = storageData.size();
+
+      tensorpipe::Message::Tensor tensor;
+      tensor.buffer = buffer;
+      tensor.metadata = std::move(metadata);
+
+      tpMessage.tensors.push_back(std::move(tensor));
       buffers.copiedTensors.push_back(std::move(storageData));
     } else {
       // TensorPipe uses the same Message class for both reading and writing, so
@@ -106,16 +112,28 @@ std::tuple<tensorpipe::Message, TensorpipeWriteBuffers> tensorpipeSerialize(
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       char* tensorPtr = const_cast<char*>(tensorData.data());
       if (tensorDataVec[i].device().is_cpu()) {
-        tpMessage.tensors.push_back(tensorpipe::Message::Tensor{
-            tensorpipe::CpuBuffer{tensorPtr, tensorData.sizeInBytes()},
-            std::move(metadata)});
+        tensorpipe::CpuBuffer buffer;
+        buffer.ptr = tensorPtr;
+        buffer.length = tensorData.sizeInBytes();
+
+        tensorpipe::Message::Tensor tensor;
+        tensor.buffer = buffer;
+        tensor.metadata = std::move(metadata);
+
+        tpMessage.tensors.push_back(std::move(tensor));
 #ifdef USE_CUDA_NOT_ROCM
       } else if (tensorDataVec[i].device().is_cuda()) {
         auto stream = ctx->getStream(tensorDataVec[i].device().index());
-        tpMessage.tensors.push_back(tensorpipe::Message::Tensor{
-            tensorpipe::CudaBuffer{
-                tensorPtr, tensorData.sizeInBytes(), stream.stream()},
-            std::move(metadata)});
+        tensorpipe::CudaBuffer buffer;
+        buffer.ptr = tensorPtr;
+        buffer.length = tensorData.sizeInBytes();
+        buffer.stream = stream.stream();
+
+        tensorpipe::Message::Tensor tensor;
+        tensor.buffer = buffer;
+        tensor.metadata = std::move(metadata);
+
+        tpMessage.tensors.push_back(std::move(tensor));
         // record tensor data ptrs on TensorPipe streams, so that the tensors
         // won't be destructed before TensorPipe finishing sending them.
         c10::cuda::CUDACachingAllocator::recordStream(


### PR DESCRIPTION
Summary:
This will ease the transition to the new API where `Buffer` does not
store a length anymore.

Test Plan: CI

Reviewed By: lw

Differential Revision: D27466385

