### PR TITLE
[Gradient Compression] Update PowerSGD warning about start_powerSGD_iter

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -98,8 +98,8 @@ class PowerSGDState(object):
     Compression statistics are logged every ``compression_stats_logging_frequency`` iterations once PowerSGD compression starts.
 
     .. warning ::
-        If error feedback or warm-up is enabled, the minimum value of ``start_powerSGD_iter`` allowed in DDP is 2.
-        This is because there is another internal optimization that rebuilds buckets at iteration 1 in DDP,
+        If error feedback or warm-up is enabled, the minimum value of ``start_powerSGD_iter`` allowed in DDP is 3.
+        This is because there is another internal optimization that rebuilds buckets at iteration 2 in DDP,
         and this can conflict with any tensor memorized before the rebuild process.
     """  # noqa
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55271 [Gradient Compression] Update PowerSGD warning about start_powerSGD_iter**

After #55248, the buckets will be rebuilt in the second iteration if static graph is built, so update a warning about `start_powerSGD_iter` in PowerSGD accordingly.

Differential Revision: [D27553337](https://our.internmc.facebook.com/intern/diff/D27553337/)