### PR TITLE
Remove the unused maximum and minimum functions in vec256_base

### DIFF
--- a/aten/src/ATen/cpu/vec256/vec256_base.h
+++ b/aten/src/ATen/cpu/vec256/vec256_base.h
@@ -578,15 +578,6 @@ Vec256<T> inline maximum(const Vec256<T> &a, const Vec256<T> &b) {
   return c;
 }
 
-template <typename T>
-inline T maximum(const T& a, const T& b) {
-  T c = (a > b) ? a : b;
-  if (_isnan(a)) {
-    c = a;
-  }
-  return c;
-}
-
 // Implements the IEEE 754 201X `minimum` operation, which propagates NaN if
 // either input is a NaN.
 template <class T,
@@ -617,15 +608,6 @@ Vec256<T> inline minimum(const Vec256<T> &a, const Vec256<T> &b) {
       // ternary operator above.
       c[i] = a[i];
     }
-  }
-  return c;
-}
-
-template <typename T>
-inline T minimum(const T& a, const T& b) {
-  T c = (a < b) ? a : b;
-  if (_isnan(a)) {
-    c = a;
   }
   return c;
 }


### PR DESCRIPTION
They are unused, unrelated to vectorization, and confusing for code
readers (each of them have 2 overloads that are actually used).


