### PR TITLE
Add missing return statement from 57057

### DIFF
--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -234,6 +234,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
         tensor = make_variable_non_differentiable_view(base, tensor);
       }
     }
+    return tensors;
   }
 
   c10::optional<ViewInfo> new_bw_info = c10::nullopt;


### PR DESCRIPTION
Fixes a bug introduced by #57057


cc @ailzhang while writing the tests, I realized that for these functions, we don't properly set the CreationMeta in no grad mode and Inference mode. Added a todo there.