### PR TITLE
[torch/deploy] remove usage of fbcode_dir

### DIFF
--- a/torch/csrc/deploy/interpreter/freeze.py
+++ b/torch/csrc/deploy/interpreter/freeze.py
@@ -245,7 +245,6 @@ parser = argparse.ArgumentParser(description="Compile py source")
 parser.add_argument("paths", nargs="*", help="Paths to freeze.")
 parser.add_argument("--verbose", action="store_true", help="Print debug logs")
 parser.add_argument("--install_dir", help="Root directory for all output files")
-parser.add_argument("--fbcode_dir", help="Root directory for all output files")
 parser.add_argument("--oss", action="store_true", help="If it's OSS build, add a fake _PyImport_FrozenModules")
 
 args = parser.parse_args()
@@ -253,8 +252,6 @@ args = parser.parse_args()
 f = Freezer(args.verbose)
 
 for p in args.paths:
-    if args.fbcode_dir:
-        p = os.path.join(args.fbcode_dir, p)
     path = Path(p)
     if path.is_dir() and not Path.exists(path / '__init__.py'):
         # this 'top level path p' is a standard directory containing modules,


### PR DESCRIPTION
Summary:
We don't actually need to peek into `--fbcode_dir` for this. There are two reasons we should avoid this:
1. The [`TARGETS` docs](https://fburl.com/wiki/zz1wh6uc) recommend against it, as it can break buck caching and dependency tracking. This doesn't seem to be a serious issue in our case (we declare our sources anyway) but worth respecting.
2. More seriously, if we want to use this script from outside fbcode (like `fbsource/third-party/pypi`), it will break since `fbcode_dir` gets set to something wild

The preferred method is apparently to use `$SRCDIR`, which represents a directory that all specified sources are copied to before exexcuting the custom rule.
Found the suggestion here: https://fburl.com/w33wae2b. Seems less fragile, since it's publically documented as well: https://buck.build/rule/genrule.html

Test Plan: sandcastle

Differential Revision: D28052570

