### PR TITLE
[8/n] [torch/elastic] Add unit tests for _RendezvousState

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -96,10 +96,10 @@ class RendezvousStateTest(TestCase):
 
         # fmt: off
         expected_max_sizes = (
-            (   5,    2 * (2 ** 10),), #    10 machines -> <=   2KB  # noqa
-            (  50,   12 * (2 ** 10),), #   100 machines -> <=  12KB  # noqa
-            ( 500,  120 * (2 ** 10),), #  1000 machines -> <= 120KB  # noqa
-            (5000, 1400 * (2 ** 10),), # 10000 machines -> <= 1.4MB  # noqa
+            (   5,    2 * (2 ** 10),),  #    10 machines <=   2KB  # noqa: E201, E241, E262
+            (  50,   12 * (2 ** 10),),  #   100 machines <=  12KB  # noqa: E201, E241, E262
+            ( 500,  120 * (2 ** 10),),  #  1000 machines <= 120KB  # noqa: E201, E241, E262
+            (5000, 1400 * (2 ** 10),),  # 10000 machines <= 1.4MB  # noqa: E201, E241, E262
         )
         # fmt: on
 

--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -97,9 +97,9 @@ class RendezvousStateTest(TestCase):
         # fmt: off
         expected_max_sizes = (
             (   5,    2 * (2 ** 10),),  #    10 machines <=   2KB  # noqa: E201, E241, E262
-            (  50,   12 * (2 ** 10),),  #   100 machines <=  12KB  # noqa: E201, E241, E262
-            ( 500,  120 * (2 ** 10),),  #  1000 machines <= 120KB  # noqa: E201, E241, E262
-            (5000, 1400 * (2 ** 10),),  # 10000 machines <= 1.4MB  # noqa: E201, E241, E262
+            (  50,   16 * (2 ** 10),),  #   100 machines <=  16KB  # noqa: E201, E241, E262
+            ( 500,  160 * (2 ** 10),),  #  1000 machines <= 160KB  # noqa: E201, E241, E262
+            (5000, 1600 * (2 ** 10),),  # 10000 machines <= 1.6MB  # noqa: E201, E241, E262
         )
         # fmt: on
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* **#56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState**
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR adds unit tests to ensure that the encoded byte length of `_RendezvousState` stays under a certain limit.

Differential Revision: [D27890704](https://our.internmc.facebook.com/intern/diff/D27890704/)