### PR TITLE
[FX] Adds PyTree support to FX through `concrete_args`

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2328,6 +2328,9 @@ class TestFX(JitTestCase):
         def f_custom_dict(x):
             return f_sum_dict(x.a) + x.b
 
+        def f_return_custom(x):
+            return Foo(x.b, x.a)
+
         tests = [
             (f_sum, [PH, PH, PH]),
             (f_sum, []),
@@ -2339,6 +2342,7 @@ class TestFX(JitTestCase):
             (f_custom, Foo(PH, PH)),
             (f_custom, Foo(PH, 3)),
             (f_custom_dict, Foo({'a': PH, 'b': PH}, PH)),
+            # (f_return_custom, Foo(PH, PH)), # Don't currently support output pytrees
         ]
         val = {'a': PH, 'z': []}
         # spec = pytree.tree_flatten(val)[1]

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1911,8 +1911,19 @@ class TestFX(JitTestCase):
         mod = Foo()
         mod_true = symbolic_trace(mod, concrete_args={'y': True})
         mod_false = symbolic_trace(mod, concrete_args={'y': False})
+        print(mod_true.code)
         self.assertEqual(mod_true(3, True), 6)
+        with self.assertRaises(AssertionError):
+            mod_true(3, False)
         self.assertEqual(mod_false(3, False), 3)
+        with self.assertRaises(AssertionError):
+            mod_false(3, True)
+
+        def f_higher(a, f):
+            return f(a)
+
+        nf = symbolic_trace(f_higher, concrete_args={'f': lambda x: x * 2})
+        self.assertEqual(nf(3, lambda x: x * 2), 6)
 
     def test_custom_traceback_raised_when_exception_source_is_graphmodule(self):
         class M(torch.nn.Module):

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2335,7 +2335,7 @@ class TestFX(JitTestCase):
             lambda x: ([x.a, x.b], None),
             lambda x, _: Foo(x[0], x[1]),
         )
-        fx_pytree._register_pytree_flatten_spec(Foo, lambda x, _: [x.a, x.b])
+        fx_pytree.register_pytree_flatten_spec(Foo, lambda x, _: [x.a, x.b])
 
         def f_custom(x):
             return x.a + x.b

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1912,8 +1912,8 @@ class TestFX(JitTestCase):
         mod_true = symbolic_trace(mod, concrete_args={'y': True})
         mod_false = symbolic_trace(mod, concrete_args={'y': False})
         self.assertEqual(mod_true(3, True), 6)
-        assert(any([i.target == torch._assert for i in mod_true.graph.nodes]))
         print(mod_true.code)
+        assert(any([i.target == torch._assert for i in mod_true.graph.nodes]))
         with self.assertRaises(AssertionError):
             mod_true(3, False)
         self.assertEqual(mod_false(3, False), 3)
@@ -2362,7 +2362,7 @@ class TestFX(JitTestCase):
         ]
 
         def verify_pytree(f, inp):
-            val = pytree.tree_map(inp, lambda x: torch.randn(3) if x == PH else x)
+            val = pytree.tree_map(lambda x: torch.randn(3) if x == PH else x, inp)
             num_flat_args = len([i == PH for i in pytree.tree_flatten(inp)[0]])
             orig_out = f(val)
             nf = symbolic_trace(f, concrete_args={'x': inp})
@@ -2396,7 +2396,7 @@ class TestFX(JitTestCase):
 
         inp = {'a': {'a': PH, 'z': PH}, 'b': True}
         nf = symbolic_trace(f, concrete_args=inp)
-        val = pytree.tree_map(inp, lambda x: torch.randn(3) if x == PH else x)
+        val = pytree.tree_map(lambda x: torch.randn(3) if x == PH else x, inp)
         self.assertEqual(nf(**val), f(**val))
 
         nf = symbolic_trace(nf)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2345,9 +2345,6 @@ class TestFX(JitTestCase):
             (f_custom_dict, Foo({'a': PH, 'b': PH}, PH)),
             # (f_return_custom, Foo(PH, PH)), # Don't currently support output pytrees
         ]
-        val = {'a': PH, 'z': []}
-        # spec = pytree.tree_flatten(val)[1]
-        # print(pytree.tree_flatten_spec(val, spec))
 
         def verify_pytree(f, inp):
             val = pytree.tree_map(inp, lambda x: torch.randn(3) if x == PH else x)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1911,8 +1911,9 @@ class TestFX(JitTestCase):
         mod = Foo()
         mod_true = symbolic_trace(mod, concrete_args={'y': True})
         mod_false = symbolic_trace(mod, concrete_args={'y': False})
-        print(mod_true.code)
         self.assertEqual(mod_true(3, True), 6)
+        assert(any([i.target == torch._assert for i in mod_true.graph.nodes]))
+        print(mod_true.code)
         with self.assertRaises(AssertionError):
             mod_true(3, False)
         self.assertEqual(mod_false(3, False), 3)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -20,6 +20,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_device_type import ops, onlyCPU, instantiate_device_type_tests
 import torch.utils._pytree as pytree
+import torch.fx._pytree as fx_pytree
 from torch.fx import symbolic_trace, Proxy, Node, GraphModule, Interpreter, Tracer, Transformer, Graph, wrap, PH
 import torch._C._fx
 from torch.fx.node import Target, Argument
