### PR TITLE
[iOS GPU][Stub] Move conv2d_prepack impl from MetalPrepackOpRegister.cpp to MetalConvolution.cpp

### DIFF
--- a/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
+++ b/aten/src/ATen/native/metal/MetalPrepackOpRegister.cpp
@@ -3,11 +3,6 @@
 #include <ATen/native/metal/MetalPrepackOpContext.h>
 #include <c10/util/accumulate.h>
 
-
-#if (C10_IOS || TARGET_OS_MAC)
-#import <ATen/native/metal/ops/MetalConvolution.h>
-#endif
-
 namespace at {
 namespace native {
 namespace metal {
@@ -92,23 +87,8 @@ c10::intrusive_ptr<Conv2dOpContext> conv2d_prepack(
       output_max);
 }
 
-Tensor conv2d_prepack_run(
-    const Tensor& input,
-    const c10::intrusive_ptr<Conv2dOpContext>& op_context) {
-#if (C10_IOS || TARGET_OS_MAC)
-  return prepack::conv2d(input, *op_context);
-#else
-  TORCH_CHECK(false, "conv2d_prepack_run can only be invoked on iOS and MacOS");
-  return input;
-#endif
-}
-
 TORCH_LIBRARY_IMPL(metal_prepack, CPU, m) {
   m.impl("conv2d_prepack", TORCH_FN(conv2d_prepack));
-}
-
-TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
-  m.impl("conv2d_run", conv2d_prepack_run);
 }
 
 } // namespace metal

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.mm
@@ -100,12 +100,10 @@ Tensor conv2d(const Tensor& input, Conv2dOpContext& context) {
 Tensor conv2d_prepack_run(
     const Tensor& input,
     const c10::intrusive_ptr<Conv2dOpContext>& op_context) {
-    
   return conv2d(input, *op_context);
 }
 
 } // namespace prepack
-
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl("conv2d", TORCH_FN(conv2d));

--- a/aten/src/ATen/native/metal/ops/MetalConvolution.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConvolution.mm
@@ -97,11 +97,23 @@ Tensor conv2d(const Tensor& input, Conv2dOpContext& context) {
   return output;
 }
 
+Tensor conv2d_prepack_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<Conv2dOpContext>& op_context) {
+    
+  return conv2d(input, *op_context);
+}
+
 } // namespace prepack
+
 
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
   m.impl("conv2d", TORCH_FN(conv2d));
 };
+
+TORCH_LIBRARY_IMPL(metal_prepack, Metal, m) {
+  m.impl("conv2d_run", prepack::conv2d_prepack_run);
+}
 
 }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56491 [iOS GPU][Stub] Move conv2d_prepack impl from MetalPrepackOpRegister.cpp to MetalConvolution.cpp**

Move the prepack convolution to the op file to get rid of the selective compilation.

Differential Revision: [D27719539](https://our.internmc.facebook.com/intern/diff/D27719539/)