### PR TITLE
[fx][normalize] Allow for args to be left as args

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -911,8 +911,8 @@ class {test_classname}(torch.nn.Module):
                         normalized_args2 = normalize_module(traced, node.target, node.args, node.kwargs)
                         assert(normalized_args == normalized_args2)
                         assert normalized_args
-                        node.args = ()
-                        node.kwargs = normalized_args
+                        node.args = normalized_args.args
+                        node.kwargs = normalized_args.kwargs
 
             traced.recompile()
 
@@ -1306,8 +1306,8 @@ class TestNormalizeOperators(JitTestCase):
                 continue
             # Test normalize_function by itself
             ref_out = op.op(*arg_values, **kwarg_values)
-            norm_kwargs = normalize_function(op.op, arg_values, kwarg_values, arg_types, kwarg_types)
-            test_out = op.op(**norm_kwargs)
+            norm_args_and_kwargs = normalize_function(op.op, arg_values, kwarg_values, arg_types, kwarg_types)
+            test_out = op.op(*norm_args_and_kwargs.args, **norm_args_and_kwargs.kwargs)
             self.assertEqual(test_out, ref_out)
 
             # Test normalized_arguments as part of FX
@@ -1351,8 +1351,8 @@ class TestModule(torch.nn.Module):
                 if node.op == 'call_function':
                     normalized_args = node.normalized_arguments(traced, arg_types, kwarg_types)
                     assert normalized_args
-                    node.args = ()
-                    node.kwargs = normalized_args
+                    node.args = normalized_args.args
+                    node.kwargs = normalized_args.kwargs
             traced.recompile()
 
             test_out = traced(*param_values)

--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -13,9 +13,10 @@ class NormalizeArgs(Transformer):
     """
     Normalize arguments to Python targets. This means that
     `args/kwargs` will be matched up to the module/functional's
-    signature and rewritten to exclusively kwargs in positional order.
-    Also populates default values. Does not support positional-only
-    parameters or varargs parameters (*args, **kwargs).
+    signature and rewritten to exclusively kwargs in positional order
+    if `normalize_to_only_use_kwargs` is true. Also populates default
+    values. Does not support positional-only parameters or varargs
+    parameters (*args, **kwargs).
 
     If the nodes have 'type' metadata, it will use it to disambiguate
     overloads. Otherwise, it will throw an error.
@@ -25,9 +26,11 @@ class NormalizeArgs(Transformer):
         traced = torch.fx.symbolic_trace(m)
         traced = NormalizeArgs(traced).transform()
     """
-    def __init__(self, module : torch.nn.Module):
+    def __init__(self, module : torch.nn.Module,
+                 normalize_to_only_use_kwargs : bool = True):
         super().__init__(module)
         self.node_map: Dict[Proxy, Node] = {}
+        self.normalize_to_only_use_kwargs = normalize_to_only_use_kwargs
 
     def run_node(self, n: Node) -> Any:
         args, kwargs = self.fetch_args_kwargs_from_env(n)
@@ -51,17 +54,21 @@ class NormalizeArgs(Transformer):
             self, target : Target, args : Tuple[Argument, ...], kwargs : Dict[str, Any],
             arg_types: Optional[Tuple[Any, ...]] = None, kwarg_types : Optional[Dict[str, Any]] = None):
         assert callable(target)
-        new_kwargs = normalize_function(target, args, kwargs, arg_types, kwarg_types)  # type: ignore[arg-type]
-        if new_kwargs:
-            return self.tracer.create_proxy('call_function', target, (), new_kwargs)
+        new_args_and_kwargs = normalize_function(target, args, kwargs, arg_types, kwarg_types,  # type: ignore[arg-type]
+                                                 self.normalize_to_only_use_kwargs)
+        if new_args_and_kwargs:
+            new_args, new_kwargs = new_args_and_kwargs
+            return self.tracer.create_proxy('call_function', target, new_args, new_kwargs)
         else:
             return super().call_function(target, args, kwargs)
 
     def call_module(self, target : Target, args : Tuple[Argument, ...], kwargs : Dict[str, Any]):
         assert isinstance(target, str)
-        new_kwargs = normalize_module(self.module, target, args, kwargs)  # type: ignore[arg-type]
-        if new_kwargs:
-            return super().call_module(target, (), new_kwargs)
+        new_args_and_kwargs = normalize_module(self.module, target, args, kwargs,  # type: ignore[arg-type]
+                                               self.normalize_to_only_use_kwargs)
+        if new_args_and_kwargs:
+            new_args, new_kwargs = new_args_and_kwargs
+            return super().call_module(target, new_args, new_kwargs)
         else:
             return super().call_module(target, args, kwargs)
 

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -4,7 +4,7 @@ from .immutable_collections import immutable_dict, immutable_list
 import torch
 import builtins
 import types
-from torch.fx.operator_schemas import normalize_function, normalize_module
+from torch.fx.operator_schemas import normalize_function, normalize_module, ArgsKwargsPair
 
 if TYPE_CHECKING:
     from .graph import Graph
@@ -446,11 +446,13 @@ class Node:
 
     def normalized_arguments(
             self, root : torch.nn.Module, arg_types : Optional[Tuple[Any]] = None,
-            kwarg_types : Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+            kwarg_types : Optional[Dict[str, Any]] = None,
+            normalize_to_only_use_kwargs : bool = False) -> Optional[ArgsKwargsPair]:
         """
         Returns normalized arguments to Python targets. This means that
         `args/kwargs` will be matched up to the module/functional's
-        signature and return exclusively kwargs in positional order.
+        signature and return exclusively kwargs in positional order
+        if `normalize_to_only_use_kwargs` is true.
         Also populates default values. Does not support positional-only
         parameters or varargs parameters.
 
@@ -462,10 +464,11 @@ class Node:
             root (torch.nn.Module): Module upon which to resolve module targets.
             arg_types (Optional[Tuple[Any]]): Tuple of arg types for the args
             kwarg_types (Optional[Dict[str, Any]]): Dict of arg types for the kwargs
+            normalize_to_only_use_kwargs (bool): Whether to normalize to only use kwargs.
 
         Returns:
 
-            Returns normalized_kwargs, or `None` if not successful.
+            Returns NamedTuple ArgsKwargsPair, or `None` if not successful.
         """
         if self.op == 'call_function':
             assert callable(self.target)


### PR DESCRIPTION
Summary: Normalization is kind of broken currently. But making default arguments visible still appears to work, and is nice functionality to still be able to rely on/use. Adds an option to `NormalizeArgs`'s `__init__` called `normalize_to_only_use_kwargs` which defaults to true, which if set to false will keep using the same signature as provided, but additionally set kwargs in kwargs.

Test Plan: Added test to `test_fx_experimental`.

Differential Revision: D27759448

