### PR TITLE
[ONNX] Support index_add_ function.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8665,6 +8665,71 @@ class TestONNXRuntime(unittest.TestCase):
         filled_value = 7
         self.run_test(FillModule(), (x, filled_value))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_index_add_normal(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim, index, updates):
+                super(M, self).__init__()
+                self.dim = dim
+                self.index = index
+                self.updates = updates
+
+            def forward(self, x):
+                x.index_add_(self.dim, self.index, self.updates)
+                return x
+
+        x = torch.ones(5, 4, 3)
+        updates = torch.tensor([[1], [4], [7], [3], [2]], dtype=torch.float)
+        index = torch.tensor([0, 2, 3, 1, 4])
+        self.run_test(M(0, index, updates), (x,))
+
+        updates = torch.tensor([[[1, 5, 7], [2, 4, 5], [5, 5, 6], [2, 3, 4]]], dtype=torch.float)
+        index = torch.tensor([0, 2, 3, 1])
+        self.run_test(M(1, index, updates), (x,))
+
+        updates = torch.tensor([[[1, 2, 3], [4, 5, 6], [7, 8, 9], [2, 3, 4]]], dtype=torch.float)
+        index = torch.tensor([0, 2, 1])
+        self.run_test(M(2, index, updates), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_index_add_dim_size_differ(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim, index, updates):
+                super(M, self).__init__()
+                self.dim = dim
+                self.index = index
+                self.updates = updates
+
+            def forward(self, x):
+                x.index_add_(self.dim, self.index, self.updates)
+                return x
+
+        x = torch.ones(5, 4, 3)
+        updates = torch.tensor([[[1, 5, 7], [2, 4, 5], [5, 5, 6]]], dtype=torch.float)
+        index = torch.tensor([0, 2, 1])
+        self.run_test(M(1, index, updates), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_index_add_in_loop(self):
+        class M(torch.nn.Module):
+            def __init__(self, dim, index, updates, loop_count):
+                super(M, self).__init__()
+                self.dim = dim
+                self.index = index
+                self.updates = updates
+                self.loop_count = loop_count
+
+            def forward(self, x):
+                for i in range(self.loop_count):
+                    x.index_add_(self.dim, self.index, self.updates)
+                return x
+
+        x = torch.ones(5, 4, 3)
+        updates = torch.tensor([[[1, 5, 7], [2, 4, 5], [5, 5, 6], [2, 3, 4]]], dtype=torch.float)
+        index = torch.tensor([0, 2, 3, 1])
+        loop_count = torch.randint(20, (1, ))[0].item()
+        self.run_test(M(1, index, updates, loop_count), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout,
               **extra_kwargs):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3110,11 +3110,15 @@ def index_add(g, self, dim, index, other):
 
     dim = sym_help._maybe_get_const(dim, 'i')
     if dim is None:
-        return _unimplemented("index_add",
-                              "Input rank is unknown at export time.")
+        raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function with " +
+                                  "unknown 'dim' value.")
 
     self_dim_rank = sym_help._get_tensor_rank(self)
     other_dim_rank = sym_help._get_tensor_rank(other)
+
+    if self_dim_rank is None or other_dim_rank is None:
+        raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function while " +
+                                  "the rank of self tensor or tensor to be added is unknown.")
 
     if other_dim_rank != self_dim_rank:
         delta = self_dim_rank - other_dim_rank

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3106,8 +3106,13 @@ def index_add(g, self, dim, index, other):
     warnings.warn("Warning: ONNX export does not support duplicated values in 'index' field, " +
                   "this will cause the ONNX model to be incorrect.")
     from torch.onnx.symbolic_opset9 import scatter_add
+    from sys import maxsize as maxsize
 
     dim = sym_help._maybe_get_const(dim, 'i')
+    if dim is None:
+        return _unimplemented("index_add",
+                              "Input rank is unknown at export time.")
+
     self_dim_rank = sym_help._get_tensor_rank(self)
     other_dim_rank = sym_help._get_tensor_rank(other)
 
@@ -3119,28 +3124,27 @@ def index_add(g, self, dim, index, other):
     other_dim_size = sym_help._get_tensor_dim_size(other, dim)
     self_dim_size = sym_help._get_tensor_dim_size(self, dim)
 
