### PR TITLE
[nnc] Disable float16 conversion test that triggers llvm bug

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1319,7 +1319,9 @@ class TestTEFuser(JitTestCase):
         dtypes = [
             torch.bool,
             torch.int,
-            torch.float16,
+            # TODO: vectorized float16 conversions expose an internal compile
+            # error in LLVM <= 9.0.  See #56090.
+            # torch.float16
             torch.float32,
             torch.float64,
         ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56116 [nnc] Don't fuse fp16 on CPU
* **#56099 [nnc] Disable float16 conversion test that triggers llvm bug**
* #56098 [nnc][trivial] Trailing underscore style for llvmCode, asmCode members
* #56097 [nnc] Separate printing of optimized llvm bitcode from assembly
* #55970 [nnc] Do not try to vectorize kernels that use float16

As reported in #56090 this test triggers an llvm bug where it tries to
vectorize some float16 ops and then can't select an instruction for it.
Disabling the test to keep CI green while we look for a workaround.

Differential Revision: [D27781684](https://our.internmc.facebook.com/intern/diff/D27781684/)