### PR TITLE
merging fix for binaryophandler with gelu,softmax,bmm additions

### DIFF
--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -1345,7 +1345,7 @@ class Quantizer:
                                 )
 
                                 # handle is_reference = True
-                                match_supported_is_reference = (
+                                supported_is_reference = (
                                     (node.target in binary_reference_op_supported_dtypes) and
                                     (dtypes in binary_reference_op_supported_dtypes[node.target])
                                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56298 merging the 2**
* #56294 fx quant: fix subtle bug in BinaryOpQuantizeHanlder logic in matching
* #56004 [quant] added dq->op->q quantization patterns for GELU and softmax ops

Summary: just combining the changes from the 2 pr's

Test Plan:
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

Reviewers:

Subscribers:

Tasks:

Tags: