### PR TITLE
Pytorch: enable many torchelastic tests

### DIFF
--- a/test/distributed/elastic/events/lib_test.py
+++ b/test/distributed/elastic/events/lib_test.py
@@ -10,6 +10,7 @@ import unittest
 from unittest.mock import patch
 
 from torch.distributed.elastic.events import _get_or_create_logger, Event, EventSource
+from torch.testing._internal.common_utils import run_tests
 
 
 class EventLibTest(unittest.TestCase):
@@ -46,3 +47,7 @@ class EventLibTest(unittest.TestCase):
         json_event = event.serialize()
         deser_event = Event.deserialize(json_event)
         self.assert_event(event, deser_event)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/metrics/api_test.py
+++ b/test/distributed/elastic/metrics/api_test.py
@@ -16,6 +16,7 @@ from torch.distributed.elastic.metrics.api import (
     _get_metric_name,
     prof,
 )
+from torch.testing._internal.common_utils import run_tests
 
 
 def foo_1():
@@ -63,6 +64,10 @@ class MetricsApiTest(unittest.TestCase):
         pass
 
     def test_get_metric_name(self):
+        # Note: since pytorch uses main method to launch tests,
+        # the module will be different between fb and oss, this
+        # allows keeping the module name consistent.
+        foo_1.__module__ = "api_test"
         self.assertEqual("api_test.foo_1", _get_metric_name(foo_1))
         self.assertEqual("MetricsApiTest.foo_2", _get_metric_name(self.foo_2))
 
@@ -106,3 +111,7 @@ class MetricsApiTest(unittest.TestCase):
 
             self.assertEqual(1, handler.metric_data["Child.func.success"].value)
             self.assertIn("Child.func.duration.ms", handler.metric_data)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/timer/local_timer_example.py
+++ b/test/distributed/elastic/timer/local_timer_example.py
@@ -13,7 +13,13 @@ import unittest
 
 import torch.distributed.elastic.timer as timer
 import torch.multiprocessing as torch_mp
