### PR TITLE
Correct many OpInfos "test_out" skips.

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -960,7 +960,7 @@ static void addbmm_impl_(
   TORCH_CHECK(self.size(0) == dim1 && self.size(1) == dim2,
       "self tensor does not match matmul output shape");
 
-  at::native::resize_output(result, self.sizes());
+  result.resize_as_(self);
 
   if (beta.to<c10::complex<double>>() != 0.0 && !self.is_same(result)) {
     result.copy_(self);
@@ -1027,7 +1027,7 @@ Tensor &addmm_cpu_(Tensor& self, const Tensor& mat1, const Tensor& mat2, const S
 Tensor& mm_cpu_out(const Tensor & self, const Tensor & mat2, Tensor & result) {
   TORCH_CHECK(self.dim() == 2, "self must be a matrix");
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
-  at::native::resize_output(result, {self.sizes()[0], mat2.sizes()[1]});
+  native::resize_(result, {self.sizes()[0], mat2.sizes()[1]});
   return addmm_cpu_out(result, self, mat2, 0, 1, result);
 }
 
@@ -1122,7 +1122,7 @@ static inline Tensor& bmm_out_or_baddbmm_(Tensor& self_or_result, const Tensor& 
 
   if (is_bmm_out) {
     // Here it is result
-    at::native::resize_output(self_or_result, {bs, res_rows, res_cols});
+    self_or_result.resize_({bs, res_rows, res_cols});
   } else {
     const auto self_sizes = self_or_result.sizes();
     TORCH_CHECK(self_sizes[0] == bs && self_sizes[1] == res_rows && self_sizes[2] == res_cols);
@@ -1189,7 +1189,7 @@ Tensor baddbmm_cpu(const Tensor& self, const Tensor& batch1, const Tensor& batch
 Tensor& baddbmm_out_cpu(const Tensor& self_, const Tensor& batch1, const Tensor& batch2, const Scalar& beta, const Scalar& alpha, Tensor &result) {
   Tensor self;
   std::tie(self) = expand_size(self_, {batch1.size(0), batch1.size(1), batch2.size(2)}, "baddbmm");
-  at::native::resize_output(result, self.sizes());
+  result.resize_(self.sizes());
   result.copy_(self);
   return at::native::baddbmm__cpu(result, batch1, batch2, beta, alpha);
 }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -449,8 +449,8 @@ std::tuple<Tensor&, Tensor&> cummax_out(const Tensor& self, int64_t dim, Tensor&
   check_scalar_type_device_layout_equal(indices, at::empty({0}, self.options().dtype(at::kLong)));
   {
     NoNamesGuard guard;
-    resize_output(values, self.sizes());
-    resize_output(indices, self.sizes());
+    at::native::resize_output(values, self.sizes());
+    at::native::resize_output(indices, self.sizes());
     if(self.dim() == 0) {
       values.fill_(self);
       indices.fill_(0);
@@ -484,8 +484,8 @@ std::tuple<Tensor&, Tensor&> cummin_out(const Tensor& self, int64_t dim, Tensor&
   check_scalar_type_device_layout_equal(indices, at::empty({0}, self.options().dtype(at::kLong)));
   {
     NoNamesGuard guard;
-    resize_output(values, self.sizes());
-    resize_output(indices, self.sizes());
+    at::native::resize_output(values, self.sizes());
+    at::native::resize_output(indices, self.sizes());
     if(self.dim() == 0) {
       values.fill_(self);
       indices.fill_(0);

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <ATen/ATen.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/WrapDimUtilsMulti.h>
 
@@ -149,7 +150,7 @@ static void allocate_reduction_result(
     }
   }
   if (result.defined()) {
-    result.resize_(shape);
+    at::native::resize_output(result, shape);
   } else {
     result = at::empty(shape, self.options().dtype(dtype));
   }

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -84,7 +84,7 @@ static inline void checkInBoundsForStorage(
     const caffe2::TypeMeta data_type,
     const Storage& new_storage) {
   int64_t storage_size_bytes =
-      detail::computeStorageNbytes(size, stride, data_type.itemsize());
+      at::detail::computeStorageNbytes(size, stride, data_type.itemsize());
   int64_t storage_offset_bytes = storage_offset * data_type.itemsize();
   if (storage_size_bytes == 0) {
     // NB: (a tensor with arbitrary 0 dims)'s storage can have any numel.

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -683,8 +683,9 @@ std::tuple<Tensor&, Tensor&> sort_out_cpu_stable(const Tensor& self,
     bool descending,
     Tensor& values,
     Tensor& indices) {
-  values.resize_(self.sizes()).copy_(self);
-  indices.resize_(self.sizes());
+  at::native::resize_output(values, self.sizes());
+  values.copy_(self);
+  at::native::resize_output(indices, self.sizes());
 
   // check if self is scalar
   if (self.dim() == 0 && self.numel() == 1) {

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -683,9 +683,8 @@ std::tuple<Tensor&, Tensor&> sort_out_cpu_stable(const Tensor& self,
     bool descending,
     Tensor& values,
     Tensor& indices) {
-  at::native::resize_output(values, self.sizes());
-  values.copy_(self);
-  at::native::resize_output(indices, self.sizes());
+  values.resize_(self.sizes()).copy_(self);
+  indices.resize_(self.sizes());
 
   // check if self is scalar
   if (self.dim() == 0 && self.numel() == 1) {

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -1183,7 +1183,7 @@ void take_out_cpu_template(
             "But got different types: ", output.scalar_type(), " and ", input.scalar_type());
     TORCH_CHECK(index.scalar_type() == kLong, "index must be an int64 tensor");
 
-    at::native::resize_output(output, index.sizes());
+    output.resize_(index.sizes());
     auto output_contiguous = output.contiguous();
     auto index_continuous = index.contiguous();
     bool is_contiguous = input.is_contiguous();

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -671,7 +671,7 @@ Tensor & index_select_out_cpu_(const Tensor & self, int64_t dim, const Tensor & 
   if (self.dim() > 0) {
     result_size[dim] = numel;
   }
-  result.resize_(result_size);
+  at::native::resize_output(result, result_size);
 
   auto index_contig = index.contiguous();
 
@@ -884,7 +884,7 @@ Tensor& gather_out_cpu_cuda(
     const Tensor& index,
     bool sparse_grad,
     Tensor& result) {
-  resize_output(result, index.sizes());
+  at::native::resize_output(result, index.sizes());
   at::assert_no_internal_overlap(result);
   at::assert_no_overlap(result, self);
   at::assert_no_partial_overlap(result, index);
@@ -1086,7 +1086,7 @@ static Tensor & masked_select_out_impl_cpu(Tensor & result, const Tensor & self,
 
   auto shape = _self.sizes();
   int64_t numel = _mask.sum().item().toLong();
-  result.resize_({numel});
+  at::native::resize_output(result, {numel});
   if (numel == 0) {
     return result;
   }
@@ -1183,7 +1183,7 @@ void take_out_cpu_template(
             "But got different types: ", output.scalar_type(), " and ", input.scalar_type());
     TORCH_CHECK(index.scalar_type() == kLong, "index must be an int64 tensor");
 
-    output.resize_(index.sizes());
+    at::native::resize_output(output, index.sizes());
     auto output_contiguous = output.contiguous();
     auto index_continuous = index.contiguous();
     bool is_contiguous = input.is_contiguous();

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2165,7 +2165,7 @@ void apply_diag(Tensor& result, const Tensor& self, int64_t dimension) {
     auto self_stride = self.stride(0);
     int64_t sz = self_size + std::abs(dimension);
 
-    result.resize_({sz, sz});
+    at::native::resize_output(result, {sz, sz});
     result.zero_();
     auto r_data = result.data_ptr<scalar_t>();
     auto r_stride_0 = result.stride(0);
@@ -2186,7 +2186,7 @@ void apply_diag(Tensor& result, const Tensor& self, int64_t dimension) {
       sz = std::min(self.size(0) + dimension, self.size(1));
     }
 
-    result.resize_({sz});
+    at::native::resize_output(result, {sz});
     result.zero_();
     auto r_data = result.data_ptr<scalar_t>();
     auto r_stride_0 = result.stride(0);

--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -9,6 +9,7 @@
 #include <ATen/CPUApplyUtils.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/Math.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/UnaryOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/NamedTensorUtils.h>
@@ -92,7 +93,7 @@ static inline Tensor& unary_op_impl_with_complex_to_float_out(Tensor& result, co
       stub(iter.device_type(), iter);
 
       // Copies the complex result to the actual result and returns it
-      result.resize_(complex_result.sizes());
+      at::native::resize_output(result, complex_result.sizes());
       result.copy_(at::real(complex_result));
       return result;
     }
@@ -486,7 +487,7 @@ Tensor& nan_to_num_out(const Tensor& self,
       self.scalar_type());
 
   if (c10::isIntegralType(self.scalar_type(), /*includeBool=*/true)) {
-    result.resize_as_(self);
+    at::native::resize_output(result, self.sizes());
     result.copy_(self);
     return result;
   }
@@ -571,7 +572,7 @@ Tensor& logical_not_out(const Tensor& self, Tensor& result) {
 Tensor& signbit_out(const Tensor& self, Tensor& result) {
   TORCH_CHECK(!self.is_complex(), "signbit is not implemented for complex tensors.");
   TORCH_CHECK(result.scalar_type() == at::kBool, "signbit does not support non-boolean outputs.");
-  result.resize_(self.sizes());
+  at::native::resize_output(result, self.sizes());
 
   if (self.dtype() == at::kBool) {
     return result.fill_(false);

--- a/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/ReduceOpsKernel.cpp
@@ -6,6 +6,7 @@
 #include <ATen/cpu/vec256/vec256.h>
 #include <ATen/native/ReduceOps.h>
 #include <ATen/native/ReduceOpsUtils.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/ReduceOpsUtils.h>
@@ -25,7 +26,7 @@ static inline void cpu_cum_base_kernel(Tensor& result,
     const func_t& f,
     scalar_t init_val) {
   if (result.sizes() != self.sizes()) {
-    result.resize_as_(self);
+    at::native::resize_output(result, self.sizes());
   }
   if (self.numel() == 0) {
     return;
@@ -36,6 +37,7 @@ static inline void cpu_cum_base_kernel(Tensor& result,
     return;
   }
 
+  // TODO This probably should be using at::native::make_reduction
   auto iter = TensorIteratorConfig()
     .check_all_same_dtype(false)
     .resize_outputs(false)

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -712,7 +712,7 @@ void index_select_out_cuda_impl(Tensor& out, const Tensor& self, long dim,
   if (self.dim() > 0) {
     newSize[dim] = numIndices;
   }
-  at::native::resize_(out, newSize, {});
+  at::native::resize_output(out, newSize);
 
   ptrdiff_t outTotalSize = out.numel();
   if (outTotalSize == 0) {

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -7,6 +7,7 @@
 #include <ATen/MemoryOverlap.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
+#include <ATen/native/Resize.h>
 #include <ATen/AccumulateType.h>
 #include <ATen/cuda/detail/IndexUtils.cuh>
 #include <ATen/cuda/CUDAUtils.h>

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -194,7 +194,7 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
   TORCH_CHECK(batch1_sizes[2] == batch2_sizes[1], "batch1 dim 2 must match batch2 dim 1");
 
   if (!result.is_same(self)) {
-    at::native::resize_output(result, self.sizes());
+    result.resize_as_(self);
     if (beta.to<c10::complex<double>>() != 0.0) {
       result.copy_(self);
     }
@@ -271,7 +271,7 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
 } // anonymous namespace
 
 Tensor& mm_out_cuda(const Tensor& self, const Tensor& mat2, Tensor& result) {
-  at::native::resize_output(result, { self.size(0), mat2.size(1) });
+  result.resize_({ self.size(0), mat2.size(1) });
   return addmm_out_cuda_impl(result, result, self, mat2, 0, 1);
 }
 
@@ -331,7 +331,7 @@ Tensor& baddbmm__cuda(Tensor& self, const Tensor& batch1, const Tensor& batch2, 
 }
 
 Tensor& bmm_out_cuda(const Tensor& batch1, const Tensor& batch2, Tensor &result) {
-  at::native::resize_output(result, { batch1.size(0), batch1.size(1), batch2.size(2) });
+  result.resize_({ batch1.size(0), batch1.size(1), batch2.size(2) });
   Scalar beta(0.0);
   Scalar alpha(1.0);
   {

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -6,6 +6,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/LinearAlgebra.h>
 #include <ATen/native/DispatchStub.h>
+#include <ATen/native/Resize.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/Reduce.cuh>
 #include <ATen/native/SharedReduceOps.h>
@@ -98,7 +99,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
       mat2_sizes[0]);
 
   if (&result != &self) {
-    at::native::resize_as_(result, self_);
+    at::native::resize_output(result, self_.sizes());
     if (beta.toComplexDouble() != 0.0) {
       at::native::copy_(result, self_);
     }
@@ -193,7 +194,7 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
   TORCH_CHECK(batch1_sizes[2] == batch2_sizes[1], "batch1 dim 2 must match batch2 dim 1");
 
   if (!result.is_same(self)) {
-    result.resize_as_(self);
+    at::native::resize_output(result, self.sizes());
     if (beta.to<c10::complex<double>>() != 0.0) {
       result.copy_(self);
     }
@@ -270,7 +271,7 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
 } // anonymous namespace
 
 Tensor& mm_out_cuda(const Tensor& self, const Tensor& mat2, Tensor& result) {
-  result.resize_({ self.size(0), mat2.size(1) });
+  at::native::resize_output(result, { self.size(0), mat2.size(1) });
   return addmm_out_cuda_impl(result, result, self, mat2, 0, 1);
 }
 
@@ -330,7 +331,7 @@ Tensor& baddbmm__cuda(Tensor& self, const Tensor& batch1, const Tensor& batch2, 
 }
 
 Tensor& bmm_out_cuda(const Tensor& batch1, const Tensor& batch2, Tensor &result) {
-  result.resize_({ batch1.size(0), batch1.size(1), batch2.size(2) });
+  at::native::resize_output(result, { batch1.size(0), batch1.size(1), batch2.size(2) });
   Scalar beta(0.0);
   Scalar alpha(1.0);
   {

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -4,6 +4,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/NumericUtils.h>
+#include <ATen/native/Resize.h>
 #include <c10/util/accumulate.h>
 #include <THC/THCGeneral.h>
 #include <THC/THCNumerics.cuh>

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -544,7 +544,7 @@ void scan_dim(const Tensor& self, Tensor& result,
 }
 
 Tensor& _logcumsumexp_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
-  at::native::resize_output(result, self.sizes());
+  result.resize_(self.sizes());
   if (self.dim() == 0) {
     result.fill_(self);
     return result;

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -543,7 +543,7 @@ void scan_dim(const Tensor& self, Tensor& result,
 }
 
 Tensor& _logcumsumexp_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
-  result.resize_(self.sizes());
+  at::native::resize_output(result, self.sizes());
   if (self.dim() == 0) {
     result.fill_(self);
     return result;
@@ -590,7 +590,7 @@ Tensor& _cumsum_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
   checkAllSameGPU("cumsum", {output_arg, input_arg});
   checkSameType("cumsum", output_arg, input_arg);
 
-  result.resize_(self.sizes());
+  at::native::resize_output(result, self.sizes());
   if (self.dim() == 0) {
     result.fill_(self);
     return result;
@@ -626,7 +626,7 @@ Tensor& _cumprod_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
   checkAllSameGPU("cumprod", {output_arg, input_arg});
   checkSameType("cumprod", output_arg, input_arg);
 
-  result.resize_(self.sizes());
+  at::native::resize_output(result, self.sizes());
   if (self.dim() == 0) {
     result.fill_(self);
     return result;

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -3,6 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/NativeFunctions.h>
+#include <ATen/native/Resize.h>
 
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/detail/IndexUtils.cuh>
@@ -86,7 +87,7 @@ Tensor& tril_cuda_(Tensor &self, int64_t k) {
 
 Tensor& tril_cuda_out(const Tensor& self, int64_t k, Tensor &result) {
   if (result.sizes() != self.sizes()) {
-    result.resize_as_(self);
+    at::native::resize_output(result, self.sizes());
   }
   if (self.numel() == 0) {
     return result;
@@ -100,7 +101,7 @@ Tensor& triu_cuda_(Tensor &self, int64_t k) {
 
 Tensor& triu_cuda_out(const Tensor& self, int64_t k, Tensor &result) {
   if (result.sizes() != self.sizes()) {
-    result.resize_as_(self);
+    at::native::resize_output(result, self.sizes());
   }
   if (self.numel() == 0) {
     return result;
@@ -170,7 +171,7 @@ Tensor& apply_diag(Tensor& result, const Tensor& self, int64_t dimension) {
       sz = std::min(self.size(0) + dimension, self.size(1));
     }
 
-    result.resize_({sz});
+    at::native::resize_output(result, {sz});
     if (sz > 0) {
       at::assert_no_internal_overlap(result);
       auto result_stride = result.stride(0);
@@ -198,7 +199,7 @@ Tensor& apply_diag(Tensor& result, const Tensor& self, int64_t dimension) {
     auto n_elems = self.numel();
     auto sz = (dimension > 0) ? n_elems + dimension : n_elems - dimension;
     auto self_stride = self.stride(0);
-    result.resize_({sz, sz});
+    at::native::resize_output(result, {sz, sz});
     result.zero_();
     if (sz > 0) {
       at::assert_no_internal_overlap(result);

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -87,7 +87,7 @@ Tensor& tril_cuda_(Tensor &self, int64_t k) {
 
 Tensor& tril_cuda_out(const Tensor& self, int64_t k, Tensor &result) {
   if (result.sizes() != self.sizes()) {
-    at::native::resize_output(result, self.sizes());
+    result.resize_as_(self);
   }
   if (self.numel() == 0) {
     return result;
@@ -101,7 +101,7 @@ Tensor& triu_cuda_(Tensor &self, int64_t k) {
 
 Tensor& triu_cuda_out(const Tensor& self, int64_t k, Tensor &result) {
   if (result.sizes() != self.sizes()) {
-    at::native::resize_output(result, self.sizes());
+    result.resize_as_(self);
   }
   if (self.numel() == 0) {
     return result;

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -622,8 +622,8 @@ class TestCommon(JitCommonTestCase):
 
             out = _apply_out_transform(_case_five_transform, expected)
             msg_fail = "" if not isinstance(expected, torch.Tensor) else \
-                       ("Expected RuntimeError when doing an unsafe cast from a result of type {expected.dtype}"
-                        f"into an out with dtype torch.long")
+                       ("Expected RuntimeError when doing an unsafe cast from a result of dtype "
+                        f"{expected.dtype} into an out= with dtype torch.long")
             with self.assertRaises(RuntimeError, msg=msg_fail):
                 op_out(out=out)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -601,7 +601,7 @@ class TestCommon(JitCommonTestCase):
                 return make_tensor(t.shape, dtype=t.dtype, device=wrong_device)
 
             out = _apply_out_transform(_case_four_transform, expected)
-            with self.assertRaises(RuntimeError, msg=f"Expected RuntimeError when calling with input.device={device} and out.device={out.device}"):
+            with self.assertRaises(RuntimeError, msg=f"Expected RuntimeError when calling with input.device={device} and out.device={wrong_device}"):
                 op_out(out=out)
 
         # Case 5: out= with correct shape and device, but a dtype
@@ -614,7 +614,7 @@ class TestCommon(JitCommonTestCase):
         #   tensor is a floating point or complex dtype.
         _dtypes = floating_and_complex_types_and(torch.float16, torch.bfloat16)
         if (isinstance(expected, torch.Tensor) and expected.dtype in _dtypes or
-            (not isinstance(expected, torch.Tensor) and any(t.dtype in _dtypes for t in expected))):
+                (not isinstance(expected, torch.Tensor) and any(t.dtype in _dtypes for t in expected))):
             def _case_five_transform(t):
                 return make_tensor(t.shape, dtype=torch.long, device=t.device)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,4 +1,4 @@
-from functools import partial, wraps, reduce
+from functools import partial, wraps
 import warnings
 
 import torch
@@ -565,7 +565,8 @@ class TestCommon(JitCommonTestCase):
             return make_tensor(wrong_shape, dtype=t.dtype, device=t.device)
 
         out = _apply_out_transform(_case_two_transform, expected)
-        with self.assertWarnsRegex(UserWarning, "An output with one or more elements", msg="Resized a non-empty tensor but did not warn about it."):
+        msg_fail = "Resized a non-empty tensor but did not warn about it."
+        with self.assertWarnsRegex(UserWarning, "An output with one or more elements", msg=msg_fail):
             op_out(out=out)
         self.assertEqual(expected, out)
 
@@ -601,7 +602,8 @@ class TestCommon(JitCommonTestCase):
                 return make_tensor(t.shape, dtype=t.dtype, device=wrong_device)
 
             out = _apply_out_transform(_case_four_transform, expected)
-            with self.assertRaises(RuntimeError, msg=f"Expected RuntimeError when calling with input.device={device} and out.device={wrong_device}"):
+            msg_fail = f"Expected RuntimeError when calling with input.device={device} and out.device={wrong_device}"
+            with self.assertRaises(RuntimeError, msg=msg_fail):
                 op_out(out=out)
 
         # Case 5: out= with correct shape and device, but a dtype
@@ -619,10 +621,10 @@ class TestCommon(JitCommonTestCase):
                 return make_tensor(t.shape, dtype=torch.long, device=t.device)
 
             out = _apply_out_transform(_case_five_transform, expected)
-            msg = "" if not isinstance(expected, torch.Tensor) else \
-                  ("Expected RuntimeError when doing an unsafe cast from an out "
-                   f"with dtype torch.long to expected.dtype={expected.dtype}")
-            with self.assertRaises(RuntimeError, msg=msg):
+            msg_fail = "" if not isinstance(expected, torch.Tensor) else \
+                       ("Expected RuntimeError when doing an unsafe cast from an out "
+                        f"with dtype torch.long to expected.dtype={expected.dtype}")
+            with self.assertRaises(RuntimeError, msg=msg_fail):
                 op_out(out=out)
 
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -622,8 +622,8 @@ class TestCommon(JitCommonTestCase):
 
             out = _apply_out_transform(_case_five_transform, expected)
             msg_fail = "" if not isinstance(expected, torch.Tensor) else \
-                       ("Expected RuntimeError when doing an unsafe cast from an out "
-                        f"with dtype torch.long to expected.dtype={expected.dtype}")
+                       ("Expected RuntimeError when doing an unsafe cast from a result of type {expected.dtype}"
+                        f"into an out with dtype torch.long")
             with self.assertRaises(RuntimeError, msg=msg_fail):
                 op_out(out=out)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2199,11 +2199,6 @@ op_db: List[OpInfo] = [
                        # Reference: https://github.com/pytorch/pytorch/issues/49224
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
                                 dtypes=[torch.int8], active_if=TEST_WITH_ASAN),
-                       # TODO: Fix test_out_arg_all_dtypes as torch.empty_like(expected_output) where expected_output=op(input)
-                       # We can break the logic of the loop over all possible types but it is OK.
-                       # https://github.com/pytorch/pytorch/blob/master/test/test_unary_ufuncs.py#L440-L449
-                       SkipInfo('TestUnaryUfuncs', 'test_out_arg_all_dtypes',
-                                dtypes=[torch.cfloat, torch.cdouble]),
                    ),
                    supports_inplace_autograd=False,
                    assert_autodiffed=True),
@@ -2280,9 +2275,7 @@ op_db: List[OpInfo] = [
                #   doesn't work on all platforms
                SkipInfo('TestOpInfo', 'test_unsupported_dtypes', dtypes=(torch.bfloat16,)),
                # TODO: remove redundant method_tests() entries
-               SkipInfo('TestOpInfo', 'test_duplicate_method_tests'),
-               # addmm does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out')),
+               SkipInfo('TestOpInfo', 'test_duplicate_method_tests')),
            sample_inputs_func=sample_inputs_addmm),
     OpInfo('addr',
            dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
@@ -2298,30 +2291,18 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_addr),
     OpInfo('amax',
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           sample_inputs_func=sample_inputs_amax_amin,
-           skips=(
-               # amax does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),)),
+           sample_inputs_func=sample_inputs_amax_amin,),
     OpInfo('amin',
            dtypes=all_types_and(torch.float16, torch.bfloat16, torch.bool),
-           sample_inputs_func=sample_inputs_amax_amin,
-           skips=(
-               # amin does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),)),
+           sample_inputs_func=sample_inputs_amax_amin),
     OpInfo('argmax',
            dtypes=all_types_and(torch.float16, torch.bfloat16),
            supports_autograd=False,
-           sample_inputs_func=sample_inputs_argmax_argmin,
-           skips=(
-               # argmax does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),)),
+           sample_inputs_func=sample_inputs_argmax_argmin,),
     OpInfo('argmin',
            dtypes=all_types_and(torch.float16, torch.bfloat16),
            supports_autograd=False,
-           sample_inputs_func=sample_inputs_argmax_argmin,
-           skips=(
-               # argmin does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),)),
+           sample_inputs_func=sample_inputs_argmax_argmin,),
     UnaryUfuncInfo('asin',
                    aliases=('arcsin', ),
                    ref=np.arcsin,
@@ -2537,7 +2518,7 @@ op_db: List[OpInfo] = [
                # "cumsum_out_{cpu,cuda}" not implemented for 'Bool'
                SkipInfo('TestOpInfo', 'test_supported_dtypes',
                         dtypes=(torch.bool,)),
-               # cumsum does not correctly warn when resizing out= inputs
+               # cumsum does not handle correctly out= dtypes
                SkipInfo('TestCommon', 'test_out'),
            ),
            sample_inputs_func=sample_inputs_cumulative_ops),
@@ -2548,7 +2529,7 @@ op_db: List[OpInfo] = [
                # "cumprod_out_{cpu, cuda}" not implemented for 'Bool'
                SkipInfo('TestOpInfo', 'test_supported_dtypes',
                         dtypes=(torch.bool,)),
-               # cumprod does not correctly warn when resizing out= inputs
+               # cumprod does not handle correctly out= dtypes
                SkipInfo('TestCommon', 'test_out',
                         dtypes=[torch.float32]),
            ),
@@ -2624,10 +2605,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bool),
            dtypesIfCPU=all_types_and_complex_and(torch.bool),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half),
-           sample_inputs_func=sample_inputs_diag,
-           skips=(
-               # diag does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),)),
+           sample_inputs_func=sample_inputs_diag),
     UnaryUfuncInfo('frac',
                    ref=lambda x: np.modf(x)[0],
                    dtypes=floating_types_and(torch.bfloat16, torch.float16),
@@ -3016,12 +2994,7 @@ op_db: List[OpInfo] = [
            dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
            dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
-           sample_inputs_func=sample_inputs_masked_select,
-           supports_out=True,
-           skips=(
-               # masked_select does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-           )),
+           sample_inputs_func=sample_inputs_masked_select),
     OpInfo('max',
            op=torch.max,
            variant_test_name='binary',
@@ -3093,7 +3066,7 @@ op_db: List[OpInfo] = [
            skips=(
                # "cumprod_cuda" not implemented for 'BFloat16'
                SkipInfo('TestOpInfo', 'test_supported_backward', dtypes=(torch.bfloat16,)),
-               # prod does not correctly warn when resizing out= inputs
+               # prod does not support the (Tensor, *, out) overload
                SkipInfo('TestCommon', 'test_out',
                         dtypes=[torch.float32]),
            ),
@@ -3230,11 +3203,7 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and(torch.bfloat16, torch.half),
                    dtypesIfCPU=all_types_and(torch.bool, torch.bfloat16, torch.half),
                    dtypesIfCUDA=all_types_and(torch.bool, torch.bfloat16, torch.half),
-                   supports_autograd=False,
-                   skips=(
-                       # signbit does not correctly warn when resizing out= inputs
-                       SkipInfo('TestCommon', 'test_out'),
-                   )),
+                   supports_autograd=False,),
     OpInfo('solve',
            op=torch.solve,
            dtypes=floating_and_complex_types(),
@@ -3568,10 +3537,6 @@ op_db: List[OpInfo] = [
            sample_inputs_func=sample_inputs_index_copy),
     OpInfo('index_select',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
-           skips=(
-               # index_select does not correctly warn when resizing out= inputs
-               SkipInfo('TestCommon', 'test_out'),
-           ),
            sample_inputs_func=sample_inputs_index_select),
     OpInfo('index_add',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2851,7 +2851,7 @@ op_db: List[OpInfo] = [
                # "pow" not implemented for 'BFloat16' or 'half'
                SkipInfo('TestOpInfo', 'test_supported_backward',
                         dtypes=(torch.bfloat16, torch.float16)),
-               # linalg.norm does not correctly warn when resizing out= inputs
+               # linalg.norm does not fail when out= has a different dtype to input
                SkipInfo('TestCommon', 'test_out'),
            )),
     OpInfo('linalg.qr',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2199,6 +2199,11 @@ op_db: List[OpInfo] = [
                        # Reference: https://github.com/pytorch/pytorch/issues/49224
                        SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_normal',
                                 dtypes=[torch.int8], active_if=TEST_WITH_ASAN),
+                       # TODO: Fix test_out_arg_all_dtypes as torch.empty_like(expected_output) where expected_output=op(input)
+                       # We can break the logic of the loop over all possible types but it is OK.
+                       # https://github.com/pytorch/pytorch/blob/master/test/test_unary_ufuncs.py#L440-L449
+                       SkipInfo('TestUnaryUfuncs', 'test_out_arg_all_dtypes',
+                                dtypes=[torch.cfloat, torch.cdouble]),
                    ),
                    supports_inplace_autograd=False,
                    assert_autodiffed=True),


### PR DESCRIPTION
Partially solves https://github.com/pytorch/pytorch/issues/54061

This PR solves many of the "easy to solve" problems with `out=` not notifying when it resizes a tensor. It also reports the cause of some fails of the `out=` operation in the tests. Hopefully this way we will be able to catch some errors that do not come simply from not using `resize_output`.
cc @mruberry @anjali411 