### PR TITLE
RPC PS Benchmark

### DIFF
--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_cuda_rpc_batch_for_both_sparse_and_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_cuda_rpc_batch_for_both_sparse_and_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=8
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_cuda_rpc_for_both_sparse_and_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_cuda_rpc_for_both_sparse_and_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=7
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cpu_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cpu_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=4
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cuda_batch_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cuda_batch_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=6
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cuda_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_cuda_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=5
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_gloo_allreduce_for_both_sparse_and_dense_parameters.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_gloo_allreduce_for_both_sparse_and_dense_parameters.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=1
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_gloo_allreduce_for_sparse_nccl_allreduce_for_dense.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_gloo_allreduce_for_sparse_nccl_allreduce_for_dense.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=2
+dconfig_id=1
+mconfig_id=1
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_nccl_allreduce.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/ddp_with_nccl_allreduce.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# configuration ids
+bconfig_id=3
+dconfig_id=1
+mconfig_id=2
+
+# moves to directory and runs the benchmark with the configurations selected
+cd "$(dirname $(dirname "$0"))"
+source ./bash_experiment_scripts/helper_functions.sh
+run_benchmark_basic "$bconfig_id" "$dconfig_id" "$mconfig_id"

--- a/benchmarks/distributed/rpc/ps/bash_experiment_scripts/helper_functions.sh
+++ b/benchmarks/distributed/rpc/ps/bash_experiment_scripts/helper_functions.sh
@@ -1,0 +1,4 @@
+run_benchmark_basic() {
+    gpurun='srun -p q2 --cpus-per-task=16 -t 5:00:00 --gpus-per-node=4'
+    $gpurun python benchmark.py --bconfig_id=$1 --dconfig_id=$2 --mconfig_id=$3
+}

--- a/benchmarks/distributed/rpc/ps/benchmark.py
+++ b/benchmarks/distributed/rpc/ps/benchmark.py
@@ -5,6 +5,11 @@ import time
 import threading
 import copy
 import sys
+import json
+from pathlib import Path
+import argparse
+import pprint
+pp = pprint.PrettyPrinter(indent=4)
 
 import torch
 import torch.distributed as dist
@@ -21,13 +26,29 @@ import torch.nn.functional as F
 import torch.distributed as c10d
 import torch.distributed.rpc as rpc
 
+# --------------------------- constants -----------------------------------------
+
 GLOO = "gloo"
 NCCL = "nccl"
+SPARSE = "sparse"
+INDICES = "indices"
+VALUES = "values"
+SIZE = "size"
+GRADIENT = "gradient"
+HOOK_METRIC = "hook_metric"
+FORWARD_METRIC = "foward_metric"
+BACKWARD_METRIC = "backward_metric"
+BATCH_LEVEL_METRIC = "batch_level_metric"
+RANK = "rank"
+TRAINER_COUNT = "trainer_count"
+USE_CUDA_RPC = "use_cuda_rpc"
+BATCH_MODE = "batch_mode"
 
-# --------------------------- privates -----------------------------------------
+
+# --------------------------- basic helpers -----------------------------------------
 
 
-def _get_name(rank, world_size):
+def get_name(rank, world_size):
     if rank < world_size - 2:
         return "trainer{}".format(rank)
     elif rank == world_size - 2:
@@ -35,290 +56,405 @@ def _get_name(rank, world_size):
     else:
         return "master"
 
-
-def _call_method(method, rref, *args, **kwargs):
-    return method(rref.local_value(), *args, **kwargs)
+# --------------------------- metrics -----------------------------------------
 
 
-def _remote_method(method, rref, *args, **kwargs):
-    args = [method, rref] + list(args)
-    return rpc.rpc_async(rref.owner(), _call_method, args=args, kwargs=kwargs)
+def record_event(rank, metric_type, key, name, metrics):
+    event = torch.cuda.Event(enable_timing=True)
+    if metric_type not in metrics:
+        metrics[metric_type] = {}
+    metrics = metrics[metric_type]
+    if key in metrics:
+        assert "end" not in metrics[key]
+        metrics[key]["end"] = event
+    else:
+        metrics[key] = {
+            "name": name,
+            "start": event
+        }
+    with torch.cuda.device(rank):
+        event.record()
 
 # --------------------------- Parameter Server -----------------------------------------
 
+# TODO: fix implementation to allow for multiple gradient servers
 
-class GradientServer(nn.Module):
+class GradientServer:
 
-    def __init__(self, world_size):
-        super().__init__()
-        torch.manual_seed(0)
+    #TODO: find out how to use cuda kernel for sparse tensor addition / implement if there is no kernel
+    #TODO: metrics for computations in average_gradient
+
+    def __init__(self, rank, trainer_count, backend, use_cuda_rpc, batch_mode):
         self.lock = threading.Lock()
-        self.rank_gradient_counters = [[0] * world_size, [0] * world_size]
-        self.gradient_dicts = [{}, {}]
-        self.gradient_dim = {}
 
-    # batch processing just store the gradients
-    # trainer and server update every iteration
-    # batch case - 1 cuda kernel
-    # iteration case - n cuda kernels
+        self.rank = rank
+        self.trainer_count = trainer_count
+        self.use_cuda_rpc = use_cuda_rpc
+        self.backend = backend
+        self.batch_mode = batch_mode
 
+        self.futures = {}
+        self.gradient = {}
+        self.batch_number = 0
+
+
+    @staticmethod
     @rpc.functions.async_execution
-    def add_to_sparse_gradient(self, rank, gradient, dim):
-        gradient = gradient.cuda()
-        sparse_gradient_dict = self.gradient_dicts[0]
+    def average_gradient(gs_rref, rank, bp_loc, received_batch_number, **kwargs):
+        sparse_gradient = False
+        if SPARSE in kwargs and kwargs[SPARSE]:
+            assert INDICES in kwargs and kwargs[INDICES] is not None
+            assert VALUES in kwargs and kwargs[VALUES] is not None
+            assert SIZE in kwargs and kwargs[SIZE] is not None
+            sparse_gradient = True
+            gradient = torch.sparse_coo_tensor(kwargs[INDICES], kwargs[VALUES], kwargs[SIZE])
+        else:
+            gradient = kwargs[GRADIENT]
+        self = gs_rref.local_value()
+        gradient = gradient.cuda(self.rank)
+        fut = torch.futures.Future()
         with self.lock:
-            loc = self.rank_gradient_counter[0][rank]
-            if loc not in sparse_gradient_dict:
-                sparse_gradient_dict[loc] = gradient
-                gradient_dim[loc] = dim
+            if self.batch_number < received_batch_number[0]:
+                self.batch_number = received_batch_number[0]
+                self.clear_state()
+            if bp_loc not in self.gradient:
+                if self.batch_mode:
+                    self.gradient[bp_loc] = [gradient]
+                else:
+                    self.gradient[bp_loc] = gradient
+                self.futures[bp_loc] = [fut]
             else:
-                sparse_gradient_dict[loc] += gradient
-            self.rank_gradient_counter[0][rank] += 1
+                if self.batch_mode:
+                    self.gradient[bp_loc].append(gradient)
+                else:
+                    self.gradient[bp_loc] += gradient
+                self.futures[bp_loc].append(fut)
+            if len(self.futures[bp_loc]) == self.trainer_count:
+                if self.batch_mode:
+                    # TODO: cuda kernel
+                    bp_loc_avg = self.gradient[bp_loc][0]
+                    for i in range(1, self.trainer_count):
+                        bp_loc_avg += self.gradient[bp_loc][i]
+                else:
+                    bp_loc_avg = self.gradient[bp_loc]
+                bp_loc_avg / (1.0 * self.trainer_count)
+                if not self.use_cuda_rpc:
+                    bp_loc_avg = bp_loc_avg.cpu()
+                if sparse_gradient:
+                    if self.backend == GLOO:
+                        bp_loc_avg = bp_loc_avg.coalesce()
+                    bp_loc_avg = [bp_loc_avg._indices(), bp_loc_avg._values(), bp_loc_avg.size()]
+                for cur_fut in self.futures[bp_loc]:
+                    cur_fut.set_result(bp_loc_avg)
+                return fut
+        return fut
 
-    @rpc.functions.async_execution
-    def add_to_dense_gradient(self, rank, gradient, dim):
-        gradient = gradient.cuda()
-        dense_gradient_dict = self.gradient_dicts[1]
-        with self.lock:
-            loc = self.rank_gradient_counter[1][rank]
-            if loc not in sparse_gradient_dict:
-                dense_gradient_dict[loc] = gradient
-            else:
-                dense_gradient_dict[loc] += gradient
-            self.rank_gradient_counter[1][rank] += 1
+    def clear_state(self):
+        self.futures.clear()
+        self.gradient.clear()
 
-    @rpc.functions.async_execution
-    def get_loc_gradient(self, loc, sparse):
-        index = 0 if sparse else 1
-        with self.lock:
-            gradient_cpu = self.gradient_dict[index][loc].cpu()
-            if index == 0:
-                return gradient_cpu, self.gradient_dim[loc]
-            else:
-                return gradient_cpu
-
-    def reset_gradients(self):
-        self.gradient_dict = {}
-
+    def reset(gs_rref):
+        self = gs_rref.local_value()
+        self.futures.clear()
+        self.gradient.clear()
+        self.batch_number = 0
 
 # --------------------------- Model -----------------------------------------
 
-class MixedModel(nn.Module):
-    def __init__(self):
+
+class DummyModel(nn.Module):
+    def __init__(self, num_embeddings=4, embedding_dim=4, dense_input_size=4, dense_output_size=4, sparse=True):
         super().__init__()
-        self.embedding = nn.EmbeddingBag(4, 4, sparse=True)
-        self.fc1 = nn.Linear(4, 4)
+        self.embedding = nn.EmbeddingBag(num_embeddings, embedding_dim, sparse=sparse)
+        self.fc1 = nn.Linear(dense_input_size, dense_output_size)
 
     def forward(self, x):
         x = self.embedding(x)
         return F.softmax(self.fc1(x), dim=1)
 
+def get_model(model_id, model_config):
+    if model_id == 1:
+        return DummyModel(**model_config)
+    sys.exit("model_id not found")
+
+# --------------------------- Data -----------------------------------------
+
+
+class RandomData:
+    def __init__(self, min_val: int = 0, max_val: int = 4, batch_size: int = 4, mult: int = 2):
+        self.input = torch.randint(min_val, max_val, [batch_size, mult])
+        self.target = torch.randint(min_val, max_val, [batch_size])
+
+    def get_input_and_target(self):
+        return self.input, self.target
+
+def get_data(data_id, data_config):
+    if data_id == 1:
+        return RandomData(**data_config)
+    sys.exit("data_id not found")
+
 # --------------------------- Hooks -----------------------------------------
 
+#TODO look into refactoring this method
+def register_hook(hook_id, ddp_model, process_group, gs_rref, world_size, rank, use_cuda_rpc, futures, bp_location, batch_number, metrics):
 
-def register_ddp_with_rpc_for_sparse_and_dense_hook(ddp_model, process_group, gs_rref, world_size):
-    """
-        DDP with CUDA RPC for both sparse and dense parameters.
-        hook_id = 1
-
-    """
-    sparse_future_container = []
-    dense_future_container = []
-
-    def rpc_for_sparse_and_dense_hook(state, bucket):
-        grad = bucket.get_tensors()[0]
-        if grad.is_sparse:
-            dim = grad.sparse_dim()
-            cpu_tensor = grad.to_dense().cpu()
-            sparse_future_container.append(
-                _remote_method(
-                    GradientServer.add_to_sparse_gradient,
-                    gs_rref,
-                    rank=rank,
-                    gradient=cpu_tensor,
-                    dim=dim,
-                )
-            )
+    def get_tensors(bucket):
+        parameter_tensors = bucket.get_per_parameter_tensors()
+        parameter_tensors_count = len(parameter_tensors)
+        if parameter_tensors_count > 0:
+            return parameter_tensors
         else:
