### PR TITLE
Add call_kwargs(args, kwargs) method to torch::deploy api

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -2,6 +2,7 @@
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <assert.h>
 #include <torch/csrc/deploy/interpreter/interpreter_impl.h>
+#include <torch/csrc/jit/serialization/import.h>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -30,7 +31,6 @@ struct TORCH_API InterpreterSession {
   Obj from_ivalue(at::IValue ivalue) {
     return impl_->from_ivalue(std::move(ivalue));
   }
-
   ReplicatedObj create_movable(Obj obj);
   Obj from_movable(const ReplicatedObj& obj);
 
@@ -164,7 +164,14 @@ struct TORCH_API ReplicatedObj {
   }
 
   at::IValue call_kwargs(
-      std::vector<std::tuple<std::string, at::IValue>> kwargs) const {
+      std::vector<at::IValue> args,
+      std::unordered_map<std::string, c10::IValue> kwargs) const {
+    auto I = acquire_session();
+    return I.self.call_kwargs(std::move(args), std::move(kwargs)).toIValue();
+  }
+
+  [[nodiscard]] at::IValue call_kwargs(
+      std::unordered_map<std::string, c10::IValue> kwargs) const {
     auto I = acquire_session();
     return I.self.call_kwargs(std::move(kwargs)).toIValue();
   }
@@ -177,6 +184,7 @@ struct TORCH_API ReplicatedObj {
   std::shared_ptr<ReplicatedObjImpl> pImpl_;
   friend struct Package;
   friend struct InterpreterSession;
+  friend struct InterpreterManager;
 };
 
 struct TORCH_API Package {

--- a/torch/csrc/deploy/interpreter/interpreter_impl.cpp
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.cpp
@@ -429,20 +429,24 @@ struct ConcreteInterpreterSessionImpl
 
   Obj call_kwargs(
       Obj obj,
-      std::vector<std::tuple<std::string, at::IValue>> kwargs) override {
-    std::vector<std::tuple<std::string, py::object>> kwargs_list;
-    kwargs_list.reserve(kwargs.size());
-    for (auto& kv : kwargs) {
-      kwargs_list.emplace_back(
-          std::get<0>(kv), torch::jit::toPyObject(std::get<1>(kv)));
+      std::vector<at::IValue> args,
+      std::unordered_map<std::string, c10::IValue> kwargs) override {
+    py::tuple py_args(args.size());
+    for (size_t i = 0, N = args.size(); i != N; ++i) {
+      py_args[i] = torch::jit::toPyObject(args[i]);
     }
-    py::object o = py::cast(kwargs_list);
-    if (!o) {
-      throw py::error_already_set();
+
+    py::dict py_kwargs;
+    for (auto [key, value] : kwargs) {
+      py_kwargs[py::cast(key)] = torch::jit::toPyObject(value);
     }
-    py::dict py_kwargs(o);
-    py::list py_args;
     return wrap(call(unwrap(obj), py_args, py_kwargs));
+  }
+
+  Obj call_kwargs(Obj obj, std::unordered_map<std::string, c10::IValue> kwargs)
+      override {
+    std::vector<at::IValue> args;
+    return call_kwargs(obj, args, kwargs);
   }
 
   Obj attr(Obj obj, const char* attr) override {

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -33,7 +33,10 @@ struct Obj {
   at::IValue toIValue() const;
   Obj operator()(at::ArrayRef<Obj> args);
   Obj operator()(at::ArrayRef<at::IValue> args);
-  Obj call_kwargs(std::vector<std::tuple<std::string, at::IValue>> kwargs);
+  Obj call_kwargs(
+      std::vector<at::IValue> args,
+      std::unordered_map<std::string, c10::IValue> kwargs);
+  Obj call_kwargs(std::unordered_map<std::string, c10::IValue> kwargs);
   Obj attr(const char* attr);
 
  private:
@@ -56,7 +59,6 @@ struct InterpreterSessionImpl {
   virtual Obj create_or_get_package_importer_from_container_file(
       const std::shared_ptr<caffe2::serialize::PyTorchStreamReader>&
           container_file_) = 0;
-
   virtual PickledObject pickle(Obj container, Obj obj) = 0;
   virtual Obj unpickle_or_get(int64_t id, const PickledObject& obj) = 0;
   virtual void unload(int64_t id) = 0;
@@ -67,7 +69,11 @@ struct InterpreterSessionImpl {
   virtual Obj call(Obj obj, at::ArrayRef<at::IValue> args) = 0;
   virtual Obj call_kwargs(
       Obj obj,
-      std::vector<std::tuple<std::string, at::IValue>> kwargs) = 0;
+      std::vector<at::IValue> args,
+      std::unordered_map<std::string, c10::IValue> kwargs) = 0;
+  virtual Obj call_kwargs(
+      Obj obj,
+      std::unordered_map<std::string, c10::IValue> kwargs) = 0;
   virtual Obj attr(Obj obj, const char* attr) = 0;
 
  protected:
@@ -97,7 +103,12 @@ inline Obj Obj::operator()(at::ArrayRef<at::IValue> args) {
 }
 
 inline Obj Obj::call_kwargs(
-    std::vector<std::tuple<std::string, at::IValue>> kwargs) {
+    std::vector<at::IValue> args,
+    std::unordered_map<std::string, c10::IValue> kwargs) {
+  return interaction_->call_kwargs(*this, std::move(args), std::move(kwargs));
+}
+inline Obj Obj::call_kwargs(
+    std::unordered_map<std::string, c10::IValue> kwargs) {
   return interaction_->call_kwargs(*this, std::move(kwargs));
 }
 inline Obj Obj::attr(const char* attr) {

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -85,6 +85,19 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   for (size_t i = 0; i < ninterp; i++) {
     ASSERT_TRUE(ref_output.equal(outputs[i]));
   }
+
+  // test kwargs api with args
+  std::vector<c10::IValue> args;
+  args.emplace_back(input);
+  std::unordered_map<std::string, c10::IValue> kwargs_empty;
+  auto jit_output_args = model.call_kwargs(args, kwargs_empty).toTensor();
+  ASSERT_TRUE(ref_output.equal(jit_output_args));
+
+  // and with kwargs only
+  std::unordered_map<std::string, c10::IValue> kwargs;
+  kwargs["input"] = input;
+  auto jit_output_kwargs = model.call_kwargs(kwargs).toTensor();
+  ASSERT_TRUE(ref_output.equal(jit_output_kwargs));
 }
 
 TEST(TorchpyTest, ThreadedSimpleModel) {


### PR DESCRIPTION
Summary: To be used by PyTorchPredictor integration for deploy.

Test Plan: tested via new unit tests

Differential Revision: D28154522

