### PR TITLE
Pass contiguous weight to NNPACK convolution

### DIFF
--- a/aten/src/ATen/native/NNPACK.cpp
+++ b/aten/src/ATen/native/NNPACK.cpp
@@ -227,8 +227,9 @@ Tensor _nnpack_spatial_convolution(
   };
 
   const auto input_ = input.contiguous();
+  const auto weight_ = weight.contiguous();
   // If we don't have a defined bias Tensor, we need to create one filled with zeroes
-  const auto bias_ = bias.defined() ? bias : at::zeros({weight.size(0)}, input.options());
+  const auto bias_ = bias.defined() ? bias.contiguous() : at::zeros({weight.size(0)}, input.options());
 
   const auto compute = [&](const size_t batch_size) -> nnp_status {
     if ((batch_size == 1) || (output_subsample.width != 1) || (output_subsample.height != 1)) {
@@ -246,7 +247,7 @@ Tensor _nnpack_spatial_convolution(
             kernel_size,
             output_subsample,
             input_.data_ptr<float>() + batch * input_size_per_batch,
-            weight.data_ptr<float>(),
+            weight_.data_ptr<float>(),
             bias_.data_ptr<float>(),
             output.data_ptr<float>() + batch * output_size_per_batch,
             workspace,
@@ -273,7 +274,7 @@ Tensor _nnpack_spatial_convolution(
         input_padding,
         kernel_size,
         input_.data_ptr<float>(),
-        weight.data_ptr<float>(),
+        weight_.data_ptr<float>(),
         bias_.data_ptr<float>(),
         output.data_ptr<float>(),
         workspace,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -854,9 +854,10 @@ class TestNN(NNTestCase):
         self.assertFalse(weight.is_contiguous())
         y = torch.nn.functional.conv2d(x, weight, None)
         if torch.backends.mkldnn.is_available():
+            # Disable MKLDNN explicitly, so that either NNPACK or THCNN will be used
             with torch.backends.mkldnn.flags(enabled=False):
                 y_ = torch.nn.functional.conv2d(x, weight, None)
-                self.assertTrue(torch.allclose(y, y_))
+                self.assertEqual(y, y_)
         self.assertEqual(y.sum(), 4186112.)
 
     def test_invalid_conv2d(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -847,6 +847,18 @@ class TestNN(NNTestCase):
 
             F.conv2d(x, w)
 
+    def test_conv2d_discontiguous_weight(self):
+        # Test for https://github.com/pytorch/pytorch/issues/55781
+        x = torch.ones(64, 16, 16, 16)
+        weight = torch.arange(0, 1.0, 1 / 2.0 ** 10).reshape(32, 16, 1, 2)[:, :, :, ::2]
+        self.assertFalse(weight.is_contiguous())
+        y = torch.nn.functional.conv2d(x, weight, None)
+        if torch.backends.mkldnn.is_available():
+            with torch.backends.mkldnn.flags(enabled=False):
+                y_ = torch.nn.functional.conv2d(x, weight, None)
+                self.assertTrue(torch.allclose(y, y_))
+        self.assertEqual(y.sum(), 4186112.)
+
     def test_invalid_conv2d(self):
         for dtype in [torch.bfloat16, torch.float, torch.double]:
             module = torch.nn.Conv2d(1, 1, kernel_size=3, dilation=2, stride=2).to(dtype)


### PR DESCRIPTION
Added TestNN.test_conv2d_discontiguous_weight to prevent further regressions

Fixes https://github.com/pytorch/pytorch/issues/55781
