### PR TITLE
[19/n][torch/elastic][upstream] Replace pytorch.distributed.launch with torchelastic launcher

### DIFF
--- a/test/distributed/argparse_util_test.py
+++ b/test/distributed/argparse_util_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+import unittest
+from argparse import ArgumentParser
+
+from torch.distributed.argparse_util import check_env, env
+
+
+class ArgParseUtilTest(unittest.TestCase):
+    def setUp(self):
+        # remove any lingering environment variables
+        for e in os.environ.keys():
+            if e.startswith("PET_"):
+                del os.environ[e]
+
+    def test_env_string_arg_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar")
+
+        self.assertEqual("bar", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_string_arg_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar")
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_int_arg_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default=1, type=int)
+
+        self.assertEqual(1, parser.parse_args([]).foo)
+        self.assertEqual(2, parser.parse_args(["-f", "2"]).foo)
+        self.assertEqual(2, parser.parse_args(["--foo", "2"]).foo)
+
+    def test_env_int_arg_env(self):
+        os.environ["PET_FOO"] = "3"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default=1, type=int)
+
+        self.assertEqual(3, parser.parse_args([]).foo)
+        self.assertEqual(2, parser.parse_args(["-f", "2"]).foo)
+        self.assertEqual(2, parser.parse_args(["--foo", "2"]).foo)
+
+    def test_env_no_default_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env)
+
+        self.assertIsNone(parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_no_default_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env)
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_required_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, required=True)
+
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_env_required_env(self):
+        os.environ["PET_FOO"] = "env_baz"
+        parser = ArgumentParser()
+        parser.add_argument("-f", "--foo", action=env, default="bar", required=True)
+
+        self.assertEqual("env_baz", parser.parse_args([]).foo)
+        self.assertEqual("baz", parser.parse_args(["-f", "baz"]).foo)
+        self.assertEqual("baz", parser.parse_args(["--foo", "baz"]).foo)
+
+    def test_check_env_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["-v"]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_no_env(self):
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["-v"]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_env_zero(self):
+        os.environ["PET_VERBOSE"] = "0"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_env_one(self):
+        os.environ["PET_VERBOSE"] = "1"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_env_zero(self):
+        os.environ["PET_VERBOSE"] = "0"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertFalse(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)
+
+    def test_check_env_default_env_one(self):
+        os.environ["PET_VERBOSE"] = "1"
+        parser = ArgumentParser()
+        parser.add_argument("-v", "--verbose", action=check_env, default=True)
+
+        self.assertTrue(parser.parse_args([]).verbose)
+        self.assertTrue(parser.parse_args(["--verbose"]).verbose)

