### PR TITLE
Fix distributed.test_jit_c10d flaky tests

### DIFF
--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -47,7 +47,7 @@ class ProcessGroupNCCLJitTest(JitTestCase):
             raise unittest.SkipTest("NCCL test requires 2+ GPUs")
 
     def _create_nccl_pg(self, name_prefix):
-        tcp_store = create_tcp_store()
+        tcp_store = create_tcp_store(jit_class=True)
         opts = torch.classes.dist_c10d.ProcessGroupNCCLOptions(0, True)
 
         name = unique_process_group_name(name_prefix)
@@ -55,7 +55,7 @@ class ProcessGroupNCCLJitTest(JitTestCase):
         return torch.classes.dist_c10d.ProcessGroupNCCL(tcp_store, self.rank, self.world_size, opts, name)
 
     def _create_nccl_pg_as_base_process_group(self, name):
-        tcp_store = create_tcp_store()
+        tcp_store = create_tcp_store(jit_class=True)
 
         return torch.classes.dist_c10d.frontend().new_process_group_helper(
             self.world_size, self.rank, [], "nccl", tcp_store, name, 0)
@@ -174,7 +174,7 @@ class C10dFrontendJitTest(JitTestCase):
         frontend1 = torch.classes.dist_c10d.frontend()
         frontend2 = torch.classes.dist_c10d.frontend()
 
-        tcp_store = create_tcp_store()
+        tcp_store = create_tcp_store(jit_class=True)
 
         pg_name = unique_process_group_name("singleton_test_process_group")
 
@@ -196,7 +196,7 @@ class C10dProcessGroupSerialization(JitTestCase):
         class TestModule(torch.nn.Module):
             def __init__(self):
                 super(TestModule, self).__init__()
