### PR TITLE
Make JSON files more human readable

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1018,7 +1018,6 @@ def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float])
     with open(test_times_filename, 'w+') as file:
         job_times_json = get_job_times_json(test_times)
         json.dump(job_times_json, file, indent='    ', separators=(',', ': '))
-    with open(test_times_filename, 'a') as file:
         file.write('\n')
 
 def main():

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1017,7 +1017,9 @@ def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float])
         print(f'Overwriting existent file: {test_times_filename}')
     with open(test_times_filename, 'w+') as file:
         job_times_json = get_job_times_json(test_times)
-        json.dump(job_times_json, file)
+        json.dump(job_times_json, file, indent='    ', separators=(',', ': '))
+    with open(test_times_filename, 'a') as file:
+        file.write('\n')
 
 def main():
     options = parse_args()

--- a/tools/export_slow_tests.py
+++ b/tools/export_slow_tests.py
@@ -43,6 +43,8 @@ def export_slow_tests(filename: str) -> None:
     with open(filename, 'w+') as file:
         slow_test_times: Dict[str, float] = filter_slow_tests(get_test_case_times())
         json.dump(slow_test_times, file, indent='    ', separators=(',', ': '))
+    with open(filename, 'a') as file:
+        file.write('\n')
 
 
 def parse_args():

--- a/tools/export_slow_tests.py
+++ b/tools/export_slow_tests.py
@@ -43,7 +43,6 @@ def export_slow_tests(filename: str) -> None:
     with open(filename, 'w+') as file:
         slow_test_times: Dict[str, float] = filter_slow_tests(get_test_case_times())
         json.dump(slow_test_times, file, indent='    ', separators=(',', ': '))
-    with open(filename, 'a') as file:
         file.write('\n')
 
 


### PR DESCRIPTION
Prettifies JSON files .pytorch-test-times and .pytorch-slow-tests so that not everything is on one single line.

This is of slightly more importance as generated  .pytorch-slow-tests ends up getting stored in our test-infra repo ([example](https://github.com/pytorch/test-infra/commit/ad9cd8756589aa28b6f2817caaf074ca93e76cd9)), and it is nice to not have that lil red symbol at the end.