### PR TITLE
Use absolute path for local linter

### DIFF
--- a/tools/actions_local_runner.py
+++ b/tools/actions_local_runner.py
@@ -9,8 +9,7 @@ import asyncio
 from typing import List, Dict, Any, Optional
 
 
-REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
-
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 class col:
     HEADER = "\033[95m"


### PR DESCRIPTION


In some cases the `__file__` here was relative, so in the linter script it ended up setting the repo root to `''`, which `asyncio` doesn't handle.

Differential Revision: [D27922510](https://our.internmc.facebook.com/intern/diff/27922510/)