### PR TITLE
relax type equality constraint for scalars

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1117,11 +1117,12 @@ class TestAsserts(TestCase):
 
     @onlyCPU
     def test_scalar(self, device):
-        tensor = torch.rand(1, device=device)
-        actual = expected = tensor.item()
+        number = torch.randint(10, size=(), device=device).item()
+        for actual, expected in itertools.product((int(number), float(number), complex(number)), repeat=2):
+            check_dtype = type(actual) is type(expected)
 
-        for fn in self.assert_fns_with_inputs(actual, expected):
-            fn()
+            for fn in self.assert_fns_with_inputs(actual, expected):
+                fn(check_dtype=check_dtype)
 
     @onlyCPU
     def test_msg_str(self, device):


### PR DESCRIPTION
Currently we require type equality for `torch.testing.assert_(equal|close)`:

https://github.com/pytorch/pytorch/blob/3db45bcb915a32ffa60378205fd9d96c45d7113f/torch/testing/_asserts.py#L509-L513

That means `assert_equal(1, 1.0)` will correctly fail. Although the type of a scalar is similiar to a dtype of a tensor, `assert_equal(1, 1.0, check_dtype=False)` will also fail while `assert_equal(torch.as_tensor(1), torch.as_tensor(1.0), check_dtype=False)` will pass.

To make the interface more consistent, this PR relaxes the type equality constraint, by disabling it in case both inputs are scalars.
