### PR TITLE
[9/n] [torch/elastic] Introduce RendezvousSettings

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -166,14 +166,14 @@ class DynamicRendezvousHandlerTest(TestCase):
 
         self.assertEqual(handler.get_backend(), self._backend.name)
         self.assertEqual(handler.get_run_id(), self._run_id)
-        self.assertEqual(handler.run_id, self._run_id)
-        self.assertEqual(handler.min_nodes, self._min_nodes)
-        self.assertEqual(handler.max_nodes, self._max_nodes)
+        self.assertEqual(handler.settings.run_id, self._run_id)
+        self.assertEqual(handler.settings.min_nodes, self._min_nodes)
+        self.assertEqual(handler.settings.max_nodes, self._max_nodes)
 
         if self._timeout is None:
-            self.assertIsNotNone(handler.timeout)
+            self.assertIsNotNone(handler.settings.timeout)
         else:
-            self.assertIs(handler.timeout, self._timeout)
+            self.assertIs(handler.settings.timeout, self._timeout)
 
     def test_init_initializes_handler_if_timeout_is_not_specified(self) -> None:
         self._timeout = None
@@ -240,11 +240,11 @@ class CreateHandlerTest(TestCase):
 
         self.assertEqual(handler.get_backend(), self._backend.name)
         self.assertEqual(handler.get_run_id(), self._params.run_id)
-        self.assertEqual(handler.min_nodes, self._params.min_nodes)
-        self.assertEqual(handler.max_nodes, self._params.max_nodes)
-        self.assertEqual(handler.timeout.join, self._expected_timeout.join)
-        self.assertEqual(handler.timeout.last_call, self._expected_timeout.last_call)
-        self.assertEqual(handler.timeout.close, self._expected_timeout.close)
+        self.assertEqual(handler.settings.min_nodes, self._params.min_nodes)
+        self.assertEqual(handler.settings.max_nodes, self._params.max_nodes)
+        self.assertEqual(handler.settings.timeout.join, self._expected_timeout.join)
+        self.assertEqual(handler.settings.timeout.last_call, self._expected_timeout.last_call)
+        self.assertEqual(handler.settings.timeout.close, self._expected_timeout.close)
 
     def test_create_handler_returns_handler_if_timeout_is_not_specified(self) -> None:
         del self._params.config["join_timeout"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* **#56537 [9/n] [torch/elastic] Introduce RendezvousSettings**
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR introduces the `RendezvousSettings` type to consolidate the arguments passed to `DynamicRendezvousHandler`.

Differential Revision: [D27890155](https://our.internmc.facebook.com/intern/diff/D27890155/)