### PR TITLE
[torch] handle embedding bag with empty bag

### DIFF
--- a/aten/src/ATen/native/EmbeddingBag.cpp
+++ b/aten/src/ATen/native/EmbeddingBag.cpp
@@ -136,10 +136,12 @@ index_select_add(const Tensor &select_indices,
     } else {
       output_size = offsets.numel();
       offsets_include_last.resize(offsets.numel() + 1);
-      std::memcpy(
-          offsets_include_last.data(),
-          offsets.data_ptr<index_t>(),
-          sizeof(index_t) * offsets.numel());
+      if (offsets.numel() > 0) {
+        std::memcpy(
+            offsets_include_last.data(),
+            offsets.data_ptr<index_t>(),
+            sizeof(index_t) * offsets.numel());
+      }
       offsets_include_last[offsets.numel()] = select_indices.numel();
       offsets_data = offsets_include_last.data();
     }
@@ -399,15 +401,16 @@ void check_arguments(
   checkScalarTypes("embedding_bag", weight_arg, {kFloat, kDouble});
 
   AT_DISPATCH_INDEX_TYPES(offsets.scalar_type(), "_embedding_bag_cpu_impl", [&]() {
-    TORCH_CHECK(offsets.sizes()[0] >= 1, "offsets should have at least 1 element");
-    index_t offset_0 = offsets.data_ptr<index_t>()[0];
-    index_t offset_n = offsets.data_ptr<index_t>()[offsets.sizes()[0]-1];
-    TORCH_CHECK(offset_0 == 0, "offsets[0] has to be 0, i.e., the first sequence "
-                              "in the mini-batch has to start from position 0. "
-                              "However, got ", offsets[0]);
-    TORCH_CHECK(offset_n <= indices.sizes()[0], "offsets[-1] can not "
-                "be greater than input's length ", indices.sizes()[0], " but got offsets[-1] of ",
-                offset_n);
+    if (offsets.sizes()[0] > 0) {
+      index_t offset_0 = offsets.data_ptr<index_t>()[0];
+      index_t offset_n = offsets.data_ptr<index_t>()[offsets.sizes()[0]-1];
+      TORCH_CHECK(offset_0 == 0, "offsets[0] has to be 0, i.e., the first sequence "
+                                "in the mini-batch has to start from position 0. "
+                                "However, got ", offsets[0]);
+      TORCH_CHECK(offset_n <= indices.sizes()[0], "offsets[-1] can not "
+                  "be greater than input's length ", indices.sizes()[0], " but got offsets[-1] of ",
+                  offset_n);
+    }
   });
 
   if (per_sample_weights.has_value() && per_sample_weights.value().defined()) {
@@ -443,7 +446,9 @@ void make_bag_size_out(
           offsets.slice(0, 1, num_bags, 1) -
           offsets.slice(0, 0, num_bags - 1, 1);
     }
-    bag_size_out[-1] = indices.sizes()[0] - offsets[num_bags - 1];
+    if (num_bags > 0) {
+      bag_size_out[-1] = indices.sizes()[0] - offsets[num_bags - 1];
+    }
   }
 }
 


### PR DESCRIPTION
Summary: GPU EmbeddingBag is handling L == 0 . Matching CPU version.

Test Plan: buck test //deeplearning/fbgemm/fbgemm_gpu:split_table_batched_embeddings_test -- test_forward

Differential Revision: D28145090

