### PR TITLE
Add Per Tensor Quantization Support to FXIRImporter

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -77,14 +77,17 @@ class TestFXExperimental(JitTestCase):
             if node.op == "output":
                 node.meta['shape'] = a.shape
                 node.meta['dtype'] = a.dtype
+                node.meta['is_quantized'] = a.is_quantized
         for mod in module_with_submodules.modules():
             if isinstance(mod, GraphModule):
                 for node in mod.graph.nodes:
                     node.meta['shape'] = a.shape
                     node.meta['dtype'] = a.dtype
+                    node.meta['is_quantized'] = a.is_quantized
         for node in module_with_submodules.graph.nodes:
             node.meta['shape'] = a.shape
             node.meta['dtype'] = a.dtype
+            node.meta['is_quantized'] = a.is_quantized
 
         weights1 = {}
         weights2 = {}
@@ -122,9 +125,9 @@ class TestFXExperimental(JitTestCase):
         )
         result = graph_manipulation.serialize_tensor_quantization(q_tensor)
         result2 = graph_manipulation.serialize_tensor_quantization(q_tensor_channel)
-        assert result["q_scheme"] == "torch.per_tensor_affine"
+        assert result["qscheme"] == "torch.per_tensor_affine"
         assert result["q_scale"] == 1.0
-        assert result2["q_scheme"] == "torch.per_channel_affine"
+        assert result2["qscheme"] == "torch.per_channel_affine"
         assert len(result2["q_per_channel_scales"]) == 2
 
     def test_find_single_partition(self):

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -54,6 +54,14 @@ class ShapeProp(torch.fx.Interpreter):
             n.meta['shape'] = result.shape
             n.meta['dtype'] = result.dtype
             n.meta['stride'] = result.stride()
+            n.meta['is_quantized'] = result.is_quantized
+
+            if n.meta['is_quantized']:
+                n.meta['qscheme'] = result.qscheme()
+
+                if n.meta['qscheme'] in {torch.per_tensor_affine, torch.per_tensor_symmetric}:
+                    n.meta['q_scale'] = result.q_scale()
+                    n.meta['q_zero_point'] = result.q_zero_point()
 
         return result
 


### PR DESCRIPTION
Summary:
Allows FXIRImport to import quantized model.

This diff doesn't include the supports for per-channel weights, linear and conv. Will address them in the next diff.

Test Plan: buck test glow/fb/fx/nnpi_importer:test_importer

Reviewed By: jackm321

Differential Revision: D27313543

