### PR TITLE
Update _torch_docs.py to close #56240.

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7007,6 +7007,7 @@ Args:
         Can be a variable number of arguments or a collection like a list or tuple.
 
 Keyword args:
+    {generator}
     {out}
     {dtype}
     {layout}
@@ -7133,6 +7134,7 @@ Args:
         Can be a variable number of arguments or a collection like a list or tuple.
 
 Keyword args:
+    {generator}
     {out}
     {dtype}
     {layout}


### PR DESCRIPTION
Update _torch_docs.py to close #56240.
Added the "generator" argument to the docs of torch.rand and torch.randn.

Fixes #56240
