### PR TITLE
Name .coverage.jit with timestamp to prevent loss of stats

### DIFF
--- a/tools/coverage_plugins_package/src/coverage_plugins/jit_plugin.py
+++ b/tools/coverage_plugins_package/src/coverage_plugins/jit_plugin.py
@@ -39,9 +39,11 @@ class JitPlugin(CoveragePlugin):
             # built-in modules or functions as those do not seem to be JIT'd either.
             if is_not_builtin_class(obj) or ismodule(obj) or ismethod(obj) or isfunction(obj) or iscode(obj):
                 filename = getsourcefile(obj)
-                sourcelines, starting_lineno = getsourcelines(obj)
-                line_data = {filename: range(starting_lineno, starting_lineno + len(sourcelines))}
-                cov_data.add_lines(line_data)
+                # We don't want to report for filename = None
+                if filename:
+                    sourcelines, starting_lineno = getsourcelines(obj)
+                    line_data = {filename: range(starting_lineno, starting_lineno + len(sourcelines))}
+                    cov_data.add_lines(line_data)
         super().dynamic_context(frame)
 
 def coverage_init(reg, options):

--- a/tools/coverage_plugins_package/src/coverage_plugins/jit_plugin.py
+++ b/tools/coverage_plugins_package/src/coverage_plugins/jit_plugin.py
@@ -10,11 +10,12 @@ marked as covered.
 
 from coverage import CoveragePlugin, CoverageData
 from inspect import ismodule, isclass, ismethod, isfunction, iscode, getsourcefile, getsourcelines
+from time import time
 
 # All coverage stats resulting from this plug-in will be in a separate .coverage file that should be merged later with
 # `coverage combine`. The convention seems to be .coverage.dotted.suffix based on the following link:
 # https://coverage.readthedocs.io/en/coverage-5.5/cmd.html#combining-data-files-coverage-combine
-cov_data = CoverageData(basename='.coverage.jit')
+cov_data = CoverageData(basename=f'.coverage.jit.{time()}')
 
 
 def is_not_builtin_class(obj):


### PR DESCRIPTION
This PR fixes the errors we were seeing after #56310 was landed. Since that PR was reverted, this PR would be a no-op. BUT the test plan below was _before_ the PR was reverted so we still see some gains in coverage.

________________________________________________________________________________________________________________

The reason we were not seeing so many wins was because .coverage.jit would overwrite itself every coverage run. (What a noob mistake who wrote that code?!?!)

This should fix that.

Test:
Coverage in CI should audibly increase. It does, somewhat:
Check out https://codecov.io/github/pytorch/pytorch/commit/f8a475b056cb913844461a8bc2a3097e997b372e! New covered files include:
Classes in torch/distributed/optim
torch/utils/mkldnn.py
(Or look at https://codecov.io/gh/pytorch/pytorch/compare/57cba8e...f8a475b/changes)