### PR TITLE
make beg_size output deterministic for EmbeddingBag

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -625,6 +625,10 @@ void _embedding_bag_cpu_impl_out(Tensor& output, Tensor& offset2bag,
       });
     });
     apply_bag_size(mode, output, bag_size);
+    if (mode == MODE_SUM) {
+      // make bag_size output deterministic
+      at::native::zero_(bag_size);
+    }
     max_indices = bag_size;
   } else { // MODE_MAX
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(


### PR DESCRIPTION
Summary: Under some conditions (requires_grad = false and mode=SUM) bag_size and max_indices will be created via at::empty and will not be modified, that is why corresponding outputs is not deterministic and causing tests to fail.

Test Plan: buck test mode/opt //caffe2/benchmarks/static_runtime:static_runtime_cpptest -- --exact 'caffe2/benchmarks/static_runtime:static_runtime_cpptest - StaticRuntime.EmbeddingBag' --run-disabled

Differential Revision: D27931445

