### PR TITLE
Use stack trace implementation in common/process on fbcode

### DIFF
--- a/c10/util/Backtrace.cpp
+++ b/c10/util/Backtrace.cpp
@@ -19,6 +19,10 @@
 #include <execinfo.h>
 #endif
 
+#ifdef FBCODE_CAFFE2
+#include <common/process/StackTrace.h>
+#endif
+
 namespace c10 {
 
 #if SUPPORTS_BACKTRACE
@@ -167,7 +171,14 @@ std::string get_backtrace(
     size_t frames_to_skip,
     size_t maximum_number_of_frames,
     bool skip_python_frames) {
-#if SUPPORTS_BACKTRACE
+#ifdef FBCODE_CAFFE2
+  // For some reason, the stacktrace implementation in fbcode is
+  // better than ours, see  https://github.com/pytorch/pytorch/issues/56399
+  // When it's available, just use that.
+  facebook::process::StackTrace st;
+  return st.toString();
+
+#elif SUPPORTS_BACKTRACE
 
   // We always skip this frame (backtrace).
   frames_to_skip += 1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56400 Use stack trace implementation in common/process on fbcode**

See https://github.com/pytorch/pytorch/issues/56399

I don't have time to fix this properly, so this is just to stem the
bleeding.  Someone should go and figure out what it is that common/process
is doing better.

Differential Revision: [D27861908](https://our.internmc.facebook.com/intern/diff/D27861908/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27861908/)!