### PR TITLE
AutoNonVariableTypeMode->InferenceMode in OSS.

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -201,8 +201,7 @@ After that, you can use libtorch C++ API from your native code.
 namespace pytorch_testapp_jni {
 namespace {
     struct JITCallGuard {
-      torch::autograd::AutoGradMode no_autograd_guard{false};
-      torch::AutoNonVariableTypeMode non_var_guard{true};
+      c10::InferenceMode guard;
       torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard{false};
     };
 }

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_jit.cpp
@@ -26,14 +26,8 @@ namespace pytorch_jni {
 namespace {
 
 struct JITCallGuard {
-  // AutoGrad is disabled for mobile by default.
-  torch::autograd::AutoGradMode no_autograd_guard{false};
-  // VariableType dispatch is not included in default mobile build. We need set
-  // this guard globally to avoid dispatch error (only for dynamic dispatch).
-  // Thanks to the unification of Variable class and Tensor class it's no longer
-  // required to toggle the NonVariableTypeMode per op - so it doesn't hurt to
-  // always set NonVariableTypeMode for inference only use case.
-  torch::AutoNonVariableTypeMode non_var_guard{true};
+  // Inference only workload.
+  c10::InferenceMode guard;
   // Disable graph optimizer to ensure list of unused ops are not changed for
   // custom mobile build.
   torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard{false};

--- a/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
+++ b/android/pytorch_android/src/main/cpp/pytorch_jni_lite.cpp
@@ -17,14 +17,8 @@ namespace pytorch_jni {
 namespace {
 
 struct LiteJITCallGuard {
-  // VariableType dispatch is not included in default mobile build. We need set
-  // this guard globally to avoid dispatch error (only for dynamic dispatch).
-  // Thanks to the unification of Variable class and Tensor class it's no longer
-  // required to toggle the NonVariableTypeMode per op - so it doesn't hurt to
-  // always set NonVariableTypeMode for inference only use case.
-  // TODO: avoid having to set this guard for custom mobile build with mobile
-  // interpreter.
-  torch::AutoNonVariableTypeMode non_var_guard{true};
+  // Inference only workload.
+  c10::InferenceMode guard;
 };
 
 } // namespace

--- a/android/test_app/app/src/main/cpp/pytorch_testapp_jni.cpp
+++ b/android/test_app/app/src/main/cpp/pytorch_testapp_jni.cpp
@@ -24,8 +24,7 @@ void log(const char* m, T t) {
 }
 
 struct JITCallGuard {
-  torch::autograd::AutoGradMode no_autograd_guard{false};
-  torch::AutoNonVariableTypeMode non_var_guard{true};
+  c10::InferenceMode guard;
   torch::jit::GraphOptimizerEnabledGuard no_optimizer_guard{false};
 };
 } // namespace

--- a/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_fuser_overhead.cpp
@@ -32,8 +32,7 @@ static void FusedOverhead(benchmark::State& state) {
 }
 
 static void UnfusedOverhead(benchmark::State& state) {
-  torch::NoGradGuard ng;
-  torch::AutoNonVariableTypeMode nv;
+  c10::InferenceMode guard;
   overrideCanFuseOnCPU(false);
 
   Module m("m");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56424 AutoDispatchBelowAutograd takes no arguments.
* #56423 s/AutoNonVariableTypeMode/AutoDispatchBelowAutograd/
* #56422 Rename AutoNonVariableTypeMode to AutoDispatchBelowAutograd and add a warning.
* #56434 Switch assertWarnsOnceRegex logic to check any instead of all.
* **#56421 AutoNonVariableTypeMode->InferenceMode in OSS.**

Differential Revision: [D27866609](https://our.internmc.facebook.com/intern/diff/D27866609)