### PR TITLE
Add a shortcut to test all torchbench models.

### DIFF
--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -28,7 +28,7 @@ start: {control}
 end: {treatment}
 threshold: 100
 direction: decrease
-timeout: 60
+timeout: 360
 tests:"""
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]):

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -37,7 +37,7 @@ def gen_abtest_config(control: str, treatment: str, models: List[str]):
     d["treatment"] = treatment
     config = ABTEST_CONFIG_TEMPLATE.format(**d)
     if models == ["ALL"]:
-        return config
+        return config + "\n"
     for model in models:
         config = f"{config}\n  - {model}"
     config = config + "\n"
@@ -63,7 +63,8 @@ def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> List[str]:
     if model_list == ["ALL"]:
         return model_list
     # Sanity check: make sure all the user specified models exist in torchbench repository
-    full_model_list = os.listdir(os.path.join(torchbench_path, "torchbenchmark", "models"))
+    benchmark_path = os.path.join(torchbench_path, "torchbenchmark", "models")
+    full_model_list = [ model for model in os.listdir(benchmark_path) if os.path.isdir(os.path.join(benchmark_path, model)) ]
     for m in model_list:
         if m not in full_model_list:
             print(f"The model {m} you specified does not exist in TorchBench suite. Please double check.")

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -36,6 +36,8 @@ def gen_abtest_config(control: str, treatment: str, models: List[str]):
     d["control"] = control
     d["treatment"] = treatment
     config = ABTEST_CONFIG_TEMPLATE.format(**d)
+    if models == ["ALL"]:
+        return config
     for model in models:
         config = f"{config}\n  - {model}"
     config = config + "\n"
@@ -57,6 +59,9 @@ def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> List[str]:
         if magic_lines:
             # Only the first magic line will be respected.
             model_list = list(map(lambda x: x.strip(), magic_lines[0][len(MAGIC_PREFIX):].split(",")))
+    # Shortcut: if model_list is ["ALL"], run all the tests
+    if model_list == ["ALL"]:
+        return model_list
     # Sanity check: make sure all the user specified models exist in torchbench repository
     full_model_list = os.listdir(os.path.join(torchbench_path, "torchbenchmark", "models"))
     for m in model_list:

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -64,7 +64,7 @@ def extract_models_from_pr(torchbench_path: str, prbody_file: str) -> List[str]:
         return model_list
     # Sanity check: make sure all the user specified models exist in torchbench repository
     benchmark_path = os.path.join(torchbench_path, "torchbenchmark", "models")
-    full_model_list = [ model for model in os.listdir(benchmark_path) if os.path.isdir(os.path.join(benchmark_path, model)) ]
+    full_model_list = [model for model in os.listdir(benchmark_path) if os.path.isdir(os.path.join(benchmark_path, model))]
     for m in model_list:
         if m not in full_model_list:
             print(f"The model {m} you specified does not exist in TorchBench suite. Please double check.")

--- a/.github/scripts/run_torchbench.py
+++ b/.github/scripts/run_torchbench.py
@@ -28,7 +28,7 @@ start: {control}
 end: {treatment}
 threshold: 100
 direction: decrease
-timeout: 360
+timeout: 720
 tests:"""
 
 def gen_abtest_config(control: str, treatment: str, models: List[str]):

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -14,6 +14,8 @@ jobs:
     # Only run the job when the body contains magic word "RUN_TORCHBENCH:"
     if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_TORCHBENCH:') }}
     runs-on: [self-hosted, bm-runner]
+    # Set to 12 hours
+    timeout-minutes: 720
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -14,6 +14,7 @@ jobs:
     # Only run the job when the body contains magic word "RUN_TORCHBENCH:"
     if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_TORCHBENCH:') }}
     runs-on: [self-hosted, bm-runner]
+    timeout-minutes: 300 # 5 hours
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2

--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -14,7 +14,6 @@ jobs:
     # Only run the job when the body contains magic word "RUN_TORCHBENCH:"
     if: ${{ github.repository_owner == 'pytorch' && contains(github.event.pull_request.body, 'RUN_TORCHBENCH:') }}
     runs-on: [self-hosted, bm-runner]
-    timeout-minutes: 300 # 5 hours
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds a shortcut of specifying all models in TorchBench CI

Test plan:
CI

RUN_TORCHBENCH: ALL
