### PR TITLE
[WIP][Not for review] Added skeleton of python dispatch key

### DIFF
--- a/c10/core/DispatchKey.h
+++ b/c10/core/DispatchKey.h
@@ -133,6 +133,7 @@ enum class DispatchKey : uint8_t {
   // can be registered to implement the custom determination of the
   // correct backend.
   BackendSelect,
+  PythonKey,
 
   // The named dispatch key is set for any tensors with named dimensions.
   // Although we have a dispatch key for named tensors, for historical reasons,

--- a/nnc_compile.py
+++ b/nnc_compile.py
@@ -1,0 +1,330 @@
+import time
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch._C._te as te
+import torch.fx as fx
+from torch.fx import map_arg
+from torch.fx.passes.shape_prop import ShapeProp
+import operator
+scope = te.KernelScope()
+
+# Decomposition Pass
+
+def binary_mapping(op):
+    def f(a, b):
+        return op(a, b)
+    return f
+
+decomposition_rules = {}
+binary_decompositions = [
+    (operator.matmul, torch.mm),
+    (operator.add, torch.add),
+    (operator.mul, torch.mul),
+    (operator.sub, torch.sub),
+    (operator.truediv, torch.div),
+    (operator.eq, torch.eq),
+    (operator.gt, torch.gt),
+    (operator.ge, torch.ge),
+    (operator.lt, torch.lt),
+    (operator.le, torch.le),
+    (operator.ne, torch.ne),
+    (operator.and_, torch.bitwise_and),
+    (operator.pow, torch.pow)
+]
+for old, new in binary_decompositions:
+    decomposition_rules[old] = binary_mapping(new)
+
+def addmm_decompose(input, mat1, mat2, beta=1, alpha=1, out=None):
+    assert(out is None)
+    return beta*input + alpha*(torch.mm(mat1, mat2))
+
+def matmul_decompose(A, B, out=None):
+    assert(out is None)
+    if A.dim() == 1 and B.dim() == 1:
+        return torch.dot(A, B)
+    if A.dim() == 2 and B.dim() == 2:
+        return torch.mm(A, B)
+    if A.dim() == 2 and B.dim() == 1:
+        return torch.mv(A, B)
+    else:
+        raise RuntimeError("nyi")
+
+decomposition_rules[torch.addmm] = addmm_decompose
+decomposition_rules[operator.neg] = lambda x: 0 - x
+decomposition_rules[torch.matmul] = matmul_decompose
+
+
+def method_torch_decompose(method):
+    def f(self, *args):
+        return getattr(torch, method)(self, *args)
+    return f
+
+tensor_methods_simple = ['add', 'sub', 'mul', 'div', 'matmul']
+
+for meth in tensor_methods_simple:
+    decomposition_rules[(torch.Tensor, meth)] = method_torch_decompose(meth)
+
+def method_reshape_decompose(self, *shape):
+    return torch.reshape(self, shape)
+
+decomposition_rules[(torch.Tensor, 'reshape')] = method_reshape_decompose
+
+def method_t_decompose(self):
+    assert(self.dim() <= 2)
+    if self.dim() < 2: return self
+    else: return torch.transpose(self, 1, 0)
+decomposition_rules[(torch.Tensor, 't')] = method_t_decompose
+
+def module_conv2d_decompose(module, x):
+    return F.conv2d(x, module.weight, module.bias, module.stride, module.padding, module.dilation, module.groups)
+
+def module_relu6_decompose(module, x):
+    return torch.clamp(x, 0.0, 6.0)
+
+def module_dropout_decompose(module, x):
+    if module.training == False:
+        return x
+    else:
+        return F.dropout(x, module.p, module.training)
+
+def module_linear_decompose(module, x):
+    weight, bias = module.weight, module.bias
+    if x.dim() == 2 and bias is not None:
+        # fused op is marginally faster
+        ret = torch.addmm(bias, x, weight.t())
+    else:
+        output = x.matmul(weight.t())
+        if bias is not None:
+            output += bias
+        ret = output
+    return ret
+
+decomposition_rules[nn.Conv2d] = module_conv2d_decompose
+decomposition_rules[nn.ReLU6] = module_relu6_decompose
+decomposition_rules[nn.Dropout] = module_dropout_decompose
+decomposition_rules[nn.Linear] = module_linear_decompose
+
+# NNC Lowering Pass
+
+class kernel_arena_scope(object):
+    def __enter__(self):
+        self.scope = te.KernelScope()
+
+    def __exit__(self, typ, val, traceback):
+        self.scope = None
+
+def get_dim_args(dims):
+    dim_args = []
+    for dim in dims:
+        dim_args.append(te.DimArg(te.ExprHandle.int(dim), 'i' + str(len(dim_args))))
+    return dim_args
+
+def get_te_shapes(shape):
+    return [te.ExprHandle.int(i) for i in shape]
+
+def to_expr(x):
+    if isinstance(x, int):
+        return te.ExprHandle.int(x)
+    elif isinstance(x, float):
+        return te.ExprHandle.float(x)
+    else:
+        raise RuntimeError(f"type {type(x)} not supported")
+
+def get_nnc_type(dtype):
+    if dtype == torch.float:
+        return te.Dtype.Float
+    elif dtype == torch.long:
+        return te.Dtype.Long
+    else:
+        raise RuntimeError("nyi")
+
+
+lowering_functions = { }
+def index_or_broadcast(shape, *args):
+    out = []
+    for idx, arg in enumerate(args):
+        if idx >= len(shape): continue
+        if shape[idx] == 1:
+            out.append(to_expr(0))
+        else:
+            out.append(arg)
+    return out
+def sum_lower(name, out_shape, inp_shapes, args):
+    assert(args[1] is None)
+    A = args[0]
+    return te.Reduce(name, get_dim_args([]), te.Sum(), A, get_dim_args(inp_shapes[0][0]))
+
+def ones_like_lower(name, out_shape, inp_shapes, args):
+    def f(*idxs):
+        return to_expr(1.0)
+    res = te.Compute(name, get_dim_args(out_shape), f)
+    return res
+
+def expand_lower(name, out_shape, inp_shapes, args):
+    inp_shape = inp_shapes[0][0]
+    A = args[0]
+    def f(*idxs):
+        return A.load(index_or_broadcast(inp_shape, args))
+    return te.Compute(name, get_dim_args(out_shape), f)
+
+
+lowering_functions[torch.ops.aten.sum] = sum_lower
+lowering_functions[torch.ops.aten.ones_like] = ones_like_lower
+lowering_functions[torch.ops.aten.expand] = expand_lower
+func_to_aten = {
+    operator.getitem: torch.ops.aten.slice,
+    operator.add: torch.ops.aten.add,
+    operator.mul: torch.ops.aten.mul,
+    torch.mul: torch.ops.aten.mul,
+    torch.sin: torch.ops.aten.sin,
+    torch.cos: torch.ops.aten.cos,
+}
+
+
+def process_shape(x):
+    if len(x) == 0:
+        return [1]
+    return x
+def lower_function(node, op, nnc_args, args):
+    inp_shapes = fx.node.map_aggregate(args, lambda arg: (process_shape(arg.meta['tensor_meta'].shape), arg.meta['tensor_meta'].dtype) if isinstance(arg, fx.Node) and 'tensor_meta' in arg.meta else None)
+    if op in lowering_functions:
+        out = lowering_functions[op](node.name, process_shape(node.meta['tensor_meta'].shape), inp_shapes, nnc_args)
+    else:
+        if op in func_to_aten:
+            op = func_to_aten[op]
+        aten_str = f'aten::{op.__name__}'
+        # print(aten_str, nnc_args)
+        out = te.lower(aten_str, list(nnc_args), get_te_shapes(node.meta['tensor_meta'].shape), get_nnc_type(torch.float))
+    assert(isinstance(out, te.Tensor))
+    return out.buf(), [out.stmt()]
+
+def nnc_compile(model: torch.nn.Module, example_inputs) -> torch.nn.Module:
+    """
+    nnc_compile(model, example_inputs) returns a function with the same args
+    as `model.forward`, with an extra argument corresponding to where the
+    output is stored. This function takes the inputs (which must be PyTorch
+    tensors with the same shapes as example_inputs), and passes them to an
+    NNC executor.
+    """
+    fx_model = fx.symbolic_trace(model)
+    ShapeProp(fx_model).propagate(*example_inputs)
+
+    # This env maps from nodes to `te.ExprHandle`, which represent the output
+    # of an NNC computation.
+    env = {}
+
+
+    def get_te_type(node):
+        return get_nnc_type(node.meta['tensor_meta'].dtype)
+
+    def gen_compute(args):
+        te_args = [env[arg.name] for arg in args]
+
+    def lookup_env(l):
+        res = fx.node.map_aggregate(l, lambda x: env[x.name] if isinstance(x, fx.Node) else x)
+        return res
+
+    def fetch_attr(target : str):
+        target_atoms = target.split('.')
+        attr_itr = fx_model
+        for i, atom in enumerate(target_atoms):
+            if not hasattr(attr_itr, atom):
+                raise RuntimeError(f"Node referenced nonexistant target {'.'.join(target_atoms[:i])}")
+            attr_itr = getattr(attr_itr, atom)
+        return attr_itr
+
+    outs = None
+    inputs = []
+    module_attrs = []
+    compute_stmts = []
+    for node in fx_model.graph.nodes:
+        if node.op == 'placeholder':
+            # We simply map the input placeholder to a `te.Placeholder`, which
+            # also represents an input to the NNC computation.
+            shapes = get_te_shapes(node.meta['tensor_meta'].shape)
+            placeholder = te.Placeholder(node.name, get_te_type(node), shapes)
+            env[node.name] = placeholder
+            inputs.append(placeholder)
+        elif node.op == 'call_function':
+            # This does the bulk of the work - we call `lower_function`, which
+            # returns a `te.ExprHandle` (the output of a NNC computation), and
+            # put it in our environment.
+            if 'tensor_meta' in node.meta:
+                # todo: fix kwargs handling
+                if node.kwargs:
+                    raise RuntimeError("kwargs nyi")
+                buf, stmt = lower_function(node, node.target, lookup_env(node.args), node.args)
+                # if isinstance(stmt, list)
+                compute_stmts.extend(stmt)
+                env[node.name] = buf
+            elif node.target == getattr or node.target == operator.getitem:
+                # todo: handle non-tensor computations correctly
+                continue
+        elif node.op == 'output':
+            args = node.args
+            if not isinstance(args, tuple):
+                args = (args,)
+            if isinstance(args[0], tuple):
+                args = args[0]
+            te_args = lookup_env(args)
+            outs = (list(te_args), [i.meta['tensor_meta'].shape for i in args])
+        elif node.op == 'get_attr':
+            # As NNC doesn't have any concept of state, we pull out the module
+            # attributes and pass them in as inputs to NNC.
+            module_attrs.append(node)
+            shapes = get_te_shapes(node.meta['tensor_meta'].shape)
+            placeholder = te.Placeholder(node.name, get_te_type(node), shapes)
+            env[node.name] = placeholder
+        else:
+            print(node.op, node.target)
+            raise RuntimeError("not yet implemented")
+
+
+    loopnest = te.LoopNest(te.Stmt(compute_stmts), outs[0])
+    # loopnest.inline_intermediate_bufs(True)
+    loopnest.simplify()
+    # print(loopnest)
+    loopnest.prepare_for_codegen()
+    stmt = te.simplify(loopnest.root_stmt())
+    cg = te.construct_codegen('llvm', stmt, [te.BufferArg(x) for x in [env[i.name] for i in module_attrs] + inputs + outs[0]])
+    alloc_results = [torch.empty(i) for i in outs[1]]
+    def f(*inps, out_tensors=None):
+        if out_tensors is None:
+            results = alloc_results
+        else:
+            results = out_tensors
+        if module_attrs:
+            module_stuff = [fetch_attr(i.target).data for i in module_attrs]
+        else:
+            module_stuff = []
+        cg.call(module_stuff + list(inps) + results)
+        if out_tensors is None:
+            if len(results) == 1:
+                return results[0]
+            return results
+    return f
+
+
+################################
+# Example usage and Benchmarking
+################################
+
+def bench(f, warmup=3, iters=1000):
+    for _ in range(warmup):
+        f()
+    begin = time.time()
+    for _ in range(iters):
+        f()
+    print(time.time()-begin)
+if __name__ == '__main__':
+    def f(a, b):
+        return (torch.cos(a)* torch.sin(b))[:2000]
+
+    mod = fx.symbolic_trace(f)
+    inps = (torch.randn(5000), torch.randn(5000))
+    ShapeProp(mod).propagate(*inps)
+    cg = nnc_compile(mod, inps)
+    bench(lambda: cg(*inps))
+    bench(lambda: f(*inps))
+    exit(0)

--- a/python_key.py
+++ b/python_key.py
@@ -1,0 +1,22 @@
+import torch
+import torch._C.key as key
+
+HANDLED_FUNCTIONS = {}
+class ScalarTensor(object):
+    def __init__(self, N, value):
+        self._N = N
+        self._value = value
+
+    def __repr__(self):
+        return "DiagonalTensor(N={}, value={})".format(self._N, self._value)
+
+    def tensor(self):
+        return self._value * torch.eye(self._N)
+
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        import pdb; pdb.set_trace()
+        return NotImplemented
+x = ScalarTensor(5, 1)
+out = key.makePython(x)
+out*2
+# import pdb; pdb.set_trace()

--- a/python_key.py
+++ b/python_key.py
@@ -2,7 +2,7 @@ import torch
 import torch._C.key as key
 
 HANDLED_FUNCTIONS = {}
-class PythonTensor(object):
+class PythonTensor(torch.Tensor):
     def __init__(self, shape):
         self.value = torch.empty(shape)
 
@@ -11,19 +11,34 @@ class PythonTensor(object):
 
     def tensor(self):
         return self.value
-
+    func_mapping = {
+        'aten::_unsafe_view': torch.Tensor.view,
+    }
     def __torch_function__(self, func, types, args=(), kwargs={}):
-        args = [i.value if isinstance(i, PythonTensor) else i for i in args]
-        print(func, args)
-        out = func(*args)
+        print(func)
+        # if isinstance(func, str):
+        #     if func in self.func_mapping:
+        #         func = self.func_mapping[func]
+        #     else:
+        #         import pdb; pdb.set_trace()
+        out = kwargs['val']
         if isinstance(out, torch.Tensor):
             return PythonTensor(out.shape)
         else:
             return out
+
 x = PythonTensor((5, 5))
+# def f(x):
+#     return x*2
 def f(x):
-    return x*2*3
-out = f(key.makePython(x))
-# print(torch.jit.trace(torch.vmap(f),(x,y)))
-print(out)
+    out = (x*2).sum()
+    out.backward()
+    # return x.view((25,))
+    # return torch.dot(x, torch.ones(5))
+grad_x = key.addKey(x)
+grad_x.requires_grad = True
+out = f(grad_x)
+# print(torch.vmap(f)(key.addKey(x)))
+# print(torch.jit.trace(torch.vmap(f),(x)))
+# print(key.removeKey(out))
 # import pdb; pdb.set_trace()

--- a/python_key.py
+++ b/python_key.py
@@ -4,56 +4,49 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch._C.key as key
 import torch.fx as fx
+from torch.fx import PythonTensor
 from nnc_compile import nnc_compile
 torch._C._jit_override_can_fuse_on_cpu(True)
 # import torch.autograd.functional
 from types import FunctionType, CodeType
 
-HANDLED_FUNCTIONS = {}
-class PythonTensor(object):
-    def __init__(self, out, proxy):
-        if isinstance(out, torch.Tensor):
-            self.value = torch.empty_like(out)
-        else:
-            self.value = torch.empty(out)
-        self.proxy = proxy
-
-    def __repr__(self):
-        return f"PythonTensor({tuple(self.value.shape)})"
-
-    def tensor(self):
-        return self.value
-
-    def __torch_function__(self, func, types, args=(), kwargs={}):
-        namespace, func_name = func.split("::")
-        func = getattr(getattr(torch.ops, namespace), func_name)
-        outs = kwargs['val']
-        rets = []
-        proxy_args = [i.proxy if isinstance(i, PythonTensor) else i for i in args]
-        out_proxy = func(*proxy_args)
-        if len(outs) == 1 and isinstance(outs[0], torch.Tensor):
-            return [PythonTensor(outs[0], out_proxy)]
-        for idx, out in enumerate(outs):
-            if isinstance(out, torch.Tensor):
-                rets.append(PythonTensor(out, out_proxy[idx]))
-            else:
-                rets.append(out)
-        return rets
 
 import torchvision.models as models
 
 
+def fetch_attr(mod, target : str):
+    target_atoms = target.split('.')
+    attr_itr = mod
+    for i, atom in enumerate(target_atoms):
+        if not hasattr(attr_itr, atom):
+            raise RuntimeError(f"Node referenced nonexistant target {'.'.join(target_atoms[:i])}")
+        attr_itr = getattr(attr_itr, atom)
+    return attr_itr
+
 class ModuleBackward(nn.Module):
-    def __init__(self, mod):
+    def __init__(self, mod, inps):
         super().__init__()
         self.mod = mod
+        self.inps = inps
 
-    def forward(self, x):
-        x_grad = key.addKey(PythonTensor((1, 3, 224, 224), x))
-        x_grad.requires_grad = True
-        out = self.mod(x_grad).sum()
+    def f_grad(self, args):
+        for idx in range(len(self.inps)):
+            args[idx] = key.addKey(PythonTensor(self.inps[idx].shape, args[idx]))
+            # args[idx].requires_grad = False
+        out = self.mod(*args)
         out.backward()
-        return key.removeKey(x_grad.grad).proxy
+        # import pdb; pdb.set_trace()
+        # return tuple(key.removeKey(p.grad) for p in self.parameters())
+        param_grads = []
+        for k,v in self.state_dict().items():
+            val = fetch_attr(self, k)
+            # param_grads[k] = key.removeKey(val.grad).proxy
+            param_grads.append(key.removeKey(val.grad).proxy)
+        return tuple(param_grads)
+        # return tuple(key.removeKey(args[idx].grad).proxy for idx in range(len(inps)))
+
+    def forward(self, a):
+        return self.f_grad([a])
 
 def grad(f, inps):
     def f_grad(args):
@@ -71,28 +64,112 @@ def grad(f, inps):
             return f_grad([a, b])
     return f_out
 
-def f(a, b):
-    return (a*b).sum()
 
-inps = (torch.randn(3000), torch.randn(3000))
-grad_f = fx.symbolic_trace(grad(f, inps))
+class Foo(torch.nn.Module):
+    def __init__(self, num_features=50):
+        super(Foo, self).__init__()
+        self.linear = nn.Linear(num_features, 1, bias=False)
+        self.w = (nn.Parameter(torch.randn(1, num_features)))
+
+    def forward(self, x):
+        return (self.linear(x * torch.sin(self.w))**2).sum()
+
+# grad_foo = ModuleBackward(f, inps)
+# nnc_grad = nnc_compile(grad_foo, inps)
+
+# Phabricate sample inputs
+num_features = 128
+def gen_inputs():
+    x = torch.randn(1, num_features)
+    inps = (x,)
+    return inps
+inps = gen_inputs()
+
+iters = 10000
+lr = 0.001
+
+torch.manual_seed(3)
+f = Foo(num_features)
+
+train_mod = ModuleBackward(f, inps)
+for p in f.parameters():
+    p.grad = None
+grad_f = fx.symbolic_trace(train_mod)
 print(grad_f.code)
-grad_f = nnc_compile(grad_f, inps)
+nnc_grad = nnc_compile(grad_f, inps)
+
+
+avg = -1
+eps = 0.01
+begin = time.time()
+for iter in range(iters):
+    inps = gen_inputs()
+    begin = time.time()
+    grads = nnc_grad(*inps)
+    print(time.time()-begin)
+    avg = (1-eps)*avg + eps*grads[0].sum()
+    # print(grads)
+    # if iter % 1000 == 0:
+    #     print(f"itr {iter}: {avg}")
+    for p, g in zip(grad_f.parameters(), grads):
+        p.data -= lr*g
+print("NNC train runtme: ", time.time()-begin)
+print()
+
+torch.manual_seed(3)
+avg = -1
+f = Foo(num_features)
+begin = time.time()
+for iter in range(iters):
+    inps = gen_inputs()
+    begin = time.time()
+    f(*inps).backward()
+    print(time.time()-begin)
+    grads = [p.grad for p in f.parameters()]
+    avg = (1-eps)*avg + eps*grads[0].sum()
+    # if iter % 1000 == 0:
+    #     print(f"itr {iter}: {avg}")
+    # print(grads)
+    for p, g in zip(f.parameters(), grads):
+        p.data -= lr*g
+        p.grad = None
+print("eager train runtime: ", time.time()-begin)
+exit(0)
+
+
+
+grad_f(*inps)
 
 iters = 1000
-for _ in range(3):
-    grads = grad_f(*inps)
-# print(grads[0].sum(), grads[1].sum())
+# for _ in range(3):
+#     grads = grad_f(*inps)
+
+# if isinstance(grads, torch.Tensor):
+#     print(grads.sum())
+# else:
+#     print([i.sum() for i in grads])
 begin = time.time()
 for _ in range(iters):
     grad_f(*inps)
 print(time.time() - begin)
 
-for inp in inps:
-    inp.requires_grad = True
+
+# for inp in inps:
+#     inp.requires_grad = True
+
 f(*inps).backward()
-# print(inps[0].sum(), inps[1].sum())
+print([v.grad.sum() for v in f.parameters()])
+
+
 begin = time.time()
 for _ in range(iters):
     f(*inps).backward()
 print(time.time() - begin)
+
+# exit(0)
+
+# def f(a, b):
+#     return (a*b).sum()
+# inps = (torch.randn(3000), torch.randn(3000))
+# grad_f = fx.symbolic_trace(grad(f, inps))
+# print(grad_f.code)

--- a/torch/csrc/fx/fx_init.cpp
+++ b/torch/csrc/fx/fx_init.cpp
@@ -200,11 +200,9 @@ void pythonFallBack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
       pyArgs.push_back(pyTensor->value_);
       pyTensorArgs.push_back(pyTensor->value_);
       unwrappedArgs.push_back(getValueFromPyTensor(pyTensor->value_));
-      // torch::jit::push(stack,
     } else {
       pyArgs.push_back(torch::jit::toPyObject(ivalue));
       unwrappedArgs.push_back(ivalue);
-      // torch::jit::push(stack, ivalue);
     }
   }
 

