### PR TITLE
Fix TestTypeHints.test_doc_examples

### DIFF
--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -129,7 +129,7 @@ class TestTypeHints(TestCase):
                     str(fn),
                 ])
             if result != 0:
-                self.fail(f"mypy failed: {stderr}\n{stdout}")
+                self.fail(f"mypy failed:\n{stderr}\n{stdout}")
 
 
 if __name__ == '__main__':

--- a/test/test_type_hints.py
+++ b/test/test_type_hints.py
@@ -77,7 +77,7 @@ class TestTypeHints(TestCase):
         """
         Run documentation examples through mypy.
         """
-        fn = os.path.join(os.path.dirname(__file__), 'generated_type_hints_smoketest.py')
+        fn = Path(__file__).resolve().parent / 'generated_type_hints_smoketest.py'
         with open(fn, "w") as f:
             print(get_all_examples(), file=f)
 
@@ -126,10 +126,10 @@ class TestTypeHints(TestCase):
                 (stdout, stderr, result) = mypy.api.run([
                     '--cache-dir=.mypy_cache/doc',
                     '--no-strict-optional',  # needed because of torch.lu_unpack, see gh-36584
-                    os.path.abspath(fn),
+                    str(fn),
                 ])
             if result != 0:
-                self.fail(f"mypy failed:\n{stdout}")
+                self.fail(f"mypy failed: {stderr}\n{stdout}")
 
 
 if __name__ == '__main__':

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3199,9 +3199,9 @@ Example::
     >>> x = torch.arange(9.)
     >>> mantissa, exponent = torch.frexp(x)
     >>> mantissa
-    >>> tensor([0.0000, 0.5000, 0.5000, 0.7500, 0.5000, 0.6250, 0.7500, 0.8750, 0.5000])
+    tensor([0.0000, 0.5000, 0.5000, 0.7500, 0.5000, 0.6250, 0.7500, 0.8750, 0.5000])
     >>> exponent
-    >>> tensor([0, 1, 2, 2, 3, 3, 3, 3, 4], dtype=torch.int32)
+    tensor([0, 1, 2, 2, 3, 3, 3, 3, 4], dtype=torch.int32)
     >>> torch.ldexp(mantissa, exponent)
     tensor([0., 1., 2., 3., 4., 5., 6., 7., 8.])
 """)


### PR DESCRIPTION
#54268 removed `test_run_mypy` since now we're running `mypy` as its own job in GitHub Actions, but previously we used this `set_cwd` context manager in that test to ensure that we picked up the `mypy` config correctly. However, for some reason, we have not been doing that in `test_doc_examples`, which has been succeeding in CI for a while despite being broken.

Specifically, [`run_test.py` changes the working directory to `test/` before running test files](https://github.com/pytorch/pytorch/blob/48aaea3359cffe7982ce24b8742c7a1f4b456a92/test/run_test.py#L534-L535), which is contrary to [what `CONTRIBUTING.md` instructs developers to do](https://github.com/pytorch/pytorch/blob/48aaea3359cffe7982ce24b8742c7a1f4b456a92/CONTRIBUTING.md#python-unit-testing). As a result, in CI, `test/test_type_hints.py` has been passing in CI, but if you run it locally from the root of the repo, this you get this error:
```
F
======================================================================
FAIL: test_doc_examples (__main__.TestTypeHints)
Run documentation examples through mypy.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_type_hints.py", line 127, in test_doc_examples
    self.fail(f"mypy failed:\n{stdout}")
AssertionError: mypy failed:
test/generated_type_hints_smoketest.py:851: error: Name 'tensor' is not defined  [name-defined]
test/generated_type_hints_smoketest.py:853: error: Name 'tensor' is not defined  [name-defined]
Found 2 errors in 1 file (checked 1 source file)


----------------------------------------------------------------------
Ran 1 test in 1.416s

FAILED (failures=1)
```

**Test plan:**

Before this PR, the first of the following two commands should fail (since that is essentially what is run in CI), but the second should fail:
```
python test/run_test.py -i test_type_hints
python test/test_type_hints.py
```
After this PR, both commands should succeed.