### PR TITLE
Small optimization of index_add with dim>1 on the cpu with ~5% speedup

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -587,11 +587,13 @@ Tensor& index_add_cpu_(Tensor & self, int64_t dim, const Tensor & index, const T
 
     AT_DISPATCH_INDEX_TYPES(index.scalar_type(), "index_add_cpu_", [&] () {
       auto index_data = index_contig.data_ptr<index_t>();
+      auto self_data = static_cast<char*>(selfSlice.data_ptr());
+      auto source_data = static_cast<char*>(sourceSlice.data_ptr());
       for (auto i = 0; i < numel; i++) {
           auto self_i = index_data[i];
           TORCH_CHECK_INDEX((self_i >= 0) && (self_i < self_dim_size), "index out of range in self");
-          auto self_data = static_cast<char*>(selfSlice.data_ptr()) + self_i * self_stride_bytes;
-          auto source_data = static_cast<char*>(sourceSlice.data_ptr()) + i * source_stride_bytes;
+          self_data += self_stride_bytes;
+          source_data += source_stride_bytes;
           iter.unsafe_replace_operand(0, self_data);
           iter.unsafe_replace_operand(1, self_data);
           iter.unsafe_replace_operand(2, source_data);


### PR DESCRIPTION

This is a small speedup for the index_add operation in aten/src/ATen/native/TensorAdvancedIndexing.cpp

| Elements | Before in s | After in s | 
| --- | --- | --- | 
| 10 | 0.040 | 0.035 |
| 100 | 0.105 | 0.100 |
| 1000 | 0.753 | 0.704 |
| 10000 | 6.91 | 6.82  |
| 100000 | 65.4 |  60.4 |

Let me know if there's anything else to do.

I measured it with this small script:
```
import time
import torch
      
for N in [10, 100, 1000, 10000, 100000]:
import torch
import time

for N in [10, 100, 1000, 10000, 100000]:
    a = torch.zeros([N,1], dtype=torch.float32)
    indices = torch.arange(0, N, step=2, dtype=torch.int64)
    add_tensor = torch.arange(0, N, step=2, dtype=torch.float32).add_(1).reshape(-1,1)
    t0 = time.time()
    for _ in range(10000):
        a.index_add_(0, indices, add_tensor)          
    t1 = time.time()
    print("N = " + str(N)+". Time " + str( t1-t0))    
    assert a[0] == 10000
```
