### PR TITLE
[torchelastic] Make sure torchelastic mp wait for queue to be drained before finishing the process

### DIFF
--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -18,6 +18,7 @@ from itertools import product
 from typing import Dict, List
 from unittest import mock
 
+import torch
 import torch.multiprocessing as mp
 from torch.distributed.elastic.multiprocessing import ProcessFailure, start_processes
 from torch.distributed.elastic.multiprocessing.api import (
@@ -143,6 +144,11 @@ def echo_large(size: int) -> Dict[int, str]:
         out[idx] = f"test{idx}"
     return out
 
+def dummy_compute() -> torch.Tensor:
+    """
+    returns a predefined size random Tensor
+    """
+    return torch.rand(100, 100)
 
 def redirects() -> List[Std]:
     return [
@@ -205,6 +211,7 @@ class StartProcessesTest(unittest.TestCase):
 
         for stdout_redir, stderr_redir in redirs:
             queue = multiprocessing.SimpleQueue()
+            worker_finished_event_mock = mock.Mock()
             _wrap(
                 local_rank=0,
                 fn=echo1,
@@ -213,12 +220,14 @@ class StartProcessesTest(unittest.TestCase):
                 stdout_redirects={0: stdout_redir},
                 stderr_redirects={0: stderr_redir},
                 ret_vals={0: queue},
+                queue_finished_reading_event=worker_finished_event_mock,
             )
             self.assertEqual("hello_0", queue.get())
             if stdout_redir:
                 self.assert_in_file(["hello stdout from 0"], stdout_log)
             if stderr_redir:
                 self.assert_in_file(["hello stderr from 0"], stderr_log)
+            worker_finished_event_mock.wait.assert_called_once()
 
     def test_invalid_log_dir(self):
         with tempfile.NamedTemporaryFile(dir=self.test_dir) as not_a_dir:
@@ -338,6 +347,26 @@ class StartProcessesTest(unittest.TestCase):
                         self.assert_in_file(
                             [f"hello stderr from {i}"], results.stderrs[i]
                         )
+
+    @unittest.skipIf(
+        TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"
+    )
+    def test_function_with_tensor(self):
+        for start_method in self._start_methods:
+            pc = start_processes(
+                name="dummy_compute",
+                entrypoint=dummy_compute,
+                args={},
+                envs={},
+                log_dir=self.log_dir(),
+                start_method=start_method,
+            )
+
+            results = pc.wait()
+            self.assert_pids_noexist(pc.pids())
+            for return_value in results.return_values.values():
+                self.assertIsInstance(return_value, torch.Tensor)
+                self.assertEqual((100, 100), return_value.shape)
 
     @unittest.skipIf(
         TEST_WITH_ASAN or TEST_WITH_TSAN, "tests incompatible with tsan or asan"


### PR DESCRIPTION
Summary:
The diff resolves bug where worker processes could exit before torchelastic process would read the return values. This is a rare event, but still can happen, e.g. https://fb.workplace.com/groups/319878845696681/permalink/512409069776990/

When users want to return torch.Tensor object from worker process, the torchelastic multiprocessing will fail. Currently worker process finishes its job after it writes output to the IPC queue without receiver process confirmation. When this happens, the underlying channel between worker and torchelastic process could be closed (in case of mp.SimpleQueue it is file descriptors, that is why we see FileNotFoundException: since worker process finished execution, the file descriptor just got deleted, and torchelastic process cannot find it).

Test Plan:
buck test mode/dev-nosan //caffe2/test/distributed/elastic/agent/server/test:local_agent_test

User workflow: f263531643

Differential Revision: D27602838

