### PR TITLE
[Demo] Asserts all tensor are defined in dispatch wrapper

### DIFF
--- a/aten/src/ATen/core/op_registration/adaption.h
+++ b/aten/src/ATen/core/op_registration/adaption.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ATen/TensorUtils.h>
+#include <ATen/core/List.h>
 #include <c10/core/TensorOptions.h>
 
 /*
@@ -55,6 +57,36 @@ check_tensor_options_and_extract_memory_format(
     return memory_format;
   } else {
     return options.memory_format_opt();
+  }
+}
+
+inline void undefined_device_check_failure(at::CheckedFrom methodName, at::CheckedFrom argName) {
+  TORCH_CHECK(false,
+    "Tensor is undefined."
+    "(when checking arugment for argument ", argName, " in method ", methodName, ")");
+}
+
+inline void assert_defined_tensor(const at::Tensor& tensor, at::CheckedFrom methodName, at::CheckedFrom argName) {
+  if (C10_UNLIKELY(!tensor.defined())) {
+    undefined_device_check_failure(methodName, argName);
+  }
+}
+
+inline void assert_defined_tensor(const optional<at::Tensor>& tensor, at::CheckedFrom methodName, at::CheckedFrom argName) {
+  if (tensor.has_value()) {
+    assert_defined_tensor(tensor.value(), methodName, argName);
+  }
+}
+
+inline void assert_defined_tensor(at::TensorList tensors, at::CheckedFrom methodName, at::CheckedFrom argName) {
+  for (const auto& tensor : tensors) {
+    assert_defined_tensor(tensor, methodName, argName);
+  }
+}
+
+inline void assert_defined_tensor(const List<optional<at::Tensor>>& tensors, at::CheckedFrom methodName, at::CheckedFrom argName) {
+  for (const auto& tensor : tensors) {
+    assert_defined_tensor(tensor, methodName, argName);
   }
 }
 } // namespace impl

--- a/tools/codegen/dest/register_dispatch_key.py
+++ b/tools/codegen/dest/register_dispatch_key.py
@@ -155,6 +155,11 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
 
             args_exprs_str = ', '.join(a.name for a in args)
 
+            defined_tensor_assertion = ""
+            for arg in f.func.arguments.flat_positional:
+                if arg.type.is_tensor_like():
+                    defined_tensor_assertion += f'  c10::impl::assert_defined_tensor({arg.name}, "{name}", "{arg.name}");\n'
+
             device_guard = "// DeviceGuard omitted"  # default
 
             if f.device_guard and is_cuda_dispatch_key(self.dispatch_key):
@@ -184,6 +189,7 @@ return {sig.name()}({', '.join(e.expr for e in translate(cpp_sig.arguments(), si
 namespace {{
 
 {returns_type} {name}({args_str}) {{
+{defined_tensor_assertion}
   {device_guard}
   return {impl_name}({args_exprs_str});
 }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56564 Asserts all tensor are defined in dispatch wrapper**

Differential Revision: [D27902833](https://our.internmc.facebook.com/intern/diff/D27902833/)