### PR TITLE
linalg.eig backwards and linalg.eigvals

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -10,7 +10,6 @@
 #include <ATen/native/cpu/zmath.h>
 #include <ATen/Parallel.h>
 
-#include <torch/csrc/autograd/functions/utils.h>
 #include <c10/util/irange.h>
 
 #include <TH/TH.h>  // for USE_LAPACK
@@ -2737,7 +2736,7 @@ Tensor& linalg_eigvals_out(const Tensor& input, Tensor& values) {
 Tensor linalg_eigvals(const Tensor& input) {
   // if input requires grad we must compute the eigenvectors to make this function differentiable
   // the eigenvectors are not exposed to the user
-  if (torch::autograd::compute_requires_grad(input)) {
+  if (at::GradMode::is_enabled() && input.requires_grad()) {
     return std::get<0>(at::linalg_eig(input));
   }
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9535,14 +9535,9 @@
 
 - func: linalg_eigvals(Tensor self) -> Tensor
   python_module: linalg
-  variants: function
-  dispatch:
-    CPU, CUDA: linalg_eigvals
 
 - func: linalg_eigvals.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   python_module: linalg
-  dispatch:
-    CPU, CUDA: linalg_eigvals_out
 
 - func: linalg_eigh(Tensor self, str UPLO="L") -> (Tensor eigenvalues, Tensor eigenvectors)
   python_module: linalg

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -1154,8 +1154,8 @@
 - name: linalg_eigh(Tensor self, str UPLO="L") -> (Tensor eigenvalues, Tensor eigenvectors)
   self: symeig_backward(grads, self, /*eigenvectors=*/true, /*upper=*/true, eigenvalues, eigenvectors)
 
-- name: linalg_eigvals(Tensor self) -> Tensor
-  self: non_differentiable
+- name: linalg_eig(Tensor self) -> (Tensor eigenvalues, Tensor eigenvectors)
+  self: linalg_eig_backward(grads, self, eigenvalues, eigenvectors)
 
 - name: t(Tensor(a) self) -> Tensor(a)
   self: grad.t()

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -94,7 +94,7 @@ GRADIENT_IMPLEMENTED_FOR_COMPLEX = {
     'matrix_exp', 'linalg_eigh', 'cholesky_solve', 'linalg_qr', '_svd_helper', '_fft_c2c', '_fft_r2c',
     'linalg_solve', 'sqrt', 'stack', 'gather', 'index_select', 'index_add_', 'linalg_inv',
     'l1_loss_backward', 'baddbmm', 'addbmm', 'addmm', 'addmv', 'addr', 'linalg_householder_product',
-    'constant_pad_nd', 'reflection_pad1d', 'reflection_pad2d', 'linalg_cholesky_ex',
+    'constant_pad_nd', 'reflection_pad1d', 'reflection_pad2d', 'linalg_cholesky_ex', 'linalg_eig',
     'reflection_pad1d_backward', 'reflection_pad2d_backward', 'symeig',
     'replication_pad1d', 'replication_pad2d', 'replication_pad3d', 'take', 'put_',
     'replication_pad1d_backward', 'replication_pad2d_backward', 'replication_pad3d_backward',

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -3,6 +3,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/BatchedTensorImpl.h>
+#include <ATen/core/grad_mode.h>
 #include <ATen/core/Reduction.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2326,11 +2326,13 @@ Tensor eig_backward(const std::vector<torch::autograd::Variable> &grads, const T
   return at::linalg_solve(Uh, at::matmul(U_contrib, Uh) + D_contrib * Uh);
 }
 
-Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
-                     const Tensor& lambda, const Tensor& v) {
-	// https://arxiv.org/pdf/1701.00392.pdf Eq 4.77
-	// For A = VLV^{-1}, denoting the gradients gV and gL, we have
- 	// gA = V^{-H}(diag_embed(gL) + (V^H gV -V^HV diag(real(V^H gV))) / E*)V
+Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads,
+                           const Tensor& self,
+                           const Tensor& lambda,
+                           const Tensor& v) {
+  // https://arxiv.org/pdf/1701.00392.pdf Eq 4.77
+  // For A = VLV^{-1}, denoting the gradients gV and gL, we have
+  // gA = V^{-H}(diag_embed(gL) + (V^H gV -V^HV diag(real(V^H gV))) / E*)V
   // Where:
   //   - E_ij = L_i - L_j if i != j
   //   - diag_embed takes a vector into a diagonal matrix
@@ -2367,14 +2369,14 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, 
     }
 
     // Conjugate by V^{-H}
-		result = at::linalg_solve(vh, at::matmul(result, vh));
+    result = at::linalg_solve(vh, at::matmul(result, vh));
     // If it is real, we have to project the derivative onto the real numbers
     return self.is_complex() ? result : at::real(result);
   }
   else {
     if (glambda.defined()) {
-		  // Compute V^-H dL V^H
-			const auto result = at::linalg_solve(vh, glambda.unsqueeze(-1) * vh);
+      // Compute V^-H dL V^H
+      const auto result = at::linalg_solve(vh, glambda.unsqueeze(-1) * vh);
       // If it is real, we have to project the derivative onto the real numbers
       return self.is_complex() ? result : at::real(result);
     } else {

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2332,7 +2332,7 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads,
                            const Tensor& V) {
   // https://arxiv.org/pdf/1701.00392.pdf Eq 4.77
   // For A = VLV^{-1}, denoting the gradients gA, gV and gL, we have
-  // gA = V^{-H}(diag_embed(gL) + (V^H gV -V^HV diag(real(V^H gV))) / E*)V
+  // gA = V^{-H}(diag_embed(gL) + (V^H gV -V^HV diag(real(V^H gV))) / E*)V^H
   // Where:
   //   - E_ij = L_i - L_j if i != j
   //   - diag_embed takes a vector into a diagonal matrix

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2342,7 +2342,7 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads,
 
   const auto gL = grads[0];
   const auto gV = grads[1];
-  const auto Vh = V.conj().transpose(-2, -1);
+  const auto Vh = V.transpose(-2, -1).conj();
 
   if (gV.defined()) {
     const auto L_conj = L.conj();

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2343,7 +2343,8 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, 
 
 
   if (gv.defined()) {
-    auto Econj = (lambda.unsqueeze(-2) - lambda.unsqueeze(-1)).conj();
+    const auto lambda_conj = lambda.conj();
+    auto Econj = lambda_conj.unsqueeze(-2) - lambda_conj.unsqueeze(-1);
     if (at::GradMode::is_enabled()) {
       // Avoids differentiating through at infinity when doing gradgrad
       // 1 could be any number, as we are going to overwrite the diagonal
@@ -2374,6 +2375,7 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, 
     if (glambda.defined()) {
 		  // Compute V^-H dL V^H
 			const auto result = at::linalg_solve(vh, glambda.unsqueeze(-1) * vh);
+      // If it is real, we have to project the derivative onto the real numbers
       return self.is_complex() ? result : at::real(result);
     } else {
       // If neither is defined, there's nothing to do

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2340,13 +2340,16 @@ Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads,
   //   - diag zeroes out elements outside of the diagonal
   //   - The division by E is done just outside of the diagonal. In the diagonal it is set to zero
 
+  // Note: the term '-V^HV diag(real(V^H gV))' comes from the fact that the eigenvalue
+  // decomposition is returned with eigenvectors normalized to have norm one.
+
   const auto gL = grads[0];
   const auto gV = grads[1];
   const auto Vh = V.transpose(-2, -1).conj();
 
   if (gV.defined()) {
-    const auto L_conj = L.conj();
-    auto Econj = L_conj.unsqueeze(-2) - L_conj.unsqueeze(-1);
+    const auto Lconj = L.conj();
+    auto Econj = Lconj.unsqueeze(-2) - Lconj.unsqueeze(-1);
     if (at::GradMode::is_enabled()) {
       // Avoids differentiating through at infinity when doing gradgrad
       // 1 could be any number, as we are going to overwrite the diagonal

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -150,6 +150,8 @@ Tensor slice_backward_wrapper(
     int64_t step);
 Tensor symeig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
                     bool eigenvectors, bool upper, const Tensor& lambda, const Tensor& v);
+Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
+                     const Tensor& lambda, const Tensor& v);
 std::tuple<Tensor, Tensor> triangular_solve_backward(
     const Tensor & grad_x, const Tensor & grad_m,
     const Tensor & b, const Tensor & a, const Tensor & x,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -151,7 +151,7 @@ Tensor slice_backward_wrapper(
 Tensor symeig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
                     bool eigenvectors, bool upper, const Tensor& lambda, const Tensor& v);
 Tensor linalg_eig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
-                     const Tensor& lambda, const Tensor& v);
+                           const Tensor& L, const Tensor& V);
 std::tuple<Tensor, Tensor> triangular_solve_backward(
     const Tensor & grad_x, const Tensor & grad_m,
     const Tensor & b, const Tensor & a, const Tensor & x,

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -377,7 +377,8 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 .. seealso::
 
         :func:`torch.linalg.eigvals` computes only the eigenvalues.
-        Unlike :func:`torch.linalg.eig`, the gradients of this function are always numerically stable.
+        Unlike :func:`torch.linalg.eig`, the gradients of :func:`~eigvals` are always
+        numerically stable.
 
         :func:`torch.linalg.eigh` for a (faster) function that computes the eigenvalue decomposition
         for Hermitian and symmetric matrices.
@@ -526,8 +527,9 @@ The eigenvalues are returned in ascending order.
 
 .. seealso::
 
-        :func:`torch.linalg.eigvalsh` computes only the eigenvalues,
-        but its gradients are always numerically stable.
+        :func:`torch.linalg.eigvalsh` computes only the eigenvalues values of a Hermitian matrix.
+        Unlike :func:`torch.linalg.eigh`, the gradients of :func:`~eigvalsh` are always
+        numerically stable.
 
         :func:`torch.linalg.cholesky` for a different decomposition of a Hermitian matrix.
         The Cholesky decomposition gives less information about the matrix but is much faster
@@ -1380,8 +1382,9 @@ Differences with `numpy.linalg.svd`:
 
 .. seealso::
 
-        :func:`torch.linalg.svdvals` computes only the singular values,
-        but its gradients are always numerically stable.
+        :func:`torch.linalg.svdvals` computes only the singular values.
+        Unlike :func:`torch.linalg.svd`, the gradients of :func:`~svdvals` are always
+        numerically stable.
 
         :func:`torch.linalg.eig` for a function that computes another type of spectral
         decomposition of a matrix. The eigendecomposition works just on on square matrices.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -373,7 +373,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 .. seealso::
 
         :func:`torch.linalg.eigvals` computes only the eigenvalues.
-        However, that function is not differentiable.
+        Unlike :func:`torch.linalg.eig`, the gradients of this function are always stable.
 
         :func:`torch.linalg.eigh` for a (faster) function that computes the eigenvalue decomposition
         for Hermitian and symmetric matrices.
@@ -445,8 +445,9 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 .. note:: {sync_note}
 
-.. note:: This function is not differentiable. If you need differentiability use
-          :func:`torch.linalg.eig` instead, which also computes the eigenvectors.
+.. seealso::
+
+        :func:`torch.linalg.eig` computes the full eigenvalue decomposition.
 
 Args:
     A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -354,6 +354,10 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 .. note:: {sync_note}
 
+.. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (e.g. when all the
+             eigenvalues are different). If it is not diagonalizable, the returned
+             eigenvalues will be correct but :math:`A \neq V \operatorname{diag}(\Lambda)V^{-1}`.
+
 .. warning:: The eigenvectors of a matrix are not unique, nor are they continuous with respect to
              :attr:`A`. Due to this lack of uniqueness, different hardware and software may compute
              different eigenvectors.
@@ -364,11 +368,11 @@ Also supports batched inputs, and, if the input is batched, the output is batche
              `1` and largest real component.
 """.format(**common_notes) + r"""
 
-.. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (e.g. when all the
-             eigenvalues are different). If it is not diagonalizable, the returned
-             eigenvalues will be correct but :math:`A \neq V \operatorname{diag}(\Lambda)V^{-1}`.
-
-.. warning:: This function does not yet support autograd.
+.. warning:: Gradients computed using `V` will only be finite when :attr:`A` does not have repeated eigenvalues.
+             Furthermore, if the distance between any two eigenvalues is close to zero,
+             the gradient will be numerically unstable, as it depends on the eigenvalues
+             :math:`\lambda_i` through the computation of
+             :math:`\frac{1}{\min_{i \neq j} \lambda_i - \lambda_j}`.
 
 .. seealso::
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -354,7 +354,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 .. note:: {sync_note}
 
-.. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (e.g. when all the
+.. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (for example, when all the
              eigenvalues are different). If it is not diagonalizable, the returned
              eigenvalues will be correct but :math:`A \neq V \operatorname{diag}(\Lambda)V^{-1}`.
 

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -377,7 +377,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 .. seealso::
 
         :func:`torch.linalg.eigvals` computes only the eigenvalues.
-        Unlike :func:`torch.linalg.eig`, the gradients of this function are always stable.
+        Unlike :func:`torch.linalg.eig`, the gradients of this function are always numerically stable.
 
         :func:`torch.linalg.eigh` for a (faster) function that computes the eigenvalue decomposition
         for Hermitian and symmetric matrices.

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -32,9 +32,10 @@ where :math:`L` is a lower triangular matrix and
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
-""" + r"""
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. seealso::
 
@@ -93,7 +94,7 @@ Examples::
             [-1.8509,  1.1014]]], dtype=torch.float64)
     >>> torch.allclose(l @ l.transpose(-2, -1), a)
     True
-""".format(**common_notes))
+""")
 
 cholesky_ex = _add_docstr(_linalg.linalg_cholesky_ex, r"""
 linalg.cholesky_ex(input, *, check_errors=False, out=None) -> (Tensor, Tensor)
@@ -160,7 +161,6 @@ its **inverse matrix** :math:`A^{-1} \in \mathbb{K}^{n \times n}` (if it exists)
     A^{-1}A = AA^{-1} = \mathrm{I}_n
 
 where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
-""" + r"""
 
 The inverse matrix exists if and only if :math:`A` is `invertible`_. In this case,
 the inverse is unique.
@@ -168,7 +168,9 @@ the inverse is unique.
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. note::
     Consider using :func:`torch.linalg.solve` if possible for multiplying a matrix on the left by
@@ -225,7 +227,7 @@ Examples::
 
 .. _invertible:
     https://en.wikipedia.org/wiki/Invertible_matrix#The_invertible_matrix_theorem
-""".format(**common_notes))
+""")
 
 det = _add_docstr(_linalg.linalg_det, r"""
 linalg.det(A, *, out=None) -> Tensor
@@ -235,8 +237,10 @@ Computes the determinant of a square matrix.
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
+""" + fr"""
 .. note:: This function is computed using :func:`torch.lu`.
-          {sync_note}
+          {common_notes["sync_note"]}
+""" + r"""
 
 .. seealso::
 
@@ -278,7 +282,7 @@ Examples::
              [-0.7089,  0.9032]]])
     >>> torch.linalg.det(a)
     tensor([1.1990, 0.4099, 0.7386])
-""".format(**common_notes))
+""")
 
 slogdet = _add_docstr(_linalg.linalg_slogdet, r"""
 linalg.slogdet(A, *, out=None) -> (Tensor, Tensor)
@@ -291,8 +295,10 @@ determinant, that is, a logarithmic polar decomposition of the determinant.
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
+""" + fr"""
 .. note:: This function is computed using :func:`torch.lu`.
-          {sync_note}
+          {common_notes["sync_note"]}
+""" + r"""
 
 .. note:: The determinant can be recovered as `sign * exp(logabsdet)`.
 
@@ -328,7 +334,7 @@ Examples::
     tensor(nan)
     >>> torch.linalg.slogdet(A)
     torch.return_types.linalg_slogdet(sign=tensor(-1.), logabsdet=tensor(-0.2776))
-""".format(**common_notes))
+""")
 
 eig = _add_docstr(_linalg.linalg_eig, r"""
 linalg.eig(A, *, out=None) -> (Tensor, Tensor)
