### PR TITLE
Adds DLPack support

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -39,7 +39,7 @@ DLDataType getDLDataType(const Tensor& t) {
       dtype.code = DLDataTypeCode::kDLFloat;
       break;
     case ScalarType::Bool:
-      dtype.code = DLDataTypeCode::kDLUInt;
+      TORCH_CHECK(false, "Bool type is not supported by dlpack");
       break;
     case ScalarType::ComplexHalf:
       dtype.code = DLDataTypeCode::kDLComplex;

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7101,6 +7101,8 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
+        if device == 'xla':
+            return
         x = make_tensor((5,), device, dtype, low=-9, high=9)
         z = from_dlpack(to_dlpack(x))
         self.assertEqual(z, x)
@@ -7112,6 +7114,8 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
+        if device == 'xla':
+            return
         x = make_tensor((5,), device, dtype, low=-9, high=9)
         z = from_dlpack(x)
         self.assertEqual(z, x)
@@ -7122,6 +7126,8 @@ else:
         # DLpack does not explicitly support bool
         # It does it through uint8 type
         if dtype is torch.bool:
+            return
+        if device == 'xla':
             return
         # Create a stream where the tensor will reside
         if device == 'cuda':
@@ -7140,6 +7146,8 @@ else:
         # DLpack does not explicitly support bool
         # It does it through uint8 type
         if dtype is torch.bool:
+            return
+        if device == 'xla':
             return
         if device == 'cuda':
             from torch._C import _from_dlpack
@@ -7164,6 +7172,8 @@ else:
         # DLpack does not explicitly support bool
         # It does it through uint8 type
         if dtype is torch.bool:
+            return
+        if device == 'xla':
             return
         with self.assertRaises(TypeError):
             x = make_tensor((5,), device, dtype, low=-9, high=9)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7101,7 +7101,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        if device == 'xla':
+        if 'xla' in device:
             return
         x = make_tensor((5,), device, dtype, low=-9, high=9)
         z = from_dlpack(to_dlpack(x))
@@ -7114,7 +7114,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        if device == 'xla':
+        if 'xla' in device:
             return
         x = make_tensor((5,), device, dtype, low=-9, high=9)
         z = from_dlpack(x)
@@ -7127,7 +7127,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        if device == 'xla':
+        if 'xla' in device:
             return
         # Create a stream where the tensor will reside
         if device == 'cuda':
@@ -7147,7 +7147,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        if device == 'xla':
+        if 'xla' in device:
             return
         if device == 'cuda':
             from torch._C import _from_dlpack
@@ -7173,7 +7173,7 @@ else:
         # It does it through uint8 type
         if dtype is torch.bool:
             return
-        if device == 'xla':
+        if 'xla' in device:
             return
         with self.assertRaises(TypeError):
             x = make_tensor((5,), device, dtype, low=-9, high=9)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -759,6 +759,8 @@ from ._vmap_internals import vmap as vmap
 quantized_lstm = torch.ops.aten.quantized_lstm
 quantized_gru = torch.ops.aten.quantized_gru
 
+from torch.utils.dlpack import from_dlpack, to_dlpack
+
 
 def _register_device_module(device_type, module):
     r"""Register an external runtime module of the specific :attr:`device_type`

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1056,8 +1056,8 @@ class Tensor(torch._C._TensorBase):
 
     def __dlpack__(self, stream=None):
         """
-        Creates a DLpack `capsule https://data-apis.org/array-api/latest/design_topics/data_interchange.html#data-interchange`_ of the current tensor to
-        be exported to other libraries.
+        Creates a DLpack `capsule https://data-apis.org/array-api/latest/design_topics/data_interchange.html#data-interchange`_
+        of the current tensor to be exported to other libraries.
 
         This function will be called from the `from_dlpack` method
         of the library that will consume the capsule. `from_dlpack` passes the current

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1106,7 +1106,7 @@ class Tensor(torch._C._TensorBase):
             device_type = 'cpu_pinned'
         try:
             return (DLPackIds[device_type], idx)
-        except AttributeError:
+        except KeyError:
             raise ValueError('Unknown device type {} for Dlpack'.format(device_type))
 
     __module__ = 'torch'

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1083,7 +1083,7 @@ class Tensor(torch._C._TensorBase):
                 # Only synchronize on different streams
                 if stream != torch.cuda.current_stream:
                     event = torch.cuda.Event()
-                    event.record(stream)
+                    event.record(torch.cuda.current_stream())
                     torch.cuda.current_stream().wait_event(event)
         return torch.to_dlpack(self)
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1102,17 +1102,16 @@ class Tensor(torch._C._TensorBase):
         if has_torch_function_unary(self):
             return handle_torch_function(Tensor.__dlpack_device__, (self,), self)
         idx = self.device.index if self.device.index is not None else 0
-        device_type = self.device.type
-        if device_type == 'cuda' and torch.version.hip is not None:
+        if self.device.type == 'cuda' and torch.version.hip is not None:
             device_type = DLDeviceType.kDLROCM
-        elif device_type == 'cpu' and self.is_pinned():
+        elif self.device.type == 'cpu' and self.is_pinned():
             device_type = DLDeviceType.kDLCPUPinned
-        elif device_type == 'cuda':
+        elif self.device.type == 'cuda':
             device_type = DLDeviceType.kDLGPU
-        elif device_type == 'cpu':
+        elif self.device.type == 'cpu':
             device_type = DLDeviceType.kDLCPU
         else:
-            raise ValueError('Unknown device type {} for Dlpack'.format(device_type))
+            raise ValueError('Unknown device type {} for Dlpack'.format(self.device.type))
         return (device_type, idx)
 
     __module__ = 'torch'

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1104,9 +1104,10 @@ class Tensor(torch._C._TensorBase):
             device_type = 'rocm'
         elif device_type == 'cpu' and self.is_pinned():
             device_type = 'cpu_pinned'
-        if device_type not in DLPackIds:
+        try:
+            return (DLPackIds[device_type], idx)
+        except AttributeError:
             raise ValueError('Unknown device type {} for Dlpack'.format(device_type))
-        return (DLPackIds[device_type], idx)
 
     __module__ = 'torch'
 

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1159,7 +1159,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         Tensor.view: lambda self, shape: -1,
         Tensor.view_as: lambda self, other: -1,
         Tensor.zero_: lambda self: -1,
-        Tensor.__dlpack__: lambda self: -1,
+        Tensor.__dlpack__: lambda self, stream=None: -1,
         Tensor.__dlpack_device__: lambda self: -1,
         torch.linalg.lstsq: lambda self, b, cond=None, driver=None: -1,
     }

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1159,6 +1159,8 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         Tensor.view: lambda self, shape: -1,
         Tensor.view_as: lambda self, other: -1,
         Tensor.zero_: lambda self: -1,
