### PR TITLE
[fix][tests] fix logic if env variables not present

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -476,24 +476,23 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
     generic_members = set(generic_test_class.__dict__.keys()) - set(empty_class.__dict__.keys())
     generic_tests = [x for x in generic_members if x.startswith('test')]
 
+    def split_if_not_empty(x):
+        return x.split(",") if len(x) != 0 else []
+
     # Derive defaults from environment variables if available, default is still none
     # Usage:
     # export PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda,cpu
     # export PYTORCH_TESTING_DEVICE_EXCEPT_FOR=xla
     if only_for is None:
-        only_for = os.getenv("PYTORCH_TESTING_DEVICE_ONLY_FOR", None)
-        if only_for is not None:
-            only_for = only_for.split(',')
+        only_for = split_if_not_empty(os.getenv("PYTORCH_TESTING_DEVICE_ONLY_FOR", ''))
 
     if except_for is None:
-        except_for = os.getenv("PYTORCH_TESTING_DEVICE_EXCEPT_FOR", None)
-        if except_for is not None:
-            except_for = except_for.split(',')
+        except_for = split_if_not_empty(os.getenv("PYTORCH_TESTING_DEVICE_EXCEPT_FOR", ''))
 
     # Creates device-specific test cases
     for base in device_type_test_bases:
         # Skips bases listed in except_for
-        if except_for is not None and only_for is not None:
+        if except_for != [] and only_for != []:
             assert base.device_type not in except_for or base.device_type not in only_for,\
                 "same device cannot appear in except_for and only_for"
         if except_for and base.device_type in except_for:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -492,7 +492,7 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
     # Creates device-specific test cases
     for base in device_type_test_bases:
         # Skips bases listed in except_for
-        if except_for != [] and only_for != []:
+        if except_for and only_for:
             assert base.device_type not in except_for or base.device_type not in only_for,\
                 "same device cannot appear in except_for and only_for"
         if except_for and base.device_type in except_for:

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -481,14 +481,19 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
     # export PYTORCH_TESTING_DEVICE_ONLY_FOR=cuda,cpu
     # export PYTORCH_TESTING_DEVICE_EXCEPT_FOR=xla
     if only_for is None:
-        only_for = os.getenv("PYTORCH_TESTING_DEVICE_ONLY_FOR", ""). split(",")
+        only_for = os.getenv("PYTORCH_TESTING_DEVICE_ONLY_FOR", None)
+        if only_for is not None:
+            only_for = only_for.split(',')
+
     if except_for is None:
-        except_for = os.getenv("PYTORCH_TESTING_DEVICE_EXCEPT_FOR", ""). split(",")
+        except_for = os.getenv("PYTORCH_TESTING_DEVICE_EXCEPT_FOR", None)
+        if except_for is not None:
+            except_for = except_for.split(',')
 
     # Creates device-specific test cases
     for base in device_type_test_bases:
         # Skips bases listed in except_for
-        if except_for and only_for:
+        if except_for is not None and only_for is not None:
             assert base.device_type not in except_for or base.device_type not in only_for,\
                 "same device cannot appear in except_for and only_for"
         if except_for and base.device_type in except_for:


### PR DESCRIPTION
Fixes: #55670
Reference: https://github.com/pytorch/pytorch/pull/55522

**Cant Run tests locally without setting the ENV variables**

<details>

```
(pytorch-cuda-dev) kshiteej@qgpu1:~/Pytorch/pytorch_opinfo$ pytest test/test_ops.py
======================================================================= test session starts ========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/kshiteej/Pytorch/pytorch_opinfo, configfile: pytest.ini
plugins: hypothesis-5.38.1
collected 0 items                                                                                                                                                  

========================================================================= warnings summary =========================================================================
../../.conda/envs/pytorch-cuda-dev/lib/python3.8/site-packages/torch/backends/cudnn/__init__.py:73
  /home/kshiteej/.conda/envs/pytorch-cuda-dev/lib/python3.8/site-packages/torch/backends/cudnn/__init__.py:73: UserWarning: PyTorch was compiled without cuDNN/MIOpen support. To use cuDNN/MIOpen, rebuild PyTorch making sure the library is visible to the build system.
    warnings.warn(

../../.conda/envs/pytorch-cuda-dev/lib/python3.8/site-packages/torch/testing/_internal/common_nn.py:1195
  /home/kshiteej/.conda/envs/pytorch-cuda-dev/lib/python3.8/site-packages/torch/testing/_internal/common_nn.py:1195: UserWarning: Legacy tensor constructor is deprecated. Use: torch.tensor(...) for creating tensors from tensor-like objects; or torch.empty(...) for creating an uninitialized tensor with specific sizes. (Triggered internally at  ../torch/csrc/utils/tensor_new.cpp:474.)
    random_samples = torch.DoubleTensor(1, 3, 2).uniform_()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================================= 2 warnings in 2.85s ========================================================================
```

</details>


https://github.com/pytorch/pytorch/blob/c7312f5271b9ce9ac988fffde90818354e5841b8/torch/testing/_internal/common_device_type.py#L479-L486

(When running locally where the environment variable is not set)

The case when the env variable is not present, `os.getenv` returns `''` which is split and we get `['']` for `only_for` and `except_for`.

https://github.com/pytorch/pytorch/blob/c7312f5271b9ce9ac988fffde90818354e5841b8/torch/testing/_internal/common_device_type.py#L496-L497

At this point, we take the branch and skip all the tests.
```python
>>> if [''] and 'cuda' not in ['']:
...     print("TRUE")
... 
TRUE
```
