### PR TITLE
Adjust computeLRWorkDim() to work with Accelerate.framework

### DIFF
--- a/aten/src/ATen/native/LinearAlgebraUtils.h
+++ b/aten/src/ATen/native/LinearAlgebraUtils.h
@@ -463,9 +463,14 @@ static inline std::vector<int64_t> create_reverse_permutation(std::vector<int64_
 static inline int64_t computeLRWorkDim(const char jobz, int64_t m, int64_t n) {
   auto mn = std::min(m, n);
   auto mx = std::max(m, n);
-  // These settings are valid for on LAPACK 3.6+
   if (jobz == 'N') {
+#ifdef __APPLE__
+    // According to `vecLib.framework/Headers/clapack.h` Accelerate.framework is based on LAPACK 3.2.1
+    return 7 * mn;
+#else
+    // These setting is valid for on LAPACK 3.6+
     return 5 * mn;
+#endif
   }
   if (mx > 10 * mn) {
     return 5 * mn * mn + 5 * mn;


### PR DESCRIPTION
According to `vecLib.framework/Headers/clapack.h` Accelerate.framework's LAPACK implementation is based on 3.2.1, and so LRWORK should be computed using following formula (from
```
*>          If JOBZ = 'N', LRWORK >= 7*min(M,N).
*>          Otherwise,
*>          LRWORK >= min(M,N)*max(5*min(M,N)+7,2*max(M,N)+2*min(M,N)+1)
```

Found while looking at test_linalg.py crashes on M1, but would have happen on x86 as well, if Pytorch+Accelerate framework are to be tested on x86_64
