### PR TITLE
patching requires_grad on DifferentiableGraph

### DIFF
--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -61,7 +61,15 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             o = y + 1.5
             o2 = torch.relu(o)
             o3 = o1 + o2
-            return o1, o2, o3
+
+            _ = o1.add_(1.0)
+            _ = o2.add_(1.0)
+            o = o1 * 1.0
+            oo1 = torch.relu(o)
+            o = o2 * 2.0
+            oo2 = torch.relu(o)
+            oo3 = oo1 + oo2
+            return o1, o2, o3, oo1, oo2, oo3
 
         with enable_profiling_mode_for_profiling_tests():
 

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -222,6 +222,7 @@ bool guardDifferentiableGraph(Node* dnode) {
     }
   }
   if (all_inputs_seen) {
+    setRequiresGradOnDiffGraph(dnode);
     // we may have seen both true and false for requires_grad. In this case
     // we guard with true here and the other case is in the fallback. This
     // will give us trouble when we get "alternating patterns" of gradients
@@ -234,7 +235,6 @@ bool guardDifferentiableGraph(Node* dnode) {
               t->requiresGrad().value_or(true));
         },
         prim::RequiresGradCheck);
-    setRequiresGradOnDiffGraph(dnode);
     return true;
   } else {
     // we inline the differentiable graph as a fallback


### PR DESCRIPTION
The retrieval of profile node is much easier prior to inserting guard node.
test cases updated to reflect the patch on a previously failing cases.