### PR TITLE
take advantage of borrow capability in add

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -771,16 +771,28 @@ void TensorIteratorBase::build_binary_float_op(const Tensor& out, const Tensor& 
      .promote_integer_inputs_to_float(true));
 }
 
+// This cannot be a function because TensorIteratorConfig is not
+// copyable or movable, so it can't be returned from the function.
+#define BINARY_OP_CONFIG()                              \
+  TensorIteratorConfig()                                \
+    .set_check_mem_overlap(true)                        \
+    .allow_cpu_scalars(true)                            \
+    .promote_inputs_to_common_dtype(true)               \
+    .cast_common_dtype_to_outputs(true)                 \
+    .enforce_safe_casting_to_output(true)               \
+
 void TensorIteratorBase::build_binary_op(const Tensor& out, const Tensor& a, const Tensor& b) {
-  build(TensorIteratorConfig()
-    .set_check_mem_overlap(true)
-    .add_output(out)
-    .add_input(a)
-    .add_input(b)
-    .allow_cpu_scalars(true)
-    .promote_inputs_to_common_dtype(true)
-    .cast_common_dtype_to_outputs(true)
-    .enforce_safe_casting_to_output(true));
+  build(BINARY_OP_CONFIG()
+      .add_output(out)
+      .add_input(a)
+      .add_input(b));
+}
+
+void TensorIteratorBase::build_borrowing_binary_op(const Tensor& out, const Tensor& a, const Tensor& b) {
+  build(BINARY_OP_CONFIG()
+      .add_borrowed_output(out)
+      .add_borrowed_input(a)
+      .add_borrowed_input(b));
 }
 
 void TensorIteratorBase::build_unary_float_op(const Tensor& out, const Tensor& a) {

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -335,6 +335,7 @@ public:
 
   void build_binary_float_op(const Tensor& out, const Tensor& a, const Tensor& b);
   void build_binary_op(const Tensor& out, const Tensor& a, const Tensor& b);
+  void build_borrowing_binary_op(const Tensor& out, const Tensor& a, const Tensor& b);
   void build_unary_float_op(const Tensor& out, const Tensor& a);
   void build_unary_op(const Tensor& out, const Tensor& a);
 

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -16,7 +16,7 @@ namespace meta {
 TORCH_META_FUNC2(add, Tensor) (
   const Tensor& self, const Tensor& other, const Scalar& alpha
 ) {
-  build_binary_op(maybe_get_output(), self, other);
+  build_borrowing_binary_op(maybe_get_output(), self, other);
   native::alpha_check(dtype(), alpha);
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55423 take advantage of borrow capability in add**
* #55422 always-inline OperandInfo ctor/dtor
* #55421 [PyTorch] WIP: support (but don't use) borrowing Tensors in TensorIterator
* #55420 [PyTorch] Remove non-const TensorIterator::tensor() method
* #55419 [PyTorch] Allow copy operations on MaybeOwned
* #55258 [PyTorch] Format generated structured kernels code better
* #55351 [PyTorch] Fix const correctness for resize native functions

XXX: This causes the TensorIterator output's dtype to be
ScalarType::Undefined, but doesn't trigger any ASAN or UBSAN
errors. Need to carefully review prior changes.

Differential Revision: [D27607295](https://our.internmc.facebook.com/intern/diff/D27607295/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27607295/)!