### PR TITLE
test inserted commit

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1333,6 +1333,7 @@ Tensor* tensorexpr::computeOperandValue(
                 tensorOrConstant(inputs[4], {c}), // var
                 constant(inputs[7]) // eps
             };
+
             if (hasWeight) {
               exprInputs.push_back(tensorOrConstant(inputs[1], {c}));
             }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56718 Added skeleton of python dispatch key
* **#56720 test inserted commit**
* #56679 moved lowerings out of the TensorExprKernel and into independent functions
* #56456 Added matmul/unified dtypes
* #55372 [NNC] Move computeNOperand operations over

