### PR TITLE
model_dump: Use DumpUnpickler.load instead of .dump

### DIFF
--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -210,7 +210,7 @@ def get_model_info(
         version = zf.read(path_prefix + "/version").decode("utf-8").strip()
 
         with zf.open(path_prefix + "/data.pkl") as handle:
-            raw_model_data = torch.utils.show_pickle.DumpUnpickler.dump(handle, out_stream=io.StringIO())
+            raw_model_data = torch.utils.show_pickle.DumpUnpickler(handle).load()
             model_data = hierarchical_pickle(raw_model_data)
 
         # Intern strings that are likely to be re-used.
@@ -288,7 +288,7 @@ def get_model_info(
                 # TODO: handle errors here and just ignore the file?
                 # NOTE: For a lot of these files (like bytecode),
                 # we could get away with just unpickling, but this should be safer.
-                obj = torch.utils.show_pickle.DumpUnpickler.dump(handle, out_stream=io.StringIO())
+                obj = torch.utils.show_pickle.DumpUnpickler(handle).load()
             buf = io.StringIO()
             pprint.pprint(obj, buf)
             contents = buf.getvalue()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57661 show_pickle/model_dump: Handle invalid UTF-8 in pickles
* #57660 model_dump: Accept variable-length debug info
* **#57659 model_dump: Use DumpUnpickler.load instead of .dump**
* #57658 model_dump: Add a section that summarizes tensor memory usage
* #57657 model_dump: Handle dict rendering
* #57656 model_dump: Handle torch.device objects
* #57655 model_dump: Refactor renderTensor into a helper method
* #57654 model_dump: Implement "Hider" properly

Summary:
Faster since we don't do an automatic pprint, and shorter, simpler code.

Test Plan:
Dumped some models.

Differential Revision: [D28531398](https://our.internmc.facebook.com/intern/diff/D28531398)