### PR TITLE
[Gradient Compression] Update _powerSGD_comm_hook_wrapper to only expose 2 most critical hyperparameters

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/__init__.py
@@ -20,8 +20,7 @@ def _powerSGD_comm_hook_wrapper(
     model,
     state,
     matrix_approximation_rank,
-    use_error_feedback=True,
-    random_seed=0,
+    start_powerSGD_iter,
 ):
     """
     To be consistent with the wrappers of other DDP comm hooks, the input state only needs to be a process group,
@@ -30,8 +29,7 @@ def _powerSGD_comm_hook_wrapper(
     powerSGD_state = powerSGD.PowerSGDState(
         process_group=state,
         matrix_approximation_rank=matrix_approximation_rank,
-        use_error_feedback=use_error_feedback,
-        random_seed=random_seed,
+        start_powerSGD_iter=start_powerSGD_iter,
     )
     model.register_comm_hook(powerSGD_state, comm_hook)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55295 [Gradient Compression] Update _powerSGD_comm_hook_wrapper to only expose 2 most critical hyperparameters**
* #55272 [Gradient Compression] Update the default value of start_powerSGD_iter and update the docstring

Update `_powerSGD_comm_hook_wrapper` to only expose 2 most critical hyperparameters, to make this API more clear to any future user (although the second hyperparameter `start_powerSGD_iter` is not in use yet).

Facebook: PyTorch STL/Lightning team once tried to use this API.

Differential Revision: [D27561734](https://our.internmc.facebook.com/intern/diff/D27561734/)