### PR TITLE
Remove unused `type: ignore` comments

### DIFF
--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -39,7 +39,7 @@ if args.aten_root:
     sys.path.insert(0, os.path.join(args.aten_root, '..'))
     from tools.codegen.code_template import CodeTemplate as CT
 else:
-    from tools.codegen.code_template import CodeTemplate as CT  # type: ignore[import,no-redef]
+    from tools.codegen.code_template import CodeTemplate as CT
 
 OP_TEMPLATE = CT.from_file(
     os.path.join(args.template_dir, 'aten_op_template.h'))

--- a/caffe2/distributed/file_store_handler_op_test.py
+++ b/caffe2/distributed/file_store_handler_op_test.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 import shutil
 
-from caffe2.distributed.python import StoreHandlerTimeoutError  # type: ignore[import]
+from caffe2.distributed.python import StoreHandlerTimeoutError
 from caffe2.distributed.store_ops_test_util import StoreOpsTests
 from caffe2.python import core, workspace, dyndep
 from caffe2.python.test_util import TestCase

--- a/caffe2/distributed/redis_store_handler_op_test.py
+++ b/caffe2/distributed/redis_store_handler_op_test.py
@@ -6,7 +6,7 @@
 import os
 import uuid
 
-from caffe2.distributed.python import StoreHandlerTimeoutError  # type: ignore[import]
+from caffe2.distributed.python import StoreHandlerTimeoutError
 from caffe2.distributed.store_ops_test_util import StoreOpsTests
 from caffe2.python import core, workspace, dyndep
 from caffe2.python.test_util import TestCase

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,7 @@ plugins = mypy_plugins/check_mypy_version.py
 cache_dir = .mypy_cache/normal
 warn_unused_configs = True
 warn_redundant_casts = True
+warn_unused_ignores = True
 show_error_codes = True
 check_untyped_defs = True
 follow_imports = silent

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -285,7 +285,7 @@ class TestFunctionalIterDataPipe(TestCase):
                 self.assertEqual(len(wa), 1)
                 self.assertRegex(str(wa[0].message), r"^Lambda function is not supported for pickle")
                 with self.assertRaises(AttributeError):
-                    p = pickle.dumps(datapipe)  # type: ignore
+                    p = pickle.dumps(datapipe)
 
     def test_concat_datapipe(self):
         input_dp1 = IDP(range(10))

--- a/test/test_futures.py
+++ b/test/test_futures.py
@@ -21,22 +21,22 @@ class TestFuture(TestCase):
 
         f = Future[T]()
         # Set exception
-        f.set_exception(value_error)  # type: ignore
+        f.set_exception(value_error)
         # Exception should throw on wait
         with self.assertRaisesRegex(ValueError, "Intentional"):
             f.wait()
 
         # Exception should also throw on value
         f = Future()
-        f.set_exception(value_error)  # type: ignore
+        f.set_exception(value_error)
         with self.assertRaisesRegex(ValueError, "Intentional"):
             f.value()  # type: ignore
 
         def cb(fut):
-            fut.value()  # type: ignore
+            fut.value()
 
         f = Future()
-        f.set_exception(value_error)  # type: ignore
+        f.set_exception(value_error)
 
         with self.assertRaisesRegex(RuntimeError, "Got the following error"):
             cb_fut = f.then(cb)
@@ -55,11 +55,11 @@ class TestFuture(TestCase):
         f = Future[T]()
         t = threading.Thread(target=wait_future, args=(f, ))
         t.start()
-        f.set_exception(value_error)  # type: ignore
+        f.set_exception(value_error)
         t.join()
 
         def cb(fut):
-            fut.value()  # type: ignore
+            fut.value()
 
         def then_future(f):
             fut = f.then(cb)
@@ -69,7 +69,7 @@ class TestFuture(TestCase):
         f = Future[T]()
         t = threading.Thread(target=then_future, args=(f, ))
         t.start()
-        f.set_exception(value_error)  # type: ignore
+        f.set_exception(value_error)
         t.join()
 
     def test_done(self) -> None:

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -270,7 +270,7 @@ class TestNumPyInterop(TestCase):
         ]
         for tp, dtype in zip(types, dtypes):
             # Only concrete class can be given where "Type[number[_64Bit]]" is expected
-            if np.dtype(dtype).kind == 'u':  # type: ignore[misc]
+            if np.dtype(dtype).kind == 'u':
                 # .type expects a XxxTensor, which have no type hints on
                 # purpose, so ignore during mypy type checking
                 x = torch.tensor([1, 2, 3, 4]).type(tp)  # type: ignore
@@ -299,7 +299,7 @@ class TestNumPyInterop(TestCase):
             asarray = np.asarray(x, dtype=dtype)
             self.assertEqual(asarray.dtype, dtype)
             # Only concrete class can be given where "Type[number[_64Bit]]" is expected
-            if np.dtype(dtype).kind == 'u':  # type: ignore[misc]
+            if np.dtype(dtype).kind == 'u':
                 wrapped_x = np.array([1, -2, 3, -4], dtype=dtype)
                 for i in range(len(x)):
                     self.assertEqual(asarray[i], wrapped_x[i])
@@ -337,7 +337,7 @@ class TestNumPyInterop(TestCase):
             for t_dtype in [torch.float, torch.double]:
                 # mypy raises an error when np.floatXY(2.0) is called
                 # even though this is valid code
-                np_sc = np_dtype(2.0)  # type: ignore
+                np_sc = np_dtype(2.0)
                 t = torch.ones(2, requires_grad=True, dtype=t_dtype)
                 r1 = t * np_sc
                 self.assertIsInstance(r1, torch.Tensor)
@@ -352,7 +352,7 @@ class TestNumPyInterop(TestCase):
     def test_parse_numpy_int(self, device):
         # Only concrete class can be given where "Type[number[_64Bit]]" is expected
         self.assertRaisesRegex(RuntimeError, "Overflow",
-                               lambda: torch.mean(torch.randn(1, 1), np.uint64(-1)))  # type: ignore[call-overload]
+                               lambda: torch.mean(torch.randn(1, 1), np.uint64(-1)))
         # https://github.com/pytorch/pytorch/issues/29252
         for nptype in [np.int16, np.int8, np.uint8, np.int32, np.int64]:
             scalar = 3

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -724,7 +724,7 @@ class TestAssert(TestCase):
         # data can be passed without errors
         x = torch.randn(4, 4).fill_(1.0)
         ms(x)
-        with self.assertRaisesRegex(torch.jit.Error, "foo"):  # type: ignore[type-var]
+        with self.assertRaisesRegex(torch.jit.Error, "foo"):
             ms(torch.tensor([False], dtype=torch.bool))
 
 

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Union, Any, cast
 from typing_extensions import Literal, TypedDict
 
 try:
-    import boto3  # type: ignore[import]
+    import boto3
     import botocore  # type: ignore[import]
     HAVE_BOTO3 = True
 except ImportError:

