### PR TITLE
ns for fx: add fp16 function shadowing

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -224,6 +224,13 @@ class AllConvFunctional(torch.nn.Module):
 def _wrapped_hardswish(x):
     return F.hardswish(x)
 
+@torch.fx.wrap
+def _wrapped_hardswish_fp16(x):
+    x = x.dequantize()
+    x = F.hardswish(x)
+    x = x.to(torch.float16)
+    return x
+
 
 class TestFXGraphMatcher(QuantizationTestCase):
 
@@ -1299,7 +1306,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
         class M2(nn.Module):
             def forward(self, x):
-                x = _wrapped_hardswish(x)
+                x = _wrapped_hardswish_fp16(x)
                 return x
 
         qconfig_dict = {'': torch.quantization.default_qconfig}
@@ -1309,7 +1316,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
 
         base_name_to_sets_of_related_ops = get_base_name_to_sets_of_related_ops()
         base_name_to_sets_of_related_ops['torch.nn.functional.hardswish'].add(
-            _wrapped_hardswish)
+            _wrapped_hardswish_fp16)
 
         # test compare weights
         results = _extract_weights_impl(
@@ -1338,7 +1345,7 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         # test shadowed activations
 
         node_type_to_io_type_map = get_node_type_to_io_type_map()
-        node_type_to_io_type_map['funs_io_type_fp32'].add(_wrapped_hardswish)
+        node_type_to_io_type_map['funs_io_type_fp16'].add(_wrapped_hardswish_fp16)
 
         m1_shadows_m2_ns = _add_shadow_loggers_impl(
             'a', m1, 'b', m2, OutputLogger,

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -175,18 +175,8 @@ def _insert_dtype_cast_after_node(
     ):
         dtype_cast_op = torch.dequantize
     elif (
-        node_input_type_a == NodeInputOrOutputType.FP32 and
-        node_input_type_c == NodeInputOrOutputType.FP32
-    ):
-        dtype_cast_mod_cls = torch.nn.Identity
-    elif (
-        node_input_type_a == NodeInputOrOutputType.INT8 and
-        node_input_type_c == NodeInputOrOutputType.INT8
-    ):
-        dtype_cast_mod_cls = torch.nn.Identity
-    elif (
-        node_input_type_a == NodeInputOrOutputType.FP32_OR_INT8 and
-        node_input_type_c == NodeInputOrOutputType.FP32_OR_INT8
+        node_input_type_a == node_input_type_c and
+        node_input_type_a != NodeInputOrOutputType.UNKNOWN
     ):
         dtype_cast_mod_cls = torch.nn.Identity
     else:

--- a/torch/quantization/ns/mappings.py
+++ b/torch/quantization/ns/mappings.py
@@ -32,6 +32,8 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
         F.silu,
     ])
 
+    FUNS_IO_TYPE_FP16: Set[NSNodeTargetType] = set()
+
     FUNS_IO_TYPE_INT8: Set[NSNodeTargetType] = set([
         toq.linear,
         toq.linear_relu,
@@ -194,6 +196,7 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
 
     return {
         'funs_io_type_fp32': FUNS_IO_TYPE_FP32,
+        'funs_io_type_fp16': FUNS_IO_TYPE_FP16,
         'funs_io_type_int8': FUNS_IO_TYPE_INT8,
         'funs_io_type_fp32_or_int8': FUNS_IO_TYPE_FP32_OR_INT8,
         'mods_io_type_fp32': MODS_IO_TYPE_FP32,

--- a/torch/quantization/ns/utils.py
+++ b/torch/quantization/ns/utils.py
@@ -45,6 +45,7 @@ def get_node_first_input_and_output_type(
 
     # TODO(future PR): clean this up
     FUNS_IO_TYPE_FP32 = node_type_to_io_type_map['funs_io_type_fp32']
+    FUNS_IO_TYPE_FP16 = node_type_to_io_type_map['funs_io_type_fp16']
     FUNS_IO_TYPE_INT8 = node_type_to_io_type_map['funs_io_type_int8']
     FUNS_IO_TYPE_FP32_OR_INT8 = node_type_to_io_type_map['funs_io_type_fp32_or_int8']
     MODS_IO_TYPE_FP32 = node_type_to_io_type_map['mods_io_type_fp32']
@@ -55,6 +56,8 @@ def get_node_first_input_and_output_type(
     if node.op == 'call_function':
         if node.target in FUNS_IO_TYPE_FP32:
             return (NodeInputOrOutputType.FP32, NodeInputOrOutputType.FP32)
+        if node.target in FUNS_IO_TYPE_FP16:
+            return (NodeInputOrOutputType.FP16, NodeInputOrOutputType.FP16)
         elif node.target in FUNS_IO_TYPE_INT8:
             return (NodeInputOrOutputType.INT8, NodeInputOrOutputType.INT8)
         elif node.target in FUNS_IO_TYPE_FP32_OR_INT8:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57028 ns for fx: additional bugfix for user defined functions
* #57027 ns for fx: allow comparing int8 to int8 for functionals
* #57026 ns for fx: add option to skip matching classes and functions
* #57025 ns for fx: support binary ops when adding unshadowed loggers for inputs
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* **#57023 ns for fx: add fp16 function shadowing**
* #57022 ns for fx: allow user functions in shadowing
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Adds functionality for shadowing user functions with fp16 I/O dtype.

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Differential Revision: [D28030092](https://our.internmc.facebook.com/intern/diff/D28030092)