### PR TITLE
Fix nvcc warnings

### DIFF
--- a/aten/src/ATen/native/cuda/SpectralOps.cu
+++ b/aten/src/ATen/native/cuda/SpectralOps.cu
@@ -228,6 +228,8 @@ static void exec_cufft_plan(
 // tensors being contiguous, and that the strides at the innermost signal
 // dimension being unit (1) w.r.t. the corresponding data type.
 
+#pragma push
+#pragma diag_suppress 177   // Function was declared but never referenced
 static inline Tensor _run_cufft(
     const CuFFTConfig &config, Tensor& input, int64_t signal_ndim,
     bool complex_input, bool complex_output, bool inverse,
@@ -280,6 +282,7 @@ static inline Tensor _run_cufft(
   }
   return output;
 }
+#pragma pop
 
 // The cuFFT plan cache
 // unique_ptr for nullability and to avoid reference invalidation on vector resize

--- a/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
+++ b/aten/src/ATen/native/cuda/UnaryFractionKernels.cu
@@ -109,9 +109,12 @@ __host__ __device__ static inline c10::complex<float> nearbyint_wrapper(c10::com
   return c10::complex<float>(::nearbyintf(static_cast<float>(a.real())), ::nearbyintf(static_cast<float>(a.imag())));
 }
 
+#pragma push
+#pragma diag_suppress 177   // Function was declared but never referenced
 __host__ __device__ static inline c10::complex<double> nearbyint_wrapper(c10::complex<double> a) {
   return c10::complex<double>(::nearbyint(static_cast<double>(a.real())), ::nearbyint(static_cast<double>(a.imag())));
 }
+#pragma pop
 
 void round_kernel_cuda(TensorIterator& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND(ScalarType::Half, iter.dtype(), "round_cuda", [&]() {

--- a/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu
@@ -57,6 +57,11 @@ Tensor _to_csr_int(const Tensor& rowIndices, int64_t dim, int64_t nnz) {
   return csr;
 }
 
+
+#pragma push
+// NVCC complains that confirm_mult_size is not used,
+// but it is used in specializations of CusparseMatrixMultiplyOp below
+#pragma diag_suppress 177   // Function was declared but never referenced
 int confirm_mult_size(const std::vector<int>& mat1_size, const std::vector<int>& mat2_size) {
   TORCH_CHECK(
       mat1_size[1] == mat2_size[0],
@@ -71,6 +76,7 @@ int confirm_mult_size(const std::vector<int>& mat1_size, const std::vector<int>&
       ")");
   return mat1_size[1];
 }
+#pragma pop
 
 void create_general_description_(cusparseMatDescr_t& description_) {
   TORCH_CUDASPARSE_CHECK(cusparseCreateMatDescr(&description_));


### PR DESCRIPTION
Summary:
During compilation, nvcc emits several warnings about unused variables and static funcions:

```
caffe2/aten/src/ATen/native/cuda/SpectralOps.cu(231): warning: function "at::native::_run_cufft" was declared but never referenced

caffe2/aten/src/ATen/native/sparse/cuda/SparseMatMul.cu(60): warning: function "at::native::<unnamed>::confirm_mult_size" was declared but never referenced

caffe2/aten/src/ATen/native/cuda/UnaryFractionKernels.cu(112): warning: function "at::native::nearbyint_wrapper(c10::complex<double>)" was declared but never referenced

caffe2/aten/src/ATen/native/cuda/TensorFactories.cu(106): warning: variable "d_temp_storage" was declared but never referenced

caffe2/torch/fb/sparsenn/sparsenn_operators_gpu.cu(2325): warning: variable "kMaxThreads" was declared but never referenced
```

To reproduce, run the following build command on remote/master:
```
buck build mode/dev-nosan caffe2/torch/fb/sparsenn:sparsenn_operators_gpu
```

Warnings about unused variables are fixed by removing the variable declaration. However, I don't want to remove the unused static functions. They were probably used before some other part of the code was refactored. They might be useful again in the future. So, I added a #pragma firectives to disable warnings for such functions.

Test Plan: Compilation does not produce warnings any more.

Differential Revision: D27577342

