### PR TITLE
[22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -1047,7 +1047,7 @@ class DummyRendezvousBackend(RendezvousBackend):
         return None
 
 
-class DynamicRendezvousHandlerTest(TestCase):
+class DynamicRendezvousHandlerFromBackendTest(TestCase):
     def setUp(self) -> None:
         self._run_id = "dummy_run_id"
         self._store = DummyStore()
@@ -1057,7 +1057,7 @@ class DynamicRendezvousHandlerTest(TestCase):
         self._timeout: Optional[RendezvousTimeout] = RendezvousTimeout()
 
     def _create_handler(self) -> DynamicRendezvousHandler:
-        return DynamicRendezvousHandler(
+        return DynamicRendezvousHandler.from_backend(
             run_id=self._run_id,
             store=self._store,
             backend=self._backend,
@@ -1068,9 +1068,6 @@ class DynamicRendezvousHandlerTest(TestCase):
 
     def test_init_initializes_handler(self) -> None:
         handler = self._create_handler()
-
-        self.assertIs(handler.store, self._store)
-        self.assertIs(handler.backend, self._backend)
 
         self.assertEqual(handler.get_backend(), self._backend.name)
         self.assertEqual(handler.get_run_id(), self._run_id)
@@ -1130,7 +1127,6 @@ class CreateHandlerTest(TestCase):
             run_id="dummy_run_id",
             min_nodes=3,
             max_nodes=6,
-            store_port="1234",
             join_timeout="50",
             last_call_timeout="60",
             close_timeout="70",
@@ -1142,9 +1138,6 @@ class CreateHandlerTest(TestCase):
 
     def test_create_handler_returns_handler(self) -> None:
         handler = create_handler(self._store, self._backend, self._params)
-
-        self.assertIs(handler.store, self._store)
-        self.assertIs(handler.backend, self._backend)
 
         self.assertEqual(handler.get_backend(), self._backend.name)
         self.assertEqual(handler.get_run_id(), self._params.run_id)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57151 [23/n] [torch/elastic] Introduce the implementation of DynamicRendezvousHandler
* **#57150 [22/n] [torch/elastic] Introduce a new from_backend static constructor for DynamicRendezvousHandler**
* #57149 [21/n] [torch/elastic] Introduce _RendezvousJoinOp
* #57148 [20/n] [torch/elastic] Introduce _RendezvousExitOp
* #57147 [19/n] [torch/elastic] Introduce _RendezvousKeepAliveOp
* #57146 [18/n] [torch/elastic] Introduce _RendezvousCloseOp
* #57145 [17/n] [torch/elastic] Introduce _DistributedRendezvousOpExecutor
* #57144 [16/n] [torch/elastic] Introduce _RendezvousOpExecutor
* #56538 [15/n] [torch/elastic] Introduce _RendezvousStateHolder
* #57143 [14/n] [torch/elastic] Introduce a name attribute to _PeriodicTimer
* #57142 [13/n] [torch/elastic] Extend the return type of RendezvousBackend's set_state method
* #57141 [12/n] [torch/elastic] Rename last_keep_alives to last_heartbeats in _RendezvousState
* #57140 [11/n] [torch/elastic] Add heartbeat timeout to RendezvousTimeout
* #57139 [10/n] [torch/elastic] Add comparison operators to _NodeDesc
* #56537 [9/n] [torch/elastic] Introduce RendezvousSettings
* #56536 [8/n] [torch/elastic] Add unit tests for _RendezvousState
* #56535 [7/n] [torch/elastic] Rename _Rendezvous to _RendezvousState
* #56534 [6/n] [torch/elastic] Reorder type definitions in dynamic_rendezvous.py
* #56533 [5/n] [torch/elastic] Introduce the delay utility function
* #56532 [4/n] [torch/elastic] Fix the finalizer of PeriodicTimer

This PR refactors the `__init__` method of `DynamicRendezvousHandler` to a `from_backend` static constructor for easier testing and future extensibility.

Differential Revision: [D28060336](https://our.internmc.facebook.com/intern/diff/D28060336/)