### PR TITLE
Add stricter check for function schemas with varargs

### DIFF
--- a/test/test_function_schema.py
+++ b/test/test_function_schema.py
@@ -91,5 +91,9 @@ class TestFunctionSchema(TestCase):
         schema_b = parse_schema(str(schema_a))
         self.assertEquals(schema_a, schema_b)
 
+    def test_schema_error(self):
+        with self.assertRaisesRegex(RuntimeError, r"schemas with vararg \(...\) can't have default value args"):
+            schema = parse_schema("any.foo(int arg1, int arg2=0, ...)")
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -61,9 +61,10 @@ struct SchemaParser {
 
     // check if all arguments are not-default for vararg schemas
     if (is_vararg) {
-      for(const auto& arg: arguments) {
-        if (arg.default_value().has_value()){
-          throw ErrorReport(L.cur()) << "schemas with vararg (...) can't have default value args";
+      for (const auto& arg : arguments) {
+        if (arg.default_value().has_value()) {
+          throw ErrorReport(L.cur())
+              << "schemas with vararg (...) can't have default value args";
         }
       }
     }

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -58,6 +58,16 @@ struct SchemaParser {
             idx++, /*is_return=*/false, /*kwarg_only=*/kwarg_only));
       }
     });
+
+    // check if all arguments are not-default for vararg schemas
+    if (is_vararg) {
+      for(const auto& arg: arguments) {
+        if (arg.default_value().has_value()){
+          throw ErrorReport(L.cur()) << "schemas with vararg (...) can't have default value args";
+        }
+      }
+    }
+
     idx = 0;
     L.expect(TK_ARROW);
     if (L.nextIf(TK_DOTS)) {
@@ -79,6 +89,7 @@ struct SchemaParser {
       returns.push_back(
           parseArgument(0, /*is_return=*/true, /*kwarg_only=*/false));
     }
+
     return make_right<OperatorName, FunctionSchema>(
         std::move(name.name),
         std::move(name.overload_name),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56079 Enable forward/backward compatibility in TS mobile
* **#56509 Add stricter check for function schemas with varargs**

Differential Revision: [D27889626](https://our.internmc.facebook.com/intern/diff/D27889626)