### PR TITLE
Replace windows CUDA 11.2 CI with 11.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8063,8 +8063,8 @@ workflows:
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
-          name: periodic_pytorch_windows_cuda11.2_build
+          cuda_version: "11.3"
+          name: periodic_pytorch_windows_cuda11.3_build
           python_version: "3.6"
           use_cuda: "1"
           vc_product: BuildTools
@@ -8072,12 +8072,12 @@ workflows:
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.2_test1
+          name: periodic_pytorch_windows_cuda11.3_test1
           python_version: "3.6"
           requires:
-            - periodic_pytorch_windows_cuda11.2_build
+            - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -8085,12 +8085,12 @@ workflows:
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.2_test2
+          name: periodic_pytorch_windows_cuda11.3_test2
           python_version: "3.6"
           requires:
-            - periodic_pytorch_windows_cuda11.2_build
+            - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -8145,8 +8145,8 @@ workflows:
                 - /release\/.*/
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
-          name: pytorch_windows_vs2019_py36_cuda11.2_build
+          cuda_version: "11.3"
+          name: pytorch_windows_vs2019_py36_cuda11.3_build
           python_version: "3.6"
           use_cuda: "1"
           vc_product: BuildTools
@@ -8159,12 +8159,12 @@ workflows:
                 - /release\/.*/
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.2_test1
+          name: pytorch_windows_vs2019_py36_cuda11.3_test1
           python_version: "3.6"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.2_build
+            - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -8177,12 +8177,12 @@ workflows:
                 - /release\/.*/
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.2_test2
+          name: pytorch_windows_vs2019_py36_cuda11.3_test2
           python_version: "3.6"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.2_build
+            - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -15,7 +15,7 @@ elif [[ "$cuda_major_version" == "11" ]]; then
     elif [[ "${CUDA_VERSION}" == "11.3" ]]; then
         cuda_installer_name="cuda_11.3.0_465.89_win10"
         msbuild_project_dir="visual_studio_integration/CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
-        cuda_install_packages="nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
+        cuda_install_packages="thrust_11.3 nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
     else
         echo "This should not happen! ABORT."
         exit 1

--- a/.circleci/scripts/windows_cuda_install.sh
+++ b/.circleci/scripts/windows_cuda_install.sh
@@ -12,10 +12,10 @@ elif [[ "$cuda_major_version" == "11" ]]; then
         cuda_installer_name="cuda_11.1.0_456.43_win10"
         msbuild_project_dir="visual_studio_integration/CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
         cuda_install_packages="nvcc_11.1 cuobjdump_11.1 nvprune_11.1 nvprof_11.1 cupti_11.1 cublas_11.1 cublas_dev_11.1 cudart_11.1 cufft_11.1 cufft_dev_11.1 curand_11.1 curand_dev_11.1 cusolver_11.1 cusolver_dev_11.1 cusparse_11.1 cusparse_dev_11.1 npp_11.1 npp_dev_11.1 nvrtc_11.1 nvrtc_dev_11.1 nvml_dev_11.1"
-    elif [[ "${CUDA_VERSION}" == "11.2" ]]; then
-        cuda_installer_name="cuda_11.2.2_461.33_win10_1"
+    elif [[ "${CUDA_VERSION}" == "11.3" ]]; then
+        cuda_installer_name="cuda_11.3.0_465.89_win10"
         msbuild_project_dir="visual_studio_integration/CUDAVisualStudioIntegration/extras/visual_studio_integration/MSBuildExtensions"
-        cuda_install_packages="nvcc_11.2 cuobjdump_11.2 nvprune_11.2 nvprof_11.2 cupti_11.2 cublas_11.2 cublas_dev_11.2 cudart_11.2 cufft_11.2 cufft_dev_11.2 curand_11.2 curand_dev_11.2 cusolver_11.2 cusolver_dev_11.2 cusparse_11.2 cusparse_dev_11.2 npp_11.2 npp_dev_11.2 nvrtc_11.2 nvrtc_dev_11.2 nvml_dev_11.2"
+        cuda_install_packages="nvcc_11.3 cuobjdump_11.3 nvprune_11.3 nvprof_11.3 cupti_11.3 cublas_11.3 cublas_dev_11.3 cudart_11.3 cufft_11.3 cufft_dev_11.3 curand_11.3 curand_dev_11.3 cusolver_11.3 cusolver_dev_11.3 cusparse_11.3 cusparse_dev_11.3 npp_11.3 npp_dev_11.3 nvrtc_11.3 nvrtc_dev_11.3 nvml_dev_11.3"
     else
         echo "This should not happen! ABORT."
         exit 1

