### PR TITLE
port neg to structure kernel

### DIFF
--- a/aten/src/ATen/native/UnaryOps.cpp
+++ b/aten/src/ATen/native/UnaryOps.cpp
@@ -74,6 +74,7 @@ CREATE_UNARY_FLOAT_META_FUNC(tanh)
 CREATE_UNARY_META_FUNC(bitwise_not)
 CREATE_UNARY_META_FUNC(frac)
 CREATE_UNARY_META_FUNC(i0)
+CREATE_UNARY_META_FUNC(neg)
 CREATE_UNARY_META_FUNC(round)
 
 } // namespace meta
@@ -112,6 +113,7 @@ CREATE_UNARY_TORCH_IMPL_FUNC(log)
 CREATE_UNARY_TORCH_IMPL_FUNC(log10)
 CREATE_UNARY_TORCH_IMPL_FUNC(log1p)
 CREATE_UNARY_TORCH_IMPL_FUNC(log2)
+CREATE_UNARY_TORCH_IMPL_FUNC(neg)
 CREATE_UNARY_TORCH_IMPL_FUNC(reciprocal)
 CREATE_UNARY_TORCH_IMPL_FUNC(round)
 CREATE_UNARY_TORCH_IMPL_FUNC(rsqrt)
@@ -492,15 +494,6 @@ Tensor& trunc_(Tensor& self) { return unary_op_impl_(self, at::trunc_out); }
 Tensor& fix_out(const Tensor& self, Tensor& result) { return at::trunc_out(result, self); }
 Tensor fix(const Tensor& self) { return self.trunc(); }
 Tensor& fix_(Tensor& self) { return self.trunc_(); }
-
-Tensor& neg_out(const Tensor& self, Tensor& result) {
-  TORCH_CHECK(self.scalar_type() != kBool,
-              "Negation, the `-` operator, on a bool tensor is not supported. "
-              "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
-  return unary_op_impl_out(result, self, neg_stub);
-}
-Tensor neg(const Tensor& self) { return unary_op_impl(self, at::neg_out); }
-Tensor& neg_(Tensor& self) { return unary_op_impl_(self, at::neg_out); }
 
 Tensor& negative_out(const Tensor& self, Tensor& result) { return at::neg_out(result, self); }
 Tensor negative(const Tensor& self) { return self.neg(); }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2962,17 +2962,16 @@
     CPU, CUDA: reciprocal_out
 
 - func: neg(Tensor self) -> Tensor
+  structured_delegate: neg.out
   variants: function, method
-  dispatch:
-    CPU, CUDA, SparseCPU, SparseCUDA: neg
 
 - func: neg_(Tensor(a!) self) -> Tensor(a!)
+  structured_delegate: neg.out
   variants: function, method
-  dispatch:
-    CPU, CUDA: neg_
-    SparseCPU, SparseCUDA: neg_sparse_
 
 - func: neg.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  structured_inherits: TensorIteratorBase
   dispatch:
     CPU, CUDA: neg_out
     SparseCPU, SparseCUDA: neg_out_sparse

--- a/tmp.py
+++ b/tmp.py
@@ -1,0 +1,56 @@
+import ruamel.yaml
+from ruamel.yaml.tokens import CommentToken
+from ruamel.yaml.error import CommentMark
+from tools.codegen.model import *  # noqa: F403
+
+with open("aten/src/ATen/native/native_functions.yaml", "r") as f:
+    contents = f.read()
+
+yaml = ruamel.yaml.YAML()
+yaml.preserve_quotes = True
+yaml.width = 1000
+yaml.boolean_representation = ['False', 'True']
+r = yaml.load(contents)
+
+convert = '''\
+neg'''.split()
+
+for e in r:
+    f = NativeFunction.from_yaml(e, Location("", 0))
+    if f.structured or f.structured_delegate is not None:
+        continue
+    n = f.func.name.name.base
+    if n not in convert:
+        continue
+    # mutate e to make changes
+    if f.func.kind() == SchemaKind.out:
+        e.insert(1, 'structured', True)
+        e.insert(2, 'structured_inherits', 'TensorIteratorBase')
+    else:
+        # TODO: The .out overload assumption is not sound in general
+        e.insert(1, 'structured_delegate', f'{n}.out')
+
+        e['dispatch'].pop('CPU', None)
+        e['dispatch'].pop('CUDA', None)
+        e['dispatch'].pop('CPU, CUDA', None)
+        e['dispatch'].pop('CompositeExplicitAutograd', None)
+
+        *_, last_k = e.keys()
+        needs_fixup = False
+
+        if not e['dispatch']:
+            if last_k == 'dispatch':
+                needs_fixup = True
+            del e['dispatch']
+
+        # Manually fix up newlines at the end, because ruamel
+        # made some bad life choices about where to associate trailing
+        # whitespace for nested dicts; see
+        # https://stackoverflow.com/questions/42172399/modifying-yaml-using-ruamel-yaml-adds-extra-new-lines
+        if needs_fixup:
+            *_, last_k = e.keys()
+            # post_key, pre_key, post_value, pre_value
+            e.ca.items[last_k] = [None, None, CommentToken('\n\n', CommentMark(0), None), None]
+
+with open("aten/src/ATen/native/native_functions.yaml.new", "w") as f:
+    yaml.dump(r, f)


### PR DESCRIPTION
creating this to test the migration

TODOs
- [ ] validate CI passes
- [ ] sparse is not correctly dispatched, (or is it?)
- [ ] `negative` alias is currently associated with structured `neg`