-            cpu_tensor = grad.cpu()
-            dense_future_container.append(
-                _remote_method(
-                    GradientServer.add_to_dense_gradient,
+            return [bucket.get_tensor()]        
+
+    def send_request(tensor, sparse=True, dense=False):
+
+        if use_cuda_rpc:
+            tensor = tensor.cuda(rank)
+        else:
+            tensor = tensor.cpu()
+
+        if tensor.is_sparse and sparse:
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), 
+            "sparse_rpc", metrics)
+            tensor_indices = tensor._indices()
+            tensor_values = tensor._values()
+            tensor_size = tensor.size()
+            fut = rpc.rpc_async(
+                gs_rref.owner(),
+                GradientServer.average_gradient,
+                args=(
                     gs_rref,
-                    rank=rank,
-                    gradient=cpu_tensor,
-                )
+                    rank,
+                    bp_location[0],
+                    batch_number
+                ),
+                kwargs={
+                    SPARSE: True,
+                    INDICES: tensor_indices,
+                    VALUES: tensor_values,
+                    SIZE: tensor_size})
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "sparse_rpc", metrics)
+        elif not tensor.is_sparse and dense:
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "dense_rpc", metrics)
+            fut = rpc.rpc_async(
+                gs_rref.owner(),
+                GradientServer.average_gradient,
+                args=(
+                    gs_rref, 
+                    rank,
+                    bp_location[0],
+                    batch_number
+                ),
+                kwargs={GRADIENT: tensor}
             )
-        fut = torch.futures.Future()
-        fut.set_result(bucket.get_tensors()[0])
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "dense_rpc", metrics)
+        else:
+            sys.exit("invalid request tensor={}, sparse={}, dense={}".format(tensor, sparse, dense))
         return fut
 
-    ddp_model.register_comm_hook(None, rpc_for_sparse_and_dense_hook)
+    def send_requests(bucket, sparse=True, dense=False):
+        tensors = get_tensors(bucket)
+        tensors_len = len(tensors)
+        # TODO find a method to skip sending requests during warmup
+        if batch_number[0] >= 0:
+            for i in range(tensors_len):
+                fut = send_request(tensors[tensors_len - 1 - i], sparse, dense)
+                futures.append([fut, bp_location[0]])
+                bp_location[0] += 1
 
-    return sparse_future_container, dense_future_container
-
-
-def register_dpp_with_rpc_for_sparse_nccl_allreduce_dense_hook(ddp_model, process_group, gs_rref, world_size):
-    """
-        DDP with CPU RPC for sparse parameters + NCCL AllReduce for dense parameters
-        hook_id = 2
-
-    """
-    sparse_future_container = []
-
-    def rpc_for_sparse_nccl_allreduce_dense_hook(state, bucket):
-        grad = bucket.get_tensors()[0]
-        if grad.is_sparse:
-            dim = grad.sparse_dim()
-            cpu_tensor = grad.to_dense()
-            sparse_future_container.append(
-                _remote_method(
-                    GradientServer.add_to_sparse_gradient,
-                    gs_rref,
-                    rank=rank,
-                    gradient=cpu_tensor,
-                    dim=dim,
-                )
-            )
+    if hook_id == 1:
+        def rpc_for_sparse_and_dense_hook(state, bucket):
+            send_requests(bucket, True, True)
+            # After the backward pass, we can manually synchronous sparse gradients or parameters
             fut = torch.futures.Future()
-            fut.set_result(bucket.get_tensors())
+            fut.set_result([bucket.get_tensor()])
             return fut
-        else:
-            tensors = [t / world_size for t in bucket.get_tensors()]
-            return process_group.allreduce(tensors).get_future()
-
-    ddp_model.register_comm_hook(None, rpc_for_sparse_nccl_allreduce_dense_hook)
-
-    return sparse_future_container
-
-
-def register_gloo_allreduce_for_sparse_and_nccl_allreduce_for_dense_hook(ddp_model, process_group, gs_rref, world_size):
-    pass
-
-
-def register_dpp_with_nccl_allreduce_hook(ddp_model, process_group, gs_rref, world_size):
-    """
-        DDP with NCCL ALLReduce for both sparse and dense gradients
-        hook_id = 4
-    """
-
-    def nccl_all_reduce_hook(state, bucket):
-        tensors = [t / world_size for t in bucket.get_tensors()]
-        return process_group.allreduce(tensors).get_future()
-
-    ddp_model.register_comm_hook(None, nccl_all_reduce_hook)
-
-
-def register_gloo_allreduce_hook(ddp_model, process_group, gs_rref, world_size):
-    """
-        DDP with Gloo ALLReduce for both sparse and dense gradients
-        hook_id = 5
-    """
-
-    def gloo_allreduce_hook(state, bucket):
-        work = process_group.allreduce(bucket.get_tensors())
-        work.wait()
-        fut = torch.futures.Future()
-        fut.set_result([t * world_size for t in bucket.get_tensors()])
-        return fut
-
-    ddp_model.register_comm_hook(None, gloo_allreduce_hook)
+        ddp_model.register_comm_hook(None, rpc_for_sparse_and_dense_hook)
+    elif hook_id == 2:
+        def rpc_for_sparse_nccl_allreduce_dense_hook(state, bucket):
+            tensor = bucket.get_tensor()
+            tensors_count = len(get_tensors(bucket))
+            if tensor.is_sparse:
+                send_requests(bucket, True, False)
+                # After the backward pass, we can manually synchronous sparse gradients or parameters
+                fut = torch.futures.Future()
+                fut.set_result([bucket.get_tensor()])
+                return fut
+            else:
+                tensor = [tensor / world_size]
+                record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce_dense", metrics)
+                fut=process_group.allreduce(tensor).get_future()
+                record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce_dense", metrics)
+                bp_location[0] += tensors_count
+                return fut
+        ddp_model.register_comm_hook(None, rpc_for_sparse_nccl_allreduce_dense_hook)
+    elif hook_id == 3:
+        pass
+    elif hook_id == 4:
+        def nccl_all_reduce_hook(state, bucket):
+            tensor=bucket.get_tensor()
+            tensors_count = len(get_tensors(bucket))
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce", metrics)
+            fut=process_group.allreduce(tensor).get_future()
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce", metrics)
+            bp_location[0] += tensors_count
+            return fut
+        ddp_model.register_comm_hook(None, nccl_all_reduce_hook)
+    elif hook_id == 5:
+        def gloo_allreduce_hook(state, bucket):
+            tensor = bucket.get_tensor()
+            tensors_count = len(get_tensors(bucket))
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "gloo_allreduce", metrics)
+            work=process_group.allreduce([bucket.get_tensor()])
+            work.wait()
+            fut=torch.futures.Future()
+            fut.set_result([bucket.get_tensor() / world_size])
+            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "gloo_allreduce", metrics)
+            bp_location[0] += tensors_count
+            return fut
+        ddp_model.register_comm_hook(None, gloo_allreduce_hook)
 
 # --------------------------- Run Worker -----------------------------------------
 
 
-def _run_trainer(benchmark_configurations, model, rank, gs_rref):
+def run_trainer(configurations, model, data, rank, gs_rref):
 
     torch.manual_seed(0)
     torch.cuda.set_device(rank)
     model.cuda(rank)
 
-    process_group_size = benchmark_configurations.world_size - 2
+    process_group_size=configurations.world_size - 2
 
-    store = c10d.FileStore("/tmp/tmpn_k_8so02", process_group_size)
+    store=c10d.FileStore("/tmp/tmpn_k_8so02", process_group_size)
 
-    if benchmark_configurations.backend == GLOO:
-        process_group = c10d.ProcessGroupGloo(store, rank, process_group_size)
-    else:
-        process_group = c10d.ProcessGroupNCCL(store, rank, process_group_size)
+    if configurations.backend == GLOO:
+        process_group=c10d.ProcessGroupGloo(store, rank, process_group_size)
+    elif configurations.backend == NCCL:
+        process_group=c10d.ProcessGroupNCCL(store, rank, process_group_size)
 
-    ddp_model = DDP(model, device_ids=[rank], process_group=process_group)
-    criterion = nn.CrossEntropyLoss().cuda(rank)
-    optimizer = torch.optim.SGD(model.parameters(), 1e-4)
+    ddp_model=DDP(model, device_ids=[rank], process_group=process_group)
+    criterion=nn.CrossEntropyLoss().cuda(rank)
+    optimizer=torch.optim.SGD(ddp_model.parameters(), 1e-4)
 
-    hook_gradient_futures = inverse_hook_map[benchmark_configurations.hook_id](
-        ddp_model, process_group, gs_rref, process_group_size)
+    input, target=data.get_input_and_target()
+    input=input.split(process_group_size)[rank].cuda(rank)
+    target=target.split(process_group_size)[rank].cuda(rank)
 
-    # TODO -> add data models
-    mult = 2
-    batch_size = 4
-    input = torch.randint(0, 4, [batch_size, 2]).split(mult)[rank].cuda(rank)
-    target = torch.randint(0, 4, [batch_size]).split(mult)[rank].cuda(rank)
+    hook_gradient_futures=[]
+    bp_location = [0]
+    batch_number = [-20]
+    metrics={}
 
-    for i in range(benchmark_configurations.iterations):
-        optimizer.zero_grad()
+    register_hook(
+        configurations.hook_id,
+        ddp_model,
+        process_group,
+        gs_rref,
+        process_group_size,
+        rank,
+        configurations.use_cuda_rpc,
+        hook_gradient_futures,
+        bp_location,
+        batch_number,
+        metrics
+    )
+
+    # better name?
+    def state_helper():
+        hook_gradient_futures.clear()
+        bp_location[0] = 0
+        batch_number[0] += 1
+    
+    # rpc warmup required
+    # .. warning::
+    # Since the buckets are rebuilt after the first iteration, should not rely on the indices at the beginning of training.
+    for _ in range(10):  
+        state_helper()    
         out = ddp_model(input)
-        loss = criterion(out, target)
+        loss=criterion(out, target)
         loss.backward()
+        for fut, bp_loc in hook_gradient_futures:
+            gradient=fut.wait()  
+                 
+    if rank == 0:
+        rpc.rpc_sync(gs_rref.owner(),GradientServer.reset, args=(gs_rref,))     
+    batch_number[0] = 0
+    metrics.clear()
+    process_group.barrier()
 
-        if hook_gradient_futures is not None:
-            for gradient_futures in hook_gradient_futures:
-                for fut in gradient_futures:
-                    fut.wait()
-            process_group.barrier()
-            sparse_loc = 0
-            dense_loc = 0
-            for param in ddp_model.parameters():
-                if param.grad.is_sparse:
-                    gradient_value, dim = _remote_method(
-                        GradientServer.get_loc_gradient, gs_rref, loc=sparse_loc, sparse=True
-                    ).wait()
-                    gradient_value /= (1.0 * process_group_size)
-                    gradient_value = gradient_value.to_sparse(dim)
-                    gradient_value = gradient_value.cuda(rank)
-                    param.grad = gradient_value
-                    sparse_loc += 1
-                elif len(hook_gradient_futures) > 1:
-                    gradient_value = _remote_method(
-                        GradientServer.get_loc_gradient, gs_rref, loc=dense_loc, sparse=False
-                    ).wait()
-                    gradient_value /= (1.0 * process_group_size)
-                    gradient_value = gradient_value.cuda(rank)
-                    param.grad = gradient_value
-                    dense_loc += 1
 
