### PR TITLE
[quant][refactor] Dedup the batch norm code

### DIFF
--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -1,68 +1,61 @@
 import torch
 import torch.nn.quantized.functional
-import torch.nn.intrinsic as nni
 
-class BatchNorm2d(torch.nn.BatchNorm2d):
-    r"""This is the quantized version of :class:`~torch.nn.BatchNorm2d`.
-    """
 
+class _BatchNormBase(torch.nn.modules.batchnorm._BatchNorm):
     def __init__(self, num_features, eps=1e-5, momentum=0.1):
-        super(BatchNorm2d, self).__init__(num_features)
-        self.eps = eps
+        r"""Base class for the batch norm"""
+        super().__init__(num_features, eps, momentum)
         self.scale = 1.0
         self.zero_point = 0
+
+    def _get_name(self):
+        return self._NAME
+
+    def forward(self, x):
+        raise NotImplementedError("Cannot use instance of `_BatchNormBase`")
+
+    @classmethod
+    def from_float(cls, mod):
+        activation_post_process = mod.activation_post_process
+        if type(mod) == cls._INTRINSIC_MODULE:
+            mod = mod[0]
+        scale, zero_point = activation_post_process.calculate_qparams()
+        new_mod = cls(mod.num_features, mod.eps)
+        new_mod.weight = mod.weight
+        new_mod.bias = mod.bias
+        new_mod.running_mean = mod.running_mean
+        new_mod.running_var = mod.running_var
+        new_mod.scale = float(scale)
+        new_mod.zero_point = int(zero_point)
+        return new_mod
+
+    def _check_input_dim(self, x):
+        if self._DIM == 1 and x.dim() != 2 and x.dim() != 3:
+            raise ValueError(f'Expected 2D or 3D input (got {x.dim()}D)')
+        elif x.dim() != self._DIM + 2:
+            raise ValueError(f'Expected {self._DIM}D input (got {x.dim()}D)')
+
+
+class BatchNorm2d(_BatchNormBase):
+    r"""This is the quantized version of :class:`~torch.nn.BatchNorm2d`.
+    """
+    _INTRINSIC_MODULE = torch.nn.intrinsic.BNReLU2d
+    _DIM = 2
+    _NAME = 'QuantizedBatchNorm2d'
 
     def forward(self, input):
         return torch.ops.quantized.batch_norm2d(input, self.weight, self.bias, self.running_mean,
                                                 self.running_var, self.eps, self.scale, self.zero_point)
 
-    def _get_name(self):
-        return 'QuantizedBatchNorm2d'
 
-    @classmethod
-    def from_float(cls, mod):
-        activation_post_process = mod.activation_post_process
-        if type(mod) == nni.BNReLU2d:
-            mod = mod[0]
-        scale, zero_point = activation_post_process.calculate_qparams()
-        new_mod = cls(mod.num_features, mod.eps)
-        new_mod.weight = mod.weight
-        new_mod.bias = mod.bias
-        new_mod.running_mean = mod.running_mean
-        new_mod.running_var = mod.running_var
-        new_mod.scale = float(scale)
-        new_mod.zero_point = int(zero_point)
-        return new_mod
-
-# TODO: dedup with BatchNorm2d
-class BatchNorm3d(torch.nn.BatchNorm3d):
+class BatchNorm3d(_BatchNormBase):
     r"""This is the quantized version of :class:`~torch.nn.BatchNorm3d`.
     """
-
-    def __init__(self, num_features, eps=1e-5, momentum=0.1):
-        super(BatchNorm3d, self).__init__(num_features)
-        self.eps = eps
-        self.scale = 1.0
-        self.zero_point = 0
+    _INTRINSIC_MODULE = torch.nn.intrinsic.BNReLU3d
+    _DIM = 3
+    _NAME = 'QuantizedBatchNorm3d'
 
     def forward(self, input):
         return torch.ops.quantized.batch_norm3d(input, self.weight, self.bias, self.running_mean,
                                                 self.running_var, self.eps, self.scale, self.zero_point)
-
-    def _get_name(self):
-        return 'QuantizedBatchNorm3d'
-
-    @classmethod
-    def from_float(cls, mod):
-        activation_post_process = mod.activation_post_process
-        if type(mod) == nni.BNReLU3d:
-            mod = mod[0]
-        scale, zero_point = activation_post_process.calculate_qparams()
-        new_mod = cls(mod.num_features, mod.eps)
-        new_mod.weight = mod.weight
-        new_mod.bias = mod.bias
-        new_mod.running_mean = mod.running_mean
-        new_mod.running_var = mod.running_var
-        new_mod.scale = float(scale)
-        new_mod.zero_point = int(zero_point)
-        return new_mod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55761 [quant] ConvBNReLU1d
* #55760 [quant][refactor] Renaming layer names in the batch norm test
* #55759 [quant][refactor] BatchNorm factor out common code
* **#55758 [quant][refactor] Dedup the batch norm code**

Batch norm 2d and 3d were carbon copies of each other. This factors out the duplicated portions

Differential Revision: [D27702396](https://our.internmc.facebook.com/intern/diff/D27702396/)