--- a/test/distributed/elastic/rendezvous/static_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/static_rendezvous_test.py
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+from contextlib import closing
+
+from torch.distributed.elastic.rendezvous import RendezvousParameters
+from torch.distributed.elastic.rendezvous.static_tcp_rendezvous import (
+    create_rdzv_handler,
+)
+from torch.distributed.elastic.utils import get_socket_with_port
+
+
+class StaticTCPRendezvousTest(unittest.TestCase):
+    def test_missing_port(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="localhost",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_empty_endpoint(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_ipv6_addr(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:90",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_ipv6_addr_localhost(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="[::1]:90",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+        )
+        with self.assertRaises(ValueError):
+            create_rdzv_handler(rdzv_params)
+
+    def test_get_backend(self):
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint="localhost:123",
+            run_id="test",
+            min_nodes=1,
+            max_nodes=1,
+            timeout=60,
+            rank=0,
+        )
+
+        static_rdzv = create_rdzv_handler(rdzv_params)
+        self.assertEqual("static", static_rdzv.get_backend())
+
+    def test_static_rdzv_multiple_calls(self):
+        sock = get_socket_with_port()
+        with closing(sock):
+            master_port = sock.getsockname()[1]
+        master_addr = "localhost"
+
+        rdzv_params = RendezvousParameters(
+            backend="static",
+            endpoint=f"{master_addr}:{master_port}",
+            run_id="test_id",
+            min_nodes=1,
+            max_nodes=1,
+            rank=0,
+        )
+        rdzv_handler = create_rdzv_handler(rdzv_params)
+
+        # Call rendezvous two times
+        store, rank, world_size = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(store)
+        self.assertEqual(0, rank)
+        self.assertEqual(1, world_size)
+
+        store, rank, world_size = rdzv_handler.next_rendezvous()
+        self.assertIsNotNone(store)
+        self.assertEqual(0, rank)
+        self.assertEqual(1, world_size)

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -27,6 +27,7 @@ if is_available():
         FileStore,
         TCPStore,
         ProcessGroup,
+        PrefixStore,
         Reducer,
         Logger,
         BuiltinCommHookType,

--- a/torch/distributed/argparse_util.py
+++ b/torch/distributed/argparse_util.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import os
+from argparse import Action
+
+
+class env(Action):
+    """
+    Gets argument values from ``PET_{dest}`` before defaulting
+    to the given ``default`` value. For flags (e.g. ``--standalone``)
+    use ``check_env`` instead.
+
+    .. note:: when multiple option strings are specified, ``dest`` is
+              the longest option string (e.g. for ``"-f", "--foo"``
+              the env var to set is ``PET_FOO`` not ``PET_F``)
+
+    Example:
+
+    ::
+
+     parser.add_argument("-f", "--foo", action=env, default="bar")
+
+     ./program                                      -> args.foo="bar"
+     ./program -f baz                               -> args.foo="baz"
+     ./program --foo baz                            -> args.foo="baz"
+     PET_FOO="env_bar" ./program -f baz    -> args.foo="baz"
+     PET_FOO="env_bar" ./program --foo baz -> args.foo="baz"
+     PET_FOO="env_bar" ./program           -> args.foo="env_bar"
+
+     parser.add_argument("-f", "--foo", action=env, required=True)
+
+     ./program                                      -> fails
+     ./program -f baz                               -> args.foo="baz"
+     PET_FOO="env_bar" ./program           -> args.foo="env_bar"
+     PET_FOO="env_bar" ./program -f baz    -> args.foo="baz"
+    """
+
+    def __init__(self, dest, default=None, required=False, **kwargs) -> None:
+        env_name = f"PET_{dest.upper()}"
+        default = os.environ.get(env_name, default)
+
+        # ``required`` means that it NEEDS to be present  in the command-line args
+        # rather than "this option requires a value (either set explicitly or default"
+        # so if we found default then we don't "require" it to be in the command-line
+        # so set it to False
+        if default:
+            required = False
+
+        super().__init__(dest=dest, default=default, required=required, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values)
+
+
+class check_env(Action):
+    """
+    For flags, checks whether the env var ``PET_{dest}`` exists
+    before defaulting to the given ``default`` value. Equivalent to
+    ``store_true`` argparse built-in action except that the argument can
+    be omitted from the commandline if the env var is present and has a
+    non-zero value.
+
+    .. note:: it is redundant to pass ``default=True`` for arguments
+              that use this action because a flag should be ``True``
+              when present and ``False`` otherwise.
+
+    Example:
+
+    ::
+
+     parser.add_argument("--verbose", action=check_env)
+
+     ./program                                  -> args.verbose=False
+     ./program --verbose                        -> args.verbose=True
+     PET_VERBOSE=1 ./program           -> args.verbose=True
+     PET_VERBOSE=0 ./program           -> args.verbose=False
+     PET_VERBOSE=0 ./program --verbose -> args.verbose=True
+
+    Anti-pattern (don't do this):
+
+    ::
+
+     parser.add_argument("--verbose", action=check_env, default=True)
+
+     ./program                                  -> args.verbose=True
+     ./program --verbose                        -> args.verbose=True
+     PET_VERBOSE=1 ./program           -> args.verbose=True
+     PET_VERBOSE=0 ./program           -> args.verbose=False
+
+    """
+
+    def __init__(self, dest, default=False, **kwargs) -> None:
+        env_name = f"PET_{dest.upper()}"
+        default = bool(int(os.environ.get(env_name, "1" if default else "0")))
+        super().__init__(dest=dest, const=True, default=default, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, self.const)

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -21,6 +21,7 @@ from torch.distributed.elastic.agent.server.api import (
 )
 from torch.distributed.elastic.metrics.api import prof
 from torch.distributed.elastic.multiprocessing import start_processes, PContext
+from torch.distributed.elastic.utils import macros
 
 
 log = logging.getLogger(__name__)
@@ -104,7 +105,7 @@ class LocalElasticAgent(SimpleElasticAgent):
     ):
         super().__init__(spec, exit_barrier_timeout)
         self._start_method = start_method
-        self._pcontext : Optional[PContext] = None
+        self._pcontext: Optional[PContext] = None
         rdzv_run_id = spec.rdzv_handler.get_run_id()
         self._log_dir = self._make_log_dir(log_dir, rdzv_run_id)
 
@@ -127,8 +128,11 @@ class LocalElasticAgent(SimpleElasticAgent):
     def _start_workers(self, worker_group: WorkerGroup) -> Dict[int, Any]:
         spec = worker_group.spec
         store = worker_group.store
+        assert store is not None
         master_addr, master_port = super()._get_master_addr_port(store)
         restart_count = spec.max_restarts - self._remaining_restarts
+
+        use_agent_store = spec.rdzv_handler.get_backend() == "static"
 
         args: Dict[int, Tuple] = {}
         envs: Dict[int, Dict[str, str]] = {}
@@ -142,18 +146,22 @@ class LocalElasticAgent(SimpleElasticAgent):
                 "ROLE_NAME": spec.role,
                 "LOCAL_WORLD_SIZE": str(spec.local_world_size),
                 "WORLD_SIZE": str(worker.world_size),
+                "GROUP_WORLD_SIZE": str(worker_group.group_world_size),
                 "ROLE_WORLD_SIZE": str(worker.role_world_size),
                 "MASTER_ADDR": master_addr,
                 "MASTER_PORT": str(master_port),
                 "TORCHELASTIC_RESTART_COUNT": str(restart_count),
                 "TORCHELASTIC_MAX_RESTARTS": str(spec.max_restarts),
                 "TORCHELASTIC_RUN_ID": spec.rdzv_handler.get_run_id(),
+                "TORCHELASTIC_USE_AGENT_STORE": str(use_agent_store),
                 "NCCL_ASYNC_ERROR_HANDLING": str(1),
             }
             if "OMP_NUM_THREADS" in os.environ:
                 worker_env["OMP_NUM_THREADS"] = os.environ["OMP_NUM_THREADS"]
             envs[local_rank] = worker_env
-            args[local_rank] = spec.args
+            worker_args = list(spec.args)
+            worker_args = macros.substitute(worker_args, str(local_rank))
+            args[local_rank] = tuple(worker_args)
 
         # scaling events do not count towards restarts (gets same attempt #)
         # remove existing log dir if this restart is due to a scaling event

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -15,7 +15,7 @@ from torch.distributed import Store, TCPStore
 
 from .api import RendezvousConnectionError, RendezvousParameters, RendezvousStateError
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _matches_machine_hostname, _parse_rendezvous_endpoint
+from .utils import _matches_machine_hostname, parse_rendezvous_endpoint
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class C10dRendezvousBackend(RendezvousBackend):
 
 
 def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
-    host, port = _parse_rendezvous_endpoint(params.endpoint, default_port=29500)
+    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=29500)
 
     cfg_is_host = params.get_as_bool("is_host")
     # If the user has explicitly specified whether our process should host the

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -23,7 +23,7 @@ from torch.distributed.elastic.rendezvous import (
     RendezvousTimeoutError,
 )
 
-from .utils import _parse_rendezvous_endpoint
+from .utils import parse_rendezvous_endpoint
 from .etcd_store import EtcdStore, cas_delay
 
 
@@ -975,7 +975,7 @@ def _create_etcd_client(params: RendezvousParameters) -> etcd.Client:
     """
     Creates a new ``etcd.Client`` from the specified ``RendezvousParameters``.
     """
-    hostname, port = _parse_rendezvous_endpoint(params.endpoint, 2379)
+    hostname, port = parse_rendezvous_endpoint(params.endpoint, 2379)
 
     # The communication protocol
     protocol = params.config.get("protocol")

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -20,7 +20,7 @@ from etcd import (  # type: ignore
 
 from .api import RendezvousConnectionError, RendezvousParameters, RendezvousStateError
 from .dynamic_rendezvous import RendezvousBackend, Token
-from .utils import _parse_rendezvous_endpoint
+from .utils import parse_rendezvous_endpoint
 
 
 class EtcdRendezvousBackend(RendezvousBackend):
@@ -145,7 +145,7 @@ class EtcdRendezvousBackend(RendezvousBackend):
 
 
 def _create_etcd_client(params: RendezvousParameters) -> EtcdClient:
-    host, port = _parse_rendezvous_endpoint(params.endpoint, default_port=2379)
+    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=2379)
 
     # The timeout
     read_timeout = cast(int, params.get_as_int("read_timeout", 60))
