### PR TITLE
model_dump: Accept variable-length debug info

### DIFF
--- a/torch/utils/model_dump/__init__.py
+++ b/torch/utils/model_dump/__init__.py
@@ -246,8 +246,7 @@ def get_model_info(
 
             code_parts = []
             for di, di_next in zip(debug_info, debug_info[1:]):
-                # accounting for source range serialization format change
-                start, source_range, _ = di
+                start, source_range, *_ = di
                 end = di_next[0]
                 assert end > start
                 source, s_start, s_end = source_range


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57661 show_pickle/model_dump: Handle invalid UTF-8 in pickles
* **#57660 model_dump: Accept variable-length debug info**
* #57659 model_dump: Use DumpUnpickler.load instead of .dump
* #57658 model_dump: Add a section that summarizes tensor memory usage
* #57657 model_dump: Handle dict rendering
* #57656 model_dump: Handle torch.device objects
* #57655 model_dump: Refactor renderTensor into a helper method
* #57654 model_dump: Implement "Hider" properly

Summary:
Ignore trailing elements so we're compatible with both old and new
models.

Test Plan:
Dumped and old model.  Unit test.

Differential Revision: [D28531391](https://our.internmc.facebook.com/intern/diff/D28531391)