### PR TITLE
Filter out more expected errors from sccache log

### DIFF
--- a/.jenkins/pytorch/print_sccache_log.py
+++ b/.jenkins/pytorch/print_sccache_log.py
@@ -8,10 +8,10 @@ with open(log_file_path) as f:
 for line in lines:
     # Ignore errors from CPU instruction set, symbol existing testing,
     # or compilation error formatting
-    keywords = [
+    ignored_keywords = [
         'src.c',
         'CheckSymbolExists.c',
         'test_compilation_error_formatting',
     ]
-    if all([keyword not in line for keyword in keywords]):
+    if all([keyword not in line for keyword in ignored_keywords]):
         print(line)

--- a/.jenkins/pytorch/print_sccache_log.py
+++ b/.jenkins/pytorch/print_sccache_log.py
@@ -6,7 +6,12 @@ with open(log_file_path) as f:
     lines = f.readlines()
 
 for line in lines:
-    # Ignore errors from CPU instruction set or symbol existing testing
-    keywords = ['src.c', 'CheckSymbolExists.c']
+    # Ignore errors from CPU instruction set, symbol existing testing,
+    # or compilation error formatting
+    keywords = [
+        'src.c',
+        'CheckSymbolExists.c',
+        'test_compilation_error_formatting',
+    ]
     if all([keyword not in line for keyword in keywords]):
         print(line)


### PR DESCRIPTION
This PR extends `.jenkins/pytorch/print_sccache_log.py` to filter out a distracting "error" message that @walterddr came across while debugging failures in #55176:

```
=================== sccache compilation log ===================
ERROR 2021-04-05T15:44:18Z: sccache::server: Compilation failed: Output { status: ExitStatus(ExitStatus(256)), stdout: "", stderr: "/var/lib/jenkins/.cache/torch_extensions/test_compilation_error_formatting/main.cpp: In function ‘int main()’:\n/var/lib/jenkins/.cache/torch_extensions/test_compilation_error_formatting/main.cpp:2:23: error: expected ‘;’ before ‘}’ token\n int main() { return 0 }\n                       ^\n" }
```

**Test plan:**

TODO (reviewers: is there an easy way to test this?)