### PR TITLE
[nnc] Separate printing of optimized llvm bitcode from assembly

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -550,10 +550,13 @@ void LLVMCodeGenImpl::emitKernel(
 
   optimize(*module_);
 
-  // print graph debug info after optimization
   asmBuffer.set_size(0);
   module_->print(asmStream, nullptr);
   llvmCode = asmStream.str().str();
+  GRAPH_DEBUG(
+      "\nLLVM module after optimizations\n\n", asmStream.str().str(), "\n");
+
+  // print graph debug info after optimization
   asmBuffer.set_size(0);
   llvm::legacy::PassManager PM;
   jit_->getTargetMachine().addPassesToEmitFile(
@@ -569,7 +572,7 @@ void LLVMCodeGenImpl::emitKernel(
   asmCode = asmStream.str().str();
 
   GRAPH_DEBUG(
-      "\nLLVM module after optimizations\n\n", llvmCode, "\n", asmCode, "\n");
+      "\nLLVM generated assembly code\n\n", asmCode, "\n");
 }
 
 // TODO: The binary ops are copypasta.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56116 [nnc] Don't fuse fp16 on CPU
* #56099 [nnc] Disable float16 conversion test that triggers llvm bug
* #56098 [nnc][trivial] Trailing underscore style for llvmCode, asmCode members
* **#56097 [nnc] Separate printing of optimized llvm bitcode from assembly**
* #55970 [nnc] Do not try to vectorize kernels that use float16

I was debugging an issue during instruction selection and wanted to
see the input bitcode.  This way we always print it before going into the asm
generation pass.

Differential Revision: [D27781683](https://our.internmc.facebook.com/intern/diff/D27781683/)