### PR TITLE
Fix segmentation fault due to access to destroyed CudaIPCGlobalEntities instance

### DIFF
--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -19,13 +19,20 @@ void warnProducerTerminatedBeforeSharedTensorsReleased() {
 }
 
 struct CudaIPCGlobalEntities {
+  // This class is used as a singleton (see cuda_ipc_global_entities)
+  // This variable is used to track its lifetime to avoid accessing it
+  // after it was destroyed which would lead to segmentation faults
+  // Note that a trvial type is used which doesn't suffer from construction
+  // and destruction order issues
+  static bool alive;
+
   std::mutex ref_counters_mutex_;
   std::atomic<int64_t> sync_events_used_{0};
   std::map<std::string, std::shared_ptr<CudaIPCRefCountersFile>>
       ref_counters_files_;
   std::shared_ptr<CudaIPCRefCountersFile> next_available_ref_counters_file_;
   CudaIPCSentDataLimbo CudaIPCSentDataLimbo_;
-  CudaIPCGlobalEntities()  = default;
+  CudaIPCGlobalEntities() { alive = true; }
   ~CudaIPCGlobalEntities() {
     CudaIPCSentDataLimbo_.collect();
     // Clear shared blocks to avoid releasing shared blocks after
@@ -37,6 +44,7 @@ struct CudaIPCGlobalEntities {
     if (next_available_ref_counters_file_) {
       warnProducerTerminatedBeforeSharedTensorsReleased();
     }
+    alive = false;
   }
   void safe_clean_current_file() {
     std::lock_guard<std::mutex> lock(ref_counters_mutex_);
@@ -48,6 +56,7 @@ struct CudaIPCGlobalEntities {
   }
 };
 
+bool CudaIPCGlobalEntities::alive = false;
 CudaIPCGlobalEntities cuda_ipc_global_entities;
 
 CudaIPCSentDataLimbo::~CudaIPCSentDataLimbo() {
@@ -102,6 +111,9 @@ void CudaIPCSentDataLimbo::add(std::unique_ptr<CudaIPCSentData> shared_block) {
 void CudaIPCSentDataDelete(void* ptr) {
   std::unique_ptr<CudaIPCSentData> sent_data(
       static_cast<CudaIPCSentData*>(ptr));
+  if(!CudaIPCGlobalEntities::alive) {
+    return;
+  }
   if (sent_data->counter_value() > 0) {
     cuda_ipc_global_entities.CudaIPCSentDataLimbo_.add(std::move(sent_data));
   }
@@ -109,6 +121,9 @@ void CudaIPCSentDataDelete(void* ptr) {
 }
 
 void ReturnRefCounter(const std::string& handle, uint64_t offset /* unused */) {
+  if(!CudaIPCGlobalEntities::alive) {
+    return;
+  }
   std::lock_guard<std::mutex> lock(
       cuda_ipc_global_entities.ref_counters_mutex_);
   auto& map = cuda_ipc_global_entities.ref_counters_files_;
@@ -180,6 +195,9 @@ CudaIPCSentData::~CudaIPCSentData() {
     if (event_sync_required_) {
       at::cuda::CUDAGuard device_guard(device_.index());
       cudaEventDestroy(event_);
+      if(!CudaIPCGlobalEntities::alive) {
+        return;
+      }
       cuda_ipc_global_entities.sync_events_used_ --;
     }
   } catch (...) { /* No throw */
@@ -226,6 +244,9 @@ at::DataPtr GetNewRefCountedSentData(void* data, at::Device device) {
 }
 
 bool CudaIPCCollect() {
+  if(!CudaIPCGlobalEntities::alive) {
+    return true;
+  }
   bool freed_memory = cuda_ipc_global_entities.CudaIPCSentDataLimbo_.collect();
   if (cuda_ipc_global_entities.CudaIPCSentDataLimbo_.size() == 0) {
     cuda_ipc_global_entities.safe_clean_current_file();

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -35,11 +35,6 @@ struct CudaIPCGlobalEntities {
   CudaIPCGlobalEntities() { alive = true; }
   ~CudaIPCGlobalEntities() {
     CudaIPCSentDataLimbo_.collect();
-    // Clear shared blocks to avoid releasing shared blocks after
-    // ~CudaIPCGlobalEntities is done since circular references causes the
-    // destructor of ~CudaIPCSentData to access the cuda_ipc_global_entities
-    // again.
-    CudaIPCSentDataLimbo_.clear_shared_blocks();
     safe_clean_current_file();
     if (next_available_ref_counters_file_) {
       warnProducerTerminatedBeforeSharedTensorsReleased();

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -61,14 +61,6 @@ CudaIPCSentDataLimbo::~CudaIPCSentDataLimbo() {
   }
 }
 
-void CudaIPCSentDataLimbo::clear_shared_blocks() {
-  std::vector<std::unique_ptr<CudaIPCSentData>> tmp_blocks;
-  {
-    std::lock_guard<std::mutex> lock(limbo_mutex_);
-    tmp_blocks = std::move(shared_blocks_);
-  }
-}
-
 bool CudaIPCSentDataLimbo::collect() {
   bool freed_memory = false;
   std::vector<std::unique_ptr<CudaIPCSentData>> reset_blocks;

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -65,9 +65,7 @@ struct CudaIPCSentDataLimbo final {
   bool collect();
   void clear_shared_blocks();
   void add(std::unique_ptr<CudaIPCSentData> shared_block);
-  uint64_t size() {
-    return shared_blocks_.size();
-  }
+  uint64_t size();
 
  private:
   // TODO: Can be changed to FIFO in order to avoid full traverse on every

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -63,7 +63,6 @@ constexpr int64_t CUDA_IPC_MAXIMUM_EVENTS_TO_USE = 1000;
 struct CudaIPCSentDataLimbo final {
   ~CudaIPCSentDataLimbo();
   bool collect();
-  void clear_shared_blocks();
   void add(std::unique_ptr<CudaIPCSentData> shared_block);
   uint64_t size();
 


### PR DESCRIPTION
There is an instance of the static destruction order fiasco where cuda_ipc_global_entities may be accessed after it is destroyed. See #51961

This change uses a flag and avoids accesses to the destroyed class when it is set to false.

Fixes #51961

This removes the function to clear shared_blocks introduced by #53080 which had multiple issues: Unprotected access to a shared structure and modification of the vector which is being cleared by the destructors of the objects contained.
I.e. what happened was:

- `CudaIPCSentDataLimbo_.clear_shared_blocks();` is called from the destructor of CudaIPCGlobalEntities as of your PR
- This deletes instances of `CudaIPCSentData` which hold `at::DataPtr` created by `GetNewRefCountedSentData`
- This means `CudaIPCSentDataDelete` is called with still active pointers
- Hence `CudaIPCSentDataLimbo_.add` is called adding a new value to `shared_blocks_`

