### PR TITLE
Immediately mark DLPack capsule as used after stealing the ownership

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -394,6 +394,9 @@ PyObject *THPModule_fromDLPack(PyObject *_unused, PyObject *data)
   // out of scope. When the destructor is called, the dlMTensor is destructed too.
   auto atensor = at::fromDLPack(dlMTensor);
 
+  // Make sure this capsule will never be used again.
+  PyCapsule_SetName(data, "used_dltensor");
+
   // It is possible that the call to at::fromDLPack is the very first
   // call to create a Tensor in PyTorch. If so, then _lazy_init has
   // not been called, and the attempt to call createPyObject will fail
@@ -403,8 +406,6 @@ PyObject *THPModule_fromDLPack(PyObject *_unused, PyObject *data)
   if(atensor.is_cuda()) {
     py::module::import("torch.cuda").attr("init")();
   }
-  // Make sure this capsule will never be used again.
-  PyCapsule_SetName(data, "used_dltensor");
   return THPVariable_Wrap(std::move(atensor));
   END_HANDLE_TH_ERRORS
 }


### PR DESCRIPTION
After stealing the ownership of the tensor passed via DLPack capsule, PyTorch should immediately mark it as used (by changing its name to `used_dltensor`). This fix is needed because the following line may raise an exception:

```cpp
py::module::import("torch.cuda").attr("init")();
```

When an exception is raised, Tensor created by `at::fromDLPack` calls the `deleter`. However as the causple is not consumed, the producer (a library that created the capsule) also calls the `deleter`, causing a double free.

Reprodcuer (I'm running this code on A100 GPU + PyTorch wheel which does not include `sm_80` support; in this configuration `torch.cuda.init` will raise a warning):
```py
$ python -Werror
>>> import torch.utils.dlpack
>>> import cupy
>>> tensor = torch.utils.dlpack.from_dlpack(cupy.arange(10).toDlpack())
free(): double free detected in tcache 2
zsh: abort (core dumped)  python -Werror
```

Once this fix is merged users can now see the exception correctly:

```
A100-PCIE-40GB with CUDA capability sm_80 is not compatible with the current PyTorch installation.
The current PyTorch install supports CUDA capabilities sm_37 sm_50 sm_60 sm_70.
If you want to use the A100-PCIE-40GB GPU with PyTorch, please check the instructions at https://pytorch.org/get-started/locally/
```