### PR TITLE
Store coverage.xml as artifact for windows test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,6 +818,8 @@ jobs:
           when: always
       - store_test_results:
           path: test/test-reports
+      - store_artifacts:
+          path: test/coverage.xml
   binary_linux_build:
     <<: *binary_linux_build_params
     steps:

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -380,3 +380,5 @@ jobs:
           when: always
       - store_test_results:
           path: test/test-reports
+      - store_artifacts:
+          path: test/coverage.xml


### PR DESCRIPTION
Currently, coverage stats is getting covered for sharded windows tests. This PR attempts to store the coverage.xml file as an artifact.

Test plan:
https://app.circleci.com/pipelines/github/pytorch/pytorch/302678/workflows/82e2f359-2728-4d5e-8dd0-248c372e7201/jobs/12464025 should now save coverage.xml which it does in its last step
