### PR TITLE
Back out "fx: Fix type_matches for Optional[List[int]] arguments"

### DIFF
--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -133,9 +133,9 @@ def type_matches(signature_type : Any, argument_type : Any):
             return True
         return all(c is int or (c is Ellipsis) for c in contained)
 
-    if signature_type is List[int]:
+    if signature_type is List[int] and is_homogeneous_int_tuple(argument_type):
         # Tuple[int] is accepted for List[int] parameters
-        return is_homogeneous_int_tuple(argument_type)
+        return True
 
     # Dtype is an int in schemas
     if signature_type is int and argument_type is torch.dtype:
@@ -218,16 +218,14 @@ def normalize_function(
                     arg_types = arg_types if arg_types else cast(Tuple[Any], ())
                     kwarg_types = kwarg_types if kwarg_types else {}
                     for candidate_signature in torch_op_schemas:
+                        sig_matches = True
                         try:
                             bound_types = candidate_signature.bind(*arg_types, **kwarg_types)
+                            for arg_name, arg_type in bound_types.arguments.items():
+                                param = candidate_signature.parameters[arg_name]
+                                sig_matches = sig_matches and type_matches(param.annotation, arg_type)
                         except TypeError as e:
-                            continue
-
-                        sig_matches = True
-                        for arg_name, arg_type in bound_types.arguments.items():
-                            param = candidate_signature.parameters[arg_name]
-                            sig_matches = sig_matches and type_matches(param.annotation, arg_type)
-
+                            sig_matches = False
                         if sig_matches:
                             new_args_and_kwargs = _args_kwargs_to_normalized_args_kwargs(candidate_signature, args, kwargs,
                                                                                          normalize_to_only_use_kwargs)


### PR DESCRIPTION
Summary:
Original commit changeset: c5aa5f61a215

Diff: D27987746 (https://github.com/pytorch/pytorch/commit/267b554b6fd7d8dfdfb9885c663fbe48fb26b2f8)

Test Plan: `buck test` under the glow-buck target is the target that this reversion is intended to fix

Reviewed By: jfix71

Differential Revision: D28019659

