### PR TITLE
[fx splitter] Fix fusion group utility

### DIFF
--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -2,10 +2,19 @@ import argparse
 from typing import Any, Callable, Tuple, Dict, Optional, List
 
 import torch
+import torch.fx
 from torch.fx.node import map_arg
 
+from .shape_prop import ShapeProp
 from .split_utils import split_by_tags
-from .tools_common import Tensors, TensorOrTensors, CALLABLE_NODE_OPS, Nodes
+from .tools_common import (
+    Tensors,
+    TensorOrTensors,
+    NodeList,
+    NodeSet,
+    CALLABLE_NODE_OPS,
+    FxNetAccFusionsFinder,
+)
 
 
 class FxNetMinimizerBadModuleError(Exception):
@@ -100,6 +109,8 @@ class _MinimizerBase:
         compare_fn: Callable[[TensorOrTensors, TensorOrTensors], Tuple[float, bool]],
         settings: _MinimizerSettingBase,
     ):
+        assert isinstance(module, torch.fx.GraphModule)
+
         self.module = module
         self.sample_input = sample_input
         self.compare_fn = compare_fn
@@ -113,6 +124,12 @@ class _MinimizerBase:
 
         # Stores the results of compare_fn
         self.results: Dict[Any, Any] = {}
+
+        callable_nodes = {
+            node for node in self.module.graph.nodes if node.op in CALLABLE_NODE_OPS
+        }
+        ShapeProp(self.module).propagate(*self.sample_input)
+        self.fusions = FxNetAccFusionsFinder(self.module, callable_nodes)()
 
         # Check if number of input in sample_input matches the number of placeholders
         placeholders = [
@@ -221,7 +238,7 @@ class _MinimizerBase:
 
         return a_input, b_input
 
-    def _tag_nodes(self, selected_nodes: Nodes):
+    def _tag_nodes(self, selected_nodes: NodeSet):
         """
         Tag selected nodes with tag "minimize". Nodes with the same tags will
         be split to the same submodule afterwards.
@@ -245,7 +262,7 @@ class _MinimizerBase:
             else:
                 node.tag = "main_1"
 
-    def _build_submodule(self, nodes: Nodes) -> Tuple[torch.fx.GraphModule, str]:
+    def _build_submodule(self, nodes: NodeSet) -> Tuple[torch.fx.GraphModule, str]:
         """
         Split self.module so that one submodule consists of `nodes` and only `nodes`.
 
@@ -303,7 +320,7 @@ class _MinimizerBase:
         a_input, b_input = self._get_submod_inputs(split_module, submod_name)
 
         if output_names:
-            output_nodes = []
+            output_nodes: NodeList = []
             for node in submodule.graph.nodes:
                 if node.op == "output":
                     submodule.graph.erase_node(node)
@@ -332,26 +349,32 @@ class _MinimizerBase:
         if not bool_result:
             raise FxNetMinimizerResultMismatchError(f"Result mismatch for {result_key}")
 
-    def _binary_search_impl(self, nodes: Nodes) -> Nodes:
+    def _binary_search_impl(self, nodes: NodeList) -> NodeSet:
         """
         Recursive binary search implementation.
         """
+        cur_nodes: NodeSet = set(nodes)
+        for node in nodes:
+            if node in self.fusions:
+                cur_nodes.update(self.fusions[node])
+
         try:
-            split_module, submod_name = self._build_submodule(nodes)
+            split_module, submod_name = self._build_submodule(cur_nodes)
             self._run_and_compare(
                 split_module,
                 submod_name,
             )
         except (FxNetMinimizerRunFuncError, FxNetMinimizerResultMismatchError):
             if len(nodes) == 1:
-                return nodes
+                return cur_nodes
+
             mid = len(nodes) // 2
 
             culprits = self._binary_search_impl(nodes[:mid])
             if not self.settings.find_all:
                 return culprits
 
-            culprits += self._binary_search_impl(nodes[mid:])
+            culprits.update(self._binary_search_impl(nodes[mid:]))
             if len(culprits) == 0:
                 raise FxNetMinimizerBadModuleError(
                     "Found an error in a group of nodes, but was not able to minimize",
@@ -359,40 +382,48 @@ class _MinimizerBase:
                 )
             return culprits
         else:
-            return []
+            return set()
 
-    def _binary_traverse(self, nodes: Nodes) -> Nodes:
+    def _binary_traverse(self, nodes: NodeList) -> NodeSet:
         """
         Binary search on `nodes` for culprit.
         """
         return self._binary_search_impl(nodes)
 
-    def _sequential_traverse(self, nodes: Nodes) -> Nodes:
+    def _sequential_traverse(self, nodes: NodeList) -> NodeSet:
         """
         Traverse `nodes` one by one and determine if any of them is a culprit.
         """
-        culprits = []
-        for node in nodes:
-            try:
-                split_module, submod_name = self._build_submodule([node])
-                self._run_and_compare(split_module, submod_name)
-            except (
-                FxNetMinimizerRunFuncError,
-                FxNetMinimizerResultMismatchError,
-            ):
-                culprits.append(node)
+        culprits: NodeSet = set()
 
+        for node in nodes:
+            cur_nodes: NodeSet = {node}
+
+            if node in self.fusions:
+                cur_nodes = self.fusions[node]
+
+            try:
+                split_module, submod_name = self._build_submodule(cur_nodes)
+                self._run_and_compare(
+                    split_module, submod_name, output_names=[node.name]
+                )
+            except (FxNetMinimizerResultMismatchError):
+                culprits.add(node)
+                if not self.settings.find_all:
+                    return culprits
+            except (FxNetMinimizerRunFuncError):
+                culprits.update(cur_nodes)
                 if not self.settings.find_all:
                     return culprits
 
         return culprits
 
-    def _collect_nodes(self, start: Optional[str], end: Optional[str]) -> Nodes:
+    def _collect_nodes(self, start: Optional[str], end: Optional[str]) -> NodeList:
         """
         Collect nodes in the model that between nodes with name of `start` and `end`.
         These two nodes are also included.
         """
-        nodes = []
+        nodes: NodeList = []
         add_node = start is None
 
         for node in self.module.graph.nodes:
@@ -425,13 +456,19 @@ class _MinimizerBase:
                 model.
         """
         nodes = self._collect_nodes(start, end)
+        cur_nodes = set(nodes)
+
+        for node in nodes:
+            if node in self.fusions:
+                cur_nodes.update(self.fusions[node])
+
         output_names = None
 
         if self.settings.return_intermediate:
             output_names = [node.name for node in nodes]
 
         try:
-            split_module, submod_name = self._build_submodule(nodes)
+            split_module, submod_name = self._build_submodule(cur_nodes)
             self._run_and_compare(split_module, submod_name, output_names)
         except (
             FxNetMinimizerRunFuncError,
@@ -439,7 +476,7 @@ class _MinimizerBase:
         ) as e:
             print(e)
 
-    def minimize(self, start: Optional[str] = None, end: Optional[str] = None) -> Nodes:
+    def minimize(self, start: Optional[str] = None, end: Optional[str] = None) -> NodeSet:
         """
         Minimizing the model from node with name `start` to node with name `end` base
         on self.settings. Find culprits that causes FxNetMinimizerRunFuncError or

--- a/torch/fx/passes/operator_support.py
+++ b/torch/fx/passes/operator_support.py
@@ -1,44 +1,9 @@
-from typing import Dict, Any
+from typing import Dict
 
 import torch
 import torch.fx
-from torch.fx.node import _get_qualified_name
 
-from .tools_common import CALLABLE_NODE_OPS
-
-
-def get_node_target(submodules: Dict[str, torch.nn.Module], node: torch.fx.Node) -> str:
-    """
-    Given a `node` returns its target typename.
-
-    For "call_method" node, return node.target which is the name of that method being called.
-    This could potential lead to conflict but should be okay because normally it's on a tensor.
-
-    For "call_function" node, return typename of node.target.
-
-    For "call_module" node, return typename of the module that node.target point to.
-
-    If seeing "_VariableFunctionsClass" in the target name string, it will be replaced by
-    "torch". e.g. _VariableFunctionsClass.relu would become torch.relu.
-    """
-
-    assert node.op in CALLABLE_NODE_OPS, (
-        "Expect op types of " + ", ".join(CALLABLE_NODE_OPS) + f", but found {node.op}"
-    )
-
-    if node.op == "call_module":
-        assert isinstance(node.target, str)
-        return torch.typename(submodules[node.target])
-    elif node.op == "call_function":
-        target: Any = node.target
-        return (
-            f"acc_ops.{target.__name__}"
-            if target.__module__ == "glow.fb.fx.acc_ops"
-            else _get_qualified_name(target)
-        )
-    else:
-        assert isinstance(node.target, str)
-        return node.target
+from .tools_common import get_node_target, CALLABLE_NODE_OPS
 
 
 class OperatorSupport:

--- a/torch/fx/passes/split_utils.py
+++ b/torch/fx/passes/split_utils.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict
 import torch.fx
 import torch.nn as nn
 from torch.fx.graph import map_arg
-from .tools_common import Nodes
+from .tools_common import NodeList, NodeSet
 
 
 @dataclass
@@ -97,11 +97,11 @@ def split_by_tags(gm: torch.fx.GraphModule, tags: List[str]) -> torch.fx.GraphMo
         return main_1
     """
 
-    def flatten(x: torch.fx.node.Argument) -> Nodes:
+    def flatten(x: torch.fx.node.Argument) -> NodeList:
         """
         Stores nodes in x to a list and returns the list.
         """
-        r: Nodes = []
+        r: NodeList = []
         map_arg(x, r.append)
         return r
 
@@ -119,13 +119,13 @@ def split_by_tags(gm: torch.fx.GraphModule, tags: List[str]) -> torch.fx.GraphMo
     all_components: List[Component] = []
 
     # Stores nodes that will be used in main graph.
-    used_in_main = set()
+    used_in_main: NodeSet = set()
 
     # Main graph after split.
     main_g = torch.fx.Graph()
 
-    # Mapping from node in original module  to node in main graph after split.
-    main_remapping = {}
+    # Mapping from node in original module to node in main graph after split.
+    main_remapping: Dict[torch.fx.Node, torch.fx.Node] = {}
 
     # Output node of original module.
     output_node: Optional[torch.fx.Node] = None

--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -1,21 +1,26 @@
 import argparse
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import List, Dict, Set, Optional, Tuple
+from typing import List, Dict, Optional, Tuple
 
 import torch
 from torch.fx.experimental.graph_manipulation import get_size_of_node
 from torch.fx.node import map_arg
-from torch.fx.passes import shape_prop
 
 from .operator_support import (
     get_node_target,
     OperatorSupport,
 )
 from .graph_drawer import FxGraphDrawer
+from .shape_prop import ShapeProp
 from .split_utils import split_by_tags
-from .tools_common import CALLABLE_NODE_OPS, Tensors, Nodes
-
+from .tools_common import (
+    FxNetAccFusionsFinder,
+    CALLABLE_NODE_OPS,
+    Tensors,
+    NodeList,
+    NodeSet,
+)
 
 class _SplitterSettingBase:
     def __init__(self):
@@ -78,8 +83,8 @@ class FxNetAccNodesFinder:
         self.allow_non_tensor = allow_non_tensor
 
     def reduce_acc_nodes_non_tensor_input_helper(
-        self, cpu_worklist: Nodes
-    ) -> None:
+        self, cpu_worklist: NodeList
+    ):
         """
         Transitively excludes nodes from ACC supported set.
         For every node in the worklist:
@@ -96,12 +101,12 @@ class FxNetAccNodesFinder:
                     if "tensor_meta" not in user.meta:
                         cpu_worklist.append(user)
 
-    def reduce_acc_nodes_non_tensor_input(self) -> None:
+    def reduce_acc_nodes_non_tensor_input(self):
         """
         Excludes nodes from ACC supported set that have direct
         upstream CPU nodes that produce non-tensor outputs.
         """
-        non_tensor_cpu_nodes: Nodes = []
+        non_tensor_cpu_nodes: NodeList = []
 
         for node in self.module.graph.nodes:
             if node.op not in CALLABLE_NODE_OPS:
@@ -114,13 +119,13 @@ class FxNetAccNodesFinder:
 
         self.reduce_acc_nodes_non_tensor_input_helper(non_tensor_cpu_nodes)
 
-    def reduce_acc_nodes_non_tensor_output(self) -> None:
+    def reduce_acc_nodes_non_tensor_output(self):
         """
         Excludes nodes from ACC supported set that produce non-tensor
         outputs and have downstream CPU nodes.
         """
         while True:
-            new_cpu_nodes: Nodes = []
+            new_cpu_nodes: NodeList = []
 
             for acc_node in self.acc_nodes:
                 if "tensor_meta" in acc_node.meta:
@@ -138,7 +143,7 @@ class FxNetAccNodesFinder:
 
             self.reduce_acc_nodes_non_tensor_input_helper(new_cpu_nodes)
 
-    def __call__(self) -> Set[torch.fx.Node]:
+    def __call__(self) -> NodeSet:
         submodules = dict(self.module.named_modules())
         self.acc_nodes = {
             n
@@ -154,70 +159,6 @@ class FxNetAccNodesFinder:
         return self.acc_nodes
 
 
-class FxNetAccFusionsFinderError(Exception):
-    pass
-
-
-class FxNetAccFusionsFinder:
-    """
-    Finds groups of connected ACC nodes that pass non-tensor data between each other.
-    Such groups are called fusion groups.
-    """
-
-    def __init__(self, module: torch.fx.GraphModule, acc_nodes: Set[torch.fx.Node]):
-        self.module = module
-        self.acc_nodes = acc_nodes
-
-    def __call__(self) -> Dict[torch.fx.Node, Set[torch.fx.Node]]:
-        result: Dict[torch.fx.Node, Set[torch.fx.Node]] = {}
-
-        for node in self.acc_nodes:
-            if node in result:
-                continue
-            if node.op not in CALLABLE_NODE_OPS:
-                continue
-            if "tensor_meta" in node.meta:
-                continue
-
-            fusion_nodes: Set[torch.fx.Node] = set()
-            current_fusion_nodes: Nodes = [node]
-            while current_fusion_nodes:
-                node = current_fusion_nodes.pop(0)
-                fusion_nodes.add(node)
-
-                # Optionally add downstream nodes
-                if "tensor_meta" not in node.meta:
-                    for user in node.users:
-                        if user.op not in CALLABLE_NODE_OPS:
-                            continue
-                        if user in fusion_nodes:
-                            continue
-                        if user in result:
-                            raise FxNetAccFusionsFinderError(
-                                "Node can't belong to more than one fusion group"
-                            )
-                        current_fusion_nodes.append(user)
-
-                # Add some upstream nodes
-                for arg in node.all_input_nodes:
-                    if arg.op not in CALLABLE_NODE_OPS:
-                        continue
-                    if "tensor_meta" in arg.meta:
-                        continue
-                    if arg in fusion_nodes:
-                        continue
-                    if arg in result:
-                        raise FxNetAccFusionsFinderError(
-                            "Node can't belong to more than one fusion group"
-                        )
-                    current_fusion_nodes.append(arg)
-
-            for fusion_node in fusion_nodes:
-                result[fusion_node] = fusion_nodes
-
-        return result
-
-
 class FxNetSplitterInternalError(Exception):
     pass
 
@@ -225,7 +166,7 @@ class FxNetSplitterInternalError(Exception):
 @dataclass
 class Subgraph:
     is_acc: bool
-    nodes: Nodes
+    nodes: NodeList
 
 
 class _SplitterBase:
@@ -289,8 +230,10 @@ class _SplitterBase:
         - builds a map of fused nodes to their fusions.
         As a result we get self.acc_nodes, self.deps and self.fusions.
         """
+        assert isinstance(module, torch.fx.GraphModule)
+
         self.module = module
-        shape_prop.ShapeProp(self.module).propagate(*sample_input)
+        ShapeProp(self.module).propagate(*sample_input)
 
         self.settings = settings
         self.operator_support = operator_support
@@ -310,7 +253,7 @@ class _SplitterBase:
     # Helpers for ctor and initial state
     # ===============================================================
 
-    def find_deps(self) -> Dict[torch.fx.Node, Set[torch.fx.Node]]:
+    def find_deps(self) -> Dict[torch.fx.Node, NodeSet]:
         """
         Builds a graph of node dependencies. Leaf nodes don't have any
         dependencies and the "output" node doesn't have nodes depending on it.
@@ -318,7 +261,7 @@ class _SplitterBase:
         Resulting graph has only direct dependencies, i.e. there are no
         transitive dependencies.
         """
-        deps: Dict[torch.fx.Node, Set[torch.fx.Node]] = defaultdict(set)
+        deps: Dict[torch.fx.Node, NodeSet] = defaultdict(set)
         for node in self.module.graph.nodes:
             if node.op not in CALLABLE_NODE_OPS:
                 continue
@@ -328,7 +271,7 @@ class _SplitterBase:
                     deps[user].add(node)
         return deps
 
-    def update_deps_for_fusions(self) -> None:
+    def update_deps_for_fusions(self):
         """
         Updates graph of dependencies so that:
         - nodes from the same fusion depend on the same set of outer nodes,
@@ -367,7 +310,7 @@ class _SplitterBase:
         return "Unable to find a culprit because _find_culprit() function is not implemented."
 
     def _draw_graph_based_on_node_support(
-        self, mod: torch.fx.GraphModule, supported_nodes: Nodes
+        self, mod: torch.fx.GraphModule, supported_nodes: NodeList
     ):
         color_map = {
             "default": "AliceBlue",
@@ -394,7 +337,7 @@ class _SplitterBase:
     def node_support_preview(self, dump_graph: bool = False):
         submodules = dict(self.module.named_modules())
 
-        supported_nodes = []
+        supported_nodes: NodeList = []
         supported_node_types = defaultdict(set)
         unsupported_node_types = defaultdict(set)
 
@@ -510,7 +453,7 @@ class _SplitterBase:
                 submod_inputs = get_submod_inputs(
                     split_mod, submod, self.sample_input
                 )
-                shape_prop.ShapeProp(submod).propagate(*submod_inputs)
+                ShapeProp(submod).propagate(*submod_inputs)
 
                 total_input_bytes = 0
                 total_output_bytes = 0
@@ -572,12 +515,12 @@ class _SplitterBase:
 
     def find_reverse_deps(
         self, tag_id: Optional[int] = None
-    ) -> Dict[torch.fx.Node, Set[torch.fx.Node]]:
+    ) -> Dict[torch.fx.Node, NodeSet]:
         """
         Builds reversed topological node dependencies, if tag_id is specified,
         we ignore nodes that are in later subgraph i.e. nodes have greater tag_id.
         """
-        result: Dict[torch.fx.Node, Set[torch.fx.Node]] = defaultdict(set)
+        result: Dict[torch.fx.Node, NodeSet] = defaultdict(set)
 
         for node in self.module.graph.nodes:
             if node.op not in CALLABLE_NODE_OPS:
@@ -593,7 +536,7 @@ class _SplitterBase:
         return result
 
     def update_reverse_deps_for_fusions(
-        self, deps: Dict[torch.fx.Node, Set[torch.fx.Node]]
+        self, deps: Dict[torch.fx.Node, NodeSet]
     ):
         processed_node = set()
 
@@ -621,7 +564,7 @@ class _SplitterBase:
 
                 processed_node.add(n)
 
-    def find_parent_nodes_of_subgraph(self, tag: str) -> Set[torch.fx.Node]:
+    def find_parent_nodes_of_subgraph(self, tag: str) -> NodeSet:
         """
         Finds parent nodes of the `tag` subgraph.
 
@@ -650,7 +593,7 @@ class _SplitterBase:
         # Parent nodes of the subgraph
         parent_nodes = self.find_parent_nodes_of_subgraph(tag)
 
-        visited_nodes: Set[torch.fx.Node] = set()
+        visited_nodes: NodeSet = set()
 
         while parent_nodes:
             node = None
@@ -684,12 +627,12 @@ class _SplitterBase:
     # Helpers for split() method
     # ===============================================================
 
-    def starter_nodes(self) -> Tuple[Set[torch.fx.Node], Set[torch.fx.Node]]:
+    def starter_nodes(self) -> Tuple[NodeSet, NodeSet]:
         """
         Finds nodes that consume module inputs or getattr nodes.
         """
-        starter_cpu_nodes: Set[torch.fx.Node] = set()
-        starter_acc_nodes: Set[torch.fx.Node] = set()
+        starter_cpu_nodes: NodeSet = set()
+        starter_acc_nodes: NodeSet = set()
         for node in self.module.graph.nodes:
             if node.op not in {"placeholder", "getattr"}:
                 continue
@@ -703,11 +646,11 @@ class _SplitterBase:
     def put_nodes_into_subgraphs(self) -> List[Subgraph]:
         # We start graph traversal from leaf nodes
         current_cpu_nodes, current_acc_nodes = self.starter_nodes()
-        visited_nodes: Set[torch.fx.Node] = set()
+        visited_nodes: NodeSet = set()
 
         # If there are CPU nodes, start with them
         acc_subgraph: bool = not current_cpu_nodes
-        current_subgraph_nodes: Nodes = []
+        current_subgraph_nodes: NodeList = []
 
         # Result accumulator
         subgraphs: List[Subgraph] = []

--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -1,10 +1,179 @@
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Dict, Any, Set
+from dataclasses import dataclass
 
 import torch
 import torch.fx
+from torch.fx.node import _get_qualified_name
 
 
 Tensors = Union[Tuple[torch.Tensor], List[torch.Tensor]]
 TensorOrTensors = Union[torch.Tensor, Tensors]
-Nodes = List[torch.fx.Node]
+NodeList = List[torch.fx.Node]
+NodeSet = Set[torch.fx.Node]
 CALLABLE_NODE_OPS = {"call_module", "call_function", "call_method"}
+
+
+def get_node_target(submodules: Dict[str, torch.nn.Module], node: torch.fx.Node) -> str:
+    """
+    Given a `node` returns its target typename.
+
+    For "call_method" node, return node.target which is the name of that method being called.
+    This could potential lead to conflict but should be okay because normally it's on a tensor.
+
+    For "call_function" node, return typename of node.target.
+
+    For "call_module" node, return typename of the module that node.target point to.
+
+    If seeing "_VariableFunctionsClass" in the target name string, it will be replaced by
+    "torch". e.g. _VariableFunctionsClass.relu would become torch.relu.
+    """
+
+    assert node.op in CALLABLE_NODE_OPS, (
+        "Expect op types of " + ", ".join(CALLABLE_NODE_OPS) + f", but found {node.op}"
+    )
+
+    if node.op == "call_module":
+        assert isinstance(node.target, str)
+        return torch.typename(submodules[node.target])
+    elif node.op == "call_function":
+        target: Any = node.target
+        return (
+            f"acc_ops.{target.__name__}"
+            if target.__module__ == "glow.fb.fx.acc_ops"
+            else _get_qualified_name(target)
+        )
+    else:
+        assert isinstance(node.target, str)
+        return node.target
+
+
+class FxNetAccFusionsFinder:
+    """
+    Finds groups of connected ACC nodes that pass non-tensor data between each other.
+    Such groups are called fusion groups.
+    """
+
+    def __init__(self, module: torch.fx.GraphModule, acc_nodes: NodeSet):
+        self.module = module
+        self.nodes = list(module.graph.nodes)
+        self.acc_nodes = acc_nodes
+
+    @dataclass
+    class FusionGroup:
+        # The smallest idx of nodes in the fusion group after topological sorting all the nodes in the model.
+        top_node_idx: int
+
+        # Nodes in this fusion group.
+        nodes: NodeSet
+
+        # Inputs to this fusion group.
+        inputs: NodeSet
+
+        # Nodes that in the fusion group that haven't been processed yet.
+        nodes_need_process: NodeSet
+
+        def add_node(self, node):
+            """
+            Add a node to fusion group.
+            """
+            if node in self.nodes:
+                return
+
+            self.nodes_need_process.add(node)
+            self.nodes.add(node)
+            self.inputs.discard(node)
+            self.inputs.update(
+                {
+                    n
+                    for n in node.all_input_nodes
+                    if n.op in CALLABLE_NODE_OPS and n not in self.nodes
+                }
+            )
+
+    def recursive_add_node(
+        self,
+        fusion_group: "FxNetAccFusionsFinder.FusionGroup",
+        inputs: Union[NodeSet, NodeList],
+    ):
+        """
+        Start from inputs and going reverse topological order. If any upstream node
+        is in the fusion group, add all the nodes in this path to fusion group.
+        """
+        for arg in inputs:
+            # Skip placeholder and get_attr because they won't be in the fusion group.
+            if arg.op not in CALLABLE_NODE_OPS:
+                continue
+
+            # If the node has smaller idx, it's already an upstream node of the fusion
+            # group. We don't need to check it anymore.
+            if self.nodes.index(arg) < fusion_group.top_node_idx:
+                continue
+
+            # If the node is in the fusion group, return True.
+            if arg in fusion_group.nodes:
+                return True
+
+            # Check the upstream nodes of the node, if any of them is in the fusion group
+            # we'll add this node to fusion group and return True.
+            if self.recursive_add_node(fusion_group, arg.all_input_nodes):
+                fusion_group.add_node(arg)
+                return True
+
+        return False
+
+    def __call__(self) -> Dict[torch.fx.Node, NodeSet]:
+        result: Dict[torch.fx.Node, NodeSet] = {}
+        acc_nodes = list(self.acc_nodes)
+
+        for node in acc_nodes:
+            if node in result:
+                continue
+            if node.op not in CALLABLE_NODE_OPS:
+                continue
+            if "tensor_meta" in node.meta:
+                continue
+            if node not in self.acc_nodes:
+                continue
+
+            fusion_group: "FxNetAccFusionsFinder.FusionGroup" = self.FusionGroup(
+                top_node_idx=self.nodes.index(node),
+                nodes={node},
+                inputs=set(node.all_input_nodes),
+                nodes_need_process={node},
+            )
+            while fusion_group.nodes_need_process:
+                node = fusion_group.nodes_need_process.pop()
+
+                # Optionally add downstream nodes
+                if "tensor_meta" not in node.meta:
+                    for user in node.users:
+                        if user.op not in CALLABLE_NODE_OPS:
+                            continue
+                        if user in fusion_group.nodes:
+                            continue
+
+                        fusion_group.add_node(user)
+                        self.recursive_add_node(fusion_group, fusion_group.inputs)
+
+                # Add some upstream nodes
+                for arg in node.all_input_nodes:
+                    if arg.op not in CALLABLE_NODE_OPS:
+                        continue
+                    if "tensor_meta" in arg.meta:
+                        continue
+                    if arg in fusion_group.nodes:
+                        continue
+
+                    fusion_group.add_node(user)
+                    fusion_group.top_node_idx = min(
+                        fusion_group.top_node_idx, self.nodes.index(user)
+                    )
+                    self.recursive_add_node(fusion_group, fusion_group.inputs)
+
+            if not (set(fusion_group.nodes) <= self.acc_nodes):
+                self.acc_nodes -= fusion_group.nodes
+            else:
+                for n in fusion_group.nodes:
+                    result[n] = fusion_group.nodes
+
+        return result


### PR DESCRIPTION
Summary:
We've found an issue that fusion group would results in circular dependency. For example
```
a -> b -> c -> d
|              ^
+ -------------+

Only a has non tensor output and currently we would create a fusion group (a, b, d). This results in circular dependency because now the fusion group depends on c while c depends on the fusion group as well.
```

This diff implement the solution discussed before. When we add a node to fusion group, we add all the nodes that are in the middle of the fusion group and this newly added node.

Use the same logic in minimizer to build fusion group.

Test Plan: split_tests and net_min_tests

Reviewed By: khabinov

Differential Revision: D27917432

