### PR TITLE
Make c10 clang-tidy clean

### DIFF
--- a/c10/benchmark/intrusive_ptr_benchmark.cpp
+++ b/c10/benchmark/intrusive_ptr_benchmark.cpp
@@ -28,17 +28,21 @@ class Bar : public std::enable_shared_from_this<Bar> {
 static void BM_IntrusivePtrCtorDtor(benchmark::State& state) {
   intrusive_ptr<Foo> var = make_intrusive<Foo>(0);
   while (state.KeepRunning()) {
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     volatile intrusive_ptr<Foo> var2 = var;
   }
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 BENCHMARK(BM_IntrusivePtrCtorDtor);
 
 static void BM_SharedPtrCtorDtor(benchmark::State& state) {
   std::shared_ptr<Bar> var = std::make_shared<Bar>(0);
   while (state.KeepRunning()) {
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     volatile std::shared_ptr<Bar> var2 = var;
   }
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 BENCHMARK(BM_SharedPtrCtorDtor);
 
 static void BM_IntrusivePtrArray(benchmark::State& state) {
@@ -54,6 +58,7 @@ static void BM_IntrusivePtrArray(benchmark::State& state) {
     }
   }
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-magic-numbers)
 BENCHMARK(BM_IntrusivePtrArray)->RangeMultiplier(2)->Range(16, 4096);
 
 static void BM_SharedPtrArray(benchmark::State& state) {
@@ -69,6 +74,7 @@ static void BM_SharedPtrArray(benchmark::State& state) {
     }
   }
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-avoid-magic-numbers)
 BENCHMARK(BM_SharedPtrArray)->RangeMultiplier(2)->Range(16, 4096);
 } // namespace
 

--- a/c10/core/Allocator.cpp
+++ b/c10/core/Allocator.cpp
@@ -18,7 +18,9 @@ at::DataPtr InefficientStdFunctionContext::makeDataPtr(
           device};
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 C10_API at::Allocator* allocator_array[at::COMPILE_TIME_MAX_DEVICE_TYPES];
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 C10_API uint8_t allocator_priority[at::COMPILE_TIME_MAX_DEVICE_TYPES] = {0};
 
 void SetAllocator(at::DeviceType t, at::Allocator* alloc, uint8_t priority) {
@@ -48,6 +50,7 @@ void reportMemoryUsageToProfiler(void* ptr, int64_t alloc_size, Device device) {
   }
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 MemoryReportingInfoBase::MemoryReportingInfoBase() {}
 
 } // namespace c10

