### PR TITLE
[17/n][torch/elastic] Make torchelastic launcher compatible with the caffe2.distributed.launch

### DIFF
--- a/test/distributed/elastic/rendezvous/static_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/static_rendezvous_test.py
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+from contextlib import closing
+
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.elastic.rendezvous.static_tcp_rendezvous import (
+    create_rdzv_handler,
+)
+from torch.distributed.elastic.utils import get_socket_with_port
+
+
+class StaticTCPRendezvousTest(unittest.TestCase):
+    def test_missing_port(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="localhost",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_empty_endpoint(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_ipv6_addr(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:90",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_ipv6_addr_localhost(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="[::1]:90",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_get_backend(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="localhost:123",
+            run_id="test",
+            min_nodes=1,
+            max_nodes=1,
+            timeout=60,
+            rank=0,
+        )
+
+        static_rdzv = create_rdzv_handler(rdzv_params)
+        self.assertEqual("static", static_rdzv.get_backend())
+
+    def test_static_rdzv_multiple_calls(self):
+        sock = get_socket_with_port()
+        with closing(sock):
+            master_port = sock.getsockname()[1]
+        master_addr = "localhost"
+
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint=f"{master_addr}:{master_port}",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+            rank=0,
+        )
+        rdzv_handler = create_rdzv_handler(rdzv_params)
+
+        # Call rendezvous two times
+        store, rank, world_size = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(store)
+        self.assertEqual(0, rank)
+        self.assertEqual(1, world_size)
+
+        store, rank, world_size = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(store)
+        self.assertEqual(0, rank)
+        self.assertEqual(1, world_size)

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -27,6 +27,7 @@ if is_available():
         FileStore,
         TCPStore,
         ProcessGroup,
+        PrefixStore,
         Reducer,
         Logger,
         BuiltinCommHookType,

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -21,6 +21,7 @@ from torch.distributed.elastic.agent.server.api import (
 )
 from torch.distributed.elastic.metrics.api import prof
 from torch.distributed.elastic.multiprocessing import start_processes, PContext
+from torch.distributed.elastic.utils import macros
 
 
 log = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     ):
         super().__init__(spec, exit_barrier_timeout)
         self._start_method = start_method
-        self._pcontext : Optional[PContext] = None
+        self._pcontext: Optional[PContext] = None
         rdzv_run_id = spec.rdzv_handler.get_run_id()
         self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
 
@@ -127,8 +128,11 @@ class LocalElasticAgent(SimpleElasticAgent):
     def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
         spec = worker_group.spec
         store = worker_group.store
+        assert store is not None
         master_addr, master_port = super()._get_master_addr_port(store)
         restart_count = spec.max_restarts - self._remaining_restarts
+
+        use_agent_store = spec.rdzv_handler.get_backend() == "static"
 
         args: Dict[int, Tuple] = {}
         envs: Dict[int, Dict[str, str]] = {}
@@ -142,18 +146,22 @@ class LocalElasticAgent(SimpleElasticAgent):
                 "ROLE_NAME": spec.role,
                 "LOCAL_WORLD_SIZE": str(spec.local_world_size),
                 "WORLD_SIZE": str(worker.world_size),
+                "GROUP_WORLD_SIZE": str(worker_group.group_world_size),
                 "ROLE_WORLD_SIZE": str(worker.role_world_size),
                 "MASTER_ADDR": master_addr,
                 "MASTER_PORT": str(master_port),
                 "TORCHELASTIC_RESTART_COUNT": str(restart_count),
                 "TORCHELASTIC_MAX_RESTARTS": str(spec.max_restarts),
                 "TORCHELASTIC_RUN_ID": spec.rdzv_handler.get_run_id(),
+                "TORCHELASTIC_USE_AGENT_STORE": str(use_agent_store),
                 "NCCL_ASYNC_ERROR_HANDLING": str(1),
             }
             if "OMP_NUM_THREADS" in os.environ:
                 worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]
             envs[local_rank] = worker_env
