### PR TITLE
[nnc] Enable CPU fusion only when num_threads == 1

### DIFF
--- a/test/cpp/tensorexpr/test_te_fuser_pass.cpp
+++ b/test/cpp/tensorexpr/test_te_fuser_pass.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <ATen/Parallel.h>
 #include <test/cpp/tensorexpr/test_base.h>
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -15,15 +16,19 @@ namespace jit {
 using namespace torch::jit::tensorexpr;
 
 struct WithCPUFuser {
-  WithCPUFuser(bool val = true) : cpuFuserEnabled(canFuseOnCPU()) {
+  WithCPUFuser(bool val = true)
+      : cpuFuserEnabled(canFuseOnCPU()), numThreads(at::get_num_threads()) {
     overrideCanFuseOnCPU(val);
+    at::set_num_threads(1);
   }
 
   ~WithCPUFuser() {
     overrideCanFuseOnCPU(cpuFuserEnabled);
+    at::set_num_threads(numThreads);
   }
 
   bool cpuFuserEnabled;
+  int numThreads;
 };
 
 TEST(TEFuserPass, FuserPass_1) {

--- a/test/jit/test_profiler.py
+++ b/test/jit/test_profiler.py
@@ -29,6 +29,8 @@ class TestProfiler(JitTestCase):
         torch._C._debug_set_fusion_group_inlining(False)
         self.old_te_must_use_llvm_cpu = torch._C._jit_get_te_must_use_llvm_cpu()
         torch._C._jit_set_te_must_use_llvm_cpu(False)
+        self.old_num_threads = torch.get_num_threads()
+        torch.set_num_threads(1)
 
     def tearDown(self):
         torch._C._jit_set_profiling_executor(self.prev_exec)
@@ -40,6 +42,7 @@ class TestProfiler(JitTestCase):
         torch._C._jit_set_texpr_reductions_enabled(self.old_reduction_enabled)
         torch._C._debug_set_fusion_group_inlining(self.old_fusion_inlining)
         torch._C._jit_set_te_must_use_llvm_cpu(self.old_te_must_use_llvm_cpu)
+        torch.set_num_threads(self.old_num_threads)
 
     def test_tensor_type_not_determined_by_inputs(self):
         @torch.jit.script

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -74,6 +74,10 @@ class TestTEFuser(JitTestCase):
         self.old_te_must_use_llvm_cpu = torch._C._jit_get_te_must_use_llvm_cpu()
         torch._C._jit_set_te_must_use_llvm_cpu(False)
 
+        # TODO: CPU fuser currently is disabled when multithreading.
+        self.old_num_threads = torch.get_num_threads()
+        torch.set_num_threads(1)
+
         self.devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
         self.int_dtypes = [
             torch.int8,
@@ -100,6 +104,7 @@ class TestTEFuser(JitTestCase):
 
         torch._C._jit_set_texpr_fuser_enabled(self.texpr_fuser_state)
         torch._C._jit_set_te_must_use_llvm_cpu(self.old_te_must_use_llvm_cpu)
+        torch.set_num_threads(self.old_num_threads)
 
     def assertLastGraphAllFused(self):
         self.assertAllFused(torch.jit.last_executed_optimized_graph())

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -27,6 +27,9 @@ class BaseTestClass(JitTestCase):
         torch._C._debug_set_fusion_group_inlining(False)
         self.old_te_must_use_llvm_cpu = torch._C._jit_get_te_must_use_llvm_cpu()
         torch._C._jit_set_te_must_use_llvm_cpu(False)
+        # TODO: CPU fuser currently is disabled when multithreading.
+        self.old_num_threads = torch.get_num_threads()
+        torch.set_num_threads(1)
 
         self.devices = ['cpu'] if not torch.cuda.is_available() else ['cpu', 'cuda']
 
@@ -39,6 +42,7 @@ class BaseTestClass(JitTestCase):
         torch._C._jit_override_can_fuse_on_cpu(self.old_cpu_fuser_state)
         torch._C._debug_set_fusion_group_inlining(self.old_fusion_inlining)
         torch._C._jit_set_te_must_use_llvm_cpu(self.old_te_must_use_llvm_cpu)
+        torch.set_num_threads(self.old_num_threads)
 
     def assertLastGraphAllFused(self):
         self.assertAllFused(torch.jit.last_executed_optimized_graph())

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/passes/tensorexpr_fuser.h>
 
+#include <ATen/Parallel.h>
 #include <ATen/record_function.h>
 #include <c10/util/FunctionRef.h>
 #include <torch/csrc/jit/codegen/fuser/interface.h>
@@ -883,7 +884,8 @@ class TensorExprFuser {
       return false;
     }
     if (device->is_cpu()) {
-      return canFuseOnCPU();
+      // CPU fusion is only supported for single-thread.
+      return canFuseOnCPU() && at::get_num_threads() == 1;
     } else if (device->is_cuda()) {
       return canFuseOnGPU();
     } else if (device->is_xpu()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55970 [nnc] Do not try to vectorize kernels that use float16
* **#55621 [nnc] Enable CPU fusion only when num_threads == 1**

Fuser support for thread-level parallelism is a work in progress, so
only fuse when the program is running single-threaded.

Differential Revision: [D27652485](https://our.internmc.facebook.com/intern/diff/D27652485/)