### PR TITLE
[torch distributed] Implementing reduce_scatter_base

### DIFF
--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -277,6 +277,11 @@ class ProcessGroup:
         output_tensors: Tensor,
         input_tensor: List[Tensor],
     ) -> Work: ...
+    def _reduce_scatter_base(
+        self,
+        outputTensor: Tensor,
+        inputTensor: Tensor,
+    ) -> Work: ...
     @overload
     def alltoall_base(
         self,

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -1114,6 +1114,14 @@ Arguments:
               py::call_guard<py::gil_scoped_release>())
 
           .def(
+              "_reduce_scatter_base",
+              &::c10d::ProcessGroup::_reduce_scatter_base,
+              py::arg("outputTensor"),
+              py::arg("inputTensor"),
+              py::arg("opts") = ::c10d::ReduceScatterOptions(),
+              py::call_guard<py::gil_scoped_release>())
+
+          .def(
               "alltoall_base",
               &::c10d::ProcessGroup::alltoall_base,
               py::arg("output_tensor"),

--- a/torch/distributed/__init__.py
+++ b/torch/distributed/__init__.py
@@ -56,5 +56,6 @@ if is_available():
     from .distributed_c10d import (
         _backend,
         _all_gather_base,
+        _reduce_scatter_base,
         _create_process_group_wrapper
     )

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2340,6 +2340,46 @@ def reduce_scatter(output, input_list, op=ReduceOp.SUM, group=None, async_op=Fal
     else:
         work.wait()
 
+def _reduce_scatter_base(output,
+                         input,
+                         op=ReduceOp.SUM,
+                         group=None,
+                         async_op=False):
+    """
+    Reduces, then scatters a flattened tensor to all processes in a group.
+
+    Args:
+        output (Tensor): Output tensor.
+        input (Tensor): Input tensor that is of size output tensor size times world size
+        group (ProcessGroup, optional): The process group to work on. If None,
+            the default process group will be used.
+        async_op (bool, optional): Whether this op should be an async op.
+
+    Returns:
+        Async work handle, if async_op is set to True.
+        None, if not async_op or if not part of the group.
+
+    """
+    _check_single_tensor(output, "output")
+    _check_single_tensor(input, "input")
+
+    if _rank_not_in_group(group):
+        return
+
+    opts = ReduceScatterOptions()
+    opts.reduceOp = op
+
+    if group is None:
+        default_pg = _get_default_group()
+        work = default_pg._reduce_scatter_base(output, input, opts)
+    else:
+        work = group._reduce_scatter_base(output, input, opts)
+
+    if async_op:
+        return work
+    else:
+        work.wait()
+
 
 def all_to_all_single(
     output,

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -41,6 +41,8 @@ std::string opTypeToString(OpType opType) {
       return "BARRIER";
     case OpType::UNKNOWN:
       return "UNKNOWN";
+    case OpType::_REDUCE_SCATTER_BASE:
+      return "_REDUCE_SCATTER_BASE";
     default:
       TORCH_INTERNAL_ASSERT("Unknown op type!");
   }

--- a/torch/lib/c10d/ProcessGroup.hpp
+++ b/torch/lib/c10d/ProcessGroup.hpp
@@ -45,6 +45,7 @@ enum class OpType : std::uint8_t {
   RECV = 13,
   RECVANYSOURCE = 14,
   BARRIER = 15,
+  _REDUCE_SCATTER_BASE = 16,
   UNKNOWN = 100,
 };
 
@@ -258,6 +259,14 @@ class ProcessGroup : public torch::CustomClassHolder {
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) = 0;
+
+  virtual c10::intrusive_ptr<ProcessGroup::Work> _reduce_scatter_base(
+      at::Tensor&,
+      at::Tensor&,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) {
+    throw std::runtime_error("ProcessGroup does not support reduce_scatter_base");
+  }
+
 
   virtual c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
       at::Tensor& outputTensor,

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -4,6 +4,7 @@
 
 #include <exception>
 #include <map>
+#include <stdexcept>
 #include <tuple>
 #include <unordered_set>
 
@@ -1538,6 +1539,58 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
       [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {},
       OpType::REDUCE_SCATTER,
       "nccl:reduce_scatter");
+}
+
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::_reduce_scatter_base(
+    at::Tensor& outputTensor,
+    at::Tensor& inputTensor,
+    const ReduceScatterOptions& opts) {
+
+  if (inputTensor.dtype() != outputTensor.dtype()) {
+    throw std::runtime_error("input tensor must be the same type as the outut tensor.");
+  }
+
+  if (inputTensor.numel() != outputTensor.numel() * size_) {
+    throw std::runtime_error("input tensor must be the same size as output size times world size");
+  }
+
+  // @lint-ignore CLANGTIDY
+  const auto& tensor = outputTensor;
+  RECORD_PARAM_COMMS(
+      rank_,                      // rank
+      "_reduce_scatter_base",     // colName
+      tensor.numel() *            // inSize
+        this->getSize(),
+      tensor.numel(),             // outSize
+      tensor.scalar_type(),       // dtype
+      std::vector<int64_t>(),      // inSplitSizes
+      std::vector<int64_t>());     // outSplitSizes
+
+  auto inputs = std::vector<at::Tensor> {inputTensor};
+  auto outputs = std::vector<at::Tensor> {outputTensor};
+
+  return collective(
+      inputs,
+      outputs,
+      [&](at::Tensor& input,
+          at::Tensor& output,
+          ncclComm_t comm,
+          at::cuda::CUDAStream& stream) {
+        c10::cuda::CUDACachingAllocator::recordStream(
+            output.storage().data_ptr(), stream);
+        return ncclReduceScatter(
+            input.data_ptr(),
+            output.data_ptr(),
+            output.numel(),
+            getNcclDataType(input.scalar_type()),
+            getNcclReduceOp(opts.reduceOp, input),
+            comm,
+            stream.stream());
+      },
+      [&](std::vector<at::cuda::CUDAStream>&) {},
+      [&](std::vector<at::cuda::CUDAStream>&) {},
+      OpType::_REDUCE_SCATTER_BASE,
+      "nccl:_reduce_scatter_base");
 }
 
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(

--- a/torch/lib/c10d/ProcessGroupNCCL.hpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.hpp
@@ -274,6 +274,11 @@ class ProcessGroupNCCL : public ProcessGroup {
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
+  c10::intrusive_ptr<ProcessGroup::Work> _reduce_scatter_base(
+      at::Tensor& outputTensor,
+      at::Tensor& inputTensor,
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
+
   c10::intrusive_ptr<ProcessGroup::Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 


### PR DESCRIPTION
Summary: Support flattened reduce_scatter.

Test Plan:
buck test mode/opt -c fbcode.enable_gpu_sections=true //caffe2/torch/lib/c10d:ProcessGroupNCCLTest
buck test mode/opt -c fbcode.enable_gpu_sections=true //caffe2/test/distributed:c10d

Differential Revision: D27876281