--- a/torch/csrc/fx/fx_init.cpp
+++ b/torch/csrc/fx/fx_init.cpp
@@ -119,7 +119,8 @@ static PyObject* patch_function(PyObject* self, PyObject* args) {
 }
 
 bool isPythonTensor(at::Tensor tensor) {
-  return tensor.unsafeGetTensorImpl()->key_set().has(c10::DispatchKey::PythonKey);
+  return tensor.unsafeGetTensorImpl()->key_set().has(
+      c10::DispatchKey::PythonKey);
 }
 PythonTensorImpl* getPythonImpl(at::Tensor tensor) {
   return static_cast<PythonTensorImpl*>(tensor.unsafeGetTensorImpl());
@@ -133,7 +134,6 @@ py::object removeKey(at::Tensor tensor) {
   assert(isPythonTensor(tensor));
   return getPythonImpl(tensor)->value_;
 }
-
 
 void initFx(PyObject* module) {
   static std::array<PyMethodDef, 2> PatchMethods = {{
@@ -179,10 +179,10 @@ py::tuple vectorToPyTuple(const std::vector<T> &data, std::function<PyObject*(T)
 		}
 		PyTuple_SET_ITEM(tuple, i, num);
 	}
-	return py::cast<py::tuple>(tuple);
+        return py::cast<py::tuple>(tuple);
 }
 void pythonFallBack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
-  std::cout<<"python fallback"<<std::endl;
+  std::cout << "python fallback" << std::endl;
   const auto& schema = op.schema();
   const auto num_returns = schema.returns().size();
 
@@ -207,7 +207,7 @@ void pythonFallBack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   }
 
   py::object torch_function = PyObject_FastGetAttrString(pyTensorArgs[0].ptr(), "__torch_function__");
-  for (auto v: unwrappedArgs) {
+  for (auto v : unwrappedArgs) {
     torch::jit::push(stack, v);
   }
   op.callBoxed(stack);
@@ -216,12 +216,13 @@ void pythonFallBack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   py::tuple py_types = py::cast<py::tuple>(vectorToPyTuple<py::object>(pyArgs, [](py::object x) -> PyObject* { return PyObject_Type(x.ptr()); }));
 
   py::dict kwargs;
-  kwargs["val"] =torch::jit::toPyObject(realOut);
+  kwargs["val"] = torch::jit::toPyObject(realOut);
 
   std::string func_name = op.operator_name().name;
   std::string delimiter = "aten::";
-  func_name = func_name.substr(func_name.find(delimiter)+delimiter.size());
-  py::object torch_api_function = PyObject_FastGetAttrString(THPVariableClass, (char*)func_name.c_str());
+  func_name = func_name.substr(func_name.find(delimiter) + delimiter.size());
+  py::object torch_api_function =
+      PyObject_FastGetAttrString(THPVariableClass, (char*)func_name.c_str());
   if (torch_api_function == nullptr) {
     torch_api_function = py::str(op.operator_name().name);
   }

--- a/torch/csrc/fx/fx_init.cpp
+++ b/torch/csrc/fx/fx_init.cpp
@@ -206,7 +206,17 @@ void pythonFallBack(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
       pyArgs.push_back(pyTensor->value_);
       pyTensorArgs.push_back(pyTensor->value_);
       unwrappedArgs.push_back(getValueFromPyTensor(pyTensor->value_));
-    } else {
+    } else{
+      if(ivalue.isList()) {
+        auto l = ivalue.toList();
+        for (int jdx=0; jdx<l.size(); jdx++) {
+          auto nv = l.get(jdx);
+          if (nv.isTensor() && isPythonTensor(nv.toTensor())) {
+            auto pyTensor = getPythonImpl(nv.toTensor());
+            pyTensorArgs.push_back(pyTensor->value_);
+          }
+        }
+      }
       pyArgs.push_back(torch::jit::toPyObject(ivalue));
       unwrappedArgs.push_back(ivalue);
     }

--- a/torch/csrc/fx/fx_init.h
+++ b/torch/csrc/fx/fx_init.h
@@ -1,9 +1,36 @@
 #pragma once
 
-#include <Python.h>
+#include <torch/csrc/utils/python_strings.h>
+#include <ATen/Tensor.h>
+#include <torch/library.h>
 
 namespace torch {
 namespace fx {
+struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
+  explicit PythonTensorImpl(py::object value): TensorImpl(c10::DispatchKeySet(c10::DispatchKey::PythonKey), caffe2::TypeMeta::Make<float>(),c10::Device(at::kCPU)), value_(value) {
+
+    // asm("int $0x3\n");
+    py::object torch_function = PyObject_FastGetAttrString(value.ptr(), "__torch_function__");
+    // PyObject_CallFunctionObjArgs(torch_function.ptr(), 0, 0, 0, 0, 0);
+  }
+
+
+  // Returns a reference to BatchDims that represent which dimensions of this
+  // tensor are private.
+
+  // Override a bunch of methods inherited from TensorImpl to return error messages.
+//   bool is_contiguous_custom(at::MemoryFormat memory_format) const override;
+//   void set_size(int64_t dim, int64_t new_size) override;
+//   void set_stride(int64_t dim, int64_t new_stride) override;
+//   void set_storage_offset(int64_t storage_offset) override;
+// #ifdef DEBUG
+//   bool has_storage() const override;
+// #endif
+
+  py::object value_;
+};
+
 void initFx(PyObject* module);
+
 } // namespace fx
 } // namespace torch

--- a/torch/csrc/fx/fx_init.h
+++ b/torch/csrc/fx/fx_init.h
@@ -8,10 +8,6 @@ namespace torch {
 namespace fx {
 struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
   explicit PythonTensorImpl(py::object value): TensorImpl(c10::DispatchKeySet(c10::DispatchKey::PythonKey), caffe2::TypeMeta::Make<float>(),c10::Device(at::kCPU)), value_(value) {
-
-    // asm("int $0x3\n");
-    py::object torch_function = PyObject_FastGetAttrString(value.ptr(), "__torch_function__");
-    // PyObject_CallFunctionObjArgs(torch_function.ptr(), 0, 0, 0, 0, 0);
   }
 
 

--- a/torch/csrc/fx/fx_init.h
+++ b/torch/csrc/fx/fx_init.h
@@ -7,12 +7,10 @@
 namespace torch {
 namespace fx {
 
-
 inline at::Tensor getValueFromPyTensor(const py::object& pyTensor) {
   auto out = pyTensor.attr("value").cast<at::Tensor>();
   return out;
 }
-
 
 struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
   explicit PythonTensorImpl(py::object value): TensorImpl(c10::DispatchKeySet(c10::DispatchKey::PythonKey), caffe2::TypeMeta::Make<float>(),c10::Device(at::kCPU)), value_(value) {
@@ -24,8 +22,8 @@ struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
     const auto value_strides = tensor.strides();
     sizes_and_strides_.resize(tensor.dim());
     for (int64_t dim = 0; dim < tensor.dim(); dim++) {
-        sizes_and_strides_.size_at_unchecked(dim) = value_sizes.at(dim);
-        sizes_and_strides_.stride_at_unchecked(dim) = value_strides.at(dim);
+      sizes_and_strides_.size_at_unchecked(dim) = value_sizes.at(dim);
+      sizes_and_strides_.stride_at_unchecked(dim) = value_strides.at(dim);
     }
     refresh_numel();
     refresh_contiguous();

--- a/torch/csrc/fx/fx_init.h
+++ b/torch/csrc/fx/fx_init.h
@@ -13,7 +13,7 @@ inline at::Tensor getValueFromPyTensor(const py::object& pyTensor) {
 }
 
 struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
-  explicit PythonTensorImpl(py::object value): TensorImpl(c10::DispatchKeySet(c10::DispatchKey::PythonKey), caffe2::TypeMeta::Make<float>(),c10::Device(at::kCPU)), value_(value) {
+  explicit PythonTensorImpl(py::object value): TensorImpl(c10::DispatchKeySet(c10::DispatchKey::PythonKey), getValueFromPyTensor(value).dtype(), c10::Device(at::kCPU)), value_(value) {
     set_storage_access_should_throw();
     // asm("int $0x3\n");
     auto tensor = getValueFromPyTensor(value_);
@@ -28,6 +28,13 @@ struct TORCH_API PythonTensorImpl : public c10::TensorImpl {
     refresh_numel();
     refresh_contiguous();
   }
+  c10::intrusive_ptr<c10::TensorImpl> shallow_copy_and_detach(
+      const c10::VariableVersion& version_counter,
+      bool allow_tensor_metadata_change) const;
+
+  c10::intrusive_ptr<c10::TensorImpl> shallow_copy_and_detach(
+      c10::VariableVersion&& version_counter,
+      bool allow_tensor_metadata_change) const;
 
 
   // Returns a reference to BatchDims that represent which dimensions of this

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/variant.h>
 #include <torch/csrc/jit/tensorexpr/kernel.h>
 
 #include <ATen/ExpandUtils.h>
@@ -10,6 +11,7 @@
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/operators/conv2d.h>
+#include <iostream>
 
 using namespace torch::jit;
 using namespace torch::jit::tensorexpr;
@@ -355,7 +357,7 @@ ArgValue TensorExprKernel::jitToArgValue(const torch::jit::Value* v) const {
     throw malformed_input("no scalar in Constant");
   }
 
-  return ArgValue(scalars_.at(v));
+  return scalars_.at(v);
 }
 
 ExprHandle TensorExprKernel::tensorOrConstant(
@@ -366,7 +368,6 @@ ExprHandle TensorExprKernel::tensorOrConstant(
   }
   return constant(v);
 }
-
 ExprHandle TensorExprKernel::tensorOrConstant(
     const torch::jit::Value* v,
     const std::vector<ExprHandle>& axes) {
@@ -513,7 +514,6 @@ std::vector<ExprHandle> TensorExprKernel::inferSizesForValue(
       }
       return broadcastShapes(shapes);
     }
-
     case prim::ConstantChunk: {
       auto shape = sizesForValue(v->node()->input());
       int dim = v->node()->i(attr::dim);
@@ -852,56 +852,30 @@ std::vector<ExprHandle> TensorExprKernel::valueShape(const ArgValue& v) {
 
 Tensor* TensorExprKernel::computeOneOperand(
     const std::string& name,
-    const torch::jit::Value* v,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<ExprHandle(const ExprHandle&)>& innerExpr,
     const int checkParamTypes) {
-  auto const& n = v->node();
-  auto const& shape = valueShape(n->input(0));
   return Compute(
       name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr, checkParamTypes](
+      c10::fmap<DimArg>(outputShape),
+      [this, inputValues, outputTensorType, innerExpr, checkParamTypes](
           const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(0), indices)};
+            tensorOrConstant(inputValues[0], indices)};
         promoteInputs(inputs, checkParamTypes);
         ExprHandle compute = innerExpr(inputs[0]);
-        return demoteOutput(compute, n->output());
+        return demoteOutput(compute, outputTensorType);
       });
 }
 
 Tensor* TensorExprKernel::computeTwoOperand(
     const std::string& name,
-    const torch::jit::Value* v,
-    const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
-        innerExpr) {
-  auto const& n = v->node();
-  auto const& shape =
-      broadcastShapes(valueShape(n->input(0)), valueShape(n->input(1)));
-  return Compute(
-      name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr](const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
-        std::vector<ExprHandle> indices(axes.begin(), axes.end());
-        std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(0), indices),
-            tensorOrConstant(n->input(1), indices),
-        };
-
-        promoteInputs(inputs);
-        ExprHandle compute = innerExpr(inputs[0], inputs[1]);
-        return demoteOutput(compute, n->output());
-      });
-}
-
-Tensor* TensorExprKernel::computeTwoOperand(
-    const std::string& name,
-    const std::vector<ArgValue> inputValues,
-    const c10::optional<at::ScalarType> outputTensorType,
-    const std::vector<ExprHandle> outputShape,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
         innerExpr) {
   return Compute(
@@ -923,128 +897,112 @@ Tensor* TensorExprKernel::computeTwoOperand(
 
 Tensor* TensorExprKernel::computeTwoOperandWithAlpha(
     const std::string& name,
-    const torch::jit::Value* v,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
         innerExpr) {
-  auto const& n = v->node();
-  auto const& shape =
-      broadcastShapes(valueShape(n->input(0)), valueShape(n->input(1)));
   return Compute(
       name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr](const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
+      c10::fmap<DimArg>(outputShape),
+      [this, inputValues, outputTensorType, innerExpr](
+          const std::vector<VarHandle>& axes) {
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(0), indices),
-            tensorOrConstant(n->input(1), indices),
-            tensorOrConstant(n->input(2), indices),
+            tensorOrConstant(inputValues[0], indices),
+            tensorOrConstant(inputValues[1], indices),
+            tensorOrConstant(inputValues[2], indices),
         };
 
         promoteInputs(inputs);
         ExprHandle compute = innerExpr(inputs[0], inputs[2] * inputs[1]);
-        return demoteOutput(compute, n->output());
+        return demoteOutput(compute, outputTensorType);
       });
 }
 
 Tensor* TensorExprKernel::computeConditionWithTwoOperand(
     const std::string& name,
-    const torch::jit::Value* v,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<
         ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
         innerExpr) {
-  auto const& n = v->node();
-  std::vector<std::vector<ExprHandle>> shapes;
-  for (size_t idx = 0; idx < 2; idx++) {
-    torch::jit::Value* inp = n->input(idx);
-    shapes.push_back(sizesForValue(inp));
-  }
-  auto const& shape = broadcastShapes(shapes);
   return Compute(
       name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr](const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
+      c10::fmap<DimArg>(outputShape),
+      [this, inputValues, outputTensorType, innerExpr](
+          const std::vector<VarHandle>& axes) {
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(1), indices),
-            tensorOrConstant(n->input(2), indices),
+            tensorOrConstant(inputValues[1], indices),
+            tensorOrConstant(inputValues[2], indices),
         };
 
         promoteInputs(inputs);
         // First expr is the condition, which we don't promote
-        inputs.emplace(inputs.begin(), tensorOrConstant(n->input(0), indices));
+        inputs.emplace(
+            inputs.begin(), tensorOrConstant(inputValues[0], indices));
         ExprHandle compute = innerExpr(inputs[0], inputs[1], inputs[2]);
-        return demoteOutput(compute, n->output());
+        return demoteOutput(compute, outputTensorType);
       });
 }
 
 Tensor* TensorExprKernel::computeThreeOperand(
     const std::string& name,
-    const torch::jit::Value* v,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<
         ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
         innerExpr,
     bool promote_inputs) {
-  auto const& n = v->node();
-  std::vector<std::vector<ExprHandle>> shapes;
-  for (size_t idx = 0; idx < 3; idx++) {
-    torch::jit::Value* inp = n->input(idx);
-    shapes.push_back(sizesForValue(inp));
-  }
-  auto const& shape = broadcastShapes(shapes);
   return Compute(
       name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr, promote_inputs](const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
+      c10::fmap<DimArg>(outputShape),
+      [this, inputValues, outputTensorType, innerExpr, promote_inputs](
+          const std::vector<VarHandle>& axes) {
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(0), indices),
-            tensorOrConstant(n->input(1), indices),
-            tensorOrConstant(n->input(2), indices),
+            tensorOrConstant(inputValues[0], indices),
+            tensorOrConstant(inputValues[1], indices),
+            tensorOrConstant(inputValues[2], indices),
         };
 
         if (promote_inputs) {
           promoteInputs(inputs);
         }
         ExprHandle compute = innerExpr(inputs[0], inputs[1], inputs[2]);
-        return demoteOutput(compute, n->output());
+        return demoteOutput(compute, outputTensorType);
       });
 }
