### PR TITLE
Remove code and logic for old style custom autograd Function 

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2115,46 +2115,6 @@ class TestAutograd(TestCase):
         for _ in range(10):
             CollectOnDelete().forward(torch.randn(1, requires_grad=True)).backward()
 
-    # Delete this test when legacy custom autograd functions are deleted.
-    def test_naughty_legacy_variable_grad_fn(self):
-        class Id(Function):
-            def forward(self, x):
-                return x
-
-            def backward(self, grad_x):
-                return grad_x
-
-        self.assertRaises(RuntimeError, lambda: Variable(torch.zeros(1), _grad_fn=Id()))
-
-    # Delete this test when legacy custom autograd functions are deleted.
-    def test_naughty_legacy_function_backward_before_forward(self):
-        class Id(Function):
-            def forward(self, x):
-                return x
-
-            def backward(self, grad_x):
-                return grad_x
-
-        f = Id()
-        self.assertRaises(RuntimeError, lambda: f._do_backward((torch.zeros(0), ), False))
-
-    # Delete this test when legacy custom autograd functions are deleted.
-    def test_naughty_legacy_function_early_access(self):
-        class Id(Function):
-            def forward(self, x):
-                return x
-
-            def backward(self, grad_x):
-                return grad_x
-
-        f = Id()
-        # A legacy autograd function is not fully initialized until you actually
-        # apply it.  That means a lot of accessors on them don't actually work.
-        # Test that we properly error in this case.
-        self.assertRaises(RuntimeError, lambda: f.register_hook(lambda x, y: None))
-        self.assertRaises(RuntimeError, lambda: f.next_functions)
-        self.assertRaises(RuntimeError, lambda: f.metadata)
-
     @unittest.expectedFailure
     def test_naughty_anomaly_access(self):
         class MyFunction(Function):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -142,9 +142,9 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
     def __init__(self, *args, **kwargs):
         cls = self.__class__
         warnings.warn(f"{cls} should not be instantiated. Methods on autograd functions"
-                       "are all static, so you should invoke them on the class itself. "
-                       "Instantiating an autograd function will raise an "
-                       "error in a future version of PyTorch.", DeprecationWarning)
+                      "are all static, so you should invoke them on the class itself. "
+                      "Instantiating an autograd function will raise an "
+                      "error in a future version of PyTorch.", DeprecationWarning)
 
     def __call__(self, *args, **kwargs):
         raise RuntimeError(

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -141,9 +141,9 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
     """
     def __init__(self, *args, **kwargs):
         cls = self.__class__
-        warnings.warn(f"{cls} should not be instantiated. For new-style autograd functions "
-                       "`apply` is a class method, so you can invoke its `.apply()` "
-                       "directly. Instantiating autograd functions will raise an "
+        warnings.warn(f"{cls} should not be instantiated. Methods on autograd functions"
+                       "are all static, so you should invoke them on the class itself. "
+                       "Instantiating an autograd function will raise an "
                        "error in a future version of PyTorch.", DeprecationWarning)
 
     def __call__(self, *args, **kwargs):

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -82,8 +82,6 @@ class _HookMixin(object):
 
 
 class BackwardCFunction(_C._FunctionBase, _ContextMethodMixin, _HookMixin):
-    _is_legacy = False
-
     def apply(self, *args):
         # _forward_cls is defined by derived class
         return self._forward_cls.backward(self, *args)  # type: ignore[attr-defined]
@@ -93,29 +91,16 @@ class FunctionMeta(type):
     """Function metaclass.
 
     This metaclass sets up the following properties:
-        _is_legacy: True if forward is not defined as a static method.
         _backward_cls: The Function class corresponding to the differentiated
             version of this function (which is generated on the fly by this
             metaclass).
     """
-
     def __init__(cls, name, bases, attrs):
-        for super_cls in cls.mro():
-            forward = super_cls.__dict__.get('forward')
-            if forward is not None:
-                has_static_forward = isinstance(forward, staticmethod) or isinstance(forward, classmethod)
-                break
-
-        cls._is_legacy = not has_static_forward
-
-        # old-style functions
-        if not has_static_forward:
-            return super(FunctionMeta, cls).__init__(name, bases, attrs)
-
         backward_fn = type(name + 'Backward', (BackwardCFunction,), {'_forward_cls': cls})
         cls._backward_cls = backward_fn
 
         return super(FunctionMeta, cls).__init__(name, bases, attrs)
+
 
 # mypy doesn't understand `with_metaclass` from torch._six
 class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixin, _HookMixin)):  # type: ignore[misc]

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -139,6 +139,12 @@ class Function(with_metaclass(FunctionMeta, _C._FunctionBase, _ContextMethodMixi
         >>> #Use it by calling the apply method:
         >>> output = Exp.apply(input)
     """
+    def __init__(self, *args, **kwargs):
+        cls = self.__class__
+        warnings.warn(f"{cls} should not be instantiated. For new-style autograd functions "
+                       "`apply` is a class method, so you can invoke its `.apply()` "
+                       "directly. Instantiating autograd functions will raise an "
+                       "error in a future version of PyTorch.", DeprecationWarning)
 
     def __call__(self, *args, **kwargs):
         raise RuntimeError(

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -53,49 +53,6 @@ void PyNode::throw_python_error() {
   err.persist();
   throw err;
 }
-auto PyNode::legacy_apply(const variable_list& inputs) -> variable_list {
-  pybind11::gil_scoped_acquire gil;
-
-  THPObjectPtr pyInputs(PyTuple_New(inputs.size()));
-  if (!pyInputs) throw_python_error();
-
-  for (size_t i = 0; i != inputs.size(); ++i) {
-    PyTuple_SET_ITEM(pyInputs.get(), i, THPVariable_Wrap(inputs[i]));
-  }
-
-  THPObjectPtr r(PyObject_CallMethod(
-      obj, "_do_backward", "OO", pyInputs.get(), Py_True));
-  if (!r) throw_python_error();
-
-  auto num_outputs = PyTuple_GET_SIZE(r.get());
-  tensor_list tensor_results(num_outputs);
-  for (int i = 0; i != num_outputs; ++i) {
-    PyObject* obj = PyTuple_GET_ITEM(r.get(), i);
-    if (obj != Py_None) {
-      if (!THPVariable_Check(obj)) {
-        std::string msg("expected Variable (got '");
-        msg += THPUtils_typename(obj);
-        msg += "')'";
-        throw std::runtime_error(msg);
-      }
-      tensor_results[i] = THPVariable_Unpack(obj).tensor_data();
-    }
-  }
-
-  // XXX: this might get requires_grad wrong - there's no way to figure out
-  // if _do_backward didn't use ctx.saved_tensors and as a result some
-  // Variables might require grad, even if no args do. Unfortunately, this
-  // leads to unexpected error messages ("no nodes require computing gradients"),
-  // but I don't have a better idea. These functions would raise an error
-  // in backward anyway.
-  return wrap_outputs(
-      inputs,
-      std::move(tensor_results),
-      [this](edge_list&& next_edges) {
-        return std::make_shared<Error>(
-            name() + " is not differentiable twice", std::move(next_edges));
-      });
-}
 
 // NOTE: this function is written in a way that assumes it's only called for backward;
 // it's used by engine.cpp.  This is responsible for forwarding a call from
@@ -104,11 +61,6 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   pybind11::gil_scoped_acquire gil;
   at::OptionalDeviceGuard _device_guard;
   THPFunction* py_fn = (THPFunction*)obj;
-
-  THPObjectPtr _legacy(PyObject_GetAttrString(obj, "_is_legacy"));
-  if (_legacy == Py_True) {
-    return legacy_apply(inputs);
-  }
 
   // Massage a C++ variable_list into a Python arguments tuple
   auto num_inputs = inputs.size();
@@ -212,11 +164,6 @@ auto PyNode::name() const -> std::string {
   pybind11::gil_scoped_acquire gil;
   auto f = (THPFunction*) obj;
   auto name = std::string(Py_TYPE(f)->tp_name);
-  // Python API functions are not const-correct
-  THPObjectPtr _legacy(PyObject_GetAttrString(const_cast<PyObject*>(obj), "_is_legacy")); // NOLINT
-  if (_legacy == Py_True) {
-    name += "LegacyBackward";
-  }
   return name;
 }
 
@@ -225,10 +172,8 @@ auto PyNode::name() const -> std::string {
 // Traverse and clear are required for supporting Python's GC cycle handling.
 static int THPFunction_traverse(THPFunction *self, visitproc visit, void *arg)
 {
-  // cdata could be null if someone constructed a legacy function but haven't
-  // actually called backward() on it yet, or if the PyNode has already
-  // gone out of scope by the time we're GC'ing this THPFunction (e.g., the
-  // user saved grad_fn only).
+  // cdata could be null if the PyNode has already gone out of scope
+  // by the time we're GC'ing this THPFunction (e.g., the user saved grad_fn only).
   //
   // TODO: I'm not really sure if we're actually obligated to traverse PyObject
   // that is stored in PyNode, since we don't really own that C++ object.
@@ -312,8 +257,6 @@ PyObject *THPFunction_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 ////////////////////////////////////////////////////////////////////////////////
 // Forward
 ////////////////////////////////////////////////////////////////////////////////
-
-using t2var_type = std::unordered_map<PyObject *, THPVariable *>;
 
 // Bump the counters of all recorded dirty input tensors, adding each of them
 // into dirty_inputs.  Also does some sanity checking.
@@ -504,15 +447,6 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
   return std::make_pair(std::move(unpacked), std::move(flags));
 }
 
-static void _assert_not_tracing(const char* name, const variable_list& input_vars) {
-  if (jit::tracer::isTracing()) {
-    std::ostringstream oss;
-    oss << "Attempted to trace " << name;
-    oss << ", but tracing of legacy functions is not supported";
-    throw std::runtime_error(oss.str());
-  }
-}
-
 static torch::jit::Node* _trace_pre_record(
     PyObject* op_obj,
     PyObject *input_objects,
@@ -694,127 +628,6 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// Backward
-////////////////////////////////////////////////////////////////////////////////
-
-static void _prepare_grads(THPFunction *self, THPObjectPtr& raw_grads, bool is_grad_output)
-{
-  at::OptionalDeviceGuard device_guard;
-  int num_grads = PyTuple_GET_SIZE(raw_grads.get());
-  // First, check if any of grads is None. If not, there's nothing to do
-  bool has_none = false;
-  for (int i = 0; i < num_grads; i++) {
-    has_none |= PyTuple_GET_ITEM(raw_grads.get(), i) == Py_None;
-  }
-  if (!has_none)
-      return;
-
-  THPObjectPtr grads;
-  grads = PyTuple_New(num_grads);
-  if (!grads) throw python_error();
-
-  // Look for Nones and replace them with new buffers
-  auto& grads_info = is_grad_output ? self->output_info : self->input_info;
-  AT_ASSERT(grads_info.size() == (size_t)num_grads);
-  for (int i = 0; i < num_grads; i++) {
-    PyObject *grad = PyTuple_GET_ITEM(raw_grads.get(), i);
-    if (grad == Py_None) {
-      grad = THPVariable_Wrap(grads_info[i].zeros(device_guard));
-      if (!grad) throw python_error();
-    } else {
-      Py_INCREF(grad);
-    }
-    PyTuple_SET_ITEM(grads.get(), i, grad);
-  }
-  raw_grads = grads.release();
-}
-
-static void _trim_grad_input(const std::shared_ptr<PyNode>& cdata, THPFunction *self, THPObjectPtr& grad_input)
-{
-  int num_grads = PyTuple_GET_SIZE(grad_input.get());
-  const int num_outputs = cdata->num_outputs();
-  if (num_grads > num_outputs) {
-    // Check that all extra grads are none
-    bool all_none = true;
-    for (int i = num_outputs; i < num_grads; i++) {
-      all_none = (PyTuple_GET_ITEM(grad_input.get(), i) == Py_None);
-      if (!all_none) break;
-    }
-    // If yes, slice the tuple
-    if (all_none) {
-      num_grads = num_outputs;
-      grad_input = PyTuple_GetSlice(grad_input.get(), 0, num_grads);
-      if (!grad_input) throw python_error();
-    }
-  }
-}
-
-PyObject * THPFunction_do_backward(PyObject *_self, PyObject *args)
-{
-  try {
-    Py_ssize_t num_args = args ? PyTuple_GET_SIZE(args) : 0;
-    THPUtils_assert(num_args == 2, "_do_backward expects exactly two arguments");
-    PyObject *raw_grad_output = PyTuple_GET_ITEM(args, 0);
-    PyObject *retain_variables = PyTuple_GET_ITEM(args, 1);
-    if (!PyTuple_Check(raw_grad_output) || !PyBool_Check(retain_variables)) {
-      THPUtils_invalidArguments(args, nullptr, "_do_backward", 1, "(tuple, bool)");
-      return nullptr;
-    }
-
-    auto self = (THPFunction*)_self;
-    auto cdata = self->cdata.lock();
-    // In obscure situations, cdata might be nullptr because it's expired.  THAT
-    // is an internal error and I'd like to know about it, but since this is
-    // all dead soon I didn't bother implementing a sanity check here.  See
-    // https://stackoverflow.com/questions/45507041/how-to-check-if-weak-ptr-is-empty-non-assigned
-    // for how to do it.
-    TORCH_CHECK(cdata,
-      "Legacy autograd function attempted to call backward before forward "
-      "was called.  This could occur if you manually called _do_backward on Function.  "
-      "In any case, this is very naughty!  If you absolutely need this to work, "
-      "try porting your code to use non-legacy autograd function, see: "
-      "https://pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd");
-    THPUtils_assert(PyTuple_GET_SIZE(raw_grad_output) == cdata->num_inputs(),
-                    "%s got an invalid number of gradients (expected %d got %d)",
-                    THPUtils_typename(self), cdata->num_inputs(),
-                    PyTuple_GET_SIZE(raw_grad_output));
-
-    // Some of the output might have been unused, so we have to allocate
-    // zero-filled buffers instead
-    Py_INCREF(raw_grad_output);
-    THPObjectPtr grad_output(raw_grad_output);
-    if (self->materialize_grads) {
-      _prepare_grads(self, grad_output, true);
-    }
-
-    // self.backward(*grad_output)
-    THPObjectPtr backward_fn(PyObject_GetAttrString((PyObject*)self, "backward"));
-    THPUtils_assert(backward_fn.get(), "function %s doesn't implement a required "
-        "'backward' method", THPUtils_typename((PyObject*)self));
-    THPObjectPtr grad_input(PyObject_CallObject(backward_fn, grad_output.get()));
-    if (!grad_input) return nullptr;
-    ensure_tuple(grad_input);
-
-    // We allow functions to return more gradients, than there were outputs,
-    // if and only if the additional ones are all None
-    _trim_grad_input(cdata, self, grad_input);
-    int num_grads = PyTuple_GET_SIZE(grad_input.get());
-    int num_outputs = cdata->num_outputs();
-    THPUtils_assert(num_grads == num_outputs, "%s returned an invalid number of "
-        "gradient tensors (expected %d, but got %d)", THPUtils_typename(self),
-        num_outputs, num_grads);
-
-    return grad_input.release();
-
-  } catch (python_error& e) {
-    return nullptr;
-  } catch (std::exception& e) {
-    THPUtils_setError(e.what());
-    return nullptr;
-  }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // Other methods / attributes
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -828,11 +641,6 @@ PyObject* THPFunction__register_hook_dict(PyObject *_self, PyObject *_var)
       var->backward_hooks, tensor.output_nr()));
   auto self = (THPFunction*)_self;
   auto cdata = self->cdata.lock();
-  TORCH_CHECK(cdata,
-    "Legacy autograd function had register_hook called before the function was "
-    "invoked.  This usage pattern is no longer supported: please call register_hook "
-    "AFTER calling your function, or port your code to use non-legacy autograd function, see: "
-    "https://pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd")
   cdata->add_pre_hook(std::move(hook));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -843,11 +651,6 @@ PyObject* THPFunction_register_hook(PyObject *_self, PyObject *hook)
   HANDLE_TH_ERRORS
   auto self= (THPFunction*)_self;
   auto cdata = self->cdata.lock();
-  TORCH_CHECK(cdata,
-    "Legacy autograd function had _register_hook called before the function was "
-    "invoked.  This usage pattern is no longer supported: please call _register_hook "
-    "AFTER calling your function, or port your code to use non-legacy autograd function, see: "
-    "https://pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd")
   return torch::autograd::registerFunctionHook(*cdata, hook);
   END_HANDLE_TH_ERRORS
 }
@@ -925,11 +728,6 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
 {
   HANDLE_TH_ERRORS
   auto cdata = self->cdata.lock();
-  TORCH_CHECK(cdata,
-    "Legacy autograd function had next_functions accessed before the function was "
-    "invoked.  This doesn't make any sense: we have no idea what the next "
-    "functions are, because you haven't actually inserted this grad_fn inside "
-    "a graph.  Try invoking your function first before accessing this field.")
   const auto num_outputs = cdata->num_outputs();
   THPObjectPtr result(PyTuple_New(num_outputs));
   if (!result)
@@ -1037,7 +835,6 @@ static struct PyGetSetDef THPFunction_properties[] = {
 static struct PyMethodDef THPFunction_methods[] = {
   {(char*)"name", THPFunction_name, METH_NOARGS, nullptr},
   {(char*)"apply", THPFunction_apply, METH_CLASS | METH_VARARGS, nullptr},
-  {(char*)"_do_backward", THPFunction_do_backward, METH_VARARGS, nullptr},
   {(char*)"_register_hook_dict", THPFunction__register_hook_dict, METH_O, nullptr},
   {(char*)"register_hook", THPFunction_register_hook, METH_O, nullptr},
   {nullptr}

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -425,7 +425,7 @@ std::pair<UnpackedInput, InputFlags> unpack_input(PyObject *args) {
     if (!is_variable) {
       // TODO: remove this code path once Variable and Tensor are merged in Python
       if (enforce_variables) {
-        THPUtils_setError("expected a Variable argument, but got %s",
+        THPUtils_setError("expected a Tensor argument, but got %s",
                           THPUtils_typename(arg));
         throw python_error();
       }
@@ -564,6 +564,12 @@ PyObject* process_outputs(PyObject *op_obj, const std::shared_ptr<PyNode>& cdata
 PyObject* THPFunction_name(PyObject *self, PyObject* noargs) {
   HANDLE_TH_ERRORS
   auto cdata = ((THPFunction*)self)->cdata.lock();
+  TORCH_CHECK(cdata,
+    "Attribute 'name' is invalid for this instance of _C._FunctionBase. "
+    "Accessing this attribute directly on an instance of autograd.Function is a legacy "
+    "access pattern that is no longer supported. For examples on how to use new-style "
+    "autograd functions, see "
+    "https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function ");
   return THPUtils_packString(cdata->name());
   END_HANDLE_TH_ERRORS
 }
@@ -634,13 +640,19 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
 PyObject* THPFunction__register_hook_dict(PyObject *_self, PyObject *_var)
 {
   HANDLE_TH_ERRORS
-  THPUtils_assert(THPVariable_Check(_var), "_register_hook_dict expected a variable");
+  THPUtils_assert(THPVariable_Check(_var), "_register_hook_dict expected a Tensor");
   THPVariable* var = reinterpret_cast<THPVariable*>(_var);
   const auto& tensor = THPVariable_Unpack(var);
   std::unique_ptr<FunctionPreHook> hook(new PyFunctionPreHook(
       var->backward_hooks, tensor.output_nr()));
   auto self = (THPFunction*)_self;
   auto cdata = self->cdata.lock();
+  TORCH_CHECK(cdata,
+    "Attribute '_register_hook_dict' is invalid for this instance of _C._FunctionBase. "
+    "Accessing this attribute directly on an instance of autograd.Function is a legacy "
+    "access pattern that is no longer supported. For examples on how to use new-style "
+    "autograd functions, see "
+    "https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function ");
   cdata->add_pre_hook(std::move(hook));
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
@@ -651,6 +663,12 @@ PyObject* THPFunction_register_hook(PyObject *_self, PyObject *hook)
   HANDLE_TH_ERRORS
   auto self= (THPFunction*)_self;
   auto cdata = self->cdata.lock();
+  TORCH_CHECK(cdata,
+    "Attribute 'register_hook' is invalid for this instance of _C._FunctionBase. "
+    "Accessing this attribute directly on an instance of autograd.Function is a legacy "
+    "access pattern that is no longer supported. For examples on how to use new-style "
+    "autograd functions, see "
+    "https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function ");
   return torch::autograd::registerFunctionHook(*cdata, hook);
   END_HANDLE_TH_ERRORS
 }
@@ -728,6 +746,12 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
 {
   HANDLE_TH_ERRORS
   auto cdata = self->cdata.lock();
+  TORCH_CHECK(cdata,
+    "Attribute 'next_functions' is invalid for this instance of _C._FunctionBase. "
+    "Accessing this attribute directly on an instance of autograd.Function is a legacy "
+    "access pattern that is no longer supported. For examples on how to use new-style "
+    "autograd functions, see "
+    "https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function ");
   const auto num_outputs = cdata->num_outputs();
   THPObjectPtr result(PyTuple_New(num_outputs));
   if (!result)

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -25,7 +25,6 @@ struct PyNode : public Node {
   PyNode(THPObjectPtr obj) : obj(obj.release()) {}
 
   variable_list apply(variable_list&& inputs) override;
-  variable_list legacy_apply(const variable_list& inputs);
 
   // Throw a python_error with the PyErr state persisted, so that we
   // don't lose the error state if the GIL is released when we don't


### PR DESCRIPTION
Fixes #30696

### Release Notes
Instantiating a custom autograd function is now deprecated. Users should call `.apply()` on the class itself because it is a static method.

--end release notes--
 - There are a couple error messages that we can't entirely remove because accessing these attributes of the autograd function instance may segfault (due to cdata being nullptr). Also added a TORCH_CHECK for the name attribute which previously segfaulted.
 - Error message updated to convey 1) old-style functions have been deprecated 2) this access pattern was once valid
 - Updates variable -> Tensor for some error messages