### PR TITLE
introduce gain arg for kaiming initialisation

### DIFF
--- a/benchmarks/functional_autograd_benchmark/torchvision_models.py
+++ b/benchmarks/functional_autograd_benchmark/torchvision_models.py
@@ -149,7 +149,8 @@ class ResNet(nn.Module):
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
-                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                relu_gain = nn.init.calculate_gain('relu')
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', gain=relu_gain)
             elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)

--- a/test/jit/test_models.py
+++ b/test/jit/test_models.py
@@ -640,7 +640,8 @@ class TestModels(JitTestCase):
 
                 for m in self.modules():
                     if isinstance(m, nn.Conv2d):
-                        nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                        relu_gain = nn.init.calculate_gain('relu')
+                        nn.init.kaiming_normal_(m.weight, mode='fan_out', gain=relu_gain)
                     elif isinstance(m, nn.BatchNorm2d):
                         nn.init.constant_(m.weight, 1)
                         nn.init.constant_(m.bias, 0)

--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -51,7 +51,7 @@ class LinearReluFunctional(nn.Module):
         super().__init__()
         self.w1 = nn.Parameter(torch.Tensor(4, 4))
         self.b1 = nn.Parameter(torch.zeros(4))
-        torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
+        torch.nn.init.kaiming_uniform_(self.w1, gain=math.sqrt(1 / 3))
 
     def forward(self, x):
         x = F.linear(x, self.w1, self.b1)
@@ -84,7 +84,7 @@ class TestFXGraphMatcher(QuantizationTestCase):
                 super().__init__()
                 self.w = nn.Parameter(torch.Tensor(1, 4))
                 self.b = nn.Parameter(torch.zeros(1))
-                torch.nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
+                torch.nn.init.kaiming_uniform_(self.w, gain=math.sqrt(1 / 3))
 
             def forward(self, x):
                 return F.linear(x, self.w, self.b)
@@ -451,7 +451,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 super().__init__()
                 self.w = nn.Parameter(torch.Tensor(4, 4))
                 self.b = nn.Parameter(torch.zeros(4))
-                torch.nn.init.kaiming_uniform_(self.w, a=math.sqrt(5))
+                torch.nn.init.kaiming_uniform_(self.w, gain=math.sqrt(1 / 3))
 
             def forward(self, x):
                 x = F.linear(x, self.w, self.b)
@@ -486,8 +486,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 self.b1 = nn.Parameter(torch.zeros(4))
                 self.w2 = nn.Parameter(torch.Tensor(4, 4))
                 self.b2 = nn.Parameter(torch.zeros(4))
-                torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
-                torch.nn.init.kaiming_uniform_(self.w2, a=math.sqrt(5))
+                torch.nn.init.kaiming_uniform_(self.w1, gain=math.sqrt(1 / 3))
+                torch.nn.init.kaiming_uniform_(self.w2, gain=math.sqrt(1 / 3))
 
             def forward(self, x):
                 x = F.linear(x, self.w1, self.b1)
@@ -522,8 +522,8 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
                 self.b1 = nn.Parameter(torch.zeros(4))
                 self.w2 = nn.Parameter(torch.Tensor(4, 4))
                 self.b2 = nn.Parameter(torch.zeros(4))
