### PR TITLE
breakup optim, cuda documentation

### DIFF
--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -3,68 +3,104 @@ torch.cuda
 
 .. currentmodule:: torch.cuda
 
-.. automodule:: torch.cuda
-   :members:
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    StreamContext
+    can_device_access_peer
+    current_blas_handle
+    current_device
+    current_stream
+    default_stream
+    device
+    device_count
+    device_of
+    get_arch_list
+    get_device_capability
+    get_device_name
+    get_device_properties
+    get_gencode_flags
+    init
+    ipc_collect
+    is_available
+    is_initialized
+    set_device
+    set_stream
+    stream
+    synchronize
 
 Random Number Generator
 -------------------------
-.. autofunction:: get_rng_state
-.. autofunction:: get_rng_state_all
-.. autofunction:: set_rng_state
-.. autofunction:: set_rng_state_all
-.. autofunction:: manual_seed
-.. autofunction:: manual_seed_all
-.. autofunction:: seed
-.. autofunction:: seed_all
-.. autofunction:: initial_seed
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    get_rng_state
+    get_rng_state_all
+    set_rng_state
+    set_rng_state_all
+    manual_seed
+    manual_seed_all
+    seed
+    seed_all
+    initial_seed
 
 
 Communication collectives
 -------------------------
 
-.. autofunction:: torch.cuda.comm.broadcast
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autofunction:: torch.cuda.comm.broadcast_coalesced
-
-.. autofunction:: torch.cuda.comm.reduce_add
-
-.. autofunction:: torch.cuda.comm.scatter
-
-.. autofunction:: torch.cuda.comm.gather
+    comm.broadcast
+    comm.broadcast_coalesced
+    comm.reduce_add
+    comm.scatter
+    comm.gather
 
 Streams and events
 ------------------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autoclass:: Stream
-   :members:
-
-.. autoclass:: Event
-   :members:
+    Stream
+    Event
 
 Memory management
 -----------------
-.. autofunction:: empty_cache
-.. autofunction:: list_gpu_processes
-.. autofunction:: memory_stats
-.. autofunction:: memory_summary
-.. autofunction:: memory_snapshot
-.. autofunction:: memory_allocated
-.. autofunction:: max_memory_allocated
-.. autofunction:: reset_max_memory_allocated
-.. autofunction:: memory_reserved
-.. autofunction:: max_memory_reserved
-.. autofunction:: set_per_process_memory_fraction
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+     empty_cache
+     list_gpu_processes
+     memory_stats
+     memory_summary
+     memory_snapshot
+     memory_allocated
+     max_memory_allocated
+     reset_max_memory_allocated
+     memory_reserved
+     max_memory_reserved
+     set_per_process_memory_fraction
+     memory_cached
+     max_memory_cached
+     reset_max_memory_cached
+     reset_peak_memory_stats
 .. FIXME The following doesn't seem to exist. Is it supposed to?
    https://github.com/pytorch/pytorch/issues/27785
    .. autofunction:: reset_max_memory_reserved
-.. autofunction:: memory_cached
-.. autofunction:: max_memory_cached
-.. autofunction:: reset_max_memory_cached
-.. autofunction:: reset_peak_memory_stats
 
 NVIDIA Tools Extension (NVTX)
 -----------------------------
 
-.. autofunction:: torch.cuda.nvtx.mark
-.. autofunction:: torch.cuda.nvtx.range_push
-.. autofunction:: torch.cuda.nvtx.range_pop
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    nvtx.mark
+    nvtx.range_push
+    nvtx.range_pop

--- a/docs/source/cuda.rst
+++ b/docs/source/cuda.rst
@@ -1,6 +1,6 @@
 torch.cuda
 ===================================
-
+.. automodule:: torch.cuda
 .. currentmodule:: torch.cuda
 
 .. autosummary::

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -102,33 +102,39 @@ Example::
 
 .. _optimizer-algorithms:
 
-Algorithms
+Base class
 ----------
 
 .. autoclass:: Optimizer
-    :members:
-.. autoclass:: Adadelta
-    :members:
-.. autoclass:: Adagrad
-    :members:
-.. autoclass:: Adam
-    :members:
-.. autoclass:: AdamW
-    :members:
-.. autoclass:: SparseAdam
-    :members:
-.. autoclass:: Adamax
-    :members:
-.. autoclass:: ASGD
-    :members:
-.. autoclass:: LBFGS
-    :members:
-.. autoclass:: RMSprop
-    :members:
-.. autoclass:: Rprop
-    :members:
-.. autoclass:: SGD
-    :members:
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Optimizer.add_param_group
+    Optimizer.load_state_dict
+    Optimizer.state_dict
+    Optimizer.step
+    Optimizer.zero_grad
+
+Algorithms
+----------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    Adadelta
+    Adagrad
+    Adam
+    AdamW
+    SparseAdam
+    Adamax
+    ASGD
+    LBFGS
+    RMSprop
+    Rprop
+    SGD
 
 How to adjust learning rate
 ---------------------------
@@ -155,26 +161,20 @@ should write your code this way:
   if you are calling ``scheduler.step()`` at the wrong time.
 
 
-.. autoclass:: torch.optim.lr_scheduler.LambdaLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.MultiplicativeLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.StepLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.MultiStepLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.ExponentialLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.CosineAnnealingLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.ReduceLROnPlateau
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.CyclicLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.OneCycleLR
-    :members:
-.. autoclass:: torch.optim.lr_scheduler.CosineAnnealingWarmRestarts
-    :members:
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    lr_scheduler.LambdaLR
+    lr_scheduler.MultiplicativeLR
+    lr_scheduler.StepLR
+    lr_scheduler.MultiStepLR
+    lr_scheduler.ExponentialLR
+    lr_scheduler.CosineAnnealingLR
+    lr_scheduler.ReduceLROnPlateau
+    lr_scheduler.CyclicLR
+    lr_scheduler.OneCycleLR
+    lr_scheduler.CosineAnnealingWarmRestarts
 
 Stochastic Weight Averaging
 ---------------------------

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -376,7 +376,7 @@ class StreamContext(object):
 
 def stream(stream: Optional['torch.cuda.Stream']) -> StreamContext:  # type: ignore
     r"""Wrapper around the Context-manager StreamContext that
-        selects a given stream.
+    selects a given stream.
 
     Arguments:
         stream (Stream): selected stream. This manager is a no-op if it's

--- a/torch/optim/lbfgs.py
+++ b/torch/optim/lbfgs.py
@@ -182,7 +182,7 @@ def _strong_wolfe(obj_func,
 
 class LBFGS(Optimizer):
     """Implements L-BFGS algorithm, heavily inspired by `minFunc
-    <https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`.
+    <https://www.cs.ubc.ca/~schmidtm/Software/minFunc.html>`_.
 
     .. warning::
         This optimizer doesn't support per-parameter options and parameter


### PR DESCRIPTION
Related to #52256

Use autosummary instead of autofunction to create subpages for optim and cuda functions/classes.

Also fix some minor formatting issues in optim.LBFGS and cuda.stream docstings