### PR TITLE
Fix string_view::equals_ compilation by CUDA-11.3

### DIFF
--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -581,7 +581,7 @@ class basic_string_view final {
   constexpr bool equals_(basic_string_view rhs) const {
     // We don't use string_view::compare() here but implement it manually because
     // only looking at equality allows for more optimized code.
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CUDACC__)
     return size() == rhs.size() && 0 == __builtin_memcmp(data(), rhs.data(), size());
 #elif __cpp_constexpr >= 201304
     // if we are in C++14, write it iteratively. This is faster than the recursive C++11 implementation below.


### PR DESCRIPTION
__builtin_memcmp is not a constexpr for character arrays for NVCC-11.3 compiler.
Attempts to compile this code results in the following error:
```
/opt/conda/lib/python3.6/site-packages/torch/include/c10/util/string_view.h(585): note: constexpr memory comparison is only supported for top-level integer or array-of-integer objects
/opt/conda/lib/python3.6/site-packages/torch/include/c10/util/string_view.h(340): note: called from:
/opt/conda/lib/python3.6/site-packages/torch/include/c10/util/string_view.h(369): note: called from:

```

Fixes #{issue number}
