### PR TITLE
[18/n] [torch/elastic] Introduce _RendezvousCloseOp

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -683,6 +683,17 @@ class _DistributedRendezvousOpExecutor(_RendezvousOpExecutor):
         self._state.closed = True
 
 
+class _RendezvousCloseOp:
+    """Represents a rendezvous close operation."""
+
+    def __call__(self, ctx: _RendezvousContext, deadline: float) -> _Action:
+        if ctx.state.closed:
+            return _Action.FINISH
+        if time.monotonic() > deadline:
+            return _Action.ERROR_TIMEOUT
+        return _Action.MARK_RENDEZVOUS_CLOSED
+
+
 class DynamicRendezvousHandler(RendezvousHandler):
     """Represents the dynamic rendezvous handler.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* #57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* **#57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp**
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR introduces the `_RendezvousCloseOp` type that represents a rendezvous close operation to be executed via a `_RendezvousOpExecutor`.

Differential Revision: [D28059693](https://our.internmc.facebook.com/intern/diff/D28059693/)