### PR TITLE
Add supported backward_dtype to OpInfo

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -63,18 +63,16 @@ class TestOpInfo(TestCase):
     #   does NOT throw a runtime error.
     # TODO: support multi-tensor outputs
     @onlyOnCPUAndCUDA
-    @ops(op_db, allowed_dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16))
+    @ops(op_db, dtypes=OpDTypes.supported_backward,
+         allowed_dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16))
     def test_supported_backward(self, device, dtype, op):
         if not op.supports_autograd:
             self.skipTest("Skipped! Autograd not supported.")
-        if not op.supports_complex_autograd and dtype.is_complex:
-            self.skipTest("Skipped! Complex autograd not supported.")
 
         for sample in op.sample_inputs(device, dtype, requires_grad=True):
             result = op(sample.input, *sample.args, **sample.kwargs)
             if not isinstance(result, torch.Tensor):
                 continue
-
             result.sum().backward()
 
     # Verifies that ops do not have an entry in

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -309,7 +309,11 @@ class DeviceTypeTestBase(TestCase):
                 # Acquires dtypes, using the op data if unspecified
                 dtypes = cls._get_dtypes(test)
                 if dtypes is None:
-                    if test.opinfo_dtypes == OpDTypes.unsupported:
+                    if test.opinfo_dtypes == OpDTypes.unsupported_backward:
+                        dtypes = set(get_all_dtypes()).difference(op.supported_backward_dtypes(cls.device_type))
+                    elif test.opinfo_dtypes == OpDTypes.supported_backward:
+                        dtypes = op.supported_backward_dtypes(cls.device_type)
+                    elif test.opinfo_dtypes == OpDTypes.unsupported:
                         dtypes = set(get_all_dtypes()).difference(op.supported_dtypes(cls.device_type))
                     elif test.opinfo_dtypes == OpDTypes.supported:
                         dtypes = op.supported_dtypes(cls.device_type)
@@ -563,6 +567,8 @@ class OpDTypes(Enum):
     basic = 0  # Test the basic set of dtypes (default)
     supported = 1  # Test all supported dtypes
     unsupported = 2  # Test only unsupported dtypes
+    supported_backward = 3  # Test all supported backward dtypes
+    unsupported_backward = 4  # Test only unsupported backward dtypes
 
 
 # Decorator that defines the ops a test should be run with

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4118,6 +4118,7 @@ op_db: List[OpInfo] = [
            op=torch.linalg.det,
            aliases=('det', ),
            dtypes=floating_and_complex_types(),
+           # det doesn't support complex autograd, https://github.com/pytorch/pytorch/issues/57358
            backward_dtypes=floating_types(),
            aten_name='linalg_det',
            sample_inputs_func=sample_inputs_linalg_det,
@@ -4713,6 +4714,7 @@ op_db: List[OpInfo] = [
     OpInfo('std',
            dtypes=floating_types_and(),
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
+           # std doesn't support complex autograd, https://github.com/pytorch/pytorch/issues/57358
            backward_dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: std does support out in some signatures
@@ -5334,6 +5336,7 @@ op_db: List[OpInfo] = [
     OpInfo('var',
            dtypes=floating_types_and(),
            dtypesIfCUDA=floating_and_complex_types_and(torch.half, torch.bfloat16),
+           # var doesn't support complex autograd, https://github.com/pytorch/pytorch/issues/57358
            backward_dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
            sample_inputs_func=sample_inputs_std_var,
            # TODO: revisit, some var signatures do support out (see std, too)
@@ -5425,10 +5428,11 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16),
                    dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),
+                   # sigmoid doesn't support complex autograd, https://github.com/pytorch/pytorch/issues/48552
                    backward_dtypesIfCPU=all_types_and(torch.bool, torch.bfloat16),
                    backward_dtypesIfCUDA=all_types_and(torch.bool, torch.bfloat16),
                    safe_casts_outputs=True,
-                   assert_autodiffed=True),  # Reference: https://github.com/pytorch/pytorch/issues/48552
+                   assert_autodiffed=True),
     UnaryUfuncInfo('digamma',
                    ref=scipy.special.digamma if TEST_SCIPY else _NOTHING,
                    decorators=(precisionOverride({torch.float16: 5e-1}),),


### PR DESCRIPTION
Related to #55601.

- [x] removed complex autograd checker in `test_supported_backward`
- [x] created `backward_dtype[If<Device>]` that inherits from normal `dtype[If<Device>]` by default
- [x] removed all skip for backward test, instead added backward dtype
- [x] change complex autograd to a function call: `support_complex_autograd(device_type)` that depends on `backward_dtype*` since they essentially mean the same thing for complex types

TODO for next PR
- add `test_unsupported_backward` to verify they are actually unsupported.
