### PR TITLE
Enhance Pipe docs to explicitly mention RPC initialization.

### DIFF
--- a/test/distributed/pipeline/sync/test_pipe.py
+++ b/test/distributed/pipeline/sync/test_pipe.py
@@ -17,13 +17,18 @@ from torch.distributed.pipeline.sync import Pipe
 skip_if_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda required")
 
 
-def test_parameters():
+def test_pipe_without_rpc():
+    model = nn.Sequential(nn.Linear(1, 1))
+    with pytest.raises(RuntimeError, match='Please initialize RPC framework'):
+        pipe = Pipe(model, chunks=1)
+
+def test_parameters(setup_rpc):
     model = nn.Sequential(nn.Linear(1, 1))
     pipe = Pipe(model, chunks=1)
     assert list(pipe.parameters()) != []
 
 
-def test_public_attrs():
+def test_public_attrs(setup_rpc):
     class MyString:
         def __init__(self, value):
             self.value = value
@@ -41,7 +46,7 @@ def test_public_attrs():
     assert isinstance(pipe.checkpoint, str)
 
 
-def test_sequential_like():
+def test_sequential_like(setup_rpc):
     a = nn.Linear(1, 1)
     b = nn.Linear(1, 1)
 
@@ -59,7 +64,7 @@ def test_sequential_like():
     assert model[-1] is b
     assert model[-2] is a
 
-def test_chunks_less_than_1():
+def test_chunks_less_than_1(setup_rpc):
     model = nn.Sequential(nn.Linear(1, 1))
 
     with pytest.raises(ValueError):
@@ -124,14 +129,14 @@ def test_checkpoint_mode(setup_rpc):
     assert count_grad_fn(never_output.local_value().grad_fn, "CheckpointBackward") == 0
 
 
-def test_checkpoint_mode_invalid():
+def test_checkpoint_mode_invalid(setup_rpc):
     model = nn.Sequential(nn.Linear(1, 1))
 
     with pytest.raises(ValueError, match="checkpoint is not one of 'always', 'except_last', or 'never'"):
         Pipe(model, chunks=2, checkpoint="INVALID_CHECKPOINT")
 
 
-def test_checkpoint_mode_when_chunks_1():
+def test_checkpoint_mode_when_chunks_1(setup_rpc):
     model = nn.Sequential(nn.Linear(1, 1))
 
     # All checkpoint modes are fine.
@@ -441,7 +446,7 @@ def test_deferred_batch_norm_params(checkpoint, setup_rpc):
     assert torch.allclose(pipe[0].bias.grad, bn.bias.grad, atol=1e-4)
 
 
-def test_devices():
+def test_devices(setup_rpc):
     a = nn.Linear(1, 1)
     b = nn.Linear(1, 1)
     c = nn.Linear(1, 1)
@@ -455,7 +460,7 @@ def test_devices():
     assert model.devices == [cpu, cpu, cpu]
 
 
-def test_partitions():
+def test_partitions(setup_rpc):
     a = nn.Linear(1, 1)
     b = nn.Linear(1, 1)
 
@@ -469,7 +474,7 @@ def test_partitions():
     assert "partitions.0.0.weight" in model.state_dict()
 
 
-def test_deny_moving():
+def test_deny_moving(setup_rpc):
     a = nn.Linear(1, 1)
     b = nn.Linear(1, 1)
 
@@ -520,7 +525,7 @@ def test_empty_module(setup_rpc):
         model(42)
 
 
-def test_named_children():
+def test_named_children(setup_rpc):
     a = nn.Linear(1, 1)
     b = nn.Linear(1, 1)
 
@@ -537,12 +542,12 @@ def test_named_children():
         model.a
 
 
-def test_verify_module_non_sequential():
+def test_verify_module_non_sequential(setup_rpc):
     with pytest.raises(TypeError, match="module must be nn.Sequential to be partitioned"):
         Pipe(nn.Module())
 
 
-def test_verify_module_duplicate_children():
+def test_verify_module_duplicate_children(setup_rpc):
     conv = nn.Conv2d(3, 3, 1)
     model = nn.Sequential(conv, conv)
 
@@ -551,7 +556,7 @@ def test_verify_module_duplicate_children():
 
 
 @skip_if_no_cuda
-def test_verify_module_params_on_same_device():
+def test_verify_module_params_on_same_device(setup_rpc):
     class Surrogate(nn.Module):
         def __init__(self, param1, param2):
             super().__init__()
@@ -587,7 +592,7 @@ def test_verify_nested_modules(setup_rpc):
     assert out.local_value().device == torch.device("cuda:1")
     assert out.local_value().size() == torch.Size([10, 2])
 
-def test_verify_module_duplicate_parameters_on_same_device():
+def test_verify_module_duplicate_parameters_on_same_device(setup_rpc):
     class Surrogate(nn.Module):
         def __init__(self, module):
             super().__init__()

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -182,6 +182,12 @@ class Pipe(Module):
     Example::
         Pipeline of two FC layers across GPUs 0 and 1.
 
+        >>> # Need to initialize RPC framework first.
+        >>> os.environ['MASTER_ADDR'] = 'localhost'
+        >>> os.environ['MASTER_PORT'] = '29500'
+        >>> torch.distributed.rpc.init_rpc('worker', rank=0, world_size=1)
+        >>>
+        >>> # Build pipe.
         >>> fc1 = nn.Linear(16, 8).cuda(0)
         >>> fc2 = nn.Linear(8, 4).cuda(1)
         >>> model = nn.Sequential(fc1, fc2)
@@ -215,6 +221,12 @@ class Pipe(Module):
         deferred_batch_norm: bool = False,
     ) -> None:
         super().__init__()
+
+        # Check if RPC framework is initialized.
+        if not torch.distributed.rpc._is_current_rpc_agent_set():
+            raise RuntimeError(
+                'Please initialize RPC framework for Pipe using '
+                'torch.distributed.rpc.init_rpc')
 
         chunks = int(chunks)
         checkpoint = str(checkpoint)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55187 Enhance Pipe docs to explicitly mention RPC initialization.**

As described in https://github.com/pytorch/pytorch/issues/54927, Pipe
docs didn't explicitly mention initializing RPC. This PR improves the docs and
also ensures Pipe throws a more useful error message when RPC is not
initialized and not an internal assertion error.

Differential Revision: [D27521783](https://our.internmc.facebook.com/intern/diff/D27521783/)