### PR TITLE
Workaround intermittent gcc-7.5 ICE in cpp tests

### DIFF
--- a/test/cpp/api/CMakeLists.txt
+++ b/test/cpp/api/CMakeLists.txt
@@ -58,6 +58,14 @@ if(USE_CUDA)
   target_compile_definitions(test_api PRIVATE "USE_CUDA")
 endif()
 
+# Workaround for https://github.com/pytorch/pytorch/issues/40941
+if(USE_OPENMP AND CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8.0.0))
+  # Compiling transformer.cpp or pow_test.cpp with -O2+ and both -fuse-openmp and -faligned-newout any optimization
+  # Fails with internal compiler error in gcc-7.5 or older
+  # Workaround by compiling the tests without openmp (which they are not using anyway)
+  set_property(TARGET test_api APPEND_STRING PROPERTY COMPILE_FLAGS "-fno-openmp")
+endif()
+
 if(NOT MSVC)
   if(APPLE)
     target_compile_options(test_api PRIVATE


### PR DESCRIPTION
gcc-7.5 optimizer can hit internal compiler error if both `-fopenmp` and
`-faligned-new` are passed:
```
/var/lib/jenkins/workspace/test/cpp/api/transformer.cpp: In function 'void transformer_decoder_test_helper(bool)':
/var/lib/jenkins/workspace/test/cpp/api/transformer.cpp:609:6: internal compiler error: in equal_mem_array_ref_p, at tree-ssa-scopedtables.c:429
 void transformer_decoder_test_helper(bool is_cuda) {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes https://github.com/pytorch/pytorch/issues/40941

Fixes #{issue number}
