### PR TITLE
[ONNX] Fix exporting torch.norm without axes

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -3803,6 +3803,14 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(4, 2, 3, requires_grad=True)
         self.run_test(NormModel(), x)
 
+    def test_frobenius_norm_noaxes(self):
+        class NormModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.norm(x, p="fro", keepdim=True)
+
+        x = torch.randn(4, 2, 3, requires_grad=True)
+        self.run_test(NormModel(), x)
+
     def test_unfold(self):
         class UnfoldModel(torch.nn.Module):
             def forward(self, x):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2556,7 +2556,10 @@ def index(g, self, index):
 @parse_args('v', 'is', 'i')
 def frobenius_norm(g, self, dim=None, keepdim=False):
     sqr = g.op('Mul', self, self)
-    sumsqr = g.op('ReduceSum', sqr, axes_i=dim, keepdims_i=keepdim)
+    if dim != []:
+        sumsqr = g.op('ReduceSum', sqr, axes_i=dim, keepdims_i=keepdim)
+    else:
+        sumsqr = g.op('ReduceSum', sqr, keepdims_i=keepdim)
     return g.op('Sqrt', sumsqr)
 
 


### PR DESCRIPTION
When you export `torch.norm(x)`, an excception is raised:

```
==> Context: Bad node spec: input: "1" output: "2" name: "ReduceSum_1" op_type: "ReduceSum" attribute { name: "axes" type: INTS } attribute { name: "keepdims" i: 1 type: INT }
```

As it internally calls `frobenius_norm` with `dim=[]`, we
should skip setting `axes_i` when an empty list is passed.

Fixes #{issue number}
