### PR TITLE
Allow ParallelNative to preserve thread_local state.

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -50,10 +50,11 @@ grain_size: number of elements per chunk. impacts the degree of parallelization
 f: user function applied in parallel to the chunks, signature:
   void f(int64_t begin, int64_t end)
 
-Warning: parallel_for does NOT copy thread local
+Warning: Not all parallel_for implementations copy thread local
 states from the current thread to the worker threads.
-This means for example that Tensor operations CANNOT be used in the
-body of your function, only data pointers.
+See Note [Preserve thread local state across thread boundary] for details.
+For implementations that don't preserve thread local state, Tensor operations
+CANNOT be used in the body of your function, only data pointers.
 */
 template <class F>
 inline void parallel_for(
@@ -93,10 +94,11 @@ would be "+" and 0 respectively. This is similar to tbb's approach [1], where
 you need to provide a function to accumulate a subrange, a function to combine
 two partial results and an identity.
 
-Warning: parallel_reduce does NOT copy thread local
+Warning: Not all parallel_reduce implementations copy thread local
 states from the current thread to the worker threads.
-This means for example that Tensor operations CANNOT be used in the
-body of your function, only data pointers.
+See Note [Preserve thread local state across thread boundary] for details.
+For implementations that don't preserve thread local state, Tensor operations
+CANNOT be used in the body of your function, only data pointers.
 
 [1] https://software.intel.com/en-us/node/506154
 */

--- a/aten/src/ATen/ThreadLocalState.h
+++ b/aten/src/ATen/ThreadLocalState.h
@@ -9,8 +9,13 @@
 
 namespace at {
 
+// Note [Preserve thread local state across thread boundary]
 // Thread local state contains values that are preserved across
 // thread boundaries (e.g. at::launch/JIT fork, autograd, at::parallel_for)
+// Not all at::parallel_for implementations preserve thread_local
+// acrros thread boundaries! For example, ParallelNative and
+// ParallelThreadPoolNative support it but ParallelOpenMP and ParallelNativeTBB
+// don't.
 class TORCH_API ThreadLocalState {
  public:
   // Saves the thread local variables' values and

--- a/aten/src/ATen/native/ConvolutionMM2d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM2d.cpp
@@ -269,8 +269,6 @@ void slow_conv2d_backward_out_cpu_template(
   const Tensor tweight = weight.transpose(0, 1);
   const int64_t batch_size = input.size(0);
   at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-    NoGradGuard no_grad;
-    AutoDispatchBelowInplaceOrView non_variable_type_mode;
     for (int64_t t = start; t < end; t++) {
       Tensor grad_input_t = grad_input[t];
       Tensor grad_output_t = grad_output[t];
@@ -447,8 +445,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> slow_conv2d_forward_out_cpu(const Tensor& 
   output.resize_({batch_size, n_output_plane, output_height, output_width});
 
   at::parallel_for(0, batch_size, 0, [&](int64_t start, int64_t end) {
-    NoGradGuard no_grad;
-    AutoDispatchBelowInplaceOrView non_variable_type_mode;
     for (int64_t t = start; t < end; t++) {
       Tensor input_t = input[t].unsqueeze(0);
       Tensor output_t = output[t];

--- a/aten/src/ATen/native/ConvolutionMM3d.cpp
+++ b/aten/src/ATen/native/ConvolutionMM3d.cpp
@@ -370,7 +370,6 @@ void slow_conv3d_backward_out_cpu_template(
   const int64_t batch_size = input.size(0);
   at::parallel_for(
       0, batch_size, CONV3D_GRAIN_SALT, [&](int64_t start, int64_t end) {
-        AutoDispatchBelowInplaceOrView non_variable_type_mode;
         for (int64_t t = start; t < end; t++) {
           Tensor grad_input_t = grad_input[t];
           Tensor grad_output_t = grad_output_contiguous[t];
@@ -596,7 +595,6 @@ std::tuple<Tensor&, Tensor&, Tensor&> slow_conv3d_forward_out_cpu(const Tensor& 
 
   at::parallel_for(
       0, batch_size, CONV3D_GRAIN_SALT, [&](int64_t start, int64_t end) {
-        AutoDispatchBelowInplaceOrView non_variable_type_mode;
         for (int64_t t = start; t < end; t++) {
           Tensor input_t = input[t];
           Tensor output_t = output[t];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56672 Allow ParallelNative to preserve thread_local state.**
* #56657 s/AutoDispatchBelowAutograd/AutoDispatchBelowInplaceOrView.

Differential Revision: [D27934358](https://our.internmc.facebook.com/intern/diff/D27934358)