### PR TITLE
Rename job to be py2-setup-validate-errormsg

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           (! git --no-pager grep -I -no $'#include <cub/' --  ./aten  ':(exclude)aten/src/ATen/cuda/cub.cuh' || (echo "The above files have direct cub include; please include ATen/cuda/cub.cuh instead and wrap your cub calls in at::native namespace if necessary"; false))
 
-  python2-setup-compat:
+  py2-setup-validate-errormsg:
     runs-on: ubuntu-18.04
     steps:
       - name: Setup Python


### PR DESCRIPTION
This should clarify its purpose, which is:

> to make sure that we give an appropriate error message when someone tries to use python2

**Test plan:**

CI.