### PR TITLE
[c10d] Add requires_gloo decorator to test_logging_init

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -168,6 +168,7 @@ def simple_multi_input_reduce_tests(rank, world_size):
 
 
 class RendezvousEnvTest(TestCase):
+    @requires_gloo()
     @retry_on_connect_failures
     def test_logging_init(self):
         os.environ["WORLD_SIZE"] = "1"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56682 [c10d] Add requires_gloo decorator to test_logging_init**

The process group is created on a gloo backend.

Context: https://github.com/pytorch/pytorch/pull/56598#discussion_r618206941

Differential Revision: [D27936805](https://our.internmc.facebook.com/intern/diff/D27936805/)