### PR TITLE
Make run_test.py work even if s3_stat_parser fails to import

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -380,7 +380,7 @@ def get_stripped_CI_job() -> str:
     return job
 
 
-def calculate_job_times(reports: List[Report]) -> Dict[str, float]:
+def calculate_job_times(reports: List["Report"]) -> Dict[str, float]:
     # an entry will be like ("test_file_name" -> (current_avg, # values))
     jobs_to_times: Dict[str, Tuple[float, int]] = dict()
     for report in reports:
@@ -408,7 +408,7 @@ def calculate_job_times(reports: List[Report]) -> Dict[str, float]:
 def pull_job_times_from_S3() -> Dict[str, float]:
     if HAVE_BOTO3:
         ci_job_prefix = get_stripped_CI_job()
-        s3_reports: List[Report] = get_previous_reports_for_branch('origin/nightly', ci_job_prefix)
+        s3_reports: List["Report"] = get_previous_reports_for_branch('origin/nightly', ci_job_prefix)
     else:
         print('Uh oh, boto3 is not found. Either it is not installed or we failed to import s3_stat_parser.')
         print('If not installed, please install boto3 for automatic sharding and test categorization.')


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56039 Make run_test.py work even if s3_stat_parser fails to import**

Python will try to eagerly resolve the name references even if
the import failed.  Quote them so that it doesn't.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27770536](https://our.internmc.facebook.com/intern/diff/D27770536)