-    if other_dim_size == self_dim_size:
-        other = expand_as(g, other, self)
-    elif other_dim_size < self_dim_size:
-        # Construct a new shape. It's almost as same as self except the size of the 'dim'
-        # dimension is 1, so that we can expand other dimensions as expected.
-        new_shape_axes = list(range(self_dim_rank))
-        new_shape_starts = [0 for i in range(self_dim_rank)]
-        new_shape_ends = [sym_help._get_tensor_dim_size(self, i)
-                          if (i != dim)
-                          else
-                          1
-                          for i in range(self_dim_rank)]
+    if (other_dim_size is not None) and (self_dim_size is not None):
+        if other_dim_size > self_dim_size:
+            raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function with " +
+                                      "duplicated values in 'index' parameter yet.")
 
-        new_shape = sym_help._slice_helper(g,
-                                           self,
-                                           axes=new_shape_axes,
-                                           starts=new_shape_starts,
-                                           ends=new_shape_ends)
-        other = expand_as(g, other, new_shape)
-    else:
-        raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function with " +
-                                  "duplicated values in 'index' parameter yet.")
+    # Construct a new shape. It's almost as same as self except the size of the 'dim'
+    # dimension is 1, so that we can expand other dimensions as expected.
+    new_shape_axes = list(range(self_dim_rank))
+    new_shape_starts = [0 for i in range(self_dim_rank)]
+    new_shape_ends = [maxsize
+                      if (i != dim)
+                      else
+                      1
+                      for i in range(self_dim_rank)]
+
+    new_shape = sym_help._slice_helper(g,
+                                       self,
+                                       axes=new_shape_axes,
+                                       starts=new_shape_starts,
+                                       ends=new_shape_ends)
+    other = expand_as(g, other, new_shape)
 
     for i in range(dim):
         index = sym_help._unsqueeze_helper(g, index, [0])

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3100,3 +3100,52 @@ def fill(g, self, value):
         dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
 
     return full_like(g, self, value, dtype)
+
+
+def index_add(g, self, dim, index, other):
+    warnings.warn("Warning: ONNX export does not support duplicated values in 'index' field, " +
+                  "this will cause the ONNX model to be incorrect.")
+    from torch.onnx.symbolic_opset9 import scatter_add
+
+    dim = sym_help._maybe_get_const(dim, 'i')
+    self_dim_rank = sym_help._get_tensor_rank(self)
+    other_dim_rank = sym_help._get_tensor_rank(other)
+
+    if other_dim_rank != self_dim_rank:
+        delta = self_dim_rank - other_dim_rank
+        for i in range(delta):
+            other = sym_help._unsqueeze_helper(g, other, [sym_help._get_tensor_rank(other)])
+
+    other_dim_size = sym_help._get_tensor_dim_size(other, dim)
+    self_dim_size = sym_help._get_tensor_dim_size(self, dim)
+
+    if other_dim_size == self_dim_size:
+        other = expand_as(g, other, self)
+    elif other_dim_size < self_dim_size:
+        # Construct a new shape. It's almost as same as self except the size of the 'dim'
+        # dimension is 1, so that we can expand other dimensions as expected.
+        new_shape_axes = list(range(self_dim_rank))
+        new_shape_starts = [0 for i in range(self_dim_rank)]
+        new_shape_ends = [sym_help._get_tensor_dim_size(self, i)
+                          if (i != dim)
+                          else
+                          1
+                          for i in range(self_dim_rank)]
+
+        new_shape = sym_help._slice_helper(g,
+                                           self,
+                                           axes=new_shape_axes,
+                                           starts=new_shape_starts,
+                                           ends=new_shape_ends)
+        other = expand_as(g, other, new_shape)
+    else:
+        raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function with " +
+                                  "duplicated values in 'index' parameter yet.")
+
+    for i in range(dim):
+        index = sym_help._unsqueeze_helper(g, index, [0])
+
+    for i in range(self_dim_rank - dim - 1):
+        index = sym_help._unsqueeze_helper(g, index, [sym_help._get_tensor_rank(index)])
+
+    return scatter_add(g, self, dim, expand_as(g, index, other), other)


### PR DESCRIPTION
This is PR is aiming to support tensor.index_add_() method in symbolic function. We leverage scatter_add() to implement this function while ONNX doesn't have a corresponding operator.

Notes:

      1.  4 tests have been added for some scenarios.
      2.  If there are duplicated value in 'index' parameter, the export will still execute successfully but the results are wrong. Add a warning for every call to this symbolic function. And if we detect that the rank of 'index' is greater than the size of the 'dim' dimension, will raise an exception to stop exporting an incorrect ONNX file.