### PR TITLE
[NNC] Fuse loops that have the same bounds as expressions

### DIFF
--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1360,14 +1360,9 @@ For* LoopNest::fuseLoops(const std::vector<For*>& loops) {
   auto first_loop = loops.front();
 
   // Check if bounds are the same for all the loops.
-  // TODO: The following check does not consider different expressions that
-  // evaluate to the same value as the same. Improve this by performing
-  // expression equality.
   auto are_bounds_equal = [](const Expr* bound1, const Expr* bound2) {
-    if (bound1->isConstant() && bound2->isConstant()) {
-      return immediateAs<int>(bound1) == immediateAs<int>(bound2);
-    }
-    return bound1 == bound2;
+    auto diff = IRSimplifier::simplify(new Sub(bound1, bound2));
+    return diff->isConstant() && (immediateAs<int>(diff) == 0);
   };
   auto first_loop_start = IRSimplifier::simplify(first_loop->start());
   auto first_loop_stop = IRSimplifier::simplify(first_loop->stop());


### PR DESCRIPTION
This PR allows fusing loops whose bounds are specified as expressions that are equal. 

For example:
```
   for (int j = 0; j < M + N; j++) {
     A[j] = 10 * j;
   }
   for (int k = 0; k < M + N; k++) {
     B[k] = 20 * k;
   }
```
`fuseLoops(j, k)` is possible since the stop bounds of the two loops are equal though they are different `Expr*` and will result in:
```
   for (int j = 0; j < M + N; j++) {
     A[j] = 10 * j;
     B[j] = 20 * j;
   }
```