### PR TITLE
[RPC Framework] Forbid process group backend in RPC

### DIFF
--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -149,9 +149,9 @@ if is_available():
             # Ignore type error because mypy doesn't handle dynamically generated type objects (#4865)
             if backend != BackendType.TENSORPIPE:  # type: ignore[attr-defined]
                 logger.warning(
-                    f"{BackendType.TENSORPIPE} was initialized with no explicit backend but with options "  # type: ignore[attr-defined]
-                    f"corresponding to {backend}. To silence this "
-                    f"warning pass `backend={backend}` explicitly."
+                    f"{BackendType.TENSORPIPE} was initialized "  # type: ignore[attr-defined]
+                    f"with no explicit backend but with options corresponding to {backend}. "
+                    f"To silence this warning pass `backend={backend}` explicitly."
                 )
 
         if backend is None:

--- a/torch/distributed/rpc/__init__.py
+++ b/torch/distributed/rpc/__init__.py
@@ -149,9 +149,8 @@ if is_available():
             # Ignore type error because mypy doesn't handle dynamically generated type objects (#4865)
             if backend != BackendType.TENSORPIPE:  # type: ignore[attr-defined]
                 logger.warning(
-                    f"RPC was initialized with no explicit backend but with options "  # type: ignore[attr-defined]
-                    f"corresponding to {backend}, hence that backend will be used "
-                    f"instead of the default {BackendType.TENSORPIPE}. To silence this "
+                    f"{BackendType.TENSORPIPE} was initialized with no explicit backend but with options "  # type: ignore[attr-defined]
+                    f"corresponding to {backend}. To silence this "
                     f"warning pass `backend={backend}` explicitly."
                 )
 
@@ -159,12 +158,9 @@ if is_available():
             backend = BackendType.TENSORPIPE  # type: ignore[attr-defined]
 
         if backend == BackendType.PROCESS_GROUP:  # type: ignore[attr-defined]
-            warnings.warn(
-                "RPC was initialized with the PROCESS_GROUP backend which is "
-                "deprecated and slated to be removed and superseded by the TENSORPIPE "
-                "backend. It is recommended to migrate to the TENSORPIPE backend. "
-                "PyTorch v1.9 will be the last release that carries PROCESS_GROUP "
-                "RPC backend. If you have concerns or suggestions please comment in "
+            raise ValueError(
+                "RPC PROCESS_GROUP backend is deprecated. Please migrate to the TENSORPIPE backend. "
+                "If you have concerns or suggestions please comment in "
                 "https://github.com/pytorch/pytorch/issues/55615"
             )
 

--- a/torch/testing/_internal/dist_utils.py
+++ b/torch/testing/_internal/dist_utils.py
@@ -91,10 +91,10 @@ def dist_init(
         if setup_rpc:
             rpc.init_rpc(
                 name="worker%d" % self.rank,
-                backend=self.rpc_backend,
+                backend=rpc.BackendType.TENSORPIPE,
                 rank=self.rank,
                 world_size=self.world_size,
-                rpc_backend_options=self.rpc_backend_options,
+                rpc_backend_options=rpc.TensorPipeRpcBackendOptions(init_method=self.init_method),
             )
 
         return_value = old_test_method(self, *arg, **kwargs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56854 [RPC Framework] Forbid process group backend in RPC**
* #56853 Clang format dist_utils.py and rpc/__init__.py

To resolve #51670, forbid process group PRC backend. This can avoid the need of checking the current backend in the torch script `remote_module_template`.

Otherwise, we need to check the current RPC backend to determine whether we want to move the forward output back to CPU.
1) If the RPC backend is process group, then move the forward output on CUDA back to CPU, because process group backend cannot support CUDA backend.
2) If the RPC backend is TensorPipe, then we don't need to move the forward output on CUDA, as long as a device map is provided.

Differential Revision: [D27984658](https://our.internmc.facebook.com/intern/diff/D27984658/)