### PR TITLE
Preserve node meta info in split_module

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -726,6 +726,11 @@ terrible spacing
         partition_counter = 0
         NPARTITIONS = 3
 
+        # Add some random meta info to make sure it is kept around.
+        for node in my_module_traced.graph.nodes:
+            if node.op != "output":
+                node.meta["test_meta_info"] = True
+
         def mod_partition(node: Node):
             nonlocal partition_counter
             partition = partition_counter % NPARTITIONS
@@ -734,6 +739,17 @@ terrible spacing
 
         # split module in module with submodules
         module_with_submodules = split_module(my_module_traced, my_module, mod_partition)
+
+        # Check that test_meta_info was still on all nodes.
+        submodules = dict(module_with_submodules.named_modules())
+        for node in module_with_submodules.graph.nodes:
+            if node.op == "call_module":
+                submod = submodules[node.target]
+                self.assertTrue(isinstance(submod, torch.fx.GraphModule))
+                for submod_node in submod.graph.nodes:
+                    if submod_node.op != "output":
+                        stored_op = submod_node.meta.get("test_meta_info")
+                        self.assertTrue(stored_op is not None and stored_op)
 
         x = torch.rand(3, 4)
         y = torch.rand(3, 4)

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -94,6 +94,7 @@ def split_module(
         partition = partitions[partition_name]
         for input in partition.inputs:
             placeholder = partition.graph.placeholder(input)
+            placeholder.meta = orig_nodes[input].meta.copy()
             partition.environment[orig_nodes[input]] = placeholder
 
     # Transform nodes and collect targets for partition's submodule
@@ -123,6 +124,7 @@ def split_module(
             assert isinstance(gathered_kwargs, dict)
             new_node = partition.graph.create_node(op=node.op, target=target, args=gathered_args,
                                                    kwargs=gathered_kwargs)
+            new_node.meta = node.meta.copy()
             partition.environment[node] = new_node
 
     # Set up values to construct base module


### PR DESCRIPTION
Summary: The current design doesn't make it easy to use `node.copy()`. Explicitly copy over the node's meta.

Test Plan: Updated `test_subgraph_creation` in `test_fx_experimental`

Differential Revision: D27808477

