### PR TITLE
Fix type annotations for state_dict() override

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1191,10 +1191,10 @@ class Module:
     def state_dict(self, destination: T_destination, prefix: str = ..., keep_vars: bool = ...) -> T_destination:
         ...
 
-    # TODO: annotate with OrderedDict not Dict, but there is a problem:
-    # https://docs.python.org/3/library/typing.html#typing.OrderedDict
+    # TODO: Remove string escape once Python-3.6 no longer supported
+    # See https://github.com/python/mypy/issues/6904#issuecomment-496207426
     @overload
-    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> Dict[str, Tensor]:
+    def state_dict(self, prefix: str = ..., keep_vars: bool = ...) -> 'OrderedDict[str, Tensor]':
         ...
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):


### PR DESCRIPTION
Change annotation to `OrderedDict`, but stringify it to stay compatible with Python-3.6

Fixes #55302