### PR TITLE
[ONNX] Support registering custom export for prim::PythonOp from torch.autograd.Function

### DIFF
--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -8,6 +8,8 @@ import caffe2.python.onnx.backend as c2
 import numpy as np
 
 from test_pytorch_onnx_caffe2 import do_export
+from test_pytorch_onnx_onnxruntime import run_model_test
+from torch.onnx.symbolic_helper import _unimplemented
 
 class TestCustomOps(unittest.TestCase):
 
@@ -50,6 +52,78 @@ class TestCustomOps(unittest.TestCase):
         caffe2_out = prepared.run(inputs=[x.cpu().numpy(), y.cpu().numpy()])
         np.testing.assert_array_equal(caffe2_out[0], model(x, y).cpu().numpy())
 
+
+class TestCustomAutogradFunction(unittest.TestCase):
+    opset_version = 9
+    keep_initializers_as_inputs = False
+    onnx_shape_inference = True
+
+    def test_symbolic(self):
+        class MyClip(torch.autograd.Function):
+
+            @staticmethod
+            def forward(ctx, input, scalar):
+                ctx.save_for_backward(input)
+                return input.clamp(min=scalar)
+
+            @staticmethod
+            def symbolic(g, input, scalar):
+                return g.op("Clip", input, min_f=scalar)
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.clip = MyClip.apply
+
+            def forward(self, x):
+                h = self.clip(x, 2)
+                return h
+
+        x = torch.randn(2, 3, 4, requires_grad=True)
+        model = MyModule()
+        run_model_test(self, model, input=(x, ))
+
+    def test_register_custom_op(self):
+        class MyClip(torch.autograd.Function):
+
+            @staticmethod
+            def forward(ctx, input, scalar):
+                ctx.save_for_backward(input)
+                return input.clamp(min=scalar)
+
+        class MyRelu(torch.autograd.Function):
+
+            @staticmethod
+            def forward(ctx, input):
+                ctx.save_for_backward(input)
+                return input.clamp(min=0)
+
+        class MyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.clip = MyClip.apply
+                self.relu = MyRelu.apply
+
+            def forward(self, x):
+                h = self.clip(x, 2)
+                h = self.relu(h)
+                return h
+
+        def symbolic_pythonop(g, n, *args, **kwargs):
+            name = kwargs['name']
+            if name == "MyClip":
+                return g.op("Clip", args[0], min_f=args[1])
+            elif name == "MyRelu":
+                return g.op("Relu", args[0])
+            else:
+                return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
+
+        from torch.onnx import register_custom_op_symbolic
+        register_custom_op_symbolic('::prim_PythonOp', symbolic_pythonop, 1)
+
+        x = torch.randn(2, 3, 4, requires_grad=True)
+        model = MyModule()
+        run_model_test(self, model, input=(x, ))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -140,8 +140,7 @@ class TestModels(TestCase):
 
     @disableScriptTest()  # None type in outputs
     def test_inception(self):
-        x = Variable(
-            torch.randn(BATCH_SIZE, 3, 299, 299) + 1.)
+        x = Variable(torch.randn(BATCH_SIZE, 3, 299, 299))
         self.exportTest(toC(inception_v3()), toC(x))
 
     def test_squeezenet(self):

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -345,10 +345,13 @@ void NodeToONNX(
     }
 
     py::object opset_version = onnx_symbolic.attr("_export_onnx_opset_version");
