### PR TITLE
[wip] enhance DDPSink to work for general outputs

### DIFF
--- a/test/distributed/test_c10d.py
+++ b/test/distributed/test_c10d.py
@@ -4235,6 +4235,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
         else:
             output = model(input_var)
         l = loss(output, target)
+        print(f"Got l {l}")
         l.backward()
 
     def _test_ddp_checkpointing(
@@ -4273,6 +4274,7 @@ class DistributedDataParallelTest(MultiProcessTestCase):
                 self.assertTrue(i.grad is not None)
                 self.assertTrue(j.grad is not None)
                 self.assertEqual(i.grad, j.grad)
+                # print(f"grads same {i.grad}, {j.grad}")
 
     # DDP works as expect when layer is checkpointed only once
     @requires_nccl()

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 import torch
 import torch.distributed as dist
 from torch.autograd import Variable, Function
+from torch.utils._pytree import tree_flatten, tree_unflatten
 
 from . import comm
 
@@ -109,19 +110,20 @@ class _DDPUnevenInputsConfig(NamedTuple):
     ddp_join_enabled: bool
     ddp_join_divide_by_initial_world_size: bool
 
-# Add a DDPSink to queue call back of out-most backward/graph task,
+# Add a DDPSink to run various functions when backwards starts, such as
+# queueing call back of out-most backward/graph task,
 # this helps call back is fired after all gradients' calculation
 # is completed.
-class DDPSink(Function):
+class _DDPSink(Function):
     @staticmethod
-    def forward(ctx, input, reducer):
+    def forward(ctx, reducer, *inputs):
         ctx.reducer = reducer
-        return input
+        return inputs
 
     @staticmethod
-    def backward(ctx, input):
+    def backward(ctx, *grad_outputs):
         Variable._execution_engine.queue_callback(ctx.reducer._delay_all_reduce)
-        return input, None
+        return None, *grad_outputs
 
 class DistributedDataParallel(Module):
     r"""Implements distributed data parallelism that is based on
@@ -824,7 +826,15 @@ class DistributedDataParallel(Module):
         # this feature is stable, we will add this sink for all cases. E.g.
         # This sink can help capture more accuracte backward start time as well.
         if self.static_graph:
-            output = DDPSink.apply(output, self.reducer)
+            # Need to grab list of tensors from user output in order to pass
+            # to custom autograd function.
+            output_tensor_list, treespec = tree_flatten(output)
+            passthrough_tensor_list = _DDPSink.apply(
+                self.reducer,
+                *output_tensor_list
+            )
+            # Reconstruct output data structure.
+            output = tree_unflatten(passthrough_tensor_list, treespec)
         return output
 
     def scatter(self, inputs, kwargs, device_ids):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56054 [wip] enhance DDPSink to work for general outputs**
* #55248 [WIP] enable static graph training in DDP
* #54995 static graph api skeleton
* #54981 refactor autograd_hook
* #54977 refactor prepare_for_backward

Enhances use of DDPSink to work for all output types DDP supports as per https://github.com/pytorch/pytorch/issues/55876.

TODO: Add additional testing for tuple, list, dict return types

Differential Revision: [D27756985](https://our.internmc.facebook.com/intern/diff/D27756985/)