### PR TITLE
[quant][refactor] BatchNorm factor out common code

### DIFF
--- a/torch/nn/intrinsic/quantized/modules/bn_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/bn_relu.py
@@ -15,27 +15,14 @@ class BNReLU2d(nnq.BatchNorm2d):
         Same as torch.nn.quantized.BatchNorm2d
 
     """
-    _FLOAT_MODULE = torch.nn.intrinsic.BNReLU2d
-
-    def __init__(self, num_features, eps=1e-5, momentum=0.1):
-        super(BNReLU2d, self).__init__(num_features, eps=eps, momentum=momentum)
+    # TODO: Add qat support for BNReLU2d
+    _NAME = 'QuantizedBNReLU2d'
 
     def forward(self, input):
-        # Temporarily using len(shape) instead of ndim due to JIT issue
-        # https://github.com/pytorch/pytorch/issues/23890
-        if len(input.shape) != 4:
-            raise ValueError("Input shape must be `(N, C, H, W)`!")
+        self._check_input_dim(input)
         return torch.ops.quantized.batch_norm2d_relu(
             input, self.weight, self.bias, self.running_mean,
             self.running_var, self.eps, self.scale, self.zero_point)
-
-    def _get_name(self):
-        return 'QuantizedBNReLU2d'
-
-    @classmethod
-    def from_float(cls, mod):
-        # TODO: Add qat support for BNReLU2d
-        return super(BNReLU2d, cls).from_float(mod)
 
 
 class BNReLU3d(nnq.BatchNorm3d):
@@ -48,24 +35,11 @@ class BNReLU3d(nnq.BatchNorm3d):
     Attributes: Same as torch.nn.quantized.BatchNorm3d
 
     """
-    _FLOAT_MODULE = torch.nn.intrinsic.BNReLU3d
-
-    def __init__(self, num_features, eps=1e-5, momentum=0.1):
-        super(BNReLU3d, self).__init__(num_features, eps=eps, momentum=momentum)
+    # TODO: Add qat support for BNReLU3d
+    _NAME = 'QuantizedBNReLU3d'
 
     def forward(self, input):
-        # Temporarily using len(shape) instead of ndim due to JIT issue
-        # https://github.com/pytorch/pytorch/issues/23890
-        if len(input.shape) != 5:
-            raise ValueError("Input shape must be `(N, C, D, H, W)`!")
+        self._check_input_dim(input)
         return torch.ops.quantized.batch_norm3d_relu(
             input, self.weight, self.bias, self.running_mean,
             self.running_var, self.eps, self.scale, self.zero_point)
-
-    def _get_name(self):
-        return 'QuantizedBNReLU3d'
-
-    @classmethod
-    def from_float(cls, mod):
-        # TODO: Add qat support for BNReLU3d
-        return super(BNReLU3d, cls).from_float(mod)

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -18,7 +18,10 @@ class _BatchNormBase(torch.nn.modules.batchnorm._BatchNorm):
     @classmethod
     def from_float(cls, mod):
         activation_post_process = mod.activation_post_process
-        if type(mod) == cls._INTRINSIC_MODULE:
+        if hasattr(mod, '__getitem__') and type(mod[0]) == cls._FLOAT_MODULE:
+            # Intrinsic (fused) modules are treated as a sequential set.
+            # However, we need to treat them as fused, and will only take the
+            # batch norm layer.
             mod = mod[0]
         scale, zero_point = activation_post_process.calculate_qparams()
         new_mod = cls(mod.num_features, mod.eps)
@@ -40,7 +43,7 @@ class _BatchNormBase(torch.nn.modules.batchnorm._BatchNorm):
 class BatchNorm2d(_BatchNormBase):
     r"""This is the quantized version of :class:`~torch.nn.BatchNorm2d`.
     """
-    _INTRINSIC_MODULE = torch.nn.intrinsic.BNReLU2d
+    _FLOAT_MODULE = torch.nn.BatchNorm2d
     _DIM = 2
     _NAME = 'QuantizedBatchNorm2d'
 
@@ -52,7 +55,7 @@ class BatchNorm2d(_BatchNormBase):
 class BatchNorm3d(_BatchNormBase):
     r"""This is the quantized version of :class:`~torch.nn.BatchNorm3d`.
     """
-    _INTRINSIC_MODULE = torch.nn.intrinsic.BNReLU3d
+    _FLOAT_MODULE = torch.nn.BatchNorm3d
     _DIM = 3
     _NAME = 'QuantizedBatchNorm3d'
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55761 [quant] ConvBNReLU1d
* #55760 [quant][refactor] Renaming layer names in the batch norm test
* **#55759 [quant][refactor] BatchNorm factor out common code**
* #55758 [quant][refactor] Dedup the batch norm code

Batch norm had some duplicate code shared with the intrinsic. This factors out the common portions of it

Differential Revision: [D27701951](https://our.internmc.facebook.com/intern/diff/D27701951/)