### PR TITLE
Disable overloading of std::max & std::min for inputs of distinct types

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -71,7 +71,7 @@ void add_clamp_kernel(TensorIterator& iter, const Scalar& alpha_scalar, const Sc
     auto max_vec = Vec256<scalar_t>(max_scalar);
     cpu_kernel_vec(iter,
       [=](scalar_t a, scalar_t b) __ubsan_ignore_undefined__ -> scalar_t {
-        return std::min(max_scalar, std::max(min_scalar, a + alpha * b));
+        return std::min(max_scalar, std::max(min_scalar, static_cast<scalar_t>(a + alpha * b)));
       },
       [=](Vec256<scalar_t> a, Vec256<scalar_t> b) __ubsan_ignore_undefined__ {
         auto add_clamp_res = vec256::fmadd(b, alpha_vec, a);

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2995,7 +2995,7 @@ void quantize_tensor_per_tensor_affine_sub_byte_cpu(
       const auto elem_per_byte = CHAR_BIT / bit_width;
       for (int i = 0; i < numel; ++i) {
         float inv_scale = scale == 0 ? 1.0f : 1.0f / scale;
-        int qvalue = lrintf(std::nearbyint(rdata[i] * inv_scale) + zero_point);
+        int64_t qvalue = lrintf(std::nearbyint(rdata[i] * inv_scale) + zero_point);
         qvalue = std::max(quant_min, std::min(qvalue, quant_max));
 
         // We pack sub_byte values and align them to a byte.

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -106,9 +106,10 @@ int64_t _get_zero_point_from_tensor(
     int64_t quant_min,
     int64_t quant_max,
     bool is_forward) {
-  float zero_point_fp = zero_point[0].item<float>();
+  double zero_point_fp = zero_point[0].item<double>();
   zero_point_fp = is_forward ? std::nearbyint(zero_point_fp) : zero_point_fp + 0.5f;
-  float zero_point_clamped = std::min(std::max(zero_point_fp, quant_min), quant_max);
+  double zero_point_clamped = std::min(std::max(zero_point_fp, static_cast<double>(quant_min)),
+                                       static_cast<double>(quant_max));
   return static_cast<int64_t>(zero_point_clamped);
 }
 

--- a/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
+++ b/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp
@@ -106,10 +106,10 @@ int64_t _get_zero_point_from_tensor(
     int64_t quant_min,
     int64_t quant_max,
     bool is_forward) {
-  double zero_point_fp = zero_point[0].item<double>();
+  float zero_point_fp = zero_point[0].item<float>();
   zero_point_fp = is_forward ? std::nearbyint(zero_point_fp) : zero_point_fp + 0.5f;
-  double zero_point_clamped = std::min(std::max(zero_point_fp, static_cast<double>(quant_min)),
-                                       static_cast<double>(quant_max));
+  float zero_point_clamped = std::min(std::max(zero_point_fp, static_cast<float>(quant_min)),
+                                       static_cast<float>(quant_max));
   return static_cast<int64_t>(zero_point_clamped);
 }
 

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -227,26 +227,13 @@ inline C10_HOST_DEVICE BFloat16 operator/(int64_t a, BFloat16 b) {
   return static_cast<BFloat16>(a) / b;
 }
 
-// Overloading < and > operators, because std::max abd std::min use them.
-// BFloat16 is implicitly converted during comparison with floating types,
-// so overloading isn't required for them.
-template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
-inline C10_HOST_DEVICE bool operator>(BFloat16& lhs, dtype& rhs) {
+// Overloading < and > operators, because std::max and std::min use them.
+
+inline C10_HOST_DEVICE bool operator>(BFloat16& lhs, BFloat16& rhs) {
   return float(lhs) > float(rhs);
 }
 
-template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
-inline C10_HOST_DEVICE bool operator<(BFloat16& lhs, dtype& rhs) {
-  return float(lhs) < float(rhs);
-}
-
-template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
-inline C10_HOST_DEVICE bool operator>(dtype& lhs, BFloat16& rhs) {
-  return float(lhs) > float(rhs);
-}
-
-template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
-inline C10_HOST_DEVICE bool operator<(dtype& lhs, BFloat16& rhs) {
+inline C10_HOST_DEVICE bool operator<(BFloat16& lhs, BFloat16& rhs) {
   return float(lhs) < float(rhs);
 }
 

--- a/c10/util/BFloat16-inl.h
+++ b/c10/util/BFloat16-inl.h
@@ -227,6 +227,29 @@ inline C10_HOST_DEVICE BFloat16 operator/(int64_t a, BFloat16 b) {
   return static_cast<BFloat16>(a) / b;
 }
 
+// Overloading < and > operators, because std::max abd std::min use them.
+// BFloat16 is implicitly converted during comparison with floating types,
+// so overloading isn't required for them.
+template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
+inline C10_HOST_DEVICE bool operator>(BFloat16& lhs, dtype& rhs) {
+  return float(lhs) > float(rhs);
+}
+
+template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
+inline C10_HOST_DEVICE bool operator<(BFloat16& lhs, dtype& rhs) {
+  return float(lhs) < float(rhs);
+}
+
+template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
+inline C10_HOST_DEVICE bool operator>(dtype& lhs, BFloat16& rhs) {
+  return float(lhs) > float(rhs);
+}
+
+template<typename dtype, std::enable_if_t<!(std::is_floating_point<dtype>::value), bool>>
+inline C10_HOST_DEVICE bool operator<(dtype& lhs, BFloat16& rhs) {
+  return float(lhs) < float(rhs);
+}
+
 } // namespace c10
 
 namespace std {

--- a/c10/util/BFloat16-math.h
+++ b/c10/util/BFloat16-math.h
@@ -29,8 +29,6 @@ inline c10::BFloat16 lgamma(c10::BFloat16 a) { return std::lgamma(float(a));}
 inline c10::BFloat16 sqrt(c10::BFloat16 a) { return std::sqrt(float(a));}
 inline c10::BFloat16 rsqrt(c10::BFloat16 a) { return 1.0 / std::sqrt(float(a));}
 inline c10::BFloat16 abs(c10::BFloat16 a) { return std::abs(float(a));}
-inline c10::BFloat16 min(c10::BFloat16 a, c10::BFloat16 b) { return std::min(float(a), float(b));}
-inline c10::BFloat16 max(c10::BFloat16 a, c10::BFloat16 b) { return std::max(float(a), float(b));}
 #if defined(_MSC_VER) && defined(__CUDACC__)
 inline c10::BFloat16 pow(c10::BFloat16 a, double b) { return std::pow(float(a), float(b));}
 #else


### PR DESCRIPTION
Fixes #55613

### Problem
By default, `std::max` and `std::min` only operate on inputs of the same type.
In [`c10/util/BFloat16-math.h`](https://github.com/pytorch/pytorch/blob/master/c10/util/BFloat16-math.h), `std::max` & `std::min` have been overloaded:
https://github.com/pytorch/pytorch/blob/305abde976d232494c6b5252111ce15523511ffe/c10/util/BFloat16-math.h#L32-L33
@ezyang [observed](https://github.com/pytorch/pytorch/pull/55586#issuecomment-815862373) &  [illustrated](https://godbolt.org/z/bjTjPMMco) that calls to `std::max` & `std::min` for distinct input types (eg. `std::max(int, float)`) are being handled via `BFloat16`'s aforementioned overloads via implicit conversion to `BFloat16`. (I haven't looked into why yet).

### Solution implemented
1. Disabled overloading of `std::max` & `std::min` for inputs of distinct types by removing these overloads for `BFloat16`.
2. Instead, `<` and `>` operators are now being overloaded for `BFloat16` now (for comparison with another `BFloat16`), since `std::max` and `std::min` use these operators.
3. Calls to `std::max` and `std::min` with inputs of distinct types are only present at 3 places in the codebase, where they can either be handled by a `static_cast`, or by changing the type:
a. [`aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp`](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/fake_quant_per_tensor_affine.cpp#L111)
b. [`aten/src/ATen/native/cpu/BinaryOpsKernel.cpp`](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp#L74)
c. [`aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp`](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp#L2998-L2999)