### PR TITLE
OpInfo : index_fill (port remaining method_tests)

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1374,6 +1374,20 @@ def sample_inputs_index_fill(op_info, device, dtype, requires_grad, **kwargs):
             samples.append(SampleInput(tensor, args=(d, idx, fill_val)))
             samples.append(SampleInput(tensor, args=(d, -idx - 1, fill_val)))
             samples.append(SampleInput(tensor, args=(d, idx_nonctg, fill_val)))
+
+    make_arg = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    index_tensor = partial(torch.tensor, device=device, dtype=torch.long)
+
+    def unique_idx(numel, max_idx):
+        indices = random.sample(range(max_idx), numel)
+        return index_tensor(indices)
+
+    samples.append(SampleInput(make_arg((S, S)), args=(0, unique_idx(2, S), 2)))
+    samples.append(SampleInput(make_arg((S, S)), args=(0, unique_idx(2, S), make_arg(()))))
+    samples.append(SampleInput(make_arg((S, S)), args=(0, index_tensor(0), 2)))
+    samples.append(SampleInput(make_arg(()), args=(0, index_tensor([0]), 2)))
+    samples.append(SampleInput(make_arg(()), args=(0, index_tensor(0), 2)))
+
     return samples
 
 def sample_inputs_max_min_binary(op_info, device, dtype, requires_grad, **kwargs):
@@ -5711,11 +5725,6 @@ def method_tests():
         ('triu', (3, 3, S, S), NO_ARGS, 'more_batched'),
         ('cross', (S, 3), ((S, 3),)),
         ('cross', (S, 3, S), ((S, 3, S), 1), 'dim'),
