### PR TITLE
[ARM] Do not use depthwise3x3 conv in grad mode

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -162,7 +162,10 @@ auto ConvParams::use_cpu_depthwise3x3_winograd(
          !is_strided() &&
          !is_dilated() &&
          // 3x3 depthwith convolutions implementation is inference only
-         !(input.requires_grad() && GradMode::is_enabled()) &&
+         !(GradMode::is_enabled() &&
+                 (input.requires_grad() ||
+                  weight.requires_grad() ||
+                 (bias.defined() && bias.requires_grad()))) &&
          !transposed;
 #else
   return false;

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -161,6 +161,8 @@ auto ConvParams::use_cpu_depthwise3x3_winograd(
              (bias.scalar_type() == at::kFloat))) &&
          !is_strided() &&
          !is_dilated() &&
+         // 3x3 depthwith convolutions implementation is inference only
+         !(input.requires_grad() && GradMode::is_enabled()) &&
          !transposed;
 #else
   return false;


### PR DESCRIPTION
cpu_depthwise3x3_winograd is not grad aware and therefore should not be used if grad is expected on the input

Fixes #56145
