### PR TITLE
Improved docs for `torch.linalg`

### DIFF
--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -27,7 +27,7 @@ Matrix Properties
     cond
     matrix_rank
 
-Factorizations
+Decompositions
 --------------
 
 .. autosummary::
@@ -41,6 +41,7 @@ Factorizations
     eigh
     eigvalsh
     svd
+    svdvals
 
 Solvers
 -------

--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -13,32 +13,72 @@ function for details.
 .. automodule:: torch.linalg
 .. currentmodule:: torch.linalg
 
-Functions
----------
+Matrix Properties
+-----------------
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
 
-
-    cholesky
-    cond
+    norm
+    vector_norm
     det
     slogdet
+    cond
+    matrix_rank
+
+Factorizations
+--------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    cholesky
+    qr
     eig
     eigvals
     eigh
     eigvalsh
-    matrix_power
-    matrix_rank
-    multi_dot
-    norm
-    vector_norm
-    pinv
     svd
+
+Solvers
+-------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
     solve
+    lstsq
+
+Inverses
+--------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    inv
+    pinv
+
+Matrix Products
+---------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    matrix_power
+    multi_dot
+    householder_product
+
+Tensor Operations
+-----------------
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
     tensorinv
     tensorsolve
-    inv
-    qr
-    lstsq
-    householder_product

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8558,7 +8558,7 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: The singular values of a matrix are not unique. Any pair of left and right singular values may 
+.. warning:: The singular values of a matrix are not unique. Any pair of left and right singular values may
              be multiplied by `-1` in the real case or by a factor of norm `1` :math:`e^{i \phi}` in the complex case.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8502,25 +8502,30 @@ add_docstr(torch.svd,
 svd(input, some=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
 Computes the singular value decomposition of either a matrix or batch of
-matrices :attr:`input`. The singular value decomposition is represented as a
-namedtuple `(U, S, V)`, such that :attr:`input` `= U diag(S) Vᴴ`.
+matrices :attr:`input`.
+
+The singular value decomposition is represented as a
+namedtuple `(U, S, V)`, such that `input = U diag(S) Vᴴ`.
 where `Vᴴ` is the transpose of `V` for real inputs,
 and the conjugate transpose of `V` for complex inputs.
-If :attr:`input` is a batch of matrices, then `U`, `S`, and `V` are also
+If :attr:`input` is a batch of matrices, then `U`, `S`, `V` are also
 batched with the same batch dimensions as :attr:`input`.
 
+The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
+the singular values of each matrix in the batch are returned in descending order.
+
 If :attr:`some` is `True` (default), the method returns the reduced singular
-value decomposition. In this case, if the last two dimensions of :attr:`input` are
-`m` and `n`, then the returned `U` and `V` matrices will contain only
-`min(n, m)` orthonormal columns.
+value decomposition. In this case, if :attr:`input` is of size `(*, m, n)`,
+the returned `U`, `V` will be of size `(*, m, min(m, n))` and `(*, n, min(m, n))`
+respectively.
 
 If :attr:`compute_uv` is `False`, the returned `U` and `V` will be
 zero-filled matrices of shape `(m, m)` and `(n, n)`
 respectively, and the same device as :attr:`input`. The argument :attr:`some`
 has no effect when :attr:`compute_uv` is `False`.
 
-Supports :attr:`input` of float, double, cfloat and cdouble data types.
-The dtypes of `U` and `V` are the same as :attr:`input`'s. `S` will
+Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+The dtype of `U` and `V` is the same as that of :attr:`input`. `S` will
 always be real-valued, even if :attr:`input` is complex.
 
 .. warning:: :func:`torch.svd` is deprecated. Please use
@@ -8539,38 +8544,34 @@ always be real-valued, even if :attr:`input` is complex.
                tensors for `U` and `Vh`, whereas :func:`torch.linalg.svd` returns
                empty tensors.
 
-.. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-          then the singular values of each matrix in the batch are returned in descending order.
-
 .. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv` is `True`.
 
 .. note:: When :attr:`some` is `False`, the gradients on `U[..., :, min(m, n):]`
           and `V[..., :, min(m, n):]` will be ignored in the backward pass, as those vectors
           can be arbitrary bases of the corresponding subspaces.
 
-.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `?gesdd`
-          (a divide-and-conquer algorithm) instead of `?gesvd` for speed. Analogously,
+.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `gesdd`
+          (a divide-and-conquer algorithm) instead of `gesvd` for speed. Analogously,
           on GPU, it uses cuSOLVER's routines `gesvdj` and `gesvdjBatched` on CUDA 10.1.243
           and later, and MAGMA's routine `gesdd` on earlier versions of CUDA.
 
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: The gradients with respect to `U` and `V` will only be finite when the input does not
-             have zero nor repeated singular values.
-
-.. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
-             `U` and `V` will be numerically unstable, as they depends on
-             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when the matrix
-             has small singular values, as these gradients also depend on `S⁻¹`.
-
-.. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
-             as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
+.. warning:: The singular values of a matrix are not unique. Any pair of left and right singular values may 
+             be multiplied by `-1` in the real case or by a factor of norm `1` :math:`e^{i \phi}` in the complex case.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
              and `the resulting vectors will span the same subspace`_.
              Different platforms, like NumPy, or inputs on different device types,
-             may produce different `U` and `V` tensors.
+             may produce different `U` and `Vh` tensors.
+
+.. warning:: The gradients with respect to `U` and `Vh` will only be finite when :attr:`input`
+             does not have zero or repeated singular values.
+             If the distance between any two singular values is close to zero, the gradients with respect to
+             `U` and `V` will be numerically unstable, as they depends on
+             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when :attr:`input`
+             has small singular values, as these gradients also depend on `S⁻¹`.
 
 Args:
     input (Tensor): the input tensor of size `(*, m, n)` where `*` is zero or more

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -8502,30 +8502,25 @@ add_docstr(torch.svd,
 svd(input, some=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
 Computes the singular value decomposition of either a matrix or batch of
-matrices :attr:`input`.
-
-The singular value decomposition is represented as a
-namedtuple `(U, S, V)`, such that `input = U diag(S) Vᴴ`.
+matrices :attr:`input`. The singular value decomposition is represented as a
+namedtuple `(U, S, V)`, such that :attr:`input` `= U diag(S) Vᴴ`.
 where `Vᴴ` is the transpose of `V` for real inputs,
 and the conjugate transpose of `V` for complex inputs.
-If :attr:`input` is a batch of matrices, then `U`, `S`, `V` are also
+If :attr:`input` is a batch of matrices, then `U`, `S`, and `V` are also
 batched with the same batch dimensions as :attr:`input`.
 
-The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-the singular values of each matrix in the batch are returned in descending order.
-
 If :attr:`some` is `True` (default), the method returns the reduced singular
-value decomposition. In this case, if :attr:`input` is of size `(*, m, n)`,
-the returned `U`, `V` will be of size `(*, m, min(m, n))` and `(*, n, min(m, n))`
-respectively.
+value decomposition. In this case, if the last two dimensions of :attr:`input` are
+`m` and `n`, then the returned `U` and `V` matrices will contain only
+`min(n, m)` orthonormal columns.
 
 If :attr:`compute_uv` is `False`, the returned `U` and `V` will be
 zero-filled matrices of shape `(m, m)` and `(n, n)`
 respectively, and the same device as :attr:`input`. The argument :attr:`some`
 has no effect when :attr:`compute_uv` is `False`.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The dtype of `U` and `V` is the same as that of :attr:`input`. `S` will
+Supports :attr:`input` of float, double, cfloat and cdouble data types.
+The dtypes of `U` and `V` are the same as :attr:`input`'s. `S` will
 always be real-valued, even if :attr:`input` is complex.
 
 .. warning:: :func:`torch.svd` is deprecated. Please use
@@ -8544,34 +8539,38 @@ always be real-valued, even if :attr:`input` is complex.
                tensors for `U` and `Vh`, whereas :func:`torch.linalg.svd` returns
                empty tensors.
 
+.. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
+          then the singular values of each matrix in the batch are returned in descending order.
+
 .. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv` is `True`.
 
 .. note:: When :attr:`some` is `False`, the gradients on `U[..., :, min(m, n):]`
           and `V[..., :, min(m, n):]` will be ignored in the backward pass, as those vectors
           can be arbitrary bases of the corresponding subspaces.
 
-.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `gesdd`
-          (a divide-and-conquer algorithm) instead of `gesvd` for speed. Analogously,
+.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `?gesdd`
+          (a divide-and-conquer algorithm) instead of `?gesvd` for speed. Analogously,
           on GPU, it uses cuSOLVER's routines `gesvdj` and `gesvdjBatched` on CUDA 10.1.243
           and later, and MAGMA's routine `gesdd` on earlier versions of CUDA.
 
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: The singular values of a matrix are not unique. Any pair of left and right singular values may
-             be multiplied by `-1` in the real case or by a factor of norm `1` :math:`e^{i \phi}` in the complex case.
+.. warning:: The gradients with respect to `U` and `V` will only be finite when the input does not
+             have zero nor repeated singular values.
+
+.. warning:: If the distance between any two singular values is close to zero, the gradients with respect to
+             `U` and `V` will be numerically unstable, as they depends on
+             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when the matrix
+             has small singular values, as these gradients also depend on `S⁻¹`.
+
+.. warning:: For complex-valued :attr:`input` the singular value decomposition is not unique,
+             as `U` and `V` may be multiplied by an arbitrary phase factor :math:`e^{i \phi}` on every column.
              The same happens when :attr:`input` has repeated singular values, where one may multiply
              the columns of the spanning subspace in `U` and `V` by a rotation matrix
              and `the resulting vectors will span the same subspace`_.
              Different platforms, like NumPy, or inputs on different device types,
-             may produce different `U` and `Vh` tensors.
-
-.. warning:: The gradients with respect to `U` and `Vh` will only be finite when :attr:`input`
-             does not have zero or repeated singular values.
-             If the distance between any two singular values is close to zero, the gradients with respect to
-             `U` and `V` will be numerically unstable, as they depends on
-             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when :attr:`input`
-             has small singular values, as these gradients also depend on `S⁻¹`.
+             may produce different `U` and `V` tensors.
 
 Args:
     input (Tensor): the input tensor of size `(*, m, n)` where `*` is zero or more

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -12,7 +12,8 @@ Tensor = torch.Tensor
 cholesky = _add_docstr(_linalg.linalg_cholesky, r"""
 linalg.cholesky(input, *, out=None) -> Tensor
 
-Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix. Supports batched inputs.
+Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix.
+Supports batched inputs.
 
 For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1172,7 +1172,7 @@ the **full SVD** of a matrix
 .. math::
 
     A = U \operatorname{diag}(S) V^{\text{H}}
-    \mathrlap{\qquad U \in \mathbb{K}^{m \times m}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{n \times n}}
+    \mathrlap{\qquad U \in \mathbb{K}^{m \times m}, S \in \mathbb{R}^k, V \in \mathbb{K}^{n \times n}}
 
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{m \times n}`,
 :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
@@ -1183,7 +1183,7 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
 .. math::
 
     A = U \operatorname{diag}(S) V^{\text{H}}
-    \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
+    \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, S \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
 
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`. In this case, :math:`U` and :math:`V` also have orthonormal columns.
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -294,8 +294,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 .. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
 .. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
-          respectively.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+          respectively. For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. warning:: The eigenvectors of a matrix are not unique, nor are they continuous with respect to
              :attr:`A`. Due to this lack of uniqueness, different hardware and software may compute
@@ -1227,7 +1226,8 @@ Differences with `numpy.linalg.svd`:
           On CUDA, it uses cuSOLVER's `gesvdj` and `gesvdjBatched` on CUDA 10.1.243 and later,
           and MAGMA's `gesdd` on earlier versions of CUDA.
 
-.. warning:: The `U` and `V` are not unique, nor are they continuous with respect to :attr:`A`.
+.. warning:: The returned tensors `U` and `V` are not unique, nor are they continuous with
+             respect to :attr:`A`.
              Due to this lack of uniqueness, different hardware and software may compute
              different singular vectors.
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -895,7 +895,7 @@ Examples::
 multi_dot = _add_docstr(_linalg.linalg_multi_dot, r"""
 linalg.multi_dot(tensors, *, out=None)
 
-Efficiently multiplies two or more matrices by reordering the multiplications so that 
+Efficiently multiplies two or more matrices by reordering the multiplications so that
 the fewest arithmetic operations are performed.
 
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1364,7 +1364,7 @@ linalg.cond(A, p=None, *, out=None) -> Tensor
 Computes the condition number of a matrix with respect to a matrix norm.
 
 Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
-The **condition number** :math:`\kappa` of a matrix
+the **condition number** :math:`\kappa` of a matrix
 :math:`A \in \mathbb{K}^{n \times n}` is defined as
 
 .. math::
@@ -1429,7 +1429,7 @@ Args:
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
-Returnsk:
+Returns:
     A real-valued tensor, even when :attr:`A` is complex.
 
 Raises:

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1185,7 +1185,7 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
     A = U \operatorname{diag}(S) V^{\text{H}}
     \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
 
-where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`,
+where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`. In this case, :math:`U` and :math:`V` also have orthonormal columns.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
@@ -1195,17 +1195,13 @@ which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
 
 The singular values are returned in descending order.
 
-The parameter :attr:`full_matrices` controls the shape of the output. If :attr:`A` has shape
-`(*, m, n)`, denoting `k = min(m, n)`
+The parameter :attr:`full_matrices` chooses between the full and reduced SVD.
+If :attr:`A` has shape `(*, m, n)`, denoting `k = min(m, n)`
 
-- :attr:`full_matrices`\ `= True` (default): Returns the full SVD decomposition.
+- :attr:`full_matrices`\ `= True` (default): Returns the full SVD.
   The returned tensors `(U, S, Vh)` will have shapes `(*, m, m)`, `(*, k)`, `(*, n, n)` respectively.
-- :attr:`full_matrices`\ `= False`: Returns the reduced SVD decomposition.
+- :attr:`full_matrices`\ `= False`: Returns the reduced SVD.
   The returned tensors `(U, S, Vh)` will have shapes `(*, m, k)`, `(*, k)`, `(*, k, n)` respectively.
-
-If :attr:`compute_uv`\ `= False`, the returned `U` and `Vh` will be empty
-tensors with no elements and the same device as :attr:`A`. The
-:attr:`full_matrices` argument has no effect when :attr:`compute_uv`\ `= False`.
 
 Differences with `numpy.linalg.svd`:
 
@@ -1213,9 +1209,7 @@ Differences with `numpy.linalg.svd`:
   When :attr:`compute_uv`\ `= False`, `U`, `Vh` are empty tensors.
   This behavior may change in a future PyTorch release.
   Please use :func:`torch.linalg.svdvals`, which computes only the singular values,
-  instead of `compute_uv=False`.
-
-.. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv`\ `= True`.
+  instead of :attr:`compute_uv`\ `= False`.
 
 .. note:: When :attr:`full_matrices`\ `= True`, the gradients with respect to `U[..., :, min(m, n):]`
           and `Vh[..., min(m, n):, :]` will be ignored, as those vectors can be arbitrary bases

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -12,7 +12,7 @@ Tensor = torch.Tensor
 cholesky = _add_docstr(_linalg.linalg_cholesky, r"""
 linalg.cholesky(input, *, out=None) -> Tensor
 
-Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix or of a batch of such matrices.
+Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix. Supports batched inputs.
 
 For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 
@@ -93,7 +93,7 @@ Examples::
 inv = _add_docstr(_linalg.linalg_inv, r"""
 linalg.inv(input, *, out=None) -> Tensor
 
-Computes the `inverse`_ of square matrix or of a batch of square matrices if it exists.
+Computes the `inverse`_ of square matrix if it exists. Supports batched inputs
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
@@ -155,7 +155,7 @@ Examples::
 det = _add_docstr(_linalg.linalg_det, r"""
 linalg.det(input, *, out=None) -> Tensor
 
-Computes the determinant of a matrix or of a batch of matrices.
+Computes the determinant of a square matrix. Supports batched inputs.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
@@ -210,10 +210,10 @@ Example::
 slogdet = _add_docstr(_linalg.linalg_slogdet, r"""
 linalg.slogdet(input, *, out=None) -> (Tensor, Tensor)
 
-Computes the sign and logarithm of the norm of the determinant of a square matrix or of a batch of square matrices.
+Computes the sign and logarithm of the norm of the determinant of a square matrix. Supports batched inputs.
 
-For a complex :attr:`input`, as the determinant is complex in this case, it returns the angle
-and the logarithm of the modulus of the determinant, that is, a logarithmic polar decomposition of the determinant.
+For a complex :attr:`input`, it returns the angle and the logarithm of the modulus of the
+determinant, that is, a logarithmic polar decomposition of the determinant.
 
 It returns a named tuple `(sign, logabsdet)`.
 If :attr:`input` is a batch of matrices, then `sign`, `logabsdet` are also batched with the same
@@ -259,7 +259,7 @@ Example::
 eig = _add_docstr(_linalg.linalg_eig, r"""
 linalg.eig(input, *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a square matrix or of a batch of square matrices if it exists.
+Computes the eigenvalue decomposition of a square matrix if it exists. Supports batched inputs.
 
 For a square matrix :math:`A`, this is defined as
 
@@ -346,7 +346,7 @@ Examples::
 eigvals = _add_docstr(_linalg.linalg_eigvals, r"""
 linalg.eigvals(input, *, out=None) -> Tensor
 
-Computes the eigenvalues of a square matrix or of a batch of square matrices.
+Computes the eigenvalues of a square matrix. Supports batched inputs.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 The output tensor will always be complex-valued, even when :attr:`input` is real.
@@ -380,7 +380,7 @@ Examples::
 eigh = _add_docstr(_linalg.linalg_eigh, r"""
 linalg.eigh(input, UPLO='L', *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix or of a batch of such matrices.
+Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix. Supports batched inputs.
 
 For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 
@@ -482,8 +482,7 @@ Examples::
 eigvalsh = _add_docstr(_linalg.linalg_eigvalsh, r"""
 linalg.eigvalsh(input, UPLO='L', *, out=None) -> Tensor
 
-Computes the eigenvalues and eigenvectors of a complex Hermitian or real symmetric
-matrix or of a batch of such matrices.
+Computes the eigenvalues of a complex Hermitian or real symmetric matrix. Supports batched inputs.
 
 The eigenvalues are returned in ascending order.
 
@@ -544,7 +543,7 @@ Examples::
 householder_product = _add_docstr(_linalg.linalg_householder_product, r"""
 householder_product(input, tau, *, out=None) -> Tensor
 
-Computes the first `n` columns of a product of Householder matrices or of a batch of such matrices
+Computes the first `n` columns of a product of Householder matrices. Supports batched inputs.
 
 Assume that :attr:`input` has shape `(*, m, n)` with `m >= n` and :attr:`tau` has shape
 `(*, k)` with `k <= n` where `*` is zero or more batch dimensions. Denoting
@@ -613,7 +612,7 @@ Examples::
 lstsq = _add_docstr(_linalg.linalg_lstsq, r"""
 torch.linalg.lstsq(input, b, cond=None, *, driver=None) -> (Tensor, Tensor, Tensor, Tensor)
 
-Computes the least squares solution of a system (or of a batch of systems) of linear equations.
+Computes the least squares solution of a system  of linear equations. Supports batched inputs.
 
 Assume that :attr:`input`, :attr:`b` have shapes `(*, m, n)`, `(*, m, k)` where `*` is zero
 or more batch dimensions. For every matrix :math:`A` in :attr:`input` and every set :math:`B`
@@ -714,7 +713,7 @@ Example::
 matrix_power = _add_docstr(_linalg.linalg_matrix_power, r"""
 matrix_power(input, n, *, out=None) -> Tensor
 
-Computes the :attr:`n`-th power of a matrix or of a batch of matrices for an integer :attr:`n`.
+Computes the :attr:`n`-th power of a matrix for an integer :attr:`n`. Supports batched inputs.
 
 If :attr:`n` `= 0`, it returns the identity matrix (or batch) of the same shape
 as :attr:`input`. If :attr:`n` is negative, it returns the inverse of each matrix
@@ -754,7 +753,7 @@ Example::
 matrix_rank = _add_docstr(_linalg.linalg_matrix_rank, r"""
 matrix_rank(input, tol=None, hermitian=False, *, out=None) -> Tensor
 
-Computes the numerical rank of a matrix or of a batch of matrices
+Computes the numerical rank of a matrix. Supports batched inputs.
 
 The matrix rank is computed as the number of singular values
 (or eigenvalues in absolute value when :attr:`hermitian`\ `= True`)
@@ -831,7 +830,7 @@ Examples::
 vector_norm = _add_docstr(_linalg.linalg_vector_norm, r"""
 linalg.vector_norm(input, ord=None, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
 
-Computes the vector norm of a vector or of a batch of vectors.
+Computes the vector norm of a vector. Supports batched inputs.
 
 If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
 
@@ -961,7 +960,7 @@ Examples::
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
 
-Computes the matrix norm or vector norm of a vector or a matrix or of a batch of any of the two.
+Computes the vector norm of a vector or the matrix norm of a matrix. Supports batched inputs.
 
 If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
 
@@ -1084,13 +1083,13 @@ Using the :attr:`dim` argument to compute matrix norms::
 svd = _add_docstr(_linalg.linalg_svd, r"""
 linalg.svd(input, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
-Computes the singular value decomposition of a matrix or of a batch of matrices.
+Computes the singular value decomposition of a matrix. Supports batched inputs.
 
 For a matrix :math:`A`, this is defined as
 
 .. math::
 
-    \text{input} = U \operatorname{diag}(S) V^{\text{H}}
+    A = U \operatorname{diag}(S) V^{\text{H}}
 
 where :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
 The matrices  :math:`U`, :math:`V` (and thus :math:`V^{\text{H}}`) are orthogonal in the real case,
@@ -1257,7 +1256,7 @@ Example::
 cond = _add_docstr(_linalg.linalg_cond, r"""
 linalg.cond(input, p=None, *, out=None) -> Tensor
 
-Computes the condition number with respect to a norm of a matrix or of a batch of matrices.
+Computes the condition number of a matrix with respect to a norm. Supports batched inputs.
 
 The condition number :math:`\kappa` of a matrix :math:`A` is defined as
 
@@ -1386,7 +1385,7 @@ Examples::
 pinv = _add_docstr(_linalg.linalg_pinv, r"""
 linalg.pinv(input, rcond=1e-15, hermitian=False, *, out=None) -> Tensor
 
-Computes the Moore-Penrose pseudoinverse of a matrix or of a batch of matrices.
+Computes the Moore-Penrose pseudoinverse of a matrix. Supports batched inputs.
 
 If :attr:`hermitian`\ `= True`, :attr:`input` should be a complex Hermitian or real symmetric
 matrix or batch of matrices. In this case, it will just use the lower-triangular half of the matrix.
@@ -1483,7 +1482,7 @@ Examples::
 solve = _add_docstr(_linalg.linalg_solve, r"""
 linalg.solve(input, other, *, out=None) -> Tensor
 
-Computes the solution of a square system (or of a batch of square systems) of linear equations with unique solution.
+Computes the solution of a square system  of linear equations with unique solution. Supports batched inputs.
 
 This method accepts both matrices and vectors as the right-hand side of the linear equation.
 We will denote by `*` zero or more batch dimensions.
@@ -1621,7 +1620,7 @@ Examples::
 tensorsolve = _add_docstr(_linalg.linalg_tensorsolve, r"""
 linalg.tensorsolve(input, other, dims=None, *, out=None) -> Tensor
 
-Computes the action of the multiplicative inverse of :func:`torch.tensordot` on a tensor.
+Computes the solution `X` to the system `torch.tensordot(input, X) = other`.
 
 If `m` is the product of the first :attr:`other`\ `.ndim`  dimensions of :attr:`input` and
 `n` is the product of the rest of the dimensions, this function expects `m` and `n` to be equal.
@@ -1685,7 +1684,7 @@ Examples::
 qr = _add_docstr(_linalg.linalg_qr, r"""
 qr(input, mode='reduced', *, out=None) -> (Tensor, Tensor)
 
-Computes the QR decomposition of a matrix or of a batch of matrices.
+Computes the QR decomposition of a matrix. Supports batched inputs.
 
 For a matrix :math:`A`, this is defined as
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -93,7 +93,7 @@ Examples::
 inv = _add_docstr(_linalg.linalg_inv, r"""
 linalg.inv(A, *, out=None) -> Tensor
 
-Computes the `inverse`_ of a square matrix if it exists.
+Computes the inverse of a square matrix if it exists.
 Throws a `RuntimeError` if the matrix is not invertible.
 
 Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
@@ -164,8 +164,6 @@ Examples::
     >>> torch.dist(z, torch.eye(4, dtype=torch.cdouble))
     tensor(7.5107e-16, dtype=torch.float64)
 
-.. _inverse:
-    https://en.wikipedia.org/wiki/Invertible_matrix
 .. _invertible:
     https://en.wikipedia.org/wiki/Invertible_matrix#The_invertible_matrix_theorem
 """)
@@ -779,7 +777,7 @@ Example::
 matrix_power = _add_docstr(_linalg.linalg_matrix_power, r"""
 matrix_power(A, n, *, out=None) -> Tensor
 
-Computes the n-th power of a square matrix for an integer n.
+Computes the `n`-th power of a square matrix for an integer `n`.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
@@ -913,7 +911,7 @@ Examples::
 vector_norm = _add_docstr(_linalg.linalg_vector_norm, r"""
 linalg.vector_norm(A, ord=None, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
 
-Computes a vector norm of a vector.
+Computes a vector norm.
 
 If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
 
@@ -1175,7 +1173,8 @@ the **full SVD** of a matrix
 
 .. math::
 
-    A = U \operatorname{diag}(S) V^{\text{H}}\mathrlap{\qquad U \in \mathbb{K}^{m \times m}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{n \times n}}
+    A = U \operatorname{diag}(S) V^{\text{H}}
+    \mathrlap{\qquad U \in \mathbb{K}^{m \times m}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{n \times n}}
 
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{m \times n}`,
 :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
@@ -1185,7 +1184,8 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
 
 .. math::
 
-    A = U \operatorname{diag}(S) V^{\text{H}}\mathrlap{\qquad U \in \mathbb{K}^{m \times k}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
+    A = U \operatorname{diag}(S) V^{\text{H}}
+    \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, \Lambda \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
 
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`,
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1171,7 +1171,8 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
     A = U \operatorname{diag}(S) V^{\text{H}}
     \mathrlap{\qquad U \in \mathbb{K}^{m \times k}, S \in \mathbb{R}^k, V \in \mathbb{K}^{k \times n}}
 
-where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`. In this case, :math:`U` and :math:`V` also have orthonormal columns.
+where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`.
+In this case, :math:`U` and :math:`V` also have orthonormal columns.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -28,8 +28,7 @@ where :math:`L` is a lower triangular matrix and
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-.. note:: This function uses LAPACK's and MAGMA's `potrf` for CPU and CUDA inputs respectively.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. seealso::
 
@@ -112,11 +111,7 @@ the inverse is unique.
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-.. note:: This function is computed using LAPACK's `getrf` and `getri` for CPU inputs.
-          For CUDA inputs, cuSOLVER's `getrf` and `getrs` as well as cuBLAS' `getrf`
-          and `getri` are used if CUDA version >= 10.1.243, otherwise MAGMA's `getrf`
-          and `getri` are used instead.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. seealso::
 
@@ -292,8 +287,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 .. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
-.. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
-          respectively. For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. warning:: The eigenvectors of a matrix are not unique, nor are they continuous with respect to
              :attr:`A`. Due to this lack of uniqueness, different hardware and software may compute
@@ -382,9 +376,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
           The eigenvalues of a matrix are always well-defined, even when the matrix is not diagonalizable.
 
-.. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
-          respectively.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: This function is not differentiable. If you need differentiability use
           :func:`torch.linalg.eig` instead, which also computes the eigenvectors.
@@ -435,10 +427,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 The eigenvalues are returned in ascending order.
 
-.. note:: If the inputs are symmetric, this function is computed using LAPACK's and MAGMA's
-          `syevd` for CPU and CUDA inputs,
-          If the inputs are Hermitian, it is computed using LAPACK's and MAGMA's `heevd`.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: The eigenvalues of real symmetric or complex Hermitian matrices are always real.
 
@@ -545,9 +534,7 @@ The eigenvalues are returned in ascending order.
 - If :attr:`UPLO`\ `= 'L'` (default), only the lower triangular part of the matrix is used in the computation.
 - If :attr:`UPLO`\ `= 'U'`, only the upper triangular part of the matrix is used.
 
-.. note:: This function is computed using LAPACK's and MAGMA's `syevd` / `heevd` for
-          CPU and CUDA symmetric / Hermitian inputs respectively.
-          For CUDA inputs, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: This function is not differentiable. If you need differentiability use
           :func:`torch.linalg.eigh` instead, which also computes the eigenvectors.
@@ -615,9 +602,6 @@ See `Representation of Orthogonal or Unitary Matrices`_ for further details.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
-
-.. note:: This function is computed using LAPACK's `orgqr` for CPU inputs,
-          and cuSOLVER's `orgqr` for CUDA inputs if CUDA version >= 10.1.243.
 
 .. note:: This function only uses the values strictly below the main diagonal of :attr:`A`.
           The other values are ignored.
@@ -1208,10 +1192,6 @@ Differences with `numpy.linalg.svd`:
 .. note:: When :attr:`full_matrices`\ `= True`, the gradients with respect to `U[..., :, min(m, n):]`
           and `Vh[..., min(m, n):, :]` will be ignored, as those vectors can be arbitrary bases
           of the corresponding subspaces.
-
-.. note:: On CPU, this function uses LAPACK's `gesdd` instead of `gesvd` for speed.
-          On CUDA, it uses cuSOLVER's `gesvdj` and `gesvdjBatched` on CUDA 10.1.243 and later,
-          and MAGMA's `gesdd` on earlier versions of CUDA.
 
 .. warning:: The returned tensors `U` and `V` are not unique, nor are they continuous with
              respect to :attr:`A`.
@@ -1835,8 +1815,6 @@ Differences with `numpy.linalg.qr`:
 .. note:: The elements in the diagonal of `R` are not necessarily positive.
 
 .. note:: :attr:`mode`\ `= 'r'` does not support backpropagation. Use :attr:`mode`\ `= 'reduced'` instead.
-
-.. note:: This function uses LAPACK and MAGMA for CPU and CUDA inputs respectively.
 
 .. warning:: The QR decomposition is only unique up to the sign of the diagonal of `R` when the
              first `k = min(m, n)` columns of :attr:`A` are linearly independent.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -24,7 +24,7 @@ For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 where :math:`L` is a lower triangular matrix and
 :math:`L^{\text{H}}` is the conjugate transpose when :math:`L` is complex, and the transpose when :math:`L` is real-valued.
 
-If :attr:`input` is a batch of matrices, then the returned matrices are also batched with the
+If :attr:`input` is a batch of matrices, then `L` is also batched with the
 same batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
@@ -217,7 +217,7 @@ For a complex :attr:`input`, it returns the angle and the logarithm of the modul
 determinant, that is, a logarithmic polar decomposition of the determinant.
 
 It returns a named tuple `(sign, logabsdet)`.
-If :attr:`input` is a batch of matrices, then `sign`, `logabsdet` are also batched with the same
+If :attr:`input` is a batch of matrices, then `sign` and `logabsdet` are also batched with the same
 batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
@@ -272,7 +272,7 @@ This decomposition exists if and only if :math:`A` is `diagonalizable`_. This is
 
 The returned decomposition is a named tuple `(eigenvalues, eigenvectors)`,
 which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
-then `L`, `V` are also batched with the same batch dimensions.
+then `L` and `V` are also batched with the same batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 The output tensors `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`input` is real.
@@ -399,7 +399,7 @@ When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is use
 
 The returned decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`,
 which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
-then `L`, `V` are also batched with the same batch dimensions.
+then `L` and `V` are also batched with the same batch dimensions.
 
 The eigenvalues are returned in ascending order.
 
@@ -684,7 +684,7 @@ Args:
 
 Keyword args:
     driver (str, optional): name of the LAPACK/MAGMA method to be used.
-        If `None`, `'gelsy'` is used for CPU inputs and `'gels'` for GPU inputs.
+        If `None`, `'gelsy'` is used for CPU inputs and `'gels'` for CUDA inputs.
         Default: `None`.
 
 Example::
@@ -1100,7 +1100,7 @@ and unitary in the complex case.
 
 The returned decomposition is a named tuple `(U, S, Vh)`
 which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
-If :attr:`input` is a batch of matrices, then `U`, `S`, `Vh` are also batched with the same
+If :attr:`input` is a batch of matrices, then `U`, `S` and `Vh` are also batched with the same
 batch dimensions.
 
 The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
@@ -1695,7 +1695,7 @@ For a matrix :math:`A`, this is defined as
 where :math:`Q` is orthogonal in the real case and unitary in the complex case, and :math:`R` is upper triangular.
 
 The returned decomposition is a named tuple `(Q, R)`.
-If :attr:`input` is a batch of matrices, then `Q`, `R` are also batched with the same
+If :attr:`input` is a batch of matrices, then `Q` and `R` are also batched with the same
 batch dimensions.
 
 The parameter :attr:`mode` controls the shape of the output. If :attr:`input` has shape

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -123,7 +123,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
         :func:`torch.linalg.pinv` computes the pseudoinverse (Moore-Penrose inverse) of matrices
         of any shape.
 
-        :func:`torch.linalg.solve` computes :attr:`A`\ `.inv() @ \ `:attr:`B`.
+        :func:`torch.linalg.solve` computes :attr:`A`\ `.inv() @ \ `:attr:`B` with a stable algorithm.
 
         It is always prefered to use :func:`torch.linalg.solve` when possible, as it is
         faster and more stable than computing the inverse and then multiplying.
@@ -191,7 +191,7 @@ Args:
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
-Example::
+Examples::
 
     >>> a = torch.randn(3, 3)
     >>> a
@@ -256,8 +256,7 @@ Returns:
 
     `sign` will have the same dtype as :attr:`A`.
 
-
-Example::
+Examples::
 
     >>> A = torch.randn(3, 3)
     >>> A
@@ -337,7 +336,6 @@ Returns:
 
     `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`A` is real.
 
-
 Examples::
 
     >>> a = torch.randn(2, 2, dtype=torch.complex128)
@@ -388,8 +386,8 @@ Also supports batched inputs, and, if the input is batched, the output is batche
           respectively.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: This function is not differentiable. Use :func:`torch.linalg.eig`
-          instead, which also computes the eigenvectors.
+.. note:: This function is not differentiable. If you need differentiability use
+          :func:`torch.linalg.eig` instead, which also computes the eigenvectors.
 
 Args:
     A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
@@ -551,8 +549,8 @@ The eigenvalues are returned in ascending order.
           CPU and CUDA symmetric / Hermitian inputs respectively.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: This function is not differentiable. Please use :func:`torch.linalg.eigh`
-          instead, which also computes the eigenvectors.
+.. note:: This function is not differentiable. If you need differentiability use
+          :func:`torch.linalg.eigh` instead, which also computes the eigenvectors.
 
 Args:
     A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
@@ -566,7 +564,6 @@ Keyword args:
 Returns:
     A real-valued tensor cointaining the eigenvalues even when :attr:`A` is complex.
     The eigenvalues are returned in ascending order.
-
 
 Examples::
 
@@ -748,7 +745,7 @@ Keyword args:
 Returns:
     A named tuple `(solution, residuals, rank, singular_values)`.
 
-Example::
+Examples::
 
     >>> a = torch.tensor([[10, 2, 3], [3, 10, 5], [5, 6, 12]], dtype=torch.float)
     >>> a.unsqueeze_(0)
@@ -787,7 +784,7 @@ as :attr:`A`. If :attr:`n` is negative, it returns the inverse of each matrix
 
 .. seealso::
 
-        :func:`torch.linalg.solve` computes :attr:`A`\ `.inv() @ \ `:attr:`B`.
+        :func:`torch.linalg.solve` computes :attr:`A`\ `.inv() @ \ `:attr:`B` with a stable algorithm.
 
         It is always prefered to use :func:`~matrix_power` with :attr:`n`\ `> 0` followed
         by :func:`torch.linalg.solve` when possible, rather than
@@ -805,7 +802,7 @@ Raises:
     RuntimeError: if :attr:`n`\ `< 0` and the matrix :attr:`A` or any matrix in the
                   batch of matrices :attr:`A` is not invertible.
 
-Example::
+Examples::
 
     >>> a = torch.randn(3, 3)
     >>> a
@@ -979,20 +976,22 @@ the fewest arithmetic operations are performed.
 Supports inputs of float, double, cfloat and cdouble dtypes.
 This function does not support batched inputs.
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which
-may be 1D. If the first tensor is a 1D vector of shape `n` it is treated as a row vector
-of shape `(1, n)`, similarly if the last tensor is a 1D vector of shape `n` it is treated
+may be 1D. If the first tensor is a 1D vector of shape `(n,)` it is treated as a row vector
+of shape `(1, n)`, similarly if the last tensor is a 1D vector of shape `(n,)` it is treated
 as a column vector of shape `(n, 1)`.
 
 If the first and last tensors are matrices, the output will be a matrix.
 However, if either is a 1D vector, then the output will be a 1D vector.
 
+Differences with `numpy.linalg.multi_dot`:
+
+- Unlike `numpy.linalg.multi_dot`, the first and last tensors must either be 1D or 2D
+  whereas NumPy allows them to be nD
+
 .. warning:: This function does not broadcast.
 
 .. note:: This function is implemented by chaining :func:`torch.mm` calls after
           computing the optimal matrix multiplication order.
-
-.. note:: This function is similar to NumPy's `multi_dot` except that the first and last
-          tensors must be either 1D or 2D whereas NumPy allows them to be nD.
 
 .. note:: The cost of multiplying two matrices with shapes `(a, b)` and `(b, c)` is
           `a * b * c`. Given matrices `A`, `B`, `C` with shapes `(10, 100)`,
@@ -1214,7 +1213,7 @@ Differences with `numpy.linalg.svd`:
   When :attr:`compute_uv`\ `= False`, `U`, `Vh` are empty tensors.
   This behavior may change in a future PyTorch release.
   Please use :func:`torch.linalg.svdvals`, which computes only the singular values,
-  instead of ``compute_uv=False``.
+  instead of `compute_uv=False`.
 
 .. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv`\ `= True`.
 
@@ -1250,6 +1249,9 @@ Differences with `numpy.linalg.svd`:
 
 .. seealso::
 
+        :func:`torch.linalg.svdvals` computes only the singular values.
+        However, that function is not differentiable.
+
         :func:`torch.linalg.eig` for a function that computes another type of spectral
         decomposition of a matrix. The eigendecomposition works just on on square matrices.
 
@@ -1280,7 +1282,7 @@ Returns:
 
     `U` and `Vh` will have the same dtype as :attr:`A`.
 
-Example::
+Examples::
 
     >>> a = torch.randn(5, 3)
     >>> a
@@ -1316,31 +1318,32 @@ Example::
 """)
 
 svdvals = _add_docstr(_linalg.linalg_svdvals, r"""
-linalg.svdvals(input, *, out=None) -> Tensor
+linalg.svdvals(A, *, out=None) -> Tensor
 
 Computes the singular values of a matrix.
-
-The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-then the singular values of each matrix in the batch are returned in descending order.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-.. note:: This function is not differentiable. Please use :func:`torch.linalg.svd`
-          instead, which also computes the singular vectors.
+The singular values are returned in descending order.
 
-.. note:: This function is equivalent to NumPy's ``linalg.svd`` with ``compute_uv=False``.
+.. note:: This function is not differentiable. If you need differentiability use
+          :func:`torch.linalg.svd` instead, which also computes the singular vectors.
 
-.. note:: When given inputs on a CUDA device, this function synchronizes that device with the CPU.
+.. note:: This function is equivalent to NumPy's `linalg.svd(A, compute_uv=False)`.
+
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 Args:
-    input (Tensor): the `m \times n` matrix or the batch of such matrices of size
-                    `(*, m, n)` where `*` is one or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
-Example::
+Returns:
+    A real-valued tensor, even when :attr:`A` is complex.
+
+Examples::
 
     >>> import torch
     >>> a = torch.randn(5, 3)
@@ -1435,7 +1438,6 @@ Raises:
         and the :attr:`A` matrix or any matrix in the batch :attr:`A` is not square
         or invertible.
 
-
 Examples::
 
     >>> a = torch.randn(3, 4, 4, dtype=torch.complex64)
@@ -1515,7 +1517,7 @@ that are below the specified :attr:`rcond` threshold are treated as zero and dis
 
         :func:`torch.linalg.inv` computes the inverse of a square matrix.
 
-        :func:`torch.linalg.lstsq` computes :attr:`A`\ `.pinv() @ \ `:attr:`B`.
+        :func:`torch.linalg.lstsq` computes :attr:`A`\ `.pinv() @ \ `:attr:`B` with a stable algorithm.
 
         It is always prefered to use :func:`torch.linalg.lstsq` when possible, as it is
         faster and more stable than computing the pseudoinverse and then multiplying.
@@ -1800,7 +1802,6 @@ Examples::
     True
 """)
 
-
 qr = _add_docstr(_linalg.linalg_qr, r"""
 qr(A, mode='reduced', *, out=None) -> (Tensor, Tensor)
 
@@ -1871,8 +1872,7 @@ Keyword args:
 Returns:
     A named tuple `(Q, R)`.
 
-
-Example::
+Examples::
 
     >>> a = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
     >>> q, r = torch.linalg.qr(a)

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -689,13 +689,15 @@ In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing o
 If :attr:`cond`\ `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`A`.
 
 This function returns the solution to the problem and some extra information in a named tuple of
-four tensors `(solution, residuals, rank, singular_values)` containing:
+four tensors `(solution, residuals, rank, singular_values)`. For inputs :attr:`A`, :attr:`B`
+of shape `(*, m, n)`, `(*, m, k)` respectively, it cointains
 
-- `solution`: the least squares solution
-- `residuals`: the squared residuals of the solutions, that is :math:`\|AX - B\|_F^2`.
-  It is computed when `m > n` and the matrix is full-rank,
+- `solution`: the least squares solution. It has shape `(*, n, k)`.
+- `residuals`: the squared residuals of the solutions, that is, :math:`\|AX - B\|_F^2`.
+  It has shape equal to the batch dimensions of :attr:`A`.
+  It is computed when `m > n` and every matrix in :attr:`A` is full-rank,
   otherwise, it is an empty tensor.
-- `rank`: tensor of ranks of the matrices in :attr:`A`
+- `rank`: tensor of ranks of the matrices in :attr:`A`.
   It has shape equal to the batch dimensions of :attr:`A`.
   It is computed when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`),
   otherwise it is an empty tensor.
@@ -717,9 +719,9 @@ four tensors `(solution, residuals, rank, singular_values)` containing:
 Args:
     A (Tensor): lhs tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     B (Tensor): rhs tensor of shape `(*, m, k)` where `*` is zero or more batch dimensions.
-    cond (float, optional): used to determine the effective rank of the input.
+    cond (float, optional): used to determine the effective rank of :attr:`A`.
                             If :attr:`cond`\ `= None`, :attr:`cond` is set to the machine
-                            of the dtype of :attr:`A`. Default: `None`.
+                            precision of the dtype of :attr:`A`. Default: `None`.
 
 Keyword args:
     driver (str, optional): name of the LAPACK/MAGMA method to be used.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -634,8 +634,9 @@ See the note below on how to choose the best driver. See also the `full descript
 
 :attr:`cond` is used to determine the effective rank of the matrices in :attr:`input`
 for rank-revealing drivers, that is, when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`).
-In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing order, :math:`\sigma_i` will be rounded down to zero if
-:math:`\sigma_i \leq \text{cond} \cdot \sigma_1`. If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`input`.
+In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing order,
+:math:`\sigma_i` will be rounded down to zero if :math:`\sigma_i \leq \text{cond} \cdot \sigma_1`.
+If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`input`.
 
 This function returns the solution to the problem and some extra information in a namedtuple of
 four tensors `(solution, residuals, rank, singular_values)` containing:
@@ -966,7 +967,8 @@ If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs
 
 - If :attr:`dim` is an `int`, the vector norm will be computed.
 - If :attr:`dim` is a `2`-`tuple`, the matrix norm will be computed.
-- If :attr:`dim`\ `= None` and :attr:`ord` `= None`, :attr:`input` is flattened to 1D and the `2`-norm of the resulting vector is returned.
+- If :attr:`dim`\ `= None` and :attr:`ord` `= None`,
+  :attr:`input` is flattened to 1D and the `2`-norm of the resulting vector is returned.
 - If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`input` must be 1D or 2D.
 
 :attr:`ord` defines the norm that is computed. The following norms are supported:

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -545,14 +545,18 @@ householder_product(input, tau, *, out=None) -> Tensor
 
 Computes the first `n` columns of a product of Householder matrices or batch of matrices
 
-Assume that :attr:`input` is of size `(*, m, n)` with `m ≥ n` and :attr:`tau` is of size `(*, k)` with `k ≤ n` where `*` is zero or more batch dimensions. Denoting :math:`v_i` `= \ `:attr:`input`\ `[..., :, i]` and :math:`\tau_i` `= \ `:attr:`tau`\ `[..., i]`, for every element of the batch this function returns the first `n` columns of the matrix
+Assume that :attr:`input` is of size `(*, m, n)` with `m ≥ n` and :attr:`tau` is of size
+`(*, k)` with `k ≤ n` where `*` is zero or more batch dimensions. Denoting
+:math:`v_i` `= \ `:attr:`input`\ `[..., :, i]` and :math:`\tau_i` `= \ `:attr:`tau`\ `[..., i]`,
+for every element of the batch this function returns the first `n` columns of the matrix
 
 .. math::
 
     H_1H_2 ... H_k \qquad\text{with}\qquad H_i = \mathrm{I}_m - \tau_i v_i v_i^{\text{H}}
 
 where :math:`\mathrm{I}_m` is the `m`-dimensional identity matrix and
-:math:`v^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in the real case. The size of the output is `(*, m, n)`.
+:math:`v^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in the real case.
+The size of the output is `(*, m, n)`.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 :attr:`tau` should have the same dtype as :attr:`input`.
@@ -612,13 +616,16 @@ torch.linalg.lstsq(input, b, cond=None, *, driver=None) -> (Tensor, Tensor, Tens
 
 Computes the least squares solution of a system of linear equations.
 
-Assume that :attr:`input`, :attr:`b` have sizes `(*, m, n)`, `(*, m, k)` where `*` is zero or more batch dimensions. For every matrix :math:`A` in :attr:`input` and every set :math:`B` in :attr:`b` of `k` vectors of dimension `m`, this function returns the solution to the problem
+Assume that :attr:`input`, :attr:`b` have sizes `(*, m, n)`, `(*, m, k)` where `*` is zero
+or more batch dimensions. For every matrix :math:`A` in :attr:`input` and every set :math:`B`
+in :attr:`b` of `k` vectors of dimension `m`, this function returns the solution to the problem
 
 .. math::
 
     \min_{X \in \mathbb{K}^{n \times k}} \|AX - B\|_F
 
-where :math:`\mathbb{K} = \mathbb{R}` or :math:`\mathbb{C}`, and :math:`\|-\|_F` denotes the Frobenius norm. The size of the output is then `(*, m, k)`.
+where :math:`\mathbb{K} = \mathbb{R}` or :math:`\mathbb{C}`, and :math:`\|-\|_F` denotes the Frobenius norm.
+The size of the output is then `(*, m, k)`.
 
 :attr:`driver` chooses the LAPACK/MAGMA driver that will be used.
 For CPU inputs the valid values are (`'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`).
@@ -948,7 +955,7 @@ Examples::
     >>> multi_dot((a.to(torch.float), torch.empty(3, 0), torch.empty(0, 2)))
     tensor([[0., 0.],
             [0., 0.]])
-""")
+""")  # no qa
 
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
@@ -1393,7 +1400,8 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
 .. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
 
-.. note:: This function uses :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` and :func:`torch.linalg.eigh` if :attr:`hermitian`\ `= True`.
+.. note:: This function uses :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` and
+          :func:`torch.linalg.eigh` if :attr:`hermitian`\ `= True`.
 
 .. seealso::
 
@@ -1480,19 +1488,24 @@ linalg.solve(input, other, *, out=None) -> Tensor
 
 Computes the solution of a square system (or batch of systems) of linear equations with unique solution.
 
-This method accepts both matrices and vectors as the right-hand side of the linear equation. We will denote by `*` zero or more batch dimensions.
+This method accepts both matrices and vectors as the right-hand side of the linear equation.
+We will denote by `*` zero or more batch dimensions.
 
-- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n)`, for every matrix :math:`A` in :attr:`input` and vector :math:`b` in :attr:`other`, this function returns a vector :math:`x` such that
+- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n)`, for every matrix :math:`A`
+  in :attr:`input` and vector :math:`b` in :attr:`other`, this function returns a vector :math:`x` such that
 
   .. math:: Ax = b
 
   The returned tensor will be of size `(*, n)`.
-- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n, k)`, for every pair of matrices  :math:`A` in :attr:`input` and :math:`B` in :attr:`other`, this function returns a matrix :math:`X` such that
+- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n, k)`, for every pair of matrices
+  :math:`A` in :attr:`input` and :math:`B` in :attr:`other`, this function returns a matrix :math:`X` such that
 
   .. math:: AX = B
 
   The returned tensor will be of size `(*, n, k)`.
-- If none of the above apply and :attr:`input`, :attr:`other` are of sizes `(*, n, n)`, `(n,)` (resp. `(n, k)`), the vector (resp. matrix) :attr:`other` is broadcasted to be of size `(*, n)` (resp. `(*, n, k)`). This function then  returns the solution of the resulting batch of systems of linear equations.
+- If none of the above apply and :attr:`input`, :attr:`other` are of sizes `(*, n, n)`, `(n,)` (resp. `(n, k)`),
+  the vector (resp. matrix) :attr:`other` is broadcasted to be of size `(*, n)` (resp. `(*, n, k)`).
+  This function then  returns the solution of the resulting batch of systems of linear equations.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 :attr:`other` should have the same dtype as :attr:`input`.
@@ -1614,7 +1627,9 @@ Computes the action of the multiplicative inverse of :func:`torch.tensordot` on 
 If `m` is the product of the first :attr:`other`\ `.ndim`  dimensions of :attr:`input` and
 `n` is the product of the rest of the dimensions, this function expects `m` and `n` to be equal.
 
-The returned tensor `x` satisfies `tensordot(\ `:attr:`input`\ `, x, dims=x.ndim) == \ `:attr:`other`. `x` has shape :attr:`input`\ `[other.ndim:]`.
+The returned tensor `x` satisfies
+`tensordot(\ `:attr:`input`\ `, x, dims=x.ndim) == \ `:attr:`other`.
+`x` has shape :attr:`input`\ `[other.ndim:]`.
 
 If :attr:`dims` is specified, :attr:`input` will be reshaped as
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -895,7 +895,8 @@ Examples::
 multi_dot = _add_docstr(_linalg.linalg_multi_dot, r"""
 linalg.multi_dot(tensors, *, out=None)
 
-Efficiently multiplies two or more matrices by reordering the multiplications so that the fewest arithmetic operations are performed.
+Efficiently multiplies two or more matrices by reordering the multiplications so that 
+the fewest arithmetic operations are performed.
 
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which
 may be 1D. If the first tensor is a 1D vector of size `n` it is treated as a row vector
@@ -955,7 +956,7 @@ Examples::
     >>> multi_dot((a.to(torch.float), torch.empty(3, 0), torch.empty(0, 2)))
     tensor([[0., 0.],
             [0., 0.]])
-""")  # no qa
+""")
 
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -12,42 +12,40 @@ Tensor = torch.Tensor
 cholesky = _add_docstr(_linalg.linalg_cholesky, r"""
 linalg.cholesky(input, *, out=None) -> Tensor
 
-Computes the Cholesky decomposition of a complex Hermitian (or real symmetric) positive-definite matrix or batch of matrices.
+Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix or of a batch of such matrices.
 
-For a complex Hermitian (or real symmetric) matrix :math:`A`, this is defined as
+For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 
 .. math::
 
     A = LL^{\text{H}}
 
 where :math:`L` is a lower triangular matrix and
-:math:`L^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in the real case.
+:math:`L^{\text{H}}` is the conjugate transpose when :math:`L` is complex, and the transpose when :math:`L` is real-valued.
 
 If :attr:`input` is a batch of matrices, then the returned matrices are also batched with the
 same batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
-.. note:: This function is computed using LAPACK's and MAGMA's `potrf` routine for
-          CPU and CUDA inputs, respectively.
+.. note:: This function uses LAPACK's and MAGMA's `potrf` for CPU and CUDA inputs respectively.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. seealso::
 
         :func:`torch.linalg.eigh` for a different decomposition of a Hermitian matrix.
-        The eigenvalue decomposition gives more information about about the matrix but it
-        is slower to compute than the Cholesky decomposition.
+        The eigenvalue decomposition gives more information about the matrix but it
+        slower to compute than the Cholesky decomposition.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` symmetric or Hermitian positive-definite matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                    consisting of symmetric or Hermitian positive-definite matrices.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the matrix or any matrix in the batch :attr:`input` is not Hermitian
+    RuntimeError: if the :attr:`input` matrix or any matrix in a batched :attr:`input` is not Hermitian
                   (resp. symmetric) positive-definite. If :attr:`input` is a batch of matrices,
                   the error message will include the batch index of the first matrix that fails
                   to meet this condition.
@@ -95,27 +93,28 @@ Examples::
 inv = _add_docstr(_linalg.linalg_inv, r"""
 linalg.inv(input, *, out=None) -> Tensor
 
-Computes the `inverse`_ of square matrix or batch of matrices
+Computes the `inverse`_ of square matrix or of a batch of square matrices if it exists.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
-.. note:: This function is computed using LAPACK's `getrf` and `getri` routines for CPU inputs.
-          For CUDA inputs, cuSOLVER's `getrf` and `getrs` routines as well as cuBLAS' `getrf`
+.. note:: This function is computed using LAPACK's `getrf` and `getri` for CPU inputs.
+          For CUDA inputs, cuSOLVER's `getrf` and `getrs` as well as cuBLAS' `getrf`
           and `getri` are used if CUDA version >= 10.1.243, otherwise MAGMA's `getrf`
           and `getri` are used instead.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. seealso::
 
-        :func:`torch.linalg.pinv` computes the Moore-Penrose pseudoinverse of a general matrix
+        :func:`torch.linalg.pinv` computes the Moore-Penrose pseudoinverse of matrices of
+        any shape.
 
-        :func:`torch.linalg.solve` computes the action of the inverse on another matrix.
-        This is faster and more stable than computing the inverse and then multiplying
+        :func:torch.linalg.solve computes ``input.inv() @ other``.
+        It is always prefered to use :func:`torch.linalg.solve` when possible, as it is
+        faster and more stable than computing the inverse and then multiplying.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                    consisting of invertible matrices.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -156,13 +155,12 @@ Examples::
 det = _add_docstr(_linalg.linalg_det, r"""
 linalg.det(input, *, out=None) -> Tensor
 
-Computes the determinant of a matrix or batch of matrices.
+Computes the determinant of a matrix or of a batch of matrices.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
 .. note:: This function is computed using :func:`torch.lu`.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: Backward through `det` internally uses :func:`torch.linalg.svd` when :attr:`input` is not
           invertible. In this case, double backward through `det` will be unstable when :attr:`input`
@@ -171,11 +169,10 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 .. seealso::
 
         :func:`torch.linalg.slogdet` computes the sign and logarithm of the norm of
-        the determinant of a square matrix
+        the determinant of square matrices.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -213,42 +210,36 @@ Example::
 slogdet = _add_docstr(_linalg.linalg_slogdet, r"""
 linalg.slogdet(input, *, out=None) -> (Tensor, Tensor)
 
-Computes the sign and logarithm of the norm of the determinant of a square matrix or batch of square matrices.
+Computes the sign and logarithm of the norm of the determinant of a square matrix or of a batch of square matrices.
 
 For a complex :attr:`input`, as the determinant is complex in this case, it returns the angle
-and the logarithm of the modulus of the determinant.
+and the logarithm of the modulus of the determinant, that is, a logarithmic polar decomposition of the determinant.
 
-The returend value decomposition is represented as a namedtuple `(sign, logabsdet)`.
+It returns a named tuple `(sign, logabsdet)`.
 If :attr:`input` is a batch of matrices, then `sign`, `logabsdet` are also batched with the same
-batch dimensions. The determinant can be recovered as `sign * exp(logabsdet)`.
+batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-`logabsdet` will always be real-valued, even if :attr:`input` is complex.
-`sign` will have the same dtype as :attr:`input`.
+The output tensor `logabsdet` will always be real-valued, even when :attr:`input` is complex.
+The output tensor `sign` will have the same dtype as :attr:`input`.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
 
 .. note:: This function is computed using :func:`torch.lu`.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: For matrices that have zero determinant, this returns `(0, -inf)`.
-          If :attr:`input` is batched then the entries in the result tensors corresponding
-          to matrices with the zero determinant have sign 0 and the natural logarithm of
-          the norm of the determinant `-inf`.
+.. note:: The determinant can be recovered as `sign * exp(logabsdet)`.
+
+.. note:: When a matrix has a determinant of zero, it returns `(0, -inf)`.
 
 .. seealso::
 
-        :func:`torch.linalg.det` computes the determinant of a square matrix
+        :func:`torch.linalg.det` computes the determinant of square matrices.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.
-
-Returns:
-    A namedtuple (sign, logabsdet) containing the sign of the determinant and the natural logarithm
-    of the norm of determinant, respectively.
 
 Example::
 
@@ -268,7 +259,7 @@ Example::
 eig = _add_docstr(_linalg.linalg_eig, r"""
 linalg.eig(input, *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a square matrix or batch of square matrices.
+Computes the eigenvalue decomposition of a square matrix or of a batch of square matrices if it exists.
 
 For a square matrix :math:`A`, this is defined as
 
@@ -276,49 +267,54 @@ For a square matrix :math:`A`, this is defined as
 
     A = V \operatorname{diag}(L) V^{-1}
 
-This decomposition exists if :math:`A` is diagonalizable (for example, when all its eigenvalues are different).
+This decomposition exists if and only if :math:`A` is `diagonalizable`_. This is the case when all its eigenvalues are different.
 
-The returned decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`,
+The returned decomposition is a named tuple `(eigenvalues, eigenvectors)`,
 which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
 then `L`, `V` are also batched with the same batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The eigenvalues and eigenvectors will always be complex-valued, even if :attr:`input` is real.
+The output tensors `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`input` is real.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
+.. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
-.. note:: This function is computed using LAPACK's and MAGMA's `geev` routine for
-          CPU and CUDA inputs, respectively.
+.. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
+          respectively.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: The eigenvectors of a matrix are not unique. Any eigenvector may be multiplied by
-          any non zero number.  As such, the returned eigenvectors are normalized to have norm
+.. note:: The eigenvectors of a matrix are not unique, as multiplying an eigenvector by a
+          non-zero number produces another set of eigenvectors for the matrix.
+          As such, the returned eigenvectors are normalized to have norm
           `1` and largest real component.
           In particular, the eigenvectors are not continuous functions of the inputs.
 
-.. warning:: This function assumes that :attr:`input` is diagonalizable (e.g. when all the
-             eigenvalues are different). If it is not, it will return the correct eigenvalues,
-             but the eigenvectors will be incorrect.
+.. warning:: This function assumes that :attr:`input` is `diagonalizable`_ (e.g. when all the
+             eigenvalues are different). If it is not diagonalizable, the returned
+             `eigenvalues` will be correct but
+
+             .. code::
+
+                input != eigenvectors @ torch.diag(eigenvalues) @ eigenvectors.transpose(-2, -1)
 
 .. warning:: Differentiation support for this function is not implemented yet.
 
 .. seealso::
 
-        :func:`torch.linalg.eigvals` for a related function that computes only eigenvalues.
+        :func:`torch.linalg.eigvals` computes only the eigenvalues.
         However, that function is not differentiable.
 
         :func:`torch.linalg.eigh` for a (faster) function that computes the eigenvalue decomposition
         for Hermitian and symmetric matrices.
 
         :func:`torch.linalg.svd` for a function that computes another type of spectral
-        decomposition. The SVD decomposition works on matrices that are not necessarily square.
+        decomposition that works on matrices of any shape.
 
-        :func:`torch.linalg.qr` for another (much faster) decomposition that works on general
-        matrices.
-
+        :func:`torch.linalg.qr` for another (much faster) decomposition that works on matrices of
+        any shape.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                    consisting of diagonalizable matrices.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.
@@ -342,27 +338,30 @@ Examples::
     >>> w, v = torch.linalg.eig(a)
     >>> torch.allclose(torch.matmul(v, torch.matmul(w.diag_embed(), v.inverse())).real, a)
     True
+
+.. _diagonalizable:
+    https://en.wikipedia.org/wiki/Diagonalizable_matrix#Definition
 """)
 
 eigvals = _add_docstr(_linalg.linalg_eigvals, r"""
 linalg.eigvals(input, *, out=None) -> Tensor
 
-Computes the eigenvalues of a square matrix or a batch of matrices :attr:`input`.
+Computes the eigenvalues of a square matrix or of a batch of square matrices.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The eigenvalues will always be complex-valued, even if :attr:`input` is real.
+The output tensor will always be complex-valued, even when :attr:`input` is real.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
+.. note:: The eigenvalues of a real matrix may be complex.
 
-.. note:: This function is computed using LAPACK's and MAGMA's `geev` routine for
-          CPU and CUDA inputs, respectively.
+.. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
+          respectively.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: This function doesn't support backpropagation. Use :func:`torch.linalg.eig`
+.. note:: This function is not differentiable. Use :func:`torch.linalg.eig`
           instead, which also computes the eigenvectors.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -381,73 +380,76 @@ Examples::
 eigh = _add_docstr(_linalg.linalg_eigh, r"""
 linalg.eigh(input, UPLO='L', *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a complex Hermitian (or real symmetric) matrix or batch of matrices.
+Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix or of a batch of such matrices.
 
-For a complex Hermitian (or real symmetric) matrix :math:`A`, this is defined as
+For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 
 .. math::
 
     A = V \operatorname{diag}(L) V^{\text{H}}
 
-where :math:`V^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in
-the real case. The matris :math:`V` (and thus :math:`V^{\text{H}}`)
-is orthogonal in the real case, and unitary in the complex case.
-
-The decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`, which
-corresepond to `(L, V)` above. If :attr:`input` is a batch of matrices, then `L`, `V` are also
-batched with the same batch dimensions.
-
-The eigenvalues are returned in ascending order.
+where :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
+The matrix :math:`V` (and thus :math:`V^{\text{H}}`) is orthogonal in the real case,
+and unitary in the complex case.
 
 :attr:`input` is assumed to be Hermitian (resp. symmetric), but this is not checked internally.
 When :attr:`UPLO` is `'L'` (default), only the lower triangular part of each matrix is used in the computation.
 When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is used.
 
+The returned decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`,
+which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
+then `L`, `V` are also batched with the same batch dimensions.
+
+The eigenvalues are returned in ascending order.
+
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The eigenvalues will always be real-valued, even if :attr:`input` is complex.
-The eigenvectors will have the same dtype as :attr:`input`.
+The output tensor `eigenvalues` will always be real-valued, even when :attr:`input` is complex.
+The output tensor `eigenvectors` will have the same dtype as :attr:`input`.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
-.. note:: This function is computed using LAPACK's and MAGMA's `syevd` and `heevd` routines for
-          CPU and CUDA symmetric and Hermitian inputs respectively.
+.. note:: If the inputs are symmetric, this function is computed using LAPACK's and MAGMA's
+          `syevd` for CPU and CUDA inputs,
+          If the inputs are Hermitian, it is computed using LAPACK's and MAGMA's `heevd`.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: The eigenvalues of real symmetric or complex Hermitian matrices are always real.
 
+
 .. warning:: The eigenvectors of a matrix are not unique. Any eigenvector may be multiplied by `-1`
              in the real case or by :math:`e^{i \phi}` for any :math:`\phi \in \mathbb{R}` in the
-             complex case.
+             complex case, and the resulting singular vectors will give a different
+             eigendecomposition of the matrix.
              As such, the eigenvectors are not continuous functions of the inputs, and different
              platforms, like NumPy, or inputs on different devices, may produce different
              eigenvectors.
 
-.. warning:: If `V` is used in the loss function, the gradient will only be finite when
+.. warning:: If `V` is used to compute gradients, the gradient will only be finite when
              :attr:`input` does not have repeated eigenvalues.
-             If the distance between any two eigenvalues is close to zero, the gradient with
-             respect to `V` will be numerically unstable, as it depends on
+             Furthermore, if the distance between any two eigvalues is close to zero,
+             the gradient will be numerically unstable, as it depends on the eigenvalues
+             :math:`\lambda_i` through the computation of
              :math:`\frac{1}{\min_{i \neq j} \lambda_i - \lambda_j}`.
 
 .. seealso::
 
-        :func:`torch.linalg.eigvalsh` for a related function that computes only eigenvalues.
+        :func:`torch.linalg.eigvalsh` computes only the eigenvalues.
         However, that function is not differentiable.
 
         :func:`torch.linalg.cholesky` for a different decomposition of a Hermitian matrix.
-        The Cholesky decomposition gives less information about the matrix but it is much faster
+        The Cholesky decomposition gives less information about the matrix but is much faster
         to compute than the eigenvalue decomposition.
 
         :func:`torch.linalg.eig` for a (slower) function that computes the eigenvalue decomposition
-        of a not necessarily Hermitian matrix.
+        of a not necessarily Hermitian square matrix.
 
         :func:`torch.linalg.svd` for a (slower) function that computes the more general SVD
-        decomposition of a not necessarily square matrix.
+        decomposition of matrices of any shape.
 
         :func:`torch.linalg.qr` for another (much faster) decomposition that works on general
         matrices.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` symmetric or Hermitian matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                    consisting of symmetric or Hermitian matrices.
     UPLO ('L', 'U', optional): controls whether to use the upper or lower triangular part
                                of :attr:`input` in the computations. Default: `'L'`.
 
@@ -480,8 +482,8 @@ Examples::
 eigvalsh = _add_docstr(_linalg.linalg_eigvalsh, r"""
 linalg.eigvalsh(input, UPLO='L', *, out=None) -> Tensor
 
-Computes the eigenvalues and eigenvectors of a complex Hermitian (or real symmetric)
-matrix or batch of matrices.
+Computes the eigenvalues and eigenvectors of a complex Hermitian or real symmetric
+matrix or of a batch of such matrices.
 
 The eigenvalues are returned in ascending order.
 
@@ -490,21 +492,20 @@ When :attr:`UPLO` is `'L'` (default), only the lower triangular part of each mat
 When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is used.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The eigenvalues will always be real-valued, even if :attr:`input` is complex.
+The output tensor will always be real-valued, even when :attr:`input` is complex.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
-.. note:: This function is computed using LAPACK's and MAGMA's `syevd` and `heevd` routines for
-          CPU and CUDA symmetric and Hermitian inputs respectively.
+.. note:: This function is computed using LAPACK's and MAGMA's `syevd` / `heevd` for
+          CPU and CUDA symmetric / Hermitian inputs respectively.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. note:: The eigenvalues of real symmetric or complex Hermitian matrices are always real.
 
-.. note:: This function doesn't support backpropagation. Please use :func:`torch.linalg.eigh`
+.. note:: This function is not differentiable. Please use :func:`torch.linalg.eigh`
           instead, which also computes the eigenvectors.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` symmetric or Hermitian matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                    consisting of symmetric or Hermitian matrices.
     UPLO ('L', 'U', optional): controls whether to use the upper or lower triangular part
                                of :attr:`input` in the computations. Default: `'L'`.
 
@@ -543,10 +544,10 @@ Examples::
 householder_product = _add_docstr(_linalg.linalg_householder_product, r"""
 householder_product(input, tau, *, out=None) -> Tensor
 
-Computes the first `n` columns of a product of Householder matrices or batch of matrices
+Computes the first `n` columns of a product of Householder matrices or of a batch of such matrices
 
-Assume that :attr:`input` is of size `(*, m, n)` with `m ≥ n` and :attr:`tau` is of size
-`(*, k)` with `k ≤ n` where `*` is zero or more batch dimensions. Denoting
+Assume that :attr:`input` has shape `(*, m, n)` with `m >= n` and :attr:`tau` has shape
+`(*, k)` with `k <= n` where `*` is zero or more batch dimensions. Denoting
 :math:`v_i` `= \ `:attr:`input`\ `[..., :, i]` and :math:`\tau_i` `= \ `:attr:`tau`\ `[..., i]`,
 for every element of the batch this function returns the first `n` columns of the matrix
 
@@ -555,36 +556,34 @@ for every element of the batch this function returns the first `n` columns of th
     H_1H_2 ... H_k \qquad\text{with}\qquad H_i = \mathrm{I}_m - \tau_i v_i v_i^{\text{H}}
 
 where :math:`\mathrm{I}_m` is the `m`-dimensional identity matrix and
-:math:`v^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in the real case.
-The size of the output is `(*, m, n)`.
+:math:`v^{\text{H}}` is the conjugate transpose when :math:`v` is complex, and the transpose when :math:`v` is real-valued.
+The output has shape `(*, m, n)`.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 :attr:`tau` should have the same dtype as :attr:`input`.
 
 See `Representation of Orthogonal or Unitary Matrices`_ for further details.
 
-.. note:: This function is computed using LAPACK's `orgqr` routine for CPU inputs,
-          and cuSOLVER's `orgqr` routine for CUDA inputs if CUDA version >= 10.1.243.
+.. note:: This function is computed using LAPACK's `orgqr` for CPU inputs,
+          and cuSOLVER's `orgqr` for CUDA inputs if CUDA version >= 10.1.243.
 
 .. note:: This function only uses the values strictly below the main diagonal of :attr:`input`.
           The other values are ignored.
 
 .. seealso::
 
-        :func:`torch.geqrf` is used together with this function to form the Q from the QR decomposition
+        :func:`torch.geqrf` is used together with this function to form the Q from the QR decomposition.
 
 Args:
-    input (Tensor): tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices.
-    tau (Tensor): tensor of size `(*, k)` where `*` is zero or more batch dimensions consisting
-                  of `k`-dimensional vectors.
+    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    tau (Tensor): tensor of shape `(*, k)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if :attr:`input` doesn't satisfy the requirement `m ≥ n`,
-                  or :attr:`tau` doesn't satisfy the requirement `n ≥ r`
+    RuntimeError: if :attr:`input` doesn't satisfy the requirement `m >= n`,
+                  or :attr:`tau` doesn't satisfy the requirement `n >= r`
 
 Examples::
 
@@ -614,9 +613,9 @@ Examples::
 lstsq = _add_docstr(_linalg.linalg_lstsq, r"""
 torch.linalg.lstsq(input, b, cond=None, *, driver=None) -> (Tensor, Tensor, Tensor, Tensor)
 
-Computes the least squares solution of a system of linear equations.
+Computes the least squares solution of a system (or of a batch of systems) of linear equations.
 
-Assume that :attr:`input`, :attr:`b` have sizes `(*, m, n)`, `(*, m, k)` where `*` is zero
+Assume that :attr:`input`, :attr:`b` have shapes `(*, m, n)`, `(*, m, k)` where `*` is zero
 or more batch dimensions. For every matrix :math:`A` in :attr:`input` and every set :math:`B`
 in :attr:`b` of `k` vectors of dimension `m`, this function returns the solution to the problem
 
@@ -625,10 +624,10 @@ in :attr:`b` of `k` vectors of dimension `m`, this function returns the solution
     \min_{X \in \mathbb{K}^{n \times k}} \|AX - B\|_F
 
 where :math:`\mathbb{K} = \mathbb{R}` or :math:`\mathbb{C}`, and :math:`\|-\|_F` denotes the Frobenius norm.
-The size of the output is then `(*, m, k)`.
+The output has shape `(*, m, k)`.
 
 :attr:`driver` chooses the LAPACK/MAGMA driver that will be used.
-For CPU inputs the valid values are (`'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`).
+For CPU inputs the valid values are `'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`.
 For CUDA input, the only valid driver is `'gels'`.
 The driver `'gels'` assumes that the input is full-rank.
 The drivers `'gelsy'`, `'gelsd'`, `'gelss'` handle rank-deficient inputs.
@@ -636,9 +635,8 @@ See the note below on how to choose the best driver. See also the `full descript
 
 :attr:`cond` is used to determine the effective rank of the matrices in :attr:`input`
 for rank-revealing drivers, that is, when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`).
-If `σᵢ` are the singular values of `A` in decreasing order, `σᵢ` will be rounded down to zero if
-`σᵢ ≤ \ `:attr:`cond` · `σ₁`.
-If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`input`.
+In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing order, :math:`\sigma_i` will be rounded down to zero if
+:math:`\sigma_i \leq \text{cond} \cdot \sigma_1`. If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`input`.
 
 This function returns the solution to the problem and some extra information in a namedtuple of
 four tensors `(solution, residuals, rank, singular_values)` containing:
@@ -657,9 +655,9 @@ four tensors `(solution, residuals, rank, singular_values)` containing:
   otherwise it is an empty tensor.
 
 .. note::
-    The solution to this problem can be computed in terms of the Moore-Penrose pseudo-inverse of
-    `A` by computing `A.pinv() @ B`.
-    As such, this function is a faster and more stable way of computing `A.pinv() @ B`.
+    The solution to this problem can be computed in terms of the Moore-Penrose pseudoinverse of
+    `A` as `A.pinv() @ B`.
+    For this reason, this function is a faster and more stable way of computing `A.pinv() @ B`.
 
 .. note::
     Choosing :attr:`driver`: if :attr:`input` is well-conditioned (its `condition number`_ is not
@@ -677,10 +675,8 @@ four tensors `(solution, residuals, rank, singular_values)` containing:
     breaking changes.
 
 Args:
-    input (Tensor): lhs tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices.
-    b (Tensor): rhs tensor of size `(*, m, k)` where `*` is zero or more batch dimensions
-                consisting of `k` vectors of dimension `m`.
+    input (Tensor): lhs tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    b (Tensor): rhs tensor of shape `(*, m, k)` where `*` is zero or more batch dimensions.
     cond (float, optional): used to determine the effective rank of the input.
                             If :attr:`cond` `= None`, :attr:`cond` is set to the machine
                             of the dtype of :attr:`input`. Default: `None`.
@@ -718,16 +714,15 @@ Example::
 matrix_power = _add_docstr(_linalg.linalg_matrix_power, r"""
 matrix_power(input, n, *, out=None) -> Tensor
 
-Computes the :attr:`n`-th power of a matrix or a batch of matrices for an integer :attr:`n`.
+Computes the :attr:`n`-th power of a matrix or of a batch of matrices for an integer :attr:`n`.
 
 If :attr:`n` `= 0`, it returns the identity matrix (or batch) of the same shape
 as :attr:`input`. If :attr:`n` is negative, it returns the inverse of each matrix
 (if invertible) raised to the power of `abs(n)`.
 
 Args:
-    input (Tensor): tensor of size `(*, m, m)` where `*` is zero or more batch dimensions
-                    consisting of `(m, m)` matrices.
-    n (int): the exponent to raise the :attr:`input` to
+    input (Tensor): tensor of shape `(*, m, m)` where `*` is zero or more batch dimensions.
+    n (int): the exponent.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -759,7 +754,7 @@ Example::
 matrix_rank = _add_docstr(_linalg.linalg_matrix_rank, r"""
 matrix_rank(input, tol=None, hermitian=False, *, out=None) -> Tensor
 
-Computes the numerical rank of a matrix or batch of matrices
+Computes the numerical rank of a matrix or of a batch of matrices
 
 The matrix rank is computed as the number of singular values
 (or eigenvalues in absolute value when :attr:`hermitian`\ `= True`)
@@ -769,22 +764,27 @@ If :attr:`hermitian`\ `= True`, :attr:`input` is assumed to be Hermitian if comp
 symmetric if real.
 
 If :attr:`tol` is not specified and :attr:`input` is a matrix of dimensions `(m, n)`,
-:attr:`tol`\ `= σ₁ · max(m, n) · ε`, where `σ₁` is the largest
-singular value (or eigenvalue in absolute value when :attr:`hermitian`\ `= True`), and
-`ε` is the epsilon value for the dtype of :attr:`input` (see :class:`torch.finfo`).
+the tolerance is set to be
+
+.. math::
+
+    \text{tol} = \sigma_1 \max(m, n) \varepsilon
+
+where :math:`\sigma_1` is the largest singular value
+(or eigenvalue in absolute value when :attr:`hermitian`\ `= True`), and
+:math:`\varepsilon` is the epsilon value for the dtype of :attr:`input` (see :class:`torch.finfo`).
 If :attr:`input` is a batch of matrices, :attr:`tol` is computed this way for every element of
 the batch.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
-
 .. note:: The matrix rank is computed using singular value decomposition
           :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` (default) and the eigenvalue
           decomposition :func:`torch.linalg.eigvalsh` when :attr:`hermitian`\ `= True`.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 Args:
-    input (Tensor): the input matrix of size `(m, n)` or the batch of matrices of size `(*, m, n)`
+    input (Tensor): the input matrix of shape `(m, n)` or the batch of matrices of shape `(*, m, n)`
                     where `*` is one or more batch dimensions.
     tol (float, Tensor, optional): the tolerance value. See above for the value it takes when `None`.
                                    Default: `None`.
@@ -831,7 +831,7 @@ Examples::
 vector_norm = _add_docstr(_linalg.linalg_vector_norm, r"""
 linalg.vector_norm(input, ord=None, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
 
-Computes the vector norm of a vector or batch of vectors.
+Computes the vector norm of a vector or of a batch of vectors.
 
 If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
 
@@ -842,7 +842,7 @@ If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs
 :attr:`ord` defines the vector norm that is computed. The following norms are supported:
 
 ======================   =======================================================
-:attr:`ord`              norm for vectors
+:attr:`ord`              vector norm
 ======================   =======================================================
 `None` (default)         `2`-norm
 `inf`                    `max(abs(x))`
@@ -854,10 +854,10 @@ other `int` or `float`   `sum(abs(x)**\ `:attr:`ord`\ `)**(1./\ `:attr:`ord`\ `)
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The returned tensor will always be real-valued, even if :attr:`input` is complex.
+The output tensor will always be real-valued, even when :attr:`input` is complex.
 
 Args:
-    input (Tensor): a tensor of any size.
+    input (Tensor): a tensor of any shape.
 
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `None`
 
@@ -866,7 +866,7 @@ Args:
         Default: `None`
 
     keepdim (bool, optional): If set to `True`, the reduced dimensions are retained
-        in the result as dimensions with size one. Default: `False`
+        in the result as dimensions with shape one. Default: `False`
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -899,9 +899,9 @@ Efficiently multiplies two or more matrices by reordering the multiplications so
 the fewest arithmetic operations are performed.
 
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which
-may be 1D. If the first tensor is a 1D vector of size `n` it is treated as a row vector
-of size `(1, n)`, similarly if the last tensor is a 1D vector of size `n` it is treated
-as a column vector of size `(n, 1)`.
+may be 1D. If the first tensor is a 1D vector of shape `n` it is treated as a row vector
+of shape `(1, n)`, similarly if the last tensor is a 1D vector of shape `n` it is treated
+as a column vector of shape `(n, 1)`.
 
 If the first and last tensors are matrices, the output will be a matrix.
 However, if either is a 1D vector, then the output will be a 1D vector.
@@ -915,7 +915,7 @@ However, if either is a 1D vector, then the output will be a 1D vector.
           tensors must be either 1D or 2D whereas NumPy allows them to be nD.
 
 .. note:: The cost of multiplying two matrices with shapes `(a, b)` and `(b, c)` is
-          `a · b · c`. Given matrices `A`, `B`, `C` with shapes `(10, 100)`,
+          `a * b * c`. Given matrices `A`, `B`, `C` with shapes `(10, 100)`,
           `(100, 5)`, `(5, 50)` respectively, we can calculate the cost of different
           multiplication orders as follows:
 
@@ -961,14 +961,14 @@ Examples::
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
 
-Computes the matrix norm or vector norm of a vector or a matrix or batch of any of the two.
+Computes the matrix norm or vector norm of a vector or a matrix or of a batch of any of the two.
 
 If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
 
 - If :attr:`dim` is an `int`, the vector norm will be computed.
 - If :attr:`dim` is a `2`-`tuple`, the matrix norm will be computed.
-- If :attr:`dim`\ `= None` and :attr:`ord`\ `= None`, :attr:`input` is flattened to 1D and the `2`-norm of the resulting vector is returned.
-- If :attr:`dim`\ `= None` and :attr:`ord`\ `≠ None`, :attr:`input` must be 1D or 2D.
+- If :attr:`dim`\ `= None` and :attr:`ord` `= None`, :attr:`input` is flattened to 1D and the `2`-norm of the resulting vector is returned.
+- If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`input` must be 1D or 2D.
 
 :attr:`ord` defines the norm that is computed. The following norms are supported:
 
@@ -991,10 +991,10 @@ other `int` or `float`     -- not supported --        `sum(abs(x)**\ `:attr:`ord
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The returned tensor will always be real-valued, even if :attr:`input` is complex.
+The output tensor will always be real-valued, even when :attr:`input` is complex.
 
 Args:
-    input (Tensor): the input tensor. The allowed sizes follow the rules described above.
+    input (Tensor): the input tensor. The allowed shapes follow the rules described above.
 
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `None`
 
@@ -1084,7 +1084,7 @@ Using the :attr:`dim` argument to compute matrix norms::
 svd = _add_docstr(_linalg.linalg_svd, r"""
 linalg.svd(input, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
-Computes the singular value decomposition of a matrix or batch of matrices.
+Computes the singular value decomposition of a matrix or of a batch of matrices.
 
 For a matrix :math:`A`, this is defined as
 
@@ -1092,21 +1092,21 @@ For a matrix :math:`A`, this is defined as
 
     \text{input} = U \operatorname{diag}(S) V^{\text{H}}
 
-where :math:`V^{\text{H}}` denotes the conjugate transpose in the complex case and the transpose in
-the real case. The matrices  :math:`U`, :math:`V`
-(and thus :math:`V^{\text{H}}`) are orthogonal in the real case, and unitary in the complex case.
+where :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
+The matrices  :math:`U`, :math:`V` (and thus :math:`V^{\text{H}}`) are orthogonal in the real case,
+and unitary in the complex case.
 
-The returned decomposition is represented as a namedtuple `(U, S, Vh)`
+The returned decomposition is a named tuple `(U, S, Vh)`
 which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
 If :attr:`input` is a batch of matrices, then `U`, `S`, `Vh` are also batched with the same
 batch dimensions.
 
 The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-the singular values of each matrix in the batch are returned in descending order.
+then the singular values of each matrix in the batch are also returned in descending order.
 
 If :attr:`full_matrices` `= False`, the method will return the reduced singular
-value decomposition. In this case, if :attr:`input` is of size `(*, m, n)`,
-the returned `U`, `Vh` will be of size `(*, m, min(m, n))` and `(*, min(m, n), n)`
+value decomposition. In this case, if :attr:`input` has shape `(*, m, n)`,
+the returned `U`, `Vh` will have shape `(*, m, min(m, n))` and `(*, min(m, n), n)`
 respectively.
 
 If :attr:`compute_uv` `= False`, the returned `U` and `Vh` will be empty
@@ -1114,8 +1114,8 @@ tensors with no elements and the same device as :attr:`input`. The
 :attr:`full_matrices` argument has no effect when :attr:`compute_uv` `= False`.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-`S` will always be real-valued, even if :attr:`input` is complex.
-`U` and `Vh` will have the same dtype as :attr:`input`.
+The output tensor `S` will always be real-valued, even when :attr:`input` is complex.
+The output tensors `U` and `Vh` will have the same dtype as :attr:`input`.
 
 Differences with `numpy.linalg.svd`:
 
@@ -1131,30 +1131,32 @@ Differences with `numpy.linalg.svd`:
           and `Vh[..., min(m, n):, :]` will be ignored in the backwards pass, as those vectors
           can be arbitrary bases of the corresponding subspaces.
 
-.. note:: The implementation of :func:`torch.linalg.svd` on CPU uses LAPACK's routine `gesdd`
-          (a divide-and-conquer algorithm) instead of `gesvd` for speed. Analogously,
-          on GPU, it uses cuSOLVER's routines `gesvdj` and `gesvdjBatched` on CUDA 10.1.243
-          and later, and MAGMA's routine `gesdd` on earlier versions of CUDA.
+.. note:: On CPU, this function uses LAPACK's `gesdd` instead of `gesvd` for speed.
+          On CUDA, it uses cuSOLVER's `gesvdj` and `gesvdjBatched` on CUDA 10.1.243 and later,
+          and MAGMA's `gesdd` on earlier versions of CUDA.
 
 .. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
           be represented as a column-major matrix (i.e. Fortran-contiguous).
 
-.. warning:: The singular vectors of a matrix are not unique. Any pair of left and right singular
-             vectors may be multiplied by `-1` in the real case or by :math:`e^{i \phi}` for any
-             :math:`\phi \in \mathbb{R}` in the complex case.
-             The same happens when :attr:`input` has repeated singular values, where one may multiply
-             the columns of the spanning subspace in `U` and `V` by a rotation matrix
-             and `the resulting vectors will span the same subspace`_.
-             As such, `U` and `Vh` are not continuous functions of the inputs, and different
+.. warning:: The singular vectors of a matrix are not unique. Any pair of singular
+             vectors :math:`u_k, v_k` may be multiplied by `-1` when `U` and `V` are real-valued or
+             by :math:`e^{i \phi}` for any :math:`\phi \in \mathbb{R}` when `U` and `V` are complex,
+             and the resulting singular vectors will give a different SVD of the matrix.
+             This non-uniqueness problem is even worse when the matrix has repeated singular values.
+             In this case, one may multiply the associated singular vectors of `U` and `V` spanning
+             the subspace by a rotation matrix and `the resulting vectors will span the same subspace`_.
+             As such, `U` and `Vh` are not continuous functions of the inputs. Furthermore, different
              platforms, like NumPy, or inputs on different devices, may produce different
              `U` and `Vh` tensors.
 
-.. warning:: If `U` or `Vh` are used in the loss function, the gradient will only be finite when
-             :attr:`input` does not have zero as a singular valuer or repeated singular values.
-             If the distance between any two singular values is close to zero, the gradient will
-             be numerically unstable, as it depends on
-             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`. The same happens when
-             :attr:`input` has small singular values, as the gradient also depend on `S⁻¹`.
+.. warning:: If `U` or `Vh` are used to compute gradients, the gradient will only be finite when
+             :attr:`input` does not have zero as a singular value or repeated singular values.
+             Furthermore, if the distance between any two singular values is close to zero,
+             the gradient will be numerically unstable, as it depends on the singular values
+             :math:`\sigma_i` through the computation of
+             :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`.
+             The gradient will also be numerically unstable when :attr:`input` has small singular
+             values, as it also depends on the computaiton of :math:`\frac{1}{\sigma_i}`.
 
 .. seealso::
 
@@ -1168,8 +1170,7 @@ Differences with `numpy.linalg.svd`:
         matrices.
 
 Args:
-    input (Tensor): tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices.
+    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     full_matrices (bool, optional): controls whether to compute the full or reduced decomposition, and
                                     consequently, the shape of returned `U` and `Vh`. Default: `True`.
     compute_uv (bool, optional): controls whether to compute `U` and `Vh`. Default: `True`.
@@ -1256,7 +1257,7 @@ Example::
 cond = _add_docstr(_linalg.linalg_cond, r"""
 linalg.cond(input, p=None, *, out=None) -> Tensor
 
-Computes the condition number with respect to a norm of a matrix or batch of matrices.
+Computes the condition number with respect to a norm of a matrix or of a batch of matrices.
 
 The condition number :math:`\kappa` of a matrix :math:`A` is defined as
 
@@ -1264,15 +1265,34 @@ The condition number :math:`\kappa` of a matrix :math:`A` is defined as
 
     \kappa(A) = \|A\|_p\|A^{-1}\|_p
 
-The condition number of `A` meadures the numerical stability of a linear system `AX = B` measured
+The condition number of `A` measures the numerical stability of the linear system `AX = B`
 in some specific matrix norm.
 
-For :attr:`p` in `{'fro', 'nuc', inf, -inf, 1, -1}`, this is computed using
+:attr:`p` defines the matrix norm that is computed. The following norms are supported:
+
+=========    =================================
+:attr:`p`    matrix norm
+=========    =================================
+`None`       `2`-norm (largest singular value)
+`'fro'`      Frobenius norm
+`'nuc'`      nuclear norm
+`inf`        `max(sum(abs(x), dim=1))`
+`-inf`       `min(sum(abs(x), dim=1))`
+`1`          `max(sum(abs(x), dim=0))`
+`-1`         `min(sum(abs(x), dim=0))`
+`2`          largest singular value
+`-2`         smallest singular value
+=========    =================================
+
+where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
+
+For :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`, this function uses
 :func:`torch.linalg.norm` and :func:`torch.linalg.inv`.
 As such, in this case, the matrix (or every matrix in the batch) :attr:`input` should be square
 and invertible.
 
-For :attr:`p` in `{2, -2}`, this can be simplified using singular values. If `σ₁ ≥ ... ≥ σₙ`,
+For :attr:`p` in `(2, -2)`, this function can be computed in terms of the singular values
+:math:`\sigma_1 \geq \ldots \geq \sigma_n`
 
 .. math::
 
@@ -1282,10 +1302,10 @@ In these cases, it is computed using :func:`torch.linalg.svd`. For these norms, 
 (or every matrix in the batch) :attr:`input` may be rectangular
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The returned tensor will always be real-valued, even if :attr:`input` is complex.
+The output tensor will always be real-valued, even when :attr:`input` is complex.
 
-.. note:: When :attr:`input` is on a CUDA device, this function may synchronize that device with
-          the CPU if :attr:`p` is one of `{'fro', 'nuc', inf, -inf, 1, -1}`.
+.. note :: For CUDA inputs, this function synchronizes that device with the CPU if
+           if :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`.
 
 .. seealso::
 
@@ -1294,41 +1314,18 @@ The returned tensor will always be real-valued, even if :attr:`input` is complex
         :func:`torch.linalg.lstsq` for a function that solves linear systems of general matrices.
 
 Args:
-    input (Tensor): tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices for :attr:`p` in `{2, -2}`, and of size
-                    `(*, n, n)` and invertible matrices for :attr:`p` in
-                    `{'fro', 'nuc', inf, -inf, 1, -1}`.
+    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions
+                    for :attr:`p` in `(2, -2)`, and of shape `(*, n, n)` where every matrix
+                    is invertible for :attr:`p` in `('fro', 'nuc', inf, -inf, 1, -1)`.
     p (int, inf, -inf, 'fro', 'nuc', optional):
-        the type of the matrix norm to use in the computations.
-        inf refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
-        The following norms can be used:
-
-        =========    =================================
-        :attr:`p`    norm for matrices
-        =========    =================================
-        `None`       `2`-norm (largest singular value)
-        `'fro'`      Frobenius norm
-        `'nuc'`      nuclear norm
-        `inf`        `max(sum(abs(x), dim=1))`
-        `-inf`       `min(sum(abs(x), dim=1))`
-        `1`          `max(sum(abs(x), dim=0))`
-        `-1`         `min(sum(abs(x), dim=0))`
-        `2`          largest singular value
-        `-2`         smallest singular value
-        =========    =================================
-
-        Default: `None`
+        the type of the matrix norm to use in the computations (see above). Default: `None`
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
-Returns:
-    The condition number of :attr:`input`. The output dtype is always real valued
-    even for complex inputs (e.g. float if :attr:`input` is cfloat).
-
 Raises:
     RuntimeError:
-        if :attr:`p` is one of `{'fro', 'nuc', inf, -inf, 1, -1}`
+        if :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`
         and the :attr:`input` matrix or any matrix in the batch :attr:`input` is not square
         or invertible.
 
@@ -1389,9 +1386,9 @@ Examples::
 pinv = _add_docstr(_linalg.linalg_pinv, r"""
 linalg.pinv(input, rcond=1e-15, hermitian=False, *, out=None) -> Tensor
 
-Computes the Moore-Penrose pseudoinverse of a matrix or a batch of matrices.
+Computes the Moore-Penrose pseudoinverse of a matrix or of a batch of matrices.
 
-If :attr:`hermitian`\ `= True`, :attr:`input` should be a complex Hermitian (or real symmetric)
+If :attr:`hermitian`\ `= True`, :attr:`input` should be a complex Hermitian or real symmetric
 matrix or batch of matrices. In this case, it will just use the lower-triangular half of the matrix.
 
 The singular values (or the norm of the eigenvalues when :attr:`hermitian`\ `= True`)
@@ -1399,24 +1396,23 @@ that are below the specified :attr:`rcond` threshold are treated as zero and dis
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
 
 .. note:: This function uses :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` and
           :func:`torch.linalg.eigh` if :attr:`hermitian`\ `= True`.
+          For CUDA inputs, this function synchronizes that device with the CPU.
 
 .. seealso::
 
-        :func:`torch.linalg.inv` computes the inverse of a square matrix
+        :func:`torch.linalg.inv` computes the inverse of a square matrix.
 
-        :func:`torch.linalg.lstsq` computes the action of the Moore-Penrose pseudoinverse on
-        another matrix.
-        This is faster and more stable than computing the pseudoinverse and then multiplying
+        :func:torch.linalg.lstsq computes ``input.pinv() @ other``.
+        It is always prefered to use :func:`torch.linalg.lstsq` when possible, as it is
+        faster and more stable than computing the pseudoinverse and then multiplying.
 
 Args:
-    input (Tensor): tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices.
+    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     rcond (float or Tensor, optional): the tolerance value to determine when is a singular value zero
-                                       If it is a :class:`torch.Tensor` its size must be
+                                       If it is a :class:`torch.Tensor`, its shape must be
                                        broadcastable to that of the singular values of
                                        :attr:`input` as returned by :func:`torch.svd`.
                                        Default: `1e-15`.
@@ -1487,40 +1483,39 @@ Examples::
 solve = _add_docstr(_linalg.linalg_solve, r"""
 linalg.solve(input, other, *, out=None) -> Tensor
 
-Computes the solution of a square system (or batch of systems) of linear equations with unique solution.
+Computes the solution of a square system (or of a batch of square systems) of linear equations with unique solution.
 
 This method accepts both matrices and vectors as the right-hand side of the linear equation.
 We will denote by `*` zero or more batch dimensions.
 
-- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n)`, for every matrix :math:`A`
+- If :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(*, n)`, for every matrix :math:`A`
   in :attr:`input` and vector :math:`b` in :attr:`other`, this function returns a vector :math:`x` such that
 
   .. math:: Ax = b
 
-  The returned tensor will be of size `(*, n)`.
-- If :attr:`input`, :attr:`other` are of size `(*, n, n)`, `(*, n, k)`, for every pair of matrices
+  The returned tensor have shape `(*, n)`.
+- If :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(*, n, k)`, for every pair of matrices
   :math:`A` in :attr:`input` and :math:`B` in :attr:`other`, this function returns a matrix :math:`X` such that
 
   .. math:: AX = B
 
-  The returned tensor will be of size `(*, n, k)`.
-- If none of the above apply and :attr:`input`, :attr:`other` are of sizes `(*, n, n)`, `(n,)` (resp. `(n, k)`),
-  the vector (resp. matrix) :attr:`other` is broadcasted to be of size `(*, n)` (resp. `(*, n, k)`).
+  The returned tensor have shape `(*, n, k)`.
+- If none of the above apply and :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(n,)` (resp. `(n, k)`),
+  the vector (resp. matrix) :attr:`other` is broadcasted to have shape `(*, n)` (resp. `(*, n, k)`).
   This function then  returns the solution of the resulting batch of systems of linear equations.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 :attr:`other` should have the same dtype as :attr:`input`.
 
-.. note:: The solution to these problem can be computed in terms of the inverse of `A`
-          by computing `A.inv() @ B`.
-          As such, this function is a faster and more stable way of computing `A.inv() @ B`.
+.. note:: The solution to these problems can be computed in terms of the inverse of `A`
+          as `A.inv() @ b` and `A.inv() @ B` respectively.
+          This function can be seen as faster and more stable way of computing these quantities.
 
 
-.. note:: When :attr:`input` is on a CUDA device, this function synchronizes that device with the CPU.
+.. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 Args:
-    input (Tensor): tensor of size `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of `(n, n)` matrices.
+    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
     other (Tensor): right-hand side tensor of shape `(*, n)` or  `(*, n, k)` or `(n,)` or `(n, k)`
                     according to the rules described above
 
@@ -1528,7 +1523,8 @@ Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the :attr:`input` matrix or any matrix in the batch :attr:`input` is not invertible
+    RuntimeError: if the :attr:`input` matrix is not invertible or any matrix in a batched :attr:`input`
+                  is not invertible
 
 Examples::
 
@@ -1586,9 +1582,11 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
 .. seealso::
 
-        :func:`torch.linalg.tensorsolve` computes the action of the inverse of
-        :func:`torch.tensordot` on another matrix.  This is faster and more stable than
-        computing :func:`~tensorinv` and then using :func:`torch.tensordot`.
+        :func:`torch.linalg.tensorsolve` computes
+        `torch.tensordot(tensorinv(\ `:attr:`input`\ `), \ `:attr:`other`\ `)`.
+        It is always prefered to use :func:`~tensorsolve` when possible, as it is
+        faster and more stable than using
+        :func:`~tensorinv` followed by :func:`torch.tensordot`.
 
 Args:
     input (Tensor): tensor to invert. Its shape must satisfy
@@ -1651,7 +1649,7 @@ Args:
 .. seealso::
 
         :func:`torch.linalg.tensorinv` computes the multiplicative inverse of
-        :func:`torch.tensordot`
+        :func:`torch.tensordot`.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -1687,7 +1685,7 @@ Examples::
 qr = _add_docstr(_linalg.linalg_qr, r"""
 qr(input, mode='reduced', *, out=None) -> (Tensor, Tensor)
 
-Computes the QR decomposition of a matrix or batch of matrices.
+Computes the QR decomposition of a matrix or of a batch of matrices.
 
 For a matrix :math:`A`, this is defined as
 
@@ -1697,15 +1695,16 @@ For a matrix :math:`A`, this is defined as
 
 where :math:`Q` is orthogonal in the real case and unitary in the complex case, and :math:`R` is upper triangular.
 
-The returned decomposition is represented as a namedtuple `(Q, R)`
+The returned decomposition is a named tuple `(Q, R)`.
 If :attr:`input` is a batch of matrices, then `Q`, `R` are also batched with the same
 batch dimensions.
 
-The parameter :attr:`mode` controls the size of the output. If :attr:`input` has size `(*, m, n)`, denoting `k = min(m, n)`
+The parameter :attr:`mode` controls the shape of the output. If :attr:`input` has shape
+`(*, m, n)`, denoting `k = min(m, n)`
 
-- :attr:`mode` `= 'reduced'` (default): Returns `(Q, R)` of sizes `(*, m, k)`, `(*, k, n)` respectively.
-- :attr:`mode` `= 'complete'`: Returns `(Q, R)` of sizes `(*, m, m)`, `(*, m, n)` respectively.
-- :attr:`mode` `= 'r'`: Computes only `R`. Returns `(Q, R)` with `Q` empty and `R` of size `(*, k, n)`.
+- :attr:`mode` `= 'reduced'` (default): Returns `(Q, R)` of shapes `(*, m, k)`, `(*, k, n)` respectively.
+- :attr:`mode` `= 'complete'`: Returns `(Q, R)` of shapes `(*, m, m)`, `(*, m, n)` respectively.
+- :attr:`mode` `= 'r'`: Computes only `R`. Returns `(Q, R)` with `Q` empty and `R` of shape `(*, k, n)`.
 
 Differences with `numpy.linalg.qr`:
 
@@ -1718,7 +1717,7 @@ Differences with `numpy.linalg.qr`:
 
 .. note:: :attr:`mode` `= 'r'` does not support backpropagation. Use :attr:`mode` `= 'reduced'` instead.
 
-.. note:: This function uses LAPACK for CPU inputs and MAGMA for CUDA inputs,
+.. note:: This function uses LAPACK and MAGMA for CPU and CUDA inputs respectively.
 
 .. warning:: The QR decomposition is only locally unique when the input matrix has
              independent columns. If this is not the case, different platforms, like NumPy,
@@ -1731,10 +1730,9 @@ Differences with `numpy.linalg.qr`:
              This is because the QR decomposition is not differentiable at these points.
 
 Args:
-    input (Tensor): tensor of size `(*, m, n)` where `*` is zero or more batch dimensions
-                    consisting of `(m, n)` matrices.
+    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     mode (str, optional): one of `'reduced'`, `'complete'`, `'r'`.
-                          Controls the size of the output tensors. Default: `'reduced'`.
+                          Controls the shape of the output tensors. Default: `'reduced'`.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1137,9 +1137,6 @@ Differences with `numpy.linalg.svd`:
           On CUDA, it uses cuSOLVER's `gesvdj` and `gesvdjBatched` on CUDA 10.1.243 and later,
           and MAGMA's `gesdd` on earlier versions of CUDA.
 
-.. note:: The returned `U` will not be contiguous. The matrix (or batch of matrices) will
-          be represented as a column-major matrix (i.e. Fortran-contiguous).
-
 .. warning:: The singular vectors of a matrix are not unique. Any pair of singular
              vectors :math:`u_k, v_k` may be multiplied by `-1` when `U` and `V` are real-valued or
              by :math:`e^{i \phi}` for any :math:`\phi \in \mathbb{R}` when `U` and `V` are complex,

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -10,24 +10,23 @@ Tensor = torch.Tensor
 # also connects the torch.linalg Python namespace to the torch._C._linalg builtins.
 
 cholesky = _add_docstr(_linalg.linalg_cholesky, r"""
-linalg.cholesky(input, *, out=None) -> Tensor
+linalg.cholesky(A, *, out=None) -> Tensor
 
 Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix.
-Supports batched inputs.
 
-For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix
+:math:`A \in \mathbb{K}^{n \times n}` is defined as
 
 .. math::
 
-    A = LL^{\text{H}}
+    A = LL^{\text{H}}\mathrlap{\qquad L \in \mathbb{K}^{n \times n}}
 
 where :math:`L` is a lower triangular matrix and
 :math:`L^{\text{H}}` is the conjugate transpose when :math:`L` is complex, and the transpose when :math:`L` is real-valued.
 
-If :attr:`input` is a batch of matrices, then `L` is also batched with the
-same batch dimensions.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 .. note:: This function uses LAPACK's and MAGMA's `potrf` for CPU and CUDA inputs respectively.
           For CUDA inputs, this function synchronizes that device with the CPU.
@@ -39,15 +38,15 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
         slower to compute than the Cholesky decomposition.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
-                    consisting of symmetric or Hermitian positive-definite matrices.
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+                consisting of symmetric or Hermitian positive-definite matrices.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the :attr:`input` matrix or any matrix in a batched :attr:`input` is not Hermitian
-                  (resp. symmetric) positive-definite. If :attr:`input` is a batch of matrices,
+    RuntimeError: if the :attr:`A` matrix or any matrix in a batched :attr:`A` is not Hermitian
+                  (resp. symmetric) positive-definite. If :attr:`A` is a batch of matrices,
                   the error message will include the batch index of the first matrix that fails
                   to meet this condition.
 
@@ -92,11 +91,22 @@ Examples::
 """)
 
 inv = _add_docstr(_linalg.linalg_inv, r"""
-linalg.inv(input, *, out=None) -> Tensor
+linalg.inv(A, *, out=None) -> Tensor
 
-Computes the `inverse`_ of square matrix if it exists. Supports batched inputs.
+Computes the `inverse`_ of square matrix if it exists.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+for a matrix :math:`A \in \mathbb{K}^{n \times n}`,
+its inverse matrix :math:`A^{-1} \in \mathbb{K}^{n \times n}` is defined as
+
+.. math::
+
+    A^{-1}A = AA^{-1} = \mathrm{I}_n
+
+where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 .. note:: This function is computed using LAPACK's `getrf` and `getri` for CPU inputs.
           For CUDA inputs, cuSOLVER's `getrf` and `getrs` as well as cuBLAS' `getrf`
@@ -109,19 +119,19 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
         :func:`torch.linalg.pinv` computes the pseudoinverse (Moore-Penrose inverse) of matrices
         of any shape.
 
-        :func:torch.linalg.solve computes ``input.inv() @ other``.
+        :func:`torch.linalg.solve` computes :attr:`A`\ `.pinv() @ \ `:attr:`B`.
         It is always prefered to use :func:`torch.linalg.solve` when possible, as it is
         faster and more stable than computing the inverse and then multiplying.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
                     consisting of invertible matrices.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the :attr:`input` matrix or any matrix in the batch :attr:`input` is not invertible.
+    RuntimeError: if the :attr:`A` matrix or any matrix in the batch :attr:`A` is not invertible.
 
 Examples::
 
@@ -154,17 +164,18 @@ Examples::
 """)
 
 det = _add_docstr(_linalg.linalg_det, r"""
-linalg.det(input, *, out=None) -> Tensor
+linalg.det(A, *, out=None) -> Tensor
 
-Computes the determinant of a square matrix. Supports batched inputs.
+Computes the determinant of a square matrix.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 .. note:: This function is computed using :func:`torch.lu`.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: Backward through `det` internally uses :func:`torch.linalg.svd` when :attr:`input` is not
-          invertible. In this case, double backward through `det` will be unstable when :attr:`input`
+.. note:: Backward through `det` internally uses :func:`torch.linalg.svd` when :attr:`A` is not
+          invertible. In this case, double backward through `det` will be unstable when :attr:`A`
           doesn't have distinct singular values. See :func:`torch.linalg.svd` for more details.
 
 .. seealso::
@@ -174,7 +185,7 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
         square matrices.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -210,22 +221,20 @@ Example::
 """)
 
 slogdet = _add_docstr(_linalg.linalg_slogdet, r"""
-linalg.slogdet(input, *, out=None) -> (Tensor, Tensor)
+linalg.slogdet(A, *, out=None) -> (Tensor, Tensor)
 
 Computes the sign and natural logarithm of the absolute value of the determinant of a square matrix.
-Supports batched inputs.
 
-For a complex :attr:`input`, it returns the angle and the natural logarithm of the modulus of the
+
+For a complex :attr:`A`, it returns the angle and the natural logarithm of the modulus of the
 determinant, that is, a logarithmic polar decomposition of the determinant.
 
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
 It returns a named tuple `(sign, logabsdet)`.
-If :attr:`input` is a batch of matrices, then `sign` and `logabsdet` are also batched with the same
-batch dimensions.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor `logabsdet` will always be real-valued, even when :attr:`input` is complex.
-The output tensor `sign` will have the same dtype as :attr:`input`.
-
+The returned tensor `logabsdet` will always be real-valued, even when :attr:`A` is complex.
+The returned tensor `sign` will have the same dtype as :attr:`A`.
 
 .. note:: This function is computed using :func:`torch.lu`.
           For CUDA inputs, this function synchronizes that device with the CPU.
@@ -239,7 +248,7 @@ The output tensor `sign` will have the same dtype as :attr:`input`.
         :func:`torch.linalg.det` computes the determinant of square matrices.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.
@@ -260,24 +269,27 @@ Example::
 """)
 
 eig = _add_docstr(_linalg.linalg_eig, r"""
-linalg.eig(input, *, out=None) -> (Tensor, Tensor)
+linalg.eig(A, *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a square matrix if it exists. Supports batched inputs.
+Computes the eigenvalue decomposition of a square matrix if it exists.
 
-For a square matrix :math:`A`, this is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the eigenvalue decomposition of a square matrix
+:math:`A \in \mathbb{K}^{n \times n}` is defined as
 
 .. math::
 
-    A = V \operatorname{diag}(\Lambda) V^{-1}
+    A = V \operatorname{diag}(\Lambda) V^{-1}\mathrlap{\qquad V \in \mathbb{C}^{n \times n}, \Lambda in \mathbb{C}^n}
 
-This decomposition exists if and only if :math:`A` is `diagonalizable`_. This is the case when all its eigenvalues are different.
+This decomposition exists if and only if :math:`A` is `diagonalizable`_.
+This is the case when all its eigenvalues are different.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 The returned decomposition is a named tuple `(eigenvalues, eigenvectors)`,
-which corresponds to :math:`\Lambda`, :math:`V` above. If :attr:`input` is a batch of matrices,
-then `eigenvalues` and `eigenvectors` are also batched with the same batch dimensions.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensors `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`input` is real.
+which correspond to :math:`\Lambda` and :math:`V` above.
+The output tensors `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`A` is real.
 
 .. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
@@ -285,19 +297,21 @@ The output tensors `eigenvalues` and `eigenvectors` will always be complex-value
           respectively.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: The eigenvectors of a matrix are not unique, as multiplying an eigenvector by a
-          non-zero number produces another set of eigenvectors for the matrix.
-          As such, the returned eigenvectors are normalized to have norm
-          `1` and largest real component.
-          In particular, the eigenvectors are not continuous functions of the inputs.
+.. warning:: The eigenvectors of a matrix are not unique, as multiplying an eigenvector by a
+             non-zero number produces another set of valid eigenvectors of the matrix.
+             As such, the returned eigenvectors are normalized to have norm
+             `1` and largest real component.
+             As this choice is not canonical, it happens that the eigenvectors are not continuous
+             functions of the inputs. For this reason, different platforms, like NumPy, or inputs
+             on different devices, may produce different singular vectors.
 
-.. warning:: This function assumes that :attr:`input` is `diagonalizable`_ (e.g. when all the
+.. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (e.g. when all the
              eigenvalues are different). If it is not diagonalizable, the returned
              `eigenvalues` will be correct but
 
              .. code::
 
-                input != eigenvectors @ torch.diag(eigenvalues) @ eigenvectors.transpose(-2, -1)
+                A != eigenvectors @ torch.diag_embed(eigenvalues) @ eigenvectors.transpose(-2, -1)
 
 .. warning:: Differentiation support for this function is not implemented yet.
 
@@ -316,7 +330,7 @@ The output tensors `eigenvalues` and `eigenvectors` will always be complex-value
         any shape.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
                     consisting of diagonalizable matrices.
 
 Keyword args:
@@ -347,14 +361,28 @@ Examples::
 """)
 
 eigvals = _add_docstr(_linalg.linalg_eigvals, r"""
-linalg.eigvals(input, *, out=None) -> Tensor
+linalg.eigvals(A, *, out=None) -> Tensor
 
-Computes the eigenvalues of a square matrix. Supports batched inputs.
+Computes the eigenvalues of a square matrix.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor will always be complex-valued, even when :attr:`input` is real.
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the eigenvalues of a square matrix :math:`A \in \mathbb{K}^{n \times n}` are defined
+as the roots (counted with multiplicity) of the polynomial of degree `n`
 
-.. note:: The eigenvalues of a real matrix may be complex.
+.. math::
+
+    p(\lambda) = \operatorname{det}(A - \lambda \mathrm{I}_n)
+
+where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+The returned tensor will always be complex-valued, even when :attr:`A` is real.
+
+.. note:: The eigenvalues of a real matrix may be complex, as the roots of a real polynomial may be complex.
+
+.. note:: The eigenvalues of a matrix are always well-defined, even when the matrix is not diagonalizable.
 
 .. note:: This function is computed using LAPACK's and MAGMA's `geev` for CPU and CUDA inputs,
           respectively.
@@ -364,7 +392,7 @@ The output tensor will always be complex-valued, even when :attr:`input` is real
           instead, which also computes the eigenvectors.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -381,33 +409,36 @@ Examples::
 """)
 
 eigh = _add_docstr(_linalg.linalg_eigh, r"""
-linalg.eigh(input, UPLO='L', *, out=None) -> (Tensor, Tensor)
+linalg.eigh(A, UPLO='L', *, out=None) -> (Tensor, Tensor)
 
-Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix. Supports batched inputs.
+Computes the eigenvalue decomposition of a complex Hermitian or real symmetric matrix.
 
-For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the eigenvalue decomposition of a complex Hermitian or real symmetric matrix
+:math:`A \in \mathbb{K}^{n \times n}` is defined as
 
 .. math::
 
-    A = Q \operatorname{diag}(\Lambda) Q^{\text{H}}
+    A = Q \operatorname{diag}(\Lambda) Q^{\text{H}}\mathrlap{\qquad Q \in \mathbb{K}^{n \times n}, \Lambda \in \mathbb{R}^n}
 
-where :math:`Q^{\text{H}}` is the conjugate transpose when :math:`Q` is complex, and the transpose when :math:`Q` is real-valued.
-The matrix :math:`Q` (and thus :math:`Q^{\text{H}}`) is orthogonal in the real case,
-and unitary in the complex case.
+:math:`Q^{\text{H}}` is the conjugate transpose when :math:`Q` is complex, and the transpose when :math:`Q` is real-valued.
+:math:`Q` is orthogonal in the real case and unitary in the complex case.
 
-:attr:`input` is assumed to be Hermitian (resp. symmetric), but this is not checked internally.
-When :attr:`UPLO` is `'L'` (default), only the lower triangular part of each matrix is used in the computation.
-When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is used.
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+:attr:`A` is assumed to be Hermitian (resp. symmetric), but this is not checked internally, instead:
+
+- If :attr:`UPLO` `= 'L'` (default), only the lower triangular part of the matrix is used in the computation.
+- If :attr:`UPLO` `= 'U'`, only the upper triangular part of the matrix is used.
 
 The returned decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`,
-which corresponds to :math:`\Lambda`, :math:`Q` above. If :attr:`input` is a batch of matrices,
+which corresponds to :math:`\Lambda`, :math:`Q` above. If :attr:`A` is a batch of matrices,
 then `eigenvalue` and `eigenvectors` are also batched with the same batch dimensions.
+The returned tensor `eigenvalues` will always be real-valued, even when :attr:`A` is complex.
+The returned tensor `eigenvectors` will have the same dtype as :attr:`A`.
 
-The eigenvalues are returned in ascending order.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor `eigenvalues` will always be real-valued, even when :attr:`input` is complex.
-The output tensor `eigenvectors` will have the same dtype as :attr:`input`.
+The `eigenvalues` are returned in ascending order.
 
 .. note:: If the inputs are symmetric, this function is computed using LAPACK's and MAGMA's
           `syevd` for CPU and CUDA inputs,
@@ -421,12 +452,12 @@ The output tensor `eigenvectors` will have the same dtype as :attr:`input`.
              in the real case or by :math:`e^{i \phi}` for any :math:`\phi \in \mathbb{R}` in the
              complex case, and the resulting singular vectors will give a different
              eigendecomposition of the matrix.
-             As such, the eigenvectors are not continuous functions of the inputs, and different
-             platforms, like NumPy, or inputs on different devices, may produce different
-             eigenvectors.
+             As this choice is not canonical, it happens that the eigenvectors are not continuous
+             functions of the input matrix. As such, different platforms, like NumPy, or inputs
+             on different devices, may produce different eigenvectors.
 
 .. warning:: If the `eigenvectors` are used to compute gradients, the gradient will only be
-             finite when :attr:`input` does not have repeated eigenvalues.
+             finite when :attr:`A` does not have repeated eigenvalues.
              Furthermore, if the distance between any two eigvalues is close to zero,
              the gradient will be numerically unstable, as it depends on the eigenvalues
              :math:`\lambda_i` through the computation of
@@ -451,10 +482,10 @@ The output tensor `eigenvectors` will have the same dtype as :attr:`input`.
         matrices.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
                     consisting of symmetric or Hermitian matrices.
     UPLO ('L', 'U', optional): controls whether to use the upper or lower triangular part
-                               of :attr:`input` in the computations. Default: `'L'`.
+                               of :attr:`A` in the computations. Default: `'L'`.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.
@@ -483,33 +514,44 @@ Examples::
 """)
 
 eigvalsh = _add_docstr(_linalg.linalg_eigvalsh, r"""
-linalg.eigvalsh(input, UPLO='L', *, out=None) -> Tensor
+linalg.eigvalsh(A, UPLO='L', *, out=None) -> Tensor
 
-Computes the eigenvalues of a complex Hermitian or real symmetric matrix. Supports batched inputs.
+Computes the eigenvalues of a complex Hermitian or real symmetric matrix.
 
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the eigenvalues of a square matrix :math:`A \in \mathbb{K}^{n \times n}` are defined
+as the roots (counted with multiplicity) of the polynomial of degree `n`
+
+.. math::
+
+    p(\lambda) = \operatorname{det}(A - \lambda \mathrm{I}_n)
+
+where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
+The eigenvalues of a real symmetric or complex Hermitian matrix are always real.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+:attr:`A` is assumed to be Hermitian (resp. symmetric), but this is not checked internally, instead:
+
+- If :attr:`UPLO` `= 'L'` (default), only the lower triangular part of the matrix is used in the computation.
+- If :attr:`UPLO` `= 'U'`, only the upper triangular part of the matrix is used.
+
+The returned tensor will always be real-valued, even when :attr:`A` is complex.
 The eigenvalues are returned in ascending order.
-
-:attr:`input` is assumed to be Hermitian (resp. symmetric), but this is not checked internally.
-When :attr:`UPLO` is `'L'` (default), only the lower triangular part of each matrix is used in the computation.
-When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is used.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor will always be real-valued, even when :attr:`input` is complex.
 
 .. note:: This function is computed using LAPACK's and MAGMA's `syevd` / `heevd` for
           CPU and CUDA symmetric / Hermitian inputs respectively.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
-.. note:: The eigenvalues of real symmetric or complex Hermitian matrices are always real.
-
 .. note:: This function is not differentiable. Please use :func:`torch.linalg.eigh`
           instead, which also computes the eigenvectors.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
                     consisting of symmetric or Hermitian matrices.
     UPLO ('L', 'U', optional): controls whether to use the upper or lower triangular part
-                               of :attr:`input` in the computations. Default: `'L'`.
+                               of :attr:`A` in the computations. Default: `'L'`.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
@@ -544,14 +586,14 @@ Examples::
 """)
 
 householder_product = _add_docstr(_linalg.linalg_householder_product, r"""
-householder_product(input, tau, *, out=None) -> Tensor
+householder_product(A, tau, *, out=None) -> Tensor
 
-Computes the first `n` columns of a product of Householder matrices. Supports batched inputs.
+Computes the first `n` columns of a product of Householder matrices.
 
-Assume that :attr:`input` has shape `(*, m, n)` with `m >= n` and :attr:`tau` has shape
-`(*, k)` with `k <= n` where `*` is zero or more batch dimensions. Denoting
-:math:`v_i` `= \ `:attr:`input`\ `[..., :, i]` and :math:`\tau_i` `= \ `:attr:`tau`\ `[..., i]`,
-for every element of the batch this function returns the first `n` columns of the matrix
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+for a matrix :math:`V \in \mathbb{K}^{m \times n}` with columns :math:`v_i \in \mathbb{K}^m`
+with :math:`m \geq n` and a vector :math:`\tau \in \mathbb{K}^k` with :math:`k \leq n`,
+this function computes the first :math:`n` columns of the matrix
 
 .. math::
 
@@ -559,17 +601,16 @@ for every element of the batch this function returns the first `n` columns of th
 
 where :math:`\mathrm{I}_m` is the `m`-dimensional identity matrix and
 :math:`v^{\text{H}}` is the conjugate transpose when :math:`v` is complex, and the transpose when :math:`v` is real-valued.
-The output has shape `(*, m, n)`.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-:attr:`tau` should have the same dtype as :attr:`input`.
 
 See `Representation of Orthogonal or Unitary Matrices`_ for further details.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 .. note:: This function is computed using LAPACK's `orgqr` for CPU inputs,
           and cuSOLVER's `orgqr` for CUDA inputs if CUDA version >= 10.1.243.
 
-.. note:: This function only uses the values strictly below the main diagonal of :attr:`input`.
+.. note:: This function only uses the values strictly below the main diagonal of :attr:`A`.
           The other values are ignored.
 
 .. seealso::
@@ -578,14 +619,14 @@ See `Representation of Orthogonal or Unitary Matrices`_ for further details.
         :func:`~qr` decomposition.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     tau (Tensor): tensor of shape `(*, k)` where `*` is zero or more batch dimensions.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if :attr:`input` doesn't satisfy the requirement `m >= n`,
+    RuntimeError: if :attr:`A` doesn't satisfy the requirement `m >= n`,
                   or :attr:`tau` doesn't satisfy the requirement `n >= k`.
 
 Examples::
@@ -614,20 +655,22 @@ Examples::
 """)
 
 lstsq = _add_docstr(_linalg.linalg_lstsq, r"""
-torch.linalg.lstsq(input, b, cond=None, *, driver=None) -> (Tensor, Tensor, Tensor, Tensor)
+torch.linalg.lstsq(A, B, cond=None, *, driver=None) -> (Tensor, Tensor, Tensor, Tensor)
 
-Computes the least squares solution of a system  of linear equations. Supports batched inputs.
+Computes a solution to the least squares problem  of a system of linear equations.
 
-Assume that :attr:`input`, :attr:`b` have shapes `(*, m, n)`, `(*, m, k)` where `*` is zero
-or more batch dimensions. For every matrix :math:`A` in :attr:`input` and every set :math:`B`
-in :attr:`b` of `k` vectors of dimension `m`, this function returns the solution to the problem
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the least squares problem for a linear system :math:`AX = B` with
+:math:`A \in \mathbb{K}^{m \times n}, B \in \mathbb{K}^{m \times k}` is defined as
 
 .. math::
 
     \min_{X \in \mathbb{K}^{n \times k}} \|AX - B\|_F
 
-where :math:`\mathbb{K} = \mathbb{R}` or :math:`\mathbb{C}`, and :math:`\|-\|_F` denotes the Frobenius norm.
-The output has shape `(*, m, k)`.
+where :math:`\|-\|_F` denotes the Frobenius norm.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 :attr:`driver` chooses the LAPACK/MAGMA driver that will be used.
 For CPU inputs the valid values are `'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`.
@@ -636,38 +679,39 @@ The driver `'gels'` assumes that the input is full-rank.
 The drivers `'gelsy'`, `'gelsd'`, `'gelss'` handle rank-deficient inputs.
 See the note below on how to choose the best driver. See also the `full description of these drivers`_
 
-:attr:`cond` is used to determine the effective rank of the matrices in :attr:`input`
+:attr:`cond` is used to determine the effective rank of the matrices in :attr:`A`
 for rank-revealing drivers, that is, when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`).
 In this case, if :math:`\sigma_i` are the singular values of `A` in decreasing order,
 :math:`\sigma_i` will be rounded down to zero if :math:`\sigma_i \leq \text{cond} \cdot \sigma_1`.
-If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`input`.
+If :attr:`cond` `= None` (default), :attr:`cond` is set to the machine precision of the dtype of :attr:`A`.
 
-This function returns the solution to the problem and some extra information in a namedtuple of
+This function returns the solution to the problem and some extra information in a named tuple of
 four tensors `(solution, residuals, rank, singular_values)` containing:
 
 - `solution`: the least squares solution
 - `residuals`: the squared residuals of the solutions, that is :math:`\|AX - B\|_F^2`.
   It is computed when `m > n` and the matrix is full-rank,
   otherwise, it is an empty tensor.
-- `rank`: tensor of ranks of the matrices in :attr:`input`
-  It has shape equal to the batch dimensions of :attr:`input`.
+- `rank`: tensor of ranks of the matrices in :attr:`A`
+  It has shape equal to the batch dimensions of :attr:`A`.
   It is computed when :attr:`driver` is one of (`'gelsy'`, `'gelsd'`, `'gelss'`),
   otherwise it is an empty tensor.
-- `singular_values`: tensor of singular values of the matrices in :attr:`input`.
+- `singular_values`: tensor of singular values of the matrices in :attr:`A`.
   It has shape `(*, min(m, n))`.
   It is computed when :attr:`driver` is one of (`'gelsd'`, `'gelss'`),
   otherwise it is an empty tensor.
 
 .. note::
-    The solution to this problem can be computed in terms of the pseudoinverse
-    (Moore-Penrose inverse) of `A` as `A.pinv() @ B`.
-    For this reason, this function is a faster and more stable way of computing `A.pinv() @ B`.
+    A solution to this problem can be computed in terms of the pseudoinverse
+    (see :func:`torch.linalg.pinv`) of :attr:`A` as :attr:`A`\ `.pinv() @ \ `:attr:`B`.
+    In particular, this function is a faster and more stable way of computing
+    :attr:`A`\ `.pinv() @ \ `:attr:`B`.
 
 .. note::
-    Choosing :attr:`driver`: if :attr:`input` is well-conditioned (its `condition number`_ is not
+    Choosing :attr:`driver`: if :attr:`A` is well-conditioned (its `condition number`_ is not
     too large) you should prefer `'gels'` (QR) if the output is full-rank and `'gelsy'`
     (QR with pivoting) otherwise.
-    If :attr:`input` is not well-conditioned, you should almost always prefer `'gelsd'`
+    If :attr:`A` is not well-conditioned, you should almost always prefer `'gelsd'`
     (tridiagonal reduction and SVD), but try `'gelss'` (full SVD) if you run into memory issues.
 
 .. note::
@@ -679,11 +723,11 @@ four tensors `(solution, residuals, rank, singular_values)` containing:
     breaking changes.
 
 Args:
-    input (Tensor): lhs tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): lhs tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     b (Tensor): rhs tensor of shape `(*, m, k)` where `*` is zero or more batch dimensions.
     cond (float, optional): used to determine the effective rank of the input.
                             If :attr:`cond` `= None`, :attr:`cond` is set to the machine
-                            of the dtype of :attr:`input`. Default: `None`.
+                            of the dtype of :attr:`A`. Default: `None`.
 
 Keyword args:
     driver (str, optional): name of the LAPACK/MAGMA method to be used.
@@ -716,16 +760,19 @@ Example::
 """)
 
 matrix_power = _add_docstr(_linalg.linalg_matrix_power, r"""
-matrix_power(input, n, *, out=None) -> Tensor
+matrix_power(A, n, *, out=None) -> Tensor
 
-Computes the :attr:`n`-th power of a matrix for an integer :attr:`n`. Supports batched inputs.
+Computes the n-th power of a square matrix for an integer n.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 If :attr:`n` `= 0`, it returns the identity matrix (or batch) of the same shape
-as :attr:`input`. If :attr:`n` is negative, it returns the inverse of each matrix
+as :attr:`A`. If :attr:`n` is negative, it returns the inverse of each matrix
 (if invertible) raised to the power of `abs(n)`.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, m)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, m)` where `*` is zero or more batch dimensions.
     n (int): the exponent.
 
 Keyword args:
@@ -756,18 +803,21 @@ Example::
 """)
 
 matrix_rank = _add_docstr(_linalg.linalg_matrix_rank, r"""
-matrix_rank(input, tol=None, hermitian=False, *, out=None) -> Tensor
+matrix_rank(A, tol=None, hermitian=False, *, out=None) -> Tensor
 
-Computes the numerical rank of a matrix. Supports batched inputs.
+Computes the numerical rank of a matrix.
 
 The matrix rank is computed as the number of singular values
 (or eigenvalues in absolute value when :attr:`hermitian`\ `= True`)
 that are greater than the specified :attr:`tol` threshold.
 
-If :attr:`hermitian`\ `= True`, :attr:`input` is assumed to be Hermitian if complex or
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+If :attr:`hermitian`\ `= True`, :attr:`A` is assumed to be Hermitian if complex or
 symmetric if real.
 
-If :attr:`tol` is not specified and :attr:`input` is a matrix of dimensions `(m, n)`,
+If :attr:`tol` is not specified and :attr:`A` is a matrix of dimensions `(m, n)`,
 the tolerance is set to be
 
 .. math::
@@ -776,11 +826,9 @@ the tolerance is set to be
 
 where :math:`\sigma_1` is the largest singular value
 (or eigenvalue in absolute value when :attr:`hermitian`\ `= True`), and
-:math:`\varepsilon` is the epsilon value for the dtype of :attr:`input` (see :class:`torch.finfo`).
-If :attr:`input` is a batch of matrices, :attr:`tol` is computed this way for every element of
+:math:`\varepsilon` is the epsilon value for the dtype of :attr:`A` (see :class:`torch.finfo`).
+If :attr:`A` is a batch of matrices, :attr:`tol` is computed this way for every element of
 the batch.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
 .. note:: The matrix rank is computed using singular value decomposition
           :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` (default) and the eigenvalue
@@ -788,11 +836,10 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
           For CUDA inputs, this function synchronizes that device with the CPU.
 
 Args:
-    input (Tensor): the input matrix of shape `(m, n)` or the batch of matrices of shape `(*, m, n)`
-                    where `*` is one or more batch dimensions.
-    tol (float, Tensor, optional): the tolerance value. See above for the value it takes when `None`.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    tol (float, Rensor, optional): the tolerance value. See above for the value it takes when `None`.
                                    Default: `None`.
-    hermitian(bool, optional): indicates whether :attr:`input` is Hermitian (or symmetric if real).
+    hermitian(bool, optional): indicates whether :attr:`A` is Hermitian (or symmetric if real).
                                Default: `False`.
 
 Keyword args:
@@ -833,35 +880,36 @@ Examples::
 """)
 
 vector_norm = _add_docstr(_linalg.linalg_vector_norm, r"""
-linalg.vector_norm(input, ord=None, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
+linalg.vector_norm(A, ord=None, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
 
-Computes the vector norm of a vector. Supports batched inputs.
+Computes the vector norm of a vector.
 
-If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
+If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
+The returned tensor will always be real-valued, even when :attr:`A` is complex.
 
-- If :attr:`dim`\ `= None`, the norm of the flattened :attr:`input` will be computed.
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+- If :attr:`dim`\ `= None`, the norm of the flattened :attr:`A` will be computed.
 - If :attr:`dim` is an `int` or a `tuple`, the norm will be computed over these dimensions
   and the other dimensions will be treated as batch dimensions.
 
 :attr:`ord` defines the vector norm that is computed. The following norms are supported:
 
-======================   =======================================================
+======================   ========================================================
 :attr:`ord`              vector norm
-======================   =======================================================
+======================   ========================================================
 `None` (default)         `2`-norm
 `inf`                    `max(abs(x))`
 `-inf`                   `min(abs(x))`
 `0`                      `sum(x != 0)`
 other `int` or `float`   `sum(abs(x)**\ `:attr:`ord`\ `)**(1./\ `:attr:`ord`\ `)`
-======================   =======================================================
+======================   ========================================================
 
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor will always be real-valued, even when :attr:`input` is complex.
-
 Args:
-    input (Tensor): a tensor of any shape.
+    A (Tensor): tensor of shape `(*, n)` where `*` is zero or more batch dimensions.
 
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `None`
 
@@ -902,6 +950,8 @@ linalg.multi_dot(tensors, *, out=None)
 Efficiently multiplies two or more matrices by reordering the multiplications so that
 the fewest arithmetic operations are performed.
 
+Supports inputs of float, double, cfloat and cdouble dtypes.
+This function does not support batched inputs.
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which
 may be 1D. If the first tensor is a 1D vector of shape `n` it is treated as a row vector
 of shape `(1, n)`, similarly if the last tensor is a 1D vector of shape `n` it is treated
@@ -963,17 +1013,21 @@ Examples::
 """)
 
 norm = _add_docstr(_linalg.linalg_norm, r"""
-linalg.norm(input, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
+linalg.norm(A, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
 
-Computes the vector norm of a vector or the matrix norm of a matrix. Supports batched inputs.
+Computes the vector norm of a vector or the matrix norm of a matrix.
 
-If :attr:`input` is complex valued, it computes the norm of :attr:`input`\ `.abs()`
+If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
+The returned tensor will always be real-valued, even when :attr:`A` is complex.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 - If :attr:`dim` is an `int`, the vector norm will be computed.
 - If :attr:`dim` is a `2`-`tuple`, the matrix norm will be computed.
 - If :attr:`dim`\ `= None` and :attr:`ord` `= None`,
-  :attr:`input` is flattened to 1D and the `2`-norm of the resulting vector is returned.
-- If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`input` must be 1D or 2D.
+  :attr:`A` is flattened to 1D and the `2`-norm of the resulting vector is returned.
+- If :attr:`dim`\ `= None` and :attr:`ord` `!= None`, :attr:`A` must be 1D or 2D.
 
 :attr:`ord` defines the norm that is computed. The following norms are supported:
 
@@ -995,16 +1049,13 @@ other `int` or `float`     -- not supported --        `sum(abs(x)**\ `:attr:`ord
 
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor will always be real-valued, even when :attr:`input` is complex.
-
 Args:
-    input (Tensor): the input tensor. The allowed shapes follow the rules described above.
+    A (Tensor): tensor of shape `(*, n)` or `(*, m, n)` where `*` is zero or more batch dimensions
 
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `None`
 
     dim (int, Tuple[int], optional): dimensions over which to compute
-        the vector or matrix norm. See above for the behavior when :attr:`dim`\ `= None`.
+        the vector or matrix norm. See above for the behavior when :attr:`dim` `= None`.
         Default: `None`
 
     keepdim (bool, optional): If set to `True`, the reduced dimensions are retained
@@ -1087,40 +1138,41 @@ Using the :attr:`dim` argument to compute matrix norms::
 """)
 
 svd = _add_docstr(_linalg.linalg_svd, r"""
-linalg.svd(input, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
+linalg.svd(A, full_matrices=True, compute_uv=True, *, out=None) -> (Tensor, Tensor, Tensor)
 
-Computes the singular value decomposition of a matrix. Supports batched inputs.
+Computes the singular value decomposition of a matrix.
 
-For a matrix :math:`A`, this is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the singular value decomposition of a matrix
+:math:`A \in \mathbb{K}^{m \times n}`, if :math:`k = \min(m,n)`, is defined as
 
 .. math::
 
-    A = U \operatorname{diag}(S) V^{\text{H}}
+    A = U \operatorname{diag}(S) V^{\text{H}}\mathrlap{\qquad U \in \mathbb{K}^{m \times m}, \Lambda \in \mathbb{R}^k, U \in \mathbb{K}^{n \times n}}
 
-where :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
-The matrices  :math:`U`, :math:`V` (and thus :math:`V^{\text{H}}`) are orthogonal in the real case,
-and unitary in the complex case.
+where :math:`\operatorname{diag}(S) \in \mathbb{K}^{m \times n}`,
+:math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
+The matrices  :math:`U`, :math:`V` (and thus :math:`V^{\text{H}}`) are orthogonal in the real case, and unitary in the complex case.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 The returned decomposition is a named tuple `(U, S, Vh)`
 which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
-If :attr:`input` is a batch of matrices, then `U`, `S` and `Vh` are also batched with the same
-batch dimensions.
+The returned tensor `S` will always be real-valued, even when :attr:`A` is complex.
+The returned tensors `U` and `Vh` will have the same dtype as :attr:`A`.
 
-The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
-then the singular values of each matrix in the batch are also returned in descending order.
+The singular values are returned in descending order.
 
 If :attr:`full_matrices` `= False`, the method will return the reduced singular
-value decomposition. In this case, if :attr:`input` has shape `(*, m, n)`,
+value decomposition. In this case, if :attr:`A` has shape `(*, m, n)`,
+where `*` is zero or more batch dimensions,
 the returned `U`, `Vh` will have shape `(*, m, min(m, n))` and `(*, min(m, n), n)`
 respectively.
 
 If :attr:`compute_uv` `= False`, the returned `U` and `Vh` will be empty
-tensors with no elements and the same device as :attr:`input`. The
+tensors with no elements and the same device as :attr:`A`. The
 :attr:`full_matrices` argument has no effect when :attr:`compute_uv` `= False`.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor `S` will always be real-valued, even when :attr:`input` is complex.
-The output tensors `U` and `Vh` will have the same dtype as :attr:`input`.
 
 Differences with `numpy.linalg.svd`:
 
@@ -1132,7 +1184,7 @@ Differences with `numpy.linalg.svd`:
 
 .. note:: The `S` tensor can only be used to compute gradients if :attr:`compute_uv` `= True`.
 
-.. note:: When :attr:`full_matrices` `= True`, the gradients on `U[..., :, min(m, n):]`
+.. note:: When :attr:`full_matrices` `= True`, the gradients with respect to `U[..., :, min(m, n):]`
           and `Vh[..., min(m, n):, :]` will be ignored in the backwards pass, as those vectors
           can be arbitrary bases of the corresponding subspaces.
 
@@ -1147,17 +1199,17 @@ Differences with `numpy.linalg.svd`:
              This non-uniqueness problem is even worse when the matrix has repeated singular values.
              In this case, one may multiply the associated singular vectors of `U` and `V` spanning
              the subspace by a rotation matrix and `the resulting vectors will span the same subspace`_.
-             As such, `U` and `Vh` are not continuous functions of the inputs. Furthermore, different
-             platforms, like NumPy, or inputs on different devices, may produce different
-             `U` and `Vh` tensors.
+             As this choice is not canonical, it happens that `U` and `V`  are not continuous
+             functions of the input matrix. For this reason, different platforms, like NumPy, or inputs
+             on different devices, may produce different singular vectors.
 
 .. warning:: If `U` or `Vh` are used to compute gradients, the gradient will only be finite when
-             :attr:`input` does not have zero as a singular value or repeated singular values.
+             :attr:`A` does not have zero as a singular value or repeated singular values.
              Furthermore, if the distance between any two singular values is close to zero,
              the gradient will be numerically unstable, as it depends on the singular values
              :math:`\sigma_i` through the computation of
              :math:`\frac{1}{\min_{i \neq j} \sigma_i^2 - \sigma_j^2}`.
-             The gradient will also be numerically unstable when :attr:`input` has small singular
+             The gradient will also be numerically unstable when :attr:`A` has small singular
              values, as it also depends on the computaiton of :math:`\frac{1}{\sigma_i}`.
 
 .. seealso::
@@ -1172,7 +1224,7 @@ Differences with `numpy.linalg.svd`:
         matrices.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     full_matrices (bool, optional): controls whether to compute the full or reduced decomposition, and
                                     consequently, the shape of returned `U` and `Vh`. Default: `True`.
     compute_uv (bool, optional): controls whether to compute `U` and `Vh`. Default: `True`.
@@ -1257,18 +1309,23 @@ Example::
 """)
 
 cond = _add_docstr(_linalg.linalg_cond, r"""
-linalg.cond(input, p=None, *, out=None) -> Tensor
+linalg.cond(A, p=None, *, out=None) -> Tensor
 
-Computes the condition number of a matrix with respect to a norm. Supports batched inputs.
+Computes the condition number of a matrix with respect to a norm.
 
-The condition number :math:`\kappa` of a matrix :math:`A` is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+The condition number :math:`\kappa` of a matrix
+:math:`A \in \mathbb{K}^{n \times n}` is defined as
 
 .. math::
 
     \kappa(A) = \|A\|_p\|A^{-1}\|_p
 
-The condition number of `A` measures the numerical stability of the linear system `AX = B`
+The condition number of :attr:`A` measures the numerical stability of the linear system `AX = B`
 in some specific matrix norm.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 :attr:`p` defines the matrix norm that is computed. The following norms are supported:
 
@@ -1290,7 +1347,7 @@ where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent ob
 
 For :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`, this function uses
 :func:`torch.linalg.norm` and :func:`torch.linalg.inv`.
-As such, in this case, the matrix (or every matrix in the batch) :attr:`input` should be square
+As such, in this case, the matrix (or every matrix in the batch) :attr:`A` should be square
 and invertible.
 
 For :attr:`p` in `(2, -2)`, this function can be computed in terms of the singular values
@@ -1301,10 +1358,9 @@ For :attr:`p` in `(2, -2)`, this function can be computed in terms of the singul
     \kappa_2(A) = \frac{\sigma_1}{\sigma_n}\qquad \kappa_{-2}(A) = \frac{\sigma_n}{\sigma_1}
 
 In these cases, it is computed using :func:`torch.linalg.svd`. For these norms, the matrix
-(or every matrix in the batch) :attr:`input` may be rectangular
+(or every matrix in the batch) :attr:`A` may be rectangular
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-The output tensor will always be real-valued, even when :attr:`input` is complex.
+The returned tensor will always be real-valued, even when :attr:`A` is complex.
 
 .. note :: For CUDA inputs, this function synchronizes that device with the CPU if
            if :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`.
@@ -1316,7 +1372,7 @@ The output tensor will always be real-valued, even when :attr:`input` is complex
         :func:`torch.linalg.lstsq` for a function that solves linear systems of general matrices.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions
                     for :attr:`p` in `(2, -2)`, and of shape `(*, n, n)` where every matrix
                     is invertible for :attr:`p` in `('fro', 'nuc', inf, -inf, 1, -1)`.
     p (int, inf, -inf, 'fro', 'nuc', optional):
@@ -1328,7 +1384,7 @@ Keyword args:
 Raises:
     RuntimeError:
         if :attr:`p` is one of `('fro', 'nuc', inf, -inf, 1, -1)`
-        and the :attr:`input` matrix or any matrix in the batch :attr:`input` is not square
+        and the :attr:`A` matrix or any matrix in the batch :attr:`A` is not square
         or invertible.
 
 
@@ -1386,18 +1442,21 @@ Examples::
 """)
 
 pinv = _add_docstr(_linalg.linalg_pinv, r"""
-linalg.pinv(input, rcond=1e-15, hermitian=False, *, out=None) -> Tensor
+linalg.pinv(A, rcond=1e-15, hermitian=False, *, out=None) -> Tensor
 
-Computes the pseudoinverse (Moore-Penrose inverse) of a matrix. Supports batched inputs.
+Computes the pseudoinverse (Moore-Penrose inverse) of a matrix.
 
-If :attr:`hermitian`\ `= True`, :attr:`input` should be a complex Hermitian or real symmetric
+The pseudoinverse may be `defined algebraically`_
+but it is more computationally convenient to understand it `through the SVD`_
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+If :attr:`hermitian`\ `= True`, :attr:`A` should be a complex Hermitian or real symmetric
 matrix or batch of matrices. In this case, it will just use the lower-triangular half of the matrix.
 
 The singular values (or the norm of the eigenvalues when :attr:`hermitian`\ `= True`)
 that are below the specified :attr:`rcond` threshold are treated as zero and discarded in the computation.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-
 
 .. note:: This function uses :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` and
           :func:`torch.linalg.eigh` if :attr:`hermitian`\ `= True`.
@@ -1407,18 +1466,18 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
         :func:`torch.linalg.inv` computes the inverse of a square matrix.
 
-        :func:torch.linalg.lstsq computes ``input.pinv() @ other``.
+        :func:`torch.linalg.lstsq` computes :attr:`A`\ `.pinv() @ \ `:attr:`B`.
         It is always prefered to use :func:`torch.linalg.lstsq` when possible, as it is
         faster and more stable than computing the pseudoinverse and then multiplying.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     rcond (float or Tensor, optional): the tolerance value to determine when is a singular value zero
                                        If it is a :class:`torch.Tensor`, its shape must be
                                        broadcastable to that of the singular values of
-                                       :attr:`input` as returned by :func:`torch.svd`.
+                                       :attr:`A` as returned by :func:`torch.svd`.
                                        Default: `1e-15`.
-    hermitian(bool, optional): indicates whether :attr:`input` is Hermitian if complex
+    hermitian(bool, optional): indicates whether :attr:`A` is Hermitian if complex
                                or symmetric if real. Default: `False`.
 
 Keyword args:
@@ -1426,12 +1485,12 @@ Keyword args:
 
 Examples::
 
-    >>> input = torch.randn(3, 5)
-    >>> input
+    >>> A = torch.randn(3, 5)
+    >>> A
     tensor([[ 0.5495,  0.0979, -1.4092, -0.1128,  0.4132],
             [-1.1143, -0.3662,  0.3042,  1.6374, -0.9294],
             [-0.3269, -0.5745, -0.0382, -0.5922, -0.6759]])
-    >>> torch.linalg.pinv(input)
+    >>> torch.linalg.pinv(A)
     tensor([[ 0.0600, -0.1933, -0.2090],
             [-0.0903, -0.0817, -0.4752],
             [-0.7124, -0.1631, -0.2272],
@@ -1439,22 +1498,22 @@ Examples::
             [-0.0308, -0.1725, -0.5216]])
 
     Batched linalg.pinv example
-    >>> a = torch.randn(2, 6, 3)
-    >>> b = torch.linalg.pinv(a)
-    >>> torch.matmul(b, a)
-    tensor([[[ 1.0000e+00,  1.6391e-07, -1.1548e-07],
-            [ 8.3121e-08,  1.0000e+00, -2.7567e-07],
-            [ 3.5390e-08,  1.4901e-08,  1.0000e+00]],
+    >>> A = torch.randn(2, 6, 3)
+    >>> B = torch.linalg.pinv(A)
+    >>> torch.matmul(B, A).round()
+    tensor([[[1., -0., 0.],
+             [0., 1., -0.],
+             [0., 0., 1.]],
 
-            [[ 1.0000e+00, -8.9407e-08,  2.9802e-08],
-            [-2.2352e-07,  1.0000e+00,  1.1921e-07],
-            [ 0.0000e+00,  8.9407e-08,  1.0000e+00]]])
+            [[1., -0., 0.],
+             [-0., 1., 0.],
+             [-0., -0., 1.]]])
 
     Hermitian input example
-    >>> a = torch.randn(3, 3, dtype=torch.complex64)
-    >>> a = a + a.t().conj()  # creates a Hermitian matrix
-    >>> b = torch.linalg.pinv(a, hermitian=True)
-    >>> torch.matmul(b, a)
+    >>> A = torch.randn(3, 3, dtype=torch.complex64)
+    >>> A = A + A.t().conj()  # creates a Hermitian matrix
+    >>> B = torch.linalg.pinv(A, hermitian=True)
+    >>> torch.matmul(B, A)
     tensor([[ 1.0000e+00+0.0000e+00j, -1.1921e-07-2.3842e-07j,
             5.9605e-08-2.3842e-07j],
             [ 5.9605e-08+2.3842e-07j,  1.0000e+00+2.3842e-07j,
@@ -1464,68 +1523,70 @@ Examples::
 
     Non-default rcond example
     >>> rcond = 0.5
-    >>> a = torch.randn(3, 3)
-    >>> torch.linalg.pinv(a)
+    >>> A = torch.randn(3, 3)
+    >>> torch.linalg.pinv(A)
     tensor([[ 0.2971, -0.4280, -2.0111],
             [-0.0090,  0.6426, -0.1116],
             [-0.7832, -0.2465,  1.0994]])
-    >>> torch.linalg.pinv(a, rcond)
+    >>> torch.linalg.pinv(A, rcond)
     tensor([[-0.2672, -0.2351, -0.0539],
             [-0.0211,  0.6467, -0.0698],
             [-0.4400, -0.3638, -0.0910]])
 
     Matrix-wise rcond example
-    >>> a = torch.randn(5, 6, 2, 3, 3)
+    >>> A = torch.randn(5, 6, 2, 3, 3)
     >>> rcond = torch.rand(2)  # different rcond values for each matrix in a[:, :, 0] and a[:, :, 1]
-    >>> torch.linalg.pinv(a, rcond)
+    >>> torch.linalg.pinv(A, rcond)
     >>> rcond = torch.randn(5, 6, 2) # different rcond value for each matrix in 'a'
-    >>> torch.linalg.pinv(a, rcond)
+    >>> torch.linalg.pinv(A, rcond)
+
+.. _defined algebraically:
+    https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Existence_and_uniqueness
+.. _through the SVD:
+    https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Singular_value_decomposition_(SVD)
 """)
 
 solve = _add_docstr(_linalg.linalg_solve, r"""
-linalg.solve(input, other, *, out=None) -> Tensor
+linalg.solve(A, B, *, out=None) -> Tensor
 
-Computes the solution of a square system  of linear equations with unique solution. Supports batched inputs.
+Computes the solution of a square system of linear equations with unique solution.
 
-This method accepts both matrices and vectors as the right-hand side of the linear equation.
-We will denote by `*` zero or more batch dimensions.
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+this function computes a solution :math:`X \in \mathbb{K}^{n \times k}` of the linear system associated to
+:math:`A \in \mathbb{K}^{n \times n}, B \in \mathbb{K}^{m \times k}`, which is defined as
 
-- If :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(*, n)`, for every matrix :math:`A`
-  in :attr:`input` and vector :math:`b` in :attr:`other`, this function returns a vector :math:`x` such that
+.. math:: AX = B
 
-  .. math:: Ax = b
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-  The returned tensor have shape `(*, n)`.
-- If :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(*, n, k)`, for every pair of matrices
-  :math:`A` in :attr:`input` and :math:`B` in :attr:`other`, this function returns a matrix :math:`X` such that
+Denote by `*` zero or more batch dimensions.
 
-  .. math:: AX = B
+- If :attr:`A` has shape `(*, n, n)` and :attr:`B` has shape `(*, n)` (a batch of vectors) or shape
+  `(*, n, k)` (a batch of matrices or "multiple right-hand sides"), this function returns `X` of shape
+  `(*, n)` or `(*, n, k)` respectively.
+- Otherwise, if :attr:`A` has shape `(*, n, n)` and  :attr:`B` has shape `(n,)`  or `(n, k)`, :attr:`B`
+  is broadcasted to have shape `(*, n)` or `(*, n, k)` respectively and returns the solution of the resulting
+  batch of systems of linear equations.
 
-  The returned tensor have shape `(*, n, k)`.
-- If none of the above apply and :attr:`input`, :attr:`other` have shapes `(*, n, n)`, `(n,)` (resp. `(n, k)`),
-  the vector (resp. matrix) :attr:`other` is broadcasted to have shape `(*, n)` (resp. `(*, n, k)`).
-  This function then  returns the solution of the resulting batch of systems of linear equations.
-
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
-:attr:`other` should have the same dtype as :attr:`input`.
-
-.. note:: The solution to these problems can be computed in terms of the inverse of `A`
-          as `A.inv() @ b` and `A.inv() @ B` respectively.
-          This function can be seen as faster and more stable way of computing these quantities.
-
+.. note::
+    A solution to this problem can be computed in terms of the inverse
+    (see :func:`torch.linalg.inv`) of :attr:`A` as :attr:`A`\ `.inv() @ \ `:attr:`B`.
+    In particular, this function is a faster and more stable way of computing
+    :attr:`A`\ `.inv() @ \ `:attr:`B`.
 
 .. note:: For CUDA inputs, this function synchronizes that device with the CPU.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
-    other (Tensor): right-hand side tensor of shape `(*, n)` or  `(*, n, k)` or `(n,)` or `(n, k)`
-                    according to the rules described above
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
+    B (Tensor): right-hand side tensor of shape `(*, n)` or  `(*, n, k)` or `(n,)` or `(n, k)`
+                according to the rules described above
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the :attr:`input` matrix is not invertible or any matrix in a batched :attr:`input`
+    RuntimeError: if the :attr:`A` matrix is not invertible or any matrix in a batched :attr:`A`
                   is not invertible.
 
 Examples::
@@ -1562,45 +1623,45 @@ Broadcasting::
 """)
 
 tensorinv = _add_docstr(_linalg.linalg_tensorinv, r"""
-linalg.tensorinv(input, ind=2, *, out=None) -> Tensor
+linalg.tensorinv(A, ind=2, *, out=None) -> Tensor
 
 Computes the multiplicative inverse of :func:`torch.tensordot`.
 
-If `m` is the product of the first :attr:`ind` dimensions of :attr:`input` and `n` is the product of
+If `m` is the product of the first :attr:`ind` dimensions of :attr:`A` and `n` is the product of
 the rest of the dimensions, this function expects `m` and `n` to be equal.
-If this is the case, it computes a tensor `x` such that
-`tensordot(\ `:attr:`input`\ `, x, \ `:attr:`ind`\ `)` is the identity matrix in dimension `m`.
-`x` will have the shape of :attr:`input` but with the first :attr:`ind` dimensions pushed back to the end
+If this is the case, it computes a tensor `X` such that
+`tensordot(\ `:attr:`A`\ `, X, \ `:attr:`ind`\ `)` is the identity matrix in dimension `m`.
+`X` will have the shape of :attr:`A` but with the first :attr:`ind` dimensions pushed back to the end
 
 .. code:: text
 
-    x.shape == input.shape[ind:] + input.shape[:ind]
+    X.shape == A.shape[ind:] + A.shape[:ind]
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+Supports :attr:`A` of float, double, cfloat and cdouble dtypes.
 
-.. note:: When :attr:`input` is a `2`-dimensional tensor and :attr:`ind`\ `=1`,
-          this function computes the (multiplicative) inverse of :attr:`input`
+.. note:: When :attr:`A` is a `2`-dimensional tensor and :attr:`ind`\ `=1`,
+          this function computes the (multiplicative) inverse of :attr:`A`
           (see :func:`torch.linalg.inv`).
 
 .. seealso::
 
         :func:`torch.linalg.tensorsolve` computes
-        `torch.tensordot(tensorinv(\ `:attr:`input`\ `), \ `:attr:`other`\ `)`.
+        `torch.tensordot(tensorinv(\ `:attr:`A`\ `), \ `:attr:`B`\ `)`.
         It is always prefered to use :func:`~tensorsolve` when possible, as it is
         faster and more stable than using
         :func:`~tensorinv` followed by :func:`torch.tensordot`.
 
 Args:
-    input (Tensor): tensor to invert. Its shape must satisfy
-                    `prod(\ `:attr:`input`\ `.shape[:\ `:attr:`ind`\ `]) ==
-                    prod(\ `:attr:`input`\ `.shape[\ `:attr:`ind`\ `:])`.
+    A (Tensor): tensor to invert. Its shape must satisfy
+                    `prod(\ `:attr:`A`\ `.shape[:\ `:attr:`ind`\ `]) ==
+                    prod(\ `:attr:`A`\ `.shape[\ `:attr:`ind`\ `:])`.
     ind (int): index at which to compute the inverse of :func:`torch.tensordot`. Default: `2`.
 
 Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the reshaped :attr:`input` is not invertible or the product of the first
+    RuntimeError: if the reshaped :attr:`A` is not invertible or the product of the first
                   :attr:`ind` dimensions is not equal to the product of the rest.
 
 Examples::
@@ -1621,31 +1682,31 @@ Examples::
 """)
 
 tensorsolve = _add_docstr(_linalg.linalg_tensorsolve, r"""
-linalg.tensorsolve(input, other, dims=None, *, out=None) -> Tensor
+linalg.tensorsolve(A, B, dims=None, *, out=None) -> Tensor
 
-Computes the solution `X` to the system `torch.tensordot(input, X) = other`.
+Computes the solution `X` to the system `torch.tensordot(A, X) = B`.
 
-If `m` is the product of the first :attr:`other`\ `.ndim`  dimensions of :attr:`input` and
+If `m` is the product of the first :attr:`B`\ `.ndim`  dimensions of :attr:`A` and
 `n` is the product of the rest of the dimensions, this function expects `m` and `n` to be equal.
 
 The returned tensor `x` satisfies
-`tensordot(\ `:attr:`input`\ `, x, dims=x.ndim) == \ `:attr:`other`.
-`x` has shape :attr:`input`\ `[other.ndim:]`.
+`tensordot(\ `:attr:`A`\ `, x, dims=x.ndim) == \ `:attr:`B`.
+`x` has shape :attr:`A`\ `[B.ndim:]`.
 
-If :attr:`dims` is specified, :attr:`input` will be reshaped as
+If :attr:`dims` is specified, :attr:`A` will be reshaped as
 
 .. code:: text
 
-    input = movedim(input, dims, range(len(dims) - input.ndim + 1, 0))
+    A = movedim(A, dims, range(len(dims) - A.ndim + 1, 0))
 
-Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
+Supports :attr:`A` of float, double, cfloat and cdouble dtypes.
 
 Args:
-    input (Tensor): tensor to solve for. Its shape must satisfy
-                    `prod(\ `:attr:`input`\ `.shape[:\ `:attr:`other`\ `.ndim]) ==
-                    prod(\ `:attr:`input`\ `.shape[\ `:attr:`other`\ `.ndim:])`.
-    other (Tensor): tensor of shape :attr:`input`\ `.shape[\ `:attr:`other`\ `.ndim]`.
-    dims (Tuple[int], optional): dimensions of :attr:`input` to be moved.
+    A (Tensor): tensor to solve for. Its shape must satisfy
+                    `prod(\ `:attr:`A`\ `.shape[:\ `:attr:`B`\ `.ndim]) ==
+                    prod(\ `:attr:`A`\ `.shape[\ `:attr:`B`\ `.ndim:])`.
+    B (Tensor): tensor of shape :attr:`A`\ `.shape[\ `:attr:`B`\ `.ndim]`.
+    dims (Tuple[int], optional): dimensions of :attr:`A` to be moved.
         If `None`, no dimensions are moved. Default: `None`.
 
 .. seealso::
@@ -1657,7 +1718,7 @@ Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the reshaped :attr:`input`\ `.view(m, m)` with `m` as above  is not
+    RuntimeError: if the reshaped :attr:`A`\ `.view(m, m)` with `m` as above  is not
                   invertible or the product of the first :attr:`ind` dimensions is not equal
                   to the product of the rest of the dimensions.
 
@@ -1685,23 +1746,26 @@ Examples::
 
 
 qr = _add_docstr(_linalg.linalg_qr, r"""
-qr(input, mode='reduced', *, out=None) -> (Tensor, Tensor)
+qr(A, mode='reduced', *, out=None) -> (Tensor, Tensor)
 
-Computes the QR decomposition of a matrix. Supports batched inputs.
+Computes the QR decomposition of a matrix.
 
-For a matrix :math:`A`, this is defined as
+Letting :math:`\mathbb{K}` be :math:`\mathbb{R}` or :math:`\mathbb{C}`,
+the QR decomposition of a matrix
+:math:`A \in \mathbb{K}^{m \times n}` is defined as
 
 .. math::
 
-    A = QR
+    A = QR\mathrlap{\qquad Q \in \mathbb{K}^{m \times m}, \mathbb{K}^{m \times n}}
 
 where :math:`Q` is orthogonal in the real case and unitary in the complex case, and :math:`R` is upper triangular.
 
-The returned decomposition is a named tuple `(Q, R)`.
-If :attr:`input` is a batch of matrices, then `Q` and `R` are also batched with the same
-batch dimensions.
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-The parameter :attr:`mode` controls the shape of the output. If :attr:`input` has shape
+The returned decomposition is a named tuple `(Q, R)`
+
+The parameter :attr:`mode` controls the shape of the output. If :attr:`A` has shape
 `(*, m, n)`, denoting `k = min(m, n)`
 
 - :attr:`mode` `= 'reduced'` (default): Returns `(Q, R)` of shapes `(*, m, k)`, `(*, k, n)` respectively.
@@ -1727,15 +1791,15 @@ Differences with `numpy.linalg.qr`:
              or inputs on different devices, may produce different valid decompositions.
 
 .. warning:: Backpropagation is only supported if the first `k = min(m, n)` columns
-             of every matrix in :attr:`input` are linearly independent.
+             of every matrix in :attr:`A` are linearly independent.
              If this condition is not met, no error will be thrown, but the gradient produced
              will be incorrect.
              This is because the QR decomposition is not differentiable at these points.
 
 Args:
-    input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
     mode (str, optional): one of `'reduced'`, `'complete'`, `'r'`.
-                          Controls the shape of the output tensors. Default: `'reduced'`.
+                          Controls the shape of the returned tensors. Default: `'reduced'`.
 
 Keyword args:
     out (tuple, optional): output tuple of two tensors. Ignored if `None`. Default: `None`.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1195,13 +1195,7 @@ which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
 
 The singular values are returned in descending order.
 
-The parameter :attr:`full_matrices` chooses between the full and reduced SVD.
-If :attr:`A` has shape `(*, m, n)`, denoting `k = min(m, n)`
-
-- :attr:`full_matrices`\ `= True` (default): Returns the full SVD.
-  The returned tensors `(U, S, Vh)` will have shapes `(*, m, m)`, `(*, k)`, `(*, n, n)` respectively.
-- :attr:`full_matrices`\ `= False`: Returns the reduced SVD.
-  The returned tensors `(U, S, Vh)` will have shapes `(*, m, k)`, `(*, k)`, `(*, k, n)` respectively.
+The parameter :attr:`full_matrices` chooses between the full (default) and reduced SVD.
 
 Differences with `numpy.linalg.svd`:
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -67,7 +67,7 @@ Examples::
             [1.9586+2.0626j, 9.4160+0.0000j]], dtype=torch.complex128)
 
     >>> a = torch.randn(3, 2, 2, dtype=torch.float64)
-    >>> a = a @ a.transpose(-2, -1) + torch.eye(2).squeeze(0)  # creates a batch of SPD matrices
+    >>> a = a @ a.transpose(-2, -1) + torch.eye(2).squeeze(0)  # symmetric positive definite  matrices
     >>> l = torch.linalg.cholesky(a)
     >>> a
     tensor([[[ 1.1629,  2.0237],
@@ -94,7 +94,7 @@ Examples::
 inv = _add_docstr(_linalg.linalg_inv, r"""
 linalg.inv(input, *, out=None) -> Tensor
 
-Computes the `inverse`_ of square matrix if it exists. Supports batched inputs
+Computes the `inverse`_ of square matrix if it exists. Supports batched inputs.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
@@ -106,8 +106,8 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
 .. seealso::
 
-        :func:`torch.linalg.pinv` computes the Moore-Penrose pseudoinverse of matrices of
-        any shape.
+        :func:`torch.linalg.pinv` computes the pseudoinverse (Moore-Penrose inverse) of matrices
+        of any shape.
 
         :func:torch.linalg.solve computes ``input.inv() @ other``.
         It is always prefered to use :func:`torch.linalg.solve` when possible, as it is
@@ -121,7 +121,7 @@ Keyword args:
     out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
 
 Raises:
-    RuntimeError: if the :attr:`input` matrix or any matrix in the batch :attr:`input` is not invertible
+    RuntimeError: if the :attr:`input` matrix or any matrix in the batch :attr:`input` is not invertible.
 
 Examples::
 
@@ -169,8 +169,9 @@ Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 
 .. seealso::
 
-        :func:`torch.linalg.slogdet` computes the sign and logarithm of the norm of
-        the determinant of square matrices.
+        :func:`torch.linalg.slogdet` computes the sign (resp. angle) and natural logarithm of the
+        absolute value (resp. modulus) of the determinant of real-valued (resp. complex)
+        square matrices.
 
 Args:
     input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
@@ -211,9 +212,10 @@ Example::
 slogdet = _add_docstr(_linalg.linalg_slogdet, r"""
 linalg.slogdet(input, *, out=None) -> (Tensor, Tensor)
 
-Computes the sign and logarithm of the norm of the determinant of a square matrix. Supports batched inputs.
+Computes the sign and natural logarithm of the absolute value of the determinant of a square matrix.
+Supports batched inputs.
 
-For a complex :attr:`input`, it returns the angle and the logarithm of the modulus of the
+For a complex :attr:`input`, it returns the angle and the natural logarithm of the modulus of the
 determinant, that is, a logarithmic polar decomposition of the determinant.
 
 It returns a named tuple `(sign, logabsdet)`.
@@ -266,13 +268,13 @@ For a square matrix :math:`A`, this is defined as
 
 .. math::
 
-    A = V \operatorname{diag}(L) V^{-1}
+    A = V \operatorname{diag}(\Lambda) V^{-1}
 
 This decomposition exists if and only if :math:`A` is `diagonalizable`_. This is the case when all its eigenvalues are different.
 
 The returned decomposition is a named tuple `(eigenvalues, eigenvectors)`,
-which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
-then `L` and `V` are also batched with the same batch dimensions.
+which corresponds to :math:`\Lambda`, :math:`V` above. If :attr:`input` is a batch of matrices,
+then `eigenvalues` and `eigenvectors` are also batched with the same batch dimensions.
 
 Supports :attr:`input` of float, double, cfloat and cdouble dtypes.
 The output tensors `eigenvalues` and `eigenvectors` will always be complex-valued, even when :attr:`input` is real.
@@ -387,10 +389,10 @@ For a complex Hermitian or real symmetric matrix :math:`A`, this is defined as
 
 .. math::
 
-    A = V \operatorname{diag}(L) V^{\text{H}}
+    A = Q \operatorname{diag}(\Lambda) Q^{\text{H}}
 
-where :math:`V^{\text{H}}` is the conjugate transpose when :math:`V` is complex, and the transpose when :math:`V` is real-valued.
-The matrix :math:`V` (and thus :math:`V^{\text{H}}`) is orthogonal in the real case,
+where :math:`Q^{\text{H}}` is the conjugate transpose when :math:`Q` is complex, and the transpose when :math:`Q` is real-valued.
+The matrix :math:`Q` (and thus :math:`Q^{\text{H}}`) is orthogonal in the real case,
 and unitary in the complex case.
 
 :attr:`input` is assumed to be Hermitian (resp. symmetric), but this is not checked internally.
@@ -398,8 +400,8 @@ When :attr:`UPLO` is `'L'` (default), only the lower triangular part of each mat
 When :attr:`UPLO` is `'U'`, only the upper triangular part of each matrix is used.
 
 The returned decomposition is represented as a namedtuple `(eigenvalues, eigenvectors)`,
-which corresponds to :math:`L`, :math:`V` above. If :attr:`input` is a batch of matrices,
-then `L` and `V` are also batched with the same batch dimensions.
+which corresponds to :math:`\Lambda`, :math:`Q` above. If :attr:`input` is a batch of matrices,
+then `eigenvalue` and `eigenvectors` are also batched with the same batch dimensions.
 
 The eigenvalues are returned in ascending order.
 
@@ -423,8 +425,8 @@ The output tensor `eigenvectors` will have the same dtype as :attr:`input`.
              platforms, like NumPy, or inputs on different devices, may produce different
              eigenvectors.
 
-.. warning:: If `V` is used to compute gradients, the gradient will only be finite when
-             :attr:`input` does not have repeated eigenvalues.
+.. warning:: If the `eigenvectors` are used to compute gradients, the gradient will only be
+             finite when :attr:`input` does not have repeated eigenvalues.
              Furthermore, if the distance between any two eigvalues is close to zero,
              the gradient will be numerically unstable, as it depends on the eigenvalues
              :math:`\lambda_i` through the computation of
@@ -572,7 +574,8 @@ See `Representation of Orthogonal or Unitary Matrices`_ for further details.
 
 .. seealso::
 
-        :func:`torch.geqrf` is used together with this function to form the Q from the QR decomposition.
+        :func:`torch.geqrf` can be used together with this function to form the `Q` from the
+        :func:`~qr` decomposition.
 
 Args:
     input (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
@@ -583,7 +586,7 @@ Keyword args:
 
 Raises:
     RuntimeError: if :attr:`input` doesn't satisfy the requirement `m >= n`,
-                  or :attr:`tau` doesn't satisfy the requirement `n >= r`
+                  or :attr:`tau` doesn't satisfy the requirement `n >= k`.
 
 Examples::
 
@@ -656,8 +659,8 @@ four tensors `(solution, residuals, rank, singular_values)` containing:
   otherwise it is an empty tensor.
 
 .. note::
-    The solution to this problem can be computed in terms of the Moore-Penrose pseudoinverse of
-    `A` as `A.pinv() @ B`.
+    The solution to this problem can be computed in terms of the pseudoinverse
+    (Moore-Penrose inverse) of `A` as `A.pinv() @ B`.
     For this reason, this function is a faster and more stable way of computing `A.pinv() @ B`.
 
 .. note::
@@ -1385,7 +1388,7 @@ Examples::
 pinv = _add_docstr(_linalg.linalg_pinv, r"""
 linalg.pinv(input, rcond=1e-15, hermitian=False, *, out=None) -> Tensor
 
-Computes the Moore-Penrose pseudoinverse of a matrix. Supports batched inputs.
+Computes the pseudoinverse (Moore-Penrose inverse) of a matrix. Supports batched inputs.
 
 If :attr:`hermitian`\ `= True`, :attr:`input` should be a complex Hermitian or real symmetric
 matrix or batch of matrices. In this case, it will just use the lower-triangular half of the matrix.
@@ -1523,7 +1526,7 @@ Keyword args:
 
 Raises:
     RuntimeError: if the :attr:`input` matrix is not invertible or any matrix in a batched :attr:`input`
-                  is not invertible
+                  is not invertible.
 
 Examples::
 
@@ -1718,14 +1721,15 @@ Differences with `numpy.linalg.qr`:
 
 .. note:: This function uses LAPACK and MAGMA for CPU and CUDA inputs respectively.
 
-.. warning:: The QR decomposition is only locally unique when the input matrix has
-             independent columns. If this is not the case, different platforms, like NumPy,
+.. warning:: The QR decomposition is only unique up to sign of the diagonal of `R` when the
+             input matrix has independent columns.
+             If this is not the case, different platforms, like NumPy,
              or inputs on different devices, may produce different valid decompositions.
 
 .. warning:: Backpropagation is only supported if the first `k = min(m, n)` columns
              of every matrix in :attr:`input` are linearly independent.
              If this condition is not met, no error will be thrown, but the gradient produced
-             may be anything.
+             will be incorrect.
              This is because the QR decomposition is not differentiable at these points.
 
 Args:


### PR DESCRIPTION
This PR tries to make the docs of `torch.linalg` have/be:
- More uniform notation and structure for every function.
- More uniform use of back-quotes and the `:attr:` directive
- More readable for a non-specialised audience through explanations of the form that factorisations take and when would it be beneficial to use what arguments in some solvers.
- More connected among the different functions through the use of  the `.. seealso::` directive.
- More information on when do gradients explode / when is a function silently returning a wrong result / when things do not work in general

I tried to follow the structure of "one short description and then the rest" to be able to format the docs like those of `torch.` or `torch.nn`. I did not do that yet, as I am waiting for the green light on this idea:
https://github.com/pytorch/pytorch/issues/54878#issuecomment-816636171

What this PR does not do:
- Clean the documentation of other functions that are not in the `linalg` module (although I started doing this for `torch.svd`, but then I realised that this PR would touch way too many functions).

Fixes https://github.com/pytorch/pytorch/issues/54878

cc @mruberry @IvanYashchuk 