### PR TITLE
Add inplace hardswish xnnpack op

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -155,6 +155,10 @@ Tensor& hardswish_out(const Tensor& self, Tensor& result) {
 }
 
 Tensor& hardswish_(Tensor& self) {
+  #if defined(C10_MOBILE) && defined(USE_XNNPACK)
+  xnnpack::hardswish_(self);
+  return self;
+  #endif
   auto iter = TensorIterator::unary_op(self, self);
   hardswish_stub(iter.device_type(), iter);
   return self;

--- a/aten/src/ATen/native/xnnpack/Engine.h
+++ b/aten/src/ATen/native/xnnpack/Engine.h
@@ -84,6 +84,7 @@ Tensor channel_shuffle(
 //
 
 Tensor hardswish(const Tensor& input);
+Tensor& hardswish_(Tensor& input);
 
 } // namespace xnnpack
 } // namespace native

--- a/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
+++ b/aten/src/ATen/native/xnnpack/RegisterOpContextClass.cpp
@@ -81,6 +81,7 @@ TORCH_LIBRARY(prepacked, m) {
   m.def(TORCH_SELECTIVE_SCHEMA("prepacked::conv2d_clamp_run(Tensor X, __torch__.torch.classes.xnnpack.Conv2dOpContext W_prepack) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA("prepacked::conv2d_transpose_clamp_run(Tensor X, __torch__.torch.classes.xnnpack.TransposeConv2dOpContext W_prepack) -> Tensor Y"));
   m.def(TORCH_SELECTIVE_SCHEMA("prepacked::hardswish(Tensor X) -> Tensor Y"));
+  m.def(TORCH_SELECTIVE_SCHEMA("prepacked::hardswish_(Tensor X) -> Tensor Y"));
 }
 
 TORCH_LIBRARY_IMPL(prepacked, CPU, m) {
@@ -91,6 +92,7 @@ TORCH_LIBRARY_IMPL(prepacked, CPU, m) {
   m.impl(TORCH_SELECTIVE_NAME("prepacked::conv2d_clamp_run"), TORCH_FN(internal::convolution2d::conv2d_clamp_run));
   m.impl(TORCH_SELECTIVE_NAME("prepacked::conv2d_transpose_clamp_run"), TORCH_FN(internal::convolution2d::conv2d_transpose_clamp_run));
   m.impl(TORCH_SELECTIVE_NAME("prepacked::hardswish"), TORCH_FN(hardswish));
+  m.impl(TORCH_SELECTIVE_NAME("prepacked::hardswish_"), TORCH_FN(hardswish_));
 }
 
 } // namespace xnnpack

--- a/test/test_xnnpack_integration.py
+++ b/test/test_xnnpack_integration.py
@@ -186,6 +186,17 @@ class TestXNNPACKOps(TestCase):
         output_hardswishprepacked = torch.ops.prepacked.hardswish(input_data)
         torch.testing.assert_allclose(ref_result, output_hardswishprepacked, rtol=1e-2, atol=1e-3)
 
+    @given(batch_size=st.integers(0, 3),
+           data_shape=hu.array_shapes(1, 3, 2, 64))
+    def test_hardswish_(self, batch_size, data_shape):
+        data_shape = [batch_size] + list(data_shape)
+        input_data = torch.rand(data_shape)
+        ref_result = F.hardswish(input_data)
+
+        output_hardswishprepacked = torch.ops.prepacked.hardswish_(input_data)
+        torch.testing.assert_allclose(ref_result, input_data, rtol=1e-2, atol=1e-3)
+
+
 
 @unittest.skipUnless(torch.backends.xnnpack.enabled,
                      " XNNPACK must be enabled for these tests."


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55801 Add inplace hardswish xnnpack op**
* #55800 Add xnnpack hardswish op

Summary:

Refactor to add inplace version of xnnpack hardswish op

Test Plan:

pytest test/test_xnnpack_integration.py::TestXNNPACKOps

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D27712305](https://our.internmc.facebook.com/intern/diff/D27712305)