-            args[local_rank] = spec.args
+            worker_args = list(spec.args)
+            worker_args = macros.substitute(worker_args, str(local_rank))
+            args[local_rank] = tuple(worker_args)
 
         # scaling events do not count towards restarts (gets same attempt #)
         # remove existing log dir if this restart is due to a scaling event

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -15,7 +15,7 @@ from torch.distributed import Store, TCPStore
 
 from .api import RendezvousConnectionError, RendezvousParameters, RendezvousStateError
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _matches_machine_hostname, _parse_rendezvous_endpoint
+from .utils import _matches_machine_hostname, parse_rendezvous_endpoint
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class C10dRendezvousBackend(RendezvousBackend):
 
 
 def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
-    host, port = _parse_rendezvous_endpoint(params.endpoint, default_port=29500)
+    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=29500)
 
     cfg_is_host = params.get_as_bool("is_host")
     # If the user has explicitly specified whether our process should host the

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -23,7 +23,7 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousTimeoutError,
 )
 
-from .utils import _parse_rendezvous_endpoint
+from .utils import parse_rendezvous_endpoint
 from .etcd_store import EtcdStore, cas_delay
 
 
@@ -975,7 +975,7 @@ def _create_etcd_client(params: RendezvousParameters) -> etcd.Client:
     """
     Creates a new ``etcd.Client`` from the specified ``RendezvousParameters``.
     """
-    hostname, port = _parse_rendezvous_endpoint(params.endpoint, 2379)
+    hostname, port = parse_rendezvous_endpoint(params.endpoint, 2379)
 
     # The communication protocol
     protocol = params.config.get("protocol")

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -20,7 +20,7 @@ from etcd import (  # type: ignore
 
 from .api import RendezvousConnectionError, RendezvousParameters, RendezvousStateError
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _parse_rendezvous_endpoint
+from .utils import parse_rendezvous_endpoint
 
 
 class EtcdRendezvousBackend(RendezvousBackend):
@@ -145,7 +145,7 @@ class EtcdRendezvousBackend(RendezvousBackend):
 
 
 def _create_etcd_client(params: RendezvousParameters) -> EtcdClient:
-    host, port = _parse_rendezvous_endpoint(params.endpoint, default_port=2379)
+    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=2379)
 
     # The timeout
     read_timeout = cast(int, params.get_as_int("read_timeout", 60))
