### PR TITLE
Separate TLS for InferenceMode (#55238)

### DIFF
--- a/c10/core/InferenceMode.cpp
+++ b/c10/core/InferenceMode.cpp
@@ -1,11 +1,18 @@
-
 #include <c10/core/InferenceMode.h>
+#include <stdexcept>
 
 namespace c10 {
+thread_local bool InferenceMode_enabled = false;
 
+// Invariant:
+//   is_enabled() == !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
+// InferenceMode::is_enabled() is in perf critical path (TensorImpl constructor)
+// so it worths a separate TLS to skip the DispatchKeySet check.
 bool InferenceMode::is_enabled() {
-  // See Note [Expected TLS state in InferenceMode]
-  return !c10::impl::tls_is_dispatch_key_included(DispatchKey::InplaceOrView);
+  return InferenceMode_enabled;
 }
 
+void InferenceMode::set_enabled(bool enabled) {
+  InferenceMode_enabled = enabled;
+}
 } // namespace c10


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/55238

I tried to avoid creating new TLS, but InferenceMode::is_enabeld()
is in perf critical path (TensorImpl constructor) so it seems
worth adding one for it.
This PR reduces one sources of instruction count increased by
https://github.com/pytorch/pytorch/pull/55008.
```
 λ ~ python compare.py
<torch.utils.benchmark.utils.valgrind_wrapper.timer_interface.FunctionCounts object at 0x7f59097ef310>
     100  0x0000000004854750
    -100  0x0000000004854760
   -4400  c10::impl::tls_is_dispatch_key_included(...)
```

Test Plan: Imported from OSS

Reviewed By: ezyang

Differential Revision: D27539230

Pulled By: ailzhang

