### PR TITLE
[6/n][torch/elastic][upstream] Move torchelastic/distributed/api to torch/distributed/elastic/launchers/api

### DIFF
--- a/test/distributed/launcher/__init__.py
+++ b/test/distributed/launcher/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/distributed/launcher/api_test.py
+++ b/test/distributed/launcher/api_test.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import multiprocessing as mp
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+import uuid
+from unittest import mock
+from unittest.mock import Mock, patch
+
+from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
+from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.launcher.api import (
+    LaunchConfig,
+    elastic_launch,
+    _get_entrypoint_name,
+)
+
+
+def path(script):
+    return os.path.join(os.path.dirname(__file__), script)
+
+
+def simple_rank_scale():
+    rank = int(os.environ["RANK"])
+    return 10 + rank
+
+
+def function_with_bug():
+    raise RuntimeError("test error")
+
+
+class MockException(Exception):
+    pass
+
+
+class ElasticLaunchTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # start a standalone, single process etcd server to use for all tests.
+        cls._etcd_server = EtcdServer()
+        cls._etcd_server.start()
+        cls._etcd_endpoint = cls._etcd_server.get_endpoint()
+
+    @classmethod
+    def tearDownClass(cls):
+        # stop the standalone etcd server.
+        cls._etcd_server.stop()
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+        # remove any lingering environment variables.
+        for env in os.environ.keys():
+            if env.startswith("PET_"):
+                del os.environ[env]
+
+        # set a sentinel env var on the parent proc.
+        # this should be present on the child and gets
+        # asserted in ``bin/test_script.py``.
+        os.environ["TEST_SENTINEL_PARENT"] = "FOOBAR"
+        os.environ["OMP_NUM_THREADS"] = str(1)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def get_test_launch_config(
+        self,
+        min_nodes: int,
+        max_nodes: int,
+        nproc_per_node: int,
+        run_id: str = "",
+    ) -> LaunchConfig:
+        return LaunchConfig(
+            min_nodes=min_nodes,
+            max_nodes=max_nodes,
+            nproc_per_node=nproc_per_node,
+            run_id=run_id,
+            rdzv_endpoint=self._etcd_endpoint,
+            monitor_interval=1,
+            rdzv_backend="etcd",
+            start_method="fork",
+            max_restarts=0,
+        )
+
+    def check_works_ran(self, world_size: int):
+        self.assertSetEqual(
+            {str(i) for i in range(world_size)}, set(os.listdir(self.test_dir))
+        )
+
+    def test_launch_script_python(self):
+        nnodes = 1
+        nproc_per_node = 4
+
+        elastic_launch(
+            self.get_test_launch_config(nnodes, nnodes, nproc_per_node),
+            sys.executable,
+        )("-u", path("bin/test_script.py"), f"--touch_file_dir={self.test_dir}")
+
+        # make sure all the workers ran.
+        # each worker touches a file with its global rank as the name.
+        world_size = nnodes * nproc_per_node
+        self.check_works_ran(world_size)
+
+    def test_launch_script_bash(self):
+        nnodes = 1
+        nproc_per_node = 4
+
+        elastic_launch(
+            self.get_test_launch_config(nnodes, nnodes, nproc_per_node),
+            path("bin/test_script.sh"),
+        )(f"{self.test_dir}")
+
+        world_size = nnodes * nproc_per_node
+        self.check_works_ran(world_size)
+
+    def test_launch_function(self):
+        nnodes = 1
+        nproc_per_node = 4
+
+        res = elastic_launch(
+            self.get_test_launch_config(nnodes, nnodes, nproc_per_node),
+            simple_rank_scale,
+        )()
+
+        expected_res = [10, 11, 12, 13]
+        actual_res = sorted(value for value in res.values())
+        self.assertEqual(expected_res, actual_res)
+
+    def test_launch_elastic(self):
+        nproc_per_node = 4
+
+        elastic_launch(
+            self.get_test_launch_config(1, 2, nproc_per_node),
+            sys.executable,
+        )("-u", path("bin/test_script.py"), f"--touch_file_dir={self.test_dir}")
+
+        world_size = nproc_per_node
+        self.check_works_ran(world_size)
+
+    @mock.patch("torch.distributed.elastic.events.record")
+    def test_launch_elastic_worker_raise_exception(self, record_mock):
+        """
+        Asserts that when the worker program fails and lancher raieses exception
+        to indicate that worker process failed.
+        """
+        nproc_per_node = 4
+
+        with self.assertRaises(ChildFailedError):
+            elastic_launch(
+                self.get_test_launch_config(1, 2, nproc_per_node),
+                sys.executable,
+            )("-u", path("bin/test_script.py"), "--fail")
+
+        record_mock.assert_called_once()
+
+    @mock.patch("torch.distributed.elastic.events.record")
+    @mock.patch(
+        "torch.distributed.elastic.agent.server.local_elastic_agent.LocalElasticAgent.run"
+    )
+    def test_launch_elastic_agent_raise_exception(self, record_mock, mock_agent_run):
+        """
+        Asserts that when the agent raises an exception
+        the launcher re-raises the original exception.
+        """
+        mock_agent_run.side_effect = MockException
+        with self.assertRaises(MockException):
+            elastic_launch(
+                self.get_test_launch_config(1, 2, 4),
+                sys.executable,
+            )("-u", path("bin/test_script.py"), f"--touch_file_dir={self.test_dir}")
+        record_mock.assert_called_once()
+
+    def test_launch_elastic_multiple_agents(self):
+        min_nodes = 1
+        max_nodes = 2
+        nproc_per_node = 4
+        nnodes = 2
+        run_id = str(uuid.uuid4().int)
+
+        def elastic_launch_wrapper():
+            """We need a wrapper function for class `elastic_launch.` in order to make multiprocess returns correct exit code."""
+            elastic_launch(
+                self.get_test_launch_config(
+                    min_nodes, max_nodes, nproc_per_node, run_id
+                ),
+                sys.executable,
+            )("-u", path("bin/test_script.py"), f"--touch_file_dir={self.test_dir}")
+
+        procs = []
+        for _ in range(nnodes - 1):
+            p = mp.Process(
+                target=elastic_launch_wrapper,
+            )
+            procs.append(p)
+            p.start()
+
+        elastic_launch_wrapper()
+
+        for i in range(nnodes - 1):
+            p = procs[i]
+            p.join()
+            self.assertEqual(0, p.exitcode)
+
+        # make sure all the workers ran
+        # each worker touches a file with its global rank as the name
+        world_size = nnodes * nproc_per_node
+        self.assertSetEqual(
+            {str(i) for i in range(world_size)}, set(os.listdir(self.test_dir))
+        )
+
+    @patch("torch.distributed.launcher.api.LocalElasticAgent")
+    def test_launch_shutdown(self, agent_mock_cls):
+        agent_mock = Mock()
+        agent_mock.run.return_value = RunResult(WorkerState.SUCCEEDED)
+        agent_mock_cls.return_value = agent_mock
+        rdzv_handler_mock = Mock()
+        with patch(
+            "torch.distributed.elastic.rendezvous.registry.get_rendezvous_handler"
+        ) as param_mock:
+            param_mock.return_value = rdzv_handler_mock
+            elastic_launch(
+                self.get_test_launch_config(1, 1, 4),
+                sys.executable,
+            )("-u", path("bin/test_script.py"), f"--touch_file_dir={self.test_dir}")
+
+            rdzv_handler_mock.shutdown.assert_called_once()
+
+    def test_get_entrypoint_name(self):
+        self.assertEqual(
+            "simple_rank_scale", _get_entrypoint_name(simple_rank_scale, [])
+        )
+        self.assertEqual("", _get_entrypoint_name(sys.executable, []))
+        self.assertEqual("", _get_entrypoint_name(sys.executable, ["-u"]))
+        self.assertEqual(
+            "test_script.py",
+            _get_entrypoint_name(sys.executable, ["-u", "test_script.py"]),
+        )
+        self.assertEqual("", _get_entrypoint_name(None, []))

