### PR TITLE
fix for nvtxstring not printing name for aten kernels

### DIFF
--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -299,11 +299,17 @@ std::string ProfilerThreadLocalState::getNvtxStr(
 #ifdef __HIP_PLATFORM_HCC__
     s << name.str();
 #endif
-    if (sequence_nr >= -1) {
+    if (sequence_nr >= 0) {
 #ifdef __HIP_PLATFORM_HCC__
       s << msg << sequence_nr;
 #else
       s << name.str() << msg << sequence_nr;
+#endif
+    } else if (sequence_nr == -1) {
+#ifdef __HIP_PLATFORM_HCC__
+      s << msg;
+#else
+      s << name.str() << msg;
 #endif
     }
     if (shapes.size() > 0) {

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -294,12 +294,12 @@ std::string ProfilerThreadLocalState::getNvtxStr(
     const char* msg,
     int64_t sequence_nr,
     const std::vector<std::vector<int64_t>>& shapes) const {
-  if (sequence_nr >= 0 || shapes.size() > 0) {
+  if (sequence_nr >= -1 || shapes.size() > 0) {
     std::stringstream s;
 #ifdef __HIP_PLATFORM_HCC__
     s << name.str();
 #endif
-    if (sequence_nr >= 0) {
+    if (sequence_nr >= -1) {
 #ifdef __HIP_PLATFORM_HCC__
       s << msg << sequence_nr;
 #else


### PR DESCRIPTION
aten kernels have a sequence number of -1

In order to ensure the names are properly printed in every case, we must change the >= 0 to => -1

Example of bug:
![Capture](https://user-images.githubusercontent.com/20074092/116767312-45959280-a9e4-11eb-92a3-c2236a00d481.PNG)
Example of fix:
![image](https://user-images.githubusercontent.com/20074092/116919709-82d96a80-ac06-11eb-8b74-e34cf1214ea5.png)
Additionally, while fixing and investigating this issue another issue was detected and has now been filed:
https://github.com/pytorch/pytorch/issues/57476