@@ -2319,8 +2320,8 @@ class TestFX(JitTestCase):
             Foo,
             lambda x: ([x.a, x.b], None),
             lambda x, _: Foo(x[0], x[1]),
-            lambda x, _: [x.a, x.b],
         )
+        fx_pytree._register_pytree_flatten_spec(Foo, lambda x, _: [x.a, x.b])
 
         def f_custom(x):
             return x.a + x.b

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2337,7 +2337,7 @@ class TestFX(JitTestCase):
             (f_dict_add, {'a': PH, 'z': (PH, PH, PH)}),
             (f_dict_add, {'a': PH, 'z': []}),
             (f_custom, Foo(PH, PH)),
-            # (f_custom, Foo(PH, 3)), # currently fails - very annoying...
+            (f_custom, Foo(PH, 3)),
             (f_custom_dict, Foo({'a': PH, 'b': PH}, PH)),
         ]
         val = {'a': PH, 'z': []}
@@ -2346,7 +2346,7 @@ class TestFX(JitTestCase):
 
         def verify_pytree(f, inp):
             val = pytree.tree_map(inp, lambda x: torch.randn(3) if x == PH else x)
-            num_flat_args = len(pytree.tree_flatten(val)[0])
+            num_flat_args = len([i == PH for i in pytree.tree_flatten(inp)[0]])
             orig_out = f(val)
             nf = symbolic_trace(f, concrete_args={'x': inp})
             self.assertEqual(nf(val), orig_out)

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2310,7 +2310,7 @@ class TestFX(JitTestCase):
         def f_dict_add(x):
             return x['a'] + sum(x['z'])
 
-        class Foo(object):
+        class Foo(object):  # noqa: B209
             def __init__(self, a, b):
                 self.a = a
                 self.b = b

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -28,7 +28,7 @@ class TestPytree(TestCase):
 
     def test_flatten_unflatten_list(self):
         def run_test(lst):
-            expected_spec = TreeSpec(list, len(lst), [LeafSpec() for _ in lst])
+            expected_spec = TreeSpec(list, None, [LeafSpec() for _ in lst])
             values, treespec = tree_flatten(lst)
             self.assertTrue(isinstance(values, list))
             self.assertEqual(values, lst)
@@ -44,7 +44,7 @@ class TestPytree(TestCase):
 
     def test_flatten_unflatten_tuple(self):
         def run_test(tup):
-            expected_spec = TreeSpec(tuple, len(tup), [LeafSpec() for _ in tup])
+            expected_spec = TreeSpec(tuple, None, [LeafSpec() for _ in tup])
             values, treespec = tree_flatten(tup)
             self.assertTrue(isinstance(values, list))
             self.assertEqual(values, list(tup))
@@ -104,7 +104,7 @@ class TestPytree(TestCase):
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
         self.assertEqual(
-            repr(spec), 'TreeSpec(tuple, 2, [*, TreeSpec(list, 3, [*, *, *])])')
+            repr(spec), 'TreeSpec(tuple, None, [*, TreeSpec(list, None, [*, *, *])])')
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -28,7 +28,7 @@ class TestPytree(TestCase):
 
     def test_flatten_unflatten_list(self):
         def run_test(lst):
-            expected_spec = TreeSpec(list, None, [LeafSpec() for _ in lst])
+            expected_spec = TreeSpec(list, len(lst), [LeafSpec() for _ in lst])
             values, treespec = tree_flatten(lst)
             self.assertTrue(isinstance(values, list))
             self.assertEqual(values, lst)
@@ -44,7 +44,7 @@ class TestPytree(TestCase):
 
     def test_flatten_unflatten_tuple(self):
         def run_test(tup):
-            expected_spec = TreeSpec(tuple, None, [LeafSpec() for _ in tup])
+            expected_spec = TreeSpec(tuple, len(tup), [LeafSpec() for _ in tup])
             values, treespec = tree_flatten(tup)
             self.assertTrue(isinstance(values, list))
             self.assertEqual(values, list(tup))
@@ -104,7 +104,7 @@ class TestPytree(TestCase):
         pytree = (0, [0, 0, 0])
         _, spec = tree_flatten(pytree)
         self.assertEqual(
-            repr(spec), 'TreeSpec(tuple, None, [*, TreeSpec(list, None, [*, *, *])])')
+            repr(spec), 'TreeSpec(tuple, 2, [*, TreeSpec(list, 3, [*, *, *])])')
 
     def test_broadcast_to_and_flatten(self):
         cases = [

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1,6 +1,6 @@
 import torch
 from torch.testing._internal.common_utils import TestCase, run_tests
-from torch.utils._pytree import tree_flatten, tree_unflatten, TreeSpec, LeafSpec
+from torch.utils._pytree import tree_flatten, tree_map, tree_unflatten, TreeSpec, LeafSpec
 from torch.utils._pytree import _broadcast_to_and_flatten
 
 class TestPytree(TestCase):
@@ -96,8 +96,31 @@ class TestPytree(TestCase):
             {'a': 0, 'b': [{'c': 1}]},
             {'a': 0, 'b': [1, {'c': 2}, torch.randn(3)], 'c': (torch.randn(2, 3), 1)},
         ]
