### PR TITLE
Fix CUDA Stream synchronization when arguments contains RRefs

### DIFF
--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -499,9 +499,7 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
     ++serverActiveCalls_;
     std::shared_ptr<JitFuture> futureResponse;
     try {
-      futureResponse = cb_->operator()(
-          message,
-          createLazyStreamContext(c10::DeviceType::CPU, nullptr, nullptr));
+      futureResponse = cb_->operator()(message, {});
     } catch (const std::exception& e) {
       futureResponse = std::make_shared<JitFuture>(at::AnyClassType::get());
       futureResponse->setError(std::current_exception());

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -499,7 +499,9 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
     ++serverActiveCalls_;
     std::shared_ptr<JitFuture> futureResponse;
     try {
-      futureResponse = cb_->operator()(message, {});
+      futureResponse = cb_->operator()(
+          message,
+          createLazyStreamContext(c10::DeviceType::CPU, nullptr, nullptr));
     } catch (const std::exception& e) {
       futureResponse = std::make_shared<JitFuture>(at::AnyClassType::get());
       futureResponse->setError(std::current_exception());

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -75,7 +75,8 @@ std::shared_ptr<JitFuture> RequestCallbackNoPython::processMessage(
          messageType = request.type(),
          id = request.id(),
          ctx = std::move(ctx)]() mutable {
-          c10::MultiStreamGuard guard(ctx->getReservedStreams());
+          c10::MultiStreamGuard guard(
+              ctx ? ctx->getReservedStreams() : ArrayRef<Stream>({}));
           // The cost of pre-request check is minimal thanks to
           // std::shared_lock. The cost is in magnitude
           // of 10us.

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -75,6 +75,7 @@ std::shared_ptr<JitFuture> RequestCallbackNoPython::processMessage(
          messageType = request.type(),
          id = request.id(),
          ctx = std::move(ctx)]() mutable {
+          c10::MultiStreamGuard guard(ctx->getReservedStreams());
           // The cost of pre-request check is minimal thanks to
           // std::shared_lock. The cost is in magnitude
           // of 10us.
@@ -90,7 +91,6 @@ std::shared_ptr<JitFuture> RequestCallbackNoPython::processMessage(
                     ->config());
           }
 
-          c10::MultiStreamGuard guard(ctx->getReservedStreams());
           processRpcWithErrors(
               *rpc, messageType, id, retFuture, std::move(ctx));
 

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -1,3 +1,6 @@
+#include <torch/csrc/distributed/rpc/request_callback_no_python.h>
+
+#include <c10/core/StreamGuard.h>
 #include <torch/csrc/distributed/autograd/context/container.h>
 #include <torch/csrc/distributed/autograd/engine/dist_engine.h>
 #include <torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h>
@@ -7,7 +10,6 @@
 #include <torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h>
 #include <torch/csrc/distributed/autograd/utils.h>
 #include <torch/csrc/distributed/rpc/profiler/server_process_global_profiler.h>
-#include <torch/csrc/distributed/rpc/request_callback_no_python.h>
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #include <torch/csrc/distributed/rpc/rref_proto.h>
@@ -88,6 +90,7 @@ std::shared_ptr<JitFuture> RequestCallbackNoPython::processMessage(
                     ->config());
           }
 
+          c10::MultiStreamGuard guard(ctx->getReservedStreams());
           processRpcWithErrors(
               *rpc, messageType, id, retFuture, std::move(ctx));
 

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -861,17 +861,20 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
                          messageId,
                          requestMessage{std::move(requestMessage)},
                          ctx{std::move(ctx)}]() mutable {
-          // create guards again as this function runs on a different thread
-          c10::MultiStreamGuard guard(ctx->getReservedStreams());
           VLOG(1) << "RPC agent for " << workerInfo_.name_
                   << " is running request #" << messageId << " from "
                   << pipe->getRemoteName() << " in thread pool";
 
           std::shared_ptr<JitFuture> futureResponseMessage;
           try {
-            // The `ctx` needs to be propagated to `process***Call` methods
-            // to synchronize CUDA streams there to make sure that we fetch
-            // the correct value from `to_here()` call.
+            // Instead of creating a MultiStreamGuard here, the ctx is pass
+            // to the callback and the MultiStreamGuard is created there,
+            // because subsequent processing can switch threads due to 1)
+            // waiting for RRef arguments to become ready 2) async_execution.
+            // Besides, the `ctx` also needs to be propagated to
+            // `process***Call` methods to synchronize CUDA streams there
+            // to make sure that we fetch the correct value from `to_here()`
+            // call.
             futureResponseMessage = cb_->operator()(requestMessage, ctx);
           } catch (const std::exception& /* unused */) {
             futureResponseMessage =

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -867,7 +867,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
 
           std::shared_ptr<JitFuture> futureResponseMessage;
           try {
-            // Instead of creating a MultiStreamGuard here, the ctx is pass
+            // Instead of creating a MultiStreamGuard here, the ctx is passed
             // to the callback and the MultiStreamGuard is created there,
             // because subsequent processing can switch threads due to 1)
             // waiting for RRef arguments to become ready 2) async_execution.

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -4820,11 +4820,13 @@ class MyConvNetForMNIST(nn.Module):
             nn.ReLU(),
             nn.Linear(128, 10),
         ).to(device)
+        self.device = device
 
     def forward(self, x, is_rref=False):
-        if is_rref:
-            return self.net(x.to_here())
-        else:
+        x = x.to_here() if is_rref else x
+        with torch.cuda.stream(torch.cuda.current_stream(self.device)):
+            # intentionally adding delay to current CUDA stream
+            torch.cuda._sleep(10 * FIFTY_MIL_CYCLES)
             return self.net(x)
 
 
@@ -5589,8 +5591,8 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
             # training of a CNN of MNIST-like data.
             # see https://github.com/pytorch/pytorch/issues/54771
             rref = rpc.remote(dst, MyConvNetForMNIST, args=(remote_device,))
-            for _ in range(20):
-                x = torch.randn(100, 1, 28, 28).to(local_device)
+            for _ in range(10):
+                x = torch.randn(200, 1, 28, 28).to(local_device)
                 actual = rref.remote().forward(x).to_here()
                 expected = rref.rpc_sync().forward(x)
                 self.assertEqual(actual, expected)
@@ -5644,8 +5646,8 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
             # training of a CNN of MNIST-like data.
             # see https://github.com/pytorch/pytorch/issues/54771
             rref = rpc.remote(dst, MyConvNetForMNIST, args=(remote_device,))
-            for _ in range(20):
-                rref_x = RRef(torch.randn(100, 1, 28, 28).to(local_device))
+            for _ in range(10):
+                rref_x = RRef(torch.randn(200, 1, 28, 28).to(local_device))
                 actual = rref.remote().forward(rref_x, True).to_here()
                 expected = rref.rpc_sync().forward(rref_x, True)
                 self.assertEqual(actual, expected)
@@ -5720,7 +5722,7 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
             # see https://github.com/pytorch/pytorch/issues/54771
             rref = rpc.remote(model_dst, MyConvNetForMNIST, args=(remote_device,))
             for _ in range(10):
-                rref_input = RRef(torch.randn(10000, 1, 28, 28).to(local_device))
+                rref_input = RRef(torch.randn(200, 1, 28, 28).to(local_device))
                 rref_out = rref.remote().forward(rref_input, True)
                 out = rpc.remote(
                     out_relay,

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -5719,8 +5719,8 @@ class TensorPipeAgentCudaRpcTest(RpcAgentTestFixture):
             # training of a CNN of MNIST-like data.
             # see https://github.com/pytorch/pytorch/issues/54771
             rref = rpc.remote(model_dst, MyConvNetForMNIST, args=(remote_device,))
-            for _ in range(20):
-                rref_input = RRef(torch.randn(200, 1, 28, 28).to(local_device))
+            for _ in range(10):
+                rref_input = RRef(torch.randn(10000, 1, 28, 28).to(local_device))
                 rref_out = rref.remote().forward(rref_input, True)
                 out = rpc.remote(
                     out_relay,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57394 Fix CUDA Stream synchronization when arguments contains RRefs**

Differential Revision: [D28131325](https://our.internmc.facebook.com/intern/diff/D28131325)