### PR TITLE
[PyTorch Edge] Eliminate non-determinism when generating build YAML file

### DIFF
--- a/tools/codegen/selective_build/selector.py
+++ b/tools/codegen/selective_build/selector.py
@@ -200,9 +200,9 @@ class SelectiveBuilder:
         ret['operators'] = operators
 
         if self._debug_info is not None:
-            ret['debug_info'] = self._debug_info
+            ret['debug_info'] = sorted(self._debug_info)
 
-        ret['kernel_metadata'] = {k: list(v) for (k, v) in self.kernel_metadata.items()}
+        ret['kernel_metadata'] = {k: sorted(list(v)) for (k, v) in self.kernel_metadata.items()}
 
         return ret
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56539 [PyTorch Edge] Eliminate non-determinism when generating build YAML file**

It seems like a potential source of non-determinism when generating YAML files during the build stems from the fact that when we write out Python lists, they get written out in list order. This isn't a problem per-se, but if you look to see how these lists are generated, you'll see that they come from sets, which are inherently [not order preserving](https://stackoverflow.com/questions/1653970/does-python-have-an-ordered-set) in Python.

I can't guarantee that this removes non-determinism, but it removes all non-determinism that I know of so far. The surface area of codegen isn't sprawling, and the YAML file is generated by converting the object `toDict()` and passing it into the YAML serializer, so this should cover it (I think). Dictionaries are serialized in key order by pyyaml, so that's not a problem.

This could be releated to the elevated Android build times being seen [here](https://fb.workplace.com/groups/pytorch.edge.users/permalink/841622146708080/).
#accept2ship

Differential Revision: [D27893058](https://our.internmc.facebook.com/intern/diff/D27893058/)