### PR TITLE
Implement hardswish/hardsigmoid on MKLDNN tensors

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -36,6 +36,7 @@ namespace c10 {
   _(prim, MKLDNNGroup)               \
   _(prim, MKLDNNHardSwish)           \
   _(prim, MKLDNNHardSigmoid)         \
+  _(prim, MKLDNNRelu6)               \
   _(prim, Drop)                      \
   _(prim, Eval)                      \
   _(prim, Expand) /* onnx */         \
@@ -99,6 +100,8 @@ namespace c10 {
   _(aten, is_pinned)                 \
   _(aten, Delete)                    \
   _(aten, relu_)                     \
+  _(aten, relu6)                     \
+  _(aten, relu6_)                    \
   _(aten, dropout_)                  \
   _(aten, sigmoid_)                  \
   _(prim, device)                    \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -34,6 +34,8 @@ namespace c10 {
   _(prim, ConstantMKLDNNTensor)      \
   _(prim, BroadcastMKLDNNTensors)    \
   _(prim, MKLDNNGroup)               \
+  _(prim, MKLDNNHardSwish)           \
+  _(prim, MKLDNNHardSigmoid)         \
   _(prim, Drop)                      \
   _(prim, Eval)                      \
   _(prim, Expand) /* onnx */         \
@@ -330,6 +332,9 @@ namespace c10 {
   _(aten, exp2)                      \
   _(aten, special_exp2)              \
   _(aten, has_torch_function)        \
+  _(aten, hardswish)                 \
+  _(aten, hardswish_)                \
+  _(aten, hardsigmoid_)              \
   FORALL_ATEN_BASE_SYMBOLS(_)        \
   _(onnx, Add)                       \
   _(onnx, Concat)                    \

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1832,7 +1832,8 @@ class TestFrozenOptimizations(JitTestCase):
         with set_default_dtype(torch.float):
             op_map = {
                 'prim::MKLDNNHardSwish' : F.hardswish,
-                'prim::MKLDNNHardSigmoid' : F.hardsigmoid
+                'prim::MKLDNNHardSigmoid' : F.hardsigmoid,
+                'prim::MKLDNNRelu6' : F.relu6
             }
 
             input_sizes = ([0], [1], [3], [1, 3, 8, 8])

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -577,16 +577,19 @@ void ComputeSubgraphInMKLDNN(Node* subgraph_node) {
     if (body_node->kind() == aten::hardswish) {
       body_node->replaceWithNewSymbol(prim::MKLDNNHardSwish);
       body_node->destroy();
+      continue;
     }
 
     if (body_node->kind() == aten::hardsigmoid) {
       body_node->replaceWithNewSymbol(prim::MKLDNNHardSigmoid);
       body_node->destroy();
+      continue;
     }
 
     if (body_node->kind() == aten::relu6) {
       body_node->replaceWithNewSymbol(prim::MKLDNNRelu6);
       body_node->destroy();
+      continue;
     }
 
     if (body_node->kind() == aten::conv2d ||
@@ -595,6 +598,7 @@ void ComputeSubgraphInMKLDNN(Node* subgraph_node) {
       if (!body_node->namedInput("padding")->type()->cast<StringType>()) {
         body_node->replaceWithNewSymbol(Symbol::prim("mkldnn_convolution"));
         body_node->destroy();
+        continue;
       }
     }
   }

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -248,7 +248,7 @@ Operation createUnaryOp(
 
     // tensor's physical size could be bigger than a logical one
     // `a_it.get_desc().get_size()` returns the real physical size (in bytes)
-    // we use it to compute `nelem` for `aten` ops 
+    // we use it to compute `nelem` for `aten` ops
     auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
     auto out_aten = at::from_blob(out_raw_data, {nelem}, topt);
     aten_op(out_aten, t);

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -1,10 +1,8 @@
 #include <ATen/Utils.h>
-
 #include <ATen/Config.h>
 #include <ATen/core/interned_strings.h>
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
-#include <dnnl_types.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/constants.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -32,6 +30,7 @@
 #include <c10/util/StringUtil.h>
 
 #if AT_MKLDNN_ENABLED()
+#include <dnnl_types.h>
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ideep.hpp>
 #endif

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -243,7 +243,8 @@ Operation createUnaryOp(
       out_raw_data = at::native::itensor_from_mkldnn(out).get_data_handle();
     }
 
-    auto out_aten = at::from_blob(out_raw_data, {a.numel()}, topt);
+    auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
+    auto out_aten = at::from_blob(out_raw_data, {nelem}, topt);
     aten_op(out_aten, t);
     push(stack, out);
   };

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -249,6 +249,8 @@ Operation createUnaryOp(
     // tensor's physical size could be bigger than a logical one
     // `a_it.get_desc().get_size()` returns the real physical size (in bytes)
     // we use it to compute `nelem` for `aten` ops
+    TORCH_INTERNAL_ASSERT(
+        a_it.get_desc().get_size() % elementSize(a.scalar_type()) == 0);
     auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
     auto out_aten = at::from_blob(out_raw_data, {nelem}, topt);
     aten_op(out_aten, t);

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -25,7 +25,6 @@
 #include <ATen/native/ConvUtils.h>
 #include <algorithm>
 #include <memory>
-#include <Functions.h>
 #include <c10/core/Layout.h>
 #include <c10/util/StringUtil.h>
 

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -262,8 +262,8 @@ Operation createUnaryOp(
     TORCH_INTERNAL_ASSERT(
         a_it.get_desc().get_size() % elementSize(a.scalar_type()) == 0);
     auto nelem = a_it.get_desc().get_size() / elementSize(a.scalar_type());
-    auto out_aten =
-        at::from_blob(out_raw_data, {nelem}, a_options_with_strided);
+    auto out_aten = at::from_blob(
+        out_raw_data, {static_cast<int64_t>(nelem)}, a_options_with_strided);
     aten_op(out_aten, in_aten);
     push(stack, out);
   };


### PR DESCRIPTION

Adding hardwish and hardsigmoid improves mobilenetv3 by ~13%

  | hardswish | base |  
-- | -- | -- | --
run 1 | 1305.032 | 1486.013 |  
run 2 | 1290.142 | 1491.001 |  
run 3 | 1305.51 | 1491.66 |  
run 4 | 1308.788 | 1495.577 |  
avg | 1302.368 | 1491.063 | 0.873449

