### PR TITLE
Allow passing cpu to CUDA RPC device maps

### DIFF
--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -210,9 +210,9 @@ def _tensorpipe_check_device_maps(agent, device_maps):
                 if not all([
                     len(device_map) == len(key_set),
                     len(device_map) == len(val_set),  # check 1-to-1 mapping
-                    min(key_set) >= 0,
+                    min(key_set) >= -1,
                     max(key_set) < device_count,  # check local range
-                    min(val_set) >= 0,
+                    min(val_set) >= -1,
                     max(val_set) < remote_device_count  # check remote range
                 ]):
                     raise ValueError(

--- a/torch/distributed/rpc/options.py
+++ b/torch/distributed/rpc/options.py
@@ -101,18 +101,16 @@ class TensorPipeRpcBackendOptions(_TensorPipeRpcBackendOptionsBase):
         for k in device_map:
             v = device_map[k]
             k, v = torch.device(k), torch.device(v)
-            if k.type != 'cuda' or v.type != 'cuda':
-                raise ValueError(
-                    "`set_device_map` only supports CUDA devices, "
-                    f"but got device pair {k}: {v}"
 
-                )
-            if to in curr_device_maps and k.index in curr_device_maps[to]:
-                curr_v = super().device_maps[to][k.index]
-                if curr_v != v.index:
+            k_index = -1 if k.type == "cpu" else k.index
+            v_index = -1 if v.type == "cpu" else v.index
+
+            if to in curr_device_maps and k_index in curr_device_maps[to]:
+                curr_v = super().device_maps[to][k_index]
+                if curr_v != v_index:
                     raise ValueError(
                         "`set_device_map` only supports 1-to-1 mapping, "
                         f"trying to map {k} to {v} and {curr_v}"
                     )
-            device_index_map[k.index] = v.index
+            device_index_map[k_index] = v_index
         super().set_device_map(to, device_index_map)

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4952,7 +4952,17 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
             device_map={0 : 0, 1 : 1}
         )
 
-    def _test_device_maps_gpu(self, x_from, y_from, z_to, device_map, dst=None):
+    @staticmethod
+    def _gpu_add_given_devices(x, y, x_to, y_to, z_to):
+        x_device = "cpu" if x.device.type == "cpu" else x.device.index
+        y_device = "cpu" if y.device.type == "cpu" else y.device.index
+        if x_device == x_to and y_device == y_to:
+            return x.to(z_to) + y.to(z_to)
+        else:
+            raise ValueError("Wrong device affinity")
+
+    def _test_device_maps_gpu(self, x_from, y_from, z_to, device_map, dst=None, fn=None):
+        fn = TensorPipeAgentCudaRpcTest._gpu_add_given_gpus if fn is None else fn
         x_to = device_map[x_from]
         y_to = device_map[y_from]
 
@@ -4971,19 +4981,26 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
         x = torch.zeros(2).to(x_from)
         y = torch.ones(2).to(y_from)
 
-        ret = rpc.rpc_sync(
-            dst,
-            TensorPipeAgentCudaRpcTest._gpu_add_given_gpus,
-            args=(x, y, x_to, y_to, z_to)
-        )
+        ret = rpc.rpc_sync(dst, fn, args=(x, y, x_to, y_to, z_to))
 
         reverse_device_map = {device_map[k] : k for k in device_map}
         z_from = reverse_device_map[z_to]
 
-        self.assertEqual(ret.device.index, z_from)
+        ret_device = "cpu" if ret.device.type == "cpu" else ret.device.index
+        self.assertEqual(ret_device, z_from)
         self.assertEqual(ret, torch.ones(2).to(z_from))
 
         rpc.shutdown()
+
+    @skip_if_lt_x_gpu(2)
+    def test_device_map_cpu(self):
+        self._test_device_maps_gpu(
+            x_from="cpu",
+            y_from="cpu",
+            z_to="cpu",
+            device_map={"cpu" : "cpu"},
+            fn=TensorPipeAgentCudaRpcTest._gpu_add_given_devices,
+        )
 
     @skip_if_lt_x_gpu(2)
     def test_device_map_gpu_default(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56043 Allow passing cpu to CUDA RPC device maps**

Differential Revision: [D27771158](https://our.internmc.facebook.com/intern/diff/D27771158)