### PR TITLE
[Experiment] Remove checks for AVX512BW

### DIFF
--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -96,7 +96,7 @@ Tensor mkldnn_convolution(
 
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_convolution: bf16 path needs the cpu support for avx512vl and avx512dq");
+        "mkldnn_convolution: bf16 path needs cpu support for avx512vl and avx512dq");
   }
   const ideep::tensor mkldnn_input = itensor_from_tensor(input);
   const ideep::tensor mkldnn_weight = itensor_from_tensor(weight);

--- a/aten/src/ATen/native/mkldnn/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/Conv.cpp
@@ -96,7 +96,7 @@ Tensor mkldnn_convolution(
 
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_convolution: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_convolution: bf16 path needs the cpu support for avx512vl and avx512dq");
   }
   const ideep::tensor mkldnn_input = itensor_from_tensor(input);
   const ideep::tensor mkldnn_weight = itensor_from_tensor(weight);

--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -55,7 +55,7 @@ Tensor mkldnn_linear(
       "mkldnn_linear: input needs to be mkldnn layout");
   if (self.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_linear: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_linear: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   // reshape first if input dim != 2 and the reshape will cost a memory copy.

--- a/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNConversions.cpp
@@ -78,7 +78,7 @@ Tensor mkldnn_reorder_conv2d_weight(
     int64_t groups) {
   if (self.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_reorder_conv2d_weight: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_reorder_conv2d_weight: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   auto w = itensor_from_mkldnn(self);
@@ -120,7 +120,7 @@ Tensor mkldnn_reorder_conv3d_weight(
     int64_t groups) {
   if (self.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_reorder_conv3d_weight: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_reorder_conv3d_weight: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   auto w = itensor_from_mkldnn(self);

--- a/aten/src/ATen/native/mkldnn/Normalization.cpp
+++ b/aten/src/ATen/native/mkldnn/Normalization.cpp
@@ -50,7 +50,7 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_batch_norm(
 
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_batch_norm: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_batch_norm: bf16 path needs the cpu support for avx512vl and avx512dq");
   }
   TORCH_CHECK(weight.defined() && bias.defined(),
              "mkldnn_batch_norm: currently mkldnn only support affine model");

--- a/aten/src/ATen/native/mkldnn/Pooling.cpp
+++ b/aten/src/ATen/native/mkldnn/Pooling.cpp
@@ -358,7 +358,7 @@ Tensor mkldnn_max_pool2d(
       "mkldnn_max_pool2d does not support dilation case");
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_max_pool2d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_max_pool2d: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   return _mkldnn_pooling(
@@ -382,7 +382,7 @@ Tensor mkldnn_max_pool3d(
       "mkldnn_max_pool3d does not support dilation case");
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_max_pool3d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_max_pool3d: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   return _mkldnn_pooling(
@@ -407,7 +407,7 @@ Tensor mkldnn_avg_pool2d(
       "mkldnn_avg_pool2d operator does not support divisor");
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_avg_pool2d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_avg_pool2d: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   return _mkldnn_pooling(
@@ -443,7 +443,7 @@ Tensor mkldnn_avg_pool3d(
   TORCH_CHECK(!divisor_override.has_value(), "mkldnn_avg_pool3d operator does not support divisor");
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_avg_pool3d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_avg_pool3d: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   return _mkldnn_pooling(
@@ -474,7 +474,7 @@ Tensor mkldnn_adaptive_avg_pool2d(
   TORCH_CHECK(input.dim() == 4, "mkldnn_adaptive_avg_pool2d: Expect 2D input");
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_adaptive_avg_pool2d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_adaptive_avg_pool2d: bf16 path needs cpu support for avx512vl and avx512dq");
   }
   auto output_size_vec =
       expand_param_if_needed(output_size, "output_size", input.dim() - 2);

--- a/aten/src/ATen/native/mkldnn/Relu.cpp
+++ b/aten/src/ATen/native/mkldnn/Relu.cpp
@@ -31,7 +31,7 @@ namespace at { namespace native {
 Tensor mkldnn_relu(const Tensor& input) {
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_relu: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_relu: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   const ideep::tensor& x = itensor_from_mkldnn(input);
@@ -45,7 +45,7 @@ Tensor mkldnn_relu(const Tensor& input) {
 Tensor& mkldnn_relu_(Tensor& input) {
   if (input.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
-        "mkldnn_relu_: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
+        "mkldnn_relu_: bf16 path needs cpu support for avx512vl and avx512dq");
   }
 
   ideep::tensor& x = itensor_from_mkldnn(input);

--- a/aten/src/ATen/native/mkldnn/Utils.h
+++ b/aten/src/ATen/native/mkldnn/Utils.h
@@ -17,8 +17,8 @@ std::vector<int64_t> pool_output_sizes(
 };
 
 inline bool mkldnn_bf16_device_check() {
-  return cpuinfo_initialize() && cpuinfo_has_x86_avx512bw()
-      && cpuinfo_has_x86_avx512vl() && cpuinfo_has_x86_avx512dq();
+  return cpuinfo_initialize() && cpuinfo_has_x86_avx512vl() &&
+      cpuinfo_has_x86_avx512dq();
 }
 
 }

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -24,9 +24,9 @@ gradcheck = functools.partial(gradcheck, check_batched_grad=False)
 gradgradcheck = functools.partial(gradgradcheck, check_batched_grad=False)
 
 
-# For OneDNN bf16 path, OneDNN requires the cpu has intel avx512 with avx512bw,
+# For OneDNN bf16 path, OneDNN requires the cpu has intel avx512bw,
 # avx512vl, and avx512dq at least. So we will skip the test case if one processor
-# is not meet the requirement.
+# does not meet the requirement.
 def has_bf16_support():
     import subprocess
     try:
@@ -267,7 +267,7 @@ class TestMkldnn(TestCase):
                 y_bf16 = mkldnn_conv_bf16(x_bf16.to_mkldnn()).to_dense(torch.float32)
                 self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
             else:
-                msg = r"bf16 path needs the cpu support avx512bw, avx512vl and avx512dq"
+                msg = r"bf16 path needs cpu support for avx512vl and avx512dq"
                 with self.assertRaisesRegex(RuntimeError, msg):
                     mkldnn_conv_bf16 = mkldnn_utils.to_mkldnn(copy.deepcopy(conv), torch.bfloat16)
                     y_bf16 = mkldnn_conv_bf16(x_bf16.to_mkldnn()).to_dense(torch.float32)
@@ -343,7 +343,7 @@ class TestMkldnn(TestCase):
             y_bf16 = fn(x_bf16.to_mkldnn()).to_dense(torch.float32)
             self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
         else:
-            msg = r"bf16 path needs the cpu support avx512bw, avx512vl and avx512dq"
+            msg = r"bf16 path needs cpu support for avx512vl and avx512dq"
             self.assertRaisesRegex(RuntimeError,
                                    msg,
                                    lambda: fn(x_bf16.to_mkldnn()))
@@ -407,7 +407,7 @@ class TestMkldnn(TestCase):
                     y_bf16 = max_pool(x_bf16.to_mkldnn()).to_dense(torch.float32)
                     self.assertEqual(y, y_bf16, atol=0.1, rtol=1e-3)
                 else:
-                    msg = "mkldnn_max_pool%dd: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq" % dim
+                    msg = "mkldnn_max_pool%dd: bf16 path needs cpu support for avx512vl and avx512dq" % dim
                     self.assertRaisesRegex(RuntimeError,
                                            msg,
                                            lambda: max_pool(x_bf16.to_mkldnn()))
@@ -523,7 +523,7 @@ class TestMkldnn(TestCase):
                 y_bf16 = avg_pool(x_bf16.to_mkldnn()).to_dense(torch.float)
                 self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
             else:
-                msg = "mkldnn_avg_pool%dd: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq" % dim
+                msg = "mkldnn_avg_pool%dd: bf16 path needs cpu for support for avx512vl and avx512dq" % dim
                 self.assertRaisesRegex(RuntimeError,
                                        msg,
                                        lambda: avg_pool(x_bf16.to_mkldnn()))
@@ -594,7 +594,7 @@ class TestMkldnn(TestCase):
             y_bf16 = adaptive_avg_pool2d(x.to_mkldnn()).to_dense(torch.float32)
             self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
         else:
-            msg = "mkldnn_adaptive_avg_pool2d: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq"
+            msg = "mkldnn_adaptive_avg_pool2d: bf16 path needs cpu support for avx512vl and avx512dq"
             self.assertRaisesRegex(RuntimeError,
                                    msg,
                                    lambda: adaptive_avg_pool2d(x_bf16.to_mkldnn()))
@@ -662,7 +662,7 @@ class TestMkldnn(TestCase):
                 y_bf16 = bn(input.to_mkldnn().to_dense(torch.float))
                 self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
             else:
-                msg = "mkldnn_batch_norm: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq"
+                msg = "mkldnn_batch_norm: bf16 path needs cpu support for avx512vl and avx512dq"
                 self.assertRaisesRegex(RuntimeError,
                                        msg,
                                        lambda: bn(x_bf16.to_mkldnn()))
@@ -947,7 +947,7 @@ class TestMkldnn(TestCase):
                 y_bf16 = mkldnn_linear_bf16(x_bf16.to_mkldnn()).to_dense(torch.float32)
                 self.assertEqual(y, y_bf16, atol=1e-1, rtol=1e-3)
             else:
-                msg = "mkldnn_linear: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq"
+                msg = "mkldnn_linear: bf16 path needs cpu support for avx512vl and avx512dq"
                 self.assertRaisesRegex(RuntimeError,
                                        msg,
                                        lambda: mkldnn_linear_bf16(x_bf16.to_mkldnn()))

--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -30,7 +30,7 @@ gradgradcheck = functools.partial(gradgradcheck, check_batched_grad=False)
 def has_bf16_support():
     import subprocess
     try:
-        cmd = "grep avx512bw /proc/cpuinfo | grep avx512vl | grep avx512dq"
+        cmd = "grep avx512vl /proc/cpuinfo | grep avx512dq"
         subprocess.check_output(cmd, shell=True)
         return True
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Experimenting to figure out if we require AVX512BW support so that OneDNN is compiled with it.
But the experiment would only work if the CI machines do not have AVX512BW but have AVX512VL & AVX512DQ.
