### PR TITLE
[ONNX] Special post process for onnx::Cast and onnx::ConstantOfShape shape type inference

### DIFF
--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -73,7 +73,8 @@ if [[ "$BUILD_ENVIRONMENT" == *ort_test1* ]]; then
     "$top_dir/test/onnx/test_models_onnxruntime.py" \
     "$top_dir/test/onnx/test_utility_funs.py" \
     "$top_dir/test/onnx/test_pytorch_onnx_caffe2.py" \
-    "$top_dir/test/onnx/test_pytorch_onnx_caffe2_quantized.py"
+    "$top_dir/test/onnx/test_pytorch_onnx_caffe2_quantized.py" \
+    "$top_dir/test/onnx/test_pytorch_onnx_shape_inference.py"
 fi
 if [[ "$BUILD_ENVIRONMENT" == *ort_test2* ]]; then
   # Update the loop for new opsets

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -2,7 +2,6 @@ import unittest
 import torch
 import numpy as np
 
-import copy
 
 def expect_tensor(scalar_type, shape=None, dynamic_shape=None):
     def verify(actual_type):
@@ -49,7 +48,7 @@ class TestONNXShapeInference(unittest.TestCase):
         # Test ConstantOfShape with input of prim::ListConstruct of static tensor
         rank = 4
         g = self.create_empty_graph()
-        constants = [self.insert_tensor_constant(g, torch.tensor(i+1)) for i in range(rank)]
+        constants = [self.insert_tensor_constant(g, torch.tensor(i + 1)) for i in range(rank)]
         shape = g.op("prim::ListConstruct", *constants)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
@@ -62,7 +61,7 @@ class TestONNXShapeInference(unittest.TestCase):
         shape = g.op("prim::ListConstruct", *inputs)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', None, (None, None, None, None)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', dynamic_shape=(None, None, None, None)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -25,7 +25,10 @@ class TestONNXShapeInference(unittest.TestCase):
             type_assertion_func(out.type())
 
     def create_empty_graph(self):
-        return torch._C.Graph()
+        g = torch._C.Graph()
+        # kick off initialization for ConstantMap.
+        torch._C._jit_pass_onnx_graph_shape_type_inference(g, {}, self.opset_version)
+        return g
 
     def insert_tensor_constant(self, g, tensor):
         return g.op("Constant", value_t=tensor)

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -3,26 +3,26 @@ import torch
 import numpy as np
 
 
-def expect_tensor(scalar_type, shape=None, dynamic_shape=None):
+def expect_tensor(scalar_type, shape=None):
     def verify(actual_type):
         np.testing.assert_equal(actual_type.scalarType(), scalar_type)
+        # if shape is not None:
+        #     np.testing.assert_equal(actual_type.sizes(), shape)
         if shape is not None:
-            np.testing.assert_equal(actual_type.sizes(), shape)
-        if dynamic_shape is not None:
-            np.testing.assert_equal(actual_type.varyingSizes(), dynamic_shape)
+            np.testing.assert_equal(actual_type.varyingSizes(), shape)
     return verify
 
 class TestONNXShapeInference(unittest.TestCase):
     from torch.onnx.symbolic_helper import _onnx_main_opset
     opset_version = _onnx_main_opset
 
-    def run_test(self, g, n, expected_types):
-        if not isinstance(expected_types, list):
-            expected_types = [expected_types]
+    def run_test(self, g, n, type_assertion_funcs):
+        if not isinstance(type_assertion_funcs, list):
+            type_assertion_funcs = [type_assertion_funcs]
 
         torch._C._jit_pass_onnx_graph_shape_type_inference(g, {}, self.opset_version)
-        for out, expected_type in zip(n.outputs(), expected_types):
-            expected_type(out.type())
+        for out, type_assertion_func in zip(n.outputs(), type_assertion_funcs):
+            type_assertion_func(out.type())
 
     def create_empty_graph(self):
         return torch._C.Graph()
@@ -43,7 +43,7 @@ class TestONNXShapeInference(unittest.TestCase):
         constant = self.insert_tensor_constant(g, torch.ones(1, 2, 3, 4))
         shape = g.op("Shape", constant)
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(1, 2, 3, 4)))
 
     def test_constant_of_shape_static(self):
         # Test ConstantOfShape with input of prim::ListConstruct of static tensor
@@ -53,7 +53,7 @@ class TestONNXShapeInference(unittest.TestCase):
         shape = g.op("prim::ListConstruct", *constants)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(1, 2, 3, 4)))
 
     def test_constant_of_shape_dynamic(self):
         # Test ConstantOfShape with input of prim::ListConstruct of dynamic tensor
