### PR TITLE
Use slow tests stats in common_utils

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -830,6 +830,7 @@ def check_slow_test_from_stats(test):
 
     if test_name in slow_tests_dict:
         getattr(test, test._testMethodName).__dict__['slow_test'] = True
+        print(f'{test_name} is slowwwwwww')  # to see if anything shows up in normal PRs
 
 
 disabled_test_from_issues: Optional[Dict[str, Any]] = None

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -831,6 +831,8 @@ def check_slow_test_from_stats(test):
     if test_name in slow_tests_dict:
         getattr(test, test._testMethodName).__dict__['slow_test'] = True
         print(f'{test_name} is slowwwwwww')  # to see if anything shows up in normal PRs
+        if not TEST_WITH_SLOW:
+            raise unittest.SkipTest("test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test")
 
 
 disabled_test_from_issues: Optional[Dict[str, Any]] = None

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -821,16 +821,14 @@ slow_tests_dict: Optional[Dict[str, float]] = None
 def check_slow_test_from_stats(test):
     global slow_tests_dict
     if slow_tests_dict is None:
-        url = 'https://raw.githubusercontent.com/janeyx99/test-infra/main/stats/.pytorch-slow-tests'
+        url = 'https://raw.githubusercontent.com/pytorch/test-infra/master/stats/.pytorch-slow-tests'
         contents = urlopen(url, timeout=1).read().decode('utf-8')
         slow_tests_dict = json.loads(contents)
-    slow_tests_dict = cast(Dict[str, float], slow_tests_dict)
     test_suite = str(test.__class__).split('\'')[1]
     test_name = f'{test._testMethodName} ({test_suite})'
 
     if test_name in slow_tests_dict:
         getattr(test, test._testMethodName).__dict__['slow_test'] = True
-        print(f'{test_name} is slowwwwwww')  # to see if anything shows up in normal PRs
         if not TEST_WITH_SLOW:
             raise unittest.SkipTest("test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test")
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -822,8 +822,12 @@ def check_slow_test_from_stats(test):
     global slow_tests_dict
     if slow_tests_dict is None:
         url = 'https://raw.githubusercontent.com/pytorch/test-infra/master/stats/.pytorch-slow-tests'
-        contents = urlopen(url, timeout=1).read().decode('utf-8')
-        slow_tests_dict = json.loads(contents)
+        try:
+            contents = urlopen(url, timeout=1).read().decode('utf-8')
+            slow_tests_dict = json.loads(contents)
+        except Exception as e:
+            print(f'Could not download slow test stats because of error {e}. Proceeding with no added slow tests.')
+            slow_tests_dict = {}
     test_suite = str(test.__class__).split('\'')[1]
     test_name = f'{test._testMethodName} ({test_suite})'
 


### PR DESCRIPTION
This is a step in adding automatic @slowTest detection to our testing infrastructure. This uses stats (updated daily) in https://github.com/pytorch/test-infra/blob/master/stats/.pytorch-slow-tests to determine whether more tests need to be marked as slow as they are run.

More details in previous PR draft/proposal [here](https://github.com/pytorch/pytorch/pull/54456#issue-598388491), though I no longer think we need the third step as using a raw git file does not require much processing.

Upon looking at [logs](https://circleci.com/api/v1.1/project/github/pytorch/pytorch/12060292/output/107/0?file=true&allocation-id=606660dbd8e5857bcc2b2e0f-0-build%2F60DCA8CD) for the coverage tests as of the first commit [when I had not skipped the tests so we could see their actual times], here are some slow tests that weren't marked as slow before:
```
test_fn_gradgrad_unfold_cpu_complex128 (__main__.TestGradientsCPU) (172.554s)
test_matmul_4d_4d_complex_cpu (__main__.TestAutogradDeviceTypeCPU) (180.057s)
test_conv1d_basic (__main__.TestXNNPACKConv1dTransformPass) (94.737s)
```

And here is a test that wasn't actually slow but was still marked as slow based on stats:
```
test_trunc_normal (__main__.TestNNInit) ... ok (1.208s)
```

The new logs show the above tests as skipped (as they should be):
[Coverage Test 1](https://app.circleci.com/pipelines/github/pytorch/pytorch/296224/workflows/ba6c2917-51f8-4fb8-be57-90151c2e5c25/jobs/12126156) and [Coverage Test 2](https://app.circleci.com/pipelines/github/pytorch/pytorch/296224/workflows/ba6c2917-51f8-4fb8-be57-90151c2e5c25/jobs/12126155)