### PR TITLE
[nnc][trivial] Trailing underscore style for llvmCode, asmCode members

### DIFF
--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -176,8 +176,8 @@ class LLVMCodeGenImpl : public IRVisitor {
   std::unordered_map<const Block*, std::vector<const Var*>> scopeToVar_;
   const Block* scope_;
 
-  std::string llvmCode;
-  std::string asmCode;
+  std::string llvmCode_;
+  std::string asmCode_;
 
  private:
   llvm::LLVMContext& getContext();
@@ -268,10 +268,10 @@ class LLVMCodeGenImpl : public IRVisitor {
 
   void optimize(llvm::Module& M);
   std::string getLLVMCodeText() {
-    return llvmCode;
+    return llvmCode_;
   }
   std::string getASMCodeText() {
-    return asmCode;
+    return asmCode_;
   }
 };
 
@@ -552,7 +552,7 @@ void LLVMCodeGenImpl::emitKernel(
 
   asmBuffer.set_size(0);
   module_->print(asmStream, nullptr);
-  llvmCode = asmStream.str().str();
+  llvmCode_ = asmStream.str().str();
   GRAPH_DEBUG(
       "\nLLVM module after optimizations\n\n", asmStream.str().str(), "\n");
 
@@ -569,10 +569,10 @@ void LLVMCodeGenImpl::emitKernel(
       llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
 #endif
   PM.run(*module_);
-  asmCode = asmStream.str().str();
+  asmCode_ = asmStream.str().str();
 
   GRAPH_DEBUG(
-      "\nLLVM generated assembly code\n\n", asmCode, "\n");
+      "\nLLVM generated assembly code\n\n", asmCode_, "\n");
 }
 
 // TODO: The binary ops are copypasta.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56116 [nnc] Don't fuse fp16 on CPU
* #56099 [nnc] Disable float16 conversion test that triggers llvm bug
* **#56098 [nnc][trivial] Trailing underscore style for llvmCode, asmCode members**
* #56097 [nnc] Separate printing of optimized llvm bitcode from assembly
* #55970 [nnc] Do not try to vectorize kernels that use float16

that's it

Differential Revision: [D27781682](https://our.internmc.facebook.com/intern/diff/D27781682/)