### PR TITLE
fixing DifferentiableGraph output with wrong requires_grad flag

### DIFF
--- a/test/jit/test_autodiff_subgraph_slicing.py
+++ b/test/jit/test_autodiff_subgraph_slicing.py
@@ -55,7 +55,7 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
         x = torch.randn(8, 2, dtype=torch.float).requires_grad_()
         y = torch.randn(8, 2, dtype=torch.float)
 
-        def t(x : torch.Tensor, y : torch.Tensor):
+        def t(x : torch.Tensor, y : torch.Tensor, flag : bool):
             o = x + 1.0
             o1 = torch.relu(o)
             o = y + 1.5
@@ -63,17 +63,17 @@ class TestAutodiffSubgraphSlicing(JitTestCase):
             o3 = o1 + o2
 
             if flag:
-              o = o1 + 1.0
-              oo1 = torch.relu(o)
-              o = o2 + 2.5
-              oo2 = torch.relu(o)
-              oo3 = oo1 + oo2
+                o = o1 + 1.0
+                oo1 = torch.relu(o)
+                o = o2 + 2.5
+                oo2 = torch.relu(o)
+                oo3 = oo1 + oo2
             else:
-              o = o1 * 1.0
-              oo1 = torch.relu(o)
-              o = o2 * 2.0
-              oo2 = torch.relu(o)
-              oo3 = oo1 + oo2
+                o = o1 * 1.0
+                oo1 = torch.relu(o)
+                o = o2 * 2.0
+                oo2 = torch.relu(o)
+                oo3 = oo1 + oo2
 
             return o1, o2, o3, oo1, oo2, oo3
 

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -159,8 +159,7 @@ static void setRequiresGradOnDiffGraph(Node* dnode) {
   auto go = dnode->g(attr::Subgraph)->outputs();
   auto set_requires_grad = [](const TensorTypePtr& t, Value* val) -> bool {
     if (t && t->requiresGrad().has_value()) {
-      GRAPH_DEBUG(
-          "setting type ", *t);
+      GRAPH_DEBUG("setting type ", *t);
       val->setType(t);
       return true;
     }
@@ -175,20 +174,25 @@ static void setRequiresGradOnDiffGraph(Node* dnode) {
       for (auto dno_use : dno->uses()) {
         GRAPH_DEBUG("found user of ", i, " as ", *dno_use.user);
         if (n->kind() == prim::profile) {
-          if (set_requires_grad(n->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+          if (set_requires_grad(
+                  n->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
             break;
           }
         } else if (dno_use.user->kind() == prim::profile) {
-          if (set_requires_grad(dno_use.user->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+          if (set_requires_grad(
+                  dno_use.user->ty(attr::profiled_type)->expect<TensorType>(),
+                  go[i])) {
             break;
           }
         } else if (dno_use.user->kind() == prim::DifferentiableGraph) {
           Value* o =
               dno_use.user->g(attr::Subgraph)->inputs().at(dno_use.offset);
-          // Is it safe to not check other uses, because we are inside a DifferentiableGraph?
+          // Is it safe to not check other uses, because we are inside a
+          // DifferentiableGraph?
           auto nn = o->uses().at(0).user;
           if (nn->kind() == prim::profile) {
-            if (set_requires_grad(nn->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+            if (set_requires_grad(
+                    nn->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
               break;
             }
           }

--- a/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
+++ b/torch/csrc/jit/runtime/profiling_graph_executor_impl.cpp
@@ -157,32 +157,41 @@ static void setRequiresGradOnDiffGraph(Node* dnode) {
   // can  set df_input_vjps and DifferentiableGraphOp can set `requires_grad=`
   // properly
   auto go = dnode->g(attr::Subgraph)->outputs();
+  auto set_requires_grad = [](const TensorTypePtr& t, Value* val) -> bool {
+    if (t && t->requiresGrad().has_value()) {
+      GRAPH_DEBUG(
+          "setting type ", *t);
+      val->setType(t);
+      return true;
+    }
+    return false;
+  };
+
   for (size_t i = 0; i < go.size(); i++) {
     auto ty = go[i]->type()->cast<TensorType>();
     if (ty) {
       auto n = go[i]->node();
       auto dno = dnode->outputs().at(i);
-      auto dno_use0 = dno->uses().at(0);
-      GRAPH_DEBUG("found first user of ", i, " as ", *dno_use0.user);
-      if (n->kind() == prim::profile) {
-        GRAPH_DEBUG(
-            "setting output ", i, " to type ", *n->ty(attr::profiled_type));
-        go[i]->setType(n->ty(attr::profiled_type));
-      } else if (dno_use0.user->kind() == prim::profile) {
-        GRAPH_DEBUG(
-            "setting output ",
-            i,
-            " to type ",
-            *dno_use0.user->ty(attr::profiled_type));
-        go[i]->setType(dno_use0.user->ty(attr::profiled_type));
-      } else if (dno_use0.user->kind() == prim::DifferentiableGraph) {
-        Value* o =
-            dno_use0.user->g(attr::Subgraph)->inputs().at(dno_use0.offset);
-        auto nn = o->uses().at(0).user;
-        if (nn->kind() == prim::profile) {
-          GRAPH_DEBUG(
-              "setting output ", i, " to type ", *nn->ty(attr::profiled_type));
-          go[i]->setType(nn->ty(attr::profiled_type));
+      for (auto dno_use : dno->uses()) {
+        GRAPH_DEBUG("found user of ", i, " as ", *dno_use.user);
+        if (n->kind() == prim::profile) {
+          if (set_requires_grad(n->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+            break;
+          }
+        } else if (dno_use.user->kind() == prim::profile) {
+          if (set_requires_grad(dno_use.user->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+            break;
+          }
+        } else if (dno_use.user->kind() == prim::DifferentiableGraph) {
+          Value* o =
+              dno_use.user->g(attr::Subgraph)->inputs().at(dno_use.offset);
+          // Is it safe to not check other uses, because we are inside a DifferentiableGraph?
+          auto nn = o->uses().at(0).user;
+          if (nn->kind() == prim::profile) {
+            if (set_requires_grad(nn->ty(attr::profiled_type)->expect<TensorType>(), go[i])) {
+              break;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Fixing requires_grad on outputs from DifferentiableGraph, the proper flag is
retrieved from profiling information. We previously only retrieves the profiling
information on the first profile node in all its uses. However, in case where
control flows are present, we need to iteratively search for profile node with
profiling information available, in case the first use is in an inactive code
path.

e.g.
```
  graph(%0 : Tensor,
        %1 : Bool):
  ..., %2 : Tensor = prim::DifferentiableGraph_0(%0)
  %3 : Tensor = prim::If(%1)
    block0():
      %4 : Tensor = prim::DifferentiableGraph_1(%2)
      -> (%4)
    block1():
      %5 : Tensor = prim::DifferentiableGraph_2(%2)
      -> (%5)
  -> (%3)
with prim::DifferentiableGraph_0 = graph(%0 : Tensor):
  ...
  %out : Tensor = aten::operation(...)
  ...
  return (..., %out)
with prim::DifferentiableGraph_1 = graph(%0 : Tensor):
  %temp : Tensor = prim::profile[profiled_type=Tensor](%0)
  ...
with prim::DifferentiableGraph_2 = graph(%0 : Tensor):
  %temp : Tensor = prim::profile[profiled_type=Float(...)](%0)
  ...
```

Fixes #{issue number}
