### PR TITLE
[13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -77,14 +77,17 @@ class C10dRendezvousBackend(RendezvousBackend):
 
     def set_state(
         self, state: bytes, token: Optional[Token] = None
-    ) -> Optional[Tuple[bytes, Token]]:
+    ) -> Optional[Tuple[bytes, Token, bool]]:
         """See base class."""
         base64_state_str: str = codecs.encode(state, "base64").decode()
 
         if token:
             # Shortcut if we know for sure that the token is not valid.
             if not isinstance(token, bytes):
-                return self.get_state()
+                result = self.get_state()
+                if result is not None:
+                    return *result, False
+                return None
 
             token = token.decode()
         else:
@@ -92,7 +95,16 @@ class C10dRendezvousBackend(RendezvousBackend):
 
         base64_state: bytes = self._call_store("compare_set", self._key, token, base64_state_str)
 
-        return self._decode_state(base64_state)
+        state_token_pair = self._decode_state(base64_state)
+        if state_token_pair is None:
+            return None
+
+        new_state, new_token = state_token_pair
+
+        # C10d Store's compare_set method does not offer an easy way to find out
+        # whether our write attempt was successful. As a brute-force solution we
+        # perform a bitwise comparison of our local state and the remote state.
+        return new_state, new_token, new_state == state
 
     def _call_store(self, store_op: str, *args, **kwargs) -> Any:
         try:
@@ -105,6 +117,7 @@ class C10dRendezvousBackend(RendezvousBackend):
     def _decode_state(self, base64_state: bytes) -> Optional[Tuple[bytes, Token]]:
         if base64_state == self._NULL_SENTINEL.encode():
             return None
+
         try:
             state = codecs.decode(base64_state, "base64")
         except binascii.Error as exc:

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -47,7 +47,7 @@ class RendezvousBackend(ABC):
     @abstractmethod
     def set_state(
         self, state: bytes, token: Optional[Token] = None
-    ) -> Optional[Tuple[bytes, Token]]:
+    ) -> Optional[Tuple[bytes, Token, bool]]:
         """Sets the rendezvous state.
 
         The new rendezvous state is set conditionally:
@@ -71,7 +71,8 @@ class RendezvousBackend(ABC):
                 to :py:meth:`get_state` or ``set_state()``.
 
         Returns:
-            A tuple of the serialized rendezvous state and its fencing token.
+            A tuple of the serialized rendezvous state, its fencing token, and
+            a boolean value indicating whether our set attempt succeeded.
 
         Raises:
             RendezvousConnectionError:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* **#57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method**
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR extends the return type of `RendezvousBackend`'s `set_state` method with an additional boolean flag that specifies whether the write attempt has succeeded.

Differential Revision: [D28058980](https://our.internmc.facebook.com/intern/diff/D28058980/)