### PR TITLE
Use _WeakTensorRef over weakref in test_autograd.py

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -831,26 +831,16 @@ class TestAutograd(TestCase):
         self.assertEqual(input * 18, input.grad)
 
     def test_retain_grad_cycle(self):
-        import gc
-        import weakref
-        counter = [0]
-        refs = [None]
-
         x = torch.ones(5, 5, requires_grad=True)
 
         def run_test():
             y = x * 2
             y.retain_grad()
 
-            def inc(*args):
-                counter[0] += 1
-            refs[0] = weakref.ref(y, inc)
-            return y / 2
+            return y / 2, torch._C._WeakTensorRef(y)
 
-        z = run_test()
-        gc.collect()
-        self.assertIsNone(refs[0]())
-        self.assertEqual(counter[0], 1)
+        z, ref = run_test()
+        self.assertTrue(ref.expired())
         z.sum().backward()
 
     def test_backward(self):
@@ -6896,64 +6886,39 @@ class TestAutogradFunctional(TestCase):
 
 class TestAutogradForwardMode(TestCase):
     def test_forward_level_cleanup(self):
-        import weakref
-
         def get_tensor_and_weak_ref():
-            # Helper function to get a Tensor and a weak ref that tells us
-            # if the c++ version of this Tensor is still alive or not.
-            #
-            # Create the following reference chain to do so:
-            #   - python Tensor t
-            #   - c++ Tensor corresponding by t
-            #   - c++ Node corresponding to t.grad_fn
-            #   - python dict of metadata from this Node
-            #   - an object in this dict that we can take a weakref of
-
-
-            # Create a new Tensor and Node
-            t = torch.rand(2, requires_grad=True).clone()
-            # Create the metadata dict
-            meta_dict = t.grad_fn.metadata
-            # Create the object in the dict
-
-            class Foo(object):
-                pass
-            my_obj = Foo()
-            meta_dict[0] = my_obj
-
-            # After exiting this function, the python Tensor t is the only
-            # thing keeping ref alive
-            ref = weakref.ref(my_obj)
-            return t, ref
+            # Create a new Tensor and weak reference
+            t = torch.rand(2, requires_grad=True)
+            return t, torch._C._WeakTensorRef(t)
 
         # Sanity check that the helper function works as expected
         t, t_ref = get_tensor_and_weak_ref()
-        self.assertIsNotNone(t_ref())
+        self.assertFalse(t_ref.expired())
 
         del t
-        self.assertIsNone(t_ref())
+        self.assertTrue(t_ref.expired())
 
         # Main test code
         foo = torch.rand(2)
 
         with fwAD.dual_level():
             tangent, tangent_ref = get_tensor_and_weak_ref()
-            self.assertIsNotNone(tangent_ref())
+            self.assertFalse(tangent_ref.expired())
 
             dual = fwAD.make_dual(foo, tangent)
-            self.assertIsNotNone(tangent_ref())
+            self.assertFalse(tangent_ref.expired())
 
             # Make sure that the tangent we provided has been re-used as is
             self.assertTrue(fwAD.unpack_dual(dual)[1] is tangent)
 
             # Make sure that dual is keeping the tangent alive
             del tangent
-            self.assertIsNotNone(tangent_ref())
+            self.assertFalse(tangent_ref.expired())
 
             # Make sure that the dual level does not keep the c++
             # version of the tangent alive
             del dual
-            self.assertIsNone(tangent_ref())
+            self.assertTrue(tangent_ref.expired())
 
     def test_size_check(self):
         foo = torch.rand(2)


### PR DESCRIPTION
There are a few autograd tests checking for tensors leaked by reference cycles. This changes them to  use `_WeakTensorRef` over `weakref`. `_WeakTensorRef`, added in #52874, accesses the C++ level `TensorImpl` reference count, compared to `weakref` which accesses python refcounts and so can only tell if the python wrapper object gets deallocated. Not only is this less code, it's also more accurately detecting that the Tensor itself is deallocated.

I didn't touch `weakref` usage in [test_anomaly_assign_parent_cleanup](https://github.com/pytorch/pytorch/blob/fc349cbcde10a5d9e8c1fc9a47bbba025a8e9018/test/test_autograd.py#L3733) and [test_nested_anomaly_printstack_cleanup](https://github.com/pytorch/pytorch/blob/fc349cbcde10a5d9e8c1fc9a47bbba025a8e9018/test/test_autograd.py#L3772) because these are intentionally testing for python object cleanup. 