### PR TITLE
[c10] Adjust macro check that detects if glibc++ use c99 csqrt

### DIFF
--- a/c10/util/complex_math.cpp
+++ b/c10/util/complex_math.cpp
@@ -1,4 +1,5 @@
 #include <c10/util/complex.h>
+#include <c10/util/math_compat.h>
 
 #include <cmath>
 
@@ -12,7 +13,7 @@
 // In libstdc++ complex square root yield invalid results
 // for -x-0.0j unless C99 csqrt/csqrtf fallbacks are used
 
-#if defined(_LIBCPP_VERSION) || (defined(_GLIBCXX11_USE_C99_COMPLEX) && !_GLIBCXX11_USE_C99_COMPLEX)
+#if defined(_LIBCPP_VERSION) || (defined(__GLIBCXX__) && !defined(_GLIBCXX11_USE_C99_COMPLEX))
 
 namespace {
 template <typename T>

--- a/c10/util/complex_math.h
+++ b/c10/util/complex_math.h
@@ -42,7 +42,7 @@ C10_HOST_DEVICE inline c10::complex<T> log2(const c10::complex<T> &x) {
 
 // Power functions
 //
-#if defined(_LIBCPP_VERSION) || (defined(_GLIBCXX11_USE_C99_COMPLEX) && !_GLIBCXX11_USE_C99_COMPLEX)
+#if defined(_LIBCPP_VERSION) || (defined(__GLIBCXX__) && !defined(_GLIBCXX11_USE_C99_COMPLEX))
 namespace _detail {
 TORCH_API c10::complex<float> sqrt(const c10::complex<float>& in);
 TORCH_API c10::complex<double> sqrt(const c10::complex<double>& in);
@@ -55,7 +55,7 @@ template<typename T>
 C10_HOST_DEVICE inline c10::complex<T> sqrt(const c10::complex<T> &x) {
 #if defined(__CUDACC__) || defined(__HIPCC__)
   return static_cast<c10::complex<T>>(thrust::sqrt(c10_internal::cuda101bug_cast_c10_complex_to_thrust_complex(x)));
-#elif !(defined(_LIBCPP_VERSION) || (defined(_GLIBCXX11_USE_C99_COMPLEX) && !_GLIBCXX11_USE_C99_COMPLEX))
+#elif !(defined(_LIBCPP_VERSION) || (defined(__GLIBCXX__) && !defined(_GLIBCXX11_USE_C99_COMPLEX)))
   return static_cast<c10::complex<T>>(std::sqrt(static_cast<std::complex<T>>(x)));
 #else
   return _detail::sqrt(x);

--- a/c10/util/math_compat.h
+++ b/c10/util/math_compat.h
@@ -6,6 +6,7 @@
 // Various hacks in this header allow the rest of the codebase to use
 // standard APIs.
 #if defined(__ANDROID__) && __ANDROID_API__ < 21 && defined(__GLIBCXX__)
+#include <stdexcept>
 
 namespace std {
   // Import double versions of these functions from the global namespace.


### PR DESCRIPTION
Summary:
This fixes `warning: '_GLIBCXX11_USE_C99_COMPLEX' is not defined, evaluates to 0`, that would be raised if https://github.com/pytorch/pytorch/pull/54820 used with libstd++ compiled without USE_C99_COMPLEX support.

In `c++config.h` `_GLIBCXX_USE_C99_COMPLEX` is aliased to either `_GLIBCXX99_USE_C99_COMPLEX` or `_GLIBCXX11_USE_C99_COMPLEX` depending on  `__cplusplus` macro, as shown here:
https://github.com/gcc-mirror/gcc/blob/0cf4813202f19768e31666f6aa82bde4dce4065a/libstdc%2B%2B-v3/include/bits/c%2B%2Bconfig#L641-L647

Abovementioned config file is generated by autoconf, that leaves macro undefined if feature is not used, so using conditional like `defined(_GLIBCXX_USE_C99_COMPLEX) && _GLIBCXX_USE_C99_COMPLEX == 0` would trigger undefined macro preprocessor warning.

Test Plan: CI

Differential Revision: D27517788

