### PR TITLE
Fix bug in gaussian_nll_loss

### DIFF
--- a/docs/source/nn.functional.rst
+++ b/docs/source/nn.functional.rst
@@ -158,6 +158,7 @@ Loss functions
     cosine_embedding_loss
     cross_entropy
     ctc_loss
+    gaussian_nll_loss
     hinge_embedding_loss
     kl_div
     l1_loss

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5418,7 +5418,7 @@ class TestNN(NNTestCase):
         input = torch.tensor([[0.5, 1.5, 2.5], [2., 4., 6.]])
         target = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
         var = torch.tensor([[0.5, 1., 1.5], [1., 1.5, 2.]])
-        component_wise_loss = 0.5 * (torch.sum(torch.log(var) + (input - target)**2 / var, dim=1))
+        component_wise_loss = 0.5 * (torch.log(var) + (input - target)**2 / var)
         self.assertEqual(component_wise_loss,
                          F.gaussian_nll_loss(input, target, var, reduction='none'))
         self.assertEqual(torch.sum(component_wise_loss),

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2599,10 +2599,6 @@ def gaussian_nll_loss(
             reduction=reduction,
         )
 
-    # Inputs and targets much have same shape
-    if input.size() != target.size():
-        raise ValueError("input and target must have same size")
-
     # Check var size
     # If var.size == input.size, the case is heteroscedastic and no further checks are needed.
     # Otherwise:

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -304,9 +304,8 @@ class GaussianNLLLoss(_Loss):
 
     The targets are treated as samples from Gaussian distributions with
     expectations and variances predicted by the neural network. For a
-    D-dimensional ``target`` tensor modelled as having heteroscedastic Gaussian
-    distributions with a D-dimensional tensor of expectations ``input`` and a
-    D-dimensional tensor of positive variances ``var`` the loss is:
+    ``target`` tensor modelled as having Gaussian distribution with a tensor 
+    of expectations ``input`` and a tensor of positive variances ``var`` the loss is:
 
     .. math::
         \text{loss} = \frac{1}{2}\left(\log\left(\text{max}\left(\text{var},
@@ -314,9 +313,9 @@ class GaussianNLLLoss(_Loss):
         {\text{max}\left(\text{var}, \ \text{eps}\right)}\right) + \text{const.}
 
     where :attr:`eps` is used for stability. By default, the constant term of
-    the loss function is omitted unless :attr:`full` is ``True``. If ``var`` is
-    a scalar (implying ``target`` tensor has homoscedastic Gaussian
-    distributions) it is broadcasted to be the same size as the input.
+    the loss function is omitted unless :attr:`full` is ``True``. If ``var`` is not the same
+    size as ``input`` (due to a homoscedastic assumption), it must either have a final dimension
+    of 1 or have one fewer dimension (with all other sizes being the same) for correct broadcasting.  
 
     Args:
         full (bool, optional): include the constant term in the loss
@@ -332,10 +331,14 @@ class GaussianNLLLoss(_Loss):
     Shape:
         - Input: :math:`(N, *)` where :math:`*` means any number of additional
           dimensions
-        - Target: :math:`(N, *)`, same shape as the input
-        - Var: :math:`(N, 1)` or :math:`(N, *)`, same shape as the input
+        - Target: :math:`(N, *)`, same shape as the input, or same shape as the input
+          but with one dimension equal to 1 (to allow for broadcasting)
+        - Var: :math:`(N, *)`, same shape as the input, or same shape as the input but
+          with one dimension equal to 1, or same shape as the input but with one fewer
+          dimension (to allow for broadcasting)
         - Output: scalar if :attr:`reduction` is ``'mean'`` (default) or
-          ``'sum'``. If :attr:`reduction` is ``'none'``, then :math:`(N)`
+          ``'sum'``. If :attr:`reduction` is ``'none'``, then :math:`(N, *)`, same
+          shape as the input
 
     Examples::
         >>> loss = nn.GaussianNLLLoss()

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -304,7 +304,7 @@ class GaussianNLLLoss(_Loss):
 
     The targets are treated as samples from Gaussian distributions with
     expectations and variances predicted by the neural network. For a
-    ``target`` tensor modelled as having Gaussian distribution with a tensor 
+    ``target`` tensor modelled as having Gaussian distribution with a tensor
     of expectations ``input`` and a tensor of positive variances ``var`` the loss is:
 
     .. math::
@@ -315,7 +315,7 @@ class GaussianNLLLoss(_Loss):
     where :attr:`eps` is used for stability. By default, the constant term of
     the loss function is omitted unless :attr:`full` is ``True``. If ``var`` is not the same
     size as ``input`` (due to a homoscedastic assumption), it must either have a final dimension
-    of 1 or have one fewer dimension (with all other sizes being the same) for correct broadcasting.  
+    of 1 or have one fewer dimension (with all other sizes being the same) for correct broadcasting.
 
     Args:
         full (bool, optional): include the constant term in the loss

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -309,15 +309,14 @@ class GaussianNLLLoss(_Loss):
     D-dimensional tensor of positive variances ``var`` the loss is:
 
     .. math::
-        \text{loss} = \frac{1}{2}\sum_{i=1}^D \left(\log\left(\text{max}\left(\text{var}[i],
-        \ \text{eps}\right)\right) + \frac{\left(\text{input}[i] - \text{target}[i]\right)^2}
-        {\text{max}\left(\text{var}[i], \ \text{eps}\right)}\right) + \text{const.}
+        \text{loss} = \frac{1}{2}\left(\log\left(\text{max}\left(\text{var},
+        \ \text{eps}\right)\right) + \frac{\left(\text{input} - \text{target}\right)^2}
+        {\text{max}\left(\text{var}, \ \text{eps}\right)}\right) + \text{const.}
 
     where :attr:`eps` is used for stability. By default, the constant term of
     the loss function is omitted unless :attr:`full` is ``True``. If ``var`` is
     a scalar (implying ``target`` tensor has homoscedastic Gaussian
     distributions) it is broadcasted to be the same size as the input.
-
 
     Args:
         full (bool, optional): include the constant term in the loss
@@ -339,14 +338,12 @@ class GaussianNLLLoss(_Loss):
           ``'sum'``. If :attr:`reduction` is ``'none'``, then :math:`(N)`
 
     Examples::
-
         >>> loss = nn.GaussianNLLLoss()
         >>> input = torch.randn(5, 2, requires_grad=True)
         >>> target = torch.randn(5, 2)
         >>> var = torch.ones(5, 2, requires_grad=True) #heteroscedastic
         >>> output = loss(input, target, var)
         >>> output.backward()
-
 
         >>> loss = nn.GaussianNLLLoss()
         >>> input = torch.randn(5, 2, requires_grad=True)

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -640,7 +640,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.nn.functional.fractional_max_pool3d_with_indices: (
             lambda input, kernel_size, output_size=None, output_ratio=None, return_indices=False,
             _random_samples=None: -1),
-        torch.nn.functional.gaussian_nll_loss: (lambda input, target, var, full=False, eps=1e-06, reduction='mean': -1),
+        torch.nn.functional.gaussian_nll_loss: lambda input, target, var, full=False, eps=1e-06, reduction='mean': -1,
         torch.nn.functional.gelu: lambda input: -1,
         torch.nn.functional.glu: lambda input, dim=-1: -1,
         torch.nn.functional.grid_sample: lambda input, grid, mode='bilinear', padding_mode='zeros', align_corners=None: -1,


### PR DESCRIPTION
Fixes #53964. cc @albanD @almson

## Major changes:
- Overhauled the actual loss calculation so that the shapes are now correct (in functional.py)
- added the missing doc in nn.functional.rst

## Minor changes (in functional.py):
- I removed the previous check on whether input and target were the same shape. This is to allow for broadcasting, say when you have 10 predictions that all have the same target. 
- I added some comments to explain each shape check in detail. Let me know if these should be shortened/cut.

Screenshots of updated docs attached. 
Let me know what you think, thanks!

## Edit: Description of change of behaviour (affecting BC):
The backwards-compatibility is only affected for the `reduction='none'` mode. This was the source of the bug. For tensors with size (N, D), the old returned loss had size (N), as incorrect summation was happening. It will now have size (N, D) as expected.

### Example
Define input tensors, all with size (2, 3).
```
input = torch.tensor([[0., 1., 3.], [2., 4., 0.]], requires_grad=True)
target = torch.tensor([[1., 4., 2.], [-1., 2., 3.]])
var = 2*torch.ones(size=(2, 3), requires_grad=True)
```

Initialise loss with reduction mode 'none'. We expect the returned loss to have the same size as the input tensors, (2, 3).
```
loss = torch.nn.GaussianNLLLoss(reduction='none')
```

Old behaviour:
```
print(loss(input, target, var)) 
# Gives tensor([3.7897, 6.5397], grad_fn=<MulBackward0>. This has size (2).
```

New behaviour:
```
print(loss(input, target, var)) 
# Gives tensor([[0.5966, 2.5966, 0.5966], [2.5966, 1.3466, 2.5966]], grad_fn=<MulBackward0>)
# This has the expected size, (2, 3).
```

To recover the old behaviour, sum along all dimensions except for the 0th:
```
print(loss(input, target, var).sum(dim=1))
# Gives tensor([3.7897, 6.5397], grad_fn=<SumBackward1>.
```


![doc1](https://user-images.githubusercontent.com/26558092/115391089-f7f47b00-a1d6-11eb-8726-e4da9057aee0.png)
![doc2](https://user-images.githubusercontent.com/26558092/115391094-f925a800-a1d6-11eb-954b-afd187f42bc7.png)

