### PR TITLE
Remove extraneous variables in windows report stats step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -802,14 +802,6 @@ jobs:
           no_output_timeout: "5m"
           command: |
             set -ex
-            export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}
-            export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
-            export CIRCLE_TAG="${CIRCLE_TAG:-}"
-            export CIRCLE_SHA1="$CIRCLE_SHA1"
-            export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-}"
-            export CIRCLE_BRANCH="$CIRCLE_BRANCH"
-            export CIRCLE_JOB="$CIRCLE_JOB"
-            export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             export PYTHONPATH="$PWD"

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -364,14 +364,6 @@ jobs:
           no_output_timeout: "5m"
           command: |
             set -ex
-            export BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}
-            export SCRIBE_GRAPHQL_ACCESS_TOKEN="${SCRIBE_GRAPHQL_ACCESS_TOKEN}"
-            export CIRCLE_TAG="${CIRCLE_TAG:-}"
-            export CIRCLE_SHA1="$CIRCLE_SHA1"
-            export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-}"
-            export CIRCLE_BRANCH="$CIRCLE_BRANCH"
-            export CIRCLE_JOB="$CIRCLE_JOB"
-            export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
             export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_WIN_BUILD_V1}
             export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_WIN_BUILD_V1}
             export PYTHONPATH="$PWD"


### PR DESCRIPTION
Testing that the CIRCLE variables in the Windows test CI report stats step aren't needed.

Test plan: 
CI