### PR TITLE
Skip RPC's CPU-only tests on CircleCI GPU jobs

### DIFF
--- a/test/distributed/rpc/test_faulty_agent.py
+++ b/test/distributed/rpc/test_faulty_agent.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
 import sys
+
+import torch
 import torch.distributed as dist
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
 from torch.testing._internal.distributed.rpc.faulty_rpc_agent_test_fixture import (
     FaultyRpcAgentTestFixture,
 )
@@ -18,15 +20,18 @@ from torch.testing._internal.distributed.rpc_utils import (
 )
 
 
-globals().update(
-    generate_tests(
-        "Faulty",
-        FaultyRpcAgentTestFixture,
-        FAULTY_AGENT_TESTS,
-        MultiProcess.SPAWN,
-        __name__,
+# On CircleCI these jobs are already run on CPU jobs, thus to save resources do
+# not run them on GPU jobs, since thet wouldn't provide additional test signal.
+if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+    globals().update(
+        generate_tests(
+            "Faulty",
+            FaultyRpcAgentTestFixture,
+            FAULTY_AGENT_TESTS,
+            MultiProcess.SPAWN,
+            __name__,
+        )
     )
-)
 
 
 if __name__ == "__main__":

--- a/test/distributed/rpc/test_process_group_agent.py
+++ b/test/distributed/rpc/test_process_group_agent.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
 import sys
+
+import torch
 import torch.distributed as dist
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
 from torch.testing._internal.distributed.rpc.process_group_agent_test_fixture import (
     ProcessGroupRpcAgentTestFixture,
 )
@@ -19,15 +21,18 @@ from torch.testing._internal.distributed.rpc_utils import (
 )
 
 
-globals().update(
-    generate_tests(
-        "ProcessGroup",
-        ProcessGroupRpcAgentTestFixture,
-        GENERIC_TESTS + PROCESS_GROUP_TESTS,
-        MultiProcess.SPAWN,
-        __name__,
+# On CircleCI these jobs are already run on CPU jobs, thus to save resources do
+# not run them on GPU jobs, since thet wouldn't provide additional test signal.
+if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+    globals().update(
+        generate_tests(
+            "ProcessGroup",
+            ProcessGroupRpcAgentTestFixture,
+            GENERIC_TESTS + PROCESS_GROUP_TESTS,
+            MultiProcess.SPAWN,
+            __name__,
+        )
     )
-)
 
 
 if __name__ == "__main__":

--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -2,13 +2,14 @@
 
 import sys
 
+import torch
 import torch.distributed as dist
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
 )
@@ -20,15 +21,18 @@ from torch.testing._internal.distributed.rpc_utils import (
 )
 
 
-globals().update(
-    generate_tests(
-        "TensorPipe",
-        TensorPipeRpcAgentTestFixture,
-        GENERIC_TESTS + TENSORPIPE_TESTS,
-        MultiProcess.SPAWN,
-        __name__,
+# On CircleCI these jobs are already run on CPU jobs, thus to save resources do
+# not run them on GPU jobs, since thet wouldn't provide additional test signal.
+if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+    globals().update(
+        generate_tests(
+            "TensorPipe",
+            TensorPipeRpcAgentTestFixture,
+            GENERIC_TESTS + TENSORPIPE_TESTS,
+            MultiProcess.SPAWN,
+            __name__,
+        )
     )
-)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55778 Skip RPC's CPU-only tests on CircleCI GPU jobs**
* #55695 Split out CUDA RPC tests

Differential Revision: [D27705941](https://our.internmc.facebook.com/intern/diff/D27705941/)