### PR TITLE
[Static Runtime] Enable check_for_memory_leak in StaticRuntime::benchmark

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.cpp
+++ b/torch/csrc/jit/runtime/static/impl.cpp
@@ -835,6 +835,7 @@ void StaticRuntime::benchmark(
                 << planner_->total_reused_tensors() << std::endl;
     }
   }
+  check_for_memory_leak();
 }
 
 float StaticRuntime::benchmark_model(
@@ -1013,6 +1014,7 @@ void StaticRuntime::check_for_memory_leak(bool output_returned) {
       }
     }
   }
+  VLOG(1) << "Finished checking for memory leak";
 }
 
 static void assign_storage_to_managed_tensors(


### PR DESCRIPTION
Summary: Enable check_for_memory_leak at the end of StaticRuntime::benchmark so this code is exercised more often.

Test Plan: Checked with adindexer merge net model

Reviewed By: edvgha

Differential Revision: D27417911

