### PR TITLE
Add support for multiple outputs in structured kernels, port fractional_max_pool2d

### DIFF
--- a/aten/src/ATen/TensorMeta.h
+++ b/aten/src/ATen/TensorMeta.h
@@ -52,6 +52,9 @@ struct TORCH_API MetaBase {
   void set_output(IntArrayRef sizes, TensorOptions options) {
     set_output(0, sizes, {}, options, {});
   }
+  void set_output(int64_t output_idx, IntArrayRef sizes, TensorOptions options) {
+    set_output(output_idx, sizes, {}, options, {});
+  }
   // Returns a reference to an undefined tensor if there is no presupplied
   // output
   const Tensor& maybe_get_output() { return maybe_get_output(0); }

--- a/aten/src/ATen/native/FractionalMaxPool2d.cpp
+++ b/aten/src/ATen/native/FractionalMaxPool2d.cpp
@@ -6,6 +6,66 @@
 #include <vector>
 
 namespace at {
+
+namespace meta {
+TORCH_META_FUNC(fractional_max_pool2d) (
+  const at::Tensor& input,
+  IntArrayRef pool_size,
+  IntArrayRef output_size,
+  const at::Tensor& randomSamples
+) {
+  TORCH_CHECK(
+      pool_size.size() == 2,
+      "fractional_max_pool2d: kernel_size must either be a single Int or tuple of Ints")
+  TORCH_CHECK(
+      output_size.size() == 2,
+      "fractional_max_pool2d: output_size must either be a single Int or tuple of Ints")
+  int64_t numBatch = 1;
+  int64_t planeDim = 0;
+  int64_t heightDim = 1;
+  int64_t widthDim = 2;
+  int64_t outputH = output_size[0];
+  int64_t outputW = output_size[1];
+  int64_t poolSizeH = pool_size[0];
+  int64_t poolSizeW = pool_size[1];
+
+  int64_t ndims = input.ndimension();
+  TORCH_CHECK(input.numel() > 0 && (ndims == 3 || ndims == 4),
+    "non-empty 3D or 4D (batch mode) tensor expected for input, but got: ",
+    ndims);
+
+  if (ndims == 4) {
+    numBatch = input.size(0);
+    planeDim++;
+    heightDim++;
+    widthDim++;
+  }
+
+  /* sizes */
+  int64_t numPlanes = input.size(planeDim);
+  int64_t inputH = input.size(heightDim);
+  int inputW = input.size(widthDim);
+
+  TORCH_CHECK(outputH + poolSizeH - 1 <= inputH,
+    "fractional_max_pool2d(): pool height ", poolSizeH,
+    " too large relative to input height ", inputH);
+  TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
+    "fractional_max_pool2d(): pool width ", poolSizeW,
+    " too large relative to input width ", inputW);
+
+  if (ndims == 3) {
+    set_output(0, {numPlanes, outputH, outputW}, input.options());
+    /* indices will contain the locations for each output point */
+    set_output(1, {numPlanes, outputH, outputW}, input.options().dtype(kLong));
+  } else {
+    set_output(0, {numBatch, numPlanes, outputH, outputW}, input.options());
+    /* indices will contain the locations for each output point */
+    set_output(1, {numBatch, numPlanes, outputH, outputW}, input.options().dtype(kLong));
+  }
+}
+
+} // namespace meta
+
 namespace native {
 namespace {
 
@@ -122,35 +182,29 @@ static void fractional_max_pool2d_out_frame(
     });
   }
 
-void fractional_max_pool2d_out_cpu_template(
+} // anonymous namespace
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_out_cpu) (
   const at::Tensor& input_,
-  at::Tensor& output,
-  IntArrayRef output_size,
   IntArrayRef pool_size,
-  at::Tensor& indices,
-  const at::Tensor& randomSamples) {
-  TORCH_CHECK(
-      pool_size.size() == 2,
-      "fractional_max_pool2d: kernel_size must either be a single Int or tuple of Ints")
-  TORCH_CHECK(
-      output_size.size() == 2,
-      "fractional_max_pool2d: output_size must either be a single Int or tuple of Ints")
-  int numBatch = 1;
-  int planeDim = 0;
-  int heightDim = 1;
-  int widthDim = 2;
-  int outputH = output_size[0];
-  int outputW = output_size[1];
-  int poolSizeH = pool_size[0];
-  int poolSizeW = pool_size[1];
+  IntArrayRef output_size,
+  const at::Tensor& randomSamples,
+  const at::Tensor& output,
+  const at::Tensor& indices) {
+
+  int64_t numBatch = 1;
+  int64_t planeDim = 0;
+  int64_t heightDim = 1;
+  int64_t widthDim = 2;
+  int64_t outputH = output_size[0]; // output.size(heightDim)
+  int64_t outputW = output_size[1]; // output.size(widthDim)
+  int64_t poolSizeH = pool_size[0];
+  int64_t poolSizeW = pool_size[1];
 
   /* get contiguous input */
   auto input = input_.contiguous();
 
-  int ndims = input.ndimension();
-  TORCH_CHECK(input.numel() > 0 && (ndims == 3 || ndims == 4),
-    "non-empty 3D or 4D (batch mode) tensor expected for input, but got: ",
-    ndims);
+  int64_t ndims = input.ndimension();
 
   if (ndims == 4) {
     numBatch = input.size(0);
@@ -160,27 +214,9 @@ void fractional_max_pool2d_out_cpu_template(
   }
 
   /* sizes */
-  int numPlanes = input.size(planeDim);
-  int inputH = input.size(heightDim);
-  int inputW = input.size(widthDim);
-
-  TORCH_CHECK(outputH + poolSizeH - 1 <= inputH,
-    "fractional_max_pool2d(): pool height ", poolSizeH,
-    " too large relative to input height ", inputH);
-  TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
-    "fractional_max_pool2d(): pool width ", poolSizeW,
-    " too large relative to input width ", inputW);
-
-  if (ndims == 3) {
-    /* resize output */
-    output.resize_({numPlanes, outputH, outputW});
-    /* indices will contain the locations for each output point */
-    indices.resize_({numPlanes, outputH, outputW});
-  } else {
-    output.resize_({numBatch, numPlanes, outputH, outputW});
-    /* indices will contain the locations for each output point */
-    indices.resize_({numBatch, numPlanes, outputH, outputW});
-  }
+  int64_t numPlanes = input.size(planeDim);
+  int64_t inputH = input.size(heightDim);
+  int64_t inputW = input.size(widthDim);
 
   AT_DISPATCH_FLOATING_TYPES(input.scalar_type(),
   "fractional_max_pool2d_out_frame", [&] {
@@ -200,6 +236,8 @@ void fractional_max_pool2d_out_cpu_template(
     }
   );
 }
+
+namespace {
 
 template <typename scalar_t>
 static void fractional_max_pool2d_backward_out_single_batch_frame(
@@ -317,41 +355,6 @@ Tensor& fractional_max_pool2d_backward_out_cpu_template(
 }
 
 } // namespace
-
-std::tuple<Tensor&, Tensor&> fractional_max_pool2d_out_cpu(
-    const at::Tensor& input,
-    IntArrayRef pool_size,
-    IntArrayRef output_size,
-    const at::Tensor& randomSamples,
-    at::Tensor& output,
-    at::Tensor& indices) {
-  fractional_max_pool2d_out_cpu_template(
-    input,
-    output,
-    output_size,
-    pool_size,
-    indices,
-    randomSamples);
-  return std::tuple<Tensor&, Tensor&>(output, indices);
-}
-
-std::tuple<Tensor, Tensor> fractional_max_pool2d_cpu(
-  const at::Tensor& input,
-  IntArrayRef pool_size,
-  IntArrayRef output_size,
-  const at::Tensor& randomSamples)
-{
-  Tensor output = at::empty({0}, input.options());
-  Tensor indices = at::empty({0}, input.options().dtype(kLong));
-  fractional_max_pool2d_out_cpu_template(
-    input,
-    output,
-    output_size,
-    pool_size,
-    indices,
-    randomSamples);
-  return std::tuple<Tensor, Tensor>(output, indices);
-}
 
 Tensor& fractional_max_pool2d_backward_out_cpu(const at::Tensor& gradOutput_,
   const at::Tensor& input,

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -121,31 +121,22 @@ __global__ void fractional_max_pool2d_backward_out_cuda_frame(
   }
 }
 
-void fractional_max_pool2d_out_cuda_template(
-  Tensor & output,
-  Tensor& indices,
+} // anonymous namespace
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_out_cuda) (
   const Tensor& input,
   IntArrayRef pool_size,
   IntArrayRef output_size,
-  const Tensor& randomSamples) {
-  TORCH_CHECK(
-      pool_size.size() == 2,
-      "fractional_max_pool2d: kernel_size must either be a single Int or tuple of Ints")
-  TORCH_CHECK(
-      output_size.size() == 2,
-      "fractional_max_pool2d: output_size must either be a single Int or tuple of Ints")
+  const Tensor& randomSamples,
+  const Tensor& output,
+  const Tensor& indices
+) {
   int planeDim = 0;
   int dimh = 1;
   int dimw = 2;
   int numBatch = 1;
 
   int ndims = input.ndimension();
-  TORCH_CHECK(input.numel() > 0,
-    "fractional_max_pool2d(): expected input to have non-empty ",
-    "spatial dimensions.");
-
-  TORCH_CHECK((ndims == 3 || ndims == 4),
-     "non-empty 3D or 4D (batch mode) tensor expected for input");
 
   if (ndims == 4) {
     numBatch = input.size(0);
@@ -156,30 +147,11 @@ void fractional_max_pool2d_out_cuda_template(
 
   /* sizes */
   int numPlanes = input.size(planeDim);
-  int inputH = input.size(dimh);
-  int inputW = input.size(dimw);
 
   int outputH = output_size[0];
   int outputW = output_size[1];
   int poolSizeH = pool_size[0];
   int poolSizeW = pool_size[1];
-
-  TORCH_CHECK(outputH + poolSizeH - 1 <= inputH,
-             "fractional_max_pool2d(): pool_size height ", poolSizeH,
-             " too large relative to input height ", inputH);
-  TORCH_CHECK(outputW + poolSizeW - 1 <= inputW,
-           "pool_size width ", poolSizeW,
-           " too large relative to input width ", inputW);
-
-  if (ndims == 3) {
-    /* resize output */
-    output.resize_({numPlanes, outputH, outputW});
-    /* indices will contain the locations for each output point */
-    indices.resize_({numPlanes, outputH, outputW});
-  } else {
-    output.resize_({numBatch, numPlanes, outputH, outputW});
-    indices.resize_({numBatch, numPlanes, outputH, outputW});
-  }
 
   auto output_ = output;
   auto input_ = input;
@@ -211,10 +183,12 @@ void fractional_max_pool2d_out_cuda_template(
         <<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
           devOutput, devIndices, devInput, devSamples,
           poolSizeH, poolSizeW);
-        C10_CUDA_KERNEL_LAUNCH_CHECK();
-       }
-     );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+     }
+   );
 }
