### PR TITLE
always-inline OperandInfo ctor/dtor

### DIFF
--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -74,7 +74,7 @@ struct DimCounter {
 struct TORCH_API OperandInfo {
   using StrideVector = SmallVector<int64_t, 6>;
   OperandInfo() {}
-  explicit OperandInfo(c10::MaybeOwned<Tensor>&& t) : tensor(std::move(t)) {
+  C10_ALWAYS_INLINE explicit OperandInfo(c10::MaybeOwned<Tensor>&& t) : tensor(std::move(t)) {
     if (tensor->defined()) {
       device = tensor->device();
       target_dtype = tensor->scalar_type();
@@ -82,6 +82,8 @@ struct TORCH_API OperandInfo {
     }
     validate();
   }
+
+  C10_ALWAYS_INLINE ~OperandInfo() = default;
 
   /// Stride after broadcasting. The stride is in bytes, not number of elements.
   StrideVector stride_bytes;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55423 take advantage of borrow capability in add
* **#55422 always-inline OperandInfo ctor/dtor**
* #55421 [PyTorch] WIP: support (but don't use) borrowing Tensors in TensorIterator
* #55420 [PyTorch] Remove non-const TensorIterator::tensor() method
* #55419 [PyTorch] Allow copy operations on MaybeOwned
* #55258 [PyTorch] Format generated structured kernels code better
* #55351 [PyTorch] Fix const correctness for resize native functions

Differential Revision: [D27607294](https://our.internmc.facebook.com/intern/diff/D27607294/)