### PR TITLE
Propagate information on torch_shm_manager execl failure to parent process

### DIFF
--- a/c10/util/tempfile.h
+++ b/c10/util/tempfile.h
@@ -85,6 +85,32 @@ struct TempFile {
   std::string name;
 };
 
+struct TempDir {
+#if !defined(_WIN32)
+  TempDir() = default;
+  explicit TempDir(std::string name) : name(std::move(name)) {}
+  TempDir(const TempDir&) = delete;
+  TempDir(TempDir&& other) noexcept : name(std::move(other.name)) {
+    other.name.clear();
+  }
+
+  TempDir& operator=(const TempDir&) = delete;
+  TempDir& operator=(TempDir&& other) {
+    name = std::move(other.name);
+    other.name.clear();
+    return *this;
+  }
+
+  ~TempDir() {
+    if (!name.empty()) {
+      rmdir(name.c_str());
+    }
+  }
+#endif  // !defined(_WIN32)
+
+  std::string name;
+};
+
 /// Attempts to return a temporary file or returns `nullopt` if an error
 /// occurred.
 ///
@@ -118,5 +144,38 @@ inline TempFile make_tempfile(std::string name_prefix = "torch-file-") {
     return std::move(*tempfile);
   }
   TORCH_CHECK(false, "Error generating temporary file: ", std::strerror(errno));
+}
+
+/// Attempts to return a temporary directory or returns `nullopt` if an error
+/// occurred.
+///
+/// The directory returned follows the pattern
+/// `<tmp-dir>/<name-prefix><random-pattern>/`, where `<tmp-dir>` is the value of
+/// the `"TMPDIR"`, `"TMP"`, `"TEMP"` or
+/// `"TEMPDIR"` environment variable if any is set, or otherwise `/tmp`;
+/// `<name-prefix>` is the value supplied to this function, and
+/// `<random-pattern>` is a random sequence of numbers.
+/// On Windows, `name_prefix` is ignored and `tmpnam` is used.
+inline c10::optional<TempDir> try_make_tempdir(
+    std::string name_prefix = "torch-dir-") {
+#if defined(_WIN32)
+  return TempDir{std::tmpnam(nullptr)};
+#else
+  std::vector<char> filename = detail::make_filename(std::move(name_prefix));
+  const char* dirname = mkdtemp(filename.data());
+  if (!dirname) {
+    return c10::nullopt;
+  }
+  return TempDir(dirname);
+#endif // defined(_WIN32)
+}
+
+/// Like `try_make_tempdir`, but throws an exception if a temporary directory could
+/// not be returned.
+inline TempDir make_tempdir(std::string name_prefix = "torch-dir-") {
+  if (auto tempdir = try_make_tempdir(std::move(name_prefix))) {
+    return std::move(*tempdir);
+  }
+  TORCH_CHECK(false, "Error generating temporary directory: ", std::strerror(errno));
 }
 } // namespace c10

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -55,15 +55,20 @@ void start_manager() {
   }
   SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[0]));
   if (handle.length() == 0) {
-    std::string msg("error executing torch_shm_manager at \"");
+    std::string msg("no response from torch_shm_manager at \"");
     msg += manager_executable_path;
     msg += "\"";
     throw std::runtime_error(msg);
   }
 
   handle.pop_back(); // remove \n
-  if (handle == "ERROR")
-    throw std::exception();
+  if (handle.rfind("ERROR: ", 0) == 0) {
+    std::string msg("torch_shm_manager at \"");
+    msg += manager_executable_path;
+    msg += "\": ";
+    msg += handle.substr(7);  // remove "ERROR: "
+    throw std::runtime_error(msg);
+  }
 
   ClientSocket manager {handle};
   managers.emplace(std::move(handle), std::move(manager));

--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -37,6 +37,12 @@ void start_manager() {
     SYSCHECK_ERR_RETURN_NEG1(dup2(pipe_ends[1], 1)); // Replace stdout
     SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[1]));
     execl(manager_executable_path.c_str(), "torch_shm_manager", NULL);
+
+    std::string msg("ERROR: execl failed: ");
+    msg += strerror(errno);
+    msg += '\n';
+    write(1, msg.c_str(), msg.size());
+
     exit(1);
   }
   SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[1]));

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -107,9 +107,14 @@ int main(int argc, char *argv[]) {
     register_fd(srv_socket->socket_fd);
     print_init_message(tempfile->name.c_str());
     DEBUG("opened socket %s", tempfile->name.c_str());
+  } catch (const std::exception& e) {
+    std::string message("ERROR: ");
+    message += e.what();
+    print_init_message(message.c_str());
+    return 1;
   } catch (...) {
-    print_init_message("ERROR");
-    throw;
+    print_init_message("ERROR: unhandled exception");
+    return 1;
   }
 
   int timeout = -1;


### PR DESCRIPTION
Summary: If we fail to exec `torch_shm_manager`, write an appropriate error message to stdout so that the parent process can have some context on the failure.

Differential Revision: D28047917

