### PR TITLE
[Perf] Use std::copy_n instead of vec256::map

### DIFF
--- a/aten/src/ATen/native/cpu/CatKernel.cpp
+++ b/aten/src/ATen/native/cpu/CatKernel.cpp
@@ -2,8 +2,6 @@
 
 #include <ATen/Dispatch.h>
 #include <ATen/native/cpu/CatKernel.h>
-#include <ATen/cpu/vec256/functional.h>
-#include <ATen/cpu/vec256/vec256.h>
 
 namespace at { namespace native {
 
@@ -31,26 +29,12 @@ void cat_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
     inputs.emplace_back(tensor, dim, result.strides()[dim]);
   }
 
-  using Vec = vec256::Vec256<scalar_t>;
   scalar_t* result_ptr = result_data;
   for (int64_t i = 0; i < outer; ++i) {
     for (int64_t j = 0; j < ninputs; j++) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
-      if (local_inner < Vec::size()) {
-        #if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
-        # pragma unroll
-        #endif
-        for (int64_t k = 0; k < local_inner; k++) {
-          result_ptr[k] = input_ptr[k];
-        }
-      } else {
-        vec256::map(
-            [](Vec x) { return x; },
-            result_ptr,
-            input_ptr,
-            local_inner);
-      }
+      std::copy_n(input_ptr, local_inner, result_ptr);
       result_ptr += local_inner;
     }
   }

--- a/aten/src/ATen/native/cpu/StackKernel.cpp
+++ b/aten/src/ATen/native/cpu/StackKernel.cpp
@@ -3,8 +3,6 @@
 #include <ATen/ATen.h>
 
 #include <ATen/Dispatch.h>
-#include <ATen/cpu/vec256/functional.h>
-#include <ATen/cpu/vec256/vec256.h>
 #include <ATen/native/cpu/StackKernel.h>
 
 namespace at {
@@ -35,24 +33,12 @@ void stack_serial_kernel_impl(Tensor& result, TensorList tensors, int64_t dim) {
     inputs.emplace_back(tensor, dim, tensor.strides()[dim]);
   }
 
-  using Vec = vec256::Vec256<scalar_t>;
   scalar_t* result_ptr = result_data;
   for (int64_t i = 0; i < outer; ++i) {
     for (int64_t j = 0; j < ninputs; j++) {
       int64_t local_inner = inputs[j].inner_size;
       scalar_t* input_ptr = (scalar_t*)(inputs[j].data_ptr) + i * local_inner;
-
-      if (local_inner < Vec::size()) {
-#if !defined(_MSC_VER) && !defined(COMPILING_FOR_MIN_SIZE)
-#pragma unroll
-#endif
-        for (int64_t k = 0; k < local_inner; k++) {
-          result_ptr[k] = input_ptr[k];
-        }
-      } else {
-        vec256::map(
-            [](Vec x) { return x; }, result_ptr, input_ptr, local_inner);
-      }
+      std::copy_n(input_ptr, local_inner, result_ptr);
       result_ptr += local_inner;
     }
   }


### PR DESCRIPTION
std::copy_n is backed by a lot of arch specific optimizations, which vec256::map is likely missing.

Running following code:
```
import torch
import torch.utils.benchmark as benchmark

def cat(*args, dim=0):
    return torch.cat(args, dim)

tensors = []
for i in range(10):
    tensors.append(torch.rand(1024, 16 *1024))

t0 = benchmark.Timer(
    stmt='cat(*tensors, dim=1)',
    setup='from __main__ import cat',
    globals={'tensors': tensors},
    num_threads=1)

print(t0.blocked_autorange())
```
On Apple M1 shows 10+% perf gains:
Before:
```
<torch.utils.benchmark.utils.common.Measurement object at 0x114b40550>
cat(*tensors, dim=1)
setup: from __main__ import cat
  Median: 71.33 ms
  3 measurements, 1 runs per measurement, 1 thread
```
after
```
cat(*tensors, dim=1)
setup: from __main__ import cat
  Median: 62.54 ms
  IQR:    2.40 ms (62.51 to 64.90)
  4 measurements, 1 runs per measurement, 1 thread
```

It should also have positive impact on #55037, as std::copy_n should be avx2 accelerated on supported Windows CPUs, while `vec256::map` wouldn't be