@@ -210,4 +210,6 @@ def create_backend(params: RendezvousParameters) -> EtcdRendezvousBackend:
     """
     client = _create_etcd_client(params)
 
-    return EtcdRendezvousBackend(client, params.run_id, key_prefix="/torch/elastic/rendezvous")
+    return EtcdRendezvousBackend(
+        client, params.run_id, key_prefix="/torch/elastic/rendezvous"
+    )

--- a/torch/distributed/elastic/rendezvous/registry.py
+++ b/torch/distributed/elastic/rendezvous/registry.py
@@ -10,6 +10,12 @@ from .dynamic_rendezvous import create_handler
 
 
 def _create_etcd_handler(params: RendezvousParameters) -> RendezvousHandler:
+    from . import static_tcp_rendezvous
+
+    return static_tcp_rendezvous.create_rdzv_handler(params)
+
+
+def _create_static_handler(params: RendezvousParameters) -> RendezvousHandler:
     from . import etcd_rendezvous
 
     return etcd_rendezvous.create_rdzv_handler(params)
@@ -38,6 +44,7 @@ def _register_default_handlers() -> None:
     handler_registry.register("etcd", _create_etcd_handler)
     handler_registry.register("c10d-experimental", _create_c10d_handler)
     handler_registry.register("etcd-experimental", _create_expr_etcd_handler)
+    handler_registry.register("static", _create_static_handler)
 
 
 # The legacy function kept for backwards compatibility.

--- a/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/static_tcp_rendezvous.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import datetime
+import logging
+from typing import Tuple, cast, Optional
+
+# pyre-ignore[21]: Could not find name `Store` in `torch.distributed`.
+from torch.distributed import Store, TCPStore, PrefixStore
+from torch.distributed.elastic.rendezvous import RendezvousHandler, RendezvousParameters
+from torch.distributed.elastic.rendezvous.utils import parse_rendezvous_endpoint
+
+log = logging.getLogger(__name__)
+
+_default_timeout_seconds = 600
+
+
+class StaticTCPRendezvous(RendezvousHandler):
+    """
+    Static rendezvous that is a wrapper around the TCPStore.
+    Creates TCPStore based on the input parameters with the
+    listener on the agent with group_rank=0
+    """
+
+    def __init__(
+        self,
+        master_addr: str,
+        master_port: int,
+        rank: int,
+        world_size: int,
+        run_id: str,
+        timeout: int,
+    ):
+        self.master_addr = master_addr
+        self.master_port = master_port
+        self.rank = rank
+        self.world_size = world_size
+        self.run_id = run_id
+        self.timeout = datetime.timedelta(seconds=timeout)
+        self._store: Optional[Store] = None
+
+    def get_backend(self) -> str:
+        return "static"
+
+    def next_rendezvous(self) -> Tuple[Store, int, int]:
+        log.info("Creating TCPStore as the c10d::Store implementation")
+        if not self._store:
+            is_master = self.rank == 0
+            self._store = TCPStore(
+                self.master_addr,
+                self.master_port,
+                self.world_size,
+                is_master,
+                self.timeout,
+            )
+        store = PrefixStore(self.run_id, self._store)
+        return store, self.rank, self.world_size
+
+    def is_closed(self):
+        return False
+
+    def set_closed(self):
+        pass
+
+    def num_nodes_waiting(self):
+        return 0
+
+    def get_run_id(self) -> str:
+        return self.run_id
+
+    def shutdown(self) -> bool:
+        return True
+
+
+def create_rdzv_handler(params: RendezvousParameters) -> RendezvousHandler:
+    if "rank" not in params.config:
+        raise ValueError(
+            "rank is absent in RendezvousParameters."
+            "Try add --node_rank to the cmd request"
+        )
+    endpoint = params.endpoint.strip()
+    if not endpoint:
+        raise ValueError(
+            "endpoint is absent in RendezvousParameters"
+            "Try add --master_port and --master_addr to the cmd request"
+        )
+    master_addr, master_port = parse_rendezvous_endpoint(endpoint, -1)
+    if master_port == -1:
+        raise ValueError(
+            f"Port is absent in endpoint: {endpoint}. Try launching with --master_port"
+        )
+    world_size = params.max_nodes
+    rank = cast(int, params.config.get("rank"))
+    run_id = params.run_id
+    if "timeout" in params.config:
+        timeout = int(params.config["timeout"])
+    else:
+        timeout = _default_timeout_seconds
+    return StaticTCPRendezvous(
+        master_addr, master_port, rank, world_size, run_id, timeout
+    )

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -55,7 +55,7 @@ def _try_parse_port(port_str: str) -> Optional[int]:
     return None
 
 
-def _parse_rendezvous_endpoint(endpoint: Optional[str], default_port: int) -> Tuple[str, int]:
+def parse_rendezvous_endpoint(endpoint: Optional[str], default_port: int) -> Tuple[str, int]:
     """Extracts the hostname and the port number from a rendezvous endpoint.
 
     Args:

--- a/torch/distributed/elastic/utils/__init__.py
+++ b/torch/distributed/elastic/utils/__init__.py
@@ -6,4 +6,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .api import get_env_variable_or_raise  # noqa F401
+from .api import get_env_variable_or_raise, get_socket_with_port, macros  # noqa F401

--- a/torch/distributed/elastic/utils/api.py
+++ b/torch/distributed/elastic/utils/api.py
@@ -7,6 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import socket
+from string import Template
+from typing import List, Any
 
 
 def get_env_variable_or_raise(env_name: str) -> str:
@@ -22,3 +25,38 @@ def get_env_variable_or_raise(env_name: str) -> str:
         msg = f"Environment variable {env_name} expected, but not set"
         raise ValueError(msg)
     return value
+
+
+def get_socket_with_port() -> socket.socket:
+    addrs = socket.getaddrinfo(
+        host="localhost", port=None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM
+    )
+    for addr in addrs:
+        family, type, proto, _, _ = addr
+        s = socket.socket(family, type, proto)
+        try:
+            s.bind(("localhost", 0))
+            s.listen(0)
+            return s
+        except OSError as e:
+            s.close()
+    raise RuntimeError("Failed to create a socket")
+
+
+class macros:
+    """
+    Defines simple macros for caffe2.distributed.launch cmd args substitution
+    """
+
+    local_rank = "${local_rank}"
+
+    @staticmethod
+    def substitute(args: List[Any], local_rank: str) -> List[str]:
+        args_sub = []
+        for arg in args:
+            if isinstance(arg, str):
+                sub = Template(arg).safe_substitute(local_rank=local_rank)
+                args_sub.append(sub)
+            else:
+                args_sub.append(arg)
+        return args_sub

