### PR TITLE
[Static runtime] Add optimize_graph_output_memory flag

### DIFF
--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/runtime/static/fusion.h>
 #include <torch/csrc/jit/runtime/static/impl.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
-#include <torch/csrc/jit/ir/alias_analysis.h>
 #include "deep_wide_pt.h"
 #include "test_scripts.h"
 
@@ -38,8 +38,8 @@ void compareTensorLists(
     ASSERT_TRUE(r[i].isTensor());
     VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
     VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
-    if (! l[i].toTensor().defined()) {
-      EXPECT_TRUE(! r[i].toTensor().defined());
+    if (!l[i].toTensor().defined()) {
+      EXPECT_TRUE(!r[i].toTensor().defined());
     } else {
       EXPECT_TRUE(l[i].toTensor().equal(r[i].toTensor()));
     }
@@ -53,8 +53,8 @@ void compareTensorLists(
   for (int i = 0; i < l.size(); ++i) {
     VLOG(2) << "expect " << i << ": \n" << l[i] << std::endl;
     VLOG(2) << "output " << i << ": \n" << r[i] << std::endl;
-    if (! l[i].defined()) {
-      EXPECT_TRUE(! r[i].defined());
+    if (!l[i].defined()) {
+      EXPECT_TRUE(!r[i].defined());
     } else {
       EXPECT_TRUE(l[i].equal(r[i]));
     }
@@ -204,14 +204,13 @@ TEST(StaticRuntime, IndividualOps_pow) {
 }
 
 TEST(StaticRuntime, IndividualOps_to) {
-  auto test_to =
-      [](at::ScalarType b, bool c, bool d, c10::MemoryFormat e) {
-        auto a = at::randn({2, 3});
-        std::vector<IValue> args0{a, b, c, d, e};
-        std::vector<IValue> args1{a, b, c, d};
-        testStaticRuntime(to_script_0, args0);
-        testStaticRuntime(to_script_1, args1);
-      };
+  auto test_to = [](at::ScalarType b, bool c, bool d, c10::MemoryFormat e) {
+    auto a = at::randn({2, 3});
+    std::vector<IValue> args0{a, b, c, d, e};
+    std::vector<IValue> args1{a, b, c, d};
+    testStaticRuntime(to_script_0, args0);
+    testStaticRuntime(to_script_1, args1);
+  };
 
   test_to(at::ScalarType::Float, true, true, c10::MemoryFormat::Contiguous);
   test_to(at::ScalarType::Half, true, false, c10::MemoryFormat::Preserve);
@@ -382,31 +381,48 @@ TEST(StaticRuntime, CleanUpMemory) {
   const int embedding_size = 32;
   const int num_features = 50;
   torch::jit::Module mod = getDeepAndWideSciptModel();
-  torch::jit::StaticModule smod(mod);
 
-  for (auto cleanup_memory : {true, false}) {
+  for (auto cleanup_activations : {true, false}) {
     for (auto enable_out_variant : {true, false}) {
-      VLOG(1) << "cleanup_memory: " << cleanup_memory
-              << ", enable_out_variant: " << enable_out_variant;
-      torch::jit::StaticModuleOptions opts{cleanup_memory, enable_out_variant};
-      torch::jit::StaticModule smod(mod, opts);
+      for (auto optimize_memory : {true, false}) {
+        for (auto optimize_graph_output_memory : {true, false}) {
+          if ((optimize_memory || optimize_graph_output_memory) &&
+              !enable_out_variant) {
+            // when optimize_memory and optimize_graph_output_memory is enabled,
+            // enable_out_variant must be true too
+            continue;
+          }
+          VLOG(1) << "cleanup_activations: " << cleanup_activations
+                  << ", enable_out_variant: " << enable_out_variant
+                  << ", optimize_memory: " << optimize_memory
+                  << ", optimize_graph_output_memory: "
+                  << optimize_graph_output_memory;
+          torch::jit::StaticModuleOptions opts{
+              cleanup_activations,
+              enable_out_variant,
+              optimize_memory,
+              optimize_graph_output_memory};
+          torch::jit::StaticModule smod(mod, opts);
 
-      for (int batch_size : {1, 8, 32}) {
-        for (int i = 0; i < 2; ++i) {
-          auto ad_emb_packed = torch::randn({batch_size, 1, embedding_size});
-          auto user_emb = torch::randn({batch_size, 1, embedding_size});
-          auto wide = torch::randn({batch_size, num_features});
+          for (int batch_size : {1, 8, 32}) {
+            for (int i = 0; i < 2; ++i) {
+              auto ad_emb_packed =
+                  torch::randn({batch_size, 1, embedding_size});
+              auto user_emb = torch::randn({batch_size, 1, embedding_size});
+              auto wide = torch::randn({batch_size, num_features});
 
-          // run jit graph executor
-          std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
-          auto output_1 = getTensor(mod.forward(inputs));
+              // run jit graph executor
+              std::vector<at::IValue> inputs({ad_emb_packed, user_emb, wide});
+              auto output_1 = getTensor(mod.forward(inputs));
 
-          // run static runtime
-          std::vector<at::Tensor> input_tensors(
-              {ad_emb_packed, user_emb, wide});
-          at::Tensor output_2 = smod(input_tensors)[0];
-          smod.runtime().check_for_memory_leak();
-          EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
+              // run static runtime
+              std::vector<at::Tensor> input_tensors(
+                  {ad_emb_packed, user_emb, wide});
+              at::Tensor output_2 = smod(input_tensors)[0];
+              smod.runtime().check_for_memory_leak();
+              EXPECT_TRUE(torch::allclose(output_1, output_2, 1e-6));
+            }
+          }
         }
       }
     }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -969,7 +969,7 @@ void StaticRuntime::check_for_memory_leak(bool output_returned) {
         // check for intermediates
         if (!ival->isNone()) {
           TORCH_CHECK(
-              ival->isTensor() || canOptimizeConstruct(pnode.node()),
+              ival->isTensor() || isOptimizableContainerType(pnode.node()),
               error_msg);
           if (ival->isTensor()) {
             const auto& t = ival->toTensor();
@@ -989,55 +989,14 @@ void StaticRuntime::check_for_memory_leak(bool output_returned) {
   }
 }
 
-MemoryPlanner::MemoryPlanner(
-    StaticRuntime* runtime,
+static void assign_storage_to_managed_tensors(
+    const StaticRuntime* runtime,
+    const std::unordered_set<const Value*>& managed_tensor_values,
     const std::unordered_map<const Value*, std::vector<const Value*>>&
         value_to_same_storage_values,
-    const std::unordered_set<const Value*>& external_values,
-    bool out_variants) {
-  // collect register indices of outputs of ops with out variant
-  std::unordered_set<const Value*> managed_values;
-  std::unordered_set<IValue*> unmanaged_ivalues;
-  for (ProcessedNode& pnode : runtime->nodes()) {
-    if (canReuseInputsOutputs(pnode.node())) {
-      for (auto i = 0; i < pnode.outputs().size(); ++i) {
-        // Types are stored in the underlying TorchScript IR
-        const Value* out_v = pnode.node()->outputs()[i];
-        IValue& out = pnode.Output(i);
-        const auto& type = out_v->type();
-        if (out_variants && !external_values.count(out_v)) {
-          if (type->cast<TensorType>()) {
-            managed_values.insert(out_v);
-          } else if (canOptimizeConstruct(pnode.node())) {
-            // We "leak" containers of this type
-          } else {
-            unmanaged_ivalues.insert(&out);
-          }
-        } else {
-          unmanaged_ivalues.insert(&out);
-        }
-      }
-    } else {
-      for (auto i = 0; i < pnode.outputs().size(); ++i) {
-        unmanaged_ivalues.insert(&pnode.Output(i));
-      }
-    }
-  }
-
-  // remove model outputs from managed_values and unmanaged_ivalues
-  for (const Value* output : runtime->graph().outputs()) {
-    managed_values.erase(output);
-  }
-  for (IValue* output : runtime->outputs()) {
-    unmanaged_ivalues.erase(output);
-  }
-
-  // unmanaged_ivalues => unmanaged_ivalues_
-  for (IValue* out : unmanaged_ivalues) {
-    unmanaged_ivalues_.emplace_back(out);
-  }
-
-  // map Value to index to managed_storage_, where multiple values can
+    std::vector<std::pair<size_t, std::vector<c10::StorageImpl*>>>&
+        managed_storage) {
+  // map Value to index to managed_storage, where multiple values can
   // map to the same index (i.e., sharing the same storage)
   std::unordered_map<const Value*, size_t> value_to_storage_idx;
   // the StorageImpls of Tensor views should not be managed
@@ -1048,7 +1007,7 @@ MemoryPlanner::MemoryPlanner(
     for (auto i = 0; i < pnode.outputs().size(); ++i) {
       const auto& ival = pnode.outputs()[i];
       const auto* val = pnode.node()->outputs()[i];
-      if (managed_values.count(val)) {
+      if (managed_tensor_values.count(val)) {
         TORCH_CHECK(ival.isTensor());
         auto* impl = ival.toTensor().storage().unsafeGetStorageImpl();
 
@@ -1058,22 +1017,89 @@ MemoryPlanner::MemoryPlanner(
         }
 
         if (value_to_storage_idx.count(val)) {
-          managed_storage_[value_to_storage_idx.at(val)].second.emplace_back(
+          managed_storage[value_to_storage_idx.at(val)].second.emplace_back(
               impl);
         } else {
           auto p =
               std::make_pair<size_t, std::vector<c10::StorageImpl*>>(0, {impl});
-          managed_storage_.emplace_back(std::move(p));
+          managed_storage.emplace_back(std::move(p));
           // first of a group, update the value_to_storage_idx map with the
           // index
           if (value_to_same_storage_values.count(val)) {
+            auto storage_idx = managed_storage.size() - 1;
             for (const auto* v : value_to_same_storage_values.at(val)) {
-              value_to_storage_idx[v] = managed_storage_.size() - 1;
+              value_to_storage_idx[v] = storage_idx;
             }
           }
         }
       }
     }
+  }
+}
+
+MemoryPlanner::MemoryPlanner(
+    StaticRuntime* runtime,
+    const std::unordered_map<const Value*, std::vector<const Value*>>&
+        value_to_same_storage_values,
+    const std::unordered_set<const Value*>& external_values,
+    bool out_variants) {
+  // collect register indices of outputs of ops with out variant
+  std::unordered_set<const Value*> managed_tensor_values;
+  std::unordered_set<const Value*> leaked_values;
+  if (out_variants) {
+    for (ProcessedNode& pnode : runtime->nodes()) {
+      if (canReuseInputsOutputs(pnode.node())) {
+        for (auto i = 0; i < pnode.outputs().size(); ++i) {
+          const Value* out_v = pnode.node()->outputs()[i];
+          if (external_values.count(out_v)) {
+            continue;
+          }
+          // Types are stored in the underlying TorchScript IR
+          const auto& type = out_v->type();
+          if (type->cast<TensorType>()) {
+            managed_tensor_values.insert(out_v);
+          } else if (isOptimizableContainerType(pnode.node())) {
+            // We "leak" certain container types because their allocations take
+            // a long time
+            leaked_values.insert(out_v);
+          }
+        }
+      }
+    }
+  }
+
+  // collect unmanaged output ivalues
+  std::unordered_set<IValue*> unmanaged_ivalues;
+  for (ProcessedNode& pnode : runtime->nodes()) {
+    for (auto i = 0; i < pnode.outputs().size(); ++i) {
+      // Types are stored in the underlying TorchScript IR
+      const Value* out_v = pnode.node()->outputs()[i];
+      if (managed_tensor_values.count(out_v) || leaked_values.count(out_v))
+        continue;
+      IValue& out = pnode.Output(i);
+      unmanaged_ivalues.insert(&out);
+    }
+  }
+  // since runtime->outputs() escape from run(), remove them from
+  // managed_tensor_values and from unmanaged_ivalues
+  for (const Value* output : runtime->graph().outputs()) {
+    managed_tensor_values.erase(output);
+  }
+  for (IValue* output : runtime->outputs()) {
+    unmanaged_ivalues.erase(output);
+  }
+
+  // copy to unmanaged_ivalues_
+  for (IValue* out : unmanaged_ivalues) {
+    unmanaged_ivalues_.emplace_back(out);
+  }
+
+  if (out_variants) {
+    ::torch::jit::assign_storage_to_managed_tensors(
+        runtime,
+        managed_tensor_values,
+        value_to_same_storage_values,
+        managed_tensor_storage_);
   }
 }
 
@@ -1099,7 +1125,7 @@ void MemoryPlanner::allocate() {
   uint8_t* start = static_cast<uint8_t*>(buffer_.get());
 
   reused_tensors_ = 0;
-  for (const auto& ms : managed_storage_) {
+  for (const auto& ms : managed_tensor_storage_) {
     auto tensor_size = ms.first;
     if (tensor_size == 0) {
       continue;
@@ -1125,7 +1151,7 @@ void MemoryPlanner::deallocate() {
 
   // free memory used by outputs of ops in out variants
   // but keep the TensorImpl and StorageImpl around
-  for (auto& ms : managed_storage_) {
+  for (auto& ms : managed_tensor_storage_) {
     const auto& impls = ms.second;
     size_t max = 0;
     for (auto& impl : impls) {
@@ -1133,9 +1159,17 @@ void MemoryPlanner::deallocate() {
       impl->reset();
       max = std::max(max, current_size);
     }
+    // Static runtime does not know the size of tensors statically, so we use
+    // the tensor size from the previous run to allocate tensors for the next
+    // run (following C2 tradition), exploiting the fact that tensor storage
+    // size does not have to match that of real tensor size. The following logic
+    // records the tensor storage size for the next run.
     ms.first = max;
     managed_bytes_ += max;
   }
+
+  // for unmanaged ivalues (either tensor or non-tensor), we reset the *iv so
+  // that the objects pointed to by *iv may be reclaimed by reference counting
   for (auto& iv : unmanaged_ivalues_) {
     *iv = IValue();
   }

--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -14,6 +14,7 @@
 #include <torch/csrc/jit/runtime/static/ops.h>
 #include <torch/csrc/jit/runtime/static/passes.h>
 #include <torch/csrc/jit/runtime/vararg_functions.h>
+#include <stdexcept>
 
 namespace torch {
 namespace jit {
@@ -511,6 +512,19 @@ StaticModule::StaticModule(
     : opts_(opts),
       graph_(std::move(graph_and_schema.first)),
       schema_(std::move(graph_and_schema.second)) {
+  // check opt flags
+  if (opts.optimize_graph_output_memory) {
+    if (!(opts_.optimize_memory && opts_.enable_out_variant)) {
+      throw std::runtime_error(
+          "When optimize_graph_output_memory is true, optimize_memory and enable_out_variant must be set to true");
+    }
+  }
+  if (opts_.optimize_memory) {
+    if (!opts_.enable_out_variant) {
+      throw std::runtime_error(
+          "When optimize_memory is true, enable_out_variant must be set to true");
+    }
+  }
   // map Value* to IValue (from inputs or prim::Constant) or null
   std::unordered_map<Value*, IValue*> value_to_ivalue;
   // map Value* to its SSA definition IR
@@ -580,9 +594,13 @@ StaticModule::StaticModule(
   external_values_ = lm.second;
   if (opts_.optimize_memory) {
     auto values = GetMemoryPlanningCandidates(graph_);
-    if (!opts_.enable_out_variant) {
-      values.first = {};
-    }
+    // Note (penguin): since it does not make sense to have optimize_memory
+    // enabled but enable_out_variant disabled, we check the flag dependence
+    // during initialization of StaticModule so that the following condition
+    // would not be true. This would make the code easier to understand
+    // if (!opts_.enable_out_variant) {
+    //   values.first = {};
+    // }
     value_to_same_storage_values_ =
         GenerateSameStorageValues(lm, values, alias_db);
   }
@@ -725,12 +743,17 @@ c10::IValue StaticRuntime::operator()(
   }
 
   if (static_module_.opts().cleanup_activations) {
+    // MemoryPlanner is created after the first invocation of `run()`. This is
+    // done intentionally because MemoryPlanner uses `TensorStorageImpl`
+    // object sizes of the previous `run()` for memory planning of subsequent
+    // runs
     if (!planner_) {
       planner_ = std::make_unique<MemoryPlanner>(
           this,
           static_module_.values_share_same_storage(),
           static_module_.external_values(),
-          static_module_.opts().enable_out_variant);
+          static_module_.opts().enable_out_variant,
+          static_module_.opts().optimize_graph_output_memory);
     }
     planner_->deallocate();
     // clean up owning refs of input tensors
@@ -892,7 +915,8 @@ StaticRuntime::IndividualMetrics StaticRuntime::benchmark_individual_ops(
             this,
             static_module_.values_share_same_storage(),
             static_module_.external_values(),
-            static_module_.opts().enable_out_variant);
+            static_module_.opts().enable_out_variant,
+            static_module_.opts().optimize_graph_output_memory);
       }
       planner_->deallocate();
       // clean up owning refs of input tensors
@@ -1042,11 +1066,12 @@ MemoryPlanner::MemoryPlanner(
     const std::unordered_map<const Value*, std::vector<const Value*>>&
         value_to_same_storage_values,
     const std::unordered_set<const Value*>& external_values,
-    bool out_variants) {
+    bool enable_out_variant,
+    bool manage_graph_output_memory) {
   // collect register indices of outputs of ops with out variant
   std::unordered_set<const Value*> managed_tensor_values;
   std::unordered_set<const Value*> leaked_values;
-  if (out_variants) {
+  if (enable_out_variant) {
     for (ProcessedNode& pnode : runtime->nodes()) {
       if (canReuseInputsOutputs(pnode.node())) {
         for (auto i = 0; i < pnode.outputs().size(); ++i) {
@@ -1094,7 +1119,7 @@ MemoryPlanner::MemoryPlanner(
     unmanaged_ivalues_.emplace_back(out);
   }
 
-  if (out_variants) {
+  if (enable_out_variant) {
     ::torch::jit::assign_storage_to_managed_tensors(
         runtime,
         managed_tensor_values,
@@ -1179,12 +1204,12 @@ void MemoryPlanner::deallocate() {
 ProcessedNode::ProcessedNode(
     Node* node,
     std::vector<const IValue*>&& inputs,
-    bool enable_out_variants)
+    bool enable_out_variant)
     : node_(node), inputs_(std::move(inputs)) {
   // TODO leverage type information
   outputs_.resize(node->outputs().size());
 
-  if (enable_out_variants && canRunOutOfPlace(node)) {
+  if (enable_out_variant && canRunOutOfPlace(node)) {
     fn_ = getOutOfPlaceOperation(node);
     std::ostringstream ss;
     node->print(ss, 0, nullptr, false);

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -14,10 +14,16 @@ namespace jit {
 
 struct TORCH_API StaticModuleOptions {
   bool cleanup_activations{true};
+  // to batch allocate (deallocate) tensor storage for all non-escaping
+  // temporary tensors
   bool enable_out_variant{true};
+  // to reuse tensor storage for tensors whose live-range do not overlap to
+  // reduce memory footprint (enable_out_variant must be true)
   bool optimize_memory{true};
-  // to enable MemoryPlanner on output tensors
-  bool optimize_output_memory{false};
+  // to batch allocate tensor storage for output tensors of the
+  // graph, where storage is deallocated outside static runtime
+  // (enable_out_variant must be true)
+  bool optimize_graph_output_memory{false};
 };
 
 /// The static runime supports two execution modes.
@@ -283,7 +289,8 @@ class MemoryPlanner {
       StaticRuntime* runtime,
       const std::unordered_map<const Value*, std::vector<const Value*>>&,
       const std::unordered_set<const Value*>& external_values,
-      bool out_variants);
+      bool enable_out_variant,
+      bool manage_graph_output_memory);
 
   void allocate();
   void deallocate();

--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -295,15 +295,25 @@ class MemoryPlanner {
   }
 
  private:
+  // ivalues created in one run but not managed by MemoryPlanner
   std::vector<IValue*> unmanaged_ivalues_;
+
   // each pair contains the size (in bytes) of data to be allocated
   // and a vector of StorageImpl's that should be backed by that same data
   // Thus, if memonger is disabled, all vectors are of size 1.
   std::vector<std::pair<size_t, std::vector<c10::StorageImpl*>>>
-      managed_storage_;
+      managed_tensor_storage_;
   size_t managed_bytes_{0};
   size_t reused_tensors_{0};
   at::DataPtr buffer_; // allocated each time we call Run()
+
+  // since output tensors are alive after one inference, their storage
+  // is managed differently (e.g., deallocation happens at client side)
+  // std::vector<std::pair<sizse_t, std::vector<c10::StorageImpl*>>>
+  //     managed_output_storage_;
+  // size_t managed_output_bytes_{0};
+  // size_t reused_output_tensors_{0};
+  // at::DataPtr output_buffer_; // allocated each time we call Run()
 
   static size_t compute_aligned_tensor_size(size_t nbytes);
   static at::DataPtr allocate_buffer(size_t size);

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -159,7 +159,7 @@ bool inputsCanRunOutOfPlace(Node* n) {
   return true;
 }
 
-bool canOptimizeConstruct(Node* n) {
+bool isOptimizableContainerType(Node* n) {
   const auto& type = n->output()->type();
   if (type->kind() == TypeKind::ListType) {
     const auto& list_type = type->expectRef<ListType>();
@@ -184,7 +184,7 @@ REGISTER_OPERATOR_FUNCTOR(
     prim_ListConstruct,
     [](Node* n) -> SROperator {
       const auto& type = n->output()->type()->expectRef<ListType>();
-      bool can_optimize = canOptimizeConstruct(n);
+      bool can_optimize = isOptimizableContainerType(n);
       return [can_optimize, &type](ProcessedNode* p_node) {
         const auto& out_l = p_node->Output(0);
         if (!out_l.isNone() && can_optimize) {
@@ -204,7 +204,7 @@ REGISTER_OPERATOR_FUNCTOR(
     prim::TupleConstruct,
     prim_TupleConstruct,
     [](Node* n) -> SROperator {
-      bool can_optimize = canOptimizeConstruct(n);
+      bool can_optimize = isOptimizableContainerType(n);
       return [can_optimize](ProcessedNode* p_node) {
         const auto& out_l = p_node->Output(0);
         if (!out_l.isNone() && can_optimize) {

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -87,7 +87,7 @@ bool opIsRegistered(const c10::Symbol& op_name);
 
 bool canRunOutOfPlace(Node* n);
 bool canReuseInputsOutputs(Node* n);
-bool canOptimizeConstruct(Node* n);
+bool isOptimizableContainerType(Node* n);
 
 std::function<void(ProcessedNode*)> getOutOfPlaceOperation(Node* n);
 


### PR DESCRIPTION
Summary:
- Added manage_graph_output_memory flag to opts (default false)
- Added checking for flag dependency between enable_out_variant and optimize_graph_output_memory and optimize_memory
- Minor refactoring for readability

Test Plan: buck test mode/dev //caffe2/caffe2/fb/predictor:pytorch_predictor_test -- --exact 'caffe2/caffe2/fb/predictor:pytorch_predictor_test - PyTorchPredictor.StaticRuntime

Reviewed By: hlu1

Differential Revision: D27573780

