### PR TITLE
Replace 11.2 linux CI with 11.3

### DIFF
--- a/.circleci/cimodel/data/simple/docker_definitions.py
+++ b/.circleci/cimodel/data/simple/docker_definitions.py
@@ -14,7 +14,7 @@ IMAGE_NAMES = [
     "pytorch-linux-xenial-cuda10.1-cudnn7-py3-gcc7",
     "pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
     "pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
-    "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7",
+    "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7",
     "pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
     "pytorch-linux-xenial-py3-clang5-asan",
     "pytorch-linux-xenial-py3-clang7-onnx",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5952,8 +5952,8 @@ workflows:
           name: "docker-pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
           image_name: "pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7"
       - docker_build_job:
-          name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          image_name: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          name: "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - docker_build_job:
           name: "docker-pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
           image_name: "pytorch-linux-xenial-py3-clang5-android-ndk-r19c"
@@ -8039,28 +8039,28 @@ workflows:
                 - master
     jobs:
       - docker_build_job:
-          name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          image_name: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          name: "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_linux_build:
-          name: periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_build
+          name: periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_linux_test:
-          name: periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_test
+          name: periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_test
           requires:
-            - periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_build
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_build
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - pytorch_linux_build:
-          name: periodic_libtorch_xenial_cuda11_2_cudnn8_gcc7_build
+          name: periodic_libtorch_xenial_cuda11_3_cudnn8_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-libtorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.2"
@@ -8101,30 +8101,30 @@ workflows:
   debuggable-scheduled-ci:
     jobs:
       - docker_build_job:
-          name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          image_name: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          name: "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
+          name: pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_test
+          name: pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_test
           requires:
-            - pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
           filters:
@@ -8133,11 +8133,11 @@ workflows:
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_build:
-          name: pytorch_libtorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
+          name: pytorch_libtorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-libtorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -150,6 +150,16 @@ case "$image" in
     VISION=yes
     KATEX=yes
     ;;
+  pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7)
+    CUDA_VERSION=11.3.0 # Deviating from major.minor to conform to nvidia's Docker image names
+    CUDNN_VERSION=8
+    ANACONDA_PYTHON_VERSION=3.6
+    GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
+    KATEX=yes
+    ;;
   pytorch-linux-xenial-py3-clang5-asan)
     ANACONDA_PYTHON_VERSION=3.6
     CLANG_VERSION=5.0

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -140,16 +140,6 @@ case "$image" in
     VISION=yes
     KATEX=yes
     ;;
-  pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7)
-    CUDA_VERSION=11.2.0 # Deviating from major.minor to conform to nvidia's Docker image names
-    CUDNN_VERSION=8
-    ANACONDA_PYTHON_VERSION=3.6
-    GCC_VERSION=7
-    PROTOBUF=yes
-    DB=yes
-    VISION=yes
-    KATEX=yes
-    ;;
   pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7)
     CUDA_VERSION=11.3.0 # Deviating from major.minor to conform to nvidia's Docker image names
     CUDNN_VERSION=8

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -93,6 +93,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     conda_install magma-cuda111 -c pytorch
   elif [[ "$CUDA_VERSION" == 11.2* ]]; then
     conda_install magma-cuda112 -c pytorch
+  elif [[ "$CUDA_VERSION" == 11.3* ]]; then
+    conda_install magma-cuda113pp -c pytorch
   fi
 
   # TODO: This isn't working atm

--- a/.circleci/docker/common/install_conda.sh
+++ b/.circleci/docker/common/install_conda.sh
@@ -91,10 +91,8 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
     conda_install magma-cuda110 -c pytorch
   elif [[ "$CUDA_VERSION" == 11.1* ]]; then
     conda_install magma-cuda111 -c pytorch
-  elif [[ "$CUDA_VERSION" == 11.2* ]]; then
-    conda_install magma-cuda112 -c pytorch
   elif [[ "$CUDA_VERSION" == 11.3* ]]; then
-    conda_install magma-cuda113pp -c pytorch
+    conda_install magma-cuda113 -c pytorch
   fi
 
   # TODO: This isn't working atm

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -9,28 +9,28 @@
                 - master
     jobs:
       - docker_build_job:
-          name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          image_name: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          name: "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_linux_build:
-          name: periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_build
+          name: periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_linux_test:
-          name: periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_test
+          name: periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_test
           requires:
-            - periodic_pytorch_xenial_cuda11_2_cudnn8_gcc7_build
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - periodic_pytorch_xenial_cuda11_3_cudnn8_gcc7_build
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
       - pytorch_linux_build:
-          name: periodic_libtorch_xenial_cuda11_2_cudnn8_gcc7_build
+          name: periodic_libtorch_xenial_cuda11_3_cudnn8_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-libtorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.2"
@@ -71,30 +71,30 @@
   debuggable-scheduled-ci:
     jobs:
       - docker_build_job:
-          name: "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          image_name: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+          name: "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          image_name: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_build:
-          name: pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
+          name: pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_test:
-          name: pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_test
+          name: pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_test
           requires:
-            - pytorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
-          build_environment: "pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-test"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - pytorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
+          build_environment: "pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-test"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           use_cuda_docker_runtime: "1"
           resource_class: gpu.medium
           filters:
@@ -103,11 +103,11 @@
                 - /ci-all\/.*/
                 - /release\/.*/
       - pytorch_linux_build:
-          name: pytorch_libtorch_linux_xenial_cuda11_2_cudnn8_py3_gcc7_build
+          name: pytorch_libtorch_linux_xenial_cuda11_3_cudnn8_py3_gcc7_build
           requires:
-            - "docker-pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
-          build_environment: "pytorch-libtorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7-build"
-          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
+            - "docker-pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
+          build_environment: "pytorch-libtorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7-build"
+          docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.3-cudnn8-py3-gcc7"
           filters:
             branches:
               only:


### PR DESCRIPTION
Let's see how 11.3 holds up! 

Test plan: 
CUDA 11.3 has passed build and test below.