### PR TITLE
[Benchmark/Note/Not For Commit] Test potential for "manually" unroll loop for compute mem overlap

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -948,6 +948,22 @@ void TensorIteratorBase::compute_mem_overlaps(const TensorIteratorConfig& config
   if (!config.check_mem_overlap_) {
     return;
   }
+
+  // hacked specialized version for binary
+  const auto& out = operands_[0].tensor;
+  const auto& op1 = operands_[1].tensor;
+  const auto& op2 = operands_[2].tensor;
+
+  if (!out.defined()) {
+    return;
+  }
+  if (!out.is_contiguous()) {
+      assert_no_internal_overlap(out);
+  }
+  assert_no_partial_overlap(out, op1);
+  assert_no_partial_overlap(out, op2);
+
+  /*
   for (int i = 0; i < num_outputs_; i++) {
     const auto& output = operands_[i].tensor;
     if (!output.defined()) continue;
@@ -959,6 +975,7 @@ void TensorIteratorBase::compute_mem_overlaps(const TensorIteratorConfig& config
       assert_no_partial_overlap(output, input);
     }
   }
+  */
 }
 
 void TensorIteratorBase::compute_shape(const TensorIteratorConfig& config) {

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -951,7 +951,9 @@ void TensorIteratorBase::compute_mem_overlaps(const TensorIteratorConfig& config
   for (int i = 0; i < num_outputs_; i++) {
     const auto& output = operands_[i].tensor;
     if (!output.defined()) continue;
-    assert_no_internal_overlap(output);
+    if (!output.is_contiguous()) {
+      assert_no_internal_overlap(output);
+    }
     for (int j = num_outputs_; j < ntensors(); j++) {
       const auto& input = operands_[j].tensor;
       assert_no_partial_overlap(output, input);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56309 [Benchmark/Memo/Not For Commit] Short circuit on contiguous tensors when compute mem overlap**

This is not for commit since it's too micro-optmization. We need to understand performance better. 

This raises up since `compute_mem_overlaps` looks quite expensive (273 instruction per call) in the benchmark `a.add_(b)`.

![Screen Shot 2021-04-16 at 3 49 12 PM](https://user-images.githubusercontent.com/799346/115091089-6e3d6880-9ecb-11eb-9058-367b1c44d058.png)

`assert_no_internal_overlap` takes about 46 instructions per call while `assert_no_partial_overlap` takes about 147 instructions per "real call" (while `assert_no_partial_overlap` has ~2000 calls, half of them get short-circuit since it's comparing the same.

Since `is_contiguous` call should only takes 9 instructions, thus benchmark with this PR:

![Screen Shot 2021-04-16 at 3 56 22 PM](https://user-images.githubusercontent.com/799346/115091441-54e8ec00-9ecc-11eb-9bbd-0c5f0c0424ff.png)

Overall, with this PR, confirmed overall instructions reduced from `3,548,022` to `3,517,022`, about 0.88% reduction, and saves about 31 instructions per call.

General open questions with `compute_mem_overlaps`:

1. Why `assert_no_internal_overlap` is so much more expensive than `is_contiguous`?  Since the implementation really just check whether `is_contiguous`: 
https://github.com/pytorch/pytorch/blob/cd780e1c6e6f5dc02fef05531acb27eba699a282/aten/src/ATen/MemoryOverlap.cpp#L10-L26

2. Why `assert_no_partial_overlap` is so expensive (147 instructions) ? Is there anyway to "fast path" it?  The key code is just to calculate the range and see whether they are overlap:
https://github.com/pytorch/pytorch/blob/cd780e1c6e6f5dc02fef05531acb27eba699a282/aten/src/ATen/MemoryOverlap.cpp#L59-L71

3. Also note the `compute_mem_overlaps` body takes about 80 instructions per call... which seems also more than necessary (which may be eliminated by specializing over arity/structure kernel calling convention, for example)
   *  Confirmed can be reduced to about 25~32 instructions if we manually unroll the loop.

  

