### PR TITLE
.github: Add options to force unzip artifacts

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.in
+++ b/.github/templates/linux_ci_workflow.yml.in
@@ -122,7 +122,7 @@ jobs:
       - name: Chown workspace
         run: |
           # Ensure the working directory gets chowned back to the current user
-          docker run --rm -v "$(pwd)":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
+          docker run --rm -v "$(pwd)/../":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
       - name: Checkout PyTorch
         uses: actions/checkout@v2
       - name: Log in to ECR
@@ -150,13 +150,18 @@ jobs:
               ;;
           esac
           echo "SHM_SIZE=${shm_size}" >> "${GITHUB_ENV}"
+      - name: Remove test binary build directories
+        run: |
+          rm -rf ../custom-op-build
+          rm -rf ../custom-backend-build
+          rm -rf ../jit-hook-build
       - uses: actions/download-artifact@v2
         name: Download PyTorch Build Artifacts
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
       - name: Unzip artifacts
         run: |
-          (cd "${GITHUB_WORKSPACE}/../" && unzip -q pytorch/artifacts.zip)
+          (cd "${GITHUB_WORKSPACE}/../" && unzip -qof pytorch/artifacts.zip)
       - name: Output disk space left
         run: |
           sudo df -H

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Chown workspace
         run: |
           # Ensure the working directory gets chowned back to the current user
-          docker run --rm -v "$(pwd)":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
+          docker run --rm -v "$(pwd)/../":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
       - name: Checkout PyTorch
         uses: actions/checkout@v2
       - name: Log in to ECR
@@ -150,13 +150,18 @@ jobs:
               ;;
           esac
           echo "SHM_SIZE=${shm_size}" >> "${GITHUB_ENV}"
+      - name: Remove test binary build directories
+        run: |
+          rm -rf ../custom-op-build
+          rm -rf ../custom-backend-build
+          rm -rf ../jit-hook-build
       - uses: actions/download-artifact@v2
         name: Download PyTorch Build Artifacts
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
       - name: Unzip artifacts
         run: |
-          (cd "${GITHUB_WORKSPACE}/../" && unzip -q pytorch/artifacts.zip)
+          (cd "${GITHUB_WORKSPACE}/../" && unzip -qof pytorch/artifacts.zip)
       - name: Output disk space left
         run: |
           sudo df -H

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Chown workspace
         run: |
           # Ensure the working directory gets chowned back to the current user
-          docker run --rm -v "$(pwd)":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
+          docker run --rm -v "$(pwd)/../":/v -w /v alpine chown -R "$(id -u):$(id -g)" .
       - name: Checkout PyTorch
         uses: actions/checkout@v2
       - name: Log in to ECR
@@ -150,13 +150,18 @@ jobs:
               ;;
           esac
           echo "SHM_SIZE=${shm_size}" >> "${GITHUB_ENV}"
+      - name: Remove test binary build directories
+        run: |
+          rm -rf ../custom-op-build
+          rm -rf ../custom-backend-build
+          rm -rf ../jit-hook-build
       - uses: actions/download-artifact@v2
         name: Download PyTorch Build Artifacts
         with:
           name: ${{ env.BUILD_ENVIRONMENT }}
       - name: Unzip artifacts
         run: |
-          (cd "${GITHUB_WORKSPACE}/../" && unzip -q pytorch/artifacts.zip)
+          (cd "${GITHUB_WORKSPACE}/../" && unzip -qof pytorch/artifacts.zip)
       - name: Output disk space left
         run: |
           sudo df -H


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56929 .github: Add options to force unzip artifacts**

Artifacts were failing to unzip since they already existed in the
current tree so this just forces the zip to go through no matter what

Was observing that test phases will fail if attempting to zip over an already existing directory, https://github.com/pytorch/pytorch/runs/2424525136?check_suite_focus=true

In the long run however it'd be good to have these binaries built out as part of the regular cmake process instead of being one off builds like they are now

**NOTE**: This wouldn't be an issue if `--ephemeral` workers was a thing, see: https://github.com/actions/runner/pull/660

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28004271](https://our.internmc.facebook.com/intern/diff/D28004271)