### PR TITLE
`replication_padding1d`: port to structured

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7699,15 +7699,14 @@
 
 - func: replication_pad1d.out(Tensor self, int[2] padding, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn
+  structured: True
   dispatch:
     CPU: replication_pad1d_out_cpu
     CUDA: replication_pad1d_out_cuda
 
 - func: replication_pad1d(Tensor self, int[2] padding) -> Tensor
   python_module: nn
-  dispatch:
-    CPU: replication_pad1d_cpu
-    CUDA: replication_pad1d_cuda
+  structured_delegate: replication_pad1d.out
 
 - func: replication_pad1d_backward.grad_input(Tensor grad_output, Tensor self, int[2] padding, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55581 Add support for multiple outputs in structured kernels, port fractional_max_pool2d
* #55537 Port replication_pad1d_backward to structured
* #55499 Port replication_padding3d to structured
* **#55481 Port replication_padding1d to structured**

Tracking issue #55070

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27641209](https://our.internmc.facebook.com/intern/diff/D27641209)