### PR TITLE
[23/n][torch/elastic][upstream] Rename torch.distributed.elastic_launch to torch.distributed.run

### DIFF
--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -16,7 +16,7 @@ from contextlib import closing
 from unittest import mock
 from unittest.mock import Mock, patch
 
-import torch.distributed.elastic_launch as launch
+import torch.distributed.run as launch
 from torch.distributed.elastic.agent.server.api import RunResult, WorkerState
 from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -2,7 +2,7 @@ r"""
 `torch.distributed.launch` is a module that spawns up multiple distributed
 training processes on each of the training nodes.
 
-NOTE: This module is deprecated, use torch.distributed.elastic_launch.
+NOTE: This module is deprecated, use torch.distributed.run.
 
 The utility can be used for single-node distributed training, in which one or
 more processes per node will be spawned. The utility can be used for either
@@ -140,7 +140,7 @@ will not pass ``--local_rank`` when you specify this flag.
 
 import logging
 
-from torch.distributed.elastic_launch import get_args_parser, run
+from torch.distributed.run import get_args_parser, run
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ def main(args=None):
     logger.warn(
         "The module torch.distributed.launch is deprecated "
         "and going to be removed in future."
-        "Migrate to torch.distributed.elastic_launch"
+        "Migrate to torch.distributed.run"
     )
     args = parse_args(args)
     run(args)

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -22,7 +22,7 @@ with the following additional functionalities:
 
 ::
 
-    >>> python -m torch.distributed.elastic_launch
+    >>> python -m torch.distributed.run
         --standalone
         --nnodes=1
         --nproc_per_node=$NUM_TRAINERS
@@ -32,7 +32,7 @@ with the following additional functionalities:
 
 ::
 
-    >>> python -m torch.distributed.elastic_launch
+    >>> python -m torch.distributed.run
         --nnodes=$NUM_NODES
         --nproc_per_node=$NUM_TRAINERS
         --rdzv_id=$JOB_ID
@@ -44,7 +44,7 @@ with the following additional functionalities:
 
 ::
 
-    >>> python -m torch.distributed.elastic_launch
+    >>> python -m torch.distributed.run
         --nnodes=1:4
         --nproc_per_node=$NUM_TRAINERS
         --rdzv_id=$JOB_ID
@@ -116,7 +116,7 @@ script:
         role. The role of the worker is specified in the ``WorkerSpec``.
 
 5. ``LOCAL_WORLD_SIZE`` - local world size (e.g. number of workers running locally).
-       Equal to ``--nproc_per_node`` specified on ``torch.distributed.elastic_launch``.
+       Equal to ``--nproc_per_node`` specified on ``torch.distributed.run``.
 
 6. ``WORLD_SIZE`` - world size (total number of workers in the job).
 
@@ -556,7 +556,7 @@ def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
     cmd.append(args.training_script)
     if not args.use_env:
         log.warning(
-            "`torch.distributed.launch` is Deprecated. Use torch.distributed.elastic_launch"
+            "`torch.distributed.launch` is Deprecated. Use torch.distributed.run"
         )
         cmd.append(f"--local_rank={macros.local_rank}")
     cmd.extend(args.training_script_args)
@@ -601,5 +601,5 @@ if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO, format="[%(levelname)s] %(asctime)s %(module)s: %(message)s"
     )
-    log.info(f"Running torch.distributed.elastic_launch with args: {sys.argv}")
+    log.info(f"Running torch.distributed.run with args: {sys.argv}")
     main()


### PR DESCRIPTION
Summary: Rename torch.distributed.elastic_launch to torch.distributed.run

Test Plan:
buck test mode/dev-nosan //pytorch/elastic/torchelastic/...
  buck test mode/dev-nosan //caffe2/test/distributed/elastic/agent/server/test/...
  flow-cli canary  pytorch.elastic.examples.classy_vision.main --entitlement gpu_prod --run-as-secure-group oncall_dai_pet --buck-target //fblearner/flow/projects/pytorch/elastic/examples:workflow

Reviewed By: kiukchung

Differential Revision: D27921159