-
 Tensor* TensorExprKernel::computeFourOperand(
     const std::string& name,
-    const torch::jit::Value* v,
+    const std::vector<ArgValue>& inputValues,
+    const c10::optional<at::ScalarType>& outputTensorType,
+    const std::vector<ExprHandle>& outputShape,
     const std::function<ExprHandle(
         const ExprHandle&,
         const ExprHandle&,
         const ExprHandle&,
         const ExprHandle&)>& innerExpr) {
-  auto const& n = v->node();
-  std::vector<std::vector<ExprHandle>> shapes;
-  for (size_t idx = 0; idx < 4; idx++) {
-    torch::jit::Value* inp = n->input(idx);
-    shapes.push_back(sizesForValue(inp));
-  }
-  auto const& shape = broadcastShapes(shapes);
   return Compute(
       name,
-      c10::fmap<DimArg>(shape),
-      [this, v, innerExpr](const std::vector<VarHandle>& axes) {
-        auto const& n = v->node();
+      c10::fmap<DimArg>(outputShape),
+      [this, inputValues, outputTensorType, innerExpr](
+          const std::vector<VarHandle>& axes) {
         std::vector<ExprHandle> indices(axes.begin(), axes.end());
         std::vector<ExprHandle> inputs = {
-            tensorOrConstant(n->input(0), indices),
-            tensorOrConstant(n->input(1), indices),
-            tensorOrConstant(n->input(2), indices),
-            tensorOrConstant(n->input(3), indices),
+            tensorOrConstant(inputValues[0], indices),
+            tensorOrConstant(inputValues[1], indices),
+            tensorOrConstant(inputValues[2], indices),
+            tensorOrConstant(inputValues[3], indices),
         };
 
         promoteInputs(inputs);
         ExprHandle compute =
             innerExpr(inputs[0], inputs[1], inputs[2], inputs[3]);
-        return demoteOutput(compute, n->output());
+        return demoteOutput(compute, outputTensorType);
       });
 }
 
@@ -1067,68 +1025,52 @@ c10::optional<ScalarType> findDtypeForValue(const torch::jit::Value* v) {
   return c10::nullopt;
 }
 
-Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
-  switch (v->node()->kind()) {
+Tensor* TensorExprKernel::computeOperandValue(
+    c10::Symbol op,
+    const std::vector<ArgValue>& inputs,
+    const c10::optional<c10::ScalarType>& outputType,
+    const std::vector<ExprHandle>& outputShape) {
+  switch (op) {
     case aten::add: {
       auto add_lambda = [](const ExprHandle& lhs, const ExprHandle& rhs) {
         return boolToInteger(lhs) + boolToInteger(rhs);
       };
-      TORCH_INTERNAL_ASSERT(
-          v->node()->inputs().size() == 2 || v->node()->inputs().size() == 3);
-      return (v->node()->inputs().size() > 2)
-          ? computeTwoOperandWithAlpha("aten_add", v, add_lambda)
-          : computeTwoOperand("aten_add", v, add_lambda);
+      TORCH_INTERNAL_ASSERT(inputs.size() == 2 || inputs.size() == 3);
+      return (inputs.size() > 2)
+          ? computeTwoOperandWithAlpha(
+                "aten_add", inputs, outputType, outputShape, add_lambda)
+          : computeTwoOperand(
+                "aten_add", inputs, outputType, outputShape, add_lambda);
     } break;
-
-    case aten::_cast_Float: {
-      return computeOneOperand("aten_cast_float", v, [](const ExprHandle& a) {
-        return cast<float>(a);
-      });
-    } break;
-
-    case aten::to: {
-      // see handling of aten::to in tensorexpr_fuser.cpp for why we only
-      // need to handle the first input
-      auto node = v->node();
-      return computeOneOperand("aten_to", v, [node](const ExprHandle& a) {
-        auto output_dtype = findDtypeForValue(node->output());
-        TORCH_INTERNAL_ASSERT(output_dtype);
-        return Cast::make(ToDtype(*output_dtype), a);
-      });
-    } break;
-
     case aten::sub: {
       auto sub_lambda = [](const ExprHandle& lhs, const ExprHandle& rhs) {
         // NB: sub isn't supported on boolean, no need to promote to integer.
         return lhs - rhs;
       };
-      TORCH_INTERNAL_ASSERT(
-          v->node()->inputs().size() == 2 || v->node()->inputs().size() == 3);
-      return (v->node()->inputs().size() > 2)
-          ? computeTwoOperandWithAlpha("aten_sub", v, sub_lambda)
-          : computeTwoOperand("aten_sub", v, sub_lambda);
+      TORCH_INTERNAL_ASSERT(inputs.size() == 2 || inputs.size() == 3);
+      return (inputs.size() > 2)
+          ? computeTwoOperandWithAlpha(
+                "aten_sub", inputs, outputType, outputShape, sub_lambda)
+          : computeTwoOperand(
+                "aten_sub", inputs, outputType, outputShape, sub_lambda);
     } break;
-
     case aten::mul: {
-      std::vector<ArgValue> argInputs;
-      for (auto inp : v->node()->inputs()) {
-        argInputs.push_back(jitToArgValue(inp));
-      }
-      auto outputType = getOutputType(v->node()->output());
-      auto outputShape = inferSizesForValue(v);
       return computeTwoOperand(
           "aten_mul",
-          argInputs,
+          inputs,
           outputType,
           outputShape,
           [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return boolToInteger(lhs) * boolToInteger(rhs);
           });
     } break;
-
     case aten::div: {
       return computeTwoOperand(
-          "aten_div", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_div",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return promoteIntegerToDefaultType(lhs) /
                 promoteIntegerToDefaultType(rhs);
           });
@@ -1136,108 +1078,150 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
 
     case aten::__and__: {
       return computeTwoOperand(
-          "aten_and", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_and",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return boolToInteger(lhs) & boolToInteger(rhs);
           });
     } break;
 
     case aten::__or__: {
       return computeTwoOperand(
-          "aten_or", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_or",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return boolToInteger(lhs) | boolToInteger(rhs);
           });
     } break;
 
     case aten::__xor__: {
       return computeTwoOperand(
-          "aten_xor", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_xor",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return boolToInteger(lhs) ^ boolToInteger(rhs);
           });
     } break;
 
     case aten::__lshift__: {
       return computeTwoOperand(
-          "aten_lshift", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_lshift",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return lhs << rhs;
           });
     } break;
 
     case aten::__rshift__: {
       return computeTwoOperand(
-          "aten_rshift", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_rshift",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return lhs >> rhs;
           });
     } break;
