### PR TITLE
[Static Runtime] Make sure the copy version of the op exist in ReplaceWithCopy

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -106,6 +106,11 @@ namespace jit {
 
 C10_DEFINE_REGISTRY(SROperatorRegistry, SROperatorFunctor);
 
+bool opIsRegistered(const c10::Symbol& op_name) {
+  const std::string name(op_name.toQualString());
+  return SROperatorRegistry()->Has(name);
+}
+
 bool canRunOutOfPlace(Node* n) {
   auto op_name = std::string(n->kind().toQualString());
   return SROperatorRegistry()->Has(op_name);

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -83,6 +83,8 @@ inline void fastResizeToZero(at::Tensor& t) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(checkResizedDataPtr(t));
 }
 
+bool opIsRegistered(const c10::Symbol& op_name);
+
 bool canRunOutOfPlace(Node* n);
 bool canReuseInputsOutputs(Node* n);
 bool canOptimizeConstruct(Node* n);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/passes/constant_pooling.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/runtime/static/ops.h>
 
 namespace torch {
 namespace jit {
@@ -406,7 +407,8 @@ void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
   bool has_inplace_ops = HasInplaceOp(graph, db);
   std::vector<std::pair<Node*, Node*>> replacement;
   for (auto* n : graph->nodes()) {
-    if (!supported.count(n->kind())) {
+    if (!supported.count(n->kind()) ||
+        !opIsRegistered(supported.at(n->kind()))) {
       continue;
     }
     DCHECK(n->outputs().size() == 1);


### PR DESCRIPTION
Summary: `static_runtime::permute_copy` is in fb-only folder. Because `caffe2/test/test_static_runtime.py` is in OSS, we can't load the fb-only operator library. The workaround is to check at runtime whether the op is registered or not.

Test Plan:
This fixed two of the broken tests:
```
    ✓ Pass: caffe2/test:static_runtime - test_multihead_attention_layer (test_static_runtime.TestStaticModule) (10.316)
    ✓ Pass: caffe2/test:static_runtime - test_mlp (test_static_runtime.TestStaticModule) (16.134)
```

Differential Revision: D27577066

