### PR TITLE
[PyTorch Edge] Support exporting old bytecode models

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -453,7 +453,7 @@ TEST(LiteInterpreterTest, ModuleInfoBasic) {
   )JIT");
 
   std::stringstream ss;
-  m._save_for_mobile(ss, {}, true);
+  m._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
   mobile::Module bc = _load_for_mobile(ss);
 
   std::unordered_set<std::string> module_debug_info_set;
@@ -511,7 +511,7 @@ TEST(LiteInterpreterTest, OneSubmoduleModuleInfo) {
   )JIT");
 
   std::stringstream ss;
-  b._save_for_mobile(ss, {}, true);
+  b._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
   mobile::Module bc = _load_for_mobile(ss);
 
   std::unordered_set<std::string> module_debug_info_set;
@@ -553,7 +553,8 @@ TEST(LiteInterpreterTest, TwoSubmodulesModuleInfo) {
   )JIT");
 
   std::stringstream ss;
-  c._save_for_mobile(ss, {}, true);
+  c._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
+
   mobile::Module bc = _load_for_mobile(ss);
 
   std::unordered_set<std::string> module_debug_info_set;
@@ -595,9 +596,8 @@ TEST(LiteInterpreterTest, SequentialModuleInfo) {
   )JIT");
 
   std::stringstream ss;
-  c._save_for_mobile(ss, {}, true);
+  c._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
   mobile::Module bc = _load_for_mobile(ss);
