### PR TITLE
[RPC Framework] Create a separate remote module template when moving CPU tensors to a cuda device is not enabled

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -35,8 +35,10 @@ _NON_SCRIPTABLE_REMOTE_MODULE_MODULE = (
 
 
 # RPC handler.
-def _instantiate_template(module_interface_cls):
-    instantiator.instantiate_scriptable_remote_module_template(module_interface_cls)
+def _instantiate_template(module_interface_cls, enable_moving_cpu_tensors_to_cuda):
+    instantiator.instantiate_scriptable_remote_module_template(
+        module_interface_cls, enable_moving_cpu_tensors_to_cuda
+    )
 
 
 def _create_module(module_cls, args, kwargs, device="cpu", module_interface_cls=None):
@@ -101,7 +103,7 @@ class _RemoteModule(nn.Module):
         ``def forward_async(input: Tensor) -> Future[Tensor]:``.
 
         .. note::
-            If the remote module is placed on cuda device,
+            If the remote module is placed on a cuda device,
             any input CPU tensors will be automatically moved to the same cuda device,
             and GPU tensors are returned over the wire according to the device map of the remote worker on TensorPipe RPC backend.
 
@@ -165,6 +167,8 @@ class _RemoteModule(nn.Module):
 
         self.on, self.device = _parse_remote_device(remote_device)
         agent = rpc._get_current_rpc_agent()
+        # If the device map of the remote worker is set,
+        # then enable moving any input CPU tensors to the same cuda device.
         self.is_device_map_set = bool(agent._get_device_map(agent.get_worker_info(self.on)))
 
         if _module_interface_cls is not None:
@@ -173,13 +177,15 @@ class _RemoteModule(nn.Module):
 
             # Instantiate template on remote side.
             fut = rpc.rpc_async(
-                self.on, _instantiate_template, (_module_interface_cls,)
+                self.on,
+                _instantiate_template,
+                (_module_interface_cls, self.is_device_map_set),
             )
 
             # Instantiate template on local side.
             generated_module = (
                 instantiator.instantiate_scriptable_remote_module_template(
-                    _module_interface_cls
+                    _module_interface_cls, self.is_device_map_set
                 )
             )
             generated_methods = generated_module._generated_methods

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -170,6 +170,7 @@ class _RemoteModule(nn.Module):
         # If the device map of the remote worker is set,
         # then enable moving any input CPU tensors to the same cuda device.
         self.is_device_map_set = bool(agent._get_device_map(agent.get_worker_info(self.on)))
+        enable_moving_cpu_tensors_to_cuda = self.device == "cuda"
 
         if _module_interface_cls is not None:
             # Users reply on this field to know if this generated RemoteModule is TorchScript-able.
@@ -179,13 +180,13 @@ class _RemoteModule(nn.Module):
             fut = rpc.rpc_async(
                 self.on,
                 _instantiate_template,
-                (_module_interface_cls, self.is_device_map_set),
+                (_module_interface_cls, enable_moving_cpu_tensors_to_cuda),
             )
 
             # Instantiate template on local side.
             generated_module = (
                 instantiator.instantiate_scriptable_remote_module_template(
-                    _module_interface_cls, self.is_device_map_set
+                    _module_interface_cls, enable_moving_cpu_tensors_to_cuda
                 )
             )
             generated_methods = generated_module._generated_methods

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -4,11 +4,11 @@ import logging
 import os
 import sys
 import tempfile
+from typing import Optional
 
 import torch
-from typing import Optional
 from torch.distributed.nn.jit.templates.remote_module_template import (
-    REMOTE_MODULE_TEMPLATE,
+    get_remote_module_template,
 )
 
 
@@ -79,8 +79,12 @@ def _write(out_path, text):
         logger.info("Skipped writing {}".format(out_path))
 
 
-def _do_instantiate_remote_module_template(generated_module_name, str_dict):
-    generated_code_text = REMOTE_MODULE_TEMPLATE.format(**str_dict)
+def _do_instantiate_remote_module_template(
+    generated_module_name, str_dict, enable_moving_cpu_tensors_to_cuda
+):
+    generated_code_text = get_remote_module_template(
+        enable_moving_cpu_tensors_to_cuda
+    ).format(**str_dict)
     out_path = os.path.join(
         INSTANTIATED_TEMPLATE_DIR_PATH, f"{generated_module_name}.py"
     )
@@ -96,7 +100,9 @@ def _do_instantiate_remote_module_template(generated_module_name, str_dict):
     return generated_module
 
 
-def instantiate_scriptable_remote_module_template(module_interface_cls):
+def instantiate_scriptable_remote_module_template(
+    module_interface_cls, enable_moving_cpu_tensors_to_cuda
+):
     if not getattr(module_interface_cls, "__torch_script_interface__", False):
         raise ValueError(
             f"module_interface_cls {module_interface_cls} must be a type object decorated by "
@@ -130,7 +136,9 @@ def instantiate_scriptable_remote_module_template(module_interface_cls):
         kwargs=kwargs_str,
         jit_script_decorator="@torch.jit.script",
     )
-    return _do_instantiate_remote_module_template(generated_module_name, str_dict)
+    return _do_instantiate_remote_module_template(
+        generated_module_name, str_dict, enable_moving_cpu_tensors_to_cuda
+    )
 
 
 def instantiate_non_scriptable_remote_module_template():
@@ -144,4 +152,6 @@ def instantiate_non_scriptable_remote_module_template():
         arrow_and_future_return_type="",
         jit_script_decorator="",
     )
