### PR TITLE
ns for fx: additional fixes for user defined functions

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -254,6 +254,11 @@ def _wrapped_hardswish_fp16(x):
     x = x.to(torch.float16)
     return x
 
+@torch.fx.wrap
+def _wrapped_sigmoid(x):
+    return F.sigmoid(x)
+
+
 
 class TestFXGraphMatcher(QuantizationTestCase):
 
@@ -1394,11 +1399,13 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         class M1(nn.Module):
             def forward(self, x):
                 x = F.hardswish(x)
+                x = x.sigmoid()
                 return x
 
         class M2(nn.Module):
             def forward(self, x):
-                x = _wrapped_hardswish_fp16(x)
+                x = _wrapped_hardswish(x)
+                x = _wrapped_sigmoid(x)
                 return x
 
         qconfig_dict = {'': torch.quantization.default_qconfig}
@@ -1408,13 +1415,15 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
         base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
         base_name_to_sets_of_related_ops['torch.nn.functional.hardswish'].add(
-            _wrapped_hardswish_fp16)
+            _wrapped_hardswish)
+        base_name_to_sets_of_related_ops['torch.sigmoid'].add(
+            _wrapped_sigmoid)
 
         # test compare weights
         results = _extract_weights_impl(
             'a', m1, 'b', m2,
             base_name_to_sets_of_related_ops=base_name_to_sets_of_related_ops)
-        self.assertTrue(len(results) == 1)
+        self.assertTrue(len(results) == 2)
         # TODO(future PR): don't store empty dictionaries for nodes
         #   without weights.
 
@@ -1431,26 +1440,27 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
         # check activation result correctness
         act_compare_dict = extract_logger_info(m1_ns, m2_ns, OutputLogger)
-        self.assertTrue(len(act_compare_dict) == 1)
+        self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 
         # test shadowed activations
 
         node_type_to_io_type_map = get_node_type_to_io_type_map()
-        node_type_to_io_type_map['funs_io_type_fp16'].add(_wrapped_hardswish_fp16)
+        node_type_to_io_type_map['funs_io_type_fp32'].add(_wrapped_hardswish)
+        node_type_to_io_type_map['funs_io_type_fp32'].add(_wrapped_sigmoid)
 
-        m1_shadows_m2_ns = _add_shadow_loggers_impl(
-            'a', m1, 'b', m2, OutputLogger,
+        m2_shadows_m1_ns = _add_shadow_loggers_impl(
+            'a', m2, 'b', m1, OutputLogger,
             should_log_inputs=False,
             base_name_to_sets_of_related_ops=base_name_to_sets_of_related_ops,
             node_type_to_io_type_map=node_type_to_io_type_map)
 
         # calibrate
-        m1_shadows_m2_ns(data)
+        m2_shadows_m1_ns(data)
 
         # check activation result correctness
-        act_compare_dict = extract_shadow_logger_info(m1_shadows_m2_ns, OutputLogger)
-        self.assertTrue(len(act_compare_dict) == 1)
+        act_compare_dict = extract_shadow_logger_info(m2_shadows_m1_ns, OutputLogger)
+        self.assertTrue(len(act_compare_dict) == 2)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 
 

--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -189,11 +189,13 @@ def _get_subgraph_relationship_type(
 
     # TODO(next): make this code handle matching by what is before the base op
     if node_a.op != node_b.op:
-        # for now, comparing call_module to call_function is not supported
-        # this can be added later if needed
-        return SubgraphTypeRelationship.NOT_RELATED
+        if not (
+            node_a.op in ('call_function', 'call_method') and
+            node_b.op in ('call_function', 'call_method')
+        ):
+            return SubgraphTypeRelationship.NOT_RELATED
 
-    if node_a.op == 'call_function':
+    if node_a.op in ('call_function', 'call_method'):
         if node_a.target == node_b.target:
             node_a_has_prev = subgraph_a.base_op_node == subgraph_a.start_node
             node_b_has_prev = subgraph_b.base_op_node == subgraph_b.start_node
@@ -229,6 +231,7 @@ def _get_subgraph_relationship_type(
             return SubgraphTypeRelationship.RELATED_BUT_NOT_EQUAL
         else:
             return SubgraphTypeRelationship.NOT_RELATED
+    # TODO(before land): delete
     elif node_a.op == 'call_method':
         assert (subgraph_a.base_op_node == subgraph_a.start_node and
                 subgraph_b.base_op_node == subgraph_b.start_node), \

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -182,7 +182,12 @@ def _insert_dtype_cast_after_node(
         (node_input_type_a == NodeInputOrOutputType.FP32 and
          node_input_type_c == NodeInputOrOutputType.INT8) or
         (node_input_type_a == NodeInputOrOutputType.FP32 and
-         node_input_type_c == NodeInputOrOutputType.FP16)
+         node_input_type_c == NodeInputOrOutputType.FP16) or
+        # TODO(future PR): determine the actual dtype of node_c,
+        # the current code only works because dequantize works with
+        # multiple input dtypes.
+        (node_input_type_a == NodeInputOrOutputType.FP32 and
+         node_input_type_c == NodeInputOrOutputType.FP32_OR_INT8)
     ):
         dtype_cast_op = torch.dequantize
     elif (

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -169,7 +169,7 @@ def extract_weight_from_node(
                 'index_of_arg': 0,
             }
 
-    else:  # call_module
+    elif node.op == 'call_module':
         # for call_module, we need to look up the modules to do the type check
         assert isinstance(node.target, str)
         mod = getattr_from_fqn(gm, node.target)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Summary:

Adds a test case for wrapped sigmoid, and fixes the following issues
to make it pass in NS:
* allows comparing between `x.sigmoid()` and `torch.sigmoid(x)`, if they are related
* allows dtype cast from FP32_OR_INT8 to FP32, via dequantize (this will be improved later)

Test Plan:

```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Reviewers:

Subscribers:

Tasks:

Tags: