### PR TITLE
Address temp file/bind race condition in torch_shm_manager

### DIFF
--- a/c10/test/util/tempfile_test.cpp
+++ b/c10/test/util/tempfile_test.cpp
@@ -1,5 +1,7 @@
 #include <c10/util/tempfile.h>
 #include <gtest/gtest.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #if !defined(_WIN32)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -8,3 +10,20 @@ TEST(TempFileTest, MatchesExpectedPattern) {
   ASSERT_NE(pattern.name.find("test-pattern-"), std::string::npos);
 }
 #endif // !defined(_WIN32)
+
+static bool directory_exists(const char* path) {
+  struct stat st;
+  return (stat(path, &st) == 0 && (st.st_mode & S_IFDIR));
+}
+
+TEST(TempDirTest, tryMakeTempdir) {
+  c10::optional<c10::TempDir> tempdir = c10::make_tempdir("test-dir-");
+  std::string tempdir_name = tempdir->name;
+
+  // directory should exist while tempdir is alive
+  ASSERT_TRUE(directory_exists(tempdir_name.c_str()));
+
+  // directory should not exist after tempdir destroyed
+  tempdir.reset();
+  ASSERT_FALSE(directory_exists(tempdir_name.c_str()));
+}

--- a/c10/util/tempfile.h
+++ b/c10/util/tempfile.h
@@ -13,7 +13,10 @@
 
 #if !defined(_WIN32)
 #include <unistd.h>
-#endif
+#else // defined(_WIN32)
+#include <Windows.h>
+#include <fileapi.h>
+#endif  // defined(_WIN32)
 
 namespace c10 {
 namespace detail {
@@ -85,6 +88,38 @@ struct TempFile {
   std::string name;
 };
 
+struct TempDir {
+  TempDir() = default;
+  explicit TempDir(std::string name) : name(std::move(name)) {}
+  TempDir(const TempDir&) = delete;
+  TempDir(TempDir&& other) noexcept : name(std::move(other.name)) {
+    other.name.clear();
+  }
+
+  TempDir& operator=(const TempDir&) = delete;
+  TempDir& operator=(TempDir&& other) {
+    name = std::move(other.name);
+    other.name.clear();
+    return *this;
+  }
+
+#if !defined(_WIN32)
+  ~TempDir() {
+    if (!name.empty()) {
+      rmdir(name.c_str());
+    }
+  }
+#else   // defined(_WIN32)
+  ~TempDir() {
+    if (!name.empty()) {
+      RemoveDirectoryA(name.c_str());
+    }
+  }
+#endif  // defined(_WIN32)
+
+  std::string name;
+};
+
 /// Attempts to return a temporary file or returns `nullopt` if an error
 /// occurred.
 ///
@@ -118,5 +153,50 @@ inline TempFile make_tempfile(std::string name_prefix = "torch-file-") {
     return std::move(*tempfile);
   }
   TORCH_CHECK(false, "Error generating temporary file: ", std::strerror(errno));
+}
+
+/// Attempts to return a temporary directory or returns `nullopt` if an error
+/// occurred.
+///
+/// The directory returned follows the pattern
+/// `<tmp-dir>/<name-prefix><random-pattern>/`, where `<tmp-dir>` is the value of
+/// the `"TMPDIR"`, `"TMP"`, `"TEMP"` or
+/// `"TEMPDIR"` environment variable if any is set, or otherwise `/tmp`;
+/// `<name-prefix>` is the value supplied to this function, and
+/// `<random-pattern>` is a random sequence of numbers.
+/// On Windows, `name_prefix` is ignored and `tmpnam` is used.
+inline c10::optional<TempDir> try_make_tempdir(
+    std::string name_prefix = "torch-dir-") {
+#if defined(_WIN32)
+  while (true) {
+    const char* dirname = std::tmpnam(nullptr);
+    if (!dirname) {
+      return c10::nullopt;
+    }
+    if (CreateDirectoryA(dirname, NULL)) {
+      return TempDir(dirname);
+    }
+    if (GetLastError() != ERROR_ALREADY_EXISTS) {
+      return c10::nullopt;
+    }
+  }
+  return c10::nullopt;
+#else
+  std::vector<char> filename = detail::make_filename(std::move(name_prefix));
+  const char* dirname = mkdtemp(filename.data());
+  if (!dirname) {
+    return c10::nullopt;
+  }
+  return TempDir(dirname);
+#endif // defined(_WIN32)
+}
+
+/// Like `try_make_tempdir`, but throws an exception if a temporary directory could
+/// not be returned.
+inline TempDir make_tempdir(std::string name_prefix = "torch-dir-") {
+  if (auto tempdir = try_make_tempdir(std::move(name_prefix))) {
+    return std::move(*tempdir);
+  }
+  TORCH_CHECK(false, "Error generating temporary directory: ", std::strerror(errno));
 }
 } // namespace c10


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57310 Propagate information on torch_shm_manager execl failure to parent process
* **#57309 Address temp file/bind race condition in torch_shm_manager**
* #57308 Make c10::TempFile non-copyable but movable
* #57307 Propagate information on torch_shm_manager failures to parent process

Addressing a race condition that can occur in `torch_shm_manager` between the time its temporary file is unlinked and when it `bind()`s the manager server socket to that same name. In that time window, other threads/processes can re-create another temporary file with the same name, causing `bind()` to fail with `EADDRINUSE`.

This diff introduces `c10::TempDir` and associated helper functions that mirror those of `c10::TempFile` and generates the manager socket name using a combination of a temporary directory, which will be valid for the lifetime of `torch_shm_manager`, and a well-known file name within that directory that will never be used outside of `bind()`.

Differential Revision: [D28047914](https://our.internmc.facebook.com/intern/diff/D28047914/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28047914/)!