### PR TITLE
[profiler] Add profiler fallback

### DIFF
--- a/torch/profiler/__init__.py
+++ b/torch/profiler/__init__.py
@@ -8,6 +8,6 @@ examine their input shapes and stack traces, study device kernel activity and vi
 
 '''
 
-from .profiler import profile, schedule, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
+from .profiler import profile, schedule, supported_activities, tensorboard_trace_handler, ProfilerAction, ProfilerActivity
 from torch.autograd import kineto_available, DeviceType
 from torch.autograd.profiler import record_function

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -81,6 +81,16 @@ def tensorboard_trace_handler(dir_name: str, worker_name: Optional[str] = None, 
         prof.export_chrome_trace(os.path.join(dir_name, file_name))
     return handler_fn
 
+def supported_activities():
+    """
+    Returns a set of supported profiler activities
+    """
+    activities = [ProfilerActivity.CPU]
+    # CUPTI profiling is not supported on ROCm
+    if torch.cuda.is_available() and torch.version.hip is None:
+        activities.append(ProfilerActivity.CUDA)
+    return set(activities)
+
 
 class profile(object):
     """Profiler context manager.
@@ -194,9 +204,7 @@ class profile(object):
         if activities:
             self.activities = set(activities)
         else:
-            self.activities = set([ProfilerActivity.CPU])
-            if torch.cuda.is_available():
-                self.activities.add(ProfilerActivity.CUDA)
+            self.activities = supported_activities()
 
         if use_cuda is not None:
             warn("use_cuda is deprecated, use activities argument instead")
@@ -205,9 +213,11 @@ class profile(object):
             elif ProfilerActivity.CUDA in self.activities:
                 self.activities.remove(ProfilerActivity.CUDA)
 
+        for activity in self.activities:
+            if activity not in supported_activities():
+                warn("Unsupported profiler activity specified (" + str(activity) + ")")
+        self.activities = self.activities.intersection(supported_activities())
         assert len(self.activities) > 0, "No profiler activities specified"
-        assert (ProfilerActivity.CUDA not in self.activities) or torch.cuda.is_available(), \
-            "CUDA activity specified, but CUDA is not available"
 
         if schedule:
             self.schedule = schedule
@@ -385,11 +395,11 @@ class profile(object):
             with_stack=self.with_stack,
             use_kineto=True,
         )
-        self.profiler._prepare_kineto_trace()
+        self.profiler._prepare_trace()
 
     def _start_trace(self):
         assert self.profiler is not None
-        self.profiler._start_kineto_trace()
+        self.profiler._start_trace()
 
     def _stop_trace(self):
         assert self.profiler is not None


### PR DESCRIPTION
Summary:
Add an ability to use new profiler API even if Kineto is not compiled
in, by falling back to the legacy profiler.

Test Plan:
compiled
USE_KINETO=0 USE_CUDA=1 USE_MKLDNN=1 BLAS=MKL BUILD_BINARY=1 python
setup.py develop install --cmake
and with USE_KINETO=1
and ran
python test/test_profiler.py -v
