### PR TITLE
Re-order tests based on changed files

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -23,7 +23,7 @@ torch.set_default_dtype(torch.double)
 
 # TODO(alband) Remove this when this flag is not needed anymore
 torch._C._set_forward_AD_enabled(True)
-
+# A comment (TODO: Delete before landing)
 from torch import nn
 from torch._six import inf, nan
 from torch.autograd.function import once_differentiable

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -23,7 +23,7 @@ torch.set_default_dtype(torch.double)
 
 # TODO(alband) Remove this when this flag is not needed anymore
 torch._C._set_forward_AD_enabled(True)
-# A comment (TODO: Delete before landing)
+
 from torch import nn
 from torch._six import inf, nan
 from torch.autograd.function import once_differentiable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56666 [wip] Re-order tests**

Addresses some of #56557 by checking for changed files when running tests. This will help deliver signal faster when a failing test is run. It should always be safe to at least try to re-order the tests, so there's no option to turn it off, and any error ends up bailing out of the sorting process. Time saved will change between tests, with more improvement for things that are further down the static list here:

https://github.com/pytorch/pytorch/blob/1e9c7ad4cb1869ea3769e1c563c78bce95da5945/test/run_test.py#L32

The results vary from not much improvement ([before: 11m](https://app.circleci.com/pipelines/github/pytorch/pytorch/307580/workflows/6ab3def6-8d63-4f41-9b8d-9c2c50f6266b/jobs/12712819/steps), [after: 10m](https://app.circleci.com/pipelines/github/pytorch/pytorch/307578/workflows/157407b4-f850-431c-b641-d2ac97916a04/jobs/12712802/steps)) to a lot ([before: 75m](https://app.circleci.com/pipelines/github/pytorch/pytorch/307580/workflows/6ab3def6-8d63-4f41-9b8d-9c2c50f6266b/jobs/12712884/steps), [after: 8m](https://app.circleci.com/pipelines/github/pytorch/pytorch/307578/workflows/157407b4-f850-431c-b641-d2ac97916a04/jobs/12712865/steps)), but overall there shouldn't be any regression in test timing. These results are also probably a little confounded since the test sharding will be different after re-ordering.


As a follow up we can use the target determination logic to figure out which tests to bring to front based on the actual code instead of just edits to test files

Differential Revision: [D27934076](https://our.internmc.facebook.com/intern/diff/D27934076)