### PR TITLE
Add more model symbolic tracing tests from torchvision

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -30,7 +30,6 @@ from copy import deepcopy
 
 from torch.fx.proxy import TraceError
 
-from fx.quantization import Quantizer
 from fx.test_subgraph_rewriter import TestSubgraphRewriter  # noqa: F401
 from fx.test_dce_pass import TestDCE  # noqa: F401
 from fx.test_fx_const_fold import TestConstFold  # noqa: F401
@@ -2252,9 +2251,7 @@ class TestFX(JitTestCase):
 
 
         import torch
-        # from torchvision.models.resnet import resnet18
         rn = torchvision_models.resnet18()
-        print('imported the model', rn)
 
         try:
             sys.setprofile(trace_func)


### PR DESCRIPTION
Fixes #55398

Generates tests that calls `symbolic_trace` on torchvision models and verifies the parity of outputs from eager model, `fx.GraphModule`, `jit.ScriptModule`. 


Test errors: GoogleNet and Inception models throw a type mismatch when scripting the traced `fx.GraphModule`.
```
Return value was annotated as having type __torch__.torchvision.models.googlenet.GoogLeNetOutputs but is actually of type Tensor:
    dropout = self.dropout(flatten);  flatten = None
    fc = self.fc(dropout);  dropout = None
    return fc
    ~~~~~~~~~ <--- HERE
```

Relevant type-inconsistency https://github.com/pytorch/vision/blob/512ea299d4b2d2bbac3498a75a2d8c0190cfcb39/torchvision/models/googlenet.py#L200
```
@torch.jit.unused
    def eager_outputs(self, x: Tensor, aux2: Tensor, aux1: Optional[Tensor]) -> GoogLeNetOutputs:
        if self.training and self.aux_logits:
            return _GoogLeNetOutputs(x, aux2, aux1)
        else:
            return x   # type: ignore[return-value]
```