### PR TITLE
[ONNX] Fix onnx/constant_fold.cpp compilation on Windows

### DIFF
--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -328,7 +328,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       return c10::nullopt;
     }
   } else if (node->kind() == onnx::Squeeze) {
-    assert(inputTensorValues.size() == 2 or inputTensorValues.size() == 1);
+    assert(inputTensorValues.size() == 2 || inputTensorValues.size() == 1);
     if (opset_version == ONNX_OPSET_13) {
       // Squeeze version 13 input axes is optional, inputTensorValues.size() ==
       // 1 means axes equal to None


### PR DESCRIPTION
VC++ does not recognize `or` as a valid operator. This breaks the build under `Debug` configuration.
