### PR TITLE
static runtime support for fb::equally_split

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -38,7 +38,7 @@ void OptimizeGraph(
 #ifdef FBCODE_CAFFE2
   if (opts.enable_out_variant) {
     ReplaceWithCopy(graph);
-    FuseSigridTransformsListUnpack(graph);
+    FuseListUnpack(graph);
   }
 #endif
   ConstantPropagation(graph);

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -477,14 +477,15 @@ void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
   }
 }
 
-void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
+void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
   auto nodes = graph->nodes();
   for (auto it = nodes.begin(); it != nodes.end(); ++it) {
-    Node* sigrid_node = *it;
-    auto kind = sigrid_node->kind();
-    if (strcmp(kind.toQualString(), "fb::sigrid_transforms") == 0 ||
-        strcmp(kind.toQualString(), "fb::sigrid_transforms_torch_bind") == 0) {
-      const Value* sigrid_out = sigrid_node->outputs()[0];
+    Node* node = *it;
+    const std::string node_qual_string = node->kind().toQualString();
+    if (node_qual_string == "fb::sigrid_transforms" ||
+        node_qual_string == "fb::sigrid_transforms_torch_bind" ||
+        node_qual_string == "fb::equally_split") {
+      const Value* sigrid_out = node->outputs()[0];
       if (sigrid_out->uses().size() > 1) {
         continue;
       }
@@ -501,7 +502,7 @@ void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
 
       // handle outputs
       for (Value* out : list_unpack_outputs) {
-        Value* new_out = sigrid_node->addOutput();
+        Value* new_out = node->addOutput();
         new_out->copyMetadata(out);
         out->replaceAllUsesWith(new_out);
       }
@@ -510,10 +511,9 @@ void FuseSigridTransformsListUnpack(std::shared_ptr<torch::jit::Graph>& graph) {
       ++it_next; // it_next points to list_unpack
       it_next.destroyCurrent(); // remove list_unpack
 
-      sigrid_node->eraseOutput(0);
+      node->eraseOutput(0);
     }
   }
 }
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/passes.h
+++ b/torch/csrc/jit/runtime/static/passes.h
@@ -5,8 +5,7 @@ namespace jit {
 
 TORCH_API void FuseInferenceOpsForSparseNN(
     std::shared_ptr<torch::jit::Graph>& graph);
-TORCH_API void FuseSigridTransformsListUnpack(
-    std::shared_ptr<torch::jit::Graph>& graph);
+TORCH_API void FuseListUnpack(std::shared_ptr<torch::jit::Graph>& graph);
 
 TORCH_API void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph);
 


### PR DESCRIPTION
Summary:
fb::equally_split get fused with ListUnpack and all outputs from ListUnpack getting attached to fb::equally_split.
So fb::equal_split will have as many outputs as ListUnpack .

Test Plan:
buck test caffe2/torch/fb/sparsenn:fb_operators_test

buck test caffe2/torch/fb/sparsenn:test -- test_equally_split_op

Differential Revision: D27902824