-        # batch processing ?
+    ddp_model_parameters=list(ddp_model.parameters())
+    ddp_model_parameters_len=len(ddp_model_parameters)
 
+    for i in range(configurations.iterations):
+        state_helper()    
+
+        record_event(rank, BATCH_LEVEL_METRIC, i, "batch_all", metrics)
+
+        optimizer.zero_grad()
+
+        record_event(rank, FORWARD_METRIC, i, "forward_pass", metrics)
+        out=ddp_model(input)
+        record_event(rank, FORWARD_METRIC, i, "forward_pass", metrics)
+
+        loss=criterion(out, target)
+
+        record_event(rank, BACKWARD_METRIC, i, "backward", metrics)
+        loss.backward()
+        record_event(rank, BACKWARD_METRIC, i, "backward", metrics)
+        
+        for fut, bp_loc in hook_gradient_futures:
+            gradient=fut.wait()
+            if isinstance(gradient, list):
+                indices=gradient[0].cuda(rank)
+                values=gradient[1].cuda(rank)
+                size=gradient[2]
+                gradient=torch.sparse_coo_tensor(indices, values, size)
+            gradient=gradient.cuda(rank)
+            ddp_model_parameters[bp_loc].grad=gradient
+            
         optimizer.step()
+
+        record_event(rank, BATCH_LEVEL_METRIC, i, "batch_all", metrics)
+
+    # need to add formatting
+    # visualization option ? print to file option?
+    # pp.pprint("rank={}, metrics={}".format(rank, metrics))
 
 # --------------------------- Run Benchmark -----------------------------------------
 
 
-def run_benchmark(rank, model, benchmark_configurations):
-    world_size = benchmark_configurations.world_size
+def run_benchmark(rank, model, data, configurations):
+    world_size=configurations.world_size
     assert world_size > 2
-    os.environ['MASTER_ADDR'] = 'localhost'
-    os.environ['MASTER_PORT'] = '29500'
-    rpc_backend_options = TensorPipeRpcBackendOptions()
-    rpc_backend_options.init_method = 'tcp://localhost:29501'
+    os.environ['MASTER_ADDR']='localhost'
+    os.environ['MASTER_PORT']='29500'
+    rpc_backend_options=TensorPipeRpcBackendOptions()
+    rpc_backend_options.init_method='tcp://localhost:29501'
     if rank == world_size - 1:
         rpc.init_rpc(
-            _get_name(rank, world_size),
+            get_name(rank, world_size),
             rank=rank,
             world_size=world_size,
             rpc_backend_options=rpc_backend_options
         )
