### PR TITLE
[14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer

### DIFF
--- a/test/distributed/elastic/rendezvous/utils_test.py
+++ b/test/distributed/elastic/rendezvous/utils_test.py
@@ -226,9 +226,7 @@ class UtilsTest(TestCase):
     def test_matches_machine_hostname_returns_true_if_hostname_is_machine_address(
         self,
     ) -> None:
-        addr_list = socket.getaddrinfo(
-            socket.gethostname(), None, proto=socket.IPPROTO_TCP
-        )
+        addr_list = socket.getaddrinfo(socket.gethostname(), None, proto=socket.IPPROTO_TCP)
 
         for addr in (addr_info[4][0] for addr_info in addr_list):
             with self.subTest(addr=addr):
@@ -256,7 +254,7 @@ class UtilsTest(TestCase):
 
 
 class PeriodicTimerTest(TestCase):
-    def test_start_can_be_called_only_once(self):
+    def test_start_can_be_called_only_once(self) -> None:
         timer = _PeriodicTimer(timedelta(seconds=1), lambda: None)
 
         timer.start()
@@ -266,7 +264,7 @@ class PeriodicTimerTest(TestCase):
 
         timer.cancel()
 
-    def test_cancel_can_be_called_multiple_times(self):
+    def test_cancel_can_be_called_multiple_times(self) -> None:
         timer = _PeriodicTimer(timedelta(seconds=1), lambda: None)
 
         timer.start()
@@ -274,29 +272,47 @@ class PeriodicTimerTest(TestCase):
         timer.cancel()
         timer.cancel()
 
-    def test_cancel_stops_background_thread(self):
+    def test_cancel_stops_background_thread(self) -> None:
+        name = "PeriodicTimer_CancelStopsBackgroundThreadTest"
+
         timer = _PeriodicTimer(timedelta(seconds=1), lambda: None)
+
+        timer.set_name(name)
 
         timer.start()
 
-        self.assertTrue(any(t.name == "PeriodicTimer" for t in threading.enumerate()))
+        self.assertTrue(any(t.name == name for t in threading.enumerate()))
 
         timer.cancel()
 
-        self.assertTrue(all(t.name != "PeriodicTimer" for t in threading.enumerate()))
+        self.assertTrue(all(t.name != name for t in threading.enumerate()))
 
-    def test_delete_stops_background_thread(self):
+    def test_delete_stops_background_thread(self) -> None:
+        name = "PeriodicTimer_DeleteStopsBackgroundThreadTest"
+
         timer = _PeriodicTimer(timedelta(seconds=1), lambda: None)
+
+        timer.set_name(name)
 
         timer.start()
 
-        self.assertTrue(any(t.name == "PeriodicTimer" for t in threading.enumerate()))
+        self.assertTrue(any(t.name == name for t in threading.enumerate()))
 
         del timer
 
-        self.assertTrue(all(t.name != "PeriodicTimer" for t in threading.enumerate()))
+        self.assertTrue(all(t.name != name for t in threading.enumerate()))
 
-    def test_timer_calls_background_thread_at_regular_intervals(self):
+    def test_set_name_cannot_be_called_after_start(self) -> None:
+        timer = _PeriodicTimer(timedelta(seconds=1), lambda: None)
+
+        timer.start()
+
+        with self.assertRaisesRegex(RuntimeError, r"^The timer has already started.$"):
+            timer.set_name("dummy_name")
+
+        timer.cancel()
+
+    def test_timer_calls_background_thread_at_regular_intervals(self) -> None:
         timer_begin_time: float
 
         # Call our function every 200ms.

--- a/torch/distributed/elastic/rendezvous/utils.py
+++ b/torch/distributed/elastic/rendezvous/utils.py
@@ -179,6 +179,7 @@ class _PeriodicTimer:
         kwargs: Dict[str, Any]
         stop_event: Event
 
+    _name: str
     _thread: Optional[Thread]
     _finalizer: Optional[weakref.finalize]
 
@@ -192,6 +193,8 @@ class _PeriodicTimer:
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        self._name = None
+
         self._ctx = self._Context()
         self._ctx.interval = interval.total_seconds()
         self._ctx.function = function  # type: ignore
@@ -202,13 +205,29 @@ class _PeriodicTimer:
         self._thread = None
         self._finalizer = None
 
+    @property
+    def name(self) -> Optional[str]:
+        """Gets the name of the timer."""
+        return self._name
+
+    def set_name(self, name: str) -> None:
+        """Sets the name of the timer.
+
+        The specified name will be assigned to the background thread and serves
+        for debugging and troubleshooting purposes.
+        """
+        if self._thread:
+            raise RuntimeError("The timer has already started.")
+
+        self._name = name
+
     def start(self) -> None:
         """Start the timer."""
         if self._thread:
             raise RuntimeError("The timer has already started.")
 
         self._thread = Thread(
-            target=self._run, name="PeriodicTimer", args=(self._ctx,), daemon=True
+            target=self._run, name=self._name or "PeriodicTimer", args=(self._ctx,), daemon=True
         )
 
         # We avoid using a regular finalizer (a.k.a. __del__) for stopping the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* **#57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer**
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR introduces a `name` attribute in `_PeriodicTimer` for testing and debugging purposes.

Differential Revision: [D28059045](https://our.internmc.facebook.com/intern/diff/D28059045/)