### PR TITLE
Disable TestComplexity.test_nn_module_test in fbcode

### DIFF
--- a/test/jit/test_complexity.py
+++ b/test/jit/test_complexity.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import unittest
 
 import torch
 
@@ -12,7 +13,7 @@ sys.path.append(pytorch_test_dir)
 from torch.testing._internal.jit_utils import JitTestCase, enable_profiling_mode
 from torch.testing._internal.jit_metaprogramming_utils import try_get_nn_module_compiled_mod_and_inputs, \
     get_nn_mod_test_name, get_all_nn_module_tests, nn_functional_tests, get_nn_functional_compiled_fn_and_inputs
-from torch.testing._internal.common_utils import run_tests, suppress_warnings
+from torch.testing._internal.common_utils import run_tests, suppress_warnings, IS_FBCODE
 
 
 def num_ifs_loops(graph):
@@ -66,6 +67,7 @@ class TestComplexity(JitTestCase):
             print(line)
 
     @suppress_warnings
+    @unittest.skipIf(IS_FBCODE, "Causes a RecursionError in fbcode")
     def test_nn_module_tests(self):
         with enable_profiling_mode():
             stats = [("Name", "Ifs/Loops", "non-tensor ops")]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56677 Disable TestComplexity.test_nn_module_test in fbcode**

This has been failing with `RecursionError: maximum recursion depth
exceeded while calling a Python object` in fbcode for a while now.  Obviously
this isn't a fix, but the test works in OSS, so...

Differential Revision: [D27934963](https://our.internmc.facebook.com/intern/diff/D27934963/)