### PR TITLE
Share VS Code settings/extensions nicely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,8 +257,10 @@ cmake-build-debug
 # Below files are not deleted by "setup.py clean".
 
 # Visual Studio Code files
-/.vscode/settings.json
 .vs
+/.vscode/*
+!/.vscode/extensions.json
+!/.vscode/settings_recommended.json
 
 # YouCompleteMe config file
 .ycm_extra_conf.py

--- a/.gitignore
+++ b/.gitignore
@@ -257,7 +257,7 @@ cmake-build-debug
 # Below files are not deleted by "setup.py clean".
 
 # Visual Studio Code files
-.vscode
+/.vscode/settings.json
 .vs
 
 # YouCompleteMe config file

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings_recommended.json
+++ b/.vscode/settings_recommended.json
@@ -1,0 +1,12 @@
+{
+  "[python]": {
+    "editor.tabSize": 4
+  },
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "python.formatting.provider": "none",
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": true
+}

--- a/mypy-strict.ini
+++ b/mypy-strict.ini
@@ -38,6 +38,7 @@ strict_equality = True
 files =
     .github/scripts/generate_binary_build_matrix.py,
     benchmarks/instruction_counts,
+    tools/actions_local_runner.py,
     tools/autograd/*.py,
     tools/clang_tidy.py,
     tools/codegen,
@@ -47,20 +48,20 @@ files =
     tools/pyi,
     tools/stats_utils,
     tools/test_history.py,
+    tools/test/test_actions_local_runner.py,
     tools/test/test_extract_scripts.py,
     tools/test/test_mypy_wrapper.py,
     tools/test/test_test_history.py,
     tools/test/test_trailing_newlines.py,
-    tools/test/test_actions_local_runner.py,
     tools/test/test_translate_annotations.py,
     tools/trailing_newlines.py,
     tools/translate_annotations.py,
-    tools/actions_local_runner.py,
+    tools/vscode_settings.py,
     torch/testing/_internal/framework_utils.py,
+    torch/utils/_pytree.py,
     torch/utils/benchmark/utils/common.py,
     torch/utils/benchmark/utils/timer.py,
-    torch/utils/benchmark/utils/valgrind_wrapper,
-    torch/utils/_pytree.py
+    torch/utils/benchmark/utils/valgrind_wrapper
 
 # Specifically enable imports of benchmark utils. As more of `torch` becomes
 # strict compliant, those modules can be enabled as well.

--- a/tools/README.md
+++ b/tools/README.md
@@ -64,10 +64,14 @@ Developer tools which you might find useful:
   trailing newline, exit with status 1 if no output printed or 0 if some
   filenames were printed.
 * [translate_annotations.py](translate_annotations.py) - Read [Flake8][] or
-   [clang-tidy][] warnings (according to a `--regex`) from a `--file`, convert
-   to the JSON format accepted by [pytorch/add-annotations-github-action], and
-   translate line numbers from `HEAD` back in time to the given `--commit` by
-   running `git diff-index --unified=0` appropriately.
+  [clang-tidy][] warnings (according to a `--regex`) from a `--file`, convert to
+  the JSON format accepted by [pytorch/add-annotations-github-action], and
+  translate line numbers from `HEAD` back in time to the given `--commit` by
+  running `git diff-index --unified=0` appropriately.
+* [vscode_settings.py](vscode_settings.py) - Merge
+  `.vscode/settings_recommended.json` into your workspace-local
+  `.vscode/settings.json`, preferring the former in case of conflicts but
+  otherwise preserving the latter as much as possible.
 
 Important if you want to run on AMD GPU:
 

--- a/tools/vscode_settings.py
+++ b/tools/vscode_settings.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    folder = Path('.vscode')
+    recommended = json.loads((folder / 'settings_recommended.json').read_text())
+    path = folder / 'settings.json'
+    current = json.loads(path.read_text())
+    with open(path, 'w') as f:
+        json.dump({**current, **recommended}, f, indent=2)
+        f.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/vscode_settings.py
+++ b/tools/vscode_settings.py
@@ -8,7 +8,10 @@ def main() -> None:
     folder = Path('.vscode')
     recommended = json.loads((folder / 'settings_recommended.json').read_text())
     path = folder / 'settings.json'
-    current = json.loads(path.read_text())
+    try:
+        current = json.loads(path.read_text())
+    except Exception:
+        current = {}
     with open(path, 'w') as f:
         json.dump({**current, **recommended}, f, indent=2)
         f.write('\n')


### PR DESCRIPTION
This is a second attempt at #51214. It should achieve the same goals with (as far as I can tell) no disadvantages, but the advantages are a bit less pronounced than in the more dictatorial approach that #51214 took:

- Unfortunately, I was unable to figure out how to include [the `mypy` configuration given in the docstring of `tools.mypy_wrapper.main`](https://github.com/pytorch/pytorch/blob/7115a4b8707115b81417481fb6240617ae934806/tools/mypy_wrapper.py#L81-L89), because as @walterddr pointed out, `"${env:HOME}/miniconda3/envs/pytorch/bin/python"` is not guaranteed to be correct on everyone's machine:
  ```json
  {
    "python.linting.enabled": true,
    "python.linting.mypyEnabled": true,
    "python.linting.mypyPath": "${env:HOME}/miniconda3/envs/pytorch/bin/python",
    "python.linting.mypyArgs": [
      "${workspaceFolder}/tools/mypy_wrapper.py"
    ]
  }
  ```

  Importantly, this does not work:
  ```json
  "python.linting.mypyPath": "${workspaceFolder}/tools/mypy_wrapper.py"
  ```
  This is because VS Code does not run the given `mypy` command inside of the user's specified virtual environment, so for instance, on my system, setting the `mypy` command to directly call `tools/mypy_wrapper.py` results in using `mypy 0.782` instead of the correct `mypy 0.812`.

  Sadly, [this](https://code.visualstudio.com/docs/editor/variables-reference#_configuration-variables) does not work either, although I'm not sure why:
  ```json
  {
    "python.linting.mypyPath": "${config:python.pythonPath}",
    "python.linting.mypyArgs": [
      "${workspaceFolder}/tools/mypy_wrapper.py"
    ]
  }
  ```

- As a result, `git clean -fdx; tools/vscode_settings.py` still results in some loss of useful configuration.

One other thing to note: as `.vscode/settings_recommended.json` shows, there are some configuration sections that only take effect within the context of a `"[language]"`, so currently, if a dev already has one of those settings, it would be entirely overwritten by `tools/vscode_settings.py` rather than a graceful merge. This could probably be fixed by using a deep merge instead of the current shallow merge strategy.

**Test plan:**

If you want, you can typecheck the small script added by this PR (no output is expected):
```sh
tools/mypy_wrapper.py $PWD/tools/vscode_settings.py
```
You can also try running it to update your own VS Code workspace settings:
```sh
tools/vscode_settings.py
```
This should have minimal impact on your existing `tools/settings.json` file other than enabling the few explicitly recommended settings (e.g. it should not reorder or remove any of your existing settings).