### PR TITLE
[ROCm] miopen immediate mode

### DIFF
--- a/aten/src/ATen/Context.h
+++ b/aten/src/ATen/Context.h
@@ -222,7 +222,12 @@ class TORCH_API Context {
   bool enabled_cudnn = true;
   bool deterministic_cudnn = false;
   bool _deterministic_algorithms = false;
+#ifdef __HIP_PLATFORM_HCC__
+  // Until MIOpen immediate mode performance is adequate, we want benchmarking by default.
+  bool benchmark_cudnn = true;
+#else
   bool benchmark_cudnn = false;
+#endif
   bool allow_tf32_cudnn = true;
   bool allow_tf32_cublas = true;
   bool enabled_mkldnn = true;

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -518,8 +518,8 @@ Workspace chooseForwardSolution(
   miopenConvSolution_t solution;
   MIOPEN_CHECK(miopenConvolutionForwardGetSolution(
       args.handle,
-      args.wdesc.desc(),
       args.idesc.desc(),
+      args.wdesc.desc(),
       args.cdesc.desc(),
       args.odesc.desc(),
       1,        // just return the fastest
@@ -537,10 +537,10 @@ Workspace chooseBackwardDataSolution(
   miopenConvSolution_t solution;
   MIOPEN_CHECK(miopenConvolutionBackwardDataGetSolution(
       args.handle,
-      args.idesc.desc(),
+      args.odesc.desc(),
       args.wdesc.desc(),
       args.cdesc.desc(),
-      args.odesc.desc(),
+      args.idesc.desc(),
       1,        // just return the fastest
       &solution_count,
       &solution));
@@ -632,8 +632,8 @@ void raw_miopen_convolution_forward_out(
     Workspace workspace = chooseForwardSolution(args, &solution_id);
     MIOPEN_CHECK(miopenConvolutionForwardImmediate(
       args.handle,
-      args.wdesc.desc(), weight.data_ptr(),
       args.idesc.desc(), input.data_ptr(),
+      args.wdesc.desc(), weight.data_ptr(),
       args.cdesc.desc(),
       args.odesc.desc(), output.data_ptr(),
       workspace.data, workspace.size,
@@ -729,8 +729,8 @@ void raw_miopen_depthwise_convolution_forward_out(
     Workspace workspace = chooseForwardSolution(args, &solution_id);
     MIOPEN_CHECK(miopenConvolutionForwardImmediate(
       args.handle,
-      args.wdesc.desc(), weight.data_ptr(),
       args.idesc.desc(), input.data_ptr(),
+      args.wdesc.desc(), weight.data_ptr(),
       args.cdesc.desc(),
       args.odesc.desc(), output.data_ptr(),
       workspace.data, workspace.size,

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -375,36 +375,23 @@ struct algorithm_search<miopenConvFwdAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return fwd_algos; }
   static BenchmarkCache<size_t>& wsscache() { return fwd_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args) {
     int perf_count;
     perf_t perf_results;
-    if (!benchmark) {
-      MIOPEN_CHECK(miopenConvolutionForwardGetSolution(
-          args.handle,
-          args.idesc.desc(),
-          args.wdesc.desc(),
-          args.cdesc.desc(),
-          args.odesc.desc(),
-          1,        // just return the fastest
-          &perf_count,
-          &perf_results));
-    }
-    else {
-      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-      Workspace ws(max_ws_size);
-      MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
-          args.handle,
-          args.idesc.desc(), args.input.data_ptr(),
-          args.wdesc.desc(), args.weight.data_ptr(),
-          args.cdesc.desc(),
-          args.odesc.desc(), args.output.data_ptr(),
-          1,        // just return the fastest
-          &perf_count,
-          &perf_results,
-          ws.data,
-          ws.size,
-          false));
-    }
+    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+    Workspace ws(max_ws_size);
+    MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
+        args.handle,
+        args.idesc.desc(), args.input.data_ptr(),
+        args.wdesc.desc(), args.weight.data_ptr(),
+        args.cdesc.desc(),
+        args.odesc.desc(), args.output.data_ptr(),
+        1,        // just return the fastest
+        &perf_count,
+        &perf_results,
+        ws.data,
+        ws.size,
+        false));
     return perf_results;
   }
 };
@@ -418,36 +405,23 @@ struct algorithm_search<miopenConvBwdDataAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return bwd_data_algos; }
   static BenchmarkCache<size_t>& wsscache() { return bwd_data_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args) {
     int perf_count;
     perf_t perf_results;
-    if (!benchmark) {
-      MIOPEN_CHECK(miopenConvolutionBackwardDataGetSolution(
-          args.handle,
-          args.odesc.desc(),
-          args.wdesc.desc(),
-          args.cdesc.desc(),
-          args.idesc.desc(),
-          1,      // just return the fastest
-          &perf_count,
-          &perf_results));
-    }
-    else {
-      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-      Workspace ws(max_ws_size);
-      MIOPEN_CHECK(miopenFindConvolutionBackwardDataAlgorithm(
-          args.handle,
-          args.odesc.desc(), args.output.data_ptr(),
-          args.wdesc.desc(), args.weight.data_ptr(),
-          args.cdesc.desc(),
-          args.idesc.desc(), args.input.data_ptr(),
-          1,      // just return the fastest
-          &perf_count,
-          &perf_results,
-          ws.data,
-          ws.size,
-          false));
-    }
+    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+    Workspace ws(max_ws_size);
+    MIOPEN_CHECK(miopenFindConvolutionBackwardDataAlgorithm(
+        args.handle,
+        args.odesc.desc(), args.output.data_ptr(),
+        args.wdesc.desc(), args.weight.data_ptr(),
+        args.cdesc.desc(),
+        args.idesc.desc(), args.input.data_ptr(),
+        1,      // just return the fastest
+        &perf_count,
+        &perf_results,
+        ws.data,
+        ws.size,
+        false));
     return perf_results;
   }
 };
@@ -461,36 +435,23 @@ struct algorithm_search<miopenConvBwdWeightsAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return bwd_filter_algos; }
   static BenchmarkCache<size_t>& wsscache() { return bwd_filter_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args) {
     int perf_count;
     perf_t perf_results;
-    if (!benchmark) {
-      MIOPEN_CHECK(miopenConvolutionBackwardWeightsGetSolution(
-          args.handle,
-          args.odesc.desc(),
-          args.idesc.desc(),
-          args.cdesc.desc(),
-          args.wdesc.desc(),
-          1,      // just return the fastest
-          &perf_count,
-          &perf_results));
-    }
-    else {
-      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-      Workspace ws(max_ws_size);
-      MIOPEN_CHECK(miopenFindConvolutionBackwardWeightsAlgorithm(
-          args.handle,
-          args.odesc.desc(), args.output.data_ptr(),
-          args.idesc.desc(), args.input.data_ptr(),
-          args.cdesc.desc(),
-          args.wdesc.desc(), args.weight.data_ptr(),
-          1,      // just return the fastest
-          &perf_count,
-          &perf_results,
-          ws.data,
-          ws.size,
-          false));
-    }
+    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+    Workspace ws(max_ws_size);
+    MIOPEN_CHECK(miopenFindConvolutionBackwardWeightsAlgorithm(
+        args.handle,
+        args.odesc.desc(), args.output.data_ptr(),
+        args.idesc.desc(), args.input.data_ptr(),
+        args.cdesc.desc(),
+        args.wdesc.desc(), args.weight.data_ptr(),
+        1,      // just return the fastest
+        &perf_count,
+        &perf_results,
+        ws.data,
+        ws.size,
+        false));
     return perf_results;
   }
 };

--- a/aten/src/ATen/native/miopen/Conv_miopen.cpp
+++ b/aten/src/ATen/native/miopen/Conv_miopen.cpp
@@ -375,23 +375,36 @@ struct algorithm_search<miopenConvFwdAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return fwd_algos; }
   static BenchmarkCache<size_t>& wsscache() { return fwd_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
     int perf_count;
     perf_t perf_results;
-    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-    Workspace ws(max_ws_size);
-    MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
-        args.handle,
-        args.idesc.desc(), args.input.data_ptr(),
-        args.wdesc.desc(), args.weight.data_ptr(),
-        args.cdesc.desc(),
-        args.odesc.desc(), args.output.data_ptr(),
-        1,        // just return the fastest
-        &perf_count,
-        &perf_results,
-        ws.data,
-        ws.size,
-        false));
+    if (!benchmark) {
+      MIOPEN_CHECK(miopenConvolutionForwardGetSolution(
+          args.handle,
+          args.idesc.desc(),
+          args.wdesc.desc(),
+          args.cdesc.desc(),
+          args.odesc.desc(),
+          1,        // just return the fastest
+          &perf_count,
+          &perf_results));
+    }
+    else {
+      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+      Workspace ws(max_ws_size);
+      MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
+          args.handle,
+          args.idesc.desc(), args.input.data_ptr(),
+          args.wdesc.desc(), args.weight.data_ptr(),
+          args.cdesc.desc(),
+          args.odesc.desc(), args.output.data_ptr(),
+          1,        // just return the fastest
+          &perf_count,
+          &perf_results,
+          ws.data,
+          ws.size,
+          false));
+    }
     return perf_results;
   }
 };
