### PR TITLE
Fix passing of jit_opt_level

### DIFF
--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -322,7 +322,7 @@ NvrtcFunction nvrtcCompile(
     if (val <= 4 && val >= 0) {
       jit_opt_level = static_cast<uint32_t>(val);
       options.push_back(CU_JIT_OPTIMIZATION_LEVEL);
-      option_vals.emplace_back(&jit_opt_level);
+      option_vals.emplace_back((void*)jit_opt_level);
     } else {
       TORCH_WARN_ONCE(
           "acceptable range for PYTORCH_CUDA_FUSER_JIT_OPT_LEVEL is between 0 and 4, but received ",


### PR DESCRIPTION
The jit_opt_level must be passed as void* directly not by reference.
This avoids failures and miscompilations as the level will be kind of random instead of one of the valid values.

Fixes #52147
See the issue for more details