### PR TITLE
model_dump: Handle torch.device objects

### DIFF
--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -156,6 +156,12 @@ def hierarchical_pickle(data):
             ls, = data.args
             assert isinstance(ls, list)
             return hierarchical_pickle(ls)
+        if typename == "torch.device":
+            assert data.state is None
+            name, = data.args
+            assert isinstance(name, str)
+            # Just forget that it was a device and return the name.
+            return name
         raise Exception(f"Can't prepare fake object of type for JS: {typename}")
     raise Exception(f"Can't prepare data of type for JS: {type(data)}")
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57661 show_pickle/model_dump: Handle invalid UTF-8 in pickles
* #57660 model_dump: Accept variable-length debug info
* #57659 model_dump: Use DumpUnpickler.load instead of .dump
* #57658 model_dump: Add a section that summarizes tensor memory usage
* #57657 model_dump: Handle dict rendering
* **#57656 model_dump: Handle torch.device objects**
* #57655 model_dump: Refactor renderTensor into a helper method
* #57654 model_dump: Implement "Hider" properly

Summary:
This came up when dumping a CUDA model.

Test Plan:
Dumped a CUDA model.

Differential Revision: [D28531396](https://our.internmc.facebook.com/intern/diff/D28531396)