### PR TITLE
[PyTorch] WIP: support (but don't use) borrowing Tensors in TensorIterator

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -20,13 +20,26 @@ using StrideVector = TensorIteratorBase::StrideVector;
 /// Construction
 TensorIteratorConfig& TensorIteratorConfig::add_output(const Tensor& output) {
   TORCH_INTERNAL_ASSERT(num_inputs_ == 0);
-  tensors_.emplace_back(output);
+  tensors_.push_back(c10::MaybeOwned<Tensor>::owned(c10::in_place, output));
   num_outputs_++;
   return *this;
 }
 
 TensorIteratorConfig& TensorIteratorConfig::add_input(const Tensor& input) {
-  tensors_.emplace_back(input);
+  tensors_.push_back(c10::MaybeOwned<Tensor>::owned(c10::in_place, input));
+  num_inputs_++;
+  return *this;
+}
+
+TensorIteratorConfig& TensorIteratorConfig::add_borrowed_output(const Tensor& output) {
+  TORCH_INTERNAL_ASSERT(num_inputs_ == 0);
+  tensors_.push_back(c10::MaybeOwned<Tensor>::borrowed(output));
+  num_outputs_++;
+  return *this;
+}
+
+TensorIteratorConfig& TensorIteratorConfig::add_borrowed_input(const Tensor& input) {
+  tensors_.push_back(c10::MaybeOwned<Tensor>::borrowed(input));
   num_inputs_++;
   return *this;
 }
@@ -176,7 +189,7 @@ ScalarType TensorIteratorBase::compute_common_dtype() {
       continue;
     }
 
-    state = at::native::update_result_type_state(op.tensor, state);
+    state = at::native::update_result_type_state(*op.tensor, state);
   }
 
   common_dtype_ = at::native::result_type(state);
