### PR TITLE
[nnc] Support `pow` on CPU

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1598,15 +1598,11 @@ class TestTEFuser(JitTestCase):
                     "Failed: {} {} {} {}".format(dtype, op.__name__, device, scalar)
                 )
 
-    def test_binary_cuda_only_ops(self):
+    def test_binary_pow(self):
         def apply_with_scalar(fn, scalar):
             return lambda x: fn(x, scalar)
 
         dtypes = [
-            torch.int8,
-            torch.int16,
-            torch.int32,
-            torch.int64,
             # FIXME: 'pow' fails with dtype=torch.float16/device=cuda/scalar=0
             # torch.float16,
             torch.float32,
@@ -1616,11 +1612,10 @@ class TestTEFuser(JitTestCase):
         binary_ops = [
             torch.pow,
         ]
-        devices = ['cuda'] if torch.cuda.is_available() else []
         # Maybe we should split this into separate tests to speed it up by
         # only using  scalar values relevant to particular ops
         scalars = [1.5, 3, 0, -2.0, -1]
-        for dtype, op, device, scalar in product(dtypes, binary_ops, devices, scalars):
+        for dtype, op, device, scalar in product(dtypes, binary_ops, self.devices, scalars):
             try:
                 x = self.data_for(dtype, device)
                 fn = apply_with_scalar(op, scalar)

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -980,13 +980,10 @@ class TestTensorExprFuser(BaseTestClass):
         self.assertLastGraphAllFused()
 
     def test_double_intrinsics(self):
-        # TODO: add "cpu" device once `pow` is supported there
-        devices = ["cuda"] if torch.cuda.is_available() else []
-
         def do_pow(x):
             return torch.pow(x, 7)
 
-        for device in devices:
+        for device in self.devices:
             x = torch.rand(10, dtype=torch.double, device=device)
             traced = torch.jit.trace(do_pow, (x))
             x = warmup_and_run_forward(traced, x)

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -910,11 +910,11 @@ class TensorExprFuser {
       "aten::__rshift__.Scalar(Tensor self, Scalar other) -> Tensor",
       "aten::__rshift__.Tensor(Tensor self, Tensor other) -> Tensor",
     };
-    static const OperatorSet cuda_only_operator_set{
-      "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor",
-    };
     static const OperatorSet cpu_only_operator_set{
       "aten::conv2d(Tensor input, Tensor weight, Tensor? bias=None, int[2] stride=1, int[2] padding=0, int[2] dilation=1, int groups=1) -> Tensor"
+    };
+    static const OperatorSet pow{
+      "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor",
     };
     // clang-format on
 
@@ -963,13 +963,16 @@ class TensorExprFuser {
       }
     }
 
-    // Operator is only supported on CUDA.
-    if (node->isMemberOf(cuda_only_operator_set)) {
-      auto device = tensorexpr::pickDeviceType(node->inputs());
-      if (!device) {
-        device = tensorexpr::pickDeviceType(node->outputs());
+    // aten::pow has special rules to avoid complicated integer cases.  We
+    // expect the first arg to be a floating point tensor, and if that's the
+    // case the type of the scalar exponent doesn't matter.
+    if (node->isMemberOf(pow)) {
+      auto const& tt = node->input(0)->type()->cast<TensorType>();
+      if (!tt) {
+        return false;
       }
-      if (!device || device->is_cpu()) {
+      auto const& st = tt->scalarType();
+      if (!st || !isFloatingType(*st)) {
         return false;
       }
     }
@@ -1013,6 +1016,7 @@ class TensorExprFuser {
         }
       }
     }
+
     if (node->kind() == aten::conv2d) {
       if (!tensorexpr::conv2dIsSupported(node)) {
         GRAPH_DEBUG("Params of conv2d are not supported");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56308 [nnc] Support `pow` on CPU**
* #56289 [nnc] Only lower float conv2d's

But only for float tensors.  Even on CUDA, int tensors just have weird
behavior with pow, and I bet FP is so much more common that it's just not worth
trying to fuse ints here.

Differential Revision: [D27834694](https://our.internmc.facebook.com/intern/diff/D27834694/)