### PR TITLE
moved lowerings out of the TensorExprKernel and into independent functions

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -225,7 +225,6 @@ bool matmulIsSupported(const torch::jit::Node* node) {
   return true;
 }
 
-
 } // namespace tensorexpr
 } // namespace jit
 } // namespace torch
@@ -328,7 +327,6 @@ ExprHandle tensorexpr::tensorOrConstant(
   return constant(v);
 }
 
-
 ArgValue TensorExprKernel::toArg(const torch::jit::Value* v) const {
   auto ti = bufs_.find(v);
   if (ti != bufs_.end()) {
@@ -372,8 +370,7 @@ ExprHandle TensorExprKernel::tensorOrConstant(
 ExprHandle tensorexpr::broadcast(
     BufHandle b,
     const std::vector<ExprHandle>& axes) {
-  return b.load(
-      computeIndicesToBroadcast(axes, b.dims()));
+  return b.load(computeIndicesToBroadcast(axes, b.dims()));
 }
 
 std::vector<ExprHandle> TensorExprKernel::sizesFromVaryingShape(
@@ -990,8 +987,6 @@ Tensor* tensorexpr::computeFourOperand(
         return demoteOutput(compute, outputTensorType);
       });
 }
-
-
 
 // Convert boolean to integer, if needed.
 ExprHandle boolToInteger(const ExprHandle& x) {
@@ -2430,7 +2425,6 @@ Tensor* tensorexpr::computeCatWoConditionals(
     const std::vector<ArgValue>& input_list,
     const ArgValue& arg_dim,
     const std::vector<ExprHandle>& output_shape) {
-
   auto inputs = processCatList(input_list);
   ScalarType high_type = inputs.first;
   std::vector<BufHandle> non_empty_inputs = inputs.second;

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -124,9 +124,7 @@ ExprHandle demoteOutput(
     const ExprHandle& e,
     const c10::optional<ScalarType> type);
 
-ExprHandle broadcast(
-    BufHandle b,
-    const std::vector<ExprHandle>& axes);
+ExprHandle broadcast(BufHandle b, const std::vector<ExprHandle>& axes);
 
 ExprHandle constant(const ArgValue& v);
 
@@ -203,9 +201,7 @@ class TORCH_API TensorExprKernel {
 
   std::vector<ExprHandle> valueShape(const torch::jit::Value* v);
 
-
   ArgValue toArg(const torch::jit::Value* v) const;
-
 
   ExprHandle tensorOrConstant(
       const torch::jit::Value* v,

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -536,29 +536,32 @@ void initTensorExprBindings(PyObject* module) {
       py::return_value_policy::reference);
 
   te.def(
-    "lower",
-    [](std::string op_str, py::list inputs, std::vector<ExprHandle> outputShape, Dtype outputType) {
-      auto op = c10::Symbol::fromQualString(op_str);
-      if (op == aten::cat) {
-        throw std::runtime_error("NYI");
-      }
-      std::vector<ArgValue> argInputs;
-      for (auto inp: inputs) {
-        if (py::isinstance<Placeholder>(inp)) {
-          argInputs.push_back(py::cast<Placeholder>(inp).handle());
-          std::cout<<"placeholder"<<std::endl;
-        } else if (py::isinstance<BufHandle>(inp)) {
-          std::cout<<"bufhandle"<<std::endl;
-        } else if (py::isinstance<VarHandle>(inp)) {
-          std::cout<<"varhandle"<<std::endl;
-        } else {
-          std::cout<<"dunno"<<std::endl;
+      "lower",
+      [](std::string op_str,
+         py::list inputs,
+         std::vector<ExprHandle> outputShape,
+         Dtype outputType) {
+        auto op = c10::Symbol::fromQualString(op_str);
+        if (op == aten::cat) {
+          throw std::runtime_error("NYI");
         }
-        // argInputs.push_back(inp.)
-      }
-      return computeOperandValue(op, argInputs, outputType.scalar_type(), outputShape);
-    }
-  );
+        std::vector<ArgValue> argInputs;
+        for (auto inp : inputs) {
+          if (py::isinstance<Placeholder>(inp)) {
+            argInputs.push_back(py::cast<Placeholder>(inp).handle());
+            std::cout << "placeholder" << std::endl;
+          } else if (py::isinstance<BufHandle>(inp)) {
+            std::cout << "bufhandle" << std::endl;
+          } else if (py::isinstance<VarHandle>(inp)) {
+            std::cout << "varhandle" << std::endl;
+          } else {
+            std::cout << "dunno" << std::endl;
+          }
+          // argInputs.push_back(inp.)
+        }
+        return computeOperandValue(
+            op, argInputs, outputType.scalar_type(), outputShape);
+      });
 
   using TSGraph = std::shared_ptr<Graph>;
   py::class_<TensorExprKernel>(te, "TensorExprKernel")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56680 moved lowerings out of the TensorExprKernel and into independent functions**
* #56679 moved lowerings out of the TensorExprKernel and into independent functions
* #56456 Added matmul/unified dtypes
* #55372 [NNC] Move computeNOperand operations over

