### PR TITLE
[PyTorch] Reapply D27404164: Devirtualize is_contiguous

### DIFF
--- a/aten/src/ATen/BatchedTensorImpl.cpp
+++ b/aten/src/ATen/BatchedTensorImpl.cpp
@@ -16,6 +16,7 @@ BatchedTensorImpl::BatchedTensorImpl(Tensor value, BatchDims bdims)
 {
   TORCH_INTERNAL_ASSERT(value_.defined());
   set_storage_access_should_throw();
+  set_has_contiguity_policy(HasContiguityPolicy::CustomBehavior);
   checkInvariants();
 
   const auto public_dims = value_.dim() - bdims_.size();
@@ -74,7 +75,7 @@ void BatchedTensorImpl::checkInvariants() const {
 }
 
 // The following are publically exposed as methods of Tensor
-bool BatchedTensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
+bool BatchedTensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
   TORCH_CHECK(memory_format == MemoryFormat::Contiguous,
       "NYI: querying is_contiguous inside of vmap for memory_format ",
       "other than torch.contiguous_format");

--- a/aten/src/ATen/BatchedTensorImpl.h
+++ b/aten/src/ATen/BatchedTensorImpl.h
@@ -73,7 +73,7 @@ struct TORCH_API BatchedTensorImpl : public c10::TensorImpl {
   int64_t actualDim(int64_t dim, bool wrap_dim = true) const;
 
   // Override a bunch of methods inherited from TensorImpl to return error messages.
-  bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const override;
+  bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;
   void set_storage_offset(int64_t storage_offset) override;

--- a/aten/src/ATen/OpaqueTensorImpl.h
+++ b/aten/src/ATen/OpaqueTensorImpl.h
@@ -29,6 +29,7 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
       : TensorImpl(key_set, data_type, device),
         opaque_handle_(std::move(opaque_handle)) {
     set_storage_access_should_throw();
+    set_has_contiguity_policy(HasContiguityPolicy::ContiguityNotSupported);
     sizes_and_strides_.set_sizes(sizes);
     refresh_numel();
     is_non_overlapping_and_dense_ = is_non_overlapping_and_dense;
@@ -41,12 +42,6 @@ struct TORCH_API OpaqueTensorImpl : public TensorImpl {
 
   IntArrayRef strides() const override {
     AT_ERROR("opaque tensors do not have strides");
-  }
-
-  bool is_contiguous(
-      c10::MemoryFormat memory_format =
-          c10::MemoryFormat::Contiguous) const override {
-    AT_ERROR("opaque tensors do not have is_contiguous");
   }
 
   int64_t stride(int64_t d) const override {

--- a/aten/src/ATen/SparseTensorImpl.cpp
+++ b/aten/src/ATen/SparseTensorImpl.cpp
@@ -51,13 +51,11 @@ SparseTensorImpl::SparseTensorImpl(at::DispatchKeySet key_set, const caffe2::Typ
 
   is_non_overlapping_and_dense_ = false;
   set_storage_access_should_throw();
+  set_has_contiguity_policy(HasContiguityPolicy::ContiguityNotSupported);
 }
 
 IntArrayRef SparseTensorImpl::strides() const {
   AT_ERROR("sparse tensors do not have strides");
-}
-bool SparseTensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
-  AT_ERROR("sparse tensors do not have is_contiguous");
 }
 int64_t SparseTensorImpl::stride(int64_t d) const {
   AT_ERROR("sparse tensors do not have strides");

--- a/aten/src/ATen/SparseTensorImpl.h
+++ b/aten/src/ATen/SparseTensorImpl.h
@@ -41,7 +41,6 @@ public:
   Tensor values() const { return values_; }
 
   IntArrayRef strides() const override;
-  bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const override;
   int64_t stride(int64_t d) const override;
   void set_size(int64_t dim, int64_t new_size) override;
   void set_stride(int64_t dim, int64_t new_stride) override;

--- a/aten/src/ATen/native/metal/MetalTensorImpl.h
+++ b/aten/src/ATen/native/metal/MetalTensorImpl.h
@@ -22,15 +22,15 @@ struct TORCH_API MetalTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             device,
             opaque_handle,
             sizes),
-        strides_(strides.vec()) {}
+        strides_(strides.vec()) {
+    TensorImpl::set_has_contiguity_policy(TensorImpl::HasContiguityPolicy::CustomBehavior);
+  }
 
   IntArrayRef strides() const override {
     return strides_;
   }
 
-  bool is_contiguous(
-      c10::MemoryFormat memory_format =
-          c10::MemoryFormat::Contiguous) const override {
+  bool is_contiguous_custom(c10::MemoryFormat memory_format) const override {
     return true;
   }
 

--- a/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
+++ b/aten/src/ATen/native/vulkan/VulkanOpaqueTensorImpl.h
@@ -23,15 +23,15 @@ struct VulkanOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
             opaque_handle,
             sizes,
             false),
-        strides_(strides.vec()) {}
+        strides_(strides.vec()) {
+    TensorImpl::set_has_contiguity_policy(TensorImpl::HasContiguityPolicy::CustomBehavior);
+  }
 
   IntArrayRef strides() const override {
     return strides_;
   }
 
-  bool is_contiguous(
-      c10::MemoryFormat memory_format =
-          c10::MemoryFormat::Contiguous) const override {
+  bool is_contiguous_custom(c10::MemoryFormat memory_format) const override {
     return true;
   }
 

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -276,17 +276,22 @@ void TensorImpl::throw_storage_access_error() const {
   TORCH_CHECK_NOT_IMPLEMENTED(false, "Cannot access storage of ", tensorimpl_type_name());
 }
 
-bool TensorImpl::is_contiguous(at::MemoryFormat memory_format) const {
-#ifdef DEBUG
-  AT_ASSERT(compute_contiguous() == is_contiguous_);
-#endif
-  if (memory_format == at::MemoryFormat::ChannelsLast) {
-      return is_channels_last_contiguous_;
+bool TensorImpl::is_contiguous_nondefault_policy_impl(at::MemoryFormat memory_format) const {
+  if (has_contiguity_ == static_cast<unsigned int>(HasContiguityPolicy::ContiguityNotSupported)) {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        false, "Tensors of type ", tensorimpl_type_name(),
+        " do not have is_contiguous");
+  } else {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(has_contiguity_ == static_cast<unsigned int>(HasContiguityPolicy::CustomBehavior));
+    return is_contiguous_custom(memory_format);
   }
-  else if (memory_format == at::MemoryFormat::ChannelsLast3d) {
-      return is_channels_last_3d_contiguous_;
-  }
-  return is_contiguous_;
+}
+
+bool TensorImpl::is_contiguous_custom(at::MemoryFormat memory_format) const {
+  TORCH_INTERNAL_ASSERT(
+      false,
+      "TensorImpl::is_contiguous_custom should never be called; did you "
+      "set_has_contiguity_policy and forget to override is_contiguous_custom?");
 }
 
 static void deletePlacementDeleteContext(void* ptr) {
@@ -381,6 +386,7 @@ void TensorImpl::copy_tensor_metadata_except_version_counter(
   dest_impl->device_opt_ = src_impl->device_opt_;
   dest_impl->key_set_ = src_impl->key_set_;
   dest_impl->is_contiguous_ = src_impl->is_contiguous_;
+  dest_impl->has_contiguity_ = src_impl->has_contiguity_;
   dest_impl->is_channels_last_contiguous_ = src_impl->is_channels_last_contiguous_;
   dest_impl->is_channels_last_3d_contiguous_ = src_impl->is_channels_last_3d_contiguous_;
   dest_impl->is_channels_last_ = src_impl->is_channels_last_;

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -277,12 +277,12 @@ void TensorImpl::throw_storage_access_error() const {
 }
 
 bool TensorImpl::is_contiguous_nondefault_policy_impl(at::MemoryFormat memory_format) const {
-  if (has_contiguity_ == static_cast<unsigned int>(HasContiguityPolicy::ContiguityNotSupported)) {
+  if (has_contiguity_ == static_cast<uint8_t>(HasContiguityPolicy::ContiguityNotSupported)) {
     TORCH_CHECK_NOT_IMPLEMENTED(
         false, "Tensors of type ", tensorimpl_type_name(),
         " do not have is_contiguous");
   } else {
-    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(has_contiguity_ == static_cast<unsigned int>(HasContiguityPolicy::CustomBehavior));
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(has_contiguity_ == static_cast<uint8_t>(HasContiguityPolicy::CustomBehavior));
     return is_contiguous_custom(memory_format);
   }
 }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -483,9 +483,37 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * Tensors with non-trivial strides are not contiguous.  See
    * compute_contiguous() for the exact definition of whether or not
    * a tensor is contiguous or not.
+   *
+   * NOTE: is_contiguous is only `TENSORIMPL_MAYBE_VIRTUAL` for
+   * backward compatibility. See `set_has_contiguity_policy` and
+   * `is_contiguous_custom` for the encouraged customization point.
    */
-  virtual bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const;
+  TENSORIMPL_MAYBE_VIRTUAL bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const {
+    if (C10_UNLIKELY(has_contiguity_ != static_cast<unsigned int>(HasContiguityPolicy::Default))) {
+      return is_contiguous_nondefault_policy_impl(memory_format);
+    }
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
+    if (memory_format == at::MemoryFormat::ChannelsLast) {
+      return is_channels_last_contiguous_;
+    }
+    else if (memory_format == at::MemoryFormat::ChannelsLast3d) {
+      return is_channels_last_3d_contiguous_;
+    }
+    return is_contiguous_;
+  }
 
+ private:
+  bool is_contiguous_nondefault_policy_impl(at::MemoryFormat) const;
+
+ protected:
+  /**
+   * Customization point for is_contiguous; must also
+   * set_has_contiguity_policy(HasContiguityPolicy::Custom) for this
+   * to be called.
+   */
+  virtual bool is_contiguous_custom(at::MemoryFormat memory_format) const;
+
+ public:
   bool is_sparse() const {
     // NB: This method is not virtual and avoid dispatches for performance reasons.
     return key_set_.has(DispatchKey::SparseCPU) ||
@@ -1725,6 +1753,24 @@ public:
   }
 
 protected:
+  // Policy for adjusting the behavior of is_contiguous(). Allows
+  // subclass customization while still being able to inline
+  // is_contiguous() in the common case.
+  enum class HasContiguityPolicy : uint8_t {
+    // Default behavior: check is_contiguous_ and similar bitflags.
+    Default,
+    // Throw a generic error message that this tensor type does not
+    // support is_contiguous.
+    ContiguityNotSupported,
+    // Call virtual is_contiguous_custom method to implement custom
+    // is_contiguous behavior.
+    CustomBehavior,
+  };
+
+  void set_has_contiguity_policy(HasContiguityPolicy p) {
+    has_contiguity_ = static_cast<unsigned int>(p);
+  }
+
   Storage storage_;
 
 private:
@@ -1801,13 +1847,19 @@ protected:
   c10::optional<c10::Device> device_opt_;
 
   // Tensor is contiguous
-  bool is_contiguous_ = true;
+  bool is_contiguous_ : 1;
+  // gcc doesn't like enum class bitfields; see
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414
+  /* HasContiguityPolicy */ unsigned int has_contiguity_ : 2;
 
   // Tensor is a subclass that does not permit storage access.
   bool storage_access_should_throw_ = false;
 
   // default member initializers for bit-fields only available with -std=c++2a or -std=gnu++2a
   inline void init_bitfields() {
+    is_contiguous_ = true;
+    has_contiguity_ = static_cast<unsigned int>(HasContiguityPolicy::Default);
+
     is_channels_last_ = false;
     is_channels_last_contiguous_ = false;
     is_channels_last_3d_ = false;

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -489,7 +489,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
    * `is_contiguous_custom` for the encouraged customization point.
    */
   TENSORIMPL_MAYBE_VIRTUAL bool is_contiguous(at::MemoryFormat memory_format=at::MemoryFormat::Contiguous) const {
-    if (C10_UNLIKELY(has_contiguity_ != static_cast<unsigned int>(HasContiguityPolicy::Default))) {
+    if (C10_UNLIKELY(has_contiguity_ != static_cast<uint8_t>(HasContiguityPolicy::Default))) {
       return is_contiguous_nondefault_policy_impl(memory_format);
     }
     TORCH_INTERNAL_ASSERT_DEBUG_ONLY(compute_contiguous() == is_contiguous_);
@@ -1768,7 +1768,7 @@ protected:
   };
 
   void set_has_contiguity_policy(HasContiguityPolicy p) {
-    has_contiguity_ = static_cast<unsigned int>(p);
+    has_contiguity_ = static_cast<uint8_t>(p);
   }
 
   Storage storage_;
@@ -1850,7 +1850,7 @@ protected:
   bool is_contiguous_ : 1;
   // gcc doesn't like enum class bitfields; see
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414
-  /* HasContiguityPolicy */ unsigned int has_contiguity_ : 2;
+  /* HasContiguityPolicy */ uint8_t has_contiguity_ : 2;
 
   // Tensor is a subclass that does not permit storage access.
   bool storage_access_should_throw_ = false;
@@ -1858,7 +1858,7 @@ protected:
   // default member initializers for bit-fields only available with -std=c++2a or -std=gnu++2a
   inline void init_bitfields() {
     is_contiguous_ = true;
-    has_contiguity_ = static_cast<unsigned int>(HasContiguityPolicy::Default);
+    has_contiguity_ = static_cast<uint8_t>(HasContiguityPolicy::Default);
 
     is_channels_last_ = false;
     is_channels_last_contiguous_ = false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55333 [PyTorch] Reapply D27404164: Devirtualize is_contiguous**

Reapplying without using enum class in a bitfield. See new
comments about gcc bug.

Differential Revision: [D27576623](https://our.internmc.facebook.com/intern/diff/D27576623/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27576623/)!