### PR TITLE
[Test, Ignore] assert empty_cuda generated tensor on expected device

### DIFF
--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -63,6 +63,7 @@ Tensor empty_cuda(IntArrayRef size, c10::optional<ScalarType> dtype_opt, c10::op
 
   auto tensor =
       detail::make_tensor<TensorImpl>(storage_impl, DispatchKey::CUDA, dtype_meta);
+  AT_ASSERT(tensor.device() == device_opt.value());
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);

--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -63,7 +63,6 @@ Tensor empty_cuda(IntArrayRef size, c10::optional<ScalarType> dtype_opt, c10::op
 
   auto tensor =
       detail::make_tensor<TensorImpl>(storage_impl, DispatchKey::CUDA, dtype_meta);
-  AT_ASSERT(tensor.device() == device_opt.value());
   // Default TensorImpl has size [0]
   if (size.size() != 1 || size[0] != 0) {
     tensor.unsafeGetTensorImpl()->set_sizes_contiguous(size);
@@ -71,6 +70,13 @@ Tensor empty_cuda(IntArrayRef size, c10::optional<ScalarType> dtype_opt, c10::op
 
   auto memory_format = memory_format_opt.value_or(MemoryFormat::Contiguous);
   tensor.unsafeGetTensorImpl()->empty_tensor_restride(memory_format);
+
+  // Sanity check before return
+  AT_ASSERT(tensor.device().has_index());
+  if (device_opt.value().has_index()) {
+    AT_ASSERT(tensor.device().index() == device_opt.value().index());
+  }
+
   return tensor;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55214 [Test, Ignore] assert empty_cuda generated tensor on expected device**

Differential Revision: [D27530377](https://our.internmc.facebook.com/intern/diff/D27530377/)