-        ('index_fill', (S, S), (0, index_variable(2, S), 2), 'dim', (), [0]),
-        ('index_fill', (S, S), (0, index_variable(2, S), ()), 'variable_dim', (), [0]),
-        ('index_fill', (S, S), (0, torch.tensor(0, dtype=torch.int64), 2), 'scalar_index_dim', (), [0]),
-        ('index_fill', (), (0, torch.tensor([0], dtype=torch.int64), 2), 'scalar_input_dim', (), [0]),
-        ('index_fill', (), (0, torch.tensor(0, dtype=torch.int64), 2), 'scalar_both_dim', (), [0]),
         ('fill_', (S, S, S), (1,), 'number'),
         ('fill_', (), (1,), 'number_scalar'),
         ('fill_', (S, S, S), ((),), 'variable'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -1379,6 +1379,8 @@ def sample_inputs_index_fill(op_info, device, dtype, requires_grad, **kwargs):
     index_tensor = partial(torch.tensor, device=device, dtype=torch.long)
 
     def unique_idx(numel, max_idx):
+        # Generate unique random indices vector of `numel`
+        # elements in range [0, max_idx).
         indices = random.sample(range(max_idx), numel)
         return index_tensor(indices)
 


### PR DESCRIPTION
Fixes #53237

Before PR (around 90s) (most time consuming tests in details)

<details>

```
pytest test/test_ops.py -k _index_fill --durations=20
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
plugins: hypothesis-5.38.1
collected 19327 items / 19225 deselected / 102 selected                                                                                                                

test/test_ops.py s..................ssssssssssssssssssss..................ss....ssssssssssssssss....sssss....ssssss....                                          [100%]

=========================================================================== warnings summary ===========================================================================
========================================================================= slowest 20 durations =========================================================================
44.14s call     test/test_ops.py::TestGradientsCUDA::test_fn_gradgrad_index_fill_cuda_complex128
13.08s call     test/test_ops.py::TestGradientsCPU::test_fn_gradgrad_index_fill_cpu_complex128
7.36s call     test/test_ops.py::TestGradientsCUDA::test_fn_grad_index_fill_cuda_complex128
4.20s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_jit_index_fill_cuda_float32
3.42s call     test/test_ops.py::TestCommonCPU::test_variant_consistency_jit_index_fill_cpu_float32
2.93s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_jit_index_fill_cuda_complex64
2.32s call     test/test_ops.py::TestGradientsCPU::test_fn_grad_index_fill_cpu_complex128
2.18s call     test/test_ops.py::TestCommonCPU::test_variant_consistency_jit_index_fill_cpu_complex64
1.03s call     test/test_ops.py::TestOpInfoCUDA::test_duplicate_method_tests_index_fill_cuda_float32
0.84s call     test/test_ops.py::TestGradientsCUDA::test_fn_grad_index_fill_cuda_float64
0.64s call     test/test_ops.py::TestGradientsCUDA::test_fn_gradgrad_index_fill_cuda_float64
0.41s call     test/test_ops.py::TestOpInfoCUDA::test_supported_backward_index_fill_cuda_complex128
0.41s call     test/test_ops.py::TestOpInfoCUDA::test_supported_backward_index_fill_cuda_bfloat16
0.39s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_eager_index_fill_cuda_complex64
0.38s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_eager_index_fill_cuda_float32
0.36s call     test/test_ops.py::TestOpInfoCUDA::test_supported_backward_index_fill_cuda_complex64
0.36s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_float16
0.35s call     test/test_ops.py::TestOpInfoCUDA::test_supported_backward_index_fill_cuda_float16
0.35s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_int16
0.35s call     test/test_ops.py::TestOpInfoCUDA::test_supported_backward_index_fill_cuda_float32
======================================================================= short test summary info ========================================================================
=============================================== 52 passed, 50 skipped, 19225 deselected, 8 warnings in 97.31s (0:01:37) ================================================
```
</details>

After PR (around 90s) (most time consuming tests in details)

<details>

```
pytest test/test_ops.py -k _index_fill --durations=20
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.6, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
plugins: hypothesis-5.38.1
collected 19327 items / 19225 deselected / 102 selected                                                                                                                

test/test_ops.py s..................ssssssssssssssssssss..................ss....ssssssssssssssss....sssss....ssssss....                                          [100%]

=========================================================================== warnings summary ===========================================================================
========================================================================= slowest 20 durations =========================================================================
40.88s call     test/test_ops.py::TestGradientsCUDA::test_fn_gradgrad_index_fill_cuda_complex128
13.12s call     test/test_ops.py::TestGradientsCPU::test_fn_gradgrad_index_fill_cpu_complex128
7.03s call     test/test_ops.py::TestGradientsCUDA::test_fn_grad_index_fill_cuda_complex128
3.48s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_jit_index_fill_cuda_complex64
3.01s call     test/test_ops.py::TestCommonCUDA::test_variant_consistency_jit_index_fill_cuda_float32
2.55s call     test/test_ops.py::TestCommonCPU::test_variant_consistency_jit_index_fill_cpu_complex64
2.43s call     test/test_ops.py::TestGradientsCPU::test_fn_grad_index_fill_cpu_complex128
2.38s call     test/test_ops.py::TestCommonCPU::test_variant_consistency_jit_index_fill_cpu_float32
1.10s call     test/test_ops.py::TestOpInfoCUDA::test_duplicate_method_tests_index_fill_cuda_float32
0.76s call     test/test_ops.py::TestGradientsCUDA::test_fn_grad_index_fill_cuda_float64
0.67s call     test/test_ops.py::TestGradientsCUDA::test_fn_gradgrad_index_fill_cuda_float64
0.50s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_bfloat16
0.50s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_uint8
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_float64
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_float16
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_complex128
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_bool
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_float32
0.49s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_int32
0.48s call     test/test_ops.py::TestOpInfoCUDA::test_supported_dtypes_index_fill_cuda_complex64
======================================================================= short test summary info ========================================================================

=============================================== 52 passed, 50 skipped, 19225 deselected, 8 warnings in 93.31s (0:01:33) ================================================
```

</details>

TODO:
* [x] Add test timings (Before and After)