### PR TITLE
Update padding_idx docs for EmbeddingBag to better match Embedding's

### DIFF
--- a/torch/csrc/api/include/torch/nn/options/embedding.h
+++ b/torch/csrc/api/include/torch/nn/options/embedding.h
@@ -21,7 +21,11 @@ struct TORCH_API EmbeddingOptions {
   TORCH_ARG(int64_t, num_embeddings);
   /// The size of each embedding vector.
   TORCH_ARG(int64_t, embedding_dim);
-  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
+  /// during training, i.e. it remains as a fixed “pad”. For a newly constructed
+  /// Embedding, the embedding vector at `padding_idx` will default to all
+  /// zeros, but can be updated to another value to be used as the padding vector.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
   TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
@@ -42,7 +46,9 @@ struct TORCH_API EmbeddingFromPretrainedOptions {
   /// If ``true``, the tensor does not get updated in the learning process.
   /// Equivalent to ``embedding.weight.requires_grad_(false)``. Default: ``true``
   TORCH_ARG(bool, freeze) = true;
-  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
+  /// during training, i.e. it remains as a fixed “pad”.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
   TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
@@ -66,7 +72,9 @@ namespace functional {
 /// F::embedding(input, weight, F::EmbeddingFuncOptions().norm_type(2.5).scale_grad_by_freq(true).sparse(true));
 /// ```
 struct TORCH_API EmbeddingFuncOptions {
-  /// If given, pads the output with the embedding vector at `padding_idx` (initialized to zeros) whenever it encounters the index.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
+  /// during training, i.e. it remains as a fixed “pad”.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
   TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
@@ -115,9 +123,12 @@ struct TORCH_API EmbeddingBagOptions {
   /// If ``true``, `offsets` has one additional element, where the last element
   /// is equivalent to the size of `indices`. This matches the CSR format.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If given, pads the embedding vector at index `padding_idx`. When
-  /// a `padding_idx` is encountered in `input` during a reduction,
-  /// it is skipped. This allows each bag to be a different logical size.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at padding_idx is not updated
+  /// during training, i.e. it remains as a fixed “pad”. For a newly constructed
+  /// EmbeddingBag, the embedding vector at `padding_idx` will default to all
+  /// zeros, but can be updated to another value to be used as the padding vector.
+  /// Note that the embedding vector at `padding_idx` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 
@@ -145,9 +156,10 @@ struct TORCH_API EmbeddingBagFromPretrainedOptions {
   /// is equivalent to the size of `indices`. This matches the CSR format. Note:
   /// this option is currently only supported when ``mode="sum"``.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If given, pads the embedding vector at index `padding_idx`. When
-  /// a `padding_idx` is encountered in `input` during a reduction,
-  /// it is skipped. This allows each bag to be a different logical size.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at padding_idx is not updated
+  /// during training, i.e. it remains as a fixed “pad”. Note that the embedding
+  /// vector at `padding_idx` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 
@@ -187,9 +199,10 @@ struct TORCH_API EmbeddingBagFuncOptions {
   /// is equivalent to the size of `indices`. This matches the CSR format. Note:
   /// this option is currently only supported when ``mode="sum"``.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If given, pads the embedding vector at index `padding_idx`. When
-  /// a `padding_idx` is encountered in `input` during a reduction,
-  /// it is skipped. This allows each bag to be a different logical size.
+  /// If specified, the entries at `padding_idx` do not contribute to the
+  /// gradient; therefore, the embedding vector at padding_idx is not updated
+  /// during training, i.e. it remains as a fixed “pad”. Note that the embedding
+  /// vector at `padding_idx` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 

--- a/torch/csrc/api/include/torch/nn/options/embedding.h
+++ b/torch/csrc/api/include/torch/nn/options/embedding.h
@@ -21,10 +21,10 @@ struct TORCH_API EmbeddingOptions {
   TORCH_ARG(int64_t, num_embeddings);
   /// The size of each embedding vector.
   TORCH_ARG(int64_t, embedding_dim);
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
-  /// during training, i.e. it remains as a fixed “pad”. For a newly constructed
-  /// Embedding, the embedding vector at `padding_idx` will default to all
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad". For a newly constructed
+  /// Embedding, the embedding vector at ``padding_idx`` will default to all
   /// zeros, but can be updated to another value to be used as the padding vector.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
@@ -46,9 +46,9 @@ struct TORCH_API EmbeddingFromPretrainedOptions {
   /// If ``true``, the tensor does not get updated in the learning process.
   /// Equivalent to ``embedding.weight.requires_grad_(false)``. Default: ``true``
   TORCH_ARG(bool, freeze) = true;
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
-  /// during training, i.e. it remains as a fixed “pad”.
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad".
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
   TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
@@ -72,9 +72,9 @@ namespace functional {
 /// F::embedding(input, weight, F::EmbeddingFuncOptions().norm_type(2.5).scale_grad_by_freq(true).sparse(true));
 /// ```
 struct TORCH_API EmbeddingFuncOptions {
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at `padding_idx` is not updated
-  /// during training, i.e. it remains as a fixed “pad”.
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad".
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
   /// If given, each embedding vector with norm larger than `max_norm` is renormalized to have norm `max_norm`.
   TORCH_ARG(c10::optional<double>, max_norm) = c10::nullopt;
@@ -123,12 +123,12 @@ struct TORCH_API EmbeddingBagOptions {
   /// If ``true``, `offsets` has one additional element, where the last element
   /// is equivalent to the size of `indices`. This matches the CSR format.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at padding_idx is not updated
-  /// during training, i.e. it remains as a fixed “pad”. For a newly constructed
-  /// EmbeddingBag, the embedding vector at `padding_idx` will default to all
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad". For a newly constructed
+  /// EmbeddingBag, the embedding vector at ``padding_idx`` will default to all
   /// zeros, but can be updated to another value to be used as the padding vector.
-  /// Note that the embedding vector at `padding_idx` is excluded from the reduction.
+  /// Note that the embedding vector at ``padding_idx`` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 
@@ -156,10 +156,10 @@ struct TORCH_API EmbeddingBagFromPretrainedOptions {
   /// is equivalent to the size of `indices`. This matches the CSR format. Note:
   /// this option is currently only supported when ``mode="sum"``.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at padding_idx is not updated
-  /// during training, i.e. it remains as a fixed “pad”. Note that the embedding
-  /// vector at `padding_idx` is excluded from the reduction.
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad". Note that the embedding
+  /// vector at ``padding_idx`` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 
@@ -199,10 +199,10 @@ struct TORCH_API EmbeddingBagFuncOptions {
   /// is equivalent to the size of `indices`. This matches the CSR format. Note:
   /// this option is currently only supported when ``mode="sum"``.
   TORCH_ARG(bool, include_last_offset) = false;
-  /// If specified, the entries at `padding_idx` do not contribute to the
-  /// gradient; therefore, the embedding vector at padding_idx is not updated
-  /// during training, i.e. it remains as a fixed “pad”. Note that the embedding
-  /// vector at `padding_idx` is excluded from the reduction.
+  /// If specified, the entries at ``padding_idx`` do not contribute to the
+  /// gradient; therefore, the embedding vector at ``padding_idx`` is not updated
+  /// during training, i.e. it remains as a fixed "pad". Note that the embedding
+  /// vector at ``padding_idx`` is excluded from the reduction.
   TORCH_ARG(c10::optional<int64_t>, padding_idx) = c10::nullopt;
 };
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 r"""Functional interface"""
 from typing import Callable, List, Optional, Tuple
 import math
@@ -2072,9 +2073,10 @@ def embedding_bag(
         include_last_offset (bool, optional): if ``True``, the size of offsets is equal to the number of bags + 1.
             The last element is the size of the input, or the ending index position of the last bag (sequence).
 
-        padding_idx (int, optional): If given, indicates which indices in :attr:`input` represent padding. When
-                                     a :attr:`padding_idx` is encountered in :attr:`input` during a reduction,
-                                     it is skipped. This allows each bag to be a different logical size.
+        padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
+                                     gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
+                                     during training, i.e. it remains as a fixed “pad”. Note that the embedding
+                                     vector at :attr:`padding_idx` is excluded from the reduction.
 
     Shape:
         - :attr:`input` (LongTensor) and :attr:`offsets` (LongTensor, optional)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""Functional interface"""
 from typing import Callable, List, Optional, Tuple
 import math
@@ -2075,7 +2074,7 @@ def embedding_bag(
 
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
                                      gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
-                                     during training, i.e. it remains as a fixed “pad”. Note that the embedding
+                                     during training, i.e. it remains as a fixed "pad". Note that the embedding
                                      vector at :attr:`padding_idx` is excluded from the reduction.
 
     Shape:

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from typing import Optional
 
 import torch
@@ -255,9 +256,13 @@ class EmbeddingBag(Module):
                                  supported when ``mode="max"``.
         include_last_offset (bool, optional): if ``True``, :attr:`offsets` has one additional element, where the last element
                                       is equivalent to the size of `indices`. This matches the CSR format.
-        padding_idx (int, optional): If given, indicates which indices in :attr:`input` represent padding. When
-                                     a :attr:`padding_idx` is encountered in :attr:`input` during a reduction,
-                                     it is skipped. This allows each bag to be a different logical size.
+        padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
+                                     gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
+                                     during training, i.e. it remains as a fixed “pad”. For a newly constructed
+                                     EmbeddingBag, the embedding vector at :attr:`padding_idx` will default to all
+                                     zeros, but can be updated to another value to be used as the padding vector.
+                                     Note that the embedding vector at :attr:`padding_idx` is excluded from the
+                                     reduction.
 
     Attributes:
         weight (Tensor): the learnable weights of the module of shape `(num_embeddings, embedding_dim)`

--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Optional
 
 import torch
@@ -258,7 +257,7 @@ class EmbeddingBag(Module):
                                       is equivalent to the size of `indices`. This matches the CSR format.
         padding_idx (int, optional): If specified, the entries at :attr:`padding_idx` do not contribute to the
                                      gradient; therefore, the embedding vector at :attr:`padding_idx` is not updated
-                                     during training, i.e. it remains as a fixed “pad”. For a newly constructed
+                                     during training, i.e. it remains as a fixed "pad". For a newly constructed
                                      EmbeddingBag, the embedding vector at :attr:`padding_idx` will default to all
                                      zeros, but can be updated to another value to be used as the padding vector.
                                      Note that the embedding vector at :attr:`padding_idx` is excluded from the


### PR DESCRIPTION
Match updated `Embedding` docs from https://github.com/pytorch/pytorch/pull/54026 as closely as possible. Additionally, update the C++ side `Embedding` docs, since those were missed in the previous PR.

There are 6 (!) places for docs:
1. Python module form in `sparse.py` - includes an additional line about newly constructed `Embedding`s / `EmbeddingBag`s
2. Python `from_pretrained()` in `sparse.py` (refers back to module docs)
3. Python functional form in `functional.py`
4. C++ module options - includes an additional line about newly constructed `Embedding`s / `EmbeddingBag`s
5. C++ `from_pretrained()` options
6. C++ functional options