### PR TITLE
Fix missing definitions in Vec256 for VSX

### DIFF
--- a/aten/src/ATen/cpu/vec256/vsx/vec256_complex_double_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_complex_double_vsx.h
@@ -28,7 +28,8 @@ class Vec256<ComplexDbl> {
   using value_type = ComplexDbl;
   using vec_internal_type = vfloat64;
   using vec_internal_mask_type = vbool64;
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 2;
   }
   Vec256() {}

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_complex_float_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_complex_float_vsx.h
@@ -30,8 +30,9 @@ class Vec256<ComplexFlt> {
   using value_type = ComplexFlt;
   using vec_internal_type = vfloat32;
   using vec_internal_mask_type = vbool32;
+  using size_type = int;
 
-  static constexpr int size() {
+  static constexpr size_type size() {
     return 4;
   }
   Vec256() {}

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
@@ -30,7 +30,8 @@ class Vec256<double> {
   using value_type = double;
   using vec_internal_type = vfloat64;
   using vec_internal_mask_type = vbool64;
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 4;
   }
   Vec256() {}
@@ -226,6 +227,9 @@ class Vec256<double> {
   }
   Vec256<double> atan2(const Vec256<double>& b) const {
      return {Sleef_atan2d2_u10vsx(_vec0, b._vec0), Sleef_atan2d2_u10vsx(_vec1, b._vec1)};
+  }
+  Vec256<double> copysign(const Vec256<double> &sign) const {
+    return {Sleef_copysignd2_vsx(_vec0, sign._vec0), Sleef_copysignd2_vsx(_vec1, sign._vec1)};
   }
   Vec256<double> erf() const {
      return {Sleef_erfd2_u10vsx(_vec0), Sleef_erfd2_u10vsx(_vec1)};

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
@@ -29,8 +29,9 @@ class Vec256<float> {
   using value_type = float;
   using vec_internal_type = vfloat32;
   using vec_internal_mask_type = vbool32;
+  using size_type = int;
 
-  static constexpr int size() {
+  static constexpr size_type size() {
     return 8;
   }
   Vec256() {}
@@ -265,7 +266,9 @@ class Vec256<float> {
   Vec256<float> atan2(const Vec256<float>& b) const {
      return {Sleef_atan2f4_u10vsx(_vec0, b._vec0), Sleef_atan2f4_u10vsx(_vec1, b._vec1)};
   }
-
+  Vec256<float> copysign(const Vec256<float> &sign) const {
+    return {Sleef_copysignf4_vsx(_vec0, sign._vec0), Sleef_copysignf4_vsx(_vec1, sign._vec1)};
+  }
   Vec256<float> lgamma() const {
      return {Sleef_lgammaf4_u10vsx(_vec0), Sleef_lgammaf4_u10vsx(_vec1)};
   }

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int16_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int16_vsx.h
@@ -27,7 +27,8 @@ class Vec256<int16_t> {
   using value_type = int16_t;
   using vec_internal_type = vint16;
   using vec_internal_mask_type = vbool16;
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 16;
   }
   Vec256() {}

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int32_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int32_vsx.h
@@ -27,7 +27,8 @@ class Vec256<int32_t> {
   using value_type = int32_t;
   using vec_internal_type = vint32;
   using vec_internal_mask_type = vbool32;
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 8;
   }
   Vec256() {}

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int64_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int64_vsx.h
@@ -27,7 +27,8 @@ class Vec256<int64_t> {
   using value_type = int64_t;
   using vec_internal_type = vint64;
   using vec_internal_mask_type = vbool64;
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 4;
   }
   Vec256() {}

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_qint32_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_qint32_vsx.h
@@ -49,7 +49,8 @@ struct Vec256<c10::qint32> {
  public:
   Vec256() {}
 
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 8;
   }
 

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_qint8_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_qint8_vsx.h
@@ -48,7 +48,8 @@ struct Vec256<c10::qint8> {
 
  public:
   Vec256() {}
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 32;
   }
 

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_quint8_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_quint8_vsx.h
@@ -49,7 +49,8 @@ struct Vec256<c10::quint8> {
 
  public:
   Vec256() {}
-  static constexpr int size() {
+  using size_type = int;
+  static constexpr size_type size() {
     return 32;
   }
 


### PR DESCRIPTION
Should fix #56474, although I have no Power PC system to test on.

Sleef has `copysign` support for vsx, according to https://sleef.org/ppc64.xhtml


