### PR TITLE
Fix lint for redundant-workflows list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           with open('.github/workflows/cancel_redundant_workflows.yml') as f:
                 data = yaml.safe_load(f)
                 workflows_to_cancel = data[True]['workflow_run']['workflows']
-          assert workflows.sort() == workflows_to_cancel.sort()
+          assert sorted(workflows) == sorted(workflows_to_cancel)
         shell: python
       - name: ShellCheck
         # https://github.com/koalaman/shellcheck/tree/v0.7.1#installing-a-pre-compiled-binary


### PR DESCRIPTION
Currently this lint is [passing](https://github.com/pytorch/pytorch/runs/2335195975) on #55176 when it should be failing, because it is using [`l.sort()` instead of `sorted(l)`](https://docs.python.org/3/howto/sorting.html).

**Test plan:**

Check out https://github.com/pytorch/pytorch/pull/55176/commits/0c29aa1679403df6227d9e4d0b59267457ec309f, start a `python3` shell, and run the steps from this lint. The final `assert` from before this PR should succeed, and the `assert` from this PR should fail. The lint should succeed on this PR's CI, though, since the list of workflows is correct on `master`.