### PR TITLE
Don't fail "Add annotations" if "Lint" is canceled

### DIFF
--- a/.github/workflows/add_annotations.yml
+++ b/.github/workflows/add_annotations.yml
@@ -26,32 +26,44 @@ jobs:
           # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
           script: |
             const artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{ github.event.workflow_run.id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
             });
-            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            const filteredArtifacts = artifacts.data.artifacts.filter(artifact => {
               return artifact.name == '${{ matrix.name }}';
-            })[0];
-            const download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
             });
-            const fs = require('fs');
-            fs.writeFileSync('${{ github.workspace }}/linter-output.zip', Buffer.from(download.data));
+            if (filteredArtifacts.length > 0) {
+              const matchArtifact = filteredArtifacts[0];
+              const download = await github.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              const fs = require('fs');
+              fs.writeFileSync(
+                '${{ github.workspace }}/linter-output.zip',
+                Buffer.from(download.data),
+              );
+            }
       - name: Unzip artifact
-        run: unzip linter-output.zip
-      - name: Get commit SHA
-        run: echo ::set-output name=commit-sha::$(cat commit-sha.txt)
-        id: get-commit-sha
-      - name: Add annotations
+        id: unzip
+        run: |
+          FILENAME=linter-output.zip
+          EXISTS=$([ -f $FILENAME ]; echo $?)
+          echo ::set-output name=exists::"$EXISTS"
+          if [ "$EXISTS" -eq 0 ]; then
+            unzip $FILENAME
+            echo ::set-output name=commit-sha::"$(cat commit-sha.txt)"
+          fi
+      - if: steps.unzip.outputs.exists == '0' # i.e. true
+        name: Add annotations
         uses: pytorch/add-annotations-github-action@master
         with:
           check_name: ${{ matrix.name }}
           linter_output_path: warnings.txt
-          commit_sha: ${{ steps.get-commit-sha.outputs.commit-sha }}
+          commit_sha: ${{ steps.unzip.outputs.commit-sha }}
           regex: ${{ matrix.regex }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#54779 split out the logic from our "Lint" workflow into a separate workflow that allows us to annotate PRs from forks. However, as of #54689, it is possible for the "Lint" workflow to be canceled, in which case it may not upload the "flake8-py3" and "clang-tidy" artifacts that the "Add annotations" workflow expects. This often results in GitHub pointlessly sending notification emails due to the failure in the "Add annotations" workflow. This PR fixes the issue by gracefully handling the case where the expected artifact is absent.

**Test plan:**

I tested this in the same external sandbox repo used to test #54779.