### PR TITLE
[profier] Fix double printing of FLOPs

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1531,6 +1531,16 @@ def build_table(
         assert log_flops >= 0 and log_flops < len(flop_headers)
         return (pow(10, (math.floor(log_flops) * -3.0)), flop_headers[int(log_flops)])
 
+    def flops_rate(evt):
+        US_IN_SECOND = 1000.0 * 1000.0
+        if evt.flops > 0:
+            if evt.cuda_time_total != 0:
+                return float(evt.flops) / evt.cuda_time_total * US_IN_SECOND
+            else:
+                return float(evt.flops) / evt.cpu_time_total * US_IN_SECOND
+        else:
+            return -1
+
     add_column(name_column_width)
     for _ in headers[1:]:
         add_column(DEFAULT_COLUMN_WIDTH)
@@ -1545,15 +1555,11 @@ def build_table(
 
     if with_flops:
         # Auto-scaling of flops header
-        US_IN_SECOND = 1000.0 * 1000.0  # cpu_time_total is in us
         raw_flops = []
         for evt in events:
-            if evt.flops > 0:
-                if evt.cuda_time_total != 0:
-                    evt.flops = float(evt.flops) / evt.cuda_time_total * US_IN_SECOND
-                else:
-                    evt.flops = float(evt.flops) / evt.cpu_time_total * US_IN_SECOND
-                raw_flops.append(evt.flops)
+            rate = flops_rate(evt)
+            if rate > 0:
+                raw_flops.append(rate)
         if len(raw_flops) != 0:
             (flops_scale, flops_header) = auto_scale_flops(min(raw_flops))
             headers.append(flops_header)
@@ -1657,10 +1663,11 @@ def build_table(
         if has_input_shapes:
             row_values.append(str(evt.input_shapes)[:shapes_column_width])
         if with_flops:
-            if evt.flops <= 0.0:
+            rate = flops_rate(evt)
+            if rate <= 0.0:
                 row_values.append("--")
             else:
-                row_values.append('{0:8.3f}'.format(evt.flops * flops_scale))
+                row_values.append('{0:8.3f}'.format(rate * flops_scale))
         if has_stack:
             src_field = ""
             if len(evt.stack) > 0:


### PR DESCRIPTION
Summary:
Call table() shouldn't modify the events

Test Plan:
```
import torch
from torch import nn
from torch.profiler import profile, record_function

model = nn.Conv2d(8, 64, 3, padding=1)
input = torch.randn(1, 8, 272, 272)

with profile(record_shapes=True, with_flops=True) as prof:
    with record_function("model_inference"):
        model(input)

events = prof.key_averages(group_by_input_shape=True)
print(events.table())
print(events.table())
```

```
----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
                        Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls                                   Input Shapes      GFLOPS/s
----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
                 aten::zeros         0.78%      68.000us         1.16%     101.000us     101.000us             1                           [[], [], [], [], []]            --
                 aten::empty         0.49%      43.000us         0.49%      43.000us      14.333us             3                       [[], [], [], [], [], []]            --
                 aten::zero_         0.23%      20.000us         0.23%      20.000us      20.000us             1                                          [[1]]            --
             model_inference        13.67%       1.195ms        98.84%       8.639ms       8.639ms             1                                             []            --
                aten::conv2d         0.42%      37.000us        85.13%       7.440ms       7.440ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [        91.645
           aten::convolution         0.15%      13.000us        84.70%       7.403ms       7.403ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
          aten::_convolution         0.48%      42.000us        84.55%       7.390ms       7.390ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
    aten::mkldnn_convolution        83.47%       7.295ms        84.07%       7.348ms       7.348ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
           aten::as_strided_         0.31%      27.000us         0.31%      27.000us      27.000us             1                [[1, 64, 272, 272], [], [], []]            --
----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
Self CPU time total: 8.740ms

----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
                        Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls                                   Input Shapes      GFLOPS/s
----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
                 aten::zeros         0.78%      68.000us         1.16%     101.000us     101.000us             1                           [[], [], [], [], []]            --
                 aten::empty         0.49%      43.000us         0.49%      43.000us      14.333us             3                       [[], [], [], [], [], []]            --
                 aten::zero_         0.23%      20.000us         0.23%      20.000us      20.000us             1                                          [[1]]            --
             model_inference        13.67%       1.195ms        98.84%       8.639ms       8.639ms             1                                             []            --
                aten::conv2d         0.42%      37.000us        85.13%       7.440ms       7.440ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [        91.645
           aten::convolution         0.15%      13.000us        84.70%       7.403ms       7.403ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
          aten::_convolution         0.48%      42.000us        84.55%       7.390ms       7.390ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
    aten::mkldnn_convolution        83.47%       7.295ms        84.07%       7.348ms       7.348ms             1  [[1, 8, 272, 272], [64, 8, 3, 3], [64], [], [            --
           aten::as_strided_         0.31%      27.000us         0.31%      27.000us      27.000us             1                [[1, 64, 272, 272], [], [], []]            --
----------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ---------------------------------------------  ------------
Self CPU time total: 8.740ms
```

Fixes https://github.com/pytorch/pytorch/issues/55606
