### PR TITLE
[package] PackageExporter `__import__` logic to not parse dynamic cases

### DIFF
--- a/test/package/package_b/subpackage_2.py
+++ b/test/package/package_b/subpackage_2.py
@@ -6,3 +6,7 @@ result = "subpackage_2"
 
 class PackageBSubpackage2Object_0:
     pass
+
+
+def dynamic_import_test(name: str):
+    __import__(name)

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -57,6 +57,10 @@ class _ExtractModuleReferences(ast.NodeVisitor):
     def visit_Call(self, node):
         # __import__ calls aren't routed to the visit_Import/From nodes
         if hasattr(node.func, "id") and node.func.id == "__import__":
+            if type(node.args[0]) not in [ast.Constant, ast.Str]:
+                # We don't want to parse dynamic uses of __import__
+                return
+
             name = self._grab_node_str(node.args[0])
             fromlist = []
             level = 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57283 [package] PackageExporter `__import__` logic to not parse dynamic cases**

To fix https://github.com/pytorch/pytorch/issues/57193

The find_file_dependenies.py logic currently will parse dynamic uses of `__import__` erroneously. This PR restricts the logic to only parse `__import__` calls that have Constant arguments

Differential Revision: [D28095858](https://our.internmc.facebook.com/intern/diff/D28095858)