### PR TITLE
Support layer_norm for static runtime

### DIFF
--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -67,6 +67,18 @@ std::tuple<Tensor, Tensor, Tensor, int64_t, int64_t> _prepare_layer_norm_inputs(
 
 } // namespace
 
+void layer_norm_cpu_out(
+    at::Tensor& out,
+    at::Tensor& mean,
+    at::Tensor& rstd,
+    const at::Tensor& input,
+    IntArrayRef normalized_shape,
+    const Tensor& gamma,
+    const Tensor& beta,
+    double eps,
+    int64_t M,
+    int64_t N);
+
 using forward_fn = void (*)(
     const Tensor& /* X */,
     const Tensor& /* gamma */,

--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -269,3 +269,13 @@ const auto sub_scalar_alpha = R"JIT(
   def forward(self, a: Tensor, b: float, c: int):
       return torch.sub(a, b, alpha=c)
 )JIT";
+
+const std::string layer_norm_with_weights = R"JIT(
+  def forward(self, input: Tensor, normalized_shape: List[int], weight: Tensor, bias: Tensor):
+      return torch.layer_norm(input, normalized_shape, weight, bias, 1e-05, False)
+)JIT";
+
+const std::string layer_norm_without_weights = R"JIT(
+  def forward(self, input: Tensor, normalized_shape: List[int]):
+      return torch.layer_norm(input, normalized_shape, None, None, 1e-05, False)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -141,6 +141,21 @@ TEST(StaticRuntime, EmbeddingBag) {
   testStaticRuntime(embedding_bag_max_last_offset, args);
 }
 
+TEST(StaticRuntime, LayerNorm) {
+
+  const auto input = torch::rand({20, 10, 10, 10});
+
+  for (int normalized_size: {2, 3}) {
+      std::vector<int64_t> normalized_shape(normalized_size, 10);
+      const auto weight = torch::rand(normalized_shape);
+      const auto bias = torch::rand(normalized_shape);
+      std::vector<IValue> args{input, normalized_shape, weight, bias};
+      testStaticRuntime(layer_norm_with_weights, args);
+      args = {input, normalized_shape};
+      testStaticRuntime(layer_norm_without_weights, args);
+  }
+}
+
 TEST(StaticRuntime, IndividualOps_Binary) {
   auto a = at::randn({2, 3});
   auto b = at::ones({2, 3});

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -9,6 +9,7 @@
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/TensorAdvancedIndexing.h>
+#include <ATen/native/layer_norm.h>
 #include <ATen/native/quantized/cpu/qembeddingbag.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -1201,5 +1202,60 @@ REGISTER_OPERATOR_FUNCTOR(aten::argmin, aten_argmin, [](Node* n) -> SROperator {
     at::native::argmin_out(in0_t, dim, keepdim, out_t);
   };
 });
+REGISTER_OPERATOR_FUNCTOR(
+    aten::layer_norm,
+    aten_layer_norm,
+    [](Node* n) -> SROperator {
+      return [](ProcessedNode* p_node) {
+        const auto& input = p_node->Input(0).toTensor();
+        const auto normalized_shape = p_node->Input(1).toIntVector();
+        auto weight_opt = p_node->Input(2).toOptional<at::Tensor>();
+        auto bias_opt = p_node->Input(3).toOptional<at::Tensor>();
+        float eps = p_node->Input(4).toDouble();
+
+        c10::MaybeOwned<at::Tensor> weight_maybe_owned =
+            at::borrow_from_optional_tensor(weight_opt);
+        const at::Tensor& weight = *weight_maybe_owned;
+        c10::MaybeOwned<at::Tensor> bias_maybe_owned =
+            at::borrow_from_optional_tensor(bias_opt);
+        const at::Tensor& bias = *bias_maybe_owned;
+
+        auto inputs = at::native::_prepare_layer_norm_inputs(
+            input, normalized_shape, weight, bias);
+        auto X = std::get<0>(inputs);
+        auto gamma = std::get<1>(inputs);
+        auto beta = std::get<2>(inputs);
+        auto M = std::get<3>(inputs);
+        auto N = std::get<4>(inputs);
+
+        if (p_node->Output(0).isNone()) {
+          p_node->Output(0) = at::native::empty_like(
+              X,
+              c10::nullopt /* dtype */,
+              c10::nullopt /* layout */,
+              c10::nullopt /* device */,
+              c10::nullopt /* pin_memory */,
+              at::MemoryFormat::Contiguous);
+        } else {
+          at::native::resize_(
+              p_node->Output(0).toTensor(), X.sizes(), c10::nullopt);
+        }
+        at::Tensor& output = p_node->Output(0).toTensor();
+        at::Tensor mean = at::empty({M}, X.options());
+        at::Tensor rstd = at::empty({M}, X.options());
+
+        at::native::layer_norm_cpu_out(
+            output,
+            mean,
+            rstd,
+            input,
+            normalized_shape,
+            gamma,
+            beta,
+            eps,
+            M,
+            N);
+      };
+    });
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary: Added out version for layer_norm

Test Plan:
buck test caffe2/aten:math_kernel_test -- NativeLayerNorm

buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest

Differential Revision: D27873846

