### PR TITLE
[quant][graphmode][fx] Skip observering boolean Tensors

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -3997,6 +3997,19 @@ class TestQuantizeFxOps(QuantizationTestCase):
             expected_node_occurrence=expected_occurrence
         )
 
+    def test_boolean_tensor(self):
+        """ Make sure we don't insert observer for boolean Tensors """
+        class M(torch.nn.Module):
+            def forward(self, x, mask):
+                mask = mask.unsqueeze(0)
+                x = x.masked_fill(mask, 1)
+                return x
+
+        m = M().eval()
+        m = prepare_fx(m, {"": default_qconfig})
+        m = convert_fx(m)
+        m(torch.rand(1, 2, 3, 4), torch.rand(2, 3, 4).bool())
+        return m
 
 
 class TestQuantizeFxModels(QuantizationTestCase):

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -552,7 +552,7 @@ def handle_copy_nodes(
                             observed_nodes.add(node)
                     else:
                         observed_nodes.add(node)
-        elif root_node is None: # and node.op != 'placeholder':
+        elif root_node is None and node.op != 'placeholder':
             # rule 4: remove observer for getitem if it is followed by an unmatched node
             if len(node.args) > 0:
                 maybe_observer_node = node.args[0]

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -589,8 +589,14 @@ def handle_copy_nodes(
         # similar to TorchScript
         if (node.op, node.target) == ("call_method", "masked_fill"):
             maybe_observer_node = node.args[1]
-            if is_activation_post_process_node(maybe_observer_node, modules):
+            while isinstance(maybe_observer_node, Node) and is_activation_post_process_node(maybe_observer_node, modules):
                 actpp_to_remove.add(maybe_observer_node)
+                # trace back from the current observer node
+                n = maybe_observer_node.args[0]
+                if isinstance(n, Node) and len(n.args) > 0:
+                    maybe_observer_node = n.args[0]
+                else:
+                    break
 
     for node in observed_graph.nodes:
         if node.op == "output":

--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -408,6 +408,12 @@ def node_return_type_is_int(node: Node) -> bool:
     Returns true if this node results in an integer, even if some of the args
     are Tensors.
     """
-    if node.op == 'call_method' and node.target == 'size':
-        return True
-    return False
+    return node.op == 'call_method' and node.target == 'size'
+
+def node_bool_tensor_arg_indexes(node: Node) -> List[int]:
+    """
+    Returns indexes of boolean Tensor args
+    """
+    if node.op == "call_method" and node.target == "masked_fill":
+        return [1]
+    return []


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57375 [quant][graphmode][fx] Skip observering boolean Tensors**

Summary:
Skip observing the input for masked_fill. Currently we don't have a way to
query the type of Proxy in GraphModule, hopefully we should have the functionality to annotate the type,
we'll need to annotate a Proxy to be a boolean Tensor to remove this hack.

Test Plan:
python test/test_quantization.py TestQuantizeFxOps.test_boolean_tensor

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D28126003](https://our.internmc.facebook.com/intern/diff/D28126003)