### PR TITLE
[4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

### DIFF
--- a/test/distributed/elastic/rendezvous/utils_test.py
+++ b/test/distributed/elastic/rendezvous/utils_test.py
@@ -285,7 +285,7 @@ class PeriodicTimerTest(TestCase):
         self.assertTrue(all(t.name != "PeriodicTimer" for t in threading.enumerate()))
 
     def test_timer_calls_background_thread_at_regular_intervals(self):
-        begin_time = time.monotonic()
+        timer_begin_time: float
 
         # Call our function every 200ms.
         call_interval = 0.2
@@ -304,17 +304,19 @@ class PeriodicTimerTest(TestCase):
         timer_stop_event = threading.Event()
 
         def log_call(self):
-            nonlocal begin_time, call_count
+            nonlocal timer_begin_time, call_count
 
-            actual_call_intervals.append(time.monotonic() - begin_time)
+            actual_call_intervals.append(time.monotonic() - timer_begin_time)
 
             call_count += 1
             if call_count == min_required_call_count:
                 timer_stop_event.set()
 
-            begin_time = time.monotonic()
+            timer_begin_time = time.monotonic()
 
         timer = _PeriodicTimer(timedelta(seconds=call_interval), log_call, self)
+
+        timer_begin_time = time.monotonic()
 
         timer.start()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56538 [10/n] [torch/elastic] Introduce _RendezvousStateHolder
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* **#56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer**

This PR fixes a subtle issue with the finalizer implementation of `_PeriodicTimer`.

We avoid using a regular finalizer (a.k.a. `__del__`) for stopping the timer as joining a daemon thread during the interpreter shutdown can cause deadlocks. The `weakref.finalize` is a superior alternative that provides a consistent behavior regardless of the GC implementation.

Differential Revision: [D27889289](https://our.internmc.facebook.com/intern/diff/D27889289/)