-        for case in cases:
-            run_test(case)
+
+
+    def test_treemap(self):
+        def run_test(pytree):
+            def f(x):
+                return x * 3
+            sm1 = sum(map(tree_flatten(pytree)[0], f))
+            sm2 = tree_flatten(tree_map(pytree, f))[0]
+            self.assertEqual(sm1, sm2)
+
+            def invf(x):
+                return x // 3
+
+            self.assertEqual(tree_flatten(tree_flatten(pytree, f), invf), pytree)
+
+            cases = [
+                [()],
+                ([],),
+                {'a': ()},
+                {'a': 1, 'b': [{'c': 2}]},
+                {'a': 0, 'b': [2, {'c': 3}, 4], 'c': (5, 6)},
+            ]
+            for case in cases:
+                run_test(case)
+
 
     def test_treespec_repr(self):
         # Check that it looks sane

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -103,7 +103,7 @@ class TestPytree(TestCase):
             def f(x):
                 return x * 3
             sm1 = sum(map(tree_flatten(pytree)[0], f))
-            sm2 = tree_flatten(tree_map(pytree, f))[0]
+            sm2 = tree_flatten(tree_map(f, pytree))[0]
             self.assertEqual(sm1, sm2)
 
             def invf(x):

--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -82,7 +82,7 @@ repository.
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace, Tracer, wrap, HOLE
+from .symbolic_trace import symbolic_trace, Tracer, wrap, PH
 from .graph import Graph
 from .node import Node, map_arg
 from .proxy import Proxy

--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -82,7 +82,7 @@ repository.
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace, Tracer, wrap
+from .symbolic_trace import symbolic_trace, Tracer, wrap, HOLE
 from .graph import Graph
 from .node import Node, map_arg
 from .proxy import Proxy

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -4,7 +4,7 @@ from torch.utils._pytree import PyTree, TreeSpec, LeafSpec
 FlattenFuncSpec = Callable[[PyTree, TreeSpec], List]
 
 SUPPORTED_NODES: Dict[Type[Any], Any] = {}
-def _register_pytree_flatten_spec(typ: Any, flatten_fn_spec: FlattenFuncSpec) -> None:
+def register_pytree_flatten_spec(typ: Any, flatten_fn_spec: FlattenFuncSpec) -> None:
     SUPPORTED_NODES[typ] = flatten_fn_spec
 
 def tree_flatten_spec(pytree: PyTree, spec: TreeSpec) -> List[Any]:
@@ -13,7 +13,7 @@ def tree_flatten_spec(pytree: PyTree, spec: TreeSpec) -> List[Any]:
     if spec.type not in SUPPORTED_NODES:
         raise RuntimeError(
             f"{type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with"
-            "torch.fx._pytree._register_pytree_flatten_spec.  If you have serialized your model, make"
+            "torch.fx._pytree.register_pytree_flatten_spec.  If you have serialized your model, make"
             "sure that any custom pytrees have been registered before loading it.")
     flatten_fn_spec = SUPPORTED_NODES[spec.type]
     child_pytrees = flatten_fn_spec(pytree, spec)
@@ -32,6 +32,6 @@ def _list_flatten_spec(d: List[Any], spec: TreeSpec) -> List[Any]:
 def _tuple_flatten_spec(d: Tuple[Any], spec: TreeSpec) -> List[Any]:
     return [d[i] for i in range(len(spec.children_specs))]
 
-_register_pytree_flatten_spec(dict, _dict_flatten_spec)
-_register_pytree_flatten_spec(list, _list_flatten_spec)
-_register_pytree_flatten_spec(tuple, _tuple_flatten_spec)
+register_pytree_flatten_spec(dict, _dict_flatten_spec)
+register_pytree_flatten_spec(list, _list_flatten_spec)
+register_pytree_flatten_spec(tuple, _tuple_flatten_spec)

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -10,10 +10,14 @@ def _register_pytree_flatten_spec(typ: Any, flatten_fn_spec: FlattenFuncSpec) ->
 def tree_flatten_spec(pytree: PyTree, spec: TreeSpec) -> List[Any]:
     if isinstance(spec, LeafSpec):
         return [pytree]
-    flatten_fn_spec = SUPPORTED_NODES[spec.type]
-    if flatten_fn_spec is None:
+    if spec.type not in SUPPORTED_NODES:
         raise RuntimeError(
-            f"{type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with torch.fx._pytree._register_pytree_flatten_spec")
+            f"""
+            {type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with
+            torch.fx._pytree._register_pytree_flatten_spec.  If you have serialized your model, make
+            sure that any custom pytrees have been registered before loading it.
+            """)
+    flatten_fn_spec = SUPPORTED_NODES[spec.type]
     child_pytrees = flatten_fn_spec(pytree, spec)
     result = []
     for child, child_spec in zip(child_pytrees, spec.children_specs):

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -12,7 +12,8 @@ def tree_flatten_spec(pytree: PyTree, spec: TreeSpec) -> List[Any]:
         return [pytree]
     flatten_fn_spec = SUPPORTED_NODES[spec.type]
     if flatten_fn_spec is None:
-        raise RuntimeError(f"Cannot flatten pytree {type(pytree)} from spec")
+        raise RuntimeError(
+            f"{type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with torch.fx._pytree._register_pytree_flatten_spec")
     child_pytrees = flatten_fn_spec(pytree, spec)
     result = []
     for child, child_spec in zip(child_pytrees, spec.children_specs):

--- a/torch/fx/_pytree.py
+++ b/torch/fx/_pytree.py
@@ -12,11 +12,9 @@ def tree_flatten_spec(pytree: PyTree, spec: TreeSpec) -> List[Any]:
         return [pytree]
     if spec.type not in SUPPORTED_NODES:
         raise RuntimeError(
-            f"""
-            {type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with
-            torch.fx._pytree._register_pytree_flatten_spec.  If you have serialized your model, make
-            sure that any custom pytrees have been registered before loading it.
-            """)
+            f"{type(pytree)} does not have a flatten_fn_spec associated with it. Please register one with"
+            "torch.fx._pytree._register_pytree_flatten_spec.  If you have serialized your model, make"
+            "sure that any custom pytrees have been registered before loading it.")
     flatten_fn_spec = SUPPORTED_NODES[spec.type]
     child_pytrees = flatten_fn_spec(pytree, spec)
     result = []

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -939,7 +939,7 @@ class Graph:
 
         # If the original function didn't have self as its first argument, we
         # would have added it.
-        if orig_vars[0] != 'self':
+        if len(orig_vars) == 0 or orig_vars[0] != 'self':
             orig_vars.insert(0, 'self')
         code = ''.join(body)
         code = '\n'.join('    ' + line for line in code.split('\n'))

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1,5 +1,6 @@
 from .node import Node, Argument, Target, map_arg, _type_repr, _get_qualified_name
 from torch.utils._pytree import TreeSpec
+import torch.fx._pytree as fx_pytree
 
 from typing import TYPE_CHECKING, Callable, Any, List, Dict, NamedTuple, Optional, Tuple, Set, FrozenSet
 from dataclasses import dataclass
@@ -50,7 +51,7 @@ _register_custom_builtin('nan', 'from math import nan', math.nan)
 _register_custom_builtin('NoneType', 'NoneType = type(None)', type(None))
 _register_custom_builtin('torch', 'import torch', torch)
 _register_custom_builtin('device', 'from torch import device', torch.device)
-_register_custom_builtin('pytree', 'import torch.utils._pytree as pytree', torch.utils._pytree)
+_register_custom_builtin('fx_pytree', 'import torch.fx._pytree as fx_pytree', fx_pytree)
 
 
 def _is_magic(x: str) -> bool:
@@ -933,7 +934,7 @@ class Graph:
             if has_orig_self:
                 free_vars.insert(0, 'self')
             if len(free_vars) > 0:  # pytree has no placeholders in it
-                body.insert(0, f"{', '.join(free_vars)}, = pytree.tree_flatten_spec([{', '.join(orig_vars)}], self._in_spec)\n")
+                body.insert(0, f"{', '.join(free_vars)}, = fx_pytree.tree_flatten_spec([{', '.join(orig_vars)}], self._in_spec)\n")
         else:
             orig_vars = free_vars
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -52,6 +52,7 @@ _register_custom_builtin('NoneType', 'NoneType = type(None)', type(None))
 _register_custom_builtin('torch', 'import torch', torch)
 _register_custom_builtin('device', 'from torch import device', torch.device)
 _register_custom_builtin('fx_pytree', 'import torch.fx._pytree as fx_pytree', fx_pytree)
+_register_custom_builtin('pytree', 'import torch.utils._pytree as pytree', pytree)
 
 
 def _is_magic(x: str) -> bool:
@@ -931,7 +932,10 @@ class Graph:
             elif node.op == 'output':
                 if node.type is not None:
                     maybe_return_annotation[0] = f" -> {type_repr(node.type)}"
-                body.append(f'return {repr(node.args[0])}')
+                if self._pytree_info is None:
+                    body.append(f'return {repr(node.args[0])}')
+                else:
+                    body.append(f'return pytree.tree_unflatten({repr(node.args[0])}, self._out_spec)')
                 return
             raise NotImplementedError(f'node: {node.op} {node.target}')
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -938,7 +938,7 @@ class Graph:
             has_orig_self = (orig_args[0] == 'self')
             if has_orig_self:
                 free_vars.insert(0, 'self')
-            if len(free_vars) > 0:  # pytree has no placeholders in it
+            if len(free_vars) > 0:  # pytree has placeholders in it
                 body.insert(0, f"{', '.join(free_vars)}, = fx_pytree.tree_flatten_spec([{', '.join(orig_args)}], self._in_spec)\n")
         else:
             orig_args = free_vars

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -409,10 +409,11 @@ class Graph:
         return flat_args
 
     def unflatten_outs(self, out):
-        if self._pytree_info.out_spec is None:
+        if self._pytree_info is None:
             return out
         if not isinstance(out, list):
             out = [out]
+        assert(self._pytree_info.out_spec is not None)
         return pytree.tree_unflatten(out, self._pytree_info.out_spec)
 
     def erase_node(self, to_erase : Node) -> None:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -283,7 +283,7 @@ class Graph:
         self._owners = 0
         self._owning_module = owning_module
         self._in_spec: Optional[TreeSpec] = None