-                torch.nn.init.kaiming_uniform_(self.w1, a=math.sqrt(5))
-                torch.nn.init.kaiming_uniform_(self.w2, a=math.sqrt(5))
+                torch.nn.init.kaiming_uniform_(self.w1, gain=math.sqrt(1 / 3))
+                torch.nn.init.kaiming_uniform_(self.w2, gain=math.sqrt(1 / 3))
 
             def forward(self, x):
                 x = F.linear(x, self.w1, self.b1)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12918,7 +12918,7 @@ dedent """
                 self.reset_parameters()
 
             def reset_parameters(self):
-                torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+                torch.nn.init.kaiming_uniform_(self.weight, gain=math.sqrt(1 / 3))
                 if self.bias is not None:
                     fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(self.weight)
                     bound = 1 / math.sqrt(fan_in)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10540,9 +10540,9 @@ class TestNNInit(TestCase):
 
                     if use_gain:
                         gain = self._random_float(0.1, 2)
-                        init.kaiming_uniform_(input_tensor, gain=gain)
+                        init.kaiming_uniform_(input_tensor, mode=mode, gain=gain)
                     else:
-                        init.kaiming_uniform_(input_tensor)
+                        init.kaiming_uniform_(input_tensor, mode=mode)
 
                     fan_in = input_tensor.size(1)
                     fan_out = input_tensor.size(0)
@@ -10592,9 +10592,9 @@ class TestNNInit(TestCase):
 
                     if use_gain:
                         gain = self._random_float(0.1, 2)
-                        init.kaiming_normal_(input_tensor, gain=gain)
+                        init.kaiming_normal_(input_tensor, mode=mode, gain=gain)
                     else:
-                        init.kaiming_normal_(input_tensor)
+                        init.kaiming_normal_(input_tensor, mode=mode)
 
                     fan_in = input_tensor.size(1)
                     fan_out = input_tensor.size(0)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10206,10 +10206,10 @@ class TestNNInit(TestCase):
         super(TestNNInit, self).setUp()
         random.seed(123)
 
-    def _is_normal(self, tensor, mean, std):
+    def _assert_normal(self, tensor, mean, std):
         samples = tensor.view(-1).tolist()
         p_value = stats.kstest(samples, 'norm', args=(mean, std))[1]
-        return p_value > 0.0001
+        self.assertGreater(p_value, 0.0001)
 
     def _is_trunc_normal(self, tensor, mean, std, a, b):
         # scipy's trunc norm is suited for data drawn from N(0, 1),
@@ -10219,12 +10219,12 @@ class TestNNInit(TestCase):
         a0 = (a - mean) / std
         b0 = (b - mean) / std
         p_value = stats.kstest(z_samples, 'truncnorm', args=(a0, b0))[1]
-        return p_value > 0.0001
+        self.assertGreater(p_value, 0.0001)
 
-    def _is_uniform(self, tensor, a, b):
+    def _assert_uniform(self, tensor, a, b):
         samples = tensor.view(-1).tolist()
         p_value = stats.kstest(samples, 'uniform', args=(a, (b - a)))[1]
-        return p_value > 0.0001
+        self.assertGreater(p_value, 0.0001)
 
     def _create_random_nd_tensor(self, dims, size_min, size_max):
         size = [random.randint(size_min, size_max) for _ in range(dims)]
@@ -10284,7 +10284,7 @@ class TestNNInit(TestCase):
             a = self._random_float(-3, 3)
             b = a + self._random_float(1, 5)
             init.uniform_(input_tensor, a=a, b=b)
-            assert self._is_uniform(input_tensor, a, b)
+            self._assert_uniform(input_tensor, a, b)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_normal(self):
@@ -10294,7 +10294,7 @@ class TestNNInit(TestCase):
             std = self._random_float(1, 5)
             init.normal_(input_tensor, mean=mean, std=std)
 
-            assert self._is_normal(input_tensor, mean, std)
+            self._assert_normal(input_tensor, mean, std)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_trunc_normal(self):
@@ -10306,7 +10306,7 @@ class TestNNInit(TestCase):
             b = self._random_float(mean, mean + 2 * std)
             init.trunc_normal_(input_tensor, mean=mean, std=std, a=a, b=b)
 
-            assert self._is_trunc_normal(input_tensor, mean, std, a, b)
+            self._is_trunc_normal(input_tensor, mean, std, a, b)
 
     def test_constant(self):
         for dims in [1, 2, 4]:
@@ -10466,7 +10466,7 @@ class TestNNInit(TestCase):
 
                 expected_std = gain * math.sqrt(2.0 / (fan_in + fan_out))
                 bounds = expected_std * math.sqrt(3)
-                assert self._is_uniform(input_tensor, -bounds, bounds)
+                self._assert_uniform(input_tensor, -bounds, bounds)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_xavier_normal(self):
@@ -10488,7 +10488,7 @@ class TestNNInit(TestCase):
                     fan_out *= input_tensor[0, 0].numel()
 
                 expected_std = gain * math.sqrt(2.0 / (fan_in + fan_out))
-                assert self._is_normal(input_tensor, 0, expected_std)
+                self._assert_normal(input_tensor, 0, expected_std)
 
     def test_kaiming_uniform_errors_on_inputs_smaller_than_2d(self):
         for dims in [0, 1]:
@@ -10528,7 +10528,7 @@ class TestNNInit(TestCase):
 
                     expected_std = math.sqrt(2.0 / ((1 + a**2) * n))
                     bounds = expected_std * math.sqrt(3.0)
-                    assert self._is_uniform(input_tensor, -bounds, bounds)
+                    self._assert_uniform(input_tensor, -bounds, bounds)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_kaiming_uniform(self):
@@ -10553,7 +10553,7 @@ class TestNNInit(TestCase):
                     n = fan_in if mode == 'fan_in' else fan_out
                     expected_std = gain / math.sqrt(n)
                     bound = expected_std * math.sqrt(3.0)
-                    assert self._is_uniform(input_tensor, -bound, bound)
+                    self._assert_uniform(input_tensor, -bound, bound)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_kaiming_normal_legacy(self):
@@ -10580,7 +10580,7 @@ class TestNNInit(TestCase):
                         n = fan_out
 
                     expected_std = math.sqrt(2.0 / ((1 + a**2) * n))
-                    assert self._is_normal(input_tensor, 0, expected_std)
+                    self._assert_normal(input_tensor, 0, expected_std)
 
     @unittest.skipIf(not TEST_SCIPY, "Scipy not found.")
     def test_kaiming_normal(self):
@@ -10604,7 +10604,7 @@ class TestNNInit(TestCase):
 
                     n = fan_in if mode == 'fan_in' else fan_out
                     expected_std = gain / math.sqrt(n)
-                    assert self._is_normal(input_tensor, 0, expected_std)
+                    self._assert_normal(input_tensor, 0, expected_std)
 
     def test_sparse_only_works_on_2d_inputs(self):
         for dims in [1, 3]:
@@ -10631,7 +10631,7 @@ class TestNNInit(TestCase):
                 column = input_tensor[:, col_idx]
                 assert column[column == 0].nelement() >= math.ceil(sparsity * rows)
 
-            assert self._is_normal(input_tensor[input_tensor != 0], 0, std)
+            self._assert_normal(input_tensor[input_tensor != 0], 0, std)
 
     @skipIfNoLapack
     def test_orthogonal(self):

--- a/torch/csrc/api/include/torch/nn/init.h
+++ b/torch/csrc/api/include/torch/nn/init.h
@@ -86,9 +86,13 @@ TORCH_API Tensor uniform_(Tensor tensor, double low = 0, double high = 1);
 /// No gradient will be recorded for this operation.
 TORCH_API Tensor kaiming_normal_(
     Tensor tensor,
-    double a = 0,
+    [[deprecated("Use gain parameter in combination with"
+      "`torch::nn::init::calculate_gain` instead.")]] double a = 0,
     FanModeType mode = torch::kFanIn,
-    NonlinearityType nonlinearity = torch::kLeakyReLU);
+    [[deprecated("Use gain parameter in combination with"
+      "`torch::nn::init::calculate_gain` instead.")]]
+    NonlinearityType nonlinearity = torch::kLeakyReLU,
+    double gain = M_SQRT2);
 
 /// Fills the input `Tensor` with values according to the method
 /// described in "Delving deep into rectifiers: Surpassing human-level
@@ -97,9 +101,13 @@ TORCH_API Tensor kaiming_normal_(
 /// No gradient will be recorded for this operation.
 TORCH_API Tensor kaiming_uniform_(
     Tensor tensor,
-    double a = 0,
+    [[deprecated("Use gain parameter in combination with"
+      "`torch::nn::init::calculate_gain` instead.")]] double a = 0,
     FanModeType mode = torch::kFanIn,
-    NonlinearityType nonlinearity = torch::kLeakyReLU);
+    [[deprecated("Use gain parameter in combination with"
+      "`torch::nn::init::calculate_gain` instead.")]]
+    NonlinearityType nonlinearity = torch::kLeakyReLU,
+    double gain = M_SQRT2);
 
 /// Fills the input `Tensor` with values according to the method
 /// described in "Understanding the difficulty of training deep feedforward

--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -70,7 +70,8 @@ class ResNet(nn.Module):
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
-                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                relu_gain = nn.init.calculate_gain('relu')
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', gain=relu_gain)
             elif isinstance(m, nn.BatchNorm2d):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -357,7 +357,7 @@ def _calculate_correct_fan(tensor, mode):
     return fan_in if mode == 'fan_in' else fan_out
 
 
-def _legacy_gain(a, nonlinearity, gain):
+def _legacy_kaiming_gain(a, nonlinearity, gain):
     msg = "nonlinearity and a args are deprecated, please use gain={} instead."
     if nonlinearity is not None:
         warnings.warn(msg.format(f"nn.init.calculate_gain('{nonlinearity}', {a}))"))
@@ -365,10 +365,11 @@ def _legacy_gain(a, nonlinearity, gain):
     elif a is not None:
         warnings.warn(msg.format(f"nn.init.calculate_gain('leaky_relu', {a}))"))
         gain = calculate_gain('leaky_relu', a)
+
     return gain
 
 
-def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu',
+def kaiming_uniform_(tensor, a=None, mode='fan_in', nonlinearity=None,
                      gain: float = 2. ** .5):
     r"""Fills the input `Tensor` with values according to the method
     described in `Delving deep into rectifiers: Surpassing human-level
@@ -405,14 +406,14 @@ def kaiming_uniform_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu',
         >>> nn.init.kaiming_uniform_(w, mode='fan_in', gain=relu_gain)
     """
     fan = _calculate_correct_fan(tensor, mode)
-    gain = _legacy_gain(a, nonlinearity, gain)
+    gain = _legacy_kaiming_gain(a, nonlinearity, gain)
     std = gain / math.sqrt(fan)
     bound = math.sqrt(3.0) * std  # Calculate uniform bounds from standard deviation
     with torch.no_grad():
         return tensor.uniform_(-bound, bound)
 
 
-def kaiming_normal_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu',
+def kaiming_normal_(tensor, a=None, mode='fan_in', nonlinearity=None,
                     gain: float = 2. ** .5):
     r"""Fills the input `Tensor` with values according to the method
     described in `Delving deep into rectifiers: Surpassing human-level
@@ -449,7 +450,7 @@ def kaiming_normal_(tensor, a=0, mode='fan_in', nonlinearity='leaky_relu',
         >>> nn.init.kaiming_normal_(w, mode='fan_out', gain=relu_gain)
     """
     fan = _calculate_correct_fan(tensor, mode)
-    gain = _legacy_gain(a, nonlinearity, gain)
+    gain = _legacy_kaiming_gain(a, nonlinearity, gain)
     std = gain / math.sqrt(fan)
     with torch.no_grad():
         return tensor.normal_(0, std)

--- a/torch/nn/modules/conv.py
+++ b/torch/nn/modules/conv.py
@@ -134,7 +134,7 @@ class _ConvNd(Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        init.kaiming_uniform_(self.weight, gain=math.sqrt(1 / 3))
         if self.bias is not None:
             fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
             bound = 1 / math.sqrt(fan_in)

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -84,7 +84,7 @@ class Linear(Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        init.kaiming_uniform_(self.weight, gain=math.sqrt(1 / 3))
         if self.bias is not None:
             fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
             bound = 1 / math.sqrt(fan_in)


### PR DESCRIPTION
Fixes #54030

Introduces `gain` argument for `kaiming` initialisation and deprecates `a` and `nonlinearity`.
