### PR TITLE
Fix complex mean and reduction tests not being run

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -796,7 +796,7 @@ Tensor mean_cpu_gpu(const Tensor &self, optional<ScalarType> dtype) {
 }
 
 Tensor mean_cpu_gpu(const Tensor& self, IntArrayRef dim, bool keepdim, optional<ScalarType> opt_dtype) {
-  ScalarType dtype = toValueType(get_dtype_from_self(self, opt_dtype, true));
+  ScalarType dtype = get_dtype_from_self(self, opt_dtype, true);
   Tensor result = create_reduction_result(self, dim, keepdim, dtype);
   return at::native::mean_out_cpu_gpu(self, dim, keepdim, dtype, result);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55681 std/var: Deprecate overloads with "unbiased" argument
* #55680 std/var: Require correction or unbiased parameter be given
* #55679 std/var: Deprecate default correction value
* #50903 Add correction parameter to std/var
* **#55640 Fix complex mean and reduction tests not being run**

Mean is broken for complex types, since #53218 it's now allocating the result
as a real tensor which discards the imaginary component. This wasn't picked up
in testing because `_test_dim_ops` tests are defined as closures inside of
`_test_dim_ops` instead of as methods on the test class. The result is, they
never get run.

For best results, view diff with "Hide whitespace changes".

Differential Revision: [D27671127](https://our.internmc.facebook.com/intern/diff/D27671127)