### PR TITLE
Add torch.linalg.svdvals

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2690,6 +2690,36 @@ std::tuple<Tensor&, Tensor&, Tensor&> linalg_svd_out(const Tensor& self, bool fu
   return std::tuple<Tensor&, Tensor&, Tensor&>(U, S, VT);
 }
 
+Tensor linalg_svdvals(const Tensor& input) {
+  TORCH_CHECK(
+      input.dim() >= 2,
+      "torch.linalg.svdvals: input should have at least 2 dimensions, but has ",
+      input.dim(),
+      " dimensions instead");
+  Tensor singular_values;
+  std::tie(std::ignore, singular_values, std::ignore) =
+      at::_svd_helper(input, /*full_matrices=*/false, /*compute_uv=*/false);
+  return singular_values;
+}
+
+Tensor& linalg_svdvals_out(const Tensor& input, Tensor& result) {
+  checkSameDevice("torch.linalg.svdvals", result, input);
+
+  // singular values are always real-valued
+  ScalarType real_dtype = toValueType(input.scalar_type());
+  checkLinalgCompatibleDtype(
+      "torch.linalg.svdvals", result.scalar_type(), real_dtype);
+
+  Tensor singular_values_tmp;
+  std::tie(std::ignore, singular_values_tmp, std::ignore) =
+      at::_svd_helper(input, /*full_matrices=*/false, /*compute_uv=*/false);
+
+  at::native::resize_output(result, singular_values_tmp.sizes());
+  result.copy_(singular_values_tmp);
+
+  return result;
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ lstsq ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #ifdef USE_LAPACK

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8792,6 +8792,14 @@
   python_module: linalg
   variants: function
 
+- func: linalg_svdvals(Tensor input) -> Tensor
+  python_module: linalg
+  variants: function
+
+- func: linalg_svdvals.out(Tensor input, *, Tensor(a!) out) -> Tensor(a!)
+  python_module: linalg
+  variants: function
+
 - func: linalg_cond(Tensor self, Scalar? p=None) -> Tensor
   python_module: linalg
   variants: function

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -2813,6 +2813,25 @@ class TestLinalg(TestCase):
             assert USV.V is out[2]
             self.assertEqual(USV.S, np_s)
 
+    @skipCUDAIfNoMagmaAndNoCusolver
+    @skipCPUIfNoLapack
+    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+    def test_svdvals(self, device, dtype):
+
+        def run_test(shape):
+            # NumPy doesn't have separate svdvals function, it is included in
+            # svd with compute_uv=False
+            # so we test our implementation against numpy.linalg.svd(*, compute_uv=False)
+            A = make_tensor(shape, dtype=dtype, device=device)
+            expected = np.linalg.svd(A.cpu(), compute_uv=False)
+            actual = torch.linalg.svdvals(A)
+            self.assertEqual(actual, expected)
+
+        batches = [(), (0, ), (2, ), (2, 1)]
+        ns = [5, 2, 0]
+        for batch, (m, n) in itertools.product(batches, product(ns, ns)):
+            run_test((*batch, m, n))
+
     def cholesky_solve_test_helper(self, A_dims, b_dims, upper, device, dtype):
         from torch.testing._internal.common_utils import random_hermitian_pd_matrix
 

--- a/torch/csrc/api/include/torch/linalg.h
+++ b/torch/csrc/api/include/torch/linalg.h
@@ -136,6 +136,22 @@ inline Tensor& solve_out(Tensor& result, const Tensor& input, const Tensor& othe
   return torch::linalg_solve_out(result, input, other);
 }
 
+inline std::tuple<Tensor, Tensor, Tensor> svd(const Tensor& input, bool full_matrices, bool compute_uv) {
+  return torch::linalg_svd(input, full_matrices, compute_uv);
+}
+
+inline std::tuple<Tensor&, Tensor&, Tensor&> svd_out(Tensor& U, Tensor& S, Tensor& Vh, const Tensor& input, bool full_matrices, bool compute_uv) {
+  return torch::linalg_svd_out(U, S, Vh, input, full_matrices, compute_uv);
+}
+
+inline Tensor svdvals(const Tensor& input) {
+  return torch::linalg_svdvals(input);
+}
+
+inline Tensor& svdvals_out(Tensor& result, const Tensor& input) {
+  return torch::linalg_svdvals_out(result, input);
+}
+
 inline Tensor tensorinv(const Tensor& self, int64_t ind) {
   return torch::linalg_tensorinv(self, ind);
 }
@@ -320,6 +336,28 @@ inline Tensor solve(const Tensor& input, const Tensor& other) {
 
 inline Tensor& solve_out(Tensor& result, const Tensor& input, const Tensor& other) {
   return detail::solve_out(result, input, other);
+}
+
+/// Computes the singular values and singular vectors
+///
+/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.svd
+inline std::tuple<Tensor, Tensor, Tensor> svd(const Tensor& input, bool full_matrices, bool compute_uv) {
+  return detail::svd(input, full_matrices, compute_uv);
+}
+
+inline std::tuple<Tensor&, Tensor&, Tensor&> svd_out(Tensor& U, Tensor& S, Tensor& Vh, const Tensor& input, bool full_matrices, bool compute_uv) {
+  return detail::svd_out(U, S, Vh, input, full_matrices, compute_uv);
+}
+
+/// Computes the singular values
+///
+/// See https://pytorch.org/docs/master/linalg.html#torch.linalg.svdvals
+inline Tensor svdvals(const Tensor& input) {
+  return detail::svdvals(input);
+}
+
+inline Tensor& svdvals_out(Tensor& result, const Tensor& input) {
+  return detail::svdvals_out(result, input);
 }
 
 /// Computes the inverse of a tensor

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -1021,6 +1021,8 @@ always be real-valued, even if :attr:`input` is complex.
 .. note:: Unlike NumPy's `linalg.svd`, :func:`torch.linalg.svd` always returns a namedtuple
           of three tensors, even when :attr:`compute_uv` is `False`. This behavior may
           change in a future PyTorch release.
+          Please use :func:`torch.linalg.svdvals`, which computes only the singular values,
+          instead of ``compute_uv=False``.
 
 .. note:: The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
           then the singular values of each matrix in the batch are returned in descending order.
@@ -1101,6 +1103,46 @@ Example::
 
 .. _the resulting vectors will span the same subspace:
        (https://en.wikipedia.org/wiki/Singular_value_decomposition#Singular_values,_singular_vectors,_and_their_relation_to_the_SVD)
+""")
+
+svdvals = _add_docstr(_linalg.linalg_svdvals, r"""
+linalg.svdvals(input, *, out=None) -> Tensor
+
+Computes the singular values of a matrix.
+
+The singular values are returned in descending order. If :attr:`input` is a batch of matrices,
+then the singular values of each matrix in the batch are returned in descending order.
+
+Supports inputs of float, double, cfloat and cdouble dtypes.
+Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+
+.. note:: This function is not differentiable. Please use :func:`torch.linalg.svd`
+          instead, which also computes the singular vectors.
+
+.. note:: This function is equivalent to NumPy's ``linalg.svd`` with ``compute_uv=False``.
+
+.. note:: When given inputs on a CUDA device, this function synchronizes that device with the CPU.
+
+Args:
+    input (Tensor): the `m \times n` matrix or the batch of such matrices of size
+                    `(*, m, n)` where `*` is one or more batch dimensions.
+
+Keyword args:
+    out (Tensor, optional): output tensor. Ignored if `None`. Default: `None`.
+
+Example::
+
+    >>> import torch
+    >>> a = torch.randn(5, 3)
+    >>> a
+    tensor([[-1.3490, -0.1723,  0.7730],
+            [-1.6118, -0.3385, -0.6490],
+            [ 0.0908,  2.0704,  0.5647],
+            [-0.6451,  0.1911,  0.7353],
+            [ 0.5247,  0.5160,  0.5110]])
+    >>> s = torch.linalg.svdvals(a)
+    >>> s
+    tensor([2.5139, 2.1087, 1.1066])
 """)
 
 cond = _add_docstr(_linalg.linalg_cond, r"""

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -839,6 +839,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.svd: lambda input, some=True, compute_uv=True, out=None: -1,
         torch.svd_lowrank: lambda input, q=6, niter=2, M=None: -1,
         torch.linalg.svd: lambda input, full_matrices=True, compute_uv=True, out=None: -1,
+        torch.linalg.svdvals: lambda input, out=None: -1,
         torch.symeig: lambda input, eigenvectors=False, upper=True, out=None: -1,
         torch.swapaxes: lambda input, dim0, dim1: -1,
         torch.swapdims: lambda input, axis0, axis1: -1,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2157,6 +2157,15 @@ def sample_inputs_svd(op_info, device, dtype, requires_grad=False, **kwargs):
 def sample_inputs_linalg_svd(op_info, device, dtype, requires_grad=False, **kwargs):
     return _sample_inputs_svd(op_info, device, dtype, requires_grad, is_linalg_svd=True)
 
+def sample_inputs_linalg_svdvals(op_info, device, dtype, requires_grad=False, **kwargs):
+    batches = [(), (0, ), (2, ), (1, 1)]
+    ns = [5, 2, 0]
+    samples = []
+    for batch, (m, n) in product(batches, product(ns, ns)):
+        a = make_tensor((*batch, m, n), device, dtype, low=None, high=None, requires_grad=requires_grad)
+        samples.append(SampleInput(a))
+    return samples
+
 def sample_inputs_eig(op_info, device, dtype, requires_grad=False, **kwargs):
     eigvecs = make_tensor((S, S), device=device, dtype=dtype,
                           low=None, high=None)
@@ -4574,6 +4583,15 @@ op_db: List[OpInfo] = [
                # cuda gradchecks are very slow
                # see discussion https://github.com/pytorch/pytorch/pull/47761#issuecomment-747316775
                SkipInfo('TestGradients', 'test_fn_gradgrad', device_type='cuda'),)),
+    OpInfo('linalg.svdvals',
+           op=torch.linalg.svdvals,
+           aten_name='linalg_svdvals',
+           dtypes=floating_and_complex_types(),
+           sample_inputs_func=sample_inputs_linalg_svdvals,
+           supports_autograd=False,
+           decorators=[
+               skipCUDAIfNoMagmaAndNoCusolver,
+               skipCPUIfNoLapack]),
     OpInfo('polar',
            dtypes=floating_types(),
            sample_inputs_func=sample_inputs_polar),


### PR DESCRIPTION
This PR adds `torch.linalg.svdvals(input, out=None)` that computes only the singular values of `input`.

Resolves https://github.com/pytorch/pytorch/issues/54155.
