### PR TITLE
Add multiline support parsing of typing variables

### DIFF
--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -14527,6 +14527,47 @@ dedent """
         with self.assertRaisesRegex(RuntimeError, "cannot be compiled since it inherits from nn.Module"):
             torch.jit.script(MyModule)
 
+    def test_multiline_typing_variables(self):
+        def test_list():
+            value: typing.List[
+                torch.Tensor
+            ] = [torch.ones(1), torch.ones(1), ]
+
+            return value
+        self.checkScript(test_list, ())
+
+        def test_tuple():
+            value: typing.Tuple[
+                torch.Tensor
+            ] = (torch.ones(1), )
+
+            return value
+        self.checkScript(test_tuple, ())
+
+        def test_dict():
+            value: typing.Dict[
+                int, int
+            ] = {1: 1, 2: 2}
+
+            return value
+        self.checkScript(test_dict, ())
+
+        def test_union():
+            value: typing.Union[
+                int, NoneType
+            ] = None
+
+            return value
+        self.checkScript(test_union, ())
+
+        def test_optional():
+            value: typing.Optional[
+                int
+            ] = None
+
+            return value
+        self.checkScript(test_optional, ())
+
     def test_view_write(self):
         def fn(x, y):
             l = []

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -223,7 +223,12 @@ c10::optional<std::string> ScriptTypeParser::parseBaseTypeName(
           "CharTensor",
           "ByteTensor",
           "BoolTensor"};
-      if (isTorch(select.value()) && tensor_subtypes.count(name) == 1) {
+
+      // Special case to handle types from typing module
+      const std::unordered_set<std::string> typing_types = {
+          "List", "Tuple", "Optional", "Dict", "Union"};
+      if ((isTorch(select.value()) && tensor_subtypes.count(name) == 1) ||
+          typing_types.count(name) == 1) {
         return name;
       } else {
         // Otherwise, it's a fully qualified class name


### PR DESCRIPTION
Summary:
========
Fixes #57035

Test:
====
python test/test_jit.py -k test_multiline_typing_variables
