### PR TITLE
[torch][segment_reduce] Add support for initial value

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -7,8 +7,11 @@
 namespace at {
 namespace native {
 
-using segment_reduce_fn =
-    Tensor (*)(const Tensor&, const Tensor&, int64_t, bool);
+using segment_reduce_fn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    int64_t,
+    const c10::optional<Scalar>&);
 DECLARE_DISPATCH(segment_reduce_fn, _segment_reduce_stub);
 
 using segment_reduce_backward_fn =

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9003,7 +9003,7 @@
   cpp_no_default_args: ['a', 'b']
   python_module: nn
 
-- func: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False) -> Tensor
+- func: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor
   variants: function
   dispatch:
     CPU, CUDA: segment_reduce_kernel

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -13,16 +13,24 @@ from torch.testing._internal.common_utils import (
 
 class TestSegmentReductions(TestCase):
     def _test_max_simple_1d(self, device, dtype, unsafe, axis):
-        lengths = torch.tensor([1, 2, 3], device=device)
+        lengths = torch.tensor([1, 2, 3, 0], device=device)
         data = torch.tensor(
             [1, float("nan"), 3, 4, 5, 5],
             device=device,
             dtype=dtype,
             requires_grad=True,
         )
-        expected_result = torch.tensor([1, float("nan"), 5], device=device, dtype=dtype)
+        initial_value = 0
+        expected_result = torch.tensor(
+            [1, float("nan"), 5, initial_value], device=device, dtype=dtype
+        )
         actual_result = torch.segment_reduce(
-            data=data, reduce="max", lengths=lengths, axis=axis, unsafe=unsafe
+            data=data,
+            reduce="max",
+            lengths=lengths,
+            axis=axis,
+            unsafe=unsafe,
+            initial=initial_value,
         )
         self.assertEqual(
             expected_result, actual_result, rtol=1e-03, atol=1e-05, equal_nan=True
@@ -52,7 +60,12 @@ class TestSegmentReductions(TestCase):
             self.assertTrue(
                 gradcheck(
                     lambda x: torch.segment_reduce(
-                        data=x, reduce="max", lengths=lengths, axis=axis, unsafe=unsafe
+                        data=x,
+                        reduce="max",
+                        lengths=lengths,
+                        axis=axis,
+                        unsafe=unsafe,
+                        initial=initial_value,
                     ),
                     (data,),
                 )

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2062,5 +2062,5 @@
 - name: nonzero(Tensor self) -> Tensor
   output_differentiability: [False]
 
-- name: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False) -> Tensor
+- name: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor
   data: segment_reduce_backward(grad, result, data, lengths)


### PR DESCRIPTION
Summary:
Next Steps in order:
- Add backward support for CUDA
- Add support for more aggregation types
- Benchmarking (for cuda mainly)/more testing/documentation
- Support for multi dimension

Test Plan: Updated unit test to include 0 length segment as well.

Differential Revision: D27992228

