### PR TITLE
Address temp file/bind race condition in torch_shm_manager

### DIFF
--- a/c10/test/util/tempfile_test.cpp
+++ b/c10/test/util/tempfile_test.cpp
@@ -1,5 +1,7 @@
 #include <c10/util/tempfile.h>
 #include <gtest/gtest.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #if !defined(_WIN32)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -8,3 +10,20 @@ TEST(TempFileTest, MatchesExpectedPattern) {
   ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);
 }
 #endif // !defined(_WIN32)
+
+static bool directory_exists(const char* path) {
+  struct stat st;
+  return (stat(path, &st) == 0 && (st.st_mode & S_IFDIR));
+}
+
+TEST(TempDirTest, tryMakeTempdir) {
+  c10::optional<c10::TempDir> tempdir = c10::make_tempdir("test-dir-");
+  std::string tempdir_name = tempdir->name;
+
+  // directory should exist while tempdir is alive
+  ASSERT_TRUE(directory_exists(tempdir_name.c_str()));
+
+  // directory should not exist after tempdir destroyed
+  tempdir.reset();
+  ASSERT_FALSE(directory_exists(tempdir_name.c_str()));
+}

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -55,15 +55,20 @@ void start_manager() {
   }
   SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[0]));
   if (handle.length() == 0) {
-    std::string msg("error executing torch_shm_manager at \"");
+    std::string msg("no response from torch_shm_manager at \"");
     msg += manager_executable_path;
     msg += "\"";
     throw std::runtime_error(msg);
   }
 
   handle.pop_back(); // remove \n
-  if (handle == "ERROR")
-    throw std::exception();
+  if (handle.rfind("ERROR: ", 0) == 0) {
+    std::string msg("torch_shm_manager at \"");
+    msg += manager_executable_path;
+    msg += "\": ";
+    msg += handle.substr(7);  // remove "ERROR: "
+    throw std::runtime_error(msg);
+  }
 
   ClientSocket manager {handle};
   managers.emplace(std::move(handle), std::move(manager));

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -107,9 +107,14 @@ int main(int argc, char *argv[]) {
     register_fd(srv_socket->socket_fd);
     print_init_message(tempfile->name.c_str());
     DEBUG("opened socket %s", tempfile->name.c_str());
+  } catch (const std::exception& e) {
+    std::string message("ERROR: ");
+    message += e.what();
+    print_init_message(message.c_str());
+    return 1;
   } catch (...) {
-    print_init_message("ERROR");
-    throw;
+    print_init_message("ERROR: unhandled exception");
+    return 1;
   }
 
   int timeout = -1;


### PR DESCRIPTION
Summary:
Addressing a race condition that can occur in `torch_shm_manager` between the time its temporary file is unlinked and when it `bind()`s the manager server socket to that same name. In that time window, other threads/processes can re-create another temporary file with the same name, causing `bind()` to fail with `EADDRINUSE`.

This diff introduces `c10::TempDir` and associated helper functions that mirror those of `c10::TempFile` and generates the manager socket name using a combination of a temporary directory, which will be valid for the lifetime of `torch_shm_manager`, and a well-known file name within that directory that will never be used outside of `bind()`.

Differential Revision: D28047914