--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -4,16 +4,19 @@
 #include <c10/mobile/CPUProfilingAllocator.h>
 
 // TODO: rename flags to C10
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(
     caffe2_report_cpu_memory_usage,
     false,
     "If set, print out detailed memory usage");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(
     caffe2_cpu_allocator_do_zero_fill,
     false,
     "If set, do memory zerofilling when allocating on CPU");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(
     caffe2_cpu_allocator_do_junk_fill,
     false,
@@ -49,6 +52,7 @@ void* alloc_cpu(size_t nbytes) {
       "alloc_cpu() seems to have been called with negative number: ",
       nbytes);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   void* data;
 #ifdef __ANDROID__
   data = memalign(gAlignment, nbytes);
@@ -93,12 +97,15 @@ void free_cpu(void* data) {
 #ifdef _MSC_VER
   _aligned_free(data);
 #else
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
   free(data);
 #endif
 }
 
 struct C10_API DefaultCPUAllocator final : at::Allocator {
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   DefaultCPUAllocator() {}
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ~DefaultCPUAllocator() override {}
   at::DataPtr allocate(size_t nbytes) const override {
     void* data = alloc_cpu(nbytes);
@@ -149,6 +156,7 @@ template <uint32_t PreGuardBytes, uint32_t PostGuardBytes>
 class DefaultMobileCPUAllocator final : public at::Allocator {
  public:
   DefaultMobileCPUAllocator() = default;
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~DefaultMobileCPUAllocator() override = default;
 
   static void deleter(void* const pointer) {
@@ -167,6 +175,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
       c10::free_cpu(pointer);
       // This adds extra cost to freeing memory to the default case when
       // caching allocator is not enabled.
+      // NOLINTNEXTLINE(clang-analyzer-unix.Malloc)
       CPUCachingAllocator::record_free(pointer);
       auto allocation_planner = GetThreadLocalAllocationPlanner();
       if (allocation_planner != nullptr) {
@@ -175,6 +184,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
     }
   }
 
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual DataPtr allocate(const size_t nbytes) const override {
     if (C10_UNLIKELY(0u == nbytes)) {
       return {
@@ -186,6 +196,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
     }
 
     auto alloc_size = PreGuardBytes + nbytes + PostGuardBytes;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     void* data;
     auto allocator_ptr = GetThreadLocalCachingAllocator();
     auto profiling_allocator_ptr = GetThreadLocalProfilingAllocator();
@@ -209,6 +220,7 @@ class DefaultMobileCPUAllocator final : public at::Allocator {
     };
   }
 
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual DeleterFnPtr raw_deleter() const override {
     return deleter;
   }
@@ -232,6 +244,7 @@ void SetCPUAllocator(at::Allocator* alloc, uint8_t priority) {
 //            returned to the user.
 // Post-guard: 16 bytes for XNNPACK.
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-avoid-non-const-global-variables)
 static DefaultMobileCPUAllocator<gAlignment, 16u> g_mobile_cpu_allocator;
 
 at::Allocator* GetDefaultMobileCPUAllocator() {
@@ -249,12 +262,14 @@ REGISTER_ALLOCATOR(DeviceType::CPU, &g_mobile_cpu_allocator);
 #else
 
 // Global default CPU Allocator
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static DefaultCPUAllocator g_cpu_alloc;
 
 at::Allocator* GetDefaultCPUAllocator() {
   return &g_cpu_alloc;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_ALLOCATOR(DeviceType::CPU, &g_cpu_alloc);
 
 #endif /* C10_Mobile */
@@ -311,7 +326,9 @@ void ProfiledCPUMemoryReporter::Delete(void* ptr) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_API at::Allocator* cpu_caching_alloc = nullptr;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_API uint8_t cpu_caching_alloc_priority = 0;
 
 void SetCPUCachingAllocator(Allocator* alloc, uint8_t priority) {

--- a/c10/core/CopyBytes.cpp
+++ b/c10/core/CopyBytes.cpp
@@ -5,6 +5,7 @@ namespace c10 {
 
 // First dimension of the array is `bool async`: 0 is sync,
 // 1 is async (non-blocking)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-c-arrays)
 static CopyBytesFunction g_copy_bytes[2][COMPILE_TIME_MAX_DEVICE_TYPES]
                                      [COMPILE_TIME_MAX_DEVICE_TYPES];
 

--- a/c10/core/DefaultDtype.cpp
+++ b/c10/core/DefaultDtype.cpp
@@ -2,8 +2,11 @@
 #include <c10/core/DefaultDtype.h>
 
 namespace c10 {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto default_dtype = caffe2::TypeMeta::Make<float>();
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto default_dtype_as_scalartype = default_dtype.toScalarType();
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto default_complex_dtype = caffe2::TypeMeta::Make<c10::complex<float>>();
 
 void set_default_dtype(caffe2::TypeMeta dtype) {

--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -43,6 +43,7 @@ namespace detail {
 static uint64_t readURandomLong()
 {
   int randDev = open("/dev/urandom", O_RDONLY);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint64_t randValue;
   TORCH_CHECK(randDev >= 0, "Unable to open /dev/urandom");
   ssize_t readBytes = read(randDev, &randValue, sizeof(randValue));
@@ -67,6 +68,7 @@ static uint64_t readURandomLong()
  *   a 32 bit number to 64 bit.
  */
 uint64_t getNonDeterministicRandom(bool is_cuda) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint64_t s;
   if (!is_cuda) {
     #ifdef _WIN32
@@ -77,6 +79,7 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
   } else {
     std::random_device rd;
     // limit to 53 bits to ensure unique representation in double
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     s = ((((uint64_t)rd()) << 32) + rd()) & 0x1FFFFFFFFFFFFF;
   }
   return s;

--- a/c10/core/InferenceMode.cpp
+++ b/c10/core/InferenceMode.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 
 namespace c10 {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local bool InferenceMode_enabled = false;
 
 // Invariant:

--- a/c10/core/TensorImpl.cpp
+++ b/c10/core/TensorImpl.cpp
@@ -6,11 +6,13 @@
 #include <c10/util/Optional.h>
 #include <c10/core/InferenceMode.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(
     caffe2_keep_on_shrink,
     true,
     "If set, keeps memory when a tensor is shrinking its size.");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int64(
     caffe2_max_keep_on_shrink_memory,
     LLONG_MAX,
@@ -82,8 +84,10 @@ TensorImpl::TensorImpl(
 }
 
 TensorImpl::TensorImpl(DispatchKeySet key_set, const caffe2::TypeMeta data_type, c10::optional<c10::Device> device_opt)
+    // NOLINTNEXTLINE(performance-move-const-arg)
     : TensorImpl({}, key_set, data_type, std::move(device_opt)) {}
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 TensorImpl::TensorImpl(Storage&& storage, DispatchKeySet key_set, const caffe2::TypeMeta data_type,
                        c10::optional<c10::Device> device_opt)
     : storage_(std::move(storage)),
@@ -194,6 +198,7 @@ bool TensorImpl::compute_channels_last_contiguous_2d() const {
         }
         return true;
       }
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case 3:
       // TODO dim == 3 case will be enabled once it is fully tested
       return false;
@@ -206,6 +211,7 @@ bool TensorImpl::compute_channels_last_contiguous_3d() const {
   // Please don't combine these code, constant array is used here to let
   // compiler fully unroll the loop to get better performance
   switch (sizes_and_strides_.size()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case 5:
       {
         int64_t expected = 1;
@@ -220,6 +226,7 @@ bool TensorImpl::compute_channels_last_contiguous_3d() const {
         }
         return true;
       }
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     case 4:
       // TODO dim == 4 case will be enabled once it is fully tested
       return false;
@@ -240,6 +247,7 @@ bool TensorImpl::compute_non_overlapping_and_dense() const {
   if (dim() == 1) {
     return sizes_and_strides_.size_at_unchecked(0) < 2 || sizes_and_strides_.stride_at_unchecked(0) == 1;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   SmallVector<int64_t,5> perm;
   perm.resize(dim());
   for (int64_t i = 0; i < dim(); i ++) {
@@ -335,6 +343,7 @@ at::DataPtr PlacementDeleteContext::makeDataPtr(
           device};
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 AutogradMetaInterface::~AutogradMetaInterface() {}
 
 // Setting requires_grad to true on inference tensor outside InferenceMode
@@ -461,6 +470,7 @@ void TensorImpl::copy_tensor_metadata(
 namespace impl {
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 AutogradMetaFactory* meta_factory = nullptr;
 }
 

--- a/c10/core/UndefinedTensorImpl.cpp
+++ b/c10/core/UndefinedTensorImpl.cpp
@@ -36,6 +36,7 @@ const char* UndefinedTensorImpl::tensorimpl_type_name() const {
   return "UndefinedTensorImpl";
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 UndefinedTensorImpl UndefinedTensorImpl::_singleton;
 
 }

--- a/c10/core/impl/DeviceGuardImplInterface.cpp
+++ b/c10/core/impl/DeviceGuardImplInterface.cpp
@@ -3,7 +3,9 @@
 namespace c10 {
 namespace impl {
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 std::atomic<const DeviceGuardImplInterface*>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 device_guard_impl_registry[static_cast<size_t>(DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
 
 DeviceGuardImplRegistrar::DeviceGuardImplRegistrar(DeviceType type, const DeviceGuardImplInterface* impl) {

--- a/c10/core/impl/LocalDispatchKeySet.cpp
+++ b/c10/core/impl/LocalDispatchKeySet.cpp
@@ -14,6 +14,7 @@ namespace impl {
 // we obtain the actual include keyset by XORing raw_local_dispatch_key_set.included_
 // with c10::default_included_set.  This logic is encapsulated in struct
 // PODLocalDispatchKeySet.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local PODLocalDispatchKeySet raw_local_dispatch_key_set;
 
 #if defined(_MSC_VER) || defined(C10_ANDROID)

--- a/c10/core/impl/SizesAndStrides.cpp
+++ b/c10/core/impl/SizesAndStrides.cpp
@@ -17,11 +17,13 @@ void SizesAndStrides::resizeSlowPath(const size_t newSize, const size_t oldSize)
         C10_SIZES_AND_STRIDES_MAX_INLINE_SIZE * sizeof(inlineStorage_[0]));
     // CANNOT USE freeOutOfLineStorage() HERE! outOfLineStorage_
     // HAS BEEN OVERWRITTEN!
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     free(tempStorage);
   } else {
     if (isInline()) {
       // CANNOT USE allocateOutOfLineStorage(newSize) HERE! WOULD
       // OVERWRITE inlineStorage_!
+      // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
       int64_t* tempStorage = static_cast<int64_t *>(malloc(storageBytes(newSize)));
       TORCH_CHECK(tempStorage, "Could not allocate memory to change Tensor SizesAndStrides!");
       const auto bytesToCopy = oldSize * sizeof(inlineStorage_[0]);

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -132,6 +132,7 @@ void ThreadPool::main_loop(std::size_t index) {
   } // while running_
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_SHARED_REGISTRY(
     ThreadPoolRegistry,
     TaskThreadPoolBase,

--- a/c10/mobile/CPUCachingAllocator.cpp
+++ b/c10/mobile/CPUCachingAllocator.cpp
@@ -3,13 +3,17 @@
 namespace c10 {
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local CPUCachingAllocator* caching_allocator_ptr{nullptr};
 } // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::mutex CPUCachingAllocator::mutex_;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 ska::flat_hash_map<void*, size_t> CPUCachingAllocator::allocation_map_;
 
 inline void* CPUCachingAllocator::allocate_and_cache(const size_t bytes) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   void* ptr;
   try {
     ptr = c10::alloc_cpu(bytes);

--- a/c10/mobile/CPUProfilingAllocator.cpp
+++ b/c10/mobile/CPUProfilingAllocator.cpp
@@ -6,7 +6,9 @@
 namespace c10 {
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local AllocationPlanner* allocation_planner{nullptr};
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local CPUProfilingAllocator* profiling_allocator{nullptr};
 
 struct MemBlock {
@@ -147,7 +149,9 @@ std::vector<uint64_t> formulate_greedy_allocation_plan(
   auto mem_events = create_and_sort_mem_events(allocation_sizes, allocation_lifetimes);
   uint64_t max_offset{0};
   for (const auto& mem_event : mem_events) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint64_t alloc_offset;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     uint64_t new_offset, new_size;
     if (mem_event.type == EventType::Allocate) {
       auto it = free_size_to_offset.lower_bound(mem_event.size);

--- a/c10/test/core/CompileTimeFunctionPointer_test.cpp
+++ b/c10/test/core/CompileTimeFunctionPointer_test.cpp
@@ -47,6 +47,7 @@ namespace test_run_through_type {
         }
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(CompileTimeFunctionPointerTest, runFunctionThroughType) {
         Executor<Add> executor;
         EXPECT_EQ(3, executor.execute(1, 2));
@@ -59,6 +60,7 @@ namespace test_run_through_value {
         return Func::func_ptr()(a, b);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(CompileTimeFunctionPointerTest, runFunctionThroughValue) {
         EXPECT_EQ(3, execute(TORCH_FN(add), 1, 2));
     }

--- a/c10/test/core/DeviceGuard_test.cpp
+++ b/c10/test/core/DeviceGuard_test.cpp
@@ -11,6 +11,7 @@ using namespace c10::impl;
 
 // -- DeviceGuard -------------------------------------------------------
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DeviceGuard, ResetDeviceDifferentDeviceType) {
   FakeGuardImpl<DeviceType::CUDA> cuda_impl;
   FakeGuardImpl<DeviceType::HIP> hip_impl;
@@ -26,6 +27,7 @@ TEST(DeviceGuard, ResetDeviceDifferentDeviceType) {
 
 // -- OptionalDeviceGuard -----------------------------------------------
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OptionalDeviceGuard, ResetDeviceDifferentDeviceType) {
   FakeGuardImpl<DeviceType::CUDA> cuda_impl;
   FakeGuardImpl<DeviceType::HIP> hip_impl;

--- a/c10/test/core/DispatchKeySet_test.cpp
+++ b/c10/test/core/DispatchKeySet_test.cpp
@@ -6,6 +6,7 @@
 
 using namespace c10;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, Empty) {
   DispatchKeySet empty_set;
   for (uint8_t i = 1; i < static_cast<uint8_t>(DispatchKey::NumDispatchKeys); i++) {
@@ -18,6 +19,7 @@ TEST(DispatchKeySet, Empty) {
   ASSERT_EQ(empty_set.highestPriorityTypeId(), DispatchKey::Undefined);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, Singleton) {
   for (uint8_t i = 1; i < static_cast<uint8_t>(DispatchKey::NumDispatchKeys); i++) {
     auto tid = static_cast<DispatchKey>(i);
@@ -33,6 +35,7 @@ TEST(DispatchKeySet, Singleton) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, Doubleton) {
   for (uint8_t i = 1; i < static_cast<uint8_t>(DispatchKey::NumDispatchKeys); i++) {
     for (uint8_t j = i + 1; j < static_cast<uint8_t>(DispatchKey::NumDispatchKeys); j++) {
@@ -48,6 +51,7 @@ TEST(DispatchKeySet, Doubleton) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, Full) {
   DispatchKeySet full(DispatchKeySet::FULL);
   for (uint8_t i = 1; i < static_cast<uint8_t>(DispatchKey::NumDispatchKeys); i++) {
@@ -56,6 +60,7 @@ TEST(DispatchKeySet, Full) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, IteratorBasicOps) {
   DispatchKeySet empty_set;
   DispatchKeySet full_set(DispatchKeySet::FULL);
@@ -74,6 +79,7 @@ TEST(DispatchKeySet, IteratorBasicOps) {
   ASSERT_TRUE(full_set.begin() != ++full_set.begin());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, IteratorEmpty) {
   DispatchKeySet empty_set;
   uint8_t i = 0;
@@ -84,6 +90,7 @@ TEST(DispatchKeySet, IteratorEmpty) {
   ASSERT_EQ(i, 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, IteratorFull) {
   DispatchKeySet full_set(DispatchKeySet::FULL);
   uint8_t i = 0;
@@ -97,6 +104,7 @@ TEST(DispatchKeySet, IteratorFull) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, IteratorRangeFull) {
   DispatchKeySet full_set(DispatchKeySet::FULL);
   uint8_t i = 0;
@@ -109,11 +117,14 @@ TEST(DispatchKeySet, IteratorRangeFull) {
   ASSERT_EQ(i, static_cast<uint8_t>(DispatchKey::NumDispatchKeys) - 1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, SpecificKeys) {
   DispatchKeySet keyset({
       static_cast<DispatchKey>(0), // Undefined should be ignored
       static_cast<DispatchKey>(4),
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       static_cast<DispatchKey>(10),
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       static_cast<DispatchKey>(15),
     });
   std::unordered_set<DispatchKey> visited_keys;
@@ -128,10 +139,12 @@ TEST(DispatchKeySet, SpecificKeys) {
   ASSERT_TRUE(visited_keys.find(static_cast<DispatchKey>(15)) != visited_keys.end());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(DispatchKeySet, FailAtEndIterator) {
   DispatchKeySet full_set(DispatchKeySet::FULL);
   uint64_t raw_repr = full_set.raw_repr();
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_THROW(DispatchKeySet::iterator(
                    &raw_repr,
                    static_cast<uint8_t>(DispatchKey::NumDispatchKeys) + 1

--- a/c10/test/core/impl/InlineDeviceGuard_test.cpp
+++ b/c10/test/core/impl/InlineDeviceGuard_test.cpp
@@ -17,6 +17,7 @@ static Device dev(DeviceIndex index) {
 
 using TestGuard = InlineDeviceGuard<TestGuardImpl>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineDeviceGuard, Constructor) {
   for (DeviceIndex i : {-1, 0, 1}) {
     DeviceIndex init_i = 0;
@@ -51,11 +52,14 @@ TEST(InlineDeviceGuard, Constructor) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineDeviceGuard, ConstructorError) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_ANY_THROW(InlineDeviceGuard<FakeGuardImpl<DeviceType::CUDA>>
                    g(Device(DeviceType::HIP, 1)));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineDeviceGuard, SetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
@@ -72,6 +76,7 @@ TEST(InlineDeviceGuard, SetDevice) {
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineDeviceGuard, ResetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
@@ -88,6 +93,7 @@ TEST(InlineDeviceGuard, ResetDevice) {
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineDeviceGuard, SetIndex) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
@@ -108,6 +114,7 @@ TEST(InlineDeviceGuard, SetIndex) {
 
 using MaybeTestGuard = InlineOptionalDeviceGuard<TestGuardImpl>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalDeviceGuard, Constructor) {
   for (DeviceIndex i : {-1, 0, 1}) {
     DeviceIndex init_i = 0;
@@ -140,6 +147,7 @@ TEST(InlineOptionalDeviceGuard, Constructor) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalDeviceGuard, NullaryConstructor) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
@@ -161,6 +169,7 @@ TEST(InlineOptionalDeviceGuard, NullaryConstructor) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalDeviceGuard, SetDevice) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);
@@ -176,6 +185,7 @@ TEST(InlineOptionalDeviceGuard, SetDevice) {
   ASSERT_EQ(TestGuardImpl::getDeviceIndex(), i);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalDeviceGuard, SetIndex) {
   DeviceIndex init_i = 0;
   TestGuardImpl::setDeviceIndex(init_i);

--- a/c10/test/core/impl/InlineStreamGuard_test.cpp
+++ b/c10/test/core/impl/InlineStreamGuard_test.cpp
@@ -21,6 +21,7 @@ static Stream stream(DeviceIndex index, StreamId sid) {
 
 using TestGuard = InlineStreamGuard<TestGuardImpl>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineStreamGuard, Constructor) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -40,6 +41,7 @@ TEST(InlineStreamGuard, Constructor) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineStreamGuard, ResetStreamSameSameDevice) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -57,6 +59,7 @@ TEST(InlineStreamGuard, ResetStreamSameSameDevice) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineStreamGuard, ResetStreamDifferentSameDevice) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -76,6 +79,7 @@ TEST(InlineStreamGuard, ResetStreamDifferentSameDevice) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineStreamGuard, ResetStreamDifferentDevice) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -101,6 +105,7 @@ TEST(InlineStreamGuard, ResetStreamDifferentDevice) {
 
 using OptionalTestGuard = InlineOptionalStreamGuard<TestGuardImpl>;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalStreamGuard, Constructor) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -137,6 +142,7 @@ TEST(InlineOptionalStreamGuard, Constructor) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalStreamGuard, ResetStreamSameDevice) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();
@@ -154,6 +160,7 @@ TEST(InlineOptionalStreamGuard, ResetStreamSameDevice) {
   ASSERT_EQ(TestGuardImpl::getCurrentStreamIdFor(0), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InlineOptionalStreamGuard, ResetStreamDifferentDevice) {
   TestGuardImpl::setDeviceIndex(0);
   TestGuardImpl::resetStreams();

--- a/c10/test/core/impl/SizesAndStrides_test.cpp
+++ b/c10/test/core/impl/SizesAndStrides_test.cpp
@@ -32,18 +32,23 @@ static void checkData(const SizesAndStrides& sz, IntArrayRef sizes, IntArrayRef 
   EXPECT_EQ(sz.strides_arrayref(), strides);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, DefaultConstructor) {
   SizesAndStrides sz;
   checkData(sz, {0}, {1});
   // Can't test size_at() out of bounds because it just asserts for now.
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, SetSizes) {
   SizesAndStrides sz;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.set_sizes({5, 6, 7, 8});
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {5, 6, 7, 8}, {1, 0, 0, 0});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, Resize) {
   SizesAndStrides sz;
 
@@ -53,6 +58,7 @@ TEST(SizesAndStridesTest, Resize) {
   checkData(sz, {0, 0}, {1, 0});
 
   // Small to small growing, again.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
   checkData(sz, {0, 0, 0, 0, 0}, {1, 0, 0, 0, 0});
 
@@ -61,52 +67,73 @@ TEST(SizesAndStridesTest, Resize) {
     sz.stride_at_unchecked(ii) = 2 * (ii + 1);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 5}, {2, 4, 6, 8, 10});
 
   // Small to small, shrinking.
   sz.resize(4);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4}, {2, 4, 6, 8});
 
   // Small to small with no size change.
   sz.resize(4);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4}, {2, 4, 6, 8});
 
   // Small to small, growing back so that we can confirm that our "new"
   // data really does get zeroed.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0}, {2, 4, 6, 8, 0});
 
   // Small to big.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(6);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 0}, {2, 4, 6, 8, 0, 0});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.size_at_unchecked(5) = 6;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.stride_at_unchecked(5) = 12;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6}, {2, 4, 6, 8, 0, 12});
 
   // Big to big, growing.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(7);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6, 0}, {2, 4, 6, 8, 0, 12, 0});
 
   // Big to big with no size change.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(7);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6, 0}, {2, 4, 6, 8, 0, 12, 0});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.size_at_unchecked(6) = 11;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.stride_at_unchecked(6) = 22;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6, 11}, {2, 4, 6, 8, 0, 12, 22});
 
   // Big to big, shrinking.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6}, {2, 4, 6, 8, 0, 12});
 
   // Grow back to make sure "new" elements get zeroed in big mode too.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(7);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {1, 2, 3, 4, 0, 6, 0}, {2, 4, 6, 8, 0, 12, 0});
 
   // Finally, big to small.
@@ -119,57 +146,87 @@ TEST(SizesAndStridesTest, Resize) {
     sz.stride_at_unchecked(ii) = 2 * (ii - 1);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {-1, 0, 1, 2, 3, 4, 5}, {-2, 0, 2, 4, 6, 8, 10});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {-1, 0, 1, 2, 3}, {-2, 0, 2, 4, 6});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, SetAtIndex) {
   SizesAndStrides sz;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.size_at(4) = 42;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.stride_at(4) = 23;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.size_at(5) = 43;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.stride_at(5) = 24;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, SetAtIterator) {
   SizesAndStrides sz;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.sizes_begin() + 4) = 42;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.strides_begin() + 4) = 23;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.sizes_begin() + 5) = 43;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.strides_begin() + 5) = 24;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, SetViaData) {
   SizesAndStrides sz;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.sizes_data() + 4) = 42;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.strides_data() + 4) = 23;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42}, {1, 0, 0, 0, 23});
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sz.resize(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.sizes_data() + 5) = 43;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   *(sz.strides_data() + 5) = 24;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   checkData(sz, {0, 0, 0, 0, 42, 43}, {1, 0, 0, 0, 23, 24});
 }
 
@@ -186,6 +243,7 @@ static SizesAndStrides makeSmall(int offset = 0) {
 
 static SizesAndStrides makeBig(int offset = 0) {
   SizesAndStrides big;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   big.resize(8);
   for (const auto ii : c10::irange(big.size())) {
     big.size_at_unchecked(ii) = ii - 1 + offset;
@@ -205,7 +263,9 @@ static void checkSmall(const SizesAndStrides& sm, int offset = 0) {
 }
 
 static void checkBig(const SizesAndStrides& big, int offset = 0) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   std::vector<int64_t> sizes(8), strides(8);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (int ii = 0; ii < 8; ++ii) {
     sizes[ii] = ii - 1 + offset;
     strides[ii] = 2 * (ii - 1 + offset);
@@ -213,11 +273,13 @@ static void checkBig(const SizesAndStrides& big, int offset = 0) {
   checkData(big, sizes, strides);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveConstructor) {
   SizesAndStrides empty;
 
   SizesAndStrides movedEmpty(std::move(empty));
 
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(empty.size(), 0);
   EXPECT_EQ(movedEmpty.size(), 1);
   checkData(movedEmpty, {0}, {1});
@@ -227,6 +289,7 @@ TEST(SizesAndStridesTest, MoveConstructor) {
 
   SizesAndStrides movedSmall(std::move(small));
   checkSmall(movedSmall);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(small.size(), 0);
 
   SizesAndStrides big = makeBig();
@@ -234,12 +297,15 @@ TEST(SizesAndStridesTest, MoveConstructor) {
 
   SizesAndStrides movedBig(std::move(big));
   checkBig(movedBig);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(big.size(), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyConstructor) {
   SizesAndStrides empty;
 
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   SizesAndStrides copiedEmpty(empty);
 
   EXPECT_EQ(empty.size(), 1);
@@ -250,6 +316,7 @@ TEST(SizesAndStridesTest, CopyConstructor) {
   SizesAndStrides small = makeSmall();
   checkSmall(small);
 
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   SizesAndStrides copiedSmall(small);
   checkSmall(copiedSmall);
   checkSmall(small);
@@ -257,11 +324,13 @@ TEST(SizesAndStridesTest, CopyConstructor) {
   SizesAndStrides big = makeBig();
   checkBig(big);
 
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   SizesAndStrides copiedBig(big);
   checkBig(big);
   checkBig(copiedBig);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyAssignmentSmallToSmall) {
   SizesAndStrides smallTarget = makeSmall();
   SizesAndStrides smallCopyFrom = makeSmall(1);
@@ -275,6 +344,7 @@ TEST(SizesAndStridesTest, CopyAssignmentSmallToSmall) {
   checkSmall(smallCopyFrom, 1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveAssignmentSmallToSmall) {
   SizesAndStrides smallTarget = makeSmall();
   SizesAndStrides smallMoveFrom = makeSmall(1);
@@ -285,9 +355,11 @@ TEST(SizesAndStridesTest, MoveAssignmentSmallToSmall) {
   smallTarget = std::move(smallMoveFrom);
 
   checkSmall(smallTarget, 1);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(smallMoveFrom.size(), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyAssignmentSmallToBig) {
   SizesAndStrides bigTarget = makeBig();
   SizesAndStrides smallCopyFrom = makeSmall();
@@ -301,6 +373,7 @@ TEST(SizesAndStridesTest, CopyAssignmentSmallToBig) {
   checkSmall(smallCopyFrom);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveAssignmentSmallToBig) {
   SizesAndStrides bigTarget = makeBig();
   SizesAndStrides smallMoveFrom = makeSmall();
@@ -311,9 +384,11 @@ TEST(SizesAndStridesTest, MoveAssignmentSmallToBig) {
   bigTarget = std::move(smallMoveFrom);
 
   checkSmall(bigTarget);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(smallMoveFrom.size(), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyAssignmentBigToBig) {
   SizesAndStrides bigTarget = makeBig();
   SizesAndStrides bigCopyFrom = makeBig(1);
@@ -327,6 +402,7 @@ TEST(SizesAndStridesTest, CopyAssignmentBigToBig) {
   checkBig(bigCopyFrom, 1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveAssignmentBigToBig) {
   SizesAndStrides bigTarget = makeBig();
   SizesAndStrides bigMoveFrom = makeBig(1);
@@ -337,9 +413,11 @@ TEST(SizesAndStridesTest, MoveAssignmentBigToBig) {
   bigTarget = std::move(bigMoveFrom);
 
   checkBig(bigTarget, 1);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(bigMoveFrom.size(), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyAssignmentBigToSmall) {
   SizesAndStrides smallTarget = makeSmall();
   SizesAndStrides bigCopyFrom = makeBig();
@@ -353,6 +431,7 @@ TEST(SizesAndStridesTest, CopyAssignmentBigToSmall) {
   checkBig(bigCopyFrom);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveAssignmentBigToSmall) {
   SizesAndStrides smallTarget = makeSmall();
   SizesAndStrides bigMoveFrom = makeBig();
@@ -363,9 +442,11 @@ TEST(SizesAndStridesTest, MoveAssignmentBigToSmall) {
   smallTarget = std::move(bigMoveFrom);
 
   checkBig(smallTarget);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   EXPECT_EQ(bigMoveFrom.size(), 0);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, CopyAssignmentSelf) {
   SizesAndStrides small = makeSmall();
   SizesAndStrides big = makeBig();
@@ -373,9 +454,11 @@ TEST(SizesAndStridesTest, CopyAssignmentSelf) {
   checkSmall(small);
   checkBig(big);
 
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   small = small;
   checkSmall(small);
 
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   big = big;
   checkBig(big);
 }
@@ -385,6 +468,7 @@ static void selfMove(SizesAndStrides& x, SizesAndStrides& y) {
   x = std::move(y);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(SizesAndStridesTest, MoveAssignmentSelf) {
   SizesAndStrides small = makeSmall();
   SizesAndStrides big = makeBig();

--- a/c10/test/util/Array_test.cpp
+++ b/c10/test/util/Array_test.cpp
@@ -84,8 +84,11 @@ namespace test_prepend {
 }
 
 namespace test_to_std_array {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     constexpr int obj2[3] = {3, 5, 6};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(array < int, 3 > {{3, 5, 6}} == to_array(obj2), "");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(array < int, 3 > {{3, 5, 6}} == to_array<int, 3>({3, 5, 6}), "");
 }
 

--- a/c10/test/util/Bitset_test.cpp
+++ b/c10/test/util/Bitset_test.cpp
@@ -4,6 +4,7 @@
 
 using c10::utils::bitset;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenGettingBit_thenIsZero) {
   bitset b;
   for (size_t i = 0; i < bitset::NUM_BITS(); ++i) {
@@ -11,6 +12,7 @@ TEST(BitsetTest, givenEmptyBitset_whenGettingBit_thenIsZero) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenUnsettingBit_thenIsZero) {
   bitset b;
   b.unset(4);
@@ -19,6 +21,7 @@ TEST(BitsetTest, givenEmptyBitset_whenUnsettingBit_thenIsZero) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenSettingAndUnsettingBit_thenIsZero) {
   bitset b;
   b.set(4);
@@ -28,64 +31,89 @@ TEST(BitsetTest, givenEmptyBitset_whenSettingAndUnsettingBit_thenIsZero) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenIsSet) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
   EXPECT_TRUE(b.get(6));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenSettingBit_thenOthersStayUnset) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 6; ++i) {
     EXPECT_FALSE(b.get(i));
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 7; i < bitset::NUM_BITS(); ++i) {
     EXPECT_FALSE(b.get(i));
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenIsSet) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(30);
   EXPECT_TRUE(b.get(30));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenNonemptyBitset_whenSettingBit_thenOthersStayAtOldValue) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(30);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 6; ++i) {
     EXPECT_FALSE(b.get(i));
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 7; i < 30; ++i) {
     EXPECT_FALSE(b.get(i));
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
     EXPECT_FALSE(b.get(i));
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenNonemptyBitset_whenUnsettingBit_thenIsUnset) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(30);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.unset(6);
   EXPECT_FALSE(b.get(6));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     BitsetTest,
     givenNonemptyBitset_whenUnsettingBit_thenOthersStayAtOldValue) {
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(30);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.unset(6);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 30; ++i) {
     EXPECT_FALSE(b.get(i));
   }
   EXPECT_TRUE(b.get(30));
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 31; i < bitset::NUM_BITS(); ++i) {
     EXPECT_FALSE(b.get(i));
   }
@@ -106,6 +134,7 @@ struct IndexCallbackMock final {
   }
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BitsetTest, givenEmptyBitset_whenCallingForEachBit_thenDoesntCall) {
   IndexCallbackMock callback;
   bitset b;
@@ -113,29 +142,40 @@ TEST(BitsetTest, givenEmptyBitset_whenCallingForEachBit_thenDoesntCall) {
   callback.expect_was_called_for_indices({});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     BitsetTest,
     givenBitsetWithOneBitSet_whenCallingForEachBit_thenCallsForEachBit) {
   IndexCallbackMock callback;
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(5);
   b.for_each_set_bit(callback);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   callback.expect_was_called_for_indices({5});
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     BitsetTest,
     givenBitsetWithMultipleBitsSet_whenCallingForEachBit_thenCallsForEachBit) {
   IndexCallbackMock callback;
   bitset b;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(5);
   b.set(2);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(25);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(32);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(50);
   b.set(0);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.unset(25);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   b.set(10);
   b.for_each_set_bit(callback);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   callback.expect_was_called_for_indices({0, 2, 5, 10, 32, 50});
 }

--- a/c10/test/util/ConstexprCrc_test.cpp
+++ b/c10/test/util/ConstexprCrc_test.cpp
@@ -14,4 +14,5 @@ static_assert(
 // check concrete expected values (for CRC64 with Jones coefficients and an init
 // value of 0)
 static_assert(crc64_t{0} == crc64(""), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(crc64_t{0xe9c6d914c4b8d9ca} == crc64("123456789"), "");

--- a/c10/test/util/Half_test.cpp
+++ b/c10/test/util/Half_test.cpp
@@ -6,31 +6,44 @@
 namespace {
 namespace half_legacy_impl {
 float halfbits2float(unsigned short h) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   unsigned sign = ((h >> 15) & 1);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   unsigned exponent = ((h >> 10) & 0x1f);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   unsigned mantissa = ((h & 0x3ff) << 13);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (exponent == 0x1f) { /* NaN or Inf */
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     mantissa = (mantissa ? (sign = 0, 0x7fffff) : 0);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     exponent = 0xff;
   } else if (!exponent) { /* Denorm or Zero */
     if (mantissa) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       unsigned int msb;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       exponent = 0x71;
       do {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         msb = (mantissa & 0x400000);
         mantissa <<= 1; /* normalize */
         --exponent;
       } while (!msb);
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       mantissa &= 0x7fffff; /* 1.mantissa is implicit */
     }
   } else {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     exponent += 0x70;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   unsigned result_bit = (sign << 31) | (exponent << 23) | mantissa;
 
   // Reinterpret the result bit pattern as a float
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   float result_float;
   std::memcpy(&result_float, &result_bit, sizeof(result_float));
   return result_float;
@@ -38,36 +51,52 @@ float halfbits2float(unsigned short h) {
 
 unsigned short float2halfbits(float src) {
   // Reinterpret the float as a bit pattern
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   unsigned x;
   std::memcpy(&x, &src, sizeof(x));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables,cppcoreguidelines-avoid-magic-numbers)
   unsigned u = (x & 0x7fffffff), remainder, shift, lsb, lsb_s1, lsb_m1;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   unsigned sign, exponent, mantissa;
 
   // Get rid of +NaN/-NaN case first.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (u > 0x7f800000) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return 0x7fffU;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   sign = ((x >> 16) & 0x8000);
 
   // Get rid of +Inf/-Inf, +0/-0.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (u > 0x477fefff) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return sign | 0x7c00U;
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (u < 0x33000001) {
     return (sign | 0x0000);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   exponent = ((u >> 23) & 0xff);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   mantissa = (u & 0x7fffff);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (exponent > 0x70) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     shift = 13;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     exponent -= 0x70;
   } else {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     shift = 0x7e - exponent;
     exponent = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     mantissa |= 0x800000;
   }
   lsb = (1 << shift);
@@ -79,20 +108,26 @@ unsigned short float2halfbits(float src) {
   mantissa >>= shift;
   if (remainder > lsb_s1 || (remainder == lsb_s1 && (mantissa & 0x1))) {
     ++mantissa;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     if (!(mantissa & 0x3ff)) {
       ++exponent;
       mantissa = 0;
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   return (sign | (exponent << 10) | mantissa);
 };
 } // namespace half_legacy_impl
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(HalfDoubleConversionTest, Half2Double) {
   std::vector<uint16_t> inputs = {
       0,
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       0xfbff, // 1111 1011 1111 1111
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       (1 << 15 | 1),
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       0x7bff // 0111 1011 1111 1111
   };
   for (auto x : inputs) {

--- a/c10/test/util/LeftRight_test.cpp
+++ b/c10/test/util/LeftRight_test.cpp
@@ -5,9 +5,11 @@
 using c10::LeftRight;
 using std::vector;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenInt_whenWritingAndReading_thenChangesArePresent) {
   LeftRight<int> obj;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   obj.write([] (int& obj) {obj = 5;});
   int read = obj.read([] (const int& obj) {return obj;});
   EXPECT_EQ(5, read);
@@ -18,26 +20,32 @@ TEST(LeftRightTest, givenInt_whenWritingAndReading_thenChangesArePresent) {
   EXPECT_EQ(5, read);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenVector_whenWritingAndReading_thenChangesArePresent) {
     LeftRight<vector<int>> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     obj.write([] (vector<int>& obj) {obj.push_back(5);});
     vector<int> read = obj.read([] (const vector<int>& obj) {return obj;});
     EXPECT_EQ((vector<int>{5}), read);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     obj.write([] (vector<int>& obj) {obj.push_back(6);});
     read = obj.read([] (const vector<int>& obj) {return obj;});
     EXPECT_EQ((vector<int>{5, 6}), read);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenVector_whenWritingReturnsValue_thenValueIsReturned) {
     LeftRight<vector<int>> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto a = obj.write([] (vector<int>&) -> int {return 5;});
     static_assert(std::is_same<int, decltype(a)>::value, "");
     EXPECT_EQ(5, a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, readsCanBeConcurrent) {
     LeftRight<int> obj;
     std::atomic<int> num_running_readers{0};
@@ -62,6 +70,7 @@ TEST(LeftRightTest, readsCanBeConcurrent) {
     reader2.join();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, writesCanBeConcurrentWithReads_readThenWrite) {
     LeftRight<int> obj;
     std::atomic<bool> reader_running{false};
@@ -89,6 +98,7 @@ TEST(LeftRightTest, writesCanBeConcurrentWithReads_readThenWrite) {
     writer.join();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, writesCanBeConcurrentWithReads_writeThenRead) {
     LeftRight<int> obj;
     std::atomic<bool> writer_running{false};
@@ -116,6 +126,7 @@ TEST(LeftRightTest, writesCanBeConcurrentWithReads_writeThenRead) {
     reader.join();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, writesCannotBeConcurrentWithWrites) {
     LeftRight<int> obj;
     std::atomic<bool> first_writer_started{false};
@@ -124,6 +135,7 @@ TEST(LeftRightTest, writesCannotBeConcurrentWithWrites) {
     std::thread writer1([&] () {
         obj.write([&] (int&) {
             first_writer_started = true;
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
             first_writer_finished = true;
         });
@@ -147,29 +159,36 @@ namespace {
 class MyException : public std::exception {};
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, whenReadThrowsException_thenThrowsThrough) {
     LeftRight<int> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     EXPECT_THROW(
         obj.read([](const int&) {throw MyException();}),
         MyException
     );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, whenWriteThrowsException_thenThrowsThrough) {
     LeftRight<int> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     EXPECT_THROW(
         obj.write([](int&) {throw MyException();}),
         MyException
     );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnFirstCall_thenResetsToOldState) {
     LeftRight<int> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     obj.write([](int& obj) {obj = 5;});
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     EXPECT_THROW(
         obj.write([](int& obj) {
             obj = 6;
@@ -190,12 +209,15 @@ TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnFirstCall_thenResetsToOld
 
 // note: each write is executed twice, on the foreground and background copy.
 // We need to test a thrown exception in either call is handled correctly.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnSecondCall_thenKeepsNewState) {
     LeftRight<int> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     obj.write([](int& obj) {obj = 5;});
     bool write_called = false;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     EXPECT_THROW(
         obj.write([&](int& obj) {
             obj = 6;
@@ -219,11 +241,14 @@ TEST(LeftRightTest, givenInt_whenWriteThrowsExceptionOnSecondCall_thenKeepsNewSt
     EXPECT_EQ(6, read);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LeftRightTest, givenVector_whenWriteThrowsException_thenResetsToOldState) {
     LeftRight<vector<int>> obj;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     obj.write([](vector<int>& obj) {obj.push_back(5);});
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
     EXPECT_THROW(
             obj.write([](vector<int>& obj) {
                 obj.push_back(6);

--- a/c10/test/util/Metaprogramming_test.cpp
+++ b/c10/test/util/Metaprogramming_test.cpp
@@ -60,20 +60,26 @@ template<class T> using is_my_copy_counting_class = std::is_same<CopyCounting, s
 namespace test_extract_arg_by_filtered_index {
     class MyClass {};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(3, "bla", MyClass(), 4, nullptr, 5);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto a2 = extract_arg_by_filtered_index<std::is_integral, 1>(3, "bla", MyClass(), 4, nullptr, 5);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto a3 = extract_arg_by_filtered_index<std::is_integral, 2>(3, "bla", MyClass(), 4, nullptr, 5);
         EXPECT_EQ(3, a1);
         EXPECT_EQ(4, a2);
         EXPECT_EQ(5, a3);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_singleInput) {
         auto a1 = extract_arg_by_filtered_index<std::is_integral, 0>(3);
         EXPECT_EQ(3, a1);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_movableOnly) {
         MovableOnly a1 = extract_arg_by_filtered_index<is_my_movable_only_class, 0>(3, MovableOnly(3), "test", MovableOnly(1));
         MovableOnly a2 = extract_arg_by_filtered_index<is_my_movable_only_class, 1>(3, MovableOnly(3), "test", MovableOnly(1));
@@ -81,11 +87,14 @@ namespace test_extract_arg_by_filtered_index {
         EXPECT_EQ(MovableOnly(1), a2);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyCopiesIfNecessary) {
         CopyCounting source;
         CopyCounting source2;
         CopyCounting a1 = extract_arg_by_filtered_index<is_my_copy_counting_class, 0>(3, CopyCounting(), "test", source, std::move(source2));
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class, 1>(3, CopyCounting(), "test", source, std::move(source2));
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         CopyCounting a3 = extract_arg_by_filtered_index<is_my_copy_counting_class, 2>(3, CopyCounting(), "test", source, std::move(source2));
         EXPECT_EQ(1, a1.move_count);
         EXPECT_EQ(0, a1.copy_count);
@@ -95,10 +104,12 @@ namespace test_extract_arg_by_filtered_index {
         EXPECT_EQ(1, a2.copy_count);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_onlyMovesIfNecessary) {
         CopyCounting source;
         CopyCounting source2;
         CopyCounting&& a1 = extract_arg_by_filtered_index<is_my_copy_counting_class , 0>(3, std::move(source), "test", std::move(source2));
+        // NOLINTNEXTLINE(bugprone-use-after-move)
         CopyCounting a2 = extract_arg_by_filtered_index<is_my_copy_counting_class , 1>(3, std::move(source), "test", std::move(source2));
         EXPECT_EQ(0, a1.move_count);
         EXPECT_EQ(0, a1.copy_count);
@@ -108,6 +119,7 @@ namespace test_extract_arg_by_filtered_index {
 
     template<class T> using is_true = std::true_type;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, ExtractArgByFilteredIndex_keepsLValueReferencesIntact) {
         MyClass obj;
         MyClass& a1 = extract_arg_by_filtered_index<is_true, 1>(3, obj, "test", obj);
@@ -124,13 +136,16 @@ namespace test_filter_map {
       }
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto result = filter_map<double, std::is_integral>(map_to_double(), 3, "bla", MyClass(), 4, nullptr, 5);
         static_assert(std::is_same<array<double, 3>, decltype(result)>::value, "");
         constexpr array<double, 3> expected{{3.0, 4.0, 5.0}};
         EXPECT_EQ(expected, result);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap_emptyInput) {
         auto result = filter_map<double, std::is_integral>(map_to_double());
         static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
@@ -138,6 +153,7 @@ namespace test_filter_map {
         EXPECT_EQ(expected, result);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap_emptyOutput) {
         auto result = filter_map<double, std::is_integral>(map_to_double(), "bla", MyClass(), nullptr);
         static_assert(std::is_same<array<double, 0>, decltype(result)>::value, "");
@@ -145,6 +161,7 @@ namespace test_filter_map {
         EXPECT_EQ(expected, result);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap_movableOnly_byRValue) {
         struct map_movable_by_rvalue {
           MovableOnly operator()(MovableOnly&& a) const {
@@ -152,12 +169,14 @@ namespace test_filter_map {
           }
         };
 
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto result = filter_map<MovableOnly, is_my_movable_only_class>(map_movable_by_rvalue(), MovableOnly(5), "bla", nullptr, 3, MovableOnly(2));
         static_assert(std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
         constexpr array<MovableOnly, 2> expected {{MovableOnly(5), MovableOnly(2)}};
         EXPECT_EQ(expected, result);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap_movableOnly_byValue) {
         struct map_movable_by_lvalue {
           MovableOnly operator()(MovableOnly a) const {
@@ -165,6 +184,7 @@ namespace test_filter_map {
           }
         };
 
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto result = filter_map<MovableOnly, is_my_movable_only_class>(map_movable_by_lvalue(), MovableOnly(5), "bla", nullptr, 3, MovableOnly(2));
         static_assert(std::is_same<array<MovableOnly, 2>, decltype(result)>::value, "");
         constexpr array<MovableOnly, 2> expected {{MovableOnly(5), MovableOnly(2)}};
@@ -172,6 +192,7 @@ namespace test_filter_map {
     }
 
     // See https://github.com/pytorch/pytorch/issues/35546
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, DISABLED_ON_WINDOWS(FilterMap_onlyCopiesIfNecessary)) {
         struct map_copy_counting_by_copy {
           CopyCounting operator()(CopyCounting v) const {
@@ -191,6 +212,7 @@ namespace test_filter_map {
         EXPECT_EQ(2, result[2].move_count);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, DISABLED_ON_WINDOWS(FilterMap_onlyMovesIfNecessary_1)) {
         struct map_copy_counting_by_move {
           CopyCounting operator()(CopyCounting&& v) const {
@@ -207,6 +229,7 @@ namespace test_filter_map {
         EXPECT_EQ(1, result[1].move_count);
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(MetaprogrammingTest, FilterMap_onlyMovesIfNecessary_2) {
         struct map_copy_counting_by_pointer {
           const CopyCounting* operator()(const CopyCounting& v) const {
@@ -230,16 +253,22 @@ namespace test_tuple_elements {
   // "parameter set but not used" in tuple_elements(). a good example
   // of the friction that comes with using these tools
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleElements_subsetSelection) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_elements(x, std::index_sequence<0, 2>());
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto z = std::make_tuple(0, 2.0);
     EXPECT_EQ(y, z);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleElements_reorderSelection) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_elements(x, std::index_sequence<0, 2, 1>());
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto z = std::make_tuple(0, 2.0, "HEY");
     EXPECT_EQ(y, z);
   }
@@ -248,36 +277,48 @@ namespace test_tuple_elements {
 namespace test_tuple_take {
   // note: not testing empty prefix, see note on empty selection above.
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleTake_nonemptyPrefix) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_take<decltype(x), 2>(x);
     auto z = std::make_tuple(0, "HEY");
     EXPECT_EQ(y, z);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleTake_fullPrefix) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_take<decltype(x), 3>(x);
     EXPECT_EQ(x, y);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleTake_negative) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_take<decltype(x), -2>(x);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto z = std::make_tuple("HEY", 2.0);
     EXPECT_EQ(y, z);
   }
 }
 
 namespace test_tuple_slice {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleSlice_middle) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0, false);
     auto y = tuple_slice<decltype(x), 1, 2>(x);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto z = std::make_tuple("HEY", 2.0);
     EXPECT_EQ(y, z);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleSlice_full) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto x = std::make_tuple(0, "HEY", 2.0);
     auto y = tuple_slice<decltype(x), 0, 3>(x);
     EXPECT_EQ(x, y);
@@ -285,7 +326,9 @@ namespace test_tuple_slice {
 }
 
 namespace test_tuple_map {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_simple) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_map(std::tuple<int32_t, int32_t, int32_t>(3, 4, 5), [] (int32_t a) -> int16_t {return a+1;});
     static_assert(std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::value, "");
     EXPECT_EQ(4, std::get<0>(result));
@@ -293,7 +336,9 @@ namespace test_tuple_map {
     EXPECT_EQ(6, std::get<2>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_mapperTakesDifferentButConvertibleType) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_map(std::tuple<int32_t, int32_t, int32_t>(3, 4, 5), [] (int64_t a) -> int16_t {return a+1;});
     static_assert(std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::value, "");
     EXPECT_EQ(4, std::get<0>(result));
@@ -301,7 +346,9 @@ namespace test_tuple_map {
     EXPECT_EQ(6, std::get<2>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_mapperTakesConstRef) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_map(std::tuple<int32_t, int32_t, int32_t>(3, 4, 5), [] (const int32_t& a) -> int16_t {return a+1;});
     static_assert(std::is_same<std::tuple<int16_t, int16_t, int16_t>, decltype(result)>::value, "");
     EXPECT_EQ(4, std::get<0>(result));
@@ -309,6 +356,7 @@ namespace test_tuple_map {
     EXPECT_EQ(6, std::get<2>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_mapsToDifferentTypes) {
     struct Mapper {
       std::string operator()(int32_t a) const {
@@ -324,6 +372,7 @@ namespace test_tuple_map {
     EXPECT_EQ(4, std::get<1>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_differentiatesLRValueReferences) {
     struct Mapper {
       std::string operator()(std::string&& a) const {
@@ -340,12 +389,15 @@ namespace test_tuple_map {
     EXPECT_EQ("moved", std::get<1>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_canWorkWithMovableOnlyType) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_map(std::tuple<MovableOnly>(MovableOnly(7)), [] (MovableOnly a) { return a; });
     static_assert(std::is_same<std::tuple<MovableOnly>, decltype(result)>::value, "");
     EXPECT_EQ(MovableOnly(7), std::get<0>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_doesntUnecessarilyCopyValues) {
     auto result = tuple_map(std::tuple<CopyCounting>(CopyCounting()), [] (CopyCounting a) { return a; });
     static_assert(std::is_same<std::tuple<CopyCounting>, decltype(result)>::value, "");
@@ -353,6 +405,7 @@ namespace test_tuple_map {
     EXPECT_EQ(0, std::get<0>(result).copy_count);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_doesntUnecessarilyMoveValues) {
     CopyCounting a;
     auto result = tuple_map(std::tuple<CopyCounting&&>(std::move(a)), [] (CopyCounting&& a) -> CopyCounting&& { return std::move(a); });
@@ -362,9 +415,11 @@ namespace test_tuple_map {
     EXPECT_EQ(0, std::get<0>(result).copy_count);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleMap_canBeUsedWithAutoLambdas) {
     struct A final {
       int32_t func() {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         return 5;
       }
     };
@@ -381,23 +436,28 @@ namespace test_tuple_map {
 }
 
 namespace test_tuple_concat {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_zerotuples) {
     auto result = tuple_concat();
     static_assert(std::is_same<std::tuple<>, decltype(result)>::value, "");
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_oneemptytuple) {
     auto result = tuple_concat(std::tuple<>());
     static_assert(std::is_same<std::tuple<>, decltype(result)>::value, "");
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_onenonemptytuple) {
     auto result = tuple_concat(std::tuple<int64_t>(3));
     static_assert(std::is_same<std::tuple<int64_t>, decltype(result)>::value, "");
     EXPECT_EQ(3, std::get<0>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_twotuples) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_concat(std::tuple<int64_t, std::string>(3, "4"), std::tuple<double, int16_t>(2.3, 15));
     static_assert(std::is_same<std::tuple<int64_t, std::string, double, int16_t>, decltype(result)>::value, "");
     EXPECT_EQ(3, std::get<0>(result));
@@ -406,7 +466,9 @@ namespace test_tuple_concat {
     EXPECT_EQ(15, std::get<3>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_threetuples) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_concat(std::tuple<int64_t, std::string>(3, "4"), std::tuple<double, int16_t>(2.3, 15), std::tuple<std::string, float>("5", 3.2));
     static_assert(std::is_same<std::tuple<int64_t, std::string, double, int16_t, std::string, float>, decltype(result)>::value, "");
     EXPECT_EQ(3, std::get<0>(result));
@@ -417,7 +479,9 @@ namespace test_tuple_concat {
     EXPECT_EQ(static_cast<float>(3.2), std::get<5>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_emptytupleatbeginning) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_concat(std::tuple<>(), std::tuple<double, int16_t>(2.3, 15), std::tuple<std::string, float>("5", 3.2));
     static_assert(std::is_same<std::tuple<double, int16_t, std::string, float>, decltype(result)>::value, "");
     EXPECT_EQ(2.3, std::get<0>(result));
@@ -426,7 +490,9 @@ namespace test_tuple_concat {
     EXPECT_EQ(static_cast<float>(3.2), std::get<3>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_emptytupleinmiddle) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_concat(std::tuple<double, int16_t>(2.3, 15), std::tuple<>(), std::tuple<std::string, float>("5", 3.2));
     static_assert(std::is_same<std::tuple<double, int16_t, std::string, float>, decltype(result)>::value, "");
     EXPECT_EQ(2.3, std::get<0>(result));
@@ -435,7 +501,9 @@ namespace test_tuple_concat {
     EXPECT_EQ(static_cast<float>(3.2), std::get<3>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_emptytupleatend) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto result = tuple_concat(std::tuple<double, int16_t>(2.3, 15), std::tuple<std::string, float>("5", 3.2), std::tuple<>());
     static_assert(std::is_same<std::tuple<double, int16_t, std::string, float>, decltype(result)>::value, "");
     EXPECT_EQ(2.3, std::get<0>(result));
@@ -444,10 +512,14 @@ namespace test_tuple_concat {
     EXPECT_EQ(static_cast<float>(3.2), std::get<3>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_workswithreferencesandpointers) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     double val1 = 2.3;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     int16_t val2 = 15;
     std::string val3 = "hello";
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float val4 = 3.2;
     auto result = tuple_concat(std::tuple<double&, const int16_t&>(val1, val2), std::tuple<std::string&&, float*>(std::move(val3), &val4));
     static_assert(std::is_same<std::tuple<double&, const int16_t&, std::string&&, float*>, decltype(result)>::value, "");
@@ -461,6 +533,7 @@ namespace test_tuple_concat {
     EXPECT_EQ(&val4, std::get<3>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_worksWithMovableOnlyTypes) {
     auto result = tuple_concat(std::tuple<MovableOnly, MovableOnly>(1, 2), std::tuple<MovableOnly>(3));
     static_assert(std::is_same<std::tuple<MovableOnly, MovableOnly, MovableOnly>, decltype(result)>::value, "");
@@ -469,6 +542,7 @@ namespace test_tuple_concat {
     EXPECT_EQ(MovableOnly(3), std::get<2>(result));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(MetaprogrammingTest, TupleConcat_doesntCopyMoreThanNecessary) {
     auto result = tuple_concat(std::tuple<CopyCounting, CopyCounting>(CopyCounting(), CopyCounting()), std::tuple<CopyCounting>(CopyCounting()), std::tuple<CopyCounting>(CopyCounting()));
     static_assert(std::is_same<std::tuple<CopyCounting, CopyCounting, CopyCounting, CopyCounting>, decltype(result)>::value, "");
@@ -495,8 +569,10 @@ namespace test_concat_iseq {
   static_assert(std::is_same<index_sequence<4>, concat_iseq_t<index_sequence<>, index_sequence<4>, index_sequence<>>>::value, "");
   static_assert(std::is_same<index_sequence<4, 2>, concat_iseq_t<index_sequence<4>, index_sequence<2>>>::value, "");
   static_assert(std::is_same<index_sequence<4, 2>, concat_iseq_t<index_sequence<>, index_sequence<4, 2>, index_sequence<>>>::value, "");
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   static_assert(std::is_same<index_sequence<4, 2, 9>, concat_iseq_t<index_sequence<>, index_sequence<4, 2>, index_sequence<9>>>::value, "");
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   static_assert(std::is_same<integer_sequence<int8_t, -5, -3>, concat_iseq_t<integer_sequence<int8_t, -5>, integer_sequence<int8_t, -3>>>::value, "");
 }
 

--- a/c10/test/util/TypeIndex_test.cpp
+++ b/c10/test/util/TypeIndex_test.cpp
@@ -59,6 +59,7 @@ static_assert(
     string_view::npos != get_fully_qualified_type_name<Dummy>().find("Dummy"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, TopLevelName) {
     EXPECT_NE(
         string_view::npos,
@@ -76,6 +77,7 @@ static_assert(
         get_fully_qualified_type_name<Dummy>().find("test_nested_name::Dummy"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, NestedName) {
     EXPECT_NE(
         string_view::npos,
@@ -101,6 +103,7 @@ static_assert(
             "test_type_template_parameter::Inner"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, TypeTemplateParameter) {
     EXPECT_NE(
         string_view::npos,
@@ -122,9 +125,11 @@ struct Class final {};
 #if C10_TYPENAME_SUPPORTS_CONSTEXPR
 static_assert(
     string_view::npos !=
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         get_fully_qualified_type_name<Class<38474355>>().find("38474355"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, NonTypeTemplateParameter) {
     EXPECT_NE(
         string_view::npos,
@@ -157,6 +162,7 @@ static_assert(
             .find("*"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, TypeComputationsAreResolved) {
     EXPECT_NE(
         string_view::npos,
@@ -185,6 +191,7 @@ static_assert(
             typename c10::guts::infer_function_traits_t<Functor>::func_type>(),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, FunctionTypeComputationsAreResolved) {
     EXPECT_EQ(
         get_fully_qualified_type_name<std::string(int64_t, const Type<int>&)>(),
@@ -209,6 +216,7 @@ static_assert(
             "test_function_arguments_and_returns::Dummy"),
     "");
 #endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeIndex, FunctionArgumentsAndReturns) {
     EXPECT_NE(
         string_view::npos,

--- a/c10/test/util/TypeList_test.cpp
+++ b/c10/test/util/TypeList_test.cpp
@@ -109,9 +109,11 @@ namespace test_map_types_to_values {
       template<class T> constexpr size_t operator()(T) const {return sizeof(typename T::type);}
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(TypeListTest, MapTypesToValues_sametype) {
         auto sizes =
             map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
         static_assert(std::is_same<decltype(expected), decltype(sizes)>::value, "");
         EXPECT_EQ(expected, sizes);
@@ -123,6 +125,7 @@ namespace test_map_types_to_values {
       }
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(TypeListTest, MapTypesToValues_differenttypes) {
         auto shared_ptrs =
                 map_types_to_values<typelist<int, double>>(map_make_shared());
@@ -130,15 +133,18 @@ namespace test_map_types_to_values {
     }
 
     struct Class1 {static int func() {return 3;}};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     struct Class2 {static double func() {return 2.0;}};
 
     struct mapper_call_func {
       template<class T> decltype(auto) operator()(T) { return T::type::func(); }
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(TypeListTest, MapTypesToValues_members) {
         auto result =
                 map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         std::tuple<int, double> expected(3, 2.0);
         static_assert(std::is_same<decltype(expected), decltype(result)>::value, "");
         EXPECT_EQ(expected, result);
@@ -148,6 +154,7 @@ namespace test_map_types_to_values {
       template<class T> decltype(auto) operator()(T) { return T::type::this_doesnt_exist(); }
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     TEST(TypeListTest, MapTypesToValues_empty) {
         auto result =
                 map_types_to_values<typelist<>>(mapper_call_nonexistent_function());

--- a/c10/test/util/TypeTraits_test.cpp
+++ b/c10/test/util/TypeTraits_test.cpp
@@ -41,12 +41,14 @@ namespace test_is_function_type {
     struct Functor {
         void operator()() {}
     };
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     auto lambda = [] () {};
     // func() and func__ just exists to silence a compiler warning about lambda being unused
     bool func() {
         lambda();
         return true;
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     bool func__ = func();
 
     static_assert(is_function_type<void()>::value, "");

--- a/c10/test/util/accumulate_test.cpp
+++ b/c10/test/util/accumulate_test.cpp
@@ -9,7 +9,9 @@
 
 using namespace ::testing;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(accumulate_test, vector_test) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::vector<int> ints = {1, 2, 3, 4, 5};
 
     EXPECT_EQ(c10::sum_integers(ints), 1+2+3+4+5);
@@ -27,7 +29,9 @@ TEST(accumulate_test, vector_test) {
     EXPECT_EQ(c10::numelements_between_dim(4, 2, ints), 3*4);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(accumulate_test, list_test) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::list<int> ints = {1, 2, 3, 4, 5};
 
     EXPECT_EQ(c10::sum_integers(ints), 1+2+3+4+5);
@@ -42,6 +46,7 @@ TEST(accumulate_test, list_test) {
     EXPECT_EQ(c10::numelements_between_dim(4, 2, ints), 3*4);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(accumulate_test, base_cases) {
     std::vector<int> ints = {};
 
@@ -49,19 +54,27 @@ TEST(accumulate_test, base_cases) {
     EXPECT_EQ(c10::multiply_integers(ints), 1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(accumulate_test, errors) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::vector<int> ints = {1,2,3,4,5};
 
     #ifndef NDEBUG
     EXPECT_THROW(c10::numelements_from_dim(-1, ints), c10::Error);
     #endif
 
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_to_dim(-1, ints), c10::Error);
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_between_dim(-1, 10, ints), c10::Error);
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_between_dim(10, -1, ints), c10::Error);
 
     EXPECT_EQ(c10::numelements_from_dim(10, ints),1);
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_to_dim(10, ints), c10::Error);
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_between_dim(10, 4, ints), c10::Error);
+    // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
     EXPECT_THROW(c10::numelements_between_dim(4, 10, ints), c10::Error);
 }

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -7,28 +7,39 @@ namespace {
       uint32_t exponent,
       uint32_t fraction
   ) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       uint32_t bytes;
       bytes = 0;
       bytes |= sign;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       bytes <<= 8;
       bytes |= exponent;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       bytes <<= 23;
       bytes |= fraction;
 
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       float res;
       std::memcpy(&res, &bytes, sizeof(res));
       return res;
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     float in[100];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (int i = 0; i < 100; ++i) {
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers)
       in[i] = i + 1.25;
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     c10::BFloat16 bfloats[100];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     float out[100];
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (int i = 0; i < 100; ++i) {
       bfloats[i].x = c10::detail::bits_from_f32(in[i]);
       out[i] = c10::detail::f32_from_bits(bfloats[i].x);
@@ -39,15 +50,22 @@ namespace {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Conversion, FloatToBFloat16RNEAndBack) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     float in[100];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (int i = 0; i < 100; ++i) {
+      // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers)
       in[i] = i + 1.25;
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     c10::BFloat16 bfloats[100];
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
     float out[100];
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (int i = 0; i < 100; ++i) {
       bfloats[i].x = c10::detail::round_to_nearest_even(in[i]);
       out[i] = c10::detail::f32_from_bits(bfloats[i].x);
@@ -58,7 +76,9 @@ namespace {
     }
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Conversion, NaN) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float inNaN = float_from_bytes(0, 0xFF, 0x7FFFFF);
     EXPECT_TRUE(std::isnan(inNaN));
 
@@ -68,7 +88,9 @@ namespace {
     EXPECT_TRUE(std::isnan(out));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Conversion, Inf) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float inInf = float_from_bytes(0, 0xFF, 0);
     EXPECT_TRUE(std::isinf(inInf));
 
@@ -78,6 +100,7 @@ namespace {
     EXPECT_TRUE(std::isinf(out));
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Conversion, SmallestDenormal) {
     float in =  std::numeric_limits<float>::denorm_min(); // The smallest non-zero subnormal number
     c10::BFloat16 a = c10::BFloat16(in);
@@ -86,6 +109,7 @@ namespace {
     EXPECT_FLOAT_EQ(in, out);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Math, Addition) {
     // This test verifies that if only first 7 bits of float's mantissa are
     // changed after addition, we should have no loss in precision.
@@ -93,13 +117,16 @@ namespace {
     // input bits
     // S | Exponent | Mantissa
     // 0 | 10000000 | 10010000000000000000000 = 3.125
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float input = float_from_bytes(0, 0, 0x40480000);
 
     // expected bits
     // S | Exponent | Mantissa
     // 0 | 10000001 | 10010000000000000000000 = 6.25
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float expected = float_from_bytes(0, 0, 0x40c80000);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     c10::BFloat16 b;
     b.x = c10::detail::bits_from_f32(input);
     b = b + b;
@@ -108,6 +135,7 @@ namespace {
     EXPECT_EQ(res, expected);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST(BFloat16Math, Subtraction) {
     // This test verifies that if only first 7 bits of float's mantissa are
     // changed after subtraction, we should have no loss in precision.
@@ -115,15 +143,19 @@ namespace {
     // input bits
     // S | Exponent | Mantissa
     // 0 | 10000001 | 11101000000000000000000 = 7.625
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float input = float_from_bytes(0, 0, 0x40f40000);
 
     // expected bits
     // S | Exponent | Mantissa
     // 0 | 10000000 | 01010000000000000000000 = 2.625
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     float expected = float_from_bytes(0, 0, 0x40280000);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
     c10::BFloat16 b;
     b.x = c10::detail::bits_from_f32(input);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     b = b - 5;
 
     float res = c10::detail::f32_from_bits(b.x);
@@ -131,6 +163,7 @@ namespace {
   }
 
   float BinaryToFloat(uint32_t bytes) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     float res;
     std::memcpy(&res, &bytes, sizeof(res));
     return res;
@@ -145,12 +178,14 @@ namespace {
                        public ::testing::WithParamInterface<BFloat16TestParam> {
   };
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   TEST_P(BFloat16Test, BFloat16RNETest) {
     float value = BinaryToFloat(GetParam().input);
     uint16_t rounded = c10::detail::round_to_nearest_even(value);
     EXPECT_EQ(GetParam().rne, rounded);
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   INSTANTIATE_TEST_CASE_P(
       BFloat16Test_Instantiation, BFloat16Test,
       ::testing::Values(BFloat16TestParam{0x3F848000, 0x3F84},

--- a/c10/test/util/either_test.cpp
+++ b/c10/test/util/either_test.cpp
@@ -66,8 +66,10 @@ std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_LEFT(const Left
     }, [&] (either<Left, Right>& obj) {
       EXPECT_EQ(expected, std::move(obj).left());
     }, [&] (either<Left, Right>& obj) {
+      // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
       EXPECT_ANY_THROW(obj.right());
     }, [&] (either<Left, Right>& obj) {
+      // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
       EXPECT_ANY_THROW(std::move(obj).right());
     }
   };
@@ -85,8 +87,10 @@ std::vector<std::function<void(either<Left, Right>&)>> EXPECT_IS_RIGHT(const Rig
       }, [&] (either<Left, Right>& obj) {
         EXPECT_EQ(expected, std::move(obj).right());
       }, [&] (either<Left, Right>& obj) {
+        // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
         EXPECT_ANY_THROW(obj.left());
       }, [&] (either<Left, Right>& obj) {
+        // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
         EXPECT_ANY_THROW(std::move(obj).left());
       }
   };
@@ -113,6 +117,7 @@ void TestSpaceUsage() {
 }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, SpaceUsage) {
     TestSpaceUsage<char, int>();
     TestSpaceUsage<int, short>();
@@ -121,6 +126,7 @@ TEST(EitherTest, SpaceUsage) {
     TestSpaceUsage<string, vector<string>>();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeft) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -135,6 +141,7 @@ TEST(EitherTest, givenLeft) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRight) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -149,6 +156,7 @@ TEST(EitherTest, givenRight) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMakeLeft) {
     test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -163,6 +171,7 @@ TEST(EitherTest, givenMakeLeft) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMakeLeftWithSameType) {
   test_with_matrix({
       [] (std::function<void(either<int, int>&)> test) {
@@ -177,6 +186,7 @@ TEST(EitherTest, givenMakeLeftWithSameType) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMakeRight) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -191,6 +201,7 @@ TEST(EitherTest, givenMakeRight) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMakeRightWithSameType) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
@@ -205,6 +216,7 @@ TEST(EitherTest, givenMakeRightWithSameType) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMovableOnlyMakeLeft) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, string>&)> test) {
@@ -219,6 +231,7 @@ TEST(EitherTest, givenMovableOnlyMakeLeft) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMovableOnlyMakeRight) {
   test_with_matrix({
       [] (std::function<void(either<int, MovableOnly>&)> test) {
@@ -233,34 +246,43 @@ TEST(EitherTest, givenMovableOnlyMakeRight) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMultiParamMakeLeft) {
   test_with_matrix({
       [] (std::function<void(either<pair<int, int>, string>&)> test) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         either<pair<int, int>, string> a = make_left<pair<int, int>, string>(5, 6);
         test(a);
       }, [] (std::function<void(either<pair<int, int>, string>&)> test) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto a = make_left<pair<int, int>, string>(5, 6);
         test(a);
       },
     },
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     EXPECT_IS_LEFT<pair<int, int>, string>(pair<int, int>(5, 6))
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenMultiParamMakeRight) {
   test_with_matrix({
       [] (std::function<void(either<int, pair<int, int>>&)> test) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         either<int, pair<int, int>> a = make_right<int, pair<int, int>>(5, 6);
         test(a);
       }, [] (std::function<void(either<int, pair<int, int>>&)> test) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         auto a = make_right<int, pair<int, int>>(5, 6);
         test(a);
       }
     },
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     EXPECT_IS_RIGHT<int, pair<int, int>>(pair<int, int>(5, 6))
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
@@ -273,6 +295,7 @@ TEST(EitherTest, givenLeftCopyConstructedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(string&)> test) {
@@ -285,6 +308,7 @@ TEST(EitherTest, givenLeftCopyConstructedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -297,6 +321,7 @@ TEST(EitherTest, givenRightCopyConstructedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(string&)> test) {
@@ -309,6 +334,7 @@ TEST(EitherTest, givenRightCopyConstructedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, int>&)> test) {
@@ -321,6 +347,7 @@ TEST(EitherTest, givenLeftMoveConstructedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(MovableOnly&)> test) {
@@ -333,6 +360,7 @@ TEST(EitherTest, givenLeftMoveConstructedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, MovableOnly>&)> test) {
@@ -345,6 +373,7 @@ TEST(EitherTest, givenRightMoveConstructedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(MovableOnly&)> test) {
@@ -357,6 +386,7 @@ TEST(EitherTest, givenRightMoveConstructedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssignedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
@@ -375,6 +405,7 @@ TEST(EitherTest, givenLeftCopyAssignedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssignedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(string&)> test) {
@@ -393,6 +424,7 @@ TEST(EitherTest, givenLeftCopyAssignedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssignedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -411,6 +443,7 @@ TEST(EitherTest, givenRightCopyAssignedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssignedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(string&)> test) {
@@ -429,6 +462,7 @@ TEST(EitherTest, givenRightCopyAssignedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssignedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, string>&)> test) {
@@ -447,6 +481,7 @@ TEST(EitherTest, givenLeftMoveAssignedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssignedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(MovableOnly&)> test) {
@@ -465,6 +500,7 @@ TEST(EitherTest, givenLeftMoveAssignedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssignedFromValue_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, MovableOnly>&)> test) {
@@ -483,6 +519,7 @@ TEST(EitherTest, givenRightMoveAssignedFromValue_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssignedFromValue_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(MovableOnly&)> test) {
@@ -501,10 +538,12 @@ TEST(EitherTest, givenRightMoveAssignedFromValue_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructed_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
         either<string, int> a("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, int> b(a);
         test(b);
       }
@@ -513,10 +552,12 @@ TEST(EitherTest, givenLeftCopyConstructed_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructed_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
         either<string, int> a("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, int> b(a);
         test(a);
       }
@@ -525,10 +566,12 @@ TEST(EitherTest, givenLeftCopyConstructed_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_left<string, string>("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, string> b(a);
         test(b);
       }
@@ -537,10 +580,12 @@ TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_left<string, string>("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, string> b(a);
         test(a);
       }
@@ -549,10 +594,12 @@ TEST(EitherTest, givenLeftCopyConstructed_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructed_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
         either<int, string> a("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<int, string> b(a);
         test(b);
       }
@@ -562,10 +609,12 @@ TEST(EitherTest, givenRightCopyConstructed_thenNewIsCorrect) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructed_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
         either<int, string> a("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<int, string> b(a);
         test(a);
       }
@@ -574,10 +623,12 @@ TEST(EitherTest, givenRightCopyConstructed_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructed_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_right<string, string>("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, string> b(a);
         test(b);
       }
@@ -587,10 +638,12 @@ TEST(EitherTest, givenRightCopyConstructed_withSameType_thenNewIsCorrect) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyConstructed_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
         either<string, string> a = make_right<string, string>("4");
+        // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
         either<string, string> b(a);
         test(a);
       }
@@ -599,6 +652,7 @@ TEST(EitherTest, givenRightCopyConstructed_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructed_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, int>&)> test) {
@@ -611,6 +665,7 @@ TEST(EitherTest, givenLeftMoveConstructed_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructed_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, int>&)> test) {
@@ -623,6 +678,7 @@ TEST(EitherTest, givenLeftMoveConstructed_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -635,6 +691,7 @@ TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -647,6 +704,7 @@ TEST(EitherTest, givenLeftMoveConstructed_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructed_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, MovableOnly>&)> test) {
@@ -659,6 +717,7 @@ TEST(EitherTest, givenRightMoveConstructed_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructed_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, MovableOnly>&)> test) {
@@ -671,6 +730,7 @@ TEST(EitherTest, givenRightMoveConstructed_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructed_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -683,6 +743,7 @@ TEST(EitherTest, givenRightMoveConstructed_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveConstructed_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -695,6 +756,7 @@ TEST(EitherTest, givenRightMoveConstructed_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssigned_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
@@ -713,6 +775,7 @@ TEST(EitherTest, givenLeftCopyAssigned_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssigned_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, int>&)> test) {
@@ -731,6 +794,7 @@ TEST(EitherTest, givenLeftCopyAssigned_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
@@ -749,6 +813,7 @@ TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
@@ -767,6 +832,7 @@ TEST(EitherTest, givenLeftCopyAssigned_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssigned_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -785,6 +851,7 @@ TEST(EitherTest, givenRightCopyAssigned_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssigned_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -803,6 +870,7 @@ TEST(EitherTest, givenRightCopyAssigned_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssigned_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
@@ -821,6 +889,7 @@ TEST(EitherTest, givenRightCopyAssigned_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightCopyAssigned_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, string>&)> test) {
@@ -839,6 +908,7 @@ TEST(EitherTest, givenRightCopyAssigned_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssigned_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, string>&)> test) {
@@ -857,6 +927,7 @@ TEST(EitherTest, givenLeftMoveAssigned_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssigned_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, string>&)> test) {
@@ -875,6 +946,7 @@ TEST(EitherTest, givenLeftMoveAssigned_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -893,6 +965,7 @@ TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -911,6 +984,7 @@ TEST(EitherTest, givenLeftMoveAssigned_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssigned_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, MovableOnly>&)> test) {
@@ -929,6 +1003,7 @@ TEST(EitherTest, givenRightMoveAssigned_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssigned_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<string, MovableOnly>&)> test) {
@@ -947,6 +1022,7 @@ TEST(EitherTest, givenRightMoveAssigned_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssigned_withSameType_thenNewIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -965,6 +1041,7 @@ TEST(EitherTest, givenRightMoveAssigned_withSameType_thenNewIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRightMoveAssigned_withSameType_thenOldIsCorrect) {
   test_with_matrix({
       [] (std::function<void(either<MovableOnly, MovableOnly>&)> test) {
@@ -983,22 +1060,27 @@ TEST(EitherTest, givenRightMoveAssigned_withSameType_thenOldIsCorrect) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeft_whenModified_thenValueIsChanged) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
         either<int, string> a(4);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         a.left() = 5;
         test(a);
       }, [] (std::function<void(either<int, string>&)> test) {
         either<int, string> a(4);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         a.left() = 5;
         test(a);
       }
     },
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     EXPECT_IS_LEFT<int, string>(5)
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenRight_whenModified_thenValueIsChanged) {
   test_with_matrix({
       [] (std::function<void(either<int, string>&)> test) {
@@ -1015,6 +1097,7 @@ TEST(EitherTest, givenRight_whenModified_thenValueIsChanged) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, canEmplaceConstructLeft) {
   test_with_matrix({
       [] (std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)> test) {
@@ -1026,6 +1109,7 @@ TEST(EitherTest, canEmplaceConstructLeft) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, canEmplaceConstructRight) {
   test_with_matrix({
       [] (std::function<void(either<tuple<int, int>, tuple<int, string, int>>&)> test) {
@@ -1037,30 +1121,35 @@ TEST(EitherTest, canEmplaceConstructRight) {
   );
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenEqualLefts_thenAreEqual) {
   either<string, int> a("3");
   either<string, int> b("3");
   EXPECT_TRUE(a == b);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenEqualLefts_thenAreNotUnequal) {
   either<string, int> a("3");
   either<string, int> b("3");
   EXPECT_FALSE(a != b);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenEqualRights_thenAreEqual) {
   either<string, int> a(3);
   either<string, int> b(3);
   EXPECT_TRUE(a == b);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenEqualRights_thenAreNotUnequal) {
   either<string, int> a(3);
   either<string, int> b(3);
   EXPECT_FALSE(a != b);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftAndRight_thenAreNotEqual) {
   either<string, int> a("3");
   either<string, int> b(3);
@@ -1068,6 +1157,7 @@ TEST(EitherTest, givenLeftAndRight_thenAreNotEqual) {
   EXPECT_FALSE(b == a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftAndRight_thenAreUnequal) {
   either<string, int> a("3");
   either<string, int> b(3);
@@ -1075,18 +1165,21 @@ TEST(EitherTest, givenLeftAndRight_thenAreUnequal) {
   EXPECT_TRUE(b != a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, OutputLeft) {
   ostringstream str;
   str << either<string, int>("mystring");
   EXPECT_EQ("Left(mystring)", str.str());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, OutputRight) {
   ostringstream str;
   str << either<int, string>("mystring");
   EXPECT_EQ("Right(mystring)", str.str());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftAndRightWithSameType_thenAreNotEqual) {
   either<string, string> a = make_left<string, string>("3");
   either<string, string> b = make_right<string, string>("3");
@@ -1094,6 +1187,7 @@ TEST(EitherTest, givenLeftAndRightWithSameType_thenAreNotEqual) {
   EXPECT_FALSE(b == a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest, givenLeftAndRightWithSameType_thenAreUnequal) {
   either<string, string> a = make_left<string, string>("3");
   either<string, string> b = make_right<string, string>("3");
@@ -1114,6 +1208,7 @@ public:
 class ClassWithDestructorCallback {
 public:
   ClassWithDestructorCallback(const DestructorCallback *destructorCallback) : _destructorCallback(destructorCallback) {}
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ClassWithDestructorCallback(const ClassWithDestructorCallback &rhs): _destructorCallback(rhs._destructorCallback) {}
 
   ~ClassWithDestructorCallback() {
@@ -1123,6 +1218,7 @@ public:
 private:
   const DestructorCallback *_destructorCallback;
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   ClassWithDestructorCallback &operator=(const ClassWithDestructorCallback &rhs) = delete;
 };
 class OnlyMoveableClassWithDestructorCallback {
@@ -1141,6 +1237,7 @@ private:
 
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, LeftDestructorIsCalled) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(2);  //Once for the temp object, once when the either class destructs
@@ -1149,6 +1246,7 @@ TEST(EitherTest_Destructor, LeftDestructorIsCalled) {
     either<ClassWithDestructorCallback, string> var = temp;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, RightDestructorIsCalled) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(2);  //Once for the temp object, once when the either class destructs
@@ -1157,24 +1255,29 @@ TEST(EitherTest_Destructor, RightDestructorIsCalled) {
     either<string, ClassWithDestructorCallback> var = temp;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterCopying) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
 
     ClassWithDestructorCallback temp(&destructorCallback);
     either<ClassWithDestructorCallback, string> var1 = temp;
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     either<ClassWithDestructorCallback, string> var2 = var1;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterCopying) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
 
     ClassWithDestructorCallback temp(&destructorCallback);
     either<string, ClassWithDestructorCallback> var1 = temp;
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     either<string, ClassWithDestructorCallback> var2 = var1;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoving) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
@@ -1184,6 +1287,7 @@ TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoving) {
     either<OnlyMoveableClassWithDestructorCallback, string> var2 = std::move(var1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterMoving) {
     DestructorCallback destructorCallback;
     destructorCallback.EXPECT_CALLED(3);  //Once for the temp object, once for var1 and once for var2
@@ -1193,6 +1297,7 @@ TEST(EitherTest_Destructor, RightDestructorIsCalledAfterMoving) {
     either<string, OnlyMoveableClassWithDestructorCallback> var2 = std::move(var1);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterAssignment) {
     DestructorCallback destructorCallback1;
     DestructorCallback destructorCallback2;
@@ -1206,6 +1311,7 @@ TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterAssignment) {
     var1 = var2;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterAssignment) {
     DestructorCallback destructorCallback1;
     DestructorCallback destructorCallback2;
@@ -1219,6 +1325,7 @@ TEST(EitherTest_Destructor, RightDestructorIsCalledAfterAssignment) {
     var1 = var2;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoveAssignment) {
     DestructorCallback destructorCallback1;
     DestructorCallback destructorCallback2;
@@ -1232,6 +1339,7 @@ TEST(EitherTest_Destructor, LeftDestructorIsCalledAfterMoveAssignment) {
     var1 = std::move(var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(EitherTest_Destructor, RightDestructorIsCalledAfterMoveAssignment) {
     DestructorCallback destructorCallback1;
     DestructorCallback destructorCallback2;

--- a/c10/test/util/exception_test.cpp
+++ b/c10/test/util/exception_test.cpp
@@ -22,10 +22,13 @@ inline void expectThrowsEq(Functor&& functor, const char* expectedMessage) {
 }
 } // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
 #ifdef NDEBUG
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false));
   // Does nothing - `throw_func()` should not be evaluated
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   ASSERT_NO_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(throw_func()));
 #else
   ASSERT_THROW(TORCH_INTERNAL_ASSERT_DEBUG_ONLY(false), c10::Error);
@@ -33,10 +36,12 @@ TEST(ExceptionTest, TORCH_INTERNAL_ASSERT_DEBUG_ONLY) {
 #endif
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WarningTest, JustPrintWarning) {
   TORCH_WARN("I'm a warning");
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(ExceptionTest, ErrorFormatting) {
   expectThrowsEq([]() {
     TORCH_CHECK(false, "This is invalid");
@@ -66,6 +71,7 @@ R"msg(This is invalid
   While checking Y)msg");
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static int assertionArgumentCounter = 0;
 static int getAssertionArgument() {
   return ++assertionArgumentCounter;
@@ -79,11 +85,14 @@ static void failInternalAssert() {
   TORCH_INTERNAL_ASSERT(false, "message ", getAssertionArgument());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(ExceptionTest, DontCallArgumentFunctionsTwiceOnFailure) {
   assertionArgumentCounter = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_ANY_THROW(failCheck());
   EXPECT_EQ(assertionArgumentCounter, 1) << "TORCH_CHECK called argument twice";
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_ANY_THROW(failInternalAssert());
   EXPECT_EQ(assertionArgumentCounter, 2) << "TORCH_INTERNAL_ASSERT called argument twice";
 }

--- a/c10/test/util/flags_test.cpp
+++ b/c10/test/util/flags_test.cpp
@@ -4,10 +4,12 @@
 
 #include <c10/util/Flags.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(c10_flags_test_only_flag, true, "Only used in test.");
 
 namespace c10_test {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(FlagsTest, TestGflagsCorrectness) {
 #ifdef C10_USE_GFLAGS
   EXPECT_EQ(FLAGS_c10_flags_test_only_flag, true);

--- a/c10/test/util/intrusive_ptr_test.cpp
+++ b/c10/test/util/intrusive_ptr_test.cpp
@@ -65,20 +65,24 @@ class ChildDestructableMock final : public DestructableMock {
       : DestructableMock(resourcesReleased, wasDestructed) {}
 };
 class NullType1 final {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static SomeClass singleton_;
 public:
   static constexpr SomeClass* singleton() {
     return &singleton_;
   }
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 SomeClass NullType1::singleton_;
 class NullType2 final {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static SomeClass singleton_;
 public:
   static constexpr SomeClass* singleton() {
     return &singleton_;
   }
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 SomeClass NullType2::singleton_;
 static_assert(NullType1::singleton() != NullType2::singleton(), "");
 } // namespace
@@ -87,6 +91,7 @@ static_assert(
     std::is_same<SomeClass, intrusive_ptr<SomeClass>::element_type>::value,
     "intrusive_ptr<T>::element_type is wrong");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(MakeIntrusiveTest, ClassWith0Parameters) {
   intrusive_ptr<SomeClass0Parameters> var =
       make_intrusive<SomeClass0Parameters>();
@@ -94,69 +99,85 @@ TEST(MakeIntrusiveTest, ClassWith0Parameters) {
   EXPECT_EQ(var.get(), dynamic_cast<SomeClass0Parameters*>(var.get()));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(MakeIntrusiveTest, ClassWith1Parameter) {
   intrusive_ptr<SomeClass1Parameter> var =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass1Parameter>(5);
   EXPECT_EQ(5, var->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(MakeIntrusiveTest, ClassWith2Parameters) {
   intrusive_ptr<SomeClass2Parameters> var =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass2Parameters>(7, 2);
   EXPECT_EQ(7, var->param1);
   EXPECT_EQ(2, var->param2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(MakeIntrusiveTest, TypeIsAutoDeductible) {
   auto var2 = make_intrusive<SomeClass0Parameters>();
   auto var3 = make_intrusive<SomeClass1Parameter>(2);
   auto var4 = make_intrusive<SomeClass2Parameters>(2, 3);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(MakeIntrusiveTest, CanAssignToBaseClassPtr) {
   intrusive_ptr<SomeBaseClass> var = make_intrusive<SomeChildClass>(3);
   EXPECT_EQ(3, var->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTargetTest, whenAllocatedOnStack_thenDoesntCrash) {
   SomeClass myClass;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenCallingGet_thenReturnsObject) {
   intrusive_ptr<SomeClass1Parameter> obj =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass1Parameter>(5);
   EXPECT_EQ(5, obj.get()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenCallingConstGet_thenReturnsObject) {
   const intrusive_ptr<SomeClass1Parameter> obj =
       make_intrusive<SomeClass1Parameter>(5);
   EXPECT_EQ(5, obj.get()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenInvalidPtr_whenCallingGet_thenReturnsNullptr) {
   intrusive_ptr<SomeClass1Parameter> obj;
   EXPECT_EQ(nullptr, obj.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenDereferencing_thenReturnsObject) {
   intrusive_ptr<SomeClass1Parameter> obj =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass1Parameter>(5);
   EXPECT_EQ(5, (*obj).param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenConstDereferencing_thenReturnsObject) {
   const intrusive_ptr<SomeClass1Parameter> obj =
       make_intrusive<SomeClass1Parameter>(5);
   EXPECT_EQ(5, (*obj).param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenArrowDereferencing_thenReturnsObject) {
   intrusive_ptr<SomeClass1Parameter> obj =
       make_intrusive<SomeClass1Parameter>(3);
   EXPECT_EQ(3, obj->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenConstArrowDereferencing_thenReturnsObject) {
@@ -165,6 +186,7 @@ TEST(
   EXPECT_EQ(3, obj->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenMoveAssigning_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -173,46 +195,57 @@ TEST(IntrusivePtrTest, givenValidPtr_whenMoveAssigning_thenPointsToSameObject) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenMoveAssigning_thenOldInstanceInvalid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
   obj2 = std::move(obj1);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_FALSE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToSelf_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   SomeClass* obj1ptr = obj1.get();
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_EQ(obj1ptr, obj1.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenMoveAssigningToSelf_thenStaysValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToSelf_thenStaysInvalid) {
   intrusive_ptr<SomeClass> obj1;
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_FALSE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigning_thenNewInstanceIsValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.get();
   obj2 = std::move(obj1);
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigning_thenPointsToSameObject) {
@@ -223,6 +256,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenMoveAssigningFromInvalidPtr_thenNewInstanceIsInvalid) {
@@ -233,6 +267,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToBaseClass_thenPointsToSameObject) {
@@ -244,28 +279,35 @@ TEST(
   EXPECT_EQ(1, obj2->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToBaseClass_thenOldInstanceInvalid) {
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(1);
   intrusive_ptr<SomeBaseClass> obj2 = make_intrusive<SomeBaseClass>(2);
   obj2 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_FALSE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToBaseClass_thenNewInstanceIsValid) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(5);
   intrusive_ptr<SomeBaseClass> obj2;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.get();
   obj2 = std::move(obj1);
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToBaseClass_thenPointsToSameObject) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(5);
   intrusive_ptr<SomeBaseClass> obj2;
   SomeBaseClass* obj1ptr = obj1.get();
@@ -274,6 +316,7 @@ TEST(
   EXPECT_EQ(5, obj2->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningInvalidPtrToBaseClass_thenNewInstanceIsValid) {
@@ -284,6 +327,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenNullPtr_whenMoveAssigningToDifferentNullptr_thenHasNewNullptr) {
@@ -291,12 +335,14 @@ TEST(
   intrusive_ptr<SomeClass, NullType2> obj2;
   obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_EQ(NullType1::singleton(), obj1.get());
   EXPECT_EQ(NullType2::singleton(), obj2.get());
   EXPECT_FALSE(obj1.defined());
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenCopyAssigning_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -305,6 +351,7 @@ TEST(IntrusivePtrTest, givenValidPtr_whenCopyAssigning_thenPointsToSameObject) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenCopyAssigning_thenOldInstanceValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -312,70 +359,87 @@ TEST(IntrusivePtrTest, givenValidPtr_whenCopyAssigning_thenOldInstanceValid) {
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToSelf_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   SomeClass* obj1ptr = obj1.get();
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_EQ(obj1ptr, obj1.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenValidPtr_whenCopyAssigningToSelf_thenStaysValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToSelf_thenStaysInvalid) {
   intrusive_ptr<SomeClass> obj1;
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_FALSE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigning_thenNewInstanceIsValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.get();
   obj2 = obj1;
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToBaseClass_thenPointsToSameObject) {
   intrusive_ptr<SomeChildClass> child = make_intrusive<SomeChildClass>(3);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeBaseClass> base = make_intrusive<SomeBaseClass>(10);
   base = child;
   EXPECT_EQ(3, base->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToBaseClass_thenOldInstanceInvalid) {
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(3);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeBaseClass> obj2 = make_intrusive<SomeBaseClass>(10);
   obj2 = obj1;
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToBaseClass_thenNewInstanceIsValid) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(5);
   intrusive_ptr<SomeBaseClass> obj2;
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.get();
   obj2 = obj1;
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToBaseClass_thenPointsToSameObject) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   intrusive_ptr<SomeChildClass> obj1 = make_intrusive<SomeChildClass>(5);
   intrusive_ptr<SomeBaseClass> obj2;
   SomeBaseClass* obj1ptr = obj1.get();
@@ -384,6 +448,7 @@ TEST(
   EXPECT_EQ(5, obj2->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssigningInvalidPtrToBaseClass_thenNewInstanceIsInvalid) {
@@ -394,6 +459,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenNullPtr_whenCopyAssigningToDifferentNullptr_thenHasNewNullptr) {
@@ -407,6 +473,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenMoveConstructing_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   SomeClass* obj1ptr = obj1.get();
@@ -414,18 +481,22 @@ TEST(IntrusivePtrTest, givenPtr_whenMoveConstructing_thenPointsToSameObject) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenMoveConstructing_thenOldInstanceInvalid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj1);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_FALSE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenMoveConstructing_thenNewInstanceValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj1);
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructingFromInvalidPtr_thenNewInstanceInvalid) {
@@ -434,6 +505,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenPointsToSameObject) {
@@ -444,14 +516,17 @@ TEST(
   EXPECT_EQ(objptr, base.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenOldInstanceInvalid) {
   intrusive_ptr<SomeChildClass> child = make_intrusive<SomeChildClass>(3);
   intrusive_ptr<SomeBaseClass> base = std::move(child);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_FALSE(child.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenNewInstanceValid) {
@@ -460,6 +535,7 @@ TEST(
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClassFromInvalidPtr_thenNewInstanceInvalid) {
@@ -468,46 +544,57 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenNullPtr_whenMoveConstructingToDifferentNullptr_thenHasNewNullptr) {
   intrusive_ptr<SomeClass, NullType1> obj1;
   intrusive_ptr<SomeClass, NullType2> obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_EQ(NullType1::singleton(), obj1.get());
   EXPECT_EQ(NullType2::singleton(), obj2.get());
   EXPECT_FALSE(obj1.defined());
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCopyConstructing_thenPointsToSameObject) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   SomeClass* obj1ptr = obj1.get();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_EQ(obj1ptr, obj2.get());
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCopyConstructing_thenOldInstanceValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_TRUE(obj1.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCopyConstructing_thenNewInstanceValid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_TRUE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructingFromInvalidPtr_thenNewInstanceInvalid) {
   intrusive_ptr<SomeClass> obj1;
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenPointsToSameObject) {
@@ -518,6 +605,7 @@ TEST(
   EXPECT_EQ(objptr, base.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenOldInstanceInvalid) {
@@ -526,6 +614,7 @@ TEST(
   EXPECT_TRUE(child.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenNewInstanceInvalid) {
@@ -534,6 +623,7 @@ TEST(
   EXPECT_TRUE(base.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClassFromInvalidPtr_thenNewInstanceInvalid) {
@@ -542,6 +632,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenNullPtr_whenCopyConstructingToDifferentNullptr_thenHasNewNullptr) {
@@ -554,6 +645,7 @@ TEST(
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapFunction) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -564,6 +656,7 @@ TEST(IntrusivePtrTest, SwapFunction) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapMethod) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -574,6 +667,7 @@ TEST(IntrusivePtrTest, SwapMethod) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapFunctionFromInvalid) {
   intrusive_ptr<SomeClass> obj1;
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -584,6 +678,7 @@ TEST(IntrusivePtrTest, SwapFunctionFromInvalid) {
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapMethodFromInvalid) {
   intrusive_ptr<SomeClass> obj1;
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -594,6 +689,7 @@ TEST(IntrusivePtrTest, SwapMethodFromInvalid) {
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapFunctionWithInvalid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2;
@@ -604,6 +700,7 @@ TEST(IntrusivePtrTest, SwapFunctionWithInvalid) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapMethodWithInvalid) {
   intrusive_ptr<SomeClass> obj1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2;
@@ -614,6 +711,7 @@ TEST(IntrusivePtrTest, SwapMethodWithInvalid) {
   EXPECT_EQ(obj1ptr, obj2.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapFunctionInvalidWithInvalid) {
   intrusive_ptr<SomeClass> obj1;
   intrusive_ptr<SomeClass> obj2;
@@ -622,6 +720,7 @@ TEST(IntrusivePtrTest, SwapFunctionInvalidWithInvalid) {
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, SwapMethodInvalidWithInvalid) {
   intrusive_ptr<SomeClass> obj1;
   intrusive_ptr<SomeClass> obj2;
@@ -630,36 +729,45 @@ TEST(IntrusivePtrTest, SwapMethodInvalidWithInvalid) {
   EXPECT_FALSE(obj2.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, CanBePutInContainer) {
   std::vector<intrusive_ptr<SomeClass1Parameter>> vec;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   vec.push_back(make_intrusive<SomeClass1Parameter>(5));
   EXPECT_EQ(5, vec[0]->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, CanBePutInSet) {
   std::set<intrusive_ptr<SomeClass1Parameter>> set;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   set.insert(make_intrusive<SomeClass1Parameter>(5));
   EXPECT_EQ(5, (*set.begin())->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, CanBePutInUnorderedSet) {
   std::unordered_set<intrusive_ptr<SomeClass1Parameter>> set;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   set.insert(make_intrusive<SomeClass1Parameter>(5));
   EXPECT_EQ(5, (*set.begin())->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, CanBePutInMap) {
   std::map<
       intrusive_ptr<SomeClass1Parameter>,
       intrusive_ptr<SomeClass1Parameter>>
       map;
   map.insert(std::make_pair(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass1Parameter>(5),
       make_intrusive<SomeClass1Parameter>(3)));
   EXPECT_EQ(5, map.begin()->first->param);
   EXPECT_EQ(3, map.begin()->second->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, CanBePutInUnorderedMap) {
   std::unordered_map<
       intrusive_ptr<SomeClass1Parameter>,
@@ -667,18 +775,22 @@ TEST(IntrusivePtrTest, CanBePutInUnorderedMap) {
       map;
   map.insert(std::make_pair(
       make_intrusive<SomeClass1Parameter>(3),
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_intrusive<SomeClass1Parameter>(5)));
   EXPECT_EQ(3, map.begin()->first->param);
   EXPECT_EQ(5, map.begin()->second->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Equality_AfterCopyConstructor) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> var2 = var1;
   EXPECT_TRUE(var1 == var2);
   EXPECT_FALSE(var1 != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Equality_AfterCopyAssignment) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -687,6 +799,7 @@ TEST(IntrusivePtrTest, Equality_AfterCopyAssignment) {
   EXPECT_FALSE(var1 != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Equality_Nullptr) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2;
@@ -694,6 +807,7 @@ TEST(IntrusivePtrTest, Equality_Nullptr) {
   EXPECT_FALSE(var1 != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Inequality) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -701,6 +815,7 @@ TEST(IntrusivePtrTest, Inequality) {
   EXPECT_FALSE(var1 == var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Inequality_NullptrLeft) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -708,6 +823,7 @@ TEST(IntrusivePtrTest, Inequality_NullptrLeft) {
   EXPECT_FALSE(var1 == var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, Inequality_NullptrRight) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2;
@@ -715,6 +831,7 @@ TEST(IntrusivePtrTest, Inequality_NullptrRight) {
   EXPECT_FALSE(var1 == var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, HashIsDifferent) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -723,6 +840,7 @@ TEST(IntrusivePtrTest, HashIsDifferent) {
       std::hash<intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, HashIsDifferent_ValidAndInvalid) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -731,14 +849,17 @@ TEST(IntrusivePtrTest, HashIsDifferent_ValidAndInvalid) {
       std::hash<intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, HashIsSame_AfterCopyConstructor) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> var2 = var1;
   EXPECT_EQ(
       std::hash<intrusive_ptr<SomeClass>>()(var1),
       std::hash<intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, HashIsSame_AfterCopyAssignment) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -748,6 +869,7 @@ TEST(IntrusivePtrTest, HashIsSame_AfterCopyAssignment) {
       std::hash<intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, HashIsSame_BothNullptr) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2;
@@ -756,32 +878,42 @@ TEST(IntrusivePtrTest, HashIsSame_BothNullptr) {
       std::hash<intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, OneIsLess) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
   EXPECT_TRUE(
+      // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::less<intrusive_ptr<SomeClass>>()(var1, var2) !=
+      // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::less<intrusive_ptr<SomeClass>>()(var2, var1));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, NullptrIsLess1) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2 = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_TRUE(std::less<intrusive_ptr<SomeClass>>()(var1, var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, NullptrIsLess2) {
   intrusive_ptr<SomeClass> var1 = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> var2;
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_FALSE(std::less<intrusive_ptr<SomeClass>>()(var1, var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, NullptrIsNotLessThanNullptr) {
   intrusive_ptr<SomeClass> var1;
   intrusive_ptr<SomeClass> var2;
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_FALSE(std::less<intrusive_ptr<SomeClass>>()(var1, var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenIsInvalid) {
   auto obj = make_intrusive<SomeClass>();
   EXPECT_TRUE(obj.defined());
@@ -789,6 +921,7 @@ TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenIsInvalid) {
   EXPECT_FALSE(obj.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenHoldsNullptr) {
   auto obj = make_intrusive<SomeClass>();
   EXPECT_NE(nullptr, obj.get());
@@ -796,6 +929,7 @@ TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenHoldsNullptr) {
   EXPECT_EQ(nullptr, obj.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
@@ -808,6 +942,7 @@ TEST(IntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructed_thenDestructsObjectAfterSecondDestructed) {
@@ -823,6 +958,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveConstructedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
@@ -838,6 +974,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   bool dummy = false;
   bool resourcesReleased = false;
@@ -853,6 +990,7 @@ TEST(IntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveAssignedToBaseClass_thenDestructsOldObject) {
@@ -870,6 +1008,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenMoveAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -892,6 +1031,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithBaseClassCopy_whenMoveAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -915,6 +1055,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenMoveAssignedToBaseClass_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -937,6 +1078,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveAssigned_thenDestructsObjectAfterSecondDestructed) {
@@ -954,6 +1096,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenMoveAssignedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
@@ -971,6 +1114,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructedAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -979,6 +1123,7 @@ TEST(
   {
     auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
+      // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
       intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_FALSE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -990,6 +1135,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructedToBaseClassAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1009,6 +1155,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructedAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1025,6 +1172,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyConstructedToBaseClassAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1041,6 +1189,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssignedAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1063,6 +1212,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClassAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1085,6 +1235,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssignedAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1106,6 +1257,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClassAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -1128,6 +1280,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   bool dummy = false;
   bool resourcesReleased = false;
@@ -1143,6 +1296,7 @@ TEST(IntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClass_thenDestructsOldObject) {
@@ -1160,6 +1314,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenCopyAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -1182,6 +1337,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithBaseClassCopy_whenCopyAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -1205,6 +1361,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenCopyAssignedToBaseClass_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -1227,6 +1384,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
@@ -1238,6 +1396,7 @@ TEST(IntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenCallingReset_thenDestructsAfterCopyDestructed) {
@@ -1255,6 +1414,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithCopy_whenCallingResetOnCopy_thenDestructsAfterOriginalDestructed) {
@@ -1272,6 +1432,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithMoved_whenCallingReset_thenDestructsAfterMovedDestructed) {
@@ -1280,6 +1441,7 @@ TEST(
   auto obj = make_intrusive<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     obj.reset();
     EXPECT_FALSE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
@@ -1289,6 +1451,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtrWithMoved_whenCallingResetOnMoved_thenDestructsImmediately) {
@@ -1303,84 +1466,101 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, AllowsMoveConstructingToConst) {
   intrusive_ptr<SomeClass> a = make_intrusive<SomeClass>();
   intrusive_ptr<const SomeClass> b = std::move(a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, AllowsCopyConstructingToConst) {
   intrusive_ptr<SomeClass> a = make_intrusive<SomeClass>();
   intrusive_ptr<const SomeClass> b = a;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, AllowsMoveAssigningToConst) {
   intrusive_ptr<SomeClass> a = make_intrusive<SomeClass>();
   intrusive_ptr<const SomeClass> b = make_intrusive<SomeClass>();
   b = std::move(a);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, AllowsCopyAssigningToConst) {
   intrusive_ptr<SomeClass> a = make_intrusive<SomeClass>();
   intrusive_ptr<const SomeClass> b = make_intrusive<const SomeClass>();
   b = a;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenNewPtr_thenHasUseCount1) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   EXPECT_EQ(1, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenNewPtr_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   EXPECT_TRUE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenEmptyPtr_thenHasUseCount0) {
   intrusive_ptr<SomeClass> obj;
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenEmptyPtr_thenIsNotUnique) {
   intrusive_ptr<SomeClass> obj;
   EXPECT_FALSE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenResetPtr_thenHasUseCount0) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   obj.reset();
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenResetPtr_thenIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   obj.reset();
   EXPECT_FALSE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveConstructedPtr_thenHasUseCount1) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj);
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveConstructedPtr_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj);
   EXPECT_TRUE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveConstructedPtr_thenOldHasUseCount0) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveConstructedPtr_thenOldIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = std::move(obj);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_FALSE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenHasUseCount1) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -1388,6 +1568,7 @@ TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenHasUseCount1) {
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -1395,66 +1576,83 @@ TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenIsUnique) {
   EXPECT_TRUE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenOldHasUseCount0) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
   obj2 = std::move(obj);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenMoveAssignedPtr_thenOldIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
   obj2 = std::move(obj);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move,bugprone-use-after-move)
   EXPECT_FALSE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyConstructedPtr_thenHasUseCount2) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj;
   EXPECT_EQ(2, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyConstructedPtr_thenIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj;
   EXPECT_FALSE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyConstructedPtr_thenOldHasUseCount2) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj;
   EXPECT_EQ(2, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyConstructedPtr_thenOldIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   intrusive_ptr<SomeClass> obj2 = obj;
   EXPECT_FALSE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyConstructedPtr_whenDestructingCopy_thenHasUseCount1) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   {
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     intrusive_ptr<SomeClass> obj2 = obj;
     EXPECT_EQ(2, obj.use_count());
   }
   EXPECT_EQ(1, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyConstructedPtr_whenDestructingCopy_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   {
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     intrusive_ptr<SomeClass> obj2 = obj;
     EXPECT_FALSE(obj.unique());
   }
   EXPECT_TRUE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyConstructedPtr_whenReassigningCopy_thenHasUseCount1) {
@@ -1466,6 +1664,7 @@ TEST(
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyConstructedPtr_whenReassigningCopy_thenIsUnique) {
@@ -1477,6 +1676,7 @@ TEST(
   EXPECT_TRUE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyAssignedPtr_thenHasUseCount2) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -1485,6 +1685,7 @@ TEST(IntrusivePtrTest, givenCopyAssignedPtr_thenHasUseCount2) {
   EXPECT_EQ(2, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyAssignedPtr_thenIsNotUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -1493,6 +1694,7 @@ TEST(IntrusivePtrTest, givenCopyAssignedPtr_thenIsNotUnique) {
   EXPECT_FALSE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyAssignedPtr_whenDestructingCopy_thenHasUseCount1) {
@@ -1505,6 +1707,7 @@ TEST(
   EXPECT_EQ(1, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyAssignedPtr_whenDestructingCopy_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   {
@@ -1515,6 +1718,7 @@ TEST(IntrusivePtrTest, givenCopyAssignedPtr_whenDestructingCopy_thenIsUnique) {
   EXPECT_TRUE(obj.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenCopyAssignedPtr_whenReassigningCopy_thenHasUseCount1) {
@@ -1527,6 +1731,7 @@ TEST(
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenCopyAssignedPtr_whenReassigningCopy_thenIsUnique) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> obj2 = make_intrusive<SomeClass>();
@@ -1537,6 +1742,7 @@ TEST(IntrusivePtrTest, givenCopyAssignedPtr_whenReassigningCopy_thenIsUnique) {
   EXPECT_TRUE(obj2.unique());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenReleasedAndReclaimed_thenDoesntCrash) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   SomeClass* ptr = obj.release();
@@ -1544,6 +1750,7 @@ TEST(IntrusivePtrTest, givenPtr_whenReleasedAndReclaimed_thenDoesntCrash) {
   intrusive_ptr<SomeClass> reclaimed = intrusive_ptr<SomeClass>::reclaim(ptr);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenReleasedAndReclaimed_thenIsDestructedAtEnd) {
@@ -1581,6 +1788,7 @@ TEST(IntrusivePtrTest, givenStackObject_whenReclaimed_thenCrashes) {
 #endif
 }*/
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(IntrusivePtrTest, givenPtr_whenNonOwningReclaimed_thenDoesntCrash) {
   intrusive_ptr<SomeClass> obj = make_intrusive<SomeClass>();
   SomeClass* raw_ptr = obj.get();
@@ -1591,6 +1799,7 @@ TEST(IntrusivePtrTest, givenPtr_whenNonOwningReclaimed_thenDoesntCrash) {
   EXPECT_EQ(reclaimed.get(), obj.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     IntrusivePtrTest,
     givenPtr_whenNonOwningReclaimed_thenIsDestructedAtEnd) {
@@ -1641,18 +1850,21 @@ static_assert(
     std::is_same<SomeClass, weak_intrusive_ptr<SomeClass>::element_type>::value,
     "weak_intrusive_ptr<T>::element_type is wrong");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCreatingAndDestructing_thenDoesntCrash) {
   IntrusiveAndWeak<SomeClass> var = make_weak_intrusive<SomeClass>();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenLocking_thenReturnsCorrectObject) {
   IntrusiveAndWeak<SomeClass> var = make_weak_intrusive<SomeClass>();
   intrusive_ptr<SomeClass> locked = var.weak.lock();
   EXPECT_EQ(var.ptr.get(), locked.get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, expiredPtr_whenLocking_thenReturnsNullType) {
   IntrusiveAndWeak<SomeClass> var = make_weak_intrusive<SomeClass>();
   // reset the intrusive_ptr to test if weak pointer still valid
@@ -1662,12 +1874,14 @@ TEST(WeakIntrusivePtrTest, expiredPtr_whenLocking_thenReturnsNullType) {
   EXPECT_FALSE(locked.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, weakNullPtr_locking) {
   auto weak_ptr = make_invalid_weak<SomeClass>();
   intrusive_ptr<SomeClass> locked = weak_ptr.lock();
   EXPECT_FALSE(locked.defined());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigning_thenPointsToSameObject) {
@@ -1678,6 +1892,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigning_thenOldInstanceInvalid) {
@@ -1687,6 +1902,7 @@ TEST(
   EXPECT_TRUE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     vector_insert_weak_intrusive) {
@@ -1696,16 +1912,19 @@ TEST(
   priorWorks.insert(priorWorks.end(), wips.begin(), wips.end());
   EXPECT_EQ(priorWorks.size(), 1);
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToSelf_thenPointsToSameObject) {
@@ -1715,6 +1934,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj1.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToSelf_thenStaysValid) {
@@ -1723,6 +1943,7 @@ TEST(
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigning_thenPointsToSameObject) {
@@ -1733,24 +1954,29 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigning_thenPointsToSameObject) {
@@ -1761,24 +1987,30 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.lock().get();
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningToSelf_thenPointsToSameObject) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   SomeClass* obj1ptr = obj1.lock().get();
   obj1 = std::move(obj1);
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_EQ(obj1ptr, obj1.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningFromInvalidPtr_thenNewInstanceIsInvalid) {
@@ -1789,6 +2021,7 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningFromWeakOnlyPtr_thenNewInstanceIsInvalid) {
@@ -1799,6 +2032,7 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToBaseClass_thenPointsToSameObject) {
@@ -1811,6 +2045,7 @@ TEST(
   EXPECT_EQ(1, obj2.weak.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenMoveAssigningToBaseClass_thenOldInstanceInvalid) {
@@ -1821,21 +2056,26 @@ TEST(
   EXPECT_TRUE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToBaseClass_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningToBaseClass_thenPointsToSameObject) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
@@ -1844,6 +2084,7 @@ TEST(
   EXPECT_EQ(5, obj2.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenMoveAssigningInvalidPtrToBaseClass_thenNewInstanceIsValid) {
@@ -1854,21 +2095,26 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningToBaseClass_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
   obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningToBaseClass_thenPointsToSameObject) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
@@ -1877,9 +2123,11 @@ TEST(
   EXPECT_EQ(5, obj2.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenMoveAssigningInvalidPtrToBaseClass_thenNewInstanceIsValid) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   weak_intrusive_ptr<SomeChildClass> obj1 = make_weak_only<SomeChildClass>(5);
   IntrusiveAndWeak<SomeBaseClass> obj2 = make_weak_intrusive<SomeBaseClass>(2);
   EXPECT_FALSE(obj2.weak.expired());
@@ -1887,6 +2135,7 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenMoveAssigningToDifferentNullptr_thenHasNewNullptr) {
@@ -1894,10 +2143,12 @@ TEST(
   weak_intrusive_ptr<SomeClass, NullType2> obj2 = make_invalid_weak<SomeClass, NullType2>();
   obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.expired());
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigning_thenPointsToSameObject) {
@@ -1908,6 +2159,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigning_thenOldInstanceValid) {
@@ -1917,6 +2169,7 @@ TEST(
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToSelf_thenPointsToSameObject) {
@@ -1926,6 +2179,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj1.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToSelf_thenStaysValid) {
@@ -1934,34 +2188,41 @@ TEST(
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_TRUE(obj1.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigning_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigning_thenPointsToSameObject) {
@@ -1972,59 +2233,73 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigningToSelf_thenStaysInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeClass* obj1ptr = obj1.lock().get();
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_TRUE(obj1.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigningToSelf_thenPointsToSameObject) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   SomeClass* obj1ptr = obj1.lock().get();
+  // NOLINTNEXTLINE(clang-diagnostic-self-assign-overloaded)
   obj1 = obj1;
   EXPECT_EQ(obj1ptr, obj1.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToBaseClass_thenPointsToSameObject) {
   IntrusiveAndWeak<SomeChildClass> child =
       make_weak_intrusive<SomeChildClass>(3);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   IntrusiveAndWeak<SomeBaseClass> base = make_weak_intrusive<SomeBaseClass>(10);
   base.weak = child.weak;
   EXPECT_EQ(3, base.weak.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenValidPtr_whenCopyAssigningToBaseClass_thenOldInstanceInvalid) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
       make_weak_intrusive<SomeChildClass>(3);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   IntrusiveAndWeak<SomeBaseClass> obj2 = make_weak_intrusive<SomeBaseClass>(10);
   obj2.weak = obj1.weak;
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToBaseClass_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenInvalidPtr_whenCopyAssigningToBaseClass_thenPointsToSameObject) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_invalid_weak<SomeBaseClass>();
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
@@ -2033,6 +2308,7 @@ TEST(
   EXPECT_EQ(5, obj2.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssigningInvalidPtrToBaseClass_thenNewInstanceIsInvalid) {
@@ -2043,21 +2319,26 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigningToBaseClass_thenNewInstanceIsValid) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
   obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenCopyAssigningToBaseClass_thenPointsToSameObject) {
   IntrusiveAndWeak<SomeChildClass> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeChildClass>(5);
   weak_intrusive_ptr<SomeBaseClass> obj2 = make_weak_only<SomeBaseClass>(2);
   SomeBaseClass* obj1ptr = obj1.weak.lock().get();
@@ -2066,6 +2347,7 @@ TEST(
   EXPECT_EQ(5, obj2.lock()->v);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssigningWeakOnlyPtrToBaseClass_thenNewInstanceIsValid) {
@@ -2076,6 +2358,7 @@ TEST(
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenCopyAssigningToDifferentNullptr_thenHasNewNullptr) {
@@ -2087,6 +2370,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructing_thenPointsToSameObject) {
@@ -2096,6 +2380,7 @@ TEST(
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructing_thenOldInstanceInvalid) {
@@ -2104,12 +2389,14 @@ TEST(
   EXPECT_TRUE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenMoveConstructing_thenNewInstanceValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = std::move(obj1.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingFromInvalidPtr_thenNewInstanceInvalid) {
@@ -2118,6 +2405,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingFromWeakOnlyPtr_thenNewInstanceInvalid) {
@@ -2126,6 +2414,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenPointsToSameObject) {
@@ -2137,6 +2426,7 @@ TEST(
   EXPECT_EQ(objptr, base.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenOldInstanceInvalid) {
@@ -2146,6 +2436,7 @@ TEST(
   EXPECT_TRUE(child.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClass_thenNewInstanceValid) {
@@ -2155,6 +2446,7 @@ TEST(
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClassFromInvalidPtr_thenNewInstanceInvalid) {
@@ -2163,6 +2455,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructingToBaseClassFromWeakOnlyPtr_thenNewInstanceInvalid) {
@@ -2171,16 +2464,19 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenMoveConstructingToDifferentNullptr_thenHasNewNullptr) {
   weak_intrusive_ptr<SomeClass, NullType1> obj1 = make_invalid_weak<SomeClass, NullType1>();
   weak_intrusive_ptr<SomeClass, NullType2> obj2 = std::move(obj1);
   EXPECT_NE(NullType1::singleton(), NullType2::singleton());
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   EXPECT_TRUE(obj1.expired());
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructing_thenPointsToSameObject) {
@@ -2191,34 +2487,41 @@ TEST(
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCopyConstructing_thenOldInstanceValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj1.weak;
   EXPECT_FALSE(obj1.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCopyConstructing_thenNewInstanceValid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj1.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingFromInvalidPtr_thenNewInstanceInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   weak_intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingFromWeakOnlyPtr_thenNewInstanceInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   weak_intrusive_ptr<SomeClass> obj2 = obj1;
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenPointsToSameObject) {
@@ -2230,6 +2533,7 @@ TEST(
   EXPECT_EQ(objptr, base.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenOldInstanceInvalid) {
@@ -2239,6 +2543,7 @@ TEST(
   EXPECT_FALSE(child.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClass_thenNewInstanceInvalid) {
@@ -2248,6 +2553,7 @@ TEST(
   EXPECT_FALSE(base.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClassFromInvalidPtr_thenNewInstanceInvalid) {
@@ -2256,6 +2562,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructingToBaseClassFromWeakOnlyPtr_thenNewInstanceInvalid) {
@@ -2264,6 +2571,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenNullPtr_whenCopyConstructingToDifferentNullptr_thenHasNewNullptr) {
@@ -2274,6 +2582,7 @@ TEST(
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunction) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2284,6 +2593,7 @@ TEST(WeakIntrusivePtrTest, SwapFunction) {
   EXPECT_EQ(obj1ptr, obj2.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethod) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2294,6 +2604,7 @@ TEST(WeakIntrusivePtrTest, SwapMethod) {
   EXPECT_EQ(obj1ptr, obj2.weak.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionFromInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2304,6 +2615,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionFromInvalid) {
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodFromInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2314,6 +2626,7 @@ TEST(WeakIntrusivePtrTest, SwapMethodFromInvalid) {
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionWithInvalid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
@@ -2324,6 +2637,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionWithInvalid) {
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodWithInvalid) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
@@ -2334,6 +2648,7 @@ TEST(WeakIntrusivePtrTest, SwapMethodWithInvalid) {
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionInvalidWithInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
@@ -2342,6 +2657,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionInvalidWithInvalid) {
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodInvalidWithInvalid) {
   weak_intrusive_ptr<SomeClass> obj1 = make_invalid_weak<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_invalid_weak<SomeClass>();
@@ -2350,6 +2666,7 @@ TEST(WeakIntrusivePtrTest, SwapMethodInvalidWithInvalid) {
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionFromWeakOnlyPtr) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2360,6 +2677,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionFromWeakOnlyPtr) {
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodFromWeakOnlyPtr) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2370,6 +2688,7 @@ TEST(WeakIntrusivePtrTest, SwapMethodFromWeakOnlyPtr) {
   EXPECT_TRUE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionWithWeakOnlyPtr) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
@@ -2380,6 +2699,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionWithWeakOnlyPtr) {
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodWithWeakOnlyPtr) {
   IntrusiveAndWeak<SomeClass> obj1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
@@ -2390,6 +2710,7 @@ TEST(WeakIntrusivePtrTest, SwapMethodWithWeakOnlyPtr) {
   EXPECT_EQ(obj1ptr, obj2.lock().get());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapFunctionWeakOnlyPtrWithWeakOnlyPtr) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
@@ -2398,6 +2719,7 @@ TEST(WeakIntrusivePtrTest, SwapFunctionWeakOnlyPtrWithWeakOnlyPtr) {
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, SwapMethodWeakOnlyPtrWithWeakOnlyPtr) {
   weak_intrusive_ptr<SomeClass> obj1 = make_weak_only<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = make_weak_only<SomeClass>();
@@ -2406,36 +2728,44 @@ TEST(WeakIntrusivePtrTest, SwapMethodWeakOnlyPtrWithWeakOnlyPtr) {
   EXPECT_TRUE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, CanBePutInContainer) {
   std::vector<weak_intrusive_ptr<SomeClass1Parameter>> vec;
   IntrusiveAndWeak<SomeClass1Parameter> obj =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeClass1Parameter>(5);
   vec.push_back(obj.weak);
   EXPECT_EQ(5, vec[0].lock()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, CanBePutInSet) {
   std::set<weak_intrusive_ptr<SomeClass1Parameter>> set;
   IntrusiveAndWeak<SomeClass1Parameter> obj =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeClass1Parameter>(5);
   set.insert(obj.weak);
   EXPECT_EQ(5, set.begin()->lock()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, CanBePutInUnorderedSet) {
   std::unordered_set<weak_intrusive_ptr<SomeClass1Parameter>> set;
   IntrusiveAndWeak<SomeClass1Parameter> obj =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeClass1Parameter>(5);
   set.insert(obj.weak);
   EXPECT_EQ(5, set.begin()->lock()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, CanBePutInMap) {
   std::map<
       weak_intrusive_ptr<SomeClass1Parameter>,
       weak_intrusive_ptr<SomeClass1Parameter>>
       map;
   IntrusiveAndWeak<SomeClass1Parameter> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeClass1Parameter>(5);
   IntrusiveAndWeak<SomeClass1Parameter> obj2 =
       make_weak_intrusive<SomeClass1Parameter>(3);
@@ -2444,12 +2774,14 @@ TEST(WeakIntrusivePtrTest, CanBePutInMap) {
   EXPECT_EQ(3, map.begin()->second.lock()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, CanBePutInUnorderedMap) {
   std::unordered_map<
       weak_intrusive_ptr<SomeClass1Parameter>,
       weak_intrusive_ptr<SomeClass1Parameter>>
       map;
   IntrusiveAndWeak<SomeClass1Parameter> obj1 =
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       make_weak_intrusive<SomeClass1Parameter>(5);
   IntrusiveAndWeak<SomeClass1Parameter> obj2 =
       make_weak_intrusive<SomeClass1Parameter>(3);
@@ -2458,6 +2790,7 @@ TEST(WeakIntrusivePtrTest, CanBePutInUnorderedMap) {
   EXPECT_EQ(3, map.begin()->second.lock()->param);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Equality_AfterCopyConstructor) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = var1.weak;
@@ -2465,6 +2798,7 @@ TEST(WeakIntrusivePtrTest, Equality_AfterCopyConstructor) {
   EXPECT_FALSE(var1.weak != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Equality_AfterCopyAssignment) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
@@ -2473,13 +2807,16 @@ TEST(WeakIntrusivePtrTest, Equality_AfterCopyAssignment) {
   EXPECT_FALSE(var1.weak != var2.weak);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Equality_AfterCopyAssignment_WeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   weak_intrusive_ptr<SomeClass> var2 = var1;
   EXPECT_TRUE(var1 == var2);
   EXPECT_FALSE(var1 != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Equality_Invalid) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
@@ -2487,6 +2824,7 @@ TEST(WeakIntrusivePtrTest, Equality_Invalid) {
   EXPECT_FALSE(var1 != var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Inequality) {
   IntrusiveAndWeak<SomeClass> var1 = make_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -2494,6 +2832,7 @@ TEST(WeakIntrusivePtrTest, Inequality) {
   EXPECT_FALSE(var1.weak == var2.weak);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Inequality_InvalidLeft) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_intrusive<SomeClass>();
@@ -2501,6 +2840,7 @@ TEST(WeakIntrusivePtrTest, Inequality_InvalidLeft) {
   EXPECT_FALSE(var1 == var2.weak);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Inequality_InvalidRight) {
   IntrusiveAndWeak<SomeClass> var1 = make_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
@@ -2508,6 +2848,7 @@ TEST(WeakIntrusivePtrTest, Inequality_InvalidRight) {
   EXPECT_FALSE(var1.weak == var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, Inequality_WeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_weak_only<SomeClass>();
@@ -2515,6 +2856,7 @@ TEST(WeakIntrusivePtrTest, Inequality_WeakOnly) {
   EXPECT_FALSE(var1 == var2);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsDifferent) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
@@ -2523,6 +2865,7 @@ TEST(WeakIntrusivePtrTest, HashIsDifferent) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsDifferent_ValidAndInvalid) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
@@ -2531,6 +2874,7 @@ TEST(WeakIntrusivePtrTest, HashIsDifferent_ValidAndInvalid) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsDifferent_ValidAndWeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
@@ -2539,6 +2883,7 @@ TEST(WeakIntrusivePtrTest, HashIsDifferent_ValidAndWeakOnly) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsDifferent_WeakOnlyAndWeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_weak_only<SomeClass>();
@@ -2547,6 +2892,7 @@ TEST(WeakIntrusivePtrTest, HashIsDifferent_WeakOnlyAndWeakOnly) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyConstructor) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = var1.weak;
@@ -2555,14 +2901,17 @@ TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyConstructor) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyConstructor_WeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
   weak_intrusive_ptr<SomeClass> var2 = var1;
   EXPECT_EQ(
       std::hash<weak_intrusive_ptr<SomeClass>>()(var1),
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyAssignment) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
@@ -2572,6 +2921,7 @@ TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyAssignment) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyAssignment_WeakOnly) {
   weak_intrusive_ptr<SomeClass> var1 = make_weak_only<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
@@ -2581,6 +2931,7 @@ TEST(WeakIntrusivePtrTest, HashIsSame_AfterCopyAssignment_WeakOnly) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, HashIsSame_BothInvalid) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
@@ -2589,32 +2940,42 @@ TEST(WeakIntrusivePtrTest, HashIsSame_BothInvalid) {
       std::hash<weak_intrusive_ptr<SomeClass>>()(var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, OneIsLess) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
   EXPECT_TRUE(
+      // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::less<weak_intrusive_ptr<SomeClass>>()(var1.weak, var2.weak) !=
+      // NOLINTNEXTLINE(modernize-use-transparent-functors)
       std::less<weak_intrusive_ptr<SomeClass>>()(var2.weak, var1.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, InvalidIsLess1) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   IntrusiveAndWeak<SomeClass> var2 = make_weak_intrusive<SomeClass>();
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_TRUE(std::less<weak_intrusive_ptr<SomeClass>>()(var1, var2.weak));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, InvalidIsLess2) {
   IntrusiveAndWeak<SomeClass> var1 = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_FALSE(std::less<weak_intrusive_ptr<SomeClass>>()(var1.weak, var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, InvalidIsNotLessThanInvalid) {
   weak_intrusive_ptr<SomeClass> var1 = make_invalid_weak<SomeClass>();
   weak_intrusive_ptr<SomeClass> var2 = make_invalid_weak<SomeClass>();
+  // NOLINTNEXTLINE(modernize-use-transparent-functors)
   EXPECT_FALSE(std::less<weak_intrusive_ptr<SomeClass>>()(var1, var2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingResetOnWeakPtr_thenIsInvalid) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   EXPECT_FALSE(obj.weak.expired());
@@ -2622,6 +2983,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenCallingResetOnWeakPtr_thenIsInvalid) {
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingResetOnStrongPtr_thenIsInvalid) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   EXPECT_FALSE(obj.weak.expired());
@@ -2629,106 +2991,125 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenCallingResetOnStrongPtr_thenIsInvalid) {
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, AllowsMoveConstructingToConst) {
   IntrusiveAndWeak<SomeClass> a = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<const SomeClass> b = std::move(a.weak);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, AllowsCopyConstructingToConst) {
   IntrusiveAndWeak<SomeClass> a = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<const SomeClass> b = a.weak;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, AllowsMoveAssigningToConst) {
   IntrusiveAndWeak<SomeClass> a = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<const SomeClass> b = make_weak_intrusive<const SomeClass>();
   b.weak = std::move(a.weak);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, AllowsCopyAssigningToConst) {
   IntrusiveAndWeak<SomeClass> a = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<const SomeClass> b = make_weak_intrusive<const SomeClass>();
   b.weak = a.weak;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenNewPtr_thenHasUseCount1) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   EXPECT_EQ(1, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenNewPtr_thenIsNotExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   EXPECT_FALSE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenInvalidPtr_thenHasUseCount0) {
   weak_intrusive_ptr<SomeClass> obj = make_invalid_weak<SomeClass>();
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenInvalidPtr_thenIsExpired) {
   weak_intrusive_ptr<SomeClass> obj = make_invalid_weak<SomeClass>();
   EXPECT_TRUE(obj.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenWeakOnlyPtr_thenHasUseCount0) {
   weak_intrusive_ptr<SomeClass> obj = make_weak_only<SomeClass>();
   EXPECT_EQ(0, obj.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenWeakOnlyPtr_thenIsExpired) {
   weak_intrusive_ptr<SomeClass> obj = make_weak_only<SomeClass>();
   EXPECT_TRUE(obj.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingWeakReset_thenHasUseCount0) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   obj.weak.reset();
   EXPECT_EQ(0, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingWeakReset_thenIsExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   obj.weak.reset();
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingStrongReset_thenHasUseCount0) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   obj.ptr.reset();
   EXPECT_EQ(0, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingStrongReset_thenIsExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   obj.ptr.reset();
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveConstructedPtr_thenHasUseCount1) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = std::move(obj.weak);
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveConstructedPtr_thenIsNotExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = std::move(obj.weak);
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveConstructedPtr_thenOldHasUseCount0) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = std::move(obj.weak);
   EXPECT_EQ(0, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveConstructedPtr_thenOldIsExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = std::move(obj.weak);
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenHasUseCount1) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2736,6 +3117,7 @@ TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenHasUseCount1) {
   EXPECT_EQ(1, obj2.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenIsNotExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2743,6 +3125,7 @@ TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenIsNotExpired) {
   EXPECT_FALSE(obj2.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenOldHasUseCount0) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2750,6 +3133,7 @@ TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenOldHasUseCount0) {
   EXPECT_EQ(0, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenOldIsExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   IntrusiveAndWeak<SomeClass> obj2 = make_weak_intrusive<SomeClass>();
@@ -2757,30 +3141,35 @@ TEST(WeakIntrusivePtrTest, givenMoveAssignedPtr_thenOldIsExpired) {
   EXPECT_TRUE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenCopyConstructedPtr_thenHasUseCount1) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj.weak;
   EXPECT_EQ(1, obj2.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenCopyConstructedPtr_thenIsNotExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj.weak;
   EXPECT_FALSE(obj2.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenCopyConstructedPtr_thenOldHasUseCount1) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj.weak;
   EXPECT_EQ(1, obj.weak.use_count());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenCopyConstructedPtr_thenOldIsNotExpired) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   weak_intrusive_ptr<SomeClass> obj2 = obj.weak;
   EXPECT_FALSE(obj.weak.expired());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenLastStrongPointerResets_thenReleasesResources) {
@@ -2797,6 +3186,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenDestructedButStillHasStrongPointers_thenDoesntReleaseResources) {
@@ -2813,6 +3203,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
@@ -2825,6 +3216,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenDestructed_thenDestructsObject) {
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructed_thenDestructsObjectAfterSecondDestructed) {
@@ -2840,6 +3232,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveConstructedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
@@ -2855,6 +3248,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   bool dummy = false;
   bool resourcesReleased = false;
@@ -2870,6 +3264,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenMoveAssigned_thenDestructsOldObject) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveAssignedToBaseClass_thenDestructsOldObject) {
@@ -2887,6 +3282,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenMoveAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -2909,6 +3305,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithBaseClassCopy_whenMoveAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -2932,6 +3329,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenMoveAssignedToBaseClass_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -2954,6 +3352,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveAssigned_thenDestructsObjectAfterSecondDestructed) {
@@ -2971,6 +3370,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenMoveAssignedToBaseClass_thenDestructsObjectAfterSecondDestructed) {
@@ -2988,6 +3388,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructedAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -2996,6 +3397,7 @@ TEST(
   {
     auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
     {
+      // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
       weak_intrusive_ptr<DestructableMock> copy = obj;
       EXPECT_TRUE(resourcesReleased);
       EXPECT_FALSE(wasDestructed);
@@ -3007,6 +3409,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructedToBaseClassAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3026,6 +3429,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructedAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3042,6 +3446,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyConstructedToBaseClassAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3058,6 +3463,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssignedAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3080,6 +3486,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClassAndDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3102,6 +3509,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssignedAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3123,6 +3531,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClassAndOriginalDestructed_thenDestructsObjectAfterLastDestruction) {
@@ -3145,6 +3554,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   bool dummy = false;
   bool resourcesReleased = false;
@@ -3160,6 +3570,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenCopyAssigned_thenDestructsOldObject) {
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenCopyAssignedToBaseClass_thenDestructsOldObject) {
@@ -3177,6 +3588,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenCopyAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -3199,6 +3611,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithBaseClassCopy_whenCopyAssigned_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -3222,6 +3635,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenCopyAssignedToBaseClass_thenDestructsOldObjectAfterCopyIsDestructed) {
@@ -3244,6 +3658,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   bool resourcesReleased = false;
   bool wasDestructed = false;
@@ -3255,6 +3670,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenCallingReset_thenDestructs) {
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenCallingReset_thenDestructsAfterCopyDestructed) {
@@ -3272,6 +3688,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithCopy_whenCallingResetOnCopy_thenDestructsAfterOriginalDestructed) {
@@ -3289,6 +3706,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithMoved_whenCallingReset_thenDestructsAfterMovedDestructed) {
@@ -3297,6 +3715,7 @@ TEST(
   auto obj = make_weak_only<DestructableMock>(&resourcesReleased, &wasDestructed);
   {
     auto moved = std::move(obj);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     obj.reset();
     EXPECT_TRUE(resourcesReleased);
     EXPECT_FALSE(wasDestructed);
@@ -3306,6 +3725,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtrWithMoved_whenCallingResetOnMoved_thenDestructsImmediately) {
@@ -3320,6 +3740,7 @@ TEST(
   }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenPtr_whenReleasedAndReclaimed_thenDoesntCrash) {
   IntrusiveAndWeak<SomeClass> obj = make_weak_intrusive<SomeClass>();
   SomeClass* ptr = obj.weak.release();
@@ -3327,6 +3748,7 @@ TEST(WeakIntrusivePtrTest, givenPtr_whenReleasedAndReclaimed_thenDoesntCrash) {
       weak_intrusive_ptr<SomeClass>::reclaim(ptr);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenReleasedAndReclaimed_thenDoesntCrash) {
@@ -3336,6 +3758,7 @@ TEST(
       weak_intrusive_ptr<SomeClass>::reclaim(ptr);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenPtr_whenReleasedAndReclaimed_thenIsDestructedAtEnd) {
@@ -3369,6 +3792,7 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(
     WeakIntrusivePtrTest,
     givenWeakOnlyPtr_whenReleasedAndReclaimed_thenIsDestructedAtEnd) {
@@ -3396,12 +3820,14 @@ TEST(
   EXPECT_TRUE(wasDestructed);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(WeakIntrusivePtrTest, givenStackObject_whenReclaimed_thenCrashes) {
   // This would cause very weird bugs on destruction.
   // Better to crash early on creation.
   SomeClass obj;
   weak_intrusive_ptr<SomeClass> ptr = make_invalid_weak<SomeClass>();
 #ifdef NDEBUG
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_NO_THROW(ptr = weak_intrusive_ptr<SomeClass>::reclaim(&obj));
 #else
   EXPECT_ANY_THROW(ptr = weak_intrusive_ptr<SomeClass>::reclaim(&obj));

--- a/c10/test/util/irange_test.cpp
+++ b/c10/test/util/irange_test.cpp
@@ -6,6 +6,7 @@
 
 using namespace ::testing;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(irange_test, range_test) {
     std::vector<int> test_vec;
     for(const auto i : c10::irange(4, 11)){
@@ -15,6 +16,7 @@ TEST(irange_test, range_test) {
     ASSERT_EQ(test_vec, correct);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(irange_test, end_test) {
     std::vector<int> test_vec;
     for(const auto i : c10::irange(5)){
@@ -24,6 +26,7 @@ TEST(irange_test, end_test) {
     ASSERT_EQ(test_vec, correct);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(irange_test, neg_range_test) {
     std::vector<int> test_vec;
     for(const auto i : c10::irange(-2, 3)){
@@ -33,10 +36,12 @@ TEST(irange_test, neg_range_test) {
     ASSERT_EQ(test_vec, correct);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(irange, empty_reverse_range_two_inputs){
     std::vector<int> test_vec;
     for(const auto i : c10::irange(3, -3)){
         test_vec.push_back(i);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if(i>20){ //Cap the number of elements we add if something goes wrong
             break;
         }
@@ -45,10 +50,12 @@ TEST(irange, empty_reverse_range_two_inputs){
     ASSERT_EQ(test_vec, correct);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(irange, empty_reverse_range_one_input){
     std::vector<int> test_vec;
     for(const auto i : c10::irange(-3)){
         test_vec.push_back(i);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if(i>20){ //Cap the number of elements we add if something goes wrong
             break;
         }

--- a/c10/test/util/logging_test.cpp
+++ b/c10/test/util/logging_test.cpp
@@ -10,11 +10,13 @@ using std::set;
 using std::string;
 using std::vector;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, TestEnforceTrue) {
   // This should just work.
   CAFFE_ENFORCE(true, "Isn't it?");
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, TestEnforceFalse) {
   bool kFalse = false;
   std::swap(FLAGS_caffe2_use_fatal_for_enforce, kFalse);
@@ -27,8 +29,10 @@ TEST(LoggingTest, TestEnforceFalse) {
   std::swap(FLAGS_caffe2_use_fatal_for_enforce, kFalse);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, TestEnforceEquals) {
   int x = 4;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   int y = 5;
   int z = 0;
   try {
@@ -56,6 +60,7 @@ struct EnforceEqWithCaller {
 };
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, TestEnforceMessageVariables) {
   const char *const x = "hello";
   CAFFE_ENFORCE_EQ(1, 1, "variable: ", x, " is a variable");
@@ -64,6 +69,7 @@ TEST(LoggingTest, TestEnforceMessageVariables) {
   e.test(x);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, EnforceEqualsObjectWithReferenceToTemporaryWithoutUseOutOfScope) {
   std::vector<int> x = {1, 2, 3, 4};
   // This case is a little tricky. We have a temporary
@@ -98,10 +104,12 @@ std::ostream& operator<<(std::ostream& out, const Noncopyable& nc) {
 }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, DoesntCopyComparedObjects) {
   CAFFE_ENFORCE_EQ(Noncopyable(123), Noncopyable(123));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, EnforceShowcase) {
   // It's not really a test but rather a convenient thing that you can run and
   // see all messages
@@ -127,6 +135,7 @@ TEST(LoggingTest, EnforceShowcase) {
   WRAP_AND_PRINT(CAFFE_ENFORCE_THAT(std::equal_to<void>(), ==, one * two + three, three * two));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, Join) {
   auto s = c10::Join(", ", vector<int>({1, 2, 3}));
   EXPECT_EQ(s, "1, 2, 3");
@@ -136,6 +145,7 @@ TEST(LoggingTest, Join) {
   EXPECT_EQ(s, "1, 2, 3");
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingTest, TestDanglingElse) {
   if (true)
     DCHECK_EQ(1, 1);
@@ -144,9 +154,11 @@ TEST(LoggingTest, TestDanglingElse) {
 }
 
 #if GTEST_HAS_DEATH_TEST
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(LoggingDeathTest, TestEnforceUsingFatal) {
   bool kTrue = true;
   std::swap(FLAGS_caffe2_use_fatal_for_enforce, kTrue);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_DEATH(CAFFE_ENFORCE(false, "This goes fatal."), "");
   std::swap(FLAGS_caffe2_use_fatal_for_enforce, kTrue);
 }

--- a/c10/test/util/optional_test.cpp
+++ b/c10/test/util/optional_test.cpp
@@ -24,6 +24,7 @@ bool getSampleValue() {
 
 template<>
 uint64_t getSampleValue() {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   return 42;
 }
 
@@ -45,15 +46,18 @@ using OptionalTypes = ::testing::Types<
 
 TYPED_TEST_CASE(OptionalTest, OptionalTypes);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TYPED_TEST(OptionalTest, Empty) {
   typename TestFixture::optional empty;
 
   EXPECT_FALSE((bool)empty);
   EXPECT_FALSE(empty.has_value());
 
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(empty.value(), c10::bad_optional_access);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TYPED_TEST(OptionalTest, Initialized) {
   using optional = typename TestFixture::optional;
 
@@ -66,6 +70,7 @@ TYPED_TEST(OptionalTest, Initialized) {
   optional moveAssign;
   moveAssign = std::move(moveFrom2);
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   std::array<typename TestFixture::optional *, 5> opts = {&opt, &copy, &copyAssign, &move, &moveAssign};
   for (auto* popt : opts) {
     auto& opt = *popt;

--- a/c10/test/util/ordered_preserving_dict_test.cpp
+++ b/c10/test/util/ordered_preserving_dict_test.cpp
@@ -14,6 +14,7 @@ namespace {
 using dict_int_int = ska_ordered::order_preserving_flat_hash_map<int64_t, int64_t>;
 
 dict_int_int test_dict(dict_int_int& dict) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (int64_t i = 0; i < 100; ++i) {
     dict[i] = i + 1;
   }
@@ -25,6 +26,7 @@ dict_int_int test_dict(dict_int_int& dict) {
   }
 
   // erase a few entries by themselves
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   std::unordered_set<int64_t> erase_set = {0, 2, 9, 71};
   for (auto erase: erase_set) {
     dict.erase(erase);
@@ -32,10 +34,12 @@ dict_int_int test_dict(dict_int_int& dict) {
 
   // erase via iterators
   auto begin = dict.begin();
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 20; ++i)
     begin++;
 
   auto end = begin;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 20; ++i) {
     erase_set.insert(end->first);
     end++;
@@ -43,6 +47,7 @@ dict_int_int test_dict(dict_int_int& dict) {
   dict.erase(begin, end);
 
   std::vector<size_t> order;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   for (size_t i = 0; i < 100; ++i) {
     if (!erase_set.count(i)) {
       order.push_back(i);
@@ -60,6 +65,7 @@ dict_int_int test_dict(dict_int_int& dict) {
   return dict;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, InsertAndDeleteBasic) {
   dict_int_int dict;
   test_dict(dict);
@@ -67,6 +73,7 @@ TEST(OrderedPreservingDictTest, InsertAndDeleteBasic) {
   test_dict(dict);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, InsertExistingDoesntAffectOrder) {
   dict_int_int dict;
   dict[0] = 1;
@@ -83,6 +90,7 @@ TEST(OrderedPreservingDictTest, InsertExistingDoesntAffectOrder) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, testRefType) {
   std::shared_ptr<int64_t> t;
   using dict_references = ska_ordered::order_preserving_flat_hash_map<int64_t, std::shared_ptr<int64_t>>;
@@ -101,6 +109,7 @@ TEST(OrderedPreservingDictTest, testRefType) {
 }
 
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, DictCollisions) {
   struct BadHash {
     size_t operator()(const int64_t input) {
@@ -124,6 +133,7 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
     }
 
     // erase a few entries;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     std::unordered_set<int64_t> erase_set = {0, 2, 9};
     for (auto erase : erase_set) {
       dict.erase(erase);
@@ -131,10 +141,12 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
 
     // erase a few entries via iterator
     auto begin = dict.begin();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (size_t i = 0; i < 10; ++i) {
       begin++;
     }
     auto end = begin;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for (size_t i = 0; i < 7; ++i) {
       erase_set.insert(end->first);
       end++;
@@ -162,15 +174,18 @@ TEST(OrderedPreservingDictTest, DictCollisions) {
 
 // Tests taken from https://github.com/Tessil/ordered-map/blob/master/tests/ordered_map_tests.cpp
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_range_insert) {
     // insert x values in vector, range insert x-15 values from vector to map, check values
     const int nb_values = 1000;
     std::vector<std::pair<int, int>> values;
     for(int i = 0; i < nb_values; i++) {
+        // NOLINTNEXTLINE(modernize-use-emplace,performance-inefficient-vector-operation)
         values.push_back(std::make_pair(i, i+1));
     }
 
     dict_int_int map = {{-1, 0}, {-2, 0}};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     map.insert(values.begin() + 10, values.end() - 5);
 
     TORCH_INTERNAL_ASSERT(map.size(), 987);
@@ -179,11 +194,13 @@ TEST(OrderedPreservingDictTest, test_range_insert) {
 
     ASSERT_EQUAL_PRIM(map.at(-2), 0);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     for(int i = 10, j = 2; i < nb_values - 5; i++, j++) {
         ASSERT_EQUAL_PRIM(map.at(i), i+1);
     }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_range_erase_all) {
     // insert x values, delete all
     const std::size_t nb_values = 1000;
@@ -196,6 +213,7 @@ TEST(OrderedPreservingDictTest, test_range_erase_all) {
     ASSERT_TRUE(map.empty());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_range_erase) {
     // insert x values, delete all with iterators except 10 first and 780 last values
     using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::int64_t>;
@@ -210,7 +228,9 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
       }
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto it_first = std::next(map.begin(), 10);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     auto it_last = std::next(map.begin(), 220);
 
     auto it = map.erase(it_first, it_last);
@@ -225,6 +245,7 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
     // Check order
     it = map.begin();
     for(std::size_t i = 0; i < nb_values; i++) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         if(i >= 10 && i < 220) {
             continue;
         }
@@ -234,29 +255,36 @@ TEST(OrderedPreservingDictTest, test_range_erase) {
     }
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_move_constructor_empty) {
     ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
     ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move(std::move(map));
 
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     TORCH_INTERNAL_ASSERT(map.empty());
     TORCH_INTERNAL_ASSERT(map_move.empty());
 
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
     TORCH_INTERNAL_ASSERT(map.find("") == map.end());
     TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_move_operator_empty) {
     ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map(0);
     ska_ordered::order_preserving_flat_hash_map<std::string, int64_t> map_move;
     map_move = (std::move(map));
 
+    // NOLINTNEXTLINE(bugprone-use-after-move)
     TORCH_INTERNAL_ASSERT(map.empty());
     TORCH_INTERNAL_ASSERT(map_move.empty());
 
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
     TORCH_INTERNAL_ASSERT(map.find("") == map.end());
     TORCH_INTERNAL_ASSERT(map_move.find("") == map_move.end());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_constructor) {
     using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
@@ -264,12 +292,14 @@ TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_constructor) {
     HMap map_move(std::move(map));
 
     ASSERT_EQUAL_PRIM(map_move.size(), 3);
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     ASSERT_EQUAL_PRIM(map.size(), 0);
 
     map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
     TORCH_INTERNAL_ASSERT(map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_operator) {
     using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
@@ -277,12 +307,14 @@ TEST(OrderedPreservingDictTest, test_reassign_moved_object_move_operator) {
     HMap map_move = std::move(map);
 
     ASSERT_EQUAL_PRIM(map_move.size(), 3);
+    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     ASSERT_EQUAL_PRIM(map.size(), 0);
 
     map = {{"Key4", "Value4"}, {"Key5", "Value5"}};
     TORCH_INTERNAL_ASSERT(map == (HMap({{"Key4", "Value4"}, {"Key5", "Value5"}})));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_copy_constructor_and_operator) {
     using HMap = ska_ordered::order_preserving_flat_hash_map<std::string, std::string>;
 
@@ -308,6 +340,7 @@ TEST(OrderedPreservingDictTest, test_copy_constructor_and_operator) {
     TORCH_INTERNAL_ASSERT(map_copy == map_copy3);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_copy_constructor_empty) {
     ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
     ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(map);
@@ -319,8 +352,10 @@ TEST(OrderedPreservingDictTest, test_copy_constructor_empty) {
     TORCH_INTERNAL_ASSERT(map_copy.find("") == map_copy.end());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_copy_operator_empty) {
     ska_ordered::order_preserving_flat_hash_map<std::string, int> map(0);
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::string, int> map_copy(16);
     map_copy = map;
 
@@ -335,6 +370,7 @@ TEST(OrderedPreservingDictTest, test_copy_operator_empty) {
 /**
  * at
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_at) {
     // insert x values, use at for known and unknown values.
     const ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
@@ -354,7 +390,9 @@ TEST(OrderedPreservingDictTest, test_at) {
 /**
  * equal_range
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_equal_range) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
 
     auto it_pair = map.equal_range(0);
@@ -370,8 +408,10 @@ TEST(OrderedPreservingDictTest, test_equal_range) {
 /**
  * operator[]
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_access_operator) {
     // insert x values, use at for known and unknown values.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{0, 10}, {-2, 20}};
 
     ASSERT_EQUAL_PRIM(map[0], 10);
@@ -384,8 +424,11 @@ TEST(OrderedPreservingDictTest, test_access_operator) {
 /**
  * swap
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_swap) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{1, 10}, {8, 80}, {3, 30}};
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2 = {{4, 40}, {5, 50}};
 
     using std::swap;
@@ -394,14 +437,18 @@ TEST(OrderedPreservingDictTest, test_swap) {
     TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}}));
     TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}}));
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     map.insert({6, 60});
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     map2.insert({4, 40});
 
     TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{4, 40}, {5, 50}, {6, 60}}));
     TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}, {4, 40}}));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(OrderedPreservingDictTest, test_swap_empty) {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map = {{1, 10}, {8, 80}, {3, 30}};
     ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t> map2;
 
@@ -411,7 +458,9 @@ TEST(OrderedPreservingDictTest, test_swap_empty) {
     TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{}));
     TORCH_INTERNAL_ASSERT(map2 == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{1, 10}, {8, 80}, {3, 30}}));
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     map.insert({6, 60});
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     map2.insert({4, 40});
 
     TORCH_INTERNAL_ASSERT(map == (ska_ordered::order_preserving_flat_hash_map<std::int64_t, std::int64_t>{{6, 60}}));

--- a/c10/test/util/registry_test.cpp
+++ b/c10/test/util/registry_test.cpp
@@ -13,10 +13,12 @@ class Foo {
   explicit Foo(int x) {
     // LOG(INFO) << "Foo " << x;
   }
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~Foo() {}
 };
 
 C10_DECLARE_REGISTRY(FooRegistry, Foo, int);
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_REGISTRY(FooRegistry, Foo, int);
 #define REGISTER_FOO(clsname) C10_REGISTER_CLASS(FooRegistry, clsname, clsname)
 
@@ -26,6 +28,7 @@ class Bar : public Foo {
     // LOG(INFO) << "Bar " << x;
   }
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_FOO(Bar);
 
 class AnotherBar : public Foo {
@@ -34,8 +37,10 @@ class AnotherBar : public Foo {
     // LOG(INFO) << "AnotherBar " << x;
   }
 };
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_FOO(AnotherBar);
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(RegistryTest, CanRunCreator) {
   std::unique_ptr<Foo> bar(FooRegistry()->Create("Bar", 1));
   EXPECT_TRUE(bar != nullptr) << "Cannot create bar.";
@@ -43,6 +48,7 @@ TEST(RegistryTest, CanRunCreator) {
   EXPECT_TRUE(another_bar != nullptr);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(RegistryTest, ReturnNullOnNonExistingCreator) {
   EXPECT_EQ(FooRegistry()->Create("Non-existing bar", 1), nullptr);
 }
@@ -68,11 +74,13 @@ void RegisterFooBarPreferred() {
       FooRegistry, FooWithPriority, c10::REGISTRY_PREFERRED, Bar);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(RegistryTest, RegistryPriorities) {
   FooRegistry()->SetTerminate(false);
   RegisterFooDefault();
 
   // throws because Foo is already registered with default priority
+  // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   EXPECT_THROW(RegisterFooDefaultAgain(), std::runtime_error);
 
 #ifdef __GXX_RTTI

--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -58,6 +58,7 @@ static_assert(string_view() == string_view(""), "");
 namespace test_constchar_constructor {
 static_assert(string_view("").size() == 0, "");
 constexpr string_view hello = "hello";
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == hello.size(), "");
 static_assert(string_equal("hello", hello.data(), hello.size()), "");
 } // namespace test_constchar_constructor
@@ -71,6 +72,7 @@ static_assert(string_equal("hell", hell.data(), hell.size()), "");
 
 namespace test_string_constructor {
 void test_conversion_is_implicit(string_view a) {}
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testStringConstructor) {
   std::string empty;
   EXPECT_EQ(0, string_view(empty).size());
@@ -84,6 +86,7 @@ TEST(StringViewTest, testStringConstructor) {
 } // namespace test_string_constructor
 
 namespace test_conversion_to_string {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testConversionToString) {
   string_view empty;
   EXPECT_EQ(0, std::string(empty).size());
@@ -97,6 +100,7 @@ TEST(StringViewTest, testConversionToString) {
 namespace test_copy_constructor {
 constexpr string_view hello = "hello";
 constexpr string_view copy = hello;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == copy.size(), "");
 static_assert(string_equal("hello", copy.data(), copy.size()), "");
 } // namespace test_copy_constructor
@@ -107,15 +111,19 @@ constexpr string_view assign(string_view value) {
   result = value; // this is the assignment we're testing
   return result;
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testCopyAssignment) {
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
   {
     constexpr string_view hello = assign("hello");
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(5 == hello.size(), "");
     static_assert(string_equal("hello", hello.data(), hello.size()), "");
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     static_assert(5 == (string_view() = "hello").size(), "");
     static_assert(
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         string_equal("hello", (string_view() = "hello").data(), 5), "");
   }
 #endif
@@ -148,6 +156,7 @@ static_assert('e' == *(hello.begin() + 1), "");
 static_assert('l' == *(hello.begin() + 2), "");
 static_assert('l' == *(hello.begin() + 3), "");
 static_assert('o' == *(hello.begin() + 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(hello.end() == hello.begin() + 5, "");
 } // namespace test_forward_iteration
 
@@ -158,6 +167,7 @@ static_assert('l' == *(hello.rbegin() + 1), "");
 static_assert('l' == *(hello.rbegin() + 2), "");
 static_assert('e' == *(hello.rbegin() + 3), "");
 static_assert('h' == *(hello.rbegin() + 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(hello.rend() == hello.rbegin() + 5, "");
 } // namespace test_reverse_iteration
 
@@ -175,6 +185,7 @@ static_assert('l' == hello.at(2), "");
 static_assert('l' == hello.at(3), "");
 static_assert('o' == hello.at(4), "");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCallingAccessOperatorOutOfRange_thenThrows) {
   expectThrows<std::out_of_range>(
       [] { string_view("")[1]; },
@@ -185,18 +196,22 @@ TEST(StringViewTest, whenCallingAccessOperatorOutOfRange_thenThrows) {
       "string_view::operator[] or string_view::at() out of range. Index: 1, size: 0");
 
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello")[5]; },
       "string_view::operator[] or string_view::at() out of range. Index: 5, size: 5");
 
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello").at(5); },
       "string_view::operator[] or string_view::at() out of range. Index: 5, size: 5");
 
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello")[100]; },
       "string_view::operator[] or string_view::at() out of range. Index: 100, size: 5");
 
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello").at(100); },
       "string_view::operator[] or string_view::at() out of range. Index: 100, size: 5");
 
@@ -216,14 +231,17 @@ static_assert('o' == string_view("hello").back(), "");
 } // namespace test_front_back
 
 namespace test_data {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_equal("hello", string_view("hello").data(), 5), "");
 }
 
 namespace test_size_length {
 static_assert(0 == string_view("").size(), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("hello").size(), "");
 
 static_assert(0 == string_view("").length(), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("hello").length(), "");
 } // namespace test_size_length
 
@@ -239,12 +257,14 @@ CONSTEXPR_EXCEPT_GCC5 string_view remove_prefix(string_view input, size_t len) {
   return input;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenRemovingValidPrefix_thenWorks) {
 #if IS_NOT_GCC5_CONSTEXPR
   static_assert(
       remove_prefix(string_view("hello"), 0) == string_view("hello"), "");
   static_assert(
       remove_prefix(string_view("hello"), 1) == string_view("ello"), "");
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   static_assert(remove_prefix(string_view("hello"), 5) == string_view(""), "");
 #endif
 
@@ -253,8 +273,10 @@ TEST(StringViewTest, whenRemovingValidPrefix_thenWorks) {
   EXPECT_EQ(remove_prefix(string_view("hello"), 5), string_view(""));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenRemovingTooLargePrefix_thenThrows) {
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { remove_prefix(string_view("hello"), 6); },
       "basic_string_view::remove_prefix: out of range. PrefixLength: 6, size: 5");
 }
@@ -266,12 +288,14 @@ CONSTEXPR_EXCEPT_GCC5 string_view remove_suffix(string_view input, size_t len) {
   return input;
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenRemovingValidSuffix_thenWorks) {
 #if IS_NOT_GCC5_CONSTEXPR
   static_assert(
       remove_suffix(string_view("hello"), 0) == string_view("hello"), "");
   static_assert(
       remove_suffix(string_view("hello"), 1) == string_view("hell"), "");
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   static_assert(remove_suffix(string_view("hello"), 5) == string_view(""), "");
 #endif
 
@@ -280,8 +304,10 @@ TEST(StringViewTest, whenRemovingValidSuffix_thenWorks) {
   EXPECT_EQ(remove_suffix(string_view("hello"), 5), string_view(""));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenRemovingTooLargeSuffix_thenThrows) {
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { remove_suffix(string_view("hello"), 6); },
       "basic_string_view::remove_suffix: out of range. SuffixLength: 6, size: 5");
 }
@@ -294,6 +320,7 @@ CONSTEXPR_EXCEPT_GCC5 std::pair<string_view, string_view> get() {
   swap(first, second);
   return std::make_pair(first, second);
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testSwapFunction) {
 #if IS_NOT_GCC5_CONSTEXPR
   static_assert(string_view("second") == get().first, "");
@@ -312,6 +339,7 @@ CONSTEXPR_EXCEPT_GCC5 std::pair<string_view, string_view> get() {
   first.swap(second);
   return std::make_pair(first, second);
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testSwapMethod) {
 #if IS_NOT_GCC5_CONSTEXPR
   static_assert(string_view("second") == get().first, "");
@@ -324,41 +352,55 @@ TEST(StringViewTest, testSwapMethod) {
 } // namespace test_swap_method
 
 namespace test_copy {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCopyingFullStringView_thenDestinationHasCorrectData) {
   string_view data = "hello";
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   char result[5];
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   size_t num_copied = data.copy(result, 5);
   EXPECT_EQ(5, num_copied);
   EXPECT_TRUE(string_equal("hello", result, 5));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCopyingSubstr_thenDestinationHasCorrectData) {
   string_view data = "hello";
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char result[2];
   size_t num_copied = data.copy(result, 2, 2);
   EXPECT_EQ(2, num_copied);
   EXPECT_TRUE(string_equal("ll", result, 2));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCopyingTooMuch_thenJustCopiesLess) {
   string_view data = "hello";
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
   char result[100];
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   size_t num_copied = data.copy(result, 100, 2);
   EXPECT_EQ(3, num_copied);
   EXPECT_TRUE(string_equal("llo", result, 3));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCopyingJustAtRange_thenDoesntCrash) {
   string_view data = "hello";
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char result[1];
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   size_t num_copied = data.copy(result, 2, 5);
   EXPECT_EQ(0, num_copied);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCopyingOutOfRange_thenThrows) {
   string_view data = "hello";
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   char result[2];
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-magic-numbers,modernize-avoid-c-arrays)
       [&] { data.copy(result, 2, 6); },
       "basic_string_view::copy: out of range. Index: 6, size: 5");
 }
@@ -372,6 +414,7 @@ static_assert(string_view("").substr(0, 0) == string_view(""), "");
 static_assert(string_view("hello").substr() == string_view("hello"), "");
 static_assert(string_view("hello").substr(0) == string_view("hello"), "");
 static_assert(string_view("hello").substr(1) == string_view("ello"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view("hello").substr(5) == string_view(""), "");
 
 static_assert(string_view("hello").substr(0, 0) == string_view(""), "");
@@ -379,16 +422,22 @@ static_assert(string_view("hello").substr(0, 2) == string_view("he"), "");
 static_assert(string_view("hello").substr(1, 2) == string_view("el"), "");
 static_assert(string_view("hello").substr(4, 1) == string_view("o"), "");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view("hello").substr(0, 100) == string_view("hello"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view("hello").substr(1, 100) == string_view("ello"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view("hello").substr(5, 100) == string_view(""), "");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, whenCallingSubstrWithPosOutOfRange_thenThrows) {
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello").substr(6); },
       "basic_string_view::substr parameter out of bounds. Index: 6, size: 5");
 
   expectThrows<std::out_of_range>(
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       [] { string_view("hello").substr(6, 0); },
       "basic_string_view::substr parameter out of bounds. Index: 6, size: 5");
 }
@@ -445,9 +494,11 @@ static_assert(
     0 > string_view("hello").compare(2, 2, string_view("hello"), 2, 3),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     0 < string_view("hello").compare(2, 2, string_view("hellola"), 5, 2),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     0 > string_view("hello").compare(2, 2, string_view("hellolz"), 5, 2),
     "");
 } // namespace test_compare_overload3
@@ -488,7 +539,9 @@ static_assert(0 == string_view("").compare(0, 0, "", 0, 0), "");
 static_assert(0 == string_view("hello").compare(2, 2, "hello", 2, 2), "");
 static_assert(0 < string_view("hello").compare(2, 2, "hello", 2, 1), "");
 static_assert(0 > string_view("hello").compare(2, 2, "hello", 2, 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(0 < string_view("hello").compare(2, 2, "hellola", 5, 2), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(0 > string_view("hello").compare(2, 2, "hellolz", 5, 2), "");
 } // namespace test_compare_overload6
 
@@ -686,6 +739,7 @@ static_assert(2 == string_view("abc").find('c'), "");
 static_assert(2 == string_view("abc").find('c', 1), "");
 static_assert(2 == string_view("abc").find('c', 2), "");
 static_assert(string_view::npos == string_view("abc").find('c', 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view::npos == string_view("abc").find('a', 100), "");
 static_assert(string_view::npos == string_view("abc").find('z'), "");
 static_assert(0 == string_view("ababa").find('a'), "");
@@ -694,6 +748,7 @@ static_assert(2 == string_view("ababa").find('a', 1), "");
 static_assert(2 == string_view("ababa").find('a', 2), "");
 static_assert(4 == string_view("ababa").find('a', 3), "");
 static_assert(4 == string_view("ababa").find('a', 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(string_view::npos == string_view("ababa").find('a', 5), "");
 } // namespace test_find_overload2
 
@@ -780,6 +835,7 @@ static_assert(string_view::npos == string_view("abc").rfind('c', 0), "");
 static_assert(string_view::npos == string_view("abc").rfind('c', 1), "");
 static_assert(2 == string_view("abc").rfind('c', 2), "");
 static_assert(2 == string_view("abc").rfind('c', 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(0 == string_view("abc").rfind('a', 100), "");
 static_assert(string_view::npos == string_view("abc").rfind('z'), "");
 static_assert(4 == string_view("ababa").rfind('a'), "");
@@ -788,6 +844,7 @@ static_assert(0 == string_view("ababa").rfind('a', 1), "");
 static_assert(2 == string_view("ababa").rfind('a', 2), "");
 static_assert(2 == string_view("ababa").rfind('a', 3), "");
 static_assert(4 == string_view("ababa").rfind('a', 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(4 == string_view("ababa").rfind('a', 5), "");
 } // namespace test_rfind_overload2
 
@@ -872,6 +929,7 @@ static_assert(
     string_view::npos == string_view("").find_first_of(string_view("a"), 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_first_of(string_view("abc"), 100),
     "");
 static_assert(
@@ -892,6 +950,7 @@ static_assert(
     4 == string_view("abcabc").find_first_of(string_view("b"), 3),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_first_of(string_view("c"), 5),
     "");
 static_assert(
@@ -919,6 +978,7 @@ static_assert(
     string_view::npos == string_view("abc").find_first_of('c', 3),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("abc").find_first_of('a', 100),
     "");
 static_assert(string_view::npos == string_view("abc").find_first_of('z'), "");
@@ -929,6 +989,7 @@ static_assert(2 == string_view("ababa").find_first_of('a', 2), "");
 static_assert(4 == string_view("ababa").find_first_of('a', 3), "");
 static_assert(4 == string_view("ababa").find_first_of('a', 4), "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("ababa").find_first_of('a', 5),
     "");
 } // namespace test_find_first_of_overload2
@@ -966,6 +1027,7 @@ static_assert(
     string_view::npos == string_view("").find_first_of("abc", 1, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_first_of("abcdef", 100, 3),
     "");
 static_assert(
@@ -980,6 +1042,7 @@ static_assert(
 
 static_assert(3 == string_view("abcabc").find_first_of("abc", 1, 1), "");
 static_assert(4 == string_view("abcabc").find_first_of("bac", 3, 1), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_first_of("cab", 5, 1), "");
 static_assert(4 == string_view("abcabc").find_first_of("bccda", 3, 2), "");
 static_assert(4 == string_view("abcabc").find_first_of("cbdab", 4, 3), "");
@@ -1002,6 +1065,7 @@ static_assert(1 == string_view("abcabc").find_first_of("cbd"), "");
 static_assert(string_view::npos == string_view("").find_first_of("", 1), "");
 static_assert(string_view::npos == string_view("").find_first_of("a", 1), "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_first_of("abc", 100),
     "");
 static_assert(string_view::npos == string_view("abc").find_first_of("", 1), "");
@@ -1014,6 +1078,7 @@ static_assert(
 
 static_assert(3 == string_view("abcabc").find_first_of("a", 1), "");
 static_assert(4 == string_view("abcabc").find_first_of("b", 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_first_of("c", 5), "");
 static_assert(4 == string_view("abcabc").find_first_of("bc", 3), "");
 static_assert(4 == string_view("abcabc").find_first_of("cbd", 4), "");
@@ -1041,8 +1106,11 @@ static_assert(
 
 static_assert(3 == string_view("abcabc").find_last_of(string_view("a")), "");
 static_assert(4 == string_view("abcabc").find_last_of(string_view("b")), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of(string_view("c")), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of(string_view("bc")), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of(string_view("cbd")), "");
 
 static_assert(
@@ -1052,6 +1120,7 @@ static_assert(
     string_view::npos == string_view("").find_last_of(string_view("a"), 0),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_last_of(string_view("abc"), 100),
     "");
 static_assert(
@@ -1088,6 +1157,7 @@ static_assert(string_view::npos == string_view("abc").find_last_of('c', 0), "");
 static_assert(string_view::npos == string_view("abc").find_last_of('c', 1), "");
 static_assert(2 == string_view("abc").find_last_of('c', 2), "");
 static_assert(2 == string_view("abc").find_last_of('c', 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(0 == string_view("abc").find_last_of('a', 100), "");
 static_assert(string_view::npos == string_view("abc").find_last_of('z'), "");
 static_assert(4 == string_view("ababa").find_last_of('a'), "");
@@ -1096,6 +1166,7 @@ static_assert(0 == string_view("ababa").find_last_of('a', 1), "");
 static_assert(2 == string_view("ababa").find_last_of('a', 2), "");
 static_assert(2 == string_view("ababa").find_last_of('a', 3), "");
 static_assert(4 == string_view("ababa").find_last_of('a', 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(4 == string_view("ababa").find_last_of('a', 5), "");
 } // namespace test_find_last_of_overload2
 
@@ -1132,12 +1203,15 @@ static_assert(
     4 == string_view("abcabc").find_last_of("bca", string_view::npos, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_of("cab", string_view::npos, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_of("bcab", string_view::npos, 2),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_of("cbdac", string_view::npos, 3),
     "");
 
@@ -1148,6 +1222,7 @@ static_assert(
     string_view::npos == string_view("").find_last_of("abc", 0, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_last_of("abcdef", 100, 3),
     "");
 static_assert(
@@ -1177,13 +1252,17 @@ static_assert(string_view::npos == string_view("abc").find_last_of("def"), "");
 
 static_assert(3 == string_view("abcabc").find_last_of("a"), "");
 static_assert(4 == string_view("abcabc").find_last_of("b"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of("c"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of("bc"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_of("cbd"), "");
 
 static_assert(string_view::npos == string_view("").find_last_of("", 1), "");
 static_assert(string_view::npos == string_view("").find_last_of("a", 0), "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_last_of("abc", 100),
     "");
 static_assert(string_view::npos == string_view("abc").find_last_of("", 1), "");
@@ -1249,6 +1328,7 @@ static_assert(
     "");
 static_assert(
     string_view::npos ==
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         string_view("").find_first_not_of(string_view("abc"), 100),
     "");
 static_assert(
@@ -1274,6 +1354,7 @@ static_assert(
     4 == string_view("abcabc").find_first_not_of(string_view("ac"), 4),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_first_not_of(string_view("ab"), 5),
     "");
 static_assert(
@@ -1306,6 +1387,7 @@ static_assert(
     string_view::npos == string_view("abc").find_first_not_of('c', 3),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("abc").find_first_not_of('a', 100),
     "");
 static_assert(1 == string_view("ababa").find_first_not_of('a'), "");
@@ -1317,6 +1399,7 @@ static_assert(
     string_view::npos == string_view("ababa").find_first_not_of('a', 4),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("ababa").find_first_not_of('a', 5),
     "");
 } // namespace test_find_first_not_of_overload2
@@ -1338,6 +1421,7 @@ static_assert(
     string_view::npos == string_view("abc").find_first_not_of("acdbef", 0, 4),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("abc").find_first_not_of("defabcas", 0, 6),
     "");
 
@@ -1355,6 +1439,7 @@ static_assert(
     string_view::npos == string_view("").find_first_not_of("abc", 1, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_first_not_of("abcdef", 100, 3),
     "");
 static_assert(
@@ -1364,12 +1449,14 @@ static_assert(
     string_view::npos == string_view("abc").find_first_not_of("acdbef", 3, 4),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("abc").find_first_not_of("defabcas", 2, 6),
     "");
 
 static_assert(1 == string_view("abcabc").find_first_not_of("bca", 1, 0), "");
 static_assert(3 == string_view("abcabc").find_first_not_of("bca", 1, 2), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("acb", 4, 2), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_first_not_of("abc", 5, 2), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("abac", 3, 1), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("dadab", 4, 2), "");
@@ -1405,6 +1492,7 @@ static_assert(
     string_view::npos == string_view("").find_first_not_of("a", 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_first_not_of("abc", 100),
     "");
 static_assert(
@@ -1420,6 +1508,7 @@ static_assert(
 static_assert(1 == string_view("abcabc").find_first_not_of("", 1), "");
 static_assert(3 == string_view("abcabc").find_first_not_of("bc", 1), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("ac", 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_first_not_of("ab", 5), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("a", 3), "");
 static_assert(4 == string_view("abcabc").find_first_not_of("da", 4), "");
@@ -1448,6 +1537,7 @@ static_assert(
         string_view("abc").find_last_not_of(string_view("defabc")),
     "");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_not_of(string_view("")), "");
 static_assert(
     3 == string_view("abcabc").find_last_not_of(string_view("bc")),
@@ -1456,6 +1546,7 @@ static_assert(
     4 == string_view("abcabc").find_last_not_of(string_view("ac")),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_not_of(string_view("ab")),
     "");
 static_assert(
@@ -1473,6 +1564,7 @@ static_assert(
     "");
 static_assert(
     string_view::npos ==
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         string_view("").find_last_not_of(string_view("abc"), 100),
     "");
 static_assert(
@@ -1525,6 +1617,7 @@ static_assert(0 == string_view("abc").find_last_not_of('c', 0), "");
 static_assert(1 == string_view("abc").find_last_not_of('c', 1), "");
 static_assert(1 == string_view("abc").find_last_not_of('c', 2), "");
 static_assert(1 == string_view("abc").find_last_not_of('c', 3), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(2 == string_view("abc").find_last_not_of('a', 100), "");
 static_assert(3 == string_view("ababa").find_last_not_of('a'), "");
 static_assert(
@@ -1534,6 +1627,7 @@ static_assert(1 == string_view("ababa").find_last_not_of('a', 1), "");
 static_assert(1 == string_view("ababa").find_last_not_of('a', 2), "");
 static_assert(3 == string_view("ababa").find_last_not_of('a', 3), "");
 static_assert(3 == string_view("ababa").find_last_not_of('a', 4), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(3 == string_view("ababa").find_last_not_of('a', 5), "");
 } // namespace test_find_last_not_of_overload2
 
@@ -1560,10 +1654,12 @@ static_assert(
     "");
 static_assert(
     string_view::npos ==
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         string_view("abc").find_last_not_of("defabcas", string_view::npos, 6),
     "");
 
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_not_of("cab", string_view::npos, 0),
     "");
 static_assert(
@@ -1573,6 +1669,7 @@ static_assert(
     4 == string_view("abcabc").find_last_not_of("acb", string_view::npos, 2),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     5 == string_view("abcabc").find_last_not_of("abc", string_view::npos, 2),
     "");
 static_assert(
@@ -1589,6 +1686,7 @@ static_assert(
     string_view::npos == string_view("").find_last_not_of("abc", 0, 1),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_last_not_of("abcdef", 100, 3),
     "");
 static_assert(
@@ -1598,6 +1696,7 @@ static_assert(
     string_view::npos == string_view("abc").find_last_not_of("acdbef", 3, 4),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("abc").find_last_not_of("defabcas", 2, 6),
     "");
 
@@ -1623,9 +1722,11 @@ static_assert(
     string_view::npos == string_view("abc").find_last_not_of("defabc"),
     "");
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_not_of(""), "");
 static_assert(3 == string_view("abcabc").find_last_not_of("bc"), "");
 static_assert(4 == string_view("abcabc").find_last_not_of("ac"), "");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
 static_assert(5 == string_view("abcabc").find_last_not_of("ab"), "");
 static_assert(4 == string_view("abcabc").find_last_not_of("c"), "");
 static_assert(4 == string_view("abcabc").find_last_not_of("ca"), "");
@@ -1635,6 +1736,7 @@ static_assert(
     string_view::npos == string_view("").find_last_not_of("a", 0),
     "");
 static_assert(
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     string_view::npos == string_view("").find_last_not_of("abc", 100),
     "");
 static_assert(
@@ -1663,6 +1765,7 @@ void testOutputIterator(const std::string& str) {
   EXPECT_EQ(str, actual);
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testOutputOperator) {
   testOutputIterator("");
   testOutputIterator("abc");
@@ -1670,6 +1773,7 @@ TEST(StringViewTest, testOutputOperator) {
 } // namespace test_output_operator
 
 namespace test_hash {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(StringViewTest, testHash) {
   EXPECT_EQ(
       std::hash<string_view>()(string_view()), std::hash<string_view>()(""));

--- a/c10/test/util/tempfile_test.cpp
+++ b/c10/test/util/tempfile_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #if !defined(_WIN32)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TempFileTest, MatchesExpectedPattern) {
   c10::TempFile pattern = c10::make_tempfile("test-pattern-");
   ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);

--- a/c10/test/util/typeid_test.cpp
+++ b/c10/test/util/typeid_test.cpp
@@ -15,6 +15,7 @@ CAFFE_KNOWN_TYPE(TypeMetaTestBar);
 
 namespace {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeMetaTest, TypeMetaStatic) {
   EXPECT_EQ(TypeMeta::ItemSize<int>(), sizeof(int));
   EXPECT_EQ(TypeMeta::ItemSize<float>(), sizeof(float));
@@ -27,6 +28,7 @@ TEST(TypeMetaTest, TypeMetaStatic) {
   EXPECT_EQ(TypeMeta::Id<TypeMetaTestFoo>(), TypeMeta::Id<TypeMetaTestFoo>());
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeMetaTest, Names) {
   TypeMeta null_meta;
   EXPECT_EQ("nullptr (uninitialized)", null_meta.name());
@@ -36,6 +38,7 @@ TEST(TypeMetaTest, Names) {
   EXPECT_TRUE(c10::string_view::npos != string_meta.name().find("string"));
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeMetaTest, TypeMeta) {
   TypeMeta int_meta = TypeMeta::Make<int>();
   TypeMeta float_meta = TypeMeta::Make<float>();
@@ -73,7 +76,9 @@ TEST(TypeMetaTest, TypeMeta) {
 
 class ClassAllowAssignment {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ClassAllowAssignment() : x(42) {}
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   ClassAllowAssignment(const ClassAllowAssignment& src) : x(src.x) {}
   ClassAllowAssignment& operator=(const ClassAllowAssignment& src) = default;
   int x;
@@ -81,6 +86,7 @@ class ClassAllowAssignment {
 
 class ClassNoAssignment {
  public:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   ClassNoAssignment() : x(42) {}
   ClassNoAssignment(const ClassNoAssignment& src) = delete;
   ClassNoAssignment& operator=(const ClassNoAssignment& src) = delete;
@@ -93,6 +99,7 @@ CAFFE_KNOWN_TYPE(ClassNoAssignment);
 
 namespace {
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeMetaTest, CtorDtorAndCopy) {
   TypeMeta fundamental_meta = TypeMeta::Make<int>();
   EXPECT_EQ(fundamental_meta.placementNew(), nullptr);
@@ -104,6 +111,7 @@ TEST(TypeMetaTest, CtorDtorAndCopy) {
   EXPECT_TRUE(meta_a.placementDelete() != nullptr);
   EXPECT_TRUE(meta_a.copy() != nullptr);
   ClassAllowAssignment src;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   src.x = 10;
   ClassAllowAssignment dst;
   EXPECT_EQ(dst.x, 42);
@@ -122,6 +130,7 @@ TEST(TypeMetaTest, CtorDtorAndCopy) {
 #endif
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TypeMetaTest, Float16IsNotUint16) {
   EXPECT_NE(TypeMeta::Id<uint16_t>(), TypeMeta::Id<at::Half>());
 }

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -122,9 +122,11 @@ namespace {
       }
 
     private:
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
       static thread_local WarningHandler* warning_handler_;
   };
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   thread_local WarningHandler* ThreadWarningHandler::warning_handler_ = nullptr;
 
 }
@@ -141,6 +143,7 @@ WarningHandler* get_warning_handler() noexcept(true) {
   return ThreadWarningHandler::get_handler();
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool warn_always = false;
 
 void set_warnAlways(bool setting) noexcept(true) {

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -13,6 +13,7 @@
 
 // Common code that we use regardless of whether we use glog or not.
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(
     caffe2_use_fatal_for_enforce,
     false,
@@ -22,6 +23,7 @@ C10_DEFINE_bool(
 namespace c10 {
 
 namespace {
+// NOLINTNEXTLINE(modernize-redundant-void-arg)
 std::function<string(void)>* GetFetchStackTrace() {
   static std::function<string(void)> func = []() {
     return get_backtrace(/*frames_to_skip=*/1);
@@ -164,8 +166,11 @@ DECLARE_bool(logtostderr);
 // This backward compatibility flags are in order to deal with cases where
 // Caffe2 are not built with glog, but some init flags still pass in these
 // flags. They may go away in the future.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int32(minloglevel, 0, "Equivalent to glog minloglevel");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int32(v, 0, "Equivalent to glog verbose");
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(logtostderr, false, "Equivalent to glog logtostderr");
 #endif // !defined(c10_USE_GLOG)
 
@@ -245,6 +250,7 @@ void ShowLogInfoToStderr() {
 #include <android/log.h>
 #endif // ANDROID
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int(
     caffe2_log_level,
     c10::GLOG_WARNING,

--- a/c10/util/MathConstants.cpp
+++ b/c10/util/MathConstants.cpp
@@ -7,6 +7,7 @@
 
 #include <c10/util/MathConstants.h>
 
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <math.h>
 
 static_assert(M_PI == c10::pi<double>, "c10::pi<double> must be equal to M_PI");

--- a/c10/util/SmallVector.cpp
+++ b/c10/util/SmallVector.cpp
@@ -29,8 +29,10 @@ void SmallVectorBase::grow_pod(
   if (NewCapacityInBytes < MinSizeInBytes)
     NewCapacityInBytes = MinSizeInBytes;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   void* NewElts;
   if (BeginX == FirstEl) {
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     NewElts = malloc(NewCapacityInBytes);
     if (NewElts == nullptr)
       throw std::bad_alloc();
@@ -39,6 +41,7 @@ void SmallVectorBase::grow_pod(
     memcpy(NewElts, this->BeginX, CurSizeBytes);
   } else {
     // If this wasn't grown from the inline copy, grow the allocated space.
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     NewElts = realloc(this->BeginX, NewCapacityInBytes);
     if (NewElts == nullptr)
       throw std::bad_alloc();

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -3,6 +3,7 @@
 namespace c10 {
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 thread_local std::shared_ptr<ThreadLocalDebugInfo> debug_info = nullptr;
 }
 

--- a/c10/util/Type.cpp
+++ b/c10/util/Type.cpp
@@ -33,6 +33,7 @@ std::string demangle(const char* name) {
       abi::__cxa_demangle(
           name,
           /*__output_buffer=*/nullptr,
+          // NOLINTNEXTLINE(modernize-use-nullptr)
           /*__length=*/0,
           &status),
       /*deleter=*/free);

--- a/c10/util/flags_use_no_gflags.cpp
+++ b/c10/util/flags_use_no_gflags.cpp
@@ -12,9 +12,11 @@ namespace c10 {
 
 using std::string;
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_REGISTRY(C10FlagsRegistry, C10FlagParser, const string&);
 
 namespace {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static bool gCommandLineFlagsParsed = false;
 // Since flags is going to be loaded before logging, we would
 // need to have a stringstream to hold the messages instead of directly
@@ -23,6 +25,7 @@ std::stringstream& GlobalInitStream() {
   static std::stringstream ss;
   return ss;
 }
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static const char* gUsageMessage = "(Usage message not set.)";
 } // namespace
 

--- a/c10/util/intrusive_ptr.h
+++ b/c10/util/intrusive_ptr.h
@@ -239,6 +239,7 @@ class intrusive_ptr final {
     if (target_ != NullType::singleton() && detail::atomic_refcount_decrement(target_->refcount_) == 0) {
       // justification for const_cast: release_resources is basically a destructor
       // and a destructor always mutates the object, even for const objects.
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
       const_cast<std::remove_const_t<TTarget>*>(target_)->release_resources();
 
       // See comment above about weakcount. As long as refcount>0,
@@ -560,6 +561,7 @@ class weak_intrusive_ptr final {
 
   void reset_() noexcept {
     if (target_ != NullType::singleton() && detail::atomic_weakcount_decrement(target_->weakcount_) == 0) {
+      // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
       delete target_;
     }
     target_ = NullType::singleton();

--- a/c10/util/numa.cpp
+++ b/c10/util/numa.cpp
@@ -1,5 +1,6 @@
 #include <c10/util/numa.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(caffe2_cpu_numa_enabled, false, "Use NUMA whenever possible.");
 
 #if defined(__linux__) && defined(C10_USE_NUMA) && !defined(C10_MOBILE)

--- a/c10/util/typeid.cpp
+++ b/c10/util/typeid.cpp
@@ -23,10 +23,12 @@ C10_EXPORT void _ThrowRuntimeTypeLogicError(const string& msg) {
 }
 
 // see TypeMeta::addTypeMetaData
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<uint16_t> TypeMeta::nextTypeIndex(NumScalarTypes);
 
 // fixed length array of TypeMetaData instances
 detail::TypeMetaData* TypeMeta::typeMetaDatas() {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   static detail::TypeMetaData instances[MaxTypeIndex + 1] = {
 #define SCALAR_TYPE_META(T, name)         \
     /* ScalarType::name */                \


### PR DESCRIPTION
This change was autogenerated by running:
```
% find c10 -iname "*.cpp" -exec python3 tools/clang_tidy.py -c build -x {} -s \;
```
