### PR TITLE
ns for fx: support binary ops when adding unshadowed loggers for inputs

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -105,6 +105,17 @@ class LinearReluLinearFunctional(nn.Module):
         return x
 
 
+class AddMulFunctional(nn.Module):
+    def forward(self, x, y):
+        x = x + 1.0
+        x = x * 1.0
+        x = 1.0 + x
+        x = 1.0 * x
+        x = x + y
+        x = x * y
+        return x
+
+
 class AllConvAndLinearFusionModules(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -1027,6 +1038,13 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
         self._test_match_activations(
             m, (torch.randn(1, 1, 2, 2),),
             results_len=2)
+
+    @skipIfNoFBGEMM
+    def test_add_mul_inputs_activations(self):
+        m = AddMulFunctional().eval()
+        res = self._test_match_activations(
+            m, (torch.randn(2, 2), torch.randn(2, 2)),
+            results_len=6, should_log_inputs=True)
 
     @skipIfNoFBGEMM
     def test_linear_fp16_weights(self):

--- a/torch/quantization/_numeric_suite_fx.py
+++ b/torch/quantization/_numeric_suite_fx.py
@@ -43,6 +43,7 @@ class OutputLogger(nn.Module):
         prev_node_target_type: str,
         results_type: str,
         index_within_arg: int,
+        index_of_arg: int,
     ):
         super().__init__()
         self.stats: List[torch.Tensor] = []
@@ -78,6 +79,9 @@ class OutputLogger(nn.Module):
         # index of this node within the arg of the input/output node
         # for example, in cat([x1, x2, x3], dim=0), x2 would have index_within_arg == 1
         self.index_within_arg = index_within_arg
+        # index of this node within the args of the input/output node
+        # for example, in add(x1, x2), x2 would have index_of_arg == 1
+        self.index_of_arg = index_of_arg
 
     # Note: cannot annotate the type of x because TorchScript does not support
     #   the Union type.
@@ -92,7 +96,8 @@ class OutputLogger(nn.Module):
     def __repr__(self):
         return f"""OutputLogger(ref_name={self.ref_name}, model_name={self.model_name},
 prev_node_name={self.prev_node_name}, ref_node_name={self.ref_node_name},
-results_type={self.results_type}, index_within_arg={self.index_within_arg})"""
+results_type={self.results_type}, index_within_arg={self.index_within_arg},
+index_of_arg={self.index_of_arg})"""
 
 
 class NSTracer(quantize_fx.QuantizationTracer):
@@ -293,10 +298,12 @@ def _extract_logger_info_one_model(
                 'prev_node_name': mod.prev_node_name,
                 'prev_node_target_type': mod.prev_node_target_type,
                 'index_within_arg': mod.index_within_arg,
+                'index_of_arg': mod.index_of_arg,
             })
             # ensure the list stays sorted
             results[key][mod.results_type][mod.model_name].sort(
-                key=lambda res: res['index_within_arg']
+                key=lambda res:
+                f"{res['index_of_arg']}:{res['index_within_arg']}"
             )
 
 

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -11,6 +11,7 @@ from .utils import (
     return_first_non_observer_node,
     get_number_of_non_param_args,
     get_target_type_str,
+    get_arg_indices_of_inputs_to_log,
 )
 
 from .ns_types import (
@@ -34,6 +35,7 @@ def _insert_logger_after_node(
     ref_name: str,
     results_type: str,
     index_within_arg: int,
+    index_of_arg: int,
 ) -> Node:
     """
     Given a starting graph of