-    return _do_instantiate_remote_module_template(generated_module_name, str_dict)
+    # For a non-scriptable template, always enable moving CPU tensors to a cuda device,
+    # because there is no syntax limitation on the extra handling caused by the script.
+    return _do_instantiate_remote_module_template(generated_module_name, str_dict, True)

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -101,7 +101,7 @@ def _do_instantiate_remote_module_template(
 
 
 def instantiate_scriptable_remote_module_template(
-    module_interface_cls, enable_moving_cpu_tensors_to_cuda
+    module_interface_cls, enable_moving_cpu_tensors_to_cuda=True
 ):
     if not getattr(module_interface_cls, "__torch_script_interface__", False):
         raise ValueError(

--- a/torch/distributed/nn/jit/templates/remote_module_template.py
+++ b/torch/distributed/nn/jit/templates/remote_module_template.py
@@ -1,19 +1,63 @@
 #!/usr/bin/python3
 
-REMOTE_MODULE_TEMPLATE = """from typing import *
+
+def get_remote_module_template(enable_moving_cpu_tensors_to_cuda: bool):
+    return _TEMPLATE_PREFIX + (
+        _REMOTE_FORWARD_TEMPLATE_ENABLE_MOVING_CPU_TENSORS_TO_CUDA
+        if enable_moving_cpu_tensors_to_cuda
+        else _REMOTE_FORWARD_TEMPLATE
+    )
+
+
+_TEMPLATE_PREFIX = """from typing import *
 
 import torch
 import torch.distributed.rpc as rpc
 from torch import Tensor
 from torch._jit_internal import Future
 from torch.distributed.rpc import RRef
-from typing import Tuple
+from typing import Tuple  # pyre-ignore: unused import
 
 
 {assign_module_interface_cls}
 
 
+def forward_async(self, {arg_types}){arrow_and_future_return_type}:
+    args = (self.module_rref, self.device, self.is_device_map_set, {args})
+    kwargs = {{{kwargs}}}
+    return rpc.rpc_async(
+        self.module_rref.owner(),
+        _remote_forward,
+        args,
+        kwargs,
+    )
+
+
+def forward(self, {arg_types}){arrow_and_return_type}:
+    args = (self.module_rref, self.device, self.is_device_map_set, {args})
+    kwargs = {{{kwargs}}}
+    ret_fut = rpc.rpc_async(
+        self.module_rref.owner(),
+        _remote_forward,
+        args,
+        kwargs,
+    )
+    return ret_fut.wait()
+
+
+_generated_methods = [
+    forward_async,
+    forward,
+]
+
+
 {jit_script_decorator}
+"""
+
+# This template may cause typing error (the mismatch between ``Tuple[()]`` and ``Tuple[Any]``)
+# even if the code is only used for instaniation but not execution.
+# Therefore, only include handling moving CPU tensors to a cuda device if necessary.
+_REMOTE_FORWARD_TEMPLATE_ENABLE_MOVING_CPU_TENSORS_TO_CUDA = """
 def _remote_forward(
     module_rref: RRef[module_interface_cls], device: str, is_device_map_set: bool, {arg_types}){arrow_and_return_type}:
     module = module_rref.local_value()
@@ -21,17 +65,6 @@ def _remote_forward(
 
     if device.type != "cuda":
         return module.forward({args}, {kwargs})
-
-    # FIXME: Remote this line after fixing test_load_di_parts in
-    # torch/fb/training_toolkit/applications/sparse_nn/batch_distributed_inference/tests:batch_distributed_inference_test
-    # The error is that:
-    # 1) If annotation of Tuple[()] is used for out_args and ret, then the test fails because
-    # "Variable 'ret' previously has type Tuple[()] but is now being assigned to a value of type Tuple[Tensor]".
-    # 2) If annotation of Tuple[Any] is used for out_args and ret, the the test fails because
-    # "Variable 'ret' is annotated with type Tuple[Any] but is being assigned to a value of type Tuple[()]".
-    # 3) If there is no annotation, for out_args and ret, the the test fails because
-    # "Variable 'ret' previously has type Tuple[()] but is now being assigned to a value of type Tuple[Tensor]".
-    return module.forward({args}, {kwargs})
 
     # If the module is on a cuda device,
     # move any CPU tensor in args or kwargs to the same cuda device.
@@ -62,33 +95,12 @@ def _remote_forward(
         i = (i.cpu(),) if isinstance(i, Tensor) else (i,)
         ret = ret + i
     return ret
+"""
 
+_REMOTE_FORWARD_TEMPLATE = """
+def _remote_forward(
+    module_rref: RRef[module_interface_cls], device: str, is_device_map_set: bool, {arg_types}){arrow_and_return_type}:
+    module = module_rref.local_value()
 
-def forward_async(self, {arg_types}){arrow_and_future_return_type}:
-    args = (self.module_rref, self.device, self.is_device_map_set, {args})
-    kwargs = {{{kwargs}}}
-    return rpc.rpc_async(
-        self.module_rref.owner(),
-        _remote_forward,
-        args,
-        kwargs,
-    )
-
-
-def forward(self, {arg_types}){arrow_and_return_type}:
-    args = (self.module_rref, self.device, self.is_device_map_set, {args})
-    kwargs = {{{kwargs}}}
-    ret_fut = rpc.rpc_async(
-        self.module_rref.owner(),
-        _remote_forward,
-        args,
-        kwargs,
-    )
-    return ret_fut.wait()
-
-
-_generated_methods = [
-    forward_async,
-    forward,
-]
+    return module.forward({args}, {kwargs})
 """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57414 [RPC Framework] Clang-format remote_module.py and instantiator.py
* **#57413 [RPC Framework] Create a separate remote module template when moving CPU tensors to a cuda device is not enabled**

An internal test fails because somehow `Tuple[()]` is not considered compatible with `Tuple[Any]` in TorchScript, even if the code that involves this type of variables is not executed at all.

Therefore, create separate templates for instantiation to avoid typing check failure. This can address the FIXME left in https://github.com/pytorch/pytorch/pull/57288

#Closes: https://github.com/pytorch/pytorch/issues/51670

Differential Revision: [D28138864](https://our.internmc.facebook.com/intern/diff/D28138864/)