### PR TITLE
[PyTorch] Autoformat c10, round 2

### DIFF
--- a/c10/util/DeadlockDetection.cpp
+++ b/c10/util/DeadlockDetection.cpp
@@ -8,7 +8,8 @@ PythonGILHooks* python_gil_hooks = nullptr;
 }
 
 bool check_python_gil() {
-  if (!python_gil_hooks) return false;
+  if (!python_gil_hooks)
+    return false;
   return python_gil_hooks->check_python_gil();
 }
 

--- a/c10/util/DeadlockDetection.h
+++ b/c10/util/DeadlockDetection.h
@@ -7,8 +7,8 @@
 /// as the GIL is a wide ranging lock that is taken out in many situations.
 /// The basic strategy is before performing an operation that may block, you
 /// can use TORCH_ASSERT_NO_GIL_WITHOUT_PYTHON_DEP() to assert that the GIL is
-/// not held.  This macro is to be used in contexts where no static dependency on
-/// Python is available (we will handle indirecting a virtual call for you).
+/// not held.  This macro is to be used in contexts where no static dependency
+/// on Python is available (we will handle indirecting a virtual call for you).
 ///
 /// If the GIL is held by a torchdeploy interpreter, we always report false.
 /// If you are in a context where Python bindings are available, it's better
