### PR TITLE
[ONNX] Warning when using __len__ to calculate tensor shape

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -584,7 +584,7 @@ class Tensor(torch._C._TensorBase):
             warnings.warn('Using len to get tensor shape might cause the trace to be incorrect. '
                           'Recommended usage would be tensor.shape[0]. '
                           'Passing a tensor of different shape might lead to errors or silently give '
-                          'incorrect results).', category=torch.jit.TracerWarning, stacklevel=2)
+                          'incorrect results.', category=torch.jit.TracerWarning, stacklevel=2)
         return self.shape[0]
 
     def __iter__(self):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -580,6 +580,11 @@ class Tensor(torch._C._TensorBase):
             return handle_torch_function(Tensor.__len__, (self,), self)
         if self.dim() == 0:
             raise TypeError("len() of a 0-d tensor")
+        if torch._C._get_tracing_state():
+            warnings.warn('Using len to get tensor shape might cause the trace to be incorrect. '
+                          'Recommended usage would be tensor.shape[0]. '
+                          'Passing a tensor of different shape might lead to errors or silently give '
+                          'incorrect results).', category=torch.jit.TracerWarning, stacklevel=2)
         return self.shape[0]
 
     def __iter__(self):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -76,10 +76,6 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
            enable_onnx_checker=True, use_external_data_format=False):
-    import builtins
-    len_backup = builtins.len
-    # Get rid of patch
-    # builtins.len = lambda x : x.__len__()
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir
@@ -96,7 +92,6 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
             use_external_data_format=use_external_data_format)
-    builtins.len = len_backup
 
 
 def _is_constant_tensor_list(node):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -76,6 +76,9 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            do_constant_folding=True, example_outputs=None, strip_doc_string=True,
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
            enable_onnx_checker=True, use_external_data_format=False):
+    import builtins
+    len_backup = builtins.len
+    builtins.len = lambda x:x.__len__()
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir
@@ -92,6 +95,7 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
             dynamic_axes=dynamic_axes, keep_initializers_as_inputs=keep_initializers_as_inputs,
             custom_opsets=custom_opsets, enable_onnx_checker=enable_onnx_checker,
             use_external_data_format=use_external_data_format)
+    builtins.len = len_backup
 
 
 def _is_constant_tensor_list(node):

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -78,7 +78,8 @@ def export(model, args, f, export_params=True, verbose=False, training=None,
            enable_onnx_checker=True, use_external_data_format=False):
     import builtins
     len_backup = builtins.len
-    builtins.len = lambda x:x.__len__()
+    # Get rid of patch
+    # builtins.len = lambda x : x.__len__()
     if aten or export_raw_ir:
         assert operator_export_type is None
         assert aten ^ export_raw_ir


### PR DESCRIPTION
Difference in traced graph and outputs, when using len(tensor) as compared to tensor.shape[0]

An example model is (with tensor.shape):
```
# Test len fix with variable inputs
import torch
import onnxruntime

class Model(torch.nn.Module):
    def forward(self, x):
        return x.size(1) + x.shape[0]


# Call export
dummy_x = torch.randn(3, 5)
model = Model()

import io
onnx_io = io.BytesIO()
torch.onnx.export(model, (dummy_x,), onnx_io, 
                  input_names=['input'],
                  dynamic_axes={'input': {0:'h'}},
                  verbose=True)

# Call onnxruntime runtime and compare outputs on dynamic inputs
ort_session = onnxruntime.InferenceSession(onnx_io.getvalue())

x = torch.randn(2, 5)
print(model(x))
print(ort_session.run(None, {ort_session.get_inputs()[0].name: x.numpy()}))
```
The output graph is as follows:
```
graph(%input : Float(*, 5, strides=[5, 1], requires_grad=0, device=cpu)):
  %1 : Long(2, strides=[1], device=cpu) = onnx::Shape(%input)
  %2 : Long(device=cpu) = onnx::Constant[value={1}]()
  %3 : Long(device=cpu) = onnx::Gather[axis=0](%1, %2) # test/onnx/test_m.py:9:0
  %4 : Long(2, strides=[1], device=cpu) = onnx::Shape(%input)
  %5 : Long(device=cpu) = onnx::Constant[value={0}]()
  %6 : Long(device=cpu) = onnx::Gather[axis=0](%4, %5) # test/onnx/test_m.py:9:0
  %7 : Long(requires_grad=0, device=cpu) = onnx::Add(%3, %6) # test/onnx/test_m.py:9:0
  return (%7)
```
Torch output: 7
ORT output: 7

Now replacing tensor.shape[0] with len(tensor), the graph looks like:
```
graph(%input : Float(*, 5, strides=[5, 1], requires_grad=0, device=cpu)):
  %1 : Long(2, strides=[1], device=cpu) = onnx::Shape(%input)
  %2 : Long(device=cpu) = onnx::Constant[value={1}]()
  %3 : Long(device=cpu) = onnx::Gather[axis=0](%1, %2) # test/onnx/test_m.py:9:0
  %4 : Long(requires_grad=0, device=cpu) = onnx::Constant[value={3}]()
  %5 : Long(requires_grad=0, device=cpu) = onnx::Add(%3, %4)
  return (%5)
```
Torch output: 7
ORT output: 8

In the case with __len__, %4 is traced as a constant

**Workaround to avoid the mismatch when using len to get tensor.shape**

Add the following pattern around _export call
```
    import builtins
    len_backup = builtins.len
    builtins.len = lambda x : x.__len__()

    # Call export
    _export(model, args, .....

    builtins.len = len_backup

```