### PR TITLE
Add inplace hardswish xnnpack op (#55801)

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -157,6 +157,12 @@ Tensor& hardswish_out(const Tensor& self, Tensor& result) {
 }
 
 Tensor& hardswish_(Tensor& self) {
+  #if defined(C10_MOBILE) && defined(USE_XNNPACK)
+  if (xnnpack::use_hardswish(self)) {
+    xnnpack::hardswish_(self);
+    return self;
+  }
+  #endif
   auto iter = TensorIterator::unary_op(self, self);
   hardswish_stub(iter.device_type(), iter);
   return self;

--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -6,6 +6,9 @@
 #include <ATen/NativeFunctions.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/Parallel.h>
+#if defined(C10_MOBILE) && defined(USE_XNNPACK)
+#include <ATen/native/xnnpack/Engine.h>
+#endif
 #include <ATen/core/DistributionsHelper.h>
 
 #include <c10/util/irange.h>
@@ -136,6 +139,11 @@ Tensor elu_backward(
 }
 
 Tensor hardswish(const Tensor& self) {
+  #if defined(C10_MOBILE) && defined(USE_XNNPACK)
+  if (xnnpack::use_hardswish(self)) {
+    return xnnpack::hardswish(self);
+  }
+  #endif
   Tensor result;
   auto iter = TensorIterator::unary_op(result, self);
   hardswish_stub(iter.device_type(), iter);

--- a/aten/src/ATen/native/xnnpack/Activation.cpp
+++ b/aten/src/ATen/native/xnnpack/Activation.cpp
@@ -18,27 +18,17 @@ bool use_hardswish(
            true;
 }
 
-Tensor hardswish(const Tensor& input) {
+Tensor& hardswish_impl(Tensor& input, Tensor& output) {
   using namespace internal;
 
-  const Tensor padded_input =
-      mobile::allocate_padded_contiguous_if_needed(
-          input, input.suggest_memory_format());
-
-  Tensor output = mobile::empty_with_tail_padding(
-      padded_input.sizes(),
-      padded_input.options().dtype(),
-      input.suggest_memory_format(),
-      padded_input.names());
-
   xnn_operator_t hardswish_op{};
-  const auto channels = Layout::ActivationND::channel(padded_input.sizes());
+  const auto channels = Layout::ActivationND::channel(input.sizes());
   const xnn_status create_status = xnn_create_hardswish_nc_f32(
-      channels, // channels
-      channels, // input stride
-      channels, // output stride
-      0, // flags
-      &hardswish_op);
+    channels, // channels
+    channels, // input stride
+    channels, // output stride
+    0, // flags
+    &hardswish_op);
 
   TORCH_CHECK(
     xnn_status_success == create_status,
@@ -48,8 +38,8 @@ Tensor hardswish(const Tensor& input) {
 
   const xnn_status setup_status = xnn_setup_hardswish_nc_f32(
     hardswish_op,
-    Layout::ActivationND::batch(padded_input.sizes()),  // Batch
-    padded_input.data_ptr<float>(),
+    Layout::ActivationND::batch(input.sizes()),  // Batch
+    input.data_ptr<float>(),
     output.data_ptr<float>(),
     caffe2::pthreadpool_());  // threadpool
 
@@ -65,7 +55,28 @@ Tensor hardswish(const Tensor& input) {
     xnn_status_success == run_status,
     "xnn_run_operator failed!");
 
+  return output;
+}
+
+Tensor hardswish(const Tensor& input) {
+  Tensor padded_input = mobile::allocate_padded_contiguous_if_needed(
+    input, input.suggest_memory_format());
+
+  Tensor output = mobile::empty_with_tail_padding(
+    padded_input.sizes(),
+    padded_input.options().dtype(),
+    input.suggest_memory_format(),
+    padded_input.names());
+
+  hardswish_impl(padded_input, output);
   return output.contiguous(input.suggest_memory_format());
+}
+
+Tensor& hardswish_(Tensor& input) {
+  using namespace internal;
+
+  hardswish_impl(input, input);
+  return input;
 }
 
 }

--- a/aten/src/ATen/native/xnnpack/Activation.cpp
+++ b/aten/src/ATen/native/xnnpack/Activation.cpp
@@ -1,0 +1,75 @@
+#ifdef USE_XNNPACK
+
+#include <ATen/native/xnnpack/Common.h>
+#include <ATen/native/utils/Factory.h>
+
+namespace at {
+namespace native {
+namespace xnnpack {
+
+
+bool use_hardswish(
+  const Tensor& input) {
+  return xnnpack::internal::available() &&
+          (1 <= input.ndimension()) &&
+          (input.device().is_cpu()) &&
+          (kFloat == input.scalar_type()) &&
+          !input.requires_grad() &&
+           true;
+}
+
+Tensor hardswish(const Tensor& input) {
+  using namespace internal;
+
+  const Tensor padded_input =
+      mobile::allocate_padded_contiguous_if_needed(
+          input, input.suggest_memory_format());
+
+  Tensor output = mobile::empty_with_tail_padding(
+      padded_input.sizes(),
+      padded_input.options().dtype(),
+      input.suggest_memory_format(),
+      padded_input.names());
+
+  xnn_operator_t hardswish_op{};
+  const auto channels = Layout::ActivationND::channel(padded_input.sizes());
+  const xnn_status create_status = xnn_create_hardswish_nc_f32(
+      channels, // channels
+      channels, // input stride
+      channels, // output stride
+      0, // flags
+      &hardswish_op);
+
+  TORCH_CHECK(
+    xnn_status_success == create_status,
+    "xnn_create_hardswish_nc_f32 failed!");
+
+  Operator hardswish_scoped_op(hardswish_op);
+
+  const xnn_status setup_status = xnn_setup_hardswish_nc_f32(
+    hardswish_op,
+    Layout::ActivationND::batch(padded_input.sizes()),  // Batch
+    padded_input.data_ptr<float>(),
+    output.data_ptr<float>(),
+    caffe2::pthreadpool_());  // threadpool
+
+  TORCH_CHECK(
+    xnn_status_success == setup_status,
+    "xnn_setup_hardswish_nc_f32 failed!");
+
+  const xnn_status run_status = xnn_run_operator(
+    hardswish_op,
+    caffe2::pthreadpool_());  // threadpool
+
+  TORCH_INTERNAL_ASSERT(
+    xnn_status_success == run_status,
+    "xnn_run_operator failed!");
+
+  return output.contiguous(input.suggest_memory_format());
+}
+
+}
+}
+}
+
+#endif /* USE_XNNPACK */

--- a/aten/src/ATen/native/xnnpack/Engine.h
+++ b/aten/src/ATen/native/xnnpack/Engine.h
@@ -79,6 +79,12 @@ Tensor channel_shuffle(
     const Tensor& input,
     const int64_t groups);
 
+//
+// Activations
+//
+bool use_hardswish(const Tensor& input);
+Tensor hardswish(const Tensor& input);
+
 } // namespace xnnpack
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/xnnpack/Engine.h
+++ b/aten/src/ATen/native/xnnpack/Engine.h
@@ -84,6 +84,7 @@ Tensor channel_shuffle(
 //
 bool use_hardswish(const Tensor& input);
 Tensor hardswish(const Tensor& input);
+Tensor& hardswish_(Tensor& input);
 
 } // namespace xnnpack
 } // namespace native

--- a/aten/src/ATen/test/xnnpack_test.cpp
+++ b/aten/src/ATen/test/xnnpack_test.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <torch/types.h>
+#include <torch/utils.h>
+
+#include <ATen/native/xnnpack/Engine.h>
+#include <ATen/native/xnnpack/Common.h>
+
+#if defined(C10_MOBILE) && defined(USE_XNNPACK)
+
+bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs) {
+  double maxValue = 0.0;
+  for (auto& tensor : inputs) {
+    maxValue = fmax(tensor.abs().max().item<float>(), maxValue);
+  }
+  return diff.abs().max().item<float>() < (0.01 + 2e-2 * maxValue);
+}
+bool almostEqual(const at::Tensor& a, const at::Tensor& b) {
+  return checkRtol(a - b, {a, b});
+}
+
+bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {
+  return (a - b).abs().max().item<float>() == 0.f;
+}
+
+void test_hardswish(const at::Tensor& input, const at::Tensor& expected) {
+  ASSERT_TRUE(at::native::xnnpack::use_hardswish(input));
+  auto result = at::native::xnnpack::hardswish(input);
+  auto check = almostEqual(expected, result);
+  ASSERT_TRUE(check);
+}
+
+
+// Since XNNPACK path is only taken #if defined(C10_MOBILE) && defined(USE_XNNPACK)
+// We can't compare regular CPU path with XNNPACK path in the same test binary
+// Instead we precompute regular results and compare with XNNPACK path here
+TEST(TestXNNPackOps, TestHardSwish) {
+  // input, expected_result pair
+  std::vector<std::pair<at::Tensor, at::Tensor>> input_result_pairs = {
+    {
+      torch::tensor({1, 2, 3, 4, 5}, {torch::kFloat32}),
+      torch::tensor({0.6667, 1.6667, 3.0000, 4.0000, 5.0000}, {torch::kFloat32})
+    },
+    {
+      torch::tensor({0.3330}, {torch::kFloat32}),
+      torch::tensor({0.1850}, {torch::kFloat32})
+    },
+    {
+      torch::tensor({
+        {0.4523, 0.8131, 0.9829},
+        {0.0782, 0.7395, 0.0787}
+      }),
+      torch::tensor({
+        {0.2602, 0.5167, 0.6525},
+        {0.0401, 0.4609, 0.0404}
+      })
+    },
+  };
+
+  for (const auto& input_result : input_result_pairs) {
+    test_hardswish(input_result.first, input_result.second);
+  }
+}
+
+#endif

--- a/aten/src/ATen/test/xnnpack_test.cpp
+++ b/aten/src/ATen/test/xnnpack_test.cpp
@@ -30,6 +30,13 @@ void test_hardswish(const at::Tensor& input, const at::Tensor& expected) {
   ASSERT_TRUE(check);
 }
 
+void test_hardswish_(at::Tensor input, const at::Tensor& expected) {
+  ASSERT_TRUE(at::native::xnnpack::use_hardswish(input));
+  at::native::xnnpack::hardswish_(input);
+  auto check = almostEqual(expected, input);
+  ASSERT_TRUE(check);
+}
+
 
 // Since XNNPACK path is only taken #if defined(C10_MOBILE) && defined(USE_XNNPACK)
 // We can't compare regular CPU path with XNNPACK path in the same test binary
@@ -59,6 +66,7 @@ TEST(TestXNNPackOps, TestHardSwish) {
 
   for (const auto& input_result : input_result_pairs) {
     test_hardswish(input_result.first, input_result.second);
+    test_hardswish_(input_result.first, input_result.second);
   }
 }
 

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -986,6 +986,7 @@ aten_native_source_non_codegen_list = [
     "aten/src/TH/THTensorMath.cpp",
     "aten/src/TH/THTensorMoreMath.cpp",
     "aten/src/ATen/native/utils/Factory.cpp",
+    "aten/src/ATen/native/xnnpack/Activation.cpp",
     "aten/src/ATen/native/xnnpack/ChannelShuffle.cpp",
     "aten/src/ATen/native/xnnpack/Convolution.cpp",
     "aten/src/ATen/native/xnnpack/Init.cpp",


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/55801

Refactor to add inplace version of xnnpack hardswish op

Test Plan: buck run //xplat/caffe2:pt_xnnpack_test_bin

Differential Revision: D27712305

