### PR TITLE
Separate TLS for InferenceMode

### DIFF
--- a/c10/core/InferenceMode.cpp
+++ b/c10/core/InferenceMode.cpp
@@ -28,7 +28,7 @@ bool InferenceMode::is_enabled() {
   return false;
 }
 
-void GradMode::set_enabled(bool enabled) {
+void InferenceMode::set_enabled(bool enabled) {
   throw std::runtime_error("InferenceMode::set_enabled is not supported on mobile");
 }
 

--- a/c10/core/InferenceMode.cpp
+++ b/c10/core/InferenceMode.cpp
@@ -1,11 +1,38 @@
-
 #include <c10/core/InferenceMode.h>
+#include <stdexcept>
 
 namespace c10 {
+/// thread_local is a feature that is not enabled by Caffe2 mobile
+/// build (e.g. iOS). Therefore, we only provide `at::GradMode`
+/// when we are not in mobile build or when FEATURE_TORCH_MOBILE
+/// is on.
+#if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
+thread_local bool InferenceMode_enabled = false;
+
+// We could have skipped adding a new TLS InferenceMode_enabled
+// by checking:
+//   !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
+// in InferenceMode::is_enabled().  But InferenceMode::is_enabled()
+// is in perf critical path (TensorImpl constructor) so it worths
+// a new TLS to skip the DispatchKeySet check.
+bool InferenceMode::is_enabled() {
+  return InferenceMode_enabled;
+}
+
+void InferenceMode::set_enabled(bool enabled) {
+  InferenceMode_enabled = enabled;
+}
+#else
 
 bool InferenceMode::is_enabled() {
-  // See Note [Expected TLS state in InferenceMode]
-  return !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
+  return false;
 }
+
+void GradMode::set_enabled(bool enabled) {
+  throw std::runtime_error("InferenceMode::set_enabled is not supported on mobile");
+}
+
+#endif
+
 
 } // namespace c10

--- a/c10/core/InferenceMode.cpp
+++ b/c10/core/InferenceMode.cpp
@@ -9,12 +9,10 @@ namespace c10 {
 #if !defined(C10_MOBILE) || defined(FEATURE_TORCH_MOBILE)
 thread_local bool InferenceMode_enabled = false;
 
-// We could have skipped adding a new TLS InferenceMode_enabled
-// by checking:
-//   !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
-// in InferenceMode::is_enabled().  But InferenceMode::is_enabled()
-// is in perf critical path (TensorImpl constructor) so it worths
-// a new TLS to skip the DispatchKeySet check.
+// Invariant:
+//   is_enabled() == !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
+// InferenceMode::is_enabled() is in perf critical path (TensorImpl constructor)
+// so it worths a separate TLS to skip the DispatchKeySet check.
 bool InferenceMode::is_enabled() {
   return InferenceMode_enabled;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55238 Separate TLS for InferenceMode**

I tried to avoid creating new TLS, but InferenceMode::is_enabeld()
is in perf critical path (TensorImpl constructor) so it seems
worth adding one for it.
This PR reduces one sources of instruction count increased by
https://github.com/pytorch/pytorch/pull/55008.
```
 λ ~ python compare.py
<torch.utils.benchmark.utils.valgrind_wrapper.timer_interface.FunctionCounts object at 0x7f59097ef310>
     100  0x0000000004854750
    -100  0x0000000004854760
   -4400  c10::impl::tls_is_dispatch_key_included(...)
```

Differential Revision: [D27539230](https://our.internmc.facebook.com/intern/diff/D27539230)