### PR TITLE
Fix more clang-tidy errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 ---
 # NOTE there must be no spaces before the '-', so put the comma last.
-InheritParentConfig: true
 Checks: '
 bugprone-*,
 -bugprone-forward-declaration-namespace,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -260,6 +260,7 @@ jobs:
             git submodule update --init --recursive
 
             export USE_NCCL=0
+            export USE_DEPLOY=1
             # We really only need compile_commands.json, so no need to build!
             time python setup.py --cmake-only build
 

--- a/c10/util/StringUtil.h
+++ b/c10/util/StringUtil.h
@@ -46,6 +46,7 @@ inline std::ostream& _str(std::ostream& ss) {
 
 template <typename T>
 inline std::ostream& _str(std::ostream& ss, const T& t) {
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
   ss << t;
   return ss;
 }

--- a/torch/csrc/CudaIPCTypes.cpp
+++ b/torch/csrc/CudaIPCTypes.cpp
@@ -31,6 +31,7 @@ struct CudaIPCGlobalEntities {
       ref_counters_files_;
   std::shared_ptr<CudaIPCRefCountersFile> next_available_ref_counters_file_;
   CudaIPCSentDataLimbo CudaIPCSentDataLimbo_;
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CudaIPCGlobalEntities() : ref_counters_files_() {}
   ~CudaIPCGlobalEntities() {
     CudaIPCSentDataLimbo_.collect();
@@ -129,7 +130,9 @@ void ReturnRefCounter(const std::string& handle, uint64_t offset /* unused */) {
 
 } // namespace
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 CudaIPCSentData::CudaIPCSentData(
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     std::string handle,
     int64_t offset,
     int64_t* counter_ptr,

--- a/torch/csrc/CudaIPCTypes.h
+++ b/torch/csrc/CudaIPCTypes.h
@@ -78,6 +78,7 @@ struct CudaIPCSentDataLimbo final {
 
 struct CudaIPCRefCountersFile final {
   CudaIPCRefCountersFile(
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::string handle,
       uint64_t size,
       at::DataPtr data_ptr)
@@ -135,6 +136,7 @@ namespace c10 {
 namespace {
 class CudaIPCCollectCallback : public FreeMemoryCallback {
  public:
+  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
   ~CudaIPCCollectCallback() {};
   bool Execute() override {
     return torch::CudaIPCCollect();

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -657,6 +657,7 @@ static PyObject * THPModule_are_vmap_fallback_warnings_enabled(PyObject* _unused
 
 //NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static PyMethodDef TorchMethods[] = {
   {"_initExtension",  THPModule_initExtension,   METH_O,       nullptr},
   {"_autograd_init",  THPAutograd_initExtension, METH_NOARGS,  nullptr},

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -655,9 +655,7 @@ static PyObject * THPModule_are_vmap_fallback_warnings_enabled(PyObject* _unused
   END_HANDLE_TH_ERRORS
 }
 
-//NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, modernize-avoid-c-arrays)
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
 static PyMethodDef TorchMethods[] = {
   {"_initExtension",  THPModule_initExtension,   METH_O,       nullptr},
   {"_autograd_init",  THPAutograd_initExtension, METH_NOARGS,  nullptr},

--- a/torch/csrc/TypeInfo.cpp
+++ b/torch/csrc/TypeInfo.cpp
@@ -162,6 +162,7 @@ static PyObject* THPIInfo_min(THPIInfo* self, void*) {
 static PyObject* THPIInfo_dtype(THPIInfo* self, void*) {
   std::string primary_name, legacy_name;
   std::tie(primary_name, legacy_name) = torch::utils::getDtypeNames(self->type);
+  // NOLINTNEXTLINE(clang-diagnostic-unused-local-typedef)
   return AT_DISPATCH_INTEGRAL_TYPES(self->type, "dtype", [primary_name] {
     return PyUnicode_FromString((char*)primary_name.data());
   });
@@ -184,6 +185,7 @@ static PyObject* THPFInfo_resolution(THPFInfo* self, void*) {
 static PyObject* THPFInfo_dtype(THPFInfo* self, void*) {
   std::string primary_name, legacy_name;
   std::tie(primary_name, legacy_name) = torch::utils::getDtypeNames(self->type);
+  // NOLINTNEXTLINE(clang-diagnostic-unused-local-typedef)
   return AT_DISPATCH_FLOATING_AND_COMPLEX_TYPES_AND2(at::kHalf, at::ScalarType::BFloat16, self->type, "dtype", [primary_name] {
     return PyUnicode_FromString((char*)primary_name.data());
   });

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -210,6 +210,7 @@ class BatchDataBuffer {
   struct UnwrappedBatchData {
     explicit UnwrappedBatchData(UnwrappedBatchType data) : batch_data(std::move(data)) {}
 
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     explicit UnwrappedBatchData(std::exception_ptr e) : exception(e) {}
 
     /// batch data to return

--- a/torch/csrc/api/include/torch/nn/modules/container/any.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/any.h
@@ -262,6 +262,7 @@ inline AnyModule AnyModule::clone(optional<Device> device) const {
 
 template <typename ModuleType>
 AnyModule& AnyModule::operator=(std::shared_ptr<ModuleType> module) {
+  // NOLINTNEXTLINE(cppcoreguidelines-c-copy-assignment-signature)
   return (*this = AnyModule(std::move(module)));
 }
 

--- a/torch/csrc/autograd/functions/comm.cpp
+++ b/torch/csrc/autograd/functions/comm.cpp
@@ -18,8 +18,10 @@ namespace torch {
 namespace autograd {
 Scatter::Scatter(
     std::vector<at::Device> devices,
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     const c10::optional<std::vector<int64_t>>& chunk_sizes,
     int64_t dim,
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     const c10::optional<std::vector<c10::optional<at::cuda::CUDAStream>>>& streams,
     bool unsqueeze_scalars)
     : devices_(std::move(devices)),
@@ -28,6 +30,7 @@ Scatter::Scatter(
       streams_(streams),
       unsqueeze_scalars_(unsqueeze_scalars) {}
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 Scatter::~Scatter() {}
 
 variable_list Scatter::apply(variable_list&& inputs) {
@@ -45,6 +48,7 @@ variable_list Scatter::apply(variable_list&& inputs) {
     return device.index();
   });
   auto tensors = torch::cuda::scatter(
+      // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(input), device_indices, chunk_sizes_, dim_, streams_);
 
   std::vector<Variable> variables;
@@ -69,6 +73,7 @@ variable_list Scatter::apply(variable_list&& inputs) {
 Gather::Gather(const at::Device& destination_device, int64_t dim)
     : destination_device_(destination_device), dim_(dim) {}
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 Gather::~Gather() {}
 
 variable_list Gather::apply(variable_list&& inputs) {

--- a/torch/csrc/autograd/profiler_cuda.cpp
+++ b/torch/csrc/autograd/profiler_cuda.cpp
@@ -34,6 +34,7 @@ static inline void cudaCheck(cudaError_t result, const char * file, int line) {
 struct CUDAMethods : public CUDAStubs {
   void record(int* device, CUDAEventStub* event, int64_t* cpu_ns) const override {
     TORCH_CUDA_CHECK(cudaGetDevice(device));
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     CUevent_st* cuda_event_ptr;
     TORCH_CUDA_CHECK(cudaEventCreate(&cuda_event_ptr));
     *event = std::shared_ptr<CUevent_st>(cuda_event_ptr, [](CUevent_st* ptr) {
@@ -47,8 +48,10 @@ struct CUDAMethods : public CUDAStubs {
   float elapsed(const CUDAEventStub* event, const CUDAEventStub* event2) const override{
     TORCH_CUDA_CHECK(cudaEventSynchronize(event->get()));
     TORCH_CUDA_CHECK(cudaEventSynchronize(event2->get()));
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     float ms;
     TORCH_CUDA_CHECK(cudaEventElapsedTime(&ms, event->get(), event2->get()));
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-avoid-magic-numbers,cppcoreguidelines-narrowing-conversions)
     return ms*1000.0;
   }
 
@@ -66,6 +69,7 @@ struct CUDAMethods : public CUDAStubs {
 
   void onEachDevice(std::function<void(int)> op) const override {
     at::cuda::OptionalCUDAGuard device_guard;
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse)
     int count = at::cuda::device_count();
     for(int i = 0; i < count; i++) {
       device_guard.set_index(i);

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -11,7 +11,7 @@
 
 #ifdef USE_KINETO
 namespace libkineto {
-class TraceActivity;
+struct TraceActivity;
 class ActivityTraceInterface;
 }
 #endif
@@ -28,6 +28,7 @@ enum class C10_API_ENUM ActivityType {
 
 #ifdef USE_KINETO
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct KinetoObserverContext : public at::ObserverContext {
   int64_t startUs;
   uint64_t correlationId;

--- a/torch/csrc/autograd/profiler_legacy.h
+++ b/torch/csrc/autograd/profiler_legacy.h
@@ -91,6 +91,7 @@ inline int64_t getTime(bool allow_monotonic = false) {
     mode = CLOCK_MONOTONIC;
   }
   clock_gettime(mode, &t);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   return static_cast<int64_t>(t.tv_sec) * 1000000000 + static_cast<int64_t>(t.tv_nsec);
 #endif
 }

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -162,6 +162,7 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   // Massage the Python results tuple back into a C++ variable_list
   variable_list results;
   results.reserve(num_outputs);
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   auto& input_info = py_fn->input_info;
   for (int i = 0; i != num_outputs; ++i) {
     PyObject* output = PyTuple_GET_ITEM(r.get(), i);

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -21,6 +21,7 @@ static PyObject * THCPEvent_pynew(
   unsigned char blocking = 0;
   unsigned char interprocess = 0;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   static char *kwlist[] =
     {"enable_timing", "blocking", "interprocess", nullptr};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|bbb", kwlist,
@@ -156,12 +157,14 @@ static PyObject * THCPEvent_ipc_handle(PyObject *_self, PyObject *noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static struct PyGetSetDef THCPEvent_properties[] = {
   {"device", (getter)THCPEvent_get_device, nullptr, nullptr, nullptr},
   {"cuda_event", (getter)THCPEvent_get_cuda_event, nullptr, nullptr, nullptr},
   {nullptr}
 };
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 static PyMethodDef THCPEvent_methods[] = {
   {(char*)"from_ipc_handle",
     castPyCFunctionWithKeywords(THCPEvent_from_ipc_handle),
@@ -184,36 +187,61 @@ PyTypeObject THCPEventType = {
   0,                                     /* tp_itemsize */
   (destructor)THCPEvent_dealloc,         /* tp_dealloc */
   0,                                     /* tp_vectorcall_offset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_getattr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_setattr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_reserved */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_repr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_number */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_sequence */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_mapping */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_hash  */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_call */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_str */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_getattro */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_setattro */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_buffer */
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
   nullptr,                                  /* tp_doc */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_traverse */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_clear */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_richcompare */
   0,                                     /* tp_weaklistoffset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_iter */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_iternext */
   THCPEvent_methods,                     /* tp_methods */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_members */
   THCPEvent_properties,                  /* tp_getset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_base */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_dict */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_descr_get */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_descr_set */
   0,                                     /* tp_dictoffset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_init */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_alloc */
   THCPEvent_pynew,                       /* tp_new */
 };

--- a/torch/csrc/cuda/Event.cpp
+++ b/torch/csrc/cuda/Event.cpp
@@ -157,14 +157,14 @@ static PyObject * THCPEvent_ipc_handle(PyObject *_self, PyObject *noargs) {
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
 static struct PyGetSetDef THCPEvent_properties[] = {
   {"device", (getter)THCPEvent_get_device, nullptr, nullptr, nullptr},
   {"cuda_event", (getter)THCPEvent_get_cuda_event, nullptr, nullptr, nullptr},
   {nullptr}
 };
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, modernize-avoid-c-arrays)
 static PyMethodDef THCPEvent_methods[] = {
   {(char*)"from_ipc_handle",
     castPyCFunctionWithKeywords(THCPEvent_from_ipc_handle),

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -77,6 +77,7 @@ PyObject * THCPModule_getDevice_wrap(PyObject *self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
   torch::utils::cuda_lazy_init();
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
   auto device = static_cast<int>(c10::cuda::current_device());
   return THPUtils_packInt32(device);
   END_HANDLE_TH_ERRORS
@@ -165,6 +166,7 @@ PyObject * THCPModule_setStream_wrap(PyObject *self, PyObject *obj)
     throw python_error();
   }
   auto stream = at::cuda::CUDAStream::unpack(bits);
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
   auto device = static_cast<int>(c10::cuda::current_device());
   if (device != stream.device_index()) {
     THCPModule_setDevice(stream.device_index());
@@ -260,6 +262,7 @@ PyObject * THCPModule_cudaLockMutex(PyObject *module, PyObject *noargs)
       break;
     {
       pybind11::gil_scoped_release no_gil;
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
   }
@@ -446,6 +449,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
     .def("__repr__", [](const cudaDeviceProp &prop) {
       std::ostringstream stream;
       stream << "_CudaDeviceProperties(name='" << prop.name << "', major=" << prop.major
+             // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
              << ", minor=" << prop.minor << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
       return stream.str();
@@ -511,6 +515,7 @@ static PyObject * THCPModule_initExtension(PyObject *self, PyObject *noargs)
   auto num_gpus = c10::cuda::device_count();
   auto default_cuda_generators = PyTuple_New(static_cast<Py_ssize_t>(num_gpus));
   for(int i = 0; i < num_gpus; i++) {
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     auto gen = at::cuda::detail::getDefaultCUDAGenerator(i);
     auto cast_gen = (THPGenerator*)THPGenerator_initDefaultGenerator(gen);
     // This reference is meant to be given away, so no need to incref here.
@@ -531,6 +536,7 @@ PyObject * THCPModule_getCurrentBlasHandle_wrap(PyObject *self, PyObject *noargs
   END_HANDLE_TH_ERRORS
 }
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_init",        THCPModule_initExtension,    METH_NOARGS,  nullptr},
   {"_cuda_setDevice",   THCPModule_setDevice_wrap,   METH_O,       nullptr},

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -536,7 +536,7 @@ PyObject * THCPModule_getCurrentBlasHandle_wrap(PyObject *self, PyObject *noargs
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-avoid-c-arrays)
 static struct PyMethodDef _THCPModule_methods[] = {
   {"_cuda_init",        THCPModule_initExtension,    METH_NOARGS,  nullptr},
   {"_cuda_setDevice",   THCPModule_setDevice_wrap,   METH_O,       nullptr},

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -16,12 +16,14 @@ static PyObject * THCPStream_pynew(
   PyTypeObject *type, PyObject *args, PyObject *kwargs) {
   HANDLE_TH_ERRORS
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int current_device;
   THCudaCheck(cudaGetDevice(&current_device));
 
   int priority = 0;
   uint64_t cdata = 0;
 
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   static char *kwlist[] = {"priority", "_cdata", nullptr};
   if (!PyArg_ParseTupleAndKeywords(
       args, kwargs, "|iK", kwlist, &priority, &cdata)) {
@@ -72,6 +74,7 @@ static PyObject * THCPStream_get_priority(THCPStream *self, void *unused) {
 
 static PyObject * THCPStream_priority_range(PyObject *_unused, PyObject* noargs) {
   HANDLE_TH_ERRORS
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int least_priority, greatest_priority;
   std::tie(least_priority, greatest_priority) =
     at::cuda::CUDAStream::priority_range();
@@ -105,10 +108,12 @@ static PyObject * THCPStream_eq(PyObject *_self, PyObject *_other) {
   END_HANDLE_TH_ERRORS
 }
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static struct PyMemberDef THCPStream_members[] = {
   {nullptr}
 };
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static struct PyGetSetDef THCPStream_properties[] = {
   {"cuda_stream",
     (getter)THCPStream_get_cuda_stream, nullptr, nullptr, nullptr},
@@ -116,6 +121,7 @@ static struct PyGetSetDef THCPStream_properties[] = {
   {nullptr}
 };
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static PyMethodDef THCPStream_methods[] = {
   {(char*)"query", THCPStream_query, METH_NOARGS, nullptr},
   {(char*)"synchronize",
@@ -133,36 +139,60 @@ PyTypeObject THCPStreamType = {
   0,                                     /* tp_itemsize */
   (destructor)THCPStream_dealloc,        /* tp_dealloc */
   0,                                     /* tp_vectorcall_offset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_getattr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_setattr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_reserved */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_repr */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_number */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_sequence */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_mapping */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_hash  */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_call */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_str */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_getattro */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_setattro */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_as_buffer */
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
   nullptr,                                  /* tp_doc */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_traverse */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_clear */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_richcompare */
   0,                                     /* tp_weaklistoffset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_iter */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_iternext */
   THCPStream_methods,                    /* tp_methods */
   THCPStream_members,                    /* tp_members */
   THCPStream_properties,                 /* tp_getset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_base */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_dict */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_descr_get */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_descr_set */
   0,                                     /* tp_dictoffset */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_init */
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   0,                                     /* tp_alloc */
   THCPStream_pynew,                      /* tp_new */
 };

--- a/torch/csrc/cuda/Stream.cpp
+++ b/torch/csrc/cuda/Stream.cpp
@@ -108,12 +108,12 @@ static PyObject * THCPStream_eq(PyObject *_self, PyObject *_other) {
   END_HANDLE_TH_ERRORS
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-avoid-c-arrays)
 static struct PyMemberDef THCPStream_members[] = {
   {nullptr}
 };
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-avoid-c-arrays)
 static struct PyGetSetDef THCPStream_properties[] = {
   {"cuda_stream",
     (getter)THCPStream_get_cuda_stream, nullptr, nullptr, nullptr},
@@ -121,7 +121,7 @@ static struct PyGetSetDef THCPStream_properties[] = {
   {nullptr}
 };
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTNEXTLINE(modernize-avoid-c-arrays, cppcoreguidelines-avoid-non-const-global-variables, cppcoreguidelines-avoid-c-arrays)
 static PyMethodDef THCPStream_methods[] = {
   {(char*)"query", THCPStream_query, METH_NOARGS, nullptr},
   {(char*)"synchronize",

--- a/torch/csrc/cuda/Stream.h
+++ b/torch/csrc/cuda/Stream.h
@@ -6,6 +6,7 @@
 #include <torch/csrc/python_headers.h>
 #include <THC/THC.h>
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct THCPStream : THPStream{
   at::cuda::CUDAStream cuda_stream;
 };

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -192,6 +192,7 @@ tensor_list2d broadcast_coalesced(
         for (auto& t :
              utils::unflatten_sparse_tensors(inds, vals, chunk.tensors)) {
           // See NOTE [ Version Counter in comm.*_coalesced ]
+          // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
           Variable var = t;
           device_outputs.push_back(make_variable(var.tensor_data(), false));
         }
@@ -205,6 +206,7 @@ tensor_list2d broadcast_coalesced(
         for (auto& t :
              utils::unflatten_dense_tensors(results[i], chunk.tensors)) {
           // See NOTE [ Version Counter in comm.*_coalesced ]
+          // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
           Variable var = t;
           device_outputs.push_back(make_variable(var.tensor_data(), false));
         }
@@ -247,6 +249,7 @@ std::vector<at::Tensor>& scatter_out(
         out_tensors[i].device(),
         "'");
     auto out_sizes = out_tensors[i].sizes().vec();
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     bool same_ndim = out_sizes.size() == tensor.dim();
     if (same_ndim) {
       total_size += out_sizes[dim];

--- a/torch/csrc/cuda/nccl.h
+++ b/torch/csrc/cuda/nccl.h
@@ -21,6 +21,7 @@ typedef void* ncclComm_t;
 
 /** redefine nccl unique ID in torch scope. this should be identical to native nccl impp. */
 #define NCCL_UNIQUE_ID_BYTES 128
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 typedef struct { char internal[NCCL_UNIQUE_ID_BYTES]; } ncclUniqueId;
 
 /* Error type */

--- a/torch/csrc/cuda/utils.cpp
+++ b/torch/csrc/cuda/utils.cpp
@@ -1,4 +1,5 @@
 #include <torch/csrc/python_headers.h>
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <stdarg.h>
 #include <string>
 #include <torch/csrc/cuda/THCP.h>
@@ -40,6 +41,7 @@ std::vector<c10::optional<at::cuda::CUDAStream>> THPUtils_PySequence_to_CUDAStre
     } else if (stream == Py_None) {
       streams.emplace_back();
     } else {
+      // NOLINTNEXTLINE(bugprone-throw-keyword-missing)
       std::runtime_error("Unknown data type found in stream list. Need torch.cuda.Stream or None");
     }
   }

--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -44,6 +44,7 @@ InterpreterSession::~InterpreterSession() {
 
 void ReplicatedObjImpl::unload(const Interpreter* on_this_interpreter) {
   if (!on_this_interpreter) {
+    // NOLINTNEXTLINE(clang-analyzer-core.NullDereference)
     for (auto& interp : manager_->all_instances()) {
       unload(&interp);
     }
@@ -73,6 +74,7 @@ ReplicatedObj InterpreterSession::create_movable(Obj obj) {
 
 Interpreter::Interpreter(InterpreterManager* manager)
     : handle_(nullptr), manager_(manager) {
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   char library_name[] = "/tmp/torch_deployXXXXXX";
   int fd = mkstemp(library_name);
   TORCH_INTERNAL_ASSERT(fd != -1, "failed to create temporary file");
@@ -98,6 +100,7 @@ Interpreter::Interpreter(InterpreterManager* manager)
   void* new_interpreter_impl = dlsym(handle_, "new_interpreter_impl");
   assert(new_interpreter_impl);
   pImpl_ = std::unique_ptr<InterpreterImpl>(
+      // NOLINTNEXTLINE(modernize-redundant-void-arg)
       ((InterpreterImpl * (*)(void)) new_interpreter_impl)());
 }
 
@@ -114,11 +117,13 @@ int LoadBalancer::acquire() {
   size_t minusers = SIZE_MAX;
   int min_idx = 0;
   for (size_t i = 0; i < n_; ++i, ++last) {
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     if (last >= n_) {
       last = 0;
     }
     uint64_t prev = 0;
     bool acquired = __atomic_compare_exchange_n(
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
         &uses_[8 * last],
         &prev,
         1ULL,
@@ -140,11 +145,13 @@ int LoadBalancer::acquire() {
   // we failed to find a completely free interpreter. heuristically use the
   // one with the least number of user (note that this may have changed since
   // then, so this is only a heuristic).
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   __atomic_fetch_add(&uses_[8 * min_idx], 1ULL, __ATOMIC_SEQ_CST);
   return min_idx;
 }
 
 void LoadBalancer::free(int where) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   __atomic_fetch_sub(&uses_[8 * where], 1ULL, __ATOMIC_SEQ_CST);
 }
 

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -1,4 +1,5 @@
 #pragma once
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <assert.h>
 #include <torch/csrc/deploy/interpreter/interpreter_impl.h>
 #include <fstream>
@@ -19,6 +20,7 @@ struct TORCH_API InterpreterSession {
       InterpreterManager* manager) noexcept
       : impl_(impl), manager_(manager) {}
 
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   Obj self; // when retreived from a PythonMovable this will be set.
   InterpreterSession(InterpreterSession&&) noexcept = default;
   ~InterpreterSession();
@@ -73,8 +75,10 @@ class TORCH_API Interpreter {
 struct Package;
 
 struct TORCH_API LoadBalancer {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   LoadBalancer(size_t n) : uses_(new uint64_t[8 * n]), allocated_(n), n_(n) {
     // 8*... to avoid false sharing of atomics on the same cache line
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     memset(uses_.get(), 0, 8 * n_ * sizeof(uint64_t));
   }
   void setResourceLimit(size_t n) {
@@ -85,6 +89,7 @@ struct TORCH_API LoadBalancer {
   void free(int where);
 
  private:
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   std::unique_ptr<uint64_t[]>
       uses_; // the approximate count of the number of users of interpreter
   size_t allocated_;
@@ -137,6 +142,7 @@ struct TORCH_API InterpreterManager {
 struct TORCH_API ReplicatedObjImpl {
   ReplicatedObjImpl(
       size_t object_id,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       PickledObject data,
       InterpreterManager* manager)
       : object_id_(object_id), data_(data), manager_(manager) {}

--- a/torch/csrc/deploy/example/benchmark.cpp
+++ b/torch/csrc/deploy/example/benchmark.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <vector>
 
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <assert.h>
 #include <torch/deploy.h>
 
@@ -24,6 +25,7 @@ constexpr auto latency_p = {
     50.,
     95.}; //{1., 5., 25., 50., 75., 90., 95., 99., 99.25, 99.5, 99.75, 99.9};
 
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 struct Report {
   std::string benchmark;
   std::string strategy;
@@ -143,6 +145,7 @@ struct RunJIT {
   }
   void operator()(int i) {
     if (cuda) {
+      // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
       int device_id = i % models_.size();
       auto d = torch::Device(torch::DeviceType::CUDA, device_id);
       to_device(
@@ -157,11 +160,14 @@ struct RunJIT {
 };
 
 struct Benchmark {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   Benchmark(
       torch::deploy::InterpreterManager& manager,
       size_t n_threads,
       std::string strategy,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::string file_to_run,
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       size_t n_seconds = 5)
       : manager_(manager),
         n_threads_(n_threads),
@@ -295,6 +301,7 @@ int main(int argc, char* argv[]) {
     I.global("sys", "path").attr("append")({"torch/csrc/deploy/example"});
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto n_threads = {1, 2, 4, 8, 16, 32, 40};
   for (int i = 4; i < argc; ++i) {
     std::string model_file = argv[i];

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -5,8 +5,10 @@
 #include <torch/csrc/deploy/interpreter/interpreter_impl.h>
 #include <iostream>
 
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <assert.h>
 #include <pybind11/embed.h>
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <stdio.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -294,6 +296,7 @@ struct ConcreteInterpreterImpl : public torch::deploy::InterpreterImpl {
     status = PyConfig_SetString(&config, &config.executable, L"torch_deploy");
     status = PyConfig_SetString(&config, &config.prefix, L"");
     config.module_search_paths_set = 1;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
     wchar_t* module_search_paths[0] = {};
     status = PyConfig_SetWideStringList(
         &config, &config.module_search_paths, 0, module_search_paths);

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -69,6 +69,7 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   auto model = p.load_pickle("model", "model.pkl");
   auto ref_model = torch::jit::load(path("SIMPLE_JIT", simple_jit));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto input = torch::ones({10, 20});
   size_t ninterp = 3;
   std::vector<at::Tensor> outputs;
@@ -94,6 +95,7 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   auto model = p.load_pickle("model", "model.pkl");
   auto ref_model = torch::jit::load(path("SIMPLE_JIT", simple_jit));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   auto input = torch::ones({10, 20});
 
   std::vector<at::Tensor> outputs;
@@ -101,7 +103,9 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   std::vector<std::future<at::Tensor>> futures;
   for (size_t i = 0; i < nthreads; i++) {
     futures.push_back(std::async(std::launch::async, [&model]() {
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       auto input = torch::ones({10, 20});
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       for (int i = 0; i < 100; ++i) {
         model({input}).toTensor();
       }

--- a/torch/csrc/distributed/autograd/context/container.h
+++ b/torch/csrc/distributed/autograd/context/container.h
@@ -112,12 +112,17 @@ class TORCH_API DistAutogradContainer {
     std::unordered_map<int64_t, ContextPtr> contexts;
   };
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer();
   ~DistAutogradContainer() = default;
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer(const DistAutogradContainer&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer& operator=(const DistAutogradContainer&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer(DistAutogradContainer&&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistAutogradContainer& operator=(DistAutogradContainer&&) = delete;
 
   static DistAutogradContainer& getInstanceInternal();

--- a/torch/csrc/distributed/autograd/engine/dist_engine.cpp
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.cpp
@@ -601,6 +601,7 @@ size_t DistEngine::numBackwardPasses() const {
 
 std::unordered_map<std::string, int> DistEngine::getDebugInfo() const {
   std::unordered_map<std::string, int> debugInfo;
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   auto& DistAutogradContainer = DistAutogradContainer::getInstance();
   debugInfo[kNumBackwardPasses] = numBackwardPasses();
   debugInfo[kNumAutogradContexts] =

--- a/torch/csrc/distributed/autograd/engine/dist_engine.h
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.h
@@ -61,9 +61,13 @@ class TORCH_API DistEngine {
   DistEngine();
   ~DistEngine();
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistEngine(const DistEngine&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistEngine& operator=(const DistEngine&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistEngine(DistEngine&&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   DistEngine& operator=(DistEngine&&) = delete;
 
   // Validates the input roots for the backward computations and retrieves the
@@ -160,6 +164,7 @@ class TORCH_API DistEngine {
 // Guard to clean up resources once the backward pass is done.
 class BackwardPassCleanupGuard {
  public:
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   explicit BackwardPassCleanupGuard(const ContextPtr& autogradContext)
       : autogradContext_(autogradContext) {}
 

--- a/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
+++ b/torch/csrc/distributed/autograd/functions/recvrpc_backward.cpp
@@ -16,6 +16,7 @@ RecvRpcBackward::RecvRpcBackward(
     rpc::worker_id_t fromWorkerId,
     std::unordered_map<c10::DeviceIndex, c10::DeviceIndex> deviceMap)
     : autogradMetadata_(autogradMetadata),
+      // NOLINTNEXTLINE(performance-move-const-arg)
       autogradContext_(std::move(autogradContext)),
       fromWorkerId_(fromWorkerId),
       deviceMap_(std::move(deviceMap)) {}

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -63,6 +63,7 @@ std::unique_ptr<PropagateGradientsReq> PropagateGradientsReq::fromMessage(
   tupleElements.pop_back();
 
   // Build AutogradMetadata.
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int64_t autogradContextId, autogradMessageId;
   autogradMessageId = tupleElements.back().toInt();
   tupleElements.pop_back();
@@ -77,6 +78,7 @@ std::unique_ptr<PropagateGradientsReq> PropagateGradientsReq::fromMessage(
     grads[i] = tupleElements[i].toTensor();
   }
 
+  // NOLINTNEXTLINE(modernize-make-unique)
   return std::unique_ptr<PropagateGradientsReq>(
       new PropagateGradientsReq(autogradMetadata, grads, retainGraph));
 }

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
@@ -141,6 +141,7 @@ std::unique_ptr<RpcWithProfilingReq> RpcWithProfilingReq::fromMessage(
       std::move(wrappedRpc),
       wrappedMsgType,
       std::move(wrappedMessage.tensors()),
+      // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(cfg),
       profilerId);
 }

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
@@ -124,6 +124,7 @@ std::unique_ptr<RpcWithProfilingResp> RpcWithProfilingResp::fromMessage(
   for (int i = kProfileEventsStartIdx;
        i < kProfileEventsStartIdx + profiledEventsSize;
        ++i) {
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     TORCH_CHECK(i < tupleElements.size());
     // Reconstruct remote event from the ivalues.
     torch::autograd::profiler::LegacyEvent fromIvalueEvent =

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -93,6 +93,7 @@ Message getMessageWithProfiling(
   auto wrappedProfilingMsg = RpcWithProfilingReq(
       msgType,
       std::move(wrappedRpcMessage),
+      // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(profilerConfig),
       globallyUniqueProfilingId);
 
@@ -163,6 +164,7 @@ std::shared_ptr<JitFuture> sendMessageWithAutograd(
     auto msgWithProfiling = getMessageWithProfiling(
         std::move(msg),
         rpc::MessageType::RUN_WITH_PROFILING_REQ,
+        // NOLINTNEXTLINE(performance-move-const-arg)
         std::move(profilerConfig));
     fut = agent.send(dst, std::move(msgWithProfiling), rpcTimeoutSeconds);
   } else {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -85,6 +85,7 @@ namespace c10d {
 namespace {
 
 #ifdef USE_C10D_GLOO
+// NOLINTNEXTLINE(clang-diagnostic-unused-const-variable)
 constexpr char* GLOO_SOCKET_IFNAME_ENV = "GLOO_SOCKET_IFNAME";
 #endif
 
@@ -1242,6 +1243,7 @@ options :class:`~torch.distributed.ProcessGroupNCCL.Options`).
             }
 
             options->timeout = timeout;
+            // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
             options->threads = options->devices.size() * 2;
             return c10::make_intrusive<::c10d::ProcessGroupGloo>(
                 store, rank, size, options);

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -85,7 +85,7 @@ namespace c10d {
 namespace {
 
 #ifdef USE_C10D_GLOO
-// NOLINTNEXTLINE(clang-diagnostic-unused-const-variable)
+// NOLINTNEXTLINE(clang-diagnostic-unused-const-variable,cppcoreguidelines-avoid-non-const-global-variables)
 constexpr char* GLOO_SOCKET_IFNAME_ENV = "GLOO_SOCKET_IFNAME";
 #endif
 

--- a/torch/csrc/distributed/rpc/metrics/RpcMetricsHandler.h
+++ b/torch/csrc/distributed/rpc/metrics/RpcMetricsHandler.h
@@ -6,6 +6,7 @@ namespace torch {
 namespace distributed {
 namespace rpc {
 // All metrics are prefixed with the following  key.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 constexpr char kRpcMetricsKeyPrefix[] = "torch.distributed.rpc.";
 // APIs for logging time-series metrics for RPC-based distributed
 // training. Implementations of this class should provide thread safety so that
@@ -18,6 +19,7 @@ class RpcMetricsHandler {
   virtual void accumulateMetric(const std::string& name, double value) = 0;
   // Increment a count for the metric given by the name.
   virtual void incrementMetric(const std::string& name) = 0;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~RpcMetricsHandler() {}
 };
 

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -130,6 +130,7 @@ const WorkerInfo& ProcessGroupAgent::getWorkerInfo(
 
 const WorkerInfo& ProcessGroupAgent::getWorkerInfo(worker_id_t id) const {
   TORCH_CHECK(
+      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       id >= 0 && id < allWorkerInfo_.size(), "Invalid destination: ", id);
   return allWorkerInfo_[id];
 }
@@ -364,6 +365,7 @@ std::shared_ptr<JitFuture> ProcessGroupAgent::send(
 }
 
 void ProcessGroupAgent::handleSend(const SendWork& work) {
+  // NOLINTNEXTLINE(clang-diagnostic-pessimizing-move)
   auto serializedPayload = std::make_unique<std::string>(std::move(
       wireSerialize(work.message_.payload(), work.message_.tensors())));
 
@@ -426,6 +428,7 @@ void ProcessGroupAgent::handleSend(const SendWork& work) {
 }
 
 void ProcessGroupAgent::sendToSelf(Message&& message) {
+  // NOLINTNEXTLINE(modernize-avoid-bind)
   threadPool_.run(std::bind(
       [this](const Message& message) {
         // Unlike the other cases, need to add a tensor deleter, since the
@@ -460,6 +463,7 @@ void ProcessGroupAgent::sendToSelf(Message&& message) {
 
 void ProcessGroupAgent::enqueueSend(SendWork work) {
   // NB: this can be changed to use a native move capture when moved to C++14
+  // NOLINTNEXTLINE(modernize-avoid-bind)
   threadPool_.run(std::bind(
       [this](const SendWork& work) {
         try {
@@ -585,6 +589,7 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
 }
 
 void ProcessGroupAgent::enqueueRecv(RecvWork work) {
+  // NOLINTNEXTLINE(modernize-avoid-bind)
   threadPool_.run(std::bind(
       [&](RecvWork& work) {
         try {

--- a/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
+++ b/torch/csrc/distributed/rpc/profiler/remote_profiler_manager.h
@@ -42,9 +42,13 @@ class TORCH_API RemoteProfilerManager {
  private:
   RemoteProfilerManager();
   ~RemoteProfilerManager() = default;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RemoteProfilerManager(const RemoteProfilerManager& other) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RemoteProfilerManager operator=(const RemoteProfilerManager& other) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RemoteProfilerManager(RemoteProfilerManager&&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   RemoteProfilerManager& operator=(RemoteProfilerManager&&) = delete;
   local_id_t getNextLocalId();
   std::unordered_map<ProfilingId, std::string, ProfilingId::Hash>

--- a/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
+++ b/torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h
@@ -82,7 +82,9 @@ TORCH_API extern mutexType currentStateStackEntryMutex;
 class StateStackEntry {
  public:
   StateStackEntry(
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::shared_ptr<StateStackEntry> prevPtr,
+      // NOLINTNEXTLINE(modernize-pass-by-value)
       std::shared_ptr<State> statePtr)
       : prevPtr_(prevPtr), statePtr_(statePtr) {}
 

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -87,9 +87,13 @@ class PYBIND11_EXPORT PythonRpcHandler {
   PythonRpcHandler();
   ~PythonRpcHandler() = default;
 
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   PythonRpcHandler(const PythonRpcHandler&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   PythonRpcHandler& operator=(const PythonRpcHandler&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   PythonRpcHandler(PythonRpcHandler&&) = delete;
+  // NOLINTNEXTLINE(modernize-use-equals-delete)
   PythonRpcHandler& operator=(PythonRpcHandler&&) = delete;
 
   // Ref to `torch.distributed.rpc.internal._run_function`.

--- a/torch/csrc/distributed/rpc/request_callback.h
+++ b/torch/csrc/distributed/rpc/request_callback.h
@@ -18,6 +18,7 @@ class TORCH_API RequestCallback {
       Message& request,
       std::shared_ptr<LazyStreamContext> ctx) const;
 
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~RequestCallback() {}
 
  protected:

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -337,6 +337,7 @@ void RequestCallbackImpl::processPythonRemoteCall(
   } else {
     ownerRRef = ctx.getOrCreateOwnerRRef(rrefId, PyObjectType::get());
   }
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   auto& pythonRpcHandler = PythonRpcHandler::getInstance();
 
   if (rrefId != forkId) {

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -53,6 +53,7 @@ void RpcAgent::shutdown() {
   if (rpcRetryThread_.joinable()) {
     rpcRetryThread_.join();
   }
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.PureVirtualCall)
   shutdownImpl();
 }
 

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -92,11 +92,14 @@ struct TORCH_API RpcRetryOptions {
   // sendWithRetries function.
   RpcRetryOptions() = default;
   // Maximum number of times we will retry the RPC
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   int maxRetries{5};
   // Initial duration between consecutive RPC send attempts
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   std::chrono::milliseconds rpcRetryDuration{std::chrono::milliseconds(1000)};
   // Constant for exponential backoff used while calculating future wait
   // durations
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   float retryBackoff{1.5};
 };
 
@@ -266,14 +269,20 @@ class TORCH_API RpcAgent {
       const WorkerInfo& dest);
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const WorkerInfo workerInfo_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const std::unique_ptr<RequestCallback> cb_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::atomic<std::chrono::milliseconds> rpcTimeout_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::atomic<bool> profilingEnabled_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::shared_ptr<TypeResolver> typeResolver_;
   // Atomic boolean indicating whether this agent is running. It controls
   // whether several background threads should be running. It is set in
   // RpcAgent::start() and unset in the derived class shutdown().
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::atomic<bool> rpcAgentRunning_;
 
  private:

--- a/torch/csrc/distributed/rpc/rpc_command_base.h
+++ b/torch/csrc/distributed/rpc/rpc_command_base.h
@@ -20,6 +20,7 @@ class RpcCommandBase {
   virtual ~RpcCommandBase() = 0;
 };
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 inline RpcCommandBase::~RpcCommandBase() {}
 
 } // namespace rpc

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -196,6 +196,7 @@ class TORCH_API RRef : public RRefInterface {
   explicit RRef(RRef&& other) = delete;
   RRef& operator=(RRef&& other) = delete;
 
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~RRef() = default;
 
   // returns the worker id of the owner
@@ -265,14 +266,19 @@ class TORCH_API RRef : public RRefInterface {
 
   virtual RRefForkData fork() const;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const worker_id_t ownerId_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const RRefId rrefId_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::atomic<bool> timedOut_{false};
 
   // type field to denote the type of the element that the RRef is holding
   // it could be any TypePtr that JIT support, including PyObjectType
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const TypePtr type_;
   // Future corresponding to request to create RRef on remote node.
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::shared_ptr<JitFuture> ownerCreationFuture_;
 };
 
@@ -320,6 +326,7 @@ class TORCH_API UserRRef final : public RRef {
   // https://github.com/pytorch/pytorch/blob/9116f02bebf3a5260feef5732d36c54ecb3b4033/c10/util/intrusive_ptr.h#L204
   // This is called on destructing the wrapping intrusive_ptr_target instance
   // and it's data members. We don't need to implement anything here.
+  // NOLINTNEXTLINE(modernize-use-override)
   ~UserRRef() = default;
 
  private:

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -18,15 +18,19 @@ class TORCH_API RRefMessageBase : public RpcCommandBase {
   RRefMessageBase(const RRefId& rrefId, MessageType type)
       : rrefId_(rrefId), type_(type) {}
 
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~RRefMessageBase() override = default;
 
   const RRefId& rrefId();
 
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual Message toMessageImpl() && override;
   static at::IValue fromMessage(const Message& message, MessageType type);
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const RRefId rrefId_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const MessageType type_;
 };
 
@@ -35,16 +39,19 @@ class TORCH_API ForkMessageBase : public RRefMessageBase {
   ForkMessageBase(const RRefId& rrefId, const ForkId& forkId, MessageType type)
       : RRefMessageBase(rrefId, type), forkId_(forkId) {}
 
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~ForkMessageBase() override = default;
 
   const ForkId& forkId();
 
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual Message toMessageImpl() && override;
   static std::pair<RRefId, ForkId> fromMessage(
       const Message& message,
       MessageType type);
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const ForkId forkId_;
 };
 
@@ -157,6 +164,7 @@ class TORCH_API RRefForkRequest final : public ForkMessageBase {
 
 class TORCH_API RRefAck final : public RpcCommandBase {
  public:
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   RRefAck() {}
 
   Message toMessageImpl() && override;

--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -42,6 +42,7 @@ class TORCH_API ScriptCall : public RpcCommandBase {
   Message toMessageImpl() && override;
   static std::unique_ptr<ScriptCall> fromMessage(const Message& message);
 
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~ScriptCall() = default;
 
  protected:

--- a/torch/csrc/distributed/rpc/utils.cpp
+++ b/torch/csrc/distributed/rpc/utils.cpp
@@ -488,6 +488,7 @@ std::vector<at::IValue> readWrappedPayload(
     std::vector<char>& payload,
     const rpc::Message& message) {
   // Read the additional payload remove it from the payload.
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int64_t additionalPayloadSize;
   size_t indexToRead = payload.size() - sizeof(int64_t);
   TORCH_INTERNAL_ASSERT(indexToRead >= 0);
@@ -499,6 +500,7 @@ std::vector<at::IValue> readWrappedPayload(
   payload.resize(indexToRead);
 
   TORCH_INTERNAL_ASSERT(
+      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       payload.size() > additionalPayloadSize,
       "Wrong payload sizes: payload.size() is ",
       payload.size(),
@@ -584,6 +586,7 @@ FutureFactoryRegistry& FutureFactoryRegistry::getInstance() {
 void FutureFactoryRegistry::registerFutureFactory(
     c10::DeviceType type,
     future_factory_t factory) {
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   factories_[static_cast<size_t>(type) & 0xFF] = std::move(factory);
 }
 
@@ -595,6 +598,7 @@ std::shared_ptr<JitFuture> FutureFactoryRegistry::createFuture(
       "Using FutureFactory for device type ",
       DeviceTypeName(type),
       " before registration.")
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   return factories_[static_cast<size_t>(type) & 0xFF](devices);
 }
 

--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -205,6 +205,7 @@ class TORCH_API FutureFactoryRegistry final {
       const std::vector<c10::DeviceIndex>& devices = {});
 
  private:
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
   future_factory_t factories_[static_cast<size_t>(
       c10::DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)];
 };

--- a/torch/csrc/jit/codegen/cuda/arith.cpp
+++ b/torch/csrc/jit/codegen/cuda/arith.cpp
@@ -482,6 +482,7 @@ TensorView* reductionOp(
 }
 
 TensorView* sum(TensorView* v1, const std::vector<int>& axes) {
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   Val* init;
   switch (v1->getDataType().value()) {
     case (DataType::Float):

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -182,6 +182,7 @@ class CudaKernelGenerator : private OptInConstDispatch {
     print_inline_ = true;
     const auto result = gen(stmt);
     print_inline_ = saved_inline;
+    // NOLINTNEXTLINE(performance-no-automatic-move)
     return result;
   }
 

--- a/torch/csrc/jit/codegen/cuda/executor.h
+++ b/torch/csrc/jit/codegen/cuda/executor.h
@@ -61,6 +61,7 @@ class TORCH_CUDA_CU_API FusionExecutor : public NonCopyable {
   //       codegen.
   // struct used to hold necessary information to launch compiled kernel on a
   // given input set.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct ExecutorEntry {
     bool init = false;
     LaunchParams launch_params;

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.h
@@ -17,7 +17,9 @@ struct TensorArgCodegen {
   };
 
   T* data;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   int64_t size[N];
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
   int64_t stride[N];
   constexpr int nDims() {
     return N;
@@ -49,6 +51,7 @@ struct TensorArgCodegen<T, 0> {
 };
 
 struct ArgAbstract {
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~ArgAbstract() {}
   virtual void* arg() = 0;
 };
@@ -56,6 +59,7 @@ struct ArgAbstract {
 struct ULongArg : public ArgAbstract {
   uint64_t val_;
   ULongArg(uint64_t _val) : val_(_val){};
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   void* arg() {
     return &val_;
   }
@@ -64,6 +68,7 @@ struct ULongArg : public ArgAbstract {
 struct LongArg : public ArgAbstract {
   int64_t val_;
   LongArg(int64_t _val) : val_(_val){};
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   void* arg() {
     return &val_;
   }
@@ -72,6 +77,7 @@ struct LongArg : public ArgAbstract {
 struct IntArg : public ArgAbstract {
   int val_;
   IntArg(int _val) : val_(_val){};
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   void* arg() {
     return &val_;
   }
@@ -80,12 +86,14 @@ struct IntArg : public ArgAbstract {
 struct FloatArg : public ArgAbstract {
   float val_;
   FloatArg(float _val) : val_(_val){};
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   void* arg() {
     return &val_;
   }
 };
 
 struct TensorArgAbstract : ArgAbstract {
+  // NOLINTNEXTLINE(modernize-use-override,modernize-use-equals-default)
   virtual ~TensorArgAbstract(){};
   virtual void setSize(int i, int64_t size) = 0;
   virtual void setStride(int i, int64_t stride) = 0;
@@ -125,13 +133,21 @@ std::unique_ptr<TensorArgAbstract> getTensorArg(int nDims) {
       return std::make_unique<TensorArg<TensorArgCodegen<T, 3>>>();
     case (4):
       return std::make_unique<TensorArg<TensorArgCodegen<T, 4>>>();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (5):
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<TensorArgCodegen<T, 5>>>();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (6):
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<TensorArgCodegen<T, 6>>>();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (7):
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<TensorArgCodegen<T, 7>>>();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     case (8):
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
       return std::make_unique<TensorArg<TensorArgCodegen<T, 8>>>();
     default:
       TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -315,6 +315,7 @@ NvrtcFunction nvrtcCompile(
   }
 
   const char* ptxas_opt_level = getenv("PYTORCH_CUDA_FUSER_JIT_OPT_LEVEL");
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   uint32_t jit_opt_level;
 
   std::vector<CUjit_option> options;
@@ -344,6 +345,7 @@ NvrtcFunction nvrtcCompile(
         program, args.size(), args.data());
 
     if (result != NVRTC_SUCCESS) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       size_t logsize;
       at::globalContext().getNVRTC().nvrtcGetProgramLogSize(program, &logsize);
       std::vector<char> log(logsize);
@@ -406,6 +408,7 @@ NvrtcFunction nvrtcCompile(
       myPtxFile.close();
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     CUlinkState linkState;
 
     AT_CUDA_DRIVER_CHECK(at::globalContext().getNVRTC().cuLinkCreate(
@@ -421,7 +424,9 @@ NvrtcFunction nvrtcCompile(
         options.data(),
         option_vals.data()));
 
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     size_t cubinSize;
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     void* cubin;
     AT_CUDA_DRIVER_CHECK(at::globalContext().getNVRTC().cuLinkComplete(
         linkState, &cubin, &cubinSize));

--- a/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
+++ b/torch/csrc/jit/codegen/cuda/graph_fuser.cpp
@@ -567,6 +567,7 @@ struct CudaGraphFuser {
         if (original_input->type()->isSubtypeOf(TensorType::get())) {
           AT_ASSERT(chunked_inputs_it != chunked_inputs.end());
           chunked_op->addInput(
+              // NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
               chunked_inputs_it->at(chunk_sel->offset() % nchunks));
           ++chunked_inputs_it;
         } else {
@@ -848,6 +849,7 @@ struct CudaGraphFuser {
       any_changed = false;
       refreshAliasDb();
       for (auto it = block_->nodes().rbegin(); it != block_->nodes().rend();) {
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
         bool changed;
         std::tie(it, changed) = scanNode(*it);
         any_changed |= changed;

--- a/torch/csrc/jit/codegen/cuda/index_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/index_compute.cpp
@@ -303,6 +303,7 @@ void IndexCompute::handle(Merge* merge) {
     }
 
     index_map_[GpuLower::lowerValue(*(input_ids.end() - 1))
+                   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
                    ->as<kir::IterDomain>()] = out_ind;
     return;
   }
@@ -858,6 +859,7 @@ std::unordered_map<kir::ForLoop*, Val*> indexMapFromTV(
   std::unordered_map<kir::ForLoop*, Val*> loop_to_ind_map;
 
   for (auto loop : loops) {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (!within_alloc) {
       loop_to_ind_map[loop] = zero;
     } else if (loop->iter_domain()->isBlockDim() && is_shared) {
@@ -872,6 +874,7 @@ std::unordered_map<kir::ForLoop*, Val*> indexMapFromTV(
       within_alloc = true;
     }
   }
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return loop_to_ind_map;
 }
 
@@ -1230,6 +1233,7 @@ std::pair<std::vector<Val*>, bool> Index::getConsumerRootPredIndices(
     }
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   auto index_map = generateIndexAndExtentMap(
                        tv_stack,
                        std::deque<kir::ForLoop*>(loops.begin(), loops.end()),

--- a/torch/csrc/jit/codegen/cuda/instrumentation.h
+++ b/torch/csrc/jit/codegen/cuda/instrumentation.h
@@ -2,6 +2,7 @@
 
 #include <torch/csrc/jit/codegen/cuda/utils.h>
 
+// NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <stdio.h>
 #include <chrono>
 

--- a/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_base_nodes.h
@@ -132,7 +132,9 @@ class TORCH_CUDA_CU_API Statement : public NonCopyable, public PolymorphicBase {
   void print() const;
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   StmtNameType name_ = UNINITIALIZED_STMTNAMETYPE;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   Fusion* fusion_ = nullptr;
 };
 
@@ -165,6 +167,7 @@ class TORCH_CUDA_CU_API Statement : public NonCopyable, public PolymorphicBase {
  */
 class TORCH_CUDA_CU_API Val : public Statement {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~Val() = default;
 
   Val() = delete;
@@ -220,6 +223,7 @@ class TORCH_CUDA_CU_API Val : public Statement {
   Expr* getOrigin();
   const Expr* getOrigin() const;
 
+  // NOLINTNEXTLINE(cppcoreguidelines-explicit-virtual-functions,clang-diagnostic-inconsistent-missing-override,modernize-use-override)
   virtual bool sameType(const Statement* other) {
     return Statement::sameType(other) &&
         getDataType() == other->as<Val>()->getDataType();
@@ -243,7 +247,9 @@ class TORCH_CUDA_CU_API Val : public Statement {
   static Statement* mutatorDispatch(T mutator, Val*);
 
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const ValType vtype_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const DataType dtype_;
 };
 
@@ -291,6 +297,7 @@ class TORCH_CUDA_CU_API Expr : public Statement {
   Expr() = delete;
   explicit Expr(ExprType _type);
   Expr(const Expr* src, IrCloner* ir_cloner);
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~Expr() = default;
 
   Expr(const Expr& other) = delete;

--- a/torch/csrc/jit/codegen/cuda/ir_cloner.h
+++ b/torch/csrc/jit/codegen/cuda/ir_cloner.h
@@ -32,6 +32,7 @@ class TORCH_CUDA_CU_API IrCloner : private OptInConstDispatch {
   std::vector<T*> clone(const std::vector<T*>& container) {
     std::vector<T*> copy;
     for (auto p : container) {
+      // NOLINTNEXTLINE(performance-inefficient-vector-operation)
       copy.push_back(clone(p));
     }
     return copy;

--- a/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_interface_nodes.h
@@ -25,6 +25,7 @@ namespace cuda {
  */
 class TORCH_CUDA_CU_API Bool : public Val {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Bool() = default;
 
   Bool() : Val(ValType::Scalar, DataType::Bool), maybe_value_{c10::nullopt} {}
@@ -65,6 +66,7 @@ class TORCH_CUDA_CU_API Float : public Val {
  public:
   using ScalarType = double;
 
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Float() = default;
 
   Float() : Val(ValType::Scalar, DataType::Float), maybe_value_{c10::nullopt} {}
@@ -103,6 +105,7 @@ class TORCH_CUDA_CU_API Float : public Val {
  */
 class TORCH_CUDA_CU_API Half : public Val {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Half() = default;
 
   Half() : Val(ValType::Scalar, DataType::Half), maybe_value_{c10::nullopt} {}
@@ -140,6 +143,7 @@ class TORCH_CUDA_CU_API Int : public Val {
  public:
   using ScalarType = int64_t;
 
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Int() = default;
 
   Int() : Val(ValType::Scalar, DataType::Int), maybe_value_{c10::nullopt} {}
@@ -202,6 +206,7 @@ class TVDomainGuard;
 // to be non-const is the biggest headache.
 class TORCH_CUDA_CU_API TensorView : public Val {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~TensorView() = default;
 
   TensorView(const TensorView& other) = delete;

--- a/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
+++ b/torch/csrc/jit/codegen/cuda/ir_internal_nodes.h
@@ -37,6 +37,7 @@ bool areEqualScalars(Val* v1, Val* v2);
  */
 class TORCH_CUDA_CU_API UnaryOp : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~UnaryOp() = default;
   UnaryOp(UnaryOpType _type, Val* _out, Val* _in);
 
@@ -75,6 +76,7 @@ class TORCH_CUDA_CU_API UnaryOp : public Expr {
  */
 class TORCH_CUDA_CU_API BinaryOp : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~BinaryOp() = default;
   BinaryOp(BinaryOpType _type, Val* _out, Val* _lhs, Val* _rhs);
 
@@ -115,6 +117,7 @@ class TORCH_CUDA_CU_API BinaryOp : public Expr {
  */
 class TORCH_CUDA_CU_API BroadcastOp : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~BroadcastOp() = default;
   BroadcastOp(Val* _out, Val* _in);
 
@@ -149,6 +152,7 @@ class TORCH_CUDA_CU_API BroadcastOp : public Expr {
  */
 class TORCH_CUDA_CU_API ReductionOp : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~ReductionOp() = default;
   ReductionOp(BinaryOpType _reduction_op_type, Val* _init, Val* _out, Val* _in);
 
@@ -185,6 +189,7 @@ class TORCH_CUDA_CU_API ReductionOp : public Expr {
 
 class TORCH_CUDA_CU_API TernaryOp : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~TernaryOp() = default;
   TernaryOp(TernaryOpType _type, Val* _out, Val* _in1, Val* _in2, Val* _in3);
 
@@ -366,6 +371,7 @@ class TORCH_CUDA_CU_API IterDomain : public Val {
 class TORCH_CUDA_CU_API TensorDomain : public Val {
  public:
   TensorDomain() = delete;
+  // NOLINTNEXTLINE(modernize-use-override)
   ~TensorDomain() = default;
 
   TensorDomain(const TensorDomain& other) = delete;
@@ -558,6 +564,7 @@ class TORCH_CUDA_CU_API TensorDomain : public Val {
  */
 class TORCH_CUDA_CU_API Split : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Split() = default;
 
   Split(const Split& other) = delete;
@@ -600,6 +607,7 @@ class TORCH_CUDA_CU_API Split : public Expr {
  */
 class TORCH_CUDA_CU_API Merge : public Expr {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~Merge() = default;
   Merge(IterDomain* _out, IterDomain* _outer, IterDomain* _inner);
 
@@ -638,9 +646,11 @@ class TORCH_CUDA_CU_API Merge : public Expr {
  */
 class TORCH_CUDA_CU_API NamedScalar : public Val {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   ~NamedScalar() = default;
   NamedScalar() = delete;
 
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   NamedScalar(std::string _name, DataType dtype)
       : Val(ValType::NamedScalar, dtype), name_(_name) {}
 

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -41,6 +41,7 @@ class TORCH_CUDA_CU_API IrPrinter : public OptInConstDispatch {
   // eventhough fusion should remain unchanged.
   // Need to look into this.
   virtual void handle(const Fusion* f) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     handle(const_cast<Fusion*>(f));
   }
 

--- a/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
+++ b/torch/csrc/jit/codegen/cuda/ir_nodes.cpp
@@ -465,6 +465,7 @@ std::pair<IterDomain*, IterDomain*> IterDomain::split(
 // TODO(kir): review if this is still needed in the Fusion IR
 Val* IterDomain::extent() const {
   if (isThread()) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     if (extent_->getValType() == ValType::Scalar)
       if (extent_->as<Int>()->isConst())
         return extent_;

--- a/torch/csrc/jit/codegen/cuda/iter_visitor.h
+++ b/torch/csrc/jit/codegen/cuda/iter_visitor.h
@@ -32,6 +32,7 @@ namespace cuda {
  */
 class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~IterVisitor() = default;
 
   IterVisitor() = default;
@@ -94,10 +95,12 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
   // guarenteed to be all siblings throughout traversal). stmt_stack.front()
   // contains the outputs we started with (not guarenteed to be all outputs
   // throughout traversal).
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<std::vector<Statement*>> stmt_stack;
 
   // Statements to stop traversal on if they're hit (pretends they're leaf
   // nodes in next)
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::unordered_set<Statement*> termination_stmts;
 
   void traverse_(
@@ -149,6 +152,7 @@ class TORCH_CUDA_CU_API IterVisitor : public OptOutDispatch {
  */
 class TORCH_CUDA_CU_API BackwardVisitor : public OptOutDispatch {
  public:
+  // NOLINTNEXTLINE(modernize-use-override)
   virtual ~BackwardVisitor() = default;
 
   BackwardVisitor() = default;
@@ -171,16 +175,19 @@ class TORCH_CUDA_CU_API BackwardVisitor : public OptOutDispatch {
 
   // This handle functions is called on every Statement* in topological order,
   // starting from outputs to inputs.
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual void handle(Statement* stmt) override {
     OptOutDispatch::handle(stmt);
   }
   // This handle functions is called on every Expr* in topological order,
   // starting from outputs to inputs.
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual void handle(Expr* expr) override {
     OptOutDispatch::handle(expr);
   }
   // This handle functions is called on every Val* in topological order,
   // starting from outputs to inputs.
+  // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
   virtual void handle(Val* val) override {
     OptOutDispatch::handle(val);
   }

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -28,6 +28,7 @@ int getCommonDeviceCUDA(const at::ArrayRef<IValue>& inputs) {
     if (index != -1 && index != cur_index) {
       return -1;
     }
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse)
     index = cur_index;
   }
   return index;

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.h
@@ -29,6 +29,7 @@ namespace cuda {
 class TORCH_CUDA_CU_API InputsIdLookup {
  public:
   //! constructor where maximum cache size is fixed during init
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   explicit InputsIdLookup(size_t max_cache_size = 10)
       : max_cache_size_(max_cache_size){};
 
@@ -53,6 +54,7 @@ class TORCH_CUDA_CU_API InputsIdLookup {
 
  private:
   //! entry stored in `encoding_lookup_` to implement LRU
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   struct EncodingEntry {
     size_t id;
     std::list<std::string>::iterator lru_iter;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.cpp
@@ -72,6 +72,7 @@ IterDomain::IterDomain(Passkey, const fuser::cuda::IterDomain* iter_domain)
 Val* IterDomain::extent() const {
   TORCH_CHECK(isLoweredVal(extent_));
   if (isThread()) {
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     if (extent_->getValType() == ValType::KirScalar) {
       if (extent_->as<kir::Int>()->isConst()) {
         return extent_;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir.h
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir.h
@@ -31,11 +31,13 @@ class IrBuilder;
 //!
 class Passkey {
   friend class IrBuilder;
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   Passkey() {}
 };
 
 class TORCH_CUDA_CU_API NamedScalar : public Val {
  public:
+  // NOLINTNEXTLINE(modernize-pass-by-value)
   NamedScalar(Passkey, std::string name, DataType dtype)
       : Val(ValType::KirNamedScalar, dtype, true, true), name_(name) {}
 

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_builder.cpp
@@ -53,12 +53,14 @@ Val* IrBuilder::newResult(const Val* lhs, const Val* rhs) {
 Val* IrBuilder::newArithmeticExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
   auto result = newResult(lhs, rhs);
   create<BinaryOp>(op_type, result, lhs, rhs);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return result;
 }
 
 Val* IrBuilder::newLogicExpr(BinaryOpType op_type, Val* lhs, Val* rhs) {
   auto result = create<Bool>(c10::nullopt);
   create<BinaryOp>(op_type, result, lhs, rhs);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   return result;
 }
 

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -55,10 +55,12 @@ void GpuLower::replaceSymbolicSizes() {
       const Val* orig_size = id->extent();
 
       // Output sizes could have reduction axes, which isn't what gets output.
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (id->isReduction()) {
         continue;
       } else if (id->getIterType() == IterType::BroadcastWithoutStride) {
         continue;
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       } else if (id->getIterType() == IterType::BroadcastWithStride) {
         dim++;
         continue;
@@ -206,6 +208,7 @@ class TORCH_CUDA_CU_API GpuLower::KernelIrMapper : private OptInConstDispatch {
       default:
         TORCH_CHECK(false, "Unexpected expression type");
     }
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   }
 
   void handle(const Statement* node) override {

--- a/torch/csrc/jit/codegen/cuda/lower2device.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower2device.cpp
@@ -60,7 +60,7 @@ void GpuLower::replaceSymbolicSizes() {
         continue;
       } else if (id->getIterType() == IterType::BroadcastWithoutStride) {
         continue;
-      // NOLINTNEXTLINE(bugprone-branch-clone)
+        // NOLINTNEXTLINE(bugprone-branch-clone)
       } else if (id->getIterType() == IterType::BroadcastWithStride) {
         dim++;
         continue;
@@ -208,7 +208,7 @@ class TORCH_CUDA_CU_API GpuLower::KernelIrMapper : private OptInConstDispatch {
       default:
         TORCH_CHECK(false, "Unexpected expression type");
     }
-  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   }
 
   void handle(const Statement* node) override {

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -168,6 +168,7 @@ void LoopNestGenerator::initReduction(
   // Work through the iter domains that we need to initialize on, outside to
   // inside, to construct the loop nest for the initialization.
   for (auto id : ids) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     kir::ForLoop* new_fl;
 
     if (id->isThread()) {
@@ -478,6 +479,7 @@ void groupExpressions(
     TargetGroupMapT& computed_at_exprs,
     ExprScoreMapT& scores) {
   TensorView* target_tensor = nullptr;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   ScoreT score;
   findTargetTensor(expr, target_tensor, score);
   scores.emplace(expr, score);

--- a/torch/csrc/jit/codegen/cuda/parser.cpp
+++ b/torch/csrc/jit/codegen/cuda/parser.cpp
@@ -94,9 +94,11 @@ class IrParser {
     for (const JitOp* node : block->nodes()) {
       processJitNode(node);
       if (node->kind() == aten::rand_like) {
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
         disable_unroll = true;
       }
       if (node->kind() == aten::sum) {
+        // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
         has_reduction = true;
       }
     }
@@ -540,6 +542,7 @@ class IrParser {
 
   bool registerScalar(const JitValue* val) {
     if (val->type()->isSubtypeOf(static_cast<c10::TypePtr>(FloatType::get()))) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
       if (auto ival = constant_as<float>(val)) {
         cg_val = new Float(ival.value());
@@ -550,6 +553,7 @@ class IrParser {
       return true;
     } else if (val->type()->isSubtypeOf(
                    static_cast<c10::TypePtr>(IntType::get()))) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
       if (auto ival = constant_as<int>(val)) {
         cg_val = new Int(ival.value());
@@ -560,6 +564,7 @@ class IrParser {
       return true;
     } else if (val->type()->isSubtypeOf(
                    static_cast<c10::TypePtr>(BoolType::get()))) {
+      // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       CgValue cg_val;
       if (auto ival = constant_as<bool>(val)) {
         cg_val = new Bool(ival.value());
@@ -582,6 +587,7 @@ class IrParser {
   }
 
   bool registerTensor(const JitValue* val) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     CgValue cg_val;
     if (auto tensor_type = val->type()->cast<TensorType>()) {
       // TODO: make this a static function in Tensor class;

--- a/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
+++ b/torch/csrc/jit/codegen/cuda/predicate_compute.cpp
@@ -112,6 +112,7 @@ kir::Bool* PredicateCompute::getInlinePredicate(
       continue;
     }
     auto inp_tv = inp->as<TensorView>();
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (inp_tv->domain()->hasRFactor()) {
       continue;
     } else if (
@@ -205,6 +206,7 @@ kir::Bool* UnrollPredicate::get(
     }
   }
   TORCH_INTERNAL_ASSERT(
+      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
       unroll_pred->getValType().value() == ValType::KirScalar &&
       unroll_pred->getDataType().value() == DataType::Bool);
   return unroll_pred->as<kir::Bool>();
@@ -226,6 +228,7 @@ void UnrollPredicate::predicateOn(Expr* tv_expr) {
       continue;
     }
     auto inp_tv = inp->as<TensorView>();
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (inp_tv->domain()->hasRFactor()) {
       continue;
     } else if (

--- a/torch/csrc/jit/codegen/cuda/scheduler.cpp
+++ b/torch/csrc/jit/codegen/cuda/scheduler.cpp
@@ -220,6 +220,7 @@ ReductionParams reductionHeuristic(
   // Decision to do a cross-warp reduction per block
   if (red_elems_per_thread >= (bdimy * kMinValuesPerThread) ||
       red_elems_per_thread >= kMaxValuesPerThread || !rparams.fastest_dim) {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     inputs_consumed_per_block_iter *= bdimy;
     red_elems_per_thread = ceilDiv(red_elems_per_thread, bdimy);
     rparams.cross_block = true;

--- a/torch/csrc/jit/codegen/cuda/transform_iter.h
+++ b/torch/csrc/jit/codegen/cuda/transform_iter.h
@@ -41,12 +41,19 @@ struct id_int_lt {
 // operations it can't.
 class TORCH_CUDA_CU_API ReplayTransformations : public IterVisitor {
  protected:
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   const std::vector<IterDomain*>& target_domain_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::unordered_map<IterDomain*, IterDomain*> id_map_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::unordered_map<IterDomain*, size_t> leaf_ids_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   std::vector<IterDomain*> leaf_vec_;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   size_t counter = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   bool error_on_failure_ = true;
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
   bool ran_replay = false; // Mark if replay has been run
   using IterVisitor::handle;
 

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -46,18 +46,25 @@ void codegenOutputQuery(
   // based on the NVRTC version
   major = prop->major;
   minor = prop->minor;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (nvrtc_major <= 7 && prop->major > 5) { // 7 supports 2-5.x
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 5;
     minor = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 6;
     minor = 0;
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 7;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     minor = (prop->major == 7 && prop->minor <= 2) ? prop->minor : 0;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 10 && prop->major >= 7) { // 10 supports 3-7.5
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 7;
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     minor = (prop->major == 7 && prop->minor <= 5) ? prop->minor : 0;
@@ -76,6 +83,7 @@ void codegenOutputQuery(
 }
 
 // Compiles the specified kernel and stores the metadata required to run it
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 FusedKernelCUDA::FusedKernelCUDA(
     at::DeviceIndex device,
     std::string name,
@@ -95,11 +103,13 @@ FusedKernelCUDA::FusedKernelCUDA(
           has_random),
       device_(device) {
   // Initializes driver's API context (if necessary)
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   CUcontext pctx = 0;
   AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
   if (!pctx) {
     std::unique_lock<std::mutex> cudaFreeMutexLock(
         *(c10::cuda::CUDACachingAllocator::getFreeMutex()));
+    // NOLINTNEXTLINE(modernize-use-nullptr)
     cudaFree(0);
   }
 
@@ -111,11 +121,13 @@ FusedKernelCUDA::FusedKernelCUDA(
   // Acquires device and NVRTC properties (for compile arch and occupancy
   // calculations)
   prop_ = at::cuda::getCurrentDeviceProperties();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int major, minor;
   bool compile_to_sass = false;
   codegenOutputQuery(prop_, major, minor, compile_to_sass);
 
   // Creates the NVRTC program
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   nvrtcProgram program;
   AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcCreateProgram(
       &program, code_.c_str(), nullptr, 0, nullptr, nullptr));
@@ -146,6 +158,7 @@ FusedKernelCUDA::FusedKernelCUDA(
   const auto result =
       nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
   if (result != NVRTC_SUCCESS) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     size_t logsize;
     AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLogSize(program, &logsize));
     std::vector<char> log(logsize);
@@ -157,6 +170,7 @@ FusedKernelCUDA::FusedKernelCUDA(
   ResourceGuard holdProgram(
       [&] { AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcDestroyProgram(&program)); });
   AT_CUDA_NVRTC_CHECK(result);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   size_t ptx_size;
 #if CUDA_VERSION >= 11010
   // compile_to_sass determines whether we are generating SASS or PTX, hence
@@ -203,6 +217,7 @@ static int ceilDiv(const int a, const int b) {
 void FusedKernelCUDA::launch_raw(
     const uint32_t numel,
     std::vector<void*>& arguments) const {
+  // NOLINTNEXTLINE(bugprone-unused-raii)
   at::cuda::CUDAGuard{device_};
   // Hacked at::DeviceGuard (see note above)
   const auto prior_device = at::cuda::current_device();

--- a/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
+++ b/torch/csrc/jit/codegen/fuser/cuda/fused_kernel.cpp
@@ -51,12 +51,12 @@ void codegenOutputQuery(
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 5;
     minor = 0;
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 8 && prop->major > 6) { // 8 supports 2-6.x
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 6;
     minor = 0;
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_major <= 9 && prop->major >= 7) { // 9 supports 3-7.2
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     major = 7;

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -147,6 +147,7 @@ c10::optional<at::Tensor> runTorchSlice_opset10(
     auto axes_a = inputTensorValues[3].accessor<int64_t, 1>();
     axes.reserve(inputTensorValues[3].sizes()[0]);
     // ONNX slice accepts negative axis, fix this for aten op
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     for (size_t i = 0; i < inputTensorValues[3].sizes()[0]; ++i) {
       axes[i] = axes_a[i] < 0 ? axes_a[i] + inputTensorValues[0].sizes().size()
                               : axes_a[i];
@@ -171,6 +172,7 @@ c10::optional<at::Tensor> runTorchSlice_opset10(
       return c10::nullopt;
     }
     auto steps_a = inputTensorValues[4].accessor<int64_t, 1>();
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     for (size_t i = 0; i < inputTensorValues[4].sizes()[0]; ++i) {
       // Only steps == 1 are supported for constant-folding.
       if (steps_a[i] != 1) {
@@ -184,6 +186,7 @@ c10::optional<at::Tensor> runTorchSlice_opset10(
   auto starts_a = inputTensorValues[1].accessor<int64_t, 1>();
   auto ends_a = inputTensorValues[2].accessor<int64_t, 1>();
   auto updated_val = inputTensorValues[0];
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (size_t i = 0; i < inputTensorValues[1].sizes()[0]; ++i) {
     // ONNX slice accepts negative starts and ends values.
     int64_t start = starts_a[i], end = ends_a[i], axis = axes[i];

--- a/torch/csrc/jit/passes/onnx/eval_peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/eval_peephole.cpp
@@ -88,6 +88,7 @@ static void fuseConvBatchNorm(Block* b, ValueToParamPairMap& valsToParamsMap) {
       bn_scale = bn_scale.div(bn_var);
 
       // Calculate weight
+      // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       for (size_t i = 0; i < w_conv.size(0); i++) {
         w_conv[i] = w_conv[i].mul(bn_scale[i]);
       }

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -118,8 +118,7 @@ std::vector<Value*> ConvertSequenceDependencies(Node* node, int opset_version) {
   }
 
   auto* loop_node = node;
-  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   auto* graph = loop_node->owningGraph();
 
   TORCH_INTERNAL_ASSERT(loop_node->blocks().size() == 1);
@@ -379,8 +378,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   }
   GRAPH_DUMP("Graph before fixing controlflow: ", node->owningGraph());
   auto* if_node = node;
-  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
+  // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores,clang-diagnostic-unused-variable)
   auto* graph = if_node->owningGraph();
   FixupONNXSubblockOutputs(node);
   ONNXFixupUninitializedOutput(if_node);

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -119,6 +119,7 @@ std::vector<Value*> ConvertSequenceDependencies(Node* node, int opset_version) {
 
   auto* loop_node = node;
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   auto* graph = loop_node->owningGraph();
 
   TORCH_INTERNAL_ASSERT(loop_node->blocks().size() == 1);
@@ -379,6 +380,7 @@ std::vector<Value*> FixupONNXIfNode(Node* node, int opset_version) {
   GRAPH_DUMP("Graph before fixing controlflow: ", node->owningGraph());
   auto* if_node = node;
   // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+  // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   auto* graph = if_node->owningGraph();
   FixupONNXSubblockOutputs(node);
   ONNXFixupUninitializedOutput(if_node);

--- a/torch/csrc/jit/runtime/register_cuda_ops.cpp
+++ b/torch/csrc/jit/runtime/register_cuda_ops.cpp
@@ -118,6 +118,7 @@ RegisterOperators const reg({
           auto s = v.toCustomClass<torch::jit::CUDAStream>();
           auto stream_device_idx = static_cast<int64_t>(s->device_index());
           auto cur_device_idx =
+              // NOLINTNEXTLINE(bugprone-signed-char-misuse)
               static_cast<int64_t>(c10::cuda::current_device());
           // If the stream is not on the current device, change the
           // device to the device of the stream.

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -84,16 +84,26 @@ static void codegenOutputQuery(
 
   CudaVersion dev_version = CudaVersion(prop->major, prop->minor);
   CudaVersion max_dev_version(dev_version);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   if (nvrtc_version.first <= 7) { // 7 supports 2-5.x
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(5, 0);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(6, 0);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 9) { // 9 supports 3-7.2
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(7, 2);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(7, 5);
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first == 11 && nvrtc_version.second == 0) {
     // 11.0 supports 3-8.0
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(8, 0);
   }
   if (dev_version > max_dev_version) {
@@ -163,6 +173,7 @@ void CudaAnalysis::visit(const For* v) {
       throw std::runtime_error("support only 3D gpu_block_index");
     }
     const Expr* prev = nullptr;
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     if (gpu_block_extents_.size() <= gpu_block_index) {
       gpu_block_extents_.resize(gpu_block_index + 1);
     } else {
@@ -174,6 +185,7 @@ void CudaAnalysis::visit(const For* v) {
           std::to_string(v->start()));
     }
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (prev == nullptr) {
       gpu_block_extents_[gpu_block_index] = v->stop();
     } else if (prev->isConstant() && immediateEquals(prev, 1)) {
@@ -190,6 +202,7 @@ void CudaAnalysis::visit(const For* v) {
       throw std::runtime_error("support only 3D gpu_thread_index");
     }
     const Expr* prev = nullptr;
+    // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
     if (gpu_thread_extents_.size() <= gpu_thread_index) {
       gpu_thread_extents_.resize(gpu_thread_index + 1);
     } else {
@@ -201,6 +214,7 @@ void CudaAnalysis::visit(const For* v) {
           std::to_string(v->start()));
     }
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (prev == nullptr) {
       gpu_thread_extents_[gpu_thread_index] = v->stop();
     } else if (prev->isConstant() && immediateEquals(prev, 1)) {
@@ -358,6 +372,7 @@ class AtomicAddFuser : public IRMutator {
       const std::unordered_set<const Var*>& thread_local_bufs,
       const GPUMetaVarRewriter& metavars)
       : thread_local_bufs_(thread_local_bufs) {
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
     size_t DIMS = 3;
 
     const std::vector<const Expr*>& block_extents =
@@ -546,6 +561,7 @@ class PrioritizeLoad : public IRMutator {
           v->indices().size() == nested_store_->indices().size()) {
         // also check indices
         bool same = true;
+        // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
         for (int i = 0; i < v->indices().size(); ++i) {
           if (!exprEquals(v->indices()[i], nested_store_->indices()[i])) {
             same = false;
@@ -605,6 +621,7 @@ class PrioritizeLoad : public IRMutator {
   }
 
   Stmt* mutate(const Block* v) override {
+    // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
     bool any_change = false;
 
     Block* v1 = const_cast<Block*>(v); // NOLINT
@@ -980,7 +997,9 @@ void CudaCodeGen::Initialize() {
     os() << cudaDtypeCppString(dtype) << (buffer_arg.isVar() ? " " : "* ")
          << name_manager()->get_unique_name(var);
   }
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Var* rand_seed;
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   const Var* rand_offset;
   if (has_random_) {
     // TODO: switch to kUint64 when it is available.
@@ -1131,6 +1150,7 @@ void CudaCodeGen::call(const std::vector<CallArg>& args) {
   if (has_random_) {
     auto gen = at::cuda::detail::getDefaultCUDAGenerator();
     // TODO: total hack. Switch to numel when it is available.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     int64_t total_elements_per_thread = (1LL << 28);
     {
       std::lock_guard<std::mutex> lock(gen.mutex());
@@ -1183,6 +1203,7 @@ at::Tensor CudaCodeGen::empty_strided(
 void CudaCodeGen::CompileToNVRTC(
     const std::string& code,
     const std::string& func_name) {
+  // NOLINTNEXTLINE(modernize-use-nullptr)
   CUcontext pctx = 0;
   AT_CUDA_DRIVER_CHECK(nvrtc().cuCtxGetCurrent(&pctx));
   // Note: hacked at::DeviceGuard since at::DeviceGuard was failing to work
@@ -1202,11 +1223,13 @@ void CudaCodeGen::CompileToNVRTC(
   // Acquires device and NVRTC properties (for compile arch and occupancy
   // calculations)
   cudaDeviceProp* prop = at::cuda::getCurrentDeviceProperties();
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   int major, minor;
   bool compile_to_sass = false;
   codegenOutputQuery(prop, major, minor, compile_to_sass);
 
   // Creates the NVRTC program
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   nvrtcProgram program;
   AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcCreateProgram(
       &program, code.c_str(), nullptr, 0, nullptr, nullptr));
@@ -1238,6 +1261,7 @@ void CudaCodeGen::CompileToNVRTC(
   const auto result =
       nvrtc().nvrtcCompileProgram(program, args.size(), args.data());
   if (result != NVRTC_SUCCESS) {
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     size_t logsize;
     AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcGetProgramLogSize(program, &logsize));
     std::vector<char> log(logsize);
@@ -1251,6 +1275,7 @@ void CudaCodeGen::CompileToNVRTC(
   ResourceGuard holdProgram(
       [&] { AT_CUDA_NVRTC_CHECK(nvrtc().nvrtcDestroyProgram(&program)); });
   AT_CUDA_NVRTC_CHECK(result);
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   size_t ptx_size;
   std::vector<char> ptx;
 #if CUDA_VERSION >= 11010
@@ -1270,6 +1295,7 @@ void CudaCodeGen::CompileToNVRTC(
   ptx.resize(ptx_size);
   AT_CUDA_NVRTC_CHECK(getFunc(program, ptx.data()));
 
+  // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   CUmodule module;
   AT_CUDA_DRIVER_CHECK(nvrtc().cuModuleLoadData(&module, ptx.data()));
   AT_CUDA_DRIVER_CHECK(

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.cpp
@@ -88,19 +88,19 @@ static void codegenOutputQuery(
   if (nvrtc_version.first <= 7) { // 7 supports 2-5.x
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(5, 0);
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 8) { // 8 supports 2-6.x
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(6, 0);
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 9) { // 9 supports 3-7.2
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(7, 2);
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first <= 10) { // 10 supports 3-7.5
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     max_dev_version = CudaVersion(7, 5);
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
   } else if (nvrtc_version.first == 11 && nvrtc_version.second == 0) {
     // 11.0 supports 3-8.0
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)

--- a/torch/csrc/jit/tensorexpr/cuda_codegen.h
+++ b/torch/csrc/jit/tensorexpr/cuda_codegen.h
@@ -190,6 +190,7 @@ class CudaPrinter : public IRPrinter {
 class TORCH_CUDA_CU_API CudaCodeGen : public CodeGen {
  public:
   template <typename... Ts>
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CudaCodeGen(Stmt* stmt, Ts... ts)
       : CodeGen(
             stmt,
@@ -198,6 +199,7 @@ class TORCH_CUDA_CU_API CudaCodeGen : public CodeGen {
     Initialize();
   }
 
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
   CudaCodeGen(
       Stmt* stmt,
       const std::vector<BufferArg>& buffer_args,

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -149,6 +149,7 @@ class BinaryOpNode : public ExprNode<Op> {
       IRNodeType expr_type,
       ScalarType ret_type = ScalarType::Undefined)
       : ExprNode<Op>(
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
             BinaryOpDtype(lhs_v->dtype(), rhs_v->dtype(), ret_type),
             expr_type),
         lhs_(CastIfNeeded(lhs_v, ExprNode<Op>::dtype())),

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1127,6 +1127,7 @@ const Expr* combineMinMaxTerms(
       scalar = opterm->scalar();
       variables = opterm->variables();
     }
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     if (expr->isConstant()) {
       scalar = combine_scalars(scalar, expr);
     } else {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3006,6 +3006,7 @@ void TensorExprKernel::compile() {
     if (properly_strided_output->stmt()) {
       block->append_stmt(properly_strided_output->stmt());
     }
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     bufs_[output] = properly_strided_output->buf();
     const auto& tt = output->type()->expect<TensorType>();
     auto sizes = *tt->sizes().concrete_sizes();

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -382,6 +382,7 @@ bool is_scalar_list(PyObject* obj) {
   }
   // NOLINTNEXTLINE(bugprone-branch-clone)
   auto size = tuple ? PyTuple_GET_SIZE(obj) : PyList_GET_SIZE(obj);
+  // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (size_t idx = 0; idx < size; idx++) {
     PyObject* iobj = tuple ? PyTuple_GET_ITEM(obj, idx) : PyList_GET_ITEM(obj, idx);
     if (!THPUtils_checkScalar(iobj)) {

--- a/torch/csrc/utils/python_strings.h
+++ b/torch/csrc/utils/python_strings.h
@@ -76,6 +76,7 @@ inline void THPUtils_internStringInPlace(PyObject** obj) {
  *
  */
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static py::object PyObject_FastGetAttrString(PyObject *obj, char *name)
 {
     PyTypeObject *tp = Py_TYPE(obj);


### PR DESCRIPTION
In my last PR I've missed CUDA and distributed folders, fixing this now
This change is autogenerated by `python tool/clang_tidy.py -s`