### PR TITLE
Generalize HIP-specific launch bounds to apply to CUDA as well

### DIFF
--- a/aten/src/ATen/cuda/CUDAApplyUtils.cuh
+++ b/aten/src/ATen/cuda/CUDAApplyUtils.cuh
@@ -398,6 +398,14 @@ inline bool getApplyGrid(uint64_t totalElements, dim3& grid, int64_t curDevice) 
   return true;
 }
 
+constexpr int getApplyBlocksPerSM() {
+  return AT_APPLY_BLOCKS_PER_SM;
+}
+
+constexpr int getApplyBlockSize() {
+  return AT_APPLY_THREADS_PER_BLOCK;
+}
+
 inline dim3 getApplyBlock() {
   return dim3(AT_APPLY_THREADS_PER_BLOCK);
 }

--- a/aten/src/ATen/native/cuda/Dropout.cu
+++ b/aten/src/ATen/native/cuda/Dropout.cu
@@ -25,22 +25,21 @@ namespace {
 const int UNROLL = 4;
 
 template <
-          typename scalar_t,
-          typename accscalar_t,
-          typename IndexType,
-          int ADims,
-          int VEC>
-#if __CUDA_ARCH__ >= 350
-C10_LAUNCH_BOUNDS_2(256, 4)
-#elif defined (__HIP_PLATFORM_HCC__)
+    typename scalar_t,
+    typename accscalar_t,
+    typename IndexType,
+    int ADims,
+    int VEC>
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_2(256, 4)
 #endif
-__global__ void
-fused_dropout_kernel_vec(at::cuda::detail::TensorInfo<scalar_t, IndexType> a,
-                         at::cuda::detail::TensorInfo<scalar_t, IndexType> b,
-                         at::cuda::detail::TensorInfo<uint8_t, IndexType> c,
-                         IndexType totalElements, accscalar_t p,
-                         PhiloxCudaState philox_args) {
+__global__ void fused_dropout_kernel_vec(
+    at::cuda::detail::TensorInfo<scalar_t, IndexType> a,
+    at::cuda::detail::TensorInfo<scalar_t, IndexType> b,
+    at::cuda::detail::TensorInfo<uint8_t, IndexType> c,
+    IndexType totalElements,
+    accscalar_t p,
+    PhiloxCudaState philox_args) {
   // make sure we don't break assumption that we can't have > 4 elements / thread
   static_assert(VEC <= 4, "Value of VEC must be in [2, 4]");
 
@@ -115,22 +114,21 @@ fused_dropout_kernel_vec(at::cuda::detail::TensorInfo<scalar_t, IndexType> a,
 }
 
 template <
-          typename scalar_t,
-          typename accscalar_t,
-          typename IndexType,
-          int ADims,
-          int BDims=ADims>
-#if __CUDA_ARCH__ >= 350
-C10_LAUNCH_BOUNDS_2(256, 4)
-#elif defined (__HIP_PLATFORM_HCC__)
+    typename scalar_t,
+    typename accscalar_t,
+    typename IndexType,
+    int ADims,
+    int BDims = ADims>
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_2(256, 4)
 #endif
-__global__ void
-fused_dropout_kernel(cuda::detail::TensorInfo<scalar_t, IndexType> a,
-                     cuda::detail::TensorInfo<scalar_t, IndexType> b,
-                     cuda::detail::TensorInfo<uint8_t, IndexType> c,
-                     IndexType totalElements, accscalar_t p,
-                     PhiloxCudaState philox_args) {
+__global__ void fused_dropout_kernel(
+    cuda::detail::TensorInfo<scalar_t, IndexType> a,
+    cuda::detail::TensorInfo<scalar_t, IndexType> b,
+    cuda::detail::TensorInfo<uint8_t, IndexType> c,
+    IndexType totalElements,
+    accscalar_t p,
+    PhiloxCudaState philox_args) {
   auto seeds = at::cuda::philox::unpack(philox_args);
   IndexType idx = blockIdx.x * blockDim.x + threadIdx.x;
   curandStatePhilox4_32_10_t state;

--- a/aten/src/ATen/native/cuda/SortingCommon.cuh
+++ b/aten/src/ATen/native/cuda/SortingCommon.cuh
@@ -75,9 +75,7 @@ __device__ __forceinline__ index_t getLinearBlockId() {
 // (sliceSize - 1) * sliceStride, we fill that slice from `0` to
 // `sliceSize - 1`.
 template <typename index_t, int Dim>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(1024)
-#endif
 __global__ void fillSliceWithIndex_kernel(
     cuda::detail::TensorInfo<int64_t, index_t> out,
     index_t totalSlices,

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -43,7 +43,7 @@ template <
     int BDims,
     CUDAHistogramMemoryType MemoryType = CUDAHistogramMemoryType::MULTI_BLOCK,
     typename Op>
-C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
+C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
 __global__ void kernelHistogram1D(
     detail::TensorInfo<output_t, IndexType> a, /* output */
     detail::TensorInfo<output_t, IndexType> p, /* partial output */

--- a/aten/src/ATen/native/cuda/SummaryOps.cu
+++ b/aten/src/ATen/native/cuda/SummaryOps.cu
@@ -43,9 +43,7 @@ template <
     int BDims,
     CUDAHistogramMemoryType MemoryType = CUDAHistogramMemoryType::MULTI_BLOCK,
     typename Op>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
-#endif
+C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
 __global__ void kernelHistogram1D(
     detail::TensorInfo<output_t, IndexType> a, /* output */
     detail::TensorInfo<output_t, IndexType> p, /* partial output */

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -41,10 +41,17 @@ kernel_pointwise_flip_apply2(const cuda::detail::TensorInfo<scalar_t, IndexType>
 }
 
 template <typename scalar_t>
-__global__
-void flip_cuda_kernel(scalar_t* in_tensor, scalar_t* out_tensor, int64_t N, int64_t* flip_dims, int64_t flip_dims_size,
-                      int64_t* strides, int64_t* strides_contiguous, int64_t* shape, int64_t total_dims) {
-
+C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
+__global__ void flip_cuda_kernel(
+    scalar_t* in_tensor,
+    scalar_t* out_tensor,
+    int64_t N,
+    int64_t* flip_dims,
+    int64_t flip_dims_size,
+    int64_t* strides,
+    int64_t* strides_contiguous,
+    int64_t* shape,
+    int64_t total_dims) {
   int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
   if (linear_index >= N) {
     return;
@@ -73,7 +80,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
   const int64_t flip_dims_size = dims.size(), total_dims = in_tensor.dim(), N = in_tensor.numel();
   flip_check_errors(total_dims, flip_dims_size, dims);
 
-  int64_t block_size = 512;
+  int64_t block_size = AT_APPLY_THREADS_PER_BLOCK;
   dim3 dim_block(block_size);
   dim3 dim_grid((N + block_size - 1) / block_size);
 
@@ -139,13 +146,16 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
 }
 
 template <typename scalar_t>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
-#endif
-__global__
-void roll_cuda_kernel(scalar_t* in_tensor, scalar_t* out_tensor, int64_t N,
-                      int64_t roll_dim, int64_t start,
-                      int64_t size, int64_t stride, int64_t total_dims) {
+C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
+__global__ void roll_cuda_kernel(
+    scalar_t* in_tensor,
+    scalar_t* out_tensor,
+    int64_t N,
+    int64_t roll_dim,
+    int64_t start,
+    int64_t size,
+    int64_t stride,
+    int64_t total_dims) {
   int64_t linear_index = blockIdx.x * blockDim.x + threadIdx.x;
   if (linear_index >= N) {
     return;

--- a/aten/src/ATen/native/cuda/TensorTransformations.cu
+++ b/aten/src/ATen/native/cuda/TensorTransformations.cu
@@ -12,19 +12,16 @@
 namespace at {
 namespace native {
 
-constexpr uint32_t AT_APPLY_THREADS_PER_BLOCK = 512;
-constexpr uint32_t AT_APPLY_BLOCKS_PER_SM = 4;
-
 template <typename scalar_t, typename IndexType>
 #if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_2(AT_APPLY_THREADS_PER_BLOCK, AT_APPLY_BLOCKS_PER_SM)
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
-__global__ void
-kernel_pointwise_flip_apply2(const cuda::detail::TensorInfo<scalar_t, IndexType> in_tensor_info,
-                          cuda::detail::TensorInfo<scalar_t, IndexType> out_tensor_info,
-                          IndexType N,
-                          int flip_dim,
-                          IndexType total_dims) {
+__global__ void kernel_pointwise_flip_apply2(
+    const cuda::detail::TensorInfo<scalar_t, IndexType> in_tensor_info,
+    cuda::detail::TensorInfo<scalar_t, IndexType> out_tensor_info,
+    IndexType N,
+    int flip_dim,
+    IndexType total_dims) {
   for (IndexType linear_index = blockIdx.x * blockDim.x + threadIdx.x; linear_index < N; linear_index += gridDim.x * blockDim.x) {
     IndexType dst_offset = 0;
     if (flip_dim == 0) {
@@ -41,7 +38,7 @@ kernel_pointwise_flip_apply2(const cuda::detail::TensorInfo<scalar_t, IndexType>
 }
 
 template <typename scalar_t>
-C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
+C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
 __global__ void flip_cuda_kernel(
     scalar_t* in_tensor,
     scalar_t* out_tensor,
@@ -80,7 +77,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
   const int64_t flip_dims_size = dims.size(), total_dims = in_tensor.dim(), N = in_tensor.numel();
   flip_check_errors(total_dims, flip_dims_size, dims);
 
-  int64_t block_size = AT_APPLY_THREADS_PER_BLOCK;
+  int64_t block_size = cuda::getApplyBlockSize();
   dim3 dim_block(block_size);
   dim3 dim_grid((N + block_size - 1) / block_size);
 
@@ -146,7 +143,7 @@ Tensor flip_cuda(const Tensor& self, IntArrayRef dims) {
 }
 
 template <typename scalar_t>
-C10_LAUNCH_BOUNDS_1(AT_APPLY_THREADS_PER_BLOCK)
+C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
 __global__ void roll_cuda_kernel(
     scalar_t* in_tensor,
     scalar_t* out_tensor,

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -14,14 +14,12 @@ namespace native {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ triu/tril ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <typename scalar_t, typename IndexType, bool upper>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
-#endif
-__global__
-void triu_tril_kernel(
+C10_LAUNCH_BOUNDS_1(cuda::getApplyBlockSize())
+__global__ void triu_tril_kernel(
     cuda::detail::TensorInfo<scalar_t, IndexType> result_info,
     const cuda::detail::TensorInfo<scalar_t, IndexType> self_info,
-    const int64_t k, const int64_t N) {
+    const int64_t k,
+    const int64_t N) {
   int64_t linear_idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (linear_idx >= N) {
     return;
@@ -111,9 +109,7 @@ Tensor& triu_cuda_out(const Tensor& self, int64_t k, Tensor &result) {
 
 // Copy the kth diagonal of a matrix B to a vector A.
 template <typename scalar_t>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(1024)
-#endif
 __global__ void copy_from_diagonal_kernel(
     scalar_t* a,
     scalar_t* b,
@@ -131,9 +127,7 @@ __global__ void copy_from_diagonal_kernel(
 
 // Copy vector B to the kth diagonal of a matrix A
 template <typename scalar_t>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(1024)
-#endif
 __global__ void copy_to_diagonal_kernel(
     scalar_t* a,
     scalar_t* b,

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -15,9 +15,7 @@ namespace native {
 namespace {
 
 template <typename scalar_t, typename accscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(1024)
-#endif
 __global__ void upsample_linear1d_out_frame(
     const int n,
     const accscalar_t rwidth,
@@ -64,9 +62,7 @@ __global__ void upsample_linear1d_out_frame(
 
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename scalar_t, typename accscalar_t>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(1024)
-#endif
 __global__ void upsample_linear1d_out_frame_backward(
     const int n,
     const accscalar_t rwidth,

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDAApplyUtils.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/cuda/detail/TensorInfo.cuh>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <c10/macros/Macros.h>
 
 namespace at { namespace native {
@@ -40,8 +41,8 @@ __device__ void applyOp3(
 // Assume both dense and values are contiguous.
 // Currently only used in add_out_dense_sparse_cuda: add(dense, sparse, scalar).
 template <typename Op, typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void sparseElementwiseKernel(
     Op op,
@@ -70,8 +71,8 @@ __global__ void sparseElementwiseKernel(
 // Assume dense is contiguous.
 // Currently only used in add_out_dense_sparse_cuda: add(dense, sparse, scalar).
 template <typename Op, typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void sparseElementwiseKernelScalar(
     Op op,
@@ -94,8 +95,8 @@ __global__ void sparseElementwiseKernelScalar(
 }
 
 template <typename OpBoth, typename OpLeft, typename OpRight, typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void valueSparseUnionKernel(
     OpBoth opBoth,
@@ -141,8 +142,8 @@ __global__ void valueSparseUnionKernel(
 
 // TODO find a way to parallelize this...
 template <typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void indexSparseUnionKernel(
     TensorInfo<indexT, IndexType> r_indices,
@@ -191,8 +192,8 @@ __global__ void indexSparseUnionKernel(
 }
 
 template <typename Op, typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void valueSparseIntersectionKernel(
     Op op,
@@ -230,8 +231,8 @@ __global__ void valueSparseIntersectionKernel(
 
 // TODO find a way to parallelize this...
 template <typename IndexType, typename Real>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
+C10_LAUNCH_BOUNDS_2(cuda::getApplyBlockSize(), cuda::getApplyBlocksPerSM())
 #endif
 __global__ void indexSparseIntersectionKernel(
     TensorInfo<indexT, IndexType> r_indices,
@@ -296,6 +297,7 @@ __global__ void indexSparseIntersectionKernel(
 // }
 
 template <typename Dtype, typename Acctype>
+C10_LAUNCH_BOUNDS_1(C10_WARP_SIZE*4)
 __global__ void coalesceValuesKernel(
   int64_t *segment_offsets, int64_t *value_indices,
   Dtype *values, Dtype *newValues,

--- a/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCUDATensor.cu
@@ -33,18 +33,15 @@ using at::cuda::detail::getTensorInfo;
 namespace {
 
 template <typename scalar_t>
-#ifdef __HIP_PLATFORM_HCC__
-C10_LAUNCH_BOUNDS_1(512)
-#endif
+C10_LAUNCH_BOUNDS_1(1024)
 __global__ void _sparse_mask_copy_kernel(
-  int64_t total_threads,
-  int64_t t_nnz,
-  const TensorInfo<int64_t, int64_t> t_indices_ti,
-  const TensorInfo<int64_t, int64_t> mask_indices_ti,
-  const TensorInfo<int64_t, int64_t> t_indices_pos_ti,
-  const TensorInfo<scalar_t, int64_t> t_values_ti,
-  TensorInfo<scalar_t, int64_t> r_values_ti
-) {
+    int64_t total_threads,
+    int64_t t_nnz,
+    const TensorInfo<int64_t, int64_t> t_indices_ti,
+    const TensorInfo<int64_t, int64_t> mask_indices_ti,
+    const TensorInfo<int64_t, int64_t> t_indices_pos_ti,
+    const TensorInfo<scalar_t, int64_t> t_values_ti,
+    TensorInfo<scalar_t, int64_t> r_values_ti) {
   const int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i >= total_threads) return;
   const int64_t j = t_indices_pos_ti.data[i];

--- a/aten/src/THC/THCApply.cuh
+++ b/aten/src/THC/THCApply.cuh
@@ -118,7 +118,7 @@ template <typename Op,
           typename Ta,
           typename IndexType,
           int ADims>
-#if defined __HIP_PLATFORM_HCC__
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_2(THC_APPLY_THREADS_PER_BLOCK, THC_APPLY_BLOCKS_PER_SM)
 #endif
 __global__ void
@@ -138,7 +138,7 @@ template <typename Op,
           typename Ta, typename Tb,
           typename IndexType,
           int ADims, int BDims>
-#if defined __HIP_PLATFORM_HCC__
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_2(THC_APPLY_THREADS_PER_BLOCK, THC_APPLY_BLOCKS_PER_SM)
 #endif
 __global__ void
@@ -157,7 +157,7 @@ template <typename Op,
           typename Ta, typename Tb, typename Tc,
           typename IndexType,
           int ADims, int BDims, int CDims>
-#if defined __HIP_PLATFORM_HCC__
+#if __CUDA_ARCH__ >= 350 || defined __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_2(THC_APPLY_THREADS_PER_BLOCK, THC_APPLY_BLOCKS_PER_SM)
 #endif
 __global__ void

--- a/aten/src/THC/THCReduceAll.cuh
+++ b/aten/src/THC/THCReduceAll.cuh
@@ -31,9 +31,7 @@ template <typename T,
           typename ReduceOp,
           int ADims>
 __global__ void
-#if defined(__HIP_PLATFORM_HCC__)
 C10_LAUNCH_BOUNDS_1(THC_REDUCE_ALL_BLOCK_SIZE)
-#endif
 kernelReduceAll(TensorInfo<T, IndexType> in,
                 IndexType totalElements,
                 AccT init,
@@ -78,9 +76,7 @@ template <typename T,
           typename ModifyOp,
           typename ReduceOp,
           int ADims>
-#if defined(__HIP_PLATFORM_HCC__)
 C10_LAUNCH_BOUNDS_1(THC_REDUCE_ALL_BLOCK_SIZE)
-#endif
 __global__ void
 kernelReduceAllPass1(TensorInfo<T, IndexType> in,
                      IndexType totalElements,
@@ -111,9 +107,7 @@ kernelReduceAllPass1(TensorInfo<T, IndexType> in,
 }
 
 template <typename T, typename ReduceOp>
-#if defined(__HIP_PLATFORM_HCC__)
 C10_LAUNCH_BOUNDS_1(THC_REDUCE_ALL_BLOCK_SIZE)
-#endif
 __global__ void
 kernelReduceAllPass2(int numPass1Blocks,
                      T init,

--- a/aten/src/THC/THCTensorScatterGather.cu
+++ b/aten/src/THC/THCTensorScatterGather.cu
@@ -79,9 +79,7 @@ struct IndexToScatterGatherOffsets<IndexType, Real, -1> {
 };
 
 template <typename IndexType, typename Real, int Dims>
-#ifdef __HIP_PLATFORM_HCC__
 C10_LAUNCH_BOUNDS_1(512)
-#endif
 __global__ void THCudaTensor_gatherKernel(
     TensorInfo<Real, IndexType> tensor,
     TensorInfo<Real, IndexType> src,

--- a/aten/src/THCUNN/MultiLabelMarginCriterion.cu
+++ b/aten/src/THCUNN/MultiLabelMarginCriterion.cu
@@ -11,9 +11,7 @@
 #define MULTILABELMARGIN_THREADS 1024
 
 template <typename Dtype, typename Acctype>
-#if defined(__HIP_PLATFORM_HCC__)
 C10_LAUNCH_BOUNDS_1(MULTILABELMARGIN_THREADS)
-#endif
 __global__ void cunn_MultiLabelMarginCriterion_updateOutput_kernel(Dtype *output,
                                                                    Dtype *input,
                                                                    THCIndex_t *target,
@@ -81,9 +79,7 @@ __global__ void cunn_MultiLabelMarginCriterion_updateOutput_kernel(Dtype *output
 }
 
 template <typename Dtype, typename Acctype>
-#if defined(__HIP_PLATFORM_HCC__)
 C10_LAUNCH_BOUNDS_1(MULTILABELMARGIN_THREADS)
-#endif
 __global__ void cunn_MultiLabelMarginCriterion_updateGradInput_kernel(Dtype *gradInput,
                                                                       Dtype *gradOutput,
                                                                       Dtype *input,

--- a/aten/src/THCUNN/SpatialClassNLLCriterion.cu
+++ b/aten/src/THCUNN/SpatialClassNLLCriterion.cu
@@ -15,12 +15,13 @@
 #include <thrust/functional.h>
 
 template <typename Dtype>
+C10_LAUNCH_BOUNDS_1(CUDA_NUM_THREADS)
 __global__ void SpatialClassNLLCriterion_updateOutput_no_reduce_kernel(
     int64_t nthreads,
     THCDeviceTensor<Dtype, 4> input,
     THCDeviceTensor<THCIndex_t, 3> target,
     THCDeviceTensor<Dtype, 3> output,
-    Dtype *weights,
+    Dtype* weights,
     int64_t ignore_index) {
   int64_t batch_size = input.getSize(0);
   int64_t H = input.getSize(2);
@@ -44,12 +45,13 @@ __global__ void SpatialClassNLLCriterion_updateOutput_no_reduce_kernel(
 }
 
 template <typename Dtype>
+C10_LAUNCH_BOUNDS_1(CUDA_NUM_THREADS)
 __global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
     int64_t nthreads,
     THCDeviceTensor<THCIndex_t, 3> target,
     THCDeviceTensor<Dtype, 3> gradOutput,
     THCDeviceTensor<Dtype, 4> gradInput,
-    Dtype *weights,
+    Dtype* weights,
     int64_t ignore_index) {
   int64_t batch_size = target.getSize(0);
   int64_t H = target.getSize(1);
@@ -71,22 +73,19 @@ __global__ void SpatialClassNLLCriterion_updateGradInput_no_reduce_kernel(
 }
 
 template <typename T, typename AccumT>
-#if defined(__HIP_PLATFORM_HCC__)
-C10_LAUNCH_BOUNDS_1(1024)
-#endif
+C10_LAUNCH_BOUNDS_1(CUDA_NUM_THREADS)
 __global__ void cunn_SpatialClassNLLCriterion_updateOutput_kernel(
-          T *output,
-          T *total_weight,
-          T *input,
-          THCIndex_t *target,
-          T *weights,
-          int size_average,
-          int batch_size,
-          int n_classes,
-          int map_nelem,
-          int blocks_per_sample,
-          int64_t ignore_index)
-{
+    T* output,
+    T* total_weight,
+    T* input,
+    THCIndex_t* target,
+    T* weights,
+    int size_average,
+    int batch_size,
+    int n_classes,
+    int map_nelem,
+    int blocks_per_sample,
+    int64_t ignore_index) {
   __shared__ AccumT partial_sums[CUDA_NUM_THREADS];
 
   int i, t;
@@ -135,20 +134,20 @@ __global__ void cunn_SpatialClassNLLCriterion_sizeAverage_kernel(
   }
 }
 
-template<typename T>
+template <typename T>
+C10_LAUNCH_BOUNDS_1(CUDA_NUM_THREADS)
 __global__ void cunn_SpatialClassNLLCriterion_updateGradInput_kernel(
-          T *gradInput,
-          T *gradOutput,
-          THCIndex_t *target,
-          T *weights,
-          T *total_weight,
-          int size_average,
-          int batch_size,
-          int n_classes,
-          int map_nelem,
-          int blocks_per_sample,
-          int64_t ignore_index)
-{
+    T* gradInput,
+    T* gradOutput,
+    THCIndex_t* target,
+    T* weights,
+    T* total_weight,
+    int size_average,
+    int batch_size,
+    int n_classes,
+    int map_nelem,
+    int blocks_per_sample,
+    int64_t ignore_index) {
   if (*total_weight <= 0)
     return;
 


### PR DESCRIPTION
Launch bounds for HIP were added along the way, but the smaller CUDA devices (like Jetson) also benefit from them.
So here I go over the HIP-specific launch bounds and try to generalize them to cover CUDA, too.

The long term goal is to eventually not need to resort to somewhat ad-hoc adaptations like the reduction of block size discussed in #8103, but have good coverage of our kernels with launch bound annotations.
