### PR TITLE
Remove glaringlee from C++ frontend codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,6 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-/docs/cpp @glaringlee
-/torch/csrc/api/ @glaringlee
-/test/cpp/api/ @glaringlee
 /torch/utils/cpp_extension.py @fmassa @soumith @ezyang
 
 # Not there to strictly require the approval, but to be tagged as a reviewer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57130 Remove glaringlee from C++ frontend codeowners**

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28059800](https://our.internmc.facebook.com/intern/diff/D28059800)