### PR TITLE
Correct the name of the label in auto-label-rocm

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -36,7 +36,7 @@ jobs:
             -X POST \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             "https://api.github.com/repos/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}/labels" \
-            -d '{"labels":["ROCm"]}'
+            -d '{"labels":["module: rocm"]}'
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The label name was meant to be "module: rocm".

**Test plan:**

None.