### PR TITLE
Fix timer overflow on small, fast snippets

### DIFF
--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -166,9 +166,13 @@ class TestBenchmarkUtils(TestCase):
         ).timeit(5).median
         self.assertIsInstance(sample, float)
 
+    @slowTest
+    @unittest.skipIf(IS_SANDCASTLE, "C++ timing is OSS only.")
     def test_timer_tiny_fast_snippet(self):
         timer = benchmark_utils.Timer(
-            'auto x = 1;', language='cpp'
+            'auto x = 1;',
+            timer=timeit.default_timer,
+            language=benchmark_utils.Language.CPP,
         )
         median = timer.blocked_autorange().median
         self.assertIsInstance(median, float)

--- a/test/benchmark_utils/test_benchmark_utils.py
+++ b/test/benchmark_utils/test_benchmark_utils.py
@@ -166,6 +166,13 @@ class TestBenchmarkUtils(TestCase):
         ).timeit(5).median
         self.assertIsInstance(sample, float)
 
+    def test_timer_tiny_fast_snippet(self):
+        timer = benchmark_utils.Timer(
+            'auto x = 1;', language='cpp'
+        )
+        median = timer.blocked_autorange().median
+        self.assertIsInstance(median, float)
+
     @slowTest
     @unittest.skipIf(IS_SANDCASTLE, "C++ timing is OSS only.")
     def test_cpp_timer(self):

--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -310,6 +310,9 @@ class Timer(object):
                     break
                 if time_taken > min_run_time:
                     break
+                # Avoid overflow in C++ pybind11 interface
+                if number * 10 > 2147483647:
+                    break
                 number *= 10
         return number
 


### PR DESCRIPTION
- Fixes #54114
- Capped estimated block size to the largest multiple of ten less than C++ INT_MAX
- Test plan: unit test doesn't throw exception as expected