### PR TITLE
Mechanism in TensorUtils.h to check if all tensors are on the same device

### DIFF
--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -151,6 +151,18 @@ void checkAllSameGPU(CheckedFrom c, ArrayRef<TensorArg> tensors) {
   checkAllSame(c, tensors, checkSameGPU);
 }
 
+void checkTensorsSameDevice(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
+  TORCH_CHECK(
+    t1->get_device() == t2->get_device(),
+    "Expected tensor for ", t1, " to have the same device as tensor for ", t2,
+    "; but device ", t1->get_device(), " does not equal ", t2->get_device(),
+    " (while checking arguments for ", c, ")");
+}
+
+void checkAllSameDevice(CheckedFrom c, ArrayRef<TensorArg> tensors) {
+  checkAllSame(c, tensors, checkTensorsSameDevice);
+}
+  
 void checkSameType(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
   TORCH_CHECK(
     t1->options().type_equal(t2->options()),

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -162,7 +162,7 @@ void checkTensorsSameDevice(CheckedFrom c, const TensorArg& t1, const TensorArg&
 void checkAllSameDevice(CheckedFrom c, ArrayRef<TensorArg> tensors) {
   checkAllSame(c, tensors, checkTensorsSameDevice);
 }
-  
+
 void checkSameType(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
   TORCH_CHECK(
     t1->options().type_equal(t2->options()),

--- a/aten/src/ATen/TensorUtils.cpp
+++ b/aten/src/ATen/TensorUtils.cpp
@@ -151,7 +151,7 @@ void checkAllSameGPU(CheckedFrom c, ArrayRef<TensorArg> tensors) {
   checkAllSame(c, tensors, checkSameGPU);
 }
 
-void checkTensorsSameDevice(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
+void checkSameDevice(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {
   TORCH_CHECK(
     t1->get_device() == t2->get_device(),
     "Expected tensor for ", t1, " to have the same device as tensor for ", t2,
@@ -160,7 +160,7 @@ void checkTensorsSameDevice(CheckedFrom c, const TensorArg& t1, const TensorArg&
 }
 
 void checkAllSameDevice(CheckedFrom c, ArrayRef<TensorArg> tensors) {
-  checkAllSame(c, tensors, checkTensorsSameDevice);
+  checkAllSame(c, tensors, checkSameDevice);
 }
 
 void checkSameType(CheckedFrom c, const TensorArg& t1, const TensorArg& t2) {

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -106,6 +106,11 @@ TORCH_API void checkSameGPU(
     const TensorArg& t1,
     const TensorArg& t2);
 TORCH_API void checkAllSameGPU(CheckedFrom c, ArrayRef<TensorArg> tensors);
+TORCH_API void checkTensorsSameDevice(
+    CheckedFrom c,
+    const TensorArg& t1,
+    const TensorArg& t2);
+TORCH_API void checkAllSameDevice(CheckedFrom c, ArrayRef<TensorArg> tensors);
 TORCH_API void checkSameType(
     CheckedFrom c,
     const TensorArg& t1,

--- a/aten/src/ATen/TensorUtils.h
+++ b/aten/src/ATen/TensorUtils.h
@@ -106,7 +106,7 @@ TORCH_API void checkSameGPU(
     const TensorArg& t1,
     const TensorArg& t2);
 TORCH_API void checkAllSameGPU(CheckedFrom c, ArrayRef<TensorArg> tensors);
-TORCH_API void checkTensorsSameDevice(
+TORCH_API void checkSameDevice(
     CheckedFrom c,
     const TensorArg& t1,
     const TensorArg& t2);


### PR DESCRIPTION
`checkAllSameGPU` in `TensorUtils.h` allows to check if all tensors are on the same GPU.
But there's no such mechanism for checking if all tensors are on the device as well, irrespective of whether it's a GPU or CPU.

`LinearAlgebraUtils.h` has `CheckSameDevice` which only allows checking two tensors (one input and one output) at a time.

`checkAllSameDevice` checks if all tensors are on the same device.
Its usage is same as that of `checkAllSameGPU`.