### PR TITLE
[ONNX] Add support for calling tensor.to(tensor.device). 

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8423,6 +8423,22 @@ class TestONNXRuntime(unittest.TestCase):
                       input_names=['input_x', 'input_y'],
                       dynamic_axes={'input_x': [0, 1, 2, 3], 'input_y': [0, 1, 2, 3]})
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_to_device(self):
+        class M_ToDevice(torch.nn.Module):
+            def forward(self, x, y):
+                return x.to(y.device), y
+
+        class M_ToDeviceDtype(torch.nn.Module):
+            def forward(self, x, y):
+                return x.to(y.device, dtype=torch.long), y
+
+        x = torch.randn(6)
+        y = torch.randn(6)
+
+        self.run_test(M_ToDevice(), (x, y))
+        self.run_test(M_ToDeviceDtype(), (x, y))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout,
               **extra_kwargs):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1948,7 +1948,7 @@ def topk(g, self, k, dim, largest, sorted, out=None):
 def to(g, self, *args):
     # ONNX doesn't have a concept of a device, so we ignore device casts
     if len(args) == 4:
-        if args[0].type().isSubtypeOf(ListType.ofInts()):
+        if args[0].node().kind() == 'prim::device' or args[0].type().isSubtypeOf(ListType.ofInts()):
             # aten::to(Tensor, Device, bool, bool, memory_format)
             return self
         else:


### PR DESCRIPTION
Currently, if we call tensor.to() method and pass a device as the parameter. It will fail, because in symbolic function of to() we didn't handle such case.

So add a check in the beginning of this symbolic function, if this is a device cast, we return self directly. A test has also been added.
