### PR TITLE
Remove C++17 only optional include

### DIFF
--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -15,7 +15,6 @@
 #include <torch/csrc/autograd/variable.h>
 
 #include <cstddef>
-#include <optional>
 #include <vector>
 
 namespace torch {
@@ -38,7 +37,7 @@ struct unique_type_checker {
     unique = type_id_.value() == type_id;
   }
 
-  optional<size_t> type_id_;
+  c10::optional<size_t> type_id_;
   bool unique = true;
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56782 Remove C++17 only optional include**

Fixes #56749

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28000019](https://our.internmc.facebook.com/intern/diff/D28000019)