+        Tensor.__dlpack__: lambda self: -1,
+        Tensor.__dlpack_device__: lambda self: -1,
         torch.linalg.lstsq: lambda self, b, cond=None, driver=None: -1,
     }
 

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -27,8 +27,8 @@ Returns a DLPack representing the tensor.
 Args:
     tensor: a tensor to be exported
 
-The dlpack shares the tensors memory.
-Note that each dlpack can only be consumed once.
+The DLPack shares the tensors memory.
+Note that each DLPack can only be consumed once.
 """)
 
 # TODO: add a typing.Protocol to be able to tell Mypy that only objects with
@@ -40,13 +40,14 @@ def from_dlpack(ext_tensor: Any) -> torch.Tensor:
     by means of the ``__dlpack__`` protocol.
 
     The tensor will share the memory with the object represented
-    in the dlpack.
+    in the DLPack.
 
-    Note that each dlpack capsule can only be consumed once. Otherwise
-    memory errors could happen.
+    .. warning::
+      Only call from_dlpack once per capsule. Its behavior when used
+      on the same capsule multiple times is undefined.
 
     Args:
-        ext_tensor (object with __dlpack__ attribute or dlpack capsule):
+        ext_tensor (object with __dlpack__ attribute or DLPack capsule):
             The tensor or DLPack capsule to convert.
     """
     if hasattr(ext_tensor, '__dlpack__'):

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -16,12 +16,12 @@ Note that each dlpack can only be consumed once.
 
 
 def from_dlpack(ext_tensor) -> torch.Tensor:
-    """from_dlpack(dlpack) -> Tensor
+    """from_dlpack(ext_tensor) -> Tensor
 
     Decodes a DLPack to a tensor.
 
     Args:
-        dlpack: a PyCapsule object with the dltensor
+        ext_tensor: a PyCapsule object with the dltensor
 
     The tensor will share the memory with the object represented
     in the dlpack.
@@ -32,14 +32,17 @@ def from_dlpack(ext_tensor) -> torch.Tensor:
             The tensor from an external library that will be converted
             to a PyTorch one.
     """
-    if hasattr(dlpack, '__dlpack__'):
-        device = dlpack.__dlpack_device__()
+    if hasattr(ext_tensor, '__dlpack__'):
+        device = ext_tensor.__dlpack_device__()
         # device is either CUDA or ROCm, we need to pass the current
         # stream
         if device[0] in (2, 10):
-            stream = torch.cuda.stream.current_stream('cuda:{}'.format(device[1]))
-            # Should we pass an id? or the producer can accept a stream object
+            stream = torch.cuda.current_stream('cuda:{}'.format(device[1]))
+            # cuda_stream is the pointer to the stream and it is a public
+            # attribute, but it is not documented
             dlpack = ext_tensor.__dlpack__(stream=stream.cuda_stream)
+        else:
+            dlpack = ext_tensor.__dlpack__()
     else:
         # Old versions just call the converter
         dlpack = tensor

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import torch
 
 from torch._C import _from_dlpack
@@ -15,17 +17,18 @@ Note that each dlpack can only be consumed once.
 """)
 
 
