### PR TITLE
Added sm_75 support for CI Xenial CUDA 11.1 cuDNN 8 builds

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -184,7 +184,7 @@ fi
 # Target only our CI GPU machine's CUDA arch to speed up the build
 export TORCH_CUDA_ARCH_LIST="5.2"
 
-# Add sm_75 support for the Linux CUDA 11.1 cuDNN 8 build
+# Add sm_75 support for the Linux CUDA 11.1 cuDNN 8 CircleCI build
 if [[ "$BUILD_ENVIRONMENT" == *xenial-cuda11.1-cudnn8*build ]]; then
   export TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST";7.5"
 fi

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -184,8 +184,8 @@ fi
 # Target only our CI GPU machine's CUDA arch to speed up the build
 export TORCH_CUDA_ARCH_LIST="5.2"
 
-# Add sm_75 support for the Linux CUDA 10.2 cuDNN 7 build
-if [[ "$BUILD_ENVIRONMENT" == *cuda10.2-cudnn7*build ]]; then
+# Add sm_75 support for the Linux CUDA 11.1 cuDNN 8 build
+if [[ "$BUILD_ENVIRONMENT" == *xenial-cuda11.1-cudnn8*build ]]; then
   export TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST";7.5"
 fi
 


### PR DESCRIPTION
This PR adds `sm_75` CUDA architecture support for the PR CI build Xenial CUDA 11.1 cuDNN 8, with build name:`pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_build`, so that generated artifacts from these builds can be installed and run on machines with CUDA capability sm_75.

In PR #57207, the Xenial CUDA 10.2 cuDNN 7 build `pytorch_linux_xenial_cuda10_2_cudnn7_py3_gcc7_build` was taken off the list of builds done for PRs to `master`. PR #56619 has added `sm_75` support for this build. This PR removes this support for the Xenial CUDA 10.2 cuDNN7 builds, and adds it for the current PR CI build Xenial CUDA 11.1 cuDNN 8 `pytorch_linux_xenial_cuda11_1_cudnn8_py3_gcc7_build`.