### PR TITLE
Fix instance norm input size validation + test

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2396,7 +2396,7 @@ class TestFunctionalTracing(JitTestCase):
         "adaptive_avg_pool3d": LEN_ERROR,
         "adaptive_max_pool2d_with_indices": LEN_ERROR,
         "adaptive_max_pool3d_with_indices": LEN_ERROR,
-        "instance_norm": LEN_ERROR,
+        "instance_norm": CONTROL_FLOW,
         "pad": LEN_ERROR,
 
         "adaptive_max_pool1d": PROXY_ITERABLE,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12023,7 +12023,7 @@ class TestNNDeviceType(NNTestCase):
             m = norm(NUM_CHANNELS, track_running_stats=True)
 
             # Create an appropriately-sized input with a single spatial element.
-            input = torch.randn(BATCH_SIZE, NUM_CHANNELS, *[1 for _ in range(i+1)],
+            input = torch.randn(BATCH_SIZE, NUM_CHANNELS, *[1 for _ in range(i + 1)],
                                 device=device)
             with self.assertRaises(ValueError):
                 m(input)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12015,6 +12015,23 @@ class TestNNDeviceType(NNTestCase):
         with self.assertRaises(ValueError):
             torch.nn.InstanceNorm1d(10)(x).to(device)
 
+    def test_instancenorm_raises_error_for_single_spatial_element_during_training(self, device):
+        BATCH_SIZE = 10
+        NUM_CHANNELS = 3
+        norms = [torch.nn.InstanceNorm1d, torch.nn.InstanceNorm2d, torch.nn.InstanceNorm3d]
+        for i, norm in enumerate(norms):
+            m = norm(NUM_CHANNELS, track_running_stats=True)
+
+            # Create an appropriately-sized input with a single spatial element.
+            input = torch.randn(BATCH_SIZE, NUM_CHANNELS, *[1 for _ in range(i+1)],
+                                device=device)
+            with self.assertRaises(ValueError):
+                m(input)
+
+            # Single spatial element should be fine in eval.
+            m.eval()
+            m(input)
+
     def test_LayerNorm_general(self, device):
         self._test_LayerNorm_general(device)
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12021,6 +12021,7 @@ class TestNNDeviceType(NNTestCase):
         norms = [torch.nn.InstanceNorm1d, torch.nn.InstanceNorm2d, torch.nn.InstanceNorm3d]
         for i, norm in enumerate(norms):
             m = norm(NUM_CHANNELS, track_running_stats=True)
+            m.to(device)
 
             # Create an appropriately-sized input with a single spatial element.
             input = torch.randn(BATCH_SIZE, NUM_CHANNELS, *[1 for _ in range(i + 1)],

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2265,6 +2265,15 @@ def batch_norm(
     )
 
 
+def _verify_spatial_size(size: List[int]) -> None:
+    # Verify that there is > 1 spatial element for instance norm calculation.
+    size_prods = 1
+    for i in range(2, len(size)):
+        size_prods *= size[i]
+    if size_prods == 1:
+        raise ValueError("Expected more than 1 spatial element when training, got input size {}".format(size))
+
+
 def instance_norm(
     input: Tensor,
     running_mean: Optional[Tensor] = None,
@@ -2294,7 +2303,8 @@ def instance_norm(
             momentum=momentum,
             eps=eps,
         )
-    _verify_batch_size(input.size())
+    if use_input_stats:
+        _verify_spatial_size(input.size())
     return torch.instance_norm(
         input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, torch.backends.cudnn.enabled
     )

--- a/torch/testing/_internal/common_quantization.py
+++ b/torch/testing/_internal/common_quantization.py
@@ -1146,7 +1146,7 @@ class NormalizationTestModel(torch.nn.Module):
         x = self.quant(x)
         x = self.fc1(x)
         x = self.layer_norm(x)
-        x = self.group_norm(x.unsqueeze(-1))
+        x = self.group_norm(x.unsqueeze(-1).repeat(1, 1, 3))
         x = self.instance_norm1d(x)
         x = self.instance_norm2d(x.unsqueeze(-1))
         x = self.instance_norm3d(x.unsqueeze(-1))


### PR DESCRIPTION
Fixes #45687

Fix changes the input size check for `InstanceNorm*d` to be more restrictive and correctly reject sizes with only a single spatial element, regardless of batch size, to avoid infinite variance.