-
-    case aten::addcmul: {
-      return computeFourOperand(
-          "aten_addcmul",
-          v,
-          [](const ExprHandle& a0,
-             const ExprHandle& a1,
-             const ExprHandle& a2,
-             const ExprHandle& a3) { return a0 + a3 * a1 * a2; });
-    } break;
-
     case aten::eq: {
       return computeTwoOperand(
-          "aten_eq", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_eq",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs == rhs);
           });
     } break;
 
     case aten::ne: {
       return computeTwoOperand(
-          "aten_ne", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_ne",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs != rhs);
           });
     } break;
     case aten::ge: {
       return computeTwoOperand(
-          "aten_ge", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_ge",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs >= rhs);
           });
     } break;
 
     case aten::gt: {
       return computeTwoOperand(
-          "aten_gt", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_gt",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs > rhs);
           });
     } break;
 
     case aten::le: {
       return computeTwoOperand(
-          "aten_le", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_le",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs <= rhs);
           });
     } break;
 
     case aten::lt: {
       return computeTwoOperand(
-          "aten_lt", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_lt",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return cast<bool>(lhs < rhs);
           });
     } break;
 
     case aten::min: {
       return computeTwoOperand(
-          "aten_min", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_min",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return Min::make(boolToInteger(lhs), boolToInteger(rhs), false);
           });
     } break;
 
     case aten::max: {
       return computeTwoOperand(
-          "aten_max", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_max",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return Max::make(boolToInteger(lhs), boolToInteger(rhs), false);
           });
     } break;
-
     case aten::masked_fill: {
       return computeThreeOperand(
           "aten_masked_fill",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& input,
              const ExprHandle& mask,
              const ExprHandle& value) {
@@ -1247,27 +1231,22 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
           },
           /*promote_inputs*/ false);
     }
