### PR TITLE
addmm CPU inplace implementation shouldn't resize an input tensor

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1032,6 +1032,12 @@ Tensor addmm_cpu(const Tensor& self, const Tensor& mat1, const Tensor& mat2, con
 }
 
 Tensor &addmm_cpu_(Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
+  if (self.numel() != 0) {
+    // only empty input tensors should be resized. Non-empty tensors should have the desired dimensions & size.
+    TORCH_CHECK(((self.dim() == 2) && (self.sizes()[0] == mat1.sizes()[0]) && (self.sizes()[1] == mat2.sizes()[1])),
+    "The input tensor must be a matrix with size ", mat1.sizes()[0], "x", mat2.sizes()[1], ", but got a ", self.dim(),
+    "-D tensor with size ", self.sizes()[0], "x", self.sizes()[1]);
+  }
   return addmm_cpu_out(self, mat1, mat2, beta, alpha, self);
 }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1032,12 +1032,9 @@ Tensor addmm_cpu(const Tensor& self, const Tensor& mat1, const Tensor& mat2, con
 }
 
 Tensor &addmm_cpu_(Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
-  if (self.numel() != 0) {
-    // only empty input tensors should be resized. Non-empty tensors should have the desired dimensions & size.
-    TORCH_CHECK(((self.dim() == 2) && (self.sizes()[0] == mat1.sizes()[0]) && (self.sizes()[1] == mat2.sizes()[1])),
-    "The input tensor must be a matrix with size ", mat1.sizes()[0], "x", mat2.sizes()[1], ", but got a ", self.dim(),
-    "-D tensor with size ", self.sizes()[0], "x", self.sizes()[1]);
-  }
+  TORCH_CHECK(((self.dim() == 2) && (self.sizes()[0] == mat1.sizes()[0]) && (self.sizes()[1] == mat2.sizes()[1])),
+  "The input tensor must be a matrix with size ", mat1.sizes()[0], "x", mat2.sizes()[1], ", but got a ", self.dim(),
+  "-D tensor with size ", self.sizes()[0], "x", self.sizes()[1]);
   return addmm_cpu_out(self, mat1, mat2, beta, alpha, self);
 }
 


### PR DESCRIPTION
`addmm` CPU inplace implementation shouldn't resize an input tensor.

Fixes #56233.