### PR TITLE
Tell codegen that SparseCsrCUDA is cuda

### DIFF
--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -138,6 +138,7 @@ def is_cuda_dispatch_key(dk: DispatchKey) -> bool:
         DispatchKey.CUDA,
         DispatchKey.QuantizedCUDA,
         DispatchKey.SparseCUDA,
+        DispatchKey.SparseCsrCUDA,
         DispatchKey.AutogradCUDA,
         DispatchKey.CUDATensorId,
     }


### PR DESCRIPTION
Follow up to #50937, Fixes build failures in #56561

Currently SparseCsrCUDA is included in cpu build and also doesn't get code-generated device guards. This fixed both issues.