### PR TITLE
Respect --quiet in the build

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -61,7 +61,22 @@ if(INTERN_BUILD_ATEN_OPS)
   add_subdirectory(../aten aten)
   set(CMAKE_POSITION_INDEPENDENT_CODE ${__caffe2_CMAKE_POSITION_INDEPENDENT_CODE})
 
+  set(VERBOSE_BUILD ON)
+
+  if(DEFINED CMAKE_MESSAGE_LOG_LEVEL)
+    if(${CMAKE_MESSAGE_LOG_LEVEL} STREQUAL "ERROR")
+      set(VERBOSE_BUILD OFF)
+    endif()
+    if(${CMAKE_MESSAGE_LOG_LEVEL} STREQUAL "WARNING")
+      set(VERBOSE_BUILD OFF)
+    endif()
+  endif()
+
   # Generate the headers wrapped by our operator
+  if(NOT VERBOSE_BUILD)
+    set(GEN_QUIET "--quiet")
+  endif()
+
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/contrib/aten/aten_op.h
   COMMAND
   "${PYTHON_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten/gen_op.py
@@ -69,6 +84,7 @@ if(INTERN_BUILD_ATEN_OPS)
     --template_dir=${CMAKE_CURRENT_SOURCE_DIR}/contrib/aten
     --yaml_dir=${CMAKE_CURRENT_BINARY_DIR}/../aten/src/ATen
     --install_dir=${CMAKE_CURRENT_BINARY_DIR}/contrib/aten
+    ${GEN_QUIET}
   DEPENDS
   ATEN_CPU_FILES_GEN_TARGET
   ${CMAKE_BINARY_DIR}/aten/src/ATen/Declarations.yaml

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -24,6 +24,7 @@ from typing import Dict, List, Set
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--template_dir", default=".", help="where template.h is")
+parser.add_argument("--quiet", action='store_true', default=False, help="silence output")
 parser.add_argument("--yaml_dir", default="aten/src/ATen/ATen",
                     help="where ATen yaml files are")
 parser.add_argument("--output_prefix", default="", help="")
@@ -50,6 +51,13 @@ try:
     from yaml import CSafeLoader as Loader
 except ImportError:
     from yaml import SafeLoader as Loader  # type: ignore[misc]
+
+
+if args.quiet:
+    def report(*args, **kwargs):
+        pass
+else:
+    report = print
 
 
 def write(filename, s):
@@ -117,7 +125,7 @@ def supports(o, factory_methods):
     # Ignore all families (!) of functions that have TensorOptions (i.e. tensor factory methods).
     if o['name'] in factory_methods:
         if factory_methods[o['name']] == 0:
-            print("Skipping {} because it is a factory method".format(o['name']))
+            report("Skipping {} because it is a factory method".format(o['name']))
         factory_methods[o['name']] += 1
         return False
 
@@ -138,14 +146,14 @@ def supports(o, factory_methods):
     # skip return types we cannot handle
     for ret in o['returns']:
         if not value_has_tensors(ret) and ret['type'] not in RETURN_MAP:
-            print("Skipping {} Because of Ret: {} ({})".format(
+            report("Skipping {} Because of Ret: {} ({})".format(
                   o['name'], ret['type'], ret['dynamic_type']))
             return False
 
     # skip arguments we cannot handle
     for arg in o['arguments']:
         if not value_has_tensors(arg) and arg['type'] not in ARGUMENT_MAP:
-            print("Skipping {} Because of Arg: {} ({}) ".format(
+            report("Skipping {} Because of Arg: {} ({}) ".format(
                   o['name'], arg['type'], arg['dynamic_type']))
             return False
     return True

--- a/caffe2/contrib/aten/gen_op.py
+++ b/caffe2/contrib/aten/gen_op.py
@@ -57,7 +57,8 @@ if args.quiet:
     def report(*args, **kwargs):
         pass
 else:
-    report = print
+    def report(*args, **kwargs):
+        print(*args, **kwargs)
 
 
 def write(filename, s):

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,7 @@ package_name = os.getenv('TORCH_PACKAGE_NAME', 'torch')
 version = get_torch_version()
 report("Building wheel {}-{}".format(package_name, version))
 
-cmake = CMake()
+cmake = CMake(quiet=not VERBOSE_SCRIPT)
 
 
 def get_submodule_folders():
@@ -331,7 +331,7 @@ def check_submodules():
             start = time.time()
             subprocess.check_call(["git", "submodule", "update", "--init", "--recursive"], cwd=cwd)
             end = time.time()
-            print(' --- Submodule initialization took {:.2f} sec'.format(end - start))
+            report(' --- Submodule initialization took {:.2f} sec'.format(end - start))
         except Exception:
             print(' --- Submodule initalization failed')
             print('Please run:\n\tgit submodule update --init --recursive')
@@ -871,6 +871,10 @@ if __name__ == '__main__':
         raise SystemExit(core.gen_usage(dist.script_name) + "\nerror: %s" % msg)
     if not ok:
         sys.exit()
+
+    # Make distutils respect --quiet too
+    setuptools.distutils.log.info = report
+    setuptools.distutils.log.warn = report
 
     if RUN_BUILD_DEPS:
         build_deps()

--- a/tools/setup_helpers/cmake.py
+++ b/tools/setup_helpers/cmake.py
@@ -139,8 +139,13 @@ class CMake:
         command = [self._cmake_command] + args
 
         if self.quiet:
-            command += ["--log-level=ERROR", "-Wno-deprecated", "-Wno-dev", "-DCMAKE_INSTALL_MESSAGE=NEVER", "-DCMAKE_MESSAGE_LOG_LEVEL=ERROR"]
-            # command += ["-DCMAKE_MESSAGE_LOG_LEVEL=STATUS"]
+            command += [
+                "--log-level=ERROR",
+                "-Wno-deprecated",
+                "-Wno-dev",
+                "-DCMAKE_INSTALL_MESSAGE=NEVER",
+                "-DCMAKE_MESSAGE_LOG_LEVEL=ERROR",
+            ]
 
         if len(generator_args) > 0:
             command += ["--"] + generator_args
@@ -357,4 +362,3 @@ class CMake:
         else:
             generator_args = ['-j', max_jobs]
         self.run(build_args, generator_args=generator_args, env=my_env)
-


### PR DESCRIPTION


This adds a flag to the caffe2 op generation to turn off status and adds
some cmake flags when `--quiet` is used to supress all the check
messages. This is intended for local development only (i.e. when
iterating on code changes), and on any failures it's recommended to drop
back into verbose mode (by getting rid of the `--quiet` flag)

```
python setup.py develop --quiet
```

Differential Revision: [D27889980](https://our.internmc.facebook.com/intern/diff/27889980/)