### PR TITLE
[Draft] Deprecation / Aliases for torch.linalg

### DIFF
--- a/aten/src/ATen/LegacyTHFunctionsCPU.cpp
+++ b/aten/src/ATen/LegacyTHFunctionsCPU.cpp
@@ -332,6 +332,15 @@ Tensor _th_histc(const Tensor & self, int64_t bins, const Scalar& min, const Sca
 }
 
 std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A, Tensor & res1, Tensor & res2) {
+    TORCH_WARN_ONCE(
+      "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
+      "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
+      "the returned tuple, (it returns other information about the problem).\n",
+      "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
+      "should be replaced with\n",
+      "X = torch.linalg.lstsq(A, B).solution"
+    );
+
     // DeviceGuard omitted
     auto dispatch_scalar_type = infer_scalar_type(self);
 
@@ -358,6 +367,14 @@ std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A
     return std::tuple<Tensor &, Tensor &>(res1, res2);
 }
 std::tuple<Tensor,Tensor> _th_gels(const Tensor & self, const Tensor & A) {
+    TORCH_WARN_ONCE(
+      "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
+      "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
+      "the returned tuple, (it returns other information about the problem).\n",
+      "X, _ = torch.lstsq(B, A)\n",
+      "should be replaced with\n",
+      "X = torch.linalg.lstsq(A, B)[0]"
+    );
     // DeviceGuard omitted
     auto dispatch_scalar_type = infer_scalar_type(self);
     auto res1_ = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),DispatchKey::CPU, scalarTypeToTypeMeta(dispatch_scalar_type)).release();

--- a/aten/src/ATen/LegacyTHFunctionsCPU.cpp
+++ b/aten/src/ATen/LegacyTHFunctionsCPU.cpp
@@ -336,6 +336,9 @@ std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A
       "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
       "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
       "the returned tuple, (it returns other information about the problem).\n",
+      "The returned solution in torch.lstsq stored the residuals of the solution in the ",
+      "last m - n columns of the returned value whenever m > n. In torch.linalg.lstsq, the ",
+      "residuals in the field 'residuals' of the returned named tuple.\n",
       "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
       "should be replaced with\n",
       "X = torch.linalg.lstsq(A, B).solution"
@@ -371,9 +374,12 @@ std::tuple<Tensor,Tensor> _th_gels(const Tensor & self, const Tensor & A) {
       "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
       "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
       "the returned tuple, (it returns other information about the problem).\n",
-      "X, _ = torch.lstsq(B, A)\n",
+      "The returned solution in torch.lstsq stored the residuals of the solution in the ",
+      "last m - n columns of the returned value whenever m > n. In torch.linalg.lstsq, the ",
+      "residuals in the field 'residuals' of the returned named tuple.\n",
+      "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
       "should be replaced with\n",
-      "X = torch.linalg.lstsq(A, B)[0]"
+      "X = torch.linalg.lstsq(A, B).solution"
     );
     // DeviceGuard omitted
     auto dispatch_scalar_type = infer_scalar_type(self);

