### PR TITLE
Put llvmMathExtras in c10 namespace

### DIFF
--- a/c10/util/llvmMathExtras.h
+++ b/c10/util/llvmMathExtras.h
@@ -10,8 +10,7 @@
  //
  //===----------------------------------------------------------------------===//
 
- #ifndef LLVM_SUPPORT_MATHEXTRAS_H
- #define LLVM_SUPPORT_MATHEXTRAS_H
+ #pragma once
 
  #include <algorithm>
  #include <cassert>
@@ -55,6 +54,7 @@
  }
  #endif
 
+ namespace c10 {
  namespace llvm {
  /// The behavior an operation has on an input of 0.
  enum ZeroBehavior {
@@ -862,5 +862,4 @@
  /// Use this rather than HUGE_VALF; the latter causes warnings on MSVC.
  extern const float huge_valf;
  } // End llvm namespace
-
- #endif
+ } // End c10 namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55886 Put llvmMathExtras in c10 namespace**

We've imported llvm's MathExtras header, but now that we want to also
include LLVM (which includes its own MathExtras), we need to guard the c10
version appropriately (or interwine llvm more deeply with our build than just
the CPU fuser, which I'm not super excited about doing just yet).

Differential Revision: [D27731038](https://our.internmc.facebook.com/intern/diff/D27731038/)