### PR TITLE
Set ThreadLocalState correctly in the autograd engine

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -671,29 +671,26 @@ static variable_list call_function(
   const auto has_post_hooks = !fn.post_hooks().empty();
   variable_list outputs;
 
-  {
-    at::ThreadLocalStateGuard guard(graph_task->thread_locals_);
-    if (has_post_hooks) {
-      // In functions/accumulate_grad.cpp, there is some logic to check the
-      // conditions under which the incoming gradient can be stolen directly
-      // (which elides a deep copy) instead of cloned. One of these conditions
-      // is that the incoming gradient's refcount must be 1 (nothing else is
-      // referencing the same data).  Stashing inputs_copy here bumps the
-      // refcount, so if post hooks are employed, it's actually still ok for
-      // accumulate_grad.cpp to steal the gradient if the refcount is 2.
-      //
-      // "new_grad.use_count() <= 1 + !post_hooks().empty()" in
-      // accumulate_grad.cpp accounts for this, but also creates a silent
-      // dependency between engine.cpp (ie, this particular engine
-      // implementation) and accumulate_grad.cpp.
-      //
-      // If you change the logic here, make sure it's compatible with
-      // accumulate_grad.cpp.
-      auto inputs_copy = inputs;
-      outputs = fn(std::move(inputs_copy));
-    } else {
-      outputs = fn(std::move(inputs));
-    }
+  if (has_post_hooks) {
+    // In functions/accumulate_grad.cpp, there is some logic to check the
+    // conditions under which the incoming gradient can be stolen directly
+    // (which elides a deep copy) instead of cloned. One of these conditions
+    // is that the incoming gradient's refcount must be 1 (nothing else is
+    // referencing the same data).  Stashing inputs_copy here bumps the
+    // refcount, so if post hooks are employed, it's actually still ok for
+    // accumulate_grad.cpp to steal the gradient if the refcount is 2.
+    //
+    // "new_grad.use_count() <= 1 + !post_hooks().empty()" in
+    // accumulate_grad.cpp accounts for this, but also creates a silent
+    // dependency between engine.cpp (ie, this particular engine
+    // implementation) and accumulate_grad.cpp.
+    //
+    // If you change the logic here, make sure it's compatible with
+    // accumulate_grad.cpp.
+    auto inputs_copy = inputs;
+    outputs = fn(std::move(inputs_copy));
+  } else {
+    outputs = fn(std::move(inputs));
   }
 
   validate_outputs(fn.next_edges(), outputs, [&](const std::string& msg) {
@@ -724,6 +721,11 @@ void Engine::evaluate_function(
       for (const auto& capture : *capture_vec) {
         auto& captured_grad = graph_task->captured_vars_[capture.output_idx_];
         captured_grad = inputs[capture.input_idx_];
+        if (capture.hooks_.size() == 0) {
+          continue;
+        }
+        // Set the ThreadLocalState before calling hooks
+        at::ThreadLocalStateGuard(graph_task->thread_locals_);
         for (auto& hook : capture.hooks_) {
           captured_grad = (*hook)(captured_grad);
         }
@@ -734,6 +736,11 @@ void Engine::evaluate_function(
       return;
     }
   }
+
+  // Set the ThreadLocalState before calling the function.
+  // NB: The ThreadLocalStateGuard doesn't set the grad_mode because GraphTask
+  // always saves ThreadLocalState without grad_mode.
+  at::ThreadLocalStateGuard(graph_task->thread_locals_);
 
   // Switches to a function's CUDA stream (if applicable) before calling it
   const auto opt_parent_stream = (*func).stream(c10::DeviceType::CUDA);

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -735,7 +735,7 @@ void Engine::evaluate_function(
   // Set the ThreadLocalState before calling the function.
   // NB: The ThreadLocalStateGuard doesn't set the grad_mode because GraphTask
   // always saves ThreadLocalState without grad_mode.
-  at::ThreadLocalStateGuard(graph_task->thread_locals_);
+  at::ThreadLocalStateGuard tls_guard(graph_task->thread_locals_);
 
   // Switches to a function's CUDA stream (if applicable) before calling it
   const auto opt_parent_stream = (*func).stream(c10::DeviceType::CUDA);

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -721,11 +721,6 @@ void Engine::evaluate_function(
       for (const auto& capture : *capture_vec) {
         auto& captured_grad = graph_task->captured_vars_[capture.output_idx_];
         captured_grad = inputs[capture.input_idx_];
-        if (capture.hooks_.size() == 0) {
-          continue;
-        }
-        // Set the ThreadLocalState before calling hooks
-        at::ThreadLocalStateGuard(graph_task->thread_locals_);
         for (auto& hook : capture.hooks_) {
           captured_grad = (*hook)(captured_grad);
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56174 Set ThreadLocalState correctly in the autograd engine**

evaluate_function:
1. calls the autograd function (call_function)
2. accumulates gradients into buffers

Previously, ThreadLocalStateGuard only covered part of `call_function`.
However, it should cover all Tensor operations in `evaluate_function`,
so this PR moves it to do so.

One alternative would have been to move ThreadLocalStateGuard to here:
https://github.com/pytorch/pytorch/blob/71f9e99e293d0eff8da665b69543d044a6a4454d/torch/csrc/autograd/engine.cpp#L394

Unfortunately that adds 2% additional instructions according to the
instruction count benchmark in the next section. This is because
`evaluate_function` does an early return:
https://github.com/pytorch/pytorch/blob/71f9e99e293d0eff8da665b69543d044a6a4454d/torch/csrc/autograd/engine.cpp#L732-L735
If this is preferred, please let me know.

Test Plan:
- run existing tests. It's hard to actually come up with a test case for
this.

Benchmark plan:

TL;DR: Instruction count decreases by a little after this PR.
```
import torch
from torch.utils.benchmark import Timer

timer = Timer(
    stmt="""\
torch::autograd::grad({y}, {x}, {}, /*retain_grad=*/true);""",
    setup="""\
auto x = torch::ones({}, torch::requires_grad());
auto y = x * 2;""",
    language="cpp")

stats = timer.collect_callgrind()
print(stats)
```
This gave the following:
```
Before:
<torch.utils.benchmark.utils.valgrind_wrapper.timer_interface.CallgrindStats object at 0x7f4b28ce6a90>
torch::autograd::grad({y}, {x}, {}, /*retain_grad=*/true);
setup:
  auto x = torch::ones({}, torch::requires_grad());
  auto y = x * 2;

                           All          Noisy symbols removed
    Instructions:      3514184                    3514184
    Baseline:                0                          0
100 runs per measurement, 1 thread

After:
<torch.utils.benchmark.utils.valgrind_wrapper.timer_interface.CallgrindStats object at 0x7f9f50a33990>
torch::autograd::grad({y}, {x}, {}, /*retain_grad=*/true);
setup:
  auto x = torch::ones({}, torch::requires_grad());
  auto y = x * 2;

                           All          Noisy symbols removed
    Instructions:      3514084                    3514084
    Baseline:                0                          0
100 runs per measurement, 1 thread
```

Differential Revision: [D27799283](https://our.internmc.facebook.com/intern/diff/D27799283)