### PR TITLE
.github: Bump linux.2xlarge runners to 500

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -22,7 +22,7 @@ runner_types:
   linux.2xlarge:
     instance_type: c5.2xlarge
     os: linux
-    max_available: 200
+    max_available: 500
     disk_size: 150
   linux.8xlarge.nvidia.gpu:
     instance_type: g3.8xlarge


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56942 .github: Enable Linux CPU GHA on PRs
* **#56945 .github: Bump linux.2xlarge runners to 500**
* #56941 .github: Build test binaries in build/ directory

In preparation to turn these on for CI

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28018454](https://our.internmc.facebook.com/intern/diff/D28018454)