### PR TITLE
Move set_version_counter out of DifferentiableViewMeta constructor.

### DIFF
--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -38,9 +38,9 @@ DifferentiableViewMeta::DifferentiableViewMeta(at::TensorImpl* self_impl,
       forward_info_(std::move(forward_info)),
       creation_meta_(creation_meta) {
   is_view_ = true;
-  if (backward_info_.has_value()) {
-    self_impl->set_version_counter(impl::version_counter(backward_info_.value().base_));
-    attr_version_ = self_impl->version_counter().current_version();
+  const auto& version_counter = self_impl->version_counter();
+  if (version_counter.enabled()) {
+    attr_version_ = version_counter.current_version();
   }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55653 Move set_version_counter out of DifferentiableViewMeta constructor.**
* #55572 Make VariableVersion::DISABLED the default constructor for VariableVersion.
* #54403 Relax some limitations of InferenceMode.

It's hard for me to understand that when we call
`impl->set_autograd_meta(std::make_unique<DifferentiableViewMeta>` it
has a side effect changing `impl->set_version_counter()` as well.
I'd prefer this setter is called explicitly and it's easier for the
followup refactor.

Differential Revision: [D27669075](https://our.internmc.facebook.com/intern/diff/D27669075)