-
     case aten::clamp: {
       bool noMin = false;
       bool noMax = false;
-      if (v->node()->input(1)->node()->kind() == prim::Constant) {
-        const auto val = toIValue(v->node()->input(1)).value();
-        if (val.isNone()) {
-          noMin = true;
-        }
+      if (c10::get_if<ArgNone>(&inputs[1])) {
+        noMin = true;
       }
 
-      if (v->node()->input(2)->node()->kind() == prim::Constant) {
-        const auto val = toIValue(v->node()->input(2)).value();
-        if (val.isNone()) {
-          noMax = true;
-        }
+      if (c10::get_if<ArgNone>(&inputs[2])) {
+        noMax = true;
       }
 
       return computeThreeOperand(
           "aten_clamp",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [noMin, noMax](
               const ExprHandle& in,
               const ExprHandle& min,
@@ -1293,66 +1272,86 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
           },
           false /* promote_inputs */);
     } break;
-
+    case aten::addcmul: {
+      return computeFourOperand(
+          "aten_addcmul",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a0,
+             const ExprHandle& a1,
+             const ExprHandle& a2,
+             const ExprHandle& a3) { return a0 + a3 * a1 * a2; });
+    } break;
     case aten::sigmoid: {
-      return computeOneOperand("aten_sigmoid", v, [](const ExprHandle& a) {
-        return sigmoid(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_sigmoid",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return sigmoid(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::reciprocal: {
-      return computeOneOperand("aten_reciprocal", v, [](const ExprHandle& a) {
-        return ExprHandle(1.0f) / a;
-      });
+      return computeOneOperand(
+          "aten_reciprocal",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return ExprHandle(1.0f) / a; });
     } break;
 
     case aten::neg: {
-      return computeOneOperand("aten_neg", v, [](const ExprHandle& a) {
-        return ExprHandle(-0) - a;
-      });
+      return computeOneOperand(
+          "aten_neg", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return ExprHandle(-0) - a;
+          });
     } break;
 
     case aten::isnan: {
-      return computeOneOperand("aten_isnan", v, [](const ExprHandle& a) {
-        if (!a.dtype().is_floating_point()) {
-          return IntImm::make(0);
-        }
-        return isnan(a);
-      });
+      return computeOneOperand(
+          "aten_isnan",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            if (!a.dtype().is_floating_point()) {
+              return IntImm::make(0);
+            }
+            return isnan(a);
+          });
     } break;
 
     case aten::relu: {
-      return computeOneOperand("aten_relu", v, [](const ExprHandle& a) {
-        auto zero = Cast::make(a.dtype(), 0);
-        return CompareSelect::make(a, zero, zero, a, kLT);
-      });
+      return computeOneOperand(
+          "aten_relu",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            auto zero = Cast::make(a.dtype(), 0);
+            return CompareSelect::make(a, zero, zero, a, kLT);
+          });
     } break;
