### PR TITLE
[caffe2] Check for number of created subnets and optionally throw an error

### DIFF
--- a/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
+++ b/caffe2/contrib/tensorrt/tensorrt_tranformer.cc
@@ -518,7 +518,8 @@ void TensorRTTransformer::Transform(
     return SubnetToTrtOp(net, &mapped_ws, &exporter2, &shape_hints);
   };
 
-  NetDef net_opt = opt::OptimizeForBackend(*pred_net, supports, trt_converter);
+  auto cutResult = opt::OptimizeForBackend(*pred_net, supports, trt_converter)
+  NetDef net_opt = std::move(cutResult.net);
 
   // Need to figure out a proper place to handle device option
   net_opt.mutable_device_option()->CopyFrom(pred_net->device_option());

--- a/caffe2/opt/backend_cutting.cc
+++ b/caffe2/opt/backend_cutting.cc
@@ -360,7 +360,7 @@ void DumpGraph(NNGraph* g, const std::string& fname) {
   }
 }
 
-caffe2::NetDef OptimizeForBackend(
+CutResult OptimizeForBackend(
     caffe2::NetDef& net,
     std::function<bool(const caffe2::OperatorDef&)> supports,
     std::function<caffe2::NetDef(const caffe2::NetDef&)> transform_func,
@@ -441,9 +441,12 @@ caffe2::NetDef OptimizeForBackend(
     DumpGraph(&dfg, "dump.dot");
   }
 
+  CutResult cutResult;
+  cutResult.numberOfSubnets = subs.size();
   auto new_net = convertToCaffe2Proto(nn);
   new_net.set_name(net.name() + "_opt");
-  return new_net;
+  cutResult.net = std::move(new_net);
+  return cutResult;
 }
 
 } // namespace opt

