### PR TITLE
Wait for cuda installation on Windows

### DIFF
--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -40,6 +40,8 @@ set +e
 
 ./setup.exe -s ${cuda_install_packages} -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
 
+sleep 120
+
 set -e
 
 if [[ "${VC_YEAR}" == "2017" ]]; then

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -40,7 +40,7 @@ set +e
 
 ./setup.exe -s ${cuda_install_packages} -loglevel:6 -log:"$(pwd -W)/cuda_install_logs"
 
-sleep 120
+sleep 180
 
 set -e
 

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -58,8 +58,8 @@ fi
 run_tests() {
     # Run nvidia-smi if available
     for path in  "/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe" "/c/Windows/System32/nvidia-smi.exe"; do
-        if [ -x $path ]; then
-            $path;
+        if [ -x "$path" ]; then
+            "$path";
             break
         fi
     done

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -57,7 +57,7 @@ fi
 
 run_tests() {
     # Run nvidia-smi if available
-    for path in  /c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe /c/Windows/System32/nvidia-smi.exe; do
+    for path in  "/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe" "/c/Windows/System32/nvidia-smi.exe"; do
         if [ -x $path ]; then
             $path;
             break


### PR DESCRIPTION
Fixes #56654 

In `windows_cuda_install.sh`, `setup.exe` will not block the script execution. We should explicitly wait a bit for CUDA installation to finish.