@@ -210,4 +210,6 @@ def create_backend(params: RendezvousParameters) -> EtcdRendezvousBackend:
     """
     client = _create_etcd_client(params)
 
-    return EtcdRendezvousBackend(client, params.run_id, key_prefix="/torch/elastic/rendezvous")
+    return EtcdRendezvousBackend(
+        client, params.run_id, key_prefix="/torch/elastic/rendezvous"
+    )

--- a/torch/distributed/elastic/rendezvous/registry.py
+++ b/torch/distributed/elastic/rendezvous/registry.py
@@ -10,6 +10,12 @@ from .dynamic_rendezvous import create_handler
 
 
 def _create_etcd_handler(params: RendezvousParameters) -> RendezvousHandler:
+    from . import static_tcp_rendezvous
+
+    return static_tcp_rendezvous.create_rdzv_handler(params)
+
+
+def _create_static_handler(params: RendezvousParameters) -> RendezvousHandler:
     from . import etcd_rendezvous
 
     return etcd_rendezvous.create_rdzv_handler(params)
@@ -38,6 +44,7 @@ def _register_default_handlers() -> None:
     handler_registry.register("etcd", _create_etcd_handler)
     handler_registry.register("c10d-experimental", _create_c10d_handler)
     handler_registry.register("etcd-experimental", _create_expr_etcd_handler)
+    handler_registry.register("static", _create_static_handler)
 
 
 # The legacy function kept for backwards compatibility.

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import datetime
+import logging
+from typing import Tuple, cast, Optional
+
+# pyre-ignore[21]: Could not find name `Store` in `torch.distributed`.
+from torch.distributed import Store, TCPStore, PrefixStore
+from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
+
+log = logging.getLogger(__name__)
+
+_default_timeout_seconds = 600
+
+
+class StaticTCPRendezvous(RendezvousHandler):
+    """
+    Static rendezvous that is a wrapper around the TCPStore.
+    Creates TCPStore based on the input parameters with the
+    listener on the agent with group_rank=0
+    """
+
+    def __init__(
+        self,
+        master_addr: str,
+        master_port: int,
+        rank: int,
+        world_size: int,
+        run_id: str,
+        timeout: int,
+    ):
+        self.master_addr = master_addr
+        self.master_port = master_port
+        self.rank = rank
+        self.world_size = world_size
+        self.run_id = run_id
+        self.timeout = datetime.timedelta(seconds=timeout)
+        self._store: Optional[Store] = None
+
+    def get_backend(self) -> str:
+        return "static"
+
+    def next_rendezvous(self) -> Tuple[Store, int, int]:
+        log.info("Creating TCPStore as the c10d::Store implementation")
+        if not self._store:
+            is_master = self.rank == 0
+            self._store = TCPStore(
+                self.master_addr,
+                self.master_port,
+                self.world_size,
+                is_master,
+                self.timeout,
+            )
+        store = PrefixStore(self.run_id, self._store)
+        return store, self.rank, self.world_size
+
+    def is_closed(self):
+        return False
+
+    def set_closed(self):
+        pass
+
+    def num_nodes_waiting(self):
+        return 0
+
+    def get_run_id(self) -> str:
+        return self.run_id
+
+    def shutdown(self) -> bool:
+        return True
+
+
+def create_rdzv_handler(params: RendezvousParameters) -> RendezvousHandler:
+    if "rank" not in params.config:
+        raise ValueError(
+            "rank is absent in RendezvousParameters."
+            "Try add --node_rank to the cmd request"
+        )
+    endpoint = params.endpoint.strip()
+    if not endpoint:
+        raise ValueError(
+            "endpoint is absent in RendezvousParameters"
+            "Try add --master_port and --master_addr to the cmd request"
+        )
+    master_addr, master_port = parse_rendezvous_endpoint(endpoint, -1)
+    if master_port == -1:
+        raise ValueError(
+            f"Port is absent in endpoint: {endpoint}. Try launching with --master_port"
+        )
+    world_size = params.max_nodes
+    rank = cast(int, params.config.get("rank"))
+    run_id = params.run_id
+    if "timeout" in params.config:
+        timeout = int(params.config["timeout"])
+    else:
+        timeout = _default_timeout_seconds
+    return StaticTCPRendezvous(
+        master_addr, master_port, rank, world_size, run_id, timeout
+    )

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -55,7 +55,7 @@ def _try_parse_port(port_str: str) -> Optional[int]:
     return None
 
 
-def _parse_rendezvous_endpoint(endpoint: Optional[str], default_port: int) -> Tuple[str, int]:
+def parse_rendezvous_endpoint(endpoint: Optional[str], default_port: int) -> Tuple[str, int]:
     """Extracts the hostname and the port number from a rendezvous endpoint.
 
     Args:

--- a/torch/distributed/elastic/utils/__init__.py
+++ b/torch/distributed/elastic/utils/__init__.py
@@ -6,4 +6,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .api import get_env_variable_or_raise  # noqa F401
+from .api import get_env_variable_or_raise, get_socket_with_port, macros  # noqa F401

--- a/torch/distributed/elastic/utils/api.py
+++ b/torch/distributed/elastic/utils/api.py
@@ -7,6 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import socket
+from string import Template
+from typing import List, Any
 
 
 def get_env_variable_or_raise(env_name: str) -> str:
@@ -22,3 +25,38 @@ def get_env_variable_or_raise(env_name: str) -> str:
         msg = f"Environment variable {env_name} expected, but not set"
         raise ValueError(msg)
     return value
+
+
+def get_socket_with_port() -> socket.socket:
+    addrs = socket.getaddrinfo(
+        host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+    )
+    for addr in addrs:
+        family, type, proto, _, _ = addr
+        s = socket.socket(family, type, proto)
+        try:
+            s.bind(("localhost", 0))
+            s.listen(0)
+            return s
+        except OSError as e:
+            s.close()
+    raise RuntimeError("Failed to create a socket")
+
+
+class macros:
+    """
+    Defines simple macros for caffe2.distributed.launch cmd args substitution
+    """
+
+    local_rank = "${local_rank}"
+
+    @staticmethod
+    def substitute(args: List[Any], local_rank: str) -> List[str]:
+        args_sub = []
+        for arg in args:
+            if isinstance(arg, str):
+                sub = Template(arg).safe_substitute(local_rank=local_rank)
+                args_sub.append(sub)
+            else:
+                args_sub.append(arg)
+        return args_sub

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -9,7 +9,7 @@ import os
 import sys
 from datetime import timedelta
 from typing import Optional, Dict, Union
