### PR TITLE
[RPC Framework] Clang-format remote_module.py and instantiator.py

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -169,7 +169,9 @@ class _RemoteModule(nn.Module):
         agent = rpc._get_current_rpc_agent()
         # If the device map of the remote worker is set,
         # then enable moving any input CPU tensors to the same cuda device.
-        self.is_device_map_set = bool(agent._get_device_map(agent.get_worker_info(self.on)))
+        self.is_device_map_set = bool(
+            agent._get_device_map(agent.get_worker_info(self.on))
+        )
 
         if _module_interface_cls is not None:
             # Users reply on this field to know if this generated RemoteModule is TorchScript-able.
@@ -323,7 +325,12 @@ class _RemoteModule(nn.Module):
     def modules(self) -> Iterator[Module]:  # type: ignore[return]
         _raise_not_supported(self.modules.__name__)
 
-    def named_modules(self, memo: Optional[Set[Module]] = None, prefix: str = "", remove_duplicate: bool = True):
+    def named_modules(
+        self,
+        memo: Optional[Set[Module]] = None,
+        prefix: str = "",
+        remove_duplicate: bool = True,
+    ):
         _raise_not_supported(self.named_modules.__name__)
 
     def train(self: T, mode: bool = True) -> T:  # type: ignore[return]

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -110,9 +110,9 @@ def instantiate_scriptable_remote_module_template(
         )
 
     # Generate the template instance name.
-    module_interface_cls_name = torch._jit_internal._qualified_name(module_interface_cls).replace(
-        ".", "_"
-    )
+    module_interface_cls_name = torch._jit_internal._qualified_name(
+        module_interface_cls
+    ).replace(".", "_")
     generated_module_name = f"{_FILE_PREFIX}{module_interface_cls_name}"
 
     # Generate type annotation strs.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57414 [RPC Framework] Clang-format remote_module.py and instantiator.py**
* #57413 [RPC Framework] Create a separate remote module template when moving CPU tensors to a cuda device is not enabled

Differential Revision: [D28138870](https://our.internmc.facebook.com/intern/diff/D28138870/)