--- a/torch/distributed/elastic_launch.py
+++ b/torch/distributed/elastic_launch.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+This module provides similar functionality as ``torch.distributed.launch``,
+with the following additional functionalities:
+
+1. Worker failures are handled gracefully by restarting all workers.
+
+2. Worker ``RANK`` and ``WORLD_SIZE`` are assigned automatically.
+
+3. Number of nodes is allowed to change between min and max sizes (elasticity).
+
+**Usage:**
+
+1. Single-node multi-worker (with sidecar etcd server)
+
+::
+
+    >>> python -m torch.distributed.elastic_launch
+        --standalone
+        --nnodes=1
+        --nproc_per_node=$NUM_TRAINERS
+        YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+2. Fault tolerant (fixed sized number of workers, no elasticity).:
+
+::
+
+    >>> python -m torch.distributed.elastic_launch
+        --nnodes=$NUM_NODES
+        --nproc_per_node=$NUM_TRAINERS
+        --rdzv_id=$JOB_ID
+        --rdzv_backend=etcd
+        --rdzv_endpoint=$ETCD_HOST:$ETCD_PORT
+        YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+3. Elastic (``min=1``, ``max=4``):
+
+::
+
+    >>> python -m torch.distributed.elastic_launch
+        --nnodes=1:4
+        --nproc_per_node=$NUM_TRAINERS
+        --rdzv_id=$JOB_ID
+        --rdzv_backend=etcd
+        --rdzv_endpoint=$ETCD_HOST:$ETCD_PORT
+        YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+**Note on rendezvous backend**:
+
+For multi-node training you need to specify:
+
+1. ``--rdzv_id``: a unique job id (shared by all nodes participating in the job)
+2. ``--rdzv_backend``: an implementation of ``torch.distributed.elastic.rendevous.RendezvousHandler``
+3. ``--rdzv_endpoint``: ``host:port``-style endpoint where the rdzv backend is running.
+
+Currently only ``etcd`` rdzv backend is supported out of the box.
+To use ``etcd``, setup an etcd server with the ``v2`` api enabled
+(e.g. ``--enable-v2``).
+
+.. warning:: ``EtcdRendezvous`` uses etcd api v2. You MUST enable the v2
+             api on the etcd server. Our tests use etcd v3.4.3.
+
+**Definitions:**
+
+1. ``Node`` - Physical instance or container.
+    Maps to the unit that the job manager works with.
+
+2. ``Worker`` - A worker in the context of distributed training.
+
+3. ``Worker Group`` - Workers that execute the same function (e.g. trainers)
+
+4. ``Local Worker Group`` - Subset of the workers in the
+    worker group running on the same Node
+
+5. ``RANK`` - rank of the worker within a worker group.
+
+6. ``WORLD_SIZE`` - total number of workers in a worker group.
+
+7. ``LOCAL_RANK`` - rank of the worker within a local worker group
+
+8. ``LOCAL_WORLD_SIZE`` - size of the local worker group
+
+9. ``rdzv_id`` - user defined id that uniquely identifies the worker group
+      for a job. This id is used by each node to join as a member of a particular
+      worker group.
+
+9. ``rdzv_backend`` - the backend store of rendezvous (e.g. etcd). This is
+    typically a strongly consistent key-value store.
+
+10. ``rdzv_endpoint`` - rdzv backend server endpoint in ``host:port`` format.
+
+A ``Node`` runs ``LOCAL_WORLD_SIZE`` workers which comprise a ``LocalWorkerGroup``.
+The union of all ``LocalWorkerGroups`` in the nodes in the job comprise the
+``WorkerGroup``.
+
+**Environment Variables:**
+
+The following environment variables are made available to you in your
+script:
+
+1. ``LOCAL_RANK`` -  local rank
+
+2. ``RANK`` -  global rank
+
+3. ``GROUP_RANK`` - rank of the worker group. A number between 0 - ``max_nnodes``.
+        When running a single worker group per node, this is the rank of the node.
+
+4. ``ROLE_RANK`` -  the rank of the worker across all the workers tha have the same
+        role. The role of the worker is specified in the ``WorkerSpec``.
+
+5. ``LOCAL_WORLD_SIZE`` - local world size (e.g. number of workers running locally).
+       Equal to ``--nproc_per_node`` specified on ``torch.distributed.elastic_launch``.
+
+6. ``WORLD_SIZE`` - world size (total number of workers in the job).
+
+7. ``ROLE_WORLD_SIZE`` - the total number of workers that was launched with the same
+        role specified in ``WorkerSpec``.
+
+8. ``MASTER_ADDR`` - fqdn of the host that is running worker with rank 0.
+   Used to initialize torch distributed backend.
+
+9. ``MASTER_PORT`` - port on the ``MASTER_ADDR`` that can be used to
+   host the tcp ``c10d`` store.
+
+10. ``TORCHELASTIC_RESTART_COUNT`` - number of worker group restarts so far.
+
+11. ``TORCHELASTIC_MAX_RESTARTS`` - configured max number of restarts.
+
+12. ``TORCHELASTIC_RUN_ID`` - equal to rdzv run_id (e.g. unique job id).
+
+**Deployment:**
+
+1. Start the rdzv backend server and get the endpoint
+   (to be passed as ``--rdzv_endpoint`` to the launcher script)
+
+2. Single-node multi-worker - start the launcher on the host to start
+   the agent process which creates and monitors a local worker group.
+
+3. Multi-node multi-worker - Start the launcher with the same arguments
+   on all the nodes participating in training.
+
+When using a job/cluster manager the entry point command to the multi-node
+job is invoking this launcher.
+
+**Failure Modes:**
+
+1. Worker failure - For a training job with ``n`` workers, if ``k <= n`` workers fail
+   all workers are stopped and restarted up to ``max_restarts``.
+
+2. Agent failure - An agent failure results in local worker group failure,
+   it is up to the job manager to fail the entire job (gang semantics) or attempt
+   to replace the node. Both behaviors are supported by the agent.
+
+3. Node failure - Same as agent failure.
+
+**Membership Changes:**
+
+1. Node departure (scale-down) - agent is notified of the departure,
+   all existing workers are stopped, a new ``Worker Group`` is formed and all
+   workers are started with a new ``RANK`` and ``WORLD_SIZE``.
+
+2. Node arrival (scale-up) - the new node is admitted to the job,
+   all existing workers are stopped, a new ``Worker Group`` is formed and all
+   workers are started with a new ``RANK`` and ``WORLD_SIZE``.
+
+
+**Important Notices:**
+
+1. All the items in the important notices section of ``torch.distributed.launch``
+   apply to this module as well
+
+2. The environment variables necessary to initialize a torch process group
+   are provided to you by this module, no need for you to pass ``RANK`` manually.
+   To initialize a process group in your training script, simply run
+
+::
+
+ >>> import torch.distributed as dist
+ >>> dist.init_process_group(backend="gloo|nccl")
+
+3. On failures or membership changes ALL surviving workers are killed
+   immediately. Make sure to checkpoint your progress. The frequency of
+   checkpoints should depend on your job's tolerance for lost work.
+
+4. This module only supports homogeneous ``LOCAL_WORLD_SIZE``. That is,
+   it is assumed that all nodes run the same number of local workers (per role).
+
+5. ``RANK`` is NOT stable. Between restarts, the local workers on a node
+   can be assgined a different range of ranks than before. NEVER hard code
+   any assumptions about the stable-ness of ranks or some correlation between
+   ``RANK`` and ``LOCAL_RANK``.
+
+6. When using elasticity (``min_size != max_size``) DO NOT hard code
+   assumptions about ``WORLD_SIZE`` as the world size can change as
+   nodes are allowed to leave and join.
+
+7. It is recommended your script have the following structure
+
+::
+
+  def main():
+    load_checkpoint(checkpoint_path)
+    initialize()
+    train()
+
+  def train():
+    for batch in iter(dataset):
+      train_step(batch)
+
+      if should_checkpoint:
+        save_checkpoint(checkpoint_path)
+"""
+import logging
+import os
+import sys
+import uuid
+from argparse import REMAINDER, ArgumentParser
+from typing import List, Tuple
+
+import torch
+from torch.distributed.argparse_util import check_env, env
+from torch.distributed.elastic.multiprocessing import Std
+from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.utils import _parse_rendezvous_config
+from torch.distributed.elastic.utils import macros
+from torch.distributed.elastic.utils.logging import get_logger
+from torch.distributed.launcher.api import LaunchConfig, elastic_launch
+
+
+log = get_logger()
+
+
+def get_args_parser() -> ArgumentParser:
+    """
+    Helper function parsing the command line options.
+    """
+
+    parser = ArgumentParser(description="torchelastic elastic training launcher")
+
+    # Arguments for the launch helper
+    # worker/node size related arguments
+    parser.add_argument(
+        "--nnodes",
+        action=env,
+        type=str,
+        default="1:1",
+        help="number of nodes or MIN_NODES:MAX_NODES",
+    )
+    parser.add_argument(
+        "--nproc_per_node",
+        action=env,
+        type=str,
+        default="auto",
+        help="number of workers per node, supported values: [auto, cpu, gpu, int]",
+    )
+
+    # rendezvous related arguments
+    parser.add_argument(
+        "--rdzv_backend",
+        action=env,
+        type=str,
+        default="static",
+        help="rendezvous backend",
+    )
+    parser.add_argument(
+        "--rdzv_endpoint",
+        action=env,
+        type=str,
+        default="",
+        help="rendezvous backend server host:port",
+    )
+    parser.add_argument(
+        "--rdzv_id",
+        action=env,
+        default="<NONE>",
+        type=str,
+        help="user defined group id",
+    )
+    parser.add_argument(
+        "--rdzv_conf",
+        action=env,
+        type=str,
+        default="",
+        help="additional rdzv configuration (conf1=v1,conf2=v2,...)",
+    )
+
+    # sidecar embed rdzv backend that defaults to etcd
+    parser.add_argument(
+        "--standalone",
+        action=check_env,
+        help="starts a local, standalone rdzv backend that is represented by"
+        " etcd server on a random free port"
+        "using the etcd binary specified in TORCHELASTIC_ETCD_BINARY_PATH"
+        " env var or the one found in PATH."
+        " Useful when launching single-node, multi-worker job."
+        " If specified --rdzv_backend, --rdzv_endpoint, --rdzv_id"
+        " are autoassigned, any explicitly set values are ignored",
+    )
+
+    # user-code launch related arguments
+    parser.add_argument(
+        "--max_restarts",
+        action=env,
+        type=int,
+        default=3,
+        help="max number of worker group restarts before failing",
+    )
+    parser.add_argument(
+        "--monitor_interval",
+        action=env,
+        type=float,
+        default=5,
+        help="interval (in seconds) to monitor the state of workers",
+    )
+    parser.add_argument(
+        "--start_method",
+        action=env,
+        type=str,
+        default="spawn",
+        choices=["spawn", "fork", "forkserver"],
+        help="multiprocessing start_method to use when creating workers",
+    )
+    parser.add_argument(
+        "--role",
+        action=env,
+        type=str,
+        default="default",
+        help="user-defined role for the workers",
+    )
+    parser.add_argument(
+        "-m",
+        "--module",
+        action=check_env,
+        help="Changes each process to interpret the launch script "
+        "as a python module, executing with the same behavior as"
+        "'python -m'.",
+    )
+    parser.add_argument(
+        "--no_python",
+        action=check_env,
+        help='Do not prepend the training script with "python" - just exec '
+        "it directly. Useful when the script is not a Python script.",
+    )
+
+    parser.add_argument(
+        "--log_dir",
+        action=env,
+        type=str,
+        default=None,
+        help="base dir to use for log files (e.g. /var/log/torchelastic)"
+        " can reuse the same dir for multiple runs "
+        "(a unique job-level subdir is created with rdzv_id as the prefix)",
+    )
+
+    parser.add_argument(
+        "-r",
+        "--redirects",
+        action=env,
+        type=str,
+        default="0",
+        help="std streams to redirect into a log file in the log_dir"
+        " (e.g. [-r 3] redirects both stdout+stderr for all workers,"
+        " [-r 0:1,1:2] redirects stdout for local rank 0 and stderr for local rank 1)",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--tee",
+        action=env,
+        type=str,
+        default="0",
+        help="tee std streams into a log file and also to console (see --redirects for format)",
+    )
+
+    # backwards compatible params with caffe2.distributed.launch
+
+    parser.add_argument(
+        "--node_rank",
+        type=int,
+        action=env,
+        default=0,
+        help="The rank of the node for multi-node distributed " "training",
+    )
+
+    parser.add_argument(
+        "--master_addr",
+        default="127.0.0.1",
+        type=str,
+        action=env,
+        help="Master node (rank 0)'s address, should be either "
+        "the IP address or the hostname of node 0, for "
+        "single node multi-proc training, the "
+        "--master_addr can simply be 127.0.0.1"
+        "IPV6 should have the following pattern: `[0:0:0:0:0:0:0:1]`",
+    )
+    parser.add_argument(
+        "--master_port",
+        default=29500,
+        type=int,
+        action=env,
+        help="Master node (rank 0)'s free port that needs to "
+        "be used for communication during distributed "
+        "training",
+    )
+
+    # positional
+    parser.add_argument(
+        "training_script",
+        type=str,
+        help="The full path to the single GPU training "
+        "program/script to be launched in parallel, "
+        "followed by all the arguments for the "
+        "training script",
+    )
+
+    # rest from the training program
+    parser.add_argument("training_script_args", nargs=REMAINDER)
+    return parser
+    # return parser.parse_args(args)
+
+
+def parse_args(args):
+    parser = get_args_parser()
+    parser.add_argument(
+        "--use_env",
+        default=True,
+        action="store_true",
+        help="Use environment variable to pass "
+        "'local rank'. For legacy reasons, the default value is False. "
+        "If set to True, the script will not pass "
+        "--local_rank as argument, and will instead set LOCAL_RANK.",
+    )
+    return parser.parse_args(args)
+
+
+def parse_min_max_nnodes(nnodes: str):
+    arr = nnodes.split(":")
+
+    if len(arr) == 1:
+        min_nodes = max_nodes = int(arr[0])
+    elif len(arr) == 2:
+        min_nodes = int(arr[0])
+        max_nodes = int(arr[1])
+    else:
+        raise RuntimeError(f'nnodes={nnodes} is not in "MIN:MAX" format')
+
+    return min_nodes, max_nodes
+
+
+def determine_local_world_size(nproc_per_node: str):
+    try:
+        logging.info(f"Using nproc_per_node={nproc_per_node}.")
+        return int(nproc_per_node)
+    except ValueError:
+        if nproc_per_node == "cpu":
+            num_proc = os.cpu_count()
+            device_type = "cpu"
+        elif nproc_per_node == "gpu":
+            if not torch.cuda.is_available():
+                raise ValueError("Cuda is not available.")
+            device_type = "gpu"
+            num_proc = torch.cuda.device_count()
+        elif nproc_per_node == "auto":
+            if torch.cuda.is_available():
+                num_proc = torch.cuda.device_count()
+                device_type = "gpu"
+            else:
+                num_proc = os.cpu_count()
+                device_type = "cpu"
+        else:
+            raise ValueError(f"Unsupported nproc_per_node value: {nproc_per_node}")
+
+        log.info(
+            f"Using nproc_per_node={nproc_per_node},"
+            f" seting to {num_proc} since the instance "
+            f"has {os.cpu_count()} {device_type}"
+        )
+        return num_proc
+
+
+def get_rdzv_endpoint(args):
+    if args.rdzv_backend == "static":
+        return f"{args.master_addr}:{args.master_port}"
+    else:
+        return args.rdzv_endpoint
+
+
+def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
+    # If ``args`` not passed, defaults to ``sys.argv[:1]``
+    min_nodes, max_nodes = parse_min_max_nnodes(args.nnodes)
+    assert 0 < min_nodes <= max_nodes
+    assert args.max_restarts >= 0
+
+    nproc_per_node = determine_local_world_size(args.nproc_per_node)
+    if "OMP_NUM_THREADS" not in os.environ and nproc_per_node > 1:
+        omp_num_threads = 1
+        print(
+            f"*****************************************\n"
+            f"Setting OMP_NUM_THREADS environment variable for each process to be "
+            f"{omp_num_threads} in default, to avoid your system being overloaded, "
+            f"please further tune the variable for optimal performance in "
+            f"your application as needed. \n"
+            f"*****************************************"
+        )
+        # This env variable will be passed down to the subprocesses
+        os.environ["OMP_NUM_THREADS"] = str(omp_num_threads)
+
+    rdzv_configs = _parse_rendezvous_config(args.rdzv_conf)
+
+    if args.rdzv_backend == "static":
+        rdzv_configs["rank"] = args.node_rank
+
+    rdzv_endpoint = get_rdzv_endpoint(args)
+
+    config = LaunchConfig(
+        min_nodes=min_nodes,
+        max_nodes=max_nodes,
+        nproc_per_node=nproc_per_node,
+        run_id=args.rdzv_id,
+        role=args.role,
+        rdzv_endpoint=rdzv_endpoint,
+        rdzv_backend=args.rdzv_backend,
+        rdzv_configs=rdzv_configs,
+        max_restarts=args.max_restarts,
+        monitor_interval=args.monitor_interval,
+        start_method=args.start_method,
+        redirects=Std.from_str(args.redirects),
+        tee=Std.from_str(args.tee),
+    )
+
+    with_python = not args.no_python
+    cmd = []
+    if with_python:
+        cmd = [sys.executable, "-u"]
+        if args.module:
+            cmd.append("-m")
+    else:
+        if not args.use_env:
+            raise ValueError(
+                "When using the '--no_python' flag,"
+                " you must also set the '--use_env' flag."
+            )
+        if args.module:
+            raise ValueError(
+                "Don't use both the '--no_python' flag"
+                " and the '--module' flag at the same time."
+            )
+    cmd.append(args.training_script)
+    if not args.use_env:
+        log.warning(
+            "`torch.distributed.launch` is Deprecated. Use torch.distributed.elastic_launch"
+        )
+        cmd.append(f"--local_rank={macros.local_rank}")
+    cmd.extend(args.training_script_args)
+
+    return config, cmd
+
+
+@record
+def run(args):
+    if args.standalone:
+        etcd_server = EtcdServer()
+        etcd_server.start()
+        args.rdzv_backend = "etcd"
+        args.rdzv_endpoint = etcd_server.get_endpoint()
+        args.rdzv_id = str(uuid.uuid4())
+        log.info(
+            f"\n**************************************\n"
+            f"Rendezvous info:\n"
+            f"--rdzv_backend={args.rdzv_backend} "
+            f"--rdzv_endpoint={args.rdzv_endpoint} "
+            f"--rdzv_id={args.rdzv_id}\n"
+            f"**************************************\n"
+        )
+
+    config, cmd = config_from_args(args)
+
+    try:
+        elastic_launch(
+            config=config,
+            entrypoint=cmd[0],
+        )(*cmd[1:])
+    finally:
+        if args.standalone:
+            etcd_server.stop()
+
+
+def main(args=None):
+    args = parse_args(args)
+    run(args)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO, format="[%(levelname)s] %(asctime)s %(module)s: %(message)s"
+    )
+    log.info(f"Running torch.distributed.elastic_launch with args: {sys.argv}")
+    main()

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -2,6 +2,8 @@ r"""
 `torch.distributed.launch` is a module that spawns up multiple distributed
 training processes on each of the training nodes.
 
