### PR TITLE
Speedup render_junit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -374,6 +374,8 @@ jobs:
           set -eux
           pip install -r requirements.txt
           pip install mypy==0.812
+          # Needed to check tools/render_junit.py
+          pip install junitparser rich
       - name: Run autogen
         run: |
           set -eux

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -46,7 +46,6 @@ files =
     tools/print_test_stats.py,
     tools/pyi,
     tools/stats_utils,
-    tools/render_junit.py,
     tools/test_history.py,
     tools/test/test_extract_scripts.py,
     tools/test/test_mypy_wrapper.py,

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -46,6 +46,7 @@ files =
     tools/print_test_stats.py,
     tools/pyi,
     tools/stats_utils,
+    tools/render_junit.py,
     tools/test_history.py,
     tools/test/test_extract_scripts.py,
     tools/test/test_mypy_wrapper.py,

--- a/mypy.ini
+++ b/mypy.ini
@@ -36,6 +36,7 @@ files =
     tools/clang_format_utils.py,
     tools/clang_tidy.py,
     tools/generate_torch_version.py,
+    tools/render_junit.py,
     tools/stats_utils
 
 #


### PR DESCRIPTION
JUnitXml.__iadd__() is very slow
But since testsuites are flattened anyway in
`convert_junit_to_testcases` concatenate flattened tests right away

As result, parsing test-reports folder with 393 files and 25+ test cases
takes .5 sec instead of 193 sec

Fix typing errors and add script to mypy-strict

Print warning, rather than abort if xml can not be parsed
