### PR TITLE
Fix bug in self.assertExpectedInline

### DIFF
--- a/torch/testing/_internal/expecttest.py
+++ b/torch/testing/_internal/expecttest.py
@@ -230,7 +230,7 @@ class TestCase(unittest.TestCase):
                     lineno = EDIT_HISTORY.adjust_lineno(fn, lineno)
                     new, delta = replace_string_literal(old, lineno, actual)
 
-                    assert old != new, "Failed to substitute string at {}:{}".format(fn, lineno)
+                    assert old != new, f"Failed to substitute string at {fn}:{lineno}; did you use triple quotes?"
 
                     # Only write the backup file the first time we hit the
                     # file
@@ -258,7 +258,7 @@ class TestCase(unittest.TestCase):
         try:
             callable(*args, **kwargs)
         except exc_type as e:
-            self.assertExpectedInline(str(e), expect)
+            self.assertExpectedInline(str(e), expect, skip=1)
             return
         # Don't put this in the try block; the AssertionError will catch it
         self.fail(msg="Did not raise when expected to")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55150 Make structured functions properly check device/dtype of explicit out args
* **#55149 Fix bug in self.assertExpectedInline**

I was wondering why no one used this function.  It's because it
doesn't work!  Also a small doc improvement for expected inline.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27523880](https://our.internmc.facebook.com/intern/diff/D27523880)