### PR TITLE
[11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -31,11 +31,13 @@ class RendezvousTimeoutTest(TestCase):
             timedelta(seconds=50),
             timedelta(seconds=60),
             timedelta(seconds=70),
+            timedelta(seconds=80),
         )
 
         self.assertEqual(timeout.join, timedelta(seconds=50))
         self.assertEqual(timeout.last_call, timedelta(seconds=60))
         self.assertEqual(timeout.close, timedelta(seconds=70))
+        self.assertEqual(timeout.heartbeat, timedelta(seconds=80))
 
     def test_init_initializes_timeout_if_no_timeout_is_specified(self) -> None:
         timeout = RendezvousTimeout()
@@ -43,6 +45,7 @@ class RendezvousTimeoutTest(TestCase):
         self.assertEqual(timeout.join, timedelta(seconds=600))
         self.assertEqual(timeout.last_call, timedelta(seconds=30))
         self.assertEqual(timeout.close, timedelta(seconds=30))
+        self.assertEqual(timeout.heartbeat, timedelta(seconds=5))
 
     def test_init_raises_error_if_timeout_is_not_positive(self) -> None:
         join_timeouts = [timedelta(seconds=0), timedelta(seconds=-1)]

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -86,14 +86,17 @@ class RendezvousTimeout:
 
     Args:
         join:
-            The total time within which the rendezvous is expected to complete.
+            The time within which the rendezvous is expected to complete.
         last_call:
             An additional wait amount before completing the rendezvous once the
-            minimum number of nodes has been reached.
+            rendezvous has the minimum number of required participants.
         close:
             The time within which the rendezvous is expected to close after a
             call to :py:meth:`RendezvousHandler.set_closed` or
             :py:meth:`RendezvousHandler.shutdown`.
+        keep_alive:
+            The time within which a keep-alive heartbeat is expected to
+            complete.
     """
 
     _ZERO = timedelta(0)
@@ -102,19 +105,22 @@ class RendezvousTimeout:
         "join": timedelta(seconds=600),
         "last_call": timedelta(seconds=30),
         "close": timedelta(seconds=30),
+        "heartbeat": timedelta(seconds=5),
     }
 
     _join: timedelta
     _last_call: timedelta
     _close: timedelta
+    _heartbeat: timedelta
 
     def __init__(
         self,
         join: Optional[timedelta] = None,
         last_call: Optional[timedelta] = None,
         close: Optional[timedelta] = None,
+        heartbeat: Optional[timedelta] = None,
     ) -> None:
-        self._set_timeouts(join=join, last_call=last_call, close=close)
+        self._set_timeouts(join=join, last_call=last_call, close=close, heartbeat=heartbeat)
 
     @property
     def join(self) -> timedelta:
@@ -130,6 +136,11 @@ class RendezvousTimeout:
     def close(self) -> timedelta:
         """Gets the close timeout."""
         return self._close
+
+    @property
+    def heartbeat(self) -> timedelta:
+        """Gets the keep-alive heartbeat timeout."""
+        return self._heartbeat
 
     def _set_timeouts(self, **timeouts: Optional[timedelta]):
         for name, timeout in timeouts.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* **#57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout**
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR introduces a new `heartbeat` attribute in `RendezvousTimeout`.

Differential Revision: [D28058908](https://our.internmc.facebook.com/intern/diff/D28058908/)