-    py::object is_registered_op = onnx_registry.attr("is_registered_op")("prim_PythonOp", "", opset_version);
-    if (!py::hasattr(pyobj, "symbolic") && (!PyObject_IsTrue(is_registered_op.ptr()))) {
+    py::object is_registered_op = onnx_registry.attr("is_registered_op")(
+        "prim_PythonOp", "", opset_version);
+    if (!py::hasattr(pyobj, "symbolic") &&
+        (!PyObject_IsTrue(is_registered_op.ptr()))) {
       // Simply clone the node, unless either
-      // 1. The torch.autograd.Function class of this node object has `symbolic` method defined.
+      // 1. The torch.autograd.Function class of this node object has `symbolic`
+      // method defined.
       // 2. Custom export symbolic is registered for prim::PythonOp.
       cloneNode(op);
       return;
@@ -388,7 +391,10 @@ void NodeToONNX(
       onnx_registry.attr("register_op")(
           op->name(), pyobj.attr("symbolic"), "", opset_version);
       py::object raw_output = onnx.attr("_run_symbolic_method")(
-          new_block->owningGraph(), op->name(), pyobj.attr("symbolic"), py_symbolic_args);
+          new_block->owningGraph(),
+          op->name(),
+          pyobj.attr("symbolic"),
+          py_symbolic_args);
 
       processSymbolicOutput(op->name(), op, raw_output);
     } else {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -344,8 +344,8 @@ void NodeToONNX(
       pyobj = func->get();
     }
 
-    py::object symbolic_fn = onnx_registry.attr("is_registered_op")("PythonOp", "prim", 1);
-    if (!py::hasattr(pyobj, "symbolic") && (symbolic_fn.ptr() == Py_None)) {
+    py::object is_registered_op = onnx_registry.attr("is_registered_op")("prim_PythonOp", "", 9);
+    if (!py::hasattr(pyobj, "symbolic") && (!PyObject_IsTrue(is_registered_op.ptr()))) {
       cloneNode(op);
       return;
     }
@@ -389,7 +389,7 @@ void NodeToONNX(
 
       processSymbolicOutput(op->name(), op, raw_output);
     } else {
-      TORCH_INTERNAL_ASSERT(symbolic_fn.ptr() != Py_None);
+      TORCH_INTERNAL_ASSERT(PyObject_IsTrue(is_registered_op.ptr()));
       Node* n = static_cast<Node*>(op);
       n->s_(attr::name, op->name());
       // Call symbolic function

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -343,7 +343,9 @@ void NodeToONNX(
     if (func) {
       pyobj = func->get();
     }
-    if (!py::hasattr(pyobj, "symbolic")) {
+
+    py::object symbolic_fn = onnx_registry.attr("is_registered_op")("PythonOp", "prim", 1);
+    if (!py::hasattr(pyobj, "symbolic") && (symbolic_fn.ptr() == Py_None)) {
       cloneNode(op);
       return;
     }
@@ -351,8 +353,7 @@ void NodeToONNX(
     // Prepare args for Python. First one is the graph, and is followed
     // by regular args, with Variables replaced by corresponding nodes.
     Py_ssize_t input_nr = 0;
-    py::tuple py_symbolic_args(1 + op->cconv.size());
-    py_symbolic_args[input_nr++] = py::cast(new_block->owningGraph());
+    py::tuple py_symbolic_args(op->cconv.size());
     auto inputs = op->inputs();
     auto node_it = inputs.begin();
     auto scalar_it = op->scalar_args.begin();
@@ -375,16 +376,33 @@ void NodeToONNX(
 
     WithInsertPoint insert_point_guard(new_block);
     WithCurrentScope scope_guard(*new_block->owningGraph(), op->scope());
-    // Call the symbolic function
-    // Use a little trampoline function so we can give good error messages
-    // upon argument mismatch
-    py::object opset_version = onnx_symbolic.attr("_export_onnx_opset_version");
-    onnx_registry.attr("register_op")(
-        op->name(), pyobj.attr("symbolic"), "", opset_version);
-    py::object raw_output = onnx.attr("_run_symbolic_method")(
-        op->name(), pyobj.attr("symbolic"), py_symbolic_args);
 
-    processSymbolicOutput(op->name(), op, raw_output);
+    if (py::hasattr(pyobj, "symbolic")) {
+      // Call the symbolic function
+      // Use a little trampoline function so we can give good error messages
+      // upon argument mismatch
+      py::object opset_version = onnx_symbolic.attr("_export_onnx_opset_version");
+      onnx_registry.attr("register_op")(
+          op->name(), pyobj.attr("symbolic"), "", opset_version);
+      py::object raw_output = onnx.attr("_run_symbolic_method")(
+          new_block->owningGraph(), op->name(), pyobj.attr("symbolic"), py_symbolic_args);
+
+      processSymbolicOutput(op->name(), op, raw_output);
+    } else {
+      TORCH_INTERNAL_ASSERT(symbolic_fn.ptr() != Py_None);
+      Node* n = static_cast<Node*>(op);
+      n->s_(attr::name, op->name());
+      // Call symbolic function
+      py::object raw_output = onnx.attr("_run_symbolic_function")(
+          new_block->owningGraph(),
+          new_block,
+          n,
+          py_symbolic_args,
+          env,
+          operator_export_type);
+
+      processSymbolicOutput(op->kind().toUnqualString(), n, raw_output);
+    }
   };
 
   auto k = old_node->kind();

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -462,7 +462,7 @@ void initPythonIRBindings(PyObject* module_) {
       .VS(requires_grad)
       .def(
           "requiresGrad",
-          [](Value& n) { n.type()->expectRef<TensorType>().requiresGrad(); })
+          [](Value& n) { return n.type()->expectRef<TensorType>().requiresGrad(); })
       .def("toIValue", [](Value& n) { return toIValue(&n); })
       .def("type", [](Value& v) { return v.type(); });
 #undef VS

--- a/torch/csrc/jit/python/python_ir.cpp
+++ b/torch/csrc/jit/python/python_ir.cpp
@@ -462,7 +462,9 @@ void initPythonIRBindings(PyObject* module_) {
       .VS(requires_grad)
       .def(
           "requiresGrad",
-          [](Value& n) { return n.type()->expectRef<TensorType>().requiresGrad(); })
+          [](Value& n) {
+            return n.type()->expectRef<TensorType>().requiresGrad();
+          })
       .def("toIValue", [](Value& n) { return toIValue(&n); })
       .def("type", [](Value& v) { return v.type(); });
 #undef VS

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -1041,6 +1041,8 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                 if symbolic_fn is None:
                     return None
                 attrs = {k: n[k] for k in n.attributeNames()}
+                if op_name == 'PythonOp':
+                    inputs = (n, *inputs)
                 return symbolic_fn(g, *inputs, **attrs)
 
         elif ns == "quantized":

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -757,13 +757,13 @@ def _set_input_and_output_names(graph, input_names, output_names):
 attr_pattern = re.compile("^(.+)_([ifstgz])$")
 
 
-def _run_symbolic_method(op_name, symbolic_fn, args):
+def _run_symbolic_method(g, op_name, symbolic_fn, args):
     r"""
     This trampoline function gets invoked for every symbolic method
     call from C++.
     """
     try:
-        return symbolic_fn(*args)
+        return symbolic_fn(g, *args)
     except TypeError as e:
         # Handle the specific case where we didn't successfully dispatch
         # to symbolic_fn.  Otherwise, the backtrace will have the clues


### PR DESCRIPTION
Demo script:

```python
import torch

class MyReLU(torch.autograd.Function):
    @staticmethod
    def forward(ctx, input, scalar_tuple, scalar, scalar_list):
        ctx.save_for_backward(input)
        return input.clamp(min=scalar)
    @staticmethod
    def backward(ctx, grad_output):
        input, = ctx.saved_tensors
        grad_input = grad_output.clone()
        grad_input[input < 0] = 0
        return grad_input

class MyModule(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear_a = torch.nn.Linear(2, 2)
        self.linear_b = torch.nn.Linear(2, 2)
        self.relu = MyReLU.apply
    def forward(self, x):
        h = self.linear_a(x)
        h = self.relu(h, (5, 3), 2, [1, 2, 3])
        h = self.linear_b(h)
        return h

"""
User define how to export prim::PythonOp into custom op.
"""
def symbolic_pythonop(g, n, *args, **kwargs):
    # Print information:
    print('arguments of ', kwargs['name'], ':')
    print('original node: ', n)
    for i, out in enumerate(n.outputs()):
        print('original output {}: {}, requires grad: {}'.format(i, out, out.requiresGrad()))
    import torch.onnx.symbolic_helper as sym_helper
    for i, arg in enumerate(args):
        print('arg {}: {}, requires grad: {}'.format(i, arg, arg.requiresGrad() if sym_helper._is_value(arg) else False))
    for k, v in kwargs.items():
        print('key: ', k, ' v: ', v)

    # TODO: all inputs (tensors and scalars) are in args.
    #       backend can define CustomDomain::PythonOp and how info are stored however it deem fit.
    return g.op("CustomDomain::PythonOp", args[0], name_s=kwargs['name'])

torch.onnx.register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 9)

# Define input.
x = torch.tensor([[0.3971, 0.7544],
                  [0.5695, 0.4388]], requires_grad=True)

model = MyModule()
# Forward.
y = model(x)

torch.onnx.export(model, (x,), 'model.onnx', opset_version=12, verbose=True)
```