### PR TITLE
[10/n] [torch/elastic] Add comparison operators to _NodeDesc

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -169,7 +169,7 @@ class RendezvousSettings:
     keep_alive_max_attempt: int
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True, order=True, frozen=True)
 class _NodeDesc:
     """Describes a node in the rendezvous.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* **#57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc**
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR sets the `order` attribute of the `dataclass` annotation to `True` in order to introduce comparison operators for `_NodeDesc`.

Differential Revision: [D28058851](https://our.internmc.facebook.com/intern/diff/D28058851/)