### PR TITLE
Torchelastic: make process failure init error non-fatal

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -7,7 +7,11 @@ import tempfile
 import unittest
 from unittest import mock
 
-from torch.distributed.elastic.multiprocessing.errors import ChildFailedError, ProcessFailure, record
+from torch.distributed.elastic.multiprocessing.errors import (
+    ChildFailedError,
+    ProcessFailure,
+    record,
+)
 from torch.distributed.elastic.multiprocessing.errors.error_handler import _write_error
 from torch.testing._internal.common_utils import TEST_WITH_TSAN
 
@@ -49,6 +53,15 @@ class ApiTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.test_dir)
+
+    def test_failure_incorrect_reply_file(self):
+        content = {"unknown_key": "unknown_value"}
+        with open(self.test_error_file, "w") as fp:
+            json.dump(content, fp)
+        with self.assertRaises(Exception):
+            ProcessFailure(
+                local_rank=0, pid=997, exitcode=1, error_file=self.test_error_file
+            )
 
     def failure_with_error_file(self, exception):
         _write_error(exception, self.test_error_file)

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
+
 import os
 import shutil
 import tempfile
@@ -22,9 +22,9 @@ from torch.distributed.elastic.agent.server.api import (
 from torch.distributed.elastic.metrics.api import prof
 from torch.distributed.elastic.multiprocessing import start_processes, PContext
 from torch.distributed.elastic.utils import macros
+from torch.distributed.elastic.utils.logging import get_logger
 
-
-log = logging.getLogger(__name__)
+log = get_logger()
 
 
 class LocalElasticAgent(SimpleElasticAgent):

--- a/torch/distributed/elastic/multiprocessing/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/__init__.py
@@ -76,6 +76,9 @@ from torch.distributed.elastic.multiprocessing.api import (  # noqa: F401
     _validate_full_rank,
     to_map,
 )
+from torch.distributed.elastic.utils.logging import get_logger
+
+log = get_logger()
 
 
 def start_processes(
@@ -233,6 +236,7 @@ def start_processes(
 
         error_file = os.path.join(clogdir, "error.json")
         error_files[local_rank] = error_file
+        log.info(f"Setting worker{local_rank} reply file to: {error_file}")
         envs[local_rank]["TORCHELASTIC_ERROR_FILE"] = error_file
 
     context: PContext

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -59,8 +59,12 @@ from functools import wraps
 from string import Template
 from typing import Callable, Dict, List, Optional, Tuple, TypeVar
 
+from torch.distributed.elastic.utils.logging import get_logger
+
 from .error_handler import ErrorHandler  # noqa: F401
 from .handlers import get_error_handler  # noqa: F401
+
+log = get_logger()
 
 
 JSON = Dict
@@ -99,18 +103,23 @@ class ProcessFailure:
     timestamp: int = field(init=False)
 
     def __post_init__(self):
+        self.error_file_data = _EMPTY_ERROR_DATA
         if os.path.isfile(self.error_file):
-            with open(self.error_file, "r") as fp:
-                self.error_file_data = json.load(fp)
-                self.message = self.error_file_data["message"]["message"]
-                self.timestamp = int(
-                    self.error_file_data["message"]["extraInfo"]["timestamp"]
-                )
+            try:
+                with open(self.error_file, "r") as fp:
+                    self.error_file_data = json.load(fp)
+                    log.info(
+                        f"User process failed with error data: {json.dumps(self.error_file_data, indent=2)}"
+                    )
+                    self.message = self.error_file_data["message"]["message"]
+                    self.timestamp = int(
+                        self.error_file_data["message"]["extraInfo"]["timestamp"]
+                    )
+            except Exception:
+                log.exception(f"Failed to parse reply file: {self.error_file}")
+                raise
         else:
-            self.error_file = _NOT_AVAILABLE
-            self.error_file_data = _EMPTY_ERROR_DATA
-            self.message = ""
-            self.timestamp = int(time.time())
+            self._set_no_reply_file()
 
         # make up an informative message if not already present
         if not self.message:
@@ -122,6 +131,12 @@ class ProcessFailure:
                 )
             else:
                 self.message = f"Process failed with exitcode {self.exitcode}"
+
+    def _set_no_reply_file(self):
+        self.error_file = _NOT_AVAILABLE
+        self.error_file_data = _EMPTY_ERROR_DATA
+        self.message = ""
+        self.timestamp = int(time.time())
 
     def signal_name(self) -> str:
         if self.exitcode < 0:
@@ -275,7 +290,9 @@ def _no_error_file_warning_msg(rank: int, failure: ProcessFailure) -> str:
     return "\n".join(["\n", boarder, header, boarder, *msg, boarder])
 
 
-def record(fn: Callable[..., T], error_handler: Optional[ErrorHandler] = None) -> Callable[..., T]:
+def record(
+    fn: Callable[..., T], error_handler: Optional[ErrorHandler] = None
+) -> Callable[..., T]:
     """
     Syntactic sugar to record errors/exceptions that happened in the decorated
     function using the provided ``error_handler``.

--- a/torch/distributed/elastic_launch.py
+++ b/torch/distributed/elastic_launch.py
@@ -533,6 +533,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
         start_method=args.start_method,
         redirects=Std.from_str(args.redirects),
         tee=Std.from_str(args.tee),
+        log_dir=args.log_dir,
     )
 
     with_python = not args.no_python


### PR DESCRIPTION
Summary:
The diff makes several tiny changes:
* Add logs for each worker error file destination
* Make sure log_dir is propagated from the launcher
* Make ProcessFailure initialization error non-fatal.

Test Plan: buck test mode/dev-nosan //caffe2/test/distributed/elastic/multiprocessing/errors:api_test

Differential Revision: D27952596

