### PR TITLE
Avoid passing the LazyStreamContext around when not needed

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -319,8 +319,7 @@ void RequestCallbackImpl::processPythonRemoteCall(
     RpcCommandBase& rpc,
     const std::function<void(Message)>& markComplete,
     const int64_t messageId,
-    const std::shared_ptr<JitFuture>& responseFuture,
-    std::shared_ptr<LazyStreamContext> lsctx) const {
+    const std::shared_ptr<JitFuture>& responseFuture) const {
   auto& uprc = static_cast<UnpickledPythonRemoteCall&>(rpc);
 
   const auto& rrefId = uprc.rrefId();
@@ -358,7 +357,7 @@ void RequestCallbackImpl::processPythonRemoteCall(
         messageId,
         responseFuture,
         uprc.isAsyncExecution(),
-        [ownerRRef, rrefId, forkId, markComplete, lsctx = std::move(lsctx)](
+        [ownerRRef, rrefId, forkId, markComplete](
             const py::object& result,
             const int64_t messageId,
             PythonRpcHandler& /* unused */,
@@ -390,10 +389,9 @@ void RequestCallbackImpl::processPythonRemoteCall(
 void RequestCallbackImpl::processPythonRRefFetchCall(
     RpcCommandBase& rpc,
     const int64_t messageId,
-    const std::shared_ptr<JitFuture>& responseFuture,
-    std::shared_ptr<LazyStreamContext> lsctx) const {
+    const std::shared_ptr<JitFuture>& responseFuture) const {
   // Making this lambda mutable to allow move-capture it in callbacks
-  auto postProcessing = [responseFuture, lsctx = std::move(lsctx)](
+  auto postProcessing = [responseFuture](
                             const c10::intrusive_ptr<OwnerRRef>& rref,
                             int64_t messageId) mutable {
     auto whenValueSet = rref->getFuture();
@@ -468,10 +466,9 @@ void RequestCallbackImpl::processRpcWithErrors(
     RpcCommandBase& rpc,
     const MessageType& messageType,
     const int64_t messageId,
-    const std::shared_ptr<JitFuture>& responseFuture,
-    std::shared_ptr<LazyStreamContext> ctx) const {
+    const std::shared_ptr<JitFuture>& responseFuture) const {
   try {
-    processRpc(rpc, messageType, messageId, responseFuture, std::move(ctx));
+    processRpc(rpc, messageType, messageId, responseFuture);
   } catch (py::error_already_set& e) {
     responseFuture->markCompleted(handleError(e, messageType, messageId));
     // There are request callback impls in Python, where Python

--- a/torch/csrc/distributed/rpc/request_callback_impl.h
+++ b/torch/csrc/distributed/rpc/request_callback_impl.h
@@ -39,14 +39,12 @@ class TORCH_API RequestCallbackImpl : public RequestCallbackNoPython {
       RpcCommandBase& rpc,
       const std::function<void(Message)>& markComplete,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const override;
+      const std::shared_ptr<JitFuture>& responseFuture) const override;
 
   void processPythonRRefFetchCall(
       RpcCommandBase& rpc,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const override;
+      const std::shared_ptr<JitFuture>& responseFuture) const override;
 
   void handleRRefDelete(c10::intrusive_ptr<RRef>& rref) const override;
 
@@ -54,8 +52,7 @@ class TORCH_API RequestCallbackImpl : public RequestCallbackNoPython {
       RpcCommandBase& rpc,
       const MessageType& messageType,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const override;
+      const std::shared_ptr<JitFuture>& responseFuture) const override;
 
   bool cudaAvailable() const override;
 

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -65,8 +65,7 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       RpcCommandBase& rpc,
       const std::function<void(Message)>& markComplete,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const;
+      const std::shared_ptr<JitFuture>& responseFuture) const;
 
   void processScriptRRefFetchCall(
       RpcCommandBase& rpc,
@@ -77,8 +76,7 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
   virtual void processPythonRRefFetchCall(
       RpcCommandBase& rpc,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const;
+      const std::shared_ptr<JitFuture>& responseFuture) const;
 
   void processRRefUserDelete(
       RpcCommandBase& rpc,
@@ -95,8 +93,7 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
   void processForwardAutogradReq(
       RpcCommandBase& rpc,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const;
+      const std::shared_ptr<JitFuture>& responseFuture) const;
 
   void processBackwardAutogradReq(
       RpcCommandBase& rpc,
@@ -118,15 +115,13 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       RpcCommandBase& rpc,
       const MessageType& messageType,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const;
+      const std::shared_ptr<JitFuture>& responseFuture) const;
 
   virtual void processRpcWithErrors(
       RpcCommandBase& rpc,
       const MessageType& messageType,
       const int64_t messageId,
-      const std::shared_ptr<JitFuture>& responseFuture,
-      std::shared_ptr<LazyStreamContext> ctx) const;
+      const std::shared_ptr<JitFuture>& responseFuture) const;
 
   IValue handleError(
       const std::exception& e,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57444 Avoid passing the LazyStreamContext around when not needed**
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #57443 Make RRefContext get devices from RPC agent when creating OwnerRRef
* #57442 Replace DeviceIndexes with Devices in RRefs
* #56918 Make DataPtr extraction in CUDAFuture faster for Python values
* #57432 Ensure devices are preserved when forwarding between futures
* #57433 Avoid re-extracting DataPtrs when forwarding values between Futures

The LazyStreamContext was passed around a bunch because it was used by RRefs. Now that we have changed that in the previous PRs in this stack, we can remove all this "piping". (We can reintroduce it at any time if it will be needed again).

Differential Revision: [D28144366](https://our.internmc.facebook.com/intern/diff/D28144366/)