### PR TITLE
Fix torch.ormqr for non Fortran-contiguous inputs

### DIFF
--- a/aten/src/TH/generic/THTensorLapack.cpp
+++ b/aten/src/TH/generic/THTensorLapack.cpp
@@ -218,6 +218,8 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, bo
 
   THTensor *ra__ = NULL;
   ra__ = THTensor_(cloneColumnMajor)(ra_, c);
+  THTensor *a_ = NULL;
+  a_ = THTensor_(cloneColumnMajor)(a_, a);
 
   int m = c->size(0);
   int n = c->size(1);
@@ -236,14 +238,14 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, bo
   /* Dry-run to query the suggested size of the workspace. */
   int info = 0;
   scalar_t wkopt = 0;
-  THLapack_(ormqr)(side, trans, m, n, k, a->data<scalar_t>(), lda,
+  THLapack_(ormqr)(side, trans, m, n, k, a_->data<scalar_t>(), lda,
                    tau->data<scalar_t>(), ra__->data<scalar_t>(), ldc,
                    &wkopt, -1, &info);
 
   /* Allocate the workspace and call LAPACK to do the real work. */
   int lwork = (int)wkopt;
   THTensor *work = THTensor_(newWithSize1d)(lwork);
-  THLapack_(ormqr)(side, trans, m, n, k, a->data<scalar_t>(), lda,
+  THLapack_(ormqr)(side, trans, m, n, k, a_->data<scalar_t>(), lda,
                    tau->data<scalar_t>(), ra__->data<scalar_t>(), ldc,
                    work->data<scalar_t>(), lwork, &info);
 
@@ -254,6 +256,7 @@ void THTensor_(ormqr)(THTensor *ra_, THTensor *a, THTensor *tau, THTensor *c, bo
                            "ormqr", info,"");
   THTensor_(freeCopyTo)(ra__, ra_);
   c10::raw::intrusive_ptr::decref(work);
+  c10::raw::intrusive_ptr::decref(a_);
 }
 
 #endif

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4911,6 +4911,18 @@ class TestLinalg(TestCase):
         self.assertEqual(res1, res2)
         self.assertEqual(res2, out_holder)
 
+        # m is Fortran-contiguous, now test the C-contiguous input
+        self.assertTrue(m.transpose(-2, -1).is_contiguous())
+
+        a = m.contiguous()
+        out = torch.empty_like(mat1)
+
+        res1 = q @ mat2
+        res2 = torch.ormqr(a, tau, mat2, left=True, transpose=False)
+        torch.ormqr(a, tau, mat2, out=out_holder)
+        self.assertEqual(res1, res2)
+        self.assertEqual(res2, out_holder)
+
     @skipCUDAIfRocm
     def test_blas_empty(self, device):
         def fn(torchfn, *args, test_out=False, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57317 Add cuSOLVER path for torch.linalg.lstsq
* #57316 Add CUDA support for torch.ormqr
* #57315 Port CPU torch.ormqr to ATen
* **#57314 Fix torch.ormqr for non Fortran-contiguous inputs**
* #56257 Fix MAGMA qr for empty batched inputs
* #56256 Add cuSOLVER path for torch.linalg.qr
* #56255 Remove size arguments for internal orgqr and geqrf calls
* #56254 Add non-allocating helper function for torch.linalg.qr

Differential Revision: [D28118029](https://our.internmc.facebook.com/intern/diff/D28118029)