-
   std::unordered_set<std::string> module_debug_info_set;
   size_t pc = 0;
   while (true) {
@@ -660,7 +660,8 @@ TEST(LiteInterpreterTest, HierarchyModuleInfo) {
   )JIT");
 
   std::stringstream ss;
-  c._save_for_mobile(ss, {}, true);
+  c._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
+
   mobile::Module bc = _load_for_mobile(ss);
 
   std::unordered_set<std::string> module_debug_info_set;
@@ -703,7 +704,7 @@ TEST(LiteInterpreterTest, DuplicatedClassTypeModuleInfo) {
   )JIT");
 
   std::stringstream ss;
-  b._save_for_mobile(ss, {}, true);
+  b._save_for_mobile(ss, {}, caffe2::serialize::kProducedBytecodeVersion, true);
   mobile::Module bc = _load_for_mobile(ss);
 
   std::unordered_set<std::string> module_debug_info_set;

--- a/test/mobile/test_various_model_versions.py
+++ b/test/mobile/test_various_model_versions.py
@@ -1,0 +1,150 @@
+import torch
+from torch.utils.mobile_optimizer import optimize_for_mobile
+import io
+
+from torch.jit.mobile import _load_for_lite_interpreter
+from torch.testing._internal.common_utils import TestCase, run_tests
+import pathlib
+import tempfile
+import torch.utils.show_pickle
+import shutil
+import fnmatch
+
+class testVariousModelVersions(TestCase):
+    def test_save_load_model_v5(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, v):
+                super().__init__()
+                self.x = v
+
+            def forward(self, y: int):
+                increment = torch.ones([2, 4], dtype=torch.float64)
+                return self.x + y + increment
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # Save model v5
+            # output_model_path = tmp
+            # print("output_model_path: ", output_model_path)
+            output_model_path = pathlib.Path(tmpdirname, "script_module_v5.ptl")
+            script_module = torch.jit.script(TestModule(1))
+            optimized_scripted_module = optimize_for_mobile(script_module)
+            exported_optimized_scripted_module = optimized_scripted_module._save_for_lite_interpreter(str(output_model_path))
+            buf = io.StringIO()
+            torch.utils.show_pickle.main(["", tmpdirname + "/" + output_model_path.name + "@*/bytecode.pkl"], output_stream=buf)
+            output = buf.getvalue()
+
+            expected_result = '''
+(5,
+ ('__torch__.*.TestModule.forward',
+  (('instructions',
+    (('STOREN', 1, 2),
+     ('DROPR', 1, 0),
+     ('LOADC', 0, 0),
+     ('LOADC', 1, 0),
+     ('MOVE', 2, 0),
+     ('OP', 0, 0),
+     ('LOADC', 1, 0),
+     ('OP', 1, 0),
+     ('RET', 0, 0))),
+   ('operators', (('aten::add', 'int'), ('aten::add', 'Scalar'))),
+   ('constants',
+    (torch._utils._rebuild_tensor_v2(pers.obj(('storage', torch.DoubleStorage, 'constants/0', 'cpu', 8),),
+       0,
+       (2, 4),
+       (4, 1),
+       False,
+       collections.OrderedDict()),
+     1)),
+   ('types', ()),
+   ('register_size', 2)),
+  (('arguments',
+    ((('name', 'self'),
+      ('type', '__torch__.*.TestModule'),
+      ('default_value', None)),
+     (('name', 'y'), ('type', 'int'), ('default_value', None)))),
+   ('returns',
+    ((('name', ''), ('type', 'Tensor'), ('default_value', None)),)))))
+        '''
+            acutal_result_clean = "".join(output.split())
+            expected_result_clean = "".join(expected_result.split())
+            isMatch = fnmatch.fnmatch(acutal_result_clean, expected_result_clean)
+            assert(isMatch)
+
+            # Load model v5 and run forward method
+            mobile_module = _load_for_lite_interpreter(str(output_model_path))
+            module_input = 1
+            mobile_module_result = mobile_module(module_input)
+            expected_mobile_module_result = 3 * torch.ones([2, 4], dtype=torch.float64)
+            torch.testing.assert_allclose(mobile_module_result, expected_mobile_module_result)
+            shutil.rmtree(tmpdirname)
+
+
+    def test_save_load_model_v4(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self, v):
+                super().__init__()
+                self.x = v
+
+            def forward(self, y: int):
+                increment = torch.ones([2, 4], dtype=torch.float64)
+                return self.x + y + increment
+
+        # Save model v4
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # Save model v5
+            output_model_path = pathlib.Path(tmpdirname, "script_module_v4.ptl")
+            script_module = torch.jit.script(TestModule(1))
+            optimized_scripted_module = optimize_for_mobile(script_module)
+            exported_optimized_scripted_module = \
+                optimized_scripted_module._save_for_lite_interpreter(str(output_model_path), _version=4)
+            buf = io.StringIO()
+            torch.utils.show_pickle.main(["", tmpdirname + "/" + output_model_path.name + "@*/bytecode.pkl"], output_stream=buf)
+            output = buf.getvalue()
+
+            expected_result = '''
+(4,
+ ('__torch__.*.TestModule.forward',
+  (('instructions',
+    (('STOREN', 1, 2),
+     ('DROPR', 1, 0),
+     ('LOADC', 0, 0),
+     ('LOADC', 1, 0),
+     ('MOVE', 2, 0),
+     ('OP', 0, 0),
+     ('LOADC', 1, 0),
+     ('OP', 1, 0),
+     ('RET', 0, 0))),
+   ('operators', (('aten::add', 'int'), ('aten::add', 'Scalar'))),
+   ('constants',
+    (torch._utils._rebuild_tensor_v2(pers.obj(('storage', torch.DoubleStorage, '0', 'cpu', 8),),
+       0,
+       (2, 4),
+       (4, 1),
+       False,
+       collections.OrderedDict()),
+     1)),
+   ('types', ()),
+   ('register_size', 2)),
+  (('arguments',
+    ((('name', 'self'),
+      ('type', '__torch__.*.TestModule'),
+      ('default_value', None)),
+     (('name', 'y'), ('type', 'int'), ('default_value', None)))),
+   ('returns',
+    ((('name', ''), ('type', 'Tensor'), ('default_value', None)),)))))
+        '''
+            acutal_result_clean = "".join(output.split())
+            expected_result_clean = "".join(expected_result.split())
+            isMatch = fnmatch.fnmatch(acutal_result_clean, expected_result_clean)
+            assert(isMatch)
+
+            # Load model v4 and run forward method
+            mobile_module = _load_for_lite_interpreter(str(output_model_path))
+            module_input = 1
+            mobile_module_result = mobile_module(module_input)
+            expected_mobile_module_result = 3 * torch.ones([2, 4], dtype=torch.float64)
+            torch.testing.assert_allclose(mobile_module_result, expected_mobile_module_result)
+            shutil.rmtree(tmpdirname)
+
+if __name__ == '__main__':
+    run_tests()

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -18,6 +18,7 @@
 #include <ATen/core/qualified_name.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <caffe2/serialize/versions.h>
 
 #include <functional>
 #include <memory>
@@ -219,14 +220,20 @@ struct TORCH_API Module : public Object {
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap()) const;
 
+  // Save bytecode. If version is valid, export the corresponding bytecode.
+  // Default to export latest bytecode version.
   void _save_for_mobile(
       std::ostream& out,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
+      at::optional<uint64_t> version =
+          caffe2::serialize::kProducedBytecodeVersion,
       bool save_mobile_debug_info = false) const;
 
   void _save_for_mobile(
       const std::string& filename,
       const ExtraFilesMap& extra_files = ExtraFilesMap(),
+      at::optional<uint64_t> version =
+          caffe2::serialize::kProducedBytecodeVersion,
       bool save_mobile_debug_info = false) const;
 
   Module copy() const;

--- a/torch/csrc/jit/api/module_save.cpp
+++ b/torch/csrc/jit/api/module_save.cpp
@@ -4,36 +4,47 @@
 namespace torch {
 namespace jit {
 
+// When bytecode_version is empty, bytecode won't be exported.
 void Module::save(std::ostream& out, const ExtraFilesMap& extra_files) const {
-  ExportModule(*this, out, extra_files, false /* bytecode_format */);
+  ExportModule(
+      *this, out, extra_files, at::optional<uint64_t>() /* bytecode version*/);
 }
 
+// When bytecode_version is empty, bytecode won't be exported.
 void Module::save(const std::string& filename, const ExtraFilesMap& extra_files)
     const {
-  ExportModule(*this, filename, extra_files, false /* bytecode_format */);
+  ExportModule(
+      *this,
+      filename,
+      extra_files,
+      at::optional<uint64_t>() /* bytecode version*/);
 }
 
+// bytecode will be exported, if version is a valid and supported number.
 void Module::_save_for_mobile(
     std::ostream& out,
     const ExtraFilesMap& extra_files,
+    at::optional<uint64_t> bytecode_version,
     bool save_mobile_debug_info) const {
   ExportModule(
       *this,
       out,
       extra_files,
-      true /* bytecode_format */,
+      bytecode_version /* bytecode version */,
       save_mobile_debug_info);
 }
 
+// bytecode will be exported, if version is a valid and supported number.
 void Module::_save_for_mobile(
     const std::string& filename,
     const ExtraFilesMap& extra_files,
+    at::optional<uint64_t> bytecode_version,
     bool save_mobile_debug_info) const {
   ExportModule(
       *this,
       filename,
       extra_files,
-      true /* bytecode_format */,
+      bytecode_version /* bytecode version*/,
       save_mobile_debug_info);
 }
 

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -973,22 +973,28 @@ void initJitScriptBindings(PyObject* module) {
           [](Module& m,
              const std::string& filename,
              const ExtraFilesMap& _extra_files = ExtraFilesMap(),
+             uint64_t _version = caffe2::serialize::kProducedBytecodeVersion,
              bool _save_mobile_debug_info = false) {
-            m._save_for_mobile(filename, _extra_files, _save_mobile_debug_info);
+            m._save_for_mobile(
+                filename, _extra_files, _version, _save_mobile_debug_info);
           },
           py::arg("filename"),
           py::arg("_extra_files") = ExtraFilesMap(),
+          py::arg("_version") = caffe2::serialize::kProducedBytecodeVersion,
           py::arg("_save_mobile_debug_info") = false)
       .def(
           "_save_to_buffer_for_mobile",
           [](Module& m,
              const ExtraFilesMap& _extra_files = ExtraFilesMap(),
+             uint64_t _version = caffe2::serialize::kProducedBytecodeVersion,
              bool _save_mobile_debug_info = false) {
             std::ostringstream buf;
-            m._save_for_mobile(buf, _extra_files, _save_mobile_debug_info);
+            m._save_for_mobile(
+                buf, _extra_files, _version, _save_mobile_debug_info);
             return py::bytes(buf.str());
           },
           py::arg("_extra_files") = ExtraFilesMap(),
+          py::arg("_version") = caffe2::serialize::kProducedBytecodeVersion,
           py::arg("_save_mobile_debug_info") = false)
       .def("_set_optimized", &Module::set_optimized)
       .def(

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -70,21 +70,21 @@ TORCH_API void ExportModule(
     const Module& module,
     std::ostream& out,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::string& filename,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 TORCH_API void ExportModule(
     const Module& module,
     const std::function<size_t(const void*, size_t)>& writer_func,
     const ExtraFilesMap& metadata = ExtraFilesMap(),
-    bool bytecode_format = false,
+    at::optional<uint64_t> bytecode_version = at::optional<uint64_t>(),
     bool save_mobile_debug_info = false);
 
 // Write the bytes of a pickle archive and the tensors referenced inside that

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -558,7 +558,7 @@ if _enabled:
             Args:
                 f: a string containing a file name.
                 _extra_files: Map from filename to contents which will be stored as part of 'f'.
-
+                _version: Optional argument to export old bytecode version.
             """
             return self._c._save_for_mobile(*args, **kwargs)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56001 [PyTorch Edge] Support exporting old bytecode models**
* #56000 [PyTorch Edge] Reuse constant table from ts in bytecode

Differential Revision: [D27760087](https://our.internmc.facebook.com/intern/diff/D27760087/)