+NOTE: This module is deprecated, use torch.distributed.elastic_launch.
+
 The utility can be used for single-node distributed training, in which one or
 more processes per node will be spawned. The utility can be used for either
 CPU training or GPU training. If the utility is used for GPU training,
@@ -136,205 +138,36 @@ will not pass ``--local_rank`` when you specify this flag.
 
 """
 
+import logging
 
-import time
-import signal
-import sys
-import subprocess
-import os
-from argparse import ArgumentParser, REMAINDER
-from typing import Optional, IO, List, Any
+from torch.distributed.elastic_launch import get_args_parser, run
 
-node_local_rank_stdout_filename = "node_{}_local_rank_{}_stdout"
-node_local_rank_stderr_filename = "node_{}_local_rank_{}_stderr"
+logger = logging.getLogger(__name__)
 
-def parse_args():
-    """
-    Helper function parsing the command line options
-    @retval ArgumentParser
-    """
-    parser = ArgumentParser(description="PyTorch distributed training launch "
-                                        "helper utility that will spawn up "
-                                        "multiple distributed processes")
 
-    # Optional arguments for the launch helper
-    parser.add_argument("--nnodes", type=int, default=1,
-                        help="The number of nodes to use for distributed "
-                             "training")
-    parser.add_argument("--node_rank", type=int, default=0,
-                        help="The rank of the node for multi-node distributed "
-                             "training")
-    parser.add_argument("--nproc_per_node", type=int, default=1,
-                        help="The number of processes to launch on each node, "
-                             "for GPU training, this is recommended to be set "
-                             "to the number of GPUs in your system so that "
-                             "each process can be bound to a single GPU.")
-    parser.add_argument("--master_addr", default="127.0.0.1", type=str,
-                        help="Master node (rank 0)'s address, should be either "
-                             "the IP address or the hostname of node 0, for "
-                             "single node multi-proc training, the "
-                             "--master_addr can simply be 127.0.0.1")
-    parser.add_argument("--master_port", default=29500, type=int,
-                        help="Master node (rank 0)'s free port that needs to "
-                             "be used for communication during distributed "
-                             "training")
-    parser.add_argument("--use_env", default=False, action="store_true",
-                        help="Use environment variable to pass "
-                             "'local rank'. For legacy reasons, the default value is False. "
-                             "If set to True, the script will not pass "
-                             "--local_rank as argument, and will instead set LOCAL_RANK.")
-    parser.add_argument("-m", "--module", default=False, action="store_true",
-                        help="Changes each process to interpret the launch script "
-                             "as a python module, executing with the same behavior as"
-                             "'python -m'.")
-    parser.add_argument("--no_python", default=False, action="store_true",
-                        help="Do not prepend the training script with \"python\" - just exec "
-                             "it directly. Useful when the script is not a Python script.")
+def parse_args(args):
+    parser = get_args_parser()
     parser.add_argument(
-        "--logdir",
-        default=None,
-        type=str,
-        help=f"""Relative path to write subprocess logs to. Passing in a relative
-        path will create a directory if needed, and write the stdout and stderr to files
-        {node_local_rank_stdout_filename} and {node_local_rank_stderr_filename}. Note that
-        successive runs with the  same path to write logs to will overwrite existing logs,
-        so be sure to save logs as needed.""",
+        "--use_env",
+        default=False,
+        action="store_true",
+        help="Use environment variable to pass "
+        "'local rank'. For legacy reasons, the default value is False. "
+        "If set to True, the script will not pass "
+        "--local_rank as argument, and will instead set LOCAL_RANK.",
     )
+    return parser.parse_args(args)
 
-    # positional
-    parser.add_argument("training_script", type=str,
-                        help="The full path to the single GPU training "
-                             "program/script to be launched in parallel, "
-                             "followed by all the arguments for the "
-                             "training script")
 
-    # rest from the training program
-    parser.add_argument('training_script_args', nargs=REMAINDER)
-    return parser.parse_args()
+def main(args=None):
+    logger.warn(
+        "The module torch.distributed.launch is deprecated "
+        "and going to be removed in future."
+        "Migrate to torch.distributed.elastic_launch"
+    )
+    args = parse_args(args)
+    run(args)
 
-def main():
-    args = parse_args()
-
-    # world size in terms of number of processes
-    dist_world_size = args.nproc_per_node * args.nnodes
-
-    # set PyTorch distributed related environmental variables
-    current_env = os.environ.copy()
-    current_env["MASTER_ADDR"] = args.master_addr
-    current_env["MASTER_PORT"] = str(args.master_port)
-    current_env["WORLD_SIZE"] = str(dist_world_size)
-
-    processes: List[Any] = []
-
-    if 'OMP_NUM_THREADS' not in os.environ and args.nproc_per_node > 1:
-        current_env["OMP_NUM_THREADS"] = str(1)
-        print("*****************************************\n"
-              "Setting OMP_NUM_THREADS environment variable for each process "
-              "to be {} in default, to avoid your system being overloaded, "
-              "please further tune the variable for optimal performance in "
-              "your application as needed. \n"
-              "*****************************************".format(current_env["OMP_NUM_THREADS"]))
-
-    if args.logdir:
-        # Possibly create the directory to write subprocess log output to.
-        if os.path.exists(args.logdir):
-            if not os.path.isdir(args.logdir):
-                raise ValueError("argument --logdir must be a path to a directory.")
-        else:
-            # create the relative directory
-            os.mkdir(os.path.join(os.getcwd(), args.logdir))
-
-    subprocess_file_handles = []
-
-    for local_rank in range(0, args.nproc_per_node):
-        # each process's rank
-        dist_rank = args.nproc_per_node * args.node_rank + local_rank
-        current_env["RANK"] = str(dist_rank)
-        current_env["LOCAL_RANK"] = str(local_rank)
-
-        # spawn the processes
-        with_python = not args.no_python
-        cmd = []
-        if with_python:
-            cmd = [sys.executable, "-u"]
-            if args.module:
-                cmd.append("-m")
-        else:
-            if not args.use_env:
-                raise ValueError("When using the '--no_python' flag, you must also set the '--use_env' flag.")
-            if args.module:
-                raise ValueError("Don't use both the '--no_python' flag and the '--module' flag at the same time.")
-
-        cmd.append(args.training_script)
-
-        if not args.use_env:
-            cmd.append("--local_rank={}".format(local_rank))
-
-        cmd.extend(args.training_script_args)
-
-        stdout_handle: Optional[IO]
-        stderr_handle: Optional[IO]
-        if args.logdir:
-            directory_path = os.path.join(os.getcwd(), args.logdir)
-            node_rank = args.node_rank
-            stdout_file_name = node_local_rank_stdout_filename.format(node_rank, local_rank)
-            stderr_file_name = node_local_rank_stderr_filename.format(node_rank, local_rank)
-            stdout_handle = open(os.path.join(directory_path, stdout_file_name), "w")
-            stderr_handle = open(os.path.join(directory_path, stderr_file_name), "w")
-            subprocess_file_handles.append((stdout_handle, stderr_handle))
-            stdout_name = stdout_handle.name
-            stderr_name = stderr_handle.name
-            print(f"""Note: Stdout and stderr for node {node_rank} rank {local_rank} will
-            be written to {stdout_name}, {stderr_name} respectively.""")
-
-        sig_names = {2: "SIGINT", 15: "SIGTERM"}
-        last_return_code = None
-
-        def sigkill_handler(signum, frame):
-            for process in processes:
-                print(f"Killing subprocess {process.pid}")
-                try:
-                    process.kill()
-                except Exception:
-                    pass
-            if last_return_code is not None:
-                raise subprocess.CalledProcessError(returncode=last_return_code, cmd=cmd)
-            if signum in sig_names:
-                print(f"Main process received {sig_names[signum]}, exiting")
-            sys.exit(1)
-
-        # pass SIGINT/SIGTERM to children if the parent is being terminated
-        signal.signal(signal.SIGINT, sigkill_handler)
-        signal.signal(signal.SIGTERM, sigkill_handler)
-
-        stdout_handle = None if not subprocess_file_handles else subprocess_file_handles[local_rank][0]
-        stderr_handle = None if not subprocess_file_handles else subprocess_file_handles[local_rank][1]
-        process = subprocess.Popen(cmd, env=current_env, stdout=stdout_handle, stderr=stderr_handle)
-        processes.append(process)
-
-    try:
-        alive_processes = set(processes)
-        while len(alive_processes):
-            finished_processes = []
-            for process in alive_processes:
-                if process.poll() is None:
-                    # the process is still running
-                    continue
-                else:
-                    if process.returncode != 0:
-                        last_return_code = process.returncode  # for sigkill_handler
-                        sigkill_handler(signal.SIGTERM, None)  # not coming back
-                    else:
-                        # exited cleanly
-                        finished_processes.append(process)
-            alive_processes = set(alive_processes) - set(finished_processes)
-
-            time.sleep(1)
-    finally:
-        # close open file descriptors
-        for (stdout_handle, stderr_handle) in subprocess_file_handles:
-            stdout_handle.close()
-            stderr_handle.close()
 
 if __name__ == "__main__":
     main()

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -9,7 +9,7 @@ import os
 import sys
 from datetime import timedelta
 from typing import Optional, Dict, Union
-from torch._C._distributed_c10d import FileStore, TCPStore
+from torch.distributed import FileStore, TCPStore, PrefixStore
 from .constants import default_pg_timeout
 
 _rendezvous_handlers = {}
@@ -149,6 +149,13 @@ def _env_rendezvous_handler(url: str, timeout: timedelta = default_pg_timeout, *
     def _env_error(var):
         return _error("environment variable %s expected, but not set" % var)
 
+    def _get_env_or_raise(env_var: str) -> str:
+        env_val = os.environ.get(env_var, None)
+        if not env_val:
+            raise _env_error(env_var)
+        else:
+            return env_val
+
     result = urlparse(url)
     query: Dict[str, Union[int, str]]
     # mypy doesn't allow dict() to accept List of values (#257)
@@ -161,34 +168,33 @@ def _env_rendezvous_handler(url: str, timeout: timedelta = default_pg_timeout, *
     if "rank" in query:
         rank = int(query["rank"])
     else:
-        rank = os.environ.get("RANK", None)
-        if rank is None:
-            raise _env_error("RANK")
+        rank = int(_get_env_or_raise("RANK"))
 
     if "world_size" in query:
         world_size = int(query["world_size"])
     else:
-        world_size = os.environ.get("WORLD_SIZE", None)
-        if world_size is None:
-            raise _env_error("WORLD_SIZE")
+        world_size = int(_get_env_or_raise("WORLD_SIZE"))
 
-    master_addr = os.environ.get("MASTER_ADDR", None)
-    if master_addr is None:
-        raise _env_error("MASTER_ADDR")
+    master_addr = _get_env_or_raise("MASTER_ADDR")
+    master_port = int(_get_env_or_raise("MASTER_PORT"))
 
-    master_port = os.environ.get("MASTER_PORT", None)
-    if master_port is None:
-        raise _env_error("MASTER_PORT")
 
-    # Converting before creating the store
-    rank = int(rank)
-    world_size = int(world_size)
-    master_port = int(master_port)
+    use_torchelastic_store = os.environ.get("TORCHELASTIC_USE_AGENT_STORE", None)
 
-    # Now start the TCP store daemon on the rank 0
-    start_daemon = rank == 0
-    store = TCPStore(master_addr, master_port, world_size, start_daemon, timeout)
-    yield (store, rank, world_size)
+    if use_torchelastic_store == str(True):
+        worker_process_prefix = "/worker"
+        # When TORCHELASTIC_USE_AGENT_STORE is set up, the worker process is assumed
+        # to be invoked by the torchelastic agent. Torchelastic agent creates a tcp daemon thread
+        # on the GROUP_RANK=0, as a result all user worker processes should create store with: daemon=False
+        tcp_store = TCPStore(master_addr, master_port, world_size, False, timeout)
+        # Each if-else condition returns due to: https://github.com/python/mypy/issues/1191
+        yield (PrefixStore(worker_process_prefix, tcp_store), rank, world_size)
+    else:
+        # Start the TCP store daemon on the rank 0
+        start_daemon = rank == 0
+        store = TCPStore(master_addr, master_port, world_size, start_daemon, timeout)
+        # Each if-else condition returns due to: https://github.com/python/mypy/issues/1191
+        yield (store, rank, world_size)
 
     # If this configuration is invalidated, there is nothing we can do about it
     raise RuntimeError("Unable to perform rerendezvous using env:// method")


### PR DESCRIPTION
Summary:
The diff introduces new  `torch.distributed.elastic_launch` and removes internals of `torch.distributed.launch` keeping backwards compatibility.

Since torchelastic and torch.launch are not fully compatible due to `--use_env` arg, the `torch.distributed.launch` deprecation is going to be iterative: as part of pytorch 1.9 we are going to deprecate it, and in the following releases we will remove `torch.distributed.launch`

The diff leaves `torchelastic.distributed.launch` module, and the follow up diffs will migrate the users form `torchelastic.distributed.launch` to `torch.distributed.elastic_launch`

Test Plan: buck test mode/dev-nosan //pytorch/elastic/torchelastic/distributed/...

Differential Revision: D27753803

