### PR TITLE
Always run as many quick-checks steps as possible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Epic fail
         run: 'false'
       - name: Ensure consistent CircleCI YAML config
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
         if: steps.requirements.outcome == 'success'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,22 +30,22 @@ jobs:
       - name: Epic fail
         run: 'false'
       - name: Ensure consistent CircleCI YAML config
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           echo "Please locally run .github/scripts/regenerate_cancel_redundant_workflow.py and commit if this step fails."
           .github/scripts/regenerate_cancel_redundant_workflow.py
           git diff --exit-code .github/workflows/cancel_redundant_workflows.yml
       - name: Lint native_functions.yaml
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
       - name: Extract scripts from GitHub Actions workflows
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           # For local lints, remove the .extracted_scripts folder if it was already there
           rm -rf .extracted_scripts
@@ -62,11 +62,11 @@ jobs:
           rm -r "shellcheck-${scversion}"
           shellcheck --version
       - name: Run ShellCheck
-        if: steps.install_shellcheck.conclusion == 'success'
+        if: steps.install_shellcheck.outcome == 'success'
         run: |
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           (! git --no-pager grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
@@ -106,12 +106,12 @@ jobs:
           # shellcheck disable=SC2016
           (! find . \( -path ./third_party -o -path ./.git -o -path ./torch/bin -o -path ./build \) -prune -o -type f -executable -regextype posix-egrep -not -regex '.+(\.(bash|sh|py|so)|git-pre-commit|git-clang-format|gradlew)$' -print | grep . || (echo 'The above files have executable permission; please remove their executable permission by using `chmod -x`'; false))
       - name: C++ docs check
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
       - name: CUDA kernel launch check
-        if: steps.requirements.conclusion == 'success'
+        if: steps.requirements.outcome == 'success'
         run: |
           set -eux
           python torch/testing/check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,6 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v2
-      # TODO: remove this step before merging
-      - name: Epic fail
-        run: 'false'
       - name: Install requirements
         id: requirements
         run: pip install -r requirements.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install requirements
         run: pip install -r requirements.txt
+      - name: Epic fail
+        run: 'false'
       - name: Ensure consistent CircleCI YAML config
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,27 +24,35 @@ jobs:
       - name: Checkout PyTorch
         uses: actions/checkout@v2
       - name: Install requirements
+        id: requirements
         run: pip install -r requirements.txt
+      # TODO: remove this step before merging
       - name: Epic fail
         run: 'false'
       - name: Ensure consistent CircleCI YAML config
+        if: steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
+        if: steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           echo "Please locally run .github/scripts/regenerate_cancel_redundant_workflow.py and commit if this step fails."
           .github/scripts/regenerate_cancel_redundant_workflow.py
           git diff --exit-code .github/workflows/cancel_redundant_workflows.yml
       - name: Lint native_functions.yaml
+        if: steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
       - name: Extract scripts from GitHub Actions workflows
+        if: steps.requirements.outcome == 'success'
         run: |
           # For local lints, remove the .extracted_scripts folder if it was already there
           rm -rf .extracted_scripts
           tools/extract_scripts.py --out=.extracted_scripts
       - name: Install ShellCheck
+        id: install_shellcheck
+        if: always()
         # https://github.com/koalaman/shellcheck/tree/v0.7.2#installing-a-pre-compiled-binary
         run: |
           set -x
@@ -54,9 +62,11 @@ jobs:
           rm -r "shellcheck-${scversion}"
           shellcheck --version
       - name: Run ShellCheck
+        if: steps.install_shellcheck.outcome == 'success'
         run: |
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
+        if: steps.requirements.outcome == 'success'
         run: |
           (! git --no-pager grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
@@ -96,10 +106,12 @@ jobs:
           # shellcheck disable=SC2016
           (! find . \( -path ./third_party -o -path ./.git -o -path ./torch/bin -o -path ./build \) -prune -o -type f -executable -regextype posix-egrep -not -regex '.+(\.(bash|sh|py|so)|git-pre-commit|git-clang-format|gradlew)$' -print | grep . || (echo 'The above files have executable permission; please remove their executable permission by using `chmod -x`'; false))
       - name: C++ docs check
+        if: steps.requirements.outcome == 'success'
         run: |
-          sudo apt-get install -y doxygen && pip install -r requirements.txt
+          sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
       - name: CUDA kernel launch check
+        if: steps.requirements.outcome == 'success'
         run: |
           set -eux
           python torch/testing/check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,19 +33,19 @@ jobs:
         if: always() && steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           echo "Please locally run .github/scripts/regenerate_cancel_redundant_workflow.py and commit if this step fails."
           .github/scripts/regenerate_cancel_redundant_workflow.py
           git diff --exit-code .github/workflows/cancel_redundant_workflows.yml
       - name: Lint native_functions.yaml
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
       - name: Extract scripts from GitHub Actions workflows
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           # For local lints, remove the .extracted_scripts folder if it was already there
           rm -rf .extracted_scripts
@@ -62,11 +62,11 @@ jobs:
           rm -r "shellcheck-${scversion}"
           shellcheck --version
       - name: Run ShellCheck
-        if: steps.install_shellcheck.outcome == 'success'
+        if: always() && steps.install_shellcheck.outcome == 'success'
         run: |
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           (! git --no-pager grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
@@ -106,12 +106,12 @@ jobs:
           # shellcheck disable=SC2016
           (! find . \( -path ./third_party -o -path ./.git -o -path ./torch/bin -o -path ./build \) -prune -o -type f -executable -regextype posix-egrep -not -regex '.+(\.(bash|sh|py|so)|git-pre-commit|git-clang-format|gradlew)$' -print | grep . || (echo 'The above files have executable permission; please remove their executable permission by using `chmod -x`'; false))
       - name: C++ docs check
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
       - name: CUDA kernel launch check
-        if: steps.requirements.outcome == 'success'
+        if: always() && steps.requirements.outcome == 'success'
         run: |
           set -eux
           python torch/testing/check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,12 @@ jobs:
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@v2
-      - name: Install requirements
-        id: requirements
-        run: pip install -r requirements.txt
       # TODO: remove this step before merging
       - name: Epic fail
         run: 'false'
+      - name: Install requirements
+        id: requirements
+        run: pip install -r requirements.txt
       - name: Ensure consistent CircleCI YAML config
         if: always() && steps.requirements.outcome == 'success'
         run: cd .circleci && ./ensure-consistency.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,22 +30,22 @@ jobs:
       - name: Epic fail
         run: 'false'
       - name: Ensure consistent CircleCI YAML config
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: cd .circleci && ./ensure-consistency.py
       - name: Ensure consistent GHA workflows in cancel_redundant_workflows.yml
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           echo "Please locally run .github/scripts/regenerate_cancel_redundant_workflow.py and commit if this step fails."
           .github/scripts/regenerate_cancel_redundant_workflow.py
           git diff --exit-code .github/workflows/cancel_redundant_workflows.yml
       - name: Lint native_functions.yaml
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           pip install ruamel.yaml==0.17.4
           .github/scripts/lint_native_functions.py
       - name: Extract scripts from GitHub Actions workflows
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           # For local lints, remove the .extracted_scripts folder if it was already there
           rm -rf .extracted_scripts
@@ -62,11 +62,11 @@ jobs:
           rm -r "shellcheck-${scversion}"
           shellcheck --version
       - name: Run ShellCheck
-        if: steps.install_shellcheck.outcome == 'success'
+        if: steps.install_shellcheck.conclusion == 'success'
         run: |
           tools/run_shellcheck.sh .jenkins/pytorch .extracted_scripts
       - name: Ensure correct trailing newlines
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           (! git --no-pager grep -Il '' -- . ':(exclude)**/contrib/**' ':(exclude)third_party' ':(exclude)**.expect' ':(exclude)tools/clang_format_hash' | tools/trailing_newlines.py || (echo "The above files do not have correct trailing newlines; please normalize them"; false))
       - name: Ensure no trailing spaces
@@ -106,12 +106,12 @@ jobs:
           # shellcheck disable=SC2016
           (! find . \( -path ./third_party -o -path ./.git -o -path ./torch/bin -o -path ./build \) -prune -o -type f -executable -regextype posix-egrep -not -regex '.+(\.(bash|sh|py|so)|git-pre-commit|git-clang-format|gradlew)$' -print | grep . || (echo 'The above files have executable permission; please remove their executable permission by using `chmod -x`'; false))
       - name: C++ docs check
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           sudo apt-get install -y doxygen
           cd docs/cpp/source && ./check-doxygen.sh
       - name: CUDA kernel launch check
-        if: steps.requirements.outcome == 'success'
+        if: steps.requirements.conclusion == 'success'
         run: |
           set -eux
           python torch/testing/check_kernel_launches.py |& tee "${GITHUB_WORKSPACE}"/cuda_kernel_launch_checks.txt


### PR DESCRIPTION
This is essentially a continuation of #56700. Currently, some of the steps in **Lint / quick-checks** (such as the trailing newlines check) still don't always run if an earlier steps fail; example: https://github.com/pytorch/pytorch/runs/2504623867

This PR adds some more `if`s to remaining steps, so that they, too, can still run even when earlier steps fail.

**Test plan:**

- https://github.com/pytorch/pytorch/runs/2504706736 before this PR, many steps get skipped if an early step fails
- https://github.com/pytorch/pytorch/runs/2504778437 using this PR's technique, those steps still run
- https://github.com/pytorch/pytorch/runs/2504787234 if the requirements step doesn't run, steps still get skipped
- https://github.com/pytorch/pytorch/runs/2504796695 after this PR, `quick-checks` still succeeds