### PR TITLE
Swap CUDA 10.1 and CPU CI for windows

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -148,7 +148,7 @@ WORKFLOW_DATA = [
     WindowsJob(2, _VC2019, CudaVersion(11, 1), master_only=True),
     # VS2019 CPU-only
     WindowsJob(None, _VC2019, None),
-    WindowsJob(1, _VC2019, None),
+    WindowsJob(1, _VC2019, None, master_only=True),
     WindowsJob(2, _VC2019, None),
     WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True),
 ]

--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -148,9 +148,9 @@ WORKFLOW_DATA = [
     WindowsJob(2, _VC2019, CudaVersion(11, 1), master_only=True),
     # VS2019 CPU-only
     WindowsJob(None, _VC2019, None),
-    WindowsJob(1, _VC2019, None, master_only=True),
+    WindowsJob(1, _VC2019, None),
     WindowsJob(2, _VC2019, None),
-    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True),
+    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True, master_only=True),
 ]
 
 

--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -138,9 +138,9 @@ _VC2019 = VcSpec(2019, ["14", "28", "29333"], hide_version=True)
 
 WORKFLOW_DATA = [
     # VS2019 CUDA-10.1
-    WindowsJob(None, _VC2019, CudaVersion(10, 1)),
-    WindowsJob(1, _VC2019, CudaVersion(10, 1)),
-    WindowsJob(2, _VC2019, CudaVersion(10, 1)),
+    WindowsJob(None, _VC2019, CudaVersion(10, 1), master_only=True),
+    WindowsJob(1, _VC2019, CudaVersion(10, 1), master_only=True),
+    WindowsJob(2, _VC2019, CudaVersion(10, 1), master_only=True),
     WindowsJob('_azure_multi_gpu', _VC2019, CudaVersion(10, 1), multi_gpu=True, nightly_only=True),
     # VS2019 CUDA-11.1
     WindowsJob(None, _VC2019, CudaVersion(11, 1)),
@@ -148,9 +148,9 @@ WORKFLOW_DATA = [
     WindowsJob(2, _VC2019, CudaVersion(11, 1), master_only=True),
     # VS2019 CPU-only
     WindowsJob(None, _VC2019, None),
-    WindowsJob(1, _VC2019, None, master_only=True),
-    WindowsJob(2, _VC2019, None, master_only=True),
-    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True, master_only=True),
+    WindowsJob(1, _VC2019, None),
+    WindowsJob(2, _VC2019, None),
+    WindowsJob(1, _VC2019, CudaVersion(10, 1), force_on_cpu=True),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6904,12 +6904,6 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cpu_test1
           python_version: "3.6"
           requires:
@@ -6934,6 +6928,12 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1
           python_version: "3.6"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6785,6 +6785,12 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_build
           python_version: "3.6"
           use_cuda: "1"
@@ -6795,6 +6801,12 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
           executor: windows-with-nvidia-gpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_test1
           python_version: "3.6"
           requires:
@@ -6808,6 +6820,12 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
           executor: windows-with-nvidia-gpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_test2
           python_version: "3.6"
           requires:
@@ -6886,12 +6904,6 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cpu_test1
           python_version: "3.6"
           requires:
@@ -6904,12 +6916,6 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cpu_test2
           python_version: "3.6"
           requires:
@@ -6922,12 +6928,6 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1
           python_version: "3.6"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6904,6 +6904,12 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cpu-py3
           cuda_version: cpu
+          filters:
+            branches:
+              only:
+                - master
+                - /ci-all\/.*/
+                - /release\/.*/
           name: pytorch_windows_vs2019_py36_cpu_test1
           python_version: "3.6"
           requires:

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -41,10 +41,14 @@ popd
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
 pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting pytest
 
-:: TODO: All sharded configs run coverage. We should change that to be only one config, but right now we will just
-:: install coverage everywhere. Tracked: https://github.com/pytorch/pytorch/issues/56264
-python -mpip install coverage==5.5
-python -mpip install -e tools/coverage_plugins_package
+:: Only Windows CPU test run coverage, but it's not the most clear: https://github.com/pytorch/pytorch/issues/56264
+if "%BUILD_ENVIRONMENT%"=="pytorch-win-vs2019-cpu-py3" (
+    :: coverage config file needed for plug-ins and settings to work
+    set COVERAGE_RCFILE="%PWD%/.coveragerc"
+    set PYTORCH_COLLECT_COVERAGE=1
+    python -mpip install coverage==5.5
+    python -mpip install -e tools/coverage_plugins_package
+)
 
 if %errorlevel% neq 0 ( exit /b %errorlevel% )
 

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -41,14 +41,9 @@ popd
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
 pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting pytest
 
-:: Only the below two CPU tests run coverage, which I know is confusing: https://github.com/pytorch/pytorch/issues/56264
-if "%CIRCLE_JOB%"=="pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" (
+:: Only the CPU tests run coverage, which I know is not super clear: https://github.com/pytorch/pytorch/issues/56264
+if "%BUILD_ENVIRONMENT%" == "pytorch-win-vs2019-cpu-py3" (
     :: coverage config file needed for plug-ins and settings to work
-    set PYTORCH_COLLECT_COVERAGE=1
-    python -mpip install coverage==5.5
-    python -mpip install -e tools/coverage_plugins_package
-)
-if "%CIRCLE_JOB%"=="pytorch_windows_vs2019_py36_cpu_test2" (
     set PYTORCH_COLLECT_COVERAGE=1
     python -mpip install coverage==5.5
     python -mpip install -e tools/coverage_plugins_package

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -41,15 +41,18 @@ popd
 :: The version is fixed to avoid flakiness: https://github.com/pytorch/pytorch/issues/31136
 pip install "ninja==1.10.0.post1" future "hypothesis==4.53.2" "librosa>=0.6.2" psutil pillow unittest-xml-reporting pytest
 
-:: Only Windows CPU test run coverage, but it's not the most clear: https://github.com/pytorch/pytorch/issues/56264
-if "%BUILD_ENVIRONMENT%"=="pytorch-win-vs2019-cpu-py3" (
+:: Only the below two CPU tests run coverage, which I know is confusing: https://github.com/pytorch/pytorch/issues/56264
+if "%CIRCLE_JOB%"=="pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" (
     :: coverage config file needed for plug-ins and settings to work
-    set COVERAGE_RCFILE="%PWD%/.coveragerc"
     set PYTORCH_COLLECT_COVERAGE=1
     python -mpip install coverage==5.5
     python -mpip install -e tools/coverage_plugins_package
 )
-
+if "%CIRCLE_JOB%"=="pytorch_windows_vs2019_py36_cpu_test2" (
+    set PYTORCH_COLLECT_COVERAGE=1
+    python -mpip install coverage==5.5
+    python -mpip install -e tools/coverage_plugins_package
+)
 if %errorlevel% neq 0 ( exit /b %errorlevel% )
 
 set DISTUTILS_USE_SDK=1

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -70,8 +70,7 @@ run_tests() {
         "$SCRIPT_HELPERS_DIR"/test_custom_backend.bat
         "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
     else
-        if [[ "${CIRCLE_JOB}" == "pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" ||
-              "${CIRCLE_JOB}" == "pytorch_windows_vs2019_py36_cpu_test2" ]]; then
+        if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
           export PYTORCH_COLLECT_COVERAGE=1
           export COVERAGE_RCFILE=$PWD/.coveragerc # coverage config file needed for plug-ins and settings to work
         fi
@@ -93,8 +92,7 @@ run_tests
 assert_git_not_dirty
 echo "TEST PASSED"
 
-if [[ "${JOB_BASE_NAME}" == "pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" ||
-      "${JOB_BASE_NAME}" == "pytorch_windows_vs2019_py36_cpu_test2" ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
   pushd "$TEST_DIR"
   python -mpip install coverage==5.5
   python -mpip install -e "$PROJECT_DIR/tools/coverage_plugins_package"

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -70,9 +70,10 @@ run_tests() {
         "$SCRIPT_HELPERS_DIR"/test_custom_backend.bat
         "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
     else
-        if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
+        if [[ "${CIRCLE_JOB}" == "pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" ||
+              "${CIRCLE_JOB}" == "pytorch_windows_vs2019_py36_cpu_test2" ]]; then
           export PYTORCH_COLLECT_COVERAGE=1
-          export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
+          export COVERAGE_RCFILE=$PWD/.coveragerc # coverage config file needed for plug-ins and settings to work
         fi
         if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
             "$SCRIPT_HELPERS_DIR"/test_python_first_shard.bat "$DETERMINE_FROM"
@@ -92,7 +93,8 @@ run_tests
 assert_git_not_dirty
 echo "TEST PASSED"
 
-if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
+if [[ "${JOB_BASE_NAME}" == "pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1" ||
+      "${JOB_BASE_NAME}" == "pytorch_windows_vs2019_py36_cpu_test2" ]]; then
   pushd "$TEST_DIR"
   python -mpip install coverage==5.5
   python -mpip install -e "$PROJECT_DIR/tools/coverage_plugins_package"

--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -70,8 +70,10 @@ run_tests() {
         "$SCRIPT_HELPERS_DIR"/test_custom_backend.bat
         "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
     else
-        export PYTORCH_COLLECT_COVERAGE=1
-        export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
+        if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
+          export PYTORCH_COLLECT_COVERAGE=1
+          export COVERAGE_RCFILE="$PWD/.coveragerc" # coverage config file needed for plug-ins and settings to work
+        fi
         if [[ "${JOB_BASE_NAME}" == *-test1 ]]; then
             "$SCRIPT_HELPERS_DIR"/test_python_first_shard.bat "$DETERMINE_FROM"
             "$SCRIPT_HELPERS_DIR"/test_libtorch.bat
@@ -90,7 +92,7 @@ run_tests
 assert_git_not_dirty
 echo "TEST PASSED"
 
-if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cuda10-cudnn7-py3" ]]; then
+if [[ "${BUILD_ENVIRONMENT}" == "pytorch-win-vs2019-cpu-py3" ]]; then
   pushd "$TEST_DIR"
   python -mpip install coverage==5.5
   python -mpip install -e "$PROJECT_DIR/tools/coverage_plugins_package"


### PR DESCRIPTION
This change temporarily disables CUDA testing on PRs, but keeps it on master.
This is likely to increase the number of reverts, but this is necessary as a stop-gap measure to cap the CI costs growth.