### PR TITLE
[WIP] Generating aliases

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -378,8 +378,6 @@
     CompositeExplicitAutograd: add_
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
-  alias: dotmv
-  alias_python_module: special
   structured_delegate: addmv.out
   variants: function, method
 
@@ -1643,6 +1641,7 @@
   device_guard: False
 
 - func: eye(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+  alias: identity #with no namespace, will work for all overloads
 
 - func: eye.m(int n, int m, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -378,6 +378,8 @@
     CompositeExplicitAutograd: add_
 
 - func: addmv(Tensor self, Tensor mat, Tensor vec, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  alias: dotmv
+  alias_python_module: special
   structured_delegate: addmv.out
   variants: function, method
 

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -138,16 +138,16 @@ def is_py_torch_function(f: NativeFunction) -> bool:
     return f.python_module is None and Variant.function in f.variants
 
 def is_py_nn_function(f: NativeFunction) -> bool:
-    return f.python_module == 'nn' or f.alias_python_module == 'nn'
+    return f.python_module == 'nn'
 
 def is_py_fft_function(f: NativeFunction) -> bool:
-    return f.python_module == 'fft' or f.alias_python_module == 'fft'
+    return f.python_module == 'fft'
 
 def is_py_linalg_function(f: NativeFunction) -> bool:
-    return f.python_module == 'linalg' or f.alias_python_module == 'linalg'
+    return f.python_module == 'linalg'
 
 def is_py_special_function(f: NativeFunction) -> bool:
-    return f.python_module == 'special' or f.alias_python_module == 'special'
+    return f.python_module == 'special'
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 #
@@ -643,17 +643,10 @@ def method_def(
     if module == "torch":
         flags += ' | METH_STATIC'
 
-    names: List[str] = []#[name,]
+    names: List[str] = [name,]
 
-    module_split: Optional[List[str]] = module.split('.') if module is not None else None
-    module_str: Optional[str] = module_split[len(module_split)-1] if module_split is not None else None
     for o in overloads:
-        if (o.function.python_module is None and module == "torch") or \
-           o.function.python_module == module_str or method:
-            names.append(str(name))
-        if o.function.alias is not None and \
-           ((o.function.alias_python_module is None and module == "torch") or \
-           o.function.alias_python_module == module_str or method):
+        if o.function.alias is not None:
             names.append(o.function.alias)
     names_set = set(names)
 

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -179,6 +179,13 @@ class NativeFunction:
     # What python module to put the function in
     python_module: Optional[str]
 
+    # Alias name of the function
+    # TODO make it a list
+    alias: Optional[str]
+
+    # What python module to put alias in
+    alias_python_module: Optional[str]
+
     # TODO: figure out what this does
     category_override: Optional[str]
 
@@ -306,6 +313,12 @@ class NativeFunction:
         python_module = e.pop('python_module', None)
         assert python_module is None or isinstance(python_module, str), f'not a str: {python_module}'
 
+        alias = e.pop('alias', None)
+        assert alias is None or isinstance(alias, str), f'not a str: {python_module}'
+
+        alias_python_module = e.pop('alias_python_module', None)
+        assert alias_python_module is None or isinstance(alias_python_module, str), f'not a str: {python_python_module}'
+
         category_override = e.pop('category_override', None)
         assert category_override is None or isinstance(category_override, str), f'not a str: {category_override}'
 
@@ -356,6 +369,8 @@ class NativeFunction:
             manual_kernel_registration=manual_kernel_registration,
             manual_cpp_binding=manual_cpp_binding,
             python_module=python_module,
+            alias=alias,
+            alias_python_module=alias_python_module,
             category_override=category_override,
             dispatch=dispatch,
             device_guard=device_guard,

--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -183,9 +183,6 @@ class NativeFunction:
     # TODO make it a list
     alias: Optional[str]
 
-    # What python module to put alias in
-    alias_python_module: Optional[str]
-
     # TODO: figure out what this does
     category_override: Optional[str]
 
@@ -316,9 +313,6 @@ class NativeFunction:
         alias = e.pop('alias', None)
         assert alias is None or isinstance(alias, str), f'not a str: {python_module}'
 
-        alias_python_module = e.pop('alias_python_module', None)
-        assert alias_python_module is None or isinstance(alias_python_module, str), f'not a str: {python_python_module}'
-
         category_override = e.pop('category_override', None)
         assert category_override is None or isinstance(category_override, str), f'not a str: {category_override}'
 
@@ -370,7 +364,6 @@ class NativeFunction:
             manual_cpp_binding=manual_cpp_binding,
             python_module=python_module,
             alias=alias,
-            alias_python_module=alias_python_module,
             category_override=category_override,
             dispatch=dispatch,
             device_guard=device_guard,

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -1146,13 +1146,8 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   py::object builtin_name =
       py::module::import("torch.jit._builtins").attr("_find_builtin")(obj);
   if (!builtin_name.is_none()) {
-    std::string symbol_name = py::str(builtin_name);
-    if (symbol_name == std::string("aten::dotmv")) {
-      symbol_name = "aten::addmv";
-    }
-    //std::cout << py::str(builtin_name) << "\n";
     return std::make_shared<BuiltinFunction>(
-        Symbol::fromQualString(symbol_name), c10::nullopt);
+        Symbol::fromQualString(py::str(builtin_name)), c10::nullopt);
   }
 
   if (py::cast<bool>(py::module::import("torch._jit_internal")

--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -1146,8 +1146,13 @@ std::shared_ptr<SugaredValue> toSugaredValue(
   py::object builtin_name =
       py::module::import("torch.jit._builtins").attr("_find_builtin")(obj);
   if (!builtin_name.is_none()) {
+    std::string symbol_name = py::str(builtin_name);
+    if (symbol_name == std::string("aten::dotmv")) {
+      symbol_name = "aten::addmv";
+    }
+    //std::cout << py::str(builtin_name) << "\n";
     return std::make_shared<BuiltinFunction>(
-        Symbol::fromQualString(py::str(builtin_name)), c10::nullopt);
+        Symbol::fromQualString(symbol_name), c10::nullopt);
   }
 
   if (py::cast<bool>(py::module::import("torch._jit_internal")


### PR DESCRIPTION
Here are minimum changes to codegen that would allow us to define aliases in native_functions.yaml. 
This avoids most of the codegen for the new function, only substituting a call to the base function at the python bindings codegen level. An advantage of this approach is that there's minimum effect on build time and binary size, and autograd works automatically (it only ever sees base function which is presumably knows how to handle). Alias symbols don't get their own schema, they are short-lived and disappear as soon as we leave python. 
Issues:
1) There's an unsolved problem with jit here, because the new symbol is not added to interned strings, so jit script does not work. I could not find a convenient place in jit to do string substitution of the new symbol for the base symbol. 
2) aliases in c++ are not supported - do we need them? I don't thinks so. If we decide that we do, changes to codegeining CPUFunctions.h/CUDAFunctions.h/Functions.cpp and friends will be necessary, but not to Register**, those should work automatically (the only functions called wheh dispatching to backends should be base functions)
3) only full aliases (for all overloads) are supported, so things like `max` where we want to alias only some overloads can't be easily supported with this approach
4) for functions in the submodules (such as torch.linalg, torch.special etc) python exposure is done with `_add_docstr` mechanism in `__init__.py` file, so literally no codegen is necessary, just add `_add_docstr` linking to base function in the `__init__.py` so this is not handled in this PR
5) Docstring is not updated automatically, maybe we can see how we can do that (that'll also possibly address submodule `_add_docstr` issue).

An alternative is to define aliases like any other composite op within "composite ops in python" project. The drawback of this is that (depending on implementation) likely this will result in extra dispatch overhead (that's pretty much what's happening with aliases today, when they are implemented in ATen/native).

Another alternative is to use python language constructs to say `torch.foo = torch.bar`, but that doesn't extend well to supporting methods and script. 