-        gs_rref = rpc.remote(
-            _get_name(world_size - 2, world_size),
+        gs_rref=rpc.remote(
+            get_name(world_size - 2, world_size),
             GradientServer,
-            [world_size - 2],
+            args=(
+                world_size-2, 
+                world_size-2, 
+                configurations.use_cuda_rpc, 
+                configurations.backend,
+                configurations.batch_mode
+            )
         )
-        futs = [
+        futs=[
             rpc.rpc_async(
-                _get_name(trainer_rank, world_size),
-                _run_trainer,
+                get_name(trainer_rank, world_size),
+                run_trainer,
                 [
-                    benchmark_configurations, copy.deepcopy(model), trainer_rank, gs_rref
+                    configurations, copy.deepcopy(model), copy.deepcopy(data), trainer_rank, gs_rref
                 ]
             )
             for trainer_rank in range(0, world_size - 2)
@@ -327,16 +463,16 @@ def run_benchmark(rank, model, benchmark_configurations):
             fut.wait()
     elif rank == world_size - 2:
         rpc.init_rpc(
-            _get_name(rank, world_size),
+            get_name(rank, world_size),
             rank=rank,
             world_size=world_size,
             rpc_backend_options=rpc_backend_options
         )
     else:
-        if benchmark_configurations.use_rpc_cuda:
-            rpc_backend_options.set_device_map(_get_name(world_size - 2, world_size), {rank: world_size - 2})
+        if configurations.use_cuda_rpc:
+            rpc_backend_options.set_device_map(get_name(world_size - 2, world_size), {rank: world_size - 2})
         rpc.init_rpc(
-            _get_name(rank, world_size),
+            get_name(rank, world_size),
             rank=rank,
             world_size=world_size,
             rpc_backend_options=rpc_backend_options
@@ -346,39 +482,81 @@ def run_benchmark(rank, model, benchmark_configurations):
 # --------------------------- Main -----------------------------------------
 
 
-inverse_hook_map = {
-    1: register_ddp_with_rpc_for_sparse_and_dense_hook,
-    2: register_dpp_with_rpc_for_sparse_nccl_allreduce_dense_hook,
-    3: register_gloo_allreduce_for_sparse_and_nccl_allreduce_for_dense_hook,
-    4: register_dpp_with_nccl_allreduce_hook,
-    5: register_gloo_allreduce_hook
-}
+class Configurations:
+    def __init__(
+        self,
+        hook_id: int,
+        backend: str = GLOO,
+        ddp_trainers: int=1,
+        iterations: int=2,
+        batch_mode: bool=False,
+        use_cuda_rpc: bool=False,
+    ):
+        backend=backend.lower()
+        assert backend == GLOO or backend == NCCL
+        assert hook_id > 0 and hook_id < 6
+        assert iterations > 0
+
+        self.backend=backend
+        self.batch_mode=batch_mode
+        self.hook_id=hook_id
+        self.iterations=iterations
+        self.world_size=ddp_trainers + 2
+        self.use_cuda_rpc=use_cuda_rpc
 
 
-class BenchmarkConfigurations:
-    backend = GLOO
-    batch_rpc = False
-    batch_size = 1
-    hook_id = 1
-    iterations = 1
-    use_rpc_cuda = False
-    world_size = 4
+def main():
+    parser=argparse.ArgumentParser(description="RPC PS Benchmark")
+    parser.add_argument(
+        "--bconfig_id",
+        type=str,
+        default="1"
+    )
+    parser.add_argument(
+        "--dconfig_id",
+        type=str,
+        default="1"
+    )
+    parser.add_argument(
+        "--mconfig_id",
+        type=str,
+        default="1"
+        
+    )
+    args=parser.parse_args()
+
+    benchmark_config=json.load(
+        open(
+            os.path.join(Path(__file__).parent, "configurations/benchmark_configurations.json"), "r"
+        )
+    )[args.bconfig_id]
+    configurations=Configurations(**benchmark_config)
+
+    data_config=json.load(
+        open(
+            os.path.join(Path(__file__).parent, "configurations/data_configurations.json"), "r"
+        )
+    )[args.dconfig_id]
+    data=get_data(data_config["data_id"], data_config["configurations"])
+
+    model_config=json.load(
+        open(
+            os.path.join(Path(__file__).parent, "configurations/model_configurations.json"), "r"
+        )
+    )[args.mconfig_id]
+    model=get_model(model_config["model_id"], model_config["configurations"])
+
+    print("{}\nbconfig_id={}\ndconfig_id={}\nmconfig_id={}\n".format(parser.description, args.bconfig_id, args.dconfig_id, args.mconfig_id))
+
+    start=time.time()
+    mp.spawn(
+        run_benchmark,
+        [model, data, configurations],
+        nprocs=configurations.world_size,
+        join=True
+    )
+    print("\nbenchmark done {}".format(time.time() - start))
 
 
 if __name__ == "__main__":
-
-    benchmark_configurations = BenchmarkConfigurations()
-    benchmark_configurations.world_size = 4
-    benchmark_configurations.use_rpc_cuda = False
-    benchmark_configurations.backend = GLOO
-    benchmark_configurations.hook_id = 5
-
-    start = time.time()
-    mp.spawn(
-        run_benchmark,
-        [MixedModel(), benchmark_configurations],
-        nprocs=benchmark_configurations.world_size,
-        join=True
-    )
-    print(time.time() - start)
-
+    main()

--- a/benchmarks/distributed/rpc/ps/benchmark.py
+++ b/benchmarks/distributed/rpc/ps/benchmark.py
@@ -1,36 +1,25 @@
-from functools import wraps
-import os
-import random
-import time
-import threading
-import copy
-import sys
-import json
-from pathlib import Path
 import argparse
-import pprint
-pp = pprint.PrettyPrinter(indent=4)
-
+import copy
+import json
+import os
+import statistics
+import sys
+import threading
+from pathlib import Path
+import pandas as pd
 import torch
-import torch.distributed as dist
-import torch.distributed.autograd as dist_autograd
-from torch.distributed.optim import DistributedOptimizer
-import torch.distributed.rpc as rpc
-from torch.distributed.rpc import RRef
-from torch.distributed.rpc import TensorPipeRpcBackendOptions
-import torch.multiprocessing as mp
-from torch.nn.parallel import DistributedDataParallel as DDP
-import torch.optim as optim
-import torch.nn as nn
-import torch.nn.functional as F
 import torch.distributed as c10d
 import torch.distributed.rpc as rpc
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.nn.functional as F
+from tabulate import tabulate
+from torch.distributed.rpc import TensorPipeRpcBackendOptions
+from torch.nn.parallel import DistributedDataParallel as DDP
 
-# --------------------------- constants -----------------------------------------
 
 GLOO = "gloo"
 NCCL = "nccl"
-SPARSE = "sparse"
 INDICES = "indices"
 VALUES = "values"
 SIZE = "size"
@@ -39,24 +28,42 @@ HOOK_METRIC = "hook_metric"
 FORWARD_METRIC = "foward_metric"
 BACKWARD_METRIC = "backward_metric"
 BATCH_LEVEL_METRIC = "batch_level_metric"
+GRADIENT_SERVER_BATCH_METRIC = "gradient_server_batch_metric"
+GRADIENT_SERVER_STRAGGLER_METRIC = "gradient_server_straggler_metric"
 RANK = "rank"
 TRAINER_COUNT = "trainer_count"
 USE_CUDA_RPC = "use_cuda_rpc"
 BATCH_MODE = "batch_mode"
+CUDA_SPARSE_RPC = "cuda_sparse_rpc"
+CPU_SPARSE_RPC = "cpu_sparse_rpc"
+CUDA_DENSE_RPC = "cuda_dense_rpc"
+CPU_DENSE_RPC = "cpu_dense_rpc"
+NCCL_ALLREDUCE_DENSE = "nccl_allreduce_dense"
+NCCL_ALLREDUCE = "nccl_allreduce"
+GLOO_ALLREDUCE = "gloo_allreduce"
+BATCH_ALL = "batch_all"
+FORWARD_PASS = "forward_pass"
+BACKWARD = "backward"
+BP_LOC_STRAGGLER = "bp_loc_straggler"
+BP_LOC_BATCH = "bp_loc_batch"
 
 
-# --------------------------- basic helpers -----------------------------------------
-
-
-def get_name(rank, world_size):
-    if rank < world_size - 2:
+def get_name(rank, ddp_trainers, gradient_servers):
+    if rank < ddp_trainers:
         return "trainer{}".format(rank)
-    elif rank == world_size - 2:
-        return "gs"
+    elif rank < (ddp_trainers + gradient_servers):
+        return "gs{}".format(rank)
     else:
         return "master"
 
-# --------------------------- metrics -----------------------------------------
+
+def gs_for_rank(rank, configurations):
+    if (configurations.ddp_trainers % configurations.gradient_servers) != 0:
+        gs_rank = rank % configurations.gradient_servers
+    else:
+        x = int(configurations.ddp_trainers / configurations.gradient_servers)
+        gs_rank = int(rank / x)
+    return gs_rank + configurations.ddp_trainers
 
 
 def record_event(rank, metric_type, key, name, metrics):
@@ -65,7 +72,6 @@ def record_event(rank, metric_type, key, name, metrics):
         metrics[metric_type] = {}
     metrics = metrics[metric_type]
     if key in metrics:
-        assert "end" not in metrics[key]
         metrics[key]["end"] = event
     else:
         metrics[key] = {
@@ -75,49 +81,203 @@ def record_event(rank, metric_type, key, name, metrics):
     with torch.cuda.device(rank):
         event.record()
 
-# --------------------------- Parameter Server -----------------------------------------
+# TODO: clean up metric processing
 
-# TODO: fix implementation to allow for multiple gradient servers
+
+def process_metrics_for_elapsed_time(metrics):
+    # cannot pickle 'Event' object
+    metrics_processed = {}
+    for metric_type in metrics.keys():
+        metrics_processed[metric_type] = {}
+        for metric_key in metrics[metric_type].keys():
+            name = metrics[metric_type][metric_key]["name"]
+            start = metrics[metric_type][metric_key]["start"]
+            end = metrics[metric_type][metric_key]["end"]
+            elapsed_time = start.elapsed_time(end)
+            metrics_processed[metric_type][metric_key] = {
+                "name": name,
+                "elapsed_time": elapsed_time
+            }
+    return metrics_processed
+
+
+def print_rank_totals(rank_type, rank_totals, file_name, print_metrics_to_dir):
+    df = pd.DataFrame(
+        columns=['name', 'min', 'max', 'mean', 'variance', 'stdev']
+    )
+    totals = {}
+    for rank in rank_totals:
+        for key in sorted(rank.keys()):
+            if key not in totals:
+                totals[key] = rank[key]
+            else:
+                totals[key] += rank[key]
+
+    for key, values in totals.items():
+        row = {
+            "name": key,
+            "min": min(values),
+            "max": max(values),
+            "mean": statistics.mean(values),
+            "variance": statistics.variance(values),
+            "stdev": statistics.stdev(values)
+        }
+        df = df.append(row, ignore_index=True)
+    print("metrics for {}".format(rank_type))
+    print(tabulate(df, showindex=False, headers=df.columns, tablefmt="grid"))
+    if print_metrics_to_dir:
+        file_name = "data_frames/{}__{}.csv".format(rank_type, file_name)
+        df.to_csv(file_name, encoding='utf-8', index=False)
+
+
+def get_rank_totals_and_print(
+    rank_type, rank_metrics, file_name, print_metrics_to_dir
+):
+    rank = rank_metrics[0]
+    metrics = rank_metrics[1]
+    df = pd.DataFrame(
+        columns=['name', 'min', 'max', 'mean', 'variance', 'stdev']
+    )
+    rank_totals = {}
+    for metric_type in sorted(metrics.keys()):
+        values = []
+        name = None
+        for metric_key in sorted(metrics[metric_type].keys()):
+            metric = metrics[metric_type][metric_key]
+            values.append(metric["elapsed_time"])
+            name = metric["name"]
+        rank_totals[name] = values
+        row = {
+            "name": name,
+            "min": min(values),
+            "max": max(values),
+            "mean": statistics.mean(values),
+            "variance": statistics.variance(values),
+            "stdev": statistics.stdev(values)
+        }
+        df = df.append(row, ignore_index=True)
+    print("metrics for {}={}".format(rank_type, rank))
+    print(tabulate(df, showindex=False, headers=df.columns, tablefmt="grid"))
+    if print_metrics_to_dir:
+        file_name = "data_frames/{}_{}__{}.csv".format(
+            rank_type, rank, file_name
+        )
+        df.to_csv(file_name, encoding='utf-8', index=False)
+    return rank_totals
+
 
 class GradientServer:
 
-    #TODO: find out how to use cuda kernel for sparse tensor addition / implement if there is no kernel
-    #TODO: metrics for computations in average_gradient
+    # TODO: cuda sparse kernel
+    """
+        rank - the process number of the gradient server in the world
 
-    def __init__(self, rank, trainer_count, backend, use_cuda_rpc, batch_mode):
+        gradient_servers - the number of processes running gradient
+        servers in the world
+
+        ddp_trainers - the number of processes running ddp_trainers
+        in the world
+
+        backend - the communication backend selected for distributed
+        training
+
+        use_cuda_rpc - indicates that the RPC should be using Cuda or CPU
+
+        batch_mode - indicates if the gradient server should be waiting to
+        sum all gradients at once to reduce Cuda kernel calls
+    """
+    def __init__(
+        self,
+        rank,
+        gradient_servers,
+        ddp_trainers,
+        use_cuda_rpc,
+        backend,
+        batch_mode
+    ):
         self.lock = threading.Lock()
-
         self.rank = rank
-        self.trainer_count = trainer_count
+        self.gradient_servers = gradient_servers
+        self.ddp_trainers = ddp_trainers
+        self.trainer_count = ddp_trainers / gradient_servers
+        remainder = (ddp_trainers % gradient_servers) != 0
+        add = (rank - ddp_trainers + 1) <= (ddp_trainers % gradient_servers)
+        if remainder and add:
+            self.trainer_count += 1
         self.use_cuda_rpc = use_cuda_rpc
         self.backend = backend
         self.batch_mode = batch_mode
-
         self.futures = {}
         self.gradient = {}
         self.batch_number = 0
+        self.metrics = {}
 
+    def clear_batch_state(self):
+        self.futures.clear()
+        self.gradient.clear()
 
+    def average_gradient_bp_key(self, bp_loc):
+        return "{},{}".format(self.batch_number, bp_loc)
+
+    """
+        gs_rref - the shared pointer to the gradient server assigned
+            to the rank
+
+        rank - the process number in the world
+
+        received_batch_number - ddp_trainer batch number
+
+        backend - the communication backend selected for distributed training
+
+        use_cuda_rpc - indicates that the RPC should be using Cuda or CPU
+
+        batch_mode - indicates if the gradient server should
+            sum all gradients at once to reduce Cuda kernel calls
+    """
     @staticmethod
     @rpc.functions.async_execution
-    def average_gradient(gs_rref, rank, bp_loc, received_batch_number, **kwargs):
-        sparse_gradient = False
-        if SPARSE in kwargs and kwargs[SPARSE]:
-            assert INDICES in kwargs and kwargs[INDICES] is not None
-            assert VALUES in kwargs and kwargs[VALUES] is not None
-            assert SIZE in kwargs and kwargs[SIZE] is not None
-            sparse_gradient = True
-            gradient = torch.sparse_coo_tensor(kwargs[INDICES], kwargs[VALUES], kwargs[SIZE])
-        else:
+    def average_gradient(
+        gs_rref,
+        rank,
+        received_batch_number,
+        bp_loc,
+        **kwargs
+    ):
+        sparse_gradient = INDICES in kwargs
+        if not sparse_gradient:
             gradient = kwargs[GRADIENT]
+        else:
+            gradient = torch.sparse_coo_tensor(
+                kwargs[INDICES],
+                kwargs[VALUES],
+                kwargs[SIZE]
+            )
         self = gs_rref.local_value()
         gradient = gradient.cuda(self.rank)
         fut = torch.futures.Future()
         with self.lock:
-            if self.batch_number < received_batch_number[0]:
-                self.batch_number = received_batch_number[0]
-                self.clear_state()
+            if self.batch_number < received_batch_number:
+                self.batch_number = received_batch_number
+                self.clear_batch_state()
             if bp_loc not in self.gradient:
+                record_event(
+                    self.rank,
+                    GRADIENT_SERVER_STRAGGLER_METRIC,
+                    self.average_gradient_bp_key(
+                        self.batch_number
+                    ),
+                    BP_LOC_STRAGGLER,
+                    self.metrics
+                )
+                record_event(
+                    self.rank,
+                    GRADIENT_SERVER_BATCH_METRIC,
+                    self.average_gradient_bp_key(
+                        self.batch_number
+                    ),
+                    BP_LOC_BATCH,
+                    self.metrics
+                )
                 if self.batch_mode:
                     self.gradient[bp_loc] = [gradient]
                 else:
@@ -130,6 +290,15 @@ class GradientServer:
                     self.gradient[bp_loc] += gradient
                 self.futures[bp_loc].append(fut)
             if len(self.futures[bp_loc]) == self.trainer_count:
+                record_event(
+                    self.rank,
+                    GRADIENT_SERVER_STRAGGLER_METRIC,
+                    self.average_gradient_bp_key(
+                        self.batch_number
+                    ),
+                    BP_LOC_STRAGGLER,
+                    self.metrics
+                )
                 if self.batch_mode:
                     # TODO: cuda kernel
                     bp_loc_avg = self.gradient[bp_loc][0]
@@ -143,178 +312,226 @@ class GradientServer:
                 if sparse_gradient:
                     if self.backend == GLOO:
                         bp_loc_avg = bp_loc_avg.coalesce()
-                    bp_loc_avg = [bp_loc_avg._indices(), bp_loc_avg._values(), bp_loc_avg.size()]
+                    bp_loc_avg = [
+                        bp_loc_avg._indices(),
+                        bp_loc_avg._values(),
+                        bp_loc_avg.size()
+                    ]
                 for cur_fut in self.futures[bp_loc]:
                     cur_fut.set_result(bp_loc_avg)
+                record_event(
+                    self.rank,
+                    GRADIENT_SERVER_BATCH_METRIC,
+                    self.average_gradient_bp_key(
+                        self.batch_number
+                    ),
+                    BP_LOC_BATCH,
+                    self.metrics
+                )
                 return fut
         return fut
 
-    def clear_state(self):
-        self.futures.clear()
-        self.gradient.clear()
+    def rpc_warmup_call(tensor):
+        return tensor
 
     def reset(gs_rref):
         self = gs_rref.local_value()
-        self.futures.clear()
-        self.gradient.clear()
+        self.clear_batch_state()
         self.batch_number = 0
 
-# --------------------------- Model -----------------------------------------
+    def get_metrics(gs_rref):
+        self = gs_rref.local_value()
+        torch.cuda.synchronize(self.rank)
+        return [self.rank, process_metrics_for_elapsed_time(self.metrics)]
 
 
-class DummyModel(nn.Module):
-    def __init__(self, num_embeddings=4, embedding_dim=4, dense_input_size=4, dense_output_size=4, sparse=True):
-        super().__init__()
-        self.embedding = nn.EmbeddingBag(num_embeddings, embedding_dim, sparse=sparse)
-        self.fc1 = nn.Linear(dense_input_size, dense_output_size)
+class HookState():
+    def __init__(
+        self,
+        rank,
+        process_group,
+        process_group_size,
+        use_cuda_rpc,
+        gs_rref,
+        batch_number,
+        bp_location,
+        hook_gradient_futures,
+        metrics
+    ):
+        self.rank = rank
+        self.process_group = process_group
+        self.process_group_size = process_group_size
+        self.use_cuda_rpc = use_cuda_rpc
+        self.gs_rref = gs_rref
+        self.batch_number = batch_number
+        self.bp_location = bp_location
+        self.hook_gradient_futures = hook_gradient_futures
+        self.metrics = metrics
 
-    def forward(self, x):
-        x = self.embedding(x)
-        return F.softmax(self.fc1(x), dim=1)
-
-def get_model(model_id, model_config):
-    if model_id == 1:
-        return DummyModel(**model_config)
-    sys.exit("model_id not found")
-
-# --------------------------- Data -----------------------------------------
+    def next_batch_state(self):
+        self.bp_location = 0
+        self.batch_number += 1
+        self.hook_gradient_futures = []
 
 
-class RandomData:
-    def __init__(self, min_val: int = 0, max_val: int = 4, batch_size: int = 4, mult: int = 2):
-        self.input = torch.randint(min_val, max_val, [batch_size, mult])
-        self.target = torch.randint(min_val, max_val, [batch_size])
+def hook_metric_key(state):
+    return "{},{}".format(state.batch_number, state.bp_location)
 
-    def get_input_and_target(self):
-        return self.input, self.target
 
-def get_data(data_id, data_config):
-    if data_id == 1:
-        return RandomData(**data_config)
-    sys.exit("data_id not found")
+def get_tensors(bucket):
+    parameter_tensors = bucket.get_per_parameter_tensors()
+    parameter_tensors_count = len(parameter_tensors)
+    if parameter_tensors_count > 0:
+        return parameter_tensors
+    else:
+        return [bucket.get_tensor()]
 
-# --------------------------- Hooks -----------------------------------------
 
-#TODO look into refactoring this method
-def register_hook(hook_id, ddp_model, process_group, gs_rref, world_size, rank, use_cuda_rpc, futures, bp_location, batch_number, metrics):
+def send_request_rpc(state, tensor, rpc_type, kwargs):
+    tensor = tensor.cuda(state.rank) if state.use_cuda_rpc else tensor.cpu()
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        rpc_type,
+        state.metrics
+    )
+    fut = rpc.rpc_async(
+        state.gs_rref.owner(),
+        GradientServer.average_gradient,
+        args=(
+            state.gs_rref,
+            state.rank,
+            state.batch_number,
+            state.bp_location
+        ),
+        kwargs=kwargs
+    )
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        rpc_type,
+        state.metrics
+    )
+    return fut
 
-    def get_tensors(bucket):
-        parameter_tensors = bucket.get_per_parameter_tensors()
-        parameter_tensors_count = len(parameter_tensors)
-        if parameter_tensors_count > 0:
-            return parameter_tensors
+
+def send_requests(state, bucket):
+    tensors = get_tensors(bucket)
+    tensors_len = len(tensors)
+    for i in range(tensors_len):
+        tensor = tensors[tensors_len - i - 1]
+        kwargs = {}
+        if tensor.is_sparse:
+            kwargs[INDICES] = tensor._indices()
+            kwargs[VALUES] = tensor._values()
+            kwargs[SIZE] = tensor.size()
+            if state.use_cuda_rpc:
+                rpc_type = CUDA_SPARSE_RPC
+            else:
+                rpc_type = CPU_SPARSE_RPC
+                kwargs[INDICES] = kwargs[INDICES].cpu()
+                kwargs[VALUES] = kwargs[VALUES].cpu()
         else:
-            return [bucket.get_tensor()]        
+            kwargs[GRADIENT] = tensor
+            if state.use_cuda_rpc:
+                rpc_type = CUDA_DENSE_RPC
+            else:
+                rpc_type = CPU_DENSE_RPC
+                kwargs[GRADIENT] = kwargs[GRADIENT].cpu()
+        # Since the buckets are rebuilt after the first iteration,
+        # should not rely on the indices at the beginning of training.
+        if state.batch_number > 0:
+            fut = send_request_rpc(state, tensor, rpc_type, kwargs)
+            state.hook_gradient_futures.append([fut, state.bp_location])
+        state.bp_location += 1
 
-    def send_request(tensor, sparse=True, dense=False):
 
-        if use_cuda_rpc:
-            tensor = tensor.cuda(rank)
-        else:
-            tensor = tensor.cpu()
+def gradient_server_hook(state, bucket):
+    send_requests(state, bucket)
+    # After the backward pass,
+    # we can manually synchronous sparse gradients or parameters
+    fut = torch.futures.Future()
+    fut.set_result([bucket.get_tensor()])
+    return fut
 
-        if tensor.is_sparse and sparse:
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), 
-            "sparse_rpc", metrics)
-            tensor_indices = tensor._indices()
-            tensor_values = tensor._values()
-            tensor_size = tensor.size()
-            fut = rpc.rpc_async(
-                gs_rref.owner(),
-                GradientServer.average_gradient,
-                args=(
-                    gs_rref,
-                    rank,
-                    bp_location[0],
-                    batch_number
-                ),
-                kwargs={
-                    SPARSE: True,
-                    INDICES: tensor_indices,
-                    VALUES: tensor_values,
-                    SIZE: tensor_size})
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "sparse_rpc", metrics)
-        elif not tensor.is_sparse and dense:
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "dense_rpc", metrics)
-            fut = rpc.rpc_async(
-                gs_rref.owner(),
-                GradientServer.average_gradient,
-                args=(
-                    gs_rref, 
-                    rank,
-                    bp_location[0],
-                    batch_number
-                ),
-                kwargs={GRADIENT: tensor}
-            )
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "dense_rpc", metrics)
-        else:
-            sys.exit("invalid request tensor={}, sparse={}, dense={}".format(tensor, sparse, dense))
+
+def gradient_server_sparse_and_nccl_allreduce_dense_hook(state, bucket):
+    tensor = bucket.get_tensor()
+    tensors_count = len(get_tensors(bucket))
+    if tensor.is_sparse:
+        send_requests(state, bucket)
+        # After the backward pass,
+        # we can manually synchronous sparse gradients or parameters
+        fut = torch.futures.Future()
+        fut.set_result([bucket.get_tensor()])
+        return fut
+    else:
+        tensor = [tensor / state.process_group_size]
+        record_event(
+            state.rank,
+            HOOK_METRIC,
+            hook_metric_key(state),
+            NCCL_ALLREDUCE_DENSE,
+            state.metrics
+        )
+        fut = state.process_group.allreduce(tensor).get_future()
+        record_event(
+            state.rank,
+            HOOK_METRIC,
+            hook_metric_key(state),
+            NCCL_ALLREDUCE_DENSE,
+            state.metrics
+        )
+        state.bp_location += tensors_count
         return fut
 
