### PR TITLE
Add more logging to debug test_reduce_sum_cuda_twice

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1525,6 +1525,10 @@ class DistributedTest:
 
             if expect_event and dist.get_backend() in PROFILING_SUPPORTED_BACKENDS:
                 events = get_event(profiling_title_postfix)
+                print(f'profiling title postfix: {profiling_title_postfix}')
+                print(f'all events: {prof.function_events}')
+                print(f'events: {events}')
+                print(f'op_calls: {op_calls}')
                 self.assertEqual(len(events), len(op_calls))
                 for e in events:
                     self.assertEqual(e.count, 1)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56406 Add more logging to debug test_reduce_sum_cuda_twice**

Been hard to reproduce
https://github.com/pytorch/pytorch/issues/50840, adding some debug log to get a
better sense of the issue.

Differential Revision: [D27863328](https://our.internmc.facebook.com/intern/diff/D27863328/)