### PR TITLE
[JIT] initial support for PEP-585 types

### DIFF
--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -22,12 +22,12 @@ if __name__ == '__main__':
 
 class TestTypesAndAnnotation(JitTestCase):
     def test_pep585_type(self):
-        def fn(x: torch.Tensor) -> Tuple[torch.Tensor, Tuple[torch.Tensor]]:
+        def fn(x: torch.Tensor) -> Tuple[Tuple[torch.Tensor], Dict[str, int]]:
             xl: list[tuple[torch.Tensor]] = []
-            xd: dict[str, torch.Tensor] = {}
+            xd: dict[str, int] = {}
             xl.append((x,))
-            xd['foo'] = x
-            return xl.pop(), xd['foo']
+            xd['foo'] = 1
+            return xl.pop(), xd
 
         self.checkScript(fn, [torch.randn(2, 2)])
 

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -22,6 +22,8 @@ if __name__ == '__main__':
 
 class TestTypesAndAnnotation(JitTestCase):
     def test_pep585_type(self):
+        # TODO add test to use PEP585 type annotation for return type after py3.9
+        # see: https://www.python.org/dev/peps/pep-0585/#id5
         def fn(x: torch.Tensor) -> Tuple[Tuple[torch.Tensor], Dict[str, int]]:
             xl: list[tuple[torch.Tensor]] = []
             xd: dict[str, int] = {}

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -22,10 +22,10 @@ if __name__ == '__main__':
 
 class TestTypesAndAnnotation(JitTestCase):
     def test_pep585_type(self):
-        def fn(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-            xl: list[torch.Tensor] = []
+        def fn(x: torch.Tensor) -> Tuple[torch.Tensor, Tuple[torch.Tensor]]:
+            xl: list[tuple[torch.Tensor]] = []
             xd: dict[str, torch.Tensor] = {}
-            xl.append(x)
+            xl.append((x,))
             xd['foo'] = x
             return xl.pop(), xd['foo']
 

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
 
 class TestTypesAndAnnotation(JitTestCase):
     def test_pep585_type(self):
-        def fn(x: torch.Tensor) -> tuple[tuple[torch.Tensor], dict[str, int]]:
+        def fn(x: torch.Tensor) -> Tuple[Tuple[torch.Tensor], Dict[str, int]]:
             xl: list[tuple[torch.Tensor]] = []
             xd: dict[str, int] = {}
             xl.append((x,))

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
 
 class TestTypesAndAnnotation(JitTestCase):
     def test_pep585_type(self):
-        def fn(x: torch.Tensor) -> Tuple[Tuple[torch.Tensor], Dict[str, int]]:
+        def fn(x: torch.Tensor) -> tuple[tuple[torch.Tensor], dict[str, int]]:
             xl: list[tuple[torch.Tensor]] = []
             xd: dict[str, int] = {}
             xl.append((x,))

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -21,6 +21,15 @@ if __name__ == '__main__':
                        "instead.")
 
 class TestTypesAndAnnotation(JitTestCase):
+    def test_pep585_type(self):
+        def fn(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+            xl: list[torch.Tensor] = []
+            xd: dict[str, torch.Tensor] = {}
+            xl.append(x)
+            xd['foo'] = x
+            return xl.pop(), xd['foo']
+        self.checkScript(fn, [torch.randn(2, 2)])
+
     def test_types_as_values(self):
         def fn(m: torch.Tensor) -> torch.device:
             return m.device

--- a/test/jit/test_types.py
+++ b/test/jit/test_types.py
@@ -28,7 +28,14 @@ class TestTypesAndAnnotation(JitTestCase):
             xl.append(x)
             xd['foo'] = x
             return xl.pop(), xd['foo']
+
         self.checkScript(fn, [torch.randn(2, 2)])
+
+        x = torch.randn(2, 2)
+        expected = fn(x)
+        scripted = torch.jit.script(fn)(x)
+
+        self.assertEquals(expected, scripted)
 
     def test_types_as_values(self):
         def fn(m: torch.Tensor) -> torch.device:

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -26,7 +26,7 @@ std::string collectQualname(const Select& select) {
 TypePtr ScriptTypeParser::subscriptToType(
     const std::string& typeName,
     const Subscript& subscript) const {
-  if (typeName == "Tuple") {
+  if (typeName == "Tuple" || typename == "tuple") {
     if (subscript.subscript_exprs().size() == 1 &&
         subscript.subscript_exprs()[0].kind() == TK_TUPLE_LITERAL) {
       // `typing.Tuple` special cases syntax for empty tuple annotations,

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -45,7 +45,7 @@ TypePtr ScriptTypeParser::subscriptToType(
       subscript_expr_types.push_back(parseTypeFromExprImpl(expr));
     }
     return TupleType::create(subscript_expr_types);
-  } else if (typeName == "List") {
+  } else if (typeName == "List" || typeName == "list") {
     if (subscript.subscript_exprs().size() != 1) {
       throw ErrorReport(subscript)
           << " expected exactly one element type but found "
@@ -107,7 +107,7 @@ TypePtr ScriptTypeParser::subscriptToType(
       throw ErrorReport(subscript.range()) << err;
     }
 
-  } else if (typeName == "Dict") {
+  } else if (typeName == "Dict" || typeName == "dict") {
     if (subscript.subscript_exprs().size() != 2) {
       throw ErrorReport(subscript)
           << " expected exactly 2 element types but found "

--- a/torch/csrc/jit/frontend/script_type_parser.cpp
+++ b/torch/csrc/jit/frontend/script_type_parser.cpp
@@ -26,7 +26,7 @@ std::string collectQualname(const Select& select) {
 TypePtr ScriptTypeParser::subscriptToType(
     const std::string& typeName,
     const Subscript& subscript) const {
-  if (typeName == "Tuple" || typename == "tuple") {
+  if (typeName == "Tuple" || typeName == "tuple") {
     if (subscript.subscript_exprs().size() == 1 &&
         subscript.subscript_exprs()[0].kind() == TK_TUPLE_LITERAL) {
       // `typing.Tuple` special cases syntax for empty tuple annotations,


### PR DESCRIPTION
Relates to #56210. Initial attempt to make support for `list`, `tuple` and `dict` type in PEP-585.

Test Plan:
- newly added `test_pep585_type`
- CI
