### PR TITLE
Add a test to measure `import torch` time

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -29,6 +29,7 @@ except ImportError:
 
 
 TESTS = [
+    'test_import_time',
     'test_public_bindings',
     'test_type_hints',
     'test_autograd',

--- a/test/test_import_time.py
+++ b/test/test_import_time.py
@@ -1,15 +1,22 @@
 import subprocess
+import sys
 
 from torch.testing._internal.common_utils import TestCase, run_tests
 
 
+# these tests could eventually be changed to fail if the import/init
+# time is greater than a certain threshold, but for now we just use them
+# as a way to track the duration of `import torch` in our ossci-metrics
+# S3 bucket (see tools/print_test_stats.py)
 class TestImportTime(TestCase):
-    # this test could eventually be changed to fail if the import time
-    # is greater than a certain threshold, but for now we just use it as
-    # a way to track the duration of `import torch` in our ossci-metrics
-    # S3 bucket (see tools/print_test_stats.py)
     def test_time_import_torch(self):
         subprocess.run([sys.executable, '-c', 'import torch'])
+
+    def test_time_cuda_device_count(self):
+        subprocess.run([
+            sys.executable, '-c',
+            'import torch; torch.cuda.device_count()',
+        ])
 
 
 if __name__ == '__main__':

--- a/test/test_import_time.py
+++ b/test/test_import_time.py
@@ -1,6 +1,3 @@
-import subprocess
-import sys
-
 from torch.testing._internal.common_utils import TestCase, run_tests
 
 
@@ -10,13 +7,12 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 # S3 bucket (see tools/print_test_stats.py)
 class TestImportTime(TestCase):
     def test_time_import_torch(self):
-        subprocess.run([sys.executable, '-c', 'import torch'])
+        TestCase.runWithPytorchAPIUsageStderr('import torch')
 
     def test_time_cuda_device_count(self):
-        subprocess.run([
-            sys.executable, '-c',
+        TestCase.runWithPytorchAPIUsageStderr(
             'import torch; torch.cuda.device_count()',
-        ])
+        )
 
 
 if __name__ == '__main__':

--- a/test/test_import_time.py
+++ b/test/test_import_time.py
@@ -9,7 +9,7 @@ class TestImportTime(TestCase):
     # a way to track the duration of `import torch` in our ossci-metrics
     # S3 bucket (see tools/print_test_stats.py)
     def test_time_import_torch(self):
-        subprocess.run(['python3', '-c', 'import torch'])
+        subprocess.run([sys.executable, '-c', 'import torch'])
 
 
 if __name__ == '__main__':

--- a/test/test_import_time.py
+++ b/test/test_import_time.py
@@ -1,0 +1,16 @@
+import subprocess
+
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+class TestImportTime(TestCase):
+    # this test could eventually be changed to fail if the import time
+    # is greater than a certain threshold, but for now we just use it as
+    # a way to track the duration of `import torch` in our ossci-metrics
+    # S3 bucket (see tools/print_test_stats.py)
+    def test_time_import_torch(self):
+        subprocess.run(['python3', '-c', 'import torch'])
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
This PR adds a couple very simple tests which (as the code comment says) measure the time it takes to `import torch` and ask for the CUDA device count.

**Test plan:**

```
$ rm -r /tmp/reports ; python3 test/test_import_time.py --save-xml=/tmp/reports

Running tests...
----------------------------------------------------------------------
..
----------------------------------------------------------------------
Ran 2 tests in 1.855s

OK

Generating XML reports...
```
```
$ tools/print_test_stats.py /tmp/reports
No scribe access token provided, skip sending report!
class TestImportTime:
    tests: 2 failed: 0 skipped: 0 errored: 0
    run_time: 1.85 seconds
    avg_time: 0.93 seconds
    median_time: 0.93 seconds
    2 longest tests:
        test_time_cuda_device_count time: 1.10 seconds
        test_time_import_torch time: 0.75 seconds

Total runtime is 0:00:01
2 longest tests of entire run:
    TestImportTime.test_time_cuda_device_count  time: 1.10 seconds
    TestImportTime.test_time_import_torch  time: 0.75 seconds
```