--- a/aten/src/ATen/cuda/LegacyTHFunctionsCUDA.cpp
+++ b/aten/src/ATen/cuda/LegacyTHFunctionsCUDA.cpp
@@ -263,6 +263,14 @@ Tensor _th_cross_kernel(const Tensor & self, const Tensor & other, int64_t dim) 
 }
 
 std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A, Tensor & res1, Tensor & res2) {
+    TORCH_WARN_ONCE(
+      "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
+      "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
+      "the returned tuple, (it returns other information about the problem).\n",
+      "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
+      "should be replaced with\n",
+      "X = torch.linalg.lstsq(A, B).solution"
+    );
     // DeviceGuard omitted
     auto dispatch_scalar_type = infer_scalar_type(self);
 
@@ -289,6 +297,14 @@ std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A
     return std::tuple<Tensor &, Tensor &>(res1, res2);
 }
 std::tuple<Tensor,Tensor> _th_gels(const Tensor & self, const Tensor & A) {
+    TORCH_WARN_ONCE(
+      "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
+      "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
+      "the returned tuple, (it returns other information about the problem).\n",
+      "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
+      "should be replaced with\n",
+      "X = torch.linalg.lstsq(A, B).solution"
+    );
     // DeviceGuard omitted
     auto dispatch_scalar_type = infer_scalar_type(self);
     auto res1_ = c10::make_intrusive<TensorImpl, UndefinedTensorImpl>(c10::Storage(c10::Storage::use_byte_size_t(), 0, allocator(), true),DispatchKey::CUDA, scalarTypeToTypeMeta(dispatch_scalar_type)).release();

--- a/aten/src/ATen/cuda/LegacyTHFunctionsCUDA.cpp
+++ b/aten/src/ATen/cuda/LegacyTHFunctionsCUDA.cpp
@@ -267,6 +267,9 @@ std::tuple<Tensor &,Tensor &> _th_gels_out(const Tensor & self, const Tensor & A
       "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
       "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
       "the returned tuple, (it returns other information about the problem).\n",
+      "The returned solution in torch.lstsq stored the residuals of the solution in the ",
+      "last m - n columns of the returned value whenever m > n. In torch.linalg.lstsq, the ",
+      "residuals in the field 'residuals' of the returned named tuple.\n",
       "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
       "should be replaced with\n",
       "X = torch.linalg.lstsq(A, B).solution"
@@ -301,6 +304,9 @@ std::tuple<Tensor,Tensor> _th_gels(const Tensor & self, const Tensor & A) {
       "torch.lstsq is deprecated in favor of torch.linalg.lstsq and will be removed in a future PyTorch release.\n",
       "torch.linalg.lstsq has reversed arguments and does not return the QR decomposition in "
       "the returned tuple, (it returns other information about the problem).\n",
+      "The returned solution in torch.lstsq stored the residuals of the solution in the ",
+      "last m - n columns of the returned value whenever m > n. In torch.linalg.lstsq, the ",
+      "residuals in the field 'residuals' of the returned named tuple.\n",
       "X, _ = torch.lstsq(B, A).solution[:A.size(1)]\n",
       "should be replaced with\n",
       "X = torch.linalg.lstsq(A, B).solution"

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1173,7 +1173,7 @@ Tensor cholesky(const Tensor &self, bool upper) {
    TORCH_WARN_ONCE(
     "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be ",
     "removed in a future PyTorch release.\n",
-    "L = torch.cholesky(A, upper=False) (default)\n",
+    "L = torch.cholesky(A)\n",
     "should be replaced with\n",
     "L = torch.linalg.cholesky(A)\n",
     "and\n"
@@ -1212,7 +1212,7 @@ Tensor& cholesky_out(const Tensor &self, bool upper, Tensor &result) {
    TORCH_WARN_ONCE(
     "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be ",
     "removed in a future PyTorch release.\n",
-    "L = torch.cholesky(A, upper=False) (default)\n",
+    "L = torch.cholesky(A)\n",
     "should be replaced with\n",
     "L = torch.linalg.cholesky(A)\n",
     "and\n"
@@ -2263,7 +2263,7 @@ std::tuple<Tensor, Tensor> symeig(const Tensor& self, bool eigenvectors, bool up
   TORCH_WARN_ONCE(
     "torch.symeig is deprecated in favor of torch.linalg.eigh and will be removed in a future ",
     "PyTorch release.\n",
-    "L, _ = torch.symeig(A, eigenvectors=False) (default)\n",
+    "L, _ = torch.symeig(A)\n",
     "should be replaced with\n",
     "L = torch.linalg.eigvalsh(A)\n",
     "and\n",
@@ -2640,8 +2640,9 @@ std::tuple<Tensor&, Tensor&> eig_out(const Tensor& self, bool eigenvectors, Tens
   TORCH_WARN_ONCE(
     "torch.eig is deprecated in favor of torch.linalg.eig and will be removed in a future ",
     "PyTorch release.\n",
-    "torch.linalg.eig returns complex tensors of dtype cfloat or cdouble rather than real tensors.\n",
-    "L, _ = torch.eig(A, eigenvectors=False) (default)\n",
+    "torch.linalg.eig returns complex tensors of dtype cfloat or cdouble rather than real tensors ",
+    "mimicking complex tensors.\n",
+    "L, _ = torch.eig(A)\n",
     "should be replaced with\n",
     "L_complex = torch.linalg.eigvals(A)\n",
     "and\n",

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1153,6 +1153,13 @@ Tensor& cholesky_solve_out(const Tensor& self, const Tensor& A, bool upper, Tens
 DEFINE_DISPATCH(cholesky_stub);
 
 Tensor cholesky(const Tensor &self, bool upper) {
+  TORCH_WARN_ONCE(
+    "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be "
+    "removed in a future PyTorch release. If used with upper=False (default), it may "
+    "be replaced with torch.linalg.cholesky. If used with upper=True, torch.cholesky(A, True) "
+    "may be replaced with torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)"
+  );
+
   if (self.numel() == 0) {
     return at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   }
@@ -2571,6 +2578,19 @@ Tensor linalg_eigvals(const Tensor& input) {
 DEFINE_DISPATCH(eig_stub);
 
 std::tuple<Tensor&, Tensor&> eig_out(const Tensor& self, bool eigenvectors, Tensor& e, Tensor& v) {
+  TORCH_WARN_ONCE(
+    "torch.eig is deprecated in favor of torch.linalg.eig and will be removed in a future ",
+    "PyTorch release.\n",
+    "torch.linalg.eig returns complex tensors of dtype cfloat and cdouble rather than a pair ",
+    "of real tensors. It is strongly recommended to use complex arithmetic rather ",
+    "than working with pairs of real tensors.\n",
+    "If this is not possible, `L, _ = torch.eig(A, False)` (default) may be replaced by\n",
+    "    L_complex = torch.linalg.eigvals(A)\n",
+    "    L = torch.stack((L_complex.real, L_complex.imag), dim=1)\n",
+    "For the case `L, V = torch.eig(A, True)`, torch.linalg.eig already returns",
+    "the eigenvalues V as complex vectors with separate real and imaginary part."
+  );
+
   TORCH_CHECK(self.dim() == 2, "input should be 2 dimensional");
   TORCH_CHECK(self.size(0) == self.size(1), "input should be square");
   TORCH_CHECK(self.isfinite().all().item<bool>(), "input should not contain infs or NaNs");
@@ -2718,12 +2738,36 @@ std::tuple<Tensor, Tensor, Tensor> _svd_helper_cpu(const Tensor& self, bool some
 }
 
 std::tuple<Tensor, Tensor, Tensor> svd(const Tensor& self, bool some, bool compute_uv) {
+  TORCH_WARN_ONCE(
+    "torch.svd is deprecated in favor of torch.linalg.svd and will be ",
+    "removed in a future PyTorch release.\n",
+    "U, S, V = torch.svd(A, some=some, compute_uv=True) (default)\n",
+    "should be replaced by\n",
+    "U, S, V = torch.linalg.svd(A, full_matrices=not some)\n",
+    "and\n"
+    "_, S, _ = torch.svd(A, some=some, compute_uv=False)\n",
+    "should be replaced by\n",
+    "S = torch.svdvals(A)"
+  );
+
   TORCH_CHECK(self.dim() >= 2,
               "svd input should have at least 2 dimensions, but has ", self.dim(), " dimensions instead");
   return at::_svd_helper(self, some, compute_uv);
 }
 
 std::tuple<Tensor&, Tensor&, Tensor&> svd_out(const Tensor& self, bool some, bool compute_uv, Tensor& U, Tensor& S, Tensor& V) {
+  TORCH_WARN_ONCE(
+    "torch.svd is deprecated in favor of torch.linalg.svd and will be ",
+    "removed in a future PyTorch release.\n",
+    "U, S, V = torch.svd(A, some=some, compute_uv=True) (default)\n",
+    "should be replaced by\n",
+    "U, S, V = torch.linalg.svd(A, full_matrices=not some)\n",
+    "and\n"
+    "_, S, _ = torch.svd(A, some=some, compute_uv=False)\n",
+    "should be replaced by\n",
+    "S = torch.svdvals(A)"
+  );
+
   checkSameDevice("svd", U, self, "U");
   checkSameDevice("svd", S, self, "S");
   checkSameDevice("svd", V, self, "V");

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -733,6 +733,15 @@ std::tuple<Tensor, Tensor> _solve_helper_cpu(const Tensor& self, const Tensor& A
 
 // Supports arbitrary batch dimensions for self and A
 std::tuple<Tensor,Tensor> solve(const Tensor& self, const Tensor& A) {
+  TORCH_WARN_ONCE(
+    "torch.solve is deprecated in favor of torch.linalg.solve",
+    "and will be removed in a future PyTorch release.\n",
+    "torch.linalg.solve has its arguments reversed and does not return the LU factorization.\n",
+    "X = torch.solve(B, A).solution\n",
+    "should be replaced with\n",
+    "X = torch.linalg.solve(A, B)"
+  );
+
   TORCH_CHECK(self.dim() >= 2,
            "B should have at least 2 dimensions, but has ", self.dim(), " dimensions instead");
   TORCH_CHECK(A.dim() >= 2,
@@ -743,6 +752,14 @@ std::tuple<Tensor,Tensor> solve(const Tensor& self, const Tensor& A) {
 }
 
 std::tuple<Tensor&,Tensor&> solve_out(const Tensor& self, const Tensor& A, Tensor& solution, Tensor& lu) {
+  TORCH_WARN_ONCE(
+    "torch.solve is deprecated in favor of torch.linalg.solve",
+    "and will be removed in a future PyTorch release.\n",
+    "torch.linalg.solve has its arguments reversed and does not return the LU factorization.\n",
+    "X = torch.solve(B, A).solution\n",
+    "should be replaced with\n",
+    "X = torch.linalg.solve(A, B)"
+  );
   checkSameDevice("solve", solution, self, "solution");
   checkSameDevice("solve", lu, self, "lu");
   checkLinalgCompatibleDtype("solve", solution, self, "solution");
@@ -1153,11 +1170,16 @@ Tensor& cholesky_solve_out(const Tensor& self, const Tensor& A, bool upper, Tens
 DEFINE_DISPATCH(cholesky_stub);
 
 Tensor cholesky(const Tensor &self, bool upper) {
-  TORCH_WARN_ONCE(
-    "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be "
-    "removed in a future PyTorch release. If used with upper=False (default), it may "
-    "be replaced with torch.linalg.cholesky. If used with upper=True, torch.cholesky(A, True) "
-    "may be replaced with torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)"
+   TORCH_WARN_ONCE(
+    "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be ",
+    "removed in a future PyTorch release.\n",
+    "L = torch.cholesky(A, upper=False) (default)\n",
+    "should be replaced with\n",
+    "L = torch.linalg.cholesky(A)\n",
+    "and\n"
+    "U = torch.cholesky(A, upper=True)\n",
+    "should be replaced with\n",
+    "U = torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)"
   );
 
   if (self.numel() == 0) {
@@ -1187,6 +1209,17 @@ Tensor cholesky(const Tensor &self, bool upper) {
 }
 
 Tensor& cholesky_out(const Tensor &self, bool upper, Tensor &result) {
+   TORCH_WARN_ONCE(
+    "torch.cholesky is deprecated in favor of torch.linalg.cholesky and will be ",
+    "removed in a future PyTorch release.\n",
+    "L = torch.cholesky(A, upper=False) (default)\n",
+    "should be replaced with\n",
+    "L = torch.linalg.cholesky(A)\n",
+    "and\n"
+    "U = torch.cholesky(A, upper=True)\n",
+    "should be replaced with\n",
+    "U = torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)"
+  );
   checkSameDevice("cholesky", result, self);
   checkLinalgCompatibleDtype("cholesky", result, self);
   Tensor result_tmp = at::cholesky(self, upper);
@@ -1823,11 +1856,26 @@ std::tuple<Tensor&,Tensor&> linalg_qr_out(const Tensor& self, std::string mode, 
 }
 
 std::tuple<Tensor,Tensor> qr(const Tensor& self, bool some) {
+  TORCH_WARN_ONCE(
+    "torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.\n",
+    "The boolean parameter 'some' has been replaced with a string parameter 'mode'.\n",
+    "Q, R = torch.qr(A, some)\n",
+    "should be replaced with\n",
+    "Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete')"
+  );
+
   std::string mode = some ? "reduced" : "complete";
   return at::linalg_qr(self, mode);
 }
 
 std::tuple<Tensor&,Tensor&> qr_out(const Tensor& self, bool some, Tensor& Q, Tensor& R) {
+  TORCH_WARN_ONCE(
+    "torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.\n",
+    "The boolean parameter 'some' has been replaced with a string parameter 'mode'.\n",
+    "Q, R = torch.qr(A, some)\n",
+    "should be replaced with\n",
+    "Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete')"
+  );
   std::string mode = some ? "reduced" : "complete";
   return at::linalg_qr_out(Q, R, self, mode);
 }
@@ -2212,6 +2260,17 @@ std::tuple<Tensor, Tensor> _symeig_helper_cpu(const Tensor& self, bool eigenvect
 }
 
 std::tuple<Tensor, Tensor> symeig(const Tensor& self, bool eigenvectors, bool upper) {
+  TORCH_WARN_ONCE(
+    "torch.symeig is deprecated in favor of torch.linalg.eigh and will be removed in a future ",
+    "PyTorch release.\n",
+    "L, _ = torch.symeig(A, eigenvectors=False) (default)\n",
+    "should be replaced with\n",
+    "L = torch.linalg.eigvalsh(A)\n",
+    "and\n",
+    "L, V = torch.symeig(A, eigenvectors=True)\n"
+    "should be replaced with\n",
+    "L, V = torch.linalg.eigh(A)"
+  );
   squareCheckInputs(self);
   return at::_symeig_helper(self, eigenvectors, upper);
 }
@@ -2581,14 +2640,14 @@ std::tuple<Tensor&, Tensor&> eig_out(const Tensor& self, bool eigenvectors, Tens
   TORCH_WARN_ONCE(
     "torch.eig is deprecated in favor of torch.linalg.eig and will be removed in a future ",
     "PyTorch release.\n",
-    "torch.linalg.eig returns complex tensors of dtype cfloat and cdouble rather than a pair ",
-    "of real tensors. It is strongly recommended to use complex arithmetic rather ",
-    "than working with pairs of real tensors.\n",
-    "If this is not possible, `L, _ = torch.eig(A, False)` (default) may be replaced by\n",
-    "    L_complex = torch.linalg.eigvals(A)\n",
-    "    L = torch.stack((L_complex.real, L_complex.imag), dim=1)\n",
-    "For the case `L, V = torch.eig(A, True)`, torch.linalg.eig already returns",
-    "the eigenvalues V as complex vectors with separate real and imaginary part."
+    "torch.linalg.eig returns complex tensors of dtype cfloat or cdouble rather than real tensors.\n",
+    "L, _ = torch.eig(A, eigenvectors=False) (default)\n",
+    "should be replaced with\n",
+    "L_complex = torch.linalg.eigvals(A)\n",
+    "and\n",
+    "L, V = torch.eig(A, eigenvectors=True)\n",
+    "should be replaced with\n",
+    "L_complex, V_complex = torch.linalg.eig(A)"
   );
 
   TORCH_CHECK(self.dim() == 2, "input should be 2 dimensional");
@@ -2742,12 +2801,13 @@ std::tuple<Tensor, Tensor, Tensor> svd(const Tensor& self, bool some, bool compu
     "torch.svd is deprecated in favor of torch.linalg.svd and will be ",
     "removed in a future PyTorch release.\n",
     "U, S, V = torch.svd(A, some=some, compute_uv=True) (default)\n",
-    "should be replaced by\n",
-    "U, S, V = torch.linalg.svd(A, full_matrices=not some)\n",
-    "and\n"
+    "should be replaced with\n",
+    "U, S, Vh = torch.linalg.svd(A, full_matrices=not some)\n",
+    "V = Vh.transpose(-2, -1).conj()\n",
+    "and\n",
     "_, S, _ = torch.svd(A, some=some, compute_uv=False)\n",
-    "should be replaced by\n",
-    "S = torch.svdvals(A)"
+    "should be replaced with\n",
+    "S = torch.linalg.svdvals(A)"
   );
 
   TORCH_CHECK(self.dim() >= 2,
@@ -2760,12 +2820,13 @@ std::tuple<Tensor&, Tensor&, Tensor&> svd_out(const Tensor& self, bool some, boo
     "torch.svd is deprecated in favor of torch.linalg.svd and will be ",
     "removed in a future PyTorch release.\n",
     "U, S, V = torch.svd(A, some=some, compute_uv=True) (default)\n",
-    "should be replaced by\n",
-    "U, S, V = torch.linalg.svd(A, full_matrices=not some)\n",
-    "and\n"
+    "should be replaced with\n",
+    "U, S, Vh = torch.linalg.svd(A, full_matrices=not some)\n",
+    "V = Vh.transpose(-2, -1).conj()\n",
+    "and\n",
     "_, S, _ = torch.svd(A, some=some, compute_uv=False)\n",
-    "should be replaced by\n",
-    "S = torch.svdvals(A)"
+    "should be replaced with\n",
+    "S = torch.linalg.svdvals(A)"
   );
 
   checkSameDevice("svd", U, self, "U");

--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1179,7 +1179,7 @@ Tensor cholesky(const Tensor &self, bool upper) {
     "and\n"
     "U = torch.cholesky(A, upper=True)\n",
     "should be replaced with\n",
-    "U = torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)"
+    "U = torch.linalg.cholesky(A.transpose(-2, -1).conj()).transpose(-2, -1).conj()"
   );
 
   if (self.numel() == 0) {

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -410,7 +410,7 @@ Tensor linalg_matrix_rank(const Tensor& input, optional<double> tol, bool hermit
 Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
   TORCH_WARN_ONCE(
     "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
-    "and will be removed in a future PyTorch release. The parameter 'symmetric' was",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was ",
     "renamed in torch.linalg.matrix_rank to 'hermitian'."
   );
   return at::linalg_matrix_rank(self, optional<double>(tol), symmetric);
@@ -419,7 +419,7 @@ Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
 Tensor matrix_rank(const Tensor& self, bool symmetric) {
   TORCH_WARN_ONCE(
     "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
-    "and will be removed in a future PyTorch release. The parameter 'symmetric' was",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was ",
     "renamed in torch.linalg.matrix_rank to 'hermitian'."
   );
   return at::linalg_matrix_rank(self, c10::nullopt, symmetric);
@@ -678,7 +678,7 @@ Tensor& linalg_multi_dot_out(TensorList tensors, Tensor& result) {
 Tensor chain_matmul(TensorList matrices) {
   TORCH_WARN_ONCE(
       "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
-      "Use torch.linalg.multi_dot instead."
+      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters.."
   );
   checkAllSameDim(matrices, 2);
 
@@ -695,7 +695,7 @@ Tensor chain_matmul(TensorList matrices) {
 Tensor& chain_matmul_out(TensorList matrices, Tensor& result) {
   TORCH_WARN_ONCE(
       "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
-      "Use torch.linalg.multi_dot instead."
+      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters.."
   );
   checkAllSameDim(matrices, 2);
 

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -408,10 +408,20 @@ Tensor linalg_matrix_rank(const Tensor& input, optional<double> tol, bool hermit
 }
 
 Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
+  TORCH_WARN_ONCE(
+    "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was",
+    "renamed in torch.linalg.matrix_rank to 'hermitian'."
+  );
   return at::linalg_matrix_rank(self, optional<double>(tol), symmetric);
 }
 
 Tensor matrix_rank(const Tensor& self, bool symmetric) {
+  TORCH_WARN_ONCE(
+    "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was",
+    "renamed in torch.linalg.matrix_rank to 'hermitian'."
+  );
   return at::linalg_matrix_rank(self, c10::nullopt, symmetric);
 }
 
@@ -666,6 +676,10 @@ Tensor& linalg_multi_dot_out(TensorList tensors, Tensor& result) {
 }
 
 Tensor chain_matmul(TensorList matrices) {
+  TORCH_WARN_ONCE(
+      "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
+      "Use torch.linalg.multi_dot instead."
+  );
   checkAllSameDim(matrices, 2);
 
   TORCH_CHECK(
@@ -679,6 +693,10 @@ Tensor chain_matmul(TensorList matrices) {
 }
 
 Tensor& chain_matmul_out(TensorList matrices, Tensor& result) {
+  TORCH_WARN_ONCE(
+      "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
+      "Use torch.linalg.multi_dot instead."
+  );
   checkAllSameDim(matrices, 2);
 
   TORCH_CHECK(

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -678,7 +678,7 @@ Tensor& linalg_multi_dot_out(TensorList tensors, Tensor& result) {
 Tensor chain_matmul(TensorList matrices) {
   TORCH_WARN_ONCE(
       "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
-      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters.."
+      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters."
   );
   checkAllSameDim(matrices, 2);
 
@@ -695,7 +695,7 @@ Tensor chain_matmul(TensorList matrices) {
 Tensor& chain_matmul_out(TensorList matrices, Tensor& result) {
   TORCH_WARN_ONCE(
       "torch.chain_matmul is deprecated and will be removed in a future PyTorch release. ",
-      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters.."
+      "Use torch.linalg.multi_dot instead which accepts a list of tensors rather than multiple parameters."
   );
   checkAllSameDim(matrices, 2);
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1865,9 +1865,16 @@ of each of the individual matrices. Similarly, when :attr:`upper` is ``False``, 
 tensor will be composed of lower-triangular Cholesky factors of each of the individual
 matrices.
 
-.. note:: :func:`torch.linalg.cholesky` should be used over ``torch.cholesky`` when possible.
-          Note however that :func:`torch.linalg.cholesky` does not yet support the :attr:`upper`
-          parameter and instead always returns the lower triangular matrix.
+.. warning::
+
+    :func:`torch.cholesky` is deprecated in favor of :func:`torch.linalg.cholesky`
+    and will be removed in a future PyTorch release. If used with :attr:`upper`\ `= False`,
+    e(default), the two functions are equivalent. If :attr:`upper`\ `= True`, then
+    `torch.cholesky(A, True)` should be replaced with
+
+    .. code:: python
+
+        torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)
 
 Args:
     input (Tensor): the input tensor :math:`A` of size :math:`(*, n, n)` where `*` is zero or more
@@ -2993,6 +3000,24 @@ add_docstr(torch.eig,
 eig(input, eigenvectors=False, *, out=None) -> (Tensor, Tensor)
 
 Computes the eigenvalues and eigenvectors of a real square matrix.
+
+.. warning::
+
+    :func:`torch.eig` is deprecated in favor of :func:`torch.linalg.eig`
+    and will be removed in a future PyTorch release.
+    :func:`torch.linalg.eig` returns complex tensors of dtype `cfloat` and `cdouble`
+    rather than a pair of real tensors. It is strongly recommended to move to complex
+    arithmetic rather than working with pairs of real tensors. If this is not possible,
+    `L, _ = torch.eig(A, False)` (default) may be replaced by
+
+    .. code:: python
+
+        L_complex = torch.linalg.eigvals(A)
+        L = torch.stack((L_complex.real, L_complex.imag), dim=1)
+
+    For the case `L, V = torch.eig(A, True)`, :func:`torch.linalg.eig` already returns
+    the eigenvalues `V` as complex vectors with separate real and imaginary part.
+
 
 .. note::
     Since eigenvalues and eigenvectors might be complex, backward pass is supported only
@@ -5086,8 +5111,10 @@ specified, :attr:`tol` is set to ``S.max() * max(S.size()) * eps`` where `S` is 
 singular values (or the eigenvalues when :attr:`symmetric` is ``True``), and ``eps``
 is the epsilon value for the datatype of :attr:`input`.
 
-.. note:: :func:`torch.matrix_rank` is deprecated. Please use :func:`torch.linalg.matrix_rank` instead.
-          The parameter :attr:`symmetric` was renamed in :func:`torch.linalg.matrix_rank` to ``hermitian``.
+.. warning::
+    :func:`torch.matrix_rank` is deprecated in favor of :func:`torch.linalg.matrix_rank`
+    and will be removed in a future PyTorch release. The parameter :attr:`symmetric` was
+    renamed in :func:`torch.linalg.matrix_rank` to :attr:`hermitian`.
 
 Args:
     input (Tensor): the input 2-D tensor
@@ -8512,9 +8539,21 @@ Supports :attr:`input` of float, double, cfloat and cdouble data types.
 The dtypes of `U` and `V` are the same as :attr:`input`'s. `S` will
 always be real-valued, even if :attr:`input` is complex.
 
-.. warning:: :func:`torch.svd` is deprecated. Please use
-             :func:`torch.linalg.svd` instead, which is similar to NumPy's
-             `numpy.linalg.svd`.
+.. warning::
+
+    :func:`torch.svd` is deprecated in favor of :func:`torch.linalg.svd`
+    and will be removed in a future PyTorch release.
+    `U, S, V = torch.svd(A, some=some, compute_uv=True)` (default) may be replaced by
+
+    .. code:: python
+
+        U, S, V = torch.linalg.svd(A, full_matrices=not some)
+
+    `_, S, _ = torch.svd(A, some=some, compute_uv=False)` may be replaced by
+
+    .. code:: python
+
+        S = torch.svdvals(A)
 
 .. note:: Differences with :func:`torch.linalg.svd`:
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1870,7 +1870,7 @@ matrices.
     :func:`torch.cholesky` is deprecated in favor of :func:`torch.linalg.cholesky`
     and will be removed in a future PyTorch release.
 
-    ``L = torch.cholesky(A, upper=False)`` (default) should be replaced with
+    ``L = torch.cholesky(A)`` should be replaced with
 
     .. code:: python
 
@@ -3012,9 +3012,9 @@ Computes the eigenvalues and eigenvectors of a real square matrix.
     :func:`torch.eig` is deprecated in favor of :func:`torch.linalg.eig`
     and will be removed in a future PyTorch release.
     :func:`torch.linalg.eig` returns complex tensors of dtype `cfloat` or `cdouble`
-    rather than real tensors.
+    rather than real tensors mimicking complex tensors.
 
-    ``L, _ = torch.eig(A, eigenvectors=False)`` (default) should be replaced with
+    ``L, _ = torch.eig(A)`` should be replaced with
 
     .. code :: python
 
@@ -4980,8 +4980,11 @@ remaining :math:`m - n` rows of that column.
     and will be removed in a future PyTorch release. :func:`torch.linalg.lstsq`
     has reversed arguments and does not return the QR decomposition in the returned tuple,
     (it returns other information about the problem).
+    The returned `solution` in :func:`torch.lstsq` stores the residuals of the solution in the
+    last `m - n` columns in the case `m > n`. In :func:`torch.linalg.lstsq`, the residuals
+    are in the field 'residuals' of the returned named tuple.
 
-    ``X, _ = torch.lstsq(B, A).solution[:A.size(1)]`` should be replaced with
+    Unpacking the solution as``X = torch.lstsq(B, A).solution[:A.size(1)]`` should be replaced with
 
     .. code:: python
 
@@ -8705,7 +8708,7 @@ If :attr:`upper` is ``False``, then lower triangular portion is used.
     :func:`torch.symeig` is deprecated in favor of :func:`torch.linalg.symeig`
     and will be removed in a future PyTorch release.
 
-    ``L, _ = torch.symeig(A, eigenvectors=False)`` (default) should be replaced with
+    ``L, _ = torch.symeig(A)`` should be replaced with
 
     .. code :: python
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1868,13 +1868,19 @@ matrices.
 .. warning::
 
     :func:`torch.cholesky` is deprecated in favor of :func:`torch.linalg.cholesky`
-    and will be removed in a future PyTorch release. If used with :attr:`upper`\ `= False`,
-    e(default), the two functions are equivalent. If :attr:`upper`\ `= True`, then
-    `torch.cholesky(A, True)` should be replaced with
+    and will be removed in a future PyTorch release.
+
+    ``L = torch.cholesky(A, upper=False)`` (default) should be replaced with
 
     .. code:: python
 
-        torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)
+        L = torch.linalg.cholesky(A)
+
+    ``U = torch.cholesky(A, upper=True)`` should be replaced with
+
+    .. code:: python
+
+        U = torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)
 
 Args:
     input (Tensor): the input tensor :math:`A` of size :math:`(*, n, n)` where `*` is zero or more
@@ -3005,19 +3011,20 @@ Computes the eigenvalues and eigenvectors of a real square matrix.
 
     :func:`torch.eig` is deprecated in favor of :func:`torch.linalg.eig`
     and will be removed in a future PyTorch release.
-    :func:`torch.linalg.eig` returns complex tensors of dtype `cfloat` and `cdouble`
-    rather than a pair of real tensors. It is strongly recommended to move to complex
-    arithmetic rather than working with pairs of real tensors. If this is not possible,
-    `L, _ = torch.eig(A, False)` (default) may be replaced by
+    :func:`torch.linalg.eig` returns complex tensors of dtype `cfloat` or `cdouble`
+    rather than real tensors.
 
-    .. code:: python
+    ``L, _ = torch.eig(A, eigenvectors=False)`` (default) should be replaced with
+
+    .. code :: python
 
         L_complex = torch.linalg.eigvals(A)
-        L = torch.stack((L_complex.real, L_complex.imag), dim=1)
 
-    For the case `L, V = torch.eig(A, True)`, :func:`torch.linalg.eig` already returns
-    the eigenvalues `V` as complex vectors with separate real and imaginary part.
+    ``L, V = torch.eig(A, eigenvectors=True)`` should be replaced with
 
+    .. code :: python
+
+        L_complex, V_complex = torch.linalg.eig(A)
 
 .. note::
     Since eigenvalues and eigenvectors might be complex, backward pass is supported only
@@ -3642,6 +3649,19 @@ batches of 2D matrices. If the inputs are batches, then returns
 batched outputs `solution, LU`.
 
 Supports real-valued and complex-valued inputs.
+
+.. warning::
+
+    :func:`torch.solve` is deprecated in favor of :func:`torch.linalg.solve`
+    and will be removed in a future PyTorch release.
+    :func:`torch.linalg.solve` has its arguments reversed and does not return the
+    LU factorization of the input.
+
+    ``X = torch.solve(B, A).solution`` should be replaced with
+
+    .. code:: python
+
+        X = torch.linalg.solve(A, B)
 
 .. note::
 
@@ -4927,7 +4947,7 @@ Example::
 
 add_docstr(torch.lstsq,
            r"""
-lstsq(input, A, *, out=None) -> Tensor
+lstsq(input, A, *, out=None) -> (Tensor solution, Tensor QR)
 
 Computes the solution to the least squares and least norm problems for a full
 rank matrix :math:`A` of size :math:`(m \times n)` and a matrix :math:`B` of
@@ -4953,6 +4973,19 @@ Returned tensor :math:`X` has shape :math:`(\max(m, n) \times k)`. The first :ma
 rows of :math:`X` contains the solution. If :math:`m \geq n`, the residual sum of squares
 for the solution in each column is given by the sum of squares of elements in the
 remaining :math:`m - n` rows of that column.
+
+.. warning::
+
+    :func:`torch.lstsq` is deprecated in favor of :func:`torch.linalg.lstsq`
+    and will be removed in a future PyTorch release. :func:`torch.linalg.lstsq`
+    has reversed arguments and does not return the QR decomposition in the returned tuple,
+    (it returns other information about the problem).
+
+    ``X, _ = torch.lstsq(B, A).solution[:A.size(1)]`` should be replaced with
+
+    .. code:: python
+
+        X = torch.linalg.lstsq(A, B).solution
 
 .. note::
     The case when :math:`m < n` is not supported on the GPU.
@@ -5112,6 +5145,7 @@ singular values (or the eigenvalues when :attr:`symmetric` is ``True``), and ``e
 is the epsilon value for the datatype of :attr:`input`.
 
 .. warning::
+
     :func:`torch.matrix_rank` is deprecated in favor of :func:`torch.linalg.matrix_rank`
     and will be removed in a future PyTorch release. The parameter :attr:`symmetric` was
     renamed in :func:`torch.linalg.matrix_rank` to :attr:`hermitian`.
@@ -7029,18 +7063,18 @@ with :math:`Q` being an orthogonal matrix or batch of orthogonal matrices and
 If :attr:`some` is ``True``, then this function returns the thin (reduced) QR factorization.
 Otherwise, if :attr:`some` is ``False``, this function returns the complete QR factorization.
 
-.. warning:: ``torch.qr`` is deprecated. Please use :func:`torch.linalg.qr`
-             instead.
+.. warning::
 
-             **Differences with** ``torch.linalg.qr``:
+    :func:`torch.qr` is deprecated in favor of :func:`torch.linalg.qr`
+    and will be removed in a future PyTorch release. The boolean parameter :attr:`some` has been
+    replaced with a string parameter :attr:`mode`.
 
-             * ``torch.linalg.qr`` takes a string parameter ``mode`` instead of ``some``:
+    ``Q, R = torch.qr(A, some)`` should be replaced with
 
-               - ``some=True`` is equivalent of ``mode='reduced'``: both are the
-                 default
+    .. code:: python
 
-               - ``some=False`` is equivalent of ``mode='complete'``.
-
+        mode = "reduced" if some else "complete"
+        Q, R = torch.linalg.qr(A, mode)
 
 .. warning::
           If you plan to backpropagate through QR, note that the current backward implementation
@@ -8543,13 +8577,15 @@ always be real-valued, even if :attr:`input` is complex.
 
     :func:`torch.svd` is deprecated in favor of :func:`torch.linalg.svd`
     and will be removed in a future PyTorch release.
-    `U, S, V = torch.svd(A, some=some, compute_uv=True)` (default) may be replaced by
+
+    ``U, S, V = torch.svd(A, some=some, compute_uv=True)`` (default) should be replaced with
 
     .. code:: python
 
-        U, S, V = torch.linalg.svd(A, full_matrices=not some)
+        U, S, Vh = torch.linalg.svd(A, full_matrices=not some)
+        V = Vh.transpose(-2, -1).conj()
 
-    `_, S, _ = torch.svd(A, some=some, compute_uv=False)` may be replaced by
+    ``_, S, _ = torch.svd(A, some=some, compute_uv=False)`` should be replaced with
 
     .. code:: python
 
@@ -8663,6 +8699,23 @@ Since the input matrix :attr:`input` is supposed to be symmetric or Hermitian,
 only the upper triangular portion is used by default.
 
 If :attr:`upper` is ``False``, then lower triangular portion is used.
+
+.. warning::
+
+    :func:`torch.symeig` is deprecated in favor of :func:`torch.linalg.symeig`
+    and will be removed in a future PyTorch release.
+
+    ``L, _ = torch.symeig(A, eigenvectors=False)`` (default) should be replaced with
+
+    .. code :: python
+
+        L = torch.linalg.eigvalsh(A)
+
+    ``L, V = torch.symeig(A, eigenvectors=True)`` should be replaced with
+
+    .. code :: python
+
+        L, V = torch.linalg.eigh(A)
 
 .. note:: The eigenvalues are returned in ascending order. If :attr:`input` is a batch of matrices,
           then the eigenvalues of each matrix in the batch is returned in ascending order.

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -1880,7 +1880,7 @@ matrices.
 
     .. code:: python
 
-        U = torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)
+        U = torch.linalg.cholesky(A.transpose(-2, -1).conj()).transpose(-2, -1).conj()
 
 Args:
     input (Tensor): the input tensor :math:`A` of size :math:`(*, n, n)` where `*` is zero or more

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1478,8 +1478,10 @@ def chain_matmul(*matrices, out=None):
     If :math:`N` is 1, then this is a no-op - the original matrix is returned as is.
 
     .. warning::
+
         :func:`torch.chain_matmul` is deprecated and will be removed in a future PyTorch release.
-        Use :func:`torch.linalg.multi_dot` instead.
+        Use :func:`torch.linalg.multi_dot` instead which accepts a list of tensors rather than
+        multiple arguments.
 
     Args:
         matrices (Tensors...): a sequence of 2 or more 2-D tensors whose product is to be determined.
@@ -1504,7 +1506,10 @@ def chain_matmul(*matrices, out=None):
     """
     if has_torch_function(matrices):
         return handle_torch_function(chain_matmul, matrices, *matrices)
-    return _VF.chain_matmul(matrices)  # type: ignore[attr-defined]
+    if out is None:
+        return _VF.chain_matmul(matrices)  # type: ignore[attr-defined]
+    else:
+        return _VF.chain_matmul(matrices, out=out)  # type: ignore[attr-defined]
 
 
 def _lu_impl(A, pivot=True, get_infos=False, out=None):

--- a/torch/functional.py
+++ b/torch/functional.py
@@ -1478,7 +1478,8 @@ def chain_matmul(*matrices, out=None):
     If :math:`N` is 1, then this is a no-op - the original matrix is returned as is.
 
     .. warning::
-        :func:`torch.chain_matmul` is deprecated, use :func:`torch.linalg.multi_dot` instead.
+        :func:`torch.chain_matmul` is deprecated and will be removed in a future PyTorch release.
+        Use :func:`torch.linalg.multi_dot` instead.
 
     Args:
         matrices (Tensors...): a sequence of 2 or more 2-D tensors whose product is to be determined.


### PR DESCRIPTION
Adds deprecation notes and aliases to the documentation and code of `torch.` methods pointing to their equivalents in `torch.linalg`.

It also fixes the function `torch.chain_matmul`, which was not using the `out=` parameter when passed.

<details>
  <summary>Script to check the warnings</summary>
  
```python
import torch
from functools import partial

#DEVICE = "cpu"
DEVICE = "cuda"

def square():
    A = torch.rand(3, 3, device=DEVICE)
    A = A.T @ A  + torch.eye(3, device=DEVICE)
    return A

def warn(fun, n_args, has_out=True):
    args = [square() for _ in range(n_args)]
    print(40*"-" + "  NORMAL {}  ".format(fun.__name__ if hasattr(fun, "__name__") else "") + 40*"-")
    out = fun(*args)
    if has_out:
        print(40*"-" + "  OUT {}  ".format(fun.__name__ if hasattr(fun, "__name__") else "") + 40*"-")
        fun(*args, out=out)
    input()
    print()
    print()

# Shows one by one the warnings (press enter)
# The script should be run once with each of the possibilities for the global variable DEVICE 
warn(torch.cholesky, 1)
warn(torch.eig, 1, has_out=False)     # Warn in common
warn(torch.symeig, 1, has_out=False)  # Warn in common
warn(torch.svd, 1)
warn(torch.qr, 1)
warn(torch.matrix_rank, 1, has_out=False)
warn(partial(torch.matrix_rank, tol=1e-4), 1, has_out=False)  # Has a different path
warn(torch.chain_matmul, 2)
warn(torch.solve, 2)
warn(torch.lstsq, 2)
```
</details>

<details>
  <summary>Script to check that the suggested replacements are correct </summary>

```python
import torch
from functools import partial
from itertools import product

def square(device):
    for size in ((2, 3, 3), (3, 3)):
        A = torch.rand(*size, device=device)
        yield A.transpose(-2, -1) @ A  + torch.eye(3, device=DEVICE)

def non_square(device):
    for size in ((2, 3, 4), (2, 4, 3), (3, 4), (4, 3), (2, 3, 3), (3, 3)):
        yield torch.rand(*size, device=device)

def assert_eq(f1, f2, *args):
    X1 = f1(*args)
    X2 = f2(*args)
    if isinstance(X1, tuple):
        for t1, t2 in zip(X1, X2):
            if not torch.allclose(t1, t2, atol=1e-3, rtol=1e-4):
                print(t1, t2)
                raise RuntimeError(f"{f1.__name__}\n{f2.__name__}\n{args}")
    else:
        if not torch.allclose(X1, X2, atol=1e-3, rtol=1e-4):
            print(X1, X2)
            raise RuntimeError(f"{f1.__name__}\n{f2.__name__}\n{args}")


def cholesky(device):
    def my_cholesky(A, upper):
        if upper:
            return torch.linalg.cholesky(A.transpose(-2, -1)).transpose(-2, -1)
        else:
            return torch.linalg.cholesky(A)

    for t, upper in product(square(device), [True, False]):
        assert_eq(torch.cholesky, my_cholesky, t, upper)


def symeig(device):
    def my_symeig(A, eigenvectors):
        if eigenvectors:
            L, V = torch.linalg.eigh(A)
            return L, V.abs()
        else:
            return torch.linalg.eigvalsh(A)

    def torch_symeig(A, eigenvectors):
        if eigenvectors:
            L, V = torch.symeig(A, eigenvectors)
            return L, V.abs()
        else:
            return torch.symeig(A, eigenvectors)[0]

    for t, eigenvectors in product(square(device), [True, False]):
        assert_eq(torch_symeig, my_symeig, t, eigenvectors)

def svd(device):
    def my_svd(A, some, compute_uv):
        if compute_uv:
            U, S, Vh = torch.linalg.svd(A, full_matrices=not some)
            return U.abs(), S, Vh.transpose(-2, -1).conj().abs()
        else:
            S = torch.linalg.svdvals(A)
            return S

    def torch_svd(A, some, compute_uv):
        if compute_uv:
            U, S, V = torch.svd(A, some, True)
            return U.abs(), S, V.abs()
        else:
            _, S, _ = torch.svd(A, some, True)
            return S

    for t, some, compute_uv in product(non_square(device), [True, False], [True, False]):
        assert_eq(torch_svd, my_svd, t, some, compute_uv)

def qr(device):
    def my_qr(A, some):
        return torch.linalg.qr(A, "reduced" if some else "complete")

    for t, some in product(non_square(device), [True, False]):
        assert_eq(torch.qr, my_qr, t, some)


def matrix_rank(device):
    def my_matrix_rank(A, symmetric):
        return torch.linalg.matrix_rank(A, hermitian=symmetric)

    for t, symmetric in product(square(device), [True, False]):
        assert_eq(torch.matrix_rank, my_matrix_rank, t, symmetric)

def chain_matmul(device):
    def my_multi_dot(*tensors):
        return torch.linalg.multi_dot(tensors)

    make_t = partial(torch.rand, device=device)
    assert_eq(torch.chain_matmul, my_multi_dot, make_t(3,2), make_t(2,3))
    assert_eq(torch.chain_matmul, my_multi_dot, make_t(3,3), make_t(3,3))

def solve(device):
    def my_solve(B, A):
        return torch.linalg.solve(A, B)

    def torch_solve(B, A):
        return torch.solve(B, A).solution

    for t in square(device):
        assert_eq(torch_solve, my_solve, t, t.clone())


def lstsq(device):
    def my_lstsq(B, A):
        return torch.linalg.lstsq(A, B).solution

    def torch_lstsq(B, A):
        return torch.lstsq(B, A).solution[:A.size(1)]

    for t in non_square(device):
        if t.ndim == 3: # torch.lstsq cuda does not support batches
            continue
        if DEVICE == "cuda" and t.size(-2) < t.size(-1): # Not implemented
            continue
        assert_eq(torch_lstsq, my_lstsq, t, t.clone())


# If none of them throws, we're good

# eig is too different, we will not compare it
for device in ["cpu", "cuda"]:
    cholesky(device)
    symeig(device)
    svd(device)
    qr(device)
    matrix_rank(device)
    chain_matmul(device)
    solve(device)
    lstsq(device)
```
</details>

