### PR TITLE
Lowered minimum compute capability from 3.5 to 3. 

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -67,7 +67,7 @@ def _check_capability():
     old_gpu_warn = """
     Found GPU%d %s which is of cuda capability %d.%d.
     PyTorch no longer supports this GPU because it is too old.
-    The minimum cuda capability that we support is 3.5.
+    The minimum cuda capability that we support is 3.0.
     """
 
     if torch.version.cuda is not None:  # on ROCm we don't want this check
@@ -77,7 +77,7 @@ def _check_capability():
             major = capability[0]
             minor = capability[1]
             name = get_device_name(d)
-            if capability == (3, 0) or major < 3:
+            if capability < (3, 0) or major < 3:
                 warnings.warn(old_gpu_warn % (d, name, major, capability[1]))
             elif CUDA_VERSION <= 9000 and major >= 7 and minor >= 5:
                 warnings.warn(incorrect_binary_warn % (d, name, 10000, CUDA_VERSION))

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1521,7 +1521,7 @@ def _get_cuda_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
     # string replacement may not do the right thing
     named_arches = collections.OrderedDict([
         ('Kepler+Tesla', '3.7'),
-        ('Kepler', '3.5+PTX'),
+        ('Kepler', '3.0;3.5+PTX'),
         ('Maxwell+Tegra', '5.3'),
         ('Maxwell', '5.0;5.2+PTX'),
         ('Pascal', '6.0;6.1+PTX'),
@@ -1530,7 +1530,7 @@ def _get_cuda_arch_flags(cflags: Optional[List[str]] = None) -> List[str]:
         ('Ampere', '8.0;8.6+PTX'),
     ])
 
-    supported_arches = ['3.5', '3.7', '5.0', '5.2', '5.3', '6.0', '6.1', '6.2',
+    supported_arches = ['3.0', '3.5', '3.7', '5.0', '5.2', '5.3', '6.0', '6.1', '6.2',
                         '7.0', '7.2', '7.5', '8.0', '8.6']
     valid_arch_strings = supported_arches + [s + "+PTX" for s in supported_arches]
 


### PR DESCRIPTION
Torch, if built locally with a GPU that has a CUDA compute capability of >=sm_30, so leaving it at 3.5 breaks utilization post-build. 

