### PR TITLE
add missing comma to `run_test.py`

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -264,7 +264,7 @@ TARGET_DET_LIST = [
     'test_jit',
     'test_jit_profiling',
     'test_torch',
-    'test_binary_ufuncs'
+    'test_binary_ufuncs',
     'test_numpy_interop',
     'test_reductions',
     'test_shape_ops',


### PR DESCRIPTION
Factored out from https://github.com/pytorch/pytorch/pull/57008#discussion_r621137121:

> Without this comma, the strings are concatenated to `test_binary_ufuncstest_numpy_interop`