+
+namespace {
 
 void fractional_max_pool2d_backward_out_cuda_template(
   Tensor& gradInput,

--- a/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/FractionalMaxPool2d.cu
@@ -259,41 +259,6 @@ void fractional_max_pool2d_backward_out_cuda_template(
 
 }// namespace
 
-std::tuple<Tensor&, Tensor&> fractional_max_pool2d_out_cuda(
-    const at::Tensor& input,
-    IntArrayRef pool_size,
-    IntArrayRef output_size,
-    const at::Tensor& randomSamples,
-    at::Tensor& output,
-    at::Tensor& indices) {
-  fractional_max_pool2d_out_cuda_template(
-    output,
-    indices,
-    input,
-    pool_size,
-    output_size,
-    randomSamples);
-  return std::tuple<Tensor&, Tensor&>(output, indices);
-}
-
-std::tuple<Tensor, Tensor> fractional_max_pool2d_cuda(
-  const at::Tensor& input,
-  IntArrayRef pool_size,
-  IntArrayRef output_size,
-  const at::Tensor& randomSamples)
-{
-  Tensor output = at::empty({0}, input.options());
-  Tensor indices = at::empty({0}, input.options().dtype(kLong));
-  fractional_max_pool2d_out_cuda_template(
-    output,
-    indices,
-    input,
-    pool_size,
-    output_size,
-    randomSamples);
-  return std::tuple<Tensor, Tensor>(output, indices);
-}
-
 Tensor& fractional_max_pool2d_backward_out_cuda(const at::Tensor& gradOutput_,
   const at::Tensor& input,
   IntArrayRef pool_size,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7500,6 +7500,7 @@
 # Return: (Tensor output, Tensor indices)
 - func: fractional_max_pool2d.output(Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples, *, Tensor(a!) output, Tensor(b!) indices) -> (Tensor(a!), Tensor(b!))
   python_module: nn
+  structured: True
   dispatch:
     CPU: fractional_max_pool2d_out_cpu
     CUDA: fractional_max_pool2d_out_cuda
@@ -7507,9 +7508,7 @@
 # Return: (Tensor output, Tensor indices)
 - func: fractional_max_pool2d(Tensor self, int[2] kernel_size, int[2] output_size, Tensor random_samples) -> (Tensor, Tensor)
   python_module: nn
-  dispatch:
-    CPU: fractional_max_pool2d_cpu
-    CUDA: fractional_max_pool2d_cuda
+  structured_delegate: fractional_max_pool2d.output
 
 - func: fractional_max_pool2d_backward.grad_input(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -320,15 +320,16 @@ if (resized) {{
 
     # returns the definition of a ctor, as well as how to construct
     # this class to a variable named op
-    def gen_class_ctor(self, k: SchemaKind, class_name: str) -> str:
+    def gen_class_ctor(self, k: SchemaKind, class_name: str, returns: int) -> str:
         if k is SchemaKind.functional:
             return ""
         elif k is SchemaKind.inplace:
             # TODO: Make sure out argument is guaranteed to be self
             return f"{class_name}(Tensor& self) : outputs_{{std::ref(self)}} {{}}"
         elif k is SchemaKind.out:
-            # TODO: Stop hardcoding out here
-            return f"{class_name}(Tensor& out) : outputs_{{std::ref(out)}} {{}}"
+            out_args = ', '.join(f"Tensor& out{i}" for i in range(returns))
+            out_refs = ', '.join(f"std::ref(out{i})" for i in range(returns))
+            return f"{class_name}({out_args}) : outputs_{{ {out_refs} }} {{}}"
         else:
             assert_never(k)
 
@@ -336,12 +337,10 @@ if (resized) {{
         self, f: NativeFunction, k: SchemaKind, *, class_name: str, parent_class: str, generate_super: bool
     ) -> str:
         if k is SchemaKind.functional:
-            assert len(f.func.returns) == 1, "multi-return not supported yet"
             output_type = "Tensor"
         elif k is SchemaKind.inplace:
             output_type = "std::reference_wrapper<Tensor>"
         elif k is SchemaKind.out:
-            assert len(f.func.arguments.out) == 1, "multi-out structured not supported yet"
             output_type = "std::reference_wrapper<Tensor>"
 
         if self.dispatch_key == DispatchKey.CUDA:
@@ -356,7 +355,7 @@ if (resized) {{
 
         return f"""
 struct {class_name} final : public {parent_class} {{
-    {self.gen_class_ctor(k, class_name)}
+    {self.gen_class_ctor(k, class_name, len(f.func.returns))}
     {self.gen_class_set_output(k, parent_class, generate_super)}
     const Tensor& maybe_get_output(int64_t output_idx) override {{
         return outputs_[output_idx];
@@ -442,13 +441,12 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 parent_class = f"at::native::structured_{self.g.out.dispatch[self.dispatch_key]}"
 
             if k is SchemaKind.functional:
-                assert len(f.func.returns) == 1, "multi-return not supported yet"
                 sig_body.append(f"{class_name} op;")
             elif k is SchemaKind.inplace:
                 sig_body.append(f"{class_name} op(self);")
             elif k is SchemaKind.out:
-                assert len(f.func.arguments.out) == 1, "multi-out structured not supported yet"
-                sig_body.append(f"{class_name} op({f.func.arguments.out[0].name});")
+                out_args_str = ', '.join(a.name for a in f.func.arguments.out)
+                sig_body.append(f"{class_name} op({out_args_str});")
 
             # Translate the input native arguments into structured
             # arguments for the meta call
@@ -463,16 +461,16 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
 
             # After running meta, op.outputs_ is guaranteed to be valid;
             # add it to the context
-            # TODO: handle multi-return
-            assert ConstRefCType(BaseCType("Tensor", structured.out_arguments(self.g)[0].ctype.name)) == \
-                structured.out_arguments(self.g)[0].ctype
-            context.append(Expr(
-                expr="op.outputs_[0]",
-                # TODO: Stop hardcoding that the output type is a Tensor.  Note
-                # that for the codegen here this is fine because outputs_ is
-                # hardcoded to be tensor already
-                type=MutRefCType(BaseCType("Tensor", structured.out_arguments(self.g)[0].ctype.name)),
-            ))
+            out_args = structured.out_arguments(self.g)
+            for i, out_arg in enumerate(out_args):
+                assert ConstRefCType(BaseCType("Tensor", out_arg.ctype.name)) == out_arg.ctype
+                context.append(Expr(
+                    expr=f"op.outputs_[{i}]",
+                    # TODO: Stop hardcoding that the output type is a Tensor.  Note
+                    # that for the codegen here this is fine because outputs_ is
+                    # hardcoded to be tensor already
+                    type=MutRefCType(BaseCType("Tensor", out_arg.ctype.name)),
+                ))
 
             # With the expanded context, do the impl call (if not a meta
             # function)
@@ -511,14 +509,21 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
                 sig_body.append(f"op.impl({impl_exprs});")
 
             # Destructively return the final tensors
+            # TODO: Do this in translate instead
             if k is SchemaKind.functional:
-                assert len(f.func.returns) == 1, "multi-return not supported yet"
-                ret_expr = "std::move(op.outputs_[0])"  # small optimization
+                if len(f.func.returns) == 1:
+                    ret_expr = "std::move(op.outputs_[0])"  # small optimization
+                else:
+                    moved = ', '.join(f"std::move(op.outputs_[{i}])" for i in range(len(f.func.returns)))
+                    ret_expr = f"std::make_tuple({moved})"
             elif k is SchemaKind.inplace:
                 ret_expr = "self"
             elif k is SchemaKind.out:
-                assert len(f.func.arguments.out) == 1, "multi-out structured not supported yet"
-                ret_expr = f.func.arguments.out[0].name
+                if len(f.func.returns) == 1:
+                    ret_expr = f.func.arguments.out[0].name
+                else:
+                    refs = ', '.join(a.name for a in f.func.arguments.out)
+                    ret_expr = f"std::forward_as_tuple({refs})"
             sig_body.append(f"return {ret_expr};")
 
             sig_body_str = "\n".join(sig_body)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55581 Add support for multiple outputs in structured kernels, port fractional_max_pool2d**
* #55537 Port replication_pad1d_backward to structured
* #55499 Port replication_padding3d to structured
* #55481 Port replication_padding1d to structured

Multiple outputs now OK, as long as their all Tensor.  Ported
fractional_max_pool2d to make sure the shindig all works.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27641267](https://our.internmc.facebook.com/intern/diff/D27641267)