### PR TITLE
[dist_optim] add distributed functional rprop optimizer

### DIFF
--- a/torch/distributed/optim/functional_rprop.py
+++ b/torch/distributed/optim/functional_rprop.py
@@ -1,0 +1,81 @@
+from typing import List, Dict, Optional, Tuple
+import torch
+import torch.optim._functional as F
+
+from torch import Tensor
+
+# Define a TorchScript compatible Functional Rprop Optimizer
+# where we use these optimizer in a functional way.
+# Instead of using the `param.grad` when updating parameters,
+# we explicitly allow the distributed optimizer pass gradients to
+# the `step` function. In this way, we could separate the gradients
+# and parameters and allow multithreaded trainer to update the
+# parameters without data traces on accumulating to the same .grad.
+# NOTE: This should be only used by distributed optimizer internals
+# and not meant to expose to the user.
+@torch.jit.script
+class _FunctionalRprop(object):
+    def __init__(
+        self,
+        params: List[Tensor],
+        lr: float = 1e-2,
+        etas: Tuple[float, float] = (0.5, 1.2),
+        step_sizes: Tuple[float, float] = (1e-6, 50)
+    ):
+        self.defaults = {
+            "lr": lr,
+        }
+        self.etas = etas
+        self.step_sizes = step_sizes
+
+        if len(params) == 0:
+            raise ValueError("optimizer got an empty parameter list")
+
+        # NOTE: we only have one param_group and don't allow user to add additional
+        # param group as it's not a common use case.
+        self.param_group = {"params": params}
+
+        self.state = torch.jit.annotate(Dict[torch.Tensor, Dict[str, torch.Tensor]], {})
+
+    def step(self, gradients: List[Optional[Tensor]]):
+        params = self.param_group['params']
+        grads = []
+        prevs = []
+        step_sizes = []
+        lr = self.defaults['lr']
+        etaminus, etaplus = self.etas
+        step_size_min, step_size_max = self.step_sizes
+
+        if len(params) != len(gradients):
+            raise ValueError(
+                "the gradients passed in does not equal to the size of the parameters!"
+                + f"Params length: {len(params)}. "
+                + f"Gradients length: {len(gradients)}"
+            )
+
+        for param, gradient in zip(params, gradients):
+            if gradient is not None:
+                grads.append(gradient)
+                # Lazy state initialization
+                if param not in self.state:
+                    self.state[param] = {}
+                    state = self.state[param]
+                    state['step'] = torch.tensor(0.0)
+                    state['prev'] = torch.zeros_like(param, memory_format=torch.preserve_format)
+                    state['step_size'] = torch.full_like(gradient, lr)
+
+                state = self.state[param]
+                prevs.append(state['prev'])
+                step_sizes.append(state['step_size'])
+
+                state['step'] += 1
+
+        with torch.no_grad():
+            F.rprop(params,
+                    grads,
+                    prevs,
+                    step_sizes,
+                    step_size_min,
+                    step_size_max,
+                    etaminus,
+                    etaplus)

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -13,6 +13,7 @@ from .functional_adamw import _FunctionalAdamW
 from .functional_sgd import _FunctionalSGD
 from .functional_adadelta import _FunctionalAdadelta
 from .functional_rmsprop import _FunctionalRMSprop
+from .functional_rprop import _FunctionalRprop
 from .functional_adamax import _FunctionalAdamax
 import torch.distributed.autograd as dist_autograd
 
@@ -201,6 +202,7 @@ class DistributedOptimizer:
         optim.SGD: _FunctionalSGD,
         optim.Adadelta: _FunctionalAdadelta,
         optim.RMSprop: _FunctionalRMSprop,
+        optim.Rprop: _FunctionalRprop,
         optim.Adamax: _FunctionalAdamax,
     }
 

--- a/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
+++ b/torch/testing/_internal/distributed/rpc/dist_optimizer_test.py
@@ -208,3 +208,4 @@ class DistOptimizerTest(RpcAgentTestFixture):
         self._test_dist_optim_base(optim.Adadelta, rho=0.95)
         self._test_dist_optim_base(optim.RMSprop, lr=0.05)
         self._test_dist_optim_base(optim.Adamax, lr=0.05)
+        self._test_dist_optim_base(optim.Rprop, lr=0.05)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56185 [optim] take kw-only argument for functional optim APIs
* **#55834 [dist_optim] add distributed functional rprop optimizer**
* #55833 [dist_optim] Add distributed functional Adamax optimizer
* #55832 [optim] refactor rprop to use functional API
* #55830 [optim] refactor adamax to use functional API

Differential Revision: [D27703878](https://our.internmc.facebook.com/intern/diff/D27703878/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27703878/)!