### PR TITLE
Fix the clang-tidy diff SHA for using PR merge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,8 +136,6 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # deep clone, to allow us to use git merge-base
       - name: Prepare output dir with HEAD commit SHA
         run: |
           mkdir clang-tidy-output

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -166,8 +166,6 @@ jobs:
           git remote add upstream https://github.com/pytorch/pytorch
           git fetch upstream "$GITHUB_BASE_REF"
           BASE_SHA=${{ github.event.pull_request.base.sha }}
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          MERGE_BASE=$(git merge-base $BASE_SHA $HEAD_SHA)
 
           if [[ ! -d build ]]; then
             git submodule update --init --recursive
@@ -199,7 +197,7 @@ jobs:
           python tools/clang_tidy.py                               \
             --verbose                                              \
             --paths torch/csrc/                                    \
-            --diff "$MERGE_BASE"                                   \
+            --diff "$BASE_SHA"                                   \
             -g"-torch/csrc/jit/passes/onnx/helper.cpp"             \
             -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp"\
             -g"-torch/csrc/jit/serialization/onnx.cpp"             \


### PR DESCRIPTION
Since #54967, our clang-tidy CI job has been giving warnings on files that PRs don't touch (see the screenshot below for an example). This PR should fix the issue by comparing against the merge-base of the `merge` commit with `master`, which is just `master` itself.

![clang-tidy](https://user-images.githubusercontent.com/8246041/113618718-eb83f600-960c-11eb-9375-8b88158eb566.png)

**Test plan:**

CI.