### PR TITLE
A heuristic to avoid perf incompatible MKLDNN formats for binary ops

### DIFF
--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -1828,6 +1828,29 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
+    def test_incompatible_perf_formats(self):
+        with set_default_dtype(torch.float):
+            class Mod(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.conv = torch.nn.Conv2d(3, 64, 3, 2)
+                    self.max_pool = torch.nn.MaxPool2d(111, 111)
+
+                def forward(self, x):
+                    a = self.conv(x)
+                    b = self.max_pool(a)
+                    return a + b
+
+            model = Mod()
+            model.eval()
+            mod = torch.jit.freeze(torch.jit.script(model))
+            N, C, H, W, = 10, 3, 224, 224
+            inp = torch.randn(N, C, H, W)
+            self.run_pass("convert_frozen_ops_to_mkldnn", mod.graph)
+            print(mod.graph)
+            self.assertTrue(torch.allclose(model(inp), mod(inp)))
+
+    @unittest.skipIf(not torch._C.has_mkldnn, "MKL-DNN build is disabled")
     @skipIfNoTorchVision
     def test_conv_hardswish(self):
         with set_default_dtype(torch.float):

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -277,28 +277,68 @@ Operation BroadOp(const Node* node) {
     auto a_size = a.sizes();
     if (a_size.equals(b_size)) {
       push(stack, a, b);
+      return;
     } else {
       auto out_size = at::infer_size(a_size, b_size);
-      size_t out_numel = out_size[0];
+      int64_t out_numel = out_size[0];
       for (size_t i = 1, end = out_size.size(); i < end; ++i) {
         out_numel = out_numel * out_size[i];
       }
+
+      auto exp_a = a;
+      auto exp_b = b;
       // mkldnn tensors only support reshape, not expand or view operators
       if (a_size.equals(out_size)) {
         push(stack, a);
       } else if (out_numel == a.numel()) {
-        push(stack, a.reshape(out_size));
+        exp_a = a.reshape(out_size);
       } else {
-        push(stack, a.to_dense().expand(out_size).to_mkldnn());
+        exp_a = a.to_dense().expand(out_size).to_mkldnn();
       }
 
       if (b_size.equals(out_size)) {
         push(stack, b);
       } else if (out_numel == b.numel()) {
-        push(stack, b.reshape(out_size).to_mkldnn());
+        exp_b = b.reshape(out_size);
       } else {
-        push(stack, b.to_dense().expand(out_size).to_mkldnn());
+        exp_b = b.to_dense().expand(out_size).to_mkldnn();
       }
+
+      {
+        // If one of the inputs was expanded and converted to nchw/nhwc
+        // we might end up in a very bad spot if the second argument
+        // is in a blocked format. In this case, MKLDNN uses its
+        // reference implementation for a binary operation that follows
+        // these broadcasts and it could be up to ~100x slower.
+        // We use a very simple heuristic to convert an arg in nchw
+        // to the blocked format of the other argument.
+        c10::impl::ExcludeDispatchKeyGuard edkg(c10::autograd_dispatch_keyset);
+        auto a_it = at::native::itensor_from_mkldnn(exp_a);
+        auto b_it = at::native::itensor_from_mkldnn(exp_b);
+
+        if (!a_it.is_public_format()) {
+          if (b_it.is_public_format()) {
+            b_it = b_it.reorder_if_differ_in(a_it.get_desc());
+          }
+        } else if (!b_it.is_public_format()) {
+          if (a_it.is_public_format()) {
+            a_it = a_it.reorder_if_differ_in(b_it.get_desc());
+          }
+        }
+
+        auto a_options = exp_a.options();
+        auto a_out = at::native::new_with_itensor_mkldnn(
+            std::move(a_it),
+            optTypeMetaToScalarType(a_options.dtype_opt()),
+            a_options.device_opt());
+        push(stack, a_out);
+        auto b_options = exp_b.options();
+        auto b_out = at::native::new_with_itensor_mkldnn(
+            std::move(b_it),
+            optTypeMetaToScalarType(b_options.dtype_opt()),
+            b_options.device_opt());
+        push(stack, b_out);
+      };
     }
   };
 }


### PR DESCRIPTION
After adding new ops to a set of fusible ops, mobilenetv3 slows down to **9000ms from 1200ms** without this fix.

This happens because one of the inputs was expanded and converted to nchw/nhwc
we might end up in a very bad spot if the second argument
is in a blocked format. In this case, MKLDNN uses its
reference implementation for a binary operation that follows
these broadcasts and it could be up to ~100x slower.
We use a very simple heuristic to convert an arg in nchw
to the blocked format of the other argument.

* MKLDNN_VERBOSE without the issue:
[test_mobilenet_nopool.txt](https://github.com/pytorch/pytorch/files/6319528/test_mobilenet_nopool.txt)
* MKLDNN_VERBOSE with the issue (Note the times for `ref` operations)
[test_mobilenet_pool.txt](https://github.com/pytorch/pytorch/files/6319529/test_mobilenet_pool.txt)

