### PR TITLE
[PyTorch][Edge] Reuse readArchiveAndTensors in mobile import

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -103,6 +103,7 @@ core_sources_common = [
     "torch/csrc/jit/runtime/slice_indices_adjust.cpp",
     "torch/csrc/jit/runtime/register_ops_utils.cpp",
     "torch/csrc/jit/runtime/vararg_functions.cpp",
+    "torch/csrc/jit/serialization/import_read.cpp",
     "torch/csrc/jit/serialization/unpickler.cpp",
 ]
 

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -6,8 +6,8 @@
 #include <torch/csrc/jit/mobile/interpreter.h>
 #include <torch/csrc/jit/mobile/observer.h>
 #include <torch/csrc/jit/runtime/instruction.h>
+#include <torch/csrc/jit/serialization/import.h>
 #include <torch/csrc/jit/serialization/import_export_constants.h>
-#include <torch/csrc/jit/serialization/unpickler.h>
 #include <torch/custom_class.h>
 
 #include <exception>
@@ -459,25 +459,6 @@ std::unordered_map<std::string, std::string> BytecodeDeserializer::
 c10::IValue BytecodeDeserializer::readArchive(
     const std::string& archive_name,
     std::shared_ptr<mobile::CompilationUnit> mcu) {
-  std::stringstream picklename;
-  picklename << archive_name << ".pkl";
-  at::DataPtr pickle_ptr;
-  size_t pickle_size;
-  std::tie(pickle_ptr, pickle_size) = reader_->getRecord(picklename.str());
-
-  size_t bytes_read = 0;
-  auto data = reinterpret_cast<const char*>(pickle_ptr.get());
-  auto reader = [&](char* buffer, size_t len) -> size_t {
-    if (bytes_read >= pickle_size) {
-      return 0;
-    }
-    len = std::min(pickle_size - bytes_read, len);
-    // Copy len bytes into buffer
-    const char* start = data + bytes_read;
-    std::memcpy(buffer, start, len);
-    bytes_read += len;
-    return len;
-  };
 
   auto type_resolver = [this](const c10::QualifiedName& qn) {
     return c10::StrongTypePtr(compilation_unit_, resolveTypeName(qn));
@@ -522,19 +503,9 @@ c10::IValue BytecodeDeserializer::readArchive(
     }
   };
 
-  auto read_record = [&](const std::string& name) {
-    std::stringstream ss;
-    ss << archive_name << "/" << name;
-    return std::get<0>(reader_->getRecord(ss.str()));
-  };
-
-  Unpickler unpickler(
-      reader,
-      std::move(type_resolver),
-      std::move(obj_loader),
-      std::move(read_record),
-      device_);
-  return unpickler.parse_ivalue();
+  auto ivalues = torch::jit::readArchiveAndTensors(
+      archive_name, type_resolver, obj_loader, device_, *reader_.get());
+  return ivalues;
 }
 
 } // namespace

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -6,7 +6,7 @@
 #include <torch/csrc/jit/mobile/interpreter.h>
 #include <torch/csrc/jit/mobile/observer.h>
 #include <torch/csrc/jit/runtime/instruction.h>
-#include <torch/csrc/jit/serialization/import.h>
+#include <torch/csrc/jit/serialization/import_read.h>
 #include <torch/csrc/jit/serialization/import_export_constants.h>
 #include <torch/custom_class.h>
 

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/jit/frontend/script_type_parser.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/serialization/import_read.h>
 #include <torch/csrc/jit/serialization/import_source.h>
 #include <torch/csrc/jit/serialization/pickle.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
@@ -56,47 +57,6 @@ void postSetStateValidate(const IValue& v) {
               attrType->repr_str()));
     }
   }
