### PR TITLE
[12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -116,8 +116,8 @@ class RendezvousStateTest(TestCase):
 
                     state.wait_list.add(node_waiting)
 
-                    state.last_keep_alives[node_running] = datetime.utcnow()
-                    state.last_keep_alives[node_waiting] = datetime.utcnow()
+                    state.last_heartbeats[node_running] = datetime.utcnow()
+                    state.last_heartbeats[node_waiting] = datetime.utcnow()
 
                 bits = pickle.dumps(state)
 

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -204,8 +204,8 @@ class _NodeDesc:
 class _NodeDescGenerator:
     """Generates node descriptors.
 
-    A node descriptor is a combination of an FQDN, a process id, and an
-    auto-incremented integer that uniquely identifies a node in the rendezvous.
+    A node descriptor is a combination of an FQDN, a process id, and an auto-
+    incremented integer that uniquely identifies a node in the rendezvous.
     """
 
     _lock: threading.Lock
@@ -231,8 +231,6 @@ class _NodeDescGenerator:
 class _RendezvousState:
     """Holds the state of a rendezvous.
 
-    A rendezvous is synced across the nodes via a ``RendezvousBackend``.
-
     Attributes:
         round:
             The current round of the rendezvous.
@@ -240,8 +238,8 @@ class _RendezvousState:
             A boolean value indicating whether the current round of the
             rendezvous is complete.
         deadline:
-            The date and time at which the current round of the rendezvous will
-            be considered complete if it is still waiting for nodes to join.
+            The time at which the current round of the rendezvous will be
+            considered complete if it is still waiting for nodes to join.
         closed:
             A boolean value indicating whether the rendezvous is closed.
         participants:
@@ -249,8 +247,8 @@ class _RendezvousState:
         wait_list:
             A set of nodes that are waiting to participate in the next round of
             the rendezvous.
-        last_keep_alives:
-            A dictionary containing each node's last keep-alive time.
+        last_heartbeats:
+            A dictionary containing each node's last heartbeat time.
     """
 
     round: int
@@ -259,7 +257,7 @@ class _RendezvousState:
     closed: bool
     participants: Dict[_NodeDesc, int]
     wait_list: Set[_NodeDesc]
-    last_keep_alives: Dict[_NodeDesc, datetime]
+    last_heartbeats: Dict[_NodeDesc, datetime]
 
     def __init__(self) -> None:
         self.round = 0
@@ -268,7 +266,7 @@ class _RendezvousState:
         self.closed = False
         self.participants = {}
         self.wait_list = set()
-        self.last_keep_alives = {}
+        self.last_heartbeats = {}
 
 
 class DynamicRendezvousHandler(RendezvousHandler):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* **#57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState**
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

Per feedback this PR renames `last_keep_alives` to `last_heartbeats` in `_RendezvousState`.

Differential Revision: [D28058948](https://our.internmc.facebook.com/intern/diff/D28058948/)