### PR TITLE
Helper function for skipping module parameter / buffer initialization

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -371,6 +371,7 @@ From the ``torch.nn.utils`` module
     remove_weight_norm
     spectral_norm
     remove_spectral_norm
+    skip_init
 
 Parametrizations implemented using the new parametrization functionality
 in :func:`torch.nn.utils.parameterize.register_parametrization`.

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16243,7 +16243,7 @@ class TestNNDeviceType(NNTestCase):
         m_initialized.to(device)
 
         torch.manual_seed(1)
-        m_uninitialized = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1)
+        m_uninitialized = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1, device=device)
 
         self.assertEqual(m_initialized.weight.device, m_uninitialized.weight.device)
         self.assertFalse(torch.allclose(m_initialized.weight, m_uninitialized.weight))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16243,8 +16243,7 @@ class TestNNDeviceType(NNTestCase):
         m_initialized.to(device)
 
         torch.manual_seed(1)
-        l = torch.nn.utils.skip_init(torch.nn.Linear, device=device)
-        m_uninitialized = l(5, 1)
+        m_uninitialized = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1)
 
         self.assertEqual(m_initialized.weight.device, m_uninitialized.weight.device)
         self.assertFalse(torch.allclose(m_initialized.weight, m_uninitialized.weight))

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16236,6 +16236,19 @@ class TestNNDeviceType(NNTestCase):
         m.to_empty(device='meta')
         m(input)
 
+    @skipMeta
+    def test_skip_init(self, device):
+        torch.manual_seed(1)
+        m_initialized = torch.nn.Linear(5, 1)
+        m_initialized.to(device)
+
+        torch.manual_seed(1)
+        l = torch.nn.utils.skip_init(torch.nn.Linear, device=device)
+        m_uninitialized = l(5, 1)
+
+        self.assertEqual(m_initialized.weight.device, m_uninitialized.weight.device)
+        self.assertFalse(torch.allclose(m_initialized.weight, m_uninitialized.weight))
+
 class TestModuleGlobalHooks(TestCase):
 
     def tearDown(self):

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -6,3 +6,4 @@ from .spectral_norm import spectral_norm, remove_spectral_norm
 from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 from .memory_format import convert_conv2d_weight_memory_format
 from . import parametrizations
+from .init import skip_init

--- a/torch/nn/utils/init.py
+++ b/torch/nn/utils/init.py
@@ -11,6 +11,7 @@ def skip_init(module_cls, *args, **kwargs):
 
     1. The module must accept a `device` arg in its constructor that is passed to any parameters
     or buffers created during construction.
+
     2. The module must not perform any computation on parameters in its constructor except
     initialization (i.e. functions from :mod:`torch.nn.init`).
 

--- a/torch/nn/utils/init.py
+++ b/torch/nn/utils/init.py
@@ -2,12 +2,12 @@ import inspect
 import torch
 
 