-        self._orig_args: Optional[List[Any]] = None
+        self._orig_args: Optional[List[str]] = None
 
     @property
     def owning_module(self):
@@ -927,6 +927,7 @@ class Graph:
             # single pass statement
             body.append('pass\n')
         if self._in_spec is not None:
+            assert(self._orig_args is not None)
             orig_vars = self._orig_args
             body.insert(0, f"{', '.join(free_vars)} = pytree.tree_flatten_spec([{', '.join(orig_vars)}], self._in_spec)\n")
         else:

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1,6 +1,6 @@
 from .node import Node, Argument, Target, map_arg, _type_repr, _get_qualified_name
 from torch.utils._pytree import TreeSpec
-import torch.fx._pytree as fx_pytree
+from . import _pytree as fx_pytree
 
 from typing import TYPE_CHECKING, Callable, Any, List, Dict, NamedTuple, Optional, Tuple, Set, FrozenSet
 from dataclasses import dataclass

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -411,6 +411,8 @@ class Graph:
     def unflatten_outs(self, out):
         if self._pytree_info.out_spec is None:
             return out
+        if not isinstance(out, list):
+            out = [out]
         return pytree.tree_unflatten(out, self._pytree_info.out_spec)
 
     def erase_node(self, to_erase : Node) -> None:

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -464,8 +464,6 @@ class {module_name}(torch.nn.Module):
         """
         if self._graph._pytree_info is not None:
             self._in_spec = self._graph._pytree_info.in_spec
-        self.flatten_inps = self._graph.flatten_inps
-        self.unflatten_outs = self._graph.unflatten_outs
         python_code = self._graph.python_code(root_module='self')
         self._code = python_code.src
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -464,6 +464,7 @@ class {module_name}(torch.nn.Module):
         """
         if self._graph._pytree_info is not None:
             self._in_spec = self._graph._pytree_info.in_spec
+            self._out_spec = self._graph._pytree_info.out_spec
         python_code = self._graph.python_code(root_module='self')
         self._code = python_code.src
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -464,6 +464,8 @@ class {module_name}(torch.nn.Module):
         """
         if self._graph._pytree_info is not None:
             self._in_spec = self._graph._pytree_info.in_spec
+        self.flatten_inps = self._graph.flatten_inps
+        self.unflatten_outs = self._graph.unflatten_outs
         python_code = self._graph.python_code(root_module='self')
         self._code = python_code.src
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.overrides
-import torch.utils._pytree as pytree
 from torch.nn.modules.module import _addindent
 from torch.package import PackageImporter, PackageExporter
 import linecache
@@ -457,17 +456,13 @@ class {module_name}(torch.nn.Module):
             raise RuntimeError('Code has not been generated! Please report a bug to PyTorch')
         return self._code
 
-    def flatten_args(self, *args):
-        flat_args, spec = pytree.tree_flatten(args)
-        assert(spec == self.graph.in_spec)
-        return flat_args
-
     def recompile(self) -> PythonCode:
         """
         Recompile this GraphModule from its ``graph`` attribute. This should be
         called after editing the contained ``graph``, otherwise the generated
         code of this ``GraphModule`` will be out of date.
         """
+        self._in_spec = self._graph._in_spec
         python_code = self._graph.python_code(root_module='self')
         self._code = python_code.src
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -462,7 +462,8 @@ class {module_name}(torch.nn.Module):
         called after editing the contained ``graph``, otherwise the generated
         code of this ``GraphModule`` will be out of date.
         """
-        self._in_spec = self._graph._in_spec
+        if self._graph._pytree_info is not None:
+            self._in_spec = self._graph._pytree_info.in_spec
         python_code = self._graph.python_code(root_module='self')
         self._code = python_code.src
 

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.overrides
+import torch.utils._pytree as pytree
 from torch.nn.modules.module import _addindent
 from torch.package import PackageImporter, PackageExporter
 import linecache
@@ -456,6 +457,11 @@ class {module_name}(torch.nn.Module):
             raise RuntimeError('Code has not been generated! Please report a bug to PyTorch')
         return self._code
 
