### PR TITLE
Local lint fixes - missing steps, pin to bash

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
+      - name: Extract scripts from GitHub Actions workflows
+        run: |
+          # For local lints, remove the .extracted_scripts folder if it was already there
+          rm -rf .extracted_scripts
+          tools/extract_scripts.py --out=.extracted_scripts
       - name: Install ShellCheck
         # https://github.com/koalaman/shellcheck/tree/v0.7.2#installing-a-pre-compiled-binary
         run: |
@@ -48,8 +53,6 @@ jobs:
           shellcheck --version
       - name: Run ShellCheck
         run: |
-          rm -rf .extracted_scripts
-          tools/extract_scripts.py --out=.extracted_scripts
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
         run: |
@@ -207,6 +210,8 @@ jobs:
       - name: Fail if there were any warnings
         run: |
           set -eux
+          # Re-output flake8 status so GitHub logs show it on the step that actually failed
+          cat "${GITHUB_WORKSPACE}"/flake8-output.txt
           [ ! -s "${GITHUB_WORKSPACE}"/flake8-output.txt ]
 
   clang-tidy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,9 +37,7 @@ jobs:
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
-      - name: Extract scripts from GitHub Actions workflows
-        run: tools/extract_scripts.py --out=.extracted_scripts
-      - name: ShellCheck
+      - name: Install ShellCheck
         # https://github.com/koalaman/shellcheck/tree/v0.7.2#installing-a-pre-compiled-binary
         run: |
           set -x
@@ -48,6 +46,10 @@ jobs:
           sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
           rm -r "shellcheck-${scversion}"
           shellcheck --version
+      - name: Run ShellCheck
+        run: |
+          rm -rf .extracted_scripts
+          tools/extract_scripts.py --out=.extracted_scripts
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
         run: |
@@ -204,8 +206,8 @@ jobs:
           path: flake8-output/
       - name: Fail if there were any warnings
         run: |
-          cat flake8-output.txt
-          [ ! -s flake8-output.txt ]
+          set -eux
+          [ ! -s "${GITHUB_WORKSPACE}"/flake8-output.txt ]
 
   clang-tidy:
     if: github.event_name == 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,20 @@ setup_lint:
 	 	--job 'cmakelint' --step 'Install dependencies' --no-quiet
 	python tools/actions_local_runner.py --file .github/workflows/lint.yml \
 	 	--job 'mypy' --step 'Install dependencies' --no-quiet
+
+# TODO: This is broken on MacOS (it downloads a Linux binary)
 	python tools/actions_local_runner.py --file .github/workflows/lint.yml \
 	 	--job 'quick-checks' --step 'Install ShellCheck' --no-quiet
 	pip install jinja2
 
 quick_checks:
-# TODO: This is broken when 'git config submodule.recurse' is 'true'
+	@python tools/actions_local_runner.py \
+		--file .github/workflows/lint.yml \
+		--job 'quick-checks' \
+		--step 'Extract scripts from GitHub Actions workflows'
+
+# TODO: This is broken when 'git config submodule.recurse' is 'true' since the
+# lints will descend into third_party submodules
 	@python tools/actions_local_runner.py \
 		--file .github/workflows/lint.yml \
 		--job 'quick-checks' \


### PR DESCRIPTION


Fixes #56738

* `setup_lint` now installs mypy / shellcheck
* the shell used to execute commands is pinned to `bash` (on Ubuntu the default is `dash`, which was causing the false positives in #56738)
* the emoji check marks don't always work, so use more basic ones instead
* adds `Run autogen` step for mypy (for the `lint` step only since it's pretty slow)

Differential Revision: [D27972006](https://our.internmc.facebook.com/intern/diff/27972006/)