### PR TITLE
[PyTorch] Break up generated tag in source

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -387,7 +387,7 @@ def gen_variable_type_shard(
             assert f.is_abstract, msg
 
     fm.write_with_template(output_name, template_name, lambda: {
-        'generated_comment': f'@generated from {fm.template_dir}/{template_name}',
+        'generated_comment': '@' f'generated from {fm.template_dir}/{template_name}',
         'type_derived_method_definitions': type_definitions,
         'wrapper_registrations': wrapper_registrations,
     })


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56503 [PyTorch] Break up generated tag in source**

The presence of `@generated` causes Phabricator and hg to think the file is generated (e.g., hg won't prompt to resolve merge conflicts with an editor). Breaking up the tag is the traditional way to solve this.

Differential Revision: [D27887691](https://our.internmc.facebook.com/intern/diff/D27887691/)