### PR TITLE
Fixing error in jit cuda on ROCm: non-constant-expression cannot be n…

### DIFF
--- a/test/test_jit_cuda_fuser.py
+++ b/test/test_jit_cuda_fuser.py
@@ -3,7 +3,7 @@ import os
 
 import torch
 
-from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR, TEST_WITH_ROCM
+from torch.testing._internal.common_utils import run_tests, ProfilingMode, GRAPH_EXECUTOR
 from torch.testing._internal.codegen.random_topo_test import runDefaultTestWithSeed
 
 from test_jit import JitTestCase, RUN_CUDA
@@ -620,7 +620,6 @@ class TestCudaFuser(JitTestCase):
         self.assertTrue(self._compare("comparing output failed", o, jit_o, 1e-4))
         self.assertGraphContains(t_jit.graph_for(x, y), FUSION_GUARD)
 
-    @unittest.skipIf(TEST_WITH_ROCM, "test doesn't currently work on the ROCm stack")
     @unittest.skipIf(not RUN_CUDA, "requires CUDA")
     @unittest.skipIf(GRAPH_EXECUTOR != ProfilingMode.PROFILING,
                      "Requires fusion optimization pass to be effective")

--- a/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
@@ -125,9 +125,9 @@ offset_in_reduction_segment(const _dim3bi& block_idx, const _dim3gd& grid_dim) {
 template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD, typename _dim3>
 __device__ dim3 dimension_of_reduction_block(const _dim3& block_dim) {
   return dim3{
-      X_THREAD ? (unsigned)block_dim.x : 1,
-      Y_THREAD ? (unsigned)block_dim.y : 1,
-      Z_THREAD ? (unsigned)block_dim.z : 1};
+      X_THREAD ? (unsigned)block_dim.x : 1U,
+      Y_THREAD ? (unsigned)block_dim.y : 1U,
+      Z_THREAD ? (unsigned)block_dim.z : 1U};
 }
 
 // Returns the number of threads of each reduction block.

--- a/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
@@ -64,9 +64,9 @@ offset(const _dim3pos& pos, const _dim3dim& dim) {
 template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK, typename _dim3>
 __device__ dim3 dimension_of_reduction_segment(const _dim3& grid_dim) {
   return dim3{
-      X_BLOCK ? (unsigned)grid_dim.x : 1,
-      Y_BLOCK ? (unsigned)grid_dim.y : 1,
-      Z_BLOCK ? (unsigned)grid_dim.z : 1};
+      X_BLOCK ? (unsigned)grid_dim.x : 1U,
+      Y_BLOCK ? (unsigned)grid_dim.y : 1U,
+      Z_BLOCK ? (unsigned)grid_dim.z : 1U};
 }
 
 // Returns the number of blocks in each reduction segment.

--- a/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
+++ b/torch/csrc/jit/codegen/cuda/runtime/grid_reduction.cu
@@ -64,9 +64,9 @@ offset(const _dim3pos& pos, const _dim3dim& dim) {
 template <bool X_BLOCK, bool Y_BLOCK, bool Z_BLOCK, typename _dim3>
 __device__ dim3 dimension_of_reduction_segment(const _dim3& grid_dim) {
   return dim3{
-      X_BLOCK ? grid_dim.x : 1,
-      Y_BLOCK ? grid_dim.y : 1,
-      Z_BLOCK ? grid_dim.z : 1};
+      X_BLOCK ? (unsigned)grid_dim.x : 1,
+      Y_BLOCK ? (unsigned)grid_dim.y : 1,
+      Z_BLOCK ? (unsigned)grid_dim.z : 1};
 }
 
 // Returns the number of blocks in each reduction segment.
@@ -125,9 +125,9 @@ offset_in_reduction_segment(const _dim3bi& block_idx, const _dim3gd& grid_dim) {
 template <bool X_THREAD, bool Y_THREAD, bool Z_THREAD, typename _dim3>
 __device__ dim3 dimension_of_reduction_block(const _dim3& block_dim) {
   return dim3{
-      X_THREAD ? block_dim.x : 1,
-      Y_THREAD ? block_dim.y : 1,
-      Z_THREAD ? block_dim.z : 1};
+      X_THREAD ? (unsigned)block_dim.x : 1,
+      Y_THREAD ? (unsigned)block_dim.y : 1,
+      Z_THREAD ? (unsigned)block_dim.z : 1};
 }
 
 // Returns the number of threads of each reduction block.


### PR DESCRIPTION
On ROCm, the error when compiling was "non-constant-expression cannot be narrowed from type 'int' to 'uint32_t'"
when compiling grid_reduction.cu. 

Added typecast to fix issue. 

Also, removed test skip with ROCm : re-enabling