### PR TITLE
Fix compiler warnings in mkldnn Pooling

### DIFF
--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -3,6 +3,7 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/core/grad_mode.h>
 #include <ATen/native/utils/ParamUtils.h>
+#include <c10/util/irange.h>
 #include <tuple>
 
 
@@ -618,7 +619,7 @@ Tensor mkldnn_adaptive_avg_pool2d_backward(
 
   auto output_size_vec = grad_output.sizes();
   std::vector<int64_t> kernel_size(input.dim() - 2);
-  for (size_t i = 2; i < input.dim(); ++i) {
+  for (const auto i: c10::irange(2, input.dim())) {
     auto s1 = input.size(i);
     auto s2 = output_size_vec[i];
     TORCH_CHECK(s2 != 0, "output size can not be zero");

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -534,6 +534,8 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
   # Required workaround for LLVM 9 includes.
   if(NOT MSVC)
     set_source_files_properties(${TORCH_SRC_DIR}/csrc/jit/tensorexpr/llvm_jit.cpp PROPERTIES COMPILE_FLAGS -Wno-noexcept-type)
+    # Force -Werror on several files
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/../aten/src/ATen/native/mkldnn/Pooling.cpp PROPERTIES COMPILE_FLAGS "-Werror")
   endif()
   # Disable certain warnings for GCC-9.X
   if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))


### PR DESCRIPTION
Also, add `-Werror` flag to prevent this regressions from happening in
the future
