### PR TITLE
To add priority of int/int? over int[] on signature matching and adding {h,v,d}split methods

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3595,22 +3595,22 @@
     CompositeExplicitAutograd: split_with_sizes
 
 - func: hsplit.int(Tensor(a) self, int sections) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: hsplit.array(Tensor(a) self, int[] indices) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: vsplit.int(Tensor(a) self, int sections) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: vsplit.array(Tensor(a) self, int[] indices) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: dsplit.int(Tensor(a) self, int sections) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: dsplit.array(Tensor(a) self, int[] indices) -> Tensor(a)[]
-  variants: function
+  variants: function, method
 
 - func: squeeze(Tensor(a) self) -> Tensor(a)
   variants: function, method

--- a/docs/source/tensors.rst
+++ b/docs/source/tensors.rst
@@ -322,6 +322,7 @@ Tensor class reference
     Tensor.divide_
     Tensor.dot
     Tensor.double
+    Tensor.dsplit
     Tensor.eig
     Tensor.element_size
     Tensor.eq
@@ -378,6 +379,7 @@ Tensor class reference
     Tensor.hardshrink
     Tensor.heaviside
     Tensor.histc
+    Tensor.hsplit
     Tensor.hypot
     Tensor.hypot_
     Tensor.i0
@@ -662,6 +664,7 @@ Tensor class reference
     Tensor.vdot
     Tensor.view
     Tensor.view_as
+    Tensor.vsplit
     Tensor.where
     Tensor.xlogy
     Tensor.xlogy_

--- a/tools/autograd/gen_python_functions.py
+++ b/tools/autograd/gen_python_functions.py
@@ -759,8 +759,11 @@ def sort_overloads(
 ) -> Sequence[PythonSignatureGroup]:
 
     def is_arg_smaller(t1: Type, t2: Type) -> bool:
+        # In the discussion https://github.com/pytorch/pytorch/issues/54555 it has been
+        # discussed why it is important to prioritize int/int? over int[]
         return (str(t1) == 'Scalar' and str(t2) == 'Tensor' or
-                'Dimname' in str(t1) and 'Dimname' not in str(t2))
+                'Dimname' in str(t1) and 'Dimname' not in str(t2) or
+                str(t1) == 'int[]' and (str(t2) == 'int' or str(t2) == 'int?'))
 
     def is_smaller(s1: PythonSignature, s2: PythonSignature) -> bool:
         """Returns True if s1 < s2 in the partial order."""

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -4422,6 +4422,27 @@ tensor_split(indices_or_sections, dim=0) -> List of Tensors
 See :func:`torch.tensor_split`
 """)
 
+add_docstr_all('hsplit',
+               r"""
+hsplit(split_size_or_sections) -> List of Tensors
+
+See :func:`torch.hsplit`
+""")
+
+add_docstr_all('vsplit',
+               r"""
+vsplit(split_size_or_sections) -> List of Tensors
+
+See :func:`torch.vsplit`
+""")
+
+add_docstr_all('dsplit',
+               r"""
+dsplit(split_size_or_sections) -> List of Tensors
+
+See :func:`torch.dsplit`
+""")
+
 add_docstr_all('stft',
                r"""
 stft(frame_length, hop, fft_size=None, return_onesided=True, window=None, pad_end=0) -> Tensor


### PR DESCRIPTION
Fixes #54555

It has been discussed in the issue #54555 that {h,v,d}split methods unexpectedly matches argument of single int[] when it is expected to match single argument of int. The same unexpected behavior can happen in other functions/methods which can take both int[] and int? as single argument signatures.

In this PR we solve this problem by giving higher priority to int/int? arguments over int[] while sorting signatures.

We also add methods of {h,v,d}split methods here, which helped us to discover this unexpected behavior.