### PR TITLE
Fix nightly tool for python 3.6

### DIFF
--- a/tools/nightly.py
+++ b/tools/nightly.py
@@ -198,12 +198,12 @@ def check_branch(subcommand, branch):
         return "Branch name to checkout must be supplied with '-b' option"
     # next check that the local repo is clean
     cmd = ["git", "status", "--untracked-files=no", "--porcelain"]
-    p = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, universal_newlines=True)
     if p.stdout.strip():
         return "Need to have clean working tree to checkout!\n\n" + p.stdout
     # next check that the branch name doesn't already exist
     cmd = ["git", "show-ref", "--verify", "--quiet", "refs/heads/" + branch]
-    p = subprocess.run(cmd, capture_output=True, check=False)
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
     if not p.returncode:
         return f"Branch {branch!r} already exists"
 
@@ -283,7 +283,7 @@ def conda_solve(
     )
     cmd.extend(channel_args)
     cmd.extend(SPECS_TO_INSTALL)
-    p = subprocess.run(cmd, capture_output=True, check=True)
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
     # parse solution
     solve = json.loads(p.stdout)
     link = solve["actions"]["LINK"]
@@ -332,7 +332,7 @@ def _site_packages(dirname, platform):
 def _ensure_commit(git_sha1):
     """Make sure that we actually have the commit locally"""
     cmd = ["git", "cat-file", "-e", git_sha1 + "^{commit}"]
-    p = subprocess.run(cmd, capture_output=True, check=False)
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
     if p.returncode == 0:
         # we have the commit locally
         return
@@ -357,7 +357,7 @@ def _nightly_version(spdir):
     # now cross reference with nightly version
     _ensure_commit(git_version)
     cmd = ["git", "show", "--no-patch", "--format=%s", git_version]
-    p = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, universal_newlines=True)
     m = SHA1_RE.search(p.stdout)
     if m is None:
         raise RuntimeError(
@@ -498,7 +498,7 @@ def move_nightly_files(spdir, platform):
 
 def _available_envs():
     cmd = ["conda", "env", "list"]
-    p = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    p = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     lines = p.stdout.splitlines()
     envs = {}
     for line in map(str.strip, lines):


### PR DESCRIPTION
Given that the minimal required Python version for using PyTorch is 3.6, the development tools should also be able to handle it. `./tools/nightly.py` currently uses the parameters `capture_output` and `text` of `subprocess.run` that were only added for [Python 3.7](https://docs.python.org/3/library/subprocess.html#subprocess.run).
