### PR TITLE
[do not merge] Demo of bug in JIT parsing type ignore comments

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -12427,6 +12427,11 @@ dedent """
         def bar(x):  # type: ignore[no-redef]
             return x
 
+        # test that noqa comment is allowed after type ignore comment
+        @torch.jit.script
+        def baz(x): # type: ignore[no-redef] # noqa: E261
+            return x
+
     def test_method_casts_script(self):
         cast_types = [
             'byte', 'char', 'double', 'float', 'int', 'long', 'short'

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -601,7 +601,7 @@ class LSTM(RNNBase):
 
     # In the future, we should prevent mypy from applying contravariance rules here.
     # See torch/nn/modules/module.py::_forward_unimplemented
-    def check_forward_args(self, input: Tensor, hidden: Tuple[Tensor, Tensor], batch_sizes: Optional[Tensor]):  # type: ignore[override] # noqa: B950
+    def check_forward_args(self, input: Tensor, hidden: Tuple[Tensor, Tensor], batch_sizes: Optional[Tensor]):  # type: ignore
         self.check_input(input, batch_sizes)
         self.check_hidden_size(hidden[0], self.get_expected_hidden_size(input, batch_sizes),
                                'Expected hidden[0] size {}, got {}')
@@ -609,7 +609,7 @@ class LSTM(RNNBase):
                                'Expected hidden[1] size {}, got {}')
 
     # Same as above, see torch/nn/modules/module.py::_forward_unimplemented
-    def permute_hidden(self, hx: Tuple[Tensor, Tensor], permutation: Optional[Tensor]) -> Tuple[Tensor, Tensor]:  # type: ignore[override] # noqa: B950
+    def permute_hidden(self, hx: Tuple[Tensor, Tensor], permutation: Optional[Tensor]) -> Tuple[Tensor, Tensor]:  # type: ignore
         if permutation is None:
             return hx
         return apply_permutation(hx[0], permutation), apply_permutation(hx[1], permutation)

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -601,7 +601,7 @@ class LSTM(RNNBase):
 
     # In the future, we should prevent mypy from applying contravariance rules here.
     # See torch/nn/modules/module.py::_forward_unimplemented
-    def check_forward_args(self, input: Tensor, hidden: Tuple[Tensor, Tensor], batch_sizes: Optional[Tensor]):  # type: ignore
+    def check_forward_args(self, input: Tensor, hidden: Tuple[Tensor, Tensor], batch_sizes: Optional[Tensor]):  # type: ignore[override] # noqa: B950
         self.check_input(input, batch_sizes)
         self.check_hidden_size(hidden[0], self.get_expected_hidden_size(input, batch_sizes),
                                'Expected hidden[0] size {}, got {}')
@@ -609,7 +609,7 @@ class LSTM(RNNBase):
                                'Expected hidden[1] size {}, got {}')
 
     # Same as above, see torch/nn/modules/module.py::_forward_unimplemented
-    def permute_hidden(self, hx: Tuple[Tensor, Tensor], permutation: Optional[Tensor]) -> Tuple[Tensor, Tensor]:  # type: ignore
+    def permute_hidden(self, hx: Tuple[Tensor, Tensor], permutation: Optional[Tensor]) -> Tuple[Tensor, Tensor]:  # type: ignore[override] # noqa: B950
         if permutation is None:
             return hx
         return apply_permutation(hx[0], permutation), apply_permutation(hx[1], permutation)


### PR DESCRIPTION
This PR demonstrates [a JIT bug](https://app.circleci.com/pipelines/github/pytorch/pytorch/305647/workflows/3857d67b-a799-452e-8fd4-6e57d00276aa/jobs/12615710) uncovered while working on #56290.

**Test plan:**

```
$ python test/test_jit.py TestScript.test_mypy_type_ignore
CUDA not available, skipping tests
E
======================================================================
ERROR: test_mypy_type_ignore (__main__.TestScript)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_jit.py", line 12432, in test_mypy_type_ignore
    def baz(x): # type: ignore[no-redef] # noqa: E261
  File "/Users/sestep/github/pytorch/pytorch/torch/jit/_script.py", line 1044, in script
    ast = get_jit_def(obj, obj.__name__)
  File "/Users/sestep/github/pytorch/pytorch/torch/jit/frontend.py", line 292, in get_jit_def
    return build_def(ctx, fn_def, type_line, def_name, self_name=self_name)
  File "/Users/sestep/github/pytorch/pytorch/torch/jit/frontend.py", line 321, in build_def
    type_comment_decl = torch._C.parse_type_comment(type_line)
RuntimeError: expected type comment but found 'def' here:
def baz(x): # type: ignore[no-redef] # noqa: E261
~~~ <--- HERE


----------------------------------------------------------------------
Ran 1 test in 0.133s

FAILED (errors=1)
```