@@ -345,14 +351,15 @@ the **eigenvalue decomposition** of a square matrix
 
 This decomposition exists if and only if :math:`A` is `diagonalizable`_.
 This is the case when all its eigenvalues are different.
-r""" + """
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 .. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. warning:: This function assumes that :attr:`A` is `diagonalizable`_ (for example, when all the
              eigenvalues are different). If it is not diagonalizable, the returned
@@ -366,7 +373,6 @@ Also supports batched inputs, and, if the input is batched, the output is batche
              non-zero number produces another set of valid eigenvectors of the matrix.
              In this implmentation, the returned eigenvectors are normalized to have norm
              `1` and largest real component.
-""".format(**common_notes) + r"""
 
 .. warning:: Gradients computed using `V` will only be finite when :attr:`A` does not have repeated eigenvalues.
              Furthermore, if the distance between any two eigenvalues is close to zero,
@@ -439,7 +445,6 @@ as the roots (counted with multiplicity) of the polynomial `p` of degree `n` giv
     p(\lambda) = \operatorname{det}(A - \lambda \mathrm{I}_n)\mathrlap{\qquad \lambda \in \mathbb{C}}
 
 where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
-""" + r"""
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
@@ -448,7 +453,9 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
           The eigenvalues of a matrix are always well-defined, even when the matrix is not diagonalizable.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. seealso::
 
