### PR TITLE
Upgrade ShellCheck to v0.7.2

### DIFF
--- a/.github/workflows/auto_label.yml
+++ b/.github/workflows/auto_label.yml
@@ -25,7 +25,7 @@ jobs:
           ISSUE_NUMBER="${PR_NUMBER}"
         else
           TITLE="${ISSUE_TITLE}"
-          ISSUE_NUMBER="${ISSUE_NUMBER}"
+          # ISSUE_NUMBER is already set
         fi
         echo ::set-output name=TITLE::"${TITLE}"
         echo ::set-output name=ISSUE_NUMBER::"${ISSUE_NUMBER}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Extract scripts from GitHub Actions workflows
         run: tools/extract_scripts.py --out=.extracted_scripts
       - name: ShellCheck
-        # https://github.com/koalaman/shellcheck/tree/v0.7.1#installing-a-pre-compiled-binary
+        # https://github.com/koalaman/shellcheck/tree/v0.7.2#installing-a-pre-compiled-binary
         run: |
           set -x
-          scversion="v0.7.1"
+          scversion="v0.7.2"
           wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
           sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
           rm -r "shellcheck-${scversion}"

--- a/.jenkins/pytorch/macos-common.sh
+++ b/.jenkins/pytorch/macos-common.sh
@@ -26,7 +26,7 @@ if [ ! -d "${WORKSPACE_DIR}/miniconda3" ]; then
   retry bash "${WORKSPACE_DIR}"/miniconda3.sh -b -p "${WORKSPACE_DIR}"/miniconda3
 fi
 export PATH="${WORKSPACE_DIR}/miniconda3/bin:$PATH"
-# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 source "${WORKSPACE_DIR}"/miniconda3/bin/activate
 retry conda install -y mkl mkl-include numpy=1.18.5 pyyaml=5.3 setuptools=46.0.0 cmake cffi ninja typing_extensions dataclasses pip
 # The torch.hub tests make requests to GitHub.


### PR DESCRIPTION
[First ShellCheck release in over a year!](https://github.com/koalaman/shellcheck/releases/tag/v0.7.2) I'm thankful for doing #55109 at the beginning of this month, because otherwise `master` would have just suddenly started failing a few hours ago.

**Test plan:**

CI. You can also run `shellcheck` locally; for instance, if you're on Mac and [installed it with Homebrew](https://github.com/koalaman/shellcheck/tree/v0.7.2#installing):
```sh
brew upgrade shellcheck
rm -r .extracted_scripts ; tools/extract_scripts.py --out=.extracted_scripts
tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
```