### PR TITLE
[skip ci] Re-enable disabled tests workflow with GHA

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -1,0 +1,30 @@
+name: Update disabled tests
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled, closed, reopened]
+  # Have the ability to trigger this job manually through the API
+  workflow_dispatch:
+
+jobs:
+  update-disabled-tests:
+    if: ${{ github.repository_owner == 'pytorch' }}
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Generate new disabled test list
+        run: |
+          # score changes every request, so we strip it out to avoid creating a commit every time we query.
+          curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+label%3A%22module%3A+flaky-tests%22+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
+          | sed 's/"score": [0-9\.]*/"score": 0.0/g' > .pytorch-disabled-tests
+      - name: Push file to test-infra repository
+        uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
+        env:
+           API_TOKEN_GITHUB: ${{ secrets.TEST_INFRA_TOKEN }}
+        with:
+          source_file: '.pytorch-disabled-tests'
+          destination_repo: 'pytorch/test-infra'
+          destination_folder: 'stats'
+          destination_branch: master
+          user_email: 'test-infra@pytorch.org'
+          user_name: 'Pytorch Test Infra'
+          commit_message: 'Updating disabled tests stats'

--- a/tools/update_disabled_tests.sh
+++ b/tools/update_disabled_tests.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-EXTRACTED_REPO=https://$USERNAME:$API_KEY@github.com/zdevito/pytorch_disabled_tests.git
-git clone $EXTRACTED_REPO
-cd pytorch_disabled_tests
-curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+label%3A%22topic%3A+flaky-tests%22+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
-| sed 's/"score": [0-9\.]*/"score": 0.0/g' > result.json
-# score changes every request, so we strip it out to avoid creating a commit every time we query.
-git commit -a -m 'update'
-git push


### PR DESCRIPTION
Replace the old (and disabled) workflow to update disabled tests with a GitHub Action that would gather a list of disabled tests and export them to our test-infra repo.

Test plan:
This [workflow](https://github.com/janeyx99/gha-experiments/runs/2282792158?check_suite_focus=true) has successfully pushed, resulting in this file: https://github.com/pytorch/test-infra/blob/master/stats/.pytorch-disabled-tests