-def from_dlpack(ext_tensor) -> torch.Tensor:
+def from_dlpack(ext_tensor: Any) -> torch.Tensor:
     """from_dlpack(ext_tensor) -> Tensor
 
-    Decodes a DLPack to a tensor.
-
-    Args:
-        ext_tensor: a PyCapsule object with the dltensor
+    Convers a tensor from a external library into a ``torch.Tensor``
+    by means of the ``__dlpack__`` protocol.
 
     The tensor will share the memory with the object represented
     in the dlpack.
-    Note that each dlpack can only be consumed once.
+
+    In order to keep backward compatibility, this function also admits
+    to pass a dlpack capsule object.
+    Note that each dlpack capsule can only be consumed once.
 
     Args:
         ext_tensor (object with __dlpack__ attribute or dlpack capsule):
@@ -45,5 +48,5 @@ def from_dlpack(ext_tensor) -> torch.Tensor:
             dlpack = ext_tensor.__dlpack__()
     else:
         # Old versions just call the converter
-        dlpack = tensor
-    _from_dlpack(dlpack)
+        dlpack = ext_tensor
+    return _from_dlpack(dlpack)

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -31,8 +31,8 @@ The dlpack shares the tensors memory.
 Note that each dlpack can only be consumed once.
 """)
 
-# TODO: add a typing.Protocol to be able to tell Mypy that only objects with 
-#         __dlpack__ and __dlpack_device__ methods are accepted.
+# TODO: add a typing.Protocol to be able to tell Mypy that only objects with
+# __dlpack__ and __dlpack_device__ methods are accepted.
 def from_dlpack(ext_tensor: Any) -> torch.Tensor:
     """from_dlpack(ext_tensor) -> Tensor
 

--- a/torch/utils/dlpack.py
+++ b/torch/utils/dlpack.py
@@ -1,19 +1,7 @@
 import torch
 
-from torch._C import _from_dlpack as from_dlpack
+from torch._C import _from_dlpack
 from torch._C import _to_dlpack as to_dlpack
-
-torch._C._add_docstr(from_dlpack, r"""from_dlpack(dlpack) -> Tensor
-
-Decodes a DLPack to a tensor.
-
-Args:
-    dlpack: a PyCapsule object with the dltensor
-
-The tensor will share the memory with the object represented
-in the dlpack.
-Note that each dlpack can only be consumed once.
-""")
 
 torch._C._add_docstr(to_dlpack, r"""to_dlpack(tensor) -> PyCapsule
 
@@ -25,3 +13,34 @@ Args:
 The dlpack shares the tensors memory.
 Note that each dlpack can only be consumed once.
 """)
+
+
+def from_dlpack(ext_tensor) -> torch.Tensor:
+    """from_dlpack(dlpack) -> Tensor
+
+    Decodes a DLPack to a tensor.
+
+    Args:
+        dlpack: a PyCapsule object with the dltensor
+
+    The tensor will share the memory with the object represented
+    in the dlpack.
+    Note that each dlpack can only be consumed once.
+
+    Args:
+        ext_tensor (object with __dlpack__ attribute or dlpack capsule):
+            The tensor from an external library that will be converted
+            to a PyTorch one.
+    """
+    if hasattr(dlpack, '__dlpack__'):
+        device = dlpack.__dlpack_device__()
+        # device is either CUDA or ROCm, we need to pass the current
+        # stream
+        if device[0] in (2, 10):
+            stream = torch.cuda.stream.current_stream('cuda:{}'.format(device[1]))
+            # Should we pass an id? or the producer can accept a stream object
+            dlpack = ext_tensor.__dlpack__(stream=stream.cuda_stream)
+    else:
+        # Old versions just call the converter
+        dlpack = tensor
+    _from_dlpack(dlpack)


### PR DESCRIPTION
Partially Fixes #55090
Depends on #55365

Inspired by https://github.com/dmlc/dlpack/issues/57#issuecomment-774482973

Questions, in PyTorch we can't create streams or easily synchronize them from just an integer. Should we add an [`ExternalStream`](https://docs.cupy.dev/en/stable/reference/generated/cupy.cuda.ExternalStream.html) object like the one we have in CuPy? 

TODO: Add tests

Would like some feedback as this design needs quite a few iterations
@rgommers @leofang

cc @mruberry @rgommers @pmeier @asmeurer @leofang @AnirudhDagar @asi1024 @emcastillo @kmaehashi @heitorschueroff