### PR TITLE
Re-enable fast winograd conv on IOS

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -141,7 +141,7 @@ auto ConvParams::use_cpu_depthwise3x3_winograd(
     const at::Tensor& input,
     const at::Tensor& weight,
     const at::Tensor& bias) const -> bool {
-#if defined(__ARM_NEON__) && !defined(C10_IOS)
+#if defined(__ARM_NEON__)
   // Currently only 3x3 depthwise convolutions on tensors of float are supported.
   return (input.ndimension() == 4) &&
          (input.size(1) == groups) &&


### PR DESCRIPTION
This is the proper fix for https://github.com/pytorch/pytorch/issues/38186
@husthyc tested locally that it indeed fixes the issue there.