@@ -405,23 +418,36 @@ struct algorithm_search<miopenConvBwdDataAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return bwd_data_algos; }
   static BenchmarkCache<size_t>& wsscache() { return bwd_data_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
     int perf_count;
     perf_t perf_results;
-    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-    Workspace ws(max_ws_size);
-    MIOPEN_CHECK(miopenFindConvolutionBackwardDataAlgorithm(
-        args.handle,
-        args.odesc.desc(), args.output.data_ptr(),
-        args.wdesc.desc(), args.weight.data_ptr(),
-        args.cdesc.desc(),
-        args.idesc.desc(), args.input.data_ptr(),
-        1,      // just return the fastest
-        &perf_count,
-        &perf_results,
-        ws.data,
-        ws.size,
-        false));
+    if (!benchmark) {
+      MIOPEN_CHECK(miopenConvolutionBackwardDataGetSolution(
+          args.handle,
+          args.odesc.desc(),
+          args.wdesc.desc(),
+          args.cdesc.desc(),
+          args.idesc.desc(),
+          1,      // just return the fastest
+          &perf_count,
+          &perf_results));
+    }
+    else {
+      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+      Workspace ws(max_ws_size);
+      MIOPEN_CHECK(miopenFindConvolutionBackwardDataAlgorithm(
+          args.handle,
+          args.odesc.desc(), args.output.data_ptr(),
+          args.wdesc.desc(), args.weight.data_ptr(),
+          args.cdesc.desc(),
+          args.idesc.desc(), args.input.data_ptr(),
+          1,      // just return the fastest
+          &perf_count,
+          &perf_results,
+          ws.data,
+          ws.size,
+          false));
+    }
     return perf_results;
   }
 };
