### PR TITLE
[PyTorch][Edge] Add api to get bytecode model version

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -580,6 +580,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
   if(NOT INTERN_BUILD_MOBILE AND NOT BUILD_LITE_INTERPRETER)
     list(APPEND TORCH_SRCS
       ${TORCH_SRC_DIR}/csrc/api/src/jit.cpp
+      ${TORCH_SRC_DIR}/csrc/jit/mobile/backport.cpp
       ${TORCH_SRC_DIR}/csrc/jit/serialization/onnx.cpp
       ${TORCH_SRC_DIR}/csrc/jit/serialization/export.cpp
       ${TORCH_SRC_DIR}/csrc/jit/serialization/export_module.cpp

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/frontend/resolver.h>
+#include <torch/csrc/jit/mobile/backport.h>
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/csrc/jit/serialization/export.h>
@@ -613,6 +614,24 @@ TEST(LiteInterpreterTest, LoadAndRunByteCodeModel) {
   AT_ASSERT(compare_tensor(jit_module_v5_output, expected_result));
   AT_ASSERT(compare_tensor(mobile_module_v4_output, expected_result));
   AT_ASSERT(compare_tensor(mobile_module_v5_output, expected_result));
+}
+
+TEST(LiteInterpreterTest, GetByteCodeVersion) {
+  // Load check in model: sequence.ptl
+  std::string filePath(__FILE__);
+  auto test_model_file_v4 =
+      filePath.substr(0, filePath.find_last_of("/\\") + 1);
+  test_model_file_v4.append("script_module_v4.ptl");
+
+  auto test_model_file_v5 =
+      filePath.substr(0, filePath.find_last_of("/\\") + 1);
+  test_model_file_v5.append("script_module_v5.ptl");
+
+  auto version_v4 = torch::jit::_get_bytecode_version(test_model_file_v4);
+  AT_ASSERT(version_v4 == 4);
+
+  auto version_v5 = torch::jit::_get_bytecode_version(test_model_file_v5);
+  AT_ASSERT(version_v5 == 5);
 }
 
 TEST(LiteInterpreterTest, SequentialModuleInfo) {

--- a/test/mobile/test_bytecode.py
+++ b/test/mobile/test_bytecode.py
@@ -1,7 +1,7 @@
 import torch
 import io
 
-from torch.jit.mobile import _load_for_lite_interpreter
+from torch.jit.mobile import _load_for_lite_interpreter, _get_bytecode_version
 from torch.testing._internal.common_utils import TestCase, run_tests
 import pathlib
 import tempfile
@@ -29,6 +29,15 @@ pytorch_test_dri = Path(__file__).resolve().parents[1]
 #   str(output_model_path))
 
 class testVariousModelVersions(TestCase):
+    def test_get_bytecode_version(self):
+        script_module_v4 = pytorch_test_dri / "cpp" / "jit" / "script_module_v4.ptl"
+        script_module_v5 = pytorch_test_dri / "cpp" / "jit" / "script_module_v5.ptl"
+
+        version_v4 = _get_bytecode_version(str(script_module_v4))
+        version_v5 = _get_bytecode_version(str(script_module_v5))
+
+        assert(version_v4 == 4)
+        assert(version_v5 == 5)
 
     def test_load_and_run_model(self):
         script_module_v4 = pytorch_test_dri / "cpp" / "jit" / "script_module_v4.ptl"

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -364,6 +364,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/autograd/FunctionsManual.cpp",
     "torch/csrc/jit/api/module_save.cpp",
     "torch/csrc/jit/codegen/fuser/cpu/fused_kernel.cpp",
+    "torch/csrc/jit/mobile/backport.cpp",
     "torch/csrc/jit/mobile/export_data.cpp",
     "torch/csrc/jit/mobile/function.cpp",
     "torch/csrc/jit/mobile/import.cpp",

--- a/torch/csrc/jit/mobile/backport.cpp
+++ b/torch/csrc/jit/mobile/backport.cpp
@@ -1,0 +1,222 @@
+#include <ATen/core/ivalue.h>
+#include <caffe2/serialize/inline_container.h>
+#include <torch/csrc/jit/api/compilation_unit.h>
+#include <torch/csrc/jit/mobile/backport.h>
+#include <torch/csrc/jit/mobile/interpreter.h>
+#include <torch/csrc/jit/mobile/observer.h>
+#include <torch/csrc/jit/runtime/instruction.h>
+#include <torch/csrc/jit/serialization/import_export_constants.h>
+#include <torch/csrc/jit/serialization/pickler.h>
+#include <torch/csrc/jit/serialization/type_name_uniquer.h>
+#include <torch/csrc/jit/serialization/unpickler.h>
+#include <torch/custom_class.h>
+
+#include <exception>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace c10 {
+// std::string serializeType(const Type &t);
+TypePtr parseType(const std::string& pythonStr);
+} // namespace c10
+
+namespace torch {
+namespace jit {
+
+namespace {
+
+TypePtr resolveTypeName(
+    std::shared_ptr<CompilationUnit>& compilation_unit,
+    const c10::QualifiedName& qn) {
+  // HACK: first we check whether the name starts with special prefix to
+  // tell if it's a supported pytorch class type. There are two special
+  // prefixes. "__torch__" for nn module, and "torch.jit" from to_backend.
+  // This is a reliable
+  // check today, but there is no guarantee that this is the case. The
+  // real solution is to merge type parsers so we can share class
+  // resolution logic.
+  static const c10::QualifiedName torchPrefix = "__torch__";
+  static const c10::QualifiedName jitPrefix = "torch.jit";
+  if (torchPrefix.isPrefixOf(qn) || jitPrefix.isPrefixOf(qn)) {
+    if (compilation_unit->get_class(qn) == nullptr) {
+      auto typeptr = ClassType::create(qn, compilation_unit, true);
+      compilation_unit->register_type(typeptr);
+    }
+    return compilation_unit->get_class(qn);
+  } else {
+    return c10::parseType(qn.qualifiedName());
+  }
+}
+
+c10::IValue readArchive(
+    const std::string& archive_name,
+    std::shared_ptr<mobile::CompilationUnit> compilation_unit,
+    std::unique_ptr<caffe2::serialize::PyTorchStreamReader>& stream_reader) {
+  std::stringstream picklename;
+  picklename << archive_name << ".pkl";
+  at::DataPtr pickle_ptr;
+  size_t pickle_size;
+  std::tie(pickle_ptr, pickle_size) =
+      stream_reader->getRecord(picklename.str());
+
+  size_t bytes_read = 0;
+  auto data = reinterpret_cast<const char*>(pickle_ptr.get());
+  auto reader = [&](char* buffer, size_t len) -> size_t {
+    if (bytes_read >= pickle_size) {
+      return 0;
+    }
+    len = std::min(pickle_size - bytes_read, len);
+    // Copy len bytes into buffer
+    const char* start = data + bytes_read;
+    std::memcpy(buffer, start, len);
+    bytes_read += len;
+    return len;
+  };
+  std::shared_ptr<CompilationUnit> jit_compilation_unit =
+      std::make_shared<CompilationUnit>();
+  auto type_resolver = [&](const c10::QualifiedName& qn) {
+    return c10::StrongTypePtr(
+        jit_compilation_unit, resolveTypeName(jit_compilation_unit, qn));
+  };
+
+  auto obj_loader = [&](at::StrongTypePtr type, IValue input) {
+    auto cls = type.type_->expect<at::ClassType>();
+    auto qn = cls->name();
+    c10::QualifiedName method_name(qn.value(), "__setstate__");
+    auto setstate = compilation_unit->find_function(method_name);
+    auto find_custom_class_with_setstate = [&qn]() -> c10::ClassTypePtr {
+      auto custom_class_type = torch::jit::getCustomClass(qn->qualifiedName());
+      if (custom_class_type && custom_class_type->findMethod("__setstate__")) {
+        return custom_class_type;
+      }
+      return nullptr;
+    };
+    if (setstate) {
+      auto obj = c10::ivalue::Object::create(type, 0);
+      Stack stack({obj, input});
+      setstate->run(stack);
+      return obj;
+    } else if (auto custom_class_type = find_custom_class_with_setstate()) {
+      auto obj = c10::ivalue::Object::create(
+          c10::StrongTypePtr(nullptr, custom_class_type), 1);
+      Stack stack({obj, input});
+      custom_class_type->getMethod("__setstate__").run(stack);
+      return obj;
+    } else {
+      auto dict = std::move(input).toGenericDict();
+      size_t ndict = dict.size();
+      auto obj = c10::ivalue::Object::create(type, ndict);
+      auto it = dict.begin();
+      for (size_t i = 0; i < ndict; ++i) {
+        std::stringstream name;
+        name << it->key();
+        cls->addOrCheckAttribute(name.str(), it->key().type());
+        obj->setSlot(i, it->value());
+        ++it;
+      }
+      return obj;
+    }
+  };
+
+  static const std::string slash = "/";
+  auto read_record = [&](const std::string& name) {
+    std::size_t found = name.find(slash);
+    std::stringstream ss;
+    // In version 4, the tensor root_key doesn't include the parent path
+    // To support backward compatibility, when the name doesn't include slash
+    // assume it's version 4 and attach the archive_name_plus_slash
+    // The example tensor format is:
+    // torch._utils._rebuild_tensor_v2(
+    //     pers.obj(('storage', torch.FloatStorage, '17', 'cpu', 22736),),
+    //     0,
+    //     (1, 464, 7, 7),
+    //     (22736, 49, 7, 1),
+    //     False,
+    //     collections.OrderedDict())
+    if (found == std::string::npos) {
+      ss << archive_name << slash << name;
+      return std::get<0>(stream_reader->getRecord(ss.str()));
+    }
+
+    // In version 4+, the tensor root_key in bytecode will include the parent
+    // path. The example tensor format is: torch._utils._rebuild_tensor_v2(
+    //     pers.obj(('storage', torch.FloatStorage, 'constants/17', 'cpu',
+    //     22736),), 0, (1, 464, 7, 7), (22736, 49, 7, 1), False,
+    //     collections.OrderedDict())
+    ss << name;
+    return std::get<0>(stream_reader->getRecord(ss.str()));
+  };
+  c10::optional<at::Device> device;
+
+  Unpickler unpickler(
+      reader,
+      std::move(type_resolver),
+      std::move(obj_loader),
+      std::move(read_record),
+      device);
+  return unpickler.parse_ivalue();
+}
+
+void check_zip_file(std::unique_ptr<ReadAdapterInterface>& rai) {
+  std::array<uint8_t, 2> first_short;
+  static constexpr uint8_t first_slot = 0x80;
+  static constexpr uint8_t second_slot = 0x02;
+  rai->read(
+      /*pos=*/0,
+      /*buf=*/&first_short,
+      /*n=*/2,
+      /*what=*/"checking archive");
+  if (first_short[0] == first_slot && first_short[1] == second_slot) {
+    // NB: zip files by spec can start with any data, so technically they might
+    // start with 0x80 0x02, but in practice zip files start with a file entry
+    // which begins with 0x04034b50. Furthermore, PyTorch will never produce zip
+    // files that do not start with the file entry, so it is relatively safe to
+    // perform this check.
+    TORCH_CHECK(false, "file issue");
+  }
+}
+
+std::vector<IValue> get_bytecode_vals(
+    std::shared_ptr<mobile::CompilationUnit>& mobile_compilation_unit,
+    std::unique_ptr<caffe2::serialize::PyTorchStreamReader>& reader) {
+  std::vector<IValue> bytecode_vals;
+  bytecode_vals = readArchive("bytecode", mobile_compilation_unit, reader)
+                      .toTuple()
+                      ->elements();
+  return bytecode_vals;
+}
+
+} // namespace
+
+using caffe2::serialize::IStreamAdapter;
+using caffe2::serialize::PyTorchStreamReader;
+using caffe2::serialize::PyTorchStreamWriter;
+using caffe2::serialize::ReadAdapterInterface;
+
+int64_t _get_bytecode_version(std::istream& in) {
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  return _get_bytecode_version(std::move(rai));
+}
+
+int64_t _get_bytecode_version(const std::string& filename) {
+  std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
+  return _get_bytecode_version(std::move(rai));
+}
+
+int64_t _get_bytecode_version(std::unique_ptr<ReadAdapterInterface> rai) {
+  check_zip_file(rai);
+  auto mobile_compilation_unit = std::make_shared<mobile::CompilationUnit>();
+  auto reader = torch::make_unique<caffe2::serialize::PyTorchStreamReader>(
+      std::move(rai));
+  auto bvals = get_bytecode_vals(mobile_compilation_unit, reader);
+  if (!bvals.empty() && bvals[0].isInt()) {
+    int64_t model_version = bvals[0].toInt();
+    return model_version;
+  }
+  TORCH_WARN("Fail to get bytecode version.");
+  return -1;
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/backport.h
+++ b/torch/csrc/jit/mobile/backport.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <torch/csrc/jit/mobile/module.h>
+
+#include <istream>
+#include <memory>
+
+#include <caffe2/serialize/file_adapter.h>
+#include <caffe2/serialize/inline_container.h>
+
+namespace torch {
+namespace jit {
+using caffe2::serialize::FileAdapter;
+using caffe2::serialize::IStreamAdapter;
+using caffe2::serialize::PyTorchStreamWriter;
+using caffe2::serialize::ReadAdapterInterface;
+
+// The family of methods below to get version given bytecode model
+TORCH_API int64_t _get_bytecode_version(std::istream& in);
+
+TORCH_API int64_t _get_bytecode_version(const std::string& filename);
+
+TORCH_API int64_t
+_get_bytecode_version(std::unique_ptr<ReadAdapterInterface> rai);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/frontend/ir_emitter.h>
 #include <torch/csrc/jit/frontend/sugared_value.h>
+#include <torch/csrc/jit/mobile/backport.h>
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/module.h>
 #include <torch/csrc/jit/python/module_python.h>
@@ -1668,6 +1669,13 @@ void initJitScriptBindings(PyObject* module) {
         }
         return _load_for_mobile(in, optional_device);
       });
+  m.def("_get_bytecode_version", [](const std::string& filename) {
+    return _get_bytecode_version(filename);
+  });
+  m.def("_get_bytecode_version_from_buffer", [](const std::string& buffer) {
+    std::istringstream in(buffer);
+    return _get_bytecode_version(in);
+  });
   m.def("_export_operator_list", [](torch::jit::mobile::Module& sm) {
     return debugMakeSet(torch::jit::mobile::_export_operator_list(sm));
   });

--- a/torch/jit/mobile/__init__.py
+++ b/torch/jit/mobile/__init__.py
@@ -75,3 +75,34 @@ def _export_operator_list(module: LiteScriptModule):
     """
     # TODO fix mypy here
     return torch._C._export_operator_list(module._c)  # type: ignore[attr-defined]
+
+def _get_bytecode_version(f_input):
+    r"""
+    Args:
+        f_input: a file-like object (has to implement read, readline, tell, and seek),
+            or a string containing a file name
+
+    Returns:
+        version: An integer. If the integer is -1, the version is invalid. A warning
+            will show in the log.
+
+    Example:
+
+    .. testcode::
+
+        from torch.jit.mobile import _get_bytecode_version
+
+        # Get bytecode version from a saved file path
+        version = _get_bytecode_version("path/to/model.ptl")
+
+    """
+    if isinstance(f_input, str):
+        if not os.path.exists(f_input):
+            raise ValueError("The provided filename {} does not exist".format(f_input))
+        if os.path.isdir(f_input):
+            raise ValueError("The provided filename {} is a directory".format(f_input))
+
+    if (isinstance(f_input, str) or isinstance(f_input, pathlib.Path)):
+        return torch._C._get_bytecode_version(f_input)
+    else:
+        return torch._C._get_bytecode_version_from_buffer(f.read())


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

Add an api `_get_bytecode_version` to get version number given a bytecode model in both cxx and python, and the input can be both from file path and buffer.

Differential Revision: [D27961417](https://our.internmc.facebook.com/intern/diff/D27961417/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27961417/)!