### PR TITLE
adds data_ptr checks to in-place OpInfo variant tests and out OpInfo tests

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -226,22 +226,22 @@ class TestCommon(JitCommonTestCase):
     @_variant_ops(op_db)
     def test_variant_consistency_eager(self, device, dtype, op):
         # Acquires variants (method variant, inplace variant, aliases)
-        method = op.get_method()
-        inplace = op.get_inplace()
+
+        method = op.method_variant
+        inplace = op.inplace_variant
 
         # list of all inplace ops: inplace variant + alias inplace variants if exist
         inplace_ops = [inplace, ]
+        variants = [method, inplace]
 
-        aliases = []
         for a_op in op.aliases:
-            aliases.append(a_op.op)
-            aliases.append(a_op.method_variant)
-            aliases.append(a_op.inplace_variant)
+            variants.append(a_op.op)
+            variants.append(a_op.method_variant)
+            variants.append(a_op.inplace_variant)
             inplace_ops.append(a_op.inplace_variant)
-        aliases = tuple(aliases)
 
-        inplace_variants = tuple(v for v in inplace_ops if v is not None)
-        variants = tuple(v for v in (method, inplace) + aliases if v is not None)
+        inplace_variants = tuple(filter(None, inplace_ops))#(v for v in inplace_ops if v is not None)
+        variants = tuple(filter(None, variants))#v for v in variants if v is not None)
         outplace_variants = tuple(set(variants) - set(inplace_variants))
 
         _requires_grad = (op.supports_autograd and
@@ -300,10 +300,36 @@ class TestCommon(JitCommonTestCase):
 
         _test_consistency_helper(samples, outplace_variants)
 
+        def _test_inplace_preserve_storage(samples, variants):
+            for sample in samples:
+        # Skips inplace variants if the output dtype is not the same as
+            #   the input dtype
+                expected_forward = op(sample.input, *sample.args, **sample.kwargs)
+                tensor = sample.input if isinstance(sample.input, torch.Tensor) else sample.input[0]
+                skip_inplace = False
+                if (isinstance(expected_forward, torch.Tensor) and
+                        expected_forward.dtype is not tensor.dtype):
+                    skip_inplace = True
+                if skip_inplace:
+                    return
+                for variant in variants:
+                    cloned = clone_input_helper(sample.input) if variant in inplace_ops else sample.input
+                    inp_tensor = cloned if isinstance(cloned, torch.Tensor) else cloned[0]
+                    data_ptr = inp_tensor.data_ptr()
+                    variant_forward = variant(cloned,
+                                                *sample.args,
+                                                **sample.kwargs)
+# TODO Support non-tensor outputs if they exist for inplace ops
+                    if (isinstance(variant_forward, torch.Tensor)):
+                        self.assertEqual(data_ptr, variant_forward.data_ptr(), atol=0, rtol=0)
+                    else:
+                        self.assertTrue(False, "Non-tensor outputs for inplace ops are not supported by this test, please fix the test")
+
         if len(inplace_ops) > 0:
             inplace_samples = op.sample_inputs(device, dtype, requires_grad=_requires_grad,
                                                for_inplace_variant=True)
             _test_consistency_helper(inplace_samples, inplace_variants)
+            _test_inplace_preserve_storage(inplace_samples, inplace_variants)
 
     # Tests that the forward and backward passes of operations produce the
     #   same values for the cross-product of op variants (function, method, inplace)
@@ -548,7 +574,7 @@ class TestCommon(JitCommonTestCase):
 
         # Case 1: out= with the correct shape, dtype, and device,
         #   but noncontiguous.
-        #   Expected behavior: strides are respected.
+        #   Expected behavior: strides are respected and `out` storage is not changed.
         def _case_one_transform(t):
             return make_tensor(t.shape,
                                dtype=t.dtype,
@@ -563,14 +589,25 @@ class TestCommon(JitCommonTestCase):
             # assumes (see above) that out is an iterable of tensors
             return tuple(map(lambda t: t.stride(), out))
 
+        def _extract_data_ptrs(out):
+            if isinstance(out, torch.Tensor):
+                return (out.data_ptr(),)
+
+            # assumes (see above) that out is an iterable of tensors
+            return tuple(map(lambda t: t.data_ptr(), out))
+
+
         out = _apply_out_transform(_case_one_transform, expected)
         original_strides = _extract_strides(out)
+        original_ptrs = _extract_data_ptrs(out)
 
         op_out(out=out)
         final_strides = _extract_strides(out)
+        final_ptrs = _extract_data_ptrs(out)
 
         self.assertEqual(expected, out)
         self.assertEqual(original_strides, final_strides)
+        self.assertEqual(original_ptrs, final_ptrs)
 
         # Case 2: out= with the correct dtype and device, but the wrong shape
         #   Expected behavior: resize with a warning.

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -240,8 +240,8 @@ class TestCommon(JitCommonTestCase):
             variants.append(a_op.inplace_variant)
             inplace_ops.append(a_op.inplace_variant)
 
-        inplace_variants = tuple(filter(None, inplace_ops))#(v for v in inplace_ops if v is not None)
-        variants = tuple(filter(None, variants))#v for v in variants if v is not None)
+        inplace_variants = tuple(filter(None, inplace_ops))
+        variants = tuple(filter(None, variants))
         outplace_variants = tuple(set(variants) - set(inplace_variants))
 
         _requires_grad = (op.supports_autograd and
@@ -302,8 +302,8 @@ class TestCommon(JitCommonTestCase):
 
         def _test_inplace_preserve_storage(samples, variants):
             for sample in samples:
-        # Skips inplace variants if the output dtype is not the same as
-            #   the input dtype
+                # Skips inplace variants if the output dtype is not the same as
+                #   the input dtype
                 expected_forward = op(sample.input, *sample.args, **sample.kwargs)
                 tensor = sample.input if isinstance(sample.input, torch.Tensor) else sample.input[0]
                 skip_inplace = False
@@ -317,13 +317,13 @@ class TestCommon(JitCommonTestCase):
                     inp_tensor = cloned if isinstance(cloned, torch.Tensor) else cloned[0]
                     data_ptr = inp_tensor.data_ptr()
                     variant_forward = variant(cloned,
-                                                *sample.args,
-                                                **sample.kwargs)
+                                              *sample.args,
+                                              **sample.kwargs)
 # TODO Support non-tensor outputs if they exist for inplace ops
                     if (isinstance(variant_forward, torch.Tensor)):
                         self.assertEqual(data_ptr, variant_forward.data_ptr(), atol=0, rtol=0)
                     else:
-                        self.assertTrue(False, "Non-tensor outputs for inplace ops are not supported by this test, please fix the test")
+                        self.assertTrue(False, "Non-tensor outputs for inplace ops are not supported")
 
         if len(inplace_ops) > 0:
             inplace_samples = op.sample_inputs(device, dtype, requires_grad=_requires_grad,


### PR DESCRIPTION
Fixes #55088. 
Unfortunately, this test wouldn't have caught index_add_ breakage (because index_add_ breakage would appear only in a particular type promotion situation). 
