### PR TITLE
Add InferenceMode TLS to ThreadLocalState.

### DIFF
--- a/aten/src/ATen/ThreadLocalState.cpp
+++ b/aten/src/ATen/ThreadLocalState.cpp
@@ -10,7 +10,8 @@ namespace at {
 
 ThreadLocalState::ThreadLocalState(bool keep_grad_mode)
     : dispatch_key_(c10::impl::tls_local_dispatch_key_set()),
-      debug_info_(c10::ThreadLocalDebugInfo::current()) {
+      debug_info_(c10::ThreadLocalDebugInfo::current()),
+      inference_mode_enabled_(c10::InferenceMode::is_enabled()) {
   rf_tls_ = at::get_record_function_tls_();
 
 #if !defined(CAFFE2_IS_XPLAT_BUILD) && !defined(C10_MOBILE)
@@ -36,6 +37,8 @@ void ThreadLocalState::setThreadLocalState(
   c10::ThreadLocalDebugInfo::_forceCurrentDebugInfo(state.debug_info_);
 
   c10::impl::_force_tls_local_dispatch_key_set(state.dispatch_key_);
+
+  c10::InferenceMode::set_enabled(state.inference_mode_enabled_);
 }
 
 } // namespace at

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/core/InferenceMode.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
 #include <c10/util/Exception.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
@@ -37,6 +38,9 @@ class TORCH_API ThreadLocalState {
   bool keep_grad_mode_ = true;
   bool grad_mode_enabled_;
 #endif
+
+  // TLS for InferenceMode
+  bool inference_mode_enabled_;
 
   // Whether pre-sampling RecordFunction optimization was enabled
   bool bumped_record_all_functions_ = false;

--- a/c10/core/InferenceMode.h
+++ b/c10/core/InferenceMode.h
@@ -54,9 +54,11 @@ struct TORCH_API InferenceMode {
     c10::impl::_force_tls_local_dispatch_key_set(prev_keyset);
   }
   static bool is_enabled();
+  // set_enabled() is not user facing and should be only used in
+  // ThreadLocalState.cpp.
+  static void set_enabled(bool enabled);
 
   private:
-    static void set_enabled(bool enabled);
     bool prev_mode;
     c10::impl::LocalDispatchKeySet prev_keyset;
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55835 Cleanup since FEATURE_TORCH_MOBILE is always true.
* **#55822 Add InferenceMode TLS to ThreadLocalState.**

Differential Revision: [D27721285](https://our.internmc.facebook.com/intern/diff/D27721285)


@albanD and @ezyang suggested this change in the first PR. It was no longer applicable since I used the original raw_local_dispatch_key_set TLS in that PR. But then I forgot about it when I added a new TLS to reduce instruction counts.Thanks @bhosmer for catching this!!
@linbinyu has helped confirmed that this unblocks the issue described in https://fb.quip.com/DlSrAmTW4Wdf! Thanks! 