-from torch.testing._internal.common_utils import TEST_WITH_ASAN, TEST_WITH_TSAN
+from torch.testing._internal.common_utils import (
+    TEST_WITH_ASAN,
+    TEST_WITH_TSAN,
+    run_tests,
+    IS_WINDOWS,
+    IS_MACOS,
+)
 
 
 logging.basicConfig(
@@ -33,6 +39,7 @@ def _stuck_function(rank, mp_queue):
         time.sleep(5)
 
 
+@unittest.skipIf(IS_WINDOWS or IS_MACOS, "timer is not supported on macos or windowns")
 class LocalTimerExample(unittest.TestCase):
     """
     Demonstrates how to use LocalTimerServer and LocalTimerClient
@@ -75,9 +82,9 @@ class LocalTimerExample(unittest.TestCase):
     def test_example_start_method_spawn(self):
         self._run_example_with(start_method="spawn")
 
-    @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test is a/tsan incompatible")
-    def test_example_start_method_forkserver(self):
-        self._run_example_with(start_method="forkserver")
+    # @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test is a/tsan incompatible")
+    # def test_example_start_method_forkserver(self):
+    #     self._run_example_with(start_method="forkserver")
 
     @unittest.skipIf(TEST_WITH_TSAN, "test is tsan incompatible")
     def test_example_start_method_fork(self):
@@ -108,3 +115,7 @@ class LocalTimerExample(unittest.TestCase):
                 self.assertEqual(0, p.exitcode)
 
         server.stop()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/timer/local_timer_test.py
+++ b/test/distributed/elastic/timer/local_timer_test.py
@@ -12,9 +12,15 @@ import unittest.mock as mock
 import torch.distributed.elastic.timer as timer
 from torch.distributed.elastic.timer.api import TimerRequest
 from torch.distributed.elastic.timer.local_timer import MultiprocessingRequestQueue
-from torch.testing._internal.common_utils import TEST_WITH_TSAN
+from torch.testing._internal.common_utils import (
+    TEST_WITH_TSAN,
+    run_tests,
+    IS_WINDOWS,
+    IS_MACOS,
+)
 
 
+@unittest.skipIf(IS_WINDOWS or IS_MACOS, "timer is not supported on windows or macos")
 class LocalTimerTest(unittest.TestCase):
     def setUp(self):
         self.mp_queue = mp.Queue()
@@ -115,6 +121,7 @@ def _enqueue_on_interval(mp_queue, n, interval, sem):
         time.sleep(interval)
 
 
+@unittest.skipIf(IS_WINDOWS or IS_MACOS, "timer is not supported on windows or macos")
 class MultiprocessingRequestQueueTest(unittest.TestCase):
     def test_get(self):
         mp_queue = mp.Queue()
@@ -172,6 +179,7 @@ class MultiprocessingRequestQueueTest(unittest.TestCase):
         self.assertLessEqual(n / 2, len(requests))
 
 
+@unittest.skipIf(IS_WINDOWS or IS_MACOS, "timer is not supported on windows or macos")
 class LocalTimerServerTest(unittest.TestCase):
     def setUp(self):
         self.mp_queue = mp.Queue()
@@ -265,3 +273,7 @@ class LocalTimerServerTest(unittest.TestCase):
         self.assertTrue((-2, "test1") in self.server._timers)
         self.assertTrue((-2, "test2") in self.server._timers)
         mock_os_kill.assert_not_called()
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -16,6 +16,7 @@ from torch.distributed.elastic.utils.distributed import (
     get_free_port,
     get_socket_with_port,
 )
+from torch.testing._internal.common_utils import run_tests, IS_WINDOWS, IS_MACOS
 
 
 def _create_c10d_store_mp(is_server, server_addr, port, world_size):
@@ -26,6 +27,7 @@ def _create_c10d_store_mp(is_server, server_addr, port, world_size):
     store.set(f"test_key/{os.getpid()}", "test_value".encode("UTF-8"))
 
 
+@unittest.skipIf(IS_WINDOWS or IS_MACOS, "tests incompatible with tsan or asan")
 class DistributedUtilTest(unittest.TestCase):
     def test_create_store_single_server(self):
         store = create_c10d_store(is_server=True, server_addr=socket.gethostname())
@@ -125,3 +127,7 @@ class DistributedUtilTest(unittest.TestCase):
                     server_port=port,
                     timeout=1,
                 )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/utils/logging_test.py
+++ b/test/distributed/elastic/utils/logging_test.py
@@ -5,11 +5,10 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
 import unittest
 
 import torch.distributed.elastic.utils.logging as logging
-
+from torch.testing._internal.common_utils import run_tests
 
 log = logging.get_logger()
 
@@ -22,11 +21,15 @@ class LoggingTest(unittest.TestCase):
         local_log = logging.get_logger()
         name_override_log = logging.get_logger("foobar")
 
-        self.assertEqual("logging_test", log.name)
-        self.assertEqual("logging_test", self.clazz_log.name)
-        self.assertEqual("logging_test", local_log.name)
+        self.assertEqual(__name__, log.name)
+        self.assertEqual(__name__, self.clazz_log.name)
+        self.assertEqual(__name__, local_log.name)
         self.assertEqual("foobar", name_override_log.name)
 
     def test_derive_module_name(self):
         module_name = logging._derive_module_name(depth=1)
-        self.assertEqual("logging_test", module_name)
+        self.assertEqual(__name__, module_name)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -10,6 +10,7 @@ import unittest
 
 import torch.distributed.elastic.utils.store as store_util
 from torch.distributed.elastic.utils.logging import get_logger
+from torch.testing._internal.common_utils import run_tests
 
 
 class TestStore:
@@ -68,3 +69,7 @@ class UtilTest(unittest.TestCase):
     def test_get_logger_custom_name(self):
         logger1 = get_logger("test.module")
         self.assertEqual("test.module", logger1.name)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -150,6 +150,14 @@ TESTS = [
     'distributed/pipeline/sync/test_transparency',
     'distributed/pipeline/sync/test_worker',
     'distributed/optim/test_zero_redundancy_optimizer',
+    'distributed/elastic/timer/api_test',
+    'distributed/elastic/timer/local_timer_example',
+    'distributed/elastic/timer/local_timer_test',
+    'distributed/elastic/events/lib_test',
+    'distributed/elastic/metrics/api_test',
+    'distributed/elastic/utils/logging_test',
+    'distributed/elastic/utils/util_test',
+    'distributed/elastic/utils/distributed_test',
 ]
 
 # Tests need to be run with pytest.

--- a/torch/distributed/elastic/metrics/api.py
+++ b/torch/distributed/elastic/metrics/api.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 from functools import wraps
 from typing import Dict, Optional
 
-
 MetricData = namedtuple("MetricData", ["timestamp", "group_name", "name", "value"])
 
 

--- a/torch/distributed/elastic/utils/logging.py
+++ b/torch/distributed/elastic/utils/logging.py
@@ -48,7 +48,6 @@ def _derive_module_name(depth: int = 1) -> Optional[str]:
         assert depth < len(stack)
         # FrameInfo is just a named tuple: (frame, filename, lineno, function, code_context, index)
         frame_info = stack[depth]
-        filename = frame_info[1]
 
         module = inspect.getmodule(frame_info[0])
         if module:
@@ -57,6 +56,7 @@ def _derive_module_name(depth: int = 1) -> Optional[str]:
             # inspect.getmodule(frame_info[0]) does NOT work (returns None) in
             # binaries built with @mode/opt
             # return the filename (minus the .py extension) as modulename
+            filename = frame_info[1]
             module_name = os.path.splitext(os.path.basename(filename))[0]
         return module_name
     except Exception as e:


### PR DESCRIPTION
Summary: The diff enables metrics, events, utils and timer tests on ci/cd pipeline

Test Plan: ci/cd

Differential Revision: D28015200

