### PR TITLE
CI: Run test_lite_interpreter_runtime from built lib directly

### DIFF
--- a/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
+++ b/.jenkins/pytorch/macos-lite-interpreter-build-test.sh
@@ -27,22 +27,7 @@ if [ "${BUILD_LITE_INTERPRETER}" == 1 ]; then
     VERBOSE=1 DEBUG=1 python "${BUILD_LIBTORCH_PY}"
     popd || exit
 
-    # Unfortunately it seems like the test can't load from miniconda3
-    # without these paths being set
-    export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$PWD/miniconda3/lib"
-    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/miniconda3/lib"
-
-    echo "Finding test_lite_interpreter_runtime path"
-    find . -regex '.*test_lite_interpreter_runtime'
-
-    echo "Show current path"
-    pwd
-
-    # Copy the unittest binary test_lite_interpreter_runtime to the path
-    # where the dynamic library libtorch.dylib locates, otherwise it binary
-    # can't find the library
-    cp "${HOME}/project/torch/bin/test_lite_interpreter_runtime" "${WORKSPACE_DIR}//miniconda3/lib/python3.7/site-packages/torch/lib"
-    "${WORKSPACE_DIR}//miniconda3/lib/python3.7/site-packages/torch/lib/test_lite_interpreter_runtime"
+    "${CPP_BUILD}/caffe2/build/bin/test_lite_interpreter_runtime"
 
     # Change the permission manually from 755 to 644 to keep git clean
     chmod 644 "${HOME}/project/.jenkins/pytorch/macos-lite-interpreter-build-test.sh"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55291 CI: Run test_lite_interpreter_runtime from built lib directly**

From the script the build happens in cpp-bulid/caffe2. All the executables and dylibs are available there. It may be more straightforward and accurate to use those binaries, instead of copying the test binary to miniconda3 and use dylibs from there. 

Test: CI, especially pytorch_macos_10_13_py3_lite_interpreter_build_test.

Differential Revision: [D27566631](https://our.internmc.facebook.com/intern/diff/D27566631)