### PR TITLE
[caffe2] fix bug when weight_decay is used with fused rowwise + SLWS grad

### DIFF
--- a/caffe2/sgd/adagrad_fused_op_gpu.cu
+++ b/caffe2/sgd/adagrad_fused_op_gpu.cu
@@ -488,7 +488,7 @@ __global__
     __shared__ float row_sum_squares_avg;
 
     for (int i = threadIdx.x; i < block_size; i += blockDim.x) {
-      const float x_ij = grad[group * block_size + i] +
+      const float x_ij = grad[group * block_size + i] * in_weight_temp +
           weight_decay * param[index * block_size + i];
       sum_squares += x_ij * x_ij;
     }
@@ -496,8 +496,7 @@ __global__
 
     if (threadIdx.x == 0) {
       row_sum_squares_avg = reduce_result / static_cast<float>(block_size);
-      param_mom[index] +=
-          static_cast<T>(row_sum_squares_avg * in_weight_temp * in_weight_temp);
+      param_mom[index] += static_cast<T>(row_sum_squares_avg);
     }
     __syncthreads();
 


### PR DESCRIPTION
Summary: We did an algebraic simplification to avoid multiplying with in_weight_temp for each element but this breaks down when weight decay is not zero.

Test Plan:
In devgpu
buck test mode/dev-nosan //caffe2/caffe2/fb/net_transforms/tests:fuse_sparse_ops_test -- test_fuse_sparse_adagrad_with_sparse_lengths_weighted_sum_gradient --run-disabled

Differential Revision: D28051026

