### PR TITLE
Support `expand_dims`

### DIFF
--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -263,6 +263,7 @@ namespace c10 {
   _(aten, transpose_)                \
   _(aten, unsqueeze_)                \
   _(aten, expand_dims)               \
+  _(aten, expand_dims_)              \
   _(aten, __getitem__)               \
   _(aten, _set_item)                 \
   _(aten, manual_seed)               \

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -262,6 +262,7 @@ namespace c10 {
   _(aten, transpose)                 \
   _(aten, transpose_)                \
   _(aten, unsqueeze_)                \
+  _(aten, expand_dims)               \
   _(aten, __getitem__)               \
   _(aten, _set_item)                 \
   _(aten, manual_seed)               \

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1954,6 +1954,10 @@ Tensor expand_dims(const Tensor& self, int64_t dim) {
   return self.unsqueeze(dim);
 }
 
+Tensor & expand_dims_(Tensor& self, int64_t dim) {
+  return self.unsqueeze_(dim);
+}
+
 Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
   start_dim = maybe_wrap_dim(start_dim, self.dim());
   end_dim = maybe_wrap_dim(end_dim, self.dim());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1950,6 +1950,10 @@ Tensor & unsqueeze_(Tensor& self, int64_t dim) {
   return self.as_strided_(g.sizes, g.strides);
 }
 
+Tensor expand_dims(const Tensor& self, int64_t dim) {
+  return self.unsqueeze(dim);
+}
+
 Tensor flatten(const Tensor& self, int64_t start_dim, int64_t end_dim) {
   start_dim = maybe_wrap_dim(start_dim, self.dim());
   end_dim = maybe_wrap_dim(end_dim, self.dim());

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3776,6 +3776,9 @@
 - func: expand_dims(Tensor(a) self, int dim) -> Tensor(a)
   variants: function, method
 
+- func: expand_dims_(Tensor(a!) self, int dim) -> Tensor(a!)
+  variants: method
+
 - func: vander(Tensor x, int? N=None, bool increasing=False) -> Tensor
 
 - func: var(Tensor self, bool unbiased=True) -> Tensor

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3772,6 +3772,10 @@
   dispatch:
     CompositeExplicitAutograd: unsqueeze_
 
+# expand_dims, alias of unsqueeze
+- func: expand_dims(Tensor(a) self, int dim) -> Tensor(a)
+  variants: function, method
+
 - func: vander(Tensor x, int? N=None, bool increasing=False) -> Tensor
 
 - func: var(Tensor self, bool unbiased=True) -> Tensor

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -336,6 +336,7 @@ Tensor class reference
     Tensor.exp
     Tensor.exp_
     Tensor.expand_dims
+    Tensor.expand_dims_
     Tensor.expm1
     Tensor.expm1_
     Tensor.expand

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -335,6 +335,7 @@ Tensor class reference
     Tensor.erfinv_
     Tensor.exp
     Tensor.exp_
+    Tensor.expand_dims
     Tensor.expm1
     Tensor.expm1_
     Tensor.expand

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -90,6 +90,7 @@ Indexing, Slicing, Joining, Mutating Ops
     dsplit
     column_stack
     dstack
+    expand_dims
     gather
     hsplit
     hstack

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4375,6 +4375,13 @@ expand_dims(dim) -> Tensor
 See :func:`torch.expand_dims`
 """)
 
+add_docstr_all('expand_dims_',
+               r"""
+expand_dims_(dim) -> Tensor
+
+See :func:`torch.Tensor.unsqueeze_`
+""")
+
 add_docstr_all('sum_to_size',
                r"""
 sum_to_size(*size) -> Tensor

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4379,7 +4379,7 @@ add_docstr_all('expand_dims_',
                r"""
 expand_dims_(dim) -> Tensor
 
-See :func:`torch.Tensor.unsqueeze_`
+In-place version of :meth:`~Tensor.expand_dims`
 """)
 
 add_docstr_all('sum_to_size',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4368,6 +4368,13 @@ Args:
         as :attr:`other`.
 """)
 
+add_docstr_all('expand_dims',
+               r"""
+expand_dims(dim) -> Tensor
+
+See :func:`torch.expand_dims`
+""")
+
 add_docstr_all('sum_to_size',
                r"""
 sum_to_size(*size) -> Tensor

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3170,6 +3170,13 @@ exp2(input, *, out=None) -> Tensor
 Alias for :func:`torch.special.exp2`.
 """)
 
+add_docstr(torch.expand_dims,
+           r"""
+expand_dims(input, dim) -> Tensor
+
+Alias for :func:`torch.unsqueeze`.
+""")
+
 add_docstr(torch.expm1,
            r"""
 expm1(input, *, out=None) -> Tensor

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -60,6 +60,7 @@ const std::unordered_map<Symbol, Symbol>& getOperatorAliasMap() {
       {aten::arctanh, aten::atanh},
       {aten::arctanh_, aten::atanh_},
       {aten::expand_dims, aten::unsqueeze},
+      {aten::expand_dims_, aten::unsqueeze_},
       {aten::fix, aten::trunc},
       {aten::fix_, aten::trunc_},
       {aten::negative, aten::neg},

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -59,6 +59,7 @@ const std::unordered_map<Symbol, Symbol>& getOperatorAliasMap() {
       {aten::arcsinh_, aten::asinh_},
       {aten::arctanh, aten::atanh},
       {aten::arctanh_, aten::atanh_},
+      {aten::expand_dims, aten::unsqueeze},
       {aten::fix, aten::trunc},
       {aten::fix_, aten::trunc_},
       {aten::negative, aten::neg},

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -887,6 +887,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
         torch.unsafe_split: lambda tensor, split_size_or_sections, dim=0: -1,
         torch.unsafe_split_with_sizes: lambda tensor, split_size_or_sections, dim=0: -1,
         torch.unsqueeze: lambda input, dim, out=None: -1,
+        torch.expand_dims: lambda input, dim, out=None: -1,
         torch.var: lambda input, dim=None: -1,
         torch.var_mean: lambda input, dim=None: -1,
         torch.vsplit: lambda input, indices_or_sections: -1,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5308,6 +5308,7 @@ op_db: List[OpInfo] = [
                   supports_out=False,
                   sample_inputs_func=sample_repeat_tile),
     OpInfo('unsqueeze',
+           aliases=('expand_dims',),
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,
            assert_autodiffed=True,


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/56774

This PR implements `torch.expand_dims` for the compatibility with NumPy’s interface.
cc: @mruberry, @rgommers, @emcastillo and @kmaehashi 