@@ -472,7 +479,7 @@ Examples::
     >>> w = torch.linalg.eigvals(a)
     >>> w
     tensor([ 1.1226+0.5738j, -0.7537-0.1286j], dtype=torch.complex128)
-""".format(**common_notes))
+""")
 
 eigh = _add_docstr(_linalg.linalg_eigh, r"""
 linalg.eigh(A, UPLO='L', *, out=None) -> (Tensor, Tensor)
@@ -489,7 +496,6 @@ the **eigenvalue decomposition** of a complex Hermitian or real symmetric matrix
 
 where :math:`Q^{\text{H}}` is the conjugate transpose when :math:`Q` is complex, and the transpose when :math:`Q` is real-valued.
 :math:`Q` is orthogonal in the real case and unitary in the complex case.
-""" + r"""
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
@@ -501,10 +507,11 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 
 The eigenvalues are returned in ascending order.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. note:: The eigenvalues of real symmetric or complex Hermitian matrices are always real.
-""".format(**common_notes) + r"""
 
 .. warning:: The eigenvectors of a symmetric matrix are not unique, nor are they continuous with
              respect to :attr:`A`. Due to this lack of uniqueness, different hardware and
@@ -604,14 +611,15 @@ Supports inputs of float, double, cfloat and cdouble dtypes.
 Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
 
 The eigenvalues are returned in ascending order.
-""" + r"""
 
 :attr:`A` is assumed to be Hermitian (resp. symmetric), but this is not checked internally, instead:
 
 - If :attr:`UPLO`\ `= 'L'` (default), only the lower triangular part of the matrix is used in the computation.
 - If :attr:`UPLO`\ `= 'U'`, only the upper triangular part of the matrix is used.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. seealso::
 
@@ -657,7 +665,7 @@ Examples::
     tensor([[ 2.5797,  3.4629],
             [-4.1605,  1.3780],
             [-3.1113,  2.7381]], dtype=torch.float64)
-""".format(**common_notes))
+""")
 
 householder_product = _add_docstr(_linalg.linalg_householder_product, r"""
 householder_product(A, tau, *, out=None) -> Tensor
@@ -923,7 +931,6 @@ the tolerance is set to be
 .. math::
 
     \text{tol} = \sigma_1 \max(m, n) \varepsilon
-""" + r"""
 
 where :math:`\sigma_1` is the largest singular value
 (or eigenvalue in absolute value when :attr:`hermitian`\ `= True`), and
@@ -931,10 +938,12 @@ where :math:`\sigma_1` is the largest singular value
 If :attr:`A` is a batch of matrices, :attr:`tol` is computed this way for every element of
 the batch.
 
+""" + fr"""
 .. note:: The matrix rank is computed using singular value decomposition
           :func:`torch.linalg.svd` if :attr:`hermitian`\ `= False` (default) and the eigenvalue
           decomposition :func:`torch.linalg.eigvalsh` when :attr:`hermitian`\ `= True`.
-          {sync_note}
+          {common_notes["sync_note"]}
+""" + r"""
 
 Args:
     A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
@@ -978,7 +987,7 @@ Examples::
     >>> torch.linalg.matrix_rank(a, tol=1.0, hermitian=True)
     tensor([[2, 2, 2, 1],
             [1, 2, 2, 2]])
-""".format(**common_notes))
+""")
 
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(A, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
@@ -1460,7 +1469,9 @@ The singular values are returned in descending order.
 
 .. note:: This function is equivalent to NumPy's `linalg.svd(A, compute_uv=False)`.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 .. seealso::
 
@@ -1488,7 +1499,7 @@ Examples::
     >>> s = torch.linalg.svdvals(a)
     >>> s
     tensor([2.5139, 2.1087, 1.1066])
-""".format(**common_notes))
+""")
 
 cond = _add_docstr(_linalg.linalg_cond, r"""
 linalg.cond(A, p=None, *, out=None) -> Tensor
@@ -1753,7 +1764,6 @@ this function computes the solution :math:`X \in \mathbb{K}^{n \times k}` of the
 :math:`A \in \mathbb{K}^{n \times n}, B \in \mathbb{K}^{m \times k}`, which is defined as
 
 .. math:: AX = B
-""" + r"""
 
 This system of linear equations has one solution if and only if :math:`A` is `invertible`_.
 This function assumes that :math:`A` is invertible.
@@ -1775,7 +1785,9 @@ Letting `*` be zero or more batch dimensions,
     solution in a faster and more numerically stable way than performing the
     computations separately.
 
-.. note:: {sync_note}
+""" + fr"""
+.. note:: {common_notes["sync_note"]}
+""" + r"""
 
 Args:
     A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions.
@@ -1823,7 +1835,7 @@ Broadcasting::
 
 .. _invertible:
     https://en.wikipedia.org/wiki/Invertible_matrix#The_invertible_matrix_theorem
-""".format(**common_notes))
+""")
 
 tensorinv = _add_docstr(_linalg.linalg_tensorinv, r"""
 linalg.tensorinv(A, ind=2, *, out=None) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2138,6 +2138,18 @@ def sample_inputs_symeig(op_info, device, dtype, requires_grad=False):
         o.output_process_fn_grad = lambda output: (output[0], abs(output[1]))
     return out
 
