### PR TITLE
protect destructors of python bindings that can be kept alive by c++ objects

### DIFF
--- a/torch/csrc/autograd/python_anomaly_mode.h
+++ b/torch/csrc/autograd/python_anomaly_mode.h
@@ -18,8 +18,11 @@ struct PyAnomalyMetadata : public AnomalyMetadata {
     dict_ = PyDict_New();
   }
   ~PyAnomalyMetadata() override {
-    pybind11::gil_scoped_acquire gil;
-    Py_DECREF(dict_);
+    // If python is already dead, leak the wrapped python objects
+    if (Py_IsInitialized()) {
+      pybind11::gil_scoped_acquire gil;
+      Py_DECREF(dict_);
+    }
   }
   void store_stack() override;
   void print_stack(const std::string& current_node_name) override;

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -81,7 +81,7 @@ void PythonEngine::thread_init(int device, const std::shared_ptr<ReadyQueue>& re
 
 #ifdef IS_PYTHON_3_9_PLUS
   // Do not call PyEval_RestoreThread, PyThreadState_[Clear|DeleteCurrent] if runtime is finalizing
-  if (_Py_IsFinalizing()) {
+  if (!Py_IsInitialized()) {
     no_gil.disarm();
     // TODO: call disarm rather than leak gil_scoped_acquired once PyThreadState_Clear can safely be called from finalize
     gil.release();

--- a/torch/csrc/autograd/python_function.h
+++ b/torch/csrc/autograd/python_function.h
@@ -50,8 +50,11 @@ struct PyNode : public Node {
     // Can't use THPObjectPtr as a field in this class; destructor won't take
     // out GIL!  When I forgot to do this by hand
     // TestAutograd.test_inplace_view_python called me out about it.
-    pybind11::gil_scoped_acquire g;
-    Py_DECREF(obj);
+    // If python is already dead, leak the wrapped python objects
+    if (Py_IsInitialized()) {
+      pybind11::gil_scoped_acquire gil;
+      Py_DECREF(obj);
+    }
   }
 };
 

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -29,8 +29,11 @@ PyFunctionPreHook::PyFunctionPreHook(PyObject* dict, int value_idx)
 }
 
 PyFunctionPreHook::~PyFunctionPreHook() {
-  pybind11::gil_scoped_acquire gil;
-  Py_DECREF(dict);
+  // If python is already dead, leak the wrapped python objects
+  if (Py_IsInitialized()) {
+    pybind11::gil_scoped_acquire gil;
+    Py_DECREF(dict);
+  }
 }
 
 auto PyFunctionPreHook::operator()(const variable_list& values) -> variable_list
@@ -61,8 +64,11 @@ PyFunctionPostHook::PyFunctionPostHook(PyObject* dict) : dict(dict) {
 }
 
 PyFunctionPostHook::~PyFunctionPostHook() {
-  pybind11::gil_scoped_acquire gil;
-  Py_DECREF(dict);
+  // If python is already dead, leak the wrapped python objects
+  if (Py_IsInitialized()) {
+    pybind11::gil_scoped_acquire gil;
+    Py_DECREF(dict);
+  }
 }
 
 auto PyFunctionPostHook::operator()(


### PR DESCRIPTION
Such a deadlock was found for PyFunctionPreHook after adding https://github.com/pytorch/pytorch/pull/57057
This is fixing all occurrences in torch/csrc/autograd
