### PR TITLE
[TSAN] Fix PythonEngine data-race-on-vptr.

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -223,9 +223,17 @@ bool ReadyQueue::empty() const {
 
 Engine::Engine() : max_recursion_depth_(MAX_DEPTH), non_reentrant_device_thread_count_(0) {}
 
+Engine::~Engine() {
+  stop();
+}
+
 // Send shutdown tasks to all device_ready_queues_ if no backward tasks are running
 // Even though readyQueue should be empty, shutdown tasks have the highest priority
-Engine::~Engine() {
+void Engine::stop() {
+  if (stopped_) {
+    return;
+  }
+  stopped_ = true;
   // Under some conditions, autograd threads can hang on shutdown
   // Do not wait for them to shutdown indefinitely but rely on timeout
   auto wait_duration_str = getenv("TORCH_AUTOGRAD_SHUTDOWN_WAIT_LIMIT");

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -49,6 +49,10 @@ Engine& PythonEngine::get_python_engine() {
   return engine;
 }
 
+PythonEngine::~PythonEngine() {
+  Engine::stop();
+}
+
 #if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 9
 #define IS_PYTHON_3_9_PLUS
 #endif

--- a/torch/csrc/autograd/python_engine.h
+++ b/torch/csrc/autograd/python_engine.h
@@ -11,6 +11,7 @@ namespace torch { namespace autograd { namespace python {
 
 struct PythonEngine : public Engine {
   static Engine& get_python_engine();
+  ~PythonEngine() override;
   void thread_init(int device,
       const std::shared_ptr<ReadyQueue>& ready_queue,
       bool should_increment) override;


### PR DESCRIPTION
Summary:
For information about data-race-on-vptr in general, see https://www.internalfb.com/intern/wiki/TSAN/Common_Concurrency_Mistakes/Stopping_a_Thread_in_Destructor/

Engine::~Engine() was previously tasked with stopping the threads. This causes a data race on the object's vptr when PythonEngine is being destructed. This fixes the data race by making ~PythonEngine trigger the thread stopping before going down to the base class's destructor.

Test Plan:
Many tests are affected, but here's one example:

buck test mode/dev-tsan -c fbcode.tsan_strict_mode=true //oculus/research/orcoptics/deep_learning/srg_nn/tests:test_grating_net -- 'test_train (oculus.research.orcoptics.deep_learning.srg_nn.tests.test_grating_net.TestGratingNet)' --run-disabled

Differential Revision: D27972384

