### PR TITLE
[ROCm] Updating ROCM_HOME handling for >ROCm 4.0

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -86,10 +86,11 @@ def _find_rocm_home() -> Optional[str]:
     if rocm_home is None:
         # Guess #2
         try:
-            hipcc = subprocess.check_output(
-                ['which', 'hipcc'], stderr=subprocess.DEVNULL).decode().rstrip('\r\n')
+            pipe_hipcc = subprocess.Popen(
+                ["which hipcc | xargs readlink -f"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+            hipcc, _ = pipe_hipcc.communicate()
             # this will be either <ROCM_HOME>/hip/bin/hipcc or <ROCM_HOME>/bin/hipcc
-            rocm_home = os.path.dirname(os.path.dirname(hipcc))
+            rocm_home = os.path.dirname(os.path.dirname(hipcc.decode().rstrip('\r\n')))
             if os.path.basename(rocm_home) == 'hip':
                 rocm_home = os.path.dirname(rocm_home)
         except Exception:


### PR DESCRIPTION
- This change is required to handle the case when hipcc is
  updated to the latest using update-alternatives.
- Update-alternatives support for few ROCm binaries is available
  from ROCm 4.1 onwards.
- This change doesnt not affect any previous versions of ROCm.
