### PR TITLE
ns for fx: allow comparing int8 to int8 for functionals

### DIFF
--- a/test/quantization/test_numeric_suite_fx.py
+++ b/test/quantization/test_numeric_suite_fx.py
@@ -1119,12 +1119,10 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             m, (torch.randn(4, 4),),
             results_len=2)
 
-    @skipIfNoFBGEMM
-    def test_int8_shadows_int8(self):
+    def _test_int8_shadows_int8_impl(self, m):
         """
         Verify that shadowing works where both modules are int8
         """
-        m = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
         qconfig_dict = {'': torch.quantization.default_qconfig}
         mp = prepare_fx(m, qconfig_dict)
         mp(torch.randn(4, 1, 4, 4))
@@ -1136,6 +1134,16 @@ class TestFXNumericSuiteCoreAPIs(FXNumericSuiteQuantizationTestCase):
             mq1_shadows_mq2, OutputLogger)
         self.assertTrue(len(act_compare_dict) == 1)
         self.assert_ns_compare_dict_valid(act_compare_dict)
+
+    @skipIfNoFBGEMM
+    def test_int8_shadows_int8_mod(self):
+        m = nn.Sequential(nn.Conv2d(1, 1, 1)).eval()
+        self._test_int8_shadows_int8_impl(m)
+
+    @skipIfNoFBGEMM
+    def test_int8_shadows_int8_fun(self):
+        m = LinearFunctional().eval()
+        self._test_int8_shadows_int8_impl(m)
 
     @skipIfNoFBGEMM
     def test_user_module_scriptable(self):

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -245,7 +245,9 @@ def _copy_node_from_a_to_c(
         node_a_copy_name = \
             get_new_attr_name_with_prefix(node_a.name + '_shadow_copy_')(gm_b)  # type: ignore
         node_a_obj = getattr_from_fqn(gm_a, node_a.target)  # type: ignore
-        setattr(gm_b, node_a_copy_name, node_a_obj.detach())
+        if torch.is_tensor(node_a_obj):
+            node_a_obj = node_a_obj.detach()
+        setattr(gm_b, node_a_copy_name, node_a_obj)
         node_a_copy = graph_c.create_node(
             node_a.op, node_a_copy_name, (), {}, node_a_copy_name)
         return node_a_copy


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57028 ns for fx: additional bugfix for user defined functions
* **#57027 ns for fx: allow comparing int8 to int8 for functionals**
* #57026 ns for fx: add option to skip matching classes and functions
* #57025 ns for fx: support binary ops when adding unshadowed loggers for inputs
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* #57023 ns for fx: add fp16 function shadowing
* #57022 ns for fx: allow user functions in shadowing
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Fixes a bug to allow shadowing of linear and conv functionals.
The bug is to only detach tensors, not all objects.

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_int8_shadows_int8_fun
```

Differential Revision: [D28030090](https://our.internmc.facebook.com/intern/diff/D28030090)