### PR TITLE
[pytorch] gate TLS RecordFunctionCallbacks for Android with libgnustl

### DIFF
--- a/aten/src/ATen/record_function.h
+++ b/aten/src/ATen/record_function.h
@@ -3,6 +3,7 @@
 #include <ATen/core/ivalue.h>
 #include <ATen/core/operator_name.h>
 #include <c10/macros/Export.h>
+#include <c10/macros/Macros.h>
 #include <c10/util/Optional.h>
 #include <c10/util/SmallVector.h>
 #include <memory>
@@ -584,9 +585,11 @@ TORCH_API RecordFunctionCallbacks _getTLSCallbacks();
 TORCH_API void _setTLSCallbacks(const RecordFunctionCallbacks& callbacks);
 
 struct TORCH_API RecordFunctionTLS {
+#if !defined(C10_BROKEN_THREAD_LOCAL)
   // Thread local vector of callbacks, holds pairs (callbacks, unique_id);
   // must be sorted in increasing handles order
   RecordFunctionCallbacks sorted_tls_callbacks_;
+#endif
 
   bool tls_record_function_enabled_ = true;
 

--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -412,4 +412,11 @@ __host__ __device__
 #endif
 #endif
 
+#if defined(__ANDROID__) && !defined(_LIBCPP_VERSION)
+// The thread_local on Android with old libgnustl was broken. It can run
+// thread_local object's destructor after it frees the memory. So it's unsafe
+// to have thread_local objects with non-trivial destructor.
+#define C10_BROKEN_THREAD_LOCAL
+#endif
+
 #endif // C10_MACROS_MACROS_H_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57580 [pytorch] gate TLS RecordFunctionCallbacks for Android with libgnustl**



The thread_local on Android with old libgnustl was broken. It can run
thread_local object's destructor after it frees the memory. So it's unsafe
to have thread_local objects with non-trivial destructor.

This diff removed sorted_tls_callbacks_ from the RecordFunctionTLS
struct, which is a std::vector with non-trivial destructor. This should
fix some crashes we saw in production.

Differential Revision: [D28208027](https://our.internmc.facebook.com/intern/diff/D28208027/)

Differential Revision: [D28208027](https://our.internmc.facebook.com/intern/diff/D28208027)