### PR TITLE
[caffe2][code styling] Use range based for loop

### DIFF
--- a/caffe2/core/operator_schema.h
+++ b/caffe2/core/operator_schema.h
@@ -571,8 +571,8 @@ OpSchema::Cost PointwiseCostInference(
   const TensorShape X = inputs[0];
   uint64_t nElemX = nElemFromDim(X);
   uint64_t nElemRead = 0;
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    nElemRead += nElemFromDim(inputs[i]);
+  for (const auto & input : inputs) {
+    nElemRead += nElemFromDim(input);
   }
 
   c.flops = nElemX * OpsPerPoint;


### PR DESCRIPTION
Summary: Fix linter warning about using range based for loop. This modernized the codebase with c++ 11 features.

Test Plan: linter warning is gone now.

Reviewed By: youknowjack0

Differential Revision: D27573952

