### PR TITLE
[reland][c10d] monitored_barrier: ensure all ranks pass or none do

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2487,9 +2487,11 @@ def monitored_barrier(group=GroupMember.WORLD, timeout=None, wait_all_ranks=Fals
     barrier within that timeout. Specifically, for non-zero ranks, will block
     until a send/recv is processed from rank 0. Rank 0 will block until all send
     /recv from other ranks are processed, and will report failures for ranks
-    that failed to respond in time.
+    that failed to respond in time. Note that if one rank does not reach the
+    monitored_barrier (for example due to a hang), all other ranks would fail
+    in monitored_barrier.
 
-    This collective will block the process corresponding to rank 0 until the
+    This collective will block all processes/ranks in the group, until the
     whole group exits the function successfully, making it useful for debugging
     and synchronizing. However, it can have a performance impact and should only
     be used for debugging or scenarios that require full synhcronization points

--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -2739,94 +2739,109 @@ void ProcessGroupGloo::monitoredBarrier(
   if (rank != 0) {
     auto sendWork = send(commTensor, 0, t1);
     auto recvWork = recv(commTensor, 0, t2);
-    sendWork->wait();
-    recvWork->wait();
+    try {
+      sendWork->wait();
+      recvWork->wait();
+    } catch (const std::exception& e) {
+      const std::string error = c10::str(
+        "Rank ",
+        rank,
+        " successfully reached monitoredBarrier, but received errors while waiting",
+        " to be unblocked by rank 0. Please check rank 0 logs for faulty rank."
+      );
+      logAndThrow(
+        error,
+        c10::str(error, "\n Original exception: \n", e.what())
+      );
+    }
     return;
   }
   auto startTime = std::chrono::steady_clock::now();
   auto worldSize = this->getSize();
-  // Holds mapping of rank to pair of recv/send work.
-  std::map<
-      int,
-      std::tuple<
-          c10::intrusive_ptr<ProcessGroup::Work>,
-          c10::intrusive_ptr<ProcessGroup::Work>>>
-      works;
-  // Kick off all work
+  // Mappings of rank to recvWork/sendWork respectively.
+  std::map<int, c10::intrusive_ptr<ProcessGroup::Work>> recvWorkMap;
+  std::map<int, c10::intrusive_ptr<ProcessGroup::Work>> sendWorkMap;
+  // Kick off recvWork and wait to unblock sendWork->wait() from non-zero ranks.
+  // Failed/hanging ranks will not ack this call, letting rank 0 know about the
+  // failure.
   for (int dstRank = 1; dstRank < worldSize; ++dstRank) {
-    auto recvWork = recv(commTensor, dstRank, t1);
-    auto sendWork = send(commTensor, dstRank, t2);
-    works.insert(
-        {dstRank, std::make_tuple(std::move(recvWork), std::move(sendWork))});
+    recvWorkMap.insert({dstRank, recv(commTensor, dstRank, t1)});
   }
 
-  std::vector<int> processedRanks;
+  auto waitLoop =
+      [&](const std::map<int, c10::intrusive_ptr<ProcessGroup::Work>>& works) {
+        std::vector<int> processedRanks;
+        for (auto& work : works) {
+          bool rankResponded = false;
+          try {
+            // Note: if waitAllRanks=false, we recompute the time remaining in
+            // barrier and use this recomputed time in wait(). However, if
+            // waitAllRanks=true, we use the original timeout, since if we use
+            // up the entire timeout waiting for response from rank n, then we
+            // won't have any timeout left to query ranks beginning with n + 1.
+            auto remainingTime = getRemainingTime(
+                startTime, monitoredBarrierTimeout, waitAllRanks);
+            if (!waitAllRanks) {
+              checkRemainingTime(
+                  monitoredBarrierTimeout,
+                  remainingTime,
+                  processedRanks,
+                  rank);
+            }
+            work.second->wait(remainingTime);
+            rankResponded = true;
+          } catch (const std::exception& e) {
+            const std::string error = c10::str(
+                "Rank ",
+                work.first,
+                " failed to pass monitoredBarrier in ",
+                monitoredBarrierTimeout.count(),
+                " ms");
+            if (waitAllRanks) {
+              LOG(ERROR) << error;
+            } else {
+              logAndThrow(
+                  error,
+                  c10::str(error, "\n Original exception: \n", e.what()));
+            }
+          }
+          if (rankResponded) {
+            processedRanks.push_back(work.first);
+          }
+        }
+        // If we are collecting all failed ranks, check if we need to throw if
+        // some ranks have not responded.
+        if (waitAllRanks && processedRanks.size() != size_) {
+          std::vector<int> failedRanks;
+          for (int i = 1; i < size_; ++i) {
+            if (std::find(processedRanks.begin(), processedRanks.end(), i) ==
+                processedRanks.end()) {
+              failedRanks.push_back(i);
+            }
+          }
 
-  // Wait for send/recv from all ranks
-  for (auto& work : works) {
-    bool rankResponded = false;
-    try {
-      // Note: if waitAllRanks=false, we recompute the time remaining in barrier
-      // and use this recomputed time in wait(). However, if waitAllRanks=true,
-      // we use the original timeout, since if we use up the entire timeout
-      // waiting for response from rank n, then we won't have any timeout left to
-      // query ranks beginning with n + 1.
-      auto remainingTime =
-          getRemainingTime(startTime, monitoredBarrierTimeout, waitAllRanks);
-      if (!waitAllRanks) {
-        checkRemainingTime(
-          monitoredBarrierTimeout, remainingTime, processedRanks, rank);
-      }
-      std::get<0>(work.second)->wait(remainingTime);
-      remainingTime =
-          getRemainingTime(startTime, monitoredBarrierTimeout, waitAllRanks);
-      if (!waitAllRanks) {
-      checkRemainingTime(
-          monitoredBarrierTimeout, remainingTime, processedRanks, rank);
-      }
-      std::get<1>(work.second)->wait(remainingTime);
-      rankResponded = true;
-    } catch (const std::exception& e) {
-      const std::string error = c10::str(
-          "Rank ",
-          work.first,
-          " failed to pass monitoredBarrier in ",
-          monitoredBarrierTimeout.count(),
-          " ms");
-      if (waitAllRanks) {
-        LOG(ERROR) << error;
-      } else {
-        logAndThrow(
-          error, c10::str(error, "\n Original exception: \n", e.what()));
-      }
-    }
-    if (rankResponded) {
-      processedRanks.push_back(work.first);
-    }
+          TORCH_INTERNAL_ASSERT(!failedRanks.empty());
+          const std::string ranksStr = c10::Join(", ", failedRanks);
+          const std::string error = c10::str(
+              "Ranks ",
+              ranksStr,
+              " failed to pass monitoredBarrier in ",
+              monitoredBarrierTimeout.count(),
+              " ms");
+          logAndThrow(error, error);
+        }
+      };
+
+  waitLoop(recvWorkMap);
+  // If we've reached here successfully, this means all ranks have acked in
+  // monitoredBarrier. Unblock all ranks now by responding to their recv(). This
+  // ensures that this is a true barrier in that all ranks  exit it successfully
+  // or none of them do.
+  for (int dstRank = 1; dstRank < worldSize; ++dstRank) {
+    sendWorkMap.insert({dstRank, send(commTensor, dstRank, t2)});
   }
 
-  // If we are collecting all failed ranks, check if we need to throw if some
-  // ranks have not responded.
-  if (waitAllRanks && processedRanks.size() != size_) {
-    std::vector<int> failedRanks;
-    for (int i = 1; i < size_; ++i) {
-      if (std::find(processedRanks.begin(), processedRanks.end(), i) ==
-          processedRanks.end()) {
-        failedRanks.push_back(i);
-      }
-    }
-
-    if (!failedRanks.empty()) {
-      const std::string ranksStr = c10::Join(", ", failedRanks);
-      const std::string error = c10::str(
-          "Ranks ",
-          ranksStr,
-          " failed to pass monitoredBarrier in ",
-          monitoredBarrierTimeout.count(),
-          " ms");
-      logAndThrow(error, error);
-    }
-  }
+  waitLoop(sendWorkMap);
 
   auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - startTime);

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager, suppress
 from datetime import timedelta
 from functools import reduce
 from typing import Union, NamedTuple
-from torch.testing._internal.common_utils import IS_MACOS,IS_WINDOWS, FILE_SCHEMA
+from torch.testing._internal.common_utils import IS_MACOS, IS_WINDOWS, FILE_SCHEMA
 
 import torch
 import torch.cuda

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager, suppress
 from datetime import timedelta
 from functools import reduce
 from typing import Union, NamedTuple
+from torch.testing._internal.common_utils import IS_MACOS,IS_WINDOWS, FILE_SCHEMA
 
 import torch
 import torch.cuda
@@ -24,7 +25,6 @@ from torch.nn.parallel.distributed import _dump_DDP_relevant_env_vars
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.distributed_c10d import _get_default_group, AllreduceOptions, GroupMember
-from torch.testing._internal.common_utils import FILE_SCHEMA
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     TEST_SKIPS,
@@ -5136,6 +5136,10 @@ class DistributedTest:
 
         @require_backend({"gloo"})
         @require_backends_available({"gloo"})
+        @unittest.skipIf(
+            IS_MACOS or IS_WINDOWS,
+            "MacOS uses uv transport which does not have as robust error handling as tcp transport"
+        )
         def test_monitored_barrier_gloo(self):
             tensors = [torch.ones(10) * self.rank]
             # Kick off some allreduce work on all ranks
@@ -5147,23 +5151,26 @@ class DistributedTest:
             # All ranks besides 1 call into barrier, rank 0 should report failure
             # while others report gloo error.
             failed_rank = 1
-            if self.rank == failed_rank:
-                return
-            if self.rank == 0:
+            src_rank = 0
+            if self.rank == src_rank:
                 with self.assertRaisesRegex(
                     RuntimeError,
                     f"Rank {failed_rank} failed to pass monitoredBarrier"
                 ):
                     dist.monitored_barrier(timeout=timeout)
-            else:
-                # It is permissible for other ranks that did not fail to
-                # successfully exit or crash in the monitored barrier, the main
-                # purpose of monitored barrier is to report the rank that hung
-                # on rank 0.
-                try:
+            elif self.rank != failed_rank:
+                # Other ranks should not pass barrier since rank 0 failed.
+                err_regex = (
+                    f"Rank {self.rank} successfully reached monitoredBarrier,"
+                    f" but received errors while waiting to be unblocked by rank"
+                    f" {src_rank}"
+                )
+                with self.assertRaisesRegex(RuntimeError, err_regex):
                     dist.monitored_barrier(timeout=timeout)
-                except RuntimeError:
-                    pass
+
+            # We need a barrier since otherwise failed_rank exits too early
+            # and cause a timeout.
+            self._barrier(timeout=30)
 
         @require_backend({"gloo"})
         @require_backends_available({"gloo"})
@@ -5215,22 +5222,21 @@ class DistributedTest:
             if self.rank != 0:
                 with self.assertRaisesRegex(RuntimeError, "Caught collective operation timeout"):
                     nccl_pg.allreduce(tensors).wait(timedelta(seconds=0.1))
-                return
-
-            # Rank 0 should report first (in order) timed out rank or all ranks
-            # depending on wait_all_ranks flag passed into monitored_barrier.
-            if wait_all_ranks:
-                rank_str = ", ".join([str(i) for i in range(1, int(self.world_size))])
-                err_regex = f"Ranks {rank_str} failed to pass monitoredBarrier"
             else:
-                expected_first_fail_rank = 1
-                err_regex = f"Rank {expected_first_fail_rank} failed to pass monitoredBarrier"
-            monitored_barrier_timeout_seconds = timedelta(seconds=0.1)
-            with self.assertRaisesRegex(
-                RuntimeError,
-                err_regex
-            ):
-                gloo_pg.monitored_barrier(monitored_barrier_timeout_seconds, wait_all_ranks=wait_all_ranks)
+                # Rank 0 should report first (in order) timed out rank or all ranks
+                # depending on wait_all_ranks flag passed into monitored_barrier.
+                if wait_all_ranks:
+                    rank_str = ", ".join([str(i) for i in range(1, int(self.world_size))])
+                    err_regex = f"Ranks {rank_str} failed to pass monitoredBarrier"
+                else:
+                    expected_first_fail_rank = 1
+                    err_regex = f"Rank {expected_first_fail_rank} failed to pass monitoredBarrier"
+                monitored_barrier_timeout_seconds = timedelta(seconds=0.1)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    err_regex
+                ):
+                    gloo_pg.monitored_barrier(monitored_barrier_timeout_seconds, wait_all_ranks=wait_all_ranks)
 
         @with_nccl_blocking_wait
         @require_backend({"gloo", "nccl"})
@@ -5269,18 +5275,28 @@ class DistributedTest:
         @require_backend({"gloo"})
         @require_backends_available({"gloo"})
         @skip_if_small_worldsize
+        @unittest.skipIf(
+            IS_MACOS or IS_WINDOWS,
+            "MacOS uses uv transport which does not have as robust error handling as tcp transport"
+        )
         def test_monitored_barrier_failure_order(self):
             # Ensure that the first (in sorted order) rank is reported when
             # multiple ranks fail to pass the monitored_barrier.
             # TODO(#54879): Provide ability to wait and report all failed ranks
             expected_first_failed_rank = 2
             timeout = timedelta(seconds=2)
-            if self.rank == 0:
+            src_rank = 0
+            if self.rank == src_rank:
                 with self.assertRaisesRegex(RuntimeError, f"Rank {expected_first_failed_rank}"):
                     dist.monitored_barrier(timeout=timeout)
             elif self.rank == 1:
-                # Successfully pass barrier
-                dist.monitored_barrier(timeout=timeout)
+                err_regex = (
+                    f"Rank {self.rank} successfully reached monitoredBarrier,"
+                    f" but received errors while waiting to be unblocked by rank"
+                    f" {src_rank}"
+                )
+                with self.assertRaisesRegex(RuntimeError, err_regex):
+                    dist.monitored_barrier(timeout=timeout)
 
         @require_backend({"gloo"})
         @require_backends_available({"gloo"})
@@ -5294,7 +5310,3 @@ class DistributedTest:
                 err_regex = f"Ranks {rank_str} failed to pass monitoredBarrier"
                 with self.assertRaisesRegex(RuntimeError, err_regex):
                     dist.monitored_barrier(timeout=timeout, wait_all_ranks=True)
-
-            # We need a barrier since otherwise non-zero ranks exit too early
-            # and cause a timeout.
-            self._barrier(timeout=30)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55990 [reland][c10d] monitored_barrier: ensure all ranks pass or none do**
* #55989 [reland][c10d] Log API usage of monitored barrier

Reland of https://github.com/pytorch/pytorch/pull/55197, which fails windows test that was only run on master.

Disabled these tests for windows, similar to they are disabled on MacOS. The reason for disabling as that they use libuv transport which does not have as robust error handling as tcp on linux. The result is that non-zero ranks that were healthy don't throw immediately (like they do on linux) but they throw on timeout. Waiting for timeout will make test run for an unreasonably long time. The error handling still occurs as expected on rank 0 for all platforms.

Ci-all PR https://github.com/pytorch/pytorch/pull/55991

Differential Revision: [D27758424](https://our.internmc.facebook.com/intern/diff/D27758424/)