### PR TITLE
[reland][c10d] Log API usage of monitored barrier

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -2726,6 +2726,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupGloo::barrier(
 void ProcessGroupGloo::monitoredBarrier(
     const BarrierOptions& opts,
     bool waitAllRanks) {
+      C10_LOG_API_USAGE_ONCE("torch.distributed.monitored_barrier");
   // Use default timeout if no timeout was specified.
   auto monitoredBarrierTimeout =
       (opts.timeout == kUnsetTimeout) ? this->options_->timeout : opts.timeout;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #55990 [reland][c10d] monitored_barrier: ensure all ranks pass or none do
* **#55989 [reland][c10d] Log API usage of monitored barrier**

Reland of https://github.com/pytorch/pytorch/pull/55197, which fails windows test that was only run on master.

Differential Revision: [D27758425](https://our.internmc.facebook.com/intern/diff/D27758425/)