### PR TITLE
Add missing vec256<>::isnan() for VSX float and double vectors

### DIFF
--- a/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
@@ -359,6 +359,16 @@ class Vec256<double> {
     return map(calc_i0e);
   }
 
+  Vec256<double> _nor() const {
+    return {vec_nor(_vec0, _vec0), vec_nor(_vec1, _vec1)};
+  }
+
+  Vec256<double> isnan() const {
+    auto x = *this;
+    auto ret = (x == x);
+    return ret._nor();
+  }
+
   DEFINE_MEMBER_OP(operator==, double, vec_cmpeq)
   DEFINE_MEMBER_OP(operator!=, double, vec_cmpne)
   DEFINE_MEMBER_OP(operator<, double, vec_cmplt)

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
@@ -227,7 +227,7 @@ class Vec256<float> {
     return {vec_nor(_vec0, _vec0), vec_nor(_vec1, _vec1)};
   }
 
-  Vec256<float> _isnan() const {
+  Vec256<float> isnan() const {
     auto x = *this;
     auto ret = (x == x);
     return ret._nor();
@@ -459,8 +459,8 @@ class Vec256<float> {
     // inf and nan checks
 #if 0
                     ret = blendv(ret, v_inf, x >= vf_89);
-                    ret = blendv(ret, v_inf, ret._isnan());
-                    ret = blendv(ret, v_nan, this->_isnan());
+                    ret = blendv(ret, v_inf, ret.isnan());
+                    ret = blendv(ret, v_nan, this->isnan());
 #endif
     return ret;
   }


### PR DESCRIPTION
Obviously, have no way of testing it
Fixes #56650
