### PR TITLE
Update floor_divide behavior in line with NumPy 1.20

### DIFF
--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -169,10 +169,10 @@ void div_floor_kernel(TensorIteratorBase& iter) {
       using vec_t = Vec256<scalar_t>;
       cpu_kernel_vec(iter,
           [](scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
-						if (C10_UNLIKELY(b == 0)) {
-							// Divide by zero: return standard IEEE result
-							return a / b;
-						}
+            if (C10_UNLIKELY(b == 0)) {
+              // Divide by zero: return standard IEEE result
+              return a / b;
+            }
 
             auto mod = std::fmod(a, b);
             auto div = (a - mod) / b;
@@ -202,10 +202,10 @@ void div_floor_kernel(TensorIteratorBase& iter) {
             auto floordiv = div.floor();
             mask = (div - floordiv) > vec_t(0.5);
             floordiv = vec_t::blendv(floordiv, floordiv + one, mask);
-						const auto basic_div = a / b;
+            const auto basic_div = a / b;
             floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
-						floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
-						return floordiv;
+            floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
+            return floordiv;
           });
     });
   }

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -169,6 +169,11 @@ void div_floor_kernel(TensorIteratorBase& iter) {
       using vec_t = Vec256<scalar_t>;
       cpu_kernel_vec(iter,
           [](scalar_t a, scalar_t b) __ubsan_ignore_float_divide_by_zero__ -> scalar_t {
+						if (C10_UNLIKELY(b == 0)) {
+							// Divide by zero: return standard IEEE result
+							return a / b;
+						}
+
             auto mod = std::fmod(a, b);
             auto div = (a - mod) / b;
             if ((mod != 0) && (b < 0) != (mod < 0)) {
@@ -197,7 +202,10 @@ void div_floor_kernel(TensorIteratorBase& iter) {
             auto floordiv = div.floor();
             mask = (div - floordiv) > vec_t(0.5);
             floordiv = vec_t::blendv(floordiv, floordiv + one, mask);
-            return vec_t::blendv(floordiv, zero.copysign(a / b), div == zero);
+						const auto basic_div = a / b;
+            floordiv = vec_t::blendv(floordiv, zero.copysign(basic_div), div == zero);
+						floordiv = vec_t::blendv(floordiv, basic_div, b == zero);
+						return floordiv;
           });
     });
   }

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -126,9 +126,9 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
       using accscalar_t = at::acc_type<scalar_t, true>;
       auto b = iter.scalar_value<accscalar_t>(2);
-			if (C10_UNLIKELY(b == 0)) {
-				return div_true_kernel_cuda(iter);
-			}
+      if (C10_UNLIKELY(b == 0)) {
+        return div_true_kernel_cuda(iter);
+      }
 
       auto inv_b = accscalar_t(1.0) / b;
       iter.remove_operand(2);
@@ -154,9 +154,9 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-				if (C10_UNLIKELY(b == 0)) {
-					return a / b;
-				}
+        if (C10_UNLIKELY(b == 0)) {
+          return a / b;
+        }
 
         auto mod = std::fmod(a, b);
         auto div = (a - mod) / b;

--- a/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryMulDivKernel.cu
@@ -126,6 +126,10 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
       using accscalar_t = at::acc_type<scalar_t, true>;
       auto b = iter.scalar_value<accscalar_t>(2);
