### PR TITLE
Fix path handling on Win32 in rendezvous.py

### DIFF
--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -95,7 +95,9 @@ def _file_rendezvous_handler(url: str, **kwargs):
     path = result.path
     if sys.platform == 'win32':
         import urllib.request
-        path = urllib.request.url2pathname(result.path)
+        full_path = result.netloc + result.path
+        path = urllib.request.url2pathname(full_path)
+        path = os.path.normpath(path)
 
     if not path:
         raise _error("path missing")

--- a/torch/distributed/rendezvous.py
+++ b/torch/distributed/rendezvous.py
@@ -97,7 +97,9 @@ def _file_rendezvous_handler(url: str, **kwargs):
         import urllib.request
         full_path = result.netloc + result.path
         path = urllib.request.url2pathname(full_path)
-        path = os.path.normpath(path)
+        if path:
+            # Normalizing an empty string produces ".", which is not expected.
+            path = os.path.normpath(path)
 
     if not path:
         raise _error("path missing")


### PR DESCRIPTION
Fixes test failure after #56598

Introduced by #45335. This PR make  `_file_rendezvous_handler` accept file URL with Windows paths, for example `file://C:\Users\me\temp` and `file://C:/Users/me/temp`.
