### PR TITLE
Propagate information on torch_shm_manager failures to parent process

### DIFF
--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -55,15 +55,20 @@ void start_manager() {
   }
   SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[0]));
   if (handle.length() == 0) {
-    std::string msg("error executing torch_shm_manager at \"");
+    std::string msg("no response from torch_shm_manager at \"");
     msg += manager_executable_path;
     msg += "\"";
     throw std::runtime_error(msg);
   }
 
   handle.pop_back(); // remove \n
-  if (handle == "ERROR")
-    throw std::exception();
+  if (handle.rfind("ERROR: ", 0) == 0) {
+    std::string msg("torch_shm_manager at \"");
+    msg += manager_executable_path;
+    msg += "\": ";
+    msg += handle.substr(7);  // remove "ERROR: "
+    throw std::runtime_error(msg);
+  }
 
   ClientSocket manager {handle};
   managers.emplace(std::move(handle), std::move(manager));

--- a/torch/lib/libshm/manager.cpp
+++ b/torch/lib/libshm/manager.cpp
@@ -107,9 +107,14 @@ int main(int argc, char *argv[]) {
     register_fd(srv_socket->socket_fd);
     print_init_message(tempfile->name.c_str());
     DEBUG("opened socket %s", tempfile->name.c_str());
+  } catch (const std::exception& e) {
+    std::string message("ERROR: ");
+    message += e.what();
+    print_init_message(message.c_str());
+    return 1;
   } catch (...) {
-    print_init_message("ERROR");
-    throw;
+    print_init_message("ERROR: unhandled exception");
+    return 1;
   }
 
   int timeout = -1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57310 Propagate information on torch_shm_manager execl failure to parent process
* #57309 Address temp file/bind race condition in torch_shm_manager
* #57308 Make c10::TempFile non-copyable but movable
* **#57307 Propagate information on torch_shm_manager failures to parent process**

Extend the `"ERROR"` message that `torch_shm_manager` writes to the pipe when it encounters a fatal error with some extra context (specifically, the `what()` on a caught `std::exception`), allowing the parent process to gain some insight into the cause of the failure.

Also, simply return from `main()` with an error exit code when a fatal exception is caught rather than re-throwing, because re-throwing leads to premature process termination that may prevent standard output from being flushed (and therefore the parent process from being able to read the error context from the pipe).

Differential Revision: [D28047916](https://our.internmc.facebook.com/intern/diff/D28047916/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28047916/)!