### PR TITLE
[RPC Framework] Expose a Python API for device map getter

### DIFF
--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -685,6 +685,12 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
               TensorPipeAgent::getWorkerInfos,
           py::call_guard<py::gil_scoped_release>())
       .def(
+          "_get_device_map",
+          (tensorpipe::DeviceMap(TensorPipeAgent::*)(const WorkerInfo& dest)
+               const) &
+              TensorPipeAgent::getDeviceMap,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
           "_set_reverse_device_maps",
           // intentionally not releasing GIL to avoid unnecessary context switch
           &TensorPipeAgent::setReverseDeviceMaps);

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -576,6 +576,12 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
               ProcessGroupAgent::getWorkerInfos,
           py::call_guard<py::gil_scoped_release>())
       .def(
+          "_get_device_map",
+          (std::unordered_map<c10::DeviceIndex, c10::DeviceIndex>(
+              ProcessGroupAgent::*)(const WorkerInfo& dest) const) &
+              ProcessGroupAgent::getDeviceMap,
+          py::call_guard<py::gil_scoped_release>())
+      .def(
           "join",
           &ProcessGroupAgent::join,
           py::call_guard<py::gil_scoped_release>(),

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -287,7 +287,7 @@ bool RpcAgent::isGILProfilingEnabled() {
 }
 
 std::unordered_map<c10::DeviceIndex, c10::DeviceIndex> RpcAgent::getDeviceMap(
-    const WorkerInfo& dest) {
+    const WorkerInfo& dest) const {
   // Default implementation has no device map.
   return {};
 }

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -263,7 +263,7 @@ class TORCH_API RpcAgent {
 
   // Retrieves the device map for the provided destination worker.
   virtual std::unordered_map<c10::DeviceIndex, c10::DeviceIndex> getDeviceMap(
-      const WorkerInfo& dest);
+      const WorkerInfo& dest) const;
 
  protected:
   const WorkerInfo workerInfo_;

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1505,7 +1505,8 @@ std::vector<c10::DeviceIndex> TensorPipeAgent::getDevicesForRemote(
   }
 }
 
-tensorpipe::DeviceMap TensorPipeAgent::getDeviceMap(const WorkerInfo& dest) {
+tensorpipe::DeviceMap TensorPipeAgent::getDeviceMap(
+    const WorkerInfo& dest) const {
   auto it = opts_.deviceMaps.find(dest.name_);
   if (it == opts_.deviceMaps.end()) {
     return {};

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -203,7 +203,7 @@ class TensorPipeAgent : public RpcAgent {
 
   void addGilWaitTime(const std::chrono::microseconds gilWaitTime) override;
 
-  tensorpipe::DeviceMap getDeviceMap(const WorkerInfo& dest) override;
+  tensorpipe::DeviceMap getDeviceMap(const WorkerInfo& dest) const override;
 
   using NetworkDataDict =
       std::unordered_map<std::string, AggregatedNetworkData>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57288 [RPC Framework] Enable RemoteModule to directly send GPU tensors over the wire on TensorPipe RPC backend if a device map is provided
* **#57179 [RPC Framework] Expose a Python API for device map getter**

Expose a Python API to get the device map and unblock RemoteModule work.

See: https://github.com/pytorch/pytorch/pull/56854#issuecomment-827762398

Additionally, add a const decorator for the C++ getter.

#Original PR issue: https://github.com/pytorch/pytorch/issues/51670

Differential Revision: [D28070160](https://our.internmc.facebook.com/intern/diff/D28070160/)