### PR TITLE
Fix return type of getDeviceMap

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -271,7 +271,6 @@ if(USE_DISTRIBUTED)
     # Disable certain warnings for GCC-9.X
     if(CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0.0))
       set_source_files_properties(${TORCH_SRC_DIR}/csrc/distributed/autograd/init.cpp PROPERTIES COMPILE_FLAGS "-Wno-cast-function-type")
-      set_source_files_properties(${TORCH_SRC_DIR}/csrc/distributed/rpc/init.cpp PROPERTIES COMPILE_FLAGS "-Wno-cast-function-type")
       set_source_files_properties(${TORCH_SRC_DIR}/csrc/distributed/rpc/testing/init.cpp PROPERTIES COMPILE_FLAGS "-Wno-cast-function-type")
       set_source_files_properties(${TORCH_SRC_DIR}/csrc/distributed/c10d/init.cpp PROPERTIES COMPILE_FLAGS "-Wno-cast-function-type")
     endif()

--- a/torch/csrc/distributed/rpc/init.cpp
+++ b/torch/csrc/distributed/rpc/init.cpp
@@ -605,7 +605,7 @@ PyObject* rpc_init(PyObject* _unused, PyObject* noargs) {
           py::call_guard<py::gil_scoped_release>())
       .def(
           "_get_device_map",
-          (std::unordered_map<c10::DeviceIndex, c10::DeviceIndex>(
+          (std::unordered_map<c10::Device, c10::Device>(
               ProcessGroupAgent::*)(const WorkerInfo& dst) const) &
               ProcessGroupAgent::getDeviceMap,
           py::call_guard<py::gil_scoped_release>())


### PR DESCRIPTION
https://github.com/pytorch/pytorch/pull/57294 changed behaviour to
return `c10::Device` rather that `c10::DeviceIndex`, but missed method bind:
https://github.com/pytorch/pytorch/blob/1a6f827ae6c585be19973f071a6a05ad8f46b6a1/torch/csrc/distributed/rpc/init.cpp#L606-L611
that cast return type to map of c10::DeviceIndex rather than
c10::Device

Do not ignore cast error when compiling this code