### PR TITLE
Print non-breaking space directly in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Ensure no non-breaking spaces
         if: always()
         run: |
-          (! git --no-pager grep -In $'\u00a0' -- . ':(exclude).github/workflows/lint.yml' || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
+          # NB: We use 'printf' below rather than '\u000a' since bash pre-4.2
+          # does not support the '\u000a' syntax (which is relevant for local linters)
+          (! git --no-pager grep -In "$(printf '\xC2\xA0')" -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
       - name: Ensure canonical include
         if: always()
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Ensure no non-breaking spaces
         if: always()
         run: |
-          (! git --no-pager grep -In $'\u00a0' -- . || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
+          (! git --no-pager grep -In $'\u00a0' -- . ':(exclude).github/workflows/lint.yml' || (echo "The above lines have non-breaking spaces (U+00A0); please convert them to spaces (U+0020)"; false))
       - name: Ensure canonical include
         if: always()
         run: |


### PR DESCRIPTION


After some fun investigating, @samestep found that `\u1234` to produce a unicode character is only supported in bash > 4.2, but MacOS ship with bash/sh 3.2, so it was searching for the literal string `u1234`. This fixes the issue by printing out the char directly via its UTF-8 bytes and `printf`.

Differential Revision: [D27952866](https://our.internmc.facebook.com/intern/diff/27952866/)