### PR TITLE
Fix security of ROCm labeling workflow

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -14,18 +14,20 @@ jobs:
       id: vars
       run: |
         set -eux
-        IS_PR=${{ github.event.pull_request }}
-        if [[ -n "${IS_PR}" ]]; then
-          TITLE="${{ github.event.pull_request.title }}"
-          ISSUE_NUMBER=${{ github.event.pull_request.number }}
+        if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+          TITLE="${PR_TITLE}"
+          ISSUE_NUMBER="${PR_NUMBER}"
         else
-          TITLE="${{ github.event.issue.title }}"
-          ISSUE_NUMBER=${{ github.event.issue.number }}
+          TITLE="${ISSUE_TITLE}"
+          ISSUE_NUMBER="${ISSUE_NUMBER}"
         fi
         echo ::set-output name=TITLE::"${TITLE}"
         echo ::set-output name=ISSUE_NUMBER::"${ISSUE_NUMBER}"
-        echo ::set-output name=OWNER::"${{ github.repository_owner }}"
-        echo ::set-output name=REPO::"${{ github.event.repository.name }}"
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
     - name: Auto-label ROCm
       run: |
         set -eux
@@ -37,8 +39,8 @@ jobs:
             -d '{"labels":["ROCm"]}'
         fi
       env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        TITLE: "${{ steps.vars.outputs.TITLE }}"
-        ISSUE_NUMBER: "${{ steps.vars.outputs.ISSUE_NUMBER }}"
-        OWNER: "${{ steps.vars.outputs.OWNER }}"
-        REPO: "${{ steps.vars.outputs.REPO }}"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TITLE: ${{ steps.vars.outputs.TITLE }}
+        ISSUE_NUMBER: ${{ steps.vars.outputs.ISSUE_NUMBER }}
+        OWNER: ${{ github.repository_owner }}
+        REPO: ${{ github.event.repository.name }}


### PR DESCRIPTION
The current workflow fails when there are backticks in the PR title, because bash tries to evaluate it right away. (example: https://github.com/pytorch/pytorch/runs/2242913870) Moving the variables to the env section away from bash, which removes the security risk. 

Test plan:
my repo: https://github.com/janeyx99/gha-experiments/actions/runs/709088679