### PR TITLE
Handle JIT test failure when the GPU is newer than the CUDA compiler

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -196,7 +196,15 @@ class TestCppExtensionJIT(common.TestCase):
             archflags["5.0;6.0+PTX;7.0;7.5"] = (['50', '60', '70', '75'], ['60'])
 
         for flags, expected in archflags.items():
-            self._run_jit_cuda_archflags(flags, expected)
+            try:
+                self._run_jit_cuda_archflags(flags, expected)
+            except RuntimeError as e:
+                # Using the device default (empty flags) may fail if the device is newer than the CUDA compiler
+                # This raises a RuntimeError with a specific message which we explictely ignore here
+                if not flags and "Error building" in str(e):
+                    pass
+                else:
+                    raise
 
     @unittest.skipIf(not TEST_CUDNN, "CuDNN not found")
     def test_jit_cudnn_extension(self):


### PR DESCRIPTION
The test uses the CUDA compute capabilities of the current device to compile an extension. If nvcc is older than the device, it will fail with a message like "Unsupported gpu architecture 'compute_80'" resulting in a `RuntimeError: Error building extension 'cudaext_archflags'` ultimately failing the test.

This checks for this case and allows execution to continue

Fixes #51950