@@ -52,7 +54,7 @@ def _insert_logger_after_node(
     # create the logger object
     logger_obj = logger_cls(
         ref_node_name, node.name, model_name, ref_name, target_type,
-        results_type, index_within_arg)
+        results_type, index_within_arg, index_of_arg)
     # attach the logger object to the parent module
     setattr(gm, logger_node_name, logger_obj)
     logger_node = node.graph.create_node(
@@ -95,23 +97,32 @@ def remove_observers_add_loggers(
 
             if node in node_to_instrument_inputs_to_ref_node_name:
                 ref_name = node_to_instrument_inputs_to_ref_node_name[node]
-                if type(node.args[0]) == Node:
-                    # create a single input logger
-                    prev_node = env[node.args[0].name]
-                    env[node.args[0].name] = _insert_logger_after_node(
-                        prev_node, gm, logger_cls, '_ns_logger_', node.name,
-                        model_name, ref_name, NSSingleResultValuesType.NODE_INPUT.value,
-                        index_within_arg=0)
-                elif type(node.args[0]) == torch.fx.immutable_collections.immutable_list:
-                    # create N input loggers, one for each node
-                    for arg_idx, arg in enumerate(node.args[0]):
-                        prev_node = env[arg.name]
-                        env[prev_node.name] = _insert_logger_after_node(
+                # Ops such add and mul are special because either
+                # one or two of the first two arguments can be tensors,
+                # and if one argument is a tensor it can be first or
+                # second (x + 1 versus 1 + x).
+                arg_indices_to_log = get_arg_indices_of_inputs_to_log(node)
+                for node_arg_idx in arg_indices_to_log:
+                    node_arg = node.args[node_arg_idx]
+                    if type(node_arg) == Node:
+                        # create a single input logger
+                        prev_node = env[node_arg.name]
+                        env[node_arg.name] = _insert_logger_after_node(
                             prev_node, gm, logger_cls, '_ns_logger_', node.name,
-                            model_name, ref_name, NSSingleResultValuesType.NODE_INPUT.value,
-                            index_within_arg=arg_idx)
-                else:
-                    raise AssertionError(f"type {type(node.args[0])} is not handled yet")
+                            model_name, ref_name,
+                            NSSingleResultValuesType.NODE_INPUT.value,
+                            index_within_arg=0, index_of_arg=node_arg_idx)
+                    elif type(node_arg) == torch.fx.immutable_collections.immutable_list:
+                        # create N input loggers, one for each node
+                        for arg_idx, arg in enumerate(node_arg):
+                            prev_node = env[arg.name]
+                            env[prev_node.name] = _insert_logger_after_node(
+                                prev_node, gm, logger_cls, '_ns_logger_', node.name,
+                                model_name, ref_name,
+                                NSSingleResultValuesType.NODE_INPUT.value,
+                                index_within_arg=arg_idx, index_of_arg=node_arg_idx)
+                    else:
+                        pass
 
             # ensure env is populated with base node
             # Note: runs for both inputs and outputs
@@ -123,7 +134,7 @@ def remove_observers_add_loggers(
                 env[node.name] = _insert_logger_after_node(
                     env[node.name], gm, logger_cls, '_ns_logger_', node.name,
                     model_name, ref_name, NSSingleResultValuesType.NODE_OUTPUT.value,
-                    index_within_arg=0)
+                    index_within_arg=0, index_of_arg=0)
 
         else:
             env[node.name] = new_graph.node_copy(node, load_arg)
@@ -532,7 +543,7 @@ def create_a_shadows_b(
                             prev_node_c, gm_b, logger_cls, '_ns_logger_b_inp_',
                             node_b.name, name_b, ref_name,
                             NSSingleResultValuesType.NODE_INPUT.value,
-                            index_within_arg=0)
+                            index_within_arg=0, index_of_arg=0)
                     elif isinstance(node_b.args[0], list):
                         # first, save the prev_node instances, because they
                         # will be overwritten in the env after the first logger
@@ -545,7 +556,7 @@ def create_a_shadows_b(
                                 prev_node_c, gm_b, logger_cls, '_ns_logger_b_inp_',
                                 node_b.name, name_b, ref_name,
                                 NSSingleResultValuesType.NODE_INPUT.value,
-                                index_within_arg=arg_idx)
+                                index_within_arg=arg_idx, index_of_arg=0)
                     else:
                         # logging of inputs which are not lists is not supported yet
                         raise AssertionError(f"type {type(node_b.args[0])} is not handled yet")
@@ -603,7 +614,7 @@ def create_a_shadows_b(
                             dtype_cast_node, gm_b, logger_cls, '_ns_logger_a_inp_',
                             ref_node_name, name_a, ref_name,
                             NSSingleResultValuesType.NODE_INPUT.value,
-                            index_within_arg=0)
+                            index_within_arg=0, index_of_arg=0)
                         input_logger: Union[Node, List[Node]] = dtype_cast_node
                     else:
                         assert isinstance(dtype_cast_node, list)
@@ -613,7 +624,8 @@ def create_a_shadows_b(
                                 dtype_cast_node_inner, gm_b, logger_cls, '_ns_logger_a_inp_',
                                 ref_node_name, name_a, ref_name,
                                 NSSingleResultValuesType.NODE_INPUT.value,
-                                index_within_arg=dtype_cast_idx)
+                                index_within_arg=dtype_cast_idx,
+                                index_of_arg=0)
                             new_loggers.append(dtype_cast_logger)
                         dtype_cast_node = new_loggers
                         input_logger = dtype_cast_node
