### PR TITLE
[TensorPipe] Use targetDevice in tensorpipe_agent.

### DIFF
--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -46,6 +46,7 @@ TEST(TensorpipeSerialize, Base) {
     tensorpipe::Descriptor::Tensor t;
     t.length = tpTensor.length;
     t.sourceDevice = tpTensor.buffer.device();
+    t.targetDevice = tpTensor.targetDevice;
     t.metadata = tpTensor.metadata;
     recvingTpDescriptor.tensors.push_back(std::move(t));
   }


### PR DESCRIPTION
Summary:
Now that TensorPipe's API has `targetDevice`, use that instead of
manually writing the CUDA device index in `metadata`.

Test Plan: CI

Reviewed By: lw

Differential Revision: D27703235

