### PR TITLE
Fix ScriptMethod dispatch on __torch_function__

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13959,6 +13959,24 @@ dedent """
         with self.assertRaisesRegex(Exception, "Parameters not specified"):
             torch.jit.script(test)
 
+    def test_script_method_torch_function_overload(self):
+        class MyCustomTensor(torch.Tensor):
+            pass
+
+        class MyCustomModule(torch.nn.Module):
+            def forward(self, x):
+                return torch.relu(x)
+
+        scripted_mod = torch.jit.script(MyCustomModule())
+        t = torch.tensor([3.0])
+        ref_out = scripted_mod(t)
+
+        t_custom = MyCustomTensor([3.0])
+        out1 = scripted_mod(t_custom)
+        self.assertEqual(out1, ref_out)
+
+        out2 = scripted_mod.forward(t_custom)
+        self.assertEqual(out2, ref_out)
 
     def test_function_overloading_isinstance(self):
         @torch.jit._overload  # noqa: F811

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -989,7 +989,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
     const tuple_slice& args_no_self,
     const py::kwargs& kwargs,
     const c10::QualifiedName qualname) {
-  std::vector<py::handle> args_vec = {callee};
+  std::vector<py::handle> args_vec;
   for (const auto& arg : args_no_self) {
     args_vec.push_back(arg);
   }
@@ -1023,12 +1023,12 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
   if (overloaded_args.size() > 0) {
     return pybind11::reinterpret_steal<py::object>(
         handle_torch_function_no_python_arg_parser(
-            overloaded_args,
-            args.ptr(),
-            kwargs.ptr(),
-            qualname.name().c_str(),
-            args[0].ptr(),
-            qualname.prefix().c_str()));
+            /*overloaded_args=*/overloaded_args,
+            /*args=*/args.ptr(),
+            /*kwargs=*/kwargs.ptr(),
+            /*func_name=*/qualname.name().c_str(),
+            /*torch_api_function*/callee.ptr(),
+            /*module_name=*/qualname.prefix().c_str()));
   }
 
   return c10::nullopt;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1027,7 +1027,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
             /*args=*/args.ptr(),
             /*kwargs=*/kwargs.ptr(),
             /*func_name=*/qualname.name().c_str(),
-            /*torch_api_function*/callee.ptr(),
+            /*torch_api_function=*/callee.ptr(),
             /*module_name=*/qualname.prefix().c_str()));
   }
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -210,8 +210,7 @@ class Proxy:
         args = args if args else ()
         kwargs = kwargs if kwargs else {}
         if isinstance(orig_method, torch._C.ScriptMethod):
-            assert isinstance(args[0], torch._C.ScriptMethod)
-            args = (args[0].owner,) + args[1:]
+            args = (orig_method.owner,) + args
             return self.tracer.create_proxy('call_method', orig_method.name, args, kwargs)
         if torch.overrides.is_tensor_method_or_property(orig_method):
             return self.tracer.create_proxy('call_method', orig_method.__name__, args, kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56103 Fix ScriptMethod dispatch on __torch_function__**

I screwed up the calling convention before, the `ScriptMethod` itself should not appear as `args[0]`

Differential Revision: [D27784142](https://our.internmc.facebook.com/intern/diff/D27784142)