### PR TITLE
TensorIterator: documentation on the order of creation

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -19,7 +19,10 @@ using StrideVector = TensorIteratorBase::StrideVector;
 
 /// Construction
 TensorIteratorConfig& TensorIteratorConfig::add_output(const Tensor& output) {
-  TORCH_INTERNAL_ASSERT(num_inputs_ == 0);
+  TORCH_INTERNAL_ASSERT(
+      num_inputs_ == 0,
+      "Keep in mind that you have to add all outputs first before adding any input. "
+      "For more details, see https://github.com/pytorch/pytorch/wiki/How-to-use-TensorIterator.");
   tensors_.push_back(c10::MaybeOwned<Tensor>::owned(c10::in_place, output));
   num_outputs_++;
   return *this;
@@ -32,7 +35,10 @@ TensorIteratorConfig& TensorIteratorConfig::add_input(const Tensor& input) {
 }
 
 TensorIteratorConfig& TensorIteratorConfig::add_borrowed_output(const Tensor& output) {
-  TORCH_INTERNAL_ASSERT(num_inputs_ == 0);
+  TORCH_INTERNAL_ASSERT(
+      num_inputs_ == 0,
+      "Keep in mind that you have to add all outputs first before adding any input. "
+      "For more details, see https://github.com/pytorch/pytorch/wiki/How-to-use-TensorIterator.");
   tensors_.push_back(c10::MaybeOwned<Tensor>::borrowed(output));
   num_outputs_++;
   return *this;

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -34,6 +34,14 @@
 //     return a + b;
 //   });
 //
+// Note [Order of Construction]
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// When setting up the tensor iterator configuration, the output Tensors
+// have to be added first via TensorIteratorConfig::add_output(at::Tensor).
+// After adding all outputs, the inputs can be added via
+// TensorIteratorConfig::add_input(at::Tensor).
+// Adding another output after inputs have been added will rise an exception.
+//
 // Note [Common Dtype Computation]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Some operations have a natural notion of a "common dtype" or
@@ -478,13 +486,16 @@ public:
   C10_DISABLE_COPY_AND_ASSIGN(TensorIteratorConfig);
 
   /// Construction
+  // Stores input/output Tensors while incrementing the reference count.
+  // Important: the outputs have to be added before the inputs.
   TensorIteratorConfig& add_output(const Tensor& output);
   TensorIteratorConfig& add_input(const Tensor& input);
 
   // Advanced API: stores input/output Tensors without incrementing
-  // the reference count. The caller must ensure that these Tensors
-  // live at least as long as this TensorIteratorConfig and any
-  // TensorIteratorBase built from this TensorIteratorConfig.
+  //   the reference count. The caller must ensure that these Tensors
+  //   live at least as long as this TensorIteratorConfig and any
+  //   TensorIteratorBase built from this TensorIteratorConfig.
+  // Important: the outputs have to be added before the inputs.
   TensorIteratorConfig& add_borrowed_output(const Tensor& output);
   TensorIteratorConfig& add_borrowed_input(const Tensor& input);
 

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -492,9 +492,9 @@ public:
   TensorIteratorConfig& add_input(const Tensor& input);
 
   // Advanced API: stores input/output Tensors without incrementing
-  //   the reference count. The caller must ensure that these Tensors
-  //   live at least as long as this TensorIteratorConfig and any
-  //   TensorIteratorBase built from this TensorIteratorConfig.
+  // the reference count. The caller must ensure that these Tensors
+  // live at least as long as this TensorIteratorConfig and any
+  // TensorIteratorBase built from this TensorIteratorConfig.
   // Important: the outputs have to be added before the inputs.
   TensorIteratorConfig& add_borrowed_output(const Tensor& output);
   TensorIteratorConfig& add_borrowed_input(const Tensor& input);


### PR DESCRIPTION
Adds documentation to TensorIterator and TensorIteratorConfig that outputs need to be added first before inputs.

Fixes #57343
