### PR TITLE
Simplify benchmark patterns in mypy-strict.ini

### DIFF
--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -36,8 +36,7 @@ strict_equality = True
 
 files =
     .github/scripts/generate_binary_build_matrix.py,
-    benchmarks/instruction_counts/*.py,
-    benchmarks/instruction_counts/*/*.py,
+    benchmarks/instruction_counts,
     tools/autograd/*.py,
     tools/clang_tidy.py,
     tools/codegen/*.py,


### PR DESCRIPTION
These two lines were added in #53296, but they are needlessly complicated; this PR consolidates them.

**Test plan:**

Run this command, and verify that the same number of files is given both before and after this PR:
```
mypy --config=mypy-strict.ini
```