### PR TITLE
[iOS GPU] Use setTexture() rather than copyTexture()

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.h
@@ -25,6 +25,7 @@ class API_AVAILABLE(ios(10.0), macos(10.13)) MPSImageWrapper {
   void setCommandBuffer(MetalCommandBuffer* buffer);
   MetalCommandBuffer* commandBuffer() const;
   IntArrayRef textureSizes() const;
+  void setTexture(MPSImage* image);
   MPSImage* image() const;
   void recycleImage();
   void synchronize();

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -70,6 +70,11 @@ void MPSImageWrapper::copyFromTexture(MPSImage* image) {
   }
 }
 
+void MPSImageWrapper::setTexture(MPSImage* image) {
+    TORCH_CHECK(image);
+    _image = image;
+}
+
 void MPSImageWrapper::synchronize() {
   if ([_image isTemporaryImage]) {
     _image =

--- a/aten/src/ATen/native/metal/ops/MetalClamp.mm
+++ b/aten/src/ATen/native/metal/ops/MetalClamp.mm
@@ -25,7 +25,7 @@ Tensor& hardtanh_(Tensor& input, const Scalar& min_val, const Scalar& max_val) {
   using MetalTensorImpl = at::MetalTensorImpl<MetalTensorImplStorage>;
   MetalTensorImpl* impl = (MetalTensorImpl*)input.unsafeGetTensorImpl();
   MetalTensorImplStorage& implStorage = impl->unsafe_opaque_handle();
-  implStorage.texture()->copyFromTexture(Y);
+  implStorage.texture()->setTexture(Y);
   return input;
 }
 

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.mm
@@ -91,7 +91,7 @@ Tensor conv2d(const Tensor& input, Conv2dOpContext& context) {
     MPSCNNClampOp* clampOp =
         [MPSCNNClampOp newWithTextures:@[ Y1, Y2 ] Args:@[ @(min), @(max) ]];
     [clampOp encode:commandBuffer.buffer];
-    mt.texture()->copyFromTexture(Y2);
+    mt.texture()->setTexture(Y2);
   }
   auto output = makeTensor(std::move(mt), input.options());
   return output;

--- a/aten/src/ATen/native/metal/ops/MetalHardswish.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardswish.mm
@@ -44,7 +44,7 @@ Tensor& hardswish_(Tensor& input) {
   [X markRead];
   MetalTensorImpl* impl = (MetalTensorImpl*)input.unsafeGetTensorImpl();
   MetalTensorImplStorage& implStorage = impl->unsafe_opaque_handle();
-  implStorage.texture()->copyFromTexture(Y);
+  implStorage.texture()->setTexture(Y);
   return input;
 }
 

--- a/aten/src/ATen/native/metal/ops/MetalNeurons.mm
+++ b/aten/src/ATen/native/metal/ops/MetalNeurons.mm
@@ -41,7 +41,7 @@ Tensor& neuronKernel_(Tensor& input, MPSCNNNeuron* neuron) {
                destinationImage:Y];
   MetalTensorImpl* impl = (MetalTensorImpl*)input.unsafeGetTensorImpl();
   MetalTensorImplStorage& implStorage = impl->unsafe_opaque_handle();
-  implStorage.texture()->copyFromTexture(Y);
+  implStorage.texture()->setTexture(Y);
   return input;
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56076 [iOS GPU][MaskRCNN][Not For Landing] Run the maskrcnn model in playground
* #56075 [iOS GPU][Kernel][MaskRCNN] Implement RoIAlign in Metal shaders using Sampler
* #56074 [iOS GPU][Kernel] Implement channel split in Metal shaders
* #56073 [iOS GPU][Kernel] Implement mean.dim using MPSReduce kernel
* #54522 [iOS GPU] Implement transpose in Metal shaders
* #54521 [iOS GPU] Move the definition of `fp16_t` to MetalUtils.h
* #56072 [iOS GPU][Design] Support multiple tensors as outputs
* #56070 [Mobile GPU] Ban mutations in JIT passes
* **#56069 [iOS GPU] Use setTexture() rather than copyTexture()**

It's more efficient to capture a MPSImage object than copying a one from outside.

Differential Revision: [D27694542](https://our.internmc.facebook.com/intern/diff/D27694542/)