### PR TITLE
[Caffe2] Introduce c10::CudaError for CUDA Exceptions

### DIFF
--- a/c10/cuda/CUDAException.h
+++ b/c10/cuda/CUDAException.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/cuda/CUDAFunctions.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/Exception.h>
 #include <cuda.h>
@@ -11,15 +12,40 @@
 // macro and a function implementation if we pass along __LINE__
 // and __FILE__, but no one has found this worth doing.
 
+// Used to denote errors from CUDA framework.
+// This needs to be declared here instead util/Exception.h for proper conversion
+// during hipify.
+namespace c10 {
+class C10_CUDA_API CUDAError : public c10::Error {
+  using Error::Error;
+};
+} // namespace c10
+
 // For CUDA Runtime API
-#define C10_CUDA_CHECK(EXPR)                                         \
-  do {                                                               \
-    cudaError_t __err = EXPR;                                        \
-    if (__err != cudaSuccess) {                                      \
-      auto error_unused C10_UNUSED = cudaGetLastError();             \
-      TORCH_CHECK(false, "CUDA error: ", cudaGetErrorString(__err)); \
-    }                                                                \
+#ifdef STRIP_ERROR_MESSAGES
+#define C10_CUDA_CHECK(EXPR)                                     \
+  do {                                                           \
+    cudaError_t __err = EXPR;                                    \
+    if (__err != cudaSuccess) {                                  \
+      throw c10::CUDAError(                                      \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+          TORCH_CHECK_MSG(false, ""));                           \
+    }                                                            \
   } while (0)
+#else
+#define C10_CUDA_CHECK(EXPR)                                              \
+  do {                                                                    \
+    cudaError_t __err = EXPR;                                             \
+    if (__err != cudaSuccess) {                                           \
+      auto error_unused C10_UNUSED = cudaGetLastError();                  \
+      auto _cuda_check_prefix = c10::cuda::get_cuda_check_prefix();       \
+      throw c10::CUDAError(                                               \
+          {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},          \
+          TORCH_CHECK_MSG(                                                \
+              false, "", _cuda_check_prefix, cudaGetErrorString(__err))); \
+    }                                                                     \
+  } while (0)
+#endif
 
 #define C10_CUDA_CHECK_WARN(EXPR)                              \
   do {                                                         \

--- a/c10/cuda/CUDAFunctions.cpp
+++ b/c10/cuda/CUDAFunctions.cpp
@@ -1,4 +1,8 @@
+#include <cuda_runtime_api.h>
+
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAFunctions.h>
+#include <c10/macros/Macros.h>
 
 #include <limits>
 
@@ -135,6 +139,20 @@ void set_device(DeviceIndex device) {
 
 void device_synchronize() {
   C10_CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+const char* get_cuda_check_prefix() noexcept {
+  static char* device_blocking_flag = getenv("CUDA_LAUNCH_BLOCKING");
+  static bool blocking_enabled =
+      (device_blocking_flag && atoi(device_blocking_flag));
+  if (blocking_enabled) {
+    return "CUDA error: ";
+  } else {
+    return "CUDA kernel errors might be "
+           "asynchronously reported at some other API call,so the "
+           "stacktrace below might be incorrect. For debugging "
+           "consider passing CUDA_LAUNCH_BLOCKING=1. CUDA error: ";
+  }
 }
 
 } // namespace cuda

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -7,12 +7,8 @@
 //
 // The naming convention used here matches the naming convention of torch.cuda
 
-#include <cuda_runtime_api.h>
-
 #include <c10/core/Device.h>
-#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAMacros.h>
-#include <c10/macros/Macros.h>
 
 namespace c10 {
 namespace cuda {
@@ -33,6 +29,8 @@ C10_CUDA_API DeviceIndex current_device();
 C10_CUDA_API void set_device(DeviceIndex device);
 
 C10_CUDA_API void device_synchronize();
+
+C10_CUDA_API const char* get_cuda_check_prefix() noexcept;
 
 } // namespace cuda
 } // namespace c10

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -8136,6 +8136,7 @@ C10_MAPPINGS = collections.OrderedDict(
         ("getDefaultCUDAStream", ("getDefaultHIPStream", API_C10)),
         ("cuda::getCurrentCUDAStream", ("hip::getCurrentHIPStream", API_C10)),
         ("getCurrentCUDAStream", ("getCurrentHIPStream", API_C10)),
+        ("cuda::get_cuda_check_prefix", ("hip::get_cuda_check_prefix", API_C10)),
         ("cuda::setCurrentCUDAStream", ("hip::setCurrentHIPStream", API_C10)),
         ("setCurrentCUDAStream", ("setCurrentHIPStream", API_C10)),
         ("cuda::CUDACachingAllocator", ("hip::HIPCachingAllocator", API_C10)),


### PR DESCRIPTION
Summary: Throw c10::CudaError for CUDA Exceptions for better classification of errors

Test Plan: Test locally by running some workflows

Differential Revision: D28209356

