### PR TITLE
[SPMD] Remove _specify_ddp_gpu_num method

### DIFF
--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,6 +1,5 @@
 from typing import Optional, Any
 
-import logging
 import torch
 from torch import Tensor
 from torch.nn.parameter import Parameter, UninitializedParameter, UninitializedBuffer
@@ -658,12 +657,6 @@ class SyncBatchNorm(_BatchNorm):
             raise ValueError(
                 "SyncBatchNorm number of input channels should be non-zero"
             )
-
-    def _specify_ddp_gpu_num(self, gpu_size):
-        if gpu_size > 1:
-            raise ValueError('SyncBatchNorm is only supported for DDP with single GPU per process')
-        logging.warning("WARNING: Since DDP single-process-multiple-device mode is retired, "
-                        "no longer need to call method `_specify_ddp_gpu_num`. The input arg `gpu_size` is ignored.")
 
     def forward(self, input: Tensor) -> Tensor:
         # currently only GPU input is supported


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56425 [SPMD] Remove _specify_ddp_gpu_num method**
* #55946 [SPMD] Remove ddp_gpu_size field from SyncBatchNorm

As SPMD mode is gone, `_specify_ddp_gpu_num` becomes useless. It only checks if the module is a GPU module. This actually is already checked by the caller of this function (in fairscale and some other codebases).

Facebook:
Additionally also remove `enable_pytorch_sync_bn` wrapper that only calls this function and does nothing else.

Differential Revision: [D27866440](https://our.internmc.facebook.com/intern/diff/D27866440/)