-    def send_requests(bucket, sparse=True, dense=False):
-        tensors = get_tensors(bucket)
-        tensors_len = len(tensors)
-        # TODO find a method to skip sending requests during warmup
-        if batch_number[0] >= 0:
-            for i in range(tensors_len):
-                fut = send_request(tensors[tensors_len - 1 - i], sparse, dense)
-                futures.append([fut, bp_location[0]])
-                bp_location[0] += 1
 
-    if hook_id == 1:
-        def rpc_for_sparse_and_dense_hook(state, bucket):
-            send_requests(bucket, True, True)
-            # After the backward pass, we can manually synchronous sparse gradients or parameters
-            fut = torch.futures.Future()
-            fut.set_result([bucket.get_tensor()])
-            return fut
-        ddp_model.register_comm_hook(None, rpc_for_sparse_and_dense_hook)
-    elif hook_id == 2:
-        def rpc_for_sparse_nccl_allreduce_dense_hook(state, bucket):
-            tensor = bucket.get_tensor()
-            tensors_count = len(get_tensors(bucket))
-            if tensor.is_sparse:
-                send_requests(bucket, True, False)
-                # After the backward pass, we can manually synchronous sparse gradients or parameters
-                fut = torch.futures.Future()
-                fut.set_result([bucket.get_tensor()])
-                return fut
-            else:
-                tensor = [tensor / world_size]
-                record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce_dense", metrics)
-                fut=process_group.allreduce(tensor).get_future()
-                record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce_dense", metrics)
-                bp_location[0] += tensors_count
-                return fut
-        ddp_model.register_comm_hook(None, rpc_for_sparse_nccl_allreduce_dense_hook)
-    elif hook_id == 3:
-        pass
-    elif hook_id == 4:
-        def nccl_all_reduce_hook(state, bucket):
-            tensor=bucket.get_tensor()
-            tensors_count = len(get_tensors(bucket))
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce", metrics)
-            fut=process_group.allreduce(tensor).get_future()
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "nccl_allreduce", metrics)
-            bp_location[0] += tensors_count
-            return fut
-        ddp_model.register_comm_hook(None, nccl_all_reduce_hook)
-    elif hook_id == 5:
-        def gloo_allreduce_hook(state, bucket):
-            tensor = bucket.get_tensor()
-            tensors_count = len(get_tensors(bucket))
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "gloo_allreduce", metrics)
-            work=process_group.allreduce([bucket.get_tensor()])
-            work.wait()
-            fut=torch.futures.Future()
-            fut.set_result([bucket.get_tensor() / world_size])
-            record_event(rank, HOOK_METRIC, "{},{}".format(batch_number[0],bp_location[0]), "gloo_allreduce", metrics)
-            bp_location[0] += tensors_count
-            return fut
-        ddp_model.register_comm_hook(None, gloo_allreduce_hook)
+def nccl_allreduce_hook(state, bucket):
+    tensor = bucket.get_tensor()
+    tensors_count = len(get_tensors(bucket))
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        NCCL_ALLREDUCE,
+        state.metrics
+    )
+    fut = state.process_group.allreduce(tensor).get_future()
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        NCCL_ALLREDUCE,
+        state.metrics
+    )
+    state.bp_location += tensors_count
+    return fut
 
-# --------------------------- Run Worker -----------------------------------------
+
+def gloo_allreduce_hook(state, bucket):
+    tensors_count = len(get_tensors(bucket))
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        GLOO_ALLREDUCE,
+        state.metrics
+    )
+    work = state.process_group.allreduce([bucket.get_tensor()])
+    work.wait()
+    fut = torch.futures.Future()
+    fut.set_result([bucket.get_tensor() / state.process_group_size])
+    record_event(
+        state.rank,
+        HOOK_METRIC,
+        hook_metric_key(state),
+        GLOO_ALLREDUCE,
+        state.metrics
+    )
+    state.bp_location += tensors_count
+    return fut
 
 
 def run_trainer(configurations, model, data, rank, gs_rref):
@@ -323,163 +540,298 @@ def run_trainer(configurations, model, data, rank, gs_rref):
     torch.cuda.set_device(rank)
     model.cuda(rank)
 
-    process_group_size=configurations.world_size - 2
+    process_group_size = configurations.ddp_trainers
 
-    store=c10d.FileStore("/tmp/tmpn_k_8so02", process_group_size)
+    # random file or set store configuration?
+    store = c10d.FileStore("/tmp/tmpn_k_8so02", process_group_size)
 
     if configurations.backend == GLOO:
-        process_group=c10d.ProcessGroupGloo(store, rank, process_group_size)
+        process_group = c10d.ProcessGroupGloo(store, rank, process_group_size)
     elif configurations.backend == NCCL:
-        process_group=c10d.ProcessGroupNCCL(store, rank, process_group_size)
+        process_group = c10d.ProcessGroupNCCL(store, rank, process_group_size)
 
-    ddp_model=DDP(model, device_ids=[rank], process_group=process_group)
-    criterion=nn.CrossEntropyLoss().cuda(rank)
-    optimizer=torch.optim.SGD(ddp_model.parameters(), 1e-4)
+    ddp_model = DDP(model, device_ids=[rank], process_group=process_group)
+    criterion = nn.CrossEntropyLoss().cuda(rank)
+    optimizer = torch.optim.SGD(ddp_model.parameters(), 1e-4)
 
