### PR TITLE
Static Runtime support for aten::matmul

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -294,3 +294,8 @@ const auto norm_5arg = R"JIT(
   def forward(self, a: Tensor, p: int, dim: List[int], keepdim: bool, dtype: int):
       return torch.norm(a, p, dim, keepdim, dtype=dtype)
 )JIT";
+
+const auto aten_matmul = R"JIT(
+  def forward(self, a: Tensor, b: Tensor):
+      return torch.matmul(a, b)
+)JIT";

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -172,6 +172,24 @@ TEST(StaticRuntime, IndividualOps_Binary) {
   testStaticRuntime(tuple_construct_script_2, args);
 }
 
+TEST(StaticRuntime, IndividualOps_Binary_MatMul) {
+  // 1-D, 1-D
+  std::vector<IValue> args{at::randn({3}), at::randn({3})};
+  testStaticRuntime(aten_matmul, args);
+  // 2-D, 2-D
+  args = {at::randn({3, 2}), at::randn({2, 3})};
+  testStaticRuntime(aten_matmul, args);
+  // 1-D, 2-D
+  args = {at::randn({3}), at::randn({3, 5})};
+  testStaticRuntime(aten_matmul, args);
+  // 2-D, 1-D
+  args = {at::randn({3, 5}), at::randn({5})};
+  testStaticRuntime(aten_matmul, args);
+  // > 2-D , > 2-D
+  args = {at::randn({3, 1, 4, 5}), at::randn({2, 5, 6})};
+  testStaticRuntime(aten_matmul, args);
+}
+
 TEST(StaticRuntime, IndividualOps_Div) {
   auto a = at::randn({2, 3});
   auto b = at::randn({2, 3});

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1350,5 +1350,20 @@ REGISTER_OPERATOR_FUNCTOR(aten::norm, aten_norm, [](Node* n) -> SROperator {
   };
 });
 
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+REGISTER_OPERATOR_FUNCTOR(aten::matmul, aten_matmul, [](Node* n) -> SROperator {
+  return [](ProcessedNode* p_node) {
+    const auto& in0_t = p_node->Input(0).toTensor();
+    const auto& in1_t = p_node->Input(1).toTensor();
+
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    fastResizeToZero(out_t);
+    at::native::matmul_out(in0_t, in1_t, out_t);
+  };
+});
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Test Plan: buck test caffe2/benchmarks/static_runtime:static_runtime_cpptest -- IndividualOps_Binary_MatMul

Differential Revision: D28099671