-                tcp_store = create_tcp_store()
+                tcp_store = create_tcp_store(jit_class=True)
 
                 name = unique_process_group_name("module_member_process_group")
                 self.pg = torch.classes.dist_c10d.frontend().new_process_group_helper(

--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from typing import List
 
 import torch.testing._internal.common_utils as common
-from torch.testing._internal.common_distributed import requires_nccl
+from torch.testing._internal.common_distributed import requires_nccl, create_tcp_store
 from torch.testing._internal.common_utils import load_tests, TEST_WITH_TSAN, run_tests, IS_WINDOWS
 from torch.testing._internal.jit_utils import JitTestCase
 
@@ -32,14 +32,6 @@ def unique_process_group_name(prefix):
     now = int(time.time() * 1000)
     return "%s_%d" % (prefix, now)
 
-def _create_tcp_store():
-    addr = "localhost"
-    port = common.find_free_port()
-    timeout = timedelta(minutes=5)
-    timeout_millisecond = int(timeout / timedelta(milliseconds=1))
-    return torch.classes.dist_c10d.TCPStore(addr, port, 1, True, timeout_millisecond)
-
-
 @unittest.skipIf(
     TEST_WITH_TSAN,
     "TSAN is not fork-safe since we're forking in a multi-threaded environment",
@@ -57,7 +49,7 @@ class ProcessGroupNCCLJitTest(JitTestCase):
             raise unittest.SkipTest("NCCL test requires 2+ GPUs")
 
     def _create_nccl_pg(self, name_prefix):
-        tcp_store = _create_tcp_store()
+        tcp_store = create_tcp_store()
         opts = torch.classes.dist_c10d.ProcessGroupNCCLOptions(0, True)
 
         name = unique_process_group_name(name_prefix)
@@ -65,7 +57,7 @@ class ProcessGroupNCCLJitTest(JitTestCase):
         return torch.classes.dist_c10d.ProcessGroupNCCL(tcp_store, self.rank, self.world_size, opts, name)
 
     def _create_nccl_pg_as_base_process_group(self, name):
-        tcp_store = _create_tcp_store()
+        tcp_store = create_tcp_store()
 
         return torch.classes.dist_c10d.frontend().new_process_group_helper(
             self.world_size, self.rank, [], "nccl", tcp_store, name, 0)
@@ -184,7 +176,7 @@ class C10dFrontendJitTest(JitTestCase):
         frontend1 = torch.classes.dist_c10d.frontend()
         frontend2 = torch.classes.dist_c10d.frontend()
 
-        tcp_store = _create_tcp_store()
+        tcp_store = create_tcp_store()
 
         pg_name = unique_process_group_name("singleton_test_process_group")
 
@@ -206,7 +198,7 @@ class C10dProcessGroupSerialization(JitTestCase):
         class TestModule(torch.nn.Module):
             def __init__(self):
                 super(TestModule, self).__init__()
-                tcp_store = _create_tcp_store()
+                tcp_store = create_tcp_store()
 
                 name = unique_process_group_name("module_member_process_group")
                 self.pg = torch.classes.dist_c10d.frontend().new_process_group_helper(

--- a/test/distributed/test_jit_c10d.py
+++ b/test/distributed/test_jit_c10d.py
@@ -4,10 +4,8 @@ import sys
 import torch
 import torch.distributed as c10d
 import time
-from datetime import timedelta
 from typing import List
 
-import torch.testing._internal.common_utils as common
 from torch.testing._internal.common_distributed import requires_nccl, create_tcp_store
 from torch.testing._internal.common_utils import load_tests, TEST_WITH_TSAN, run_tests, IS_WINDOWS
 from torch.testing._internal.jit_utils import JitTestCase

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -137,9 +137,10 @@ class TCPStore(Store):
         self,
         host_name: str,
         port: int,
-        world_size: int,
-        is_master: bool,
-        timeout: timedelta,
+        world_size: int = ...,
+        is_master: bool = ...,
+        timeout: timedelta = ...,
+        wait_for_workers: bool = ...
     ): ...
 
 class PrefixStore(Store):

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -21,7 +21,7 @@ import torch.distributed as c10d
 import torch.cuda.nccl
 
 from functools import partial, reduce
-from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, FILE_SCHEMA, find_free_port
+from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, FILE_SCHEMA, find_free_port, retry_on_connect_failures
 
 logger = logging.getLogger(__name__)
 
@@ -224,21 +224,13 @@ def skip_if_win32():
         "This unit test case is not supportted on Windows platform",
     )
 
+@retry_on_connect_failures
 def create_tcp_store(addr="localhost", world_size=1, wait_for_workers=True):
     """
     Creates a TCP store. Retries if the chosen port is already in use.
     """
-    ports = []
-    for _ in range(10):
-        try:
-            port = find_free_port()
-            ports.append(port)
-            return c10d.TCPStore(addr, port, world_size, True, wait_for_workers=wait_for_workers)
-        except RuntimeError as error:
-            if str(error) == "Address already in use":
-                continue
-            raise
-    raise RuntimeError("Unable to find free port (tried %s)" % ", ".join(ports))
+    port = find_free_port()
+    return c10d.TCPStore(addr, port, world_size, True, wait_for_workers=wait_for_workers)
 
 TIMEOUT_DEFAULT = 100
 TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -226,7 +226,8 @@ def skip_if_win32():
     )
 
 @retry_on_connect_failures
-def create_tcp_store(addr="localhost", world_size=1, is_master=True, timeout=timedelta(minutes=5), wait_for_workers=True, jit_class=False):
+def create_tcp_store(addr="localhost", world_size=1, is_master=True, timeout=timedelta(minutes=5),
+                    wait_for_workers=True, jit_class=False):
     """
     Creates a TCP store. Retries if the chosen port is already in use.
     """

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import TestCase, TEST_WITH_ROCM, FILE_
 
 logger = logging.getLogger(__name__)
 
+
 class TestSkip(NamedTuple):
     exit_code: int
     message: str
@@ -68,6 +69,7 @@ def skip_if_small_worldsize(func):
 
     return wrapper
 
+
 def require_n_gpus_for_nccl_backend(n, backend):
     def decorator(func):
         @wraps(func)
@@ -81,6 +83,7 @@ def require_n_gpus_for_nccl_backend(n, backend):
         return wrapper
 
     return decorator
+
 
 def skip_if_lt_x_gpu(x):
     def decorator(func):
