### PR TITLE
[PyTorch] ifdef out ATen tests that fail with static dispatch

### DIFF
--- a/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
+++ b/aten/src/ATen/core/dispatch/backend_fallback_test.cpp
@@ -81,6 +81,7 @@ void generic_wrapper_fallback(const c10::OperatorHandle& op, torch::jit::Stack* 
   }
 }
 
+#ifndef ATEN_CPU_STATIC_DISPATCH
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(BackendFallbackTest, TestBackendFallbackWithMode) {
   auto m = MAKE_TORCH_LIBRARY_IMPL(_, TESTING_ONLY_GenericMode);
@@ -128,5 +129,6 @@ TEST(BackendFallbackTest, TestFallthroughBackendFallback) {
   Tensor b = mul(a, a);
   ASSERT_EQ(override_call_count, 1);
 }
+#endif // ATEN_CPU_STATIC_DISPATCH
 
 }

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -437,7 +437,9 @@ TEST(BasicTest, FactoryMethodsTest) {
   ASSERT_FALSE(tensor1.requires_grad());
   ASSERT_FALSE(tensor1.is_pinned());
 
-  // Sparse tensor CPU test to avoid requiring CUDA to catch simple bugs.1
+  // Sparse tensor CPU test to avoid requiring CUDA to catch simple bugs.
+  // Sparse tensors do not work with static CPU dispatch.
+#ifndef ATEN_CPU_STATIC_DISPATCH
   tensor1 = at::empty({4}, at::TensorOptions().dtype(at::kHalf).layout(at::kSparse));
   ASSERT_EQ(tensor1.dtype(), at::kHalf);
   ASSERT_EQ(tensor1.layout(), at::kSparse);
@@ -445,6 +447,7 @@ TEST(BasicTest, FactoryMethodsTest) {
   ASSERT_FALSE(tensor1.requires_grad());
   // NOLINTNEXTLINE(hicpp-avoid-goto,cppcoreguidelines-avoid-goto)
   ASSERT_ANY_THROW(tensor1.is_pinned());
+#endif // ATEN_CPU_STATIC_DISPATCH
 
   if (torch::cuda::is_available()) {
     // Test setting pin memory

--- a/aten/src/ATen/test/cpu_rng_test.cpp
+++ b/aten/src/ATen/test/cpu_rng_test.cpp
@@ -12,6 +12,7 @@
 
 using namespace at;
 
+#ifndef ATEN_CPU_STATIC_DISPATCH
 namespace {
 
 constexpr auto kCustomRNG = DispatchKey::CustomRNGKeyId;
@@ -498,3 +499,4 @@ TEST_F(RNGTest, Bernoulli_out) {
   ASSERT_TRUE(torch::allclose(actual, expected));
 }
 }
+#endif // ATEN_CPU_STATIC_DISPATCH


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57379 [PyTorch] ifdef out ATen tests that fail with static dispatch**

Differential Revision: [D27576223](https://our.internmc.facebook.com/intern/diff/D27576223/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27576223/)!