### PR TITLE
Include short test suites ln total_seconds stat

### DIFF
--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -919,9 +919,9 @@ if __name__ == '__main__':
     total_time = 0.0
     for filename, test_filename in reports_by_file.items():
         for suite_name, test_suite in test_filename.test_suites.items():
+            total_time += test_suite.total_time
             if test_suite.total_time >= args.class_print_threshold:
                 test_suite.print_report(args.longest_of_class)
-                total_time += test_suite.total_time
                 longest_tests.extend(test_suite.test_cases.values())
     longest_tests = sorted(longest_tests, key=lambda x: x.time)[-args.longest_of_run:]
 
@@ -933,8 +933,11 @@ if __name__ == '__main__':
         except Exception as e:
             print(f"error encountered when uploading to s3: {e}")
 
-    print(f"Total runtime is {datetime.timedelta(seconds=int(total_time))}")
-    print(f"{len(longest_tests)} longest tests of entire run:")
+    print(f"Total runtime is {datetime.timedelta(seconds=total_time)}")
+    print(
+        f"{len(longest_tests)} longest tests of entire run"
+        f" (ignoring suites totaling less than {args.class_print_threshold} seconds):"
+    )
     for test_case in reversed(longest_tests):
         print(f"    {test_case.class_name}.{test_case.name}  time: {test_case.time:.2f} seconds")
 


### PR DESCRIPTION
Up until this PR, the top-level `total_seconds` stat we've been uploading to S3 has only included suites longer than one second. This PR corrects that issue, and also clarifies the script's textual output for "longest tests of entire run".

(Note that the `total_time` local variable is passed as the `total_seconds` parameter in the call to `assemble_s3_object`.)

**Test plan:**

Create a simple test file (call it `test_quick_maths.py`) with these contents:

```py
from torch.testing._internal.common_utils import TestCase, run_tests


class TestQuickMaths(TestCase):
    def test_two_plus_two(self):
        self.assertEqual(2 + 2, 4)


if __name__ == '__main__':
    run_tests()
```

Run it and save the test results:

```sh
rm -r /tmp/reports ; python3 test_quick_maths.py --save-xml=/tmp/reports
```

Then display them using the script:

```sh
tools/print_test_stats.py /tmp/reports
```

- Before this PR:

  ```
  No scribe access token provided, skip sending report!
  Total runtime is 0:00:00
  0 longest tests of entire run:
  ```

- With this PR:

  ```
  No scribe access token provided, skip sending report!
  Total runtime is 0:00:00.108000
  0 longest tests of entire run (ignoring suites totaling less than 1.0 seconds):
  ```

If you were to upload this to S3 (see #49190 for an example of how to do this manually), the top-level `total_seconds` field should also change from `0` to `0.108`.