### PR TITLE
Update DLPack to 0.4

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -119,7 +119,7 @@ static Device getATenDevice(const DLDevice& ctx) {
 
 ScalarType toScalarType(const DLDataType& dtype) {
   ScalarType stype;
-  TORCH_CHECK(dtype.lanes != 1, "ATen does not support lanes != 1");
+  TORCH_CHECK(dtype.lanes == 1, "ATen does not support lanes != 1");
   switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:
       switch (dtype.bits) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -55,12 +55,12 @@ DLDataType getDLDataType(const Tensor& t) {
     case ScalarType::QUInt8:
     case ScalarType::QInt32:
     case ScalarType::QUInt4x2:
-      throw std::logic_error("QUInt/QInt types are not supported by dlpack");
+      TORCH_CHECK(false, "QUInt/QInt types are not supported by dlpack");
       break;
     case ScalarType::Undefined:
-      throw std::logic_error("Undefined is not a valid ScalarType");
+      TORCH_CHECK(false, "Undefined is not a valid ScalarType");
     case ScalarType::NumOptions:
-      throw std::logic_error("NumOptions is not a valid ScalarType");
+      TORCH_CHECK(false, "NumOptions is not a valid ScalarType");
   }
   return dtype;
 }
@@ -88,7 +88,7 @@ DLDevice getDLDevice(const Tensor& tensor, const int64_t& device_id) {
       ctx.device_type = DLDeviceType::kDLROCM;
       break;
     default:
-      throw std::logic_error("Cannot pack tensors on " + tensor.device().str());
+      TORCH_CHECK(false, "Cannot pack tensors on " + tensor.device().str());
   }
   return ctx;
 }
