### PR TITLE
[BE] Make torch/csrc/jit/tensorexpr/ clang-tidy clean

### DIFF
--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -43,7 +43,7 @@ DEFAULT_FILE_PATTERN = re.compile(r".*\.c(c|pp)?")
 
 # @@ -start,count +start,count @@
 CHUNK_PATTERN = r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@"
-CLANG_WARNING_PATTERN = re.compile(r"([^:]+):(\d+):\d+:\s+warning:.*\[([a-z\-,]+)\]")
+CLANG_WARNING_PATTERN = re.compile(r"([^:]+):(\d+):\d+:\s+warning:.*\[([^\]]+)\]")
 
 
 # Set from command line arguments in main().

--- a/torch/csrc/Device.h
+++ b/torch/csrc/Device.h
@@ -11,6 +11,7 @@ struct TORCH_API THPDevice {
   at::Device device;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern PyTypeObject THPDeviceType;
 
 inline bool THPDevice_Check(PyObject *obj) {

--- a/torch/csrc/Dtype.h
+++ b/torch/csrc/Dtype.h
@@ -9,9 +9,11 @@ const int DTYPE_NAME_LEN = 64;
 struct TORCH_API THPDtype {
   PyObject_HEAD
   at::ScalarType scalar_type;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char name[DTYPE_NAME_LEN + 1];
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern PyTypeObject THPDtypeType;
 
 inline bool THPDtype_Check(PyObject *obj) {

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -126,6 +126,7 @@ static inline void PyErr_SetString(PyObject* type, const std::string& message) {
 
 #define END_HANDLE_TH_ERRORS END_HANDLE_TH_ERRORS_RET(nullptr)
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyObject *THPException_FatalError;
 
 // Throwing this exception means that the python error flags have been already
@@ -163,6 +164,7 @@ struct python_error : public std::exception {
     }
   }
 
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual const char* what() const noexcept override {
     return message.c_str();
   }
@@ -245,6 +247,7 @@ THP_API bool get_cpp_stacktraces_enabled();
 
 // Abstract base class for exceptions which translate to specific Python types
 struct PyTorchError : public std::exception {
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   PyTorchError(const std::string& msg_ = std::string()): msg(msg_) {}
   virtual PyObject* python_type() = 0;
   const char* what() const noexcept override {
@@ -291,6 +294,7 @@ struct ValueError : public PyTorchError {
 
 // Translates to Python NotImplementedError
 struct NotImplementedError : public PyTorchError {
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   NotImplementedError() {}
   PyObject* python_type() override {
     return PyExc_NotImplementedError;
@@ -307,6 +311,7 @@ struct AttributeError : public PyTorchError {
 
 struct WarningMeta {
   WarningMeta(const c10::SourceLocation& _source_location,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::string& _msg,
       const bool _verbatim) :
       source_location_{_source_location},

--- a/torch/csrc/Generator.h
+++ b/torch/csrc/Generator.h
@@ -5,6 +5,7 @@
 
 #include <torch/csrc/THP_export.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THPGenerator {
   PyObject_HEAD
   at::Generator cdata;
@@ -18,6 +19,7 @@ THP_API PyObject * THPGenerator_initDefaultGenerator(at::Generator cdata);
 #define THPGenerator_Check(obj) \
   PyObject_IsInstance(obj, THPGeneratorClass)
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 THP_API PyObject *THPGeneratorClass;
 
 bool THPGenerator_init(PyObject *module);

--- a/torch/csrc/Layout.h
+++ b/torch/csrc/Layout.h
@@ -11,9 +11,11 @@ const int LAYOUT_NAME_LEN = 64;
 struct THPLayout {
   PyObject_HEAD
   at::Layout layout;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char name[LAYOUT_NAME_LEN + 1];
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyTypeObject THPLayoutType;
 
 inline bool THPLayout_Check(PyObject *obj) {

--- a/torch/csrc/MemoryFormat.h
+++ b/torch/csrc/MemoryFormat.h
@@ -11,9 +11,11 @@ const int MEMORY_FORMAT_NAME_LEN = 64;
 struct THPMemoryFormat {
   PyObject_HEAD
   at::MemoryFormat memory_format;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char name[MEMORY_FORMAT_NAME_LEN + 1];
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyTypeObject THPMemoryFormatType;
 
 inline bool THPMemoryFormat_Check(PyObject *obj) {

--- a/torch/csrc/QScheme.h
+++ b/torch/csrc/QScheme.h
@@ -11,9 +11,11 @@ constexpr int QSCHEME_NAME_LEN = 64;
 struct THPQScheme {
   PyObject_HEAD
   at::QScheme qscheme;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char name[QSCHEME_NAME_LEN + 1];
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyTypeObject THPQSchemeType;
 
 inline bool THPQScheme_Check(PyObject *obj) {

--- a/torch/csrc/Stream.h
+++ b/torch/csrc/Stream.h
@@ -7,6 +7,7 @@ struct THPStream {
   PyObject_HEAD
   uint64_t cdata;
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern PyTypeObject *THPStreamClass;
 
 void THPStream_init(PyObject *module);

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -111,6 +111,7 @@ private:
 
 struct TORCH_API ForwardGrad : std::enable_shared_from_this<ForwardGrad> {
 
+    // NOLINTNEXTLINE(modernize-use-equals-default)
     ForwardGrad() {}
 
     // This function must only be called when AutogradMeta or SavedVariable is being

--- a/torch/csrc/autograd/python_variable.h
+++ b/torch/csrc/autograd/python_variable.h
@@ -18,7 +18,9 @@ struct THPVariable {
     PyObject* backward_hooks = nullptr;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 THP_API PyObject *THPVariableClass;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 THP_API PyObject *ParameterClass;
 
 bool THPVariable_initModule(PyObject *module);

--- a/torch/csrc/jit/frontend/tracer.h
+++ b/torch/csrc/jit/frontend/tracer.h
@@ -44,10 +44,15 @@ struct TORCH_API TracingState
   TracingState();
   ~TracingState();
 
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::shared_ptr<Graph> graph;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   bool warn = true;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   bool strict = true;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   bool force_outplace = false;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::function<std::string(const Variable& var)> lookup_var_name_fn =
       [](const Variable& var) { return ""; };
 
@@ -137,6 +142,7 @@ struct ArgumentStash {
   }
 
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static thread_local ArgumentStash stash;
   std::unordered_map<std::string, IntArrayRefTrace> intlists;
   std::unordered_map<std::string, Value*> values;
@@ -152,9 +158,13 @@ inline bool isTracing() {
 }
 
 using warn_fn_type = void (*)(const std::string& msg);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern const char* WARN_PYTHON_DATAFLOW;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern const char* WARN_CONSTRUCTOR;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern const char* WARN_RESIZE;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API extern const char* STRICT_TRACER_MSG;
 TORCH_API void _do_warn(const char* _reason, const char* _kind);
 inline void warn(const char* _reason, const char* _kind = nullptr) {

--- a/torch/csrc/jit/ir/attributes.h
+++ b/torch/csrc/jit/ir/attributes.h
@@ -37,6 +37,7 @@ enum class AttributeKind {
   ival
 };
 static inline const char* toString(AttributeKind kind) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   static const char* names[] = {
       "f",
       "c",

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -323,6 +323,7 @@ struct TORCH_API Node {
   // null pointers next_in_graph[0] is next pointer next_in_graph[1] is prev
   // pointer using an array to allow the same iterator class for forward and
   // reverse node lists This list represents a topological sort
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-non-private-member-variables-in-classes,modernize-avoid-c-arrays)
   Node* next_in_graph[2] = {nullptr, nullptr};
 
   std::shared_ptr<Wrap<Node>> wrap() {
@@ -1428,6 +1429,7 @@ struct TORCH_API ProfileIValueOp : public Node {
   static const Symbol Kind;
   ProfileIValueOp(
       Graph* graph,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::function<void(std::vector<IValue>&)> callback)
       : Node(graph, ::c10::prim::profile_ivalue), callback_(callback) {}
 

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1429,9 +1429,8 @@ struct TORCH_API ProfileIValueOp : public Node {
   static const Symbol Kind;
   ProfileIValueOp(
       Graph* graph,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::function<void(std::vector<IValue>&)> callback)
-      : Node(graph, ::c10::prim::profile_ivalue), callback_(callback) {}
+      : Node(graph, ::c10::prim::profile_ivalue), callback_(std::move(callback)) {}
 
   void cloneFrom(Node* other_) override;
   Node* allocNewInstance(Graph* g) override;

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -1430,7 +1430,8 @@ struct TORCH_API ProfileIValueOp : public Node {
   ProfileIValueOp(
       Graph* graph,
       std::function<void(std::vector<IValue>&)> callback)
-      : Node(graph, ::c10::prim::profile_ivalue), callback_(std::move(callback)) {}
+      : Node(graph, ::c10::prim::profile_ivalue),
+        callback_(std::move(callback)) {}
 
   void cloneFrom(Node* other_) override;
   Node* allocNewInstance(Graph* g) override;

--- a/torch/csrc/jit/passes/utils/memory_dag.h
+++ b/torch/csrc/jit/passes/utils/memory_dag.h
@@ -12,6 +12,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 // Uses a compressed index representation for faster comparisons
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 typedef c10::SparseBitVector<256> MemoryLocations;
 namespace torch {
 namespace jit {
@@ -29,6 +30,7 @@ class MemoryDAG;
  */
 class TORCH_API MemoryDAGBuilder {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   MemoryDAGBuilder() {}
   MemoryDAGBuilder(const MemoryDAGBuilder&) = delete;
   MemoryDAGBuilder& operator=(const MemoryDAGBuilder&) = delete;
@@ -126,20 +128,25 @@ struct Element {
   explicit Element(unsigned index_);
 
   // Index into the owning DAG's bit vector that represents this element.
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   unsigned index;
 
   // All elements that this element *may* point to. It's possible to have
   // multiple elements that you might point to due to control flow/complex ops
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   MemoryLocations pointsTo;
   // Backreference for points-to.
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   MemoryLocations pointedFrom;
 
   // Elements can contain other elements (e.g. List[Tensor])
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   MemoryLocations containedElements;
 
   // The values that this element corresponds to. May be empty if this element
   // doesn't represent a first-class value.
   // This is for debug information only.
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::unordered_set<const Value*> values;
 
  private:

--- a/torch/csrc/jit/passes/utils/subgraph_utils.h
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.h
@@ -55,6 +55,7 @@ std::shared_ptr<Graph> getSubgraph(Node* n);
 
 TORCH_API std::string generateNameForGraph(
     const std::shared_ptr<Graph>& graph,
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     size_t maxlen = 40,
     const std::string& prefix = "fused");
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -179,6 +179,7 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
 
   void add_done_callback(py::function cb) {
     auto pf = std::make_shared<PythonFunctionGuard>(std::move(cb));
+    // NOLINTNEXTLINE(modernize-avoid-bind)
     fut->addCallback(std::bind(
         [pyFut(this->getPtr())](std::shared_ptr<PythonFunctionGuard> pf) {
           try {
@@ -299,6 +300,7 @@ inline InferredType tryToInferType(py::handle input) {
   // Try basic types first
   if (py::isinstance<py::bool_>(input)) {
     return InferredType(BoolType::get());
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (py::isinstance<py::int_>(input)) {
     return InferredType(IntType::get());
   } else if (py::isinstance<py::float_>(input)) {
@@ -951,6 +953,7 @@ inline py::object runAndInsertCall(
     auto graph = tracing_state->graph;
     std::vector<NamedValue> named_values;
     for (Value* v : input_values) {
+      // NOLINTNEXTLINE(performance-inefficient-vector-operation)
       named_values.emplace_back(v);
     }
 

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -300,7 +300,7 @@ inline InferredType tryToInferType(py::handle input) {
   // Try basic types first
   if (py::isinstance<py::bool_>(input)) {
     return InferredType(BoolType::get());
-  // NOLINTNEXTLINE(bugprone-branch-clone)
+    // NOLINTNEXTLINE(bugprone-branch-clone)
   } else if (py::isinstance<py::int_>(input)) {
     return InferredType(IntType::get());
   } else if (py::isinstance<py::float_>(input)) {

--- a/torch/csrc/jit/resource_guard.h
+++ b/torch/csrc/jit/resource_guard.h
@@ -12,6 +12,7 @@ class ResourceGuard {
   ResourceGuard(std::function<void()> destructor)
       : _destructor(std::move(destructor)), _released(false) {}
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ResourceGuard() {
     if (!_released)
       _destructor();

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -34,6 +34,7 @@ struct ArgumentInfo {
     return requires_grad_;
   }
   int dim() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     return dim_;
   }
   at::ScalarType type() const {
@@ -101,6 +102,7 @@ struct ArgumentSpec {
     if ((arg.defined_ = t->defined())) {
       arg.requires_grad_ = with_grad && autograd::Variable(*t).requires_grad();
       arg.dim_ = t->dim();
+      // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
       arg.device_ = t->is_cuda() ? t->get_device() : -1;
       arg.type_ = static_cast<unsigned>(t->scalar_type());
     }
@@ -108,6 +110,7 @@ struct ArgumentSpec {
   }
 
   void combineHash(const ArgumentInfo& arg) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     ArgumentInfo::plain_data_type arg_data;
     std::memcpy(&arg_data, &arg, sizeof(ArgumentInfo));
     hash_code = c10::hash_combine(hash_code, arg_data);
@@ -255,6 +258,7 @@ struct CompleteArgumentSpec {
         pod.defined = t.defined();
         if (pod.defined) {
           pod.type = static_cast<int>(t.scalar_type());
+          // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
           pod.device = (!t.is_cuda()) ? -1 : t.get_device();
           pod.requires_grad = with_grad && t.requires_grad();
           total_dims += t.ndimension();
@@ -367,6 +371,7 @@ struct CompleteArgumentInfo {
   int sizes_strides_offset(int j) const {
     if (j == 0)
       return 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     return 2 * pod(j - 1).total_dims;
   }
   const CompleteArgumentInfoPOD& pod(int j) const {

--- a/torch/csrc/jit/runtime/graph_executor.h
+++ b/torch/csrc/jit/runtime/graph_executor.h
@@ -9,6 +9,7 @@
 #include <torch/csrc/jit/runtime/interpreter.h>
 #include <torch/csrc/jit/runtime/variable_tensor_list.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DECLARE_bool(torch_jit_enable_new_executor);
 
 namespace torch {

--- a/torch/csrc/jit/runtime/interpreter.h
+++ b/torch/csrc/jit/runtime/interpreter.h
@@ -9,6 +9,7 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/frontend/source_range.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DECLARE_bool(torch_jit_disable_warning_prints);
 
 namespace at {

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -33,8 +33,7 @@ class HasRand : public IRVisitor {
 template <typename Node>
 class NodeFinder : public IRVisitor {
  public:
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual void visit(const Node* v) override {
+  void visit(const Node* v) override {
     nodes.push_back((Node*)v);
     IRVisitor::visit(v);
   }
@@ -56,8 +55,7 @@ class NodeFinder : public IRVisitor {
 
 class VarFinder : public IRVisitor {
  public:
-  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual void visit(const Var* v) override {
+  void visit(const Var* v) override {
     vars_.insert(v);
     IRVisitor::visit(v);
   }

--- a/torch/csrc/jit/tensorexpr/analysis.h
+++ b/torch/csrc/jit/tensorexpr/analysis.h
@@ -33,6 +33,7 @@ class HasRand : public IRVisitor {
 template <typename Node>
 class NodeFinder : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual void visit(const Node* v) override {
     nodes.push_back((Node*)v);
     IRVisitor::visit(v);
@@ -55,6 +56,7 @@ class NodeFinder : public IRVisitor {
 
 class VarFinder : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual void visit(const Var* v) override {
     vars_.insert(v);
     IRVisitor::visit(v);

--- a/torch/csrc/jit/tensorexpr/block_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/block_codegen.cpp
@@ -11,6 +11,7 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_TRIGGER(block_codegen_created);
 std::string blockDtypeCppString(const Dtype& dtype) {
   switch (dtype.scalar_type()) {
@@ -18,6 +19,7 @@ std::string blockDtypeCppString(const Dtype& dtype) {
       return "1";
     case ScalarType::Half:
       return "2";
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case ScalarType::Char:
       return "1";
     case ScalarType::Byte:
@@ -367,6 +369,7 @@ void BlockCodeGen::call(const std::vector<CallArg>& args) {
 }
 
 BlockCodeGen::~BlockCodeGen() = default;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterCodeGen<BlockCodeGen> block_codegen_reg("block_codegen");
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/block_codegen.h
+++ b/torch/csrc/jit/tensorexpr/block_codegen.h
@@ -58,6 +58,7 @@ class BlockAnalysis : public IRVisitor {
   std::unordered_map<std::string, const Buf*> map_input_to_tensor_bufs_;
   std::unordered_set<const Buf*> store_targets_;
   std::unordered_set<const Buf*> loads_;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   int block_size_ = 32;
 };
 

--- a/torch/csrc/jit/tensorexpr/bounds_inference.h
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.h
@@ -17,6 +17,7 @@ class Stmt;
 
 enum C10_API_ENUM TensorAccessKind { kLoad, kStore, kMutate };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct TORCH_API TensorAccessBoundsInfo {
   TensorAccessKind kind;
   std::vector<const Expr*> start;

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -177,6 +177,7 @@ class RegisterCodeGenList {
   TORCH_API StmtFactoryMethod FindStmtFactoryMethod(const std::string& name);
   RegisterCodeGenList(const RegisterCodeGenList&) = delete;
   RegisterCodeGenList& operator=(const RegisterCodeGenList&) = delete;
+
  private:
   template <class CodeGenType>
   friend class RegisterCodeGen;

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -22,18 +22,15 @@ class TORCH_API CodeGen {
 
   CodeGen(
       Stmt* stmt,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<BufferArg>& buffer_args,
+      std::vector<BufferArg> buffer_args,
       at::Device device = at::kCPU,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::string& kernel_func_name = "func")
+      std::string kernel_func_name = "func")
       : stmt_(stmt),
-        buffer_args_(buffer_args),
+        buffer_args_(std::move(buffer_args)),
         device_(device),
-        kernel_func_name_(kernel_func_name) {}
+        kernel_func_name_(std::move(kernel_func_name)) {}
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~CodeGen() {}
+  virtual ~CodeGen() = default;
 
   Stmt* stmt() const {
     return stmt_;
@@ -179,18 +176,15 @@ class RegisterCodeGenList {
 
   TORCH_API StmtFactoryMethod FindStmtFactoryMethod(const std::string& name);
 
+  RegisterCodeGenList(const RegisterCodeGenList&) = delete;
+  RegisterCodeGenList& operator=(const RegisterCodeGenList&) = delete;
  private:
   template <class CodeGenType>
   friend class RegisterCodeGen;
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  RegisterCodeGenList() {}
+  RegisterCodeGenList() = default;
   TORCH_API void AddStmtFactoryMethod(
       const std::string& name,
       const StmtFactoryMethod& stmt_factory_method);
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RegisterCodeGenList(const RegisterCodeGenList&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  RegisterCodeGenList& operator=(const RegisterCodeGenList&) = delete;
 
   std::unordered_map<std::string, StmtFactoryMethod> stmt_factory_methods_;
 };

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -22,14 +22,17 @@ class TORCH_API CodeGen {
 
   CodeGen(
       Stmt* stmt,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<BufferArg>& buffer_args,
       at::Device device = at::kCPU,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::string& kernel_func_name = "func")
       : stmt_(stmt),
         buffer_args_(buffer_args),
         device_(device),
         kernel_func_name_(kernel_func_name) {}
 
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~CodeGen() {}
 
   Stmt* stmt() const {
@@ -120,12 +123,15 @@ class CodeGen::CallArg {
   CallArg(const PaddedBuffer<T>& buffer);
 
   template <typename T>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-const-cast)
   CallArg(const std::vector<T>& buffer) : ptr_(const_cast<T*>(buffer.data())) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CallArg(void* ptr) : ptr_(ptr) {}
 
 #define ARG_TYPE_CTOR(Type, Name) \
   CallArg(Type v) : Name##val_(v) {}
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, ARG_TYPE_CTOR);
 #undef ARG_TYPE_CTOR
 
@@ -144,6 +150,7 @@ class CodeGen::CallArg {
   Type* Name##Ptr() const {                \
     return const_cast<Type*>(&Name##val_); \
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, ARG_PTR_DEFINE);
 #undef ARG_PTR_DEFINE
 
@@ -175,11 +182,14 @@ class RegisterCodeGenList {
  private:
   template <class CodeGenType>
   friend class RegisterCodeGen;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   RegisterCodeGenList() {}
   TORCH_API void AddStmtFactoryMethod(
       const std::string& name,
       const StmtFactoryMethod& stmt_factory_method);
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RegisterCodeGenList(const RegisterCodeGenList&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RegisterCodeGenList& operator=(const RegisterCodeGenList&) = delete;
 
   std::unordered_map<std::string, StmtFactoryMethod> stmt_factory_methods_;

--- a/torch/csrc/jit/tensorexpr/codegen.h
+++ b/torch/csrc/jit/tensorexpr/codegen.h
@@ -175,7 +175,6 @@ class RegisterCodeGenList {
       const std::string& kernel_func_name)>;
 
   TORCH_API StmtFactoryMethod FindStmtFactoryMethod(const std::string& name);
-
   RegisterCodeGenList(const RegisterCodeGenList&) = delete;
   RegisterCodeGenList& operator=(const RegisterCodeGenList&) = delete;
  private:

--- a/torch/csrc/jit/tensorexpr/dim_arg.h
+++ b/torch/csrc/jit/tensorexpr/dim_arg.h
@@ -14,9 +14,8 @@ class DimArg {
  public:
   // Intentionally leave out explicit to allow implicit conversions.
   DimArg(const ExprHandle& dim) : dim_(dim) {}
-  // NOLINTNEXTLINE(modernize-pass-by-value)
-  DimArg(const ExprHandle& dim, const std::string& name_hint)
-      : dim_(dim), name_hint_(name_hint) {}
+  DimArg(const ExprHandle& dim, std::string name_hint)
+      : dim_(dim), name_hint_(std::move(name_hint)) {}
   const ExprHandle& dim() const {
     return dim_;
   }

--- a/torch/csrc/jit/tensorexpr/dim_arg.h
+++ b/torch/csrc/jit/tensorexpr/dim_arg.h
@@ -14,6 +14,7 @@ class DimArg {
  public:
   // Intentionally leave out explicit to allow implicit conversions.
   DimArg(const ExprHandle& dim) : dim_(dim) {}
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   DimArg(const ExprHandle& dim, const std::string& name_hint)
       : dim_(dim), name_hint_(name_hint) {}
   const ExprHandle& dim() const {

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -6,8 +6,10 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_TRIGGER(simple_ir_eval_executed);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 RegisterCodeGen<SimpleIREvaluator> ir_eval_codegen_reg("simple_ir_eval");
 
 template <typename T>
@@ -51,8 +53,10 @@ inline c10::Half div_value(c10::Half lhs, c10::Half rhs) {
   return lhs / rhs;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class SimpleIREvaluatorImpl : public IRVisitor {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   SimpleIREvaluatorImpl() = default;
 
   ~SimpleIREvaluatorImpl() override = default;
@@ -431,6 +435,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     const std::vector<SrcType>& src_values = v.as_vec<SrcType>();
     std::vector<DstType> dst_values(src_values.size());
     for (int i = 0; i < src_dtype.lanes(); ++i) {
+      // NOLINTNEXTLINE(bugprone-signed-char-misuse)
       dst_values[i] = static_cast<DstType>(src_values[i]);
     }
     return dst_values;
@@ -580,6 +585,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
 
   TORCH_API void visit(const IfThenElse* v) override {
     v->condition()->accept(this);
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     bool cond_v;
     switch (value_.dtype().scalar_type()) {
 #define TYPE_CASE(Type, Name)   \
@@ -708,6 +714,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     }
     for (const Expr* a : v->args()) {
       a->accept(this);
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       int64_t val;
       if (value().dtype() == kLong) {
         val = value().as<int64_t>();
@@ -800,6 +807,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       dim->accept(this);
       total_byte_size *= value_.as<int>();
     }
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     int int_count = (total_byte_size + sizeof(int) - 1) / sizeof(int);
     std::unique_ptr<std::vector<int>> buffer(new std::vector<int>(int_count));
     auto iter = buffer_mapping_.find(buffer_var);
@@ -979,6 +987,7 @@ SimpleIREvaluator::SimpleIREvaluator(
   expand_intrinsics();
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 SimpleIREvaluator::~SimpleIREvaluator() {}
 
 void SimpleIREvaluator::call(const std::vector<CallArg>& args) {

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -987,8 +987,7 @@ SimpleIREvaluator::SimpleIREvaluator(
   expand_intrinsics();
 }
 
-// NOLINTNEXTLINE(modernize-use-equals-default)
-SimpleIREvaluator::~SimpleIREvaluator() {}
+SimpleIREvaluator::~SimpleIREvaluator() = default;
 
 void SimpleIREvaluator::call(const std::vector<CallArg>& args) {
   if (args.size() != buffer_args().size()) {

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -23,10 +23,12 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DECLARE_TRIGGER(simple_ir_eval_executed);
 
 class Value {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Value() : dtype_(kInt) {
     Intvalues.push_back(0);
   }
@@ -35,12 +37,14 @@ class Value {
   Value(Type v) : dtype_(k##Name) { \
     Name##values.push_back(v);      \
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, VALUE_CTOR);
 #undef VALUE_CTOR
 
 #define VALUE_VEC_CTOR(Type, Name)  \
   Value(const std::vector<Type>& v) \
       : dtype_(Dtype(k##Name, v.size())), Name##values(v) {}
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, VALUE_VEC_CTOR);
 #undef VALUE_VEC_CTOR
 
@@ -132,6 +136,7 @@ class ExprEval {
   using CallArg = CodeGen::CallArg;
 
   template <typename... Ts>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   ExprEval(const ExprHandle& expr, Ts... ts)
       : ExprEval(expr, {BufferArg(ts)...}) {}
 
@@ -146,6 +151,7 @@ class ExprEval {
     }
     Stmt* store_stmt =
         new Store(ret_buf.data(), indices, expr.node(), new IntImm(1));
+    // NOLINTNEXTLINE(modernize-use-emplace)
     buffer_args_extended.push_back(ret_buf);
     codegen_.reset(new CodeGenType(store_stmt, buffer_args_extended));
   }
@@ -182,10 +188,12 @@ class ExprEval {
     codegen_->call(call_args_extended);                 \
     ret_value_ = Value(ret_val_arg[0]);                 \
   } break;
+      // NOLINTNEXTLINE(modernize-use-emplace)
       AT_FORALL_SCALAR_TYPES_AND(Half, TYPE_CASE);
 #undef TYPE_CASE
       case ScalarType::Bool: {
         std::vector<unsigned char> ret_val_arg(1);
+        // NOLINTNEXTLINE(modernize-use-emplace)
         call_args_extended.push_back(CallArg(ret_val_arg.data()));
         codegen_->call(call_args_extended);
         ret_value_ = Value((bool)ret_val_arg[0]);

--- a/torch/csrc/jit/tensorexpr/eval.h
+++ b/torch/csrc/jit/tensorexpr/eval.h
@@ -150,6 +150,7 @@ class ExprEval {
       indices.push_back(zero);
     }
     Stmt* store_stmt =
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         new Store(ret_buf.data(), indices, expr.node(), new IntImm(1));
     // NOLINTNEXTLINE(modernize-use-emplace)
     buffer_args_extended.push_back(ret_buf);

--- a/torch/csrc/jit/tensorexpr/execution_counter.h
+++ b/torch/csrc/jit/tensorexpr/execution_counter.h
@@ -59,6 +59,7 @@ class ExecutionTriggerList {
 
   ExecutionTriggerList(const ExecutionTriggerList&) = delete;
   ExecutionTriggerList& operator=(const ExecutionTriggerList&) = delete;
+
  private:
   friend class ExecutionTrigger;
 

--- a/torch/csrc/jit/tensorexpr/execution_counter.h
+++ b/torch/csrc/jit/tensorexpr/execution_counter.h
@@ -59,8 +59,11 @@ class ExecutionTriggerList {
  private:
   friend class ExecutionTrigger;
 
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ExecutionTriggerList() {}
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ExecutionTriggerList(const ExecutionTriggerList&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ExecutionTriggerList& operator=(const ExecutionTriggerList&) = delete;
 
   void AddTrigger(const std::string& name, ExecutionTrigger* trigger) {
@@ -88,7 +91,9 @@ class ExecutionTrigger {
   }
 
  private:
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ExecutionTrigger(const ExecutionTrigger&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ExecutionTrigger& operator=(const ExecutionTrigger&) = delete;
   int value_ = 0;
   const std::string name_;

--- a/torch/csrc/jit/tensorexpr/execution_counter.h
+++ b/torch/csrc/jit/tensorexpr/execution_counter.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
+#include <iostream>
 #include <string>
 #include <unordered_map>
 
@@ -56,15 +57,12 @@ class ExecutionTriggerList {
     return iter->second;
   }
 
+  ExecutionTriggerList(const ExecutionTriggerList&) = delete;
+  ExecutionTriggerList& operator=(const ExecutionTriggerList&) = delete;
  private:
   friend class ExecutionTrigger;
 
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ExecutionTriggerList() {}
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ExecutionTriggerList(const ExecutionTriggerList&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ExecutionTriggerList& operator=(const ExecutionTriggerList&) = delete;
+  ExecutionTriggerList() = default;
 
   void AddTrigger(const std::string& name, ExecutionTrigger* trigger) {
     auto insert_ret = trigger_list_.insert(std::make_pair(name, trigger));
@@ -81,6 +79,8 @@ class ExecutionTrigger {
   explicit ExecutionTrigger(const std::string& name) : name_(name) {
     ExecutionTriggerList::GetInstance().AddTrigger(name, this);
   }
+  ExecutionTrigger(const ExecutionTrigger&) = delete;
+  ExecutionTrigger& operator=(const ExecutionTrigger&) = delete;
 
   int value() const {
     return value_;
@@ -91,10 +91,6 @@ class ExecutionTrigger {
   }
 
  private:
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ExecutionTrigger(const ExecutionTrigger&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  ExecutionTrigger& operator=(const ExecutionTrigger&) = delete;
   int value_ = 0;
   const std::string name_;
 };

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -131,27 +131,41 @@ ExprHandle abs(const ExprHandle& v) {
 // The default tanh is quite slow, use the Eigen version from here:
 // https://bitbucket.org/eigen/eigen/src/94875feeeeb9abe5509b314197da1991ba2070f5/Eigen/src/Core/MathFunctionsImpl.h#lines-26
 ExprHandle fast_tanh(const ExprHandle& v) {
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   Dtype dtype = v.dtype();
   // TODO: use a dedicated bind-var to make sure v is not evalualted multiple
   // times. Clamp the input expression to [-9, 9]
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle plus_9 = FloatImm::make(9.0f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle minus_9 = FloatImm::make(-9.0f);
   ExprHandle v1 = Min::make(v, plus_9, false);
   v1 = Max::make(v1, minus_9, false);
 
   // The coefficients for the numerator
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_1 = FloatImm::make(4.89352455891786e-03f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_3 = FloatImm::make(6.37261928875436e-04f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_5 = FloatImm::make(1.48572235717979e-05f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_7 = FloatImm::make(5.12229709037114e-08f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_9 = FloatImm::make(-8.60467152213735e-11f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_11 = FloatImm::make(2.00018790482477e-13f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle alpha_13 = FloatImm::make(-2.76076847742355e-16f);
 
   // The coeffecients for the denominator
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle beta_0 = FloatImm::make(4.89352518554385e-03f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle beta_2 = FloatImm::make(2.26843463243900e-03f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle beta_4 = FloatImm::make(1.18534705686654e-04f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle beta_6 = FloatImm::make(1.19825839466702e-06f);
 
   // numerator
@@ -176,6 +190,7 @@ ExprHandle fast_tanh(const ExprHandle& v) {
 ExprHandle fast_sigmoid(const ExprHandle& x) {
   // sigmoid(x) = (tanh(x / 2) + 1) / 2
   ExprHandle one_v = FloatImm::make(1.f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ExprHandle half_v = FloatImm::make(0.5f);
   ExprHandle x2 = x * half_v;
   ExprHandle y{fast_tanh(x2)};
@@ -189,13 +204,17 @@ ExprHandle fast_log(const ExprHandle& v) {
   // to generate coefficients, this tool is provided
   // https://github.com/shibatch/sleef/blob/master/src/gencoef/gencoef.txt
   auto ilogb2kf = [](ExprHandle x) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto y = (bitcast<int32_t>(x) >> IntImm::make(23)) & IntImm::make(0xff);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return y - IntImm::make(0x7f);
   };
 
   auto ldexp3kf = [](ExprHandle x, ExprHandle e) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return bitcast<float>(bitcast<int32_t>(x) + (e << IntImm::make(23)));
   };
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto e = ilogb2kf(v * FloatImm::make(1.0 / 0.75));
   auto m = ldexp3kf(v, IntImm::make(-1) * e);
   auto one = FloatImm::make(1.0f);
@@ -206,11 +225,17 @@ ExprHandle fast_log(const ExprHandle& v) {
     return x * y + FloatImm::make(z);
   };
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto t = FloatImm::make(0.2392828464508056640625);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(t, x2, 0.28518211841583251953125);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(t, x2, 0.400005877017974853515625);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(t, x2, 0.666666686534881591796875);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(t, x2, 2.0);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   x = x * t + FloatImm::make(0.693147180559945286226764) * e;
 
   auto zero = FloatImm::make(0);
@@ -227,29 +252,45 @@ ExprHandle log_vml(const ExprHandle& v) {
   };
 
   auto in = bitcast<int32_t>(v);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto a = in - IntImm::make(0x3f2aaaab);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto e = cast<float>(a >> IntImm::make(23));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto x = (a & IntImm::make(0x7fffff)) + IntImm::make(0x3f2aaaab);
   x = bitcast<float>(x) - 1.0f;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto t = FloatImm::make(-0.12891686f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, 0.139844373f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, -0.121842608f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, 0.140058696f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, -0.16680488f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, 0.200104058f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, -0.249997973f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, 0.333332151f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   t = mlaf(x, t, -0.5f);
   t = x * t;
   t = x * t + x;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto z = e * FloatImm::make(1.42860677e-06f) + t;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   z = e * FloatImm::make(0.693145752f) + z;
 
   return CompareSelect::make(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       IntImm::make(0x1000000),
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       in + IntImm::make(0x800000),
       log(v),
       z,

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -76,8 +76,7 @@ class ExprNode : public Base {
 // Also serves the primary way to build and operate on other expressions.
 class TORCH_API ExprHandle {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  ExprHandle() {}
+  ExprHandle() = default;
   explicit ExprHandle(const Expr* node)
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       : base_expr_node_(const_cast<Expr*>(node)) {}
@@ -152,9 +151,8 @@ class TORCH_API Var : public ExprNode<Var> {
     return name_hint_;
   }
 
-  // NOLINTNEXTLINE(modernize-pass-by-value)
-  Var(const std::string& name_hint, Dtype dtype)
-      : ExprNodeBase(dtype, kPrimitive), name_hint_(name_hint) {}
+  Var(std::string name_hint, Dtype dtype)
+      : ExprNodeBase(dtype, kPrimitive), name_hint_(std::move(name_hint)) {}
 
  private:
   std::string name_hint_;
@@ -183,13 +181,12 @@ class TORCH_API Buf : public ExprNode<Buf> {
       : Buf(new Var(name_hint, kHandle), dims, dtype, initializer) {}
 
   Buf(const Var* var,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Expr*>& dims,
+      std::vector<const Expr*> dims,
       Dtype dtype,
       const Expr* initializer = nullptr)
       : ExprNodeBase(dtype, kPrimitive),
         base_handle_(var),
-        dims_(dims),
+        dims_(std::move(dims)),
         initializer_(initializer) {
     TORCH_CHECK(var);
   }

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -76,8 +76,10 @@ class ExprNode : public Base {
 // Also serves the primary way to build and operate on other expressions.
 class TORCH_API ExprHandle {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ExprHandle() {}
   explicit ExprHandle(const Expr* node)
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
       : base_expr_node_(const_cast<Expr*>(node)) {}
 
   Expr* node() {
@@ -103,6 +105,7 @@ class TORCH_API ExprHandle {
 
   template <class Op>
   const Op* AsNode() const {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<ExprHandle*>(this)->AsNode<Op>();
   }
 
@@ -149,6 +152,7 @@ class TORCH_API Var : public ExprNode<Var> {
     return name_hint_;
   }
 
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   Var(const std::string& name_hint, Dtype dtype)
       : ExprNodeBase(dtype, kPrimitive), name_hint_(name_hint) {}
 
@@ -179,6 +183,7 @@ class TORCH_API Buf : public ExprNode<Buf> {
       : Buf(new Var(name_hint, kHandle), dims, dtype, initializer) {}
 
   Buf(const Var* var,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Expr*>& dims,
       Dtype dtype,
       const Expr* initializer = nullptr)
@@ -279,6 +284,7 @@ class TORCH_API VarHandle : public ExprHandle {
 
 template <class Op, class Base>
 const Expr* ExprNode<Op, Base>::accept_mutator(IRMutator* mutator) const {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   ExprNode* this_mutable = const_cast<ExprNode*>(this);
   return mutator->mutate(static_cast<Op*>(this_mutable));
 }

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -23,7 +23,7 @@ std::vector<at::Tensor> constructTensors(
   for (const auto i : c10::irange(bufs_num)) {
     buf_data_vec.push_back(buf_data[i]);
     buf_dims_vec.emplace_back();
-    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable,clang-analyzer-deadcode.DeadStores)
     for (const auto dim : c10::irange(buf_ranks[i])) {
       buf_dims_vec[i].push_back(buf_dims[buf_dims_idx++]);
     }

--- a/torch/csrc/jit/tensorexpr/external_functions.cpp
+++ b/torch/csrc/jit/tensorexpr/external_functions.cpp
@@ -23,6 +23,7 @@ std::vector<at::Tensor> constructTensors(
   for (const auto i : c10::irange(bufs_num)) {
     buf_data_vec.push_back(buf_data[i]);
     buf_dims_vec.emplace_back();
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
     for (const auto dim : c10::irange(buf_ranks[i])) {
       buf_dims_vec[i].push_back(buf_dims[buf_dims_idx++]);
     }
@@ -67,7 +68,9 @@ void nnc_aten_conv2d(
     int64_t paddingH = extra_args[2];
     int64_t paddingW = extra_args[3];
     int64_t dilationH = extra_args[4];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     int64_t dilationW = extra_args[5];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     int64_t groups = extra_args[6];
 
     try {

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -54,6 +54,7 @@ class TORCH_API HashProvider : public IRVisitor {
  public:
   template <class T>
   SimplifierHashType hash(const T* e) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     e->accept(this);
     return hashOf(e);
   }

--- a/torch/csrc/jit/tensorexpr/hash_provider.h
+++ b/torch/csrc/jit/tensorexpr/hash_provider.h
@@ -150,20 +150,24 @@ class TORCH_API HashProvider : public IRVisitor {
   // Hash funcs for various types, numbers are random.
   template <typename T>
   void _hash_combine(SimplifierHashType& seed, const T& val) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     seed._h ^= te_hash(val) + 0x1f752c19 + (seed._h << 7) + (seed._h >> 4);
   }
 
   void _hash_combine(SimplifierHashType& seed, const char* val) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     seed._h ^= te_hash(val) + 0x1f752c19 + (seed._h << 7) + (seed._h >> 4);
   }
 
   // at:::Half doesn't have a prime_number_hash, so cast to short.
   void _hash_combine(SimplifierHashType& seed, const at::Half& val) {
     seed._h ^=
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         te_hash((uint16_t)val) + 0x1f752c19 + (seed._h << 7) + (seed._h >> 4);
   }
 
   void _hash_combine(SimplifierHashType& seed, const Dtype& val) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     seed._h ^= te_hash(val.ToCppString()) + 0x1f752c19 + (seed._h << 7) +
         (seed._h >> 4);
   }
@@ -198,12 +202,15 @@ class TORCH_API HashProvider : public IRVisitor {
 
   size_t te_hash(int64_t val) {
     // put the thing down.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     size_t h = val ^ 0x647AA4D20C0B;
     // bit flip it.
     size_t h2 = ~h;
     // and reverse byte order.
     size_t h3 = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (unsigned int i = 0; i < 64; i += 8) {
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       h3 |= ((h2 >> i) & 0xFF) << (64 - i - 8);
     }
     return h3;
@@ -232,12 +239,16 @@ class TORCH_API HashProvider : public IRVisitor {
   size_t te_hash(std::string val) {
     size_t hash{0};
     int64_t intval{0};
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
     int s = val.size() - 1;
     while (s >= 0) {
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       for (unsigned int i = 0; i < 8; ++i) {
         if (s < 0)
           break;
+        // NOLINTNEXTLINE(bugprone-signed-char-misuse)
         int64_t c = val.data()[s];
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         intval |= (c << (i * 8));
 
         s--;
@@ -251,6 +262,7 @@ class TORCH_API HashProvider : public IRVisitor {
 
   size_t te_hash(double d) {
     // memcpy as type punning. Should be optimized out.
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int64_t n;
     std::memcpy(&n, &d, sizeof d);
     return te_hash(n);
@@ -258,6 +270,7 @@ class TORCH_API HashProvider : public IRVisitor {
 
   size_t te_hash(float d) {
     // memcpy as type punning. Should be optimized out.
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int32_t n;
     std::memcpy(&n, &d, sizeof d);
     return te_hash(n);
@@ -265,6 +278,7 @@ class TORCH_API HashProvider : public IRVisitor {
 
   size_t te_hash(at::Half d) {
     // memcpy as type punning. Should be optimized out.
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     int16_t n;
     std::memcpy(&n, &d, sizeof d);
     return te_hash(n);

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -33,10 +33,9 @@ void castIndicesToInts(std::vector<const Expr*>& indices) {
 Load::Load(
     Dtype dtype,
     const Buf* buf,
-    // NOLINTNEXTLINE(modernize-pass-by-value)
-    const std::vector<const Expr*>& indices,
+    std::vector<const Expr*> indices,
     const Expr* mask)
-    : ExprNodeBase(dtype), buf_(buf), indices_(indices), mask_(mask) {
+    : ExprNodeBase(dtype), buf_(buf), indices_(std::move(indices)), mask_(mask) {
   castIndicesToInts(indices_);
 }
 

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -35,7 +35,10 @@ Load::Load(
     const Buf* buf,
     std::vector<const Expr*> indices,
     const Expr* mask)
-    : ExprNodeBase(dtype), buf_(buf), indices_(std::move(indices)), mask_(mask) {
+    : ExprNodeBase(dtype),
+      buf_(buf),
+      indices_(std::move(indices)),
+      mask_(mask) {
   castIndicesToInts(indices_);
 }
 

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -33,6 +33,7 @@ void castIndicesToInts(std::vector<const Expr*>& indices) {
 Load::Load(
     Dtype dtype,
     const Buf* buf,
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     const std::vector<const Expr*>& indices,
     const Expr* mask)
     : ExprNodeBase(dtype), buf_(buf), indices_(indices), mask_(mask) {

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -40,26 +40,35 @@ inline int getPrecedence(IRNodeType ty) {
       return 2;
     case kAdd:
     case kSub:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 6;
     case kMul:
     case kDiv:
     case kMod:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 5;
     case kMax:
     case kMin:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 99;
     case kAnd:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 11;
     case kOr:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 13;
     case kLshift:
     case kRshift:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 7;
     case kXor:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 12;
     case kCompareSelect:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 16;
     default:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return 99;
   }
 }

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -441,7 +441,7 @@ class TORCH_API Load : public ExprNode<Load> {
   Load(
       Dtype dtype,
       const Buf* base_handle,
-      const std::vector<const Expr*>& indices,
+      std::vector<const Expr*> indices,
       const Expr* mask);
   Load(
       const Buf* base_handle,

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -56,6 +56,7 @@ class ExternalCall;
 
 class TORCH_API IRMutator {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~IRMutator() {}
   virtual const Expr* mutate(const Add* v);
   virtual const Expr* mutate(const Sub* v);

--- a/torch/csrc/jit/tensorexpr/ir_mutator.h
+++ b/torch/csrc/jit/tensorexpr/ir_mutator.h
@@ -56,8 +56,7 @@ class ExternalCall;
 
 class TORCH_API IRMutator {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~IRMutator() {}
+  virtual ~IRMutator() = default;
   virtual const Expr* mutate(const Add* v);
   virtual const Expr* mutate(const Sub* v);
   virtual const Expr* mutate(const Mul* v);

--- a/torch/csrc/jit/tensorexpr/ir_printer.h
+++ b/torch/csrc/jit/tensorexpr/ir_printer.h
@@ -83,6 +83,7 @@ class TORCH_API IRPrinter : public IRVisitor {
   }
   void emitIndent();
 
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   int indent_ = 0;
 
  private:

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1198,6 +1198,7 @@ bool simplifyNestedMinMax(
           rhs_opterm->variables().size() == 2) {
         auto rhs_v1 = rhs_opterm->variables()[0];
         auto rhs_v2 = rhs_opterm->variables()[1];
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         const Expr* new_op_lhs;
         if (isOperandInMinMaxTerm<OtherOpTerm>(
                 lhs_opterm, rhs_v1, hasher, &new_op_lhs)) {
@@ -1243,6 +1244,7 @@ const Expr* PolynomialTransformer::mutate(const Max* v) {
   }
 
   // Max(Min(x, y), Min(x, z)) => Min(x, Max(y, z))
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* new_op;
   if (simplifyNestedMinMax<MaxTerm, MinTerm>(
           lhs_new, rhs_new, v->propagate_nans(), hasher_, &new_op)) {
@@ -1273,6 +1275,7 @@ const Expr* PolynomialTransformer::mutate(const Min* v) {
   }
 
   // Min(Max(x, y), Max(x, z)) => Max(x, Min(y, z))
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* new_op;
   if (simplifyNestedMinMax<MinTerm, MaxTerm>(
           lhs_new, rhs_new, v->propagate_nans(), hasher_, &new_op)) {
@@ -1888,6 +1891,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
   // any further.
   while (!mods.empty() && repeat) {
     repeat = false;
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     for (int i = mods.size() - 1; i >= 0; i--) {
       const Term* m = mods[i];
       const Mod* mod = dynamic_cast<const Mod*>(m->variables()[0]);
@@ -1895,6 +1899,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
       const Expr* mod_lhs = IRSimplifier::simplify(mod->lhs());
       const Expr* mod_rhs = IRSimplifier::simplify(mod->rhs());
       bool merged = false;
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       for (int j = mod_rounds.size() - 1; j >= 0; j--) {
         const Term* mr = mod_rounds[j];
         auto a = isModRound(mr);
@@ -1932,6 +1937,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
         continue;
       }
 
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
       for (int k = rounds.size() - 1; k >= 0; k--) {
         const Term* r = rounds[k];
         const RoundOff* roundoff =
@@ -2011,6 +2017,7 @@ const Term* IRSimplifierBase::factorizePolynomial(const Polynomial* poly) {
   std::vector<const Term*> newPolyTerms;
   for (auto* t : variables) {
     // New term with the scalar divided by the GCD.
+    // NOLINTNEXTLINE(performance-inefficient-vector-operation)
     newPolyTerms.push_back(new Term(
         poly->hasher(), evaluateOp(new Div(t->scalar(), GCD)), t->variables()));
   }
@@ -2134,6 +2141,7 @@ const Expr* TermExpander::mutate(const MaxTerm* v) {
     }
     return v->scalar();
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* max;
   if (v->scalar()) {
     max = new Max(variables[0], v->scalar(), v->propagate_nans());
@@ -2156,6 +2164,7 @@ const Expr* TermExpander::mutate(const MinTerm* v) {
     }
     return v->scalar();
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Expr* min;
   if (v->scalar()) {
     min = new Min(variables[0], v->scalar(), v->propagate_nans());

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -471,12 +471,14 @@ const Expr* PolynomialTransformer::mutate(const Sub* v) {
   // Multilane folding.
   if (isMultilanePrimitive(lhs_new)) {
     if (auto* ret = combineMultilane<Sub>(lhs_new, rhs_new)) {
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
       return ret->accept_mutator(this);
     }
   }
 
   if (rhs_new->isConstant() && immediateEquals(rhs_new, 0)) {
     auto* c = new Cast(v->dtype(), lhs_new);
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return c->accept_mutator(this);
   }
 
@@ -788,6 +790,7 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
   // Multilane folding.
   if (isMultilanePrimitive(lhs_new)) {
     if (auto* ret = mulMultilane(lhs_new, rhs_new)) {
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
       return ret->accept_mutator(this);
     }
   }
@@ -807,6 +810,7 @@ const Expr* PolynomialTransformer::mutate(const Mul* v) {
   // it's Nan/Inf.
   if (scalar && immediateEquals(scalar, 1)) {
     auto* c = new Cast(v->dtype(), variable);
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return c->accept_mutator(this);
   }
 
@@ -974,6 +978,7 @@ const Expr* PolynomialTransformer::mutate(const Div* v) {
 
   // If the numerator is zero, so is the result.
   if (lhs_new->isConstant() && immediateEquals(lhs_new, 0)) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return lhs_new;
   }
 
@@ -989,6 +994,7 @@ const Expr* PolynomialTransformer::mutate(const Div* v) {
   // }
 
   if (auto ret = factorizeDivision(lhs_new, rhs_new)) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return ret->accept_mutator(this);
   }
 
@@ -1006,11 +1012,13 @@ const Expr* PolynomialTransformer::mutate(const Mod* v) {
 
   // 0 % x => 0.
   if (lhs_new->isConstant() && immediateEquals(lhs_new, 0)) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return lhs_new;
   }
 
   // x % 1 == 0.
   if (rhs_new->isConstant() && immediateEquals(rhs_new, 1)) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return getImmediateByType(v->dtype(), 0);
   }
 
@@ -1321,12 +1329,14 @@ const Expr* PolynomialTransformer::mutate(const CompareSelect* v) {
   const Expr* diff = new Sub(rhs_new, lhs_new);
   diff = diff->accept_mutator(this);
 
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   if (!diff->isConstant()) {
     return new CompareSelect(
         lhs_new,
         rhs_new,
         true_branch,
         false_branch,
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
         v->compare_select_op(),
         v->bias());
   }
@@ -1454,8 +1464,10 @@ Stmt* IRSimplifierBase::mutate(const Cond* v) {
   // If the condition is constant then we can choose the right branch now.
   if (cond_new->isConstant()) {
     if (!immediateEquals(cond_new, 0)) {
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
       return true_new ? Stmt::clone(true_new) : nullptr;
     } else {
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
       return false_new ? Stmt::clone(false_new) : nullptr;
     }
   }
@@ -1783,6 +1795,7 @@ c10::optional<class ModRound*> isModRound(const Term* e) {
   multiplier = IRSimplifier::simplify(multiplier);
 
   if (!mod) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return c10::nullopt;
   }
 
@@ -1867,6 +1880,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
 
     if (dynamic_cast<const RoundOff*>(e)) {
       rounds.push_back(c);
+      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     } else if (e->expr_type() == IRNodeType::kMod) {
       if (auto a = isModRound(c)) {
         mod_rounds.push_back(c);
@@ -1917,6 +1931,7 @@ const Expr* simplifyRoundModPattern(const Polynomial* poly) {
         // divisor.
         if (hasher.hash(mod_round->denom) == hasher.hash(mod_lhs) &&
             hasher.hash(mod_round->divisor) == hasher.hash(mod_rhs)) {
+          // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
           const Term* merged_m = new Term(
               hasher,
               mod_round->scalar,
@@ -2120,6 +2135,7 @@ const Expr* TermExpander::mutate(const Polynomial* v) {
     lastNode = new Sub(lastNode, evaluateOp(negated));
   } else {
     // we want to avoid a cast to the scalar if it would happen.
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     if (v->scalar()->dtype() != lastNode->dtype()) {
       lastNode = new Add(
           lastNode, evaluateOp(new Cast(lastNode->dtype(), v->scalar())));
@@ -2197,6 +2213,7 @@ const Expr* buf_flat_size(const Buf* v) {
   }
   flattened = IRSimplifier::simplify(flattened);
 
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return flattened;
 }
 
@@ -2289,6 +2306,7 @@ Block* TermExpander::fuseConditions(Block* v) {
       false_block = nullptr;
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     Stmt* new_cond = prev_cond->cloneWithNewBodies(true_block, false_block)
                          ->accept_mutator(this);
     prev_cond = dynamic_cast<Cond*>(new_cond);
@@ -2373,6 +2391,7 @@ Stmt* TermExpander::mutate(const Block* v) {
 
 bool exprEquals(const Expr* A, const Expr* B) {
   try {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     const Expr* diff = IRSimplifier::simplify(new Sub(A, B));
     if (!diff->isConstant()) {
       return false;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -406,8 +406,7 @@ class MinTerm : public ExprNode<MinTerm> {
 // Stmt simplification should occur in both modes.
 class TORCH_API IRSimplifierBase : public IRMutator {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default,modernize-use-override)
-  virtual ~IRSimplifierBase() {}
+  ~IRSimplifierBase() override = default;
 
   Stmt* mutate(const Block* v) override;
 

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -581,6 +581,7 @@ class TORCH_API IRSimplifier {
     // There may be terms left in the IR, expand them.
     TermExpander expander(&simplifier);
     e = e->accept_mutator(&expander);
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     if (!expander.check_safe()) {
       throw malformed_input("eliminated null Allocation without free");
     }

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -406,6 +406,7 @@ class MinTerm : public ExprNode<MinTerm> {
 // Stmt simplification should occur in both modes.
 class TORCH_API IRSimplifierBase : public IRMutator {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default,modernize-use-override)
   virtual ~IRSimplifierBase() {}
 
   Stmt* mutate(const Block* v) override;
@@ -422,6 +423,7 @@ class TORCH_API IRSimplifierBase : public IRMutator {
   }
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   HashProvider hasher_;
 };
 

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -53,6 +53,7 @@ class ExternalCall;
 
 class TORCH_API IRVisitor {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~IRVisitor() {}
   virtual void visit(const Add* v);
   virtual void visit(const Sub* v);

--- a/torch/csrc/jit/tensorexpr/ir_visitor.h
+++ b/torch/csrc/jit/tensorexpr/ir_visitor.h
@@ -53,8 +53,7 @@ class ExternalCall;
 
 class TORCH_API IRVisitor {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~IRVisitor() {}
+  virtual ~IRVisitor() = default;
   virtual void visit(const Add* v);
   virtual void visit(const Sub* v);
   virtual void visit(const Mul* v);

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -17,11 +17,17 @@ namespace torch {
 namespace jit {
 namespace tensorexpr {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static int te_cuda_pointwise_loop_levels = -1;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static int te_cuda_pointwise_block_count = -1;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static int te_cuda_pointwise_block_size = -1;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool fallback_allowed = false;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool te_generate_block_code = false;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool te_must_use_llvm_on_cpu = true;
 static bool cat_wo_conditionals = false; // NOLINT
 
@@ -367,6 +373,7 @@ std::vector<ExprHandle> TensorExprKernel::inferSizesForValue(
       if (dim < 0) {
         dim = dim + shape.size() + 1;
       }
+      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       if (dim < 0 || dim > shape.size()) {
         throw std::runtime_error("Invalid 'dim' input in aten::unsqueeze");
       }
@@ -1098,6 +1105,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
                 tensorOrConstant(n->input(0), indices), // input
                 tensorOrConstant(n->input(3), {c}), // mean
                 tensorOrConstant(n->input(4), {c}), // var
+                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
                 constant(n->input(7)) // eps
             };
             if (hasWeight) {
@@ -1119,6 +1127,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
               weight = inputs[4];
             }
             if (hasBias) {
+              // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
               bias = inputs[5];
             }
 
@@ -1644,7 +1653,9 @@ Stmt* TensorExprKernel::transformLoops(BackendType backendType, Stmt* st) {
       int blockSize = getTECudaPointwiseBlockSize();
 
       if (loopLevels == 2) {
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* outer;
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* inner;
         const int kDefaultBlockSize = 512;
         if (blockSize < 0) {
@@ -1654,9 +1665,13 @@ Stmt* TensorExprKernel::transformLoops(BackendType backendType, Stmt* st) {
         l.setGPUBlockIndex(outer, 0);
         l.setGPUThreadIndex(inner, 0);
       } else if (loopLevels == 3) {
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* outer;
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* inner;
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* inner1;
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         For* inner2;
         // TODO: change the number of microprocessors
         const int kDefaultBlockCount = 1280;
@@ -1782,6 +1797,7 @@ void TensorExprKernel::genInputDebugNames() {
     std::string sanitized_name = sanitizeName(input->debugName());
     // we could get fancier here, but name conflict is extremely unlikely
     while (name_set.count(sanitized_name)) {
+      // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
       sanitized_name = sanitized_name + "_";
     }
     value_to_name[input] = sanitized_name;
@@ -1912,6 +1928,7 @@ Tensor* TensorExprKernel::computeConv2d(const torch::jit::Value* v) {
   BufHandle w = BufHandle(tensors_.at(n->input(1))->buf());
   BufHandle b = BufHandle(tensors_.at(n->input(2))->buf());
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int sH, sW;
   auto strides_iv = *toIValue(n->input(3));
   if (strides_iv.isIntList()) {
@@ -1920,6 +1937,7 @@ Tensor* TensorExprKernel::computeConv2d(const torch::jit::Value* v) {
   } else {
     sH = sW = strides_iv.toInt();
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int pH, pW;
   auto padding_iv = *toIValue(n->input(4));
   if (padding_iv.isIntList()) {
@@ -1928,7 +1946,9 @@ Tensor* TensorExprKernel::computeConv2d(const torch::jit::Value* v) {
   } else {
     pH = pW = padding_iv.toInt();
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int dH, dW;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto dil_iv = *toIValue(n->input(5));
   if (dil_iv.isIntList()) {
     dH = dil_iv.toIntList()[0];
@@ -1936,6 +1956,7 @@ Tensor* TensorExprKernel::computeConv2d(const torch::jit::Value* v) {
   } else {
     dH = dW = dil_iv.toInt();
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   int groups = toIValue(n->input(6))->toInt();
 
   // Once we have a performant TE representation for conv2d, we could use it

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -32,9 +32,8 @@ LoopNest::LoopNest(const LoopNest& other)
 
 LoopNest::LoopNest(
     Stmt* stmt,
-    // NOLINTNEXTLINE(modernize-pass-by-value)
-    const std::unordered_set<const Buf*>& output_bufs)
-    : root_stmt_(stmt), output_bufs_(output_bufs) {
+    std::unordered_set<const Buf*> output_bufs)
+    : root_stmt_(stmt), output_bufs_(std::move(output_bufs)) {
   verify(root_stmt_);
 }
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -30,9 +30,7 @@ LoopNest::LoopNest(const LoopNest& other)
   verify(root_stmt_);
 }
 
-LoopNest::LoopNest(
-    Stmt* stmt,
-    std::unordered_set<const Buf*> output_bufs)
+LoopNest::LoopNest(Stmt* stmt, std::unordered_set<const Buf*> output_bufs)
     : root_stmt_(stmt), output_bufs_(std::move(output_bufs)) {
   verify(root_stmt_);
 }

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1477,6 +1477,7 @@ void LoopNest::reorderAxis(For* a, For* b) {
       internal_axes.push_back(f);
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     s = s->get_parent();
   }
 
@@ -1688,6 +1689,7 @@ bool LoopNest::flatten(const std::vector<For*>& loops, For** flattened) {
 
   // 'normalized' points to the outer-most loop in the normalized loopnest.
   // Collect all the normalized loops.
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
   auto normalized_loops = getLoopStmtsInLoopNest(normalized, loops.size());
 
   auto flat_var = new Var(
@@ -2503,6 +2505,7 @@ void LoopNest::rfactor(
     }
   }
   if (!found) {
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     std::stringstream ss;
     for (auto& v : new_inner) {
       ss << *v;
@@ -2554,6 +2557,7 @@ void LoopNest::rfactor(
   };
 
   if (insertion_point && insertion_point == root_for->body()) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     insertion_point = dynamic_cast<For*>(new_root_for)->body();
   } else if (insertion_point) {
     throw std::runtime_error("TODO: enable non-root insertion points");
@@ -2569,6 +2573,7 @@ void LoopNest::rfactor(
   if (output_contains_target) {
     parent_block->insert_stmt_before(init_stmt, new_root_for);
   } else {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     new_root_for->body()->prepend_stmt(init_stmt);
   }
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -32,11 +32,13 @@ LoopNest::LoopNest(const LoopNest& other)
 
 LoopNest::LoopNest(
     Stmt* stmt,
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     const std::unordered_set<const Buf*>& output_bufs)
     : root_stmt_(stmt), output_bufs_(output_bufs) {
   verify(root_stmt_);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 LoopNest::LoopNest(
     const std::vector<Tensor*>& output_tensors,
     const std::vector<Tensor*>& tensors_to_compute) {
@@ -44,6 +46,7 @@ LoopNest::LoopNest(
   verify(root_stmt_);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 LoopNest::LoopNest(const std::vector<Tensor*>& output_tensors) {
   initialize(output_tensors, output_tensors);
   verify(root_stmt_);
@@ -1020,8 +1023,11 @@ void LoopNest::vectorizeInnerLoops() {
 
   // vectorize inner loops.
   for (For* loop : innerLoops) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     For* outer1;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     For* split1;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     For* tail1;
 
     static const int kBodyVectorWidth = 8;
@@ -1029,8 +1035,11 @@ void LoopNest::vectorizeInnerLoops() {
     vectorize(split1);
 
     if (tail1) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       For* outer2;
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       For* split2;
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       For* tail2;
       static const int kTailVectorWidth = 4;
       splitWithTail(tail1, kTailVectorWidth, &outer2, &split2, &tail2);
@@ -1078,6 +1087,7 @@ void LoopNest::sliceHead(For* f, int factor, For** head, For** tail) {
   // TODO: record history of transformations
 }
 void LoopNest::sliceHead(For* f, int factor) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   For *head, *tail;
   sliceHead(f, factor, &head, &tail);
 }
@@ -1125,11 +1135,13 @@ void LoopNest::sliceTail(For* f, int factor, For** head, For** tail) {
   // TODO: record history of transformations
 }
 void LoopNest::sliceTail(For* f, int factor) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   For *head, *tail;
   sliceTail(f, factor, &head, &tail);
 }
 
 void LoopNest::splitWithTail(For* f, int factor) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   For *outer, *inner, *tail;
   splitWithTail(f, factor, &outer, &inner, &tail);
 }
@@ -1202,6 +1214,7 @@ void LoopNest::splitWithTail(
 }
 
 void LoopNest::splitWithMask(For* f, int factor) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   For *outer, *inner;
   splitWithMask(f, factor, &outer, &inner);
 }
@@ -1669,6 +1682,7 @@ bool LoopNest::flatten(const std::vector<For*>& loops, For** flattened) {
   // loop is normalized, the given pointers to inner loops point to old code.
   // For the same reason, we can't store the normalized inner loops until after
   // the outer-most loop is normalized.
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   For* normalized;
   for (size_t i = 0; i < loops.size(); ++i) {
     size_t idx = loops.size() - i - 1;

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -34,7 +34,7 @@ class TORCH_API LoopNest {
 
   // A constructor for building a LoopNest from an Stmt and a list of output
   // buffers.
-  LoopNest(Stmt* stmt, const std::unordered_set<const Buf*>& output_bufs);
+  LoopNest(Stmt* stmt, std::unordered_set<const Buf*> output_bufs);
 
   // A constructor for building a LoopNest from another loopnest. It clones the
   // other loopnest's stmt.

--- a/torch/csrc/jit/tensorexpr/mem_arena.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_arena.cpp
@@ -7,6 +7,7 @@ namespace tensorexpr {
 namespace {
 // Define in an anonymous namespace to hide this symbol from other compilation
 // units
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local KernelArena* current_arena = nullptr;
 } // namespace
 

--- a/torch/csrc/jit/tensorexpr/mem_arena.h
+++ b/torch/csrc/jit/tensorexpr/mem_arena.h
@@ -13,15 +13,12 @@ class KernelArena {
  public:
   static KernelArena* GetCurrentKernelArena();
   static void SetCurrentKernelArena(KernelArena* new_arena);
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  TORCH_API KernelArena() {}
+  TORCH_API KernelArena() = default;
   TORCH_API ~KernelArena();
+  KernelArena(const KernelArena&) = delete;
+  KernelArena& operator=(const KernelArena&) = delete;
 
  private:
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  KernelArena(const KernelArena&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  KernelArena& operator=(const KernelArena&) = delete;
   friend class KernelScopedObject;
   std::vector<KernelScopedObject*> kernel_objects_; // owned
 };
@@ -35,12 +32,10 @@ class KernelScope {
   TORCH_API KernelScope();
   TORCH_API explicit KernelScope(KernelArena* arena_);
   TORCH_API ~KernelScope();
+  KernelScope(const KernelScope&) = delete;
+  KernelScope& operator=(const KernelScope&) = delete;
 
  private:
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  KernelScope(const KernelScope&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
-  KernelScope& operator=(const KernelScope&) = delete;
   KernelArena* old_kernel_arena_ =
       nullptr; // previous arena, will be restored in destructor
   bool owning_ = false; // determines whether the arena will be freed along with
@@ -55,10 +50,7 @@ class TORCH_API KernelScopedObject {
   KernelScopedObject();
   virtual ~KernelScopedObject() = default;
 
- private:
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScopedObject(const KernelScopedObject&) = delete;
-  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScopedObject& operator=(const KernelScopedObject&) = delete;
 };
 

--- a/torch/csrc/jit/tensorexpr/mem_arena.h
+++ b/torch/csrc/jit/tensorexpr/mem_arena.h
@@ -13,11 +13,14 @@ class KernelArena {
  public:
   static KernelArena* GetCurrentKernelArena();
   static void SetCurrentKernelArena(KernelArena* new_arena);
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   TORCH_API KernelArena() {}
   TORCH_API ~KernelArena();
 
  private:
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelArena(const KernelArena&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelArena& operator=(const KernelArena&) = delete;
   friend class KernelScopedObject;
   std::vector<KernelScopedObject*> kernel_objects_; // owned
@@ -34,7 +37,9 @@ class KernelScope {
   TORCH_API ~KernelScope();
 
  private:
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScope(const KernelScope&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScope& operator=(const KernelScope&) = delete;
   KernelArena* old_kernel_arena_ =
       nullptr; // previous arena, will be restored in destructor
@@ -51,7 +56,9 @@ class TORCH_API KernelScopedObject {
   virtual ~KernelScopedObject() = default;
 
  private:
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScopedObject(const KernelScopedObject&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   KernelScopedObject& operator=(const KernelScopedObject&) = delete;
 };
 

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -42,14 +42,13 @@ class TORCH_API AccessInfo {
       AccessType type,
       const Stmt* stmt,
       const Var* var,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
       IndexBounds bounds)
       : id_(id),
         type_(type),
         stmt_(stmt),
         expr_(nullptr),
         var_(var),
-        bounds_(bounds) {}
+        bounds_(std::move(bounds)) {}
 
   AccessInfo(
       size_t id,
@@ -57,14 +56,13 @@ class TORCH_API AccessInfo {
       const Expr* expr,
       const Stmt* stmt,
       const Var* var,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
       IndexBounds bounds)
       : id_(id),
         type_(type),
         stmt_(stmt),
         expr_(expr),
         var_(var),
-        bounds_(bounds) {}
+        bounds_(std::move(bounds)) {}
 
   // Id is a unique int representing the order this access occured in the graph.
   size_t id() const {
@@ -184,8 +182,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
       const std::vector<BufHandle>& inputs,
       const std::vector<BufHandle>& outputs);
 
-  // NOLINTNEXTLINE(modernize-use-equals-default,modernize-use-override)
-  virtual ~MemDependencyChecker() {}
+  ~MemDependencyChecker() override = default;
 
   // Whether or not to allow loop execution order to influence dependency
   // calculation. If the loop may later be parallelized you don't want this.
@@ -273,8 +270,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
 
   // An internal struct holding the accesses found within a scope Block.
   struct Scope {
-    // NOLINTNEXTLINE(modernize-pass-by-value)
-    Scope(Block* b, std::shared_ptr<Scope> p) : block(b), parent(p) {}
+    Scope(Block* b, std::shared_ptr<Scope> p) : block(b), parent(std::move(p)) {}
 
     Block* block;
     std::shared_ptr<Scope> parent;

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -270,7 +270,8 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
 
   // An internal struct holding the accesses found within a scope Block.
   struct Scope {
-    Scope(Block* b, std::shared_ptr<Scope> p) : block(b), parent(std::move(p)) {}
+    Scope(Block* b, std::shared_ptr<Scope> p)
+        : block(b), parent(std::move(p)) {}
 
     Block* block;
     std::shared_ptr<Scope> parent;

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.h
@@ -42,6 +42,7 @@ class TORCH_API AccessInfo {
       AccessType type,
       const Stmt* stmt,
       const Var* var,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       IndexBounds bounds)
       : id_(id),
         type_(type),
@@ -56,6 +57,7 @@ class TORCH_API AccessInfo {
       const Expr* expr,
       const Stmt* stmt,
       const Var* var,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       IndexBounds bounds)
       : id_(id),
         type_(type),
@@ -182,6 +184,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
       const std::vector<BufHandle>& inputs,
       const std::vector<BufHandle>& outputs);
 
+  // NOLINTNEXTLINE(modernize-use-equals-default,modernize-use-override)
   virtual ~MemDependencyChecker() {}
 
   // Whether or not to allow loop execution order to influence dependency
@@ -270,6 +273,7 @@ class TORCH_API MemDependencyChecker : public IRVisitor {
 
   // An internal struct holding the accesses found within a scope Block.
   struct Scope {
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     Scope(Block* b, std::shared_ptr<Scope> p) : block(b), parent(p) {}
 
     Block* block;

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -33,6 +33,7 @@ class TORCH_API Reducer {
   Reducer(ExprHandle init, RI interaction) : init_(init.node()) {
     interaction_ = interaction;
   }
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~Reducer() {}
 
   const Expr* initializer() const {
@@ -129,6 +130,7 @@ class TORCH_API ReduceOp : public ExprNode<ReduceOp> {
  public:
   ReduceOp(
       const Expr* body,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Var*>& reduce_args,
       const Reducer& reducer)
       : ExprNodeBase(body->dtype()),

--- a/torch/csrc/jit/tensorexpr/reduction.h
+++ b/torch/csrc/jit/tensorexpr/reduction.h
@@ -33,8 +33,7 @@ class TORCH_API Reducer {
   Reducer(ExprHandle init, RI interaction) : init_(init.node()) {
     interaction_ = interaction;
   }
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  virtual ~Reducer() {}
+  virtual ~Reducer() = default;
 
   const Expr* initializer() const {
     return init_;
@@ -130,12 +129,11 @@ class TORCH_API ReduceOp : public ExprNode<ReduceOp> {
  public:
   ReduceOp(
       const Expr* body,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Var*>& reduce_args,
+      std::vector<const Var*> reduce_args,
       const Reducer& reducer)
       : ExprNodeBase(body->dtype()),
         body_(body),
-        reduce_args_(reduce_args),
+        reduce_args_(std::move(reduce_args)),
         reducer_(reducer) {}
 
   // return the body expression which obtains the value to be reduced.

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -201,8 +201,6 @@ void RegisterizerAnalysis::visit(const For* v) {
   // now we need to see which accesses we can hoist out of the for loop, their
   // costs should be multiplied by the loop extent.
   for (auto& pair : currentScope_->openAccesses()) {
-    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
-    const Buf* buf = pair.first;
     if (pair.second.empty()) {
       continue;
     }

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -201,6 +201,7 @@ void RegisterizerAnalysis::visit(const For* v) {
   // now we need to see which accesses we can hoist out of the for loop, their
   // costs should be multiplied by the loop extent.
   for (auto& pair : currentScope_->openAccesses()) {
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
     const Buf* buf = pair.first;
     if (pair.second.empty()) {
       continue;

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -52,12 +52,11 @@ class AccessInfo {
   AccessInfo(
       SimplifierHashType h,
       const Buf* b,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Expr*>& i,
+      std::vector<const Expr*> i,
       size_t accessOrder)
       : hash_(h),
         buf_(b),
-        indices_(i),
+        indices_(std::move(i)),
         store_cost_(new IntImm(0)),
         load_cost_(new IntImm(0)),
         accessOrder_(accessOrder) {}
@@ -219,9 +218,8 @@ using AccessHashMap =
 // Represents a scope block and holds all accesses contained within it.
 class Scope {
  public:
-  // NOLINTNEXTLINE(modernize-pass-by-value)
   Scope(const Block* b, std::shared_ptr<Scope> parent, size_t conditionId = 0)
-      : block_(b), parent_(parent), conditionId_(conditionId) {}
+      : block_(b), parent_(std::move(parent)), conditionId_(conditionId) {}
 
   AccessHashMap& getAccessMapByBuf(const Buf* b);
 
@@ -319,8 +317,7 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
  public:
   RegisterizerAnalysis()
       : currentScope_(std::make_shared<Scope>(nullptr, nullptr, 0)) {}
-  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
-  virtual ~RegisterizerAnalysis() {}
+  ~RegisterizerAnalysis() override = default;
 
   void visit(const For* v) override;
 

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -45,12 +45,14 @@ class Scope;
  buffer, including the number of loads and stores and the lowest common parent
  Block.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class AccessInfo {
  public:
   AccessInfo() = default;
   AccessInfo(
       SimplifierHashType h,
       const Buf* b,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Expr*>& i,
       size_t accessOrder)
       : hash_(h),
@@ -217,6 +219,7 @@ using AccessHashMap =
 // Represents a scope block and holds all accesses contained within it.
 class Scope {
  public:
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   Scope(const Block* b, std::shared_ptr<Scope> parent, size_t conditionId = 0)
       : block_(b), parent_(parent), conditionId_(conditionId) {}
 
@@ -316,6 +319,7 @@ class TORCH_API RegisterizerAnalysis : public IRVisitor {
  public:
   RegisterizerAnalysis()
       : currentScope_(std::make_shared<Scope>(nullptr, nullptr, 0)) {}
+  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
   virtual ~RegisterizerAnalysis() {}
 
   void visit(const For* v) override;

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -778,7 +778,10 @@ class TORCH_API ExternalCall : public StmtNode<ExternalCall> {
       std::string func_name,
       std::vector<const Buf*> buf_args,
       std::vector<const Expr*> args)
-      : buf_(buf), func_name_(std::move(func_name)), buf_args_(std::move(buf_args)), args_(std::move(args)) {}
+      : buf_(buf),
+        func_name_(std::move(func_name)),
+        buf_args_(std::move(buf_args)),
+        args_(std::move(args)) {}
 
  private:
   const Buf* buf_;

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -16,7 +16,7 @@ class Placeholder;
 // The common base between all statement node.
 class TORCH_API Stmt : public KernelScopedObject {
  public:
-  Stmt()  = default;
+  Stmt() = default;
   virtual void accept(IRVisitor* visitor) const = 0;
   virtual Stmt* accept_mutator(IRMutator* mutator) = 0;
 
@@ -635,7 +635,10 @@ class TORCH_API For : public StmtNode<For> {
       const Expr* stop,
       Stmt* body,
       LoopOptions loop_options)
-      : var_(var), start_(start), stop_(stop), loop_options_(std::move(loop_options)) {
+      : var_(var),
+        start_(start),
+        stop_(stop),
+        loop_options_(std::move(loop_options)) {
     if (!var) {
       throw malformed_input("invalid Var in For loop", var);
     } else if (!start) {
@@ -692,10 +695,7 @@ class TORCH_API For : public StmtNode<For> {
 // TODO: make IR nodes extensible.
 class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
  public:
-  AtomicAdd(
-      const Buf* buf,
-      std::vector<const Expr*> indices,
-      const Expr* value)
+  AtomicAdd(const Buf* buf, std::vector<const Expr*> indices, const Expr* value)
       : buf_(buf), indices_(std::move(indices)), value_(value) {}
 
   const Var* base_handle() const {

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -775,13 +775,10 @@ class TORCH_API ExternalCall : public StmtNode<ExternalCall> {
 
   ExternalCall(
       const Buf* buf,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::string& func_name,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Buf*>& buf_args,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Expr*>& args)
-      : buf_(buf), func_name_(func_name), buf_args_(buf_args), args_(args) {}
+      std::string func_name,
+      std::vector<const Buf*> buf_args,
+      std::vector<const Expr*> args)
+      : buf_(buf), func_name_(std::move(func_name)), buf_args_(std::move(buf_args)), args_(std::move(args)) {}
 
  private:
   const Buf* buf_;

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -16,8 +16,7 @@ class Placeholder;
 // The common base between all statement node.
 class TORCH_API Stmt : public KernelScopedObject {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  Stmt() {}
+  Stmt()  = default;
   virtual void accept(IRVisitor* visitor) const = 0;
   virtual Stmt* accept_mutator(IRMutator* mutator) = 0;
 
@@ -51,8 +50,7 @@ class StmtNode : public Stmt {
     visitor->visit(static_cast<const Op*>(this));
   }
   Stmt* accept_mutator(IRMutator* mutator) override;
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  StmtNode() {}
+  StmtNode() = default;
 };
 
 template <class Op>
@@ -636,9 +634,8 @@ class TORCH_API For : public StmtNode<For> {
       const Expr* start,
       const Expr* stop,
       Stmt* body,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const LoopOptions& loop_options)
-      : var_(var), start_(start), stop_(stop), loop_options_(loop_options) {
+      LoopOptions loop_options)
+      : var_(var), start_(start), stop_(stop), loop_options_(std::move(loop_options)) {
     if (!var) {
       throw malformed_input("invalid Var in For loop", var);
     } else if (!start) {
@@ -697,10 +694,9 @@ class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
  public:
   AtomicAdd(
       const Buf* buf,
-      // NOLINTNEXTLINE(modernize-pass-by-value)
-      const std::vector<const Expr*>& indices,
+      std::vector<const Expr*> indices,
       const Expr* value)
-      : buf_(buf), indices_(indices), value_(value) {}
+      : buf_(buf), indices_(std::move(indices)), value_(value) {}
 
   const Var* base_handle() const {
     return buf_->base_handle();
@@ -731,8 +727,7 @@ class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
 
 class TORCH_API SyncThreads : public StmtNode<SyncThreads> {
  public:
-  // NOLINTNEXTLINE(modernize-use-equals-default)
-  SyncThreads() {}
+  SyncThreads() = default;
 };
 
 /*

--- a/torch/csrc/jit/tensorexpr/stmt.h
+++ b/torch/csrc/jit/tensorexpr/stmt.h
@@ -16,6 +16,7 @@ class Placeholder;
 // The common base between all statement node.
 class TORCH_API Stmt : public KernelScopedObject {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   Stmt() {}
   virtual void accept(IRVisitor* visitor) const = 0;
   virtual Stmt* accept_mutator(IRMutator* mutator) = 0;
@@ -50,11 +51,13 @@ class StmtNode : public Stmt {
     visitor->visit(static_cast<const Op*>(this));
   }
   Stmt* accept_mutator(IRMutator* mutator) override;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   StmtNode() {}
 };
 
 template <class Op>
 Stmt* StmtNode<Op>::accept_mutator(IRMutator* mutator) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   StmtNode* this_mutable = const_cast<StmtNode*>(this);
   return mutator->mutate(static_cast<Op*>(this_mutable));
 }
@@ -472,6 +475,7 @@ class TORCH_API LoopOptions {
       throw malformed_input("Has no GPU block index");
     }
 
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static const char* kBlockIndexNames[] = {
         "blockIdx.x",
         "blockIdx.y",
@@ -514,6 +518,7 @@ class TORCH_API LoopOptions {
       throw malformed_input("has no GPU thread index");
     }
 
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static const char* kThreadIndexNames[] = {
         "threadIdx.x", "threadIdx.y", "threadIdx.z", "threadIdx.w"};
 
@@ -631,6 +636,7 @@ class TORCH_API For : public StmtNode<For> {
       const Expr* start,
       const Expr* stop,
       Stmt* body,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const LoopOptions& loop_options)
       : var_(var), start_(start), stop_(stop), loop_options_(loop_options) {
     if (!var) {
@@ -691,6 +697,7 @@ class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
  public:
   AtomicAdd(
       const Buf* buf,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Expr*>& indices,
       const Expr* value)
       : buf_(buf), indices_(indices), value_(value) {}
@@ -724,6 +731,7 @@ class TORCH_API AtomicAdd : public StmtNode<AtomicAdd> {
 
 class TORCH_API SyncThreads : public StmtNode<SyncThreads> {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   SyncThreads() {}
 };
 
@@ -772,8 +780,11 @@ class TORCH_API ExternalCall : public StmtNode<ExternalCall> {
 
   ExternalCall(
       const Buf* buf,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::string& func_name,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Buf*>& buf_args,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       const std::vector<const Expr*>& args)
       : buf_(buf), func_name_(func_name), buf_args_(buf_args), args_(args) {}
 

--- a/torch/csrc/jit/tensorexpr/tensor.h
+++ b/torch/csrc/jit/tensorexpr/tensor.h
@@ -57,6 +57,7 @@ class TORCH_API Tensor : KernelScopedObject {
   Stmt* stmt_;
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 class Placeholder {
  public:
   Placeholder() = default;

--- a/torch/csrc/jit/tensorexpr/types.cpp
+++ b/torch/csrc/jit/tensorexpr/types.cpp
@@ -42,8 +42,11 @@ AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, DTYPE_DEFINE)
 
 #undef DTYPE_DEFINE
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API Dtype kHandle(ScalarType::Handle, 1);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API Dtype kUninitialized(ScalarType::Uninitialized, 1);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TORCH_API Dtype kVoid(ScalarType::None, 1);
 
 Dtype ToDtype(ScalarType type) {

--- a/torch/csrc/jit/tensorexpr/types.h
+++ b/torch/csrc/jit/tensorexpr/types.h
@@ -90,12 +90,16 @@ class TORCH_API Dtype {
   int lanes_; // the width of the element for a vector time
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern TORCH_API Dtype kUninitialized;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern TORCH_API Dtype kHandle;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern TORCH_API Dtype kVoid;
 
 #define NNC_DTYPE_DECLARATION(ctype, name) extern TORCH_API Dtype k##name;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 AT_FORALL_SCALAR_TYPES_AND2(Bool, Half, NNC_DTYPE_DECLARATION)
 #undef NNC_DTYPE_DECLARATION
 

--- a/torch/csrc/python_headers.h
+++ b/torch/csrc/python_headers.h
@@ -1,4 +1,5 @@
 #pragma once
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <math.h>
 // workaround for Python 2 issue: https://bugs.python.org/issue17120
 // NOTE: It looks like this affects Python 3 as well.

--- a/torch/csrc/utils/memory.h
+++ b/torch/csrc/utils/memory.h
@@ -13,11 +13,14 @@ struct unique_type_for {
 };
 
 template <typename T>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 struct unique_type_for<T[]> {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   using unbounded_array = std::unique_ptr<T[]>;
 };
 
 template <typename T, size_t N>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 struct unique_type_for<T[N]> {
   using bounded_array = void;
 };

--- a/torch/csrc/utils/pybind.h
+++ b/torch/csrc/utils/pybind.h
@@ -28,6 +28,7 @@ namespace pybind11 { namespace detail {
 template <>
 struct type_caster<at::Tensor> {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(at::Tensor, _("at::Tensor"));
 
   bool load(handle src, bool) {
@@ -48,6 +49,7 @@ struct type_caster<at::Tensor> {
 template <>
 struct type_caster<at::Generator> {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(at::Generator, _("at::Generator"));
 
   bool load(handle src, bool) {
@@ -67,12 +69,14 @@ struct type_caster<at::Generator> {
 
 template<> struct type_caster<at::IntArrayRef> {
 public:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   PYBIND11_TYPE_CASTER(at::IntArrayRef, _("at::IntArrayRef"));
 
   bool load(handle src, bool) {
     PyObject *source = src.ptr();
     auto tuple = PyTuple_Check(source);
     if (tuple || PyList_Check(source)) {
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       auto size = tuple ? PyTuple_GET_SIZE(source) : PyList_GET_SIZE(source);
       v_value.resize(size);
       for (int idx = 0; idx < size; idx++) {

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -90,6 +90,7 @@ struct PythonArgs;
 template<int N>
 struct ParsedArgs {
   ParsedArgs() : args() { }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   PyObject* args[N];
 };
 
@@ -110,8 +111,10 @@ struct PythonArgParser {
 
 private:
   [[noreturn]]
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   void print_error(PyObject* self, PyObject* args, PyObject* kwargs, PyObject* parsed_args[]);
   void check_deprecated(const FunctionSignature & signature);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   PythonArgs raw_parse(PyObject* self, PyObject* args, PyObject* kwargs, PyObject* parsed_args[]);
 
   std::vector<FunctionSignature> signatures_;
@@ -123,6 +126,7 @@ private:
 struct PYBIND11_EXPORT FunctionSignature {
   explicit FunctionSignature(const std::string& fmt, int index);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   bool parse(PyObject* self, PyObject* args, PyObject* kwargs, PyObject* dst[], bool raise_exception);
 
   std::string toString() const;
@@ -228,6 +232,7 @@ struct FunctionParameter {
   // having this as a raw PyObject * will presumably leak it, but these are only held by static objects
   // anyway, and Py_Finalize can already be called when this is destructed.
   PyObject *python_name;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   at::SmallVector<PyObject *, 5> numpy_python_names;
   at::Scalar default_scalar;
   std::vector<int64_t> default_intlist;
@@ -236,6 +241,7 @@ struct FunctionParameter {
     bool default_bool;
     int64_t default_int;
     double default_double;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     double default_complex[2]; // see Scalar
     at::ScalarType default_scalartype;
     at::Layout default_layout;
@@ -293,6 +299,7 @@ inline std::vector<at::Scalar> PythonArgs::scalarlist(int i) {
   if (!args[i]) return std::vector<at::Scalar>();
   auto tuple = six::isTuple(args[i]);
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
   std::vector<at::Scalar> res(size);
   for (int idx = 0; idx < size; idx++) {
@@ -316,6 +323,7 @@ inline std::vector<at::Tensor> PythonArgs::tensorlist(int i) {
   if (!args[i]) return std::vector<at::Tensor>();
   auto tuple = six::isTuple(args[i]);
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
   std::vector<at::Tensor> res(size);
   for (int idx = 0; idx < size; idx++) {
@@ -331,6 +339,7 @@ inline torch::List<c10::optional<at::Tensor>> PythonArgs::list_of_optional_tenso
   if (!args[i]) return torch::List<c10::optional<at::Tensor>>();
   auto tuple = six::isTuple(args[i]);
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
   torch::List<c10::optional<at::Tensor>> res;
   res.reserve(size);
@@ -349,6 +358,7 @@ inline std::array<at::Tensor, N> PythonArgs::tensorlist_n(int i) {
   if (!args[i]) return res;
   auto tuple = six::isTuple(args[i]);
   THPObjectPtr arg = six::maybeAsTuple(args[i]);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg.get()) : PyList_GET_SIZE(arg.get());
   if (size != N) {
     throw TypeError("expected tuple of %d elements but got %d", N, (int)size);
@@ -374,6 +384,7 @@ inline std::vector<int64_t> PythonArgs::intlistWithDefault(int i, std::vector<in
     return std::vector<int64_t>(size, THPUtils_unpackIndex(arg));
   }
   auto tuple = PyTuple_Check(arg);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   size = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
   std::vector<int64_t> res(size);
   for (int idx = 0; idx < size; idx++) {
@@ -409,6 +420,7 @@ inline c10::OptionalArray<int64_t> PythonArgs::intlistOptional(int i) {
 inline std::vector<double> PythonArgs::getDoublelist(int i) {
   PyObject* arg = args[i];
   auto tuple = PyTuple_Check(arg);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
   std::vector<double> res(size);
   for (int idx = 0; idx < size; idx++) {
@@ -518,6 +530,7 @@ inline at::Dimname PythonArgs::dimname(int i) {
 
 inline std::vector<at::Dimname> parseDimnameList(PyObject* arg) {
   auto tuple = PyTuple_Check(arg);
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(arg) : PyList_GET_SIZE(arg);
   std::vector<at::Dimname> res;
   res.reserve(size);
@@ -624,6 +637,7 @@ inline double PythonArgs::toDoubleWithDefault(int i, double default_double) {
 }
 
 inline c10::complex<double> PythonArgs::toComplex(int i) {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
   c10::complex<double> default_value = *const_cast<c10::complex<double> *>(
     reinterpret_cast<const c10::complex<double> *>(signature.params[i].default_complex));
   if (!args[i]) return default_value;

--- a/torch/csrc/utils/python_numbers.h
+++ b/torch/csrc/utils/python_numbers.h
@@ -43,6 +43,7 @@ inline bool THPUtils_checkLong(PyObject* obj) {
 }
 
 inline int32_t THPUtils_unpackInt(PyObject* obj) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int overflow;
   long value = PyLong_AsLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
@@ -59,6 +60,7 @@ inline int32_t THPUtils_unpackInt(PyObject* obj) {
 }
 
 inline int64_t THPUtils_unpackLong(PyObject* obj) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int overflow;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {
@@ -177,6 +179,7 @@ inline bool THPUtils_unpackNumberAsBool(PyObject* obj) {
     return !(real_val == 0 && imag_val == 0);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int overflow;
   long long value = PyLong_AsLongLongAndOverflow(obj, &overflow);
   if (value == -1 && PyErr_Occurred()) {

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -24,6 +24,7 @@ inline std::string THPUtils_unpackString(PyObject* obj) {
     return std::string(PyBytes_AS_STRING(obj), size);
   }
   if (PyUnicode_Check(obj)) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Py_ssize_t size;
     const char* data = PyUnicode_AsUTF8AndSize(obj, &size);
     if (!data) {

--- a/torch/csrc/utils/variadic.h
+++ b/torch/csrc/utils/variadic.h
@@ -122,6 +122,7 @@ void apply(Function function, Ts&&... ts) {
   // according to the comma operator, it is evaluated and its result (`void`)
   // is discarded. Then the zero is evaluated and used as an element in the
   // array. The first zero ensures the array is not empty.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   int _[]{0, (function(std::forward<Ts>(ts)), 0)...};
   (void)_;
 }


### PR DESCRIPTION
Mostly auto-generated changes using
```
 python3 tools/clang_tidy.py -c build -x torch/csrc/jit/tensorexpr/eval.cpp -s
```
With following common patterns manually fixed
- Use ` = default` instead of `{}`
- deleted methods should be public
- Use pass-by-value + std::move instead of pass-by-reference+copy

