### PR TITLE
[7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -188,7 +188,7 @@ class _NodeDescGenerator:
         return _NodeDesc(socket.getfqdn(), os.getpid(), local_id)
 
 
-class _Rendezvous:
+class _RendezvousState:
     """Holds the state of a rendezvous.
 
     A rendezvous is synced across the nodes via a ``RendezvousBackend``.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56538 [10/n] [torch/elastic] Introduce _RendezvousStateHolder
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* **#56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState**
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR renames the `_Rendezvous` class to `_RendezvousState` in preparation of the upcoming changes.

Differential Revision: [D27889894](https://our.internmc.facebook.com/intern/diff/D27889894/)