### PR TITLE
[QAT] Fix the runtime run `cannot resize variables that require grad`

### DIFF
--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -1,12 +1,13 @@
-
+import re
 import warnings
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from functools import partial
 from typing import Any, List, Tuple, Optional, Dict, Union
-from collections import OrderedDict
+
 import torch
 import torch.nn as nn
-import re
+
 
 def _with_args(cls_or_self, **kwargs):
     r"""Wrapper that allows creation of class factories.
@@ -23,6 +24,7 @@ def _with_args(cls_or_self, **kwargs):
         >>> id(foo_instance1) == id(foo_instance2)
         False
     """
+
     class _PartialWrapper(object):
         def __init__(self, p):
             self.p = p
@@ -34,6 +36,7 @@ def _with_args(cls_or_self, **kwargs):
             return self.p.__repr__()
 
         with_args = _with_args
+
     r = _PartialWrapper(partial(cls_or_self, **kwargs))
     return r
 
@@ -53,6 +56,7 @@ class ObserverBase(ABC, nn.Module):
     Args:
         dtype: Quantized data type
     """
+
     def __init__(self, dtype):
         super(ObserverBase, self).__init__()
         self.dtype = dtype
@@ -113,8 +117,15 @@ class _ObserverBase(ObserverBase):
 
     eps: torch.Tensor
 
-    def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
-                 reduce_range=False, quant_min=None, quant_max=None, factory_kwargs=None) -> None:
+    def __init__(
+        self,
+        dtype=torch.quint8,
+        qscheme=torch.per_tensor_affine,
+        reduce_range=False,
+        quant_min=None,
+        quant_max=None,
+        factory_kwargs=None,
+    ) -> None:
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         super(_ObserverBase, self).__init__(dtype=dtype)
         self.qscheme = qscheme
@@ -124,7 +135,9 @@ class _ObserverBase(ObserverBase):
                     reduce_range will be deprecated in a future release of PyTorch."
             )
         self.reduce_range = reduce_range
-        self.register_buffer('eps', torch.tensor([torch.finfo(torch.float32).eps], **factory_kwargs))
+        self.register_buffer(
+            "eps", torch.tensor([torch.finfo(torch.float32).eps], **factory_kwargs)
+        )
         assert self.qscheme in (
             torch.per_tensor_affine,
             torch.per_tensor_symmetric,
@@ -145,18 +158,33 @@ class _ObserverBase(ObserverBase):
         self.quant_min = quant_min
         self.quant_max = quant_max
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
 
-        version = local_metadata.get('version', None)
+        version = local_metadata.get("version", None)
 
         if version is None or version == 1:
             # eps was moved to a buffer in version 2
             eps = torch.tensor([torch.finfo(torch.float32).eps])
-            state_dict[prefix + 'eps'] = eps
+            state_dict[prefix + "eps"] = eps
 
-        super(ObserverBase, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                        missing_keys, unexpected_keys, error_msgs)
+        super(ObserverBase, self)._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
 
     @torch.jit.export
     def _validate_qmin_qmax(self, quant_min: int, quant_max: int) -> None:
@@ -175,8 +203,12 @@ class _ObserverBase(ObserverBase):
         """
         # The variable names are prefixed with "initial" because their values (qmin and qmax) might be adjusted
         # based on whether quantization range is reduced and the datatype (signed/unsigned) used by the observer.
-        assert quant_min <= 0 <= quant_max, "Used-specified quantization range must include 0."
-        assert quant_min < quant_max, "qmin must be strictly less than qmax for user-specified quantization range."
+        assert (
+            quant_min <= 0 <= quant_max
+        ), "Used-specified quantization range must include 0."
+        assert (
+            quant_min < quant_max
+        ), "qmin must be strictly less than qmax for user-specified quantization range."
 
     @torch.jit.export
     def _calculate_qmin_qmax(self) -> Tuple[int, int]:
@@ -192,11 +224,15 @@ class _ObserverBase(ObserverBase):
             # attribute from Optional valid integers for use, based on TorchScript's requirements.
             custom_quant_min, custom_quant_max = self.quant_min, self.quant_max
             if custom_quant_min is not None and custom_quant_max is not None:
-                initial_quant_min, initial_quant_max = custom_quant_min, custom_quant_max
+                initial_quant_min, initial_quant_max = (
+                    custom_quant_min,
+                    custom_quant_max,
+                )
 
             qrange_len = initial_quant_max - initial_quant_min + 1
-            assert 0 < qrange_len <= 256, \
-                "quantization range should be positive and not exceed the maximum bit range (=256)."
+            assert (
+                0 < qrange_len <= 256
+            ), "quantization range should be positive and not exceed the maximum bit range (=256)."
             if self.dtype == torch.qint8:
                 quant_min, quant_max = -qrange_len // 2, qrange_len // 2 - 1
             else:
@@ -220,7 +256,9 @@ class _ObserverBase(ObserverBase):
         return quant_min, quant_max
 
     @torch.jit.export
