### PR TITLE
use importlib instead of imp as it support python 3.5+

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1695,7 +1695,7 @@ def _get_exec_path(module_name, path):
 
 
 def _import_module_from_library(module_name, path, is_python_module):
-    filepath = os.path.join(path, f"{module_name}{CLIB_EXT}")
+    filepath = os.path.join(path, f"{module_name}{LIB_EXT}")
     if is_python_module:
         # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
         spec = importlib.util.spec_from_file_location(module_name, filepath)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1699,9 +1699,10 @@ def _import_module_from_library(module_name, path, is_python_module):
         # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
         filepath = os.path.join(path, f"{module_name}.so")
         spec = importlib.util.spec_from_file_location(module_name, filepath)
-        foo = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(foo)
-        return foo
+        module = importlib.util.module_from_spec(spec)
+        assert isinstance(spec.loader, importlib.abc.Loader)
+        spec.loader.exec_module(module)
+        return module
     else:
         torch.ops.load_library(path)
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1695,7 +1695,7 @@ def _get_exec_path(module_name, path):
 
 
 def _import_module_from_library(module_name, path, is_python_module):
-    filepath = os.path.join(path, f"{module_name}.so")
+    filepath = os.path.join(path, f"{module_name}{CLIB_EXT}")
     if is_python_module:
         # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
         spec = importlib.util.spec_from_file_location(module_name, filepath)

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1695,16 +1695,16 @@ def _get_exec_path(module_name, path):
 
 
 def _import_module_from_library(module_name, path, is_python_module):
+    filepath = os.path.join(path, f"{module_name}.so")
     if is_python_module:
         # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
-        filepath = os.path.join(path, f"{module_name}.so")
         spec = importlib.util.spec_from_file_location(module_name, filepath)
         module = importlib.util.module_from_spec(spec)
         assert isinstance(spec.loader, importlib.abc.Loader)
         spec.loader.exec_module(module)
         return module
     else:
-        torch.ops.load_library(path)
+        torch.ops.load_library(filepath)
 
 
 def _write_ninja_file_to_build_library(path,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1697,9 +1697,11 @@ def _get_exec_path(module_name, path):
 def _import_module_from_library(module_name, path, is_python_module):
     if is_python_module:
         # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
-        spec = importlib.util.spec_from_file_location("module.name", "/path/to/file.py")
+        filepath = os.path.join(path, f"{module_name}.so")
+        spec = importlib.util.spec_from_file_location(module_name, filepath)
         foo = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(foo)
+        return foo
     else:
         torch.ops.load_library(path)
 

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1,6 +1,6 @@
 import copy
 import glob
-import imp
+import importlib
 import os
 import re
 import shlex
@@ -1695,14 +1695,13 @@ def _get_exec_path(module_name, path):
 
 
 def _import_module_from_library(module_name, path, is_python_module):
-    # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
-    file, path, description = imp.find_module(module_name, [path])
-    # Close the .so file after load.
-    with file:
-        if is_python_module:
-            return imp.load_module(module_name, file, path, description)  # type: ignore[arg-type]
-        else:
-            torch.ops.load_library(path)
+    if is_python_module:
+        # https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path
+        spec = importlib.util.spec_from_file_location("module.name", "/path/to/file.py")
+        foo = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(foo)
+    else:
+        torch.ops.load_library(path)
 
 
 def _write_ninja_file_to_build_library(path,


### PR DESCRIPTION
Prevent some annoying deprecation warning when importing cpp_extensions