### PR TITLE
Use cascade summation in nll_loss on CPU

### DIFF
--- a/aten/src/ATen/native/LossNLL.cpp
+++ b/aten/src/ATen/native/LossNLL.cpp
@@ -3,7 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
-#include <c10/util/llvmMathExtras.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at {
 namespace native {
@@ -24,17 +24,6 @@ inline scalar_t* optional_data(const Tensor& source) {
   return source.defined() ? source.data_ptr<scalar_t>() : nullptr;
 }
 
-
-static int64_t ceil_log2(int64_t x) {
-  if (x <= 2) {
-    return 1;
-  }
-
-  auto ux = static_cast<uint64_t>(x);
-  // Last set bit is floor(log2(x)), floor + 1 is ceil
-  // except when x is an exact powers of 2, so subtract 1 first
-  return static_cast<int64_t>(llvm::findLastSet(ux - 1)) + 1;
-}
 
 template <typename scalar_t>
 static void nll_loss_out_frame(
@@ -102,7 +91,7 @@ static void nll_loss_out_frame(
 
   constexpr int64_t cascade_sum_num_levels = 8;
   const int64_t level_power =
-      std::max(int64_t(4), ceil_log2(batch_size) / cascade_sum_num_levels);
+      std::max(int64_t(4), utils::CeilLog2(batch_size) / cascade_sum_num_levels);
   const int64_t level_step = (1 << level_power);
   const int64_t level_mask = level_step - 1;
 

--- a/aten/src/ATen/native/LossNLL2d.cpp
+++ b/aten/src/ATen/native/LossNLL2d.cpp
@@ -3,7 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
 #include <ATen/TensorUtils.h>
-#include <c10/util/llvmMathExtras.h>
+#include <ATen/native/cpu/utils.h>
 
 namespace at {
 namespace native {
@@ -77,18 +77,6 @@ inline void check_gradout_shape_nll_loss2d(
       grad_output.sizes(),
       " target: ",
       target.sizes());
-}
-
-
-static int64_t ceil_log2(int64_t x) {
-  if (x <= 2) {
-    return 1;
-  }
-
-  auto ux = static_cast<uint64_t>(x);
-  // Last set bit is floor(log2(x)), floor + 1 is ceil
-  // except when x is an exact powers of 2, so subtract 1 first
-  return static_cast<int64_t>(llvm::findLastSet(ux - 1)) + 1;
 }
 
 
@@ -167,7 +155,7 @@ static void nll_loss2d_forward_out_frame(
   scalar_t weight_partial_sums[cascade_sum_num_levels] = {0};
   scalar_t loss_partial_sums[cascade_sum_num_levels] = {0};
   const int64_t level_power =
-      std::max(int64_t(4), ceil_log2(numiter) / cascade_sum_num_levels);
+      std::max(int64_t(4), utils::CeilLog2(numiter) / cascade_sum_num_levels);
   const int64_t level_step = (1 << level_power);
   const int64_t level_mask = level_step - 1;
 

--- a/aten/src/ATen/native/LossNLL2d.cpp
+++ b/aten/src/ATen/native/LossNLL2d.cpp
@@ -199,19 +199,16 @@ static void nll_loss2d_forward_out_frame(
     }
   }
 
-  scalar_t total_weight_val = 0;
-  if (weight_data) {
-    for (int64_t level = 0; level < cascade_sum_num_levels; ++level) {
-      total_weight_val += weight_partial_sums[level];
-    }
-  } else {
-    total_weight_val = static_cast<scalar_t>(numiter - num_ignored);
-  }
 
-  scalar_t output_val = 0;
-  for (int64_t level = 0; level < cascade_sum_num_levels; ++level) {
-    output_val += loss_partial_sums[level];
-  }
+  const scalar_t total_weight_val = !weight_data ?
+    static_cast<scalar_t>(numiter - num_ignored) :
+    std::accumulate(std::begin(weight_partial_sums),
+                    std::end(weight_partial_sums),
+                    scalar_t{0});
+
+  scalar_t output_val = std::accumulate(std::begin(loss_partial_sums),
+                                        std::end(loss_partial_sums),
+                                        scalar_t{0});
 
   if (reduction == Reduction::Mean &&
       (total_weight_val != 0 || input.numel() == 0)) {

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <ATen/cpu/vec256/vec256.h>
+#include <c10/util/llvmMathExtras.h>
+
 namespace at { namespace native { namespace {
 
 template <typename T>
@@ -27,4 +30,21 @@ inline bool data_index_step(T &x, const T &X, Args &&... args) {
   return false;
 }
 
-}}}  // namespace at::native::<anonymous>
+} // namespace
+
+namespace utils {
+
+template <typename T>
+T CeilLog2(const T& x) {
+  if (x <= 2) {
+    return 1;
+  }
+  // Last set bit is floor(log2(x)), floor + 1 is ceil
+  // except when x is an exact powers of 2, so subtract 1 first
+  return static_cast<T>(llvm::findLastSet(static_cast<uint64_t>(x) - 1)) + 1;
+}
+
+} // namespace utils
+
+} // namespace native
+} // namespace at// namespace at::native::<anonymous>

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10052,6 +10052,17 @@ class TestNN(NNTestCase):
         # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
         self.assertEqualIgnoreType(input.grad, inputf.grad, atol=1e-1, rtol=0)
 
+    def test_cross_entropy_loss_precision(self):
+        # Regression test for #55657
+        loss_cpu = nn.CrossEntropyLoss().cpu()
+        inputf = torch.randn(128, 2, 768, 768, device="cpu", dtype=torch.float)
+        inputd = inputf.double()
+        target = torch.randint(2, (128, 768, 768), dtype=torch.long)
+
+        outf = loss_cpu(inputf, target)
+        outd = loss_cpu(inputd, target)
+        self.assertEqual(outf, outd, exact_dtype=False)
+
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_convert_sync_batchnorm(self):
         module = torch.nn.Sequential(


### PR DESCRIPTION
Fixes #55657

This also avoids summing `total_weight_val` when weights aren't supplied. Avoiding accumulated error completely.