### PR TITLE
Create helper function for RPC profiling in _invoke_rpc and remote

### DIFF
--- a/torch/distributed/rpc/api.py
+++ b/torch/distributed/rpc/api.py
@@ -562,28 +562,7 @@ def remote(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     dst_worker_info = _to_worker_info(to)
     should_profile = torch.autograd._profiler_enabled()
 
-    ctx_manager = contextlib.suppress()
-    if should_profile:
-        # Create appropriate string representation based on type of func
-        # (builtin, script, python)
-        if qualified_name is None:
-            func_name = (
-                torch._jit_internal._qualified_name(func)
-                if isinstance(func, torch.jit.ScriptFunction)
-                else func.__qualname__
-            )
-        else:
-            func_name = qualified_name
-        # Build RPC profiling key.
-        rpc_profiling_key = _build_rpc_profiling_key(
-            RPCExecMode.REMOTE,
-            func_name,
-            get_worker_info().name,
-            dst_worker_info.name,
-        )
-        RemoteProfilerManager.set_current_profiling_key(rpc_profiling_key)
-        # Mypy doesn't support re-def of a variable not in the same block (#1174)
-        ctx_manager = torch.autograd.profiler.record_function(rpc_profiling_key)  # type: ignore[assignment]
+    ctx_manager = _enable_rpc_profiler(should_profile, qualified_name, func, RPCExecMode.REMOTE, dst_worker_info)
 
     with ctx_manager as rf:
         args = args if args else ()
@@ -634,32 +613,9 @@ def _invoke_rpc(to, func, rpc_type, args=None, kwargs=None, rpc_timeout=UNSET_RP
     qualified_name = torch.jit._builtins._find_builtin(func)
     dst_worker_info = _to_worker_info(to)
 
-    # TODO: profiling logic does not really belong in invoke_rpc, it should be
-    # added as part of a context manager or helper (https://github.com/pytorch/pytorch/issues/36360)
     should_profile = torch.autograd._profiler_enabled()
 
-    ctx_manager = contextlib.suppress()
-    if should_profile:
-        # Create appropriate string representation based on type of func
-        # (builtin, script, python)
-        if qualified_name is None:
-            func_name = (
-                torch._jit_internal._qualified_name(func)
-                if isinstance(func, torch.jit.ScriptFunction)
-                else func.__qualname__
-            )
-        else:
-            func_name = qualified_name
-        # Build RPC profiling key.
-        rpc_profiling_key = _build_rpc_profiling_key(
-            rpc_type,
-            func_name,
-            get_worker_info().name,
-            dst_worker_info.name,
-        )
-        RemoteProfilerManager.set_current_profiling_key(rpc_profiling_key)
-        # Mypy doesn't support re-def of a variable not in the same block (#1174)
-        ctx_manager = torch.autograd.profiler.record_function(rpc_profiling_key)  # type: ignore[assignment]
+    ctx_manager = _enable_rpc_profiler(should_profile, qualified_name, func, rpc_type, dst_worker_info)
 
     with ctx_manager as rf:
         args = args if args else ()
@@ -882,3 +838,31 @@ def rpc_async(to, func, args=None, kwargs=None, timeout=UNSET_RPC_TIMEOUT):
     if hasattr(_thread_local_var, "future_list"):
         _thread_local_var.future_list.append(fut)
     return fut
+
+
+def _enable_rpc_profiler(should_profile, qualified_name, func, rpc_type, dst_worker_info):
+    ctx_manager = contextlib.suppress()
+
+    if should_profile:
+        # Create appropriate string representation based on type of func
+        # (builtin, script, python)
+        if qualified_name is None:
+            func_name = (
+                torch._jit_internal._qualified_name(func)
+                if isinstance(func, torch.jit.ScriptFunction)
+                else func.__qualname__
+            )
+        else:
+            func_name = qualified_name
+        # Build RPC profiling key.
+        rpc_profiling_key = _build_rpc_profiling_key(
+            rpc_type,
+            func_name,
+            get_worker_info().name,
+            dst_worker_info.name,
+        )
+        RemoteProfilerManager.set_current_profiling_key(rpc_profiling_key)
+        # Mypy doesn't support re-def of a variable not in the same block (#1174)
+        ctx_manager = torch.autograd.profiler.record_function(rpc_profiling_key)  # type: ignore[assignment]
+
+    return ctx_manager


### PR DESCRIPTION
Summary:
Refactor enabling rpc profiling logic in `_invoke_rpc` and `remote()` into `_rpc_profiling()` helper function.

T89058933

Test Plan: Not tested.

Differential Revision: D27922286

