### PR TITLE
Fix multinomial CUDA misalignment and non-deterministic behavior

### DIFF
--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -326,8 +326,9 @@ void multinomial_with_replacement_kernel_impl(
     int numSM = props->multiProcessorCount;
     int maxThreads = props->maxThreadsPerBlock;
     int maxShared = props->sharedMemPerBlock;
-    int requiredShared = (numCategories < maxThreads ? numCategories + 1 : maxThreads)
-                         * sizeof(accscalar_t);
+    int requiredShared =
+        (numCategories < maxThreads ? min(2, numCategories) : maxThreads) *
+        sizeof(accscalar_t);
 
     if (n_sample == 1 && maxShared >= requiredShared) {
       // Optimized allocation-free implementation

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -177,8 +177,8 @@ __global__ void sampleMultinomialOnce(
 
   // Shared Memory hold blockdim.x T for holding the cumulative sum,
   // blockDim.x AccT for normalizing the probabilities,
-  scalar_t *smem = reinterpret_cast<scalar_t *>(my_smem);
-  accscalar_t *asmem = reinterpret_cast<accscalar_t *>(&my_smem[blockDim.x * sizeof(scalar_t)]);
+  accscalar_t *asmem = reinterpret_cast<accscalar_t *>(my_smem);
+  scalar_t *smem = reinterpret_cast<scalar_t *>(&my_smem[blockDim.x * sizeof(accscalar_t)]);
 
   accscalar_t accZero = static_cast<accscalar_t>(0);
   scalar_t zero = static_cast<scalar_t>(0);

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -268,10 +268,10 @@ __global__ void sampleMultinomialOnce(
           (dist_val > zero));
 
       if (inBucket) {
-          // We're done; we have the sample
-          // Torch indices are 1-based
-          atomicMax(&foundPos, cat);
-          found = true;
+        // We're done; we have the sample
+        // Torch indices are 1-based
+        atomicMax(&foundPos, cat);
+        found = true;
       }
 
       // Store the previous scan's high value for future use

--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -182,12 +182,6 @@ __global__ void sampleMultinomialOnce(
   accscalar_t accZero = static_cast<accscalar_t>(0);
   scalar_t zero = static_cast<scalar_t>(0);
 
-  // Valid threads are those that actually process an element
-  bool is_valid_thread = threadIdx.x < categories;
-  // Block size without padding threads
-  // (so that its size is a multiple of C10_WARP_SIZE)
-  int valid_block_size = (categories < blockDim.x) ? categories : blockDim.x;
-
   for (int64_t curDist = blockIdx.x;
        curDist < distributions; curDist += gridDim.x) {
     // Each block handles one distribution

--- a/aten/src/ATen/native/cuda/block_reduce.cuh
+++ b/aten/src/ATen/native/cuda/block_reduce.cuh
@@ -8,6 +8,10 @@ namespace cuda_utils {
 
 constexpr int kCUDABlockReduceNumThreads = 512;
 
+// Sums `val` accross all threads in a warp.
+//
+// Assumptions:
+//   - The size of each block should be a multiple of `C10_WARP_SIZE`
 template <typename T>
 __inline__ __device__ T WarpReduceSum(T val) {
 #pragma unroll
@@ -17,6 +21,13 @@ __inline__ __device__ T WarpReduceSum(T val) {
   return val;
 }
 
+// Sums `val` accross all threads in a block.
+//
+// Assumptions:
+//   - Thread blocks are an 1D set of threads (indexed with `threadIdx.x` only)
+//   - The size of each block should be a multiple of `C10_WARP_SIZE`
+//   - `shared` should be a pointer to shared memory with size of, at least,
+//     `sizeof(T) * number_of_warps`
 template <typename T>
 __inline__ __device__ T BlockReduceSum(T val, T* shared) {
   const int lid = threadIdx.x % C10_WARP_SIZE;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6797,6 +6797,36 @@ else:
             self.assertEqual(prob_dist.dim(), 1, msg="wrong number of prob_dist dimensions")
             self.assertEqual(sample_indices.size(0), n_sample, msg="wrong number of samples")
 
+        # CUDA misalignment issue (#46702)
+        n_row, n_col = 2, 3
+        prob_dist = make_prob_dist([n_row, n_col], True)
+        n_sample = 1
+        sample_indices = torch.multinomial(prob_dist, n_sample, True)
+        self.assertEqual(sample_indices.dim(), 2, msg="wrong number of dimensions")
+        self.assertEqual(sample_indices.size(1), n_sample, msg="wrong number of samples")
+        
+    @onlyCUDA
+    @dtypes(torch.float, torch.double, torch.half)
+    def test_multinomial_deterministic(self, device, dtype):
+        gen = torch.Generator(device=device)
+
+        trials = 5
+        seed = 0
+        prob_dist = torch.rand(10000, 1000, device=device, dtype=dtype)
+        n_sample = 1
+
+        for i in range(trials):
+            gen.manual_seed(seed)
+            samples_1 = torch.multinomial(prob_dist, n_sample, True, generator=gen)
+
+            gen.manual_seed(seed)
+            samples_2 = torch.multinomial(prob_dist, n_sample, True, generator=gen)
+
+            self.assertEqual(samples_1, samples_2)
+            self.assertEqual(samples_1.dim(), 2, msg="wrong number of dimensions")
+            self.assertEqual(samples_1.size(1), n_sample, msg="wrong number of samples")
+
+
     @slowTest
     @dtypes(torch.float)
     def test_multinomial_rng_state_advance(self, device, dtype):

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6804,7 +6804,7 @@ else:
         sample_indices = torch.multinomial(prob_dist, n_sample, True)
         self.assertEqual(sample_indices.dim(), 2, msg="wrong number of dimensions")
         self.assertEqual(sample_indices.size(1), n_sample, msg="wrong number of samples")
-        
+
     @onlyCUDA
     @dtypes(torch.float, torch.double, torch.half)
     def test_multinomial_deterministic(self, device, dtype):


### PR DESCRIPTION
Fixes #46702 

- fails on probability distribution with odd items
  - trying to access an `acc_type` (`float`) in a `scalar_t` (`float16`) aligned memory
- produce unrepeatable result for large input tensor
  - parallel cumsum not monotonic at some positions

### Fixes
- computing cumsum on `acc_type` (`float`) instead of using `scalar_t` (`float16`) fixed both issues
- the non-monotonic behavior may happen even using `float`, though
  - in these cases, deterministic behavior may be achieved by eliminating the race condition when writing the result, using the atomic function `atomicMax`