### PR TITLE
Fix sort for slow gradcheck

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -141,6 +141,7 @@ class TestGradients(TestCase):
                                           check_batched_grad=op.check_batched_grad,
                                           check_grad_dtypes=True,
                                           nondet_tol=op.gradcheck_nondet_tol,
+                                          atol=op.gradcheck_atol,
                                           fast_mode=op.gradcheck_fast_mode))
             elif check == 'gradgradcheck':
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
@@ -148,12 +149,14 @@ class TestGradients(TestCase):
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
+                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
                                               gen_non_contig_grad_outputs=True,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
+                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
             else:
                 self.assertTrue(False, msg="Unknown check requested!")

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -141,7 +141,6 @@ class TestGradients(TestCase):
                                           check_batched_grad=op.check_batched_grad,
                                           check_grad_dtypes=True,
                                           nondet_tol=op.gradcheck_nondet_tol,
-                                          atol=op.gradcheck_atol,
                                           fast_mode=op.gradcheck_fast_mode))
             elif check == 'gradgradcheck':
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
@@ -149,14 +148,12 @@ class TestGradients(TestCase):
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
-                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
                                               gen_non_contig_grad_outputs=True,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
-                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
             else:
                 self.assertTrue(False, msg="Unknown check requested!")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -187,6 +187,7 @@ class OpInfo(object):
                  check_batched_grad=True,  # check batched grad when doing gradcheck
                  check_batched_gradgrad=True,  # check batched grad grad when doing gradgradcheck
                  gradcheck_nondet_tol=0.0,  # tolerance for nondeterminism while performing gradcheck
+                 gradcheck_atol=1e-5,  # absolute tolerance while comparing analytical and numerical values during gradcheck
                  gradcheck_fast_mode=None,  # Whether to use the fast implmentation for gradcheck/gradgradcheck.
                                             # When set to None, defers to the default value provided by the wrapper
                                             # function around gradcheck (testing._internal.common_utils.gradcheck)
@@ -243,6 +244,7 @@ class OpInfo(object):
         self.check_batched_grad = check_batched_grad
         self.check_batched_gradgrad = check_batched_gradgrad
         self.gradcheck_nondet_tol = gradcheck_nondet_tol
+        self.gradcheck_atol = gradcheck_atol
         self.gradcheck_fast_mode = gradcheck_fast_mode
 
         self.supports_sparse = supports_sparse
@@ -1327,9 +1329,20 @@ def sample_inputs_sort(op_info, device, dtype, requires_grad, **kwargs):
 
     samples = []
     # Test case for large tensor.
-    largesample = SampleInput(make_tensor((L**3,), device, dtype,
-                              low=None, high=None,
-                              requires_grad=requires_grad))
+    # We need to make sure that when we perform gradcheck, perturbing input
+    # by eps does not change the sorted order
+    valid_sample=False
+    eps = 1e-6  # NOTE: Make sure that if you change this, the eps used by
+                # gradcheck must be updated to be at least this value
+    while not valid_sample:
+        largesample = SampleInput(make_tensor((L**3,), device, dtype,
+                                  low=None, high=None,
+                                  requires_grad=requires_grad))
+        # TODO: Maybe we shouldn't assume sort is correct here
+        sorted_input, _ = largesample.input.sort()  # type: ignore[union-attr]
+                                                    # we know that input is tensor
+        if (sorted_input.diff() > eps).all():
+            valid_sample = True
     samples.append(largesample)
 
     # Test cases for small 3d tensors.
@@ -5202,7 +5215,8 @@ op_db: List[OpInfo] = [
            skips=(
                # sort does not correctly warn when resizing out= inputs
                SkipInfo('TestCommon', 'test_out'),
-           )),
+           ),
+           gradcheck_atol=1e-2),
     OpInfo('put',
            dtypes=all_types_and_complex_and(torch.bool, torch.float16, torch.bfloat16),
            supports_out=False,


### PR DESCRIPTION
Fixes #57166

Generate new inputs until we get one where we know that x + eps won't change its sorted order.