-
     case aten::batch_norm: {
       bool hasWeight = true;
       bool hasBias = true;
 
-      if (v->node()->input(1)->node()->kind() == prim::Constant) {
-        const auto val = toIValue(v->node()->input(1)).value();
-        if (val.isNone()) {
-          hasWeight = false;
-        }
+      if (c10::get_if<ArgNone>(&inputs[1])) {
+        hasWeight = false;
       }
 
-      if (v->node()->input(2)->node()->kind() == prim::Constant) {
-        const auto val = toIValue(v->node()->input(2)).value();
-        if (val.isNone()) {
-          hasBias = false;
-        }
+      if (c10::get_if<ArgNone>(&inputs[2])) {
+        hasBias = false;
       }
 
-      auto const& shape = valueShape(v->node()->input(0));
       return Compute(
           "aten_batch_norm",
-          c10::fmap<DimArg>(shape),
-          [this, v, hasWeight, hasBias](const std::vector<VarHandle>& axes) {
+          c10::fmap<DimArg>(outputShape),
+          [&](const std::vector<VarHandle>& axes) {
             TORCH_INTERNAL_ASSERT(axes.size() >= 2);
-            auto const& n = v->node();
             // axes: N, C, H, W
             std::vector<ExprHandle> indices(axes.begin(), axes.end());
             ExprHandle c = indices[1];
@@ -1360,130 +1359,144 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
             // Parameter list:
             // input, weight, bias, mean, var, training, momentum, eps,
             // cudnn_enabled
-            std::vector<ExprHandle> inputs = {
-                tensorOrConstant(n->input(0), indices), // input
-                tensorOrConstant(n->input(3), {c}), // mean
-                tensorOrConstant(n->input(4), {c}), // var
-                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-                constant(n->input(7)) // eps
+            std::vector<ExprHandle> exprInputs = {
+                tensorOrConstant(inputs[0], indices), // input
+                tensorOrConstant(inputs[3], {c}), // mean
+                tensorOrConstant(inputs[4], {c}), // var
+                constant(inputs[7]) // eps
             };
             if (hasWeight) {
-              inputs.push_back(tensorOrConstant(n->input(1), {c}));
+              exprInputs.push_back(tensorOrConstant(inputs[1], {c}));
             }
             if (hasBias) {
-              inputs.push_back(tensorOrConstant(n->input(2), {c}));
+              exprInputs.push_back(tensorOrConstant(inputs[2], {c}));
             }
-            promoteInputs(inputs);
+            promoteInputs(exprInputs);
 
-            ExprHandle input = inputs[0];
-            ExprHandle mean = inputs[1];
-            ExprHandle var = inputs[2];
-            ExprHandle eps = inputs[3];
+            ExprHandle input = exprInputs[0];
+            ExprHandle mean = exprInputs[1];
+            ExprHandle var = exprInputs[2];
+            ExprHandle eps = exprInputs[3];
             ExprHandle weight = FloatImm::make(1);
             ExprHandle bias = FloatImm::make(0);
 
             if (hasWeight) {
-              weight = inputs[4];
+              weight = exprInputs[4];
             }
             if (hasBias) {
-              // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-              bias = inputs[5];
+              bias = exprInputs[5];
             }
 
             auto inv_var = rsqrt(var + eps);
             auto alpha = inv_var * weight;
             auto beta = bias - mean * alpha;
             auto output = input * alpha + beta;
-            return demoteOutput(output, n->output());
+            return demoteOutput(output, outputType);
           });
     } break;
-
     case aten::log: {
-      return computeOneOperand("aten_log", v, [](const ExprHandle& a) {
-        return log(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_log", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return log(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::log10: {
-      return computeOneOperand("aten_log10", v, [](const ExprHandle& a) {
-        return log10(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::log1p: {
-      return computeOneOperand("aten_log1p", v, [](const ExprHandle& a) {
-        return log1p(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::log2: {
-      return computeOneOperand("aten_log2", v, [](const ExprHandle& a) {
-        return log2(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::exp: {
-      return computeOneOperand("aten_exp", v, [](const ExprHandle& a) {
-        return exp(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::expm1: {
-      return computeOneOperand("aten_expm1", v, [](const ExprHandle& a) {
-        return expm1(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::erf: {
-      return computeOneOperand("aten_erf", v, [](const ExprHandle& a) {
-        return erf(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::erfc: {
-      return computeOneOperand("aten_erfc", v, [](const ExprHandle& a) {
-        return erfc(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::cos: {
-      return computeOneOperand("aten_cos", v, [](const ExprHandle& a) {
-        return cos(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::sin: {
-      return computeOneOperand("aten_sin", v, [](const ExprHandle& a) {
-        return sin(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::tan: {
-      return computeOneOperand("aten_tan", v, [](const ExprHandle& a) {
-        return tan(promoteIntegerToDefaultType(a));
-      });
-    } break;
-
-    case aten::type_as: {
-      auto const& n = v->node();
-      const Buf* rhs = bufs_.at(n->input(1));
-      auto dtype = rhs->dtype();
       return computeOneOperand(
-          "aten_type_as", v, [dtype](const ExprHandle& lhs) {
-            return Cast::make(dtype, lhs);
+          "aten_log10",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return log10(promoteIntegerToDefaultType(a));
           });
     } break;
 
-    case aten::rand_like: {
-      hasRandom_ = true;
-      return computeOneOperand("aten_rand_like", v, [](const ExprHandle& a) {
-        return Intrinsics::make(IntrinsicsOp::kRand, a.dtype());
-      });
+    case aten::log1p: {
+      return computeOneOperand(
+          "aten_log1p",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return log1p(promoteIntegerToDefaultType(a));
+          });
     } break;
 
+    case aten::log2: {
+      return computeOneOperand(
+          "aten_log2",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return log2(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::exp: {
+      return computeOneOperand(
+          "aten_exp", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return exp(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::expm1: {
+      return computeOneOperand(
+          "aten_expm1",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return expm1(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::erf: {
+      return computeOneOperand(
+          "aten_erf", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return erf(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::erfc: {
+      return computeOneOperand(
+          "aten_erfc",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return erfc(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::cos: {
+      return computeOneOperand(
+          "aten_cos", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return cos(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::sin: {
+      return computeOneOperand(
+          "aten_sin", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return sin(promoteIntegerToDefaultType(a));
+          });
+    } break;
+
+    case aten::tan: {
+      return computeOneOperand(
+          "aten_tan", inputs, outputType, outputShape, [](const ExprHandle& a) {
+            return tan(promoteIntegerToDefaultType(a));
+          });
+    } break;
     case aten::pow: {
       return computeTwoOperand(
-          "aten_pow", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_pow",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             if (!rhs.node()->isConstant()) {
               return pow(lhs, rhs);
             }
@@ -1516,7 +1529,11 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
 
     case aten::fmod: {
       return computeTwoOperand(
-          "aten_fmod", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_fmod",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return fmod(promoteHalfToFloat(lhs), promoteHalfToFloat(rhs));
           });
     } break;
@@ -1524,7 +1541,9 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     case aten::lerp: {
       return computeThreeOperand(
           "aten_lerp",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a,
              const ExprHandle& end,
              const ExprHandle& weight) { return a + weight * (end - a); });
@@ -1539,23 +1558,21 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
         return fmod((rhs_t + fmod(lhs_t, rhs_t)), rhs_t);
       };
       {
-        auto const& n = v->node();
         auto const& shape =
-            broadcastShapes(valueShape(n->input(0)), valueShape(n->input(1)));
+            broadcastShapes(valueShape(inputs[0]), valueShape(inputs[1]));
         return Compute(
             "aten_remainder",
             c10::fmap<DimArg>(shape),
             [&](const std::vector<VarHandle>& axes) {
-              auto const& n = v->node();
               std::vector<ExprHandle> indices(axes.begin(), axes.end());
-              std::vector<ExprHandle> inputs = {
-                  tensorOrConstant(n->input(0), indices),
-                  tensorOrConstant(n->input(1), indices),
+              std::vector<ExprHandle> exprInputs = {
+                  tensorOrConstant(inputs[0], indices),
+                  tensorOrConstant(inputs[1], indices),
               };
 
-              promoteInputs(inputs);
+              promoteInputs(exprInputs);
               bool allInt = true;
-              for (auto& e : inputs) {
+              for (auto& e : exprInputs) {
                 if (e.dtype().is_floating_point()) {
                   allInt = false;
                   break;
@@ -1563,49 +1580,77 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
               }
               if (allInt) {
                 return demoteOutput(
-                    imodImpl(inputs[0], inputs[1]), n->output());
+                    imodImpl(exprInputs[0], exprInputs[1]), outputType);
               } else {
                 return demoteOutput(
-                    fmodImpl(inputs[0], inputs[1]), n->output());
+                    fmodImpl(exprInputs[0], exprInputs[1]), outputType);
               }
             });
       }
 
     } break;
-
     case aten::acos: {
-      return computeOneOperand("aten_acos", v, [](const ExprHandle& a) {
-        return acos(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_acos",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return acos(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::asin: {
-      return computeOneOperand("aten_asin", v, [](const ExprHandle& a) {
-        return asin(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_asin",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return asin(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::cosh: {
-      return computeOneOperand("aten_cosh", v, [](const ExprHandle& a) {
-        return cosh(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_cosh",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return cosh(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::sinh: {
-      return computeOneOperand("aten_sinh", v, [](const ExprHandle& a) {
-        return sinh(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_sinh",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return sinh(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::atan: {
-      return computeOneOperand("aten_atan", v, [](const ExprHandle& a) {
-        return atan(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_atan",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return atan(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::atan2: {
       return computeTwoOperand(
-          "aten_atan2", v, [](const ExprHandle& lhs, const ExprHandle& rhs) {
+          "aten_atan2",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& lhs, const ExprHandle& rhs) {
             return atan2(
                 promoteIntegerToDefaultType(lhs),
                 promoteIntegerToDefaultType(rhs));
@@ -1613,15 +1658,22 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     } break;
 
     case aten::tanh: {
-      return computeOneOperand("aten_tanh", v, [](const ExprHandle& a) {
-        return tanh(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_tanh",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return tanh(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::hardtanh: {
       return computeThreeOperand(
           "aten_hardtanh",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a,
              const ExprHandle& min_val,
              const ExprHandle& max_val) {
@@ -1631,21 +1683,33 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     } break;
 
     case aten::sqrt: {
-      return computeOneOperand("aten_sqrt", v, [](const ExprHandle& a) {
-        return tensorexpr::sqrt(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_sqrt",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return tensorexpr::sqrt(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::rsqrt: {
-      return computeOneOperand("aten_rsqrt", v, [](const ExprHandle& a) {
-        return rsqrt(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_rsqrt",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return rsqrt(promoteIntegerToDefaultType(a));
+          });
     } break;
 
     case aten::abs: {
       return computeOneOperand(
           "aten_abs",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a) {
             return tensorexpr::abs(promoteHalfToFloat(a));
           },
@@ -1654,39 +1718,67 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
 
     case aten::ceil: {
       return computeOneOperand(
-          "aten_ceil", v, [](const ExprHandle& a) { return ceil(a); });
+          "aten_ceil",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return ceil(a); });
     } break;
 
     case aten::floor: {
       return computeOneOperand(
-          "aten_floor", v, [](const ExprHandle& a) { return floor(a); });
+          "aten_floor",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return floor(a); });
     } break;
 
     case aten::round: {
       return computeOneOperand(
-          "aten_round", v, [](const ExprHandle& a) { return round(a); });
+          "aten_round",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return round(a); });
     } break;
 
     case aten::trunc: {
       return computeOneOperand(
-          "aten_trunc", v, [](const ExprHandle& a) { return trunc(a); });
+          "aten_trunc",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return trunc(a); });
+    } break;
+
+    case aten::_cast_Float: {
+      return computeOneOperand(
+          "aten_cast_float",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) { return cast<float>(a); });
     } break;
 
     case aten::threshold: {
       return computeThreeOperand(
           "aten_threshold",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a,
              const ExprHandle& threshold,
              const ExprHandle& value) {
             return ifThenElse(CompareSelect::make(a, threshold, kLE), value, a);
           });
     } break;
-
     case aten::where: {
       return computeConditionWithTwoOperand(
           "aten_where",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a0, const ExprHandle& a1, const ExprHandle& a2) {
             return ifThenElse(a0, a1, a2);
           });
@@ -1695,7 +1787,9 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     case aten::frac: {
       return computeOneOperand(
           "aten_frac",
-          v,
+          inputs,
+          outputType,
+          outputShape,
           [](const ExprHandle& a) {
             auto aa = promoteHalfToFloat(a);
             return aa - floor(aa);
@@ -1704,132 +1798,46 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
     } break;
 
     case aten::lgamma: {
-      return computeOneOperand("aten_lgamma", v, [](const ExprHandle& a) {
-        return lgamma(promoteIntegerToDefaultType(a));
-      });
+      return computeOneOperand(
+          "aten_lgamma",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return lgamma(promoteIntegerToDefaultType(a));
+          });
     } break;
 
-    case prim::ConstantChunk: {
-      return Compute(
-          "prim_constantchunk",
-          dimsFromSizes(sizesForValue(v)),
-          [this, v](const std::vector<VarHandle>& axes) {
-            auto const& n = v->node();
-            int64_t dim = n->i(attr::dim);
-            int64_t chunks = n->i(attr::chunks);
-            std::vector<ExprHandle> indices(axes.begin(), axes.end());
-            return chunk(
-                bufs_.at(n->input(0)), v->offset(), dim, chunks, indices);
+    case aten::rand_like: {
+      return computeOneOperand(
+          "aten_rand_like",
+          inputs,
+          outputType,
+          outputShape,
+          [](const ExprHandle& a) {
+            return Intrinsics::make(IntrinsicsOp::kRand, a.dtype());
           });
-    }
-
-    case aten::cat: {
-      if (getCatWoConditionals()) {
-        return computeCatWoConditionals(v);
-      }
-      return Compute(
-          "aten_cat",
-          dimsFromSizes(sizesForValue(v)),
-          [this, v](const std::vector<VarHandle>& axes) {
-            auto const& n = v->node();
-            auto inputs = n->input(0)->node()->inputs();
-            if (inputs.size() == 0) {
-              throw std::runtime_error(
-                  "Empty input list is passed to aten::cat");
-            }
-
-            // Some of the inputs can be empty tensors, we need to skip them
-            // when we construct the expression, but we need to take them into
-            // account in dtype promotion.
-            std::vector<const torch::jit::Value*> nonempty_inputs;
-            for (auto input : inputs) {
-              if (input->type()->kind() == TypeKind::TensorType) {
-                auto tt = input->type()->cast<TensorType>();
-                if (tt->isComplete() && tt->sizes().size() && tt->sizes()[0] &&
-                    *tt->sizes()[0]) {
-                  nonempty_inputs.push_back(input);
-                }
-              }
-            }
-
-            // When all inputs are empty tensors, the tensor we create for this
-            // computation would contain no elements, so it doesn't really
-            // matter what we return here, so just return 0.
-            if (!nonempty_inputs.size()) {
-              return ExprHandle(0);
-            }
-
-            int64_t dim_ = n->input(1)->node()->i(attr::value);
-            size_t dim = normalizeAndCheckIndex(dim_, axes.size());
-            // Promote input types.
-            // Note that we need to consider all inputs, including empty - they
-            // also affect the resultant dtype.
-            auto maybe_dtype = findDtypeForValue(inputs[0]);
-            TORCH_INTERNAL_ASSERT(
-                maybe_dtype, "Cannot find dtype for one of aten::cat inputs");
-            ScalarType highType = *maybe_dtype;
-            for (const auto input : inputs) {
-              auto maybe_dtype = findDtypeForValue(input);
-              TORCH_INTERNAL_ASSERT(
-                  maybe_dtype, "Cannot find dtype for one of aten::cat inputs");
-              highType = promoteTypes(highType, *maybe_dtype);
-            }
-
-            // Now we know the final dtype, we know what inputs are non-empty,
-            // and we know that there is at least one such an input. With all
-            // that we construct a tensor expression performing the
-            // concatenation.
-            // The expression we build here is a cascading if-then-else that
-            // essentially represents:
-            //
-            //              inp1[i, j, k]         if 0   < i < l1,
-            // out[i,j,k] = inp2[i, j-l1, k]      if l1 =< i < l1 + l2,
-            //              ...
-            //              inpN[i, j-l_N_1, k]   if l1+l2+...l_N_1  < i
-            // where l_i is the corresponding size of the i-th input.
-            std::vector<ExprHandle> newAxes(axes.begin(), axes.end());
-            ExprHandle load = promoteToDtype(
-                tensorOrConstant(nonempty_inputs[0], newAxes), highType);
-            size_t offset = bufferSizes(bufs_.at(nonempty_inputs[0]))[dim];
-            newAxes[dim] = newAxes[dim] - IntImm::make(offset);
-
-            for (size_t ii = 1; ii < nonempty_inputs.size(); ++ii) {
-              auto input = nonempty_inputs[ii];
-              load = ifThenElse(
-                  CompareSelect::make(axes[dim], IntImm::make(offset), kLT),
-                  load,
-                  promoteToDtype(tensorOrConstant(input, newAxes), highType));
-
-              offset += bufferSizes(bufs_.at(input))[dim];
-              newAxes[dim] = axes[dim] - IntImm::make(offset);
-            }
-
-            return load;
-          });
-    }
+    } break;
     case aten::slice: {
       return Compute(
           "aten_slice",
-          dimsFromSizes(sizesForValue(v)),
-          [this, v](const std::vector<VarHandle>& axes) {
-            auto const& n = v->node();
-            int64_t dim = toIValue(n->input(1))->toInt();
-            ExprHandle start = constant(n->input(2));
-            ExprHandle stride = constant(n->input(4));
+          c10::fmap<DimArg>(outputShape),
+          [&](const std::vector<VarHandle>& axes) {
+            int64_t dim = c10::get<int64_t>(inputs[1]);
+            ExprHandle start = constant(inputs[2]);
+            ExprHandle stride = constant(inputs[4]);
 
             std::vector<ExprHandle> newAxes(axes.begin(), axes.end());
             newAxes[dim] = stride * newAxes[dim] + start;
-            return tensorOrConstant(n->input(0), newAxes);
+            return tensorOrConstant(inputs[0], newAxes);
           });
     }
-
     case aten::unsqueeze: {
       return Compute(
           "aten_unsqueeze",
-          dimsFromSizes(sizesForValue(v)),
-          [this, v](const std::vector<VarHandle>& axes) {
-            auto const& n = v->node();
-            int64_t dim = toIValue(n->input(1))->toInt();
+          c10::fmap<DimArg>(outputShape),
+          [&](const std::vector<VarHandle>& axes) {
+            int64_t dim = c10::get<int64_t>(inputs[1]);
             if (dim < 0) {
               if (axes.size() == 0) {
                 throw malformed_input("axes are zero handling unsqueeze");
@@ -1848,9 +1856,146 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
               }
             }
 
-            return tensorOrConstant(n->input(0), indices);
+            return tensorOrConstant(inputs[0], indices);
           });
     }
+    default: {
+      throw std::runtime_error("Unhandled node kind");
+      return nullptr;
+    }
+  }
+}
+Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
+  auto inputs = v->node()->inputs();
+  switch (v->node()->kind()) {
+    case aten::rand_like:
+      hasRandom_ = true;
+      // fallthrough
+    case aten::add:
+    case aten::sub:
+    case aten::mul:
+    case aten::div:
+    case aten::__and__:
+    case aten::__or__:
+    case aten::__xor__:
+    case aten::__lshift__:
+    case aten::__rshift__:
+    case aten::eq:
+    case aten::ne:
+    case aten::ge:
+    case aten::gt:
+    case aten::le:
+    case aten::lt:
+    case aten::min:
+    case aten::max:
+    case aten::masked_fill:
+    case aten::clamp:
+    case aten::addcmul:
+    case aten::sigmoid:
+    case aten::reciprocal:
+    case aten::neg:
+    case aten::isnan:
+    case aten::relu:
+    case aten::batch_norm:
+    case aten::log:
+    case aten::log10:
+    case aten::log1p:
+    case aten::log2:
+    case aten::exp:
+    case aten::expm1:
+    case aten::erf:
+    case aten::erfc:
+    case aten::cos:
+    case aten::sin:
+    case aten::tan:
+    case aten::pow:
+    case aten::fmod:
+    case aten::lerp:
+    case aten::remainder:
+    case aten::acos:
+    case aten::asin:
+    case aten::cosh:
+    case aten::sinh:
+    case aten::atan:
+    case aten::atan2:
+    case aten::tanh:
+    case aten::hardtanh:
+    case aten::sqrt:
+    case aten::rsqrt:
+    case aten::abs:
+    case aten::ceil:
+    case aten::floor:
+    case aten::round:
+    case aten::trunc:
+    case aten::_cast_Float:
+    case aten::threshold:
+    case aten::where:
+    case aten::frac:
+    case aten::lgamma:
+    case aten::slice:
+    case aten::unsqueeze: {
+      std::vector<ArgValue> argInputs;
+      for (auto inp : inputs) {
+        argInputs.push_back(jitToArgValue(inp));
+      }
+      auto outputType = getOutputType(v->node()->output());
+      auto outputShape = sizesForValue(v);
+      return computeOperandValue(
+          v->node()->kind(), argInputs, outputType, outputShape);
+    } break;
+
+    case aten::to: {
+      // see handling of aten::to in tensorexpr_fuser.cpp for why we only
+      // need to handle the first input
+      auto outputType = getOutputType(v->node()->output());
+      auto outputShape = sizesForValue(v);
+      auto output_dtype = findDtypeForValue(v->node()->output());
+      return computeOneOperand(
+          "aten_to",
+          {jitToArgValue(inputs[0])},
+          outputType,
+          outputShape,
+          [output_dtype](const ExprHandle& a) {
+            TORCH_INTERNAL_ASSERT(output_dtype);
+            return Cast::make(ToDtype(*output_dtype), a);
+          });
+    } break;
+
+    case aten::type_as: {
+      auto outputType = getOutputType(v->node()->output());
+      auto outputShape = sizesForValue(v);
+      const Buf* rhs = bufs_.at(inputs[1]);
+      auto dtype = rhs->dtype();
+      return computeOneOperand(
+          "aten_type_as",
+          {jitToArgValue(inputs[0])},
+          outputType,
+          outputShape,
+          [dtype](const ExprHandle& lhs) { return Cast::make(dtype, lhs); });
+    } break;
+    case aten::cat: {
+      std::vector<ArgValue> inputList;
+      for (auto inp : v->node()->input(0)->node()->inputs()) {
+        inputList.push_back(jitToArgValue(inp));
+      }
+      auto outputShape = sizesForValue(v);
+      return computeCat(
+          inputList, jitToArgValue(v->node()->input(1)), outputShape);
+    } break;
+
+    case prim::ConstantChunk: {
+      return Compute(
+          "prim_constantchunk",
+          dimsFromSizes(sizesForValue(v)),
+          [this, v](const std::vector<VarHandle>& axes) {
+            auto const& n = v->node();
+            int64_t dim = n->i(attr::dim);
+            int64_t chunks = n->i(attr::chunks);
+            std::vector<ExprHandle> indices(axes.begin(), axes.end());
+            return chunk(
+                bufs_.at(n->input(0)), v->offset(), dim, chunks, indices);
+          });
+    } break;
 
     case aten::sum: {
       return computeSum(v);
@@ -1876,6 +2021,7 @@ Tensor* TensorExprKernel::computeValue(const torch::jit::Value* v) {
       throw std::runtime_error("Unhandled node kind");
     }
   }
+  return nullptr;
 }
 
 // Return the (lower, upper) loop bounds if they are constants, else nullopt.
@@ -2209,6 +2355,166 @@ std::vector<VarHandle> squeezeIndices(
 }
 
 } // namespace
+
+std::pair<ScalarType, std::vector<BufHandle>> processCatList(
+    const std::vector<ArgValue>& inputList) {
+  if (inputList.size() == 0) {
+    throw std::runtime_error("Empty input list is passed to aten::cat");
+  }
+  std::vector<BufHandle> bufInputs;
+  std::vector<BufHandle> nonEmptyInputs;
+  for (auto input : inputList) {
+    auto buf = c10::get<BufHandle>(input);
+    bufInputs.push_back(buf);
+    assert(buf.node()->dims().size() > 0);
+    if (buf.node()->dims().size() == 1 &&
+        immediateAs<int>(buf.node()->dim(0)) == 0) {
+      continue;
+    }
+    nonEmptyInputs.push_back(buf);
+  }
+  auto maybe_dtype = bufInputs[0].dtype().scalar_type();
+  ScalarType highType = maybe_dtype;
+  for (const auto input : bufInputs) {
+    auto maybe_dtype = input.dtype().scalar_type();
+    highType = promoteTypes(highType, maybe_dtype);
+  }
+  return {highType, nonEmptyInputs};
+}
+Tensor* TensorExprKernel::computeCat(
+    const std::vector<ArgValue>& inputList,
+    const ArgValue& argDim,
+    const std::vector<ExprHandle>& outputShape) {
+  if (getCatWoConditionals()) {
+    return computeCatWoConditionals(inputList, argDim, outputShape);
+  }
+  auto inputs = processCatList(inputList);
+  ScalarType highType = inputs.first;
+  std::vector<BufHandle> nonEmptyInputs = inputs.second;
+  return Compute(
+      "aten_cat",
+      c10::fmap<DimArg>(outputShape),
+      [&](const std::vector<VarHandle>& axes) {
+        if (nonEmptyInputs.size() == 0) {
+          return ExprHandle(0);
+        }
+
+        int64_t dim_ = c10::get<int64_t>(argDim);
+        size_t dim = normalizeAndCheckIndex(dim_, axes.size());
+        // Promote input types.
+        // Note that we need to consider all inputs, including empty - they
+        // also affect the resultant dtype.
+
+        // Now we know the final dtype, we know what inputs are non-empty,
+        // and we know that there is at least one such an input. With all
+        // that we construct a tensor expression performing the
+        // concatenation.
+        // The expression we build here is a cascading if-then-else that
+        // essentially represents:
+        //
+        //              inp1[i, j, k]         if 0   < i < l1,
+        // out[i,j,k] = inp2[i, j-l1, k]      if l1 =< i < l1 + l2,
+        //              ...
+        //              inpN[i, j-l_N_1, k]   if l1+l2+...l_N_1  < i
+        // where l_i is the corresponding size of the i-th input.
+        std::vector<ExprHandle> newAxes(axes.begin(), axes.end());
+        ExprHandle load = promoteToDtype(
+            tensorOrConstant(nonEmptyInputs[0], newAxes), highType);
+        size_t offset =
+            dynamic_cast<const IntImm*>(nonEmptyInputs[0].node()->dim(dim))
+                ->value();
+        newAxes[dim] = newAxes[dim] - IntImm::make(offset);
+
+        for (size_t ii = 1; ii < nonEmptyInputs.size(); ++ii) {
+          auto input = nonEmptyInputs[ii];
+          load = ifThenElse(
+              CompareSelect::make(axes[dim], IntImm::make(offset), kLT),
+              load,
+              promoteToDtype(tensorOrConstant(input, newAxes), highType));
+
+          offset +=
+              dynamic_cast<const IntImm*>(input.node()->dim(dim))->value();
+          newAxes[dim] = axes[dim] - IntImm::make(offset);
+        }
+
+        return load;
+      });
+}
+Tensor* TensorExprKernel::computeCatWoConditionals(
+    const std::vector<ArgValue>& input_list,
+    const ArgValue& arg_dim,
+    const std::vector<ExprHandle>& output_shape) {
+  auto inputs = processCatList(input_list);
+  ScalarType high_type = inputs.first;
+  std::vector<BufHandle> non_empty_inputs = inputs.second;
+
+  // Now we build one loop per input:
+  //
+  // for i
+  //   for j
+  //     for k
+  //       output[i,j,k] = inp1[i,j,k]
+  // for i
+  //   for j
+  //     for k
+  //       output[i,j+l1,k] = inp2[i,j,k]
+  // for i
+  //   for j
+  //     for k
+  //       output[i,j+l2,k] = inp3[i,j,k]
+
+  auto output_sizes_expr = ExprHandleVectorToExprVector(output_shape);
+  auto output_buf = new Buf("aten_cat", output_sizes_expr, ToDtype(high_type));
+  if (non_empty_inputs.size() == 0) {
+    return new Tensor(output_buf, new Block({}));
+  }
+
+  int64_t concat_dim = c10::get<int64_t>(arg_dim);
+  size_t norm_concat_dim =
+      normalizeAndCheckIndex(concat_dim, output_shape.size());
+
+  auto gen_code_for_input = [&](const BufHandle& inp,
+                                size_t inp_pos,
+                                const Expr* concat_dim_size,
+                                const std::vector<ExprHandle>& dims) {
+    std::vector<Var*> for_vars(dims.size());
+    std::vector<const Expr*> load_indices(dims.size());
+    std::vector<const Expr*> store_indices(dims.size());
+    for (size_t i = 0; i < dims.size(); ++i) {
+      for_vars[i] = new Var(
+          "i" + c10::to_string(inp_pos) + "_" + c10::to_string(i), kInt);
+      load_indices[i] = for_vars[i];
+      if (i == norm_concat_dim) {
+        store_indices[i] = new Add(for_vars[i], concat_dim_size);
+      } else {
+        store_indices[i] = for_vars[i];
+      }
+    }
+    auto inp_buf = inp.node();
+    auto load_expr = new Load(inp_buf, load_indices);
+    auto load_promoted = promoteToDtype(ExprHandle(load_expr), high_type);
+    Stmt* st = new Store(output_buf, store_indices, load_promoted.node());
+    for (size_t i = dims.size(); i > 0; --i) {
+      st = new For(for_vars[i - 1], new IntImm(0), dims[i - 1].node(), st);
+    }
+    return st;
+  };
+
+  Expr* concat_dim_size = nullptr;
+  auto block = new Block({});
+  for (size_t i = 0; i < non_empty_inputs.size(); ++i) {
+    auto input_dims =
+        ExprVectorToExprHandleVector(non_empty_inputs[i].node()->dims());
+    if (concat_dim_size == nullptr) {
+      concat_dim_size = new IntImm(0);
+    }
+    block->append_stmt(gen_code_for_input(
+        non_empty_inputs[i], i, concat_dim_size, input_dims));
+    concat_dim_size =
+        new Add(concat_dim_size, input_dims[norm_concat_dim].node());
+  }
+  return new Tensor(output_buf, IRSimplifier::simplify(block));
+}
 
 Tensor* TensorExprKernel::computeSum(const torch::jit::Value* v) {
   auto reduction_info = getReductionInfo(v->node());

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -118,9 +118,8 @@ class TORCH_API TensorExprKernel {
 
   ExprHandle demoteOutput(
       const ExprHandle& e,
-      const c10::optional<at::ScalarType> type);
-  ExprHandle demoteOutput(const ExprHandle& e, const torch::jit::Value* v);
-  ArgValue jitToArgValue(const torch::jit::Value* v) const;
+      const c10::optional<ScalarType> type);
+  ArgValue toArg(const torch::jit::Value* v) const;
 
   ExprHandle tensorOrConstant(
       const ArgValue& v,
@@ -133,7 +132,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeOneOperand(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&)>& innerExpr,
       const int checkParamTypes = kAllTypes);
@@ -141,7 +140,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeTwoOperand(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
           innerExpr);
@@ -149,7 +148,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeTwoOperandWithAlpha(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
           innerExpr);
@@ -157,7 +156,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeThreeOperand(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<
           ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
@@ -167,7 +166,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeConditionWithTwoOperand(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<
           ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
@@ -176,7 +175,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeFourOperand(
       const std::string& name,
       const std::vector<ArgValue>& inputValues,
-      const c10::optional<at::ScalarType>& outputTensorType,
+      const c10::optional<ScalarType>& outputTensorType,
       const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(
           const ExprHandle&,
@@ -201,7 +200,11 @@ class TORCH_API TensorExprKernel {
 
   Tensor* computeConv2d(const torch::jit::Value* v);
 
-  Tensor* computeMatmul(const torch::jit::Value* v);
+  Tensor* computeMatmul(
+      const ArgValue& A,
+      const ArgValue& B,
+      std::vector<ExprHandle> outputShape,
+      const c10::optional<ScalarType>& outputType);
 
   Tensor* computeValue(const torch::jit::Value* v);
 
@@ -210,7 +213,7 @@ class TORCH_API TensorExprKernel {
   Tensor* computeOperandValue(
       c10::Symbol op,
       const std::vector<ArgValue>& inputs,
-      const c10::optional<c10::ScalarType>& outputType,
+      const c10::optional<ScalarType>& outputType,
       const std::vector<ExprHandle>& outputShape);
 
   Stmt* transformLoops(BackendType backendType, Stmt* st);

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -132,33 +132,33 @@ class TORCH_API TensorExprKernel {
 
   Tensor* computeOneOperand(
       const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&)>& innerExpr,
       const int checkParamTypes = kAllTypes);
 
   Tensor* computeTwoOperand(
       const std::string& name,
-      const std::vector<ArgValue> inputValues,
-      const c10::optional<at::ScalarType> outputTensorType,
-      const std::vector<ExprHandle> outputShape,
-      const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
-          innerExpr);
-
-  Tensor* computeTwoOperand(
-      const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
           innerExpr);
 
   Tensor* computeTwoOperandWithAlpha(
       const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(const ExprHandle&, const ExprHandle&)>&
           innerExpr);
 
   Tensor* computeThreeOperand(
       const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<
           ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
           innerExpr,
@@ -166,14 +166,18 @@ class TORCH_API TensorExprKernel {
 
   Tensor* computeConditionWithTwoOperand(
       const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<
           ExprHandle(const ExprHandle&, const ExprHandle&, const ExprHandle&)>&
           innerExpr);
 
   Tensor* computeFourOperand(
       const std::string& name,
-      const torch::jit::Value* v,
+      const std::vector<ArgValue>& inputValues,
+      const c10::optional<at::ScalarType>& outputTensorType,
+      const std::vector<ExprHandle>& outputShape,
       const std::function<ExprHandle(
           const ExprHandle&,
           const ExprHandle&,
@@ -184,6 +188,15 @@ class TORCH_API TensorExprKernel {
 
   Tensor* computeSoftmax(const torch::jit::Value* v, bool log_softmax);
 
+  Tensor* computeCat(
+      const std::vector<ArgValue>& inputList,
+      const ArgValue& argDim,
+      const std::vector<ExprHandle>& outputShape);
+  Tensor* computeCatWoConditionals(
+      const std::vector<ArgValue>& inputList,
+      const ArgValue& argDim,
+      const std::vector<ExprHandle>& outputShape);
+
   Tensor* computeCatWoConditionals(const torch::jit::Value* v);
 
   Tensor* computeConv2d(const torch::jit::Value* v);
@@ -193,6 +206,12 @@ class TORCH_API TensorExprKernel {
   Tensor* computeValue(const torch::jit::Value* v);
 
   void bindConstant(const torch::jit::Value* v);
+
+  Tensor* computeOperandValue(
+      c10::Symbol op,
+      const std::vector<ArgValue>& inputs,
+      const c10::optional<c10::ScalarType>& outputType,
+      const std::vector<ExprHandle>& outputShape);
 
   Stmt* transformLoops(BackendType backendType, Stmt* st);
 

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -556,9 +556,9 @@ void initTensorExprBindings(PyObject* module) {
           } else if (py::isinstance<VarHandle>(inp)) {
             // std::cout << "varhandle" << std::endl;
             argInputs.push_back(py::cast<VarHandle>(inp));
-          } else if (py::isinstance<double>(inp)) {
+          } else if (py::isinstance<py::float_>(inp)) {
             argInputs.push_back(py::cast<double>(inp));
-          } else if (py::isinstance<int64_t>(inp)) {
+          } else if (py::isinstance<py::int_>(inp)) {
             argInputs.push_back(py::cast<int64_t>(inp));
           } else if (py::isinstance<py::none>(inp)){
             argInputs.push_back(ArgNone());

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -548,18 +548,20 @@ void initTensorExprBindings(PyObject* module) {
         std::vector<ArgValue> argInputs;
         for (auto inp : inputs) {
           if (py::isinstance<Placeholder>(inp)) {
-            std::cout << "placeholder" << std::endl;
+            // std::cout << "placeholder" << std::endl;
             argInputs.push_back(py::cast<Placeholder>(inp).handle());
           } else if (py::isinstance<BufHandle>(inp)) {
-            std::cout << "bufhandle" << std::endl;
+            // std::cout << "bufhandle" << std::endl;
             argInputs.push_back(py::cast<BufHandle>(inp));
           } else if (py::isinstance<VarHandle>(inp)) {
-            std::cout << "varhandle" << std::endl;
+            // std::cout << "varhandle" << std::endl;
             argInputs.push_back(py::cast<VarHandle>(inp));
           } else if (py::isinstance<double>(inp)) {
             argInputs.push_back(py::cast<double>(inp));
           } else if (py::isinstance<int64_t>(inp)) {
             argInputs.push_back(py::cast<int64_t>(inp));
+          } else if (py::isinstance<py::none>(inp)){
+            argInputs.push_back(ArgNone());
           } else {
             throw std::runtime_error("nyi");
           }

--- a/torch/fx/__init__.py
+++ b/torch/fx/__init__.py
@@ -82,7 +82,7 @@ repository.
 '''
 
 from .graph_module import GraphModule
-from .symbolic_trace import symbolic_trace, Tracer, wrap
+from .symbolic_trace import symbolic_trace, Tracer, wrap, PythonTensor
 from .graph import Graph
 from .node import Node, map_arg
 from .proxy import Proxy

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -48,6 +48,7 @@ _register_custom_builtin('inf', 'from math import inf', math.inf)
 _register_custom_builtin('nan', 'from math import nan', math.nan)
 _register_custom_builtin('NoneType', 'NoneType = type(None)', type(None))
 _register_custom_builtin('torch', 'import torch', torch)
+_register_custom_builtin('device', 'from torch import device', torch.device)
 
 
 def _is_magic(x: str) -> bool:
@@ -178,8 +179,12 @@ class PythonCode:
 
 
 def _format_args(args: Tuple[Argument, ...], kwargs: Dict[str, Argument]) -> str:
-    args_s = ', '.join(repr(a) for a in args)
-    kwargs_s = ', '.join(f'{k} = {repr(v)}' for k, v in kwargs.items())
+    def repr2(a):
+        if isinstance(a, torch.device):
+            return f'torch.{repr(a)}'
+        return repr(a)
+    args_s = ', '.join(repr2(a) for a in args)
+    kwargs_s = ', '.join(f'{k} = {repr2(v)}' for k, v in kwargs.items())
     if args_s and kwargs_s:
         return f'{args_s}, {kwargs_s}'
     return args_s or kwargs_s

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -8,8 +8,8 @@ import types
 if TYPE_CHECKING:
     from .graph import Graph
 
-BaseArgumentTypes = Union[str, int, float, bool, torch.dtype, torch.Tensor]
-base_types = BaseArgumentTypes.__args__  # type: ignore[attr-defined]
+BaseArgumentTypes = Union[str, int, float, bool, torch.dtype, torch.Tensor, torch.device]
+base_types = BaseArgumentTypes.__args__  # type: ignore
 
 Target = Union[Callable[..., Any], str]
 

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -23,6 +23,35 @@ HAS_VARSTUFF = inspect.CO_VARARGS | inspect.CO_VARKEYWORDS
 _orig_module_call : Callable = torch.nn.Module.__call__
 _orig_module_getattr : Callable = torch.nn.Module.__getattr__
 
+class PythonTensor(object):
+    def __init__(self, out, proxy):
+        if isinstance(out, torch.Tensor):
+            self.value = torch.empty_like(out)
+        else:
+            self.value = torch.empty(out)
+        self.proxy = proxy
+
+    def __repr__(self):
+        return f"PythonTensor({tuple(self.value.shape)})"
+
+    def tensor(self):
+        return self.value
+
+    def __torch_function__(self, func, types, args=(), kwargs={}):
+        namespace, func_name = func.split("::")
+        func = getattr(getattr(torch.ops, namespace), func_name)
+        outs = kwargs['val']
+        rets = []
+        proxy_args = [i.proxy if isinstance(i, PythonTensor) else i for i in args]
+        out_proxy = func(*proxy_args)
+        if len(outs) == 1 and isinstance(outs[0], torch.Tensor):
+            return [PythonTensor(outs[0], out_proxy)]
+        for idx, out in enumerate(outs):
+            if isinstance(out, torch.Tensor):
+                rets.append(PythonTensor(out, out_proxy[idx]))
+            else:
+                rets.append(out)
+        return rets
 
 def _patch_function(fn: FunctionType, nargs: int) -> FunctionType:
     co = fn.__code__
@@ -393,16 +422,18 @@ class Tracer(TracerBase):
 
         # Method dispatch on parameters is not recorded unless it's directly used.
         # Thus, we need to insert a proxy when __getattr__ requests a parameter.
-        # @functools.wraps(_orig_module_getattr)
-        # def module_getattr_wrapper(mod, attr):
-        #     attr_val = _orig_module_getattr(mod, attr)
-        #     if isinstance(attr_val, torch.nn.Parameter):
-        #         for n, p in self.root.named_parameters():
-        #             if attr_val is p:
-        #                 if n not in parameter_proxy_cache:
-        #                     parameter_proxy_cache[n] = self.create_proxy('get_attr', n, (), {})
-        #                 return parameter_proxy_cache[n]
-        #     return attr_val
+        @functools.wraps(_orig_module_getattr)
+        def module_getattr_wrapper(mod, attr):
+            attr_val = _orig_module_getattr(mod, attr)
+            if isinstance(attr_val, torch.nn.Parameter):
+                for n, p in self.root.named_parameters():
+                    if attr_val is p:
+                        if n not in parameter_proxy_cache:
+                            proxy = self.create_proxy('get_attr', n, (), {})
+                            parameter_proxy_cache[n] = key.addKey(PythonTensor(attr_val.shape, proxy))
+                            parameter_proxy_cache[n].requires_grad = True
+                        return parameter_proxy_cache[n]
+            return attr_val
 
         @functools.wraps(_orig_module_call)
         def module_call_wrapper(mod, *args, **kwargs):
@@ -416,7 +447,7 @@ class Tracer(TracerBase):
         with _CPatchManager(self):
             with _Patcher() as patcher:
                 # allow duplicate patches to support the case of nested calls
-                # patcher.patch_method(torch.nn.Module, "__getattr__", module_getattr_wrapper, deduplicate=False)
+                patcher.patch_method(torch.nn.Module, "__getattr__", module_getattr_wrapper, deduplicate=False)
                 patcher.patch_method(torch.nn.Module, "__call__", module_call_wrapper, deduplicate=False)
                 _patch_wrapped_functions(patcher)
                 _autowrap_check(patcher, fn_globals, self._autowrap_function_ids)


### PR DESCRIPTION
Successfully threads a PyObject* through the dispatcher as an attribute of `PythonTensorImpl` and calls back into its `__torch_function__`.

Starts to implement this: https://github.com/pytorch/pytorch/issues/55095

Unresolved issues:
1. How do I map from `aten::<op>` back to a python op, and pass the arguments as well?
2. I need to add some kind of shallow copy method for autograd.