### PR TITLE
Fix flaky test_rref_context_debug_info

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2692,6 +2692,12 @@ class RpcTest(RpcAgentTestFixture):
         # clear states for check 2
         rpc.rpc_sync(worker_name(dst_rank), clear_global_rref)
 
+        # Wait for owner rref to be cleared.
+        while int(info["num_owner_rrefs"]) != 0:
+            info = _rref_context_get_debug_info()
+            time.sleep(0.1)
+        dist.barrier()
+
         # Check 3: rpc.remote call should update owners_ map
         ####################################################
         rref2 = rpc.remote(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57526 Fix flaky test_rref_context_debug_info**

This test would create an RRef, delete that rref and then create two
more RRefs and validate total rrefs were 2 in the end.

Due to the async nature of delete, sometimes the RRef would not be deleted
until the assertion was made. As a result, I've fixed this by waiting for the
RRef to be deleted at the appropriate time.

#Closes: https://github.com/pytorch/pytorch/issues/55382

Differential Revision: [D28173151](https://our.internmc.facebook.com/intern/diff/D28173151/)