### PR TITLE
PyTorch Execution Graph Observers

### DIFF
--- a/torch/csrc/autograd/function.h
+++ b/torch/csrc/autograd/function.h
@@ -119,11 +119,9 @@ struct TORCH_API Node : std::enable_shared_from_this<Node> {
       assign_parent();
     }
 
-    if (profiler::profilerEnabled()) {
-      // If profiler is enabled, thread_id is stored.
-      // See NOTE [ Sequence Numbers ]
-      thread_id_ = at::RecordFunction::currentThreadId();
-    }
+    // Store the thread_id of the forward operator.
+    // See NOTE [ Sequence Numbers ]
+    thread_id_ = at::RecordFunction::currentThreadId();
   }
 
   explicit Node(edge_list&& next_edges = edge_list())


### PR DESCRIPTION
Summary:
This diff adds an execution graph observer that tracks all operators (dispatcher autograd, jit, user defined, etc.) and their inputs and outputs. The results are written to a temp JSON file which can be used for further analysis. This support various use cases, such as dependency analysis, performance optimizations, etc.

Some minor refactoring of existing code for clarity and completeness.

Test Plan:
Example output:

{F580073970}

```
=> buck build caffe2/torch/fb/observers:execution_graph_observer_runner --show-output

=> buck-out/gen/caffe2/torch/fb/observers/execution_graph_observer_runner --pytorch_enable_execution_graph_observer=true --pytorch_execution_graph_observer_iter_label="## START ##" --pytorch_execution_graph_observer_iter_target=3
I0412 23:01:34.426760 2495964 ExecutionGraphObserver.cpp:391] Enabled PyTorch execution graph observer
I0412 23:01:34.427108 2495964 ExecutionGraphObserver.cpp:394] Matching iteration start label: "## START ##"
I0412 23:01:34.427227 2495964 ExecutionGraphObserver.cpp:405] Target iteration: 3
I0412 23:01:34.427540 2495964 ExecutionGraphObserverRunner.cpp:50] Running test execution graph observer runner.
I0412 23:01:34.427655 2495964 ExecutionGraphObserverRunner.cpp:51] iterations: 10
I0412 23:01:34.771853 2495964 ExecutionGraphObserver.cpp:134] Writing PyTorch execution graph to: /tmp/pytorch_execution_graph_2495964_3.json
I0412 23:01:34.811157 2495964 ExecutionGraphObserver.cpp:304] PyTorch execution graph is written to file: /tmp/pytorch_execution_graph_2495964_3.json
```

see `/tmp/pytorch_execution_graph_[process_id]_[iter_target].json`

Differential Revision: D27238906

