### PR TITLE
 Stack sequential MapDataPipe calls into one pipe

### DIFF
--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -85,8 +85,8 @@ class _CallableIterDataPipe(IterDataPipe[T_co]):
 @functional_datapipe('map')
 class MapIterDataPipe(_CallableIterDataPipe):
     def map(self, fn: Callable = default_fn,
-                 fn_args: Optional[Tuple] = None,
-                 fn_kwargs: Optional[Dict] = None):
+            fn_args: Optional[Tuple] = None,
+            fn_kwargs: Optional[Dict] = None):
         if hasattr(fn, '__name__') and fn.__name__ == '<lambda>' and not DILL_AVAILABLE:
             warnings.warn("Lambda function is not supported for pickle, please use "
                           "regular python function or functools.partial instead.")

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -1,13 +1,13 @@
 from torch.utils.data import IterDataPipe, functional_datapipe
 from typing import Callable, TypeVar, Iterator, Optional, Tuple, Dict
 
-from .callable import MapIterDataPipe
+from .callable import _CallableIterDataPipe
 
 T_co = TypeVar('T_co', covariant=True)
 
 
 @functional_datapipe('filter')
-class FilterIterDataPipe(MapIterDataPipe):
+class FilterIterDataPipe(_CallableIterDataPipe):
     r""" :class:`FilterIterDataPipe`.
 
     Iterable DataPipe to filter elements from datapipe according to filter_fn.
@@ -28,7 +28,7 @@ class FilterIterDataPipe(MapIterDataPipe):
     def __iter__(self) -> Iterator[T_co]:
         res: bool
         for data in self.datapipe:
-            res = self.fn(data, *self.args, **self.kwargs)
+            res = self.fn[0](data, *self.args[0], **self.kwargs[0])
             if not isinstance(res, bool):
                 raise ValueError("Boolean output is required for "
                                  "`filter_fn` of FilterIterDataPipe")


### PR DESCRIPTION
Sequential calls of `.map` saved in same DataPipe (would be useful later for optimizations)

```
    def test_map_of_map(self):
        numbers_dp = NumbersDataset(size=10)
        updated = numbers_dp.map(lambda x: x * 10)
        updated_twice = updated.map(lambda x: x * 10)
        self.assertEqual(updated, updated_twice)
        expected = [i * 100 for i in range(10)]
        actual = [i for i in updated_twice]
        self.assertEqual(expected, actual)
```