### PR TITLE
[FX] Make shape_prop handle targets with aggregate outputs

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1091,6 +1091,36 @@ class TestFX(JitTestCase):
             if node.op in {'placeholder'}:
                 self.assertEqual(node.meta['tensor_meta'].memory_format, torch.channels_last)
 
+    def test_shape_prop_aggregate(self):
+        class ReturnTwo(torch.nn.Module):
+            def forward(self, x):
+                return (3, torch.sum(x))
+
+        class UnderTest(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.rt = ReturnTwo()
+
+            def forward(self, x):
+                return self.rt(x)
+
+        ut = UnderTest()
+
+        class RTTracer(torch.fx.Tracer):
+            def is_leaf_module(self, m, module_qualified_name):
+                return type(m) is ReturnTwo
+
+        graph = RTTracer().trace(ut)
+        mod = torch.fx.GraphModule(ut, graph)
+
+        shape_prop.ShapeProp(mod).propagate(torch.rand(3, 4))
+
+        for node in mod.graph.nodes:
+            if node.op == 'call_module':
+                assert 'tensor_meta' in node.meta
+                tensor_meta = node.meta['tensor_meta']
+                assert tensor_meta[0] == 3
+                assert tensor_meta[1].shape == torch.Size([])
 
     def test_shape_prop_layout_3d(self):
         class ConvTest3d(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56221 [FX] Make shape_prop handle targets with aggregate outputs**

This makes it so that, if a target returns an aggregate data structure like list or tuple or dict, we will go through and extract tensor metadata for all of the contained tensors and set `n.meta['tensor_meta']` to contain the data structure with the tensors replaced with TensorMeta

Differential Revision: [D27810693](https://our.internmc.facebook.com/intern/diff/D27810693)