### PR TITLE
[optim] refactor adamax to use functional API

### DIFF
--- a/torch/optim/_functional.py
+++ b/torch/optim/_functional.py
@@ -238,3 +238,42 @@ def rmsprop(params: List[Tensor],
             param.add_(buf, alpha=-lr)
         else:
             param.addcdiv_(grad, avg, value=-lr)
+
+
+def adamax(params: List[Tensor],
+           grads: List[Tensor],
+           exp_avgs: List[Tensor],
+           exp_infs: List[Tensor],
+           state_steps: List[int],
+           eps: float,
+           beta1: float,
+           beta2: float,
+           lr: float,
+           weight_decay: float):
+    r"""Functional API that performs adamax algorithm computation.
+
+    See :class:`~torch.optim.Adamax` for details.
+    """
+
+    for i, param in enumerate(params):
+        grad = grads[i]
+        exp_avg = exp_avgs[i]
+        exp_inf = exp_infs[i]
+        step = state_steps[i]
+
+        if weight_decay != 0:
+            grad = grad.add(param, alpha=weight_decay)
+
+        # Update biased first moment estimate.
+        exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+        # Update the exponentially weighted infinity norm.
+        norm_buf = torch.cat([
+            exp_inf.mul_(beta2).unsqueeze(0),
+            grad.abs().add_(eps).unsqueeze_(0)
+        ], 0)
+        torch.amax(norm_buf, 0, keepdim=False, out=exp_inf)
+
+        bias_correction = 1 - beta1 ** step
+        clr = lr / bias_correction
+
+        param.addcdiv_(exp_avg, exp_inf, value=-clr)

--- a/torch/optim/adamax.py
+++ b/torch/optim/adamax.py
@@ -1,4 +1,5 @@
 import torch
+from . import _functional as F
 from .optimizer import Optimizer
 
 
@@ -50,12 +51,25 @@ class Adamax(Optimizer):
                 loss = closure()
 
         for group in self.param_groups:
+            params_with_grad = []
+            grads = []
+            exp_avgs = []
+            exp_infs = []
+            state_steps = []
+
+            beta1, beta2 = group['betas']
+            eps = group['eps']
+            lr = group['lr']
+            weight_decay = group['weight_decay']
+
             for p in group['params']:
                 if p.grad is None:
                     continue
-                grad = p.grad
-                if grad.is_sparse:
+                params_with_grad.append(p)
+                if p.grad.is_sparse:
                     raise RuntimeError('Adamax does not support sparse gradients')
+                grads.append(p.grad)
+
                 state = self.state[p]
 
                 # State initialization
@@ -64,27 +78,21 @@ class Adamax(Optimizer):
                     state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
                     state['exp_inf'] = torch.zeros_like(p, memory_format=torch.preserve_format)
 
-                exp_avg, exp_inf = state['exp_avg'], state['exp_inf']
-                beta1, beta2 = group['betas']
-                eps = group['eps']
+                exp_avgs.append(state['exp_avg'])
+                exp_infs.append(state['exp_inf'])
 
                 state['step'] += 1
+                state_steps.append(state['step'])
 
-                if group['weight_decay'] != 0:
-                    grad = grad.add(p, alpha=group['weight_decay'])
-
-                # Update biased first moment estimate.
-                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
-                # Update the exponentially weighted infinity norm.
-                norm_buf = torch.cat([
-                    exp_inf.mul_(beta2).unsqueeze(0),
-                    grad.abs().add_(eps).unsqueeze_(0)
-                ], 0)
-                torch.amax(norm_buf, 0, keepdim=False, out=exp_inf)
-
-                bias_correction = 1 - beta1 ** state['step']
-                clr = group['lr'] / bias_correction
-
-                p.addcdiv_(exp_avg, exp_inf, value=-clr)
+            F.adamax(params_with_grad,
+                     grads,
+                     exp_avgs,
+                     exp_infs,
+                     state_steps,
+                     eps,
+                     beta1,
+                     beta2,
+                     lr,
+                     weight_decay)
 
         return loss


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56185 [optim] take kw-only argument for functional optim APIs
* #55834 [dist_optim] add distributed functional rprop optimizer
* #55833 [dist_optim] Add distributed functional Adamax optimizer
* #55832 [optim] refactor rprop to use functional API
* **#55830 [optim] refactor adamax to use functional API**

Differential Revision: [D26561017](https://our.internmc.facebook.com/intern/diff/D26561017/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D26561017/)!