### PR TITLE
Change return values to explicitly return a tuple

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -99,7 +99,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
       indices.resize_as_(self);
       indices.zero_();
     }
-    return {values, indices};
+    return std::tuple<Tensor &,Tensor &>(values, indices);
   }
 
   Tensor self_;
@@ -153,7 +153,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
   }
 
   if (numel == 0) {
-    return {values, indices};
+    return std::tuple<Tensor &,Tensor &>(values, indices);
   }
 
   int64_t numel_or_intmax = std::min(numel, static_cast<int64_t>(std::numeric_limits<int>::max()));
@@ -206,7 +206,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
   if (indices_tmp.defined()) {
     indices.copy_(indices_tmp);
   }
-  return {values, indices};
+  return std::tuple<Tensor &,Tensor &>(values, indices);
 }
 
 std::tuple<Tensor &,Tensor &> sort_out_cuda(const Tensor & self, int64_t dim, bool descending, Tensor & values, Tensor & indices) {


### PR DESCRIPTION
Prevents 'Error: copy-list-initialization cannot use a constructor marked "explicit"' with older compilers without N4387 support.
