### PR TITLE
[package] populate a special attribute on imported modules

### DIFF
--- a/test/package/package_a/use_dunder_package.py
+++ b/test/package/package_a/use_dunder_package.py
@@ -1,0 +1,10 @@
+if "__torch_package__" in dir():
+
+    def is_from_package():
+        return True
+
+
+else:
+
+    def is_from_package():
+        return False

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -259,6 +259,7 @@ class PackageImporter(Importer):
         ns["__file__"] = mangled_filename
         ns["__cached__"] = None
         ns["__builtins__"] = self.patched_builtins
+        ns["__torch_package__"] = True
 
         # Add this module to our private global registry. It should be unique due to mangling.
         assert module.__name__ not in _package_imported_modules


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55255 [package] populate a special attribute on imported modules**

This allows packaged code to detect whether or not they are used in a
packaged context, and do different things depending on that. An example
where this might be useful is to control dynamic dependency loading
depending on whether or not something is packaged.

Differential Revision: [D27544245](https://our.internmc.facebook.com/intern/diff/D27544245)