@@ -18,7 +18,9 @@
 namespace c10 {
 
 #define TORCH_ASSERT_NO_GIL_WITHOUT_PYTHON_DEP() \
-  TORCH_INTERNAL_ASSERT(!c10::impl::check_python_gil(), "Holding GIL before a blocking operation!  Please release the GIL before blocking, or see https://github.com/pytorch/pytorch/issues/56297 for how to release the GIL for destructors of objects")
+  TORCH_INTERNAL_ASSERT(                         \
+      !c10::impl::check_python_gil(),            \
+      "Holding GIL before a blocking operation!  Please release the GIL before blocking, or see https://github.com/pytorch/pytorch/issues/56297 for how to release the GIL for destructors of objects")
 
 namespace impl {
 

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -1,11 +1,11 @@
-#include <c10/util/Exception.h>
 #include <c10/util/Backtrace.h>
-#include <c10/util/Type.h>
+#include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
+#include <c10/util/Type.h>
 
 #include <iostream>
-#include <sstream>
 #include <numeric>
+#include <sstream>
 #include <string>
 
 namespace c10 {
@@ -78,21 +78,39 @@ void Error::add_context(std::string new_msg) {
 
 namespace detail {
 
-void torchCheckFail(const char *func, const char *file, uint32_t line, const std::string& msg) {
+void torchCheckFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const std::string& msg) {
   throw ::c10::Error({func, file, line}, msg);
 }
 
-void torchCheckFail(const char *func, const char *file, uint32_t line, const char* msg) {
+void torchCheckFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* msg) {
   throw ::c10::Error({func, file, line}, msg);
 }
 
-void torchInternalAssertFail(const char *func, const char *file, uint32_t line, const char* condMsg, const char* userMsg) {
+void torchInternalAssertFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* condMsg,
+    const char* userMsg) {
   torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
 }
 
 // This should never be called. It is provided in case of compilers
 // that don't do any dead code stripping in debug builds.
-void torchInternalAssertFail(const char *func, const char *file, uint32_t line, const char* condMsg, const std::string& userMsg) {
+void torchInternalAssertFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* condMsg,
+    const std::string& userMsg) {
   torchCheckFail(func, file, line, c10::str(condMsg, userMsg));
 }
 
@@ -101,45 +119,54 @@ void torchInternalAssertFail(const char *func, const char *file, uint32_t line, 
 namespace Warning {
 
 namespace {
-  WarningHandler* getBaseHandler() {
-    static WarningHandler base_warning_handler_ = WarningHandler();
-    return &base_warning_handler_;
-  };
+WarningHandler* getBaseHandler() {
+  static WarningHandler base_warning_handler_ = WarningHandler();
+  return &base_warning_handler_;
+};
 
-  class ThreadWarningHandler {
-    public:
-      ThreadWarningHandler() = delete;
+class ThreadWarningHandler {
+ public:
+  ThreadWarningHandler() = delete;
 
-      static WarningHandler* get_handler() {
-        if (!warning_handler_) {
-          warning_handler_ = getBaseHandler();
-        }
-        return warning_handler_;
-      }
+  static WarningHandler* get_handler() {
+    if (!warning_handler_) {
+      warning_handler_ = getBaseHandler();
+    }
+    return warning_handler_;
+  }
 
-      static void set_handler(WarningHandler* handler) {
-        warning_handler_ = handler;
-      }
+  static void set_handler(WarningHandler* handler) {
+    warning_handler_ = handler;
+  }
 
-    private:
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-      static thread_local WarningHandler* warning_handler_;
-  };
-
+ private:
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  thread_local WarningHandler* ThreadWarningHandler::warning_handler_ = nullptr;
+  static thread_local WarningHandler* warning_handler_;
+};
 
-}
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+thread_local WarningHandler* ThreadWarningHandler::warning_handler_ = nullptr;
 
-void warn(const SourceLocation& source_location, const std::string& msg, const bool verbatim) {
+} // namespace
+
+void warn(
+    const SourceLocation& source_location,
+    const std::string& msg,
+    const bool verbatim) {
   ThreadWarningHandler::get_handler()->process(source_location, msg, verbatim);
 }
 
-void warn(SourceLocation source_location, detail::CompileTimeEmptyString msg, const bool verbatim) {
+void warn(
+    SourceLocation source_location,
+    detail::CompileTimeEmptyString msg,
+    const bool verbatim) {
   warn(source_location, "", verbatim);
 }
 
-void warn(SourceLocation source_location, const char* msg, const bool verbatim) {
+void warn(
+    SourceLocation source_location,
+    const char* msg,
+    const bool verbatim) {
   ThreadWarningHandler::get_handler()->process(source_location, msg, verbatim);
 }
 
@@ -155,11 +182,11 @@ WarningHandler* get_warning_handler() noexcept(true) {
 bool warn_always = false;
 
 void set_warnAlways(bool setting) noexcept(true) {
-    warn_always = setting;
+  warn_always = setting;
 }
 
 bool get_warnAlways() noexcept(true) {
-    return warn_always;
+  return warn_always;
 }
 
 } // namespace Warning
@@ -171,7 +198,6 @@ void WarningHandler::process(
   LOG_AT_FILE_LINE(WARNING, source_location.file, source_location.line)
       << "Warning: " << msg << " (function " << source_location.function << ")";
 }
-
 
 std::string GetExceptionString(const std::exception& e) {
 #ifdef __GXX_RTTI

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -2,8 +2,8 @@
 #define C10_UTIL_EXCEPTION_H_
 
 #include <c10/macros/Macros.h>
-#include <c10/util/StringUtil.h>
 #include <c10/util/Deprecated.h>
+#include <c10/util/StringUtil.h>
 
 #include <cstddef>
 #include <exception>
@@ -69,10 +69,7 @@ class C10_API Error : public std::exception {
       const void* caller = nullptr);
 
   // Base constructor
-  Error(
-      std::string msg,
-      std::string backtrace,
-      const void* caller = nullptr);
+  Error(std::string msg, std::string backtrace, const void* caller = nullptr);
 
   // Add some new context to the message stack.  The last added context
   // will be formatted at the end of the context list upon printing.
@@ -116,7 +113,7 @@ class C10_API Error : public std::exception {
 };
 
 class C10_API WarningHandler {
-  public:
+ public:
   virtual ~WarningHandler() noexcept(false) {}
   /// The default warning handler. Prints the message to stderr.
   virtual void process(
@@ -142,13 +139,16 @@ namespace Warning {
 
 /// Issue a warning with a given message. Dispatched to the current
 /// warning handler.
-C10_API void warn(const SourceLocation& source_location,
+C10_API void warn(
+    const SourceLocation& source_location,
     const std::string& msg,
     bool verbatim);
-C10_API void warn(SourceLocation source_location,
+C10_API void warn(
+    SourceLocation source_location,
     const char* msg,
     bool verbatim);
-C10_API void warn(SourceLocation source_location,
+C10_API void warn(
+    SourceLocation source_location,
     ::c10::detail::CompileTimeEmptyString msg,
     bool verbatim);
 /// Sets the global warning handler. This is not thread-safe, so it should
@@ -213,15 +213,16 @@ C10_API std::string GetExceptionString(const std::exception& e);
 
 // Private helper macro for implementing TORCH_INTERNAL_ASSERT and TORCH_CHECK
 //
-// Note: In the debug build With MSVC, __LINE__ might be of long type (a.k.a int32_t),
-// which is different from the definition of `SourceLocation` that requires
-// unsigned int (a.k.a uint32_t) and may cause a compile error with the message:
-// error C2397: conversion from 'long' to 'uint32_t' requires a narrowing conversion
-// Here the static cast is used to pass the build.
-// if this is used inside a lambda the __func__ macro expands to operator(),
-// which isn't very useful, but hard to fix in a macro so suppressing the warning.
+// Note: In the debug build With MSVC, __LINE__ might be of long type (a.k.a
+// int32_t), which is different from the definition of `SourceLocation` that
+// requires unsigned int (a.k.a uint32_t) and may cause a compile error with the
+// message: error C2397: conversion from 'long' to 'uint32_t' requires a
+// narrowing conversion Here the static cast is used to pass the build. if this
+// is used inside a lambda the __func__ macro expands to operator(), which isn't
+// very useful, but hard to fix in a macro so suppressing the warning.
 #define C10_THROW_ERROR(err_type, msg) \
-  throw ::c10::err_type({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, msg)
+  throw ::c10::err_type(               \
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, msg)
 
 // Private helper macro for workaround MSVC misexpansion of nested macro
 // invocations involving __VA_ARGS__.  See
@@ -231,13 +232,14 @@ C10_API std::string GetExceptionString(const std::exception& e);
 // On nvcc, C10_UNLIKELY thwarts missing return statement analysis.  In cases
 // where the unlikely expression may be a constant, use this macro to ensure
 // return statement analysis keeps working (at the cost of not getting the
-// likely/unlikely annotation on nvcc). https://github.com/pytorch/pytorch/issues/21418
+// likely/unlikely annotation on nvcc).
+// https://github.com/pytorch/pytorch/issues/21418
 //
 // Currently, this is only used in the error reporting macros below.  If you
 // want to use it more generally, move me to Macros.h
 //
-// TODO: Brian Vaughan observed that we might be able to get this to work on nvcc
-// by writing some sort of C++ overload that distinguishes constexpr inputs
+// TODO: Brian Vaughan observed that we might be able to get this to work on
+// nvcc by writing some sort of C++ overload that distinguishes constexpr inputs
 // from non-constexpr.  Since there isn't any evidence that losing C10_UNLIKELY
 // in nvcc is causing us perf problems, this is not yet implemented, but this
 // might be an interesting piece of C++ code for an intrepid bootcamper to
@@ -248,7 +250,6 @@ C10_API std::string GetExceptionString(const std::exception& e);
 #define C10_UNLIKELY_OR_CONST(e) C10_UNLIKELY(e)
 #endif
 
-
 // ----------------------------------------------------------------------------
 // Error reporting macros
 // ----------------------------------------------------------------------------
@@ -256,10 +257,10 @@ C10_API std::string GetExceptionString(const std::exception& e);
 #ifdef STRIP_ERROR_MESSAGES
 #define TORCH_RETHROW(e, ...) throw
 #else
-#define TORCH_RETHROW(e, ...)      \
-  do { \
+#define TORCH_RETHROW(e, ...)               \
+  do {                                      \
     e.add_context(::c10::str(__VA_ARGS__)); \
-    throw; \
+    throw;                                  \
   } while (false)
 #endif
 
@@ -286,7 +287,9 @@ C10_API std::string GetExceptionString(const std::exception& e);
 #define TORCH_INTERNAL_ASSERT(cond, ...)                            \
   if (C10_UNLIKELY_OR_CONST(!(cond))) {                             \
     ::c10::detail::torchCheckFail(                                  \
-        __func__, __FILE__, static_cast<uint32_t>(__LINE__),        \
+        __func__,                                                   \
+        __FILE__,                                                   \
+        static_cast<uint32_t>(__LINE__),                            \
         #cond "INTERNAL ASSERT FAILED at" C10_STRINGIZE(__FILE__)); \
   }
 #else
@@ -295,16 +298,16 @@ C10_API std::string GetExceptionString(const std::exception& e);
 // as the first argument, but there doesn't seem to be any good way to
 // do that while still supporting having a first argument that isn't a
 // string literal.
-#define TORCH_INTERNAL_ASSERT(cond, ...)                     \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {                      \
-    ::c10::detail::torchInternalAssertFail(                  \
-        __func__, __FILE__, static_cast<uint32_t>(__LINE__), \
-        #cond "INTERNAL ASSERT FAILED at "                   \
-        C10_STRINGIZE(__FILE__)                              \
-        ":"                                                  \
-        C10_STRINGIZE(__LINE__)                              \
-        ", please report a bug to PyTorch. ",                \
-        c10::str(__VA_ARGS__));                              \
+#define TORCH_INTERNAL_ASSERT(cond, ...)                                        \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                                         \
+    ::c10::detail::torchInternalAssertFail(                                     \
+        __func__,                                                               \
+        __FILE__,                                                               \
+        static_cast<uint32_t>(__LINE__),                                        \
+        #cond                                                                   \
+        "INTERNAL ASSERT FAILED at " C10_STRINGIZE(__FILE__) ":" C10_STRINGIZE( \
+            __LINE__) ", please report a bug to PyTorch. ",                     \
+        c10::str(__VA_ARGS__));                                                 \
   }
 #endif
 
@@ -332,19 +335,16 @@ C10_API std::string GetExceptionString(const std::exception& e);
   TORCH_CHECK_WITH_MSG(error_t, cond, "", __VA_ARGS__)
 
 #ifdef STRIP_ERROR_MESSAGES
-#define TORCH_CHECK_MSG(cond, type, ...)                \
-  (#cond #type " CHECK FAILED at "                      \
-   C10_STRINGIZE(__FILE__))
-#define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)     \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {                    \
-    C10_THROW_ERROR(Error,                                 \
-        TORCH_CHECK_MSG(cond, type, __VA_ARGS__)           \
-    );                                                     \
+#define TORCH_CHECK_MSG(cond, type, ...) \
+  (#cond #type " CHECK FAILED at " C10_STRINGIZE(__FILE__))
+#define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)                \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                               \
+    C10_THROW_ERROR(Error, TORCH_CHECK_MSG(cond, type, __VA_ARGS__)); \
   }
 #else
 namespace c10 {
 namespace detail {
-template<typename... Args>
+template <typename... Args>
 decltype(auto) torchCheckMsgImpl(const char* msg, const Args&... args) {
   return ::c10::str(args...);
 }
@@ -352,64 +352,93 @@ inline C10_API const char* torchCheckMsgImpl(const char* msg) {
   return msg;
 }
 // If there is just 1 user-provided C-string argument, use it.
-inline C10_API const char* torchCheckMsgImpl(const char* msg, const char* args) {
+inline C10_API const char* torchCheckMsgImpl(
+    const char* msg,
+    const char* args) {
   return args;
 }
 } // namespace detail
 } // namespace c10
 
-#define TORCH_CHECK_MSG(cond, type, ...)                                \
-  (::c10::detail::torchCheckMsgImpl(                                    \
-      "Expected " #cond " to be true, but got false.  "                 \
-      "(Could this error message be improved?  If so, "                 \
-      "please report an enhancement request to PyTorch.)", ##__VA_ARGS__))
-#define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)                \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {                               \
-    C10_THROW_ERROR(error_t,                                          \
-        TORCH_CHECK_MSG(cond, type, __VA_ARGS__)                      \
-    );                                                                \
+#define TORCH_CHECK_MSG(cond, type, ...)                   \
+  (::c10::detail::torchCheckMsgImpl(                       \
+      "Expected " #cond                                    \
+      " to be true, but got false.  "                      \
+      "(Could this error message be improved?  If so, "    \
+      "please report an enhancement request to PyTorch.)", \
+      ##__VA_ARGS__))
+#define TORCH_CHECK_WITH_MSG(error_t, cond, type, ...)                  \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {                                 \
+    C10_THROW_ERROR(error_t, TORCH_CHECK_MSG(cond, type, __VA_ARGS__)); \
   }
 #endif
 
 namespace c10 {
 namespace detail {
 
-[[noreturn]] C10_API void torchCheckFail(const char *func, const char *file, uint32_t line, const std::string& msg);
-[[noreturn]] C10_API void torchCheckFail(const char *func, const char *file, uint32_t line, const char* msg);
+[[noreturn]] C10_API void torchCheckFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const std::string& msg);
+[[noreturn]] C10_API void torchCheckFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* msg);
 
 // The c10::str() call that creates userMsg can have 1 of 3 return
 // types depending on the number and types of arguments passed to
 // TORCH_INTERNAL_ASSERT.  0 arguments will get a
 // CompileTimeEmptyString, 1 const char * will be passed straight
 // through, and anything else will get converted to std::string.
-[[noreturn]] C10_API void torchInternalAssertFail(const char *func, const char *file, uint32_t line, const char* condMsg, const char* userMsg);
-[[noreturn]] inline C10_API void torchInternalAssertFail(const char *func, const char *file, uint32_t line, const char* condMsg, ::c10::detail::CompileTimeEmptyString userMsg) {
+[[noreturn]] C10_API void torchInternalAssertFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* condMsg,
+    const char* userMsg);
+[[noreturn]] inline C10_API void torchInternalAssertFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* condMsg,
+    ::c10::detail::CompileTimeEmptyString userMsg) {
   torchCheckFail(func, file, line, condMsg);
 }
-[[noreturn]] C10_API void torchInternalAssertFail(const char *func, const char *file, uint32_t line, const char* condMsg, const std::string& userMsg);
+[[noreturn]] C10_API void torchInternalAssertFail(
+    const char* func,
+    const char* file,
+    uint32_t line,
+    const char* condMsg,
+    const std::string& userMsg);
 
 } // namespace detail
 } // namespace c10
 
 #ifdef STRIP_ERROR_MESSAGES
-#define TORCH_CHECK(cond, ...)                                          \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {                                 \
-    ::c10::detail::torchCheckFail(                                      \
-        __func__, __FILE__, static_cast<uint32_t>(__LINE__),            \
-        TORCH_CHECK_MSG(cond, "", __VA_ARGS__));                        \
+#define TORCH_CHECK(cond, ...)                   \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {          \
+    ::c10::detail::torchCheckFail(               \
+        __func__,                                \
+        __FILE__,                                \
+        static_cast<uint32_t>(__LINE__),         \
+        TORCH_CHECK_MSG(cond, "", __VA_ARGS__)); \
   }
 #else
-#define TORCH_CHECK(cond, ...)                                          \
-  if (C10_UNLIKELY_OR_CONST(!(cond))) {                                 \
-    ::c10::detail::torchCheckFail(                                      \
-        __func__, __FILE__, static_cast<uint32_t>(__LINE__),            \
-        TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__));                      \
+#define TORCH_CHECK(cond, ...)                     \
+  if (C10_UNLIKELY_OR_CONST(!(cond))) {            \
+    ::c10::detail::torchCheckFail(                 \
+        __func__,                                  \
+        __FILE__,                                  \
+        static_cast<uint32_t>(__LINE__),           \
+        TORCH_CHECK_MSG(cond, "", ##__VA_ARGS__)); \
   }
 #endif
 
-// An utility macro that does what `TORCH_CHECK` does if compiled in the host code,
-// otherwise does nothing. Supposed to be used in the code shared between host and
-// device code as an alternative for `TORCH_CHECK`.
+// An utility macro that does what `TORCH_CHECK` does if compiled in the host
+// code, otherwise does nothing. Supposed to be used in the code shared between
+// host and device code as an alternative for `TORCH_CHECK`.
 #if defined(__CUDACC__) || defined(__HIPCC__)
 #define TORCH_CHECK_IF_NOT_ON_CUDA(cond, ...)
 #else
@@ -453,98 +482,120 @@ namespace detail {
 // arguments which are concatenated into the warning message using operator<<
 //
 #ifdef STRIP_ERROR_MESSAGES
-#define TORCH_WARN(...) \
-  ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::detail::CompileTimeEmptyString{}, false)
+#define TORCH_WARN(...)                                      \
+  ::c10::Warning::warn(                                      \
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+      ::c10::detail::CompileTimeEmptyString{},               \
+      false)
 #else
-#define TORCH_WARN(...) \
-  ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__), false)
+#define TORCH_WARN(...)                                      \
+  ::c10::Warning::warn(                                      \
+      {__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, \
+      ::c10::str(__VA_ARGS__),                               \
+      false)
 #endif
 
 // Report a warning to the user only once.  Accepts an arbitrary number of extra
 // arguments which are concatenated into the warning message using operator<<
 //
 #ifdef STRIP_ERROR_MESSAGES
-#define _TORCH_WARN_ONCE(...) \
-  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [&] { \
-    ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::detail::CompileTimeEmptyString{}, false); \
-    return true; \
-  }()
+#define _TORCH_WARN_ONCE(...)                                             \
+  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = \
+      [&] {                                                               \
+        ::c10::Warning::warn(                                             \
+            {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},        \
+            ::c10::detail::CompileTimeEmptyString{},                      \
+            false);                                                       \
+        return true;                                                      \
+      }()
 #else
-#define _TORCH_WARN_ONCE(...) \
-  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = [&] { \
-    ::c10::Warning::warn({__func__, __FILE__, static_cast<uint32_t>(__LINE__)}, ::c10::str(__VA_ARGS__), false); \
-    return true; \
-  }()
+#define _TORCH_WARN_ONCE(...)                                             \
+  C10_UNUSED static const auto C10_ANONYMOUS_VARIABLE(torch_warn_once_) = \
+      [&] {                                                               \
+        ::c10::Warning::warn(                                             \
+            {__func__, __FILE__, static_cast<uint32_t>(__LINE__)},        \
+            ::c10::str(__VA_ARGS__),                                      \
+            false);                                                       \
+        return true;                                                      \
+      }()
 #endif
 
-#define TORCH_WARN_ONCE(...) \
+#define TORCH_WARN_ONCE(...)              \
   if (::c10::Warning::get_warnAlways()) { \
-    TORCH_WARN(__VA_ARGS__); \
-  } else { \
-    _TORCH_WARN_ONCE(__VA_ARGS__); \
+    TORCH_WARN(__VA_ARGS__);              \
+  } else {                                \
+    _TORCH_WARN_ONCE(__VA_ARGS__);        \
   }
 
 // ----------------------------------------------------------------------------
 // Deprecated macros
 // ----------------------------------------------------------------------------
 
-namespace c10 { namespace detail {
+namespace c10 {
+namespace detail {
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-C10_DEPRECATED_MESSAGE("AT_ERROR(msg) is deprecated, use TORCH_CHECK(false, msg) instead.")
+C10_DEPRECATED_MESSAGE("AT_ERROR(msg) is deprecated, use TORCH_CHECK(false, msg)
+instead.")
 */
 inline void deprecated_AT_ERROR() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-C10_DEPRECATED_MESSAGE("AT_ASSERT is deprecated, if you mean to indicate an internal invariant failure, use " \
-                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
+C10_DEPRECATED_MESSAGE("AT_ASSERT is deprecated, if you mean to indicate an
+internal invariant failure, use " \
+                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user
+error checking, use " \ "TORCH_CHECK.  See
+https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERT() {}
 
 /*
 // Deprecation disabled until we fix sites in our codebase
-C10_DEPRECATED_MESSAGE("AT_ASSERTM is deprecated, if you mean to indicate an internal invariant failure, use " \
-                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user error checking, use " \
-                       "TORCH_CHECK.  See https://github.com/pytorch/pytorch/issues/20287 for more details.")
+C10_DEPRECATED_MESSAGE("AT_ASSERTM is deprecated, if you mean to indicate an
+internal invariant failure, use " \
+                       "TORCH_INTERNAL_ASSERT instead; if you mean to do user
+error checking, use " \ "TORCH_CHECK.  See
+https://github.com/pytorch/pytorch/issues/20287 for more details.")
 */
 inline void deprecated_AT_ASSERTM() {}
 
-}} // namespace c10::detail
+} // namespace detail
+} // namespace c10
 
 // Deprecated alias; this alias was deprecated because people kept mistakenly
 // using it for user error checking.  Use TORCH_INTERNAL_ASSERT or TORCH_CHECK
-// instead. See https://github.com/pytorch/pytorch/issues/20287 for more details.
+// instead. See https://github.com/pytorch/pytorch/issues/20287 for more
+// details.
 #define AT_ASSERT(...)                                              \
   do {                                                              \
     ::c10::detail::deprecated_AT_ASSERT();                          \
     C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(__VA_ARGS__)); \
   } while (false)
 
-// Deprecated alias, like AT_ASSERT.  The new TORCH_INTERNAL_ASSERT macro supports
-// both 0-ary and variadic calls, so having a separate message-accepting macro
-// is not necessary.
+// Deprecated alias, like AT_ASSERT.  The new TORCH_INTERNAL_ASSERT macro
+// supports both 0-ary and variadic calls, so having a separate
+// message-accepting macro is not necessary.
 //
 // NB: we MUST include cond explicitly here, as MSVC will miscompile the macro
 // expansion, shunting all of __VA_ARGS__ to cond.  An alternate workaround
 // can be seen at
 // https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
-#define AT_ASSERTM(cond, ...)                                                 \
-  do {                                                                        \
-    ::c10::detail::deprecated_AT_ASSERTM();                                   \
-    C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(cond, __VA_ARGS__));     \
+#define AT_ASSERTM(cond, ...)                                             \
+  do {                                                                    \
+    ::c10::detail::deprecated_AT_ASSERTM();                               \
+    C10_EXPAND_MSVC_WORKAROUND(TORCH_INTERNAL_ASSERT(cond, __VA_ARGS__)); \
   } while (false)
 
 // Deprecated alias; this alias was deprecated because it represents extra API
 // surface that makes it hard for people to understand what macro to use.
 // Use TORCH_CHECK(false, ...) or TORCH_INTERNAL_ASSERT(false, ...) to
 // unconditionally fail at a line of code.
-#define AT_ERROR(...)                                                         \
-  do {                                                                        \
-    ::c10::detail::deprecated_AT_ERROR();                                     \
-    C10_EXPAND_MSVC_WORKAROUND(TORCH_CHECK(false, ::c10::str(__VA_ARGS__)));  \
+#define AT_ERROR(...)                                                        \
+  do {                                                                       \
+    ::c10::detail::deprecated_AT_ERROR();                                    \
+    C10_EXPAND_MSVC_WORKAROUND(TORCH_CHECK(false, ::c10::str(__VA_ARGS__))); \
   } while (false)
 
 #endif // C10_UTIL_EXCEPTION_H_


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57645 [PyTorch] Autoformat c10, round 2**

Second round of autoformatting changes since the first pass became too large.

Differential Revision: [D28131430](https://our.internmc.facebook.com/intern/diff/D28131430/)