### PR TITLE
[nnc][tests] Skip long running tests when using TE interpreter

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1815,11 +1815,9 @@ class TestTEFuser(JitTestCase):
                 self.assertEqual(len(self.findFusionGroups(t.graph_for(x))), 0)
 
     def test_superslomo(self):
-        devices = []
-        if RUN_CUDA:
-            devices.append("cuda")
-        if LLVM_ENABLED:
-            devices.append("cpu")
+        devices = self.devices
+        if not LLVM_ENABLED:
+            devices.remove("cpu")
         for device in devices:
             # Test extracted from Super-SloMo: https://github.com/avinashpaliwal/Super-SloMo
             # A few interesting things happen here: strided inputs of mixed size,

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1815,7 +1815,12 @@ class TestTEFuser(JitTestCase):
                 self.assertEqual(len(self.findFusionGroups(t.graph_for(x))), 0)
 
     def test_superslomo(self):
-        for device in self.devices:
+        devices = []
+        if RUN_CUDA:
+            devices.append("cuda")
+        if LLVM_ENABLED:
+            devices.append("cpu")
+        for device in devices:
             # Test extracted from Super-SloMo: https://github.com/avinashpaliwal/Super-SloMo
             # A few interesting things happen here: strided inputs of mixed size,
             # plus outputs of mixed shapes.  The latter characteristic happened to
@@ -1901,6 +1906,7 @@ class TestTEFuser(JitTestCase):
         script = self.checkScript(eager_st, (s, b))
         self.assertAllFused(script.graph_for(s, b))
 
+    @unittest.skipIf(not LLVM_ENABLED, "Too slow to run with the TE interpreter")
     def test_conv2d_depthwise(self):
         def eager(input, weight, bias):
             return torch.conv2d(input, weight, bias, stride=1, padding=1, groups=72)

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1815,7 +1815,7 @@ class TestTEFuser(JitTestCase):
                 self.assertEqual(len(self.findFusionGroups(t.graph_for(x))), 0)
 
     def test_superslomo(self):
-        devices = self.devices
+        devices = self.devices.copy()
         if not LLVM_ENABLED:
             devices.remove("cpu")
         for device in devices:

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -175,7 +175,7 @@ class TestTensorExprFuser(BaseTestClass):
                 npr = a.cpu().numpy() + b.cpu().numpy() + c.cpu().numpy()
                 np.testing.assert_allclose(npr, x.cpu().numpy())
 
-            test_configs = [[36, 17, 63, 33], [32, 32, 32, 32]]
+            test_configs = [[5, 2, 7, 3], [8, 8, 8, 8]]
             for test_config in test_configs:
                 test_body(*test_config)
 
@@ -1021,7 +1021,7 @@ class TestTensorExprFuser(BaseTestClass):
 
         traced = torch.jit.trace(easy, (torch.zeros(1024, 1024)))
 
-        a = torch.zeros(1024, 1024)
+        a = torch.zeros(32, 32)
         x = warmup_and_run_forward(traced, a)
         self.assertLastGraphAllFused()
         npr = a.numpy()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57568 [nnc][tests] Skip long running tests when using TE interpreter**

Differential Revision: [D28202740](https://our.internmc.facebook.com/intern/diff/D28202740)