### PR TITLE
Disallow non-breaking spaces

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,13 +46,16 @@ jobs:
           (! git grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
         run: |
-          (! git grep -I -no ' $' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above files have trailing spaces; please remove them"; false))
+          (! git grep -I -n ' $' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))
       - name: Ensure no tabs
         run: |
-          (! git grep -I -no $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above files have tabs; please convert them to spaces"; false))
+          (! git grep -I -n $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above lines have tabs; please convert them to spaces"; false))
+      - name: Ensure no non-breaking spaces
+        run: |
+          (! git grep -I -n $'\u00a0' -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
       - name: Ensure canonical include
         run: |
-          (! git grep -I -no $'#include "' -- ./c10 ./aten ./torch/csrc ':(exclude)aten/src/ATen/native/quantized/cpu/qnnpack/**' || (echo "The above files have include with quotes; please convert them to #include <xxxx>"; false))
+          (! git grep -I -n $'#include "' -- ./c10 ./aten ./torch/csrc ':(exclude)aten/src/ATen/native/quantized/cpu/qnnpack/**' || (echo "The above lines have include with quotes; please convert them to #include <xxxx>"; false))
       # note that this next step depends on a clean checkout;
       # if you run it locally then it will likely to complain
       # about all the generated files in torch/test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
           (! git grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
         run: |
-          (! git grep -In ' $' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))
+          (! git grep -In '[[:blank:]]$' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))
       - name: Ensure no tabs
         run: |
           (! git grep -In $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above lines have tabs; please convert them to spaces"; false))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,16 +46,16 @@ jobs:
           (! git grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
         run: |
-          (! git grep -I -n ' $' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))
+          (! git grep -In ' $' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' || (echo "The above lines have trailing spaces; please remove them"; false))
       - name: Ensure no tabs
         run: |
-          (! git grep -I -n $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above lines have tabs; please convert them to spaces"; false))
+          (! git grep -In $'\t' -- . ':(exclude)*.svg' ':(exclude)**Makefile' ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude).gitattributes' ':(exclude).gitmodules' || (echo "The above lines have tabs; please convert them to spaces"; false))
       - name: Ensure no non-breaking spaces
         run: |
-          (! git grep -I -n $'\u00a0' -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
+          (! git grep -In $'\u00a0' -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
       - name: Ensure canonical include
         run: |
-          (! git grep -I -n $'#include "' -- ./c10 ./aten ./torch/csrc ':(exclude)aten/src/ATen/native/quantized/cpu/qnnpack/**' || (echo "The above lines have include with quotes; please convert them to #include <xxxx>"; false))
+          (! git grep -In $'#include "' -- ./c10 ./aten ./torch/csrc ':(exclude)aten/src/ATen/native/quantized/cpu/qnnpack/**' || (echo "The above lines have include with quotes; please convert them to #include <xxxx>"; false))
       # note that this next step depends on a clean checkout;
       # if you run it locally then it will likely to complain
       # about all the generated files in torch/test

--- a/benchmarks/operator_benchmark/README.md
+++ b/benchmarks/operator_benchmark/README.md
@@ -4,7 +4,7 @@ This benchmark suite provides a systemic way to measure the performance of opera
 
 ## Features
 
-Key Features: 
+Key Features:
 
 1\. Language used: Python
 
@@ -12,7 +12,7 @@ Key Features: 
 
 3\. Supported PyTorch mode: eager and JIT
 
-4\. Input shapes: user-defined shapes, randomly generated shapes 
+4\. Input shapes: user-defined shapes, randomly generated shapes
 
 ## Getting Started
 
@@ -99,19 +99,19 @@ Forward Execution Time (us) : 11.976
 # Input: M: 64, N: 64, K: 128
 Forward Execution Time (us) : 222.370
 ```
-At a high level, the output includes the execution time of `torch.add` with three different inputs. Let's look at each line in detail: 
+At a high level, the output includes the execution time of `torch.add` with three different inputs. Let's look at each line in detail:
 
 1\. `Tag: short` tags a group of inputs. For each operator, you could be interested in a large number of inputs, but you may not always want to run all the inputs. `Tag` allows you to only run some of the inputs. Most of the inputs to operators being supported in the benchmark are grouped using two tags. One group is tagged with `short` which stores some commonly used shapes. The other group is tagged with `long` which stores many random inputs to have better coverage compared with `short`.
 
-2\. `Benchmarking PyTorch: Add` shows name of the operator being benchmarked. 
+2\. `Benchmarking PyTorch: Add` shows name of the operator being benchmarked.
 
 3\. `Mode: Eager` shows that PyTorch eager mode is here.
 
 4\. `Name: add_M8_N16_K32` is the name of the test and it can be used to filter tests.
 
-5\. `Input: M: 8, N: 16, K: 32` shows inputs to the operator. 
+5\. `Input: M: 8, N: 16, K: 32` shows inputs to the operator.
 
-6\. `Forward Execution Time (us) : 6.651` reports the execution time of an operator in microseconds.  
+6\. `Forward Execution Time (us) : 6.651` reports the execution time of an operator in microseconds.
 
 ### Command-Line Control
 You can control all the aspects of the benchmark suite through the command-line. Please find details of those arguments by running the following command or look into `benchmark_runner.py`.
@@ -149,30 +149,30 @@ $ python -m pt.add_test --tag_filter long
 In the previous sections, we gave several examples to show how to run the already available operators in the benchmark suite. In the following sections, we'll step through the complete flow of adding PyTorch and Caffe2 operators to the benchmark suite. Existing benchmarks for operators are in `pt` and `c2` directories and we highly recommend putting your new operators in those directories as well.
 
 ### Add a New PyTorch Operator
-Let's say you want to measure the execution time of the following operator: 
+Let's say you want to measure the execution time of the following operator:
 ```
-C = torch.add(A, B) # Shape of A and B is [M, N, K] 
+C = torch.add(A, B) # Shape of A and B is [M, N, K]
 ```
-The code below shows how to add it to the benchmark suite. Let's go over the example line by line. 
+The code below shows how to add it to the benchmark suite. Let's go over the example line by line.
 ```
 import operator_benchmark as op_bench
 import torch
 
 add_long_configs = op_bench.cross_product_configs(
-    M=[8, 64, 128],
-    N=range(2, 10, 3),
-    K=[2 ** x for x in range(0, 3)],
-    tags=["long"]
+    M=[8, 64, 128],
+    N=range(2, 10, 3),
+    K=[2 ** x for x in range(0, 3)],
+    tags=["long"]
 )
 
 add_short_configs = op_bench.config_list(
-    attr_names=["M", "N", "K"],
-    attrs=[
-        [8, 16, 32],
-        [16, 16, 64],
-        [64, 64, 128],
-    ],
-    tags=["short"],
+    attr_names=["M", "N", "K"],
+    attrs=[
+        [8, 16, 32],
+        [16, 16, 64],
+        [64, 64, 128],
+    ],
+    tags=["short"],
 )
 
 class AddBenchmark(op_bench.TorchBenchmarkBase):
@@ -189,42 +189,42 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 
 if __name__ == "__main__":
-    op_bench.benchmark_runner.main()
+    op_bench.benchmark_runner.main()
 ```
 
 #### Part 1. Specify Inputs to Operators
-For the `torch.add` operator, we would like to make sure it delivers good performance with input tensors which are of small, medium and large sizes. We have introduced two helper functions for users to easily generate a combination of inputs.  
+For the `torch.add` operator, we would like to make sure it delivers good performance with input tensors which are of small, medium and large sizes. We have introduced two helper functions for users to easily generate a combination of inputs.
 ```
-# Generate list configurations that will be used for benchmark experiments 
+# Generate list configurations that will be used for benchmark experiments
 add_long_configs = op_bench.cross_product_configs(
-    M=[8, 64, 128],
-    N=range(2, 10, 3),
-    K=[2 ** x for x in range(0, 3)],
-    tags=["long"]
+    M=[8, 64, 128],
+    N=range(2, 10, 3),
+    K=[2 ** x for x in range(0, 3)],
+    tags=["long"]
 )
 
 add_short_configs = op_bench.config_list(
-    attr_names=["M", "N", "K"],
-    attrs=[
-        [8, 16, 32],
-        [16, 16, 64],
-        [64, 64, 128],
-    ],
-    tags=["short"],
+    attr_names=["M", "N", "K"],
+    attrs=[
+        [8, 16, 32],
+        [16, 16, 64],
+        [64, 64, 128],
+    ],
+    tags=["short"],
 )
 ```
 Let's look at it in detail:
 
-1\. `op_bench.config_list` is a helper function which specifies a list of inputs to operators. It takes three parameters which are `attrs_names, attrs, and tags`, all of them are python lists. `attr_names` stores the names of the inputs. `attrs` stores the real value of each input. In this example, three different inputs will be returned which are: `M=8, N=16, K=32; M=16, N=16, K=64; M=64, N=64, K=128`.  
+1\. `op_bench.config_list` is a helper function which specifies a list of inputs to operators. It takes three parameters which are `attrs_names, attrs, and tags`, all of them are python lists. `attr_names` stores the names of the inputs. `attrs` stores the real value of each input. In this example, three different inputs will be returned which are: `M=8, N=16, K=32; M=16, N=16, K=64; M=64, N=64, K=128`.
 
 2\. `op_bench.cross_product_configs` is another helper function to generate a cartesian product of the inputs. Each input is specified in a python list. In this example, the helper method will return a combination of 27 (len(M) * len(N) * len(K)) inputs.
 
 #### Part 2. Create Tensors and Add Computation
 After inputs are provided, we now look at adding the computation of an operator. Adding a new operator requires implementing a new `TorchBenchmarkBase` subclass. Every new class is required to implement 2 methods:
 * `init` is used to create tensors based on the inputs we provided before. In this example, the parameters to `init` are `M, N, and K` which have been specified in the input configuration. `init` also packed all the needed inputs together into a dictionary `self.inputs` which will be provided to `forward` as arguments for running the benchmark.
-* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Apart from `self`, the order of the arguments must match the entries specified in `self.inputs`.  
+* `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Apart from `self`, the order of the arguments must match the entries specified in `self.inputs`.
 
-The example below shows the code for `torch.add`:  
+The example below shows the code for `torch.add`:
 ```
 # Given one set of M, N, K, the init method creates input tensors based on
 # that. The forward method does torch.add calculation on those input tensors.
@@ -245,99 +245,99 @@ class AddBenchmark(op_bench.TorchBenchmarkBase):
         return torch.add(input_one, input_two)
 ```
 
-#### Part 3. Register Tests With the Benchmark Suite
-After we have inputs and the benchmark class, it's time to register them with our benchmark suite. Here is how it looks like:  
+#### Part 3. Register Tests With the Benchmark Suite
+After we have inputs and the benchmark class, it's time to register them with our benchmark suite. Here is how it looks like:
 ```
 op_bench.generate_pt_test(add_long_configs + add_short_configs, AddBenchmark)
 ```
 `generate_pt_test` takes two parameters which are inputs configs and the benchmark class.
 
-#### Part 4. Run the Registered Tests 
-To run the benchmark, we use the main method in `benchmark_runner` module. 
+#### Part 4. Run the Registered Tests
+To run the benchmark, we use the main method in `benchmark_runner` module.
 ```
 if __name__ == "__main__":
-    op_bench.benchmark_runner.main()
+    op_bench.benchmark_runner.main()
 ```
-That's it. You just added a new operator to the benchmark suite! 
+That's it. You just added a new operator to the benchmark suite!
 
 
 ### Add a New Caffe2 Operator
-The steps to add a new Caffe2 operator is the same as that for a PyTorch operator. The code below shows how to add Caffe2 `Add` operator:  
+The steps to add a new Caffe2 operator is the same as that for a PyTorch operator. The code below shows how to add Caffe2 `Add` operator:
 ```
 import operator_benchmark as op_bench
 from caffe2.python import core
 
 add_long_configs = op_bench.cross_product_configs(
-    M=[8, 64, 128],
-    N=range(2, 10, 3),
-    K=[2 ** x for x in range(0, 3)],
-    tags=["long"]
+    M=[8, 64, 128],
+    N=range(2, 10, 3),
+    K=[2 ** x for x in range(0, 3)],
+    tags=["long"]
 )
 
 add_short_configs = op_bench.config_list(
-    attrs=[
-        [8, 16, 32],
-        [16, 16, 64],
-        [64, 64, 128],
-    ],
-    attr_names=["M", "N", "K"],
-    tags=["short"],
+    attrs=[
+        [8, 16, 32],
+        [16, 16, 64],
+        [64, 64, 128],
+    ],
+    attr_names=["M", "N", "K"],
+    tags=["short"],
 )
 
 class AddBenchmark(op_bench.Caffe2BenchmarkBase):
 
-    def init(self, M, N, K):
-        self.input_one = self.tensor(M, N, K)
-        self.input_two = self.tensor(M, N, K)
-        self.output = self.tensor(M, N, K)
-        self.set_module_name("add")
+    def init(self, M, N, K):
+        self.input_one = self.tensor(M, N, K)
+        self.input_two = self.tensor(M, N, K)
+        self.output = self.tensor(M, N, K)
+        self.set_module_name("add")
 
-    def forward(self):
-        op = core.CreateOperator(
-            "Add", [self.input_one, self.input_two], self.output, **self.args
-        )
+    def forward(self):
+        op = core.CreateOperator(
+            "Add", [self.input_one, self.input_two], self.output, **self.args
+        )
 
-        return op
+        return op
 
 op_bench.generate_c2_test(add_long_configs + add_short_configs, AddBenchmark)
 
 if __name__ == "__main__":
-    op_bench.benchmark_runner.main()
+    op_bench.benchmark_runner.main()
 ```
 There are two things worth mentioning in this code:
-* `self.tensor` is a helper function which takes shapes and returns a Caffe2 blob. It is designed to make the tensor creation step easier compared to the standard Caffe2 way. 
+* `self.tensor` is a helper function which takes shapes and returns a Caffe2 blob. It is designed to make the tensor creation step easier compared to the standard Caffe2 way.
 * `generate_c2_test` is used to register Caffe2 tests with the benchmark.
 
 
 ### Add a List of Operators
 In the previous sections, we introduced the steps required to add a single operator to the benchmark suite. There are scenarios where you want to extend the benchmark suite with a list of operators which can share the same inputs. For example, to benchmark `abs` and `acos` operators, you can use the same set of inputs for both.
 
-Let's say we want to benchmark the following operators separately: 
+Let's say we want to benchmark the following operators separately:
 ```
 C = torch.abs(A) # Shape of A [M, N]
 C = torch.acos(A) # Shape of A [M, N]
 ```
-The following code shows how to do that: 
+The following code shows how to do that:
 ```
 import operator_benchmark as op_bench
 import torch
 
 unary_ops_configs = op_bench.config_list(
-    attrs=[
-        [128, 128],
-        [256, 256],
-        [1024, 1024],
-    ],
-    attr_names=["M", "N"],
-    tags=["short"]
+    attrs=[
+        [128, 128],
+        [256, 256],
+        [1024, 1024],
+    ],
+    attr_names=["M", "N"],
+    tags=["short"]
 )
 
 unary_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op_func"],
-    attrs=[
-        ["abs", torch.abs],
-        ["acos", torch.acos],
-    ],
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["abs", torch.abs],
+        ["acos", torch.acos],
+    ],
 )
 
 class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
@@ -353,28 +353,28 @@ class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
 op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
 
 if __name__ == "__main__":
-    op_bench.benchmark_runner.main()
+    op_bench.benchmark_runner.main()
 ```
 The inputs to those operators are specified using the same method we went over before. So we just skip it here.
 
 #### Part 1. Specify the List of Operators
-To add a list of operators to the benchmark suite, we introduce the `op_bench.op_list` method which takes two parameters: 
-* `attrs` stores the name of the operator and the method to do the real calculation. 
-* `attr_names` stores the names of values in attrs. 
+To add a list of operators to the benchmark suite, we introduce the `op_bench.op_list` method which takes two parameters:
+* `attrs` stores the name of the operator and the method to do the real calculation.
+* `attr_names` stores the names of values in attrs.
 
-The example below shows the code to add `torch.abs` and `torch.acos` : 
+The example below shows the code to add `torch.abs` and `torch.acos` :
 ```
 unary_ops_list = op_bench.op_list(
-    attr_names=["op_name", "op_func"],
-    attrs=[
-        ["abs", torch.abs],
-        ["acos", torch.acos],
-    ],
+    attr_names=["op_name", "op_func"],
+    attrs=[
+        ["abs", torch.abs],
+        ["acos", torch.acos],
+    ],
 )
 ```
 
 #### Part 2. Create Tensors and Add Computation
-In this example, both operators share the same input so we only need to implement one TorchBenchmakrBase subclass. 
+In this example, both operators share the same input so we only need to implement one TorchBenchmakrBase subclass.
 Every new subclass is required to implement 3 methods:
 * `init` is used to create tensors and set the operator name and function. In this example, the parameters to `init` are `M`, `N`, and `op_func` which have been specified in the configurations.
 * `forward` includes the operator to be tested and the computation based on the created tensors in `init`. Apart from `self`, the order of the arguments must match the entries specified in `self.inputs`.
@@ -395,7 +395,7 @@ class UnaryOpBenchmark(op_bench.TorchBenchmarkBase):
 ```
 
 #### Part 3. Register a List of Operators
-To register multiple operators,  we introduced the `generate_pt_tests_from_op_list` function which takes three parameters. First, the list of operators. Second,the configs. Third, the benchmark class.  
+To register multiple operators,  we introduced the `generate_pt_tests_from_op_list` function which takes three parameters. First, the list of operators. Second,the configs. Third, the benchmark class.
 Here is an example:
 ```
 op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, UnaryOpBenchmark)
@@ -405,45 +405,45 @@ op_bench.generate_pt_tests_from_op_list(unary_ops_list, unary_ops_configs, Unary
 ### Add Gradient Ops
 In this section, we go over the steps to benchmark the backward path of operators.
 #### For PyTorch Gradient Ops
-To measure the performance of an operator in its backward path, there are only two changes needed in addition to the steps we covered for the forward path: 
+To measure the performance of an operator in its backward path, there are only two changes needed in addition to the steps we covered for the forward path:
 
-1\. Specify `requires_grad=True` when creating the tensor. This is a standard PyTorch way of enabling backward path. 
+1\. Specify `requires_grad=True` when creating the tensor. This is a standard PyTorch way of enabling backward path.
 
-2\. Use `generate_pt_gradient_test` to register the tests. 
+2\. Use `generate_pt_gradient_test` to register the tests.
 
-The example below shows the relevant code for that: 
+The example below shows the relevant code for that:
 ```
 self.input_one = torch.rand(M, N, K, requires_grad=True)
 generate_pt_gradient_test(long_configs + short_configs, TorchAddBenchmark)
 ```
 #### For Caffe2 Gradient Ops
-To add Caffe2 gradient ops, we need to implement a new backward method in the benchmark class: 
+To add Caffe2 gradient ops, we need to implement a new backward method in the benchmark class:
 ```
 class AddBenchmark(op_bench.Caffe2BenchmarkBase):
 
-    def init(self, M, N, K): 
-        self.input_one = self.tensor(M, N, K) 
-        self.input_two = self.tensor(M, N, K) 
-        self.input_one_grad = self.tensor(M, N, K) 
-        self.input_two_grad = self.tensor(M, N, K) 
-        self.output = self.tensor(M, N, K)
-        self.set_module_name("add")
+    def init(self, M, N, K):
+        self.input_one = self.tensor(M, N, K)
+        self.input_two = self.tensor(M, N, K)
+        self.input_one_grad = self.tensor(M, N, K)
+        self.input_two_grad = self.tensor(M, N, K)
+        self.output = self.tensor(M, N, K)
+        self.set_module_name("add")
 
-    def forward(self):
-        op = core.CreateOperator(
-            "Add", [self.input_one, self.input_two], self.output, **self.args
-        )
+    def forward(self):
+        op = core.CreateOperator(
+            "Add", [self.input_one, self.input_two], self.output, **self.args
+        )
 
-        return op
+        return op
 
-    def backward(self):
-        grad_op = core.CreateOperator(
-            "AddGradient", 
-            [self.output, self.input_one, self.input_two],
-            [self.input_one_grad, self.input_two_grad], **self.args
-        )
+    def backward(self):
+        grad_op = core.CreateOperator(
+            "AddGradient",
+            [self.output, self.input_one, self.input_two],
+            [self.input_one_grad, self.input_two_grad], **self.args
+        )
 
-        return grad_op
+        return grad_op
 
 op_bench.generate_c2_gradient_test(long_configs + short_configs,AddBenchmark)
 ```

--- a/test/package/test_resources.py
+++ b/test/package/test_resources.py
@@ -25,15 +25,15 @@ class TestResources(PackageTestCase):
             # Layout looks like:
             #    package
             #    ├── one/
-            #    │   ├── a.txt
-            #    │   ├── b.txt
-            #    │   ├── c.txt
-            #    │   └── three/
-            #    │       ├── d.txt
-            #    │       └── e.txt
+            #    │   ├── a.txt
+            #    │   ├── b.txt
+            #    │   ├── c.txt
+            #    │   └── three/
+            #    │       ├── d.txt
+            #    │       └── e.txt
             #    └── two/
-            #       ├── f.txt
-            #       └── g.txt
+            #       ├── f.txt
+            #       └── g.txt
             pe.save_text("one", "a.txt", "hello, a!")
             pe.save_text("one", "b.txt", "hello, b!")
             pe.save_text("one", "c.txt", "hello, c!")

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -14,7 +14,7 @@ a particular functionality that combines a **distributed
 synchronization** primitive with **peer discovery**.
 
 It is used by torchelastic to gather participants of a training job
-(i.e. workers) such that they all agree on the same list of participants
+(i.e. workers) such that they all agree on the same list of participants
 and everyone’s roles, as well as make a consistent collective decision
 on when training can begin/resume.
 
@@ -45,7 +45,7 @@ interpreted as non-retryable.
 
 A simple distributed barrier would not be sufficient, as we also need to
 ensure that only one group of workers exists at any given time (for a
-given job). In other words, new workers (i.e. joining late) should not
+given job). In other words, new workers (i.e. joining late) should not
 be able to form a parallel independent group of workers for the same
 job.
 

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -109,7 +109,7 @@ class EtcdRendezvousHandler(RendezvousHandler):
     3. ``job_id == 1234`` is used as the prefix in etcd (this allows one to
        share a common etcd server for multiple jobs so long as the
        ``job_ids`` are guaranteed to be unique). Note that the job id can be
-       any string (e.g. does not need to be a number) as long as it is
+       any string (e.g. does not need to be a number) as long as it is
        unique.
     4. ``min_workers=1`` and ``max_workers=3`` specifies a range for
        membership size - torchelastic starts running the job as long as the

--- a/torch/fx/OVERVIEW.md
+++ b/torch/fx/OVERVIEW.md
@@ -83,7 +83,7 @@ In the default implementation of `Tracer().trace`, the tracer first creates Prox
 
 ## Proxy ##
 
-Proxy objects are Node wrappers used by the Tracer to record operations seen during symbolic tracing. The mechanism through which Proxy objects record computation is [`__torch_function__`](https://pytorch.org/docs/stable/notes/extending.html#extending-torch). If any custom Python type defines a method named `__torch_function__`, PyTorch will invoke that `__torch_function__` implementation when an instance of that custom type is passed to a function in the `torch` namespace. In FX, when operations on Proxy are dispatched to the `__torch_function__` handler, the `__torch_function__` handler records the operation in the Graph as a Node. The Node that was recorded in the Graph is then itself wrapped in a Proxy, facilitating further application of ops on that value.
+Proxy objects are Node wrappers used by the Tracer to record operations seen during symbolic tracing. The mechanism through which Proxy objects record computation is [`__torch_function__`](https://pytorch.org/docs/stable/notes/extending.html#extending-torch). If any custom Python type defines a method named `__torch_function__`, PyTorch will invoke that `__torch_function__` implementation when an instance of that custom type is passed to a function in the `torch` namespace. In FX, when operations on Proxy are dispatched to the `__torch_function__` handler, the `__torch_function__` handler records the operation in the Graph as a Node. The Node that was recorded in the Graph is then itself wrapped in a Proxy, facilitating further application of ops on that value.
 
 Consider the following example:
 


### PR DESCRIPTION
@malfet found a couple of these in #55346; this PR removes the rest and adds a lint that prevents them from being accidentally added again in the future. It also removes the `-o` flag added in #53733 (which was unnecessarily hiding context without reducing the number of lines of output), and updates the lint error messages to reflect that the individual line numbers are shown in the logs.

**Test plan:**

The "Lint / quick-checks" job in GitHub Actions should succeed on this PR. To verify that the lint does correctly find and error on non-breaking spaces, checkout ece075195d49c25213c96b9d53fcf7077215f44a and run it locally:
```sh
(! git --no-pager grep -In $'\u00a0' -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
```
It should print over a hundred lines of output and exit with status 1.