### PR TITLE
[NNC] Add member funtion to check whether the ret values in CompareSlect are default

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -525,6 +525,13 @@ class TORCH_API CompareSelect : public ExprNode<CompareSelect> {
   CompareSelectBias bias() const {
     return bias_;
   }
+  bool is_ret_default() const {
+    if (!ret_val1_->isConstant() || !ret_val2_->isConstant()) {
+      return false;
+    }
+    return (immediateAs<int>(ret_val1_) == 1) &&
+        (immediateAs<int>(ret_val2_) == 0);
+  }
 
   static ExprHandle make(
       const ExprHandle& lhs,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56947 [NNC] Add logical Operators '&&' and '||'
* **#56946 [NNC] Add member funtion to check whether the ret values in CompareSlect are default**

Differential Revision: [D28007343](https://our.internmc.facebook.com/intern/diff/D28007343)