### PR TITLE
[quant] ConvBNReLU1d

### DIFF
--- a/torch/nn/intrinsic/modules/__init__.py
+++ b/torch/nn/intrinsic/modules/__init__.py
@@ -9,6 +9,7 @@ from .fused import ConvReLU1d
 from .fused import ConvReLU2d
 from .fused import ConvReLU3d
 from .fused import LinearReLU
+from .fused import BNReLU1d
 from .fused import BNReLU2d
 from .fused import BNReLU3d
 

--- a/torch/nn/intrinsic/modules/fused.py
+++ b/torch/nn/intrinsic/modules/fused.py
@@ -96,6 +96,15 @@ class ConvBnReLU3d(_FusedModule):
         super().__init__(conv, bn, relu)
 
 
+class BNReLU1d(_FusedModule):
+    r"""This is a sequential container which calls the BatchNorm 1d and ReLU modules.
+    During quantization this will be replaced with the corresponding fused module."""
+    def __init__(self, batch_norm, relu):
+        assert type(batch_norm) == BatchNorm1d and type(relu) == ReLU, \
+            'Incorrect types for input modules{}{}'.format(
+                type(batch_norm), type(relu))
+        super().__init__(batch_norm, relu)
+
 class BNReLU2d(_FusedModule):
     r"""This is a sequential container which calls the BatchNorm 2d and ReLU modules.
     During quantization this will be replaced with the corresponding fused module."""

--- a/torch/nn/intrinsic/quantized/modules/__init__.py
+++ b/torch/nn/intrinsic/quantized/modules/__init__.py
@@ -1,12 +1,13 @@
 from .linear_relu import LinearReLU
 from .conv_relu import ConvReLU1d, ConvReLU2d, ConvReLU3d
-from .bn_relu import BNReLU2d, BNReLU3d
+from .bn_relu import BNReLU1d, BNReLU2d, BNReLU3d
 
 __all__ = [
     'LinearReLU',
     'ConvReLU1d',
     'ConvReLU2d',
     'ConvReLU3d',
+    'BNReLU1d',
     'BNReLU2d',
     'BNReLU3d',
 ]

--- a/torch/nn/intrinsic/quantized/modules/bn_relu.py
+++ b/torch/nn/intrinsic/quantized/modules/bn_relu.py
@@ -5,6 +5,26 @@ import torch.nn.intrinsic.qat
 import torch.nn.quantized as nnq
 
 
+class BNReLU1d(nnq.BatchNorm1d):
+    r"""
+    A BNReLU1d module is a fused module of BatchNorm1d and ReLU
+
+    We adopt the same interface as :class:`torch.nn.quantized.BatchNorm1d`.
+
+    Attributes:
+        Same as torch.nn.quantized.BatchNorm1d
+
+    """
+    # TODO: Add qat support for BNReLU1d
+    _NAME = 'QuantizedBNReLU1d'
+
+    def forward(self, input):
+        self._check_input_dim(input)
+        return torch.ops.quantized.batch_norm1d_relu(
+            input, self.weight, self.bias, self.running_mean,
+            self.running_var, self.eps, self.scale, self.zero_point)
+
+
 class BNReLU2d(nnq.BatchNorm2d):
     r"""
     A BNReLU2d module is a fused module of BatchNorm2d and ReLU

--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -2,7 +2,7 @@ import torch
 from torch.nn.modules.pooling import MaxPool2d
 
 from .activation import ReLU6, Hardswish, ELU, LeakyReLU, Sigmoid
-from .batchnorm import BatchNorm2d, BatchNorm3d
+from .batchnorm import BatchNorm1d, BatchNorm2d, BatchNorm3d
 from .normalization import LayerNorm, GroupNorm, InstanceNorm1d, \
     InstanceNorm2d, InstanceNorm3d
 from .conv import _ConvNd, Conv1d, Conv2d, Conv3d
@@ -83,6 +83,7 @@ class DeQuantize(torch.nn.Module):
         return DeQuantize()
 
 __all__ = [
+    'BatchNorm1d',
     'BatchNorm2d',
     'BatchNorm3d',
     '_ConvNd',

--- a/torch/nn/quantized/modules/batchnorm.py
+++ b/torch/nn/quantized/modules/batchnorm.py
@@ -40,6 +40,18 @@ class _BatchNormBase(torch.nn.modules.batchnorm._BatchNorm):
             raise ValueError(f'Expected {self._DIM}D input (got {x.dim()}D)')
 
 
+class BatchNorm1d(_BatchNormBase):
+    r"""This is the quantized version of :class:`~torch.nn.BatchNorm1d`.
+    """
+    _FLOAT_MODULE = torch.nn.BatchNorm1d
+    _DIM = 1
+    _NAME = 'QuantizedBatchNorm1d'
+
+    def forward(self, input):
+        return torch.ops.quantized.batch_norm1d(input, self.weight, self.bias, self.running_mean,
+                                                self.running_var, self.eps, self.scale, self.zero_point)
+
+
 class BatchNorm2d(_BatchNormBase):
     r"""This is the quantized version of :class:`~torch.nn.BatchNorm2d`.
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55761 [quant] ConvBNReLU1d**
* #55760 [quant][refactor] Renaming layer names in the batch norm test
* #55759 [quant][refactor] BatchNorm factor out common code
* #55758 [quant][refactor] Dedup the batch norm code

Although the 1d conv BN is already supported, this introduces `BNReLU1d` and `BatchNorm1d` for consistency.

Differential Revision: [D27702386](https://our.internmc.facebook.com/intern/diff/D27702386/)