### PR TITLE
`addmm`: port to structured kernel

### DIFF
--- a/aten/src/ATen/NamedTensorUtils.cpp
+++ b/aten/src/ATen/NamedTensorUtils.cpp
@@ -389,19 +389,17 @@ std::vector<Dimname> propagate_names_for_addmv(
   return unify_from_right(mv_outnames, bias.names());
 }
 
-void propagate_names_for_addmm(
-    Tensor& result,
+std::vector<Dimname> propagate_names_for_addmm(
     const Tensor& m1,
     const Tensor& m2,
     const Tensor& bias) {
   if (!m1.has_names() && !m2.has_names() &&
-      !bias.has_names() && !result.has_names()) {
-    return;
+      !bias.has_names()) {
+    return std::vector<Dimname>{};
   }
 
   auto mm_outnames = compute_matmul_outnames(m1.names(), m2.names());
-  auto add_outnames = unify_from_right(mm_outnames, bias.names());
-  propagate_names(result, add_outnames);
+  return unify_from_right(mm_outnames, bias.names());
 }
 
 void check_names_for_dot(

--- a/aten/src/ATen/NamedTensorUtils.h
+++ b/aten/src/ATen/NamedTensorUtils.h
@@ -140,8 +140,7 @@ TORCH_API TensorImpl* propagate_names(
 TORCH_API void propagate_names(TensorImpl* result, /*const */TensorImpl* src);
 
 // result = m1 @ m2 + bias
-TORCH_API void propagate_names_for_addmm(
-    Tensor& result,
+TORCH_API std::vector<Dimname> propagate_names_for_addmm(
     const Tensor& m1,
     const Tensor& m2,
     const Tensor& bias);

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -28,31 +28,19 @@
 namespace at {
 namespace meta {
 TORCH_META_FUNC(addmm)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha) {
-  TORCH_CHECK(self.dim() == 2, "input must be a matrix, got ", self.dim(), "-D tensor");
   TORCH_CHECK(mat1.dim() == 2, "mat1 must be a matrix, got ", mat1.dim(), "-D tensor");
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix, got ", mat2.dim(), "-D tensor");
 
   // Array access is faster than .size(n) and .stride(n)
   const auto self_sizes = self.sizes();
-  auto m1_strides = mat1.strides();
   auto m1_sizes = mat1.sizes();
-  auto m2_strides = mat2.strides();
   auto m2_sizes = mat2.sizes();
 
   TORCH_CHECK(
       m1_sizes[1] == m2_sizes[0], "mat1 and mat2 shapes cannot be multiplied (",
       m1_sizes[0], "x", m1_sizes[1], " and ", m2_sizes[0], "x", m2_sizes[1], ")");
 
-  TORCH_CHECK(
-      self_sizes[0] == m1_sizes[0] && self_sizes[1] == m2_sizes[1],
-      "input shape is incompatible with matrix multiplication (",
-      m1_sizes[0], "x", m1_sizes[1], " @ ", m2_sizes[0], "x", m2_sizes[1], " != ",
-      self_sizes[0], "x", self_sizes[1], ")");
-  set_output(0, IntArrayRef(mat1.sizes().data(), 1), self.options());
-  //this check can fire for inplace op only, for all other versions result is guaranteed to be correct size
-  TORCH_CHECK(((self.dim() == 2) && (self.sizes()[0] == mat1.sizes()[0]) && (self.sizes()[1] == mat2.sizes()[1])),
-  "The input tensor must be a matrix with size ", mat1.sizes()[0], "x", mat2.sizes()[1], ", but got a ", self.dim(),
-  "-D tensor with size ", self.sizes()[0], "x", self.sizes()[1]);
+  set_output(0, IntArrayRef({self.sizes()[0], mat2.sizes()[1]}), self.options());
 }
 } // namespace meta
 namespace native {
@@ -937,7 +925,8 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 }
 
 static void addmm_impl_cpu_(
-    Tensor &result, const Tensor &self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
+    Tensor &result, const Tensor &org_self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
+  auto self = *(expand_size(org_self, {m1.sizes()[0], m2.sizes()[1]}, "addmm_out"));
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);
 
   // Array access is faster than .size(n) and .stride(n)
@@ -946,6 +935,13 @@ static void addmm_impl_cpu_(
   auto m1_sizes = m1.sizes();
   auto m2_strides = m2.strides();
   auto m2_sizes = m2.sizes();
+  auto result_size = result.sizes();
+
+  TORCH_CHECK(
+      self_sizes[0] == m1_sizes[0] && self_sizes[1] == m2_sizes[1],
+      "input shape is incompatible with matrix multiplication (",
+      m1_sizes[0], "x", m1_sizes[1], " @ ", m2_sizes[0], "x", m2_sizes[1], " != ",
+      self_sizes[0], "x", self_sizes[1], ")");
 
   at::native::resize_output(result, self_sizes);
   const auto result_strides = result.strides();
@@ -1103,10 +1099,9 @@ Tensor addbmm(const Tensor& self, const Tensor& batch1, const Tensor& batch2, co
 }
 
 TORCH_IMPL_FUNC(addmm_out_cpu)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, const Tensor &result) {
-  auto b_self = expand_size(self, {mat1.sizes()[0], mat2.sizes()[1]}, "addmm_out");
   {
     at::NoNamesGuard guard;
-    addmm_impl_cpu_(const_cast<Tensor&>(result), *b_self, mat1, mat2, beta, alpha);
+    addmm_impl_cpu_(const_cast<Tensor&>(result), self, mat1, mat2, beta, alpha);
   }
 }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1113,15 +1113,14 @@ Tensor& mm_cpu_out(const Tensor & self, const Tensor & mat2, Tensor & result) {
   TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
   native::resize_(result, {self.sizes()[0], mat2.sizes()[1]});
   addmm_impl_cpu_(result, result, self, mat2, 0, 1);
+  auto names = at::namedinference::propagate_names_for_addmm(self, mat2, result);
+  at::namedinference::propagate_names_if_nonempty(result, names);
   return result;
 }
 
 Tensor mm_cpu(const Tensor & self, const Tensor & mat2) {
-  TORCH_CHECK(self.dim() == 2, "self must be a matrix");
-  TORCH_CHECK(mat2.dim() == 2, "mat2 must be a matrix");
   Tensor result = at::empty({self.sizes()[0], mat2.sizes()[1]}, self.options());
-  addmm_impl_cpu_(result, result, self, mat2, 0, 1);
-  return result;
+  return native::mm_cpu_out(self, mat2, result);
 }
 
 template <typename scalar_t, bool is_bmm>

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -922,8 +922,7 @@ Tensor outer(const Tensor& self, const Tensor& vec2) {
 }
 
 static void addmm_impl_cpu_(
-    Tensor &result, const Tensor &org_self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
-  auto self = *(expand_size(org_self, {m1.sizes()[0], m2.sizes()[1]}, "addmm_out"));
+    Tensor &result, const Tensor &self, Tensor m1, Tensor m2, const Scalar& beta, const Scalar& alpha) {
   TORCH_INTERNAL_ASSERT(self.dim() == 2 && m1.dim() == 2 && m2.dim() == 2);
 
   // Array access is faster than .size(n) and .stride(n)
@@ -1102,9 +1101,10 @@ Tensor addbmm(const Tensor& self, const Tensor& batch1, const Tensor& batch2, co
 }
 
 TORCH_IMPL_FUNC(addmm_out_cpu)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, const Tensor &result) {
+  auto b_self = expand_size(self, {mat1.sizes()[0], mat2.sizes()[1]}, "addmm_out");
   {
     at::NoNamesGuard guard;
-    addmm_impl_cpu_(const_cast<Tensor&>(result), self, mat1, mat2, beta, alpha);
+    addmm_impl_cpu_(const_cast<Tensor&>(result), *b_self, mat1, mat2, beta, alpha);
   }
 }
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1021,7 +1021,7 @@ static void addmm_impl_cpu_(
 
   // Apply BLAS routine
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16,
-      result.scalar_type(), "addmm_out_cpu",
+      result.scalar_type(), "addmm_impl_cpu_",
       [&]{
         at::native::cpublas::gemm(
             transpose_a ? cpublas::Transpose : cpublas::NoTranspose,

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -90,18 +90,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   } else {
     self_ = c10::MaybeOwned<Tensor>::borrowed(self);
     self__sizes = self_->sizes();
-    TORCH_CHECK(result.dim() == 2, "tensors must be 2-D");
-    TORCH_CHECK(self__sizes[0] == mat1_sizes[0], "self_ dim 0 must match mat1 dim 0");
-    TORCH_CHECK(self__sizes[1] == mat2_sizes[1], "self_ dim 1 must match mat2 dim 1");
   }
-
-  TORCH_CHECK(
-      mat1_sizes[1] == mat2_sizes[0],
-      "mat1 dim 1 must match mat2 dim 0",
-      " mat1 dim1:",
-      mat1_sizes[1],
-      " mat2 dim0: ",
-      mat2_sizes[0]);
 
   if (&result != &self) {
     at::native::resize_output(result, self__sizes);
@@ -272,6 +261,10 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
 
 } // anonymous namespace
 
+TORCH_IMPL_FUNC(addmm_out_cuda)(const Tensor& self, const Tensor& mat1, const Tensor& mat2, const Scalar& beta, const Scalar& alpha, const Tensor& result) {
+  addmm_out_cuda_impl(const_cast<Tensor&>(result), self, mat1, mat2, beta, alpha);
+}
+
 Tensor& mm_out_cuda(const Tensor& self, const Tensor& mat2, Tensor& result) {
   result.resize_({ self.size(0), mat2.size(1) });
   return addmm_out_cuda_impl(result, result, self, mat2, 0, 1);
@@ -280,31 +273,6 @@ Tensor& mm_out_cuda(const Tensor& self, const Tensor& mat2, Tensor& result) {
 Tensor mm_cuda(const Tensor& self, const Tensor& mat2) {
   Tensor result = at::empty({ self.size(0), mat2.size(1) }, self.options());
   return addmm_out_cuda_impl(result, result, self, mat2, 0, 1);
-}
-
-Tensor& addmm_out_cuda(const Tensor &self,
-                        const Tensor &mat1, const Tensor &mat2,
-                        const Scalar& beta, const Scalar& alpha, Tensor &out) {
-  {
-    at::NoNamesGuard guard;
-    Tensor& result = addmm_out_cuda_impl(out, self, mat1, mat2, beta, alpha);
-  }
-  at::namedinference::propagate_names_for_addmm(out, mat1, mat2, self);
-  return out;
-}
-
-Tensor addmm_cuda(const Tensor& self, const Tensor& mat1, const Tensor& mat2,
-                  const Scalar& beta, const Scalar& alpha) {
-  TORCH_CHECK(mat1.dim() == 2 && mat2.dim() == 2, "tensors must be 2-D");
-  Tensor out = at::empty({mat1.sizes()[0], mat2.sizes()[1]}, self.options());
-  addmm_out_cuda(self, mat1, mat2, beta, alpha, out);
-  return out;
-}
-
-Tensor& addmm__cuda(Tensor& self, const Tensor& mat1, const Tensor& mat2,
-                    const Scalar& beta, const Scalar& alpha) {
-  addmm_out_cuda(self, mat1, mat2, beta, alpha, self);
-  return self;
 }
 
 Tensor& baddbmm_out_cuda(const Tensor& self, const Tensor& batch1, const Tensor& batch2, const Scalar& beta, const Scalar& alpha, Tensor &result) {

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -90,6 +90,9 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   } else {
     self_ = c10::MaybeOwned<Tensor>::borrowed(self);
     self__sizes = self_->sizes();
+    TORCH_CHECK(result.dim() == 2, "tensors must be 2-D");
+    TORCH_CHECK(self__sizes[0] == mat1_sizes[0], "self_ dim 0 must match mat1 dim 0");
+    TORCH_CHECK(self__sizes[1] == mat2_sizes[1], "self_ dim 1 must match mat2 dim 1");
   }
 
   if (&result != &self) {

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4630,27 +4630,26 @@
     CompositeExplicitAutograd: _sparse_addmm
 
 - func: addmm.out(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, Tensor(a!) out) -> Tensor(a!)
+  structured: True
   dispatch:
-    CPU: addmm_cpu_out
+    CPU: addmm_out_cpu
     CUDA: addmm_out_cuda
     SparseCPU: addmm_out_sparse_dense_cpu
     SparseCUDA: addmm_out_sparse_dense_cuda
     SparseCsrCPU: addmm_out_sparse_csr_dense_cpu
 
 - func: addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor
+  structured_delegate: addmm.out
   variants: function, method
   dispatch:
-    CPU: addmm_cpu
-    CUDA: addmm_cuda
     SparseCPU: addmm_sparse_dense_cpu
     SparseCUDA: addmm_sparse_dense_cuda
     SparseCsrCPU: addmm_sparse_csr_dense_cpu
 
 - func: addmm_(Tensor(a!) self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor(a!)
+  structured_delegate: addmm.out
   variants: method
   dispatch:
-    CPU: addmm_cpu_
-    CUDA: addmm__cuda
     # Warning!  For whatever reason, the inplace sparse addmm is NON
     # broadcasting
     SparseCPU: s_addmm_sparse_dense_cpu_

--- a/benchmarks/static_runtime/deep_wide_pt.h
+++ b/benchmarks/static_runtime/deep_wide_pt.h
@@ -117,8 +117,8 @@ struct DeepAndWideFast : torch::nn::Module {
       // tensor views on the output that are passed to the _out ops above.
       at::native::_cat_out_cpu(
           {prealloc_tensors[5], prealloc_tensors[2]}, 1, prealloc_tensors[6]);
-      at::native::addmm_cpu_out(
-          fc_b_, prealloc_tensors[6], fc_w_t_, 1, 1, prealloc_tensors[7]);
+      at::cpu::addmm_out(
+          prealloc_tensors[7], fc_b_, prealloc_tensors[6], fc_w_t_, 1, 1);
       at::cpu::sigmoid_out(prealloc_tensors[7], prealloc_tensors[8]);
 
       return prealloc_tensors[8];

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -46,7 +46,7 @@ from torch.testing._internal.common_methods_invocations import (method_tests,
 from torch.testing._internal.common_device_type import (instantiate_device_type_tests, skipCUDAIfRocm,
                                                         onlyCPU, onlyCUDA, onlyOnCPUAndCUDA, dtypes, dtypesIfCUDA,
                                                         deviceCountAtLeast, skipCUDAIfCudnnVersionLessThan,
-                                                        skipCUDAIf)
+                                                        skipCUDAIf, skipMeta)
 
 _END_SENTINEL = object()
 
@@ -7810,6 +7810,7 @@ class TestAutogradDeviceType(TestCase):
                     param.grad = None
                 inp.grad = None
 
+    @skipMeta  #  LSTM cell reuses output which was resized
     def test_LSTM_grad_and_gradgrad(self, device):
         hsize = 4
         inp = torch.rand(1, 3, hsize, device=device, dtype=torch.float64, requires_grad=True)
@@ -7817,6 +7818,7 @@ class TestAutogradDeviceType(TestCase):
             mod = torch.nn.LSTM(hsize, hsize, bias=bias).to(device).to(torch.float64)
             self._test_rnn_mod(mod, inp)
 
+    @skipMeta  # GRU cell reuses output which was resized
     def test_GRU_grad_and_gradgrad(self, device):
         hsize = 4
         inp = torch.rand(1, 3, hsize, device=device, dtype=torch.float64, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7810,7 +7810,7 @@ class TestAutogradDeviceType(TestCase):
                     param.grad = None
                 inp.grad = None
 
-    @skipMeta  #  LSTM cell reuses output which was resized
+    @skipMeta  # LSTM cell reuses output which was resized
     def test_LSTM_grad_and_gradgrad(self, device):
         hsize = 4
         inp = torch.rand(1, 3, hsize, device=device, dtype=torch.float64, requires_grad=True)

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -303,7 +303,7 @@ REGISTER_OPERATOR_FUNCTOR(aten::addmm, aten_addmm, [](Node* n) -> SROperator {
     }
     auto& out_t = p_node->Output(0).toTensor();
     fastResizeToZero(out_t);
-    at::native::addmm_cpu_out(in0_t, in1_t, in2_t, in3_s, in4_s, out_t);
+    at::cpu::addmm_out(out_t, in0_t, in1_t, in2_t, in3_s, in4_s);
   };
 });
 


### PR DESCRIPTION
Port addmm to structure kernel

Follow ups
- migrate `mm` and `addbmm` to structure
- move TORCH_CHECKS currently in `addmm_cpu_impl_` and `addmm_out_cuda_impl` to meta