### PR TITLE
[nnc] Only lower float conv2d's

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -147,6 +147,16 @@ bool conv2dIsSupported(const torch::jit::Node* node) {
     return false;
   }
 
+  // Inputs should be float32.  Other dtypes need more testing.
+  auto isFloat = [](const torch::jit::Value* v) {
+    auto const& tt = v->type()->cast<TensorType>();
+    if (!tt) {
+      return false;
+    }
+    auto const& st = tt->scalarType();
+    return st && *st == c10::ScalarType::Float;
+  }
+
   // Proper ndim for tensor inputs.
   if (input->size() != 4 || weight->size() != 4 || bias->size() != 1) {
     GRAPH_DEBUG("inputs are the wrong size");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56308 [nnc] Support `pow` on CPU
* **#56289 [nnc] Only lower float conv2d's**

While there's no reason to think non-float32 conv2d's *don't* work,
they're only tested in float32 now.  Since that's the most important use case,
I'd rather restrict the dtypes than spend time testing all the weird dtype
combinations that could possibly happen.

Differential Revision: [D27828495](https://our.internmc.facebook.com/intern/diff/D27828495/)