--- a/caffe2/opt/backend_cutting.h
+++ b/caffe2/opt/backend_cutting.h
@@ -8,8 +8,13 @@
 
 namespace caffe2 {
 namespace opt {
+struct CutResult {
+  caffe2::NetDef net;
+  int numberOfSubnets{0};
+};
+
 TORCH_API void DumpGraph(nom::repr::NNGraph* g, const std::string& fname);
-TORCH_API caffe2::NetDef OptimizeForBackend(
+TORCH_API CutResult OptimizeForBackend(
     caffe2::NetDef& net,
     std::function<bool(const caffe2::OperatorDef&)> supports,
     std::function<caffe2::NetDef(const caffe2::NetDef&)> transform_func,

--- a/caffe2/opt/backend_cutting_test.cc
+++ b/caffe2/opt/backend_cutting_test.cc
@@ -51,7 +51,9 @@ TEST(BackendCuttingTest, unit) {
   net.add_external_input("W0");
   net.add_external_input("b0");
   net.add_external_output("N1");
-  auto net_opt = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto net_opt = cutResult.net;
+  EXPECT_EQ(1, cutResult.numberOfSubnets);
   EXPECT_EQ(1, net_opt.op_size());
   EXPECT_EQ(1, net_opt.external_input_size());
   EXPECT_EQ(1, net_opt.external_output_size());
@@ -79,8 +81,9 @@ TEST(BackendCuttingTest, line) {
   op->set_type("CopyOut");
   op->add_input("N2");
   op->add_output("Y");
-
-  auto net_opt = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto net_opt = cutResult.net;
+  EXPECT_EQ(1, cutResult.numberOfSubnets);
   EXPECT_EQ(3, net_opt.op_size());
 }
 
@@ -115,7 +118,9 @@ TEST(BackendCuttingTest, convergedPaths) {
   op->add_input("N5");
   op->add_output("Y");
 
-  auto net_opt = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto net_opt = cutResult.net;
+  EXPECT_EQ(1, cutResult.numberOfSubnets);
   EXPECT_EQ(3, net_opt.op_size());
 };
 
@@ -152,6 +157,8 @@ TEST(BackendCuttingTest, skipPath) {
   op->add_input("N7");
   op->add_output("Y");
 
-  auto net_opt = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto cutResult = caffe2::opt::OptimizeForBackend(net, Supports, Transform);
+  auto net_opt = cutResult.net;
+  EXPECT_EQ(2, cutResult.numberOfSubnets);
   EXPECT_EQ(4, net_opt.op_size());
 }

--- a/caffe2/opt/glow_net_transform.cc
+++ b/caffe2/opt/glow_net_transform.cc
@@ -28,6 +28,13 @@ C10_DEFINE_bool(
     "Merge all the fp32 input tensors into one, convert it to fp16 and split it back");
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+C10_DEFINE_bool(
+    verify_only_single_subnet,
+    false,
+    "Check that only one subnet is created during Onnxifi."
+)
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int32(
     onnxifi_min_ops,
     1,
@@ -134,7 +141,8 @@ void onnxifi(
     const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs,
     const c10::optional<std::string> &blacklist_ops,
     const c10::optional<size_t> &min_ops,
-    const std::unordered_set<std::string> &blocklist_blobs) {
+    const std::unordered_set<std::string> &blocklist_blobs,
+    const c10::optional<bool> &verify_only_single_subnet) {
   // Split SparseLengthsSumSparse so that we can lower the SparseLengthsSum part
   splitSparseLengthsSumSparse(net, *ws);
 
@@ -162,6 +170,7 @@ void onnxifi(
   opts.load_model_by_blob = load_model_by_blob;
   opts.enforce_fp32_inputs_into_fp16 = FLAGS_enforce_fp32_inputs_into_fp16;
   opts.merge_fp32_inputs_into_fp16 = FLAGS_merge_fp32_inputs_into_fp16;
+  opts.verify_only_single_subnet = verify_only_single_subnet.value_or(FLAGS_verify_only_single_subnet);
   opts.predictor_net_ssa_rewritten = predictor_net_ssa_rewritten;
   opts.timeout = FLAGS_onnxifi_timeout_ms;
   opts.shape_hints_per_bs = shape_hints_per_bs;

--- a/caffe2/opt/glow_net_transform.h
+++ b/caffe2/opt/glow_net_transform.h
@@ -35,7 +35,8 @@ void onnxifi(
     const std::unordered_map<int, ShapeInfoMap> &shape_hints_per_bs = {},
     const c10::optional<std::string> &blacklist_ops = c10::nullopt,
     const c10::optional<size_t> &min_ops = c10::nullopt,
-    const std::unordered_set<std::string> &blocklist_blobs = {});
+    const std::unordered_set<std::string> &blocklist_blobs = {},
+    const c10::optional<bool> & verify_only_single_subnet = c10::nullopt);
 
 std::unordered_set<int> ParseNetPositionList(const std::string& str);
 std::unordered_set<std::string> ParseBlockListOps(const std::string& str);

--- a/caffe2/opt/onnxifi_transformer.h
+++ b/caffe2/opt/onnxifi_transformer.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "caffe2/opt/backend_cutting.h"
 #include "onnx/onnx_pb.h"
 
 #include "caffe2/core/operator.h"
@@ -38,6 +39,9 @@ struct OnnxifiTransformerOptions final : public BackendTransformOptions {
   // Whether to combine fp32 batched inputs into one tensor and convert it to
   // fp16 or not
   bool merge_fp32_inputs_into_fp16{false};
+
+  // Whether to verify that a single subnet was created
+  bool verify_only_single_subnet{false};
 
   // Whether the net has been ssaRewritten
   bool predictor_net_ssa_rewritten{false};
@@ -127,7 +131,7 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Transform by passing C2 proto to backend
-  NetDef TransformViaC2(
+  opt::CutResult TransformViaC2(
       NetDef* pred_net,
       const std::unordered_set<std::string>& weights,
       const std::unordered_set<int>& blocklisted_ops,
@@ -135,7 +139,7 @@ class TORCH_API OnnxifiTransformer final : public BackendTransformerBase {
       const std::unordered_map<int, ShapeInfoMap>& shape_hints_per_bs);
 
   // Transform by passing ONNX proto to backend
-  NetDef TransformViaOnnx(
+  opt::CutResult TransformViaOnnx(
       Workspace* ws,
       NetDef* pred_net,
       const std::unordered_set<std::string>& weights,

--- a/caffe2/opt/tvm_transformer.cc
+++ b/caffe2/opt/tvm_transformer.cc
@@ -276,7 +276,7 @@ NetDef TvmTransformer::applyTvmTransform(
         return buildTvmOp(net, weights, shape_hints);
       };
 
-  return opt::OptimizeForBackend(*pred_net, tvm_supports, tvm_op_converter);
+  return opt::OptimizeForBackend(*pred_net, tvm_supports, tvm_op_converter).net;
 }
 
 void tvmTransform(


### PR DESCRIPTION
Summary:
We often get error messages such as
```
Model failed AOT (glow ahead-of-time compilation) with exception: Error during AOT optimization (non-provisioned addNetwork):
Non-recoverable device error when adding network:
Error code: PARTITIONER_ERROR
Error message: Did not find a partition with an SLS node

Error return stack:
--------------------------------------------------------------------------------
glow/glow/lib/Partitioner/Partitioner.cpp:1244
--------------------------------------------------------------------------------
glow/glow/lib/Runtime/HostManager/HostManager.cpp:375
--------------------------------------------------------------------------------
```
This makes the error message more clear by checking for the number of OnnixifiOp created before going into Glow. The check is enabled with the `check_number_subnets` flag, and is enabled by default.

Test Plan: Unit tests pass

Differential Revision: D28097674

