### PR TITLE
Do not reuse descriptor sets for contexted ops and remove persistent descriptor pool

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Context.cpp
+++ b/aten/src/ATen/native/vulkan/api/Context.cpp
@@ -233,8 +233,7 @@ Descriptor::Set dispatch_prologue(
 Descriptor::Set dispatch_prologue(
     Command::Buffer& command_buffer,
     const Context::OpCache& opcache,
-    const Shader::WorkGroup& global_work_group,
-    const VkDescriptorSet vk_descriptor_set) {
+    const Shader::WorkGroup& global_work_group) {
   Context* const context = api::context();
   const GPU gpu = context->gpu();
   Descriptor& descriptor = context->descriptor();
@@ -247,15 +246,6 @@ Descriptor::Set dispatch_prologue(
     opcache.layout_descriptor.signature,
   };
 
-  /*
-  const api::Pipeline::Object pipe_obj = {
-    opcache.pipe.get(),
-    opcache.pipe_layout.get(),
-    opcache.local_work_group,
-  };
-
-  command_buffer.bind(pipe_obj);
-  */
   Shader::WorkGroup local_group_size = {4, 4, 4};
 
   if (global_work_group.data[2u] == 1) {
@@ -278,13 +268,7 @@ Descriptor::Set dispatch_prologue(
         local_group_size,
       }));
 
-
-  return Descriptor::Set(
-      descriptor.pool.device_,
-      vk_descriptor_set,
-      shader_layout.signature);
-
-  //return descriptor.pool.allocate(shader_layout);
+  return descriptor.pool.allocate(shader_layout);
 }
 
 void dispatch_epilogue(

--- a/aten/src/ATen/native/vulkan/api/Context.h
+++ b/aten/src/ATen/native/vulkan/api/Context.h
@@ -76,12 +76,9 @@ class Context final {
     public:
       bool initted;
       api::Shader::Layout::Descriptor layout_descriptor;
-      //VkDescriptorSet descriptor_set;
       api::Shader::Layout::Factory::Handle set_layout;
       api::Pipeline::Layout::Factory::Handle pipe_layout;
       api::Shader::Factory::Handle shader_module;
-      //api::Shader::WorkGroup local_work_group;
-      //api::Pipeline::Factory::Handle pipe;
 
       explicit OpCache(const GPU& gpu);
       OpCache(const OpCache&) = delete;
@@ -115,7 +112,6 @@ class Context final {
       Command::Buffer& command_buffer,
       const Context::OpCache& opcache,
       const Shader::WorkGroup& global_work_group,
-      const VkDescriptorSet vk_descriptor_set,
       Arguments&&... arguments);
 };
 
@@ -229,21 +225,18 @@ inline void Context::dispatch(
     Command::Buffer& command_buffer,
     const Context::OpCache& opcache,
     const Shader::WorkGroup& global_work_group,
-    const VkDescriptorSet vk_descriptor_set,
     Arguments&&... arguments) {
   // Forward declaration
   Descriptor::Set dispatch_prologue(
       Command::Buffer&,
       const OpCache& opcache,
-      const Shader::WorkGroup& global_work_group,
-      const VkDescriptorSet vk_descriptor_set);
+      const Shader::WorkGroup& global_work_group);
 
   // Factor out template parameter independent code to minimize code bloat.
   Descriptor::Set descriptor_set = dispatch_prologue(
       command_buffer,
       opcache,
-      global_work_group,
-      vk_descriptor_set);
+      global_work_group);
 
   detail::bind(
       descriptor_set,

--- a/aten/src/ATen/native/vulkan/ops/Convolution.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.cpp
@@ -592,7 +592,6 @@ bool usable(const Tensor& input) {
 
 void conv2d_dw(
     api::Context* const context,
-    const VkDescriptorSet descriptor_set,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -649,7 +648,6 @@ void conv2d_dw(
         command_buffer,
         context->get_conv2d_dw_cache(),
         v_output.extents(),
-        descriptor_set,
         // Write-only access bypasses synchronization but inserts appropriate
         // barriers if necessary.
         v_output.image(
@@ -680,7 +678,6 @@ void conv2d_dw(
 
 void conv2d_pw(
     api::Context* const context,
-    const VkDescriptorSet descriptor_set,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -725,7 +722,6 @@ void conv2d_pw(
         command_buffer,
         context->get_conv2d_pw_cache(),
         v_output.extents(),
-        descriptor_set,
         // Write-only access bypasses synchronization but inserts appropriate
         // barriers if necessary.
         v_output.image(
@@ -756,7 +752,6 @@ void conv2d_pw(
 
 void conv2d(
     api::Context* const context,
-    const VkDescriptorSet descriptor_set,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -819,7 +814,6 @@ void conv2d(
         command_buffer,
         context->get_conv2d_cache(),
         v_output.extents(),
-        descriptor_set,
         // Write-only access bypasses synchronization but inserts appropriate
         // barriers if necessary.
         v_output.image(
@@ -850,7 +844,6 @@ void conv2d(
 
 void conv2d_winograd_2_3(
     api::Context* const context,
-    const VkDescriptorSet descriptor_set,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -972,7 +965,6 @@ void conv2d_winograd_2_3(
 
 void conv2d_old(
     api::Context* const context,
-    const VkDescriptorSet descriptor_set,
     vTensor& v_output,
     const vTensor& v_input,
     const vTensor& v_weight,
@@ -1134,29 +1126,6 @@ Conv2dOpContext::Conv2dOpContext(
       output_max,
     },
     method_(method) {
-  api::Descriptor::Pool& descriptor_pool = persistent()->descriptor_pool;
-  const api::Shader::Layout::Object shader_layout = {
-    api::context()->get_conv2d_cache().set_layout.get(),
-    api::context()->get_conv2d_cache().layout_descriptor.signature,
-  };
-
-  /*
-  switch(method_) {
-    case Conv2dDepthwise:
-      shader_layout = {
-        api::context()->get_conv2d_dw_cache().set_layout.get(),
-        api::context()->get_conv2d_dw_cache().layout_descriptor.signature,
-      };
-      break;
-    case Conv2dPointwise:
-      shader_layout =  {
-        api::context()->get_conv2d_pw_cache().set_layout.get(),
-        api::context()->get_conv2d_pw_cache().layout_descriptor.signature,
-      };
-      break;
-  */
-
-  descriptor_set = descriptor_pool.allocate_single(shader_layout);
 }
 
 Conv2dOpContext Conv2dOpContext::create(
@@ -1242,7 +1211,6 @@ Tensor Conv2dOpContext::run(const Tensor& input_arg) const {
   {
     void (*conv_func) (
       api::Context* const,
-      const VkDescriptorSet,
       vTensor&,
       const vTensor&,
       const vTensor&,
@@ -1274,7 +1242,6 @@ Tensor Conv2dOpContext::run(const Tensor& input_arg) const {
     }
     conv_func(
       context,
-      descriptor_set,
       v_output,
       v_input,
       packed_.v_weight,

--- a/aten/src/ATen/native/vulkan/ops/Convolution.h
+++ b/aten/src/ATen/native/vulkan/ops/Convolution.h
@@ -87,8 +87,6 @@ class Conv2dOpContext final : public torch::jit::CustomClassHolder {
   } unpacked_;
 
   Conv2dMethod method_;
-
-  VkDescriptorSet descriptor_set;
 };
 
 Tensor conv2d_clamp_run(

--- a/aten/src/ATen/native/vulkan/ops/Persistent.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Persistent.cpp
@@ -13,9 +13,6 @@ Persistent* persistent() {
           api::Resource::Pool{
             api::context()->gpu(),
           },
-          api::Descriptor::Pool {
-            api::context()->gpu(),
-          },
         };
       }
       catch (const std::exception& e) {

--- a/aten/src/ATen/native/vulkan/ops/Persistent.h
+++ b/aten/src/ATen/native/vulkan/ops/Persistent.h
@@ -23,7 +23,6 @@ namespace ops {
 
 struct Persistent final {
   api::Resource::Pool pool;
-  api::Descriptor::Pool descriptor_pool;
 };
 
 Persistent* persistent();

--- a/aten/src/ATen/native/vulkan/ops/Playground.cpp
+++ b/aten/src/ATen/native/vulkan/ops/Playground.cpp
@@ -73,7 +73,6 @@ void PlaygroundOpContext::fill_image(const api::Resource::Buffer& buffer, api::R
         cmd_buffer,
         context->get_playground_cache(),
         {3*3*4, 1, 1},
-        descriptor_set,
         buffer.object);
 
     cmd_buffer.end();
@@ -99,14 +98,6 @@ PlaygroundOpContext::PlaygroundOpContext(const Tensor& test)
     initted(false) {
   api::Resource::Pool& resource_pool = persistent()->pool;
   in_buffer = get_buffer(&resource_pool, 3, 3, 4);
-
-  api::Descriptor::Pool& descriptor_pool = persistent()->descriptor_pool;
-  const api::Shader::Layout::Object shader_layout =
-  {
-    api::context()->get_playground_cache().set_layout.get(),
-    api::context()->get_playground_cache().layout_descriptor.signature,
-  };
-  descriptor_set = descriptor_pool.allocate_single(shader_layout);
 }
 
 PlaygroundOpContext PlaygroundOpContext::create(const Tensor& test) {

--- a/aten/src/ATen/native/vulkan/ops/Playground.h
+++ b/aten/src/ATen/native/vulkan/ops/Playground.h
@@ -33,7 +33,6 @@ class PlaygroundOpContext final : public torch::jit::CustomClassHolder {
     Tensor test;
   } unpacked_;
 
-  VkDescriptorSet descriptor_set;
   api::Command::Buffer cmd_buffer;
   api::Resource::Buffer in_buffer;
   bool initted = false;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57201 Switch to Image2D for Convolution biases
* **#57200 Do not reuse descriptor sets for contexted ops and remove persistent descriptor pool**
* #57199 add -Os flag to shader compilation
* #57198 use 2D tensor views
* #57197 don't cache local work group
* #57196 optimal command buffer submission rate
* #57195 Cache vulkan objects between runs

