### PR TITLE
ns for fx: allow user functions in shadowing

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -1335,7 +1335,24 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         self.assertTrue(len(act_compare_dict) == 1)
         self.assert_ns_compare_dict_valid(act_compare_dict)
 
-        # TODO(future PR): test shadowed activations
+        # test shadowed activations
+
+        node_type_to_io_type_map = get_node_type_to_io_type_map()
+        node_type_to_io_type_map['funs_io_type_fp32'].add(_wrapped_hardswish)
+
+        m1_shadows_m2_ns = _add_shadow_loggers_impl(
+            'a', m1, 'b', m2, OutputLogger,
+            should_log_inputs=False,
+            base_name_to_sets_of_related_ops=base_name_to_sets_of_related_ops,
+            node_type_to_io_type_map=node_type_to_io_type_map)
+
+        # calibrate
+        m1_shadows_m2_ns(data)
+
+        # check activation result correctness
+        act_compare_dict = extract_shadow_logger_info(m1_shadows_m2_ns, OutputLogger)
+        self.assertTrue(len(act_compare_dict) == 1)
+        self.assert_ns_compare_dict_valid(act_compare_dict)
 
 
 class TestFXNumericSuiteCoreAPIsModels(FXNumericSuiteQuantizationTestCase):

--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -328,11 +328,15 @@ def _add_shadow_loggers_impl(
     gm_b: GraphModule,
     logger_cls: Callable,
     should_log_inputs: bool,
+    base_name_to_sets_of_related_ops: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
+    node_type_to_io_type_map: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
 ) -> nn.Module:
-    matched_subgraph_pairs = get_matching_subgraph_pairs(gm_a, gm_b)
+    matched_subgraph_pairs = get_matching_subgraph_pairs(
+        gm_a, gm_b, base_name_to_sets_of_related_ops)
     gm_a_shadows_b = create_a_shadows_b(
         name_a, gm_a, name_b, gm_b, matched_subgraph_pairs, logger_cls,
-        should_log_inputs=should_log_inputs)
+        should_log_inputs=should_log_inputs,
+        node_type_to_io_type_map=node_type_to_io_type_map)
     return gm_a_shadows_b
 
 
@@ -343,6 +347,8 @@ def add_shadow_loggers(
     model_b: nn.Module,
     logger_cls: Callable,
     should_log_inputs: bool = False,
+    base_name_to_sets_of_related_ops: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
+    node_type_to_io_type_map: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
 ) -> nn.Module:
     """
     Same thing as add_loggers, but for an `a_shadows_b` model.
@@ -357,7 +363,9 @@ def add_shadow_loggers(
     gm_b = GraphModule(model_b, tracer_b.trace(model_b))
     return _add_shadow_loggers_impl(
         name_a, gm_a, name_b, gm_b, logger_cls,
-        should_log_inputs=should_log_inputs)
+        should_log_inputs=should_log_inputs,
+        base_name_to_sets_of_related_ops=base_name_to_sets_of_related_ops,
+        node_type_to_io_type_map=node_type_to_io_type_map)
 
 
 def extract_shadow_logger_info(

--- a/torch/quantization/ns/utils.py
+++ b/torch/quantization/ns/utils.py
@@ -6,11 +6,10 @@ toq = torch.ops.quantized
 from torch.fx import GraphModule
 from torch.fx.graph import Node
 from torch.quantization.fx.quantize import is_activation_post_process
-from .mappings import (
-    get_node_type_to_io_type_map,
-)
 
-from typing import Any, Tuple, Callable
+from .ns_types import NSNodeTargetType
+
+from typing import Any, Tuple, Callable, Dict, Set
 
 def getattr_from_fqn(gm: GraphModule, fqn: str) -> Any:
     """
@@ -41,10 +40,10 @@ def get_node_first_input_and_output_type(
     node: Node,
     gm: GraphModule,
     logger_cls: Callable,
+    node_type_to_io_type_map: Dict[str, Set[NSNodeTargetType]],
 ) -> Tuple[NodeInputOrOutputType, NodeInputOrOutputType]:
 
     # TODO(future PR): clean this up
-    node_type_to_io_type_map = get_node_type_to_io_type_map()
     FUNS_IO_TYPE_FP32 = node_type_to_io_type_map['funs_io_type_fp32']
     FUNS_IO_TYPE_INT8 = node_type_to_io_type_map['funs_io_type_int8']
     FUNS_IO_TYPE_FP32_OR_INT8 = node_type_to_io_type_map['funs_io_type_fp32_or_int8']
@@ -74,7 +73,7 @@ def get_node_first_input_and_output_type(
             assert isinstance(first_arg, Node)
             _prev_node_input_type, prev_node_output_type = \
                 get_node_first_input_and_output_type(
-                    first_arg, gm, logger_cls)
+                    first_arg, gm, logger_cls, node_type_to_io_type_map)
             return (prev_node_output_type, prev_node_output_type)
         is_known_fp32_input_module = any(
             isinstance(mod, target_type) for target_type in MODS_IO_TYPE_FP32  # type: ignore
@@ -102,7 +101,8 @@ def get_node_first_input_and_output_type(
             prev_node = node.args[0]
             assert isinstance(prev_node, Node)
             _prev_node_input_type, prev_node_output_type = \
-                get_node_first_input_and_output_type(prev_node, gm, logger_cls)
+                get_node_first_input_and_output_type(
+                    prev_node, gm, logger_cls, node_type_to_io_type_map)
             return (prev_node_output_type, NodeInputOrOutputType.FP32)
 
         elif node.target == 'to':
@@ -113,7 +113,8 @@ def get_node_first_input_and_output_type(
             prev_node = node.args[0]
             assert isinstance(prev_node, Node)
             _prev_node_input_type, prev_node_output_type = \
-                get_node_first_input_and_output_type(prev_node, gm, logger_cls)
+                get_node_first_input_and_output_type(
+                    prev_node, gm, logger_cls, node_type_to_io_type_map)
 
             cur_node_dtype_target = node.args[1]
             assert cur_node_dtype_target is torch.float16, \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57028 ns for fx: additional bugfix for user defined functions
* #57027 ns for fx: allow comparing int8 to int8 for functionals
* #57026 ns for fx: add option to skip matching classes and functions
* #57025 ns for fx: support binary ops when adding unshadowed loggers for inputs
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* #57023 ns for fx: add fp16 function shadowing
* **#57022 ns for fx: allow user functions in shadowing**
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Allows usage of user functions in NS shadow APIs. We expose the
i/o mapping to the user APIs, and thread them throughout the code.

Note: the format of the mapping is currently not the best.  Saving
improving that for a future PR.

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Differential Revision: [D28030095](https://our.internmc.facebook.com/intern/diff/D28030095)