### PR TITLE
Use autosummary on torch.fft, torch.linalg

### DIFF
--- a/docs/source/fft.rst
+++ b/docs/source/fft.rst
@@ -14,25 +14,33 @@ Discrete Fourier transforms and related functions.
 Fast Fourier Transforms
 -----------------------
 
-.. autofunction:: fft
-.. autofunction:: ifft
-.. autofunction:: fft2
-.. autofunction:: ifft2
-.. autofunction:: fftn
-.. autofunction:: ifftn
-.. autofunction:: rfft
-.. autofunction:: irfft
-.. autofunction:: rfft2
-.. autofunction:: irfft2
-.. autofunction:: rfftn
-.. autofunction:: irfftn
-.. autofunction:: hfft
-.. autofunction:: ihfft
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    fft
+    ifft
+    fft2
+    ifft2
+    fftn
+    ifftn
+    rfft
+    irfft
+    rfft2
+    irfft2
+    rfftn
+    irfftn
+    hfft
+    ihfft
 
 Helper Functions
 ----------------
 
-.. autofunction:: fftfreq
-.. autofunction:: rfftfreq
-.. autofunction:: fftshift
-.. autofunction:: ifftshift
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    fftfreq
+    rfftfreq
+    fftshift
+    ifftshift

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -15,26 +15,30 @@ function for details.
 
 Functions
 ---------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
 
-.. autofunction:: cholesky
-.. autofunction:: cond
-.. autofunction:: det
-.. autofunction:: slogdet
-.. autofunction:: eig
-.. autofunction:: eigvals
-.. autofunction:: eigh
-.. autofunction:: eigvalsh
-.. autofunction:: matrix_power
-.. autofunction:: matrix_rank
-.. autofunction:: multi_dot
-.. autofunction:: norm
-.. autofunction:: vector_norm
-.. autofunction:: pinv
-.. autofunction:: svd
-.. autofunction:: solve
-.. autofunction:: tensorinv
-.. autofunction:: tensorsolve
-.. autofunction:: inv
-.. autofunction:: qr
-.. autofunction:: lstsq
-.. autofunction:: householder_product
+
+    cholesky
+    cond
+    det
+    slogdet
+    eig
+    eigvals
+    eigh
+    eigvalsh
+    matrix_power
+    matrix_rank
+    multi_dot
+    norm
+    vector_norm
+    pinv
+    svd
+    solve
+    tensorinv
+    tensorsolve
+    inv
+    qr
+    lstsq
+    householder_product


### PR DESCRIPTION
Related to #52256

Use autosummary instead of autofunction to create subpages for `torch.fft` and `torch.linalg` functions.

@zou3519