### PR TITLE
Ensure workflow consistency for autocanceling

### DIFF
--- a/.github/scripts/generate_workflow_names.py
+++ b/.github/scripts/generate_workflow_names.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import os
+import yaml
+
+rootdir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'workflows')
+for subdir, _, files in os.walk(rootdir):
+    for file in files:
+        filepath = os.path.join(subdir, file)
+        if filepath.endswith(('.yml', '.yaml')):
+            with open(filepath) as f:
+                data = yaml.safe_load(f)
+                assert 'name' in data, 'Every GHA workflow must have a name.'
+                # The reason the below key is True is because yaml parses 'on:' as a boolean.
+                # Since the solutions to maintain the key as 'on' seems more complicated than it's worth,
+                # I decided to stick with having True as a key instead of hacking my way through YAML
+                # implementation that is bound to change and become better anyway. More context below:
+                # https://stackoverflow.com/questions/36463531/pyyaml-automatically-converting-certain-keys-to-boolean-values
+                if 'pull_request' in data[True]:
+                    print(data['name'])

--- a/.github/scripts/generate_workflow_names.py
+++ b/.github/scripts/generate_workflow_names.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 
-import os
 import yaml
+from pathlib import Path
 
-rootdir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'workflows')
-for subdir, _, files in os.walk(rootdir):
-    for file in files:
-        filepath = os.path.join(subdir, file)
-        if filepath.endswith(('.yml', '.yaml')):
-            with open(filepath) as f:
-                data = yaml.safe_load(f)
-                assert 'name' in data, 'Every GHA workflow must have a name.'
-                # The reason the below key is True is because yaml parses 'on:' as a boolean.
-                # Since the solutions to maintain the key as 'on' seems more complicated than it's worth,
-                # I decided to stick with having True as a key instead of hacking my way through YAML
-                # implementation that is bound to change and become better anyway. More context below:
-                # https://stackoverflow.com/questions/36463531/pyyaml-automatically-converting-certain-keys-to-boolean-values
-                if 'pull_request' in data[True]:
-                    print(data['name'])
+workflow_paths = (Path(__file__).parent.parent / 'workflows').rglob('*')
+for path in workflow_paths:
+    if path.suffix in {'.yml', '.yaml'}:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+            assert 'name' in data, 'Every GHA workflow must have a name.'
+            # The reason the below key is True is because yaml parses 'on:' as a boolean.
+            # Since the solutions to maintain the key as 'on' seems more complicated than it's worth,
+            # I decided to stick with having True as a key instead of hacking my way through YAML
+            # implementation that is bound to change and become better anyway. More context below:
+            # https://stackoverflow.com/questions/36463531/pyyaml-automatically-converting-certain-keys-to-boolean-values
+            if 'pull_request' in data[True]:
+                print(data['name'])

--- a/.github/workflows/cancel_redundant_workflows.yml
+++ b/.github/workflows/cancel_redundant_workflows.yml
@@ -3,6 +3,7 @@ on:
   workflow_run:
     types:
       - requested
+    # NOTE: Make sure to add to this list as you add more workflows running on 'pull_request'
     workflows:
       - clang-format
       - Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ jobs:
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
         run: |
-          import os
           import yaml
           import subprocess
           workflows = subprocess.check_output(['python', '.github/scripts/generate_workflow_names.py'],

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,22 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v2
+      - name: Install requirements
+        run: pip install -r requirements.txt
       - name: Ensure consistent CircleCI YAML config
+        run: cd .circleci && ./ensure-consistency.py
+      - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
         run: |
-          pip install -r requirements.txt
-          cd .circleci && ./ensure-consistency.py
+          import os
+          import yaml
+          import subprocess
+          workflows = subprocess.check_output(['python', '.github/scripts/generate_workflow_names.py'],
+                                              encoding="ascii").splitlines()
+          with open('.github/workflows/cancel_redundant_workflows.yml') as f:
+                data = yaml.safe_load(f)
+                workflows_to_cancel = data[True]['workflow_run']['workflows']
+          assert workflows.sort() == workflows_to_cancel.sort()
+        shell: python
       - name: Shellcheck Jenkins scripts
         # https://github.com/koalaman/shellcheck/tree/v0.7.1#installing-a-pre-compiled-binary
         run: |


### PR DESCRIPTION
Currently, we only have three GHA workflows that need to be canceled on reruns. To anticipate for future workflows, this PR enables a check that will make sure any new workflow that should be autocanceled on reruns will be included in the cancel_redundant_workflows.yml GHA workflow.

Test plan:
Succeeded quick-checks https://github.com/pytorch/pytorch/runs/2249162035?check_suite_focus=true