### PR TITLE
[PyTorch] Use c10::ThreadLocal instead thread_local in record_function.cpp for specific __GLIBCXX__ on Android

### DIFF
--- a/aten/src/ATen/record_function.cpp
+++ b/aten/src/ATen/record_function.cpp
@@ -1,6 +1,7 @@
 #include <ATen/record_function.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/macros/Macros.h>
+#include <c10/util/ThreadLocal.h>
 #include <algorithm>
 #include <cstdlib>
 #include <random>
@@ -20,8 +21,17 @@ RecordFunctionHandle next_unique_record_function_handle() {
   return RecordFunctionHandle(unique_rf_id++);
 }
 
+RecordFunctionTLS& rf_tls() {
+#if defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-thread_local RecordFunctionTLS rf_tls_;
+  static c10::ThreadLocal<RecordFunctionTLS> rf_tls_;
+  return rf_tls_.get();
+#else // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static thread_local RecordFunctionTLS rf_tls_;
+  return rf_tls_;
+#endif // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+}
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<int64_t> defaultNodeId(-1);
@@ -47,25 +57,35 @@ struct CoinflipTLS {
 
 CoinflipTLS::CoinflipTLS()
     : tries_left_(0), genGeo_(std::random_device()()), genZeroOne_(std::random_device()()), distGeo_(kLowProb), distZeroOne_(0.0, 1.0) {}
+
+CoinflipTLS& coinflip_tls() {
+#if defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-thread_local CoinflipTLS coinflip_tls_;
+  static c10::ThreadLocal<CoinflipTLS> coinflip_tls_;
+  return coinflip_tls_.get();
+#else // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  static thread_local CoinflipTLS coinflip_tls_;
+  return coinflip_tls_;
+#endif // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+}
 
 int sample_geometric() {
-  return coinflip_tls_.distGeo_(coinflip_tls_.genGeo_);
+  return coinflip_tls().distGeo_(coinflip_tls().genGeo_);
 }
 
 double sample_zero_one() {
-  return coinflip_tls_.distZeroOne_(coinflip_tls_.genZeroOne_);
+  return coinflip_tls().distZeroOne_(coinflip_tls().genZeroOne_);
 }
 
 } // namespace
 
 const RecordFunctionTLS& get_record_function_tls_() {
-  return rf_tls_;
+  return rf_tls();
 }
 
 void set_record_function_tls_(const RecordFunctionTLS& tls) {
-  rf_tls_ = tls;
+  rf_tls() = tls;
 }
 
 class CallbackManager {
@@ -78,8 +98,7 @@ class CallbackManager {
     // note: monotonically increasing callbacks_unique_id keeps
     // sorted_tls_callbacks_ sorted
     auto handle = next_unique_callback_handle();
-    // NOLINTNEXTLINE(performance-move-const-arg)
-    rf_tls_.sorted_tls_callbacks_.emplace_back(std::move(cb), handle);
+    rf_tls().sorted_tls_callbacks_.emplace_back(cb, handle);
     return handle;
   }
 
@@ -115,7 +134,7 @@ class CallbackManager {
       }
       return false;
     };
-    auto found = find_and_remove(rf_tls_.sorted_tls_callbacks_);
+    auto found = find_and_remove(rf_tls().sorted_tls_callbacks_);
     if (!found) {
       found = find_and_remove(sorted_global_callbacks_);
     }
@@ -129,7 +148,7 @@ class CallbackManager {
   }
 
   void clearThreadLocalCallbacks() {
-    rf_tls_.sorted_tls_callbacks_.clear();
+    rf_tls().sorted_tls_callbacks_.clear();
   }
 
   inline bool hasGlobalCallbacks() const {
@@ -137,7 +156,7 @@ class CallbackManager {
   }
 
   inline bool hasThreadLocalCallbacks() const {
-    return !rf_tls_.sorted_tls_callbacks_.empty();
+    return !rf_tls().sorted_tls_callbacks_.empty();
   }
 
   // We need this function to be inlined: init() is a hot path and
@@ -176,11 +195,11 @@ class CallbackManager {
       // flip for kLowProb with a thread local number of tries tries_left_
       // sampled from the geometric distribution.
       if (sampling_prob < kLowProb) {
-        if (coinflip_tls_.tries_left_ == 0) {
-          coinflip_tls_.tries_left_ = sample_geometric();
+        if (coinflip_tls().tries_left_ == 0) {
+          coinflip_tls().tries_left_ = sample_geometric();
           return (sample_zero_one() < sampling_prob / kLowProb);
         } else {
-          --coinflip_tls_.tries_left_;
+          --coinflip_tls().tries_left_;
           return false;
         }
       } else {
@@ -199,7 +218,7 @@ class CallbackManager {
     bool found_needs_outputs = false;
     bool found_needs_ids = false;
 
-    for (const auto& cb: rf_tls_.sorted_tls_callbacks_) {
+    for (const auto& cb: rf_tls().sorted_tls_callbacks_) {
       if (callbackShouldRun(cb.first, scope, pre_sampled)) {
         if (cb.first.needsInputs()) {
           found_needs_inputs = true;
@@ -258,7 +277,7 @@ class CallbackManager {
         /* is_start */ true,
         rf);
     mergeRunCallbacks(
-        rf_tls_.sorted_tls_callbacks_,
+        rf_tls().sorted_tls_callbacks_,
         rf.state_->sorted_active_tls_handles_,
         rf.state_->tls_ctx_,
         /* is_start */ true,
@@ -274,7 +293,7 @@ class CallbackManager {
         /* is_start */ false,
         rf);
     mergeRunCallbacks(
-        rf_tls_.sorted_tls_callbacks_,
+        rf_tls().sorted_tls_callbacks_,
         rf.state_->sorted_active_tls_handles_,
         rf.state_->tls_ctx_,
         /* is_start */ false,
@@ -351,15 +370,15 @@ namespace {
 } // namespace
 
 RecordFunctionCallbacks _getTLSCallbacks() {
-  return rf_tls_.sorted_tls_callbacks_;
+  return rf_tls().sorted_tls_callbacks_;
 }
 
 void _setTLSCallbacks(const RecordFunctionCallbacks& callbacks) {
   // keep the original handles
-  rf_tls_.sorted_tls_callbacks_ = callbacks;
+  rf_tls().sorted_tls_callbacks_ = callbacks;
   std::sort(
-      rf_tls_.sorted_tls_callbacks_.begin(),
-      rf_tls_.sorted_tls_callbacks_.end(),
+      rf_tls().sorted_tls_callbacks_.begin(),
+      rf_tls().sorted_tls_callbacks_.end(),
       [](const std::pair<RecordFunctionCallback, CallbackHandle>& l,
           const std::pair<RecordFunctionCallback, CallbackHandle>& r) {
         return l.second < r.second;
@@ -410,15 +429,15 @@ void clearCallbacks() {
 }
 
 bool isRecordFunctionEnabled() {
-  return rf_tls_.tls_record_function_enabled_;
+  return rf_tls().tls_record_function_enabled_;
 }
 
 void enableRecordFunction(bool enable) {
-  rf_tls_.tls_record_function_enabled_ = enable;
+  rf_tls().tls_record_function_enabled_ = enable;
 }
 
 RecordFunction::RecordFunction(RecordScope scope, bool pre_sampled) {
-  auto* rf_tls_ptr = &rf_tls_;
+  auto* rf_tls_ptr = &rf_tls();
   if (rf_tls_ptr->tls_record_function_enabled_) {
     auto& m = manager();
     if (!m.sorted_global_callbacks_.empty() || !rf_tls_ptr->sorted_tls_callbacks_.empty()) {
@@ -530,7 +549,7 @@ bool checkRecordAllFunctions() {
 }
 
 bool shouldRunRecordFunction(bool* pre_sampled) {
-  auto* rf_tls_ptr = &rf_tls_;
+  auto* rf_tls_ptr = &rf_tls();
   if (rf_tls_ptr->sorted_tls_callbacks_.empty() && !manager().hasGlobalCallbacks()) {
     *pre_sampled = false;
     return false;
@@ -545,7 +564,7 @@ bool shouldRunRecordFunction(bool* pre_sampled) {
   }
 
   *pre_sampled = true;
-  auto* coinflip_tls_ptr = &coinflip_tls_;
+  auto* coinflip_tls_ptr = &coinflip_tls();
   if (coinflip_tls_ptr->tries_left_ == 0) {
     coinflip_tls_ptr->tries_left_ = sample_geometric();
     return true;

--- a/c10/test/util/ThreadLocal_test.cpp
+++ b/c10/test/util/ThreadLocal_test.cpp
@@ -1,0 +1,224 @@
+#include <c10/util/ThreadLocal.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+
+namespace {
+
+TEST(ThreadLocal, TestNoOpScopeWithOneVar) {
+  C10_DEFINE_TLS_static(std::string, str);
+}
+
+TEST(ThreadLocalTest, TestNoOpScopeWithTwoVars) {
+  C10_DEFINE_TLS_static(std::string, str);
+  C10_DEFINE_TLS_static(std::string, str2);
+}
+
+TEST(ThreadLocalTest, TestScopeWithOneVar) {
+  C10_DEFINE_TLS_static(std::string, str);
+  EXPECT_EQ(*str, std::string());
+  EXPECT_EQ(*str, "");
+
+  *str = "abc";
+  EXPECT_EQ(*str, "abc");
+  EXPECT_EQ(str->length(), 3);
+  EXPECT_EQ(str.get(), "abc");
+}
+
+TEST(ThreadLocalTest, TestScopeWithTwoVars) {
+  C10_DEFINE_TLS_static(std::string, str);
+  EXPECT_EQ(*str, "");
+
+  C10_DEFINE_TLS_static(std::string, str2);
+
+  *str = "abc";
+  EXPECT_EQ(*str, "abc");
+  EXPECT_EQ(*str2, "");
+
+  *str2 = *str;
+  EXPECT_EQ(*str, "abc");
+  EXPECT_EQ(*str2, "abc");
+
+  str->clear();
+  EXPECT_EQ(*str, "");
+  EXPECT_EQ(*str2, "abc");
+}
+
+TEST(ThreadLocalTest, TestInnerScopeWithTwoVars) {
+  C10_DEFINE_TLS_static(std::string, str);
+  *str = "abc";
+
+  {
+    C10_DEFINE_TLS_static(std::string, str2);
+    EXPECT_EQ(*str2, "");
+
+    *str2 = *str;
+    EXPECT_EQ(*str, "abc");
+    EXPECT_EQ(*str2, "abc");
+
+    str->clear();
+    EXPECT_EQ(*str2, "abc");
+  }
+
+  EXPECT_EQ(*str, "");
+}
+
+struct Foo {
+  C10_DECLARE_TLS_class_static(Foo, std::string, str_);
+};
+
+C10_DEFINE_TLS_class_static(Foo, std::string, str_);
+
+TEST(ThreadLocalTest, TestClassScope) {
+  EXPECT_EQ(*Foo::str_, "");
+
+  *Foo::str_ = "abc";
+  EXPECT_EQ(*Foo::str_, "abc");
+  EXPECT_EQ(Foo::str_->length(), 3);
+  EXPECT_EQ(Foo::str_.get(), "abc");
+}
+
+C10_DEFINE_TLS_static(std::string, global_);
+C10_DEFINE_TLS_static(std::string, global2_);
+TEST(ThreadLocalTest, TestTwoGlobalScopeVars) {
+  EXPECT_EQ(*global_, "");
+  EXPECT_EQ(*global2_, "");
+
+  *global_ = "abc";
+  EXPECT_EQ(global_->length(), 3);
+  EXPECT_EQ(*global_, "abc");
+  EXPECT_EQ(*global2_, "");
+
+  *global2_ = *global_;
+  EXPECT_EQ(*global_, "abc");
+  EXPECT_EQ(*global2_, "abc");
+
+  global_->clear();
+  EXPECT_EQ(*global_, "");
+  EXPECT_EQ(*global2_, "abc");
+  EXPECT_EQ(global2_.get(), "abc");
+}
+
+C10_DEFINE_TLS_static(std::string, global3_);
+TEST(ThreadLocalTest, TestGlobalWithLocalScopeVars) {
+  *global3_ = "abc";
+
+  C10_DEFINE_TLS_static(std::string, str);
+
+  std::swap(*global3_, *str);
+  EXPECT_EQ(*str, "abc");
+  EXPECT_EQ(*global3_, "");
+}
+
+TEST(ThreadLocalTest, TestThreadWithLocalScopeVar) {
+  C10_DEFINE_TLS_static(std::string, str);
+  *str = "abc";
+
+  std::atomic_bool b(false);
+  std::thread t([&b](){
+    EXPECT_EQ(*str, "");
+    *str = "def";
+    b = true;
+    EXPECT_EQ(*str, "def");
+  });
+  t.join();
+
+  EXPECT_TRUE(b);
+  EXPECT_EQ(*str, "abc");
+}
+
+C10_DEFINE_TLS_static(std::string, global4_);
+TEST(ThreadLocalTest, TestThreadWithGlobalScopeVar) {
+  *global4_ = "abc";
+
+  std::atomic_bool b(false);
+  std::thread t([&b](){
+    EXPECT_EQ(*global4_, "");
+    *global4_ = "def";
+    b = true;
+    EXPECT_EQ(*global4_, "def");
+  });
+  t.join();
+
+  EXPECT_TRUE(b);
+  EXPECT_EQ(*global4_, "abc");
+}
+
+TEST(ThreadLocalTest, TestObjectsAreReleased) {
+  static std::atomic<int> ctors{0};
+  static std::atomic<int> dtors{0};
+  struct A
+  {
+    A() : i() {
+      ++ ctors;
+    }
+
+    ~A() {
+      ++ dtors;
+    }
+
+    A(const A&) = delete;
+    A& operator=(const A&) = delete;
+
+    int i;
+  };
+
+  C10_DEFINE_TLS_static(A, a);
+
+  std::atomic_bool b(false);
+  std::thread t([&b](){
+    EXPECT_EQ(a->i, 0);
+    a->i = 1;
+    EXPECT_EQ(a->i, 1);
+    b = true;
+  });
+  t.join();
+
+  EXPECT_TRUE(b);
+
+  EXPECT_EQ(ctors, 1);
+  EXPECT_EQ(dtors, 1);
+}
+
+TEST(ThreadLocalTest, TestObjectsAreReleasedByNonstaticThreadLocal) {
+  static std::atomic<int> ctors(0);
+  static std::atomic<int> dtors(0);
+  struct A
+  {
+    A() : i() {
+      ++ ctors;
+    }
+
+    ~A() {
+      ++ dtors;
+    }
+
+    A(const A&) = delete;
+    A& operator=(const A&) = delete;
+
+    int i;
+  };
+
+  std::atomic_bool b(false);
+  std::thread t([&b](){
+#if defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+    ::c10::ThreadLocal<A> a;
+#else // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+    ::c10::ThreadLocal<A> a([](){ static thread_local A var; return &var; });
+#endif // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+
+    EXPECT_EQ(a->i, 0);
+    a->i = 1;
+    EXPECT_EQ(a->i, 1);
+    b = true;
+  });
+  t.join();
+
+  EXPECT_TRUE(b);
+
+  EXPECT_EQ(ctors, 1);
+  EXPECT_EQ(dtors, 1);
+}
+
+}  // namespace

--- a/c10/util/ThreadLocal.h
+++ b/c10/util/ThreadLocal.h
@@ -1,0 +1,152 @@
+#pragma once
+
+/**
+ * Android versions with libgnustl incorrectly handle thread_local C++
+ * qualifier with composite types. NDK up to r17 version is affected.
+ *
+ * (A fix landed on Jun 4 2018:
+ * https://android-review.googlesource.com/c/toolchain/gcc/+/683601)
+ *
+ * In such cases, use c10::ThreadLocal<T> wrapper
+ * which is `pthread_*` based with smart pointer semantics.
+ *
+ * In addition, convenient macro C10_DEFINE_TLS_static is available.
+ * To define static TLS variable of type std::string, do the following
+ * ```
+ *  C10_DEFINE_TLS_static(std::string, str_tls_);
+ *  ///////
+ *  {
+ *    *str_tls_ = "abc";
+ *    assert(str_tls_->length(), 3);
+ *  }
+ * ```
+ *
+ * (see c10/test/util/ThreadLocal_test.cpp for more examples)
+ */
+#if !defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+
+#if defined(C10_ANDROID) && defined(__GLIBCXX__) && __GLIBCXX__ < 20180604
+#define C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE
+#endif // defined(C10_ANDROID) && defined(__GLIBCXX__) && __GLIBCXX__ < 20180604
+
+#endif // !defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+
+#if defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+#include <c10/util/Exception.h>
+#include <memory>
+#include <pthread.h>
+namespace c10 {
+
+/**
+ * @brief Temporary thread_local C++ qualifier replacement for Android
+ * based on `pthread_*`.
+ * To be used with composite types that provide default ctor.
+ */
+template<typename Type>
+class ThreadLocal {
+public:
+  ThreadLocal()
+  {
+    pthread_key_create(&key_, [](void* buf) {
+      delete static_cast<Type*>(buf);
+    });
+  }
+
+  ~ThreadLocal() {
+    if (void* current = pthread_getspecific(key_)) {
+      delete static_cast<Type*>(current);
+    }
+
+    pthread_key_delete(key_);
+  }
+
+  ThreadLocal(const ThreadLocal&) = delete;
+  ThreadLocal& operator=(const ThreadLocal&) = delete;
+
+  Type& get() {
+    if (void* current = pthread_getspecific(key_)) {
+      return *static_cast<Type*>(current);
+    }
+
+    std::unique_ptr<Type> ptr = std::make_unique<Type>();
+    if (0 == pthread_setspecific(key_, ptr.get())) {
+      return *ptr.release();
+    }
+
+    int err = errno;
+    TORCH_INTERNAL_ASSERT(false, "pthread_setspecific() failed, errno = ", err);
+  }
+
+  Type& operator*() {
+    return get();
+  }
+
+  Type* operator->() {
+    return &get();
+  }
+
+private:
+  pthread_key_t key_;
+};
+
+} // namespace c10
+
+#define C10_DEFINE_TLS_static(Type, Name) \
+  static ::c10::ThreadLocal<Type> Name
+
+
+#define C10_DECLARE_TLS_class_static(Class, Type, Name) \
+  static ::c10::ThreadLocal<Type> Name
+
+
+#define C10_DEFINE_TLS_class_static(Class, Type, Name) \
+  ::c10::ThreadLocal<Type> Class::Name
+
+#else // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)
+
+namespace c10 {
+
+/**
+ * @brief Default thread_local implementation for non-Android cases.
+ * To be used with composite types that provide default ctor.
+ */
+template<typename Type>
+class ThreadLocal {
+public:
+  using Accessor = Type *(*)();
+  explicit ThreadLocal(Accessor accessor) : accessor_(accessor) {}
+
+  ThreadLocal(const ThreadLocal&) = delete;
+  ThreadLocal& operator=(const ThreadLocal&) = delete;
+
+  Type& get() {
+    return *accessor_();
+  }
+
+  Type& operator*() {
+    return get();
+  }
+
+  Type* operator->() {
+    return &get();
+  }
+
+private:
+  Accessor accessor_;
+};
+
+
+} // namespace c10
+
+#define C10_DEFINE_TLS_static(Type, Name) \
+  static ::c10::ThreadLocal<Type> Name([](){ static thread_local Type var; return &var; })
+
+
+#define C10_DECLARE_TLS_class_static(Class, Type, Name) \
+  static ::c10::ThreadLocal<Type> Name
+
+
+#define C10_DEFINE_TLS_class_static(Class, Type, Name) \
+  ::c10::ThreadLocal<Type> Class::Name([](){ static thread_local Type var; return &var; })
+
+#endif // defined(C10_PREFER_CUSTOM_THREAD_LOCAL_STORAGE)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57682 [PyTorch] Use c10::ThreadLocal instead thread_local in record_function.cpp for specific __GLIBCXX__ on Android**

* Older versions of libgnustd have issues with thread_local C++ qualifier on Android devices prior to r17+. Use c10::tls<> wrapper with smart pointer semantics in such cases.
* Convenient macro `C10_DEFINE_TLS_static` was added as well:

```
  // Define static TLS variable str_tls_ of type std::string
  C10_DEFINE_TLS_static(std::string, str_tls_);

  //////// Excercise it ////////
  {
     *str_tls_ = "abc";
     assert(str_tls_->length(), 3);
  }
```

Differential Revision: [D27875779](https://our.internmc.facebook.com/intern/diff/D27875779/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D27875779/)!