### PR TITLE
[PyTorch][jit] Don't allow create() on singleton types

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -34,10 +34,6 @@ using AnyTypePtr = std::shared_ptr<AnyType>;
 // Any is the top of the type hierarchy, all other types are subtypes
 // T <: Any, forall T
 struct TORCH_API AnyType : public Type {
-  static AnyTypePtr create() {
-    return AnyTypePtr(
-        new AnyType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1082,10 +1078,6 @@ struct TORCH_API EnumType : public NamedType {
 struct AnyEnumType;
 using AnyEnumTypePtr = std::shared_ptr<AnyEnumType>;
 struct TORCH_API AnyEnumType : public Type {
-  static AnyEnumTypePtr create() {
-    return AnyEnumTypePtr(
-        new AnyEnumType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1109,9 +1101,6 @@ using NumberTypePtr = std::shared_ptr<NumberType>;
 // FloatType <: NumberType
 // ComplexType <:NumberType
 struct TORCH_API NumberType : public Type {
-  static NumberTypePtr create() {
-    return NumberTypePtr(new NumberType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1136,9 +1125,6 @@ struct FloatType;
 using FloatTypePtr = std::shared_ptr<FloatType>;
 // This type represents a Python float number
 struct TORCH_API FloatType : public NumberType {
-  static FloatTypePtr create() {
-    return FloatTypePtr(new FloatType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1163,9 +1149,6 @@ struct ComplexType;
 using ComplexTypePtr = std::shared_ptr<ComplexType>;
 // This type represents a Python float number
 struct TORCH_API ComplexType : public NumberType {
-  static ComplexTypePtr create() {
-    return ComplexTypePtr(new ComplexType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1190,9 +1173,6 @@ struct IntType;
 using IntTypePtr = std::shared_ptr<IntType>;
 // This type represents a Python int number
 struct TORCH_API IntType : public NumberType {
-  static IntTypePtr create() {
-    return IntTypePtr(new IntType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1217,9 +1197,6 @@ struct BoolType;
 using BoolTypePtr = std::shared_ptr<BoolType>;
 // This node represents a Python bool value
 struct TORCH_API BoolType : public Type {
-  static BoolTypePtr create() {
-    return BoolTypePtr(new BoolType());
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1238,9 +1215,6 @@ struct StringType;
 using StringTypePtr = std::shared_ptr<StringType>;
 // This type represents a Python string
 struct TORCH_API StringType : public Type {
-  static StringTypePtr create() {
-    return StringTypePtr(new StringType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1262,9 +1236,6 @@ struct TORCH_API StringType : public Type {
 struct StorageType;
 using StorageTypePtr = std::shared_ptr<StorageType>;
 struct TORCH_API StorageType : public Type {
-  static StorageTypePtr create() {
-    return StorageTypePtr(new StorageType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1317,9 +1288,6 @@ struct NoneType;
 using NoneTypePtr = std::shared_ptr<NoneType>;
 // This type represents a Python None
 struct TORCH_API NoneType : public Type {
-  static NoneTypePtr create() {
-    return NoneTypePtr(new NoneType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1344,10 +1312,6 @@ struct GeneratorType;
 using GeneratorTypePtr = std::shared_ptr<GeneratorType>;
 // This type represents a Generator
 struct TORCH_API GeneratorType : public Type {
-  static GeneratorTypePtr create() {
-    return GeneratorTypePtr(
-        new GeneratorType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1366,10 +1330,6 @@ struct QuantizerType;
 using QuantizerTypePtr = std::shared_ptr<QuantizerType>;
 // This type represents a Quantizer
 struct TORCH_API QuantizerType : public Type {
-  static QuantizerTypePtr create() {
-    return QuantizerTypePtr(
-        new QuantizerType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1388,10 +1348,6 @@ struct QSchemeType;
 using QSchemeTypePtr = std::shared_ptr<QSchemeType>;
 // This type represents a QScheme
 struct TORCH_API QSchemeType : public Type {
-  static QSchemeTypePtr create() {
-    return QSchemeTypePtr(
-        new QSchemeType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1410,10 +1366,6 @@ struct DeviceObjType;
 using DeviceObjTypePtr = std::shared_ptr<DeviceObjType>;
 // This type represents a Device
 struct TORCH_API DeviceObjType : public Type {
-  static DeviceObjTypePtr create() {
-    return DeviceObjTypePtr(
-        new DeviceObjType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1432,10 +1384,6 @@ struct StreamObjType;
 using StreamObjTypePtr = std::shared_ptr<StreamObjType>;
 // This type represents a Generator
 struct TORCH_API StreamObjType : public Type {
-  static StreamObjTypePtr create() {
-    return StreamObjTypePtr(
-      new StreamObjType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1482,9 +1430,6 @@ using CapsuleTypePtr = std::shared_ptr<CapsuleType>;
 // This type represents a Python Capsule.
 // It does not appear in the IR and is only used during runtime
 struct TORCH_API CapsuleType : public Type {
-  static CapsuleTypePtr create() {
-    return CapsuleTypePtr(new CapsuleType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -1503,9 +1448,6 @@ struct PyObjectType;
 using PyObjectTypePtr = std::shared_ptr<PyObjectType>;
 // This type represents a PyObject Type
 struct TORCH_API PyObjectType : public Type {
-  static PyObjectTypePtr create() {
-    return PyObjectTypePtr(new PyObjectType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -2345,10 +2287,6 @@ struct LayoutType;
 using LayoutTypePtr = std::shared_ptr<LayoutType>;
 // This type represents a Generator
 struct TORCH_API LayoutType : public EnumerationType<TypeKind::LayoutType> {
-static LayoutTypePtr create() {
-return LayoutTypePtr(
-    new LayoutType()); // NOLINT(modernize-make-shared)
-}
 std::string str() const override {
 return "Layout";
 }
@@ -2364,10 +2302,6 @@ struct ScalarTypeType;
 using ScalarTypeTypePtr = std::shared_ptr<ScalarTypeType>;
 // This type represents a Generator
 struct TORCH_API ScalarTypeType : public EnumerationType<TypeKind::ScalarTypeType> {
-static ScalarTypeTypePtr create() {
-return ScalarTypeTypePtr(
-    new ScalarTypeType()); // NOLINT(modernize-make-shared)
-}
 std::string str() const override {
 return "ScalarType";
 }
@@ -2384,10 +2318,6 @@ ScalarTypeType() : EnumerationType() {}
 struct AnyListType;
 using AnyListTypePtr = std::shared_ptr<AnyListType>;
 struct TORCH_API AnyListType : public Type {
-  static AnyListTypePtr create() {
-    return AnyListTypePtr(
-        new AnyListType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -2407,10 +2337,6 @@ private:
 struct AnyTupleType;
 using AnyTupleTypePtr = std::shared_ptr<AnyTupleType>;
 struct TORCH_API AnyTupleType : public Type {
-  static AnyTupleTypePtr create() {
-    return AnyTupleTypePtr(
-        new AnyTupleType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }
@@ -2432,10 +2358,6 @@ private:
 struct AnyClassType;
 using AnyClassTypePtr = std::shared_ptr<AnyClassType>;
 struct TORCH_API AnyClassType : public Type {
-  static AnyClassTypePtr create() {
-    return AnyClassTypePtr(
-        new AnyClassType()); // NOLINT(modernize-make-shared)
-  }
   bool operator==(const Type& rhs) const override {
     return rhs.kind() == kind();
   }

--- a/aten/src/ATen/core/type.cpp
+++ b/aten/src/ATen/core/type.cpp
@@ -124,7 +124,7 @@ std::ostream& operator<<(std::ostream & out, const Type & t) {
 }
 
 AnyTypePtr AnyType::get() {
-  static auto value = AnyType::create();
+  static AnyTypePtr value(new AnyType());
   return value;
 }
 
@@ -135,63 +135,63 @@ TensorTypePtr TensorType::get() {
 }
 
 NumberTypePtr NumberType::get() {
-  static auto value = NumberType::create();
+  static NumberTypePtr value(new NumberType());
   return value;
 }
 IntTypePtr IntType::get() {
-  static auto value = IntType::create();
+  static IntTypePtr value(new IntType());
   return value;
 }
 FloatTypePtr FloatType::get() {
-  static auto value = FloatType::create();
+  static FloatTypePtr value(new FloatType());
   return value;
 }
 ComplexTypePtr ComplexType::get() {
-  static auto value = ComplexType::create();
+  static ComplexTypePtr value(new ComplexType());
   return value;
 }
 BoolTypePtr BoolType::get() {
-  static auto value = BoolType::create();
+  static BoolTypePtr value(new BoolType());
   return value;
 }
 StorageTypePtr StorageType::get() {
-  static auto value = StorageType::create();
+  static StorageTypePtr value(new StorageType());
   return value;
 }
 NoneTypePtr NoneType::get() {
-  static auto value = NoneType::create();
+  static NoneTypePtr value(new NoneType());
   return value;
 }
 GeneratorTypePtr GeneratorType::get() {
-  static auto value = GeneratorType::create();
+  static GeneratorTypePtr value(new GeneratorType());
   return value;
 }
 QuantizerTypePtr QuantizerType::get() {
-  static auto value = QuantizerType::create();
+  static QuantizerTypePtr value(new QuantizerType());
   return value;
 }
 QSchemeTypePtr QSchemeType::get() {
-  static auto value = QSchemeType::create();
+  static QSchemeTypePtr value(new QSchemeType());
   return value;
 }
 StringTypePtr StringType::get() {
-  static auto value = StringType::create();
+  static StringTypePtr value(new StringType());
   return value;
 }
 DeviceObjTypePtr DeviceObjType::get() {
-  static auto value = DeviceObjType::create();
+  static DeviceObjTypePtr value(new DeviceObjType());
   return value;
 }
 StreamObjTypePtr StreamObjType::get() {
-  static auto value = StreamObjType::create();
+  static StreamObjTypePtr value(new StreamObjType());
   return value;
 }
 ScalarTypeTypePtr ScalarTypeType::get() {
-static auto value = ScalarTypeType::create();
+static ScalarTypeTypePtr value(new ScalarTypeType());
 return value;
 }
 LayoutTypePtr LayoutType::get() {
-static auto value = LayoutType::create();
+static LayoutTypePtr value(new LayoutType());
 return value;
 }
 OptionalTypePtr OptionalType::ofTensor() {
@@ -199,11 +199,11 @@ OptionalTypePtr OptionalType::ofTensor() {
   return value;
 }
 PyObjectTypePtr PyObjectType::get() {
-  static auto value = PyObjectType::create();
+  static PyObjectTypePtr value(new PyObjectType());
   return value;
 }
 CapsuleTypePtr CapsuleType::get() {
-  static auto value = CapsuleType::create();
+  static CapsuleTypePtr value(new CapsuleType());
   return value;
 }
 ListTypePtr ListType::ofTensors() {
@@ -232,22 +232,22 @@ ListTypePtr ListType::ofStrings() {
 }
 
 AnyListTypePtr AnyListType::get() {
-  static auto value = AnyListType::create();
+  static AnyListTypePtr value(new AnyListType());
   return value;
 }
 
 AnyTupleTypePtr AnyTupleType::get() {
-  static auto value = AnyTupleType::create();
+  static AnyTupleTypePtr value(new AnyTupleType());
   return value;
 }
 
 AnyClassTypePtr AnyClassType::get() {
-  static auto value = AnyClassType::create();
+  static AnyClassTypePtr value(new AnyClassType());
   return value;
 }
 
 AnyEnumTypePtr AnyEnumType::get() {
-  static auto value = AnyEnumType::create();
+  static AnyEnumTypePtr value(new AnyEnumType());
   return value;
 }
 

--- a/aten/src/ATen/test/type_test.cpp
+++ b/aten/src/ATen/test/type_test.cpp
@@ -23,7 +23,7 @@ TEST(TypeCustomPrinter, Basic) {
   EXPECT_EQ(type->annotation_str(printer), "CustomTensor");
 
   // Unrelated types shoudl not be affected
-  const auto intType = IntType::create();
+  const auto intType = IntType::get();
   EXPECT_EQ(intType->annotation_str(printer), intType->annotation_str());
 }
 

--- a/test/cpp/rpc/e2e_test_base.h
+++ b/test/cpp/rpc/e2e_test_base.h
@@ -46,7 +46,7 @@ class TestE2EBase : public ::testing::Test {
             return c10::StrongTypePtr(
                 nullptr,
                 c10::DictType::create(
-                    c10::IntType::create(), c10::IntType::create()));
+                    c10::IntType::get(), c10::IntType::get()));
           }
           return c10::StrongTypePtr(
               nullptr, c10::TensorType::create(at::Tensor()));

--- a/torch/csrc/distributed/autograd/context/context.cpp
+++ b/torch/csrc/distributed/autograd/context/context.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<c10::ivalue::Future> DistAutogradContext::
   struct State {
     explicit State(int32_t count)
         : future(
-              std::make_shared<c10::ivalue::Future>(c10::NoneType::create())),
+              std::make_shared<c10::ivalue::Future>(c10::NoneType::get())),
           remaining(count) {}
     std::shared_ptr<c10::ivalue::Future> future;
     std::atomic<int32_t> remaining;

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -390,7 +390,7 @@ std::shared_ptr<c10::ivalue::Future> DistEngine::
   // execute after the original future is completed). This ensures we return a
   // future that waits for all gradient accumulation to finish.
   auto accumulateGradFuture =
-      std::make_shared<c10::ivalue::Future>(c10::NoneType::create());
+      std::make_shared<c10::ivalue::Future>(c10::NoneType::get());
 
   futureGrads->addCallback(
       [autogradContext, outputEdges, accumulateGradFuture, &futureGrads]() {
@@ -469,7 +469,7 @@ std::shared_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
 
     // Build the 'uber' future that waits for everything.
     auto callbackFuture =
-        std::make_shared<c10::ivalue::Future>(c10::NoneType::create());
+        std::make_shared<c10::ivalue::Future>(c10::NoneType::get());
 
     accumulateGradFuture->addCallback([autogradContext,
                                        callbackFuture,
@@ -519,7 +519,7 @@ std::shared_ptr<c10::ivalue::Future> DistEngine::executeSendFunctionAsync(
           /*node_task*/ NodeTask(graphTask, sendFunction, InputBuffer(0)),
           /*incrementOutstandingTasks*/ false);
     });
-    auto fut = std::make_shared<c10::ivalue::Future>(c10::NoneType::create());
+    auto fut = std::make_shared<c10::ivalue::Future>(c10::NoneType::get());
     fut->markCompleted(c10::IValue());
     return fut;
   }

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -136,7 +136,7 @@ bool InterpreterState::run(Stack& stack) {
         while (userObj->type()->numAttributes() <= inst.X) {
           std::stringstream ss;
           ss << userObj->type()->numAttributes();
-          userObj->type()->addAttribute(ss.str(), c10::NoneType::create());
+          userObj->type()->addAttribute(ss.str(), c10::NoneType::get());
         }
         userObj->setSlot(inst.X, std::move(v));
         ++pc;

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -218,7 +218,7 @@ void FixupONNXLoopNodeInputs(Node* node) {
   TORCH_INTERNAL_ASSERT(node->blocks().size() == 1);
   auto* sub_block = node->blocks().at(0);
   Value* cond = sub_block->insertInput(1, "cond");
-  cond->setType(BoolType::create());
+  cond->setType(BoolType::get());
 
   Value* i = sub_block->inputs().at(0);
   i->setType(TensorType::fromNumberType(IntType::get()));

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -253,11 +253,11 @@ inline TypedIValue toDictKeyIValue(py::handle key) {
   if (py::isinstance<py::str>(key)) {
     return TypedIValue(
         ConstantString::create(py::cast<std::string>(key)),
-        StringType::create());
+        StringType::get());
   } else if (py::isinstance<py::int_>(key)) {
-    return TypedIValue(py::cast<int64_t>(key), IntType::create());
+    return TypedIValue(py::cast<int64_t>(key), IntType::get());
   } else if (py::isinstance<py::float_>(key)) {
-    return TypedIValue(py::cast<double>(key), FloatType::create());
+    return TypedIValue(py::cast<double>(key), FloatType::get());
   } else {
     AT_ERROR("Dictionary inputs may only have string, int, or float keys");
   }

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -252,8 +252,7 @@ struct TypedIValue : public std::pair<IValue, TypePtr> {
 inline TypedIValue toDictKeyIValue(py::handle key) {
   if (py::isinstance<py::str>(key)) {
     return TypedIValue(
-        ConstantString::create(py::cast<std::string>(key)),
-        StringType::get());
+        ConstantString::create(py::cast<std::string>(key)), StringType::get());
   } else if (py::isinstance<py::int_>(key)) {
     return TypedIValue(py::cast<int64_t>(key), IntType::get());
   } else if (py::isinstance<py::float_>(key)) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56807 [PyTorch][jit] Don't allow create() on singleton types**

If I understand correctly, there's no reason to create your own instance of these global singleton types.

Differential Revision: [D27973447](https://our.internmc.facebook.com/intern/diff/D27973447/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27973447/)!