--- a/torch/_vmap_internals.py
+++ b/torch/_vmap_internals.py
@@ -80,7 +80,7 @@ def _create_batched_inputs(
     batch_size = _validate_and_get_batch_size(flat_in_dims, flat_args)
     # See NOTE [Ignored _remove_batch_dim, _add_batch_dim]
     batched_inputs = [arg if in_dim is None else
-                      torch._add_batch_dim(arg, in_dim, vmap_level)  # type: ignore
+                      torch._add_batch_dim(arg, in_dim, vmap_level)
                       for in_dim, arg in zip(flat_in_dims, flat_args)]
     return tree_unflatten(batched_inputs, args_spec), batch_size
 
@@ -101,7 +101,7 @@ def _unwrap_batched(
     if isinstance(batched_outputs, Tensor):
         out_dim = out_dims_as_tuple[0]
         return torch._remove_batch_dim(batched_outputs, vmap_level, batch_size, out_dim)  # type: ignore
-    return tuple(torch._remove_batch_dim(out, vmap_level, batch_size, out_dim)  # type: ignore
+    return tuple(torch._remove_batch_dim(out, vmap_level, batch_size, out_dim)
                  for out, out_dim in zip(batched_outputs, out_dims_as_tuple))
 
 # Checks that `fn` returned one or more Tensors and nothing else.

--- a/torch/autograd/variable.py
+++ b/torch/autograd/variable.py
@@ -13,4 +13,4 @@ class Variable(with_metaclass(VariableMeta, torch._C._LegacyVariableBase)):  # t
 
 
 from torch._C import _ImperativeEngine as ImperativeEngine
-Variable._execution_engine = ImperativeEngine()  # type: ignore
+Variable._execution_engine = ImperativeEngine()

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -336,7 +336,7 @@ class StreamContext(object):
     """
     cur_stream : Optional['torch.cuda.Stream']
 
-    def __init__(self, stream: Optional['torch.cuda.Stream']):  # type: ignore
+    def __init__(self, stream: Optional['torch.cuda.Stream']):
         self.stream = stream
         self.idx = _get_device_index(None, True)
         if not torch.jit.is_scripting():
@@ -356,10 +356,10 @@ class StreamContext(object):
 
         # If the stream is not on the current device, then
         # set the current stream on the device
-        if self.src_prev_stream.device != cur_stream.device:  # type: ignore
+        if self.src_prev_stream.device != cur_stream.device:
             with device(cur_stream.device):
                 self.dst_prev_stream = torch.cuda.current_stream(cur_stream.device)
-        torch.cuda.set_stream(cur_stream)  # type: ignore
+        torch.cuda.set_stream(cur_stream)
 
     def __exit__(self, type: Any, value: Any, traceback: Any):
         # Local cur_stream variable for type refinement
@@ -374,7 +374,7 @@ class StreamContext(object):
             torch.cuda.set_stream(self.dst_prev_stream)  # type: ignore
         torch.cuda.set_stream(self.src_prev_stream)  # type: ignore
 
-def stream(stream: Optional['torch.cuda.Stream']) -> StreamContext:  # type: ignore
+def stream(stream: Optional['torch.cuda.Stream']) -> StreamContext:
     r"""Wrapper around the Context-manager StreamContext that
     selects a given stream.
 

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -1556,7 +1556,7 @@ def all_gather_object(object_list, obj, group=None):
     all_gather(output_tensors, input_tensor, group=group)
     # Deserialize outputs back to object.
     for i, tensor in enumerate(output_tensors):
-        tensor = tensor.type(torch.uint8)  # type:ignore[call-overload]
+        tensor = tensor.type(torch.uint8)
         if tensor.device != torch.device("cpu"):
             tensor = tensor.cpu()
         tensor_size = object_size_list[i]
@@ -1658,7 +1658,7 @@ def gather_object(obj, object_gather_list=None, dst=0, group=None):
     if my_rank != dst:
         return
     for i, tensor in enumerate(output_tensors):
-        tensor = tensor.type(torch.uint8)  # type: ignore[call-overload]
+        tensor = tensor.type(torch.uint8)
         tensor_size = object_size_list[i]
         object_gather_list[i] = _tensor_to_object(tensor, tensor_size)
 
@@ -1753,7 +1753,7 @@ def broadcast_object_list(object_list, src=0, group=None):
     if my_rank != src:
         for i, obj_size in enumerate(object_sizes_tensor):
             obj_view = object_tensor[offset : offset + obj_size]
-            obj_view = obj_view.type(torch.uint8)  # type: ignore[call-overload]
+            obj_view = obj_view.type(torch.uint8)
             if obj_view.device != torch.device("cpu"):
                 obj_view = obj_view.cpu()
             offset += obj_size

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -10,7 +10,7 @@ from typing import Optional, Tuple, cast
 
 import urllib3.exceptions  # type: ignore
 from etcd import Client as EtcdClient  # type: ignore
-from etcd import (  # type: ignore
+from etcd import (
     EtcdAlreadyExist,
     EtcdCompareFailed,
     EtcdException,

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -225,7 +225,7 @@ class EtcdServer:
         self._etcd_proc = subprocess.Popen(etcd_cmd, close_fds=True, stderr=stderr)
         self._wait_for_ready(timeout)
 
-    def get_client(self):  # type: ignore
+    def get_client(self):
         """
         Returns:
            An etcd client object that can be used to make requests to

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -12,8 +12,8 @@ from typing import Any, Callable, Dict, List, Optional, Union, cast, Tuple
 
 import torch.distributed.elastic.rendezvous.registry as rdzv_registry
 from torch.distributed.elastic import events, metrics
-from torch.distributed.elastic.agent.server.api import WorkerSpec, WorkerState  # type: ignore[import]
-from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent  # type: ignore[import]
+from torch.distributed.elastic.agent.server.api import WorkerSpec, WorkerState
+from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent
 from torch.distributed.elastic.multiprocessing import Std
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, record
 from torch.distributed.elastic.rendezvous import RendezvousParameters
@@ -142,7 +142,7 @@ def _get_entrypoint_name(
     """
     if isinstance(entrypoint, Callable):  # type: ignore
         return entrypoint.__name__  # type: ignore
-    elif isinstance(entrypoint, str):  # type: ignore
+    elif isinstance(entrypoint, str):
         if entrypoint == sys.executable:
             return next((arg for arg in args if arg[0] != "-"), "")
         else:

--- a/torch/distributed/pipeline/sync/batchnorm.py
+++ b/torch/distributed/pipeline/sync/batchnorm.py
@@ -94,7 +94,7 @@ class DeferredBatchNorm(_BatchNorm):
         self.counter = 0
         self.tracked = 0
 
-    def forward(self, input: Tensor) -> Tensor:  # type: ignore
+    def forward(self, input: Tensor) -> Tensor:
         if not self.training:
             # Don't train parameters on the evaluation mode.
             return batch_norm(

--- a/torch/distributed/pipeline/sync/pipe.py
+++ b/torch/distributed/pipeline/sync/pipe.py
@@ -335,7 +335,7 @@ class Pipe(Module):
 
         return self._copy_streams
 
-    def forward(self, input) -> RRef:  # type: ignore
+    def forward(self, input) -> RRef:
         """
         Processes a single input mini-batch through the pipe and returns an
         :class:`~torch.distributed.rpc.RRef` pointing to the output.

--- a/torch/distributed/pipeline/sync/skip/skippable.py
+++ b/torch/distributed/pipeline/sync/skip/skippable.py
@@ -179,7 +179,7 @@ class Skippable(nn.Module):
             output = stop.args[0]
             return output
 
-    def forward(self, input: TensorOrTensors) -> TensorOrTensors:  # type: ignore
+    def forward(self, input: TensorOrTensors) -> TensorOrTensors:
         """Performs the forward propagation. :class:`stash` or :class:`pop`
         commands will be handled by portals silently. The portals won't be
         exposed to users.

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -61,7 +61,7 @@ def rendezvous(url: str, rank: int = -1, world_size: int = -1, **kwargs):
     if rank != -1 or world_size != -1:
         query_dict: Dict[str, Union[int, str]] = dict(
             # mypy doesn't allow dict() to accept List of values (#257)
-            pair.split("=") for pair in filter(None, result.query.split("&"))  # type: ignore[arg-type, misc]
+            pair.split("=") for pair in filter(None, result.query.split("&"))
         )
         assert (
             "rank" not in query_dict and "world_size" not in query_dict

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -101,7 +101,7 @@ class lazy_property(object):
     """
     def __init__(self, wrapped):
         self.wrapped = wrapped
-        update_wrapper(self, wrapped)  # type: ignore[arg-type]
+        update_wrapper(self, wrapped)
 
     def __get__(self, instance, obj_type=None):
         if instance is None:

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -735,7 +735,7 @@ def _unique_impl(input: Tensor, sorted: bool = True,
             return_counts=return_counts, dim=dim)
 
     if dim is not None:
-        output, inverse_indices, counts = _VF.unique_dim(  # type: ignore
+        output, inverse_indices, counts = _VF.unique_dim(
             input,
             dim,
             sorted=sorted,
@@ -1414,7 +1414,7 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa
     if dim is None and out is None and dtype is None and p is not None:
         if isinstance(p, str):
             if p == "fro":
-                return _VF.frobenius_norm(input, dim=(), keepdim=keepdim)  # type: ignore
+                return _VF.frobenius_norm(input, dim=(), keepdim=keepdim)
         if not isinstance(p, str):
             _dim = [i for i in range(ndim)]  # noqa: C416 TODO: rewrite as list(range(m))
             return _VF.norm(input, p, dim=_dim, keepdim=keepdim)  # type: ignore
@@ -1438,22 +1438,22 @@ def norm(input, p="fro", dim=None, keepdim=False, out=None, dtype=None):  # noqa
             if _dim is None:
                 _dim = list(range(ndim))
             if out is None:
-                return _VF.frobenius_norm(input, _dim, keepdim=keepdim)  # type: ignore
+                return _VF.frobenius_norm(input, _dim, keepdim=keepdim)
             else:
-                return _VF.frobenius_norm(input, _dim, keepdim=keepdim, out=out)  # type: ignore
+                return _VF.frobenius_norm(input, _dim, keepdim=keepdim, out=out)
         elif p == "nuc":
             if dtype is not None:
                 raise ValueError("dtype argument is not supported in nuclear norm")
             if _dim is None:
                 if out is None:
-                    return _VF.nuclear_norm(input, keepdim=keepdim)  # type: ignore
+                    return _VF.nuclear_norm(input, keepdim=keepdim)
                 else:
-                    return _VF.nuclear_norm(input, keepdim=keepdim, out=out)  # type: ignore
+                    return _VF.nuclear_norm(input, keepdim=keepdim, out=out)
             else:
                 if out is None:
-                    return _VF.nuclear_norm(input, _dim, keepdim=keepdim)  # type: ignore
+                    return _VF.nuclear_norm(input, _dim, keepdim=keepdim)
                 else:
-                    return _VF.nuclear_norm(input, _dim, keepdim=keepdim, out=out)  # type: ignore
+                    return _VF.nuclear_norm(input, _dim, keepdim=keepdim, out=out)
         raise RuntimeError(f"only valid string values are 'fro' and 'nuc', found {p}")
     else:
         if _dim is None:

--- a/torch/fx/interpreter.py
+++ b/torch/fx/interpreter.py
@@ -220,7 +220,7 @@ class Interpreter:
             Any: The value returned by the method invocation
         """
         # args[0] is the `self` object for this method call
-        self_obj, *args_tail = args  # type: ignore
+        self_obj, *args_tail = args
 
         # Execute the method and return the result
         assert isinstance(target, str)

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -32,7 +32,7 @@ _type_eval_globals = {'Tensor' : torch.Tensor, 'Device' : torch.device, 'Layout'
                       'number' : numbers.Number, 'Future' : torch.jit.Future,
                       'AnyEnumType' : enum.Enum, 'QScheme' : torch.qscheme,
                       '__torch__': _FakeGlobalNamespace(),
-                      't': typing.TypeVar('t')}  # type: ignore
+                      't': typing.TypeVar('t')}
 for k in dir(typing):
     _type_eval_globals[k] = getattr(typing, k)
 

--- a/torch/fx/passes/split_module.py
+++ b/torch/fx/passes/split_module.py
@@ -10,8 +10,8 @@ class Partition:
         self.outputs: Dict[str, None] = {}
         self.partitions_dependent_on: Dict[str, None] = {}
         self.partition_dependents: Dict[str, None] = {}
-        self.graph : torch.fx.graph.Graph = torch.fx.graph.Graph()  # type: ignore
-        self.environment : Dict[torch.fx.node.Node, torch.fx.node.Node] = {}  # type: ignore
+        self.graph : torch.fx.graph.Graph = torch.fx.graph.Graph()
+        self.environment : Dict[torch.fx.node.Node, torch.fx.node.Node] = {}
         self.targets : Dict[str, Any] = {}
 
     def __repr__(self) -> str:
@@ -26,12 +26,12 @@ class Partition:
 def split_module(
     m: GraphModule,
     root_m: torch.nn.Module,
-    split_callback: Callable[[torch.fx.node.Node], int],  # type: ignore
+    split_callback: Callable[[torch.fx.node.Node], int],
 ):
     partitions: Dict[str, Partition] = {}
-    orig_nodes: Dict[str, torch.fx.node.Node] = {}  # type: ignore
+    orig_nodes: Dict[str, torch.fx.node.Node] = {}
 
-    def record_cross_partition_use(def_node : torch.fx.node.Node, use_node : Optional[torch.fx.node.Node]):  # type: ignore
+    def record_cross_partition_use(def_node : torch.fx.node.Node, use_node : Optional[torch.fx.node.Node]):
         def_partition_name = getattr(def_node, '_fx_partition', None)
         use_partition_name = getattr(use_node, '_fx_partition', None)
         if def_partition_name != use_partition_name:
@@ -56,7 +56,7 @@ def split_module(
         if node.op in ["placeholder", "get_attr"]:
             continue
         if node.op == 'output':
-            torch.fx.graph.map_arg(node.args[0], lambda n: record_cross_partition_use(n, None))  # type: ignore
+            torch.fx.graph.map_arg(node.args[0], lambda n: record_cross_partition_use(n, None))
             continue
         partition_name = str(split_callback(node))
 
@@ -68,8 +68,8 @@ def split_module(
         partition.node_names.append(node.name)
         node._fx_partition = partition_name
 
-        torch.fx.graph.map_arg(node.args, lambda def_node: record_cross_partition_use(def_node, node))  # type: ignore
-        torch.fx.graph.map_arg(node.kwargs, lambda def_node: record_cross_partition_use(def_node, node))  # type: ignore
+        torch.fx.graph.map_arg(node.args, lambda def_node: record_cross_partition_use(def_node, node))
+        torch.fx.graph.map_arg(node.kwargs, lambda def_node: record_cross_partition_use(def_node, node))
 
     # find partitions with no dependencies
     root_partitions : List[str] = []
@@ -104,8 +104,8 @@ def split_module(
 
             # swap out old graph nodes in kw/args with references to new nodes in this submodule
             environment = partition.environment
-            gathered_args = torch.fx.graph.map_arg(node.args, lambda n : environment[n])  # type: ignore
-            gathered_kwargs = torch.fx.graph.map_arg(node.kwargs, lambda n : environment[n])  # type: ignore
+            gathered_args = torch.fx.graph.map_arg(node.args, lambda n : environment[n])
+            gathered_kwargs = torch.fx.graph.map_arg(node.kwargs, lambda n : environment[n])
 
             if node.op not in ['call_module', 'get_attr']:
                 target = node.target
@@ -128,9 +128,9 @@ def split_module(
             partition.environment[node] = new_node
 
     # Set up values to construct base module
-    base_mod_env : Dict[str, torch.fx.node.Node] = {}  # type: ignore
-    base_mod_graph : torch.fx.graph.Graph = torch.fx.graph.Graph()  # type: ignore
-    base_mod_attrs : Dict[str, torch.fx.graph_module.GraphModule] = {}  # type: ignore
+    base_mod_env : Dict[str, torch.fx.node.Node] = {}
+    base_mod_graph : torch.fx.graph.Graph = torch.fx.graph.Graph()
+    base_mod_attrs : Dict[str, torch.fx.graph_module.GraphModule] = {}
     for node in m.graph.nodes:
         if node.op == 'placeholder':
             base_mod_env[node.name] = base_mod_graph.placeholder(node.name)
@@ -159,14 +159,14 @@ def split_module(
 
         # Construct GraphModule for this partition
         submod_name = f'submod_{partition_name}'
-        base_mod_attrs[submod_name] = torch.fx.graph_module.GraphModule(partition.targets, partition.graph)  # type: ignore
+        base_mod_attrs[submod_name] = torch.fx.graph_module.GraphModule(partition.targets, partition.graph)
 
         # Emit call in base graph to this submodule
 
-        output_val = base_mod_graph.call_module(submod_name, tuple(base_mod_env[name] for name in partition.inputs))  # type: ignore
+        output_val = base_mod_graph.call_module(submod_name, tuple(base_mod_env[name] for name in partition.inputs))
         if len(partition.outputs) > 1:
             # Unpack multiple return values from submodule
-            output_val_proxy = torch.fx.proxy.Proxy(output_val)  # type: ignore
+            output_val_proxy = torch.fx.proxy.Proxy(output_val)
             for i, output_name in enumerate(partition.outputs):
                 base_mod_env[output_name] = output_val_proxy[i].node  # type: ignore
         else:
@@ -174,6 +174,6 @@ def split_module(
 
     for node in m.graph.nodes:
         if node.op == 'output':
-            base_mod_graph.output(torch.fx.graph.map_arg(node.args[0], lambda n : base_mod_env[n.name]))  # type: ignore
+            base_mod_graph.output(torch.fx.graph.map_arg(node.args[0], lambda n : base_mod_env[n.name]))
 
-    return torch.fx.graph_module.GraphModule(base_mod_attrs, base_mod_graph)  # type: ignore
+    return torch.fx.graph_module.GraphModule(base_mod_attrs, base_mod_graph)

--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -313,7 +313,7 @@ class Tracer(TracerBase):
             if concrete_args is not None and name in concrete_args:
                 return concrete_args[name]
             if name[0] == '*':
-                default = ()    # type: ignore
+                default = ()
             else:
                 param = sig.parameters[name]
                 default = () if param.default is inspect.Parameter.empty else (param.default,)  # type: ignore

--- a/torch/jit/_builtins.py
+++ b/torch/jit/_builtins.py
@@ -97,10 +97,10 @@ _builtin_ops = [
     (torch._VF.istft, "aten::istft"),  # type: ignore
     (torch._VF.cdist, "aten::cdist"),  # type: ignore
     (torch._VF.norm, "aten::norm"),  # type: ignore
-    (torch._VF.unique_dim, "aten::unique_dim"),  # type: ignore
+    (torch._VF.unique_dim, "aten::unique_dim"),
     (torch._VF.unique_consecutive, "aten::unique_consecutive"),  # type: ignore
-    (torch._VF.nuclear_norm, "aten::nuclear_norm"),  # type: ignore
-    (torch._VF.frobenius_norm, "aten::frobenius_norm"),  # type: ignore
+    (torch._VF.nuclear_norm, "aten::nuclear_norm"),
+    (torch._VF.frobenius_norm, "aten::frobenius_norm"),
     (torch._VF.tensordot, "aten::tensordot"),  # type: ignore
 ]
 
@@ -143,8 +143,8 @@ def _get_builtin_table():
 
     import torch.distributed.autograd as dist_autograd
     if dist_autograd.is_available():
-        _builtin_ops.append((dist_autograd.get_gradients, "aten::get_gradients"))  # type: ignore
-        _builtin_ops.append((dist_autograd.backward, "aten::dist_backward"))  # type: ignore
+        _builtin_ops.append((dist_autograd.get_gradients, "aten::get_gradients"))
+        _builtin_ops.append((dist_autograd.backward, "aten::dist_backward"))
 
     # populate the _builtin_table from _builtin_ops
     for builtin, aten_op in _builtin_ops:

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -520,7 +520,7 @@ def create_script_module_impl(nn_module, concrete_type, stubs_fn):
         # Wrap the original to propagate docstrings and such.
         # TODO: we don't currently do this functions that are recursively
         # compiled, we should.
-        wrapped_script_method = functools.wraps(method_stub.original_method)(script_method)  # type: ignore
+        wrapped_script_method = functools.wraps(method_stub.original_method)(script_method)
 
         # Add the methods to the script_module directly. This ensures they will
         # be found first when `name` is looked up (as opposed to the stubs or

--- a/torch/jit/quantized.py
+++ b/torch/jit/quantized.py
@@ -263,7 +263,7 @@ class QuantizedRNNBase(torch.jit.ScriptModule):
         if dtype != torch.int8 and dtype != torch.float16:
             raise RuntimeError('Unsupported dtype: {}'.format(dtype))
 
-        self.all_weights = []  # type: ignore
+        self.all_weights = []
         for layer in range(self.num_layers):
             for direction in range(num_directions):
                 layer_input_size = self.input_size if layer == 0 else self.hidden_size * num_directions

--- a/torch/nn/modules/linear.py
+++ b/torch/nn/modules/linear.py
@@ -105,7 +105,7 @@ class _LinearWithBias(Linear):
     bias: Tensor  # type: ignore
 
     def __init__(self, in_features: int, out_features: int) -> None:
-        super().__init__(in_features, out_features, bias=True)  # type: ignore
+        super().__init__(in_features, out_features, bias=True)
 
 
 class Bilinear(Module):
@@ -230,8 +230,8 @@ class LazyLinear(LazyModuleMixin, Linear):
         if self.has_uninitialized_params():
             with torch.no_grad():
                 self.in_features = input.shape[-1]
-                self.weight.materialize((self.out_features, self.in_features))  # type: ignore
+                self.weight.materialize((self.out_features, self.in_features))
                 if self.bias is not None:
-                    self.bias.materialize((self.out_features,))  # type: ignore
+                    self.bias.materialize((self.out_features,))
                 self.reset_parameters()
 # TODO: PartialLinear - maybe in sparse?

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -172,8 +172,8 @@ class RNNBase(Module):
                     torch._cudnn_rnn_flatten_weight(
                         self._flat_weights, num_weights,
                         self.input_size, rnn.get_cudnn_mode(self.mode),
-                        self.hidden_size, self.proj_size, self.num_layers,  # type: ignore
-                        self.batch_first, bool(self.bidirectional))  # type: ignore
+                        self.hidden_size, self.proj_size, self.num_layers,
+                        self.batch_first, bool(self.bidirectional))
 
     def _apply(self, fn):
         ret = super(RNNBase, self)._apply(fn)

--- a/torch/nn/parallel/scatter_gather.pyi
+++ b/torch/nn/parallel/scatter_gather.pyi
@@ -14,7 +14,7 @@ def scatter(inputs: Tensor, target_gpus: _devices_t, dim: int = ...) -> Tuple[Te
 # untyped module. Thus to mypy, the first definition of `scatter` looks strictly more general
 # than this overload.
 @overload
-def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...  # type: ignore
+def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...
 
 
 # TODO More precise types here.

--- a/torch/nn/quantizable/modules/activation.py
+++ b/torch/nn/quantizable/modules/activation.py
@@ -70,7 +70,7 @@ class MultiheadAttention(nn.MultiheadAttention):
         # TODO: The use of the `_LinearWithBias` increases the quantization noise
         # The `out_proj` in the parent is ``_LinearWithBias`, so need to ignore
         # the type for mypy not to complain.
-        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)  # type: ignore
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=bias)
 
         # Functionals
         self.q_scaling_product = nnq.FloatFunctional()
@@ -99,8 +99,8 @@ class MultiheadAttention(nn.MultiheadAttention):
         observed.qconfig = other.qconfig
 
         # Set the linear weights
-        observed.out_proj.weight = other.out_proj.weight  # type: ignore
-        observed.out_proj.bias = other.out_proj.bias  # type: ignore
+        observed.out_proj.weight = other.out_proj.weight
+        observed.out_proj.bias = other.out_proj.bias
         if other._qkv_same_embed_dim:
             # Use separate params
             bias = other.in_proj_bias
@@ -206,9 +206,9 @@ class MultiheadAttention(nn.MultiheadAttention):
             fp.k_proj_weight = nn.Parameter(wK)
             fp.v_proj_weight = nn.Parameter(wV)
             if fp.in_proj_bias is None:
-                self.linear_Q.bias = None  # type: ignore
-                self.linear_K.bias = None  # type: ignore
-                self.linear_V.bias = None  # type: ignore
+                self.linear_Q.bias = None
+                self.linear_K.bias = None
+                self.linear_V.bias = None
             else:
                 fp.in_proj_bias[0:fp.embed_dim] = bQ
                 fp.in_proj_bias[fp.embed_dim:(fp.embed_dim * 2)] = bK
@@ -440,7 +440,7 @@ class MultiheadAttention(nn.MultiheadAttention):
 
         # Reentering the quantized zone
         attn_output = self.quant_attn_output(attn_output)
-        attn_output = self.out_proj(attn_output)  # type: ignore
+        attn_output = self.out_proj(attn_output)
         attn_output_weights = self.quant_attn_output_weights(attn_output_weights)
 
         if need_weights:

--- a/torch/nn/quantized/dynamic/modules/rnn.py
+++ b/torch/nn/quantized/dynamic/modules/rnn.py
@@ -625,7 +625,7 @@ class GRU(RNNBase):
                                 sorted_indices, unsorted_indices)
         return output, self.permute_hidden(hidden, unsorted_indices)
 
-    def permute_hidden(  # type: ignore
+    def permute_hidden(
         self, hx: Tensor, permutation: Optional[Tensor]
     ) -> Tensor:
         if permutation is None:

--- a/torch/nn/quantized/modules/conv.py
+++ b/torch/nn/quantized/modules/conv.py
@@ -196,7 +196,7 @@ class _ConvNd(nn.Module):
             'Weight observer must have a dtype of qint8'
         qweight = _quantize_weight(mod.weight.float(), weight_post_process)
         # the __init__ call used is the one from derived classes and not the one from _ConvNd
-        qconv = cls(mod.in_channels, mod.out_channels, mod.kernel_size,  # type: ignore[call-arg]
+        qconv = cls(mod.in_channels, mod.out_channels, mod.kernel_size,
                     mod.stride, mod.padding, mod.dilation, mod.groups,
                     mod.bias is not None, mod.padding_mode)
         qconv.set_weight_bias(qweight, mod.bias)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -138,9 +138,9 @@ def parse_args(*arg_descriptors):
                 fn_name = fn.__name__
             except Exception:
                 arg_names = [None] * len(args)  # type: ignore
-                fn_name = None  # type: ignore
+                fn_name = None
             args = [_parse_arg(arg, arg_desc, arg_name, fn_name)  # type: ignore
-                    for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]  # type: ignore
+                    for arg, arg_desc, arg_name in zip(args, arg_descriptors, arg_names)]
             # only support _outputs in kwargs
             assert len(kwargs) <= 1
             if len(kwargs) == 1:
@@ -602,7 +602,7 @@ def _repeat_interleave_split_helper(g, self, reps, dim):
     if _export_onnx_opset_version <= 12:
         return g.op("Split", self, split_i=[1] * reps, axis_i=dim, outputs=reps)
     else:
-        from torch.onnx.symbolic_opset13 import split  # type: ignore
+        from torch.onnx.symbolic_opset13 import split
         repeats = g.op("Constant", value_t=torch.tensor([1] * reps))
         return split(g, self, repeats, dim, _outputs=reps)
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -302,4 +302,4 @@ def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128
 
 def isinf(g, input):
     from torch.onnx.symbolic_opset9 import _cast_Double  # type: ignore
-    return g.op("IsInf", _cast_Double(g, input, False))  # type: ignore
+    return g.op("IsInf", _cast_Double(g, input, False))

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -466,7 +466,7 @@ def _model_to_graph(model, args, verbose=False,
     # erased by some optimizations, so we need to set it explicitly again.
     if torch_out is not None:
         if not (isinstance(torch_out, list) or isinstance(torch_out, tuple)):
-            output_wrapped = [torch_out]  # type: ignore
+            output_wrapped = [torch_out]
         else:
             output_wrapped = torch_out  # type: ignore
 

--- a/torch/package/_package_unpickler.py
+++ b/torch/package/_package_unpickler.py
@@ -1,6 +1,6 @@
 import pickle
 
-import _compat_pickle  # type: ignore
+import _compat_pickle
 
 from .importer import Importer
 

--- a/torch/quantization/fx/fuse.py
+++ b/torch/quantization/fx/fuse.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 
-from torch.fx import (  # type: ignore
+from torch.fx import (
     GraphModule,
     Node,
     map_arg

--- a/torch/quantization/fx/graph_module.py
+++ b/torch/quantization/fx/graph_module.py
@@ -1,6 +1,6 @@
 import torch
 import copy
-from torch.fx import GraphModule  # type: ignore
+from torch.fx import GraphModule
 from torch.fx.graph import Graph
 from typing import Union, Dict, Any, List
 

--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -162,7 +162,7 @@ class BinaryOpQuantizeHandler(QuantizeHandler):
         if self.binary_op in qbin_op_mapping:
             self.quantized_binary_op = qbin_relu_op_mapping[self.binary_op] \
                 if self.relu_node is not None \
-                else qbin_op_mapping[self.binary_op]  # type: ignore
+                else qbin_op_mapping[self.binary_op]
 
     def convert(self, quantizer: QuantizerCls, node: Node, load_arg: Callable,
                 is_reference: bool = False,

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -1,5 +1,5 @@
 import torch
-from torch.fx import (  # type: ignore
+from torch.fx import (
     GraphModule,
     Proxy,
     map_arg
@@ -172,7 +172,7 @@ def maybe_insert_observer_for_special_module(
         observed_standalone_module = \
             prepare(standalone_module, sm_qconfig_dict, sm_prepare_config_dict)
         standalone_module_input_idxs = \
-            observed_standalone_module._standalone_module_input_quantized_idxs.int().tolist()  # type: ignore
+            observed_standalone_module._standalone_module_input_quantized_idxs.int().tolist()
         observed_standalone_module = ObservedStandaloneGraphModule(
             observed_standalone_module, observed_standalone_module.graph)
         parent_name, name = _parent_name(node.target)
@@ -1099,18 +1099,18 @@ class Quantizer:
                     assert isinstance(prev_node, Node)
                     observer_dtype: torch.dtype = observer_module.dtype  # type: ignore
                     quant_env[node.name] = (
-                        quantize_node(self, load_non_quantized(prev_node),  # type: ignore
-                                      observer_module, node, is_input=True),  # type: ignore
-                        observer_dtype)  # type: ignore
+                        quantize_node(self, load_non_quantized(prev_node),
+                                      observer_module, node, is_input=True),
+                        observer_dtype)
             else:
                 # replace activation post process with quantization ops
                 root_module = self.modules[""]
                 assert isinstance(node.args[0], Node)
                 dtype: torch.dtype = observer_module.dtype  # type: ignore
                 quant_env[node.name] = (
-                    quantize_node(self, load_non_quantized(node.args[0]),  # type: ignore
-                                  observer_module, node, is_input=True),  # type: ignore
-                    dtype)  # type: ignore
+                    quantize_node(self, load_non_quantized(node.args[0]),
+                                  observer_module, node, is_input=True),
+                    dtype)
 
         # additional state to override inputs to be quantized, if specified
         # by the user
@@ -1139,7 +1139,7 @@ class Quantizer:
                 is_observed_standalone_module_node = (
                     node.op == 'call_module' and
                     is_observed_standalone_module(
-                        self.modules[node.target])  # type: ignore
+                        self.modules[node.target])
                 )
                 if qconfig is None and not is_observed_standalone_module_node:
                     result = self.quantized_graph.node_copy(

--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -113,7 +113,7 @@ def get_quantize_node_info(activation_post_process: Callable) -> Tuple[str, Opti
             scale = float(scale)
             zero_point = int(zero_point)
             qparams = {"_scale_": scale, "_zero_point_": zero_point, "_dtype_": dtype}
-            quantize_op = torch.quantize_per_tensor  # type: ignore
+            quantize_op = torch.quantize_per_tensor
     elif dtype == torch.float16:
         node_type = "call_method"
         quantize_op = "to"

--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -296,7 +296,7 @@ def _get_name_for_subgraph(
 
 def _get_node_target_type(node: Node, gm: GraphModule) -> Optional[NSNodeTargetType]:
     if node.op in ('call_function', 'call_method'):
-        return node.target  # type: ignore
+        return node.target
     elif node.op == 'call_module':
         assert isinstance(node.target, str)
         mod = getattr_from_fqn(gm, node.target)
@@ -402,9 +402,9 @@ def get_matching_subgraph_pairs(
         # look up types of a and b for useful error messages
         type_start_a, type_start_b = None, None
         if cur_subgraph_a is not None:
-            type_start_a = _get_node_target_type(cur_subgraph_a.start_node, gm_a)  # type: ignore
+            type_start_a = _get_node_target_type(cur_subgraph_a.start_node, gm_a)
         if cur_subgraph_b is not None:
-            type_start_b = _get_node_target_type(cur_subgraph_b.start_node, gm_b)  # type: ignore
+            type_start_b = _get_node_target_type(cur_subgraph_b.start_node, gm_b)
 
         # check for results and determine what to do next
         if cur_subgraph_a is not None and cur_subgraph_b is not None:

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -338,7 +338,7 @@ def _insert_copy_of_node_a_after_input_node_c(
             arg_a = return_first_non_observer_node(node_a_arg, gm_a)
             if arg_a.op == 'get_attr':
                 arg_a_copy_name = \
-                    get_new_attr_name_with_prefix(arg_a.name + '_shadow_copy_')(gm_b)  # type: ignore
+                    get_new_attr_name_with_prefix(arg_a.name + '_shadow_copy_')(gm_b)
                 arg_a_obj = getattr_from_fqn(gm_a, arg_a.target)  # type: ignore
                 setattr(gm_b, arg_a_copy_name, arg_a_obj.detach())
                 node_a_arg_copy = graph_c.create_node(
@@ -356,7 +356,7 @@ def _insert_copy_of_node_a_after_input_node_c(
         if isinstance(node_a_kwarg, Node):
             kwarg_a = return_first_non_observer_node(node_a_kwarg, gm_a)
             kwarg_a_copy_name = \
-                get_new_attr_name_with_prefix(kwarg_a.name + '_shadow_copy_')(gm_b)  # type: ignore
+                get_new_attr_name_with_prefix(kwarg_a.name + '_shadow_copy_')(gm_b)
             kwarg_a_obj = getattr_from_fqn(gm_a, kwarg_a.target)  # type: ignore
             setattr(gm_b, kwarg_a_copy_name, kwarg_a_obj.detach())
             node_a_kwarg_copy = graph_c.create_node(
@@ -383,13 +383,13 @@ def _insert_copy_of_node_a_after_input_node_c(
         setattr(gm_b, new_mod_copy_name, mod_a)
         node_a_shadows_c = graph_c.create_node(
             node_a.op, new_mod_copy_name, (*input_node_c_args, *new_args),
-            new_kwargs, node_a_shadows_c_name)  # type: ignore
+            new_kwargs, node_a_shadows_c_name)
         return node_a_shadows_c
     else:
         assert node_a.op in ('call_function', 'call_method')
         node_a_shadows_c = graph_c.create_node(
             node_a.op, node_a.target, (*input_node_c_args, *new_args),
-            new_kwargs, node_a_shadows_c_name)  # type: ignore
+            new_kwargs, node_a_shadows_c_name)
         return node_a_shadows_c
 
 def create_a_shadows_b(
@@ -458,7 +458,7 @@ def create_a_shadows_b(
 
         if node_b_is_observer:
             # remove activation post process node
-            env_c[node_b.name] = env_c[node_b.args[0].name]  # type: ignore
+            env_c[node_b.name] = env_c[node_b.args[0].name]
 
         elif (node_b_is_start_node or node_b_is_end_node):
 

--- a/torch/quantization/quantize_fx.py
+++ b/torch/quantization/quantize_fx.py
@@ -1,7 +1,7 @@
 import torch
-from torch.fx import GraphModule  # type: ignore
-from torch.fx.symbolic_trace import Tracer  # type: ignore
-from torch.fx.node import Target, Node, Argument  # type: ignore
+from torch.fx import GraphModule
+from torch.fx.symbolic_trace import Tracer
+from torch.fx.node import Target, Node, Argument
 from .fx import Fuser  # noqa: F401
 from .fx import Quantizer  # noqa: F401
 from .fx.utils import graph_pretty_str  # noqa: F401
@@ -232,7 +232,7 @@ def fuse_fx(model: torch.nn.Module,
     """
     torch._C._log_api_usage_once("quantization_api.quantize_fx.fuse_fx")
     assert not model.training, 'fuse_fx only works on models in eval mode'
-    graph_module = torch.fx.symbolic_trace(model)  # type: ignore
+    graph_module = torch.fx.symbolic_trace(model)
     return _fuse_fx(graph_module, fuse_custom_config_dict)
 
 def prepare_fx(

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -2,7 +2,7 @@ import sys
 
 import torch
 from torch._C import _add_docstr, _special  # type: ignore
-from torch._torch_docs import common_args  # type: ignore
+from torch._torch_docs import common_args
 
 Tensor = torch.Tensor
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -454,8 +454,8 @@ class MultiProcessTestCase(TestCase):
         if sys.platform != 'win32' and sys.platform != 'darwin':
             # Register signal handler to dump stack traces on FATALs.
             # Windows and MacOS do not support the signal handlers.
-            import caffe2.python._import_c_extension as C  # type: ignore
-            C.set_print_stack_traces_on_fatal_signal(True)  # type: ignore
+            import caffe2.python._import_c_extension as C
+            C.set_print_stack_traces_on_fatal_signal(True)
 
         # self.id() == e.g. '__main__.TestDistributed.test_get_rank'
         # We're retrieving a corresponding test and executing it.

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -239,7 +239,7 @@ class OpInfo(object):
 
         self.supports_sparse = supports_sparse
 
-        self.aliases = ()  # type: ignore
+        self.aliases = ()
         if aliases is not None:
             self.aliases = tuple(AliasInfo(a) for a in aliases)  # type: ignore
 
@@ -879,7 +879,7 @@ def sample_inputs_div(self, device, dtype, requires_grad, rounding_mode=None, **
 
     kwargs = None  # type: ignore
     if rounding_mode is not None:
-        kwargs = dict(rounding_mode=rounding_mode)  # type: ignore
+        kwargs = dict(rounding_mode=rounding_mode)
 
     return (
         SampleInput(a, args=(b,), kwargs=kwargs),
@@ -2162,7 +2162,7 @@ def sample_kwargs_clamp(device, dtype, input):
     elif dtype.is_floating_point:
         min_val, max_val = (random.uniform(-8, 0), random.uniform(1, 8))  # type: ignore
     else:
-        min_val, max_val = (random.randint(-8, 0), random.randint(1, 8))  # type: ignore
+        min_val, max_val = (random.randint(-8, 0), random.randint(1, 8))
     return {'min': min_val, 'max': max_val}, {'a_min': min_val, 'a_max': max_val}
 
 def sample_inputs_cumprod(op_info, device, dtype, requires_grad, **kwargs):
@@ -2438,12 +2438,12 @@ def sample_inputs_rsub(op_info, device, dtype, requires_grad, variant='tensor', 
     def _samples_with_alpha_helper(args, alphas, filter_fn=lambda arg_alpha: True):
         filtered_product = filter(filter_fn, product(args, alphas))  # type: ignore
         return (SampleInput(input, args=(arg,), kwargs=dict(alpha=alpha))
-                for (input, arg), alpha in filtered_product)  # type: ignore
+                for (input, arg), alpha in filtered_product)
 
     int_alpha, float_alpha, complex_alpha = 2, 0.1, 1 + 0.6j
 
     if variant == 'tensor':
-        samples = (  # type: ignore
+        samples = (
             SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S, S)),)),
             SampleInput(_make_tensor_helper((S, S)), args=(_make_tensor_helper((S,)),)),
             SampleInput(_make_tensor_helper((S,)), args=(_make_tensor_helper((S, S)),)),
@@ -2470,11 +2470,11 @@ def sample_inputs_rsub(op_info, device, dtype, requires_grad, variant='tensor', 
                    SampleInput(_make_tensor_helper((S, S)), args=(1.5j,)),
                    SampleInput(_make_tensor_helper(()), args=(1.5j,)),
                    SampleInput(_make_tensor_helper((S, S)), args=(0.4 + 1.2j,)),
-                   SampleInput(_make_tensor_helper(()), args=(1.2 + 1.76j,)))  # type: ignore
+                   SampleInput(_make_tensor_helper(()), args=(1.2 + 1.76j,)))
 
         scalar_args = [(_make_tensor_helper((S, S)), 0.5), (_make_tensor_helper(()), 0.5),
                        (_make_tensor_helper((S, S)), 2.7j), (_make_tensor_helper(()), 2.7j),
-                       (_make_tensor_helper((S, S)), 1 - 2.7j), (_make_tensor_helper(()), 1 + 2.7j)]  # type: ignore
+                       (_make_tensor_helper((S, S)), 1 - 2.7j), (_make_tensor_helper(()), 1 + 2.7j)]
 
         alphas = [int_alpha, float_alpha, complex_alpha]
 
@@ -2612,7 +2612,7 @@ def sample_inputs_lerp(op_info, device, dtype, requires_grad):
         # SampleInput((_make_tensor_helper(()), _make_tensor_helper((S, S)), 0.4)),
         # SampleInput((_make_tensor_helper((S, 1)), _make_tensor_helper((S, S)), 0.4)),
         # SampleInput((_make_tensor_helper((S, 1)), _make_tensor_helper((S, S)), _make_tensor_helper((S, 1)))),
-    )  # type: ignore
+    )
 
     if dtype.is_complex:
         samples = samples + (  # type: ignore

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1385,7 +1385,7 @@ class TestCase(expecttest.TestCase):
             super().assertEqual(x, y, msg=msg)
 
     def assertNotEqual(self, x, y, msg: Optional[str] = None, *,                                       # type: ignore[override]
-                       atol: Optional[float] = None, rtol: Optional[float] = None, **kwargs) -> None:  # type: ignore[override]
+                       atol: Optional[float] = None, rtol: Optional[float] = None, **kwargs) -> None:
         with self.assertRaises(AssertionError, msg=msg):
             self.assertEqual(x, y, msg, atol=atol, rtol=rtol, **kwargs)
 

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 import torch.distributed as dist
 import torch.distributed.rpc as rpc
-from torch.distributed.rpc import _rref_context_get_debug_info  # type: ignore[attr-defined]
+from torch.distributed.rpc import _rref_context_get_debug_info
 from torch.testing._internal.common_utils import FILE_SCHEMA
 
 

--- a/torch/utils/_crash_handler.py
+++ b/torch/utils/_crash_handler.py
@@ -15,4 +15,4 @@ def enable_minidump_collection(directory=DEFAULT_MINIDUMP_DIR):
     elif not os.path.exists(directory):
         raise RuntimeError(f"Directory does not exist: {directory}")
 
-    torch._C._enable_minidump_collection(directory)  # type: ignore
+    torch._C._enable_minidump_collection(directory)

--- a/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
+++ b/torch/utils/benchmark/examples/spectral_ops_fuzz_test.py
@@ -52,11 +52,11 @@ def run_benchmark(name: str, function: object, dtype: torch.dtype, seed: int, de
 
 Benchmark = namedtuple('Benchmark', ['name', 'function', 'dtype'])
 BENCHMARKS = [
-    Benchmark('fft_real', torch.fft.fftn, torch.float32),  # type: ignore
-    Benchmark('fft_complex', torch.fft.fftn, torch.complex64),  # type: ignore
-    Benchmark('ifft', torch.fft.ifftn, torch.complex64),  # type: ignore
-    Benchmark('rfft', torch.fft.rfftn, torch.float32),  # type: ignore
-    Benchmark('irfft', torch.fft.irfftn, torch.complex64),  # type: ignore
+    Benchmark('fft_real', torch.fft.fftn, torch.float32),
+    Benchmark('fft_complex', torch.fft.fftn, torch.complex64),
+    Benchmark('ifft', torch.fft.ifftn, torch.complex64),
+    Benchmark('rfft', torch.fft.rfftn, torch.float32),
+    Benchmark('irfft', torch.fft.irfftn, torch.complex64),
 ]
 BENCHMARK_MAP = {b.name: b for b in BENCHMARKS}
 BENCHMARK_NAMES = [b.name for b in BENCHMARKS]

--- a/torch/utils/data/_typing.py
+++ b/torch/utils/data/_typing.py
@@ -81,7 +81,7 @@ def issubtype(left, right, recursive=True):
 
 
 def _decompose_type(t, to_list=True):
-    if isinstance(t, TypeVar):  # type: ignore
+    if isinstance(t, TypeVar):
         if t.__bound__ is not None:
             ts = [t.__bound__]
         else:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -165,7 +165,7 @@ class DataLoader(Generic[T_co]):
                  multiprocessing_context=None, generator=None,
                  *, prefetch_factor: int = 2,
                  persistent_workers: bool = False):
-        torch._C._log_api_usage_once("python.data_loader")  # type: ignore
+        torch._C._log_api_usage_once("python.data_loader")
 
         if num_workers < 0:
             raise ValueError('num_workers option should be non-negative; '

--- a/torch/utils/data/datapipes/iter/combining.py
+++ b/torch/utils/data/datapipes/iter/combining.py
@@ -34,7 +34,7 @@ class ConcatIterDataPipe(IterDataPipe):
                 raise NotImplementedError
             return self.length
         if all(isinstance(dp, Sized) and len(dp) >= 0 for dp in self.datapipes):
-            self.length = sum(len(dp) for dp in self.datapipes)  # type: ignore
+            self.length = sum(len(dp) for dp in self.datapipes)
         else:
             self.length = -1
         return len(self)
@@ -70,7 +70,7 @@ class ZipIterDataPipe(IterDataPipe[Tuple[T_co]]):
                 raise NotImplementedError
             return self.length
         if all(isinstance(dp, Sized) for dp in self.datapipes):
-            self.length = min(len(dp) for dp in self.datapipes)  # type: ignore
+            self.length = min(len(dp) for dp in self.datapipes)
         else:
             self.length = -1
         return len(self)

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -5,7 +5,7 @@ import functools
 from torch._utils import _accumulate
 from torch import randperm
 # No 'default_generator' in torch/__init__.pyi
-from torch import default_generator  # type: ignore
+from torch import default_generator
 from torch.utils.data._typing import _DataPipeMeta
 from typing import TypeVar, Generic, Iterable, Iterator, Sequence, List, Optional, Tuple, Dict, Callable
 from ... import Tensor, Generator
@@ -288,7 +288,7 @@ class ChainDataset(IterableDataset):
         for d in self.datasets:
             assert isinstance(d, IterableDataset), "ChainDataset only supports IterableDataset"
             # Cannot verify that all self.datasets are Sized
-            total += len(d)  # type: ignore
+            total += len(d)
         return total
 
 

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -829,7 +829,7 @@ class SummaryWriter(object):
             metadata, label_img, fs, subdir, global_step, tag)
         self._projector_config.embeddings.extend([embedding_info])
 
-        from google.protobuf import text_format  # type: ignore
+        from google.protobuf import text_format
         config_pbtxt = text_format.MessageToString(self._projector_config)
         write_pbtxt(self._get_file_writer().get_logdir(), config_pbtxt)
 


### PR DESCRIPTION
A prerequisite for #56290. This PR enables `mypy`'s [`warn_unused_ignores`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-warn_unused_ignores) in our non-strict `mypy.ini` config, and removes all existing unused `type: ignore` comments.

Possible downsides of doing this:

1. This could cause un-ignorable errors on files that are checked by _both_ `mypy.ini` and `mypy-strict.ini`.
2. This may cause `mypy` errors that appear on some platforms or environments but not on others.

**Test plan:**

CI, or run `mypy` locally.