### PR TITLE
`steps` argument won't be optional for `linspace` & `logspace` in PyTorch 1.9

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -12,21 +12,10 @@ namespace at { namespace native {
 DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, const Scalar&), arange_stub);
 DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, int64_t), linspace_stub);
 
-Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
-  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for linspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
-
+Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, const int64_t steps, Tensor& result) {
   if (result.numel() != steps) {
     result.resize_({steps});
   }
-
   if (steps == 0) {
     // skip
   } else if (steps == 1) {
@@ -43,17 +32,7 @@ Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<i
   return result;
 }
 
-Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
-  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for logspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
-
+Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, const int64_t steps, double base, Tensor& result) {
   if (result.numel() != steps) {
     result.resize_({steps});
   }

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -13,6 +13,7 @@ DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, const Sc
 DECLARE_DISPATCH(void(*)(TensorIterator&, const Scalar&, const Scalar&, int64_t), linspace_stub);
 
 Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, const int64_t steps, Tensor& result) {
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   if (result.numel() != steps) {
     result.resize_({steps});
   }
@@ -33,6 +34,7 @@ Tensor& linspace_cpu_out(const Scalar& start, const Scalar& end, const int64_t s
 }
 
 Tensor& logspace_cpu_out(const Scalar& start, const Scalar& end, const int64_t steps, double base, Tensor& result) {
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   if (result.numel() != steps) {
     result.resize_({steps});
   }

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -540,18 +540,16 @@ TensorOptions linspace_logspace_infer_options(
 Tensor linspace(
     const Scalar& start,
     const Scalar& end,
-    c10::optional<int64_t> steps,
+    int64_t steps,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
     c10::optional<bool> pin_memory) {
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
-
-  const auto steps_ = steps.value_or(100);
-  TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   auto result_options = linspace_logspace_infer_options(start, end, options);
-  Tensor result = at::empty({steps_}, result_options);
+  Tensor result = at::empty({steps}, result_options);
   return at::linspace_out(result, start, end, steps);
 }
 
@@ -560,7 +558,7 @@ Tensor linspace(
 Tensor logspace(
     const Scalar& start,
     const Scalar& end,
-    c10::optional<int64_t> steps,
+    int64_t steps,
     double base,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
@@ -568,11 +566,9 @@ Tensor logspace(
     c10::optional<bool> pin_memory) {
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
-
-  const auto steps_ = steps.value_or(100);
-  TORCH_CHECK(steps_ >= 0, "number of steps must be non-negative");
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   auto result_options = linspace_logspace_infer_options(start, end, options);
-  Tensor result = at::empty({steps_}, result_options);
+  Tensor result = at::empty({steps}, result_options);
   return at::logspace_out(result, start, end, steps, base);
 }
 

--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -540,7 +540,7 @@ TensorOptions linspace_logspace_infer_options(
 Tensor linspace(
     const Scalar& start,
     const Scalar& end,
-    int64_t steps,
+    const int64_t steps,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
@@ -558,7 +558,7 @@ Tensor linspace(
 Tensor logspace(
     const Scalar& start,
     const Scalar& end,
-    int64_t steps,
+    const int64_t steps,
     double base,
     c10::optional<ScalarType> dtype,
     c10::optional<Layout> layout,

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -52,8 +52,6 @@ namespace at {
 namespace native {
 
 Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
-  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
-
   if (!optional_steps.has_value()) {
     TORCH_WARN_ONCE(
       "Not providing a value for linspace's steps is deprecated and will "
@@ -110,7 +108,6 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
 }
 
 Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, double base, Tensor& result) {
-  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
 
   if (!optional_steps.has_value()) {
     TORCH_WARN_ONCE(

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -51,14 +51,7 @@ void gpu_kernel_with_index(at::Tensor &output, func_t f) {
 namespace at {
 namespace native {
 
-Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for linspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
-
+Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, const int64_t steps, Tensor& result) {
   if (result.numel() != steps) {
     result.resize_({steps});
   }
@@ -107,15 +100,7 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps,
   return result;
 }
 
-Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, double base, Tensor& result) {
-
-  if (!optional_steps.has_value()) {
-    TORCH_WARN_ONCE(
-      "Not providing a value for logspace's steps is deprecated and will "
-      "throw a runtime error in a future release. This warning will appear "
-      "only once per process.");
-  }
-
+Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, const int64_t steps, double base, Tensor& result) {
   if (result.numel() != steps) {
     result.resize_({steps});
   }

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -51,8 +51,7 @@ void gpu_kernel_with_index(at::Tensor &output, func_t f) {
 namespace at {
 namespace native {
 
-Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
 
   if (!optional_steps.has_value()) {
@@ -110,8 +109,7 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, c10::optional<
   return result;
 }
 
-Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, c10::optional<int64_t> optional_steps, double base, Tensor& result) {
-  const auto steps = optional_steps.value_or(100);
+Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, int64_t steps, double base, Tensor& result) {
   TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
 
   if (!optional_steps.has_value()) {

--- a/aten/src/ATen/native/cuda/RangeFactories.cu
+++ b/aten/src/ATen/native/cuda/RangeFactories.cu
@@ -52,6 +52,7 @@ namespace at {
 namespace native {
 
 Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, const int64_t steps, Tensor& result) {
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   if (result.numel() != steps) {
     result.resize_({steps});
   }
@@ -101,6 +102,7 @@ Tensor& linspace_cuda_out(const Scalar& start, const Scalar& end, const int64_t 
 }
 
 Tensor& logspace_cuda_out(const Scalar& start, const Scalar& end, const int64_t steps, double base, Tensor& result) {
+  TORCH_CHECK(steps >= 0, "number of steps must be non-negative");
   if (result.numel() != steps) {
     result.resize_({steps});
   }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2085,9 +2085,9 @@
 
 - func: ldexp.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
 
-- func: linspace(Scalar start, Scalar end, int? steps=None, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: linspace(Scalar start, Scalar end, int steps, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: linspace.out(Scalar start, Scalar end, int? steps=None, *, Tensor(a!) out) -> Tensor(a!)
+- func: linspace.out(Scalar start, Scalar end, int steps, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: linspace_cpu_out
     CUDA: linspace_cuda_out
@@ -2218,9 +2218,9 @@
   dispatch:
     CompositeExplicitAutograd: logdet
 
-- func: logspace(Scalar start, Scalar end, int? steps=None, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: logspace(Scalar start, Scalar end, int steps, float base=10.0, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: logspace.out(Scalar start, Scalar end, int? steps=None, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
+- func: logspace.out(Scalar start, Scalar end, int steps, float base=10.0, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
     CPU: logspace_cpu_out
     CUDA: logspace_cuda_out

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -77,6 +77,8 @@ allow_list = [
     ("aten::_addmv_impl_", datetime.date(2021, 5, 15)),
     ("aten::adaptive_avg_pool3d_backward", datetime.date(9999, 1, 1)),
     ("aten::_embedding_bag_dense_backward", datetime.date(9999, 1, 1)),
+    ("aten::linspace", datetime.date(9999, 1, 1)),
+    ("aten::logspace", datetime.date(9999, 1, 1)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -2440,17 +2440,6 @@ class TestTensorCreation(TestCase):
             self.assertEqual(t[0], a[0])
             self.assertEqual(t[steps - 1], a[steps - 1])
 
-    def _linspace_logspace_warning_helper(self, op, device, dtype):
-        with self.assertWarnsOnceRegex(UserWarning, "Not providing a value for .+"):
-            op(0, 10, device=device, dtype=dtype)
-
-    @dtypes(torch.float)
-    def test_linspace_steps_warning(self, device, dtype):
-        self._linspace_logspace_warning_helper(torch.linspace, device, dtype)
-
-    @dtypes(torch.float)
-    def test_logspace_steps_warning(self, device, dtype):
-        self._linspace_logspace_warning_helper(torch.logspace, device, dtype)
 
     @onlyCUDA
     @largeTensorTest('16GB')

--- a/test/test_type_promotion.py
+++ b/test/test_type_promotion.py
@@ -325,8 +325,8 @@ class TestTypePromotion(TestCase):
         expected = torch.ones(0, dtype=torch.int64, device=device)
         self.assertEqual(torch.arange(False, False, device=device), expected)
 
-        self.assertEqual(torch.linspace(False, True, device=device), torch.linspace(0, 1, device=device))
-        self.assertEqual(torch.logspace(False, True, device=device), torch.logspace(0, 1, device=device))
+        self.assertEqual(torch.linspace(False, True, 100, device=device), torch.linspace(0, 1, 100, device=device))
+        self.assertEqual(torch.logspace(False, True, 100, device=device), torch.logspace(0, 1, 100, device=device))
 
         # this seems like odd behavior but ints also create float tensors, numpy doesn't have this function.
         self.assertEqual(torch.scalar_tensor(False, device=device), torch.tensor(0., device=device))


### PR DESCRIPTION
Fixes #55951
From PyTorch 1.9, users would've to specify the `steps` argument of `linspace` & `logspace`. It wouldn't be optional any longer.