### PR TITLE
add a standalone extra file loader for pytorch model

### DIFF
--- a/third_party/miniz-2.0.8/miniz.h
+++ b/third_party/miniz-2.0.8/miniz.h
@@ -120,7 +120,7 @@
    If all macros here are defined the only functionality remaining will be CRC-32, adler-32, tinfl, and tdefl. */
 
 /* Define MINIZ_NO_STDIO to disable all usage and any functions which rely on stdio for file I/O. */
-#define MINIZ_NO_STDIO
+// #define MINIZ_NO_STDIO  // enable STDIO API mz_zip_reader_init_file for pytorch file extractor, see D28168870
 
 /* If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or */
 /* get/set file times, and the C run-time funcs that get/set times won't be called. */


### PR DESCRIPTION
Summary:
According to dhruvbird we should be able to read a file from pytorch model (which is a zip file) using miniz. This diff added a standalone loader so user can load a JSON (or other type) file in the extra folder of the model. The whole point is to avoid loading pytorch library first, which can be complex (voltron, dynamic loading etc).

With this the hand tracking inference config (D27937516) can no longer depends on pytorch or use dynamic_pytorch. Previous it uses torch::jit::_load_extra_only_for_mobile which requires pytorch to be loaded first. We want to avoid doing that.

Test Plan: buck test caffe2/fb/dynamic_pytorch:extract_file_test

Reviewed By: dhruvbird

Differential Revision: D28140492