-    def _calculate_qparams(self, min_val: torch.Tensor, max_val: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _calculate_qparams(
+        self, min_val: torch.Tensor, max_val: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         r"""Calculates the quantization parameters, given min and max
         value tensors. Works for both per tensor and per channel cases
 
@@ -240,7 +278,7 @@ class _ObserverBase(ObserverBase):
             return torch.tensor([1.0]), torch.tensor([0])
 
         if min_val.dim() == 0 or max_val.dim() == 0:
-            if min_val == float('inf') and max_val == float('-inf'):
+            if min_val == float("inf") and max_val == float("-inf"):
                 warnings.warn(
                     "must run observer before calling calculate_qparams.\
                                         Returning default scale and zero point "
@@ -251,9 +289,9 @@ class _ObserverBase(ObserverBase):
                 min_val, max_val
             )
         else:
-            assert torch.all(min_val <= max_val), "min {} should be less than max {}".format(
-                min_val, max_val
-            )
+            assert torch.all(
+                min_val <= max_val
+            ), "min {} should be less than max {}".format(min_val, max_val)
 
         quant_min, quant_max = self._calculate_qmin_qmax()
         min_val_neg = torch.min(min_val, torch.zeros_like(min_val))
@@ -263,14 +301,19 @@ class _ObserverBase(ObserverBase):
         scale = torch.ones(min_val_neg.size(), dtype=torch.float32, device=device)
         zero_point = torch.zeros(min_val_neg.size(), dtype=torch.int64, device=device)
 
-        if self.qscheme == torch.per_tensor_symmetric or self.qscheme == torch.per_channel_symmetric:
+        if (
+            self.qscheme == torch.per_tensor_symmetric
+            or self.qscheme == torch.per_channel_symmetric
+        ):
             max_val_pos = torch.max(-min_val_neg, max_val_pos)
             scale = max_val_pos / (float(quant_max - quant_min) / 2)
             scale = torch.max(scale, self.eps)
             if self.dtype == torch.quint8:
                 if self.has_customized_qrange:
                     # When customized quantization range is used, down-rounded midpoint of the range is chosen.
-                    zero_point = zero_point.new_full(zero_point.size(), (quant_min + quant_max) // 2)
+                    zero_point = zero_point.new_full(
+                        zero_point.size(), (quant_min + quant_max) // 2
+                    )
                 else:
                     zero_point = zero_point.new_full(zero_point.size(), 128)
         elif self.qscheme == torch.per_channel_affine_float_qparams:
@@ -294,9 +337,13 @@ class _ObserverBase(ObserverBase):
             scale = torch.tensor([float(scale)], dtype=scale.dtype, device=device)
         if len(zero_point.shape) == 0:
             # TODO: switch to zero_point.item() after adding JIT support
-            zero_point = torch.tensor([int(zero_point)], dtype=zero_point.dtype, device=device)
+            zero_point = torch.tensor(
+                [int(zero_point)], dtype=zero_point.dtype, device=device
+            )
             if self.qscheme == torch.per_channel_affine_float_qparams:
-                zero_point = torch.tensor([float(zero_point)], dtype=zero_point.dtype, device=device)
+                zero_point = torch.tensor(
+                    [float(zero_point)], dtype=zero_point.dtype, device=device
+                )
 
         return scale, zero_point
 
@@ -367,8 +414,15 @@ class MinMaxObserver(_ObserverBase):
     min_val: torch.Tensor
     max_val: torch.Tensor
 
-    def __init__(self, dtype=torch.quint8, qscheme=torch.per_tensor_affine,
-                 reduce_range=False, quant_min=None, quant_max=None, factory_kwargs=None) -> None:
+    def __init__(
+        self,
+        dtype=torch.quint8,
+        qscheme=torch.per_tensor_affine,
+        reduce_range=False,
+        quant_min=None,
+        quant_max=None,
+        factory_kwargs=None,
+    ) -> None:
 
         # For x86 quantized kernels, we need to ensure that the vpmaddubsw
         # instruction does not overflow. We allow for a reduce_range argument to
@@ -376,20 +430,26 @@ class MinMaxObserver(_ObserverBase):
         # For more details see aten/src/ATen/native/quantized/cpu/qconv.cpp
         # This is not an optimal choice for non x86 backends as it loses a bit
         # of precision for activations.
-        super(MinMaxObserver, self).__init__(dtype=dtype,
-                                             qscheme=qscheme,
-                                             reduce_range=reduce_range,
-                                             quant_min=quant_min,
-                                             quant_max=quant_max,
-                                             factory_kwargs=factory_kwargs)
+        super(MinMaxObserver, self).__init__(
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            factory_kwargs=factory_kwargs,
+        )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
-        self.register_buffer('min_val', torch.tensor(float('inf'), **factory_kwargs))
-        self.register_buffer('max_val', torch.tensor(float('-inf'), **factory_kwargs))
-        if self.qscheme == torch.per_tensor_symmetric and \
-           self.reduce_range and \
-           self.dtype == torch.quint8:
-            raise NotImplementedError("Cannot reduce range for symmetric \
-                                       quantization for quint8")
+        self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
+        self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
+        if (
+            self.qscheme == torch.per_tensor_symmetric
+            and self.reduce_range
+            and self.dtype == torch.quint8
+        ):
+            raise NotImplementedError(
+                "Cannot reduce range for symmetric \
+                                       quantization for quint8"
+            )
 
     def forward(self, x_orig):
         r"""Records the running minimum and maximum of ``x``."""
@@ -457,16 +517,26 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
     .. note:: If the running minimum equals to the running maximum, the scale
               and zero_point are set to 1.0 and 0.
     """
-    def __init__(self, averaging_constant=0.01, dtype=torch.quint8,
-                 qscheme=torch.per_tensor_affine, reduce_range=False,
-                 quant_min=None, quant_max=None, **kwargs) -> None:
+
+    def __init__(
+        self,
+        averaging_constant=0.01,
+        dtype=torch.quint8,
+        qscheme=torch.per_tensor_affine,
+        reduce_range=False,
+        quant_min=None,
+        quant_max=None,
+        **kwargs
+    ) -> None:
         self.averaging_constant = averaging_constant
-        super(MovingAverageMinMaxObserver, self).__init__(dtype=dtype,
-                                                          qscheme=qscheme,
-                                                          reduce_range=reduce_range,
-                                                          quant_min=quant_min,
-                                                          quant_max=quant_max,
-                                                          **kwargs)
+        super(MovingAverageMinMaxObserver, self).__init__(
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            **kwargs
+        )
 
     def forward(self, x_orig):
         if x_orig.numel() == 0:
@@ -475,7 +545,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         x = x.to(self.min_val.dtype)
         min_val = self.min_val
         max_val = self.max_val
-        if min_val == float('inf') and max_val == float('-inf'):
+        if min_val == float("inf") and max_val == float("-inf"):
             min_val, max_val = torch._aminmax(x)
         else:
             min_val_cur, max_val_cur = torch._aminmax(x)
@@ -486,6 +556,7 @@ class MovingAverageMinMaxObserver(MinMaxObserver):
         self.min_val.copy_(min_val)
         self.max_val.copy_(max_val)
         return x_orig
+
 
 class PerChannelMinMaxObserver(_ObserverBase):
     r"""Observer module for computing the quantization parameters based on the
@@ -515,20 +586,28 @@ class PerChannelMinMaxObserver(_ObserverBase):
     min_vals: torch.Tensor
     max_vals: torch.Tensor
 
-
-    def __init__(self, ch_axis=0, dtype=torch.quint8,
-                 qscheme=torch.per_channel_affine, reduce_range=False,
-                 quant_min=None, quant_max=None, factory_kwargs=None) -> None:
-        super(PerChannelMinMaxObserver, self).__init__(dtype=dtype,
-                                                       qscheme=qscheme,
-                                                       reduce_range=reduce_range,
-                                                       quant_min=quant_min,
-                                                       quant_max=quant_max,
-                                                       factory_kwargs=factory_kwargs)
+    def __init__(
+        self,
+        ch_axis=0,
+        dtype=torch.quint8,
+        qscheme=torch.per_channel_affine,
+        reduce_range=False,
+        quant_min=None,
+        quant_max=None,
+        factory_kwargs=None,
+    ) -> None:
+        super(PerChannelMinMaxObserver, self).__init__(
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            factory_kwargs=factory_kwargs,
+        )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.ch_axis = ch_axis
-        self.register_buffer('min_vals', torch.tensor([], **factory_kwargs))
-        self.register_buffer('max_vals', torch.tensor([], **factory_kwargs))
+        self.register_buffer("min_vals", torch.tensor([], **factory_kwargs))
+        self.register_buffer("max_vals", torch.tensor([], **factory_kwargs))
         if (
             self.qscheme == torch.per_channel_symmetric
             and self.reduce_range
@@ -577,10 +656,17 @@ class PerChannelMinMaxObserver(_ObserverBase):
         return "min_val={}, max_val={}".format(self.min_vals, self.max_vals)
 
     @torch.jit.export
-    def _load_from_state_dict(self, state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]], prefix: str,
-                              local_metadata: Dict[str, torch.Tensor], strict: bool,
-                              missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str]):
-        local_state = ['min_vals', 'max_vals']
+    def _load_from_state_dict(
+        self,
+        state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]],
+        prefix: str,
+        local_metadata: Dict[str, torch.Tensor],
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ):
+        local_state = ["min_vals", "max_vals"]
         for name in local_state:
             key = prefix + name
             if key in state_dict:
@@ -589,14 +675,14 @@ class PerChannelMinMaxObserver(_ObserverBase):
                 # of size N into uninitialized buffers of size 0. The
                 # buffers are resized here, and the values are copied in
                 # the default state_dict loading code of the parent.
-                if name == 'min_vals':
+                if name == "min_vals":
                     self.min_vals.resize_(val.shape)
                 else:
                     self.max_vals.resize_(val.shape)
                 # For torchscript module we need to update the attributes here since we do not
                 # call the `_load_from_state_dict` function defined module.py
                 if torch.jit.is_scripting():
-                    if name == 'min_vals':
+                    if name == "min_vals":
                         self.min_vals.copy_(val)
                     else:
                         self.max_vals.copy_(val)
@@ -604,15 +690,38 @@ class PerChannelMinMaxObserver(_ObserverBase):
                 missing_keys.append(key)
 
         if not torch.jit.is_scripting():
-            super(PerChannelMinMaxObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                                        missing_keys, unexpected_keys, error_msgs)
+            super(PerChannelMinMaxObserver, self)._load_from_state_dict(
+                state_dict,
+                prefix,
+                local_metadata,
+                strict,
+                missing_keys,
+                unexpected_keys,
+                error_msgs,
+            )
 
     @torch.jit.export
-    def _load_from_state_dict_script(self, state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]],
-                                     prefix: str, local_metadata: Dict[str, torch.Tensor], strict: bool,
-                                     missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str]):
+    def _load_from_state_dict_script(
+        self,
+        state_dict: Union[Dict[str, torch.Tensor], Dict[str, torch.Tensor]],
+        prefix: str,
+        local_metadata: Dict[str, torch.Tensor],
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ):
 
-        self._load_from_state_dict(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs)
+        self._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
 
 class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
     r"""Observer module for computing the quantization parameters based on the
@@ -641,12 +750,26 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
               and zero_points are set to 1.0 and 0.
     """
 
-    def __init__(self, averaging_constant=0.01, ch_axis=0, dtype=torch.quint8,
-                 qscheme=torch.per_channel_affine, reduce_range=False,
-                 quant_min=None, quant_max=None, **kwargs) -> None:
+    def __init__(
+        self,
+        averaging_constant=0.01,
+        ch_axis=0,
+        dtype=torch.quint8,
+        qscheme=torch.per_channel_affine,
+        reduce_range=False,
+        quant_min=None,
+        quant_max=None,
+        **kwargs
+    ) -> None:
         super(MovingAveragePerChannelMinMaxObserver, self).__init__(
-            ch_axis=ch_axis, dtype=dtype, qscheme=qscheme,
-            reduce_range=reduce_range, quant_min=quant_min, quant_max=quant_max, **kwargs)
+            ch_axis=ch_axis,
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            **kwargs
+        )
         self.averaging_constant = averaging_constant
 
     def forward(self, x_orig):
@@ -674,6 +797,7 @@ class MovingAveragePerChannelMinMaxObserver(PerChannelMinMaxObserver):
         self.min_vals.copy_(min_vals)
         self.max_vals.copy_(max_vals)
         return x_orig
+
 
 class HistogramObserver(_ObserverBase):
     r"""
@@ -713,23 +837,22 @@ class HistogramObserver(_ObserverBase):
         factory_kwargs=None,
     ) -> None:
         # bins: The number of bins used for histogram calculation.
-        super(HistogramObserver, self).__init__(dtype=dtype,
-                                                qscheme=qscheme,
-                                                reduce_range=reduce_range,
-                                                factory_kwargs=factory_kwargs)
+        super(HistogramObserver, self).__init__(
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+            factory_kwargs=factory_kwargs,
+        )
         factory_kwargs = torch.nn.factory_kwargs(factory_kwargs)
         self.bins = bins
-        self.register_buffer('histogram', torch.zeros(self.bins, **factory_kwargs))
-        self.register_buffer('min_val', torch.tensor(float('inf'), **factory_kwargs))
-        self.register_buffer('max_val', torch.tensor(float('-inf'), **factory_kwargs))
+        self.register_buffer("histogram", torch.zeros(self.bins, **factory_kwargs))
+        self.register_buffer("min_val", torch.tensor(float("inf"), **factory_kwargs))
+        self.register_buffer("max_val", torch.tensor(float("-inf"), **factory_kwargs))
         self.dst_nbins = 2 ** torch.iinfo(self.dtype).bits
         self.upsample_rate = upsample_rate
 
     def _get_norm(
-        self,
-        delta_begin: torch.Tensor,
-        delta_end: torch.Tensor,
-        density: torch.Tensor
+        self, delta_begin: torch.Tensor, delta_end: torch.Tensor, density: torch.Tensor
     ) -> torch.Tensor:
         r"""
         Compute the norm of the values uniformaly distributed between
@@ -740,14 +863,11 @@ class HistogramObserver(_ObserverBase):
              = density * (end^3 - begin^3) / 3
         """
         norm = (
-            delta_end * delta_end * delta_end
-            - delta_begin * delta_begin * delta_begin
+            delta_end * delta_end * delta_end - delta_begin * delta_begin * delta_begin
         ) / 3
         return density * norm
 
-    def _compute_quantization_error(
-        self, next_start_bin: int, next_end_bin: int
-    ):
+    def _compute_quantization_error(self, next_start_bin: int, next_end_bin: int):
         r"""
         Compute the quantization error if we use start_bin to end_bin as the
         min and max to do the quantization.
@@ -765,10 +885,14 @@ class HistogramObserver(_ObserverBase):
         src_bin_end = src_bin_begin + bin_width
 
         # which dst_bins the beginning and end of src_bin belong to?
-        dst_bin_of_begin = torch.clamp(src_bin_begin // dst_bin_width, 0, self.dst_nbins - 1)
+        dst_bin_of_begin = torch.clamp(
+            src_bin_begin // dst_bin_width, 0, self.dst_nbins - 1
+        )
         dst_bin_of_begin_center = (dst_bin_of_begin + 0.5) * dst_bin_width
 
-        dst_bin_of_end = torch.clamp(src_bin_end // dst_bin_width, 0, self.dst_nbins - 1)
+        dst_bin_of_end = torch.clamp(
+            src_bin_end // dst_bin_width, 0, self.dst_nbins - 1
+        )
         dst_bin_of_end_center = (dst_bin_of_end + 0.5) * dst_bin_width
 
         density = self.histogram / bin_width
@@ -783,9 +907,7 @@ class HistogramObserver(_ObserverBase):
             torch.tensor(-dst_bin_width / 2), torch.tensor(dst_bin_width / 2), density
         )
 
-        dst_bin_of_end_center = (
-            dst_bin_of_end * dst_bin_width + dst_bin_width / 2
-        )
+        dst_bin_of_end_center = dst_bin_of_end * dst_bin_width + dst_bin_width / 2
 
         delta_begin = -dst_bin_width / 2
         delta_end = src_bin_end - dst_bin_of_end_center
@@ -857,10 +979,7 @@ class HistogramObserver(_ObserverBase):
         return new_min, new_max
 
     def _adjust_min_max(
-        self,
-        combined_min: torch.Tensor,
-        combined_max: torch.Tensor,
-        upsample_rate: int
+        self, combined_min: torch.Tensor, combined_max: torch.Tensor, upsample_rate: int
     ) -> Tuple[torch.Tensor, torch.Tensor, int, int]:
         # We ensure that:
         # (combined_max - combined_min)/(downsample_rate*Nbins) = (max - min)/(upsample_rate*Nbins)
@@ -869,22 +988,31 @@ class HistogramObserver(_ObserverBase):
         # start_idx maps min_val to the histogram bin index.
 
         hist_bin_width = (self.max_val - self.min_val) / (self.bins * upsample_rate)
-        downsample_rate = int(torch.ceil(
-            (combined_max - combined_min) / (self.bins * hist_bin_width)).item())
-        e = downsample_rate * (self.bins * hist_bin_width) - (combined_max - combined_min)
+        downsample_rate = int(
+            torch.ceil(
+                (combined_max - combined_min) / (self.bins * hist_bin_width)
+            ).item()
+        )
+        e = downsample_rate * (self.bins * hist_bin_width) - (
+            combined_max - combined_min
+        )
         # Relax only the max, not the min, so that for one sided distributions, min stays at zero
         combined_max = combined_max + e
         combined_min = combined_min
-        start_idx = int(torch.round((self.min_val - combined_min) / hist_bin_width).item())
+        start_idx = int(
+            torch.round((self.min_val - combined_min) / hist_bin_width).item()
+        )
         return combined_min, combined_max, downsample_rate, start_idx
 
-    def _combine_histograms(self,
-                            orig_hist: torch.Tensor,
-                            new_hist: torch.Tensor,
-                            upsample_rate: int,
-                            downsample_rate: int,
-                            start_idx: int,
-                            Nbins: int) -> torch.Tensor:
+    def _combine_histograms(
+        self,
+        orig_hist: torch.Tensor,
+        new_hist: torch.Tensor,
+        upsample_rate: int,
+        downsample_rate: int,
+        start_idx: int,
+        Nbins: int,
+    ) -> torch.Tensor:
         # First up-sample the histogram with new data by a factor of L
         # This creates an approximate probability density thats piecwise constant
         upsampled_histogram = new_hist.repeat_interleave(upsample_rate)
@@ -892,16 +1020,23 @@ class HistogramObserver(_ObserverBase):
         # histogram, which is initialized with zeros.
         # The offset at which the histogram is introduced is determined
         # by the start index as the output histogram can cover a wider range
-        histogram_with_output_range = torch.zeros((Nbins * downsample_rate), device=orig_hist.device)
-        histogram_with_output_range[start_idx:Nbins * upsample_rate + start_idx] = upsampled_histogram
+        histogram_with_output_range = torch.zeros(
+            (Nbins * downsample_rate), device=orig_hist.device
+        )
+        histogram_with_output_range[
+            start_idx : Nbins * upsample_rate + start_idx
+        ] = upsampled_histogram
         # Compute integral histogram, double precision is needed to ensure
         # that there are no overflows
-        integral_histogram = torch.cumsum(histogram_with_output_range, 0,
-                                          dtype=torch.double)[downsample_rate - 1 :: downsample_rate]
+        integral_histogram = torch.cumsum(
+            histogram_with_output_range, 0, dtype=torch.double
+        )[downsample_rate - 1 :: downsample_rate]
         # Finally perform interpolation
         shifted_integral_histogram = torch.zeros((Nbins), device=orig_hist.device)
         shifted_integral_histogram[1:Nbins] = integral_histogram[0:-1]
-        interpolated_histogram = (integral_histogram - shifted_integral_histogram) / upsample_rate
+        interpolated_histogram = (
+            integral_histogram - shifted_integral_histogram
+        ) / upsample_rate
         orig_hist = orig_hist + interpolated_histogram.to(torch.float)
         return orig_hist
 
@@ -912,17 +1047,19 @@ class HistogramObserver(_ObserverBase):
         min_val = self.min_val
         max_val = self.max_val
         same_values = min_val.item() == max_val.item()
-        is_uninitialized = min_val == float('inf') and max_val == float('-inf')
+        is_uninitialized = min_val == float("inf") and max_val == float("-inf")
         if is_uninitialized or same_values:
             min_val, max_val = torch._aminmax(x)
             self.min_val.resize_(min_val.shape)
             self.min_val.copy_(min_val)
             self.max_val.resize_(max_val.shape)
             self.max_val.copy_(max_val)
-            assert min_val.numel() == 1 and max_val.numel() == 1, (
-                "histogram min/max values must be scalar."
+            assert (
+                min_val.numel() == 1 and max_val.numel() == 1
+            ), "histogram min/max values must be scalar."
+            torch.histc(
+                x, self.bins, min=int(min_val), max=int(max_val), out=self.histogram
             )
-            torch.histc(x, self.bins, min=int(min_val), max=int(max_val), out=self.histogram)
         else:
             new_min, new_max = torch._aminmax(x)
             combined_min = torch.min(new_min, min_val)
@@ -930,13 +1067,18 @@ class HistogramObserver(_ObserverBase):
             # combine the existing histogram and new histogram into 1 histogram
             # We do this by first upsampling the histogram to a dense grid
             # and then downsampling the histogram efficiently
-            combined_min, combined_max, downsample_rate, start_idx = \
-                self._adjust_min_max(combined_min, combined_max, self.upsample_rate)
-            assert combined_min.numel() == 1 and combined_max.numel() == 1, (
-                "histogram min/max values must be scalar."
-            )
+            (
+                combined_min,
+                combined_max,
+                downsample_rate,
+                start_idx,
+            ) = self._adjust_min_max(combined_min, combined_max, self.upsample_rate)
+            assert (
+                combined_min.numel() == 1 and combined_max.numel() == 1
+            ), "histogram min/max values must be scalar."
             combined_histogram = torch.histc(
-                x, self.bins, min=int(combined_min), max=int(combined_max))
+                x, self.bins, min=int(combined_min), max=int(combined_max)
+            )
             if combined_min == min_val and combined_max == max_val:
                 combined_histogram += self.histogram
             else:
@@ -946,7 +1088,8 @@ class HistogramObserver(_ObserverBase):
                     self.upsample_rate,
                     downsample_rate,
                     start_idx,
-                    self.bins)
+                    self.bins,
+                )
 
             self.histogram.resize_(combined_histogram.shape)
             self.histogram.copy_(combined_histogram)
@@ -958,8 +1101,9 @@ class HistogramObserver(_ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        is_uninitialized = (self.min_val == float('inf') and
-                            self.max_val == float('-inf'))
+        is_uninitialized = self.min_val == float("inf") and self.max_val == float(
+            "-inf"
+        )
         if is_uninitialized:
             warnings.warn(
                 "must run observer before calling calculate_qparams.\
@@ -976,26 +1120,36 @@ class HistogramObserver(_ObserverBase):
         return self._calculate_qparams(new_min, new_max)
 
     def _save_to_state_dict(self, destination, prefix, keep_vars):
-        super(HistogramObserver, self)._save_to_state_dict(destination, prefix, keep_vars)
-        destination[prefix + 'min_val'] = self.min_val
-        destination[prefix + 'max_val'] = self.max_val
+        super(HistogramObserver, self)._save_to_state_dict(
+            destination, prefix, keep_vars
+        )
+        destination[prefix + "min_val"] = self.min_val
+        destination[prefix + "max_val"] = self.max_val
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        version = local_metadata.get('version', None)
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        version = local_metadata.get("version", None)
 
         if version is None or version < 3:
             # if min_val and max_val are not initialized, update their shape
             # to account for the differences between v2 and v3
-            min_val_name, max_val_name = prefix + 'min_val', prefix + 'max_val'
+            min_val_name, max_val_name = prefix + "min_val", prefix + "max_val"
             if min_val_name in state_dict:
                 if state_dict[min_val_name].shape == torch.Size([0]):
-                    state_dict[min_val_name] = torch.tensor(float('inf'))
+                    state_dict[min_val_name] = torch.tensor(float("inf"))
             if max_val_name in state_dict:
                 if state_dict[max_val_name].shape == torch.Size([0]):
-                    state_dict[max_val_name] = torch.tensor(float('-inf'))
+                    state_dict[max_val_name] = torch.tensor(float("-inf"))
 
-        local_state = ['min_val', 'max_val']
+        local_state = ["min_val", "max_val"]
         for name in local_state:
             key = prefix + name
             if key in state_dict:
@@ -1003,8 +1157,16 @@ class HistogramObserver(_ObserverBase):
                 setattr(self, name, val)
             elif strict:
                 missing_keys.append(key)
-        super(HistogramObserver, self)._load_from_state_dict(state_dict, prefix, local_metadata, strict,
-                                                             missing_keys, unexpected_keys, error_msgs)
+        super(HistogramObserver, self)._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+
 
 class PlaceholderObserver(ObserverBase):
     r"""
@@ -1019,7 +1181,10 @@ class PlaceholderObserver(ObserverBase):
         custom_op_name: (temporary) specify this observer for an operator that doesn't require any observation
                         (Can be used in Graph Mode Passes for special case ops).
     """
-    def __init__(self, dtype=torch.float32, custom_op_name="", compute_dtype=None) -> None:
+
+    def __init__(
+        self, dtype=torch.float32, custom_op_name="", compute_dtype=None
+    ) -> None:
         super(PlaceholderObserver, self).__init__(dtype=dtype)
         # dtype of input of the target operator, e.g. for dynamic quantization
         # ops, the dtype will be float32
@@ -1034,8 +1199,9 @@ class PlaceholderObserver(ObserverBase):
 
     @torch.jit.export
     def calculate_qparams(self):
-        raise Exception("calculate_qparams should not be called for PlaceholderObserver")
-
+        raise Exception(
+            "calculate_qparams should not be called for PlaceholderObserver"
+        )
 
 
 class RecordingObserver(_ObserverBase):
@@ -1079,6 +1245,7 @@ class NoopObserver(ObserverBase):
         custom_op_name: (temporary) specify this observer for an operator that doesn't require any observation
                         (Can be used in Graph Mode Passes for special case ops).
     """
+
     def __init__(self, dtype=torch.float16, custom_op_name="") -> None:
         super(NoopObserver, self).__init__(dtype=dtype)
         self.dtype = dtype
@@ -1091,26 +1258,34 @@ class NoopObserver(ObserverBase):
     def calculate_qparams(self):
         raise Exception("calculate_qparams should not be called for NoopObserver")
 
+
 def _is_observer_script_module(mod, obs_type_name):
-    ''' Returns true if given mod is an instance of Observer script module.
-    '''
+    """Returns true if given mod is an instance of Observer script module."""
     if isinstance(mod, torch.jit.RecursiveScriptModule):
         # qualified name looks like '__torch__.torch.quantization.observer.___torch_mangle_2.MinMaxObserver'
-        suffix = mod._c.qualified_name.split('.', 1)[1]
-        name = re.sub(r'\.___torch_mangle_\d+', '', suffix)
+        suffix = mod._c.qualified_name.split(".", 1)[1]
+        name = re.sub(r"\.___torch_mangle_\d+", "", suffix)
         return obs_type_name in name
     return False
 
+
 def _is_activation_post_process(module):
-    return (isinstance(module, torch.quantization.ObserverBase) or
-            isinstance(module, torch.quantization.FakeQuantize) or
-            _is_observer_script_module(module, 'torch.quantization.observer'))
+    return (
+        isinstance(module, torch.quantization.ObserverBase)
+        or isinstance(module, torch.quantization.FakeQuantize)
+        or _is_observer_script_module(module, "torch.quantization.observer")
+    )
+
 
 def _is_per_channel_script_obs_instance(module):
     if isinstance(module, torch.jit.RecursiveScriptModule):
-        return _is_observer_script_module(module, "torch.quantization.observer.PerChannelMinMaxObserver") or\
-            _is_observer_script_module(module, "torch.quantization.observer.MovingAveragePerChannelMinMaxObserver")
+        return _is_observer_script_module(
+            module, "torch.quantization.observer.PerChannelMinMaxObserver"
+        ) or _is_observer_script_module(
+            module, "torch.quantization.observer.MovingAveragePerChannelMinMaxObserver"
+        )
     return False
+
 
 def get_observer_state_dict(mod):
     r"""
@@ -1120,15 +1295,16 @@ def get_observer_state_dict(mod):
     od = OrderedDict()
     if isinstance(mod, torch.jit.RecursiveScriptModule):
         for k, v in mod.state_dict().items():
-            if 'observer' in k:
+            if "observer" in k:
                 od[k] = v
     else:
         # path for GraphModule and nn.Module (eager mode)
         for k, v in mod.state_dict().items():
-            if 'activation_post_process' in k:
+            if "activation_post_process" in k:
                 od[k] = v
     od._metadata = mod.state_dict()._metadata  # type: ignore[attr-defined]
     return od
+
 
 def load_observer_state_dict(mod, obs_dict):
     r"""
@@ -1139,29 +1315,40 @@ def load_observer_state_dict(mod, obs_dict):
     missing_keys: List[str] = []
     unexpected_keys: List[str] = []
     for name, module in mod.named_modules():
-        prefix = name + '.'
+        prefix = name + "."
         if _is_activation_post_process(module):
             if _is_per_channel_script_obs_instance(module):
                 # For per-channel observers we need to call a custom load_from_state_dict to resize the tensor.
                 # However this is not called when the module is scripted and we end up calling the default one in module.py
-                module._load_from_state_dict_script(obs_dict, prefix, {}, True, missing_keys, unexpected_keys, [])
+                module._load_from_state_dict_script(
+                    obs_dict, prefix, {}, True, missing_keys, unexpected_keys, []
+                )
             else:
-                module._load_from_state_dict(obs_dict, prefix, {}, False, missing_keys, unexpected_keys, [])
+                module._load_from_state_dict(
+                    obs_dict, prefix, {}, False, missing_keys, unexpected_keys, []
+                )
     for k in missing_keys:
-        if 'observer' in k or 'activation_post_process' in k:
+        if "observer" in k or "activation_post_process" in k:
             raise Exception("Missing keys for observer {} in state_dict".format(k))
     for k in unexpected_keys:
-        if 'observer' in k or 'activation_post_process' in k:
+        if "observer" in k or "activation_post_process" in k:
             raise Exception("Unexpected keys for observer {} in state_dict".format(k))
+
 
 # Restrict activations to be in the range (0,127)
 default_observer = MinMaxObserver.with_args(reduce_range=True)
 default_placeholder_observer = PlaceholderObserver
 default_debug_observer = RecordingObserver
-default_weight_observer = MinMaxObserver.with_args(dtype=torch.qint8, qscheme=torch.per_tensor_symmetric)
+default_weight_observer = MinMaxObserver.with_args(
+    dtype=torch.qint8, qscheme=torch.per_tensor_symmetric
+)
 default_histogram_observer = HistogramObserver.with_args(reduce_range=True)
-default_per_channel_weight_observer = PerChannelMinMaxObserver.with_args(dtype=torch.qint8, qscheme=torch.per_channel_symmetric)
-default_dynamic_quant_observer = PlaceholderObserver.with_args(dtype=torch.float, compute_dtype=torch.quint8)
-default_float_qparams_observer = PerChannelMinMaxObserver.with_args(dtype=torch.quint8,
-                                                                    qscheme=torch.per_channel_affine_float_qparams,
-                                                                    ch_axis=0)
+default_per_channel_weight_observer = PerChannelMinMaxObserver.with_args(
+    dtype=torch.qint8, qscheme=torch.per_channel_symmetric
+)
+default_dynamic_quant_observer = PlaceholderObserver.with_args(
+    dtype=torch.float, compute_dtype=torch.quint8
+)
+default_float_qparams_observer = PerChannelMinMaxObserver.with_args(
+    dtype=torch.quint8, qscheme=torch.per_channel_affine_float_qparams, ch_axis=0
+)

--- a/torch/quantization/observer.py
+++ b/torch/quantization/observer.py
@@ -1091,11 +1091,11 @@ class HistogramObserver(_ObserverBase):
                     self.bins,
                 )
 
-            self.histogram.resize_(combined_histogram.shape)
+            self.histogram.detach_().resize_(combined_histogram.shape)
             self.histogram.copy_(combined_histogram)
-            self.min_val.resize_(combined_min.shape)
+            self.min_val.detach_().resize_(combined_min.shape)
             self.min_val.copy_(combined_min)
-            self.max_val.resize_(combined_max.shape)
+            self.max_val.detach_().resize_(combined_max.shape)
             self.max_val.copy_(combined_max)
         return x_orig
 


### PR DESCRIPTION
Summary:
When training with histogram observer on, we got this runtime error:
```
torch/quantization/observer.py", line 942, in forward
                    self.bins)

            self.histogram.resize_(combined_histogram.shape)
            ~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
            self.histogram.copy_(combined_histogram)
            self.min_val.resize_(combined_min.shape)
RuntimeError: cannot resize variables that require grad
```

Since this is the histogram observer that is used to collect histogram information, should not need gradient. So turn off the grad before resizing using `detach_()` method.

Test Plan:
- arc lint
- Train with histogram observer turned on, training finished successfully

f264139727

Differential Revision: D27147212