-def skip_init(module_cls, device='cpu'):
+def skip_init(module_cls, *args, **kwargs):
     r"""
-    Given a module class object, returns a function that will instantiate the module on the specified
-    device without initializing parameters / buffers. This can be useful if initialization is slow or
-    if custom initialization will be performed, making the default initialization unnecessary. There
-    are some caveats to this, due to the way this function is implemented:
+    Given a module class object and args / kwargs, instantiates the module without initializing
+    parameters / buffers.  This can be useful if initialization is slow or if custom initialization will
+    be performed, making the default initialization unnecessary. There are some caveats to this, due to
+    the way this function is implemented:
 
     1. The module must accept a `device` arg in its constructor that is passed to any parameters
     or buffers created during construction.
@@ -19,21 +19,21 @@ def skip_init(module_cls, device='cpu'):
 
     Args:
         module_cls: Class object; should be a subclass of :class:`torch.nn.Module`
-        device: Device on which to create the module. Default: 'cpu'
+        args: args to pass to the module's constructor
+        kwargs: kwargs to pass to the module's constructor
 
     Returns:
-        A function that will instantiate the module without initializing parameters / buffers
+        Instantiated module with uninitialized parameters / buffers
 
     Example::
 
         >>> import torch
-        >>> l = torch.nn.utils.skip_init(torch.nn.Linear)
-        >>> m1 = l(5, 1)
-        >>> m1.weight
+        >>> m = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1)
+        >>> m.weight
         Parameter containing:
         tensor([[0.0000e+00, 1.5846e+29, 7.8307e+00, 2.5250e-29, 1.1210e-44]],
                requires_grad=True)
-        >>> m2 = l(in_features=6, out_features=1)
+        >>> m2 = torch.nn.utils.skip_init(torch.nn.Linear, in_features=6, out_features=1)
         >>> m2.weight
         Parameter containing:
         tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00, -1.4677e+24,
@@ -45,6 +45,6 @@ def skip_init(module_cls, device='cpu'):
     if 'device' not in inspect.signature(module_cls).parameters:
         raise RuntimeError('Module must support a \'device\' arg to skip initialization')
 
-    def _instantiate(*args, **kwargs):
-        return module_cls(*args, **kwargs, device='meta').to_empty(device=device)
-    return _instantiate
+    final_device = kwargs.pop('device', 'cpu')
+    kwargs['device'] = 'meta'
+    return module_cls(*args, **kwargs).to_empty(device=final_device)

--- a/torch/nn/utils/init.py
+++ b/torch/nn/utils/init.py
@@ -1,0 +1,49 @@
+import inspect
+import torch
+
+
+def skip_init(module_cls, device='cpu'):
+    r"""
+    Given a module class object, returns a function that will instantiate the module on the specified
+    device without initializing parameters / buffers. This can be useful if initialization is slow or
+    if custom initialization will be performed, making the default initialization unnecessary. There
+    are some caveats to this, due to the way this function is implemented:
+
+    1. The module must accept a `device` arg in its constructor that is passed to any parameters
+    or buffers created during construction.
+    2. The module must not perform any computation on parameters in its constructor except
+    initialization (i.e. functions from :mod:`torch.nn.init`).
+
+    If these conditions are satisfied, the module can be instantiated with parameter / buffer values
+    uninitialized, as if having been created using :func:`torch.empty`.
+
+    Args:
+        module_cls: Class object; should be a subclass of :class:`torch.nn.Module`
+        device: Device on which to create the module. Default: 'cpu'
+
+    Returns:
+        A function that will instantiate the module without initializing parameters / buffers
+
+    Example::
+
+        >>> import torch
+        >>> l = torch.nn.utils.skip_init(torch.nn.Linear)
+        >>> m1 = l(5, 1)
+        >>> m1.weight
+        Parameter containing:
+        tensor([[0.0000e+00, 1.5846e+29, 7.8307e+00, 2.5250e-29, 1.1210e-44]],
+               requires_grad=True)
+        >>> m2 = l(in_features=6, out_features=1)
+        >>> m2.weight
+        Parameter containing:
+        tensor([[-1.4677e+24,  4.5915e-41,  1.4013e-45,  0.0000e+00, -1.4677e+24,
+                  4.5915e-41]], requires_grad=True)
+
+    """
+    if not issubclass(module_cls, torch.nn.Module):
+        raise RuntimeError('Expected a Module; got {}'.format(module_cls))
+    if 'device' not in inspect.signature(module_cls).parameters:
+        raise RuntimeError('Module must support a \'device\' arg to skip initialization')
+    def _instantiate(*args, **kwargs):
+        return module_cls(*args, **kwargs, device='meta').to_empty(device=device)
+    return _instantiate

--- a/torch/nn/utils/init.py
+++ b/torch/nn/utils/init.py
@@ -44,6 +44,7 @@ def skip_init(module_cls, device='cpu'):
         raise RuntimeError('Expected a Module; got {}'.format(module_cls))
     if 'device' not in inspect.signature(module_cls).parameters:
         raise RuntimeError('Module must support a \'device\' arg to skip initialization')
+
     def _instantiate(*args, **kwargs):
         return module_cls(*args, **kwargs, device='meta').to_empty(device=device)
     return _instantiate


### PR DESCRIPTION
This PR introduces a helper function named `torch.nn.utils.skip_init()` that accepts a module class object + `args` / `kwargs` and instantiates the module while skipping initialization of parameter / buffer values. See discussion at https://github.com/pytorch/pytorch/issues/29523 for more context. Example usage:

```python
import torch

m = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1)
print(m.weight)

m2 = torch.nn.utils.skip_init(torch.nn.Linear, 5, 1, device='cuda')
print(m2.weight)

m3 = torch.nn.utils.skip_init(torch.nn.Linear, in_features=5, out_features=1)
print(m3.weight)
```
```
Parameter containing:
tensor([[-3.3011e+28,  4.5915e-41, -3.3009e+28,  4.5915e-41,  0.0000e+00]],
       requires_grad=True)
Parameter containing:
tensor([[-2.5339e+27,  4.5915e-41, -2.5367e+27,  4.5915e-41,  0.0000e+00]],
       device='cuda:0', requires_grad=True)
Parameter containing:
tensor([[1.4013e-45, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00]],
       requires_grad=True)
```

Bikeshedding on the name / namespace is welcome, as well as comments on the design itself - just wanted to get something out there for discussion.