### PR TITLE
[package] Create API reference

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ Features described in this documentation are classified by release status:
    torch.linalg <linalg>
    torch.special <special>
    torch.overrides
+   torch.package <package>
    profiler
    nn.init
    onnx

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -3,35 +3,19 @@
 torch.package
 =============
 
+.. warning::
+
+    This module is experimental and has not yet been publically released.
+
 API Reference
 -------------
 
 .. autoclass:: torch.package.PackageExporter
+  :members:
 
   .. automethod:: __init__
-  .. automethod:: close
-  .. automethod:: deny
-  .. automethod:: extern
-  .. automethod:: file_structure
-  .. automethod:: get_unique_id
-  .. automethod:: mock
-  .. automethod:: require_module
-  .. automethod:: save_binary
-  .. automethod:: save_extern_module
-  .. automethod:: save_mock_module
-  .. automethod:: save_module
-  .. automethod:: save_pickle
-  .. automethod:: save_source_file
-  .. automethod:: save_source_string
-  .. automethod:: save_text
 
 .. autoclass:: torch.package.PackageImporter
+  :members:
 
   .. automethod:: __init__
-  .. automethod:: file_structure
-  .. automethod:: get_resource_reader
-  .. automethod:: get_source
-  .. automethod:: id
-  .. automethod:: import_module
-  .. automethod:: load_binary
-  .. automethod:: load_text

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -1,0 +1,39 @@
+.. currentmodule:: torch.package
+
+torch.package
+=============
+
+API Reference
+-------------
+
+.. autoclass:: torch.package.PackageExporter
+  :members:
+
+  .. automethod:: __init__
+  .. automethod:: close
+  .. automethod:: deny
+  .. automethod:: extern
+  .. automethod:: file_structure
+  .. automethod:: get_unique_id
+  .. automethod:: mock
+  .. automethod:: require_module
+  .. automethod:: save_binary
+  .. automethod:: save_extern_module
+  .. automethod:: save_mock_module
+  .. automethod:: save_module
+  .. automethod:: save_pickle
+  .. automethod:: save_source_file
+  .. automethod:: save_source_string
+  .. automethod:: save_text
+
+.. autoclass:: torch.package.PackageImporter
+  :members:
+
+  .. automethod:: __init__
+  .. automethod:: file_structure
+  .. automethod:: get_resource_reader
+  .. automethod:: get_source
+  .. automethod:: id
+  .. automethod:: import_module
+  .. automethod:: load_binary
+  .. automethod:: load_text

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -7,7 +7,6 @@ API Reference
 -------------
 
 .. autoclass:: torch.package.PackageExporter
-  :members:
 
   .. automethod:: __init__
   .. automethod:: close
@@ -27,7 +26,6 @@ API Reference
   .. automethod:: save_text
 
 .. autoclass:: torch.package.PackageImporter
-  :members:
 
   .. automethod:: __init__
   .. automethod:: file_structure


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55817 [package] Minor fixes to PackageExporter docstrings
* **#55812 [package] Create API reference**

**Summary**
This commit creates a barebones API reference doc for `torch.package`.
The content is sourced from the docstrings in the source for the
`torch.package`.

**Test Plan**
Continuous integration (specifically the docs tests).

Differential Revision: [D27726816](https://our.internmc.facebook.com/intern/diff/D27726816)