### PR TITLE
Deduplicate codegenOutputQuery to query maximum CUDA compute capabilities

### DIFF
--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -35,44 +35,46 @@ void codegenOutputQuery(
     int& major,
     int& minor,
     bool& compile_to_sass) {
-  int nvrtc_major = 0, nvrtc_minor = 0;
-  AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcVersion(&nvrtc_major, &nvrtc_minor));
+  using CudaVersion = std::pair<int, int>;
+  CudaVersion nvrtc_version;
+  AT_CUDA_NVRTC_CHECK(
+      nvrtc().nvrtcVersion(&nvrtc_version.first, &nvrtc_version.second));
 
-  // Short-circuits if NVRTC version too low
-  AT_ASSERT(nvrtc_major >= 6);
+  TORCH_CHECK(
+      nvrtc_version.first >= 6,
+      "NVRTC versions less than 6 are not supported. Is: ",
+      nvrtc_version.first);
 
-  // Major and minor is determined by device properties and
-  // possibly "downcompiled" to a lower (compatible) compute architecture
-  // based on the NVRTC version
-  major = prop->major;
-  minor = prop->minor;
-  if (nvrtc_major <= 7 && prop->major > 5) { // 7 supports 2-5.x
-    major = 5;
-    minor = 0;
-  } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
-    major = 6;
-    minor = 0;
-  } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
-    major = 7;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    minor = (prop->major == 7 && prop->minor <= 2) ? prop->minor : 0;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-  } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
-    major = 7;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    minor = (prop->major == 7 && prop->minor <= 5) ? prop->minor : 0;
-  } else if (
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      nvrtc_major == 11 && nvrtc_minor == 0 &&
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-      prop->major >= 8) { // 11.0 supports 3.5-8.0
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    major = 8;
-    minor = 0;
+  // Version supported by device
+  // Usually any lower version works too but is less efficient
+  const CudaVersion dev_version = CudaVersion(prop->major, prop->minor);
+  // Maximum version supported by the driver, cap dev_version to this
+  CudaVersion max_dev_version;
+  if (nvrtc_version.first <= 7) { // 7 supports 2-5.x
+    max_dev_version = CudaVersion(5, 0);
+  } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
+    max_dev_version = CudaVersion(6, 0);
+  } else if (nvrtc_version.first <= 9) { // 9 supports 3-7.2
+    max_dev_version = CudaVersion(7, 2);
+  } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
+    max_dev_version = CudaVersion(7, 5);
+  } else if (nvrtc_version == CudaVersion(11, 0)) { // 11.0 supports 3-8.0
+    max_dev_version = CudaVersion(8, 0);
+  } else {
+    // If the driver version is unknown (i.e. newer than this code)
+    // assume the driver supports this device
+    max_dev_version = dev_version;
   }
-
-  // if we are clamping major/minor, sass is not compatible
-  compile_to_sass = ((major == prop->major) && (minor == prop->minor));
+  if (dev_version > max_dev_version) {
+    major = max_dev_version.first;
+    minor = max_dev_version.second;
+    // if we are clamping major/minor, sass is not compatible
+    compile_to_sass = false;
+  } else {
+    major = dev_version.first;
+    minor = dev_version.second;
+    compile_to_sass = true;
+  }
 }
 
 // Compiles the specified kernel and stores the metadata required to run it


### PR DESCRIPTION
There were 2 versions of the same code which were slightly different although functionally equivalent.
When adding support for another CUDA / device version both would need to be changed and kept in sync. So it is better to have only 1 version of it as the unique source of truth.

I chose the implementation which looks cleaner and easier to read and added some minor enhancements and comments to further increase readability.