+    def flatten_args(self, *args):
+        flat_args, spec = pytree.tree_flatten(args)
+        assert(spec == self.graph.in_spec)
+        return flat_args
+
     def recompile(self) -> PythonCode:
         """
         Recompile this GraphModule from its ``graph`` attribute. This should be
@@ -485,7 +491,7 @@ class {module_name}(torch.nn.Module):
             err_line_len = len(frame_summary.line)
             all_src_lines = _eval_cache[frame_summary.filename]
 
-            # constiuent substrings of the error message
+            # constituent substrings of the error message
             tb_repr = traceback.format_exc()
             custom_msg = ("Call using an FX-traced Module, "
                           f"line {err_lineno} of the traced Module's "

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -377,7 +377,6 @@ class Tracer(TracerBase):
             # `concrete_args`, generate a flattening wrapper around the
             # original root function and return that.
             self.graph._pytree_info = _PyTreeInfo(orig_args[:total_args], in_spec)
-            self.graph._orig_args = orig_args[:total_args]
 
             def flatten_fn(*args):
                 tree_args = pytree.tree_unflatten(list(args), in_spec)

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -339,12 +339,7 @@ class Tracer(TracerBase):
                 default = ()
             else:
                 param = sig.parameters[name]
-<<<<<<< HEAD
                 default = () if param.default is inspect.Parameter.empty else (param.default,)  # type: ignore[assignment]
-=======
-                default = () if param.default is inspect.Parameter.empty else (param.default,)  # type: ignore
-
->>>>>>> 7e4c95a920 (fix issues)
             return self.create_proxy('placeholder', name, default, {},
                                      type_expr=fn_for_analysis.__annotations__.get(name, None))
 

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -354,7 +354,7 @@ class Tracer(TracerBase):
 
         flat_args, in_spec = pytree.tree_flatten(tuple(args))
         self.graph._in_spec = in_spec
-        self.graph._orig_args = orig_args[skip_arg_idx:total_args]
+        self.graph._orig_args = orig_args[:total_args]
         for idx, arg in enumerate(flat_args):
             if arg is PH:
                 flat_args[idx] = self.create_proxy('placeholder', f'tree_{str(idx)}', (), {})

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -339,8 +339,8 @@ class Tracer(TracerBase):
                     out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', (), {})
                     if x == PH:
                         return out
-
-                    if type(x) in base_types and type(x) != torch.Tensor:
+                    # Union[int, bool] == bool in Python <= 3.6
+                    if type(x) == bool or type(x) in base_types and type(x) != torch.Tensor:
                         torch._assert(out == x, f"{name} has been specialized to have value {x}")
                     else:
                         torch.warnings.warn(
@@ -387,7 +387,7 @@ class Tracer(TracerBase):
                 out_args, out_spec = pytree.tree_flatten(tree_out)
                 assert(self.graph._pytree_info is not None)
                 self.graph._pytree_info = self.graph._pytree_info._replace(out_spec=out_spec)
-                return tree_out
+                return out_args
 
             return flatten_fn, flat_args
         return root_fn, args

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -372,7 +372,7 @@ class Tracer(TracerBase):
             root_fn = _patch_function(root_fn, len(args))
 
         flat_args, in_spec = pytree.tree_flatten(tuple(args))
-        if not all(isinstance(i, pytree.LeafSpec) for i in in_spec.children_specs):
+        if any(not isinstance(i, pytree.LeafSpec) for i in in_spec.children_specs):
             # In the case that we have pytree-flattened inputs in
             # `concrete_args`, generate a flattening wrapper around the
             # original root function and return that.

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -360,7 +360,7 @@ class Tracer(TracerBase):
                 flat_args[idx] = self.create_proxy('placeholder', f'tree_{str(idx)}', (), {})
 
         def flatten_fn(*args):
-            tree_args = pytree.tree_unflatten(args, in_spec)
+            tree_args = pytree.tree_unflatten(list(args), in_spec)
             return root_fn(*tree_args)
 
         return flatten_fn, flat_args

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -93,7 +93,7 @@ class _CPatchManager(object):
     def __exit__(self, type, value, tb):
         sys.setprofile(None)
 
-HOLE = object()
+PH = object()
 
 class Tracer(TracerBase):
     # Reference: https://github.com/pytorch/pytorch/issues/54354
@@ -356,7 +356,7 @@ class Tracer(TracerBase):
         self.graph._in_spec = in_spec
         self.graph._orig_args = orig_args[skip_arg_idx:total_args]
         for idx, arg in enumerate(flat_args):
-            if arg is HOLE:
+            if arg is PH:
                 flat_args[idx] = self.create_proxy('placeholder', f'tree_{str(idx)}', (), {})
 
         def flatten_fn(*args):

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -7,14 +7,9 @@ from types import CodeType, FunctionType, ModuleType
 from typing import Any, Dict, NamedTuple, Optional, Set, Tuple, List, Callable, Union
 from itertools import chain
 import torch
-<<<<<<< HEAD
 import torch._C._fx  # type: ignore[import]
 from torch._C import ScriptObject  # type: ignore[attr-defined]
-=======
-import torch._C._fx  # type: ignore
-from torch._C import ScriptObject  # type: ignore
 import torch.utils._pytree as pytree
->>>>>>> 155b3eddb2 (test)
 
 import sys
 from .node import Argument, map_aggregate
@@ -334,7 +329,12 @@ class Tracer(TracerBase):
                 default = ()
             else:
                 param = sig.parameters[name]
+<<<<<<< HEAD
                 default = () if param.default is inspect.Parameter.empty else (param.default,)  # type: ignore[assignment]
+=======
+                default = () if param.default is inspect.Parameter.empty else (param.default,)  # type: ignore
+
+>>>>>>> 7e4c95a920 (fix issues)
             return self.create_proxy('placeholder', name, default, {},
                                      type_expr=fn_for_analysis.__annotations__.get(name, None))
 
@@ -355,8 +355,8 @@ class Tracer(TracerBase):
         flat_args, in_spec = pytree.tree_flatten(tuple(args))
         self.graph._in_spec = in_spec
         self.graph._orig_args = orig_args[:total_args]
-        for idx, arg in enumerate(flat_args):
-            if arg is PH:
+        for idx, arg in enumerate(flat_args[skip_arg_idx:], skip_arg_idx):
+            if not isinstance(arg, Proxy):
                 flat_args[idx] = self.create_proxy('placeholder', f'tree_{str(idx)}', (), {})
 
         def flatten_fn(*args):

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -351,7 +351,7 @@ class Tracer(TracerBase):
 
                     return x
 
-                return pytree.tree_map(concrete_args[name], replace_ph)
+                return pytree.tree_map(replace_ph, concrete_args[name])
             if name[0] == '*':
                 default = ()
             else:

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -714,14 +714,19 @@ def symbolic_trace(root : Union[torch.nn.Module, Callable], concrete_args: Optio
             else:
                 return a*2
 
-    FX can typically not trace through this due to the presence of control flow. However, we can use `concrete_args` to specialize on the value of `b` to trace through this.
+    FX can typically not trace through this due to the presence of control
+    flow. However, we can use `concrete_args` to specialize on the value of
+    `b` to trace through this.
 
         f = fx.symbolic_trace(f, concrete_args={'b': False})
         assert f(3, False)  == 6
 
     Note that although you can still pass in different values of `b`, they will be ignored.
 
-    We can also use `concrete_args` to eliminate data-structure handling from our function. This will use pytrees to flatten your input. To avoid overspecializing, pass in `fx.PH` for values that shouldn't be specialized. For example::
+    We can also use `concrete_args` to eliminate data-structure handling from
+    our function. This will use pytrees to flatten your input. To avoid
+    overspecializing, pass in `fx.PH` for values that shouldn't be
+    specialized. For example::
 
         def f(x):
             out = 0

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -385,6 +385,7 @@ class Tracer(TracerBase):
                 tree_args = pytree.tree_unflatten(list(args), in_spec)
                 tree_out = root_fn(*tree_args)
                 out_args, out_spec = pytree.tree_flatten(tree_out)
+                assert(self.graph._pytree_info is not None)
                 self.graph._pytree_info = self.graph._pytree_info._replace(out_spec=out_spec)
                 return tree_out
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -69,26 +69,26 @@ def _register_pytree_node(typ: Any, flatten_fn: FlattenFunc, unflatten_fn: Unfla
 def _dict_flatten(d: Dict[Any, Any]) -> Tuple[List[Any], Context]:
     return list(d.values()), list(d.keys())
 
-def _dict_flatten_spec(d: Dict[Any, Any], spec: TreeSpec) -> Tuple[List[Any], Context]:
-    return list([d[k] for k in spec.context])
+def _dict_flatten_spec(d: Dict[Any, Any], context: Context) -> Tuple[List[Any], Context]:
+    return list([d[k] for k in context])
 
 def _dict_unflatten(values: List[Any], context: Context) -> Dict[Any, Any]:
     return {key: value for key, value in zip(context, values)}
 
 def _list_flatten(d: List[Any]) -> Tuple[List[Any], Context]:
-    return d, None
+    return d, len(d)
 
-def _list_flatten_spec(d: List[Any], spec: TreeSpec) -> List[Any]:
-    return [d[i] for i in range(len(spec.children_specs))]
+def _list_flatten_spec(d: List[Any], context: Context) -> List[Any]:
+    return [d[i] for i in range(context)]
 
 def _list_unflatten(values: List[Any], context: Context) -> List[Any]:
     return list(values)
 
 def _tuple_flatten(d: Tuple[Any, ...]) -> Tuple[List[Any], Context]:
-    return list(d), None
+    return list(d), len(d)
 
-def _tuple_flatten_spec(d: Tuple[Any], spec: TreeSpec) -> List[Any]:
-    return [d[i] for i in range(len(spec.children_specs))]
+def _tuple_flatten_spec(d: Tuple[Any], context: Context) -> List[Any]:
+    return [d[i] for i in range(context)]
 
 def _tuple_unflatten(values: List[Any], context: Context) -> Tuple[Any, ...]:
     return tuple(values)
@@ -118,7 +118,7 @@ def tree_flatten_spec(pytree: PyTree, spec: TreeSpec):
     if isinstance(spec, LeafSpec):
         return [pytree]
     flatten_fn_spec = SUPPORTED_NODES[spec.type].flatten_fn_spec
-    child_pytrees = flatten_fn_spec(pytree, spec)
+    child_pytrees = flatten_fn_spec(pytree, spec.context)
     result = []
     for child, child_spec in zip(child_pytrees, spec.children_specs):
         flat = tree_flatten_spec(child, child_spec)

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -115,7 +115,7 @@ class LeafSpec(TreeSpec):
 
 
 def tree_flatten_spec(pytree: PyTree, spec: TreeSpec):
-    if spec.num_leaves == 1:
+    if isinstance(spec, LeafSpec):
         return [pytree]
     flatten_fn_spec = SUPPORTED_NODES[spec.type].flatten_fn_spec
     child_pytrees = flatten_fn_spec(pytree, spec)
@@ -175,6 +175,9 @@ def tree_unflatten(values: List[Any], spec: TreeSpec) -> PyTree:
 
     return unflatten_fn(child_pytrees, spec.context)
 
+def tree_map(pytree: PyTree, fn):
+    flat_args, spec = tree_flatten(pytree)
+    return tree_unflatten([fn(i) for i in flat_args], spec)
 
 # Broadcasts a pytree to the provided TreeSpec and returns the flattened
 # values. If this is not possible, then this function returns None.

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -148,7 +148,7 @@ def tree_unflatten(values: List[Any], spec: TreeSpec) -> PyTree:
 
     return unflatten_fn(child_pytrees, spec.context)
 
-def tree_map(pytree: PyTree, fn):
+def tree_map(pytree: PyTree, fn: Any) -> PyTree:
     flat_args, spec = tree_flatten(pytree)
     return tree_unflatten([fn(i) for i in flat_args], spec)
 

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -29,32 +29,6 @@ PyTree = Any
 FlattenFunc = Callable[[PyTree], Tuple[List, Context]]
 UnflattenFunc = Callable[[List, Context], PyTree]
 
-# A TreeSpec represents the structure of a pytree. It holds:
-# "type": the type of root Node of the pytree
-# context: some context that is useful in unflattening the pytree
-# children_specs: specs for each child of the root Node
-# num_leaves: the number of leaves
-class TreeSpec:
-    def __init__(self, typ: Any, context: Context, children_specs: List['TreeSpec']) -> None:
-        self.type = typ
-        self.context = context
-        self.children_specs = children_specs
-        self.num_leaves: int = sum([spec.num_leaves for spec in children_specs])
-
-    def __repr__(self) -> str:
-        return f'TreeSpec({self.type.__name__}, {self.context}, {self.children_specs})'
-
-    def __eq__(self, other: Any) -> bool:
-        result = self.type == other.type and self.context == other.context \
-            and self.children_specs == other.children_specs \
-            and self.num_leaves == other.num_leaves
-        # This should really not be necessary, but mypy errors out without it.
-        return cast(bool, result)
-
-    def __ne__(self, other: Any) -> bool:
-        return not self.__eq__(other)
-
-
 class NodeDef(NamedTuple):
     flatten_fn: FlattenFunc
     unflatten_fn: UnflattenFunc
@@ -90,6 +64,31 @@ _register_pytree_node(tuple, _tuple_flatten, _tuple_unflatten)
 # A leaf is defined as anything that is not a Node.
 def _is_leaf(pytree: PyTree) -> bool:
     return type(pytree) not in SUPPORTED_NODES.keys()
+
+# A TreeSpec represents the structure of a pytree. It holds:
+# "type": the type of root Node of the pytree
+# context: some context that is useful in unflattening the pytree
+# children_specs: specs for each child of the root Node
+# num_leaves: the number of leaves
+class TreeSpec:
+    def __init__(self, typ: Any, context: Context, children_specs: List['TreeSpec']) -> None:
+        self.type = typ
+        self.context = context
+        self.children_specs = children_specs
+        self.num_leaves: int = sum([spec.num_leaves for spec in children_specs])
+
+    def __repr__(self) -> str:
+        return f'TreeSpec({self.type.__name__}, {self.context}, {self.children_specs})'
+
+    def __eq__(self, other: Any) -> bool:
+        result = self.type == other.type and self.context == other.context \
+            and self.children_specs == other.children_specs \
+            and self.num_leaves == other.num_leaves
+        # This should really not be necessary, but mypy errors out without it.
+        return cast(bool, result)
+
+    def __ne__(self, other: Any) -> bool:
+        return not self.__eq__(other)
 
 class LeafSpec(TreeSpec):
     def __init__(self) -> None:

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -148,7 +148,7 @@ def tree_unflatten(values: List[Any], spec: TreeSpec) -> PyTree:
 
     return unflatten_fn(child_pytrees, spec.context)
 
-def tree_map(pytree: PyTree, fn: Any) -> PyTree:
+def tree_map(fn: Any, pytree: PyTree) -> PyTree:
     flat_args, spec = tree_flatten(pytree)
     return tree_unflatten([fn(i) for i in flat_args], spec)
 


### PR DESCRIPTION
```
class Foo(nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, y, x):
        for k in x:
            for v in x[k]:
                v += y
        return x

example_dict = {'x': {'a': [fx.HOLE], 'z': [fx.HOLE, fx.HOLE]}}
new_f = fx.symbolic_trace(Foo(), concrete_args=example_dict)
print(new_f.code)
new_f(torch.randn(5), {'x': {'a': [torch.randn(5)], 'z': [torch.randn(5), torch.randn(5)]}})

fx.symbolic_trace(new_f, concrete_args=example_dict)
```

prints out
```
def forward(self, y, x):
    y, tree_2, tree_3, tree_4 = pytree.tree_flatten([y, x])[0]
    add = tree_2 + y
    add_1 = tree_3 + y
    add_2 = tree_4 + y;  y = None
    return {'a': [tree_2], 'z': [tree_3, tree_4]}
```

Currently, I store `in_spec` as an extra attribute on `fx.Graph`, and then include it when we do the codegen. I'm not sure if this is the right approach - it introduces a divergence between what's in `fx.Graph` and what's in the python code.

Perhaps the best API is something explicit like `fx.Graph.flatten_args`, but that does make calling things a bit ... more verbose.