### PR TITLE
catch xml parser error during report test result phase in CI

### DIFF
--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -652,7 +652,7 @@ def parse_report(path: str) -> Iterator[TestCase]:
         dom = minidom.parse(path)
     except Exception as e:
         print(f"Error occurred when parsing {path}: {e}")
-        return 
+        return
     for test_case in dom.getElementsByTagName('testcase'):
         yield TestCase(test_case)
 

--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -648,7 +648,11 @@ class TestFile:
 
 
 def parse_report(path: str) -> Iterator[TestCase]:
-    dom = minidom.parse(path)
+    try:
+        dom = minidom.parse(path)
+    except Exception as e:
+        print(f"Error occurred when parsing {path}: {e}")
+        return 
     for test_case in dom.getElementsByTagName('testcase'):
         yield TestCase(test_case)
 


### PR DESCRIPTION
Fixes Report test result step fails the test suite entirely, such as:
https://app.circleci.com/pipelines/github/pytorch/pytorch/307916/workflows/4144870c-d1cf-4567-a6f8-93bb436471a4/jobs/12732796
and 
https://app.circleci.com/pipelines/github/pytorch/pytorch/307388/workflows/a945940f-3325-43b3-bc14-c9f885b21f50/jobs/12705944

and also not related but could be a problem that only partial test reports are uploaded:
https://app.circleci.com/pipelines/github/pytorch/pytorch/308777/workflows/bdc37967-3863-448e-8264-311bf21ca381/jobs/12777741

This skips the parser error and move on to the next file. 

Test Plan:
CI