### PR TITLE
Look for unqualified ignore in .pyi, not just .py

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,12 +79,12 @@ jobs:
         if: always()
         run: |
           # shellcheck disable=SC2016
-          (! git --no-pager grep -InP '# noqa(?!: [A-Z]+\d{3})' -- '**.py' ':(exclude)caffe2' || (echo 'The above lines have unqualified `noqa`; please convert them to `noqa: XXXX`'; false))
+          (! git --no-pager grep -InP '# noqa(?!: [A-Z]+\d{3})' -- '**.py' '**.pyi' ':(exclude)caffe2' || (echo 'The above lines have unqualified `noqa`; please convert them to `noqa: XXXX`'; false))
       - name: Ensure no unqualified type ignore
         if: always()
         run: |
           # shellcheck disable=SC2016
-          (! git --no-pager grep -InP '# type:\s*ignore(?!\[)' -- '**.py' ':(exclude)test/test_jit.py' || (echo 'The above lines have unqualified `type: ignore`; please convert them to `type: ignore[xxxx]`'; false))
+          (! git --no-pager grep -InP '# type:\s*ignore(?!\[)' -- '**.py' '**.pyi' ':(exclude)test/test_jit.py' || (echo 'The above lines have unqualified `type: ignore`; please convert them to `type: ignore[xxxx]`'; false))
       # note that this next step depends on a clean checkout;
       # if you run it locally then it will likely to complain
       # about all the generated files in torch/test

--- a/torch/nn/parallel/scatter_gather.pyi
+++ b/torch/nn/parallel/scatter_gather.pyi
@@ -14,7 +14,7 @@ def scatter(inputs: Tensor, target_gpus: _devices_t, dim: int = ...) -> Tuple[Te
 # untyped module. Thus to mypy, the first definition of `scatter` looks strictly more general
 # than this overload.
 @overload
-def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...  # type: ignore
+def scatter(inputs: T, target_gpus: _devices_t, dim: int = ...) -> List[T]: ...
 
 
 # TODO More precise types here.


### PR DESCRIPTION
**Test plan:**

On the commit that expanded the lints but didn't remove the `# type: ignore` comment, the quick-checks job failed:

- https://github.com/pytorch/pytorch/runs/2493713340

In contrast, on the tip of this PR, both the quick-checks job and the mypy job succeed:

- https://github.com/pytorch/pytorch/runs/2493744907
- https://github.com/pytorch/pytorch/runs/2493746144