### PR TITLE
Optimize constructing tensors from external data

### DIFF
--- a/aten/src/ATen/templates/Functions.h
+++ b/aten/src/ATen/templates/Functions.h
@@ -100,7 +100,7 @@ class TORCH_API TensorMaker {
 
   TensorMaker& context(void* value, ContextDeleter deleter = nullptr) noexcept {
     ctx_ = std::unique_ptr<void, ContextDeleter>{
-        value, deleter ? deleter : detail::noopDelete};
+        value, deleter != nullptr ? deleter : detail::noopDelete};
 
     return *this;
   }
@@ -130,8 +130,6 @@ class TORCH_API TensorMaker {
   DataPtr makeDataPtrFromContext() noexcept;
 
   IntArrayRef makeTempSizes() const noexcept;
-
-  Tensor makeEmptyTensor() const;
 
   void* data_;
   IntArrayRef sizes_;


### PR DESCRIPTION
This PR optimizes the way tensors are constructed from external data. It avoids allocating an empty tensor beforehand and directly constructs the target tensor by passing the newly-initialized `DataPtr`. Running some Facebook-internal benchmarks showed that combined with #54530 this PR achieves performance parity with Caffe2 tensor construction. (Overall ~2x speed improvement over the original `at::from_blob()` implementation.)

Testing is done with the existing unit and integration tests as there is no user-observable API change.