@@ -186,8 +199,8 @@ ScalarType TensorIteratorBase::compute_common_dtype() {
 }
 
 TensorOptions original_options(const OperandInfo& op) {
-  if (op.original_tensor.defined()) {
-    return op.original_tensor.options();
+  if (op.original_tensor->defined()) {
+    return op.original_tensor->options();
   } else {
     return op.options();
   }
@@ -237,7 +250,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
     }
 
     // Validates input tensors are defined
-    if (!op.tensor.defined()) {
+    if (!op.tensor->defined()) {
       TORCH_INTERNAL_ASSERT(op.is_output, "Found undefined input tensor!");
       continue;
     }
@@ -245,8 +258,8 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
     TORCH_INTERNAL_ASSERT(op.target_dtype == op.current_dtype)
 
     // Acquires the first non-CPU device (if any) as the common device
-    if (common_device == kCPU && !op.tensor.is_cpu()) {
-      common_device = op.tensor.device();
+    if (common_device == kCPU && !op.tensor->is_cpu()) {
+      common_device = op.tensor->device();
     }
 
     if (!op.is_output) {
@@ -283,7 +296,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
       (common_dtype_ != output_dtype && output_dtype != ScalarType::Undefined))) {
     // Throws an informative error message
     for (auto& op : operands_) {
-      if (!op.tensor.defined()) {
+      if (!op.tensor->defined()) {
         continue;
       }
 
@@ -327,7 +340,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
     }
 
     // Skips undefined tensors
-    if (!op.tensor.defined()) {
+    if (!op.tensor->defined()) {
       continue;
     }
 
@@ -335,8 +348,8 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
     if (config.check_all_same_device_) {
       // Handles CPU scalars on CUDA kernels that support them
       if (!common_device.is_cpu() &&
-          config.allow_cpu_scalars_ && !op.is_output && op.tensor.dim() == 0 &&
-          op.tensor.is_cpu()) {
+          config.allow_cpu_scalars_ && !op.is_output && op.tensor->dim() == 0 &&
+          op.tensor->is_cpu()) {
         TORCH_CHECK(current_cpu_scalars_on_non_cpu < max_cpu_scalars_on_non_cpu,
                     "Trying to pass too many CPU scalars to non-CPU kernel!");
         ++current_cpu_scalars_on_non_cpu;
@@ -361,7 +374,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
       // NB: we skip this on is_meta_, because the temporary allocation here is
       // unnecessary if we aren't going to actually do the compute
       if (config.cast_common_dtype_to_outputs_ && op.is_output && op.current_dtype != common_dtype_ && !is_meta_) {
-        TORCH_INTERNAL_ASSERT(op.tensor.defined());
+        TORCH_INTERNAL_ASSERT(op.tensor->defined());
         // Marker [Output original_tensor is set]
         op.original_tensor = op.tensor;
         // NB: do NOT use set_output here, as the temporary is NOT a true output;
@@ -372,11 +385,12 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
         // then after calling the out kernel, do the conversion (which
         // is cast_outputs here), but integrating this with existing
         // TensorIterator will take a little doing
-        op.tensor = at::empty_like(op.tensor,
-                                   op.tensor.options().dtype(common_dtype_),
-                                   LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+        op.tensor = c10::MaybeOwned<Tensor>::owned(
+            at::empty_like(*op.tensor,
+                           op.tensor->options().dtype(common_dtype_),
+                           LEGACY_CONTIGUOUS_MEMORY_FORMAT));
         if (!names_.empty()) {
-          namedinference::propagate_names(op.tensor, names_);
+          namedinference::propagate_names(*op.tensor, names_);
         }
         op.current_dtype = common_dtype_;
         op.target_dtype = common_dtype_;
@@ -385,7 +399,7 @@ void TensorIteratorBase::compute_types(const TensorIteratorConfig& config) {
       // Promotes inputs by creating temporaries of the correct dtype
       if (config.promote_inputs_to_common_dtype_ && !op.is_output && op.current_dtype != common_dtype_) {
         op.original_tensor = op.tensor;
-        op.tensor = op.tensor.to(common_dtype_);
+        op.tensor = c10::MaybeOwned<Tensor>::owned(op.tensor->to(common_dtype_));
         op.current_dtype = common_dtype_;
         op.target_dtype = common_dtype_;
       }
@@ -418,7 +432,7 @@ DimVector TensorIteratorBase::invert_perm(IntArrayRef input) const {
 void TensorIteratorBase::allocate_or_resize_outputs() {
   for (int i = 0; i < num_outputs_; i++) {
     auto& op = operands_[i];
-    if (!op.tensor.defined() || op.will_resize) {
+    if (!op.tensor->defined() || op.will_resize) {
       TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
       int element_size = elementSize(op.target_dtype);
       op.stride_bytes = compatible_stride(element_size);
@@ -444,10 +458,10 @@ void TensorIteratorBase::allocate_or_resize_outputs() {
         set_output(i, tensor_shape, tensor_stride, original_options(op), names_);
       }
       op.current_dtype = op.target_dtype;
-    } else if (op.tensor.defined()) {
+    } else if (op.tensor->defined()) {
       // Even if we don't resize, we still need to tell set_output about
       // the output, so that we properly set guard and propagate names
-      set_output(i, op.tensor.sizes(), {}, original_options(op), names_);
+      set_output(i, op.tensor->sizes(), {}, original_options(op), names_);
     }
   }
 }
@@ -457,14 +471,14 @@ void TensorIteratorBase::compute_names(const TensorIteratorConfig& config) {
       operands_.begin(),
       operands_.end(),
       [](const OperandInfo& op) {
-        return op.tensor.defined() && op.tensor.has_names();
+        return op.tensor->defined() && op.tensor->has_names();
       });
   if (!should_infer_names) {
     return;
   }
 
   for (auto& op : operands_) {
-    if (!op.tensor.defined()) continue;
+    if (!op.tensor->defined()) continue;
     // Don't include output tensors if we are resizing, since we will
     // clobber their names in any case.  (If the output tensor was
     // also an input tensor, we'll pick it up when it shows up again
@@ -472,9 +486,9 @@ void TensorIteratorBase::compute_names(const TensorIteratorConfig& config) {
     if (config.resize_outputs_ && op.is_output) continue;
     // perform name inference
     if (names_.empty()) {
-      names_ = op.tensor.names();
+      names_ = op.tensor->names();
     } else {
-      names_ = NameVector(unify_from_right(names_, op.tensor.names()));
+      names_ = NameVector(unify_from_right(names_, op.tensor->names()));
     }
   }
 }
@@ -696,14 +710,14 @@ bool TensorIteratorBase::is_cpu_scalar(int arg) const {
 
 void TensorIteratorBase::cast_outputs() {
   for (auto& op : operands_) {
-    if (op.is_output && op.original_tensor.defined() &&
-        op.original_tensor.scalar_type() != op.current_dtype) {
+    if (op.is_output && op.original_tensor->defined() &&
+        op.original_tensor->scalar_type() != op.current_dtype) {
       // TODO: Now that set_output resizes both the original_tensor
       // and tensor, this condition should no longer ever be true
-      if (op.original_tensor.sizes() != op.tensor.sizes()){
-        op.original_tensor.resize_as_(op.tensor).as_strided_(op.tensor.sizes(), op.tensor.strides());
+      if (op.original_tensor->sizes() != op.tensor->sizes()){
+        op.original_tensor->resize_as_(*op.tensor).as_strided_(op.tensor->sizes(), op.tensor->strides());
       }
-      op.original_tensor.copy_(op.tensor);
+      op.original_tensor->copy_(*op.tensor);
       op.tensor = op.original_tensor;
     }
   }
@@ -897,7 +911,7 @@ void TensorIteratorBase::populate_operands(TensorIteratorConfig& config) {
     // computation is a meta computation (don't do any work,
     // just compute output information).  This aligns with
     // our multiple dispatch semantics.
-    if (tensor.is_meta()) {
+    if (tensor->is_meta()) {
       is_meta_ = true;
     }
     operands_.emplace_back(std::move(tensor));
@@ -910,12 +924,12 @@ void TensorIteratorBase::mark_outputs() {
   for (int i = 0; i < num_outputs_; i++) {
     operands_[i].is_output = true;
     const auto& output = operands_[i].tensor;
-    if (!output.defined()) continue;
+    if (!output->defined()) continue;
 
     // check if output is also an input
     for (int arg = num_outputs_; arg < ntensors(); arg++) {
       const auto& input = operands_[arg].tensor;
-      if (output.is_same(input)) {
+      if (output->is_same(*input)) {
         operands_[i].is_read_write = true;
       }
     }
@@ -932,13 +946,13 @@ void TensorIteratorBase::mark_resize_outputs(const TensorIteratorConfig& config)
   }
   for (int i = 0; i < num_outputs_; i++) {
     const auto& output = operands_[i].tensor;
-    if (output.defined() && !output.sizes().equals(shape_)) {
+    if (output->defined() && !output->sizes().equals(shape_)) {
       if (config.resize_outputs_ && !operands_[i].is_read_write) {
         operands_[i].will_resize = true;
         continue;
       }
       // for reduction, output size does not match shape_, as output is reduced size, and shape_ is size of the input
-      TORCH_CHECK(is_reduction_,  "output with shape ", output.sizes(), " doesn't match the broadcast shape ",
+      TORCH_CHECK(is_reduction_,  "output with shape ", output->sizes(), " doesn't match the broadcast shape ",
                  shape_);
     }
   }
@@ -950,11 +964,11 @@ void TensorIteratorBase::compute_mem_overlaps(const TensorIteratorConfig& config
   }
   for (int i = 0; i < num_outputs_; i++) {
     const auto& output = operands_[i].tensor;
-    if (!output.defined()) continue;
-    assert_no_internal_overlap(output);
+    if (!output->defined()) continue;
+    assert_no_internal_overlap(*output);
     for (int j = num_outputs_; j < ntensors(); j++) {
       const auto& input = operands_[j].tensor;
-      assert_no_partial_overlap(output, input);
+      assert_no_partial_overlap(*output, *input);
     }
   }
 }
@@ -969,7 +983,7 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
   bool has_scalars = false;
   bool has_tensors = false;
   for (auto& op : operands_) {
-    if (!op.tensor.defined()) continue;
+    if (!op.tensor->defined()) continue;
 
     // For now, don't include output tensors when we're resizing outputs.
     // These shapes don't participate in shape computation.
@@ -977,7 +991,7 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
     // the destination tensor.  If the output tensor is also an input, we'll
     // pick it up later in the operands.
     if (config.resize_outputs_ && op.is_output) continue;
-    auto shape = op.tensor.sizes();
+    auto shape = op.tensor->sizes();
     if (shape.size() == 0) {
       has_scalars = true;
     } else {
@@ -997,10 +1011,10 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
 
 void TensorIteratorBase::compute_strides(const TensorIteratorConfig& config) {
   for (auto& op : operands_) {
-    if (op.tensor.defined()) {
-      IntArrayRef original_shape = config.static_shape_ ? shape_ : op.tensor.sizes();
-      auto original_stride = op.tensor.strides();
-      auto element_size_in_bytes = op.tensor.element_size();
+    if (op.tensor->defined()) {
+      IntArrayRef original_shape = config.static_shape_ ? shape_ : op.tensor->sizes();
+      auto original_stride = op.tensor->strides();
+      auto element_size_in_bytes = op.tensor->element_size();
       auto offset = ndim() - original_shape.size();
       if (offset > 0)
           op.stride_bytes.resize(ndim(), 0);
@@ -1087,7 +1101,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
       {
         for (int i = 0; i < num_outputs_; i++){
           auto& op = operands_[i];
-          if (!op.tensor.defined()) {
+          if (!op.tensor->defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
           }
           set_output(i, shape_, {}, original_options(op).memory_format(MemoryFormat::Contiguous), names_);
@@ -1098,7 +1112,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
       {
         for (int i = 0; i < num_outputs_; i++){
           auto& op = operands_[i];
-          if (!op.tensor.defined()) {
+          if (!op.tensor->defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
           }
           set_output(i, shape_, {}, original_options(op).memory_format(MemoryFormat::ChannelsLast), names_);
@@ -1110,15 +1124,15 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
         // find the index of a defined tensor in operands_ start from input tensor
         int i_defined; // NOLINT(cppcoreguidelines-init-variables)
         for (i_defined = ntensors() - 1; i_defined >= 0; --i_defined) {
-          if (operands_[i_defined].tensor.defined()) break;
+          if (operands_[i_defined].tensor->defined()) break;
         }
         TORCH_CHECK(i_defined >= 0, "Can not find a defined tensor when fast allocating memory to outputs");
         for (int i = 0; i < num_outputs_; i++){
           auto& op = operands_[i];
-          if (!op.tensor.defined()) {
+          if (!op.tensor->defined()) {
             TORCH_INTERNAL_ASSERT(op.is_type_defined(), "no type for operand", i);
           }
-          set_output(i, shape_, operands_[i_defined].tensor.strides(), original_options(op), names_);
+          set_output(i, shape_, operands_[i_defined].tensor->strides(), original_options(op), names_);
         }
         break;
       }
@@ -1134,7 +1148,7 @@ bool TensorIteratorBase::fast_set_up(const TensorIteratorConfig& config) {
     shape_.resize(1);
   }
   for (auto& op : operands_ ) {
-    auto element_size_in_bytes = op.tensor.element_size();
+    auto element_size_in_bytes = op.tensor->element_size();
     op.stride_bytes.resize(ndim());
     if (ndim()>0) {
       op.stride_bytes[0] = element_size_in_bytes;
@@ -1152,10 +1166,10 @@ FastSetupType TensorIteratorBase::compute_fast_setup_type(const TensorIteratorCo
   bool is_channels_last = true;
   bool is_non_overlapping_and_dense = true;
   for (const auto& op : operands_) {
-    if (op.tensor.defined() && !op.will_resize) {
-      is_contiguous &= op.tensor.is_contiguous(at::MemoryFormat::Contiguous);
-      is_channels_last &= op.tensor.is_contiguous(at::MemoryFormat::ChannelsLast);
-      is_non_overlapping_and_dense &= op.tensor.is_non_overlapping_and_dense();
+    if (op.tensor->defined() && !op.will_resize) {
+      is_contiguous &= op.tensor->is_contiguous(at::MemoryFormat::Contiguous);
+      is_channels_last &= op.tensor->is_contiguous(at::MemoryFormat::ChannelsLast);
+      is_non_overlapping_and_dense &= op.tensor->is_non_overlapping_and_dense();
     }
   }
   // TODO this leads to ambiguous cases (NC11) to be always treated as contiguous
@@ -1171,12 +1185,12 @@ FastSetupType TensorIteratorBase::compute_fast_setup_type(const TensorIteratorCo
     // Iterate from back to check input tensors' strides first, then output tensors'.
     for (int64_t i = ntensors() - 1; i >= 0; --i) {
       const auto& op = operands_[i];
-      if (op.tensor.defined() && !op.will_resize) {
+      if (op.tensor->defined() && !op.will_resize) {
         if (prev < 0) {
           prev = i;
           continue;
         }
-        if (!operands_[prev].tensor.strides().equals(op.tensor.strides())) {
+        if (!operands_[prev].tensor->strides().equals(op.tensor->strides())) {
           // [Note: stride check for non contiguous tensors in fast setup]
           // We prevent 3 cases doing fast setup here:
           // 1. input tensors have different strides.
@@ -1231,8 +1245,8 @@ void TensorIteratorBase::build(TensorIteratorConfig& config) {
   if (is_meta_) return;
 
   for (auto& op : operands_) {
-    TORCH_INTERNAL_ASSERT(op.tensor.defined());
-    op.data = op.tensor.data_ptr();
+    TORCH_INTERNAL_ASSERT(op.tensor->defined());
+    op.data = op.tensor->data_ptr();
   }
 
   // zero out offsets
@@ -1255,11 +1269,11 @@ void TensorIteratorBase::set_output(int64_t output_idx, IntArrayRef sizes, IntAr
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(output_idx < num_outputs_);
   const auto& t = maybe_get_output(output_idx);
   TORCH_INTERNAL_ASSERT(t.defined());
-  if (!op.tensor.defined()) {
-    op.tensor = t;
+  if (!op.tensor->defined()) {
+    op.tensor = c10::MaybeOwned<Tensor>::borrowed(t);
     op.current_dtype = op.target_dtype;
   } else if (op.will_resize) {
-    if (op.original_tensor.defined()) {
+    if (op.original_tensor->defined()) {
       // OK, so this is pretty weird.  To understand how we can end up in
       // this situation, first look at Marker [Output original_tensor is set].
       // That is the sole site where original_tensor may be set on an
@@ -1296,19 +1310,19 @@ void TensorIteratorBase::set_output(int64_t output_idx, IntArrayRef sizes, IntAr
       // after TensorIterator builder, waiting until we actually want
       // to do the computation.  That would also remove the necessity
       // for the is_meta_ test.
-      TORCH_INTERNAL_ASSERT(op.original_tensor.is_same(t));
-      TORCH_INTERNAL_ASSERT(!op.tensor.is_same(t));
+      TORCH_INTERNAL_ASSERT(op.original_tensor->is_same(t));
+      TORCH_INTERNAL_ASSERT(!op.tensor->is_same(t));
       // fastpath CPU to skip a dispatcher trip
-      if (op.tensor.is_cpu()) {
-        at::native::resize_output_cpu(op.tensor, sizes);
+      if (op.tensor->is_cpu()) {
+        at::native::resize_output_cpu(*op.tensor, sizes);
       } else {
-        at::native::resize_output(op.tensor, sizes);
+        at::native::resize_output(*op.tensor, sizes);
       }
       if (!strides.empty()) {
         TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
-        op.tensor.as_strided_(sizes, strides);
+        op.tensor->as_strided_(sizes, strides);
       } else if (options.memory_format_opt().has_value()) {
-        op.tensor.unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
+        op.tensor->unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
       }
     }
   }
@@ -1321,30 +1335,30 @@ void TensorIterator::set_output(int64_t output_idx, IntArrayRef sizes, IntArrayR
   // NB: intentionally no superclass call
   auto& op = operands_[output_idx];
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(output_idx < num_outputs_);
-  if (!op.tensor.defined()) {
+  if (!op.tensor->defined()) {
       if (strides.empty()) {
-        op.tensor = at::empty(sizes, options);
+        op.tensor = c10::MaybeOwned<Tensor>::owned(at::empty(sizes, options));
       } else {
-        op.tensor = at::empty_strided(sizes, strides, options);
+        op.tensor = c10::MaybeOwned<Tensor>::owned(at::empty_strided(sizes, strides, options));
       }
       op.current_dtype = op.target_dtype;
   } else if (op.will_resize) {
       // fastpath CPU to skip a dispatcher trip
-      if (op.tensor.is_cpu()) {
-        at::native::resize_output_cpu(op.tensor, sizes);
+      if (op.tensor->is_cpu()) {
+        at::native::resize_output_cpu(*op.tensor, sizes);
       } else {
-        at::native::resize_output(op.tensor, sizes);
+        at::native::resize_output(*op.tensor, sizes);
       }
       if (!strides.empty()) {
         TORCH_INTERNAL_ASSERT(!options.memory_format_opt().has_value());
-        op.tensor.as_strided_(sizes, strides);
+        op.tensor->as_strided_(sizes, strides);
       } else if (options.memory_format_opt().has_value()) {
-        op.tensor.unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
+        op.tensor->unsafeGetTensorImpl()->empty_tensor_restride(*options.memory_format_opt());
       }
   }
   if (!names.empty()) {
-    TORCH_INTERNAL_ASSERT(op.tensor.defined());
-    namedinference::propagate_names(op.tensor, names);
+    TORCH_INTERNAL_ASSERT(op.tensor->defined());
+    namedinference::propagate_names(*op.tensor, names);
   }
 }
 
@@ -1353,7 +1367,7 @@ void TensorIterator::set_output(int64_t output_idx, IntArrayRef sizes, IntArrayR
 // all the outputs are), but we have to provide all pure virtual methods
 // for MetaBase
 const Tensor& TensorIterator::maybe_get_output(int64_t output_idx) {
-  return operands_[output_idx].tensor;
+  return *operands_[output_idx].tensor;
 }
 
 SplitUntil32Bit TensorIteratorBase::with_32bit_indexing() const {

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/util/FunctionRef.h>
+#include <c10/util/MaybeOwned.h>
 #include <c10/util/SmallVector.h>
 #include <c10/util/TypeCast.h>
 #include <ATen/core/Range.h>
@@ -73,10 +74,10 @@ struct DimCounter {
 struct TORCH_API OperandInfo {
   using StrideVector = SmallVector<int64_t, 6>;
   OperandInfo() {}
-  explicit OperandInfo(Tensor&& t) : tensor(std::move(t)) {
-    if (tensor.defined()) {
-      device = tensor.device();
-      target_dtype = tensor.scalar_type();
+  explicit OperandInfo(c10::MaybeOwned<Tensor>&& t) : tensor(std::move(t)) {
+    if (tensor->defined()) {
+      device = tensor->device();
+      target_dtype = tensor->scalar_type();
       current_dtype = target_dtype;
     }
     validate();
@@ -88,11 +89,11 @@ struct TORCH_API OperandInfo {
   /// The tensor operand. Note that the strides, data pointer, and
   /// other attributes may differ due to dimension reordering and
   /// coalescing.
-  Tensor tensor;
+  c10::MaybeOwned<Tensor> tensor;
 
   // Save the original tensor operand in cases when an output is modified
   // (e.g. if dtype is changed)
-  Tensor original_tensor;
+  c10::MaybeOwned<Tensor> original_tensor = c10::MaybeOwned<Tensor>::owned(c10::in_place);
 
   /// The desired device and type for the operand. For inputs, this specifies that
   /// the input should be converted to this type if necessary. For outputs, this
@@ -112,7 +113,7 @@ struct TORCH_API OperandInfo {
     return TensorOptions(target_dtype).device(device);
   }
 
-  /// The data pointer. This may be different from tensor.data_ptr() if the
+  /// The data pointer. This may be different from tensor->data_ptr() if the
   /// iterator is split.
   void* data = nullptr;
 
@@ -124,8 +125,8 @@ struct TORCH_API OperandInfo {
 
   void validate() {
     TORCH_CHECK(
-        !tensor.defined() || tensor.layout() == kStrided,
-        "unsupported tensor layout: ", tensor.layout());
+        !tensor->defined() || tensor->layout() == kStrided,
+        "unsupported tensor layout: ", tensor->layout());
   }
 };
 
@@ -201,11 +202,11 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   bool is_scalar(int arg) const;
   bool is_cpu_scalar(int arg) const;
 
-  const Tensor& tensor(int arg) const { return operands_[arg].tensor; }
+  const Tensor& tensor(int arg) const { return *operands_[arg].tensor; }
 
   const Tensor& output(int arg=0) const {
     AT_ASSERT(arg < num_outputs_);
-    return operands_[arg].tensor;
+    return *operands_[arg].tensor;
   }
 
   // Copies from temporary outputs back to the original outputs
@@ -214,7 +215,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
 
   Tensor input(int arg=0) const {
     AT_ASSERT(arg >= 0 && arg < ntensors() - num_outputs_);
-    return operands_[num_outputs_ + arg].tensor;
+    return *operands_[num_outputs_ + arg].tensor;
   }
 
   /// Removes an operand from this iterator
@@ -238,7 +239,7 @@ struct TORCH_API TensorIteratorBase : public impl::MetaBase {
   template <typename T>
   T scalar_value(int arg) {
     auto& op = operands_[arg];
-    return c10::fetch_and_cast<T>(op.tensor.scalar_type(), op.data);
+    return c10::fetch_and_cast<T>(op.tensor->scalar_type(), op.data);
   }
 
 private:
@@ -356,7 +357,7 @@ protected:
 
 protected:
 
-  /// Records the "computation" shape of the output tensor.  The computation
+  /// Records the "computation" shape of the output tensor. The computation
   /// shape is different from the regular shape in a few ways:
   ///
   ///   - The shape may be permuted (via permute_dimensions) so that we
@@ -473,6 +474,13 @@ public:
   TensorIteratorConfig& add_output(const Tensor& output);
   TensorIteratorConfig& add_input(const Tensor& input);
 
+  // Advanced API: stores input/output Tensors without incrementing
+  // the reference count. The caller must ensure that these Tensors
+  // live at least as long as this TensorIteratorConfig and any
+  // TensorIteratorBase built from this TensorIteratorConfig.
+  TensorIteratorConfig& add_borrowed_output(const Tensor& output);
+  TensorIteratorConfig& add_borrowed_input(const Tensor& input);
+
   // Sets the check_mem_overlap_ flag, which is true by default.
   // If true, inputs are checked for partial overlap with the outputs and
   // outputs are checked for internal overlap (e.g. broadcasted views). An error
@@ -583,7 +591,7 @@ public:
   }
 
 private:
-  SmallVector<Tensor, 4> tensors_;
+  SmallVector<c10::MaybeOwned<Tensor>, 4> tensors_;
   int num_outputs_ = 0;
   int num_inputs_ = 0;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55423 take advantage of borrow capability in add
* #55422 always-inline OperandInfo ctor/dtor
* **#55421 [PyTorch] WIP: support (but don't use) borrowing Tensors in TensorIterator**
* #55420 [PyTorch] Remove non-const TensorIterator::tensor() method
* #55419 [PyTorch] Allow copy operations on MaybeOwned
* #55258 [PyTorch] Format generated structured kernels code better
* #55351 [PyTorch] Fix const correctness for resize native functions

Separate so that we can measure cost of support.

Differential Revision: [D27607293](https://our.internmc.facebook.com/intern/diff/D27607293/)