-from torch._C._distributed_c10d import FileStore, TCPStore
+from torch.distributed import FileStore, TCPStore, PrefixStore
 from .constants import default_pg_timeout
 
 _rendezvous_handlers = {}
@@ -149,6 +149,13 @@ def _env_rendezvous_handler(url: str, timeout: timedelta = default_pg_timeout, *
     def _env_error(var):
         return _error("environment variable %s expected, but not set" % var)
 
+    def _get_env_or_raise(env_var: str) -> str:
+        env_val = os.environ.get(env_var, None)
+        if not env_val:
+            raise _env_error(env_var)
+        else:
+            return env_val
+
     result = urlparse(url)
     query: Dict[str, Union[int, str]]
     # mypy doesn't allow dict() to accept List of values (#257)
@@ -161,34 +168,30 @@ def _env_rendezvous_handler(url: str, timeout: timedelta = default_pg_timeout, *
     if "rank" in query:
         rank = int(query["rank"])
     else:
-        rank = os.environ.get("RANK", None)
-        if rank is None:
-            raise _env_error("RANK")
+        rank = int(_get_env_or_raise("RANK"))
 
     if "world_size" in query:
         world_size = int(query["world_size"])
     else:
-        world_size = os.environ.get("WORLD_SIZE", None)
-        if world_size is None:
-            raise _env_error("WORLD_SIZE")
+        world_size = int(_get_env_or_raise("WORLD_SIZE"))
 
-    master_addr = os.environ.get("MASTER_ADDR", None)
-    if master_addr is None:
-        raise _env_error("MASTER_ADDR")
+    master_addr = _get_env_or_raise("MASTER_ADDR")
+    master_port = int(_get_env_or_raise("MASTER_PORT"))
 
-    master_port = os.environ.get("MASTER_PORT", None)
-    if master_port is None:
-        raise _env_error("MASTER_PORT")
 
-    # Converting before creating the store
-    rank = int(rank)
-    world_size = int(world_size)
-    master_port = int(master_port)
+    use_torchelastic_store = os.environ.get("TORCHELASTIC_USE_AGENT_STORE", None)
 
-    # Now start the TCP store daemon on the rank 0
-    start_daemon = rank == 0
-    store = TCPStore(master_addr, master_port, world_size, start_daemon, timeout)
-    yield (store, rank, world_size)
+    if use_torchelastic_store == str(True):
+        worker_process_prefix = "/worker"
+        tcp_store = TCPStore(master_addr, master_port, world_size, False, timeout)
+        # Each if-else condition returns due to: https://github.com/python/mypy/issues/1191
+        yield (PrefixStore(worker_process_prefix, tcp_store), rank, world_size)
+    else:
+        # Start the TCP store daemon on the rank 0
+        start_daemon = rank == 0
+        store = TCPStore(master_addr, master_port, world_size, start_daemon, timeout)
+        # Each if-else condition returns due to: https://github.com/python/mypy/issues/1191
+        yield (store, rank, world_size)
 
     # If this configuration is invalidated, there is nothing we can do about it
     raise RuntimeError("Unable to perform rerendezvous using env:// method")


### PR DESCRIPTION
Summary:
The diff makes sure that users can transfer the following parameters:
* master_addr
* master_port
* node_rank
* use_env

The diff implement StaticTCPRendezvous that creates a store with listener on agent rank #0

The diff modifies caffe2/rendezvous: If the worker process launched with torchelastic agent, the worker processes will create a PrefixStore("worker/") from TCPStore without listener.

The diff adds macros functionality to torch/distributed/ealstic/utils that helps to resolve local_rank parameter.

Test Plan: buck test mode/dev-nosan //pytorch/elastic/torchelastic/distributed/test:launch_test

Differential Revision: D27643206