@@ -112,16 +112,14 @@ static Device getATenDevice(const DLDevice& ctx) {
       return at::Device(DeviceType::HIP, ctx.device_id);
 #endif
     default:
-      throw std::logic_error(
-          "Unsupported device_type: " + c10::to_string(ctx.device_type));
+      TORCH_CHECK(
+          false, "Unsupported device_type: " + c10::to_string(ctx.device_type));
   }
 }
 
 ScalarType toScalarType(const DLDataType& dtype) {
   ScalarType stype;
-  if (dtype.lanes != 1) {
-      throw std::logic_error("ATen does not support lanes != 1");
-  }
+  TORCH_CHECK(dtype.lanes != 1, "ATen does not support lanes != 1");
   switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:
       switch (dtype.bits) {
@@ -129,8 +127,8 @@ ScalarType toScalarType(const DLDataType& dtype) {
           stype = ScalarType::Byte;
           break;
         default:
-          throw std::logic_error(
-              "Unsupported kUInt bits " + c10::to_string(dtype.bits));
+          TORCH_CHECK(
+              false, "Unsupported kUInt bits " + c10::to_string(dtype.bits));
       }
       break;
     case DLDataTypeCode::kDLInt:
@@ -148,8 +146,8 @@ ScalarType toScalarType(const DLDataType& dtype) {
           stype = ScalarType::Long;
           break;
         default:
-          throw std::logic_error(
-              "Unsupported kInt bits " + c10::to_string(dtype.bits));
+          TORCH_CHECK(
+              false, "Unsupported kInt bits " + c10::to_string(dtype.bits));
       }
       break;
     case DLDataTypeCode::kDLFloat:
@@ -164,8 +162,8 @@ ScalarType toScalarType(const DLDataType& dtype) {
           stype = ScalarType::Double;
           break;
         default:
-          throw std::logic_error(
-              "Unsupported kFloat bits " + c10::to_string(dtype.bits));
+          TORCH_CHECK(
+              false, "Unsupported kFloat bits " + c10::to_string(dtype.bits));
       }
       break;
     case DLDataTypeCode::kDLBfloat:
@@ -174,8 +172,8 @@ ScalarType toScalarType(const DLDataType& dtype) {
           stype = ScalarType::BFloat16;
           break;
         default:
-          throw std::logic_error(
-              "Unsupported kFloat bits " + c10::to_string(dtype.bits));
+          TORCH_CHECK(
+              false, "Unsupported kFloat bits " + c10::to_string(dtype.bits));
       }
       break;
     case DLDataTypeCode::kDLComplex:
@@ -190,12 +188,13 @@ ScalarType toScalarType(const DLDataType& dtype) {
           stype = ScalarType::ComplexDouble;
           break;
         default:
-          throw std::logic_error(
-              "Unsupported kFloat bits " + c10::to_string(dtype.bits));
+          TORCH_CHECK(
+              false, "Unsupported kFloat bits " + c10::to_string(dtype.bits));
       }
       break;
     default:
-      throw std::logic_error("Unsupported code " + c10::to_string(dtype.code));
+      TORCH_CHECK(
+          false, "Unsupported code " + c10::to_string(dtype.code));
   }
   return stype;
 }

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -40,12 +40,15 @@ DLDataType getDLDataType(const Tensor& t) {
       dtype.code = DLDataTypeCode::kDLUInt;
       break;
     case ScalarType::ComplexHalf:
+      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::ComplexFloat:
+      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::ComplexDouble:
+      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::BFloat16:
@@ -119,8 +122,11 @@ static Device getATenDevice(const DLDevice& ctx) {
 
 ScalarType toScalarType(const DLDataType& dtype) {
   ScalarType stype;
-  // if (dtype.lanes != 1)
-  //   throw std::logic_error("ATen does not support lanes != 1");
+  if (dtype.lanes != 1) {
+      if (!(dtype.lanes == 2 && dtype.code == DLDataTypeCode::kDLComplex)) {
+          throw std::logic_error("ATen does not support lanes != 1");
+      }
+  }
   switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:
       switch (dtype.bits) {

--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -40,15 +40,12 @@ DLDataType getDLDataType(const Tensor& t) {
       dtype.code = DLDataTypeCode::kDLUInt;
       break;
     case ScalarType::ComplexHalf:
-      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::ComplexFloat:
-      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::ComplexDouble:
-      dtype.lanes = 2;
       dtype.code = DLDataTypeCode::kDLComplex;
       break;
     case ScalarType::BFloat16:
@@ -123,9 +120,7 @@ static Device getATenDevice(const DLDevice& ctx) {
 ScalarType toScalarType(const DLDataType& dtype) {
   ScalarType stype;
   if (dtype.lanes != 1) {
-      if (!(dtype.lanes == 2 && dtype.code == DLDataTypeCode::kDLComplex)) {
-          throw std::logic_error("ATen does not support lanes != 1");
-      }
+      throw std::logic_error("ATen does not support lanes != 1");
   }
   switch (dtype.code) {
     case DLDataTypeCode::kDLUInt:

--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -13,7 +13,7 @@
 #endif
 
 /*! \brief The current version of dlpack */
-#define DLPACK_VERSION 010
+#define DLPACK_VERSION 040
 
 /*! \brief DLPACK_DLL prefix for windows */
 #ifdef _WIN32
@@ -33,36 +33,73 @@
 extern "C" {
 #endif
 /*!
- * \brief The device type in DLContext.
+ * \brief The device type in DLDevice.
  */
 typedef enum {
+  /*! \brief CPU device */
   kDLCPU = 1,
+  /*! \brief CUDA GPU device */
   kDLGPU = 2,
-  // kDLCPUPinned = kDLCPU | kDLGPU
+  /*!
+   * \brief Pinned CUDA GPU device by cudaMallocHost
+   * \note kDLCPUPinned = kDLCPU | kDLGPU
+   */
   kDLCPUPinned = 3,
+  /*! \brief OpenCL devices. */
   kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
   kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
   kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
   kDLROCM = 10,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
 } DLDeviceType;
 
 /*!
- * \brief A Device context for Tensor and operator.
+ * \brief A Device for Tensor and operator.
  */
 typedef struct {
   /*! \brief The device type used in the device. */
   DLDeviceType device_type;
   /*! \brief The device index */
   int device_id;
-} DLContext;
+} DLDevice;
+
+/*!
+ * \brief This is an alias for DLDevice. Notice that this will be removed in the next release.
+ */
+typedef DLDevice DLContext;
 
 /*!
  * \brief The type code options DLDataType.
  */
 typedef enum {
+  /*! \brief signed integer */
   kDLInt = 0U,
+  /*! \brief unsigned integer */
   kDLUInt = 1U,
+  /*! \brief IEEE floating point */
   kDLFloat = 2U,
+  /*!
+   * \brief Opaque handle type, reserved for testing purposes.
+   * Frameworks need to agree on the handle data type for the exchange to be well-defined.
+   */
+  kDLOpaqueHandle = 3U,
+  /*! \brief bfloat16 */
+  kDLBfloat = 4U,
+  /*!
+   * \brief complex number
+   * (C/C++/Python layout: compact struct per complex number)
+   */
+  kDLComplex = 5U,
 } DLDataTypeCode;
 
 /*!
@@ -93,13 +130,27 @@ typedef struct {
  */
 typedef struct {
   /*!
-   * \brief The opaque data pointer points to the allocated data.
-   *  This will be CUDA device pointer or cl_mem handle in OpenCL.
-   *  This pointer is always aligns to 256 bytes as in CUDA.
+   * \brief The opaque data pointer points to the allocated data. This will be
+   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
+   * aligned to 256 bytes as in CUDA.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
    */
   void* data;
-  /*! \brief The device context of the tensor */
-  DLContext ctx;
+  /*! \brief The device of the tensor */
+  DLDevice device;
   /*! \brief Number of dimensions */
   int ndim;
   /*! \brief The data type of the pointer*/
@@ -107,8 +158,8 @@ typedef struct {
   /*! \brief The shape of the tensor */
   int64_t* shape;
   /*!
-   * \brief strides of the tensor,
-   *  can be NULL, indicating tensor is compact.
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
    */
   int64_t* strides;
   /*! \brief The offset in bytes to the beginning pointer to data */
@@ -132,10 +183,11 @@ typedef struct DLManagedTensor {
   /*! \brief Destructor signature void (*)(void*) - this should be called
    *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
    *   if there is no way for the caller to provide a reasonable destructor.
+   *   The destructors deletes the argument self as well.
    */
   void (*deleter)(struct DLManagedTensor * self);
 } DLManagedTensor;
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C
 #endif
-#endif  // DLPACK_DLPACK_H_
+#endif  // DLPACK_DLPACK_H_:

--- a/aten/src/ATen/dlpack.h
+++ b/aten/src/ATen/dlpack.h
@@ -190,4 +190,4 @@ typedef struct DLManagedTensor {
 #ifdef __cplusplus
 }  // DLPACK_EXTERN_C
 #endif
-#endif  // DLPACK_DLPACK_H_:
+#endif  // DLPACK_DLPACK_H_

--- a/aten/src/ATen/test/cuda_dlconvertor_test.cpp
+++ b/aten/src/ATen/test/cuda_dlconvertor_test.cpp
@@ -45,9 +45,9 @@ TEST(TestDlconvertor, TestDlconvertorCUDAHIP) {
   DLManagedTensor* dlMTensor = toDLPack(a);
 
 #if AT_ROCM_ENABLED()
-  ASSERT_TRUE(dlMTensor->dl_tensor.ctx.device_type == DLDeviceType::kDLROCM);
+  ASSERT_TRUE(dlMTensor->dl_tensor.device.device_type == DLDeviceType::kDLROCM);
 #else
-  ASSERT_TRUE(dlMTensor->dl_tensor.ctx.device_type == DLDeviceType::kDLGPU);
+  ASSERT_TRUE(dlMTensor->dl_tensor.device.device_type == DLDeviceType::kDLGPU);
 #endif
 
   Tensor b = fromDLPack(dlMTensor);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6655,6 +6655,10 @@ else:
     @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_dlpack_conversion(self, device, dtype):
+        # DLpack does not explicitly support bool
+        # It does it through uint8 type
+        if dtype is torch.bool:
+            return
         x = torch.randn(1, 2, 3, 4, device=device, dtype=torch.float).type(dtype)
         z = from_dlpack(to_dlpack(x))
         self.assertEqual(z, x)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6659,7 +6659,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        x = torch.randn(1, 2, 3, 4, device=device, dtype=torch.float).type(dtype)
+        x = make_tensor((5,), device, dtype, low=-9, high=9)
         z = from_dlpack(to_dlpack(x))
         self.assertEqual(z, x)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6653,8 +6653,9 @@ else:
                 _test_helper(x, op, unary=True)
 
     @skipMeta
-    def test_dlpack_conversion(self, device):
-        x = torch.randn(1, 2, 3, 4, device=device, dtype=torch.float)
+    @dtypes(*torch.testing.get_all_dtypes())
+    def test_dlpack_conversion(self, device, dtype):
+        x = torch.randn(1, 2, 3, 4, device=device, dtype=torch.float).type(dtype)
         z = from_dlpack(to_dlpack(x))
         self.assertEqual(z, x)
 


### PR DESCRIPTION
Fixes #55090

I included the header directly, but I am not sure if we should add this as a git submodule, what do you guys think?
Also regarding the implementation, in ATen lanes seems not to be supported, but from CuPy complex types are exported with 2 lanes, I am not sure wether this is correct or not. However, in PyTorch this seems to be working properly, so I forgive 2 lanes for complex datatypes.

TODO: add tests for complex and bfloat

Easy test script against cupy

```python
import cupy
import torch

from torch.utils.dlpack import to_dlpack
from torch.utils.dlpack import from_dlpack

# Create a PyTorch tensor.
tx1 = torch.tensor(
    [2 + 1j, 3 + 2j, 4 + 3j, 5 + 4j], dtype=torch.complex128
).cuda()

# Convert it into a DLPack tensor.
dx = to_dlpack(tx1)

# Convert it into a CuPy array.
cx = cupy.fromDlpack(dx)

# Convert it back to a PyTorch tensor.
tx2 = from_dlpack(cx.toDlpack())
torch.testing.assert_allclose(tx1, tx2)
```

Thanks to @leofang who updated CuPy's dlpack version and his PR served me as the guide for this one.