### PR TITLE
[profiler] Add sequenceNr and fwdThreadId to the trace

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -138,16 +138,28 @@ struct TORCH_API KinetoThreadLocalState : public ProfilerThreadLocalState {
   void finalizeCPUTrace() {
     TORCH_INTERNAL_ASSERT(cpu_trace->activities.size() == kineto_events_.size());
     for (size_t idx = 0; idx < cpu_trace->activities.size(); ++idx) {
-      if (kineto_events_[idx].hasShapes()) {
-        cpu_trace->activities[idx].addMetadata("Input Dims", shapesToStr(kineto_events_[idx].shapes()));
+      auto& kineto_event = kineto_events_[idx];
+      auto& activity = cpu_trace->activities[idx];
+
+      if (kineto_event.hasShapes()) {
+        activity.addMetadata("Input Dims", shapesToStr(kineto_event.shapes()));
+      }
+      if (kineto_event.hasStack()) {
+        activity.addMetadata("Call stack", stacksToStr(kineto_event.stack()));
+      }
+      if (kineto_event.hasTypes()) {
+        activity.addMetadata("Input type", dtypesToStr(kineto_event.dtypes()));
       }
 
-      if (kineto_events_[idx].hasStack()) {
-        cpu_trace->activities[idx].addMetadata("Call stack", stacksToStr(kineto_events_[idx].stack()));
-      }
-
-      if (kineto_events_[idx].hasTypes()) {
-        cpu_trace->activities[idx].addMetadata("Input type", dtypesToStr(kineto_events_[idx].dtypes()));
+      // add information about an associated forward op, if a sequence number
+      // is available (e.g. during training)
+      if (kineto_event.sequenceNr() >= 0) {
+        activity.addMetadata(
+            "Fwd thread id",
+            std::to_string(kineto_event.fwdThreadId()));
+        activity.addMetadata(
+            "Sequence number",
+            std::to_string(kineto_event.sequenceNr()));
       }
     }
   }


### PR DESCRIPTION
Summary:
Adding sequenceNr and fwdThreadId to the trace, to associate fwd ops with
backward ops

Test Plan: CI

Differential Revision: D28070725

