### PR TITLE
Added sm_75 to CUDA Arch List for Linux CI GPU builds

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -182,7 +182,7 @@ if [ -z "$MAX_JOBS" ]; then
 fi
 
 # Target only our CI GPU machine's CUDA arch to speed up the build
-export TORCH_CUDA_ARCH_LIST="7.5"
+export TORCH_CUDA_ARCH_LIST="5.2;7.5"
 
 if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -182,7 +182,12 @@ if [ -z "$MAX_JOBS" ]; then
 fi
 
 # Target only our CI GPU machine's CUDA arch to speed up the build
-export TORCH_CUDA_ARCH_LIST="5.2;7.5"
+export TORCH_CUDA_ARCH_LIST="5.2"
+
+# Add sm_75 support for the Linux CUDA 10.2 cuDNN 7 build
+if [[ "$BUILD_ENVIRONMENT" == *cuda10.2-cudnn7*build ]]; then
+  export TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST";7.5"
+fi
 
 if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -182,7 +182,7 @@ if [ -z "$MAX_JOBS" ]; then
 fi
 
 # Target only our CI GPU machine's CUDA arch to speed up the build
-export TORCH_CUDA_ARCH_LIST="5.2;7.5"
+export TORCH_CUDA_ARCH_LIST="7.5"
 
 if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -182,7 +182,7 @@ if [ -z "$MAX_JOBS" ]; then
 fi
 
 # Target only our CI GPU machine's CUDA arch to speed up the build
-export TORCH_CUDA_ARCH_LIST="5.2"
+export TORCH_CUDA_ARCH_LIST="5.2;7.5"
 
 if [[ "$BUILD_ENVIRONMENT" == *ppc64le* ]]; then
   export TORCH_CUDA_ARCH_LIST="6.0"


### PR DESCRIPTION
This PR adds `sm_75` CUDA architecture support for CircleCI GPU builds, so that generated artifacts from these builds can be installed and run on machines with CUDA capability `sm_75`.

This PR is currently to see how much longer the PR CI GPU builds will take with `TORCH_CUDA_ARCH_LIST="7.5"` rather than `TORCH_CUDA_ARCH_LIST="5.2"`.