### PR TITLE
Fix warnings in ivalue test

### DIFF
--- a/aten/src/ATen/test/ivalue_test.cpp
+++ b/aten/src/ATen/test/ivalue_test.cpp
@@ -608,9 +608,9 @@ TEST(IValueTest, getSubValues) {
   IValue list(std::vector<at::Tensor>{t1, t2});
   IValue tuple(ivalue::Tuple::create({tv1, tv2}));
 
-  std::unordered_map<int64_t, at::Tensor> m;
-  m[1] = t1;
-  m[2] = t2;
+  c10::Dict<int64_t, at::Tensor> m;
+  m.insert(1, t1);
+  m.insert(2, t2);
 
   IValue dict(std::move(m));
 


### PR DESCRIPTION


Simple conversion of `std::unordered_map` -> `c10::Dict`

Differential Revision: [D27833970](https://our.internmc.facebook.com/intern/diff/27833970/)