### PR TITLE
[package] fix corner case in PacakgeImporter.whichmodule

### DIFF
--- a/test/package/test_importer.py
+++ b/test/package/test_importer.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+import torch
 from torch.package import (
     Importer,
     OrderedImporter,
@@ -115,6 +116,39 @@ class TestImporter(PackageTestCase):
 
         notfound_then_foo = OrderedImporter(dummy_importer_not_found, dummy_importer_foo)
         self.assertEqual(notfound_then_foo.whichmodule(DummyClass(), ""), "foo")
+
+    def test_package_importer_whichmodule_no_dunder_module(self):
+        """Exercise corner case where we try to pickle an object whose
+        __module__ doesn't exist because it's from a C extension.
+        """
+        # torch.float16 is an example of such an object: it is a C extension
+        # type for which there is no __module__ defined. The default pickler
+        # finds it using special logic to traverse sys.modules and look up
+        # `float16` on each module (see pickle.py:whichmodule).
+        #
+        # We must ensure that we emulate the same behavior from PackageImporter.
+        my_dtype = torch.float16
+
+        # Set up a PackageImporter which has a torch.float16 object pickled:
+        buffer = BytesIO()
+        with PackageExporter(buffer, verbose=False) as exporter:
+            exporter.save_pickle("foo", "foo.pkl", my_dtype)
+        buffer.seek(0)
+
+        importer = PackageImporter(buffer)
+        my_loaded_dtype = importer.load_pickle("foo", "foo.pkl")
+
+        # Re-save a package with only our PackageImporter as the importer
+        buffer2 = BytesIO()
+        with PackageExporter(buffer2, verbose=False, importer=importer) as exporter:
+            exporter.save_pickle("foo", "foo.pkl", my_loaded_dtype)
+
+        buffer2.seek(0)
+
+        importer2 = PackageImporter(buffer2)
+        my_loaded_dtype2 = importer2.load_pickle("foo", "foo.pkl")
+        self.assertIs(my_dtype, my_loaded_dtype)
+        self.assertIs(my_dtype, my_loaded_dtype2)
 
 
 if __name__ == "__main__":

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from pickle import _getattribute, _Pickler  # type: ignore[attr-defined]
 from pickle import whichmodule as _pickle_whichmodule  # type: ignore[attr-defined]
 from types import ModuleType
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Dict
 
 from ._mangling import demangle, get_mangle_prefix, is_mangled
 
@@ -40,6 +40,7 @@ class Importer(ABC):
         obj2 = getattr(module, obj_name)
         assert obj1 is obj2
     """
+    modules: Dict[str, ModuleType]
 
     @abstractmethod
     def import_module(self, module_name: str) -> ModuleType:
@@ -141,8 +142,23 @@ class Importer(ABC):
         module_name = getattr(obj, "__module__", None)
         if module_name is not None:
             return module_name
-        else:
-            return "__main__"
+
+        # Protect the iteration by using a list copy of self.modules against dynamic
+        # modules that trigger imports of other modules upon calls to getattr.
+        for module_name, module in self.modules.copy().items():
+            if (
+                module_name == "__main__"
+                or module_name == "__mp_main__"  # bpo-42406
+                or module is None
+            ):
+                continue
+            try:
+                if _getattribute(module, name)[0] is obj:
+                    return module_name
+            except AttributeError:
+                pass
+
+        return "__main__"
 
 
 class _SysImporter(Importer):

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -44,7 +44,7 @@ class PackageImporter(Importer):
     """The dictionary of already loaded modules from this package, equivalent to `sys.modules` but
     local to this importer.
     """
-    modules: Dict[str, Optional[types.ModuleType]]
+    modules: Dict[str, types.ModuleType]
 
     def __init__(
         self,
@@ -343,7 +343,7 @@ class PackageImporter(Importer):
                 return self.modules[name]
             parent_module = self.modules[parent]
             try:
-                path = parent_module.__path__  # type: ignore[union-attr]
+                path = parent_module.__path__  # type: ignore[attr-defined]
             except AttributeError:
                 msg = (_ERR_MSG + "; {!r} is not a package").format(name, parent)
                 raise ModuleNotFoundError(msg, name=name) from None


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57651 [package] fix corner case in PacakgeImporter.whichmodule**

We've gone back and forth on whether to emulate the `sys.modules` lookup
behavior in our own `whichmodule`, the provided test is a concrete case
for doing so.

An additional minor cleanup is to make the type of `self.modules` in
importers `Dict[str, ModuleType]`. Modules could only be None in the
dictionary in older versions of the import system

Differential Revision: [D28226536](https://our.internmc.facebook.com/intern/diff/D28226536)