### PR TITLE
.circleci: Add /opt/openssl to CI images

### DIFF
--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+OPENSSL=openssl-1.1.1k
+
+wget -q -O "${OPENSSL}.tar.gz https://www.openssl.org/source/${OPENSSL}.tar.gz"
+tar xf "${OPENSSL}.tar.gz"
+cd "${OPENSSL}"
+./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'
+# NOTE: opensl errors out when built with the -j option
+make install_sw
+cd ..
+rm -rf "${OPENSSL}"

--- a/.circleci/docker/common/install_openssl.sh
+++ b/.circleci/docker/common/install_openssl.sh
@@ -4,7 +4,7 @@ set -ex
 
 OPENSSL=openssl-1.1.1k
 
-wget -q -O "${OPENSSL}.tar.gz https://www.openssl.org/source/${OPENSSL}.tar.gz"
+wget -q -O "${OPENSSL}.tar.gz" "https://www.openssl.org/source/${OPENSSL}.tar.gz"
 tar xf "${OPENSSL}.tar.gz"
 cd "${OPENSSL}"
 ./config --prefix=/opt/openssl -d '-Wl,--enable-new-dtags,-rpath,$(LIBRPATH)'

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -94,6 +94,7 @@ ENV TORCH_NVCC_FLAGS "-Xfatbin -compress-all"
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
 
 ADD ./common/install_openssl.sh install_openssl.sh
+ENV OPENSSL_ROOT_DIR /opt/openssl
 RUN bash ./install_openssl.sh
 
 USER jenkins

--- a/.circleci/docker/ubuntu-cuda/Dockerfile
+++ b/.circleci/docker/ubuntu-cuda/Dockerfile
@@ -93,5 +93,8 @@ ENV TORCH_NVCC_FLAGS "-Xfatbin -compress-all"
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
 
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh
+
 USER jenkins
 CMD ["bash"]

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -130,5 +130,8 @@ ENV BUILD_ENVIRONMENT ${BUILD_ENVIRONMENT}
 # Install LLVM dev version (Defined in the pytorch/builder github repository)
 COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
 
+ADD ./common/install_openssl.sh install_openssl.sh
+RUN bash ./install_openssl.sh
+
 USER jenkins
 CMD ["bash"]

--- a/.circleci/docker/ubuntu/Dockerfile
+++ b/.circleci/docker/ubuntu/Dockerfile
@@ -132,6 +132,7 @@ COPY --from=pytorch/llvm:9.0.1 /opt/llvm /opt/llvm
 
 ADD ./common/install_openssl.sh install_openssl.sh
 RUN bash ./install_openssl.sh
+ENV OPENSSL_ROOT_DIR /opt/openssl
 
 USER jenkins
 CMD ["bash"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57071 .circleci: Add /opt/openssl to CI images**

Adds /opt/openssl v1.1.1 to cpu CI images to enable testing for Gloo
TCP_TLS

Similar to https://github.com/pytorch/builder/pull/712

Enables https://github.com/pytorch/pytorch/pull/56442

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28061203](https://our.internmc.facebook.com/intern/diff/D28061203)