### PR TITLE
torch: Add cpython as a dependency for torch_python_obj

### DIFF
--- a/torch/csrc/deploy/interpreter/CMakeLists.txt
+++ b/torch/csrc/deploy/interpreter/CMakeLists.txt
@@ -95,6 +95,7 @@ set_property(TARGET torch_deployinterpreter APPEND_STRING PROPERTY
 # need to ensure headers are present before any .cpp in interpreter are compiled,
 # but cpp themselves don't clearly depend on cpython so there is a race otherwise
 add_dependencies(torch_deployinterpreter cpython)
+add_dependencies(torch_python_obj cpython)
 target_compile_options(
     torch_deployinterpreter PRIVATE
     -fvisibility=hidden


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56498 DO NOT MERGE, testing Linux CUDA GHA workflows
* #56494 .github: Add initial Linux CI for CUDA
* **#56740 torch: Add cpython as a dependency for torch_python_obj**

Was running into a race condition where the torch_python_obj was
attempting to build before cpython was actually finished installing,
this should resolve that issue.

Only applicable on builds that use the `USE_DEPLOY=ON` option

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D27953782](https://our.internmc.facebook.com/intern/diff/D27953782)