### PR TITLE
Revert caffe2 print stack traces flag

### DIFF
--- a/caffe2/utils/signal_handler.cc
+++ b/caffe2/utils/signal_handler.cc
@@ -305,7 +305,7 @@ void uninstallFatalSignalHandlers() {
 #if defined(CAFFE2_SUPPORTS_FATAL_SIGNAL_HANDLERS)
 C10_DEFINE_bool(
     caffe2_print_stacktraces,
-    true,
+    false,
     "If set, prints stacktraces when a fatal signal is raised.");
 #endif
 


### PR DESCRIPTION


This reverts the change in #56198 which broke some internal tests

Differential Revision: [D27886611](https://our.internmc.facebook.com/intern/diff/27886611/)