### PR TITLE
Set show_error_codes = True in mypy-strict.ini

### DIFF
--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -13,6 +13,7 @@ plugins = mypy_plugins/check_mypy_version.py
 
 cache_dir = .mypy_cache/strict
 strict_optional = True
+show_error_codes = True
 show_column_numbers = True
 warn_no_return = True
 disallow_any_unimported = True


### PR DESCRIPTION
This should make it easier to resolve issues surfaced by #56290. Also see https://github.com/pytorch/pytorch/pull/56559#discussion_r617828152 for context.

**Test plan:**

You could add a type error in a strict-checked file like `tools/test_history.py`, and then run this command:
```
$ mypy --config=mypy-strict.ini tools/test_history.py
```

Output before this PR:
```
tools/test_history.py:13:1: error: Function is missing a type annotation for one or more arguments
Found 1 error in 1 file (checked 1 source file)
```

Output after this PR:
```
tools/test_history.py:13:1: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
Found 1 error in 1 file (checked 1 source file)
```