-}
-
-IValue readArchiveAndTensors(
-    const std::string& archive_name,
-    c10::optional<TypeResolver> type_resolver,
-    c10::optional<ObjLoader> obj_loader,
-    c10::optional<at::Device> device,
-    PyTorchStreamReader& stream_reader) {
-  std::string picklename = archive_name + ".pkl";
-  at::DataPtr pickle_ptr;
-  size_t pickle_size;
-  std::tie(pickle_ptr, pickle_size) = stream_reader.getRecord(picklename);
-
-  size_t bytes_read = 0;
-  auto data = reinterpret_cast<const char*>(pickle_ptr.get());
-  auto reader = [&](char* buffer, size_t len) -> size_t {
-    if (bytes_read >= pickle_size) {
-      return 0;
-    }
-    len = std::min(pickle_size - bytes_read, len);
-    // Copy len bytes into buffer
-    const char* start = data + bytes_read;
-    std::memcpy(buffer, start, len);
-    bytes_read += len;
-    return len;
-  };
-
-  std::string archive_name_plus_slash = archive_name + "/";
-  auto read_record = [&](const std::string& name) {
-    std::string ss = archive_name_plus_slash + name;
-    return std::get<0>(stream_reader.getRecord(ss));
-  };
-
-  Unpickler unpickler(
-      reader,
-      type_resolver ? std::move(*type_resolver) : nullptr,
-      obj_loader ? std::move(*obj_loader) : nullptr,
-      std::move(read_record),
-      device);
-  unpickler.set_version(stream_reader.version());
-  return unpickler.parse_ivalue();
 }
 
 namespace {

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -89,12 +89,5 @@ TORCH_API Module load(
     c10::optional<c10::Device> device,
     ExtraFilesMap& extra_files);
 
-TORCH_API IValue readArchiveAndTensors(
-    const std::string& archive_name,
-    c10::optional<TypeResolver> type_resolver,
-    c10::optional<ObjLoader> obj_loader,
-    c10::optional<at::Device> device,
-    caffe2::serialize::PyTorchStreamReader& stream_reader);
-
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -1,0 +1,48 @@
+#include <torch/csrc/jit/serialization/import_read.h>
+
+namespace torch {
+namespace jit {
+
+IValue readArchiveAndTensors(
+    const std::string& archive_name,
+    c10::optional<TypeResolver> type_resolver,
+    c10::optional<ObjLoader> obj_loader,
+    c10::optional<at::Device> device,
+    caffe2::serialize::PyTorchStreamReader& stream_reader) {
+  std::string picklename = archive_name + ".pkl";
+  at::DataPtr pickle_ptr;
+  size_t pickle_size = 0;
+  std::tie(pickle_ptr, pickle_size) = stream_reader.getRecord(picklename);
+
+  size_t bytes_read = 0;
+  auto data = reinterpret_cast<const char*>(pickle_ptr.get());
+  auto reader = [&](char* buffer, size_t len) -> size_t {
+    if (bytes_read >= pickle_size) {
+      return 0;
+    }
+    len = std::min(pickle_size - bytes_read, len);
+    // Copy len bytes into buffer
+    const char* start = data + bytes_read;
+    std::memcpy(buffer, start, len);
+    bytes_read += len;
+    return len;
+  };
+
+  std::string archive_name_plus_slash = archive_name + "/";
+  auto read_record = [&](const std::string& name) {
+    std::string ss = archive_name_plus_slash + name;
+    return std::get<0>(stream_reader.getRecord(ss));
+  };
+
+  Unpickler unpickler(
+      reader,
+      type_resolver ? std::move(*type_resolver) : nullptr,
+      obj_loader ? std::move(*obj_loader) : nullptr,
+      std::move(read_record),
+      device);
+  unpickler.set_version(stream_reader.version());
+  return unpickler.parse_ivalue();
+}
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/serialization/import_read.h
+++ b/torch/csrc/jit/serialization/import_read.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <caffe2/serialize/inline_container.h>
+#include <torch/csrc/jit/serialization/unpickler.h>
+
+namespace torch {
+namespace jit {
+
+TORCH_API IValue readArchiveAndTensors(
+    const std::string& archive_name,
+    c10::optional<TypeResolver> type_resolver,
+    c10::optional<ObjLoader> obj_loader,
+    c10::optional<at::Device> device,
+    caffe2::serialize::PyTorchStreamReader& stream_reader);
+
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/serialization/pickle.cpp
+++ b/torch/csrc/jit/serialization/pickle.cpp
@@ -4,7 +4,7 @@
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/serialization/export.h>
-#include <torch/csrc/jit/serialization/import.h>
+#include <torch/csrc/jit/serialization/import_read.h>
 
 namespace torch {
 namespace jit {


### PR DESCRIPTION
## Summary 

The function from jit `torch::jit::readArchiveAndTensors` is quite general and can be reused in `mobile/import.h`. 

## Test plan
CI

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56996 [PyTorch][Edge] Reuse readArchiveAndTensors in mobile import**