@@ -670,7 +682,7 @@ def create_a_shadows_b(
                     env_c[node_a_shadows_c.name], gm_b, logger_cls, '_ns_logger_a_',
                     node_a_shadows_c.name, name_a, ref_name,
                     NSSingleResultValuesType.NODE_OUTPUT.value,
-                    index_within_arg=0)
+                    index_within_arg=0, index_of_arg=0)
                 # subgraph so far:
                 #
                 #       dtype_cast_node -> (logger_a_input)? -> subgraph_a_copy -> logger_a
@@ -684,7 +696,7 @@ def create_a_shadows_b(
                     env_c[node_b.name], gm_b, logger_cls, '_ns_logger_b_',
                     node_b.name, name_b, ref_name,
                     NSSingleResultValuesType.NODE_OUTPUT.value,
-                    index_within_arg=0)
+                    index_within_arg=0, index_of_arg=0)
                 # subgraph so far:
                 #
                 #       dtype_cast_node -> (logger_a_input)? -> subgraph_a_copy -> logger_a

--- a/torch/quantization/ns/mappings.py
+++ b/torch/quantization/ns/mappings.py
@@ -30,6 +30,10 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
         F.layer_norm,
         F.leaky_relu,
         F.silu,
+        # TODO(future PR): implement shadowing for binary ops and
+        # uncomment below
+        # operator.add,
+        # operator.mul,
     ])
 
     FUNS_IO_TYPE_FP16: Set[NSNodeTargetType] = set()
@@ -49,6 +53,10 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
         toq.instance_norm,
         toq.layer_norm,
         toq.leaky_relu,
+        # TODO(future PR): implement shadowing for binary ops and
+        # uncomment below
+        # toq.add,
+        # toq.mul,
     ])
 
     FUNS_IO_TYPE_FP32_OR_INT8: Set[NSNodeTargetType] = set([

--- a/torch/quantization/ns/ns_types.py
+++ b/torch/quantization/ns/ns_types.py
@@ -32,6 +32,9 @@ NSSubgraph = NamedTuple(
 #   # index of this node within the arg of the input/output node
 #   # for example, in cat([x1, x2, x3], dim=0), x2 would have index_within_arg == 1
 #   'index_within_arg': 0,
+#   # index of this node within the args of the input/output node
+#   # for example, in add(x1, x2), x2 would have index_of_arg == 1
+#   'index_of_arg': 0,
 # }
 NSSingleResultType = Dict[str, Any]
 

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -155,6 +155,7 @@ def extract_weight_from_node(
                 'prev_node_target_type': str(node.target),
                 'ref_node_name': node.name,
                 'index_within_arg': 0,
+                'index_of_arg': 0,
             }
         elif (related_to_conv1d or related_to_conv2d or related_to_conv3d):
             weight = get_conv_fun_weight(node, gm)
@@ -165,6 +166,7 @@ def extract_weight_from_node(
                 'prev_node_target_type': str(node.target),
                 'ref_node_name': node.name,
                 'index_within_arg': 0,
+                'index_of_arg': 0,
             }
 
     else:  # call_module
@@ -194,6 +196,7 @@ def extract_weight_from_node(
                 'prev_node_target_type': str(type(mod)),
                 'ref_node_name': node.name,
                 'index_within_arg': 0,
+                'index_of_arg': 0,
             }
         elif related_to_lstm_mod:
             weights = get_lstm_mod_weights(mod)
@@ -204,6 +207,7 @@ def extract_weight_from_node(
                 'prev_node_target_type': str(type(mod)),
                 'ref_node_name': node.name,
                 'index_within_arg': 0,
+                'index_of_arg': 0,
             }
         elif related_to_linear_mod:
             weights = [get_linear_mod_weight(mod)]
@@ -214,6 +218,7 @@ def extract_weight_from_node(
                 'prev_node_target_type': str(type(mod)),
                 'ref_node_name': node.name,
                 'index_within_arg': 0,
+                'index_of_arg': 0,
             }
 
     return None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57028 ns for fx: additional bugfix for user defined functions
* #57027 ns for fx: allow comparing int8 to int8 for functionals
* #57026 ns for fx: add option to skip matching classes and functions
* **#57025 ns for fx: support binary ops when adding unshadowed loggers for inputs**
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* #57023 ns for fx: add fp16 function shadowing
* #57022 ns for fx: allow user functions in shadowing
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Adds the ability to log unshadowed inputs of binary ops such as `add`
and `mul`, when indices 0, 1, or 0 and 1 are tensors.

Note: making shadowing support this is saved for a future PR.

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_add_mul_inputs_activations
```

Differential Revision: [D28030098](https://our.internmc.facebook.com/intern/diff/D28030098)