@@ -140,6 +143,7 @@ def with_nccl_blocking_wait(func):
 
     return wrapper
 
+
 def with_dist_debug_levels(levels):
     """
     Runs a test for each distributed debug level specified in levels.
@@ -169,6 +173,7 @@ def requires_gloo():
         "c10d was not compiled with the Gloo backend",
     )
 
+
 def requires_nccl_version(version, msg):
     if not c10d.is_nccl_available():
         return unittest.skip(
@@ -181,6 +186,7 @@ def requires_nccl_version(version, msg):
                 version,
                 torch.cuda.nccl.version(), msg),
         )
+
 
 def requires_nccl():
     return unittest.skipUnless(
@@ -195,6 +201,7 @@ def requires_mpi():
         "c10d was not compiled with the MPI backend",
     )
 
+
 def skip_if_rocm_single_process(func):
     """Skips a test for ROCm in a single process environment"""
     func.skip_if_rocm = True
@@ -206,6 +213,7 @@ def skip_if_rocm_single_process(func):
         raise unittest.SkipTest("Test skipped for ROCm")
 
     return wrapper
+
 
 def skip_if_rocm(func):
     """Skips a test for ROCm"""
@@ -219,15 +227,17 @@ def skip_if_rocm(func):
 
     return wrapper
 
+
 def skip_if_win32():
     return unittest.skipIf(
         sys.platform == 'win32',
         "This unit test case is not supportted on Windows platform",
     )
 
+
 @retry_on_connect_failures
 def create_tcp_store(addr="localhost", world_size=1, is_master=True, timeout=timedelta(minutes=5),
-                    wait_for_workers=True, jit_class=False):
+                     wait_for_workers=True, jit_class=False):
     """
     Creates a TCP store. Retries if the chosen port is already in use.
     """
@@ -237,6 +247,7 @@ def create_tcp_store(addr="localhost", world_size=1, is_master=True, timeout=tim
         return torch.classes.dist_c10d.TCPStore(addr, port, world_size, is_master, timeout_millisecond)
     else:
         return c10d.TCPStore(addr, port, world_size, is_master, wait_for_workers=wait_for_workers)
+
 
 TIMEOUT_DEFAULT = 100
 TIMEOUT_OVERRIDE = {"test_ddp_uneven_inputs": 400}
@@ -252,6 +263,7 @@ def create_device(interface=None):
 def get_timeout(test_id):
     return TIMEOUT_OVERRIDE.get(test_id.split('.')[-1], TIMEOUT_DEFAULT)
 
+
 @contextmanager
 def captured_output():
     new_out, new_err = StringIO(), StringIO()
@@ -261,6 +273,7 @@ def captured_output():
         yield sys.stdout, sys.stderr
     finally:
         sys.stdout, sys.stderr = old_out, old_err
+
 
 def simple_sparse_reduce_tests(rank, world_size, num_inputs=1):
     """
@@ -304,7 +317,10 @@ def simple_sparse_reduce_tests(rank, world_size, num_inputs=1):
         ]
     ]
 
+
 tmp_dir = None
+
+
 def initialize_temp_directories(init_method=None):
     global tmp_dir
     tmp_dir = tempfile.TemporaryDirectory()
@@ -321,6 +337,7 @@ def initialize_temp_directories(init_method=None):
             init_dir_path, "shared_init_file"
         )
 
+
 def cleanup_temp_dir():
     if tmp_dir is not None:
         tmp_dir.cleanup()
@@ -335,6 +352,8 @@ def cleanup_temp_dir():
 # then use the provided test function name to retrieve the function attribute
 # from the test instance and run it. The main process simply waits for all
 # subprocesses to join.
+
+
 class MultiProcessTestCase(TestCase):
     MAIN_PROCESS_RANK = -1
     # This exit code is used to indicate that the test code had an error and


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56410 Fix distributed.test_jit_c10d flaky tests**

Changes:
- Move create_tcp_store() helper function to common file
- Update test_jit_c10d to retry TCP Store creation in case allocated port becomes used

fixes https://github.com/pytorch/pytorch/issues/55053

Differential Revision: [D27869560](https://our.internmc.facebook.com/intern/diff/D27869560)