### PR TITLE
breakup autograd documentation

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -220,7 +220,7 @@ and nvprof based (registers both CPU and GPU activity) using
     profiler.profile.key_averages
     profiler.profile.self_cpu_time_total
     profiler.profile.total_average
- 
+
 .. autoclass:: torch.autograd.profiler.emit_nvtx
 
 

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -7,9 +7,12 @@ Automatic differentiation package - torch.autograd
 .. automodule:: torch.autograd
 .. currentmodule:: torch.autograd
 
-.. autofunction:: backward
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autofunction:: grad
+    backward
+    grad
 
 .. _functional-api:
 
@@ -31,28 +34,29 @@ For example, for a function ``f`` that takes three inputs, a Tensor for which we
 tensor that should be considered constant and a boolean flag as ``f(input, constant, flag=flag)``
 you can use it as ``functional.jacobian(lambda x: f(x, constant, flag=flag), input)``.
 
-.. autofunction:: torch.autograd.functional.jacobian
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autofunction:: torch.autograd.functional.hessian
-
-.. autofunction:: torch.autograd.functional.vjp
-
-.. autofunction:: torch.autograd.functional.jvp
-
-.. autofunction:: torch.autograd.functional.vhp
-
-.. autofunction:: torch.autograd.functional.hvp
+    functional.jacobian
+    functional.hessian
+    functional.vjp
+    functional.jvp
+    functional.vhp
+    functional.hvp
 
 .. _locally-disable-grad:
 
 Locally disabling gradient computation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: no_grad
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autoclass:: enable_grad
-
-.. autoclass:: set_grad_enabled
+    no_grad
+    enable_grad
+    set_grad_enabled
 
 .. _default-grad-layouts:
 
@@ -148,47 +152,54 @@ Variable (deprecated)
 
 Tensor autograd functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: torch.Tensor
-   :noindex:
+.. autosummary::
+    :nosignatures:
 
-   .. autoattribute:: grad
-      :noindex:
-   .. autoattribute:: requires_grad
-      :noindex:
-   .. autoattribute:: is_leaf
-      :noindex:
-   .. automethod:: backward
-      :noindex:
-   .. automethod:: detach
-      :noindex:
-   .. automethod:: detach_
-      :noindex:
-   .. automethod:: register_hook
-      :noindex:
-   .. automethod:: retain_grad
-      :noindex:
+   torch.Tensor.grad
+   torch.Tensor.requires_grad
+   torch.Tensor.is_leaf
+   torch.Tensor.backward
+   torch.Tensor.detach
+   torch.Tensor.detach_
+   torch.Tensor.register_hook
+   torch.Tensor.retain_grad
 
 :hidden:`Function`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: Function
-    :members:
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Function.backward
+    Function.forward
 
 Context method mixins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When creating a new :class:`Function`, the following methods are available to `ctx`.
 
-.. autoclass:: torch.autograd.function._ContextMethodMixin
-    :members:
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    function._ContextMethodMixin.mark_dirty
+    function._ContextMethodMixin.mark_non_differentiable
+    function._ContextMethodMixin.save_for_backward
+    function._ContextMethodMixin.set_materialize_grads
 
 .. _grad-check:
 
 Numerical gradient checking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: gradcheck
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autofunction:: gradgradcheck
+    gradcheck
+    gradgradcheck
 
 Profiler
 ^^^^^^^^
@@ -200,12 +211,24 @@ and nvprof based (registers both CPU and GPU activity) using
 :class:`~torch.autograd.profiler.emit_nvtx`.
 
 .. autoclass:: torch.autograd.profiler.profile
-    :members:
 
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    profiler.profile.export_chrome_trace
+    profiler.profile.key_averages
+    profiler.profile.self_cpu_time_total
+    profiler.profile.total_average
+ 
 .. autoclass:: torch.autograd.profiler.emit_nvtx
-    :members:
 
-.. autofunction:: torch.autograd.profiler.load_nvprof
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    profiler.load_nvprof
 
 Anomaly detection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/torch/autograd/__init__.py
+++ b/torch/autograd/__init__.py
@@ -73,7 +73,8 @@ def backward(
     grad_variables: Optional[_TensorOrTensors] = None,
     inputs: Optional[_TensorOrTensors] = None,
 ) -> None:
-    r"""Computes the sum of gradients of given tensors w.r.t. graph leaves.
+    r"""Computes the sum of gradients of given tensors with respect to graph
+    leaves.
 
     The graph is differentiated using the chain rule. If any of ``tensors``
     are non-scalar (i.e. their data has more than one element) and require
@@ -157,7 +158,8 @@ def grad(
     only_inputs: bool = True,
     allow_unused: bool = False
 ) -> Tuple[torch.Tensor, ...]:
-    r"""Computes and returns the sum of gradients of outputs w.r.t. the inputs.
+    r"""Computes and returns the sum of gradients of outputs with respect to
+    the inputs.
 
     ``grad_outputs`` should be a sequence of length matching ``output``
     containing the "vector" in Jacobian-vector product, usually the pre-computed

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -12,11 +12,13 @@ entr(input, *, out=None) -> Tensor
 Computes the entropy on :attr:`input` (as defined below), elementwise.
 
 .. math::
+    \begin{align}
     \text{entr(x)} = \begin{cases}
         -x * \ln(x)  & x > 0 \\
         0 &  x = 0.0 \\
         -\infty & x < 0
     \end{cases}
+    \end{align}
 """ + """
 
 Args:
@@ -131,13 +133,15 @@ Returns a new tensor with the logit of the elements of :attr:`input`.
 When eps is None and :attr:`input` < 0 or :attr:`input` > 1, the function will yields NaN.
 
 .. math::
-    y_{i} = \ln(\frac{z_{i}}{1 - z_{i}}) \\
-    z_{i} = \begin{cases}
+    \begin{align}
+    y_{i} &= \ln(\frac{z_{i}}{1 - z_{i}}) \\
+    z_{i} &= \begin{cases}
         x_{i} & \text{if eps is None} \\
         \text{eps} & \text{if } x_{i} < \text{eps} \\
         x_{i} & \text{if } \text{eps} \leq x_{i} \leq 1 - \text{eps} \\
         1 - \text{eps} & \text{if } x_{i} > 1 - \text{eps}
     \end{cases}
+    \end{align}
 """ + r"""
 Args:
     {input}


### PR DESCRIPTION
Related to #52256

Use autosummary instead of autofunction to create subpages for autograd functions. I left the autoclass parts intact but manually laid out their members. 

Also the Latex formatting of the spcecial page emitted a warning (solved by adding `\begin{align}...\end{align}`) and fixed alignment of equations (by using `&=` instead of `=`).

@zou3519