### PR TITLE
fx quant: remove matching hack for binary qhandler

### DIFF
--- a/torch/quantization/fx/quantization_patterns.py
+++ b/torch/quantization/fx/quantization_patterns.py
@@ -265,9 +265,18 @@ class BinaryOpQuantizeHandler(QuantizeHandler):
             # path will not be hit.
             return False
 
+    def input_output_observed(self):
+        # for x + y where x and y are scalars, we do not observe anything
+        return self.num_tensor_args > 0
+
     def convert(self, quantizer: QuantizerCls, node: Node, load_arg: Callable,
                 is_reference: bool = False,
                 convert_custom_config_dict: Dict[str, Any] = None) -> Node:
+
+        if self.num_tensor_args == 0:
+            # example: x + y, when x and y are scalars
+            return quantizer.quantized_graph.node_copy(
+                node, load_arg(quantized=None))
 
         qconfig = quantizer.qconfig_map[node.name]
         dtypes = get_qconfig_dtypes(qconfig)

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -1349,11 +1349,6 @@ class Quantizer:
                     if is_match(modules, node, pattern):
                         skip_this_match = False
                         if value is BinaryOpQuantizeHandler:
-                            use_copy_node = all_node_args_have_no_tensors(node, modules, cache_for_no_tensor_check)
-                            if use_copy_node:
-                                # TODO(future PR): update the pattern to quantize
-                                # handler logic to take this into account.
-                                value = CopyNodeQuantizeHandler  # type: ignore[assignment]
 
                             # to properly check for dtype support, we need to
                             # navigate to the base node of an add-relu or mul-relu


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57519 [not ready for review][rfc] fx quant: refactor observer insertion
* **#57470 fx quant: remove matching hack for binary qhandler**

Summary:

Removes the earlier hack of matching patterns originally matched
to BinaryOpQuantizeHandler to switch to CopyHandler. After this PR,
each pattern can only be matched to one type of QuantizeHandler or
to nothing.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D28152909](https://our.internmc.facebook.com/intern/diff/D28152909)