### PR TITLE
mark embedding backward non-deterministic for max mode rather than all reducing modes

### DIFF
--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -2659,13 +2659,14 @@ new_module_tests = [
     ),
     dict(
         module_name='EmbeddingBag',
-        constructor_args=(4, 3),
-        cpp_constructor_args='torch::nn::EmbeddingBagOptions(4, 3)',
+        constructor_args=(4, 3, None, 2., False, 'max'),
+        cpp_constructor_args='''torch::nn::EmbeddingBagOptions(4, 3)
+                                .max_norm(c10::nullopt).norm_type(2.).scale_grad_by_freq(false).mode(torch::kMax)''',
         input_fn=lambda: torch.empty(2, 3, dtype=torch.long).random_(4),
         check_gradgrad=False,
         desc='alert_nondeterministic',
         test_cpu=False,
-        decorator=expectedAlertNondeterministic('_embedding_bag_dense_backward_cuda', fn_has_device_arg=False)
+        decorator=expectedAlertNondeterministic('embedding_bag_backward_cuda_max', fn_has_device_arg=False)
     ),
     dict(
         module_name='EmbeddingBag',


### PR DESCRIPTION
Summary: nn.EmbeddingBag backward is non-deterministic when reducing_mode = Max and on GPU, reducing mode Mean and Sum should be deterministic

Test Plan: NA

Differential Revision: D27633832

