### PR TITLE
Refactor and add handling of boolean comparisons to integer value refinement

### DIFF
--- a/torch/csrc/jit/passes/integer_value_refinement.cpp
+++ b/torch/csrc/jit/passes/integer_value_refinement.cpp
@@ -61,10 +61,6 @@ struct IntegerValueRefiner {
           }
         }
       }
-      if (n->kind() == prim::RaiseException) {
-        throwing_blocks_.insert(b);
-      }
-
       for (size_t input = 0; input < n->inputs().size(); ++input) {
         Value* input_v = n->inputs().at(input);
         if (!input_v->type()->cast<IntType>()) {
@@ -147,6 +143,8 @@ struct IntegerValueRefiner {
             true_block_refinements,
             false_block_refinements,
             info_);
+      } else {
+        handleCommonRefinentOperators(n, throwing_blocks_, info_);
       }
     }
 

--- a/torch/csrc/jit/passes/peephole_list_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_list_idioms.cpp
@@ -90,53 +90,14 @@ struct ListLenRefiner {
               ? BooleanRefinementMapping::TrueRefinements(std::move(refine))
               : BooleanRefinementMapping::FalseRefinements(std::move(refine));
         }
-      }
-      if (n->kind() == prim::RaiseException) {
-        throwing_blocks_.insert(b);
-      }
-      if (n->kind() == aten::len) {
+      } else if (n->kind() == aten::len) {
         if (auto maybe_len = tryFindRefinement(n->input(0))) {
           changed_ = true;
           WithInsertPoint guard(n);
           n->output()->replaceAllUsesWith(
               graph_->insertConstant(static_cast<int64_t>(*maybe_len)));
         }
-      }
-      if (n->kind() == aten::__not__ &&
-          n->inputs().at(0)->type()->cast<BoolType>()) {
-        // __not__(inp) -> reverse refinements
-        if (boolean_value_refinements_.count(n->input())) {
-          auto& input_ref = boolean_value_refinements_[n->input()];
-          boolean_value_refinements_[n->output()] = BooleanRefinementMapping(
-              input_ref.false_refine(), input_ref.true_refine());
-        }
-      }
-      if (n->matches("aten::eq(bool a, bool b) -> bool") ||
-          (n->matches("aten::ne(bool a, bool b) -> bool"))) {
-        for (size_t const_index : {0, 1}) {
-          if (n->input(const_index)->node()->kind() != prim::Constant) {
-            continue;
-          }
-          auto const_input = constant_as<bool>(n->input(const_index)).value();
-          auto non_const_input = n->input(1 - const_index);
-          if (!boolean_value_refinements_.count(non_const_input)) {
-            continue;
-          }
-          // value == False / value != True -> equivalent to __not__ value
-          // value == True / value != False -> equivalent to value
-          auto& input_ref = boolean_value_refinements_[non_const_input];
-          if ((!const_input && n->kind() == aten::eq) ||
-              (const_input && n->kind() == aten::ne)) {
-            boolean_value_refinements_[n->output()] = BooleanRefinementMapping(
-                input_ref.false_refine(), input_ref.true_refine());
-          } else {
-            boolean_value_refinements_[n->output()] = BooleanRefinementMapping(
-                input_ref.true_refine(), input_ref.false_refine());
-          }
-        }
-      }
-
-      if (n->kind() == prim::If) {
+      } else if (n->kind() == prim::If) {
         IfView if_n(n);
         bool has_cond_ref = boolean_value_refinements_.count(if_n.cond()) != 0;
         ListRefinement empty;
@@ -157,6 +118,9 @@ struct ListLenRefiner {
             true_block_refinements,
             false_block_refinements,
             boolean_value_refinements_);
+      } else {
+        handleCommonRefinentOperators(
+            n, throwing_blocks_, boolean_value_refinements_);
       }
     }
     active_refinements_.pop_back();

--- a/torch/csrc/jit/passes/value_refinement_utils.h
+++ b/torch/csrc/jit/passes/value_refinement_utils.h
@@ -71,5 +71,12 @@ TORCH_API void joinIfRefinements(
     ListRefinement& false_block_refinements,
     std::unordered_map<Value*, BooleanRefinementMapping>& info);
 
+// handles adding blocks to throwing blocks and propagating refinements via
+// boolean comparisons
+TORCH_API bool handleCommonRefinentOperators(
+    Node* n,
+    std::unordered_set<Block*>& throwing_blocks,
+    std::unordered_map<Value*, BooleanRefinementMapping>& info);
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57044 Refactor and add handling of boolean comparisons to integer value refinement**
* #56966 [JIT] Disable Complete Shape Inlining For Testing Purposes
* #56828 Add unary/binary ops necessary for mobilenet
* #56815 Add Symbolic Shape Registry and define in C++
* #56642 Only optimize while change has been made
* #56438 [JIT] integer value refinement
* #56437 Factor out isDominatedBy
* #56436 Factor out value refinement to common util
* #55978 Add Value * == Value * peephole
* #55977 [JIT] [Easy] Factor out non tensor peephole
* #55926 Add list len refinement
* #55925 Add handling of symbolic shapes
* #54809 Initial Symbolic Shape Analysis

