### PR TITLE
[nnc] Don't fuse fp16 on CPU

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -905,15 +905,22 @@ class TensorExprFuser {
     for (const Value* v : node->inputs()) {
       if (auto const& tt = v->type()->cast<TensorType>()) {
         auto const& st = tt->scalarType();
+        auto const& device = tt->device();
 
         // All tensors must be typed.
-        if (!st) {
+        if (!st || !device) {
           return false;
         }
 
         // Byte tensors introduce too many corner cases in type promotion.
         // Better not to try to handle them.
         if (*st == c10::ScalarType::Byte) {
+          return false;
+        }
+
+        // Float16 has a few kinks on LLVM.  Disable it until we either move to
+        // a more stable version or find workarounds.
+        if (*st == c10::ScalarType::Half && *device == c10::kCPU) {
           return false;
         }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56119 [nnc] Don't fuse fp16 on CPU**
* #56118 [nnc][trivial] Trailing underscore style for llvmCode, asmCode members
* #56117 [nnc] Separate printing of optimized llvm bitcode from assembly

There are apparently still more issues with fp16 on LLVM so let's just
nuke it from orbit while we develop a robust workaround.

Differential Revision: [D27787080](https://our.internmc.facebook.com/intern/diff/D27787080/)