### PR TITLE
torch: Fix flake8 errors from leftover import

### DIFF
--- a/torch/distributed/elastic_launch.py
+++ b/torch/distributed/elastic_launch.py
@@ -227,7 +227,6 @@ from typing import List, Tuple
 import torch
 from torch.distributed.argparse_util import check_env, env
 from torch.distributed.elastic.multiprocessing import Std
-from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 from torch.distributed.elastic.rendezvous.utils import _parse_rendezvous_config
 from torch.distributed.elastic.utils import macros


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56614 torch: Fix flake8 errors from leftover import**

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D27917831](https://our.internmc.facebook.com/intern/diff/D27917831)