### PR TITLE
[FX] Speed up _Namespace.create_name

### DIFF
--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -120,13 +120,20 @@ class _Namespace:
         if candidate[0].isdigit():
             candidate = f'_{candidate}'
 
+        match = self._name_suffix_regex.match(candidate)
+        if match is None:
+            base = candidate
+            num = None
+        else:
+            base, num_str = match.group(1, 2)
+            num = int(num_str)
+
+        candidate = base if num is None else f'{base}_{num}'
+        num = num if num else 0
+
         while candidate in self._used_names or self._is_illegal_name(candidate, obj):
-            match = self._name_suffix_regex.match(candidate)
-            if match is None:
-                candidate = candidate + '_1'
-            else:
-                base, num = match.group(1, 2)
-                candidate = f'{base}_{int(num) + 1}'
+            num += 1
+            candidate = f'{base}_{num}'
 
         self._used_names.setdefault(candidate)
         if obj is None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55580 [FX] Speed up _Namespace.create_name**

Previously, we were applying `self._name_suffix_regex` in a loop to the carried dependency `candidate`. However, this is foolish because we're just undoing the f-string concatenation we did in the previous iteration. This makes it so that we maintain the base name and the integer number suffix separately and only do the string generation in the loop, rather than parsing it out again with a regex

Microbenchmark:

```
import torch
import torch.fx
from torch.fx.graph import _Namespace
import time

for NITER in [1, 10, 100, 1000]:
    ns = _Namespace()

    st = 'fooooo_1_2_3_4_5' 

    s = time.time()
    for _ in range(NITER):
        ns.create_name(st, None)
    e = time.time()

    time_per_iter = (e - s) / NITER
    bytes_per_iter = len(st) * 2
    bytes_per_sec = bytes_per_iter / time_per_iter

    print('NITER', NITER, 'time_per_iter', time_per_iter, 'bytes_per_iter', bytes_per_iter, 'byte_per_sec', bytes_per_sec)
```

Before
```
NITER 1 time_per_iter 9.298324584960938e-06 bytes_per_iter 32 byte_per_sec 3441480.205128205
NITER 10 time_per_iter 7.343292236328125e-06 bytes_per_iter 32 byte_per_sec 4357718.441558441
NITER 100 time_per_iter 4.958391189575195e-05 bytes_per_iter 32 byte_per_sec 645370.62076261
NITER 1000 time_per_iter 0.00048487043380737304 bytes_per_iter 32 byte_per_sec **65997.01233322221**
```

After 
```
NITER 1 time_per_iter 1.7881393432617188e-05 bytes_per_iter 32 byte_per_sec 1789569.7066666668
NITER 10 time_per_iter 4.57763671875e-06 bytes_per_iter 32 byte_per_sec 6990506.666666667
NITER 100 time_per_iter 1.3833045959472657e-05 bytes_per_iter 32 byte_per_sec 2313301.0685970355
NITER 1000 time_per_iter 0.0001204981803894043 bytes_per_iter 32 byte_per_sec **265564.17612770724**
```

Runtime is 4x faster for NITER=1000. Note we still have scaling issues and the next thing to look at is probably storing a mapping from base to the highest int value that's been used in `self._used_names`

Differential Revision: [D27641156](https://our.internmc.facebook.com/intern/diff/D27641156)