### PR TITLE
[android] Fix headers publishing in aar

### DIFF
--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -118,38 +118,37 @@ afterEvaluate {
 
 tasks.whenTaskAdded { task ->
   if (task.name.startsWith("bundle") && task.name.endsWith("Aar")) {
-    task.configure {
-      finalizedBy
-      addFolderToAarTask(
-        "addHeadersTo" + task.name,
-        task.archivePath,
-        getLibtorchHeadersDir(),
-        "headers")
+    doLast {
+      addFolderToAar("addHeadersTo" + task.name, task.archivePath, getLibtorchHeadersDir(), 'headers')
     }
   }
 }
 
 def addFolderToAarTask(taskName, aarPath, folderPath, folderPathInAar) {
-  def tmpDir = file("${buildDir}/${taskName}")
-  tmpDir.mkdir()
-  def tmpDirFolder = file("${tmpDir.path}/${folderPathInAar}")
-  tmpDirFolder.mkdir()
-  return tasks.create(name: taskName) {
+  return tasks.register(taskName) {
     doLast {
-      copy {
-        from zipTree(aarPath)
-        into tmpDir
-      }
-      copy {
-        from fileTree(folderPath)
-        into tmpDirFolder
-      }
-      ant.zip(destfile: aarPath) {
-        fileset(dir: tmpDir.path)
-      }
-      delete tmpDir
+      addFolderToAar(taskName, aarPath, folderPath, folderPathInAar) 
     }
   }
+}
+
+def addFolderToAar(taskName, aarPath, folderPath, folderPathInAar) {
+    def tmpDir = file("${buildDir}/${taskName}")
+    tmpDir.mkdir()
+    def tmpDirFolder = file("${tmpDir.path}/${folderPathInAar}")
+    tmpDirFolder.mkdir()
+    copy {
+      from zipTree(aarPath)
+      into tmpDir
+    }
+    copy {
+      from fileTree(folderPath)
+      into tmpDirFolder
+    }
+    ant.zip(destfile: aarPath) {
+      fileset(dir: tmpDir.path)
+    }
+    delete tmpDir
 }
 
 artifacts.add('archives', sourcesJar)

--- a/android/pytorch_android/build.gradle
+++ b/android/pytorch_android/build.gradle
@@ -127,7 +127,7 @@ tasks.whenTaskAdded { task ->
 def addFolderToAarTask(taskName, aarPath, folderPath, folderPathInAar) {
   return tasks.register(taskName) {
     doLast {
-      addFolderToAar(taskName, aarPath, folderPath, folderPathInAar) 
+      addFolderToAar(taskName, aarPath, folderPath, folderPathInAar)
     }
   }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56068 [android] Fix headers publishing in aar**

Differential Revision: [D27776655](https://our.internmc.facebook.com/intern/diff/D27776655)




headers were not added to nightly builds after moving to maven central publishing.

This PR fixes the problem,
gradle -p android uploadArchives
publishes aar that contains headers folder
https://oss.sonatype.org/content/repositories/snapshots/org/pytorch/pytorch_android/1.9.0-SNAPSHOT/