### PR TITLE
Use --rcfile instead of COVERAGE_RCFILE

### DIFF
--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -102,7 +102,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # TODO: Why is scipy pinned
   # Pin MyPy version because new errors are likely to appear with each release
   # Pin hypothesis to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
-  # Pin coverage so we can use COVERAGE_RCFILE
+  # Pin coverage to avoid new errors with plug-ins
   as_jenkins pip install --progress-bar off pytest \
     scipy==1.1.0 \
     scikit-image \

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
+# NOTE!!!!! This file is currently referenced in the codebase in .jenkins/pytorch/test.sh, .jenkins/pytorch/win-test.sh,
+# and twice in test/run_test.py. If you move this file, please remember to update those references!
 [run]
 plugins =
     coverage_plugins.jit_plugin

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -25,7 +25,6 @@ fi
 
 if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   export PYTORCH_COLLECT_COVERAGE=1
-  export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
   pip install -e tools/coverage_plugins_package # allows coverage to run with JitPlugin for JIT coverage
 fi
 
@@ -472,7 +471,7 @@ fi
 if [[ "$BUILD_ENVIRONMENT" == *coverage* ]]; then
   pushd test
   echo "Generating XML coverage report"
-  time python -mcoverage xml
+  time python -mcoverage xml --rcfile=../.coveragerc
   popd
   pushd build
   echo "Generating lcov coverage report for C++ sources"

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -71,7 +71,6 @@ run_tests() {
         "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
     else
         export PYTORCH_COLLECT_COVERAGE=1
-        export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
         if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
             "$SCRIPT_HELPERS_DIR"/test_python_first_shard.bat "$DETERMINE_FROM"
             "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
@@ -95,7 +94,7 @@ if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
   python -mpip install coverage==5.5
   python -mpip install -e "$PROJECT_DIR/tools/coverage_plugins_package"
   echo "Generating XML coverage report"
-  time python -mcoverage xml
+  time python -mcoverage xml --rcfile="$PROJECT_DIR/.coveragerc"
   popd
 
   pushd "$PROJECT_DIR"

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -501,7 +501,11 @@ def get_slow_tests_based_on_S3() -> List[str]:
 
 def get_executable_command(options, allow_pytest, disable_coverage=False):
     if options.coverage and not disable_coverage:
-        executable = ['coverage', 'run', '--parallel-mode', '--source=torch']
+        # We specify rcfile because COVERAGE_RCFILE does not seem to be applied for every call to coverage.
+        # That means that we do not actually use the plugin for any coverage call after the first. Currently,
+        # the .coveragerc config file is in the root directory, so if we move or rename it, we must change it
+        # all throughout the codebase, including here.
+        executable = ['coverage', 'run', '--parallel-mode', '--source=torch', '--rcfile=../.coveragerc']
     else:
         executable = [sys.executable]
     if options.pytest:
@@ -1139,7 +1143,7 @@ def main():
             from coverage import Coverage
             test_dir = os.path.dirname(os.path.abspath(__file__))
             with set_cwd(test_dir):
-                cov = Coverage()
+                cov = Coverage(config_file='../.coveragerc')
                 if PYTORCH_COLLECT_COVERAGE:
                     cov.load()
                 cov.combine(strict=False)


### PR DESCRIPTION
Upon noticing we aren't scoring as many wins as I'd expected for JIT coverage, I am back again tryna figure out what that is the case. My suspicion is that COVERAGE_RCFILE is not really getting preserved across the entire run (unsure why), so instead, we will just reference it every single `coverage` call. 