-    input, target=data.get_input_and_target()
-    input=input.split(process_group_size)[rank].cuda(rank)
-    target=target.split(process_group_size)[rank].cuda(rank)
+    input, target = data.get_input_and_target()
+    input = input.split(process_group_size)[rank].cuda(rank)
+    target = target.split(process_group_size)[rank].cuda(rank)
 
-    hook_gradient_futures=[]
-    bp_location = [0]
-    batch_number = [-20]
-    metrics={}
+    # rpc calls to gradient server warmpup
+    for _ in range(30):
+        rpc.rpc_sync(
+            gs_rref.owner(),
+            GradientServer.rpc_warmup_call,
+            args=(torch.tensor([[1] * 100] * 100),)
+        )
 
-    register_hook(
-        configurations.hook_id,
-        ddp_model,
-        process_group,
-        gs_rref,
-        process_group_size,
+    metrics = {}
+    hook_state = HookState(
         rank,
+        process_group,
+        process_group_size,
         configurations.use_cuda_rpc,
-        hook_gradient_futures,
-        bp_location,
-        batch_number,
+        gs_rref,
+        0,
+        0,
+        [],
         metrics
     )
 
-    # better name?
-    def state_helper():
-        hook_gradient_futures.clear()
-        bp_location[0] = 0
-        batch_number[0] += 1
-    
-    # rpc warmup required
-    # .. warning::
-    # Since the buckets are rebuilt after the first iteration, should not rely on the indices at the beginning of training.
-    for _ in range(10):  
-        state_helper()    
-        out = ddp_model(input)
-        loss=criterion(out, target)
-        loss.backward()
-        for fut, bp_loc in hook_gradient_futures:
-            gradient=fut.wait()  
-                 
-    if rank == 0:
-        rpc.rpc_sync(gs_rref.owner(),GradientServer.reset, args=(gs_rref,))     
-    batch_number[0] = 0
+    hook_id = configurations.hook_id
+    if hook_id == 1:
+        ddp_model.register_comm_hook(
+            hook_state,
+            gradient_server_hook
+        )
+    elif hook_id == 2:
+        ddp_model.register_comm_hook(
+            hook_state,
+            gradient_server_sparse_and_nccl_allreduce_dense_hook
+        )
+    elif hook_id == 3:
+        raise NotImplementedError("hook_id={}".format(hook_id))
+    elif hook_id == 4:
+        ddp_model.register_comm_hook(
+            hook_state,
+            nccl_allreduce_hook
+        )
+    elif hook_id == 5:
+        ddp_model.register_comm_hook(
+            hook_state,
+            gloo_allreduce_hook
+        )
+
+    # bucket index reordering
+    criterion(ddp_model(input), target).backward()
     metrics.clear()
     process_group.barrier()
 
-
-    ddp_model_parameters=list(ddp_model.parameters())
-    ddp_model_parameters_len=len(ddp_model_parameters)
+    ddp_model_parameters = list(ddp_model.parameters())
 
     for i in range(configurations.iterations):
-        state_helper()    
+        hook_state.next_batch_state()
 
-        record_event(rank, BATCH_LEVEL_METRIC, i, "batch_all", metrics)
+        record_event(rank, BATCH_LEVEL_METRIC, i, BATCH_ALL, metrics)
 
         optimizer.zero_grad()
 
-        record_event(rank, FORWARD_METRIC, i, "forward_pass", metrics)
-        out=ddp_model(input)
-        record_event(rank, FORWARD_METRIC, i, "forward_pass", metrics)
+        record_event(rank, FORWARD_METRIC, i, FORWARD_PASS, metrics)
+        out = ddp_model(input)
+        record_event(rank, FORWARD_METRIC, i, FORWARD_PASS, metrics)
 
-        loss=criterion(out, target)
+        loss = criterion(out, target)
 
-        record_event(rank, BACKWARD_METRIC, i, "backward", metrics)
+        record_event(rank, BACKWARD_METRIC, i, BACKWARD, metrics)
         loss.backward()
-        record_event(rank, BACKWARD_METRIC, i, "backward", metrics)
-        
-        for fut, bp_loc in hook_gradient_futures:
-            gradient=fut.wait()
+        record_event(rank, BACKWARD_METRIC, i, BACKWARD, metrics)
+
+        for fut, bp_loc in hook_state.hook_gradient_futures:
+            gradient = fut.wait()
             if isinstance(gradient, list):
-                indices=gradient[0].cuda(rank)
-                values=gradient[1].cuda(rank)
-                size=gradient[2]
-                gradient=torch.sparse_coo_tensor(indices, values, size)
-            gradient=gradient.cuda(rank)
-            ddp_model_parameters[bp_loc].grad=gradient
-            
+                indices = gradient[0].cuda(rank)
+                values = gradient[1].cuda(rank)
+                size = gradient[2]
+                gradient = torch.sparse_coo_tensor(indices, values, size)
+            gradient = gradient.cuda(rank)
+            ddp_model_parameters[bp_loc].grad = gradient
+
         optimizer.step()
 
-        record_event(rank, BATCH_LEVEL_METRIC, i, "batch_all", metrics)
+        record_event(rank, BATCH_LEVEL_METRIC, i, BATCH_ALL, metrics)
 
-    # need to add formatting
-    # visualization option ? print to file option?
-    # pp.pprint("rank={}, metrics={}".format(rank, metrics))
+    torch.cuda.synchronize(rank)
 
-# --------------------------- Run Benchmark -----------------------------------------
+    return [rank, process_metrics_for_elapsed_time(metrics)]
 
 
 def run_benchmark(rank, model, data, configurations):
-    world_size=configurations.world_size
-    assert world_size > 2
-    os.environ['MASTER_ADDR']='localhost'
-    os.environ['MASTER_PORT']='29500'
-    rpc_backend_options=TensorPipeRpcBackendOptions()
-    rpc_backend_options.init_method='tcp://localhost:29501'
-    if rank == world_size - 1:
-        rpc.init_rpc(
-            get_name(rank, world_size),
-            rank=rank,
-            world_size=world_size,
-            rpc_backend_options=rpc_backend_options
-        )
-        gs_rref=rpc.remote(
-            get_name(world_size - 2, world_size),
-            GradientServer,
-            args=(
-                world_size-2, 
-                world_size-2, 
-                configurations.use_cuda_rpc, 
-                configurations.backend,
-                configurations.batch_mode
+    world_size = configurations.world_size
+    try:
+        os.environ['MASTER_ADDR'] = 'localhost'
+        os.environ['MASTER_PORT'] = '29500'
+        rpc_backend_options = TensorPipeRpcBackendOptions()
+        rpc_backend_options.init_method = 'tcp://localhost:29501'
+        if rank == world_size - 1:
+            rpc.init_rpc(
+                get_name(
+                    rank,
+                    configurations.ddp_trainers,
+                    configurations.gradient_servers
+                ),
+                rank=rank,
+                world_size=world_size,
+                rpc_backend_options=rpc_backend_options
             )
-        )
-        futs=[
-            rpc.rpc_async(
-                get_name(trainer_rank, world_size),
-                run_trainer,
-                [
-                    configurations, copy.deepcopy(model), copy.deepcopy(data), trainer_rank, gs_rref
-                ]
+            # TODO: fix for no gradient servers
+            gradient_servers = {}
+            for i in range(
+                configurations.ddp_trainers, configurations.world_size - 1
+            ):
+                gs_rref = rpc.remote(
+                    get_name(
+                        i,
+                        configurations.ddp_trainers,
+                        configurations.gradient_servers
+                    ),
+                    GradientServer,
+                    args=(
+                        i,
+                        configurations.gradient_servers,
+                        configurations.ddp_trainers,
+                        configurations.use_cuda_rpc,
+                        configurations.backend,
+                        configurations.batch_mode
+                    )
+                )
+                gradient_servers[i] = gs_rref
+            futs = [
+                rpc.rpc_async(
+                    get_name(
+                        trainer_rank,
+                        configurations.ddp_trainers,
+                        configurations.gradient_servers
+                    ),
+                    run_trainer,
+                    [
+                        configurations,
+                        copy.deepcopy(model),
+                        copy.deepcopy(data),
+                        trainer_rank,
+                        gradient_servers[
+                            gs_for_rank(trainer_rank, configurations)
+                        ]
+                    ]
+                )
+                for trainer_rank in range(0, configurations.ddp_trainers)
+            ]
+
+            # metrics
+            if not os.path.exists("./data_frames"):
+                os.makedirs("./data_frames")
+            rank_trainer_metric_totals = []
+            for fut in futs:
+                rank_metrics = fut.wait()
+                rank_trainer_metric_totals.append(
+                    get_rank_totals_and_print(
+                        "trainer",
+                        rank_metrics,
+                        configurations.to_string(),
+                        configurations.print_metrics_to_dir
+                    )
+                )
+            print_rank_totals(
+                "trainers",
+                rank_trainer_metric_totals,
+                configurations.to_string(),
+                configurations.print_metrics_to_dir
             )
-            for trainer_rank in range(0, world_size - 2)
-        ]
-        for fut in futs:
-            fut.wait()
-    elif rank == world_size - 2:
-        rpc.init_rpc(
-            get_name(rank, world_size),
-            rank=rank,
-            world_size=world_size,
-            rpc_backend_options=rpc_backend_options
-        )
-    else:
-        if configurations.use_cuda_rpc:
-            rpc_backend_options.set_device_map(get_name(world_size - 2, world_size), {rank: world_size - 2})
-        rpc.init_rpc(
-            get_name(rank, world_size),
-            rank=rank,
-            world_size=world_size,
-            rpc_backend_options=rpc_backend_options
-        )
+            rank_gradient_server_metric_totals = []
+            for gs_rref in gradient_servers.values():
+                gs_metrics = rpc.rpc_sync(
+                    gs_rref.owner(),
+                    GradientServer.get_metrics,
+                    args=(gs_rref,)
+                )
+                if gs_metrics:
+                    rank_gradient_server_metric_totals.append(
+                        get_rank_totals_and_print(
+                            "gradient server",
+                            gs_metrics,
+                            configurations.to_string(),
+                            configurations.print_metrics_to_dir
+                        )
+                    )
+            print_rank_totals(
+                "gradient servers",
+                rank_gradient_server_metric_totals,
+                configurations.to_string(),
+                configurations.print_metrics_to_dir
+            )
+
+        elif rank >= configurations.ddp_trainers:
+            rpc.init_rpc(
+                get_name(
+                    rank,
+                    configurations.ddp_trainers,
+                    configurations.gradient_servers
+                ),
+                rank=rank,
+                world_size=world_size,
+                rpc_backend_options=rpc_backend_options
+            )
+        else:
+            if configurations.use_cuda_rpc:
+                gs_rank = gs_for_rank(rank, configurations)
+                rpc_backend_options.set_device_map(
+                    get_name(
+                        gs_rank,
+                        configurations.ddp_trainers,
+                        configurations.gradient_servers
+                    ),
+                    {rank: gs_rank}
+                )
+            rpc.init_rpc(
+                get_name(
+                    rank,
+                    configurations.ddp_trainers,
+                    configurations.gradient_servers
+                ),
+                rank=rank,
+                world_size=world_size,
+                rpc_backend_options=rpc_backend_options
+            )
+    except Exception as e:
+        print("error: {}".format(e))
     rpc.shutdown()
 
-# --------------------------- Main -----------------------------------------
+
+class DummyModel(nn.Module):
+    def __init__(
+        self,
+        num_embeddings=4,
+        embedding_dim=4,
+        dense_input_size=4,
+        dense_output_size=4,
+        sparse=True
+    ):
+        super().__init__()
+        self.embedding = nn.EmbeddingBag(
+            num_embeddings, embedding_dim, sparse=sparse
+        )
+        self.fc1 = nn.Linear(dense_input_size, dense_output_size)
+
+    def forward(self, x):
+        x = self.embedding(x)
+        return F.softmax(self.fc1(x), dim=1)
+
+
+def get_model(model_id, model_config):
+    if model_id == 1:
+        return DummyModel(**model_config)
+    sys.exit("model_id not found")
+
+
+class RandomData:
+    def __init__(
+        self,
+        min_val: int = 0,
+        max_val: int = 4,
+        batch_size: int = 4,
+        mult: int = 2
+    ):
+        self.input = torch.randint(min_val, max_val, [batch_size, mult])
+        self.target = torch.randint(min_val, max_val, [batch_size])
+
+    def get_input_and_target(self):
+        return self.input, self.target
+
+
+def get_data(data_id, data_config):
+    if data_id == 1:
+        return RandomData(**data_config)
+    sys.exit("data_id not found")
 
 
 class Configurations:
@@ -487,26 +839,47 @@ class Configurations:
         self,
         hook_id: int,
         backend: str = GLOO,
-        ddp_trainers: int=1,
-        iterations: int=2,
-        batch_mode: bool=False,
-        use_cuda_rpc: bool=False,
+        ddp_trainers: int = 1,
+        gradient_servers: int = 1,
+        iterations: int = 2,
+        batch_mode: bool = False,
+        use_cuda_rpc: bool = False,
+        print_metrics_to_dir: bool = False
     ):
-        backend=backend.lower()
+        backend = backend.lower()
         assert backend == GLOO or backend == NCCL
         assert hook_id > 0 and hook_id < 6
         assert iterations > 0
+        assert gradient_servers <= ddp_trainers
 
-        self.backend=backend
-        self.batch_mode=batch_mode
-        self.hook_id=hook_id
-        self.iterations=iterations
-        self.world_size=ddp_trainers + 2
-        self.use_cuda_rpc=use_cuda_rpc
+        self.backend = backend
+        self.batch_mode = batch_mode
+        self.hook_id = hook_id
+        self.iterations = iterations
+        self.world_size = ddp_trainers + gradient_servers + 1
+        self.ddp_trainers = ddp_trainers
+        self.gradient_servers = gradient_servers
+        self.use_cuda_rpc = use_cuda_rpc
+        self.print_metrics_to_dir = print_metrics_to_dir
+
+    def to_string(self):
+        output = ""
+        class_items = list(self.__dict__.items())
+        for i in range(len(class_items)):
+            attr, value = class_items[i]
+            if i > 0:
+                output += "__"
+            output += "{}_{}".format(attr, value)
+        return output
+
+
+"""
+    user needs to confirm cluster or server meets GPU requirements
+"""
 
 
 def main():
-    parser=argparse.ArgumentParser(description="RPC PS Benchmark")
+    parser = argparse.ArgumentParser(description="RPC PS Benchmark")
     parser.add_argument(
         "--bconfig_id",
         type=str,
@@ -521,41 +894,50 @@ def main():
         "--mconfig_id",
         type=str,
         default="1"
-        
-    )
-    args=parser.parse_args()
 
-    benchmark_config=json.load(
+    )
+    args = parser.parse_args()
+
+    benchmark_config_file = "configurations/benchmark_configurations.json"
+    benchmark_config = json.load(
         open(
-            os.path.join(Path(__file__).parent, "configurations/benchmark_configurations.json"), "r"
+            os.path.join(Path(__file__).parent, benchmark_config_file),
+            "r"
         )
     )[args.bconfig_id]
-    configurations=Configurations(**benchmark_config)
+    configurations = Configurations(**benchmark_config)
 
-    data_config=json.load(
+    data_config_file = "configurations/data_configurations.json"
+    data_config = json.load(
         open(
-            os.path.join(Path(__file__).parent, "configurations/data_configurations.json"), "r"
+            os.path.join(
+                Path(__file__).parent, data_config_file
+            ),
+            "r"
         )
     )[args.dconfig_id]
-    data=get_data(data_config["data_id"], data_config["configurations"])
+    data = get_data(data_config["data_id"], data_config["configurations"])
 
-    model_config=json.load(
+    model_config_file = "configurations/model_configurations.json"
+    model_config = json.load(
         open(
-            os.path.join(Path(__file__).parent, "configurations/model_configurations.json"), "r"
+            os.path.join(
+                Path(__file__).parent, model_config_file
+            ),
+            "r"
         )
     )[args.mconfig_id]
-    model=get_model(model_config["model_id"], model_config["configurations"])
+    model = get_model(model_config["model_id"], model_config["configurations"])
 
-    print("{}\nbconfig_id={}\ndconfig_id={}\nmconfig_id={}\n".format(parser.description, args.bconfig_id, args.dconfig_id, args.mconfig_id))
+    print("{}\nbconfig_id={}\ndconfig_id={}\nmconfig_id={}\n".format(
+        parser.description, args.bconfig_id, args.dconfig_id, args.mconfig_id))
 
-    start=time.time()
     mp.spawn(
         run_benchmark,
         [model, data, configurations],
         nprocs=configurations.world_size,
         join=True
     )
-    print("\nbenchmark done {}".format(time.time() - start))
 
 
 if __name__ == "__main__":

--- a/benchmarks/distributed/rpc/ps/benchmark.py
+++ b/benchmarks/distributed/rpc/ps/benchmark.py
@@ -1,0 +1,384 @@
+from functools import wraps
+import os
+import random
+import time
+import threading
+import copy
+import sys
+
+import torch
+import torch.distributed as dist
+import torch.distributed.autograd as dist_autograd
+from torch.distributed.optim import DistributedOptimizer
+import torch.distributed.rpc as rpc
+from torch.distributed.rpc import RRef
+from torch.distributed.rpc import TensorPipeRpcBackendOptions
+import torch.multiprocessing as mp
+from torch.nn.parallel import DistributedDataParallel as DDP
+import torch.optim as optim
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.distributed as c10d
+import torch.distributed.rpc as rpc
+
+GLOO = "gloo"
+NCCL = "nccl"
+
+# --------------------------- privates -----------------------------------------
+
+
+def _get_name(rank, world_size):
+    if rank < world_size - 2:
+        return "trainer{}".format(rank)
+    elif rank == world_size - 2:
+        return "gs"
+    else:
+        return "master"
+
+
+def _call_method(method, rref, *args, **kwargs):
+    return method(rref.local_value(), *args, **kwargs)
+
+
+def _remote_method(method, rref, *args, **kwargs):
+    args = [method, rref] + list(args)
+    return rpc.rpc_async(rref.owner(), _call_method, args=args, kwargs=kwargs)
+
+# --------------------------- Parameter Server -----------------------------------------
+
+
+class GradientServer(nn.Module):
+
+    def __init__(self, world_size):
+        super().__init__()
+        torch.manual_seed(0)
+        self.lock = threading.Lock()
+        self.rank_gradient_counters = [[0] * world_size, [0] * world_size]
+        self.gradient_dicts = [{}, {}]
+        self.gradient_dim = {}
+
+    # batch processing just store the gradients
+    # trainer and server update every iteration
+    # batch case - 1 cuda kernel
+    # iteration case - n cuda kernels
+
+    @rpc.functions.async_execution
+    def add_to_sparse_gradient(self, rank, gradient, dim):
+        gradient = gradient.cuda()
+        sparse_gradient_dict = self.gradient_dicts[0]
+        with self.lock:
+            loc = self.rank_gradient_counter[0][rank]
+            if loc not in sparse_gradient_dict:
+                sparse_gradient_dict[loc] = gradient
+                gradient_dim[loc] = dim
+            else:
+                sparse_gradient_dict[loc] += gradient
+            self.rank_gradient_counter[0][rank] += 1
+
+    @rpc.functions.async_execution
+    def add_to_dense_gradient(self, rank, gradient, dim):
+        gradient = gradient.cuda()
+        dense_gradient_dict = self.gradient_dicts[1]
+        with self.lock:
+            loc = self.rank_gradient_counter[1][rank]
+            if loc not in sparse_gradient_dict:
+                dense_gradient_dict[loc] = gradient
+            else:
+                dense_gradient_dict[loc] += gradient
+            self.rank_gradient_counter[1][rank] += 1
+
+    @rpc.functions.async_execution
+    def get_loc_gradient(self, loc, sparse):
+        index = 0 if sparse else 1
+        with self.lock:
+            gradient_cpu = self.gradient_dict[index][loc].cpu()
+            if index == 0:
+                return gradient_cpu, self.gradient_dim[loc]
+            else:
+                return gradient_cpu
+
+    def reset_gradients(self):
+        self.gradient_dict = {}
+
+
+# --------------------------- Model -----------------------------------------
+
+class MixedModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embedding = nn.EmbeddingBag(4, 4, sparse=True)
+        self.fc1 = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.embedding(x)
+        return F.softmax(self.fc1(x), dim=1)
+
+# --------------------------- Hooks -----------------------------------------
+
+
+def register_ddp_with_rpc_for_sparse_and_dense_hook(ddp_model, process_group, gs_rref, world_size):
+    """
+        DDP with CUDA RPC for both sparse and dense parameters.
+        hook_id = 1
+
+    """
+    sparse_future_container = []
+    dense_future_container = []
+
+    def rpc_for_sparse_and_dense_hook(state, bucket):
+        grad = bucket.get_tensors()[0]
+        if grad.is_sparse:
+            dim = grad.sparse_dim()
+            cpu_tensor = grad.to_dense().cpu()
+            sparse_future_container.append(
+                _remote_method(
+                    GradientServer.add_to_sparse_gradient,
+                    gs_rref,
+                    rank=rank,
+                    gradient=cpu_tensor,
+                    dim=dim,
+                )
+            )
+        else:
+            cpu_tensor = grad.cpu()
+            dense_future_container.append(
+                _remote_method(
+                    GradientServer.add_to_dense_gradient,
+                    gs_rref,
+                    rank=rank,
+                    gradient=cpu_tensor,
+                )
+            )
+        fut = torch.futures.Future()
+        fut.set_result(bucket.get_tensors()[0])
+        return fut
+
+    ddp_model.register_comm_hook(None, rpc_for_sparse_and_dense_hook)
+
+    return sparse_future_container, dense_future_container
+
+
+def register_dpp_with_rpc_for_sparse_nccl_allreduce_dense_hook(ddp_model, process_group, gs_rref, world_size):
+    """
+        DDP with CPU RPC for sparse parameters + NCCL AllReduce for dense parameters
+        hook_id = 2
+
+    """
+    sparse_future_container = []
+
+    def rpc_for_sparse_nccl_allreduce_dense_hook(state, bucket):
+        grad = bucket.get_tensors()[0]
+        if grad.is_sparse:
+            dim = grad.sparse_dim()
+            cpu_tensor = grad.to_dense()
+            sparse_future_container.append(
+                _remote_method(
+                    GradientServer.add_to_sparse_gradient,
+                    gs_rref,
+                    rank=rank,
+                    gradient=cpu_tensor,
+                    dim=dim,
+                )
+            )
+            fut = torch.futures.Future()
+            fut.set_result(bucket.get_tensors())
+            return fut
+        else:
+            tensors = [t / world_size for t in bucket.get_tensors()]
+            return process_group.allreduce(tensors).get_future()
+
+    ddp_model.register_comm_hook(None, rpc_for_sparse_nccl_allreduce_dense_hook)
+
+    return sparse_future_container
+
+
+def register_gloo_allreduce_for_sparse_and_nccl_allreduce_for_dense_hook(ddp_model, process_group, gs_rref, world_size):
+    pass
+
+
+def register_dpp_with_nccl_allreduce_hook(ddp_model, process_group, gs_rref, world_size):
+    """
+        DDP with NCCL ALLReduce for both sparse and dense gradients
+        hook_id = 4
+    """
+
+    def nccl_all_reduce_hook(state, bucket):
+        tensors = [t / world_size for t in bucket.get_tensors()]
+        return process_group.allreduce(tensors).get_future()
+
+    ddp_model.register_comm_hook(None, nccl_all_reduce_hook)
+
+
+def register_gloo_allreduce_hook(ddp_model, process_group, gs_rref, world_size):
+    """
+        DDP with Gloo ALLReduce for both sparse and dense gradients
+        hook_id = 5
+    """
+
+    def gloo_allreduce_hook(state, bucket):
+        work = process_group.allreduce(bucket.get_tensors())
+        work.wait()
+        fut = torch.futures.Future()
+        fut.set_result([t * world_size for t in bucket.get_tensors()])
+        return fut
+
+    ddp_model.register_comm_hook(None, gloo_allreduce_hook)
+
+# --------------------------- Run Worker -----------------------------------------
+
+
+def _run_trainer(benchmark_configurations, model, rank, gs_rref):
+
+    torch.manual_seed(0)
+    torch.cuda.set_device(rank)
+    model.cuda(rank)
+
+    process_group_size = benchmark_configurations.world_size - 2
+
+    store = c10d.FileStore("/tmp/tmpn_k_8so02", process_group_size)
+
+    if benchmark_configurations.backend == GLOO:
+        process_group = c10d.ProcessGroupGloo(store, rank, process_group_size)
+    else:
+        process_group = c10d.ProcessGroupNCCL(store, rank, process_group_size)
+
+    ddp_model = DDP(model, device_ids=[rank], process_group=process_group)
+    criterion = nn.CrossEntropyLoss().cuda(rank)
+    optimizer = torch.optim.SGD(model.parameters(), 1e-4)
+
+    hook_gradient_futures = inverse_hook_map[benchmark_configurations.hook_id](
+        ddp_model, process_group, gs_rref, process_group_size)
+
+    # TODO -> add data models
+    mult = 2
+    batch_size = 4
+    input = torch.randint(0, 4, [batch_size, 2]).split(mult)[rank].cuda(rank)
+    target = torch.randint(0, 4, [batch_size]).split(mult)[rank].cuda(rank)
+
+    for i in range(benchmark_configurations.iterations):
+        optimizer.zero_grad()
+        out = ddp_model(input)
+        loss = criterion(out, target)
+        loss.backward()
+
+        if hook_gradient_futures is not None:
+            for gradient_futures in hook_gradient_futures:
+                for fut in gradient_futures:
+                    fut.wait()
+            process_group.barrier()
+            sparse_loc = 0
+            dense_loc = 0
+            for param in ddp_model.parameters():
+                if param.grad.is_sparse:
+                    gradient_value, dim = _remote_method(
+                        GradientServer.get_loc_gradient, gs_rref, loc=sparse_loc, sparse=True
+                    ).wait()
+                    gradient_value /= (1.0 * process_group_size)
+                    gradient_value = gradient_value.to_sparse(dim)
+                    gradient_value = gradient_value.cuda(rank)
+                    param.grad = gradient_value
+                    sparse_loc += 1
+                elif len(hook_gradient_futures) > 1:
+                    gradient_value = _remote_method(
+                        GradientServer.get_loc_gradient, gs_rref, loc=dense_loc, sparse=False
+                    ).wait()
+                    gradient_value /= (1.0 * process_group_size)
+                    gradient_value = gradient_value.cuda(rank)
+                    param.grad = gradient_value
+                    dense_loc += 1
+
+        # batch processing ?
+
+        optimizer.step()
+
+# --------------------------- Run Benchmark -----------------------------------------
+
+
+def run_benchmark(rank, model, benchmark_configurations):
+    world_size = benchmark_configurations.world_size
+    assert world_size > 2
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '29500'
+    rpc_backend_options = TensorPipeRpcBackendOptions()
+    rpc_backend_options.init_method = 'tcp://localhost:29501'
+    if rank == world_size - 1:
+        rpc.init_rpc(
+            _get_name(rank, world_size),
+            rank=rank,
+            world_size=world_size,
+            rpc_backend_options=rpc_backend_options
+        )
+        gs_rref = rpc.remote(
+            _get_name(world_size - 2, world_size),
+            GradientServer,
+            [world_size - 2],
+        )
+        futs = [
+            rpc.rpc_async(
+                _get_name(trainer_rank, world_size),
+                _run_trainer,
+                [
+                    benchmark_configurations, copy.deepcopy(model), trainer_rank, gs_rref
+                ]
+            )
+            for trainer_rank in range(0, world_size - 2)
+        ]
+        for fut in futs:
+            fut.wait()
+    elif rank == world_size - 2:
+        rpc.init_rpc(
+            _get_name(rank, world_size),
+            rank=rank,
+            world_size=world_size,
+            rpc_backend_options=rpc_backend_options
+        )
+    else:
+        if benchmark_configurations.use_rpc_cuda:
+            rpc_backend_options.set_device_map(_get_name(world_size - 2, world_size), {rank: world_size - 2})
+        rpc.init_rpc(
+            _get_name(rank, world_size),
+            rank=rank,
+            world_size=world_size,
+            rpc_backend_options=rpc_backend_options
+        )
+    rpc.shutdown()
+
+# --------------------------- Main -----------------------------------------
+
+
+inverse_hook_map = {
+    1: register_ddp_with_rpc_for_sparse_and_dense_hook,
+    2: register_dpp_with_rpc_for_sparse_nccl_allreduce_dense_hook,
+    3: register_gloo_allreduce_for_sparse_and_nccl_allreduce_for_dense_hook,
+    4: register_dpp_with_nccl_allreduce_hook,
+    5: register_gloo_allreduce_hook
+}
+
+
+class BenchmarkConfigurations:
+    backend = GLOO
+    batch_rpc = False
+    batch_size = 1
+    hook_id = 1
+    iterations = 1
+    use_rpc_cuda = False
+    world_size = 4
+
+
+if __name__ == "__main__":
+
+    benchmark_configurations = BenchmarkConfigurations()
+    benchmark_configurations.world_size = 4
+    benchmark_configurations.use_rpc_cuda = False
+    benchmark_configurations.backend = GLOO
+    benchmark_configurations.hook_id = 5
+
+    start = time.time()
+    mp.spawn(
+        run_benchmark,
+        [MixedModel(), benchmark_configurations],
+        nprocs=benchmark_configurations.world_size,
+        join=True
+    )
+    print(time.time() - start)
+

--- a/benchmarks/distributed/rpc/ps/configurations/benchmark_configurations.json
+++ b/benchmarks/distributed/rpc/ps/configurations/benchmark_configurations.json
@@ -1,0 +1,47 @@
+{
+    "1":{
+        "backend":"gloo",
+        "hook_id":5,
+        "ddp_trainers":2
+    },
+    "2":{
+        "backend":"gloo_and_nccl",
+        "hook_id":-1
+    },
+    "3":{
+        "backend":"nccl",
+        "hook_id":4,
+        "ddp_trainers":2
+    },
+    "4":{
+        "backend":"nccl",
+        "hook_id":2,
+        "ddp_trainers":2
+    },
+    "5":{
+        "backend":"nccl",
+        "hook_id":2,
+        "ddp_trainers":2,
+        "use_cuda_rpc": true
+    },
+    "6":{
+        "backend":"nccl",
+        "hook_id":2,
+        "ddp_trainers":2,
+        "use_cuda_rpc": true,
+        "batch_mode":true
+    },
+    "7":{
+        "backend":"gloo",
+        "hook_id":1,
+        "ddp_trainers":2,
+        "use_cuda_rpc": true
+    },
+    "8":{
+        "backend":"gloo",
+        "hook_id":1,
+        "ddp_trainers":2,
+        "use_cuda_rpc": true,
+        "batch_mode":true
+    }
+}

--- a/benchmarks/distributed/rpc/ps/configurations/benchmark_configurations.json
+++ b/benchmarks/distributed/rpc/ps/configurations/benchmark_configurations.json
@@ -11,18 +11,22 @@
     "3":{
         "backend":"nccl",
         "hook_id":4,
-        "ddp_trainers":2
+        "ddp_trainers":2,
+        "gradient_servers": 1
     },
     "4":{
         "backend":"nccl",
         "hook_id":2,
-        "ddp_trainers":2
+        "ddp_trainers":1,
+        "gradient_servers": 1
     },
     "5":{
         "backend":"nccl",
         "hook_id":2,
         "ddp_trainers":2,
-        "use_cuda_rpc": true
+        "use_cuda_rpc": true,
+        "iterations": 10,
+        "gradient_servers": 2
     },
     "6":{
         "backend":"nccl",

--- a/benchmarks/distributed/rpc/ps/configurations/data_configurations.json
+++ b/benchmarks/distributed/rpc/ps/configurations/data_configurations.json
@@ -1,0 +1,11 @@
+{
+    "1":{
+        "data_id":1,
+        "configurations":{
+            "min_val":0,
+            "max_val":4,
+            "batch_size":4,
+            "mult":2
+        }
+    }
+}

--- a/benchmarks/distributed/rpc/ps/configurations/model_configurations.json
+++ b/benchmarks/distributed/rpc/ps/configurations/model_configurations.json
@@ -1,0 +1,22 @@
+{
+    "1":{
+        "model_id":1,
+        "configurations":{
+            "num_embeddings":4,
+            "embedding_dim": 4,
+            "dense_input_size": 4,
+            "dense_output_size": 4,
+            "sparse": true
+        }
+    },
+    "2":{
+        "model_id":1,
+        "configurations":{
+            "num_embeddings":4,
+            "embedding_dim": 4,
+            "dense_input_size": 4,
+            "dense_output_size": 4,
+            "sparse": false
+        }
+    }
+}


### PR DESCRIPTION
# **I am updating the code to be modular and creating a new pr so that there are fewer changes. I am closing the pr.**


not in pr:
1.  controlling percentage of embeddings used by the input data in each iteration
2.  per-iteration metrics printing

things to fix in future commits or prs:

1. add rpc warmup for backend communication 
2. add checks for rpc warmup. for example if there is no gradient server
3. add the ability to have zero gradient servers 
4. metric printing overwriting metrics in the same metric_type. if n metric types in metric_type only one will be left after processing
5. refactor metric processing
6. math use modulus for gradient server assignment
7. unnecessary calls example .cuda(rank) when the tensor is already on the device. 
8. replace strings with constants
9. comment block style
10. add README.md

Example of measurements printed for experiment Addp_with_cuda_rpc_for_sparse_parameters_nccl_allreduce_for_dense_parameters

![Screen Shot 2021-04-20 at 00 38 03](https://user-images.githubusercontent.com/80843680/115338529-fc864880-a170-11eb-8eaf-562db9321513.png)


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55632 RPC PS Benchmark**

