### PR TITLE
Propagate information on torch_shm_manager execl failure to parent process

### DIFF
--- a/torch/lib/libshm/core.cpp
+++ b/torch/lib/libshm/core.cpp
@@ -37,6 +37,12 @@ void start_manager() {
     SYSCHECK_ERR_RETURN_NEG1(dup2(pipe_ends[1], 1)); // Replace stdout
     SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[1]));
     execl(manager_executable_path.c_str(), "torch_shm_manager", NULL);
+
+    std::string msg("ERROR: execl failed: ");
+    msg += strerror(errno);
+    msg += '\n';
+    write(1, msg.c_str(), msg.size());
+
     exit(1);
   }
   SYSCHECK_ERR_RETURN_NEG1(close(pipe_ends[1]));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57310 Propagate information on torch_shm_manager execl failure to parent process**
* #57309 Address temp file/bind race condition in torch_shm_manager
* #57308 Make c10::TempFile non-copyable but movable
* #57307 Propagate information on torch_shm_manager failures to parent process

If we fail to exec `torch_shm_manager`, write an appropriate error message to stdout so that the parent process can have some context on the failure.

Differential Revision: [D28047917](https://our.internmc.facebook.com/intern/diff/D28047917/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28047917/)!