@@ -63,7 +63,26 @@ class TestONNXShapeInference(unittest.TestCase):
         shape = g.op("prim::ListConstruct", *inputs)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', dynamic_shape=(None, None, None, None)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(None, None, None, None)))
+
+    def test_reshape(self):
+        g = self.create_empty_graph()
+        constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 5))
+        constant_2 = self.insert_tensor_constant(g, torch.tensor([2, 0, -1]))
+        shape = g.op("Reshape", constant, constant_2)
+        self.run_test(g, shape.node(), expect_tensor('Float', shape=(2, 16, 25)))
+
+        g = self.create_empty_graph()
+        constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 4))
+        constant_2 = self.insert_tensor_constant(g, torch.tensor([-1, 0, 4]))
+        shape = g.op("Reshape", constant, constant_2)
+        self.run_test(g, shape.node(), expect_tensor('Float', shape=(10, 16, 4)))
+
+        g = self.create_empty_graph()
+        constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 4))
+        constant_2 = self.insert_tensor_constant(g, torch.tensor([-1, 0, 0]))
+        shape = g.op("Reshape", constant, constant_2)
+        self.run_test(g, shape.node(), expect_tensor('Float', shape=(8, 16, 5)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -45,6 +45,7 @@ class TestONNXShapeInference(unittest.TestCase):
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
         self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
 
+    def test_constant_of_shape_static(self):
         # Test ConstantOfShape with input of prim::ListConstruct of static tensor
         rank = 4
         g = self.create_empty_graph()
@@ -54,6 +55,7 @@ class TestONNXShapeInference(unittest.TestCase):
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
         self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
 
+    def test_constant_of_shape_dynamic(self):
         # Test ConstantOfShape with input of prim::ListConstruct of dynamic tensor
         rank = 4
         g = self.create_empty_graph()

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -1,72 +1,68 @@
 import unittest
 import torch
+import numpy as np
 
 import copy
 
-import test_pytorch_onnx_onnxruntime
-from test_pytorch_onnx_onnxruntime import TestONNXRuntime
-from torch.onnx import utils, OperatorExportTypes, TrainingMode
-from torch.onnx.utils import _validate_dynamic_axes
-from torch.onnx.symbolic_helper import (_set_opset_version, _set_operator_export_type,
-                                        _set_onnx_shape_inference, _set_training_mode,
-                                        _is_tensor_list, _is_tensor, _is_none)
+def expect_tensor(scalar_type, shape=None, dynamic_shape=None):
+    def verify(actual_type):
+        np.testing.assert_equal(actual_type.scalarType(), scalar_type)
+        if shape is not None:
+            np.testing.assert_equal(actual_type.sizes(), shape)
+        if dynamic_shape is not None:
+            np.testing.assert_equal(actual_type.varyingSizes(), dynamic_shape)
+    return verify
 
+class TestONNXShapeInference(unittest.TestCase):
+    from torch.onnx.symbolic_helper import _onnx_main_opset
+    opset_version = _onnx_main_opset
 
-def verify_inferred_shape(graph):
-    # Check every node in graph has type properly assigned.
-    for n in graph.nodes():
-        for out in n.outputs():
-            if not _is_tensor_list(out) and not _is_tensor(out) and not _is_none(out):
-                raise RuntimeError("Output of node is neither type Tensor nor type list of Tensor: ", out)
-            if _is_tensor(out) and out.type().scalarType() is None:
-                raise RuntimeError("Output of node does not have type assigned", out)
-            if _is_tensor(out) and out.type().dim() is None:
-                raise RuntimeError("Output of node does not have shape assigned", out)
+    def run_test(self, g, n, expected_types):
+        if not isinstance(expected_types, list):
+            expected_types = [expected_types]
 
+        torch._C._jit_pass_onnx_graph_shape_type_inference(g, {}, self.opset_version)
+        for out, expected_type in zip(n.outputs(), expected_types):
+            expected_type(out.type())
 
-def run_model_test(self, model, batch_size=2, state_dict=None,
-                   input=None, use_gpu=True, rtol=0.001, atol=1e-7,
-                   example_outputs=None, do_constant_folding=True,
-                   dynamic_axes=None, test_with_inputs=None,
-                   input_names=None, output_names=None,
-                   fixed_batch_size=False):
-    model.eval()
+    def create_empty_graph(self):
+        return torch._C.Graph()
 
-    if input is None:
-        input = torch.randn(batch_size, 3, 224, 224, requires_grad=True)
+    def insert_tensor_constant(self, g, tensor):
+        return g.op("Constant", value_t=tensor)
 
-    with torch.no_grad():
-        if isinstance(input, torch.Tensor):
-            input = (input,)
-        # In-place operators will update input tensor data as well.
-        # Thus inputs are replicated before every forward call.
-        input_copy = copy.deepcopy(input)
-        output = model(*input_copy)
-        if isinstance(output, torch.Tensor):
-            output = (output,)
+    def test_cast(self):
+        # Test cast with input of unknown scalar type.
+        g = self.create_empty_graph()
+        input = g.addInput()
+        cast_out = g.op("Cast", input, to_i=1)
+        self.run_test(g, cast_out.node(), expect_tensor('Float'))
 
-        _set_opset_version(self.opset_version)
-        _set_operator_export_type(OperatorExportTypes.ONNX)
-        _set_onnx_shape_inference(True)
-        _set_training_mode(False)
-        if dynamic_axes is None:
-            dynamic_axes = {}
-        _validate_dynamic_axes(dynamic_axes, model, input_names, output_names)
+    def test_constant_of_shape(self):
+        # Test ConstantOfShape with input of onnx::Shape node.
+        g = self.create_empty_graph()
+        constant = self.insert_tensor_constant(g, torch.ones(1, 2, 3, 4))
+        shape = g.op("Shape", constant)
+        constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
 
-        input_copy = copy.deepcopy(input)
-        graph, _, _ = utils._model_to_graph(model, input_copy,
-                                            input_names=input_names,
-                                            output_names=output_names,
-                                            operator_export_type=OperatorExportTypes.ONNX,
-                                            example_outputs=output,
-                                            do_constant_folding=do_constant_folding,
-                                            training=TrainingMode.EVAL,
-                                            dynamic_axes=dynamic_axes)
-        verify_inferred_shape(graph)
+        # Test ConstantOfShape with input of prim::ListConstruct of static tensor
+        rank = 4
+        g = self.create_empty_graph()
+        constants = [self.insert_tensor_constant(g, torch.tensor(i+1)) for i in range(rank)]
+        shape = g.op("prim::ListConstruct", *constants)
+        shape.setType(torch._C.ListType.ofInts())
+        constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', (1, 2, 3, 4)))
 
+        # Test ConstantOfShape with input of prim::ListConstruct of dynamic tensor
+        rank = 4
+        g = self.create_empty_graph()
+        inputs = [g.addInput() for i in range(rank)]
+        shape = g.op("prim::ListConstruct", *inputs)
+        shape.setType(torch._C.ListType.ofInts())
+        constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
+        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', None, (None, None, None, None)))
 
 if __name__ == '__main__':
-    TestONNXRuntime.opset_version = 12
-    test_pytorch_onnx_onnxruntime.run_model_test = run_model_test
-
     unittest.main()

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1157,6 +1157,57 @@ void SpecialPostProcess(Node* n) {
       }
       break;
     }
+    case ::c10::onnx::Cast: {
+      // ONNX shape inference is not able to assign output tensor shape,
+      // when input to onnx::Cast has incomplete tensor shape, for example
+      // missing shape, rank, dtype, etc. This postprocess sets the correct
+      // dtype for output tensor, since the dtype info is stored in Cast attribute.
+      TensorTypePtr t_type = n->output()->type()->cast<TensorType>();
+      if (nullptr != t_type && !t_type->scalarType().has_value()) {
+        auto onnx_dtype = n->i(attr::to);
+        auto aten_dtype = ONNXTypeToATenType(onnx_dtype);
+        n->output()->setType(t_type->withScalarType(aten_dtype));
+      }
+      break;
+    }
+    case ::c10::onnx::ConstantOfShape: {
+      // ONNX shape inference is not able to propagate output tensor shape
+      // for onnx::ConstantOfShape if input `shape` is not constant.
+      // This is a temporary solution when some partial information is available,
+      // for example, knowing rank of output tensor, or knowing symbolic shape.
+      // This solution won't be needed once we have proper symbolic propagation.
+      auto shape_node = n->input(0)->node();
+      if (shape_node->kind() == ::c10::onnx::Shape) {
+        // shape -> ConstantOfShape
+        auto orig_type = shape_node->input()->type()->cast<TensorType>();
+        auto v_type = n->output()->type()->cast<TensorType>();
+        if (v_type && !v_type->sizes().concrete_sizes()) {
+          if (orig_type && orig_type->dim()) {
+            // Assign symbolic shape of original input of onnx::Shape.
+            v_type = v_type->withSymbolicShapes(orig_type->symbolic_sizes());
+            n->output()->setType(v_type);
+          } else if (shape_node->input()->node()->kind() == ::c10::prim::ListConstruct) {
+            // Assign rank of original input of onnx::Shape.
+            v_type = v_type->withSizes({shape_node->input()->node()->inputs().size()});
+            n->output()->setType(v_type);
+          }
+        }
+      } else if (shape_node->kind() == ::c10::prim::ListConstruct) {
+        // ListConstruct -> ConstantOfShape
+        auto v_type = n->output()->type()->cast<TensorType>();
+        if (v_type && !v_type->sizes().concrete_sizes()) {
+          auto value = n->t(attr::value);
+          v_type = v_type->withScalarType(value.scalar_type());
+          std::vector<c10::ShapeSymbol> sizes;
+          for (auto i : shape_node->inputs()) {
+            sizes.emplace_back(c10::ShapeSymbol::newSymbol());
+          }
+          v_type = v_type->withSymbolicShapes(c10::SymbolicShape(sizes));
+          n->output()->setType(v_type);
+        }
+      }
+      break;
+    }
   }
 }
 

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1192,8 +1192,8 @@ void SpecialPostProcess(Node* n) {
               shape_node->input()->node()->kind() ==
               ::c10::prim::ListConstruct) {
             // Assign rank of original input of onnx::Shape.
-            v_type = v_type->withSizes(
-                {shape_node->input()->node()->inputs().size()});
+            v_type = v_type->withSizes({static_cast<int64_t>(
+                shape_node->input()->node()->inputs().size())});
             n->output()->setType(v_type);
           }
         }

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1161,7 +1161,8 @@ void SpecialPostProcess(Node* n) {
       // ONNX shape inference is not able to assign output tensor shape,
       // when input to onnx::Cast has incomplete tensor shape, for example
       // missing shape, rank, dtype, etc. This postprocess sets the correct
-      // dtype for output tensor, since the dtype info is stored in Cast attribute.
+      // dtype for output tensor, since the dtype info is stored in Cast
+      // attribute.
       TensorTypePtr t_type = n->output()->type()->cast<TensorType>();
       if (nullptr != t_type && !t_type->scalarType().has_value()) {
         auto onnx_dtype = n->i(attr::to);
@@ -1173,12 +1174,13 @@ void SpecialPostProcess(Node* n) {
     case ::c10::onnx::ConstantOfShape: {
       // ONNX shape inference is not able to propagate output tensor shape
       // for onnx::ConstantOfShape if input `shape` is not constant.
-      // This is a temporary solution when some partial information is available,
-      // for example, knowing rank of output tensor, or knowing symbolic shape.
-      // This solution won't be needed once we have proper symbolic propagation.
+      // This is a temporary solution when some partial information is
+      // available, for example, knowing rank of output tensor, or knowing
+      // symbolic shape. This solution won't be needed once we have proper
+      // symbolic propagation.
       auto shape_node = n->input(0)->node();
       if (shape_node->kind() == ::c10::onnx::Shape) {
-        // shape -> ConstantOfShape
+        // Shape -> ConstantOfShape
         auto orig_type = shape_node->input()->type()->cast<TensorType>();
         auto v_type = n->output()->type()->cast<TensorType>();
         if (v_type && !v_type->sizes().concrete_sizes()) {
@@ -1186,9 +1188,12 @@ void SpecialPostProcess(Node* n) {
             // Assign symbolic shape of original input of onnx::Shape.
             v_type = v_type->withSymbolicShapes(orig_type->symbolic_sizes());
             n->output()->setType(v_type);
-          } else if (shape_node->input()->node()->kind() == ::c10::prim::ListConstruct) {
+          } else if (
+              shape_node->input()->node()->kind() ==
+              ::c10::prim::ListConstruct) {
             // Assign rank of original input of onnx::Shape.
-            v_type = v_type->withSizes({shape_node->input()->node()->inputs().size()});
+            v_type = v_type->withSizes(
+                {shape_node->input()->node()->inputs().size()});
             n->output()->setType(v_type);
           }
         }
@@ -1198,10 +1203,8 @@ void SpecialPostProcess(Node* n) {
         if (v_type && !v_type->sizes().concrete_sizes()) {
           auto value = n->t(attr::value);
           v_type = v_type->withScalarType(value.scalar_type());
-          std::vector<c10::ShapeSymbol> sizes;
-          for (auto i : shape_node->inputs()) {
-            sizes.emplace_back(c10::ShapeSymbol::newSymbol());
-          }
+          std::vector<c10::ShapeSymbol> sizes(
+              shape_node->inputs().size(), c10::ShapeSymbol::newSymbol());
           v_type = v_type->withSymbolicShapes(c10::SymbolicShape(sizes));
           n->output()->setType(v_type);
         }


### PR DESCRIPTION
* Special post process for onnx::Cast and onnx::ConstantOfShape 
* Update `test_pytorch_onnx_shape_inference.py` to be unit test over shape inference patterns.