### PR TITLE
Fix NVRTC versioning for CUDA 11.X (X>=3), CUDA 12 and later

### DIFF
--- a/aten/src/ATen/DynamicLibrary.cpp
+++ b/aten/src/ATen/DynamicLibrary.cpp
@@ -32,10 +32,10 @@ DynamicLibrary::DynamicLibrary(const char* name, const char* alt_name) {
     if (alt_name) {
       handle = dlopen(alt_name, RTLD_LOCAL | RTLD_NOW);
       if (!handle) {
-        AT_ERROR("Error in dlopen or dlsym for ", name, "and ", alt_name);
+        AT_ERROR("Error in dlopen for library ", name, "and ", alt_name);
       }
     } else {
-      AT_ERROR("Error in dlopen or dlsym: ", dlerror());
+      AT_ERROR("Error in dlopen: ", dlerror());
     }
   }
 }

--- a/aten/src/ATen/DynamicLibrary.cpp
+++ b/aten/src/ATen/DynamicLibrary.cpp
@@ -30,9 +30,12 @@ DynamicLibrary::DynamicLibrary(const char* name, const char* alt_name) {
   handle = dlopen(name, RTLD_LOCAL | RTLD_NOW);
   if (!handle) {
     if (alt_name) {
-      handle = checkDL(dlopen(alt_name, RTLD_LOCAL | RTLD_NOW));
+      handle = dlopen(alt_name, RTLD_LOCAL | RTLD_NOW);
+      if (!handle) {
+        AT_ERROR("Error in dlopen or dlsym for ", name, "and ", alt_name);
+      }
     } else {
-        AT_ERROR("Error in dlopen or dlsym: ", dlerror());
+      AT_ERROR("Error in dlopen or dlsym: ", dlerror());
     }
   }
 }

--- a/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
+++ b/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
@@ -53,7 +53,7 @@ at::DynamicLibrary& getNVRTCLibrary() {
   std::string alt_libname;
 #else
   if (major < 11 || (major == 11 && minor < 3)) {
-    lib_version = lib_version = std::to_string(major) + "." + std::to_string(minor);
+    lib_version = std::to_string(major) + "." + std::to_string(minor);
   } else if (major == 11) {
     lib_version = "11.2";
   } else {

--- a/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
+++ b/aten/src/ATen/cuda/detail/LazyNVRTC.cpp
@@ -59,9 +59,9 @@ at::DynamicLibrary& getNVRTCLibrary() {
   } else {
     lib_version = std::to_string(major);
   }
-  static auto libname = std::string("libnvrtc.so.") + lib_version;
+  auto libname = std::string("libnvrtc.so.") + lib_version;
 #ifdef NVRTC_SHORTHASH
-  static auto alt_libname = std::string("libnvrtc-") + C10_STRINGIZE(NVRTC_SHORTHASH) + ".so." + lib_version;
+  auto alt_libname = std::string("libnvrtc-") + C10_STRINGIZE(NVRTC_SHORTHASH) + ".so." + lib_version;
 #else
   std::string alt_libname;
 #endif


### PR DESCRIPTION
NVRTC versioning has changed starting 11.3, and will change again for CUDA 12.X. See comment in code for detail. As a result, jit on CUDA 11.3 is broken.

Also, the error message is misleading: When both `libname` and `alt_libname` are non-empty, the error message is only reporting `alt_libname`, it should report both.

To reproduce the error, you can use:

```python
import torch

torch._C._jit_set_profiling_mode(False)
torch._C._jit_set_profiling_executor(False)
torch._C._jit_override_can_fuse_on_cpu(True)
torch._C._jit_override_can_fuse_on_gpu(True)

@torch.jit.script
def jit_relu_dropout(x, prob) :
    # type: (Tensor, float) -> Tensor
    x = torch.nn.functional.relu(x)
    x = torch.nn.functional.dropout(x, p=prob, training=True)
    return x

x = torch.randn((64, 40, 12, 1024), device="cuda:0", dtype=torch.float16, requires_grad=True)
y = jit_relu_dropout(x, 0.5)
```
with CUDA 11.3, and you will see
```
Traceback (most recent call last):
  File "/home/gaoxiang/misc/nvrtc-failure.py", line 16, in <module>
    y = jit_relu_dropout(x, 0.5)
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
RuntimeError: The following operation failed in the TorchScript interpreter.
Traceback of TorchScript (most recent call last):
RuntimeError: Error in dlopen or dlsym: libnvrtc-8aa72235.so.11.3: cannot open shared object file: No such file or directory
```