### PR TITLE
Fix default dtype for randperm, triu/tril_indices inside TorchScript

### DIFF
--- a/aten/src/ATen/native/TensorFactories.cpp
+++ b/aten/src/ATen/native/TensorFactories.cpp
@@ -879,6 +879,10 @@ Tensor randperm(int64_t n, c10::optional<Generator> generator,
     c10::optional<Layout> layout,
     c10::optional<Device> device,
     c10::optional<bool> pin_memory) {
+  if (!dtype.has_value()) {
+    dtype = ScalarType::Long;
+  }
+
   // See [Note: hacky wrapper removal for TensorOptions]
   TensorOptions options = TensorOptions().dtype(dtype).layout(layout).device(device).pinned_memory(pin_memory);
 
@@ -937,6 +941,10 @@ Tensor range(
 Tensor tril_indices_cpu(
     int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype_opt,
     c10::optional<Layout> layout_opt, c10::optional<Device> device_opt, c10::optional<bool> pin_memory_opt) {
+  if (!dtype_opt.has_value()) {
+    dtype_opt = ScalarType::Long;
+  }
+
   check_args(row, col, layout_opt);
 
   auto tril_size = get_tril_size(row, col, offset);
@@ -983,6 +991,10 @@ Tensor tril_indices_cpu(
 Tensor triu_indices_cpu(
     int64_t row, int64_t col, int64_t offset, c10::optional<ScalarType> dtype_opt,
     c10::optional<Layout> layout_opt, c10::optional<Device> device_opt, c10::optional<bool> pin_memory_opt) {
+  if (!dtype_opt.has_value()) {
+    dtype_opt = ScalarType::Long;
+  }
+
   check_args(row, col, layout_opt);
 
   auto triu_size = row * col - get_tril_size(row, col, offset - 1);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2924,9 +2924,9 @@
 
 - func: randn_like(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
 
-- func: randperm(int n, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randperm(int n, *, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
-- func: randperm.generator(int n, *, Generator? generator, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
+- func: randperm.generator(int n, *, Generator? generator, ScalarType? dtype=long, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
 
 - func: randperm.out(int n, *, Tensor(a!) out) -> Tensor(a!)
 

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -79,6 +79,7 @@ allow_list = [
     ("aten::_addmv_impl_", datetime.date(2021, 5, 15)),
     ("aten::adaptive_avg_pool3d_backward", datetime.date(9999, 1, 1)),
     ("aten::_embedding_bag_dense_backward", datetime.date(9999, 1, 1)),
+    ("aten::randperm", datetime.date(9999, 1, 1)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/jit/test_tensor_creation_ops.py
+++ b/test/jit/test_tensor_creation_ops.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+import torch
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+from torch.testing._internal.jit_utils import JitTestCase
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestTensorCreationOps(JitTestCase):
+    """
+    A suite of tests for ops that create tensors.
+    """
+
+    def test_randperm_default_dtype(self):
+        def randperm(x: int):
+            perm = torch.randperm(x)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert perm.dtype == torch.int64
+
+        self.checkScript(randperm, (3, ))
+
+    def test_randperm_specifed_dtype(self):
+        def randperm(x: int):
+            perm = torch.randperm(x, dtype=torch.float)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert perm.dtype == torch.float
+
+        self.checkScript(randperm, (3, ))
+
+    def test_triu_indices_default_dtype(self):
+        def triu_indices(rows: int, cols: int):
+            indices = torch.triu_indices(rows, cols)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert indices.dtype == torch.int64
+
+        self.checkScript(triu_indices, (3, 3))
+
+    def test_triu_indices_specified_dtype(self):
+        def triu_indices(rows: int, cols: int):
+            indices = torch.triu_indices(rows, cols, dtype=torch.float)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert indices.dtype == torch.float
+
+        self.checkScript(triu_indices, (3, 3))
+
+    def test_tril_indices_default_dtype(self):
+        def tril_indices(rows: int, cols: int):
+            indices = torch.tril_indices(rows, cols)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert indices.dtype == torch.int64
+
+        self.checkScript(tril_indices, (3, 3))
+
+    def test_tril_indices_specified_dtype(self):
+        def tril_indices(rows: int, cols: int):
+            indices = torch.tril_indices(rows, cols, dtype=torch.float)
+            # Have to perform assertion here because TorchScript returns dtypes
+            # as integers, which are not comparable against eager torch.dtype.
+            assert indices.dtype == torch.float
+
+        self.checkScript(tril_indices, (3, 3))

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -47,6 +47,7 @@ from jit.test_jit_utils import TestJitUtils  # noqa: F401
 from jit.test_scriptmod_ann import TestScriptModuleInstanceAttributeTypeAnnotation  # noqa: F401
 from jit.test_types import TestTypesAndAnnotation  # noqa: F401
 from jit.test_misc import TestMisc  # noqa: F401
+from jit.test_tensor_creation_ops import TestTensorCreationOps  # noqa: F401
 
 # Torch
 from torch import Tensor


### PR DESCRIPTION
Fixes #56676
