### PR TITLE
[5/n] [torch/elastic] Introduce the delay utility function

### DIFF
--- a/test/distributed/elastic/rendezvous/utils_test.py
+++ b/test/distributed/elastic/rendezvous/utils_test.py
@@ -13,10 +13,11 @@ from unittest import TestCase
 
 from torch.distributed.elastic.rendezvous.utils import (
     _PeriodicTimer,
+    _delay,
     _matches_machine_hostname,
     _parse_rendezvous_config,
-    parse_rendezvous_endpoint,
     _try_parse_port,
+    parse_rendezvous_endpoint,
 )
 
 
@@ -241,6 +242,17 @@ class UtilsTest(TestCase):
         for host in hosts:
             with self.subTest(host=host):
                 self.assertFalse(_matches_machine_hostname(host))
+
+    def test_delay_suspends_thread(self) -> None:
+        for seconds in 0.2, (0.2, 0.4):
+            with self.subTest(seconds=seconds):
+                time1 = time.monotonic()
+
+                _delay(seconds)  # type: ignore[arg-type]
+
+                time2 = time.monotonic()
+
+                self.assertGreaterEqual(time2 - time1, 0.2)
 
 
 class PeriodicTimerTest(TestCase):

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import ipaddress
+import random
 import re
 import socket
+import time
 import weakref
 from datetime import timedelta
 from threading import Event, Thread
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 
 def _parse_rendezvous_config(config_str: str) -> Dict[str, str]:
@@ -141,6 +143,21 @@ def _matches_machine_hostname(host: str) -> bool:
             return True
 
     return False
+
+
+def _delay(seconds: Union[float, Tuple[float, float]]) -> None:
+    """Suspends the current thread for ``seconds``.
+
+    Args:
+        seconds:
+            Either the delay, in seconds, or a tuple of a lower and an upper
+            bound within which a random delay will be picked.
+    """
+    if isinstance(seconds, tuple):
+        seconds = random.uniform(*seconds)
+    # Ignore delay requests that are less than 10 milliseconds.
+    if seconds >= 0.01:
+        time.sleep(seconds)
 
 
 class _PeriodicTimer:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56538 [10/n] [torch/elastic] Introduce _RendezvousStateHolder
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* **#56533 [5/n] [torch/elastic] Introduce the delay utility function**
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR introduces a small utility function to delay the execution of the current thread.

Differential Revision: [D27889671](https://our.internmc.facebook.com/intern/diff/D27889671/)