### PR TITLE
DOC: Add note to mutating methods

### DIFF
--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -624,6 +624,9 @@ class Module:
         it should be called before constructing optimizer if the module will
         live on GPU while being optimized.
 
+        .. note::
+            This method modifies the module in-place.
+
         Args:
             device (int, optional): if specified, all parameters will be
                 copied to that device
@@ -640,6 +643,9 @@ class Module:
         it should be called before constructing optimizer if the module will
         live on XPU while being optimized.
 
+        .. note::
+            This method modifies the module in-place.
+
         Arguments:
             device (int, optional): if specified, all parameters will be
                 copied to that device
@@ -652,6 +658,9 @@ class Module:
     def cpu(self: T) -> T:
         r"""Moves all model parameters and buffers to the CPU.
 
+        .. note::
+            This method modifies the module in-place.
+
         Returns:
             Module: self
         """
@@ -659,6 +668,9 @@ class Module:
 
     def type(self: T, dst_type: Union[dtype, str]) -> T:
         r"""Casts all parameters and buffers to :attr:`dst_type`.
+
+        .. note::
+            This method modifies the module in-place.
 
         Args:
             dst_type (type or string): the desired type
@@ -671,6 +683,9 @@ class Module:
     def float(self: T) -> T:
         r"""Casts all floating point parameters and buffers to float datatype.
 
+        .. note::
+            This method modifies the module in-place.
+
         Returns:
             Module: self
         """
@@ -678,6 +693,9 @@ class Module:
 
     def double(self: T) -> T:
         r"""Casts all floating point parameters and buffers to ``double`` datatype.
+
+        .. note::
+            This method modifies the module in-place.
 
         Returns:
             Module: self
@@ -687,6 +705,9 @@ class Module:
     def half(self: T) -> T:
         r"""Casts all floating point parameters and buffers to ``half`` datatype.
 
+        .. note::
+            This method modifies the module in-place.
+
         Returns:
             Module: self
         """
@@ -694,6 +715,9 @@ class Module:
 
     def bfloat16(self: T) -> T:
         r"""Casts all floating point parameters and buffers to ``bfloat16`` datatype.
+
+        .. note::
+            This method modifies the module in-place.
 
         Returns:
             Module: self


### PR DESCRIPTION
Fixes #56243 by adding a note to mutating functions not following the trailing `_` convention in `torch/nn/modules/module.py`

I can also raise separate PRs for other files, if needed
