### PR TITLE
Handle error reporting when reply file already exists

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -134,11 +134,19 @@ class ErrorHandler:
 
     def _rm(self, my_error_file):
         if os.path.isfile(my_error_file):
+            # Log the contents of the original file.
             with open(my_error_file, "r") as fp:
-                original = json.dumps(json.load(fp), indent=2)
-                log.warning(
-                    f"{my_error_file} already exists"
-                    f" and will be overwritten."
-                    f" Original contents:\n{original}"
-                )
+                try:
+                    original = json.dumps(json.load(fp), indent=2)
+                    log.warning(
+                        f"{my_error_file} already exists"
+                        f" and will be overwritten."
+                        f" Original contents:\n{original}"
+                    )
+                except json.decoder.JSONDecodeError as err:
+                    log.warning(
+                        f"{my_error_file} already exists"
+                        f" and will be overwritten."
+                        f" Unable to load original contents:\n"
+                    )
             os.remove(my_error_file)


### PR DESCRIPTION
Summary:
In torch multiprocessing error handler, we try to remove the file if it already exists. Before removing, we try to log the contents of the file. Here the assumption is that the contents would be valid json.
However, in some cases, it isn't and then we end up not clearing the file.
Let's handle this error and make sure that the file is cleaned irrespective of the contents of the file.

Reviewed By: devashisht

Differential Revision: D28041470

