### PR TITLE
.github: Add workflow to reserve runners for ssh

### DIFF
--- a/.github/workflows/reserve-runner.yml
+++ b/.github/workflows/reserve-runner.yml
@@ -1,0 +1,16 @@
+name: Reserve Github Actions Runner
+
+on:
+  workflow-dispatch:
+    inputs:
+      runnerType: "linux.2xlarge"
+
+jobs:
+  reserve-runner:
+    runs-on: ${{ inputs.runnerType }}
+    steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@18c3652e863e41474701cc45349bfc24a902636e #v3.5
+        timeout-minutes: 120 # 2 hours
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/reserve-runner.yml
+++ b/.github/workflows/reserve-runner.yml
@@ -3,7 +3,9 @@ name: Reserve Github Actions Runner
 on:
   workflow-dispatch:
     inputs:
-      runnerType: "linux.2xlarge"
+      runnerType:
+        description: 'The type of runner you would like to reserve'
+        default: "linux.2xlarge"
 
 jobs:
   reserve-runner:

--- a/.github/workflows/reserve_runner.yml
+++ b/.github/workflows/reserve_runner.yml
@@ -1,7 +1,7 @@
 name: Reserve Github Actions Runner
 
 on:
-  workflow-dispatch:
+  workflow_dispatch:
     inputs:
       runnerType:
         description: 'The type of runner you would like to reserve'
@@ -9,10 +9,11 @@ on:
 
 jobs:
   reserve-runner:
-    runs-on: ${{ inputs.runnerType }}
+    runs-on: ${{ github.event.inputs.runnerType }}
     steps:
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@18c3652e863e41474701cc45349bfc24a902636e #v3.5
+      - name: Setup tmate session for ${{ github.event.inputs.runnerType }}
+        uses: seemethere/action-tmate@f708e7bca76af1b52bb8c8e5fe790ef5e01a4fc8
         timeout-minutes: 120 # 2 hours
         with:
           limit-access-to-actor: true
+          install_dependencies: false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55972 .github: Add workflow to reserve runners for ssh**

Verified here: https://github.com/seemethere/test-repo/actions/runs/74951561

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D27773100](https://our.internmc.facebook.com/intern/diff/D27773100)