### PR TITLE
Remove Tensor/Scalar check in TensorItearotr::compute_shape

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -966,8 +966,6 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
   }
 
   all_ops_same_shape_ = true;
-  bool has_scalars = false;
-  bool has_tensors = false;
   for (auto& op : operands_) {
     if (!op.tensor.defined()) continue;
 
@@ -978,14 +976,6 @@ void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {
     // pick it up later in the operands.
     if (config.resize_outputs_ && op.is_output) continue;
     auto shape = op.tensor.sizes();
-    if (shape.size() == 0) {
-      has_scalars = true;
-    } else {
-      has_tensors = true;
-    }
-    if (has_scalars && has_tensors) {
-      all_ops_same_shape_ = false;
-    }
     if (shape_.empty()) {
       shape_ = shape;
     } else if (!shape.equals(shape_)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56220 Throw in TensorIterator::maybe_get_output
* **#56208 Remove Tensor/Scalar check in TensorItearotr::compute_shape**

Only used to compute all_ops_same_shape_, which is covered by shape check.

Differential Revision: [D27807801](https://our.internmc.facebook.com/intern/diff/D27807801/)