### PR TITLE
Revert "Only allow hub.load() from original repo. (#54451)"

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -695,13 +695,6 @@ class TestHub(TestCase):
             self.assertEqual(sum_of_state_dict(loaded_state),
                              SUM_OF_HUB_EXAMPLE)
 
-    @retry(URLError, tries=3, skip_after_retries=True)
-    def test_load_commit_from_forked_repo(self):
-        with self.assertRaisesRegex(
-                ValueError,
-                'If it\'s a commit from a forked repo'):
-            model = torch.hub.load('pytorch/vision:4e2c216', 'resnet18', force_reload=True)
-
 class TestHipify(TestCase):
     def test_import_hipify(self):
         from torch.utils.hipify import hipify_python # noqa

--- a/torch/hub.py
+++ b/torch/hub.py
@@ -1,6 +1,5 @@
 import errno
 import hashlib
-import json
 import os
 import re
 import shutil
@@ -112,16 +111,6 @@ def _parse_repo_info(github):
     repo_owner, repo_name = repo_info.split('/')
     return repo_owner, repo_name, branch
 
-def _validate_not_a_forked_repo(repo_owner, repo_name, branch):
-    # Use urlopen to avoid depending on local git.
-    url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/branches'
-    with urlopen(url) as r:
-        response = json.loads(r.read().decode(r.headers.get_content_charset('utf-8')))
-    for br in response:
-        if br['name'] == branch or br['commit']['sha'].startswith(branch):
-            return
-    raise ValueError(f'Cannot find {branch} in https://github.com/{repo_owner}/{repo_name}. '
-                     'If it\'s a commit from a forked repo, please call hub.load() with forked repo directly.')
 
 def _get_cache_or_reload(github, force_reload, verbose=True):
     # Setup hub_dir to save downloaded files
@@ -130,7 +119,6 @@ def _get_cache_or_reload(github, force_reload, verbose=True):
         os.makedirs(hub_dir)
     # Parse github repo information
     repo_owner, repo_name, branch = _parse_repo_info(github)
-
     # Github allows branch name with slash '/',
     # this causes confusion with path on both Linux and Windows.
     # Backslash is not allowed in Github branch name so no need to
@@ -148,9 +136,6 @@ def _get_cache_or_reload(github, force_reload, verbose=True):
         if verbose:
             sys.stderr.write('Using cache found in {}\n'.format(repo_dir))
     else:
-        # Validate the tag/branch is from the original repo instead of a forked repo
-        _validate_not_a_forked_repo(repo_owner, repo_name, branch)
-
         cached_file = os.path.join(hub_dir, normalized_br + '.zip')
         _remove_if_exists(cached_file)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56048 Revert "Only allow hub.load() from original repo. (#54451)"**

This reverts commit c411017a41988e9c5184279c1ec7dd7ef4e1a6fe.

This implementation broke CI in pytorch/vision and it's not handling
tags properly. So I want to revert it first to unblock vision CI and
send out a proper fix later.

Differential Revision: [D27771701](https://our.internmc.facebook.com/intern/diff/D27771701)