### PR TITLE
Write mini dump on pybind exceptions

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import contextlib
+import io
 import re
 import shutil
 import random
@@ -25,6 +27,16 @@ from urllib.error import URLError
 load_tests = load_tests
 
 HAS_CUDA = torch.cuda.is_available()
+
+def check_breakpad():
+    try:
+        torch._C._get_minidump_directory()  # type: ignore[attr-defined]
+        return True
+    except RuntimeError as e:
+        return "Minidump handler is uninintialized, make sure to call" in str(e)
+
+HAS_BREAKPAD = check_breakpad()
+
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 
@@ -726,6 +738,30 @@ class TestAssert(TestCase):
         ms(x)
         with self.assertRaisesRegex(torch.jit.Error, "foo"):  # type: ignore[type-var]
             ms(torch.tensor([False], dtype=torch.bool))
+
+
+class TestCrashHandler(TestCase):
+    @unittest.skipIf(not HAS_BREAKPAD, "Crash handler lib was not linked in")
+    def test_python_exception_writing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            torch.utils._crash_handler.enable_minidump_collection(temp_dir)
+
+            files = os.listdir(temp_dir)
+            self.assertEqual(len(files), 0)
+
+            f = io.StringIO()
+            with contextlib.redirect_stderr(f):
+                try:
+                    @torch.jit.script
+                    def x(i: int):
+                        return i + "2"  # type: ignore[operator]
+                except RuntimeError as e:
+                    pass
+
+            files = os.listdir(temp_dir)
+            self.assertEqual(len(files), 1)
+            self.assertTrue(files[0].endswith(".dmp"))
+            torch.utils._crash_handler.disable_minidump_collection()
 
 
 @unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -49,6 +49,7 @@
 #include <torch/csrc/utils/tensor_qschemes.h>
 #include <torch/csrc/utils/tensor_numpy.h>
 #include <torch/csrc/utils/python_dispatch.h>
+#include <torch/csrc/utils/crash_handler.h>
 #include <torch/csrc/jit/python/python_tracer.h>
 #include <torch/csrc/jit/python/init.h>
 #include <torch/csrc/jit/python/python_ir.h>
@@ -925,6 +926,10 @@ PyObject* initModule() {
 
   // Automatically translate errors thrown from pybind11 functions
   py::register_exception_translator([](std::exception_ptr e) { // NOLINT
+    if (torch::crash_handler::is_enabled()) {
+      torch::crash_handler::write_minidump();
+    }
+
     try {
       if (e) {
         std::rethrow_exception(e);

--- a/torch/csrc/utils/crash_handler.cpp
+++ b/torch/csrc/utils/crash_handler.cpp
@@ -36,6 +36,10 @@ void _enable_minidump_collection(const std::string& dir) {
       -1);
 }
 
+void _disable_minidump_collection() {
+  handler.reset();
+}
+
 const std::string& _get_minidump_directory() {
   if (handler == nullptr) {
     AT_ERROR(
@@ -43,12 +47,33 @@ const std::string& _get_minidump_directory() {
   }
   return minidump_directory;
 }
+bool is_enabled() {
+  return handler != nullptr;
+}
+void write_minidump() {
+  TORCH_CHECK(handler != nullptr,"Minidump handler is uninintialized, make sure to call _enable_minidump_collection first");
+  handler->WriteMinidump();
+}
 #else
 void _enable_minidump_collection(const std::string& dir) {
   AT_ERROR(
       "Minidump collection is currently only implemented for Linux platforms");
 }
+
+void _disable_minidump_collection() {
+  // Purposefully do nothing
+}
+
 const std::string& _get_minidump_directory() {
+  AT_ERROR(
+      "Minidump collection is currently only implemented for Linux platforms");
+}
+
+bool is_enabled() {
+  return false;
+}
+
+void write_minidump() {
   AT_ERROR(
       "Minidump collection is currently only implemented for Linux platforms");
 }

--- a/torch/csrc/utils/crash_handler.h
+++ b/torch/csrc/utils/crash_handler.h
@@ -7,8 +7,13 @@ namespace torch {
 namespace crash_handler {
 
 TORCH_API void _enable_minidump_collection(const std::string& dir);
+TORCH_API void _disable_minidump_collection();
 
 TORCH_API const std::string& _get_minidump_directory();
+
+bool is_enabled();
+
+void write_minidump();
 
 } // namespace crash_handler
 } // namepsace torch

--- a/torch/csrc/utils/init.cpp
+++ b/torch/csrc/utils/init.cpp
@@ -58,6 +58,7 @@ void initCrashHandlerBindings(PyObject* module) {
   auto m = pybind11::handle(module).cast<pybind11::module>();
 
   m.def("_enable_minidump_collection", _enable_minidump_collection)
+      .def("_disable_minidump_collection", _disable_minidump_collection)
       .def("_get_minidump_directory", _get_minidump_directory);
 }
 } // namespace crash_handler

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -2,7 +2,7 @@ import os.path as _osp
 import sys
 
 from .throughput_benchmark import ThroughputBenchmark
-from ._crash_handler import enable_minidump_collection
+from ._crash_handler import enable_minidump_collection, disable_minidump_collection
 
 # Set the module for a given object for nicer printing
 def set_module(obj, mod):

--- a/torch/utils/_crash_handler.py
+++ b/torch/utils/_crash_handler.py
@@ -16,3 +16,6 @@ def enable_minidump_collection(directory=DEFAULT_MINIDUMP_DIR):
         raise RuntimeError(f"Directory does not exist: {directory}")
 
     torch._C._enable_minidump_collection(directory)  # type: ignore
+
+def disable_minidump_collection():
+    torch._C._disable_minidump_collection()  # type: ignore


### PR DESCRIPTION


We register an [error handler](https://pybind11.readthedocs.io/en/stable/advanced/exceptions.html#registering-custom-translators) with pybind so that C++ exceptions are passed to Python and raised as runtime errors that can be `try...except`ed etc. Since these don't terminate the program (until Python does), they never fire the signal handler to write a minidump out with the crash information. This PR adds some logic in the exception translator to write out a minidump if enabled.

Differential Revision: [D27830952](https://our.internmc.facebook.com/intern/diff/27830952/)