### PR TITLE
[NNC] API to reorder multiple loops

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -202,6 +202,32 @@ class TORCH_API LoopNest {
 
   void reorderAxis(For* a, For* b);
 
+  // Reorder the given list of loops according to the permutation specified.
+  // Here permutation[i] represents the location of the loop i in the result.
+  //
+  // For example, consider the following code:
+  //   for p
+  //     for q
+  //       for r
+  //         for s
+  //           A[p,q,r,s] =
+  //
+  // reorder({p, q, r, s}, {2, 3, 0, 1}) will return the list of loops in the
+  // following form:
+  //    for r
+  //      for s
+  //        for p
+  //          for q
+  //            A[p,q,r,s] =
+  static std::vector<For*> reorder(
+      const std::vector<For*>& loops,
+      const std::vector<size_t>& permutation);
+
+  // Returns true if the given loops are perfectly nested, i.e., every loop
+  // (except the innermost) should have exactly one statement in its body
+  // and that statement must be the next inner loop.
+  static bool areLoopsPerfectlyNested(const std::vector<For*>& loops);
+
   static void unroll(For* f, Stmt** unrolled);
   static void normalize(For* f, For** normalized);
   static bool flatten(const std::vector<For*>& f, For** flattened);

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -681,6 +681,23 @@ class TORCH_API For : public StmtNode<For> {
     return new For(var_, start_, stop_, body, loop_options_);
   }
 
+  Block* removeBody() {
+    auto res = body_;
+    set_parent(res, nullptr);
+    body_ = nullptr;
+    return res;
+  }
+
+  Block* setBody(Stmt* body) {
+    Block* b = dynamic_cast<Block*>(body);
+    if (!b) {
+      b = new Block({body});
+    }
+    body_ = b;
+    set_parent(body_, this);
+    return body_;
+  }
+
  private:
   const Var* var_;
   const Expr* start_;


### PR DESCRIPTION
Fixes #52690

This PR adds the following APIs:

```
static bool areLoopsPerfectlyNested(const std::vector<For*>& loops);

static std::vector<For*> reorder(
      const std::vector<For*>& loops,
      const std::vector<size_t>& permutation);
```

The first API checks if the given list of loops are perfectly nested. The second API reorders the given list of loops according to the permutation specified.

