### PR TITLE
[PyTorch] Reduce errors of `foreach` functions

### DIFF
--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -7,13 +7,14 @@ namespace at {
 namespace native {
 namespace {
 // Check if tensor list has either a boolean tensor or a integer tensor
-bool has_int_or_bool_tensor(TensorList tensors) {
-  for (const auto & tensor : tensors) {
-    if (at::isIntegralType(tensor.scalar_type(), /* includeBool= */true)) {
-      return true;
-    }
-  }
-  return false;
+bool has_integral_tensor(TensorList tensors, const bool includeBool) {
+  return std::any_of(tensors.begin(), tensors.end(),
+    [&includeBool](const auto & t) { return at::isIntegralType(t.scalar_type(), includeBool); });
+}
+// check if tensor list has bool tensors
+bool has_bool_tensor(TensorList tensors) {
+  return std::any_of(tensors.begin(), tensors.end(),
+    [](const auto & t) -> bool { return t.scalar_type() == ScalarType::Bool; });
 }
 
 // Check foreach API restrictions

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -129,6 +129,8 @@ bool check_fast_path_restrictions(
           return false;
         }
       } else if (scalarList.size() > 1) {
+        // FIXME(mkozuki): Consider specializing `TensorListScalarListMetadata` for complex dtypes
+        // to access the following comment.
         // Complex scalar list is not supported due to the limit for kernel launch argument (4KB)
         if (scalarList[i].isComplex()) {
           return false;

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -20,69 +20,40 @@ bool has_int_or_bool_tensor(TensorList tensors) {
 // - Tensor lists must be non-empty.
 // - All TensorLists and ScalarLists must have the same number of elements.
 // - Corresponding tensors must have the same size.
-// - [optional] All tensors in all lists must have the same dtype.
-//     This condition is now checked by `check_fast_path_restrictions`.
-//     In general, `foreach` functions go through fast path if possible, otherwise slow path.
-//     If a function goes through a slow path, tensors can have different dtypes because
-//     a slow path is basically either `for (auto & t : tensors) at::func(t)`.
-//     or `for (auto & t : tensors) t.op_()`.
-//     But this is MUST for some cases, for example,
-//     `_amp_foreach_non_finite_check_and_unscale_cuda_`.
-void check_foreach_api_restrictions(TensorList tensors, const bool check_dtype=false) {
+void check_foreach_api_restrictions(TensorList tensors) {
   TORCH_CHECK(tensors.size() > 0, "Tensor list must have at least one tensor.");
-  if (check_dtype) {
-    const auto expected_dtype = tensors[0].dtype();
-    for (const auto & t : tensors) {
-      TORCH_CHECK(t.dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
-    }
-  }
 }
 
-void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars, const bool check_dtype=false) {
-  check_foreach_api_restrictions(tensors, check_dtype);
+void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars) {
+  check_foreach_api_restrictions(tensors);
   TORCH_CHECK(tensors.size() == scalars.size(), "Tensor list must have same number of elements as scalar list.");
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, const bool check_dtype=false) {
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
   TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
 
-  const auto expected_dtype = tensors1[0].dtype();
-
   for (const auto i : c10::irange(tensors1.size())) {
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
-
-    if (check_dtype) {
-      TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
-      TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
-    }
   }
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, const bool check_dtype=false) {
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
   TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors3.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
   TORCH_CHECK(tensors1.size() == tensors3.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors3.size());
 
-  const auto expected_dtype = tensors1[0].dtype();
-
   for (const auto i : c10::irange(tensors1.size())) {
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
     TORCH_CHECK(tensors1[i].sizes() == tensors3[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors3[i].sizes());
-
-    if (check_dtype) {
-      TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
-      TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
-      TORCH_CHECK(tensors3[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
-    }
   }
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, ArrayRef<Scalar> scalars, const bool check_dtype=false) {
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3, check_dtype);
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, ArrayRef<Scalar> scalars) {
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3);
   TORCH_CHECK(tensors1.size() == scalars.size(), "Tensor list must have same number of elements as scalar list, got ", tensors1.size(), " and ", scalars.size());
 }
 

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -8,13 +8,12 @@ namespace native {
 namespace {
 // Check if tensor list has either a boolean tensor or a integer tensor
 bool has_int_or_bool_tensor(TensorList tensors) {
-  bool has_integral{false};
   for (const auto & tensor : tensors) {
     if (at::isIntegralType(tensor.scalar_type(), /* includeBool= */true)) {
-      has_integral = true;
+      return true;
     }
   }
-  return has_integral;
+  return false;
 }
 
 // Check foreach API restrictions

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -21,44 +21,74 @@ bool has_int_or_bool_tensor(TensorList tensors) {
 // - Tensor lists must be non-empty.
 // - All TensorLists and ScalarLists must have the same number of elements.
 // - Corresponding tensors must have the same size.
-void check_foreach_api_restrictions(TensorList tensors) {
+// - [optional] All tensors in all lists must have the same dtype.
+//     This condition is now checked by `check_fast_path_restrictions`.
+//     In general, `foreach` functions go through fast path if possible, otherwise slow path.
+//     If a function goes through a slow path, tensors can have different dtypes because
+//     a slow path is basically either `for (auto & t : tensors) at::func(t)`.
+//     or `for (auto & t : tensors) t.op_()`.
+//     But this is MUST for some cases, for example,
+//     `_amp_foreach_non_finite_check_and_unscale_cuda_`.
+void check_foreach_api_restrictions(TensorList tensors, const bool check_dtype=false) {
   TORCH_CHECK(tensors.size() > 0, "Tensor list must have at least one tensor.");
+  if (check_dtype) {
+    const auto expected_dtype = tensors[0].dtype();
+    for (const auto & t : tensors) {
+      TORCH_CHECK(t.dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
+    }
+  }
 }
 
-void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars) {
-  check_foreach_api_restrictions(tensors);
+void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars, const bool check_dtype=false) {
+  check_foreach_api_restrictions(tensors, check_dtype);
   TORCH_CHECK(tensors.size() == scalars.size(), "Tensor list must have same number of elements as scalar list.");
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, const bool check_dtype=false) {
   TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
 
+  const auto expected_dtype = tensors1[0].dtype();
+
   for (const auto i : c10::irange(tensors1.size())) {
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
+
+    if (check_dtype) {
+      TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
+      TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
+    }
   }
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3) {
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, const bool check_dtype=false) {
   TORCH_CHECK(tensors1.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors3.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
   TORCH_CHECK(tensors1.size() == tensors3.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors3.size());
 
+  const auto expected_dtype = tensors1[0].dtype();
+
   for (const auto i : c10::irange(tensors1.size())) {
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
     TORCH_CHECK(tensors1[i].sizes() == tensors3[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors3[i].sizes());
+
+    if (check_dtype) {
+      TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
+      TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
+      TORCH_CHECK(tensors3[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype");
+    }
   }
 }
 
-void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, ArrayRef<Scalar> scalars) {
-  check_foreach_api_restrictions(tensors1, tensors2, tensors3);
+void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, TensorList tensors3, ArrayRef<Scalar> scalars, const bool check_dtype=false) {
+  check_foreach_api_restrictions(tensors1, tensors2, tensors3, check_dtype);
   TORCH_CHECK(tensors1.size() == scalars.size(), "Tensor list must have same number of elements as scalar list, got ", tensors1.size(), " and ", scalars.size());
 }
 
 // To go via 'fast' path, several conditions must be satisfied
+// - All tensors in all lists must have the same dtype.
 // - All tensors must be on the same device
 // - All tensors must have strided layout
 // - All tensors must be non-overlapping and dense

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -6,17 +6,23 @@
 namespace at {
 namespace native {
 namespace {
+// Check if tensor list has either a boolean tensor or a integer tensor
+bool has_int_or_bool_tensor(TensorList tensors) {
+  bool has_integral{false};
+  for (const auto & tensor : tensors) {
+    if (at::isIntegralType(tensor.scalar_type(), /* includeBool= */true)) {
+      has_integral = true;
+    }
+  }
+  return has_integral;
+}
+
 // Check foreach API restrictions
 // - Tensor lists must be non-empty.
-// - All tensors in all lists must have the same dtype.
 // - All TensorLists and ScalarLists must have the same number of elements.
 // - Corresponding tensors must have the same size.
 void check_foreach_api_restrictions(TensorList tensors) {
   TORCH_CHECK(tensors.size() > 0, "Tensor list must have at least one tensor.");
-  auto expected_dtype = tensors[0].dtype();
-  for (const auto& t : tensors) {
-    TORCH_CHECK(t.dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
-  }
 }
 
 void check_foreach_api_restrictions(TensorList tensors, ArrayRef<Scalar> scalars) {
@@ -29,11 +35,7 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2) {
   TORCH_CHECK(tensors2.size() > 0, "Tensor list must have at least one tensor.");
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
 
-  auto expected_dtype = tensors1[0].dtype();
-
   for (const auto i : c10::irange(tensors1.size())) {
-    TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
-    TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
   }
 }
@@ -45,11 +47,7 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, Te
   TORCH_CHECK(tensors1.size() == tensors2.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors2.size());
   TORCH_CHECK(tensors1.size() == tensors3.size(), "Tensor lists must have the same number of tensors, got ", tensors1.size(), " and ", tensors3.size());
 
-  auto expected_dtype = tensors1[0].dtype();
-
   for (const auto i : c10::irange(tensors1.size())) {
-    TORCH_CHECK(tensors1[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
-    TORCH_CHECK(tensors2[i].dtype() == expected_dtype, "All tensors in the tensor list must have the same dtype.");
     TORCH_CHECK(tensors1[i].sizes() == tensors2[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors2[i].sizes());
     TORCH_CHECK(tensors1[i].sizes() == tensors3[i].sizes(), "Corresponding tensors in lists must have the same size, got ", tensors1[i].sizes(), " and ", tensors3[i].sizes());
   }
@@ -67,6 +65,21 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, Te
 // - Resulting tensor must have the same dtype as the input one
 
 bool will_promote_tensor(const Tensor& tensor, const Scalar& scalar, bool does_op_promote_integer_inputs_to_float = false) {
+  // complex scalar + float/int/bool tensor will result in complex tensor
+  if (scalar.isComplex() && (at::isIntegralType(tensor.scalar_type(), /* includeBool= */true) || at::isFloatingType(tensor.scalar_type())) ) {
+    return true;
+  }
+
+  // float scalar + int/bool tensor will result in float tensor
+  if (scalar.isFloatingPoint() && at::isIntegralType(tensor.scalar_type(), /* includeBool= */true)) {
+    return true;
+  }
+
+  // int scalar + bool tensor will result in int tensor
+  if (scalar.isIntegral(/* includeBool= */false) && tensor.dtype() == at::kBool) {
+    return true;
+  }
+
   // In case of division, integer inputs will result in float
   if (does_op_promote_integer_inputs_to_float) {
     if (at::isIntegralType(tensor.scalar_type(), /*includeBool*/ true)) {
@@ -83,10 +96,12 @@ bool check_fast_path_restrictions(
   ArrayRef<TensorList> tensorLists,
   ArrayRef<Scalar> scalarList = {},
   bool does_op_promote_integer_inputs_to_float = false) {
-    auto expected_device = tensorLists[0][0].device();
+    const auto expected_dtype = tensorLists[0][0].dtype();
+    const auto expected_device = tensorLists[0][0].device();
 
     auto is_tensor_okay = [&](const Tensor& tensor) {
-      return tensor.device() == expected_device &&
+      return tensor.dtype() == expected_dtype &&
+             tensor.device() == expected_device &&
              tensor.layout() == at::kStrided &&
              tensor.is_non_overlapping_and_dense();
     };

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -101,7 +101,7 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
   TORCH_CHECK(found_inf.scalar_type() == at::ScalarType::Float, "found_inf must be a float tensor.");
 
   // Ensures client code (GradScaler) filtered scaled_grads by dtype.
-  check_foreach_api_restrictions(scaled_grads, /* check_dtype = */true);
+  check_foreach_api_restrictions(scaled_grads);
 
   std::vector<std::vector<at::Tensor>> tensor_lists;
 
@@ -113,6 +113,7 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
     //  - all scaled_grads are strided
     //  - all scaled_grads are non overlapping and dense
     //  - all scaled_grads are on the same device
+    //  - all scaled_grads are of the same dtype
     TORCH_CHECK(scaled_grads[0].is_cuda(), "scaled_grads must be CUDA tensors.");
     // Sets up MTA launch to use scaled_grads as-is.
     tensor_lists.emplace_back(scaled_grads.vec());
@@ -126,12 +127,13 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
     tensor_lists.resize(1);
     tensor_lists[0].reserve(scaled_grads.size());
     auto expected_device = scaled_grads[0].device();
+    const auto expected_dtype = scaled_grads[0].scalar_type();
     for (const Tensor& t : scaled_grads) {
       // Ensures GradScaler filtered scaled_grads by device.
       TORCH_CHECK(t.is_cuda(), "one of scaled_grads was not a CUDA tensor.");
       TORCH_CHECK(t.device() == expected_device, "scaled_grads must be on the same device.");
       TORCH_CHECK(t.layout() == at::kStrided, "one of scaled_grads was not a strided tensor.");
-      if (!t.is_non_overlapping_and_dense()) {
+      if (!t.is_non_overlapping_and_dense() || t.scalar_type() != expected_dtype) {
         // t is acceptable but not MTA-safe.  Falls back to single-tensor TensorIterator kernel.
         _amp_non_finite_check_and_unscale_cuda_(const_cast<Tensor&>(t),
                                                 found_inf,

--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -101,7 +101,7 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
   TORCH_CHECK(found_inf.scalar_type() == at::ScalarType::Float, "found_inf must be a float tensor.");
 
   // Ensures client code (GradScaler) filtered scaled_grads by dtype.
-  check_foreach_api_restrictions(scaled_grads);
+  check_foreach_api_restrictions(scaled_grads, /* check_dtype = */true);
 
   std::vector<std::vector<at::Tensor>> tensor_lists;
 

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -105,7 +105,7 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
 std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
                                                                                                                                       \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral_tensor(input, /* includeBool */ true)) {             \
         return at::native::foreach_tensor_##NAME##_scalar_slow(input, tensors1, tensors2, scalar);                                    \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -115,7 +115,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, Tensor
 void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
                                                                                                                                       \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral_tensor(input, /* includeBool */ true)) {             \
         return at::native::foreach_tensor_##NAME##_scalar_slow_(input, tensors1, tensors2, scalar);                                   \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -127,7 +127,7 @@ void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1,
 std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
                                                                                                                                                          \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral_tensor(input, /* includeBool */ true)) {                               \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow(input, tensors1, tensors2, scalars);                                                  \
     }                                                                                                                                                    \
                                                                                                                                                          \
@@ -137,7 +137,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, Te
 void foreach_tensor_##NAME##_scalarlist_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
                                                                                                                                                          \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral_tensor(input, /* includeBool */ true)) {                               \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow_(input, tensors1, tensors2, scalars);                                                 \
     }                                                                                                                                                    \
                                                                                                                                                          \
@@ -149,15 +149,6 @@ FOREACH_POINTWISE_OP_SCALAR(addcdiv, std::divides);
 FOREACH_POINTWISE_OP_SCALARLIST(addcmul, std::multiplies);
 FOREACH_POINTWISE_OP_SCALARLIST(addcdiv, std::divides);
 
-
-bool has_bool_tensor(TensorList tensors) {
-  for (const auto & tensor : tensors) {
-    if (tensor.scalar_type() == ScalarType::Bool) {
-      return true;
-    }
-  }
-  return false;
-}
 
 #define FOREACH_MAXIMUM_MINIMUM_OP(NAME, OP)                                                               \
 std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList tensors2) {               \

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -150,6 +150,9 @@ FOREACH_POINTWISE_OP_SCALARLIST(addcmul, std::multiplies);
 FOREACH_POINTWISE_OP_SCALARLIST(addcdiv, std::divides);
 
 
+// Why bool tensors are pushed to slowpath?
+// Because `AT_DISPATCH_ALL_TYPES_AND` is used below.
+// TODO(mkozuki): Check whether it's possible to handle bool tensors in fastpath.
 #define FOREACH_MAXIMUM_MINIMUM_OP(NAME, OP)                                                               \
 std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList tensors2) {               \
     check_foreach_api_restrictions(tensors1, tensors2);                                                    \

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -104,9 +104,7 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
 #define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                                                                                         \
 std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
-    const bool has_integral = has_int_or_bool_tensor(input);                                                                          \
-                                                                                                                                      \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral) {                                                  \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow(input, tensors1, tensors2, scalar);                                    \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -115,9 +113,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, Tensor
                                                                                                                                       \
 void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
-    const bool has_integral = has_int_or_bool_tensor(input);                                                                          \
-                                                                                                                                      \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral) {                                                  \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow_(input, tensors1, tensors2, scalar);                                   \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -128,9 +124,7 @@ void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1,
 #define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                                                                                                        \
 std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
-    const bool has_integral = has_int_or_bool_tensor(input);                                                                                             \
-                                                                                                                                                         \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral) {                                                                     \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow(input, tensors1, tensors2, scalars);                                                  \
     }                                                                                                                                                    \
                                                                                                                                                          \
@@ -139,9 +133,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, Te
                                                                                                                                                          \
 void foreach_tensor_##NAME##_scalarlist_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
-    const bool has_integral = has_int_or_bool_tensor(input);                                                                                             \
-                                                                                                                                                         \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral) {                                                                     \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow_(input, tensors1, tensors2, scalars);                                                 \
     }                                                                                                                                                    \
                                                                                                                                                          \

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -145,10 +145,20 @@ FOREACH_POINTWISE_OP_SCALAR(addcdiv, std::divides);
 FOREACH_POINTWISE_OP_SCALARLIST(addcmul, std::multiplies);
 FOREACH_POINTWISE_OP_SCALARLIST(addcdiv, std::divides);
 
+
+bool has_bool_tensor(TensorList tensors) {
+  for (const auto & tensor : tensors) {
+    if (tensor.scalar_type() == ScalarType::Bool) {
+      return true;
+    }
+  }
+  return false;
+}
+
 #define FOREACH_MAXIMUM_MINIMUM_OP(NAME, OP)                                                               \
 std::vector<Tensor> foreach_tensor_##NAME##_cuda(TensorList tensors1, TensorList tensors2) {               \
     check_foreach_api_restrictions(tensors1, tensors2);                                                    \
-    if (!can_use_fast_route({tensors1, tensors2})) {                                                       \
+    if (!can_use_fast_route({tensors1, tensors2}) || has_bool_tensor(tensors1)) {                          \
         return at::native::foreach_tensor_##NAME##_slow(tensors1, tensors2);                               \
     }                                                                                                      \
                                                                                                            \

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -104,6 +104,7 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
 #define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                                                                                         \
 std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
+                                                                                                                                      \
     if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow(input, tensors1, tensors2, scalar);                                    \
     }                                                                                                                                 \
@@ -113,6 +114,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, Tensor
                                                                                                                                       \
 void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
+                                                                                                                                      \
     if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_int_or_bool_tensor(input)) {                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow_(input, tensors1, tensors2, scalar);                                   \
     }                                                                                                                                 \
@@ -124,6 +126,7 @@ void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1,
 #define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                                                                                                        \
 std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
+                                                                                                                                                         \
     if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow(input, tensors1, tensors2, scalars);                                                  \
     }                                                                                                                                                    \
@@ -133,6 +136,7 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, Te
                                                                                                                                                          \
 void foreach_tensor_##NAME##_scalarlist_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
+                                                                                                                                                         \
     if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_int_or_bool_tensor(input)) {                                                    \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow_(input, tensors1, tensors2, scalars);                                                 \
     }                                                                                                                                                    \

--- a/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachPointwiseOp.cu
@@ -104,8 +104,9 @@ std::vector<Tensor> foreach_pointwise_op(TensorList input, TensorList tensors1, 
 #define FOREACH_POINTWISE_OP_SCALAR(NAME, OP)                                                                                         \
 std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
+    const bool has_integral = has_int_or_bool_tensor(input);                                                                          \
                                                                                                                                       \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar)) {                                                                   \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral) {                                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow(input, tensors1, tensors2, scalar);                                    \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -114,8 +115,9 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalar_cuda(TensorList input, Tensor
                                                                                                                                       \
 void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, const Scalar& scalar) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2);                                                                        \
+    const bool has_integral = has_int_or_bool_tensor(input);                                                                          \
                                                                                                                                       \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalar)) {                                                                   \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalar) || has_integral) {                                                  \
         return at::native::foreach_tensor_##NAME##_scalar_slow_(input, tensors1, tensors2, scalar);                                   \
     }                                                                                                                                 \
                                                                                                                                       \
@@ -126,8 +128,9 @@ void foreach_tensor_##NAME##_scalar_cuda_(TensorList input, TensorList tensors1,
 #define FOREACH_POINTWISE_OP_SCALARLIST(NAME, OP)                                                                                                        \
 std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {  \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
+    const bool has_integral = has_int_or_bool_tensor(input);                                                                                             \
                                                                                                                                                          \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars)) {                                                                                     \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral) {                                                                     \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow(input, tensors1, tensors2, scalars);                                                  \
     }                                                                                                                                                    \
                                                                                                                                                          \
@@ -136,8 +139,9 @@ std::vector<Tensor> foreach_tensor_##NAME##_scalarlist_cuda(TensorList input, Te
                                                                                                                                                          \
 void foreach_tensor_##NAME##_scalarlist_cuda_(TensorList input, TensorList tensors1, TensorList tensors2, at::ArrayRef<Scalar> scalars) {                \
     check_foreach_api_restrictions(input, tensors1, tensors2, scalars);                                                                                  \
+    const bool has_integral = has_int_or_bool_tensor(input);                                                                                             \
                                                                                                                                                          \
-    if (!can_use_fast_route({input, tensors1, tensors2}, scalars)) {                                                                                     \
+    if (!can_use_fast_route({input, tensors1, tensors2}, scalars) || has_integral) {                                                                     \
         return at::native::foreach_tensor_##NAME##_scalarlist_slow_(input, tensors1, tensors2, scalars);                                                 \
     }                                                                                                                                                    \
                                                                                                                                                          \

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -247,15 +247,10 @@ struct Abs {
 
 std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    bool has_complex_or_integer = false;
-    for (const auto& t : tensors) {
-        if (at::isComplexType(t.scalar_type())) {
-            has_complex_or_integer = true;
-            break;
-        }
-    }
-
-    if (!can_use_fast_route(tensors) || has_complex_or_integer) {
+    const bool has_complex = std::any_of(
+        tensors.begin(), tensors.end(),
+        [](const auto & t) { return at::isComplexType(t.scalar_type()); });
+    if (!can_use_fast_route(tensors) || has_complex) {
         return at::native::foreach_tensor_abs_slow(tensors);
     }
 
@@ -264,15 +259,10 @@ std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
 
 void foreach_tensor_abs_cuda_(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    bool has_complex_or_integer = false;
-    for (const auto& t : tensors) {
-        if (at::isComplexType(t.scalar_type())) {
-            has_complex_or_integer = true;
-            break;
-        }
-    }
-
-    if (!can_use_fast_route(tensors) || has_complex_or_integer) {
+    const bool has_complex = std::any_of(
+        tensors.begin(), tensors.end(),
+        [](const auto & t) { return at::isComplexType(t.scalar_type()); });
+    if (!can_use_fast_route(tensors) || has_complex) {
         return at::native::foreach_tensor_abs_slow_(tensors);
     }
 

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -133,14 +133,14 @@ struct functor_name {                                                \
 #define OP_CUSTOM_FUNCTOR(function, op_name, functor_name)                \
 std::vector<Tensor> foreach_tensor_##op_name##_cuda(TensorList tensors) { \
     check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors) || has_int_or_bool_tensor(tensors)) { \
+    if (!can_use_fast_route(tensors) || has_integral_tensor(tensors, /* includeBool */ true)) { \
         return at::native::foreach_tensor_##op_name##_slow(tensors);      \
     }                                                                     \
     return function<functor_name>(tensors);                               \
 }                                                                         \
 void foreach_tensor_##op_name##_cuda_(TensorList tensors) {               \
     check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors) || has_int_or_bool_tensor(tensors)) { \
+    if (!can_use_fast_route(tensors) || has_integral_tensor(tensors, /* includeBool */ true)) { \
         return at::native::foreach_tensor_##op_name##_slow_(tensors);     \
     }                                                                     \
                                                                           \

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -133,16 +133,14 @@ struct functor_name {                                                \
 #define OP_CUSTOM_FUNCTOR(function, op_name, functor_name)                \
 std::vector<Tensor> foreach_tensor_##op_name##_cuda(TensorList tensors) { \
     check_foreach_api_restrictions(tensors);                              \
-    const bool has_integral = has_int_or_bool_tensor(tensors);            \
-    if (!can_use_fast_route(tensors) || has_integral) {                   \
+    if (!can_use_fast_route(tensors) || has_int_or_bool_tensor(tensors)) { \
         return at::native::foreach_tensor_##op_name##_slow(tensors);      \
     }                                                                     \
     return function<functor_name>(tensors);                               \
 }                                                                         \
 void foreach_tensor_##op_name##_cuda_(TensorList tensors) {               \
     check_foreach_api_restrictions(tensors);                              \
-    const bool has_integral = has_int_or_bool_tensor(tensors);            \
-    if (!can_use_fast_route(tensors) || has_integral) {                   \
+    if (!can_use_fast_route(tensors) || has_int_or_bool_tensor(tensors)) { \
         return at::native::foreach_tensor_##op_name##_slow_(tensors);     \
     }                                                                     \
                                                                           \

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -249,8 +249,9 @@ std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
     bool has_complex_or_integer = false;
     for (const auto& t : tensors) {
-        if (at::isComplexType(t.scalar_type()) || at::isIntegralType(t.scalar_type(), /* includeBool= */true)) {
+        if (at::isComplexType(t.scalar_type())) {
             has_complex_or_integer = true;
+            break;
         }
     }
 
@@ -265,8 +266,9 @@ void foreach_tensor_abs_cuda_(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
     bool has_complex_or_integer = false;
     for (const auto& t : tensors) {
-        if (at::isComplexType(t.scalar_type()) || at::isIntegralType(t.scalar_type(), /* includeBool= */true)) {
+        if (at::isComplexType(t.scalar_type())) {
             has_complex_or_integer = true;
+            break;
         }
     }
 

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -133,14 +133,16 @@ struct functor_name {                                                \
 #define OP_CUSTOM_FUNCTOR(function, op_name, functor_name)                \
 std::vector<Tensor> foreach_tensor_##op_name##_cuda(TensorList tensors) { \
     check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors)) {                                   \
+    const bool has_integral = has_int_or_bool_tensor(tensors);            \
+    if (!can_use_fast_route(tensors) || has_integral) {                   \
         return at::native::foreach_tensor_##op_name##_slow(tensors);      \
     }                                                                     \
     return function<functor_name>(tensors);                               \
 }                                                                         \
 void foreach_tensor_##op_name##_cuda_(TensorList tensors) {               \
     check_foreach_api_restrictions(tensors);                              \
-    if (!can_use_fast_route(tensors)) {                                   \
+    const bool has_integral = has_int_or_bool_tensor(tensors);            \
+    if (!can_use_fast_route(tensors) || has_integral) {                   \
         return at::native::foreach_tensor_##op_name##_slow_(tensors);     \
     }                                                                     \
                                                                           \
@@ -247,14 +249,14 @@ struct Abs {
 
 std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    bool has_complex = false;
-    for (auto t : tensors) {
-        if (at::isComplexType(t.scalar_type())) {
-            has_complex = true;
+    bool has_complex_or_integer = false;
+    for (const auto& t : tensors) {
+        if (at::isComplexType(t.scalar_type()) || at::isIntegralType(t.scalar_type(), /* includeBool= */true)) {
+            has_complex_or_integer = true;
         }
     }
 
-    if (!can_use_fast_route(tensors) || has_complex) {
+    if (!can_use_fast_route(tensors) || has_complex_or_integer) {
         return at::native::foreach_tensor_abs_slow(tensors);
     }
 
@@ -263,14 +265,14 @@ std::vector<Tensor> foreach_tensor_abs_cuda(TensorList tensors) {
 
 void foreach_tensor_abs_cuda_(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    bool has_complex = false;
-    for (auto t : tensors) {
-        if (at::isComplexType(t.scalar_type())) {
-            has_complex = true;
+    bool has_complex_or_integer = false;
+    for (const auto& t : tensors) {
+        if (at::isComplexType(t.scalar_type()) || at::isIntegralType(t.scalar_type(), /* includeBool= */true)) {
+            has_complex_or_integer = true;
         }
     }
 
-    if (!can_use_fast_route(tensors) || has_complex) {
+    if (!can_use_fast_route(tensors) || has_complex_or_integer) {
         return at::native::foreach_tensor_abs_slow_(tensors);
     }
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1905,13 +1905,16 @@ torch.cuda.synchronize()
                 for grad in grads:
                     self.assertTrue(torch.allclose(grad, torch.ones_like(grad), atol=1e-7))
 
-        # Passing lists with mismatched devices or dtypes to a raw
-        # _amp_foreach_non_finite_check_and_unscale_ call should raise errors.
-        with self.assertRaisesRegex(RuntimeError, r"must have the same dtype"):
-            torch._amp_foreach_non_finite_check_and_unscale_([g.clone(), g.to(dtype=torch.float16)],
-                                                             found_inf,
-                                                             inv_scale)
+        # When passing lists with mismatched dtypes to a raw
+        # _amp_foreach_non_finite_check_and_unscale_ call,
+        # it's expected to fall back to single-tensor TensorIterator kernel.
+        grads = [g.clone(), g.to(dtype=torch.float16)]
+        torch._amp_foreach_non_finite_check_and_unscale_(grads, found_inf, inv_scale)
+        for grad in grads:
+            self.assertTrue(torch.allclose(grad, torch.ones_like(grad), atol=1e-7))
 
+        # Passing lists with mismatched devices to a raw
+        # _amp_foreach_non_finite_check_and_unscale_ call should raise errors.
         if TEST_MULTIGPU:
             with self.assertRaisesRegex(RuntimeError, r"scaled_grads must be on the same device."):
                 torch._amp_foreach_non_finite_check_and_unscale_([g.clone(), g.to(device="cuda:1")],

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -878,8 +878,11 @@ class TestForeach(TestCase):
             # `tensors2`: ['cuda', 'cpu']
             _cuda_tensors = self._get_test_data(device, dtype, 2)
             _cpu_tensors = self._get_test_data('cpu', dtype, 2)
-            tensors1, tensors2 = [[_cuda_tensors[i], _cpu_tensors[i]] for i in range(2)]
+            tensors1, tensors2 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
 
+            # note(mkozuki): Why handling sub with bool differently?
+            # Because the error message includes at least one special character, `^`,
+            # causing the regex match to fail in the following `try-except` block.
             if dtype == torch.bool and native_op == torch.sub:
                 with self.assertRaisesRegex(RuntimeError, "Subtraction, the `-` operator"):
                     foreach_op(tensors1, tensors2)
@@ -918,8 +921,11 @@ class TestForeach(TestCase):
             # tensors3: ['cuda', 'cpu]
             _cuda_tensors = self._get_test_data(device, dtype, 3)
             _cpu_tensors = self._get_test_data('cpu', dtype, 3)
-            tensors1, tensors2, tensors3 = [[_cuda_tensors[i], _cpu_tensors[i]] for i in range(3)]
+            tensors1, tensors2, tensors3 = list(tensors for tensors in zip(_cuda_tensors, _cpu_tensors))
 
+            # note(mkozuki): Why handling addcdiv with int and bool differently?
+            # Because the error message includes some special characters, `*`,
+            # causing the regex match to fail in the following `try-except` block.
             if native_op == torch.addcdiv:
                 if dtype in torch.testing.get_all_int_dtypes() + [torch.bool]:
                     with self.assertRaisesRegex(RuntimeError, "Integer division with addcdiv"):

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -126,7 +126,6 @@ class TestForeach(TestCase):
             else:
                 self.assertEqual(tensors1, expected)
 
-    @skipMeta
     @ops(foreach_unary_op_db)
     def test_unary(self, device, dtype, op):
         for N in N_values:
@@ -152,7 +151,6 @@ class TestForeach(TestCase):
     #
     # Pointwise ops
     #
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
     def test_addcmul(self, device, dtype):
         if self.device_type == 'cpu':
@@ -164,7 +162,6 @@ class TestForeach(TestCase):
 
         self._test_pointwise_op(device, dtype, torch._foreach_addcmul, torch._foreach_addcmul_, torch.addcmul)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
     def test_addcdiv(self, device, dtype):
         if dtype in [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]:
@@ -181,7 +178,6 @@ class TestForeach(TestCase):
                 return
         self._test_pointwise_op(device, dtype, torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_complex=False))
     def test_min_max(self, device, dtype):
         for N in N_values:
@@ -204,7 +200,6 @@ class TestForeach(TestCase):
             res_min = torch._foreach_minimum(tensors1, tensors2)
             self.assertEqual(res_min, expected_min)
 
-    @skipMeta
     @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
     def test_max_min_float_inf_nan(self, device, dtype):
         a = [
@@ -229,7 +224,6 @@ class TestForeach(TestCase):
         res = torch._foreach_minimum(a, b)
         self.assertEqual(expected, res)
 
-    @skipMeta
     @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
     def test_max_min_inf_nan(self, device, dtype):
         a = [
@@ -258,7 +252,6 @@ class TestForeach(TestCase):
     # Ops with scalar
     #
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_int_scalar_op(self, device, dtype):
         for N in N_values:
@@ -325,7 +318,6 @@ class TestForeach(TestCase):
     # As optimizers work with float tensors, the result will always be torch.float32 for now.
     # Current schema is using 'float[]' as scalar list type.
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_int_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -368,7 +360,6 @@ class TestForeach(TestCase):
                         self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_float_scalar_op(self, device, dtype):
         for N in N_values:
@@ -411,7 +402,6 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, expected)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_float_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -484,7 +474,6 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, expected)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_complex_scalar_op(self, device, dtype):
         for N in N_values:
@@ -519,7 +508,6 @@ class TestForeach(TestCase):
                     self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_complex_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -549,7 +537,6 @@ class TestForeach(TestCase):
                     self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_bool_scalar_op(self, device, dtype):
         for N in N_values:
@@ -580,7 +567,6 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, res)
 
     @skipCUDAIfRocm
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_bool_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -622,7 +608,6 @@ class TestForeach(TestCase):
                     foreach_bin_op_(tensors, scalars)
                     self.assertEqual(tensors, res)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_mixed_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -655,7 +640,6 @@ class TestForeach(TestCase):
                     with self.assertRaisesRegex(RuntimeError, "can't be cast to the desired output type"):
                         foreach_bin_op_(tensors, scalars)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_with_different_size_tensors(self, device, dtype):
         if dtype == torch.bool:
@@ -666,7 +650,6 @@ class TestForeach(TestCase):
         torch._foreach_add_(tensors, 1)
         self.assertEqual(expected, tensors)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
         # TODO: enable empty list case
@@ -677,7 +660,6 @@ class TestForeach(TestCase):
             torch._foreach_add_(tensors, 1)
             self.assertEqual(res, tensors)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_scalar_with_overlapping_tensors(self, device, dtype):
         tensors = [torch.ones(1, 1, device=device, dtype=dtype).expand(2, 1, 3)]
@@ -690,6 +672,9 @@ class TestForeach(TestCase):
         res = torch._foreach_add(tensors, 1)
         self.assertEqual(res, expected)
 
+    # note(mkozuki): this test case fails with Meta at least in my local environment.
+    # The message was
+    # `AssertionError: NotImplementedError("Could not run 'aten::_foreach_add.Scalar' with arguments from the 'Meta' backend.`
     @skipMeta
     def test_bin_op_scalar_with_different_tensor_dtypes(self, device):
         tensors = [torch.tensor([1.1], dtype=torch.float, device=device),
@@ -704,7 +689,6 @@ class TestForeach(TestCase):
     #
     # Ops with list
     #
-    @skipMeta
     def test_bin_op_list_error_cases(self, device):
         for bin_op, bin_op_, _ in self.bin_ops:
             tensors1 = []
@@ -748,13 +732,11 @@ class TestForeach(TestCase):
             with self.assertRaisesRegex(RuntimeError, r", got \[10, 10\] and \[11, 11\]"):
                 bin_op_(tensors1, tensors2)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list(self, device, dtype):
         self._test_bin_op_list(device, dtype, torch._foreach_add, torch._foreach_add_, torch.add)
         self._test_bin_op_list_alpha(device, dtype, torch._foreach_add, torch._foreach_add_, torch.add)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_sub_list(self, device, dtype):
         if dtype == torch.bool:
@@ -767,12 +749,10 @@ class TestForeach(TestCase):
             self._test_bin_op_list(device, dtype, torch._foreach_sub, torch._foreach_sub_, torch.sub)
             self._test_bin_op_list_alpha(device, dtype, torch._foreach_sub, torch._foreach_sub_, torch.sub)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_mul_list(self, device, dtype):
         self._test_bin_op_list(device, dtype, torch._foreach_mul, torch._foreach_mul_, torch.mul)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_div_list(self, device, dtype):
         if dtype in torch.testing.integral_types_and(torch.bool):
@@ -797,7 +777,6 @@ class TestForeach(TestCase):
             self.assertEqual(res, tensors1)
             self.assertEqual(tensors1, res)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list_different_sizes(self, device, dtype):
         tensors1 = [torch.zeros(10 + n, 10 + n, device=device, dtype=dtype) for n in range(10)]
@@ -809,7 +788,6 @@ class TestForeach(TestCase):
         self.assertEqual(res, [torch.ones(10 + n, 10 + n, device=device, dtype=dtype) for n in range(10)])
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not found")
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list_slow_path(self, device, dtype):
         # 0-strides
@@ -905,7 +883,6 @@ class TestForeach(TestCase):
             else:
                 self.assertEqual(actual, tensors1)
 
-    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=True))
     def test_pointwise_op_tensors_on_different_devices(self, device, dtype):
         if self.device_type != 'cuda':

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -183,7 +183,7 @@ class TestForeach(TestCase):
         self._test_pointwise_op(device, dtype, torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv)
 
     @skipMeta
-    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
+    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_complex=False))
     def test_min_max(self, device, dtype):
         for N in N_values:
             tensors1 = self._get_test_data(device, dtype, N)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -1,8 +1,9 @@
+import itertools
 import torch
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, dtypes, skipCUDAIfRocm, skipMeta, ops)
+    (instantiate_device_type_tests, deviceCountAtLeast, dtypes, skipCUDAIfRocm, skipMeta, ops)
 from torch._six import inf, nan
 from torch.testing._internal.common_methods_invocations import foreach_unary_op_db
 
@@ -841,6 +842,102 @@ class TestForeach(TestCase):
         res = torch._foreach_add([tensor1], [tensor2])
         torch._foreach_add_([tensor1], [tensor2])
         self.assertEqual(res, [tensor1])
+
+    # Below three methods are test to check whether foreach ops works or not
+    # when tensors are on different devices
+    # but tensors with the same index are on the same device.
+    @skipMeta
+    @deviceCountAtLeast(2)
+    @ops(foreach_unary_op_db)
+    def test_unary_op_tensors_on_different_devices(self, devices, dtype, op):
+        if 'abs' in op.ref.__name__ and dtype == torch.bool:
+            return
+        for dev_list in itertools.combinations(['cpu'] + devices, 2):
+            if 'cpu' in dev_list and dtype == torch.float16:
+                continue
+            # devices of `tensors` are: [dev_list[0], dev_list[0], dev_list[1]]
+            tensors = self._get_test_data(dev_list[0], dtype, 3)
+            tensors = [t.to(dev_list[i - 1]) if i > 0 else t for i, t in enumerate(tensors)]
+            expected = [op.ref(t) for t in tensors]
+            actual = op.get_method()(tensors)
+            self.assertEqual(expected, actual)
+            if 'abs' in op.ref.__name__ and dtype in torch.testing.get_all_complex_dtypes():
+                continue
+            if dtype not in torch.testing.get_all_int_dtypes():
+                op.get_inplace()(tensors)
+                self.assertEqual(expected, tensors)
+
+    # Test that if foreach ops works or not
+    # when tensors are on different devices
+    # but tensors with the same index are on the same device.
+    @skipMeta
+    @deviceCountAtLeast(2)
+    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=True))
+    def test_bin_op_tensors_on_different_devices(self, devices, dtype):
+        for foreach_op, foreach_op_, native_op in self.bin_ops:
+            if dtype == torch.bool and "sub" in native_op.__name__:
+                self.skipTest("Subtraction does not work with bool")
+            for dev0, dev1 in itertools.combinations(['cpu'] + devices, 2):
+                # devices of `tensors` are
+                # `tensors1`: [dev0, dev1]
+                # `tensors2`: [dev0, dev1]
+                tensors1 = self._get_test_data(dev0, dtype, 2)
+                tensors2 = self._get_test_data(dev1, dtype, 2)
+                tmp1, tmp2 = tensors2[0], tensors1[1]
+                tensors2[0] = tmp2
+                tensors1[1] = tmp1
+
+                expected = [native_op(t1, t2) for t1, t2 in zip(tensors1, tensors2)]
+                actual = foreach_op(tensors1, tensors2)
+                self.assertEqual(expected, actual)
+                if not (dtype in torch.testing.get_all_int_dtypes() and "div" in native_op.__name__):
+                    foreach_op_(tensors1, tensors2)
+                    self.assertEqual(expected, tensors1)
+
+    # Test that if foreach ops works or not
+    # when tensors are on different devices
+    # but tensors with the same index are on the same device.
+    @skipMeta
+    @deviceCountAtLeast(3)
+    @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=True))
+    def test_pointwise_op_tensors_on_different_devices(self, devices, dtype):
+        pointwise_ops = [
+            (torch._foreach_addcmul, torch._foreach_addcmul_, torch.addcmul),
+            (torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv),
+        ]
+        for foreach_op, foreach_op_, native_op in pointwise_ops:
+            if dtype == torch.bool and "sub" in native_op.__name__:
+                continue
+            for dev_list in itertools.combinations(['cpu'] + devices, 3):
+                if dtype == torch.bool:
+                    continue
+                if 'cpu' in dev_list and dtype in (torch.float16, torch.bfloat16):
+                    continue
+                if "addcdiv" in native_op.__name__ and dtype in torch.testing.get_all_int_dtypes():
+                    continue
+
+                # devices of `tensors` are as follows
+                # tensors1: [dev0, dev1, dev2]
+                # tensors2: [dev0, dev1, dev2]
+                # tensors3: [dev0, dev1, dev2]
+                dev0, dev1, dev2 = dev_list
+                tensors1 = self._get_test_data(dev0, dtype, 3)
+                tensors2 = self._get_test_data(dev1, dtype, 3)
+                tensors3 = self._get_test_data(dev2, dtype, 3)
+                tmp21, tmp31 = tensors2[0], tensors3[0]
+                tensors2[0], tensors3[0] = tensors1[1:]
+                tensors1[1:] = [tmp21, tmp31]
+                tmp23 = tensors2[2]
+                tmp32 = tensors3[1]
+                tensors2[2] = tmp32
+                tensors3[1] = tmp23
+
+                expected = [native_op(t1, t2, t3) for t1, t2, t3 in zip(tensors1, tensors2, tensors3)]
+                actual = foreach_op(tensors1, tensors2, tensors3)
+                self.assertEqual(expected, actual)
+                foreach_op_(tensors1, tensors2, tensors3)
+                self.assertEqual(expected, tensors1)
+
 
 instantiate_device_type_tests(TestForeach, globals())
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -2,7 +2,7 @@ import torch
 import unittest
 from torch.testing._internal.common_utils import TestCase, run_tests, TEST_WITH_ROCM, TEST_WITH_SLOW
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, dtypes, skipCUDAIfRocm, ops)
+    (instantiate_device_type_tests, dtypes, skipCUDAIfRocm, skipMeta, ops)
 from torch._six import inf, nan
 from torch.testing._internal.common_methods_invocations import foreach_unary_op_db
 
@@ -126,6 +126,7 @@ class TestForeach(TestCase):
             else:
                 self.assertEqual(tensors1, expected)
 
+    @skipMeta
     @ops(foreach_unary_op_db)
     def test_unary(self, device, dtype, op):
         for N in N_values:
@@ -151,6 +152,7 @@ class TestForeach(TestCase):
     #
     # Pointwise ops
     #
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
     def test_addcmul(self, device, dtype):
         if self.device_type == 'cpu':
@@ -162,6 +164,7 @@ class TestForeach(TestCase):
 
         self._test_pointwise_op(device, dtype, torch._foreach_addcmul, torch._foreach_addcmul_, torch.addcmul)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
     def test_addcdiv(self, device, dtype):
         if dtype in [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]:
@@ -178,6 +181,7 @@ class TestForeach(TestCase):
                 return
         self._test_pointwise_op(device, dtype, torch._foreach_addcdiv, torch._foreach_addcdiv_, torch.addcdiv)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes(include_bfloat16=False, include_bool=False, include_complex=False))
     def test_min_max(self, device, dtype):
         for N in N_values:
@@ -200,6 +204,7 @@ class TestForeach(TestCase):
             res_min = torch._foreach_minimum(tensors1, tensors2)
             self.assertEqual(res_min, expected_min)
 
+    @skipMeta
     @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
     def test_max_min_float_inf_nan(self, device, dtype):
         a = [
@@ -224,6 +229,7 @@ class TestForeach(TestCase):
         res = torch._foreach_minimum(a, b)
         self.assertEqual(expected, res)
 
+    @skipMeta
     @dtypes(*(torch.testing.get_all_fp_dtypes(include_half=True, include_bfloat16=False)))
     def test_max_min_inf_nan(self, device, dtype):
         a = [
@@ -252,6 +258,7 @@ class TestForeach(TestCase):
     # Ops with scalar
     #
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_int_scalar_op(self, device, dtype):
         for N in N_values:
@@ -318,6 +325,7 @@ class TestForeach(TestCase):
     # As optimizers work with float tensors, the result will always be torch.float32 for now.
     # Current schema is using 'float[]' as scalar list type.
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_int_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -360,6 +368,7 @@ class TestForeach(TestCase):
                         self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_float_scalar_op(self, device, dtype):
         for N in N_values:
@@ -402,6 +411,7 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, expected)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_float_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -474,6 +484,7 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, expected)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_complex_scalar_op(self, device, dtype):
         for N in N_values:
@@ -508,6 +519,7 @@ class TestForeach(TestCase):
                     self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_complex_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -537,6 +549,7 @@ class TestForeach(TestCase):
                     self.assertEqual(res, tensors)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_bool_scalar_op(self, device, dtype):
         for N in N_values:
@@ -567,6 +580,7 @@ class TestForeach(TestCase):
                     self.assertEqual(tensors, res)
 
     @skipCUDAIfRocm
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_bool_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -608,6 +622,7 @@ class TestForeach(TestCase):
                     foreach_bin_op_(tensors, scalars)
                     self.assertEqual(tensors, res)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_tensorlist_mixed_scalarlist_op(self, device, dtype):
         for N in N_values:
@@ -640,6 +655,7 @@ class TestForeach(TestCase):
                     with self.assertRaisesRegex(RuntimeError, "can't be cast to the desired output type"):
                         foreach_bin_op_(tensors, scalars)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_with_different_size_tensors(self, device, dtype):
         if dtype == torch.bool:
@@ -650,6 +666,7 @@ class TestForeach(TestCase):
         torch._foreach_add_(tensors, 1)
         self.assertEqual(expected, tensors)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_scalar_with_empty_list_and_empty_tensor(self, device, dtype):
         # TODO: enable empty list case
@@ -660,6 +677,7 @@ class TestForeach(TestCase):
             torch._foreach_add_(tensors, 1)
             self.assertEqual(res, tensors)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_scalar_with_overlapping_tensors(self, device, dtype):
         tensors = [torch.ones(1, 1, device=device, dtype=dtype).expand(2, 1, 3)]
@@ -672,14 +690,21 @@ class TestForeach(TestCase):
         res = torch._foreach_add(tensors, 1)
         self.assertEqual(res, expected)
 
+    @skipMeta
     def test_bin_op_scalar_with_different_tensor_dtypes(self, device):
         tensors = [torch.tensor([1.1], dtype=torch.float, device=device),
                    torch.tensor([1], dtype=torch.long, device=device)]
-        self.assertRaises(RuntimeError, lambda: torch._foreach_add(tensors, 1))
+        runtime_error = None
+        try:
+            torch._foreach_add(tensors, 1)
+        except RuntimeError as e:
+            runtime_error = e
+        self.assertIsNone(runtime_error)
 
     #
     # Ops with list
     #
+    @skipMeta
     def test_bin_op_list_error_cases(self, device):
         for bin_op, bin_op_, _ in self.bin_ops:
             tensors1 = []
@@ -706,15 +731,6 @@ class TestForeach(TestCase):
             with self.assertRaisesRegex(RuntimeError, "Tensor lists must have the same number of tensors, got 1 and 2"):
                 bin_op_(tensors1, tensors2)
 
-            # Different dtypes
-            tensors1 = [torch.zeros(10, 10, device=device, dtype=torch.float) for _ in range(10)]
-            tensors2 = [torch.ones(10, 10, device=device, dtype=torch.int) for _ in range(10)]
-
-            with self.assertRaisesRegex(RuntimeError, "All tensors in the tensor list must have the same dtype."):
-                bin_op(tensors1, tensors2)
-            with self.assertRaisesRegex(RuntimeError, "All tensors in the tensor list must have the same dtype."):
-                bin_op_(tensors1, tensors2)
-
             # different devices
             if torch.cuda.is_available() and torch.cuda.device_count() > 1:
                 tensor1 = torch.zeros(10, 10, device="cuda:0")
@@ -732,11 +748,13 @@ class TestForeach(TestCase):
             with self.assertRaisesRegex(RuntimeError, r", got \[10, 10\] and \[11, 11\]"):
                 bin_op_(tensors1, tensors2)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list(self, device, dtype):
         self._test_bin_op_list(device, dtype, torch._foreach_add, torch._foreach_add_, torch.add)
         self._test_bin_op_list_alpha(device, dtype, torch._foreach_add, torch._foreach_add_, torch.add)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_sub_list(self, device, dtype):
         if dtype == torch.bool:
@@ -749,10 +767,12 @@ class TestForeach(TestCase):
             self._test_bin_op_list(device, dtype, torch._foreach_sub, torch._foreach_sub_, torch.sub)
             self._test_bin_op_list_alpha(device, dtype, torch._foreach_sub, torch._foreach_sub_, torch.sub)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_mul_list(self, device, dtype):
         self._test_bin_op_list(device, dtype, torch._foreach_mul, torch._foreach_mul_, torch.mul)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_div_list(self, device, dtype):
         if dtype in torch.testing.integral_types_and(torch.bool):
@@ -777,6 +797,7 @@ class TestForeach(TestCase):
             self.assertEqual(res, tensors1)
             self.assertEqual(tensors1, res)
 
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list_different_sizes(self, device, dtype):
         tensors1 = [torch.zeros(10 + n, 10 + n, device=device, dtype=dtype) for n in range(10)]
@@ -788,6 +809,7 @@ class TestForeach(TestCase):
         self.assertEqual(res, [torch.ones(10 + n, 10 + n, device=device, dtype=dtype) for n in range(10)])
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not found")
+    @skipMeta
     @dtypes(*torch.testing.get_all_dtypes())
     def test_add_list_slow_path(self, device, dtype):
         # different strides


### PR DESCRIPTION
This is based on  #48224. 

To make `foreach` more flexible, this PR pushes unsupported cases to slow path.
Also, this adds some tests to verify that
- `foreach` functions work with tensors of different dtypes and/or memory layouts in https://github.com/pytorch/pytorch/commit/7bd4b2c89fad23c17a58969623ea7145833548a1
- `foreach` functions work with tensors on different devices in a list, but are on the same device if the indices are the same: https://github.com/pytorch/pytorch/commit/def4b9b5a19c325bb7f82ef6d69ca28fa2927131

Future plans:
1. Improve the coverage of unittests using `ops` decorator & updating `foreach_unary_op_db` and creating `foreach_(binary|pointwise|minmax)_db`.
2. Support broadcasting in slow path. Ref:  https://github.com/pytorch/pytorch/pull/52448
3. Support type promotion in fast path. Ref https://github.com/pytorch/pytorch/pull/52449

CC: @ngimel @mcarilli  @ptrblck 