### PR TITLE
Make sure full backward hook fire when no input requires grad

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -580,6 +580,46 @@ class TestNN(NNTestCase):
         mod.register_full_backward_hook(lambda mod, gI, gO: None)
         mod(inp, inp.detach(), inp)
 
+    def test_hook_no_requires_grad(self):
+        mod = nn.Linear(2, 3)
+
+        inp = torch.rand(1, 2)
+
+        return_val = "None"
+        hook_called = [0]
+        def hook(mod, grad_input, grad_output):
+            hook_called[0] += 1
+            for gI in grad_input:
+                self.assertIsNone(gI)
+            for gO in grad_output:
+                self.assertEqual(gO.size(), (1, 3))
+
+            if return_val == "grad_input":
+                return grad_input
+            elif return_val == "invalid":
+                # If the inputs were requiring gradients, this would be
+                # a valid return
+                return inp
+            elif return_val == "None":
+                return None
+            else:
+                raise RuntimeError("Invalid return_val string")
+
+        mod.register_full_backward_hook(hook)
+
+        # This should run and trigger the hook properly
+        mod(inp).sum().backward()
+        self.assertEqual(hook_called[0], 1)
+
+        return_val = "grad_input"
+
+        mod(inp).sum().backward()
+        self.assertEqual(hook_called[0], 2)
+
+        return_val = "invalid"
+        with self.assertRaisesRegex(RuntimeError, "where no input requires gradient"):
+            mod(inp).sum().backward()
+
     def test_hook_extra_input(self):
         class MyModule(nn.Module):
             def forward(self, non_tensor, tensor):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -587,6 +587,7 @@ class TestNN(NNTestCase):
 
         return_val = "None"
         hook_called = [0]
+
         def hook(mod, grad_input, grad_output):
             hook_called[0] += 1
             for gI in grad_input:


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/56380


BC-breaking note:
This changes the behavior of full backward hooks as they will now fire properly even if no input to the Module require gradients.