### PR TITLE
Fix for derivative of sinc(x) when x is positive but very very small

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2955,7 +2955,12 @@ class TestAutograd(TestCase):
     def test_sinc(self):
         # The derivative of sinc(x) at x=0 has to be special cased.
         # A naive computation will result in 0/0 -> NaN.
-        a = torch.tensor([0.0, 1.0], dtype=torch.double, requires_grad=True)
+        # We also need to be careful when we are very close to 0, as the
+        # derivative's denominator is squared, and there are some floats
+        # that are positive and whose squares are zero.
+        a = torch.tensor([0.0, torch.finfo(torch.double).tiny, 1.0],
+                         dtype=torch.double,
+                         requires_grad=True)
         gradcheck(torch.sinc, a)
 
     def test_igamma(self):

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3091,8 +3091,8 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 }
 
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
-  auto self_pi = self * M_PI
-  auto self_squared_pi = self * self * M_PI
+  auto self_pi = self * M_PI;
+  auto self_squared_pi = self * self * M_PI;
   auto out = grad * ((self_pi * self_pi.cos() - self_pi.sin()) / self_squared_pi).conj();
   return at::where(self_squared_pi == 0.0, at::zeros({}, grad.options()), out);
 }

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3091,8 +3091,10 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 }
 
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
-  auto out = grad * ((M_PI * self * (M_PI * self).cos() - (M_PI * self).sin()) / (M_PI * self * self)).conj();
-  return at::where(self == 0.0, at::zeros({}, grad.options()), out);
+  auto self_pi = self * M_PI
+  auto self_squared_pi = self * self * M_PI
+  auto out = grad * ((self_pi * self_pi.cos() - self_pi.sin()) / (self_squared_pi)).conj();
+  return at::where(self_squared_pi == 0.0, at::zeros({}, grad.options()), out);
 }
 
 Tensor sparse_constructor_values_backward(const Tensor& sparse_grad_out, const Tensor& indices) {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3093,7 +3093,7 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
 Tensor sinc_backward(const Tensor& grad, const Tensor& self) {
   auto self_pi = self * M_PI
   auto self_squared_pi = self * self * M_PI
-  auto out = grad * ((self_pi * self_pi.cos() - self_pi.sin()) / (self_squared_pi)).conj();
+  auto out = grad * ((self_pi * self_pi.cos() - self_pi.sin()) / self_squared_pi).conj();
   return at::where(self_squared_pi == 0.0, at::zeros({}, grad.options()), out);
 }
 


### PR DESCRIPTION
Problem arises for sinc'(x) where x != 0, but x ** 2 == 0, which happens for some very small floats.

I realized that my solution from #56763 was incomplete when I did a quick implementation using `torch.autograd.Function` and still got a `NaN` from my derivative.