### PR TITLE
Fix warnings in tensor_flatten.cpp

### DIFF
--- a/torch/csrc/utils/tensor_flatten.cpp
+++ b/torch/csrc/utils/tensor_flatten.cpp
@@ -7,6 +7,7 @@ namespace torch { namespace utils {
 
 using namespace at;
 
+
 std::vector<TensorGroup> take_tensors(
     TensorList tensors,
     size_t size_limit,
@@ -18,7 +19,7 @@ std::vector<TensorGroup> take_tensors(
   size_t cur_group_size = 0;
 
   for (const auto & tensor : tensors) {
-    size_t tensor_size;
+    size_t tensor_size = 0;
     if (tensor.is_sparse()) {
       const auto& indices = tensor._indices();
       const auto& values = tensor._values();
@@ -28,7 +29,7 @@ std::vector<TensorGroup> take_tensors(
       tensor_size = tensor.numel() * tensor.element_size();
     }
 
-    auto& type_group = groups[tensor.type().id()];
+    auto& type_group = groups[type_id(tensor)];
     type_group.tensors.push_back(tensor);
 
     if (fine_grained) {
@@ -64,17 +65,17 @@ std::vector<TensorGroup> take_tensors(
 
 void reorder_tensors_like(std::vector<Tensor>& tensors, TensorList order) {
   AT_ASSERT(tensors.size() == order.size());
-  std::unordered_map<at::DeprecatedTypeProperties*, std::vector<size_t>> type_indices;
+  std::unordered_map<size_t, std::vector<size_t>> type_id_to_indices;
   for (size_t i = 0, num_tensors = tensors.size(); i < num_tensors; ++i)
-    type_indices[&tensors[i].type()].push_back(i);
+    type_id_to_indices[type_id(tensors[i])].push_back(i);
 
-  std::unordered_map<at::DeprecatedTypeProperties*, size_t> type_used;
+  std::unordered_map<size_t, size_t> type_id_to_type_used;
   std::vector<Tensor> ordered_tensors;
   ordered_tensors.reserve(tensors.size());
   for (auto & tmpl_tensor : order) {
-    auto * type = &tmpl_tensor.type();
-    auto & indices = type_indices[type];
-    auto & used = type_used[type];
+    size_t tmpl_type_id = type_id(tmpl_tensor);
+    auto & indices = type_id_to_indices[tmpl_type_id];
+    auto & used = type_id_to_type_used[tmpl_type_id];
     ordered_tensors.push_back(tensors[indices[used++]]);
   }
   std::swap(tensors, ordered_tensors);

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -8,10 +8,13 @@
 
 namespace torch { namespace utils {
 
-inline int64_t type_id(const at::Tensor& tensor) {
-  return static_cast<int64_t>(tensor.options().backend()) *
-      static_cast<int64_t>(at::ScalarType::NumOptions) +
-      static_cast<int64_t>(tensor.scalar_type());
+/// Generate an ID for a combination of tensor backend + scalar type to be used
+/// when ordering tensors ('like' tensors are grouped by pulling out their
+/// backend + scalar type, so this function combines that into a single number)
+inline size_t type_id(const at::Tensor& tensor) {
+  return static_cast<size_t>(tensor.options().backend()) *
+      static_cast<size_t>(at::ScalarType::NumOptions) +
+      static_cast<size_t>(tensor.scalar_type());
 }
 
 inline at::Tensor flatten_dense_tensors(at::TensorList tensors) {

--- a/torch/csrc/utils/tensor_flatten.h
+++ b/torch/csrc/utils/tensor_flatten.h
@@ -4,8 +4,15 @@
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <ATen/ATen.h>
 #include <utility>
+#include <c10/core/TensorOptions.h>
 
 namespace torch { namespace utils {
+
+inline int64_t type_id(const at::Tensor& tensor) {
+  return static_cast<int64_t>(tensor.options().backend()) *
+      static_cast<int64_t>(at::ScalarType::NumOptions) +
+      static_cast<int64_t>(tensor.scalar_type());
+}
 
 inline at::Tensor flatten_dense_tensors(at::TensorList tensors) {
   static auto flatten = [](const at::Tensor &t) { return t.contiguous().view({-1}); };
@@ -39,9 +46,14 @@ struct TensorGroup {
   std::vector<at::Tensor> tensors;
   size_t size = 0;
 
-  at::DeprecatedTypeProperties& type() {
+  size_t type_id() {
     AT_ASSERT(!tensors.empty());
-    return tensors[0].type();
+    return ::torch::utils::type_id(tensors[0]);
+  }
+
+  const at::TensorOptions options() {
+    AT_ASSERT(!tensors.empty());
+    return tensors[0].options();
   }
 };
 


### PR DESCRIPTION


Switch to use `TensorOptions` instead of deprecated `.type()` to fix compiler warnings as part of #55952

Differential Revision: [D27830504](https://our.internmc.facebook.com/intern/diff/27830504/)