### PR TITLE
Transition to new tensorpipe::Message::Tensor API.

### DIFF
--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -44,10 +44,10 @@ TEST(TensorpipeSerialize, Base) {
   for (auto& tpTensor : sendingTpMessage.tensors) {
     tensorpipe::CpuBuffer buffer;
     buffer.ptr = nullptr;
-    buffer.length = tpTensor.buffer.unwrap<tensorpipe::CpuBuffer>().length;
 
     tensorpipe::Message::Tensor t;
     t.buffer = buffer;
+    t.length = tpTensor.length;
     t.metadata = tpTensor.metadata;
     recvingTpMessage.tensors.push_back(std::move(t));
   }
@@ -75,7 +75,7 @@ TEST(TensorpipeSerialize, Base) {
     memcpy(
         dstTensor.buffer.unwrap<tensorpipe::CpuBuffer>().ptr,
         srcTensor.buffer.unwrap<tensorpipe::CpuBuffer>().ptr,
-        srcTensor.buffer.unwrap<tensorpipe::CpuBuffer>().length);
+        srcTensor.length);
   }
 
   // Mimic read() callback:
@@ -124,11 +124,7 @@ TEST(TensorpipeSerialize, RecopySparseTensors) {
   EXPECT_NE(
       tiny.storage().data(),
       sendingTpMessage.tensors[1].buffer.unwrap<tensorpipe::CpuBuffer>().ptr);
-  EXPECT_EQ(
-      tiny.element_size() * k1K,
-      sendingTpMessage.tensors[1]
-          .buffer.unwrap<tensorpipe::CpuBuffer>()
-          .length);
+  EXPECT_EQ(tiny.element_size() * k1K, sendingTpMessage.tensors[1].length);
 }
 
 TEST(TensorpipeSerialize, NoDeleterTensors) {
@@ -152,15 +148,9 @@ TEST(TensorpipeSerialize, NoDeleterTensors) {
   EXPECT_EQ(tpBuffers.copiedTensors.size(), 2);
   EXPECT_EQ(sendingTpMessage.tensors.size(), 2);
   EXPECT_EQ(
-      tpBuffers.copiedTensors[0].size(),
-      sendingTpMessage.tensors[0]
-          .buffer.unwrap<tensorpipe::CpuBuffer>()
-          .length);
+      tpBuffers.copiedTensors[0].size(), sendingTpMessage.tensors[0].length);
   EXPECT_EQ(
-      tpBuffers.copiedTensors[1].size(),
-      sendingTpMessage.tensors[1]
-          .buffer.unwrap<tensorpipe::CpuBuffer>()
-          .length);
+      tpBuffers.copiedTensors[1].size(), sendingTpMessage.tensors[1].length);
   EXPECT_EQ(
       tpBuffers.copiedTensors[0].data(),
       sendingTpMessage.tensors[0].buffer.unwrap<tensorpipe::CpuBuffer>().ptr);
@@ -171,14 +161,10 @@ TEST(TensorpipeSerialize, NoDeleterTensors) {
       memcmp(
           tpBuffers.copiedTensors[0].data(),
           t1.storage().data(),
-          sendingTpMessage.tensors[0]
-              .buffer.unwrap<tensorpipe::CpuBuffer>()
-              .length) == 0);
+          sendingTpMessage.tensors[0].length) == 0);
   EXPECT_TRUE(
       memcmp(
           tpBuffers.copiedTensors[1].data(),
           t2.storage().data(),
-          sendingTpMessage.tensors[1]
-              .buffer.unwrap<tensorpipe::CpuBuffer>()
-              .length) == 0);
+          sendingTpMessage.tensors[1].length) == 0);
 }


### PR DESCRIPTION
Now that `tensorpipe::Message::Tensor` has a length member, fill that instead of `{Cpu,Cuda}Buffer.length`, which is going away.

Test Plan: CI

Reviewed By: lw

Differential Revision: D27466387