--- a/test/distributed/launcher/bin/test_script.py
+++ b/test/distributed/launcher/bin/test_script.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+from pathlib import Path
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="test script")
+
+    parser.add_argument(
+        "--fail",
+        default=False,
+        action="store_true",
+        help="forces the script to throw a RuntimeError",
+    )
+
+    # file is used for assertions
+    parser.add_argument(
+        "--touch_file_dir",
+        type=str,
+        help="dir to touch a file with global rank as the filename",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    env_vars = [
+        "LOCAL_RANK",
+        "RANK",
+        "GROUP_RANK",
+        "ROLE_RANK",
+        "ROLE_NAME",
+        "LOCAL_WORLD_SIZE",
+        "WORLD_SIZE",
+        "ROLE_WORLD_SIZE",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "TORCHELASTIC_RESTART_COUNT",
+        "TORCHELASTIC_MAX_RESTARTS",
+        "TORCHELASTIC_RUN_ID",
+        "OMP_NUM_THREADS",
+        "TEST_SENTINEL_PARENT",
+        "TORCHELASTIC_ERROR_FILE",
+    ]
+
+    print("Distributed env vars set by agent:")
+    for env_var in env_vars:
+        value = os.environ[env_var]
+        print(f"{env_var} = {value}")
+
+    if args.fail:
+        raise RuntimeError("raising exception since --fail flag was set")
+    else:
+        file = os.path.join(args.touch_file_dir, os.environ["RANK"])
+        Path(file).touch()
+        print(f"Success, created {file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/distributed/launcher/bin/test_script.sh
+++ b/test/distributed/launcher/bin/test_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+FILE="$1/$RANK"
+echo "creating $FILE"
+touch "$FILE"

--- a/torch/distributed/launcher/__init__.py
+++ b/torch/distributed/launcher/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env/python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from torch.distributed.launcher.api import (  # noqa F401
+    LaunchConfig,
+    elastic_launch,
+    launch_agent,
+)

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import sys
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Union, cast
+
+import torch.distributed.elastic.rendezvous.registry as rdzv_registry
+from torch.distributed.elastic import events, metrics
+from torch.distributed.elastic.agent.server.api import WorkerSpec, WorkerState  # type: ignore[import]
+from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent  # type: ignore[import]
+from torch.distributed.elastic.multiprocessing import Std
+from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, record
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.elastic.utils.logging import get_logger
+
+
+logger = get_logger()
+
+
+@dataclass
+class LaunchConfig:
+    """
+    min_nodes: Minimum amount of nodes that the user function will
+                     be launched on. Elastic agent ensures that the user
+                     function start only when the min_nodes amount enters
+                     the rendezvous.
+    max_nodes: Maximum amount of nodes that the user function
+                     will be launched on.
+    nproc_per_node: On each node the elastic agent will launch
+                          this amount of workers that will execute user
+                          defined function.
+    rdzv_backend: rdzv_backend to use in the rendezvous (zeus-adapter, etcd).
+    rdzv_endpoint: The endpoint of the rdzv sync. storage.
+    rdzv_id: The unique run id of the job (if not passed a unique one will be
+             deduced from run environment - flow workflow id in flow - or auto generated).
+    role: User defined role of the worker (defaults to "trainer").
+    max_restarts: The maximum amount of restarts that elastic agent will conduct
+                  on workers before failure.
+    monitor_interval: The interval in seconds that is used by the elastic_agent
+                      as a period of monitoring workers.
+    start_method: The method is used by the elastic agent to start the
+                  workers (spawn, fork, forkserver).
+    log_dir: base log directory where log files are written. If not set,
+             one is created in a tmp dir but NOT removed on exit.
+    redirects: configuration to redirect stdout/stderr to log files.
+               Pass a single ``Std`` enum to redirect all workers,
+               or a mapping keyed by local_rank to selectively redirect.
+    tee: configuration to "tee" stdout/stderr to console + log file.
+    metrics_cfg: configuration to initialize metrics.
+    """
+
+    min_nodes: int
+    max_nodes: int
+    nproc_per_node: int
+    run_id: str = ""
+    role: str = "default_role"
+    rdzv_endpoint: str = ""
+    rdzv_backend: str = "etcd"
+    rdzv_configs: Dict[str, Any] = field(default_factory=dict)
+    rdzv_timeout: int = 300
+    max_restarts: int = 3
+    monitor_interval: float = 30
+    start_method: str = "spawn"
+    log_dir: Optional[str] = None
+    redirects: Union[Std, Dict[int, Std]] = Std.NONE
+    tee: Union[Std, Dict[int, Std]] = Std.NONE
+    metrics_cfg: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.rdzv_configs["timeout"] = self.rdzv_timeout
+
+
+class elastic_launch:
+    """
+    Launches an torchelastic agent on the container that invoked the entrypoint.
+
+        1. Pass the ``entrypoint`` arguments as non ``kwargs`` (e.g. no named parameters)/
+           ``entrypoint`` can be a function or a command.
+        2. The return value is a map of each worker's output mapped
+           by their respective global rank.
+
+    Usage
+
+    ::
+
+    def worker_fn(foo):
+        # ...
+
+    def main():
+        # entrypoint is a function.
+        outputs = elastic_launch(LaunchConfig, worker_fn)(foo)
+        # return rank 0's output
+        return outputs[0]
+
+        # entrypoint is a command and ``script.py`` is the python module.
+        ouptuts = elestic_launch(LaunchConfig, "script.py")(args)
+        ouptuts = elestic_launch(LaunchConfig, "python")("script.py")
+    """
+
+    def __init__(
+        self,
+        config: LaunchConfig,
+        entrypoint: Union[Callable, str, None],
+    ):
+        self._config = config
+        self._entrypoint = entrypoint
+
+    def __call__(self, *args, **kwargs):
+        return launch_agent(self._config, self._entrypoint, list(args))
+
+
+def _construct_event(config: LaunchConfig) -> events.Event:
+    metadata = {
+        "rdzv_backend": config.rdzv_backend,
+        "run_id": config.run_id,
+        "role": config.role,
+    }
+    return events.Event(
+        name="torch.distributed.elastic.launch_agent",
+        source=events.EventSource.AGENT,
+        metadata=cast(Dict[str, events.EventMetadataValue], metadata),
+    )
+
+
+def _get_entrypoint_name(
+    entrypoint: Union[Callable, str, None], args: List[Any]
+) -> str:
+    """Retrive entrypoint name with the rule:
+    1. If entrypoint is a function, use ``entrypont.__qualname__``.
+    2. If entrypoint is a string, check its value:
+        2.1 if entrypoint equals to ``sys.executable`` (like "python"), use the first element from ``args``
+            which does not start with hifen letter (for example, "-u" will be skipped).
+        2.2 otherwise, use ``entrypoint`` value.
+    3. Otherwise, return empty string.
+    """
+    if isinstance(entrypoint, Callable):  # type: ignore
+        return entrypoint.__name__  # type: ignore
+    elif isinstance(entrypoint, str):  # type: ignore
+        if entrypoint == sys.executable:
+            return next((arg for arg in args if arg[0] != "-"), "")
+        else:
+            return entrypoint
+    else:
+        return ""
+
+
+# pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+# torch.distributed.elastic.multiprocessing.errors.record.
+@record
+def launch_agent(
+    config: LaunchConfig,
+    entrypoint: Union[Callable, str, None],
+    args: List[Any],
+) -> Dict[int, Any]:
+    if not config.run_id:
+        run_id = str(uuid.uuid4().int)
+        logger.warning(f"config has no run_id, generate a new one: {run_id}")
+        config.run_id = run_id
+
+    entrypoint_name = _get_entrypoint_name(entrypoint, args)
+
+    logger.info(
+        f"Starting elastic_operator with launch configs:\n"
+        f"  entrypoint       : {entrypoint_name}\n"
+        f"  min_nodes        : {config.min_nodes}\n"
+        f"  max_nodes        : {config.max_nodes}\n"
+        f"  nproc_per_node   : {config.nproc_per_node}\n"
+        f"  run_id           : {config.run_id}\n"
+        f"  rdzv_backend     : {config.rdzv_backend}\n"
+        f"  rdzv_endpoint    : {config.rdzv_endpoint}\n"
+        f"  rdzv_configs     : {config.rdzv_configs}\n"
+        f"  max_restarts     : {config.max_restarts}\n"
+        f"  monitor_interval : {config.monitor_interval}\n"
+        f"  log_dir          : {config.log_dir}\n"
+        f"  metrics_cfg      : {config.metrics_cfg}\n"
+    )
+
+    rdzv_parameters = RendezvousParameters(
+        backend=config.rdzv_backend,
+        endpoint=config.rdzv_endpoint,
+        run_id=config.run_id,
+        min_nodes=config.min_nodes,
+        max_nodes=config.max_nodes,
+        **config.rdzv_configs,
+    )
+
+    agent = None
+    rdzv_handler = rdzv_registry.get_rendezvous_handler(rdzv_parameters)
+    try:
+        spec = WorkerSpec(
+            role=config.role,
+            local_world_size=config.nproc_per_node,
+            entrypoint=entrypoint,
+            args=tuple(args),
+            rdzv_handler=rdzv_handler,
+            max_restarts=config.max_restarts,
+            monitor_interval=config.monitor_interval,
+            redirects=config.redirects,
+            tee=config.tee,
+        )
+
+        cfg = metrics.MetricsConfig(config.metrics_cfg) if config.metrics_cfg else None
+        metrics.initialize_metrics(cfg)
+
+        agent = LocalElasticAgent(
+            spec=spec, start_method=config.start_method, log_dir=config.log_dir
+        )
+
+        result = agent.run()
+        events.record(agent.get_agent_status_event(WorkerState.SUCCEEDED))
+        if result.is_failed():
+            # ChildFailedError is treated specially by @record
+            # if the error files for the failed children exist
+            # @record will copy the first error (root cause)
+            # to the error file of the launcher process.
+            raise ChildFailedError(
+                name=entrypoint_name,
+                failures=result.failures,
+            )
+        else:
+            return result.return_values
+    except ChildFailedError:
+        raise
+    except Exception:
+        if agent:
+            events.record(agent.get_agent_status_event(WorkerState.FAILED))
+        else:
+            events.record(_construct_event(config))
+        raise
+    finally:
+        rdzv_handler.shutdown()


### PR DESCRIPTION
Summary: Move torchelastic/distributed/api to torch/distributed/elastic/launchers/api

Test Plan:
buck test mode/dev-nosan //pytorch/elastic/torchelastic/...
    buck test mode/dev-nosan //caffe2/test/distributed/elastic/agent/server/test/...

SyncSGD: tsm_aivanou-SparseNNApplication_432fc009

f263322216

Differential Revision: D27614353

