### PR TITLE
[PyTorch Edge] Reuse constant table from ts in bytecode

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -67,7 +67,11 @@ constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 //  0x3L: (Comment missing)
 //  0x4L: (Comment missing)
 //  0x4L: (update) Added schema to function tuple. Forward-compatible change.
-constexpr uint64_t kProducedBytecodeVersion = 0x4L;
+//  0x5L: (update)
+//  1. Update tensor storage schema. The root key of tensor storage is
+//  updated from {index} to {archive_name/index}. Forward-compatible change.
+//  2. Update api with extra optional argument {_version} to export old models.
+constexpr uint64_t kProducedBytecodeVersion = 0x5L;
 
 static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
     "kProducedBytecodeVersion must be higher or equal to kProducedFileFormatVersion.");

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -521,9 +521,32 @@ c10::IValue BytecodeDeserializer::readArchive(
     }
   };
 
+  static const std::string slash = "/";
   auto read_record = [&](const std::string& name) {
+    std::size_t found = name.find(slash);
     std::stringstream ss;
-    ss << archive_name << "/" << name;
+    // In version 4, the tensor root_key doesn't include the parent path
+    // To support backward compatibility, when the name doesn't include slash
+    // assume it's version 4 and attach the archive_name_plus_slash
+    // The example tensor format is:
+    // torch._utils._rebuild_tensor_v2(
+    //     pers.obj(('storage', torch.FloatStorage, '17', 'cpu', 22736),),
+    //     0,
+    //     (1, 464, 7, 7),
+    //     (22736, 49, 7, 1),
+    //     False,
+    //     collections.OrderedDict())
+    if (found == std::string::npos) {
+      ss << archive_name << slash << name;
+      return std::get<0>(reader_->getRecord(ss.str()));
+    }
+
+    // In version 4+, the tensor root_key in bytecode will include the parent
+    // path. The example tensor format is: torch._utils._rebuild_tensor_v2(
+    //     pers.obj(('storage', torch.FloatStorage, 'constants/17', 'cpu',
+    //     22736),), 0, (1, 464, 7, 7), (22736, 49, 7, 1), False,
+    //     collections.OrderedDict())
+    ss << name;
     return std::get<0>(reader_->getRecord(ss.str()));
   };
 

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -294,7 +294,18 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
       std::string(toString(tensor.scalar_type())).append("Storage");
   pushGlobal("torch", data_type);
   // root_key
-  pushString(c10::to_string(tensor_data_.size()));
+  // if tensors_archive_table_ includes the tensor, root_key will be,
+  // for example: constants/0, such that it refers to the existing tensor
+  // archive/index.
+  const auto& found = tensors_archive_table_.find(tensor);
+  std::string root_key;
+  if (found != tensors_archive_table_.end()) {
+    std::string archive_name_slash = found->second.first + "/";
+    root_key = archive_name_slash + c10::to_string(found->second.second);
+  } else {
+    root_key = c10::to_string(tensor_data_.size());
+  }
+  pushString(root_key);
   // location
   pushString(tensor.device().str());
   // size

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -14,6 +14,42 @@
 namespace torch {
 namespace jit {
 
+// Example tensor_str: "Columns 1 to 26 1  1  1  1  1  1  1  1  1  1  1  1  1  1
+// 1  1  1  1  1  1  1  1  1  1  1  1\n\nColumns 27 to 52 1  1  1  1  1  1  1  1
+// 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1\n\nColumns 53 to 78 1  1
+// 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+// 1\n\nColumns 79 to 104 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
+// 1  1  1  1  1  1  1  1\n\nColumns 105 to 115 1  1  1  1  1  1  1  1  1  1
+// 1\n[ CPULongType{1,115} ]"
+struct tensor_value_hash {
+  std::size_t operator()(const at::Tensor& tensor) const {
+    std::stringstream tensor_stream;
+    tensor_stream << tensor;
+    std::string tensor_str = tensor_stream.str();
+    std::size_t h1 = std::hash<std::string>{}(tensor_str);
+    return h1;
+  }
+};
+
+struct tensor_value_equal {
+  bool operator()(const at::Tensor& a, const at::Tensor& b) const {
+    std::stringstream a_stream;
+    a_stream << a;
+    std::string a_str = a_stream.str();
+
+    std::stringstream b_stream;
+    b_stream << b;
+    std::string b_str = b_stream.str();
+    return a_str == b_str;
+  }
+};
+
+using TensorIndexMap = std::unordered_map<
+    at::Tensor,
+    std::pair<std::string, int>,
+    tensor_value_hash,
+    tensor_value_equal>;
+
 // See Python's pickletools.py for a detailed description of each of these codes
 enum class PickleOpCode : char {
   MARK = '(',
@@ -149,6 +185,11 @@ class TORCH_API Pickler {
     return tensor_data_;
   }
 
+  void updateTensorsArchiveTable(const TensorIndexMap& tensors_archive_table) {
+    tensors_archive_table_.insert(
+        tensors_archive_table.begin(), tensors_archive_table.end());
+  }
+
   void pushEmptyDict();
   void pushDict(const IValue& ivalue);
   void pushInt(int64_t value);
@@ -260,6 +301,14 @@ class TORCH_API Pickler {
   // similar to ivalues, they are memoized using BINPUT
   std::vector<at::Tensor> tensor_data_;
   std::unordered_map<const void*, uint32_t> memoized_storage_map_;
+
+  // tensors_archive_table_ is a map of (tensor) => (archive_name, index)
+  // when the tensor exists in the map, it is available under the corresponding
+  // archive, and there is no need to rewrite the tensor. It will just update
+  // archive_name.pkl with the corresponding archive path, for example:
+  // constants/0. Currently, this map is only used for bytecode archive
+  // referring constant archive.
+  TensorIndexMap tensors_archive_table_;
 
   std::unordered_map<std::string, uint32_t> memoized_globals_map_;
   std::unordered_map<std::string, uint32_t> memoized_strings_map_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56001 [PyTorch Edge] Support exporting old bytecode models
* **#56000 [PyTorch Edge] Reuse constant table from ts in bytecode**

Differential Revision: [D27759891](https://our.internmc.facebook.com/intern/diff/D27759891/)