### PR TITLE
[caffe2] fix -Wrange-loop-construct in onnx_exporter.cc

### DIFF
--- a/caffe2/onnx/onnx_exporter.cc
+++ b/caffe2/onnx/onnx_exporter.cc
@@ -412,7 +412,7 @@ std::unordered_map<std::string, std::string> SsaRewrite(
     // output. If so add a mapping from it's latest renamed version to its
     // original name.
     std::unordered_map<std::string, std::string> renamed_external_outputs;
-    for (const auto it : blob_versions) {
+    for (const auto& it : blob_versions) {
       if (external_outputs.count(it.first)) {
         renamed_external_outputs.emplace(
             SsaName(it.first, it.second), it.first);


### PR DESCRIPTION
Summary:
```
 caffe2/caffe2/onnx/onnx_exporter.cc:415:21: error: loop variable 'it' creates a copy from type 'const std::pair<const std::basic_string<char>, int>' [-Werror,-Wrange-loop-construct]
    for (const auto it : blob_versions) {
                    ^
caffe2/caffe2/onnx/onnx_exporter.cc:415:10: note: use reference type 'const std::pair<const std::basic_string<char>, int> &' to prevent copying
    for (const auto it : blob_versions) {
         ^~~~~~~~~~~~~~~
                    &
```

Test Plan:
```lang=bash
buck build mode/dev-nosan admarket/adfinder:adfinder admarket/adindexer:adindexer -c cxx.compiler_variant=clang-12 -c cxx.modules=false -c cxx.extra_cxxflags='-Wno-implicit-const-int-float-conversion -Wno-sign-compare -Wno-deprecated-copy -Wno-deprecated-declarations'
```

Differential Revision: D27960126

