### PR TITLE
Remove some wildcards from mypy configs

### DIFF
--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -43,8 +43,8 @@ files =
     tools/extract_scripts.py,
     tools/mypy_wrapper.py,
     tools/print_test_stats.py,
-    tools/pyi/*.py,
-    tools/stats_utils/*.py,
+    tools/pyi,
+    tools/stats_utils,
     tools/test_history.py,
     tools/test/test_extract_scripts.py,
     tools/test/test_mypy_wrapper.py,
@@ -56,7 +56,7 @@ files =
     torch/testing/_internal/framework_utils.py,
     torch/utils/benchmark/utils/common.py,
     torch/utils/benchmark/utils/timer.py,
-    torch/utils/benchmark/utils/valgrind_wrapper/*.py,
+    torch/utils/benchmark/utils/valgrind_wrapper,
     torch/utils/_pytree.py
 
 # Specifically enable imports of benchmark utils. As more of `torch` becomes

--- a/mypy.ini
+++ b/mypy.ini
@@ -36,7 +36,7 @@ files =
     tools/clang_format_utils.py,
     tools/clang_tidy.py,
     tools/generate_torch_version.py,
-    tools/stats_utils/*.py
+    tools/stats_utils
 
 #
 # `exclude` is a regex, not a list of paths like `files` (sigh)


### PR DESCRIPTION
See https://github.com/pytorch/pytorch/pull/56523#issuecomment-823562134 for context. Basically the idea is that people (including myself) keep assuming that the single-asterisk `*` wildcard means "match in this directory and in its subdirectories", which is _not_ true. Removing the wildcards thus reduces confusion.

Ideally I would like to remove _all_ of these wildcards and then add a lint to disallow them in the future (and also greatly simplify the pattern-matching logic in `tools/mypy_wrapper.py`; see #55702 for context), but currently this one can't be removed:

```
tools/autograd/*.py,
```

That is because there is a file called `tools/autograd/templates/annotated_fn_args.py` (added in #41575) which is not a valid Python file and thus cannot be checked by `mypy`. @ezyang would it be possible to rename that file to use a suffix other than `.py`?

**Test plan:**

```
$ mypy                         
Success: no issues found in 1317 source files
$ mypy --config=mypy-strict.ini
Success: no issues found in 72 source files
```
The numbers of source files should be the same before and after this PR.