### PR TITLE
[iOS GPU] Add Metal API availability check

### DIFF
--- a/aten/src/ATen/native/metal/MetalDevice.h
+++ b/aten/src/ATen/native/metal/MetalDevice.h
@@ -1,0 +1,47 @@
+#ifndef PYTORCH_MOBILE_METAL_DEVICE_H_
+#define PYTORCH_MOBILE_METAL_DEVICE_H_
+
+#import <Metal/Metal.h>
+
+#include <string>
+
+namespace at {
+namespace native {
+namespace metal {
+
+struct MetalDeviceInfo {
+  std::string name;
+  MTLLanguageVersion languageVersion;
+};
+
+static inline MetalDeviceInfo createDeviceInfo(id<MTLDevice> device) {
+  MetalDeviceInfo device_info;
+  device_info.name = device.name.UTF8String;
+  if (@available(macOS 11.0, iOS 14.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion2_3;
+  } else if (@available(macOS 10.15, iOS 13.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion2_2;
+  } else if (@available(macOS 10.14, iOS 12.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion2_1;
+  } else if (@available(macOS 10.13, iOS 11.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion2_0;
+  } else if (@available(macOS 10.12, iOS 10.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion1_2;
+  } else if (@available(macOS 10.11, iOS 9.0, *)) {
+    device_info.languageVersion = MTLLanguageVersion1_1;
+  }
+#if (                                                    \
+    defined(__IPHONE_9_0) &&                             \
+    __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0) || \
+    (defined(__MAC_10_11) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_11)
+#else
+#error "Metal is not available on the current platform."
+#endif
+  return device_info;
+}
+
+}
+}
+}
+
+#endif

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.h
@@ -3,6 +3,7 @@
 #import <MetalPerformanceShaders/MetalPerformanceShaders.h>
 
 API_AVAILABLE(ios(10.0), macos(10.13))
+// TODO[T79947194]: Convert this class to C++
 @interface MPSCNNContext : NSObject
 @property(nonatomic, strong, readonly) id<MTLDevice> device;
 @property(nonatomic, strong, readonly) id<MTLCommandQueue> commandQueue;

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
@@ -1,3 +1,4 @@
+#import <ATen/native/metal/MetalDevice.h>
 #import <ATen/native/metal/MetalShaders.h>
 #import <ATen/native/metal/mpscnn/MPSCNNContext.h>
 
@@ -11,8 +12,10 @@
 #import <Foundation/NSProcessInfo.h>
 #endif
 
+using namespace at::native::metal;
 @implementation MPSCNNContext {
   std::mutex _pipelineCacheMutex;
+  MetalDeviceInfo _deviceInfo;
   NSMutableDictionary<NSString*, id<MTLComputePipelineState>>* _pipelineCache;
 }
 
@@ -21,12 +24,10 @@
   static MPSCNNContext* instance = nil;
   dispatch_once(&onceToken, ^{
     instance = [[MPSCNNContext alloc] init];
-    instance->_device = MTLCreateSystemDefaultDevice();
-    NSError* compileError = nil;
-    instance->_library = [instance.device
-        newLibraryWithSource:[NSString stringWithUTF8String:PT_METAL_SHADERS]
-                     options:nil
-                       error:&compileError];
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    instance->_device = device;
+    instance->_deviceInfo = createDeviceInfo(device);
+    instance->_library = nil;
     instance->_commandQueue = [instance.device newCommandQueue];
     instance->_pipelineCache =
         [NSMutableDictionary<NSString*, id<MTLComputePipelineState>> new];
@@ -38,6 +39,7 @@
 #if !defined(__APPLE__)
   return false;
 #elif TARGET_IPHONE_SIMULATOR
+  // TODO[T90135707]: Enable Metal on iOS Simulators
   return false;
 #elif TARGET_OS_IPHONE
   if (!MPSSupportsMTLDevice(_device)) {
@@ -46,8 +48,7 @@
   if ([UIDevice currentDevice].systemVersion.floatValue < 10.2) {
     return false;
   }
-  if (![MTLCreateSystemDefaultDevice()
-          supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v2]) {
+  if (![_device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v2]) {
     return false;
   }
 #elif TARGET_OS_MAC
@@ -59,14 +60,15 @@
           isOperatingSystemAtLeastVersion:supportedVer]) {
     return false;
   }
-  if (![MTLCreateSystemDefaultDevice()
-          supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v3]) {
+  if (![_device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v3]) {
     return false;
   }
 #else
   return false;
 #endif
-
+  // Compile shader
+  NSError* error = [self compileProgram];
+  TORCH_CHECK(!error, error.localizedDescription.UTF8String);
   return _device && _library && _commandQueue;
 }
 
@@ -135,6 +137,32 @@
                               encoding:NSUTF8StringEncoding];
   _pipelineCache[kernel] = state;
   return state;
+}
+
+- (NSError*)compileProgram {
+  __block NSError* compilationError = nil;
+  // To ensure thread safety here.
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSError* localError = nil;
+    MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+    [options setLanguageVersion:_deviceInfo.languageVersion];
+    [options setFastMathEnabled:YES];
+    _library = [_device
+        newLibraryWithSource:[NSString stringWithUTF8String:PT_METAL_SHADERS]
+                     options:options
+                       error:&localError];
+    compilationError = localError;
+  });
+  return compilationError;
+}
+
+- (NSString*)description {
+  NSString* desc =
+      [NSString stringWithFormat:@"DeviceName: %s, LanguageVersion: %lu",
+                                 _deviceInfo.name.c_str(),
+                                 _deviceInfo.languageVersion];
+  return desc;
 }
 
 @end


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56076 [iOS GPU][MaskRCNN][Not For Landing] Run the maskrcnn model in playground
* #56075 [iOS GPU][Kernel][MaskRCNN] Implement RoIAlign in Metal shaders using Sampler
* #57668 [iOS GPU][perf][5/n] Replace std::vector with  IntArrayRef and SmallVector
* #57667 [iOS GPU][Perf][4/n] Reuse the same command buffer when copying results to CPU
* #57666 [iOS GPU][Perf][3/n] Cache the compuation pipeline state object
* #57665 [iOS GPU][Perf][2/n] Prepack linear + Fuse relu/hardtanh
* #57664 [iOS GPU][Perf][1/n] Use aten::contiguous instead of permuting weights manually
* **#57663 [iOS GPU] Add Metal API availability check**

Detail error messages when shader compilation fails.

Differential Revision: [D28177176](https://our.internmc.facebook.com/intern/diff/D28177176/)