### PR TITLE
rename .pytorch-disabled-tests to disabled-tests.json

### DIFF
--- a/.github/workflows/update_disabled_tests.yml
+++ b/.github/workflows/update_disabled_tests.yml
@@ -15,13 +15,13 @@ jobs:
         run: |
           # score changes every request, so we strip it out to avoid creating a commit every time we query.
           curl 'https://api.github.com/search/issues?q=is%3Aissue+is%3Aopen+label%3A%22module%3A+flaky-tests%22+repo:pytorch/pytorch+in%3Atitle+DISABLED' \
-          | sed 's/"score": [0-9\.]*/"score": 0.0/g' > .pytorch-disabled-tests
+          | sed 's/"score": [0-9\.]*/"score": 0.0/g' > disabled-tests.json
       - name: Push file to test-infra repository
         uses: dmnemec/copy_file_to_another_repo_action@5f40763ccee2954067adba7fb8326e4df33bcb92
         env:
            API_TOKEN_GITHUB: ${{ secrets.TEST_INFRA_TOKEN }}
         with:
-          source_file: '.pytorch-disabled-tests'
+          source_file: 'disabled-tests.json'
           destination_repo: 'pytorch/test-infra'
           destination_folder: 'stats'
           destination_branch: master


### PR DESCRIPTION
We shouldn't store it as a hidden file, and having the json extension is useful.

Test plan:
https://github.com/janeyx99/gha-experiments/runs/2298470065?check_suite_focus=true in my own repo