### PR TITLE
[not for land] testing out fx type annotations on fx graph mode quant

### DIFF
--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -2,6 +2,7 @@ import torch
 from torch.fx import GraphModule  # type: ignore
 from torch.fx.symbolic_trace import Tracer  # type: ignore
 from torch.fx.node import Target, Node, Argument  # type: ignore
+from torch.fx.experimental.schema_type_annotation import AnnotateTypesWithSchema
 from .fx import Fuser  # noqa: F401
 from .fx import Quantizer  # noqa: F401
 from .fx.utils import graph_pretty_str  # noqa: F401
@@ -171,6 +172,8 @@ forward graph of the parent module,
         skipped_module_names, skipped_module_classes)
     graph_module = GraphModule(model, tracer.trace(model))
     graph_module = _fuse_fx(graph_module, prepare_custom_config_dict)
+    # annotate types
+    graph_module = AnnotateTypesWithSchema(graph_module).transform()
     quantizer = Quantizer()
     prepared = quantizer.prepare(
         graph_module,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55390 [not for land] testing out fx type annotations on fx graph mode quant**

Summary:

Takes https://github.com/pytorch/pytorch/pull/53653 for a test drive.

The tests pass with this enabled, but I did have some questions whether
this could be extended to capture types of:
1. x.size(1) typed as int
2. x.ndim typed as int
3. figuring out the types of add, sub, mul

Here are some gists of tests cases which test the current (hack)
solutions to 1, 2, 3 in fx graph mode quant.
* https://gist.github.com/vkuzo/df7a5e2be59092f94950cd214772334f
* https://gist.github.com/vkuzo/a0a115bc9a01dec9d2a4911fd86a53dd

We can see in the
printouts of the test case models that the types of 1, 2, 3 above
are currently not annotated.  Would love thoughts if I'm calling
the annotation class correctly, and whether adding the functionality
to parse these generically is doable.

Test Plan:

All quantization tests pass:
```
python test/test_quantization.py TestQuantizeFx
```

Reviewers:

Subscribers:

Tasks:

Tags: