### PR TITLE
Updated internal code for orgqr function

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1698,15 +1698,8 @@ std::tuple<Tensor, Tensor> _linalg_qr_helper_cpu(const Tensor& self, std::string
   }
 
   // Next perform ORGQR for Q using the results (both raw R and TAU) from GEQRF
-  auto infos_orgqr = at::empty({std::max<int64_t>(1, batchCount(self))}, self.options().dtype(kInt));
-  AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES(self.scalar_type(), "qr_cpu", [&]{
-    apply_orgqr<scalar_t>(q_working_copy, tau_working_copy, infos_orgqr, n_columns_q);
-  });
-  if (self.dim() > 2) {
-    batchCheckErrors(infos_orgqr, "qr_cpu");
-  } else {
-    singleCheckErrors(infos_orgqr.item().toInt(), "qr_cpu");
-  }
+  orgqr_stub(q_working_copy.device().type(), q_working_copy, tau_working_copy, n_columns_q);
+
   return std::make_tuple(q_working_copy.narrow(-1, 0, n_columns_q), R);
 }
 
@@ -1754,11 +1747,10 @@ DEFINE_DISPATCH(orgqr_stub);
   * `input` - Tensor with the directions of the elementary reflectors below the diagonal.
   * `tau` - Tensor containing the magnitudes of the elementary reflectors.
   * `result` - result Tensor, which will contain the orthogonal (or unitary) matrix Q.
-  * `infos` - Tensor to store LAPACK/MAGMA error codes
 
   For further details, please see the LAPACK/MAGMA documentation.
 */
-Tensor& householder_product_out_info(const Tensor& input, const Tensor& tau, Tensor& result, Tensor& infos) {
+Tensor& householder_product_out_helper(const Tensor& input, const Tensor& tau, Tensor& result) {
   TORCH_INTERNAL_ASSERT(input.dim() >= 2);
   TORCH_INTERNAL_ASSERT(input.size(-2) >= input.size(-1));
   TORCH_INTERNAL_ASSERT(input.size(-1) >= tau.size(-1));
@@ -1768,10 +1760,6 @@ Tensor& householder_product_out_info(const Tensor& input, const Tensor& tau, Ten
 
   TORCH_INTERNAL_ASSERT(result.scalar_type() == input.scalar_type());
   TORCH_INTERNAL_ASSERT(result.device() == input.device());
-
-  TORCH_INTERNAL_ASSERT(infos.scalar_type() == at::kInt);
-  TORCH_INTERNAL_ASSERT(infos.device() == input.device());
-  TORCH_INTERNAL_ASSERT(infos.numel() == std::max<int64_t>(1, batchCount(input)));
 
   // if result has no elements we can modify it
   if (result.numel() == 0) {
@@ -1793,12 +1781,8 @@ Tensor& householder_product_out_info(const Tensor& input, const Tensor& tau, Ten
   // orgqr_stub (apply_orgqr) performs calculations in-place and result must be a copy of input
   result.copy_(input);
 
-  // infos must be contiguous
-  TORCH_INTERNAL_ASSERT(infos.is_contiguous());
-  infos.fill_(0);
-
   auto n = input.size(-1);
-  result = orgqr_stub(result.device().type(), result, tau_, infos, n);
+  result = orgqr_stub(result.device().type(), result, tau_, n);
   return result;
 }
 
@@ -1850,10 +1834,6 @@ Tensor& linalg_householder_product_out(const Tensor& input, const Tensor& tau, T
   //   "result shape ", result.sizes(), " does not match input shape ", input.sizes());
   // }
 
-  // cuSOLVER and MAGMA are used for CUDA inputs and cuSOLVER requires 'infos' to reside in GPU memory
-  // MAGMA path doesn't use it
-  auto infos = at::empty({std::max<int64_t>(1, batchCount(input))}, input.options().dtype(kInt));
-
   bool result_input_same_type = (result.scalar_type() == input.scalar_type());
   bool result_equal_expected_shape = result.sizes().equals(input.sizes());
   bool is_batched_column_major = false;
@@ -1868,20 +1848,14 @@ Tensor& linalg_householder_product_out(const Tensor& input, const Tensor& tau, T
   // we have to allocate a temporary tensor
   if (copy_needed) {
     Tensor result_tmp = at::empty({0}, input.options());
-    result_tmp = householder_product_out_info(input, tau, result_tmp, infos);
+    result_tmp = householder_product_out_helper(input, tau, result_tmp);
     at::native::resize_output(result, result_tmp.sizes());
     result.copy_(result_tmp);
   } else {
     // use result's storage directly
-    result = householder_product_out_info(input, tau, result, infos);
+    result = householder_product_out_helper(input, tau, result);
   }
 
-  // Now check LAPACK/MAGMA error codes
-  if (result.dim() > 2) {
-    batchCheckErrors(infos, "torch.linalg.householder_product");
-  } else {
-    singleCheckErrors(infos.item().toInt(), "torch.linalg.householder_product");
-  }
   return result;
 }
 

--- a/aten/src/ATen/native/BatchLinearAlgebra.h
+++ b/aten/src/ATen/native/BatchLinearAlgebra.h
@@ -43,72 +43,7 @@ using linalg_eig_fn = void (*)(Tensor& /*eigenvalues*/, Tensor& /*eigenvectors*/
 
 DECLARE_DISPATCH(linalg_eig_fn, linalg_eig_stub);
 
-/*
-  The orgqr function allows reconstruction of an orthogonal (or unitary) matrix Q,
-  from a sequence of elementary reflectors, such as produced by the geqrf function.
-
-  Args:
-  * `self` - Tensor with the directions of the elementary reflectors below the diagonal,
-              it will be overwritten with the result
-  * `tau` - Tensor containing the magnitudes of the elementary reflectors
-  * `infos` - Tensor to store LAPACK's error codes
-  * `n_columns` - The number of columns of Q to be computed
-
-  For further details, please see the LAPACK documentation for ORGQR and UNGQR.
-*/
-template <typename scalar_t>
-inline void apply_orgqr(Tensor& self, const Tensor& tau, Tensor& infos, int64_t n_columns) {
-#ifndef USE_LAPACK
-  TORCH_CHECK(false, "Calling torch.orgqr on a CPU tensor requires compiling ",
-    "PyTorch with LAPACK. Please use PyTorch built with LAPACK support.");
-#else
-  // Some LAPACK implementations might not work well with empty matrices:
-  // workspace query might return lwork as 0, which is not allowed (requirement is lwork >= 1)
-  // We don't need to do any calculations in this case, so let's return early
-  if (self.numel() == 0) {
-    infos.fill_(0);
-    return;
-  }
-
-  using value_t = typename c10::scalar_value_type<scalar_t>::type;
-  auto self_data = self.data_ptr<scalar_t>();
-  auto tau_data = tau.data_ptr<scalar_t>();
-  auto infos_data = infos.data_ptr<int>();
-  auto self_matrix_stride = matrixStride(self);
-  auto tau_stride = tau.size(-1);
-  auto batch_size = batchCount(self);
-  auto m = self.size(-2);
-  auto k = tau.size(-1);
-  auto lda = std::max<int64_t>(1, m);
-
-  // LAPACK's requirement
-  TORCH_INTERNAL_ASSERT(m >= n_columns);
-  TORCH_INTERNAL_ASSERT(n_columns >= k);
-
-  // Run once, first to get the optimum work size.
-  // Since we deal with batches of matrices with the same dimensions, doing this outside
-  // the loop saves (batch_size - 1) workspace queries which would provide the same result
-  // and (batch_size - 1) calls to allocate and deallocate workspace using at::empty()
-  int lwork = -1;
-  scalar_t wkopt;
-  lapackOrgqr<scalar_t>(m, n_columns, k, self_data, lda, tau_data, &wkopt, lwork, &infos_data[0]);
-  lwork = std::max<int>(1, real_impl<scalar_t, value_t>(wkopt));
-  Tensor work = at::empty({lwork}, self.options());
-
-  for (int64_t i = 0; i < batch_size; i++) {
-    scalar_t* self_working_ptr = &self_data[i * self_matrix_stride];
-    scalar_t* tau_working_ptr = &tau_data[i * tau_stride];
-    int* info_working_ptr = &infos_data[i];
-    // now compute the actual Q
-    lapackOrgqr<scalar_t>(m, n_columns, k, self_working_ptr, lda, tau_working_ptr, work.data_ptr<scalar_t>(), lwork, info_working_ptr);
-    if (*info_working_ptr != 0) {
-      return;
-    }
-  }
-#endif
-}
-
-using orgqr_fn = Tensor& (*)(Tensor& /*result*/, const Tensor& /*tau*/, Tensor& /*infos*/, int64_t /*n_columns*/);
+using orgqr_fn = Tensor& (*)(Tensor& /*result*/, const Tensor& /*tau*/, int64_t /*n_columns*/);
 DECLARE_DISPATCH(orgqr_fn, orgqr_stub);
 
 using linalg_eigh_fn = void (*)(

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1948,14 +1948,14 @@ REGISTER_DISPATCH(triangular_solve_stub, &triangular_solve_kernel);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ orgqr ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tensor& orgqr_kernel_impl(Tensor& result, const Tensor& tau, Tensor& infos, int64_t n_columns) {
+Tensor& orgqr_kernel_impl(Tensor& result, const Tensor& tau, int64_t n_columns) {
   // TODO: It is possible to implement efficient batched orgqr for small tau (tau.size(-1) <= 32)
   // using MAGMA, however it fails on Windows because of some illegal memory reads inside MAGMA.
   // See discussions in https://github.com/pytorch/pytorch/pull/51348 for comparison of cuSOLVER-MAGMA
   // and Windows failure.
   // For reference here is the MAGMA-based implementation: https://gist.github.com/IvanYashchuk/2db50002c9d3c1462ff769e6410ad983
   #if defined(USE_CUSOLVER)
-    return orgqr_helper_cuda_lib(result, tau, infos, n_columns); // cusolver
+    return orgqr_helper_cusolver(result, tau, n_columns); // cusolver
   #else
     TORCH_CHECK(false, "Calling torch.orgqr on a CUDA tensor requires compiling ",
       "PyTorch with cuSOLVER. Please use PyTorch built with cuSOLVER support.");

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.h
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebraLib.h
@@ -32,7 +32,7 @@ Tensor _cholesky_helper_cuda_cusolver(const Tensor& self, bool upper);
 Tensor _cholesky_solve_helper_cuda_cusolver(const Tensor& self, const Tensor& A, bool upper);
 Tensor& cholesky_inverse_kernel_impl_cusolver(Tensor &result, Tensor& infos, bool upper);
 
-Tensor& orgqr_helper_cuda_lib(Tensor& result, const Tensor& tau, Tensor& infos, int64_t n_columns);
+Tensor& orgqr_helper_cusolver(Tensor& result, const Tensor& tau, int64_t n_columns);
 
 void linalg_eigh_cusolver(Tensor& eigenvalues, Tensor& eigenvectors, Tensor& infos, bool upper, bool compute_eigenvectors);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56257 Fix MAGMA qr for empty batched inputs
* #56256 Add cuSOLVER path for torch.linalg.qr
* #56255 Remove size arguments for internal orgqr and geqrf calls
* #56254 Add non-allocating helper function for torch.linalg.qr
* #56253 Add cuBLAS path for batched torch.geqrf
* #56252 Add cuSOLVER path for torch.geqrf
* #56251 Port CUDA torch.geqrf to ATen
* #56250 Update internal code for torch.geqrf
* #56249 Port CPU torch.geqrf to ATen
* #56248 Removed infos vector in torch.linalg.qr
* **#56247 Updated internal code for orgqr function**

Moved `apply_orgqr` to `BatchLinearAlgebraKernel.cpp`.

Removed `infos` tensor parameter. We don't need to expose
lapack/cusolver error codes because they do not contain any useful
information about the input. Its value is checked only in debug mode now
removing the device syncronization from the cuSOLVER path of
`torch.linalg.householder_product` or `torch.orgqr`.

Differential Revision: [D27844339](https://our.internmc.facebook.com/intern/diff/D27844339)