### PR TITLE
[RPC Framework] Supporting reading the input from the remote worker

### DIFF
--- a/torch/distributed/nn/jit/templates/remote_module_template.py
+++ b/torch/distributed/nn/jit/templates/remote_module_template.py
@@ -48,9 +48,9 @@ def _remote_forward(
     # and a device map is explicitly provided to TensorPipe backend,
     # we can leave the forward output on CUDA device and avoid the post-processing here.
     ret = ()
-    for arg in module.forward(*out_args, {kwargs}):
-        arg = (arg.cpu(),) if isinstance(arg, Tensor) else (arg,)
-        ret = ret + arg
+    for i in module.forward(*out_args, {kwargs}):
+        i = (i.cpu(),) if isinstance(i, Tensor) else (i,)
+        ret = ret + i
     return ret
 
 

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -509,3 +509,27 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             # TODO: Once the RPC backend can support directly sending GPU tensors, the expected device type should be "cuda:0".
             self.assertEqual(ret[0].device.type, "cpu")
             self.assertEqual(ret[2].device.type, "cpu")
+
+    @skip_if_lt_x_gpu(1)
+    @dist_utils.dist_init
+    def test_input_moved_to_cuda_device_script(self):
+        if self.rank != 0:
+            return
+        dst_worker_name = dist_utils.worker_name((self.rank + 1) % self.world_size)
+
+        scripted_remote_module = next(
+            self._create_remote_module_iter(
+                "{}/cuda:0".format(dst_worker_name), modes=[ModuleCreationMode.MODULE_CTOR_WITH_INTERFACE]
+            )
+        )
+
+        @torch.jit.script
+        def run_forward(scripted_remote_module: MyModuleInterface):
+            ret = scripted_remote_module.forward(torch.ones(1), 2, "3")
+            return ret
+
+        ret = run_forward(scripted_remote_module)
+
+        self.assertEqual(ret, ("3", 2, torch.ones(1)))
+        # TODO: Once the RPC backend can support directly sending GPU tensors, the expected device type should be "cuda:0".
+        self.assertEqual(ret[2].device.type, "cpu")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56943 [RPC Framework] Supporting reading the input from the remote worker**
* #56853 Clang format dist_utils.py and rpc/__init__.py

If the module is placed on a CUDA device, then all the CPU tensors in `args` and `kwargs` will also be implicitly moved to the same CUDA device to run forward.

Currently still need to move the forward output from CUDA device back to CPU, until:
1) Process group RPC backend is completely deprecated, and we always use TensorPipe RPC backend;
2) A device map is explicitly provided to TensorPipe RPC backend.

These steps will be done in a separate PR.

#Original PR issue: https://github.com/pytorch/pytorch/issues/51670

Differential Revision: [D27934791](https://our.internmc.facebook.com/intern/diff/D27934791/)