@@ -435,23 +461,36 @@ struct algorithm_search<miopenConvBwdWeightsAlgorithm_t> {
   static BenchmarkCache<algo_t>& cache() { return bwd_filter_algos; }
   static BenchmarkCache<size_t>& wsscache() { return bwd_filter_wssizes; }
 
-  static perf_t findAlgorithm(const ConvolutionArgs& args) {
+  static perf_t findAlgorithm(const ConvolutionArgs& args, bool benchmark) {
     int perf_count;
     perf_t perf_results;
-    size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
-    Workspace ws(max_ws_size);
-    MIOPEN_CHECK(miopenFindConvolutionBackwardWeightsAlgorithm(
-        args.handle,
-        args.odesc.desc(), args.output.data_ptr(),
-        args.idesc.desc(), args.input.data_ptr(),
-        args.cdesc.desc(),
-        args.wdesc.desc(), args.weight.data_ptr(),
-        1,      // just return the fastest
-        &perf_count,
-        &perf_results,
-        ws.data,
-        ws.size,
-        false));
+    if (!benchmark) {
+      MIOPEN_CHECK(miopenConvolutionBackwardWeightsGetSolution(
+          args.handle,
+          args.odesc.desc(),
+          args.idesc.desc(),
+          args.cdesc.desc(),
+          args.wdesc.desc(),
+          1,      // just return the fastest
+          &perf_count,
+          &perf_results));
+    }
+    else {
+      size_t max_ws_size = getWorkspaceSize(args, DEFAULT_ALGO);
+      Workspace ws(max_ws_size);
+      MIOPEN_CHECK(miopenFindConvolutionBackwardWeightsAlgorithm(
+          args.handle,
+          args.odesc.desc(), args.output.data_ptr(),
+          args.idesc.desc(), args.input.data_ptr(),
+          args.cdesc.desc(),
+          args.wdesc.desc(), args.weight.data_ptr(),
+          1,      // just return the fastest
+          &perf_count,
+          &perf_results,
+          ws.data,
+          ws.size,
+          false));
+    }
     return perf_results;
   }
 };

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -502,12 +502,6 @@ PyObject *THPModule_setBenchmarkCuDNN(PyObject *_unused, PyObject *arg)
 {
   THPUtils_assert(PyBool_Check(arg), "set_benchmark_cudnn expects a bool, "
           "but got %s", THPUtils_typename(arg));
-#ifdef __HIP_PLATFORM_HCC__
-  if (arg == Py_False) {
-    TORCH_WARN_ONCE("Disabling benchmark mode for MIOpen is NOT supported. Overriding value to True");
-    arg = Py_True;
-  }
-#endif
   at::globalContext().setBenchmarkCuDNN(arg == Py_True);
   Py_RETURN_NONE;
 }


### PR DESCRIPTION
Implements the ability to skip the benchmarking of convolution kernels for ROCm/MIOpen.