### PR TITLE
Cache vulkan objects between runs

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Cache.h
+++ b/aten/src/ATen/native/vulkan/api/Cache.h
@@ -47,6 +47,8 @@ class Cache final {
 
   auto retrieve(const Descriptor& descriptor);
 
+  auto generate(const Descriptor& descriptor);
+
   // Only call this function infrequently, if ever.  This cache is only intended
   // for immutable Vulkan objects of which a small finite instances are required
   // at runtime.  A good place to call this function is between model loads.
@@ -81,6 +83,13 @@ inline auto Cache<Factory>::retrieve(
   }
 
   return iterator->second.get();
+}
+
+template<typename Factory>
+inline auto Cache<Factory>::generate(
+    const Descriptor& descriptor) {
+
+  return factory_(descriptor);
 }
 
 template<typename Factory>

--- a/aten/src/ATen/native/vulkan/api/Command.cpp
+++ b/aten/src/ATen/native/vulkan/api/Command.cpp
@@ -10,7 +10,8 @@ namespace {
 
 VkCommandPool create_command_pool(
     const VkDevice device,
-    const uint32_t queue_family_index) {
+    const uint32_t queue_family_index,
+    const bool persistent) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       device,
       "Invalid Vulkan device!");
@@ -18,7 +19,7 @@ VkCommandPool create_command_pool(
   const VkCommandPoolCreateInfo command_pool_create_info{
     VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
     nullptr,
-    VK_COMMAND_POOL_CREATE_TRANSIENT_BIT,
+    persistent ? VK_COMMAND_POOL_CREATE_TRANSIENT_BIT : VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
     queue_family_index,
   };
 
@@ -105,6 +106,9 @@ void Command::Buffer::Buffer::begin() {
     nullptr,
   };
 
+  VK_CHECK(vkResetCommandBuffer(
+      command_buffer_,
+      0u));
   VK_CHECK(vkBeginCommandBuffer(
       command_buffer_,
       &command_buffer_begin_info));
@@ -112,6 +116,17 @@ void Command::Buffer::Buffer::begin() {
   // Reset
   bound_.reset();
   barriers_.reset();
+}
+
+void Command::Buffer::Buffer::reset() {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      command_buffer_,
+      "This command buffer is in an invalid state! "
+      "Potential reason: This command buffer is moved from.");
+
+  VK_CHECK(vkResetCommandBuffer(
+      command_buffer_,
+      0u));
 }
 
 void Command::Buffer::Buffer::end() {
@@ -311,6 +326,10 @@ void Command::Buffer::invalidate() {
   command_buffer_ = VK_NULL_HANDLE;
 }
 
+bool Command::Buffer::valid() {
+  return command_buffer_ == VK_NULL_HANDLE;
+}
+
 inline void Command::Buffer::Bound::reset() {
   pipeline = {};
   descriptor_set = VK_NULL_HANDLE;
@@ -329,7 +348,10 @@ inline void Command::Buffer::Barrier::reset() {
 Command::Pool::Pool(const GPU& gpu)
   : device_(gpu.device),
     command_pool_(
-        create_command_pool(gpu.device, gpu.adapter->compute_queue_family_index),
+        create_command_pool(gpu.device, gpu.adapter->compute_queue_family_index, false),
+        VK_DELETER(CommandPool)(device_)),
+    persistent_pool_(
+        create_command_pool(gpu.device, gpu.adapter->compute_queue_family_index, true),
         VK_DELETER(CommandPool)(device_)),
     buffer_{} {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
@@ -346,6 +368,7 @@ Command::Pool::Pool(const GPU& gpu)
 Command::Pool::Pool(Pool&& pool)
   : device_(std::move(pool.device_)),
     command_pool_(std::move(pool.command_pool_)),
+    persistent_pool_(std::move(pool.persistent_pool_)),
     buffer_(std::move(pool.buffer_)),
     stream_(std::move(pool.stream_)) {
   pool.invalidate();
@@ -355,6 +378,7 @@ Command::Pool& Command::Pool::operator=(Pool&& pool) {
   if (&pool != this) {
     device_ = std::move(pool.device_);
     command_pool_ = std::move(pool.command_pool_);
+    persistent_pool_ = std::move(pool.persistent_pool_);
     buffer_ = std::move(pool.buffer_);
     stream_ = std::move(pool.stream_);
 
@@ -368,6 +392,9 @@ Command::Pool::~Pool() {
   try {
     if (device_ && command_pool_) {
       purge();
+    }
+    if (device_ && persistent_pool_) {
+      purge_persistent();
     }
   }
   catch (const std::exception& e) {
@@ -403,6 +430,22 @@ Command::Buffer Command::Pool::allocate() {
   return Buffer(buffer_.pool[buffer_.in_use++]);
 }
 
+Command::Buffer Command::Pool::allocate_persistent() {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      device_ && persistent_pool_,
+      "This command pool is in an invalid state! "
+      "Potential reason: This command pool is moved from.");
+
+  VkCommandBuffer cmd_buffer;
+  allocate_command_buffers(
+      device_,
+      persistent_pool_.get(),
+      &cmd_buffer,
+      1u);
+
+  return Buffer(cmd_buffer);
+}
+
 Command::Buffer& Command::Pool::stream() {
   if (!stream_.buffer) {
     stream_.buffer = allocate();
@@ -411,6 +454,11 @@ Command::Buffer& Command::Pool::stream() {
   }
 
   return stream_.buffer;
+}
+
+Command::Buffer& Command::Pool::stream_persistent() {
+  Command::Buffer buffer = allocate_persistent();
+  return buffer;
 }
 
 void Command::Pool::purge() {
@@ -425,7 +473,23 @@ void Command::Pool::purge() {
       "submitted to the queue for execution prior to reclaiming pool memory.");
 
   buffer_.in_use = 0u;
+  if (stream_.buffer)
+    stream_.buffer.invalidate();
   VK_CHECK(vkResetCommandPool(device_, command_pool_.get(), 0u));
+}
+
+void Command::Pool::purge_persistent() {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      device_ && command_pool_,
+      "This command pool is in an invalid state! "
+      "Potential reason: This command pool is moved from.");
+
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      !stream_.buffer,
+      "Pending command buffer detected.  Make sure all command buffers are "
+      "submitted to the queue for execution prior to reclaiming pool memory.");
+
+  VK_CHECK(vkResetCommandPool(device_, persistent_pool_.get(), 0u));
 }
 
 void Command::Pool::submit(

--- a/aten/src/ATen/native/vulkan/api/Command.h
+++ b/aten/src/ATen/native/vulkan/api/Command.h
@@ -34,6 +34,7 @@ struct Command final {
     VkCommandBuffer handle() const;
 
     void begin();
+    void reset();
     void end();
 
     void barrier(const Pipeline::Barrier& barrier);
@@ -42,13 +43,15 @@ struct Command final {
     void copy(Resource::Buffer::Object source, Resource::Buffer::Object destination);
     void dispatch(const Shader::WorkGroup& global_work_group);
 
+    bool valid();
+
    private:
     friend class Pool;
 
     void barrier();
     void invalidate();
 
-   private:
+   public:
     VkCommandBuffer command_buffer_;
 
     struct Bound final {
@@ -87,8 +90,11 @@ struct Command final {
     ~Pool();
 
     Buffer allocate();
+    Buffer allocate_persistent();
     Buffer& stream();
+    Buffer& stream_persistent();
     void purge();
+    void purge_persistent();
 
     void submit(
         VkQueue queue,
@@ -102,11 +108,12 @@ struct Command final {
     struct Configuration final {
       static constexpr uint32_t kQuantum = 4u;
       static constexpr uint32_t kReserve = 16u;
-      static constexpr uint32_t kSubmit = 10u;
+      static constexpr uint32_t kSubmit = 32u;
     };
 
     VkDevice device_;
     Handle<VkCommandPool, VK_DELETER(CommandPool)> command_pool_;
+    Handle<VkCommandPool, VK_DELETER(CommandPool)> persistent_pool_;
 
     struct {
       std::vector<VkCommandBuffer> pool;

--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -392,6 +392,28 @@ Descriptor::Set Descriptor::Pool::allocate(
       shader_layout.signature);
 }
 
+VkDescriptorSet Descriptor::Pool::allocate_single(
+    const Shader::Layout::Object& shader_layout) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      device_ && descriptor_pool_,
+      "This descriptor pool is in an invalid state! "
+      "Potential reason: This descriptor pool is moved from.");
+
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      shader_layout,
+      "Invalid Vulkan shader layout!");
+
+  VkDescriptorSet descriptor_set{};
+  allocate_descriptor_sets(
+      device_,
+      descriptor_pool_.get(),
+      shader_layout.handle,
+      &descriptor_set,
+      1);
+
+  return descriptor_set;
+}
+
 void Descriptor::Pool::purge() {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       device_ && descriptor_pool_,

--- a/aten/src/ATen/native/vulkan/api/Descriptor.h
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.h
@@ -114,6 +114,7 @@ struct Descriptor final {
     ~Pool();
 
     Set allocate(const Shader::Layout::Object& shader_layout);
+    VkDescriptorSet allocate_single(const Shader::Layout::Object& shader_layout);
     void purge();
 
    private:
@@ -125,7 +126,10 @@ struct Descriptor final {
       static constexpr uint32_t kReserve = 64u;
     };
 
+   public:
     VkDevice device_;
+
+   private:
     Handle<VkDescriptorPool, VK_DELETER(DescriptorPool)> descriptor_pool_;
 
     struct {

--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -170,6 +170,7 @@ struct Pipeline final {
     ~Cache() = default;
 
     Object retrieve(const Descriptor& descriptor);
+    auto generate(const Descriptor& descriptor);
     void purge();
 
    private:
@@ -240,6 +241,11 @@ inline Pipeline::Object Pipeline::Cache::retrieve(
     descriptor.pipeline_layout,
     descriptor.local_work_group,
   };
+}
+
+inline auto Pipeline::Cache::generate(
+    const Descriptor& descriptor) {
+  return cache_.generate(descriptor);
 }
 
 } // namespace api

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -98,6 +98,7 @@ struct Shader final {
       ~Cache() = default;
 
       Object retrieve(const Descriptor& descriptor);
+      auto generate(const Descriptor& descriptor);
       void purge();
 
      private:
@@ -216,6 +217,11 @@ inline Shader::Layout::Object Shader::Layout::Cache::retrieve(
     cache_.retrieve(descriptor),
     descriptor.signature,
   };
+}
+
+inline auto Shader::Layout::Cache::generate(
+    const Descriptor& descriptor) {
+  return cache_.generate(descriptor);
 }
 
 inline bool operator==(

--- a/aten/src/ATen/native/vulkan/glsl/playground.glsl
+++ b/aten/src/ATen/native/vulkan/glsl/playground.glsl
@@ -1,0 +1,20 @@
+#version 450 core
+#define PRECISION $precision
+
+layout(std430) buffer;
+
+/* Qualifiers: layout - storage - precision - memory */
+
+layout(set = 0, binding = 0) buffer  PRECISION restrict Buffer {
+  float data[];
+} uBuffer;
+
+layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
+
+void main() {
+  const ivec3 pos = ivec3(gl_GlobalInvocationID);
+
+  if (pos.x < 3*3*4) {
+    uBuffer.data[pos.x] = uBuffer.data[pos.x]+2;
+  }
+}

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -87,6 +87,8 @@ class Conv2dOpContext final : public torch::jit::CustomClassHolder {
   } unpacked_;
 
   Conv2dMethod method_;
+
+  VkDescriptorSet descriptor_set;
 };
 
 Tensor conv2d_clamp_run(

--- a/aten/src/ATen/native/vulkan/ops/Persistent.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Persistent.cpp
@@ -13,6 +13,9 @@ Persistent* persistent() {
           api::Resource::Pool{
             api::context()->gpu(),
           },
+          api::Descriptor::Pool {
+            api::context()->gpu(),
+          },
         };
       }
       catch (const std::exception& e) {

--- a/aten/src/ATen/native/vulkan/ops/Persistent.h
+++ b/aten/src/ATen/native/vulkan/ops/Persistent.h
@@ -23,6 +23,7 @@ namespace ops {
 
 struct Persistent final {
   api::Resource::Pool pool;
+  api::Descriptor::Pool descriptor_pool;
 };
 
 Persistent* persistent();

--- a/aten/src/ATen/native/vulkan/ops/Playground.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Playground.cpp
@@ -1,0 +1,174 @@
+#include <ATen/native/vulkan/ops/Playground.h>
+#include <ATen/native/vulkan/ops/Persistent.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+namespace {
+
+using namespace api::utils;
+
+api::Resource::Image get_image(api::Resource::Pool* const pool, long x, long y, long z) {
+  VkFormat image_format = VK_FORMAT_R32G32B32A32_SFLOAT;
+  return pool->image({
+      VK_IMAGE_TYPE_3D,
+      image_format,
+      {x,y,div_up(z, INT64_C(4))},
+      // Usage
+      {
+        VK_IMAGE_USAGE_SAMPLED_BIT |
+        VK_IMAGE_USAGE_STORAGE_BIT,
+        {
+          VMA_MEMORY_USAGE_GPU_ONLY,
+          0u,
+          0u,
+        },
+      },
+      // View
+      {
+        VK_IMAGE_VIEW_TYPE_3D,
+        image_format
+      },
+      // Sampler
+      {
+        VK_FILTER_NEAREST,
+        VK_SAMPLER_MIPMAP_MODE_NEAREST,
+        VK_SAMPLER_ADDRESS_MODE_REPEAT,
+        VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK,
+      },
+    });
+}
+
+api::Resource::Buffer get_buffer(api::Resource::Pool* const pool, long x, long y, long z) {
+  VkDeviceSize buffer_size = x * y * align_up(z, INT64_C(4)) * 4;
+  const VkFlags usage =
+      VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+      VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+      VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+  return pool->buffer({
+      buffer_size,
+      {
+        usage,
+        {
+          VMA_MEMORY_USAGE_GPU_TO_CPU,
+          0u,
+          VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+        }
+      }
+    });
+}
+
+} // namespace
+
+void PlaygroundOpContext::fill_image(const api::Resource::Buffer& buffer, api::Resource::Fence& fence) {
+  api::Context* const context = api::context();
+  api::Command::Pool& command_pool = context->command().pool;
+  if (!initted) {
+    std::cout << "Creating command buffer" << std::endl;
+
+    cmd_buffer.begin();
+
+    context->dispatch(
+        cmd_buffer,
+        context->get_playground_cache(),
+        {3*3*4, 1, 1},
+        descriptor_set,
+        buffer.object);
+
+    cmd_buffer.end();
+
+    initted = true;
+  }
+  else {
+    std::cout << "Using cached command buffer" << std::endl;
+  }
+
+  command_pool.submit(context->gpu().queue, cmd_buffer, fence);
+}
+
+PlaygroundOpContext::PlaygroundOpContext(const Tensor& test)
+  : packed_{
+      convert(test.is_vulkan() ? test : test.vulkan())
+    },
+    unpacked_{
+      test
+    },
+    cmd_buffer(api::context()->command().pool.allocate_persistent()),
+    in_buffer{},
+    initted(false) {
+  api::Resource::Pool& resource_pool = persistent()->pool;
+  in_buffer = get_buffer(&resource_pool, 3, 3, 4);
+
+  api::Descriptor::Pool& descriptor_pool = persistent()->descriptor_pool;
+  const api::Shader::Layout::Object shader_layout =
+  {
+    api::context()->get_playground_cache().set_layout.get(),
+    api::context()->get_playground_cache().layout_descriptor.signature,
+  };
+  descriptor_set = descriptor_pool.allocate_single(shader_layout);
+}
+
+PlaygroundOpContext PlaygroundOpContext::create(const Tensor& test) {
+  // Pass in the originals
+  return PlaygroundOpContext{test};
+}
+
+Tensor PlaygroundOpContext::run(const Tensor& input) {
+  api::Context* const context = api::context();
+
+  api::Resource::Pool& resource_pool = persistent()->pool;
+
+  /*
+  const vTensor& v_input = convert(input);
+  api::Command::Pool& command_pool = context->command().pool;
+  api::Command::Buffer& command_buffer = command_pool.stream();
+  api::Resource::Buffer buffer = v_input.buffer_straight(command_buffer, vTensor::Stage::Compute);
+  */
+
+  void* data = nullptr;
+  VK_CHECK(vmaMapMemory(in_buffer.memory.allocator, in_buffer.memory.allocation, &data));
+  float* float_data = reinterpret_cast<float*>(data);
+
+  memcpy(
+      float_data,
+      input.cpu().data_ptr<float>(),
+      in_buffer.object.range);
+
+  Tensor test_cpu = at::rand({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat));
+
+  api::Resource::Fence fence = resource_pool.fence();
+  fill_image(in_buffer, fence);
+  fence.wait();
+
+  memcpy(
+      test_cpu.data_ptr<float>(),
+      float_data,
+      in_buffer.object.range);
+
+  context->flush();
+
+  return test_cpu;
+}
+
+PlaygroundOpContext::State PlaygroundOpContext::unpack() const {
+  return PlaygroundOpContext::State{
+      unpacked_.test,
+  };
+}
+
+c10::intrusive_ptr<PlaygroundOpContext> playground_prepack(Tensor&& test) {
+  return c10::make_intrusive<PlaygroundOpContext>(
+      PlaygroundOpContext::create(std::move(test)));
+}
+
+Tensor playground_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<PlaygroundOpContext>& context) {
+  return context->run(input);
+}
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/vulkan/ops/Playground.h
+++ b/aten/src/ATen/native/vulkan/ops/Playground.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#ifdef USE_VULKAN_API
+
+#include <ATen/native/vulkan/ops/Common.h>
+#include <torch/custom_class.h>
+
+namespace at {
+namespace native {
+namespace vulkan {
+namespace ops {
+
+class PlaygroundOpContext final : public torch::jit::CustomClassHolder {
+ public:
+  static PlaygroundOpContext create(const Tensor& test);
+
+  using State = std::tuple<Tensor>;
+
+  Tensor run(const Tensor& input);
+  State unpack() const;
+
+  void fill_image(const api::Resource::Buffer& buffer, api::Resource::Fence& fence);
+
+ private:
+  PlaygroundOpContext(const Tensor& test);
+
+ private:
+  struct {
+    vTensor v_test;
+  } packed_;
+
+  struct {
+    Tensor test;
+  } unpacked_;
+
+  VkDescriptorSet descriptor_set;
+  api::Command::Buffer cmd_buffer;
+  api::Resource::Buffer in_buffer;
+  bool initted = false;
+};
+
+c10::intrusive_ptr<PlaygroundOpContext> playground_prepack(Tensor&& test);
+
+Tensor playground_run(
+    const Tensor& input,
+    const c10::intrusive_ptr<PlaygroundOpContext>& context);
+
+
+} // namespace ops
+} // namespace vulkan
+} // namespace native
+} // namespace at
+
+#endif /* USE_VULKAN_API */

--- a/aten/src/ATen/native/vulkan/ops/Register.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Register.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/vulkan/ops/Common.h>
 #include <ATen/native/vulkan/ops/Convolution.h>
 #include <ATen/native/vulkan/ops/Mm.h>
+#include <ATen/native/vulkan/ops/Playground.h>
 #include <torch/custom_class.h>
 #include <torch/library.h>
 
@@ -42,6 +43,17 @@ TORCH_LIBRARY(vulkan, m) {
             return linear_prepack(
                 std::move(std::get<0>(state)), std::move(std::get<1>(state)));
           });
+
+  m.class_<PlaygroundOpContext>("PlaygroundOpContext")
+      .def_pickle(
+          // __getstate__
+          [](const c10::intrusive_ptr<PlaygroundOpContext>& context) {
+            return context->unpack();
+          },
+          // __setstate__
+          [](PlaygroundOpContext::State state) {
+            return playground_prepack(std::move(std::get<0>(state)));
+          });
 }
 
 TORCH_LIBRARY(vulkan_prepack, m) {
@@ -59,16 +71,24 @@ TORCH_LIBRARY(vulkan_prepack, m) {
   m.def(
       "linear_run(Tensor X, "
       "__torch__.torch.classes.vulkan.LinearOpContext BW_prepack) -> Tensor Y");
+  m.def(
+      "playground_prepack(Tensor T) "
+      "-> __torch__.torch.classes.vulkan.PlaygroundOpContext");
+  m.def(
+      "playground_run(Tensor X, "
+      "__torch__.torch.classes.vulkan.PlaygroundOpContext P_prepack) -> Tensor Y");
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, CPU, m) {
   m.impl("conv2d_clamp_prepack", TORCH_FN(conv2d_clamp_prepack));
   m.impl("linear_prepack", TORCH_FN(linear_prepack));
+  m.impl("playground_prepack", TORCH_FN(playground_prepack));
 }
 
 TORCH_LIBRARY_IMPL(vulkan_prepack, Vulkan, m) {
   m.impl("conv2d_clamp_run", TORCH_FN(conv2d_clamp_run));
   m.impl("linear_run", TORCH_FN(linear_run));
+  m.impl("playground_run", TORCH_FN(playground_run));
 }
 
 } // namespace

--- a/aten/src/ATen/test/vulkan_api_test.cpp
+++ b/aten/src/ATen/test/vulkan_api_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 #include <ATen/ATen.h>
+#include <ATen/core/dispatch/Dispatcher.h>
 
 // TODO: These functions should move to a common place.
 
@@ -62,10 +63,36 @@ void showRtol(const at::Tensor& a, const at::Tensor& b) {
   }
 }
 
+template <class... Inputs>
+inline std::vector<c10::IValue> makeStack(Inputs&&... inputs) {
+  return {std::forward<Inputs>(inputs)...};
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByHandle(
+        const c10::OperatorHandle& op,
+            Args... args) {
+    auto stack = makeStack(std::forward<Args>(args)...);
+    c10::Dispatcher::singleton().callBoxed(op, &stack);
+    return stack;
+}
+
+template <class... Args>
+inline std::vector<c10::IValue> callOpByName(
+        const char* func_name,
+        const char* overload_name,
+        Args... args) {
+    const c10::optional<c10::OperatorHandle> op_handle =
+          c10::Dispatcher::singleton().findSchema({func_name, overload_name});
+    assert(op_handle.has_value());
+    return callOpByHandle(op_handle.value(), std::forward<Args>(args)...);
+}
+
 } // namespace
 
 namespace {
 
+/*
 TEST(VulkanAPITest, adaptive_avg_pool2d) {
   if (!at::is_vulkan_available()) {
     return;
@@ -1709,6 +1736,34 @@ TEST(VulkanAPITest, mobilenetv2) {
   }
 
   ASSERT_TRUE(check);
+}
+*/
+
+TEST(VulkanAPITest, playground) {
+  if (!at::is_vulkan_available()) {
+    return;
+  }
+
+  const auto test_cpu = at::rand({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  auto play = callOpByName("vulkan_prepack::playground_prepack", "", test_cpu);
+
+  std::cout << "=== Run 1 ===" << std::endl;
+  //const auto in_vulkan = at::ones({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()*1.34;
+  const auto in_cpu = at::rand({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in_vulkan = in_cpu.vulkan();
+  auto out = callOpByName("vulkan_prepack::playground_run", "", in_vulkan, play[0])[0].toTensor().cpu();
+
+  std::cout << in_cpu << std::endl;
+  std::cout << out << std::endl;
+
+  std::cout << "=== Run 2 ===" << std::endl;
+  //const auto in2_vulkan = at::ones({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat)).vulkan()*0.77;
+  const auto in2_cpu = at::rand({1, 4, 3, 3}, at::device(at::kCPU).dtype(at::kFloat));
+  const auto in2_vulkan = in2_cpu.vulkan();
+  auto out2 = callOpByName("vulkan_prepack::playground_run", "", in2_vulkan, play[0])[0].toTensor().cpu();
+
+  std::cout << in2_cpu << std::endl;
+  std::cout << out2 << std::endl;
 }
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57201 Switch to Image2D for Convolution biases
* #57200 Do not reuse descriptor sets for contexted ops and remove persistent descriptor pool
* #57199 add -Os flag to shader compilation
* #57198 use 2D tensor views
* #57197 don't cache local work group
* #57196 optimal command buffer submission rate
* **#57195 Cache vulkan objects between runs**

