### PR TITLE
cmake: Enable (s)ccache for nccl builds

### DIFF
--- a/cmake/External/nccl.cmake
+++ b/cmake/External/nccl.cmake
@@ -22,10 +22,6 @@ if(NOT __NCCL_INCLUDED)
       CONFIGURE_COMMAND ""
       BUILD_COMMAND
         env
-        # TODO: remove these flags when
-        # https://github.com/pytorch/pytorch/issues/13362 is fixed
-        "CCACHE_DISABLE=1"
-        "SCCACHE_DISABLE=1"
         make
         "CXX=${CMAKE_CXX_COMPILER}"
         "CUDA_HOME=${CUDA_TOOLKIT_ROOT_DIR}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55814 cmake: Enable (s)ccache for nccl builds**

I don't really know if the original issue is resolved but let's just
check and see if this passes CI so that we can potentially get some
speed up on our builds

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D27715734](https://our.internmc.facebook.com/intern/diff/D27715734)