### PR TITLE
Flip clip_grad_norm default for error_if_nonfinite to false

### DIFF
--- a/test/cpp/api/nn_utils.cpp
+++ b/test/cpp/api/nn_utils.cpp
@@ -222,7 +222,7 @@ TEST_F(NNUtilsTest, ClipGradNormErrorIfNonfinite) {
       for (auto p : parameters) {
         grads_before.push_back(p.grad().clone());
       }
-      EXPECT_THROW(utils::clip_grad_norm_(parameters, 1., norm_type), std::exception) << msg;
+      EXPECT_THROW(utils::clip_grad_norm_(parameters, 1., norm_type, true), std::exception) << msg;
       // Grads should not change if error is thrown
       for (int64_t p_idx = 0; p_idx < parameters.size(); p_idx++) {
         ASSERT_TRUE(torch::allclose(parameters[p_idx].grad(), grads_before[p_idx], 1.0, 0.0, /*equal_nan*/ true)) << msg;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -15051,7 +15051,7 @@ class TestNNDeviceType(NNTestCase):
                 grads_before = [p.grad.clone() for p in parameters]
 
                 with self.assertRaisesRegex(RuntimeError, error_msg, msg=msg):
-                    clip_grad_norm_(parameters, 1, norm_type=norm_type)
+                    clip_grad_norm_(parameters, 1, norm_type=norm_type, error_if_nonfinite=True)
 
                 # Grad should not change if error is thrown
                 grads_after = [p.grad for p in parameters]

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -15,9 +15,11 @@ inline double clip_grad_norm_(
     double max_norm,
     double norm_type = 2.0,
     bool error_if_nonfinite = false) {
-  TORCH_WARN_ONCE("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
-                  "to error out by default if a non-finite total norm is encountered. At that point, "
-                  "setting error_if_nonfinite=false will be required to retain the old behavior.");
+  if (!error_if_nonfinite) {
+    TORCH_WARN_ONCE("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
+                    "to error out by default if a non-finite total norm is encountered. At that point, "
+                    "setting error_if_nonfinite=false will be required to retain the old behavior.");
+  }
   std::vector<Tensor> params_with_grad;
 
   for (const auto& param : parameters) {

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -48,7 +48,7 @@ inline double clip_grad_norm_(
       "`error_if_nonfinite=false`");
 
     TORCH_WARN_ONCE("Non-finite norm encountered in torch.nn.utils.clip_grad_norm_; continuing anyway. "
-                    "Note that this behavior will change in a future release to error out by default "
+                    "Note that the default behavior will change in a future release to error out "
                     "if a non-finite total norm is encountered. At that point, setting "
                     "error_if_nonfinite=false will be required to retain the old behavior.");
   }

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -14,7 +14,7 @@ inline double clip_grad_norm_(
     std::vector<Tensor> parameters,
     double max_norm,
     double norm_type = 2.0,
-    bool error_if_nonfinite = true) {
+    bool error_if_nonfinite = false) {
   std::vector<Tensor> params_with_grad;
 
   for (const auto& param : parameters) {
@@ -63,7 +63,7 @@ inline double clip_grad_norm_(
     std::initializer_list<Tensor> parameters,
     double max_norm,
     double norm_type = 2.0,
-    bool error_if_nonfinite = true) {
+    bool error_if_nonfinite = false) {
   return clip_grad_norm_(std::vector<Tensor>(parameters), max_norm, norm_type, error_if_nonfinite);
 }
 
@@ -73,7 +73,7 @@ inline double clip_grad_norm_(
     Tensor parameter,
     double max_norm,
     double norm_type = 2.0,
-    bool error_if_nonfinite = true) {
+    bool error_if_nonfinite = false) {
   std::vector<Tensor> params = {parameter};
   return clip_grad_norm_(params, max_norm, norm_type, error_if_nonfinite);
 }

--- a/torch/csrc/api/include/torch/nn/utils/clip_grad.h
+++ b/torch/csrc/api/include/torch/nn/utils/clip_grad.h
@@ -15,6 +15,9 @@ inline double clip_grad_norm_(
     double max_norm,
     double norm_type = 2.0,
     bool error_if_nonfinite = false) {
+  TORCH_WARN_ONCE("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
+                  "to error out by default if a non-finite total norm is encountered. At that point, "
+                  "setting error_if_nonfinite=false will be required to retain the old behavior.");
   std::vector<Tensor> params_with_grad;
 
   for (const auto& param : parameters) {

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -27,10 +27,11 @@ def clip_grad_norm_(
     Returns:
         Total norm of the parameters (viewed as a single vector).
     """
-    warnings.warn("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
-                  "to error out by default if a non-finite total norm is encountered. At that point, "
-                  "setting error_if_nonfinite=false will be required to retain the old behavior.",
-                  FutureWarning, stacklevel=2)
+    if not error_if_nonfinite:
+        warnings.warn("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
+                      "to error out by default if a non-finite total norm is encountered. At that point, "
+                      "setting error_if_nonfinite=false will be required to retain the old behavior.",
+                      FutureWarning, stacklevel=2)
 
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -22,7 +22,7 @@ def clip_grad_norm_(
             infinity norm.
         error_if_nonfinite (bool): if True, an error is thrown if the total
             norm of the gradients from :attr:``parameters`` is ``nan``,
-            ``inf``, or ``-inf``. Default: True
+            ``inf``, or ``-inf``. Default: False (will switch to True in the future)
 
     Returns:
         Total norm of the parameters (viewed as a single vector).

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -27,6 +27,11 @@ def clip_grad_norm_(
     Returns:
         Total norm of the parameters (viewed as a single vector).
     """
+    warnings.warn("The behavior of torch.nn.utils.clip_grad_norm_ will change in a future release "
+                  "to error out by default if a non-finite total norm is encountered. At that point, "
+                  "setting error_if_nonfinite=false will be required to retain the old behavior.",
+                  FutureWarning, stacklevel=2)
+
     if isinstance(parameters, torch.Tensor):
         parameters = [parameters]
     parameters = [p for p in parameters if p.grad is not None]

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -52,7 +52,7 @@ def clip_grad_norm_(
                           "Note that the default behavior will change in a future release to error out "
                           "if a non-finite total norm is encountered. At that point, setting "
                           "error_if_nonfinite=false will be required to retain the old behavior.",
-                          FutureWarning, stacklevel=2);
+                          FutureWarning, stacklevel=2)
     clip_coef = max_norm / (total_norm + 1e-6)
     if clip_coef < 1:
         for p in parameters:

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -49,7 +49,7 @@ def clip_grad_norm_(
                 'set `error_if_nonfinite=False`')
         else:
             warnings.warn("Non-finite norm encountered in torch.nn.utils.clip_grad_norm_; continuing anyway. "
-                          "Note that this behavior will change in a future release to error out by default "
+                          "Note that the default behavior will change in a future release to error out "
                           "if a non-finite total norm is encountered. At that point, setting "
                           "error_if_nonfinite=false will be required to retain the old behavior.",
                           FutureWarning, stacklevel=2);

--- a/torch/nn/utils/clip_grad.py
+++ b/torch/nn/utils/clip_grad.py
@@ -8,7 +8,7 @@ _tensor_or_tensors = Union[torch.Tensor, Iterable[torch.Tensor]]
 
 def clip_grad_norm_(
         parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.0,
-        error_if_nonfinite: bool = True) -> torch.Tensor:
+        error_if_nonfinite: bool = False) -> torch.Tensor:
     r"""Clips gradient norm of an iterable of parameters.
 
     The norm is computed over all gradients together, as if they were
@@ -55,7 +55,7 @@ def clip_grad_norm_(
 
 def clip_grad_norm(
         parameters: _tensor_or_tensors, max_norm: float, norm_type: float = 2.,
-        error_if_nonfinite: bool = True) -> torch.Tensor:
+        error_if_nonfinite: bool = False) -> torch.Tensor:
     r"""Clips gradient norm of an iterable of parameters.
 
     .. warning::


### PR DESCRIPTION
Summary: Non-backwards-compatible change introduced in https://github.com/pytorch/pytorch/pull/53843 is tripping up a lot of code. Better to set it to False initially and then potentially flip to True in the later version to give people time to adapt.

Differential Revision: D27511150

