### PR TITLE
[jit][mkldnn] dont fuse from linear

### DIFF
--- a/torch/csrc/jit/ir/ir.cpp
+++ b/torch/csrc/jit/ir/ir.cpp
@@ -103,7 +103,7 @@ std::ostream& operator<<(
 
 static void printAttribute(std::ostream& out, const at::Tensor& tensor) {
   // 1-elem tensors are usually boxed scalars, so print them like it
-  if (tensor.numel() == 1) {
+  if (tensor.numel() == 1 && !tensor.is_mkldnn()) {
     auto scalar_tensor = tensor.view(std::vector<int64_t>{}).item();
     out << "{";
     if (scalar_tensor.isFloatingPoint()) {

--- a/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
+++ b/torch/csrc/jit/passes/frozen_ops_to_mkldnn.cpp
@@ -687,7 +687,7 @@ bool frozenMkldnnCompatibleConvNode(Node* n) {
 }
 
 // [mkldnn perf strategy]
-// Certain ops - aten::linear, aten::conv2d, aten::conv3d - provide a huge speed
+// Certain ops - aten::conv2d, aten::conv3d - provide a huge speed
 // up just by converting the constant weights to MKLDNN AOT, and then at runtime
 // converting the non-constant input to_mkldnn before the op, and then back to
 // its original layout after the op. The speed up holds even if you end up
@@ -767,8 +767,7 @@ class MKLDNNSubgraphSlicer {
       return true;
     }
     // see [mkldnn perf strategy]
-    return frozenMkldnnCompatibleLinearNode(node) ||
-        frozenMkldnnCompatibleConvNode(node);
+    return frozenMkldnnCompatibleConvNode(node);
   }
 
  private:


### PR DESCRIPTION
Currently, when running linear in mkldnn mkldnn doesnt not used blocked formats so you do not get any speedup compared to eager. This makes it unprofitable to start a fusion group from Linear nodes, since you might induce two additional layout transformations without any speedups. The previous benchmarking I did was on a faulty server :/ When rebenchmarked there was no speedup by running linear in mkldnn. 