### PR TITLE
Make test_randperm work with meta device

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -3171,11 +3171,12 @@ class TestRandomTensorCreation(TestCase):
             torch.rand(size, size, out=res2)
             self.assertEqual(res1, res2)
 
-    @onlyCUDA
     def test_randperm(self, device):
-        if device == 'cpu':
+        if device == 'cpu' or device == 'meta':
             rng_device = None
         else:
+            # TODO: This won't actually work for non-CUDA device
+            # see https://github.com/pytorch/pytorch/issues/54282
             rng_device = [device]
 
         # Test core functionality. On CUDA, for small n, randperm is offloaded to CPU instead. For large n, randperm is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56976 Make test_randperm work with meta device**

Band-aid fix for #54282

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28020401](https://our.internmc.facebook.com/intern/diff/D28020401)