### PR TITLE
ns for fx: add option to skip matching classes and functions

### DIFF
--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -9,9 +9,7 @@ from torch.fx.graph import Graph, Node
 from .utils import getattr_from_fqn
 from .ns_types import NSSubgraph, NSNodeTargetType
 from .mappings import (
-    FUNS_UNMATCHABLE,
-    MODS_UNMATCHABLE,
-    METHS_UNMATCHABLE,
+    get_unmatchable_types_map,
 )
 from .pattern_utils import (
     get_base_name_to_sets_of_related_ops,
@@ -20,32 +18,10 @@ from .pattern_utils import (
     end_node_matches_reversed_fusion,
 )
 
-from typing import Dict, Tuple, List, Optional, Set, Callable, Any
+from typing import Dict, Tuple, List, Optional, Set, Any
 
 def _get_output_nodes(g: Graph) -> List[Node]:
     return [n for n in g.nodes if n.op == 'output']
-
-def get_non_matchable_functions() -> Set[Callable]:
-    """
-    `call_function` nodes pointing to these functions are non-matchable.
-    """
-    # TODO(future PR): allow customizations
-    return FUNS_UNMATCHABLE
-
-def get_non_matchable_modules() -> Set[Callable]:
-    """
-    `call_module` nodes pointing to instances of these types are non-matchable.
-    """
-    # TODO(future PR): allow customizations
-    return MODS_UNMATCHABLE
-
-def get_non_matchable_methods() -> Set[str]:
-    """
-    `call_method` nodes pointing to these targets are non-matchable.
-
-    """
-    # TODO(future PR): allow customizations
-    return METHS_UNMATCHABLE
 
 class _NSGraphMatchableSubgraphsIterator:
     """
@@ -58,14 +34,14 @@ class _NSGraphMatchableSubgraphsIterator:
     def __init__(
         self,
         gm: GraphModule,
-        non_matchable_functions: Set[Callable],
-        non_matchable_modules: Set[Callable],
-        non_matchable_methods: Set[str],
+        non_matchable_functions: Set[NSNodeTargetType],
+        non_matchable_modules: Set[NSNodeTargetType],
+        non_matchable_methods: Set[NSNodeTargetType],
     ):
         self.gm: GraphModule = gm
-        self.non_matchable_functions: Set[Callable] = non_matchable_functions
-        self.non_matchable_modules: Set[Callable] = non_matchable_modules
-        self.non_matchable_methods: Set[str] = non_matchable_methods
+        self.non_matchable_functions: Set[NSNodeTargetType] = non_matchable_functions
+        self.non_matchable_modules: Set[NSNodeTargetType] = non_matchable_modules
+        self.non_matchable_methods: Set[NSNodeTargetType] = non_matchable_methods
         self.seen_nodes: Set[Node] = set()
         self.stack: List[Node] = []
         for start_node in _get_output_nodes(self.gm.graph):
@@ -307,6 +283,7 @@ def get_matching_subgraph_pairs(
     gm_a: GraphModule,
     gm_b: GraphModule,
     base_name_to_sets_of_related_ops: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
+    unmatchable_types_map: Optional[Dict[str, Set[NSNodeTargetType]]] = None,
 ) -> Dict[str, Tuple[NSSubgraph, NSSubgraph]]:
     """
     Matches matchable subgraphs of graph_a to graph_b.
@@ -371,9 +348,12 @@ def get_matching_subgraph_pairs(
         ),
     }
     """
-    non_matchable_functions = get_non_matchable_functions()
-    non_matchable_modules = get_non_matchable_modules()
-    non_matchable_methods = get_non_matchable_methods()
+    if unmatchable_types_map is None:
+        unmatchable_types_map = get_unmatchable_types_map()
+    non_matchable_functions = unmatchable_types_map['funs_unmatchable']
+    non_matchable_modules = unmatchable_types_map['mods_unmatchable']
+    non_matchable_methods = unmatchable_types_map['meths_unmatchable']
+
     graph_a_iterator = _NSGraphMatchableSubgraphsIterator(
         gm_a, non_matchable_functions, non_matchable_modules,
         non_matchable_methods)

--- a/torch/quantization/ns/mappings.py
+++ b/torch/quantization/ns/mappings.py
@@ -14,7 +14,7 @@ import torch.nn.qat as nnqat
 
 from .ns_types import NSNodeTargetType
 
-from typing import Callable, Set, Dict
+from typing import Set, Dict
 
 # TODO(future PR): clean this up
 def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
@@ -213,36 +213,46 @@ def get_node_type_to_io_type_map() -> Dict[str, Set[NSNodeTargetType]]:
         'meths_io_type_fp32_or_int8': METHS_IO_TYPE_FP32_OR_INT8,
     }
 
-FUNS_UNMATCHABLE: Set[Callable] = set([
-    torch.quantize_per_tensor,
-    operator.getitem,
-])
-MODS_UNMATCHABLE: Set[Callable] = set([
-    torch.quantization.ObserverBase,
-    torch.quantization.FakeQuantizeBase,
-])
 
-METHS_UNMATCHABLE = set([
-    'to',
-    'dequantize',
-    'reshape',
-    'view',
-    'unsqueeze_',
-    'unsqueeze',
-    'transpose',
-    'squeeze_',
-    'squeeze',
-    'size',
-    'shape',
-    'resize_',
-    'repeat_interleave',
-    'repeat',
-    'permute',
-    'numel',
-    'mean',
-    'detach_',
-    'detach',
-    'contiguous',
-    'clamp',
-    'chunk',
-])
+def get_unmatchable_types_map() -> Dict[str, Set[NSNodeTargetType]]:
+
+    FUNS_UNMATCHABLE: Set[NSNodeTargetType] = set([
+        torch.quantize_per_tensor,
+        operator.getitem,
+    ])
+
+    MODS_UNMATCHABLE: Set[NSNodeTargetType] = set([
+        torch.quantization.ObserverBase,
+        torch.quantization.FakeQuantizeBase,
+    ])
+
+    METHS_UNMATCHABLE: Set[NSNodeTargetType] = set([
+        'to',
+        'dequantize',
+        'reshape',
+        'view',
+        'unsqueeze_',
+        'unsqueeze',
+        'transpose',
+        'squeeze_',
+        'squeeze',
+        'size',
+        'shape',
+        'resize_',
+        'repeat_interleave',
+        'repeat',
+        'permute',
+        'numel',
+        'mean',
+        'detach_',
+        'detach',
+        'contiguous',
+        'clamp',
+        'chunk',
+    ])
+
+    return {
+        'funs_unmatchable': FUNS_UNMATCHABLE,
+        'mods_unmatchable': MODS_UNMATCHABLE,
+        'meths_unmatchable': METHS_UNMATCHABLE,
+    }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57028 ns for fx: additional bugfix for user defined functions
* #57027 ns for fx: allow comparing int8 to int8 for functionals
* **#57026 ns for fx: add option to skip matching classes and functions**
* #57025 ns for fx: support binary ops when adding unshadowed loggers for inputs
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* #57023 ns for fx: add fp16 function shadowing
* #57022 ns for fx: allow user functions in shadowing
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Adds a config option to skip matching classes by class type
and functions by function type.

This is useful when users make custom modules which return
types other than tensors. With the current implementation of
Logger, these are not scriptable.

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_module_scriptable
```

Differential Revision: [D28030093](https://our.internmc.facebook.com/intern/diff/D28030093)