### PR TITLE
ns for fx: additional bugfix for user defined functions

### DIFF
--- a/torch/quantization/ns/graph_matcher.py
+++ b/torch/quantization/ns/graph_matcher.py
@@ -165,11 +165,13 @@ def _get_subgraph_relationship_type(
 
     # TODO(next): make this code handle matching by what is before the base op
     if node_a.op != node_b.op:
-        # for now, comparing call_module to call_function is not supported
-        # this can be added later if needed
-        return SubgraphTypeRelationship.NOT_RELATED
+        if not (
+            node_a.op in ('call_function', 'call_method') and
+            node_b.op in ('call_function', 'call_method')
+        ):
+            return SubgraphTypeRelationship.NOT_RELATED
 
-    if node_a.op == 'call_function':
+    if node_a.op in ('call_function', 'call_method'):
         if node_a.target == node_b.target:
             node_a_has_prev = subgraph_a.base_op_node == subgraph_a.start_node
             node_b_has_prev = subgraph_b.base_op_node == subgraph_b.start_node
@@ -201,17 +203,6 @@ def _get_subgraph_relationship_type(
         if type(mod_a) == type(mod_b):
             return SubgraphTypeRelationship.EQUAL
         key = (type(mod_a), type(mod_b))
-        if key in type_a_related_to_b:
-            return SubgraphTypeRelationship.RELATED_BUT_NOT_EQUAL
-        else:
-            return SubgraphTypeRelationship.NOT_RELATED
-    elif node_a.op == 'call_method':
-        assert (subgraph_a.base_op_node == subgraph_a.start_node and
-                subgraph_b.base_op_node == subgraph_b.start_node), \
-            "Matching call_method patterns where base_op_node != start_node is not supported yet"
-        if node_a.target == node_b.target:
-            return SubgraphTypeRelationship.EQUAL
-        key = (node_a.target, node_b.target)
         if key in type_a_related_to_b:
             return SubgraphTypeRelationship.RELATED_BUT_NOT_EQUAL
         else:

--- a/torch/quantization/ns/graph_passes.py
+++ b/torch/quantization/ns/graph_passes.py
@@ -182,7 +182,12 @@ def _insert_dtype_cast_after_node(
         (node_input_type_a == NodeInputOrOutputType.FP32 and
          node_input_type_c == NodeInputOrOutputType.INT8) or
         (node_input_type_a == NodeInputOrOutputType.FP32 and
-         node_input_type_c == NodeInputOrOutputType.FP16)
+         node_input_type_c == NodeInputOrOutputType.FP16) or
+        # TODO(future PR): determine the actual dtype of node_c,
+        # the current code only works because dequantize works with
+        # multiple input dtypes.
+        (node_input_type_a == NodeInputOrOutputType.FP32 and
+         node_input_type_c == NodeInputOrOutputType.FP32_OR_INT8)
     ):
         dtype_cast_op = torch.dequantize
     elif (

--- a/torch/quantization/ns/weight_utils.py
+++ b/torch/quantization/ns/weight_utils.py
@@ -169,7 +169,7 @@ def extract_weight_from_node(
                 'index_of_arg': 0,
             }
 
-    else:  # call_module
+    elif node.op == 'call_module':
         # for call_module, we need to look up the modules to do the type check
         assert isinstance(node.target, str)
         mod = getattr_from_fqn(gm, node.target)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57028 ns for fx: additional bugfix for user defined functions**
* #57027 ns for fx: allow comparing int8 to int8 for functionals
* #57026 ns for fx: add option to skip matching classes and functions
* #57025 ns for fx: support binary ops when adding unshadowed loggers for inputs
* #57024 ns for fx: bug fix for shadowing fp16 emulation patterns
* #57023 ns for fx: add fp16 function shadowing
* #57022 ns for fx: allow user functions in shadowing
* #57021 ns for fx: move node I/O dtype mapping to be local instead of global

Summary:

Adds a test case for wrapped sigmoid, and fixes the following issues
to make it pass in NS:
* allows comparing between x.sigmoid() and torch.sigmoid(x), if they are related
* allows dtype cast from FP32_OR_INT8 to FP32, via dequantize (this will be improved later)

Test Plan:
```
python test/test_quantization.py TestFXNumericSuiteCoreAPIs.test_user_defined_function
```

Differential Revision: [D28030089](https://our.internmc.facebook.com/intern/diff/D28030089)