### PR TITLE
Port `scatter` and `scatter_add` to `OpInfo`

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2766,9 +2766,7 @@ def sample_inputs_scatter(op_info, device, dtype, requires_grad):
         (_tensor(()), (0, zero.clone().detach(), 2.5)),
     )
 
-    samples = [SampleInput(tensor, args=args) for tensor, args in test_cases]
-
-    return samples
+    return [SampleInput(tensor, args=args) for tensor, args in test_cases]
 
 def sample_inputs_scatter_add(op_info, device, dtype, requires_grad):
     def _tensor(shape, dtype=dtype, low=None, high=None):
@@ -2788,9 +2786,7 @@ def sample_inputs_scatter_add(op_info, device, dtype, requires_grad):
         (_tensor(()), (0, zero.clone().detach(), _tensor(()))),
     )
 
-    samples = [SampleInput(tensor, args=args) for tensor, args in test_cases]
-
-    return samples
+    return [SampleInput(tensor, args=args) for tensor, args in test_cases]
 
 foreach_unary_op_db: List[OpInfo] = [
     ForeachUnaryFuncInfo('exp'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2772,7 +2772,7 @@ def sample_inputs_scatter_ops(op_info, device, dtype, requires_grad):
         ))
 
     return samples
-    
+
 foreach_unary_op_db: List[OpInfo] = [
     ForeachUnaryFuncInfo('exp'),
     ForeachUnaryFuncInfo('acos'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2749,15 +2749,20 @@ def sample_inputs_scatter_ops(op_info, device, dtype, requires_grad):
     def _make(shape, dtype=dtype, low=None, high=None):
         return make_tensor(shape, device, dtype, low=low, high=high, requires_grad=requires_grad)
 
-    cases = (
-        (_make((M, S)), (0, _make((S, S), dtype=torch.long, low=0, high=M), _make((S, S))),),
-        (_make((M, S)), (1, _make((M, S // 2), dtype=torch.long, low=0, high=S), _make((M, S // 2))),),
-        (_make((M, S)), (-1, _make((M, S // 2), dtype=torch.long, low=0, high=S), _make((M, S // 2))),),
-        (_make(()), (0, torch.tensor(0, dtype=torch.long, device=device), _make(())),),
-        (_make(()), (0, torch.tensor(0, dtype=torch.long, device=device), 2.5)),
-    )
+    def _make_idx(shape, high):
+        return _make(shape, dtype=torch.long, low=0, high=high)
 
-    inputs = list(SampleInput(tensor, args=args) for tensor, args in cases)
+    cases = [
+        (_make((M, S)), (0, _make_idx((S, S), high=M), _make((S, S))),),
+        (_make((M, S)), (1, _make_idx((M, S // 2), high=S), _make((M, S // 2))),),
+        (_make((M, S)), (-1, _make_idx((M, S // 2), high=S), _make((M, S // 2))),),
+        (_make(()), (0, torch.tensor(0, dtype=torch.long, device=device), _make(())),),
+    ]
+
+    if op_info.name == 'scatter':
+        cases.append((_make(()), (0, torch.tensor(0, dtype=torch.long, device=device), 2.5)))
+
+    inputs = [SampleInput(tensor, args=args) for tensor, args in cases]
     return inputs
 
 foreach_unary_op_db: List[OpInfo] = [

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2756,11 +2756,11 @@ def sample_inputs_scatter(op_info, device, dtype, requires_grad):
 
     zero = torch.tensor(0, dtype=torch.long, device=device)
     test_cases = (
-        (_tensor((M, S)), ( 0, _gather((S, S), 1, M), _tensor((S, S)))),
-        (_tensor((M, S)), ( 1, _gather((S, S), 0, S), _tensor((S, S)))),
+        (_tensor((M, S)), (0, _gather((S, S), 1, M), _tensor((S, S)))),
+        (_tensor((M, S)), (1, _gather((S, S), 0, S), _tensor((S, S)))),
         (_tensor((M, S)), (-1, _gather((S, S), 0, S), _tensor((S, S)))),
-        (_tensor((M, S)), ( 0, _gather((M, S // 2), 1, M), _tensor((M, S // 2)))),
-        (_tensor((M, S)), ( 1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
+        (_tensor((M, S)), (0, _gather((M, S // 2), 1, M), _tensor((M, S // 2)))),
+        (_tensor((M, S)), (1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
         (_tensor((M, S)), (-1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
         (_tensor(()), (0, zero.clone().detach(), _tensor(()))),
         (_tensor(()), (0, zero.clone().detach(), 2.5)),
@@ -2777,11 +2777,11 @@ def sample_inputs_scatter_add(op_info, device, dtype, requires_grad):
 
     zero = torch.tensor(0, dtype=torch.long, device=device)
     test_cases = (
-        (_tensor((M, S)), ( 0, _gather((S, S), 1, M), _tensor((S, S)))),
-        (_tensor((M, S)), ( 1, _gather((S, S), 0, S), _tensor((S, S)))),
+        (_tensor((M, S)), (0, _gather((S, S), 1, M), _tensor((S, S)))),
+        (_tensor((M, S)), (1, _gather((S, S), 0, S), _tensor((S, S)))),
         (_tensor((M, S)), (-1, _gather((S, S), 0, S), _tensor((S, S)))),
-        (_tensor((M, S)), ( 0, _gather((M, S // 2), 1, M), _tensor((M, S // 2)))),
-        (_tensor((M, S)), ( 1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
+        (_tensor((M, S)), (0, _gather((M, S // 2), 1, M), _tensor((M, S // 2)))),
+        (_tensor((M, S)), (1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
         (_tensor((M, S)), (-1, _gather((M, S // 2), 0, S), _tensor((M, S // 2)))),
         (_tensor(()), (0, zero.clone().detach(), _tensor(()))),
     )


### PR DESCRIPTION
Fixes #54302
Tracking Issue #54261 

**Summary:**
- Port `scatter` and `scatter_add` tests to `OpInfo`
- `masked_scatter` was already ported to `OpInfo`