### PR TITLE
[torch] Add backward support for segment reduce (CPU only)

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -9,6 +9,7 @@ namespace native {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(_segment_reduce_stub);
+DEFINE_DISPATCH(_segment_reduce_backward_stub);
 
 namespace {
 
@@ -61,6 +62,54 @@ Tensor _segment_reduce_cpu_kernel(
   return output;
 }
 
+Tensor _segment_reduce_cpu_backward_kernel(
+    const Tensor& grad_contig,
+    const Tensor& output_contig,
+    const Tensor& data_contig,
+    const Tensor& lengths_contig) {
+  auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
+
+  int64_t batch_size = lengths_contig.numel();
+  const auto* lengths_data = lengths_contig.data_ptr<int64_t>();
+
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      data_contig.scalar_type(),
+      "_segment_reduce_cpu",
+      ([&]() {
+        auto* output_data = output_contig.data_ptr<scalar_t>();
+        auto* grad_data = grad_contig.data_ptr<scalar_t>();
+        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+        const auto* values_data = data_contig.data_ptr<scalar_t>();
+        int64_t k = 0;
+        for (int64_t i = 0; i < batch_size; ++i) {
+          int64_t counter = 0;
+          for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            if (at::_isnan(values_data[k]) ||
+                values_data[k] == output_data[i]) {
+              grad_input_data[k] = grad_data[i];
+              counter++;
+            }
+            k++;
+          }
+          // Average gradient output based on number of maximum in the segment
+          TORCH_INTERNAL_ASSERT(counter > 0);
+          if (counter < 2) {
+            continue;
+          }
+          for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            int64_t index = k - j - 1;
+            if (grad_input_data[index] > 0) {
+              grad_input_data[index] = grad_input_data[index] / counter;
+            }
+          }
+        }
+      }));
+
+  return grad_input;
+}
+
 } // namespace
 
 enum SegmentReductionType { MAX };
@@ -107,6 +156,45 @@ REGISTER_AVX_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_AVX2_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
 REGISTER_VSX_DISPATCH(_segment_reduce_stub, &_segment_reduce_cpu_kernel);
+
+// Currently some computation is beind duplicated across forward and backward.
+// TODO: Cache indices in forward pass to re-use in backward
+Tensor segment_reduce_backward_kernel(
+    const Tensor& grad,
+    const Tensor& output,
+    const Tensor& data,
+    const c10::optional<Tensor>& lengths) {
+  TORCH_CHECK(
+      lengths.has_value(),
+      "Currently only lengths based reduction is supported!")
+  const auto& lengths_value = lengths.value();
+
+  const auto grad_contig = grad.contiguous();
+  const auto output_contig = output.contiguous();
+  const auto data_contig = data.contiguous();
+  const auto lengths_contig = lengths_value.contiguous();
+
+  return _segment_reduce_backward_stub(
+      grad_contig.device().type(),
+      grad_contig,
+      output_contig,
+      data_contig,
+      lengths_contig);
+}
+
+REGISTER_ARCH_DISPATCH(
+    _segment_reduce_backward_stub,
+    DEFAULT,
+    &_segment_reduce_cpu_backward_kernel);
+REGISTER_AVX_DISPATCH(
+    _segment_reduce_backward_stub,
+    &_segment_reduce_cpu_backward_kernel);
+REGISTER_AVX2_DISPATCH(
+    _segment_reduce_backward_stub,
+    &_segment_reduce_cpu_backward_kernel);
+REGISTER_VSX_DISPATCH(
+    _segment_reduce_backward_stub,
+    &_segment_reduce_cpu_backward_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -11,5 +11,9 @@ using segment_reduce_fn =
     Tensor (*)(const Tensor&, const Tensor&, int64_t, bool);
 DECLARE_DISPATCH(segment_reduce_fn, _segment_reduce_stub);
 
+using segment_reduce_backward_fn =
+    Tensor (*)(const Tensor&, const Tensor&, const Tensor&, const Tensor&);
+DECLARE_DISPATCH(segment_reduce_backward_fn, _segment_reduce_backward_stub);
+
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -8972,3 +8972,8 @@
   variants: function
   dispatch:
     CPU, CUDA: segment_reduce_kernel
+
+- func: segment_reduce_backward(Tensor grad, Tensor output, Tensor data, *, Tensor? lengths=None) -> Tensor
+  variants: function
+  dispatch:
+    CPU, CUDA: segment_reduce_backward_kernel

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -7,32 +7,64 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
+    gradcheck,
 )
 
 
 class TestSegmentReductions(TestCase):
