### PR TITLE
Add a lint for native_functions.yaml

### DIFF
--- a/.github/scripts/lint_native_functions.py
+++ b/.github/scripts/lint_native_functions.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+'''
+Verify that it is possible to round-trip native_functions.yaml via ruamel under some
+configuration.  Keeping native_functions.yaml consistent in this way allows us to
+run codemods on the file using ruamel without introducing line noise.  Note that we don't
+want to normalize the YAML file, as that would to lots of spurious lint failures.  Anything
+that ruamel understands how to roundtrip, e.g., whitespace and comments, is OK!
+
+ruamel is a bit picky about inconsistent indentation, so you will have to indent your
+file properly.  Also, if you are working on changing the syntax of native_functions.yaml,
+you may find that you want to use some format that is not what ruamel prefers.  If so,
+it is OK to modify this script (instead of reformatting native_functions.yaml)--the point
+is simply to make sure that there is *some* configuration of ruamel that can round trip
+the YAML, not to be prescriptive about it.
+'''
+
+import ruamel.yaml
+import difflib
+import sys
+from pathlib import Path
+from io import StringIO
+
+def fn(base):
+    return str(base / Path("aten/src/ATen/native/native_functions.yaml"))
+
+with open(Path(__file__).parent.parent.parent / fn('.'), "r") as f:
+    contents = f.read()
+
+yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
+yaml.width = 1000
+yaml.boolean_representation = ['False', 'True']
+r = yaml.load(contents)
+
+# Cuz ruamel's author intentionally didn't include conversion to string
+# https://stackoverflow.com/questions/47614862/best-way-to-use-ruamel-yaml-to-dump-to-string-not-to-stream
+string_stream = StringIO()
+yaml.dump(r, string_stream)
+new_contents = string_stream.getvalue()
+string_stream.close()
+
+if contents != new_contents:
+    print("""\
+
+## LINT FAILURE: native_functions.yaml ##
+
+native_functions.yaml failed lint; please apply the diff below to fix lint.
+If you think this is in error, please see .github/scripts/lint_native_functions.py
+""", file=sys.stderr)
+    sys.stdout.writelines(difflib.unified_diff(contents.splitlines(True), new_contents.splitlines(True), fn('a'), fn('b')))
+    sys.exit(1)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,10 @@ jobs:
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
         run: .github/scripts/ensure_consistent_workflows.py
+      - name: Lint native_functions.yaml
+        run: |
+          pip install ruamel.yaml==0.17.4
+          .github/scripts/lint_native_functions.py
       - name: ShellCheck
         # https://github.com/koalaman/shellcheck/tree/v0.7.1#installing-a-pre-compiled-binary
         run: |

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2055,7 +2055,7 @@
 
 - func: mkldnn_linear_backward_input(int[] input_size, Tensor grad_output, Tensor weight) -> Tensor
   dispatch:
-      MkldnnCPU: mkldnn_linear_backward_input
+    MkldnnCPU: mkldnn_linear_backward_input
 
 - func: mkldnn_linear_backward_weights(Tensor grad_output, Tensor input, Tensor weight, bool bias_defined) -> (Tensor, Tensor)
   dispatch:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56059 Add a lint for native_functions.yaml**

The lint doesn't do very much, mostly it enforces that indentation
is consistent.  The real point of the lint is to just make sure
that we can still do surgery on codemod with tools like ruamel,
by reusing the configuration in this script.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D27774590](https://our.internmc.facebook.com/intern/diff/D27774590)