+			if (C10_UNLIKELY(b == 0)) {
+				return div_true_kernel_cuda(iter);
+			}
+
       auto inv_b = accscalar_t(1.0) / b;
       iter.remove_operand(2);
       gpu_kernel(iter, [b, inv_b] GPU_LAMBDA (scalar_t a) -> scalar_t {
@@ -150,6 +154,10 @@ void div_floor_kernel_cuda(TensorIteratorBase& iter) {
   } else {
     AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, dtype, "div_floor_cuda", [&]() {
       gpu_kernel_with_scalars(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+				if (C10_UNLIKELY(b == 0)) {
+					return a / b;
+				}
+
         auto mod = std::fmod(a, b);
         auto div = (a - mod) / b;
         if ((mod != 0) && (b < 0) != (mod < 0)) {

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -380,9 +380,9 @@ class TestBinaryUfuncs(TestCase):
         a = make_tensor((4096,), device, dtype, low=low, high=high)
         b = make_tensor((4096,), device, dtype, low=low, high=high)
 
-        # Avoid integer division by zero which raises
-        if not dtype.is_floating_point:
-            b[b == 0] = 1
+        # Avoid division by zero which raises for integers and, for floats,
+        # NumPy behavior changed in 1.20
+        b[b == 0] = 1
 
         # Compare bfloat16 against NumPy float
         exact_dtype = dtype != torch.bfloat16

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -313,10 +313,12 @@ class TestBinaryUfuncs(TestCase):
     def test_div_rounding_nonfinite(self, device, dtype):
 
         # Compare division of special floating point values against NumPy
-        x = torch.tensor([1.0, -1.0, 0, 0.1, -0.1, np.pi, -np.pi, np.inf, -np.inf, np.nan],
-                         dtype=dtype)
+        num = torch.tensor([1.0, -1.0, 0, 0.1, -0.1, np.pi, -np.pi, np.inf, -np.inf, np.nan],
+                           dtype=dtype)
+        # Divide by zero is tested seperately
+        denom = num[num != 0]
 
-        a, b = x[None, :].clone(), x[:, None].clone()
+        a, b = num[None, :].clone(), denom[:, None].clone()
 
         # Compare bfloat16 against NumPy float
         exact_dtype = dtype != torch.bfloat16
@@ -335,14 +337,37 @@ class TestBinaryUfuncs(TestCase):
                              exact_device=False, exact_dtype=exact_dtype)
 
         # Compare contiguous (likely vectorized) against non-contiguous (not vectorized)
-        storage = torch.empty((20, 20), dtype=dtype, device=device)
-        storage[::2, ::2] = a
-        storage[1::2, 1::2] = b
+        a_noncontig = torch.empty([2 * i for i in a.shape], dtype=dtype, device=device)[::2, ::2]
+        a_noncontig[:] = a
+        b_noncontig = torch.empty([2 * i for i in b.shape], dtype=dtype, device=device)[::2, ::2]
+        b_noncontig[:] = b
 
         for rounding_mode in (None, "trunc", "floor"):
-            expect = torch.divide(storage[::2, ::2], storage[1::2, 1::2], rounding_mode=rounding_mode)
+            expect = torch.divide(a_noncontig, b_noncontig, rounding_mode=rounding_mode)
             actual = torch.divide(a, b, rounding_mode=rounding_mode)
             self.assertEqual(actual, expect)
+
+    @dtypes(torch.bfloat16, torch.half, torch.float32, torch.float64)
+    def test_divide_by_zero_rounding(self, device, dtype):
+        a = torch.tensor([1.0, -1.0, 0, 0.1, -0.1, np.pi, -np.pi, np.inf, -np.inf, np.nan],
+                         dtype=dtype)
+        exact_dtype = (dtype != torch.bfloat16)
+        if exact_dtype:
+            an = a.cpu().numpy()
+        else:
+            an = a.float().cpu().numpy()
+
+        zero = torch.zeros_like(a)
+
+        # NOTE: NumPy's floor_divide rounding changed in 1.20.0 to be consistent with divide
+        expect = np.divide(an, 0)
+        for rounding_mode in (None, 'floor'):
+            # CPU scalar
+            actual = torch.divide(a, 0, rounding_mode=rounding_mode)
+            self.assertEqual(actual, expect, exact_dtype=exact_dtype)
+            # Device tensor
+            actual = torch.divide(a, zero, rounding_mode=rounding_mode)
+            self.assertEqual(actual, expect, exact_dtype=exact_dtype)
 
     @dtypes(*torch.testing.get_all_dtypes(
         include_bool=False, include_complex=False, include_bfloat16=False))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #50438 Support JIT shape analysis for div with rounding_mode argument
* #55225 grad_fn getter for optional strings
* #51989 Sparse support for division rounding_mode argument
* **#56893 Update floor_divide behavior in line with NumPy 1.20**
* #55380 Vectorize floating point floor_divide

Fixes gh-56814

Differential Revision: [D28025814](https://our.internmc.facebook.com/intern/diff/D28025814)

## BC-breaking note

### `torch.divide` with `rounding_mode='floor'` now returns infinity when a non-zero number is divided by zero

This fixes the `rounding_mode='floor'` behaviour to return the same non-finite values as other rounding modes when there is a division by zero. Previously it would always result in a NaN value, but a non-zero number divided by zero should return +/- infinity in IEEE floating point arithmetic.

Note this does not effect `torch.floor_divide` or the floor division operator, which currently use `rounding_mode='trunc'` (and are also deprecated for that reason).

Example:

Version 1.8.1:
```
>>> a = torch.tensor([-1.0, 0.0, 1.0])
>>> b = torch.tensor([0.0])
>>> torch.divide(a, b, rounding_mode='floor')
tensor([nan, nan, nan])
```

Version 1.9.0:
```
>>> a = torch.tensor([-1.0, 0.0, 1.0])
>>> b = torch.tensor([0.0])
>>> torch.divide(a, b, rounding_mode='floor')
tensor([-inf, nan, inf])
```

