### PR TITLE
.github: Bump disk size for auto-scaled workers

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -23,9 +23,9 @@ runner_types:
     instance_type: c5.2xlarge
     os: linux
     max_available: 200
-    disk_size: 100
+    disk_size: 150
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge
     os: linux
     max_available: 50
-    disk_size: 100
+    disk_size: 150


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55955 .github: Bump disk size for auto-scaled workers**

Was experiencing build failures related to disk size issues, let's bump
to 150 to see if that resolves these issues

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D27747958](https://our.internmc.facebook.com/intern/diff/D27747958)