### PR TITLE
[torch/debuggability] use log.info() in addition to print() in timeoutguard

### DIFF
--- a/caffe2/python/timeout_guard.py
+++ b/caffe2/python/timeout_guard.py
@@ -55,6 +55,7 @@ class WatcherThread(threading.Thread):
                 log.info("Prepared output, dumping threads. ")
                 print("Caller thread was: {}".format(self.caller_thread))
                 print("-----After force------")
+                log.info("-----After force------")
                 import sys
                 import traceback
                 code = []
@@ -66,7 +67,9 @@ class WatcherThread(threading.Thread):
                             if line:
                                 code.append("  %s" % (line.strip()))
 
+                # Log also with logger, as it is comment practice to suppress print().
                 print("\n".join(code))
+                log.info("\n".join(code))
                 log.error("Process did not terminate cleanly in 10 s, forcing")
                 os.abort()
 
@@ -85,7 +88,9 @@ class WatcherThread(threading.Thread):
                     if line:
                         code.append("  %s" % (line.strip()))
 
+            # Log also with logger, as it is comment practice to suppress print().
             print("\n".join(code))
+            log.info("\n".join(code))
             os.kill(os.getpid(), signal.SIGINT)
 
 


### PR DESCRIPTION
Summary: Seems many trainers disable print(), so we cannot see the thread dumps with CompleteInTimeOrDie(). So log.info() also.

Test Plan: sandcastle

Reviewed By: aalmah

Differential Revision: D28098738

