### PR TITLE
[pthreadpool] Apply cap for macos builds

### DIFF
--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -12,8 +12,9 @@ C10_DEFINE_bool(
 // Whether or not threadpool caps apply to Android
 C10_DEFINE_int(caffe2_threadpool_android_cap, true, "");
 
-// Whether or not threadpool caps apply to iOS
+// Whether or not threadpool caps apply to iOS and MacOS
 C10_DEFINE_int(caffe2_threadpool_ios_cap, true, "");
+C10_DEFINE_int(caffe2_threadpool_macos_cap, true, "");
 
 C10_DEFINE_int(pthreadpool_size, 0, "Override the default thread pool size.");
 
@@ -28,6 +29,8 @@ size_t getDefaultNumThreads() {
   applyCap = FLAGS_caffe2_threadpool_android_cap;
 #elif defined(C10_IOS)
   applyCap = FLAGS_caffe2_threadpool_ios_cap;
+#elif defined(TARGET_OS_MAC)
+  applyCap = FLAGS_caffe2_threadpool_macos_cap;
 #endif
 
   if (applyCap) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55435 [pthreadpool] Apply cap for macos builds**

We've seen issues from the macos skylight app that PyTorch is super slow due to the lack of cap support in pthreadpools. For mac builds, we set the thread count to `#threads/2`.

Differential Revision: [D27578871](https://our.internmc.facebook.com/intern/diff/D27578871/)