### PR TITLE
DOC: add note for torch.clamp() special case min > max See #45664

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1901,6 +1901,12 @@ Let min_value and max_value be :attr:`min` and :attr:`max`, respectively, this r
     y_i = \min(\max(x_i, \text{min\_value}), \text{max\_value})
 """ + r"""
 
+.. note::
+    If :attr:`min` is greater than :attr:`max` :func:`torch.clamp(..., min, max) <torch.clamp>`
+    sets all values equal to :attr:`max`.
+
+    This is shown in the second example below.
+
 Args:
     {input}
     min (Number): lower-bound of the range to be clamped to
@@ -1916,6 +1922,8 @@ Example::
     tensor([-1.7120,  0.1734, -0.0478, -0.0922])
     >>> torch.clamp(a, min=-0.5, max=0.5)
     tensor([-0.5000,  0.1734, -0.0478, -0.0922])
+    >>> torch.clamp(a, min=8.0, max=11.0)
+    tensor([1., 1., 1., 1.])
 
 .. function:: clamp(input, *, min, out=None) -> Tensor
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1903,9 +1903,7 @@ Let min_value and max_value be :attr:`min` and :attr:`max`, respectively, this r
 
 .. note::
     If :attr:`min` is greater than :attr:`max` :func:`torch.clamp(..., min, max) <torch.clamp>`
-    sets all values equal to :attr:`max`.
-
-    This is shown in the second example below.
+    sets all elements in :attr:`input` to the value of :attr:`max`.
 
 Args:
     {input}
@@ -1922,8 +1920,6 @@ Example::
     tensor([-1.7120,  0.1734, -0.0478, -0.0922])
     >>> torch.clamp(a, min=-0.5, max=0.5)
     tensor([-0.5000,  0.1734, -0.0478, -0.0922])
-    >>> torch.clamp(a, min=8.0, max=11.0)
-    tensor([1., 1., 1., 1.])
 
 .. function:: clamp(input, *, min, out=None) -> Tensor
 


### PR DESCRIPTION
Fixes #45664

This PR adds a note to the documentation for `torch.clamp()` to alert users to a special case: If `min` is greater than `max`, all values are set to the `max` value.

Also, an example was added after the first code example. And this one is referenced in the note.
