### PR TITLE
[PyTorch] Add & document borrow_from_optional_tensor

### DIFF
--- a/aten/src/ATen/core/op_registration/adaption.h
+++ b/aten/src/ATen/core/op_registration/adaption.h
@@ -12,11 +12,13 @@
  * To remove the hacky wrapper, the C++ function is changed to take
  * optional<Tensor> and unwrap the Tensor value at the beginning of
  * the function, e.g.:
- *   > const Tensor& weight =
-     >     c10::value_or_else(weight_opt, [] {returnTensor();});
+ *   > c10::MaybeOwned<Tensor> weight_maybe_owned =
+ *   >     at::borrow_from_optional_tensor(weight_opt);
+ *   > const Tensor& weight = *weight_maybe_owned;
  *
- * We may want make the kernel handle optional directly without going through
- * the creation of a default constructed tensor.
+ * We may want to make the kernel handle optional directly without
+ * going through the creation of a default-constructed Tensor in
+ * at::borrow_from_optional_tensor.
  */
 
 /*

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -979,6 +979,14 @@ struct MaybeOwnedTraits<at::Tensor> {
 } // namespace c10
 
 namespace at {
+
+inline c10::MaybeOwned<Tensor> borrow_from_optional_tensor(
+    const c10::optional<Tensor>& opt) {
+  return opt.has_value()
+    ? c10::MaybeOwned<Tensor>::borrowed(*opt)
+    : c10::MaybeOwned<Tensor>::owned(c10::in_place);
+}
+
 inline c10::MaybeOwned<Tensor> Tensor::expect_contiguous(MemoryFormat memory_format) const & {
   if (is_contiguous(memory_format)) {
     return c10::MaybeOwned<Tensor>::borrowed(*this);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56648 [PyTorch] Migrate hacky wrapper removal to borrow_from_optional_tensor
* **#56647 [PyTorch] Add & document borrow_from_optional_tensor**

This should be more efficient than the old hacky wrapper for optional Tensor pattern. Despite appearances, the old pattern did a reference count bump for non-empty optionals. Following diff will contain an automated change to migrate callsites.

Differential Revision: [D27925838](https://our.internmc.facebook.com/intern/diff/D27925838/)