### PR TITLE
Revert "Revert back to old assert behavior in as_view (#57499)"

### DIFF
--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -213,13 +213,8 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
   if ((!diff_view_meta || diff_view_meta->shared_view_info()) && is_bw_differentiable && is_fw_differentiable) {
     c10::optional<ViewInfo> new_shared_info;
     if (diff_view_meta) {
-      // TODO: fix fb internal use-case so that it doesn't trigger this internal assert when the base is not a view.
-      // For now, we only do that same (wrong) thing as the old code which is to only check when the inputs is a
-      // backward differentiable view
-      if (diff_view_meta->has_bw_view()) {
-        TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
-                              "Functions that result multiple view must have a creation meta reflecting this behavior.");
-      }
+      TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
+                            "Functions that result multiple view must have a creation meta reflecting this behavior.");
       creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
       const auto& base_bw_info = diff_view_meta->get_backward_view();
       new_shared_info = ViewInfo(base_bw_info.base_, /* view_func */ nullptr);
@@ -243,8 +238,6 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
     auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(base);
     if (diff_view_meta && diff_view_meta->has_bw_view()) {
       const auto& base_bw_info = diff_view_meta->get_backward_view();
-      // TODO: fix fb internal use-case so that it doesn't trigger this internal assert when the base is not a view.
-      // In this code, the assert should be outside of the if statement.
       TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
                             "Functions that result multiple view must have a creation meta reflecting this behavior.");
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are


### PR DESCRIPTION
This reverts commit b3c0ef4a400e4d7e1c1c0e76c739cb503105accf.

I though it would solve some assert issue for internal workloads but that is not the case.
https://github.com/pytorch/pytorch/pull/57669 is a more probable candidate.