+def sample_inputs_linalg_eig(op_info, device, dtype, requires_grad=False):
+    """
+    This function generates input for torch.linalg.eigh with UPLO="U" or "L" keyword argument.
+    """
+    def out_fn(output):
+        return output[0], abs(output[1])
+
+    samples = sample_inputs_linalg_invertible(op_info, device, dtype, requires_grad)
+    for sample in samples:
+        sample.output_process_fn_grad = out_fn
+
+    return samples
 
 def sample_inputs_linalg_eigh(op_info, device, dtype, requires_grad=False, **kwargs):
     """
@@ -4487,8 +4499,8 @@ op_db: List[OpInfo] = [
            aten_name='linalg_eig',
            op=torch.linalg.eig,
            dtypes=floating_and_complex_types(),
-           supports_autograd=False,
-           sample_inputs_func=sample_inputs_linalg_invertible,
+           check_batched_gradgrad=False,
+           sample_inputs_func=sample_inputs_linalg_eig,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack]),
     OpInfo('linalg.eigvals',
            aten_name='linalg_eigvals',

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4506,7 +4506,7 @@ op_db: List[OpInfo] = [
            aten_name='linalg_eigvals',
            op=torch.linalg.eigvals,
            dtypes=floating_and_complex_types(),
-           supports_autograd=False,
+           check_batched_gradgrad=False,
            sample_inputs_func=sample_inputs_linalg_invertible,
            decorators=[skipCUDAIfNoMagma, skipCUDAIfRocm, skipCPUIfNoLapack]),
     OpInfo('linalg.eigh',


### PR DESCRIPTION
This PR adds backwards support for `eig` and `eigvals`.