### PR TITLE
[Pytorch Edge] Remove run_on_bundled_input

### DIFF
--- a/test/test_bundled_inputs.py
+++ b/test/test_bundled_inputs.py
@@ -59,7 +59,7 @@ class TestBundledInputs(TestCase):
         inflated = loaded.get_all_bundled_inputs()
         self.assertEqual(loaded.get_num_bundled_inputs(), len(samples))
         self.assertEqual(len(inflated), len(samples))
-        self.assertTrue(loaded.run_on_bundled_input(0) is inflated[0][0])
+        self.assertTrue(loaded(inflated[0]) is inflated[0][0])
 
         for idx, inp in enumerate(inflated):
             self.assertIsInstance(inp, tuple)
@@ -133,7 +133,7 @@ class TestBundledInputs(TestCase):
         loaded = save_and_load(sm)
         inflated = loaded.get_all_bundled_inputs()
         self.assertEqual(inflated, samples)
-        self.assertTrue(loaded.run_on_bundled_input(0) == "first 1")
+        self.assertTrue(loaded(inflated[0]) == "first 1")
 
     def test_multiple_methods_with_inputs(self):
         class MultipleMethodModel(torch.nn.Module):
@@ -185,7 +185,7 @@ class TestBundledInputs(TestCase):
         self.assertEqual(inflated, loaded.get_all_bundled_inputs_for_foo())
 
         # Check running and size helpers
-        self.assertTrue(loaded.run_on_bundled_input(0) is inflated[0][0])
+        self.assertTrue(loaded(inflated[0]) is inflated[0][0])
         self.assertEqual(loaded.get_num_bundled_inputs(), len(samples))
 
         # Check helper that work on all functions

--- a/test/test_bundled_inputs.py
+++ b/test/test_bundled_inputs.py
@@ -59,7 +59,7 @@ class TestBundledInputs(TestCase):
         inflated = loaded.get_all_bundled_inputs()
         self.assertEqual(loaded.get_num_bundled_inputs(), len(samples))
         self.assertEqual(len(inflated), len(samples))
-        self.assertTrue(loaded(inflated[0]) is inflated[0][0])
+        self.assertTrue(loaded(*inflated[0]) is inflated[0][0])
 
         for idx, inp in enumerate(inflated):
             self.assertIsInstance(inp, tuple)
@@ -133,7 +133,7 @@ class TestBundledInputs(TestCase):
         loaded = save_and_load(sm)
         inflated = loaded.get_all_bundled_inputs()
         self.assertEqual(inflated, samples)
-        self.assertTrue(loaded(inflated[0]) == "first 1")
+        self.assertTrue(loaded(*inflated[0]) == "first 1")
 
     def test_multiple_methods_with_inputs(self):
         class MultipleMethodModel(torch.nn.Module):
@@ -185,7 +185,7 @@ class TestBundledInputs(TestCase):
         self.assertEqual(inflated, loaded.get_all_bundled_inputs_for_foo())
 
         # Check running and size helpers
-        self.assertTrue(loaded(inflated[0]) is inflated[0][0])
+        self.assertTrue(loaded(*inflated[0]) is inflated[0][0])
         self.assertEqual(loaded.get_num_bundled_inputs(), len(samples))
 
         # Check helper that work on all functions

--- a/torch/utils/bundled_inputs.py
+++ b/torch/utils/bundled_inputs.py
@@ -74,9 +74,6 @@ def augment_many_model_functions_with_bundled_inputs(
             Equivalent to `len(model.get_all_bundled_inputs())`,
             but slightly easier to call from C++.
 
-        `run_on_bundled_input(idx: int) -> Any`
-            Run the model on bundled input number `idx`
-
     Inputs can be specified in one of two ways:
 
       - The model can define `_generate_bundled_inputs_for_<function_name>`
@@ -200,10 +197,6 @@ def augment_many_model_functions_with_bundled_inputs(
             model.define(textwrap.dedent("""
                 def get_num_bundled_inputs(self):
                     return len(self.get_all_bundled_inputs_for_forward())
-                """))
-            model.define(textwrap.dedent("""
-                def run_on_bundled_input(self, idx: int):
-                    return self(*self.get_all_bundled_inputs()[idx])
                 """))
 
 

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -124,7 +124,6 @@ def _get_bundled_inputs_preserved_attributes(script_module: torch.jit.ScriptModu
     if hasattr(script_module, 'get_all_bundled_inputs'):
         bundled_inputs_attributes.append('get_all_bundled_inputs')
         bundled_inputs_attributes.append('get_num_bundled_inputs')
-        bundled_inputs_attributes.append('run_on_bundled_input')
 
     # Bundled inputs in module after the change that introduced bundled inputs for multiple functions
     if hasattr(script_module, 'get_bundled_inputs_functions_and_info'):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55313 [Pytorch Edge] Remove run_on_bundled_input**

Not aware of anyone using this api, and its kind of more trouble then its worth. Due to the way optimization in-lines function calls, the call to forward gets inlined meaning any optimizations applied to forward are __not__ carried over to this function. This can cause lots of subtle bugs between performance varying between calling forward directly vs calling this api, the operators being brought into the runtime through selective build, etc.

Differential Revision: [D27570817](https://our.internmc.facebook.com/intern/diff/D27570817/)