### PR TITLE
`nn.ModuleList.forward()` now raises `NotImplementedException` for all possible inputs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1456,6 +1456,15 @@ class TestNN(NNTestCase):
         module_list.extend(s.modules())
         check()
 
+        # test that ModuleList raises NotImplementedError for all arguments
+        modules = nn.ModuleList()
+        with self.assertRaises(NotImplementedError):
+            modules.forward()
+        with self.assertRaises(NotImplementedError):
+            modules.forward(torch.zeros(4))
+        with self.assertRaises(NotImplementedError):
+            modules.forward(torch.tensor((2, 3)), torch.zeros(4))
+
     def test_ModuleDict(self):
         modules = OrderedDict([
             ('act', nn.ReLU()),

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -250,7 +250,7 @@ class ModuleList(Module):
             self.add_module(str(offset + i), module)
         return self
 
-    def forward(self):
+    def forward(self, *args):
         raise NotImplementedError()
 
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -250,7 +250,7 @@ class ModuleList(Module):
             self.add_module(str(offset + i), module)
         return self
 
-    def forward(self, *args):
+    def forward(self, *args: Any) -> None:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
Fixes #55459 

An alternative solution would be to completely remove the implementation of `forward` in `nn.ModuleList`, allowing the not-implemented handler of `nn.Module` to kick in, which handles this case correctly as well.