### PR TITLE
[package] fix error handling with allow_empty

### DIFF
--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -233,6 +233,22 @@ class TestDependencyAPI(PackageTestCase):
         with self.assertRaises(NotImplementedError):
             hi.load_pickle("obj", "obj.pkl")
 
+    def test_allow_empty_with_error(self):
+        """If an error occurs during packaging, it should not be shadowed by the allow_empty error."""
+        buffer = BytesIO()
+        with self.assertRaises(ModuleNotFoundError):
+            with PackageExporter(buffer, verbose=False) as pe:
+                # Even though we did not extern a module that matches this
+                # pattern, we want to show the save_module error, not the allow_empty error.
+
+                pe.extern("foo", allow_empty=False)
+                pe.save_module("aodoifjodisfj")  # will error
+
+                # we never get here, so technically the allow_empty check
+                # should raise an error. However, the error above is more
+                # informative to what's actually going wrong with packaging.
+                pe.save_source_string("bar", "import foo\n")
+
 
 if __name__ == "__main__":
     run_tests()

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -77,7 +77,7 @@ class TestDependencyAPI(PackageTestCase):
         Test that an error is thrown when a extern glob is specified with allow_empty=True
         and no matching module is required during packaging.
         """
-        import package_a.subpackage
+        import package_a.subpackage  # noqa: F401
 
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):
@@ -176,7 +176,7 @@ class TestDependencyAPI(PackageTestCase):
         Test that an error is thrown when a mock glob is specified with allow_empty=True
         and no matching module is required during packaging.
         """
-        import package_a.subpackage
+        import package_a.subpackage  # noqa: F401
 
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):

--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -77,11 +77,13 @@ class TestDependencyAPI(PackageTestCase):
         Test that an error is thrown when a extern glob is specified with allow_empty=True
         and no matching module is required during packaging.
         """
+        import package_a.subpackage
+
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):
             with PackageExporter(buffer, verbose=False) as exporter:
-                exporter.extern(include=["package_a.*"], allow_empty=False)
-                exporter.save_module("package_b.subpackage")
+                exporter.extern(include=["package_b.*"], allow_empty=False)
+                exporter.save_module("package_a.subpackage")
 
     def test_deny(self):
         """
@@ -174,11 +176,13 @@ class TestDependencyAPI(PackageTestCase):
         Test that an error is thrown when a mock glob is specified with allow_empty=True
         and no matching module is required during packaging.
         """
+        import package_a.subpackage
+
         buffer = BytesIO()
         with self.assertRaisesRegex(EmptyMatchError, r"did not match any modules"):
             with PackageExporter(buffer, verbose=False) as exporter:
-                exporter.mock(include=["package_a.*"], allow_empty=False)
-                exporter.save_module("package_b.subpackage")
+                exporter.mock(include=["package_b.*"], allow_empty=False)
+                exporter.save_module("package_a.subpackage")
 
     def test_module_glob(self):
         from torch.package.package_exporter import _GlobGroup

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -578,6 +578,8 @@ node [shape=box];
         # attempt to finalize the package. Instead, control is returned to the
         # caller to continue raising the exception.
         if exc_type is not None:
+            # Do the bare minimum to leave the open buffer in a valid state.
+            self._finalize_zip()
             return
 
         self.close()
@@ -621,6 +623,10 @@ node [shape=box];
             self.zip_file.write_record(name, storage.data_ptr(), num_bytes)
         contents = "\n".join(self.extern_modules) + "\n"
         self._write(".data/extern_modules", contents)
+        self._finalize_zip()
+
+    def _finalize_zip(self):
+        """Called at the very end of packaging to leave the zipfile in a closed but valid state."""
         del self.zip_file
         if self.buffer:
             self.buffer.flush()

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -573,7 +573,13 @@ node [shape=box];
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
+        # If __exit__ was called because an exception was raised, we do not attempt to
+        # attempt to finalize the package. Instead, control is returned to the
+        # caller to continue raising the exception.
+        if exc_type is not None:
+            return
+
         self.close()
 
     def _write(self, filename, str_or_bytes):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56190 [package] fix error handling with allow_empty**

Previously, if we had some code that did the following:
```
- pattern A, allow_empty=False
- save module B, but throws an exception for whatever reason
- save module that causes match against A
```

Then the resulting behavior would be:
1. exception thrown, which triggers `__close__` on `PackageExporter`
2. `PackageExporter` checks that all patterns are matched against, and sees that A was not matched.
3. Error is raised that we didn't match against pattern A.

This is confusing, since the *real* error that caused packaging to fail
occurred when trying to package module B, but it's being hidden by the
error about module A (even though if packaging module B had succeeded,
there would be no error).

Change it so that the behavior looks like:
1. exception thrown, which triggers `__close__` on `PackageExporter`
2. `PackageExporter` recognizes that an exception is happening and
immediately just returns control flow to the caller to handle the "real"
exception.

Differential Revision: [D27803988](https://our.internmc.facebook.com/intern/diff/D27803988)