### PR TITLE
Fix json parse error for profiler call stack

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -328,7 +328,7 @@ std::string stacksToStr(const std::vector<std::string>& stacks) {
   std::copy(stacks.begin(), stacks.end(), std::ostream_iterator<std::string>(oss, ";"));
   auto rc = oss.str();
   rc.pop_back();
-  return rc;
+  return "\"" + rc + "\"";
 }
 
 } // namespace


### PR DESCRIPTION
The call stack in profiler result json file lacks surrounding double quotes, and result in json parse error.
This PR just add it.

@ilia-cher 