-    def _test_max_simple_1d(self, device, dtype, unsafe):
+    def _test_max_simple_1d(self, device, dtype, unsafe, axis):
         lengths = torch.tensor([1, 2, 3], device=device)
-        data = torch.tensor([1, float("nan"), 3, 4, 5, 6], device=device, dtype=dtype)
-        expected_result = torch.tensor([1, float("nan"), 6], device=device, dtype=dtype)
-        actual_result = torch.segment_reduce(
-            data=data, reduce="max", lengths=lengths, axis=0, unsafe=unsafe
+        data = torch.tensor(
+            [1, float("nan"), 3, 4, 5, 5],
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
         )
-        self.assertEqual(
-            expected_result, actual_result, rtol=1e-03, atol=1e-05, equal_nan=True
-        )
+        expected_result = torch.tensor([1, float("nan"), 5], device=device, dtype=dtype)
         actual_result = torch.segment_reduce(
-            data=data, reduce="max", lengths=lengths, axis=-1, unsafe=unsafe
+            data=data, reduce="max", lengths=lengths, axis=axis, unsafe=unsafe
         )
         self.assertEqual(
             expected_result, actual_result, rtol=1e-03, atol=1e-05, equal_nan=True
         )
 
+        # Backward is only supported for cpu tensors for now. Return early if cuda
+        if data.is_cuda:
+            return
+
+        # Test backward
+        expected_grad = torch.tensor([1, 1, 0, 0, 0.5, 0.5], device=device, dtype=dtype)
+        actual_result.sum().backward()
+        self.assertEqual(
+            expected_grad, data.grad, rtol=1e-03, atol=1e-05, equal_nan=True
+        )
+
+        # gradcheck does not work well with bfloat16 or fp16 cpu types
+        # also there is small numerical difference with fp32
+        if dtype not in [torch.half, torch.bfloat16, torch.float]:
+            # gradcheck does not like "nan" input
+            data = torch.tensor(
+                [1, 10, 3, 4, 5, 5],
+                device=device,
+                dtype=dtype,
+                requires_grad=True,
+            )
+            self.assertTrue(
+                gradcheck(
+                    lambda x: torch.segment_reduce(
+                        data=x, reduce="max", lengths=lengths, axis=axis, unsafe=unsafe
+                    ),
+                    (data,),
+                )
+            )
+
     @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_max_simple_1d(self, device, dtype):
-        self._test_max_simple_1d(device, dtype, False)
-        self._test_max_simple_1d(device, dtype, True)
+        self._test_max_simple_1d(device, dtype, False, 0)
+        self._test_max_simple_1d(device, dtype, False, -1)
+        self._test_max_simple_1d(device, dtype, True, 0)
+        self._test_max_simple_1d(device, dtype, True, -1)
 
 
 instantiate_device_type_tests(TestSegmentReductions, globals())

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2051,3 +2051,6 @@
 
 - name: nonzero(Tensor self) -> Tensor
   output_differentiability: [False]
+
+- name: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False) -> Tensor
+  data: segment_reduce_backward(grad, result, data, lengths)


### PR DESCRIPTION
Summary:
This is to setup boiler plate code for backward and CPU implementation.

Next Steps in order:
- Add backward support for CUDA
- Add support for more aggregation types
- Benchmarking (for cuda mainly)/more testing/documentation
- Support for multi dimension

Test Plan:
Updated unit test to also check correctness of backward.

Wait for CI signal

Differential Revision: D27970340