--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -8,8 +8,8 @@ if [[ "$cuda_major_version" == "10" ]]; then
 elif [[ "$cuda_major_version" == "11" ]]; then
     if [[ "${CUDA_VERSION}" == "11.1" ]]; then
         cudnn_installer_name="cudnn-${CUDA_VERSION}-windows-x64-v8.0.5.39"
-    elif [[ "${CUDA_VERSION}" == "11.2" ]]; then
-        cudnn_installer_name="cudnn-${CUDA_VERSION}-windows-x64-v8.1.0.77"
+    elif [[ "${CUDA_VERSION}" == "11.3" ]]; then
+        cudnn_installer_name="cudnn-${CUDA_VERSION}-windows-x64-v8.2.0.53"
     else
         echo "This should not happen! ABORT."
         exit 1

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -33,8 +33,8 @@
           docker_image: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-xenial-cuda11.2-cudnn8-py3-gcc7"
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
-          name: periodic_pytorch_windows_cuda11.2_build
+          cuda_version: "11.3"
+          name: periodic_pytorch_windows_cuda11.3_build
           python_version: "3.6"
           use_cuda: "1"
           vc_product: BuildTools
@@ -42,12 +42,12 @@
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.2_test1
+          name: periodic_pytorch_windows_cuda11.3_test1
           python_version: "3.6"
           requires:
-            - periodic_pytorch_windows_cuda11.2_build
+            - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -55,12 +55,12 @@
           vc_year: "2019"
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: periodic_pytorch_windows_cuda11.2_test2
+          name: periodic_pytorch_windows_cuda11.3_test2
           python_version: "3.6"
           requires:
-            - periodic_pytorch_windows_cuda11.2_build
+            - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -115,8 +115,8 @@
                 - /release\/.*/
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
-          name: pytorch_windows_vs2019_py36_cuda11.2_build
+          cuda_version: "11.3"
+          name: pytorch_windows_vs2019_py36_cuda11.3_build
           python_version: "3.6"
           use_cuda: "1"
           vc_product: BuildTools
@@ -129,12 +129,12 @@
                 - /release\/.*/
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.2_test1
+          name: pytorch_windows_vs2019_py36_cuda11.3_test1
           python_version: "3.6"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.2_build
+            - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -147,12 +147,12 @@
                 - /release\/.*/
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
-          cuda_version: "11.2"
+          cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.2_test2
+          name: pytorch_windows_vs2019_py36_cuda11.3_test2
           python_version: "3.6"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.2_build
+            - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes,
      onlyCPU, skipCUDAIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
      skipCUDAIfNoMagmaAndNoCusolver, skipCUDAIfRocm, onlyOnCPUAndCUDA, dtypesIfCUDA,
-     onlyCUDA, skipMeta, skipCUDAIfNoCusolver)
+     onlyCUDA, skipCUDAVersionIn, skipMeta, skipCUDAIfNoCusolver)
 from torch.testing import floating_and_complex_types, floating_types, all_types
 from torch.testing._internal.common_cuda import SM53OrLater, tf32_on_and_off, CUDA11OrLater, CUDA9
 
@@ -3111,6 +3111,7 @@ class TestLinalg(TestCase):
     @skipCPUIfNoLapack
     @onlyOnCPUAndCUDA   # TODO: XLA doesn't raise exception
     @skipCUDAIfRocm
+    @skipCUDAVersionIn([(11, 3)])  # https://github.com/pytorch/pytorch/issues/57482
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     def test_inverse_errors_large(self, device, dtype):
         # Test batched inverse of singular matrices reports errors without crashing (gh-51930)


### PR DESCRIPTION
Testing 11.3 with current CI.

Test plan:
Relevant CI (11.3) pass! 

Disclaimer: Skipped test_inverse_errors_large for CUDA 11.3 as it failed. Issue documented at #57482.