### PR TITLE
[PyTorch] Fix waste in unfold()

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2133,19 +2133,22 @@ Tensor alias(const Tensor& self) {
 Tensor unfold(const Tensor& self, int64_t dimension, int64_t size, int64_t step) {
   // some special handling to deal with allow dimension == 0 when self.dim() == 0
   dimension = at::maybe_wrap_dim(dimension, self.dim(), /*wrap_scalar=*/true);
-  int64_t max_size = self.dim() == 0 ? 1 : self.size(dimension);
+
+  const auto sizes = self.sizes();
+  const auto strides = self.strides();
+  int64_t max_size = self.dim() == 0 ? 1 : sizes[0];
   TORCH_CHECK(size <= max_size, "maximum size for tensor at dimension ", dimension,
                                 " is ", max_size, " but size is ", size);
   TORCH_CHECK(step > 0, "step is ", step, " but must be > 0");
 
-  std::vector<int64_t> new_size(self.dim() + 1);
-  std::vector<int64_t> new_stride(self.dim() + 1);
+  DimVector new_size(self.dim() + 1);
+  DimVector new_stride(self.dim() + 1);
 
   new_size[self.dim()] = size;
-  new_stride[self.dim()] = self.dim() == 0 ? 1 : self.stride(dimension);
+  new_stride[self.dim()] = self.dim() == 0 ? 1 : strides[dimension];
   for(const auto d : c10::irange(self.dim())) {
-    auto self_size = self.size(d);
-    auto self_stride = self.stride(d);
+    const auto self_size = sizes[d];
+    const auto self_stride = strides[d];
     if(d == dimension) {
       new_size[d] = (self_size - size) / step + 1;
       new_stride[d] = step*self_stride;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -2136,7 +2136,7 @@ Tensor unfold(const Tensor& self, int64_t dimension, int64_t size, int64_t step)
 
   const auto sizes = self.sizes();
   const auto strides = self.strides();
-  int64_t max_size = self.dim() == 0 ? 1 : sizes[0];
+  int64_t max_size = self.dim() == 0 ? 1 : sizes[dimension];
   TORCH_CHECK(size <= max_size, "maximum size for tensor at dimension ", dimension,
                                 " is ", max_size, " but size is ", size);
   TORCH_CHECK(step > 0, "step is ", step, " but must be > 0");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55339 [PyTorch] Fix waste in unfold()**
* #55336 [PyTorch] Cache self.size(dim) in TensorShape functions

Use DimVector. Avoid calling size()/stride() when we know argument is in bounds.

Differential Revision: [D27577647](https://our.internmc.facebook.com/intern/diff/D27577647/)