### PR TITLE
Torchelastic: add support for the new error file format

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -74,6 +74,16 @@ class ApiTest(unittest.TestCase):
             local_rank=0, pid=997, exitcode=exitcode, error_file="ignored.json"
         )
 
+    def test_process_failure_new_format(self):
+        error_data = {"message": "test error message", "timestamp": 10}
+        with open(self.test_error_file, "w") as fp:
+            json.dump(error_data, fp)
+        pf = ProcessFailure(
+            local_rank=0, pid=997, exitcode=1, error_file=self.test_error_file
+        )
+        self.assertEqual("test error message", pf.message)
+        self.assertEqual(10, pf.timestamp)
+
     def test_process_failure(self):
         pf = self.failure_with_error_file(exception=SentinelError("foobar"))
         self.assertEqual(0, pf.local_rank)

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -77,7 +77,6 @@ class ErrorHandler:
         except Exception as e:
             warnings.warn(f"Unable to write error to file. {type(e).__name__}: {e}")
 
-
     def record_exception(self, e: BaseException) -> None:
         """
         Writes a structured information about the exception into an error file in
@@ -85,7 +84,6 @@ class ErrorHandler:
         that would have been written to the error file.
         """
         _write_error(e, self._get_error_file_path())
-
 
     def dump_error_file(self, rootcause_error_file: str, error_code: int = 0):
         """
@@ -100,6 +98,11 @@ class ErrorHandler:
                     log.warning(
                         f"child error file ({rootcause_error_file}) does not have field `message`. \n"
                         f"cannot override error code: {error_code}"
+                    )
+                elif isinstance(rootcause_error["message"], str):
+                    log.warning(
+                        f"child error file ({rootcause_error_file}) has a new message format. \n"
+                        f"skipping error code override"
                     )
                 else:
                     rootcause_error["message"]["errorCode"] = error_code
@@ -122,7 +125,7 @@ class ErrorHandler:
             # will write to the parent's error file. In this case just log the
             # original error file contents and overwrite the error file.
             self._rm(my_error_file)
-            self._write_error_file(my_error_file , json.dumps(rootcause_error))
+            self._write_error_file(my_error_file, json.dumps(rootcause_error))
             log.info(f"dumped error file to parent's {my_error_file}")
         else:
             log.error(


### PR DESCRIPTION
Summary:
The diff adds support for new error message file format:

    {
        "message":"test",
        "timestamp": 12
    }

Test Plan:
fbcode buck test mode/dev-nosan //caffe2/test/distributed/elastic/multiprocessing/errors:api_test

example job: tsm_aivanou-torchelastic_distributed_sum_77c0b147

Reviewed By: borovsky-d, wilson100hong

Differential Revision: D28042764

