### PR TITLE
Support for getting all the intermediate nodes and for accumulate nodes traversal

### DIFF
--- a/torch/fx/experimental/fx2trt/example/fx2trt_example.py
+++ b/torch/fx/experimental/fx2trt/example/fx2trt_example.py
@@ -72,7 +72,7 @@ class TensorRTMinimizer(net_min_base._MinimizerBase):
         self,
         module: torch.fx.GraphModule,
         sample_input: Tuple[torch.Tensor],
-        compare_fn: Callable[[Any, Any], Tuple[float, bool]],
+        compare_fn: Callable[[Any, Any, Any], Tuple[float, bool]],
         settings: net_min_base._MinimizerSettingBase = None,
     ):
         if settings is None:
@@ -142,7 +142,7 @@ class TensorRTSplitter(splitter_base._SplitterBase):
         that is responsible for the error.
         """
         # Since we don't care about accuracy here, we pass in a dummy compare function.
-        minimizer = TensorRTMinimizer(mod, inputs, lambda a, b: (1, True))
+        minimizer = TensorRTMinimizer(mod, inputs, lambda a, b, c: (1, True))
         minimizer.settings.traverse_method = "sequential"
         minimizer.settings.find_all = True
         culprits = minimizer.minimize()

--- a/torch/fx/passes/net_min_base.py
+++ b/torch/fx/passes/net_min_base.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Any, Callable, Tuple, Dict, Optional, List
+from typing import Any, Callable, Tuple, Dict, Optional
 
 import torch
 import torch.fx
@@ -14,6 +14,7 @@ from .tools_common import (
     NodeSet,
     CALLABLE_NODE_OPS,
     FxNetAccFusionsFinder,
+    Names
 )
 
 
@@ -55,7 +56,7 @@ class _MinimizerSettingBase:
         parser.add_argument(
             "--traverse_method",
             default="sequential",
-            choices=["sequential", "binary"],
+            choices=["sequential", "binary", "accumulate"],
             help="Determine the way of traverse the nodes in FX module.",
         )
         parser.add_argument(
@@ -106,7 +107,7 @@ class _MinimizerBase:
         self,
         module: torch.fx.GraphModule,
         sample_input: Tensors,
-        compare_fn: Callable[[TensorOrTensors, TensorOrTensors], Tuple[float, bool]],
+        compare_fn: Callable[[TensorOrTensors, TensorOrTensors, Names], Tuple[float, bool]],
         settings: _MinimizerSettingBase,
     ):
         assert isinstance(module, torch.fx.GraphModule)
@@ -304,7 +305,7 @@ class _MinimizerBase:
         self,
         split_module: torch.fx.GraphModule,
         submod_name: str,
-        output_names: Optional[List[str]] = None,
+        output_names: Names
     ):
         """
         Run the submodule in `split_module` that has name `submod_name`
@@ -344,7 +345,10 @@ class _MinimizerBase:
         self._store_outputs(a_result, b_result, submodule)
 
         # Compare results
-        numeric_result, bool_result = self.compare_fn(a_result, b_result)
+        names: Names = output_names
+        if output_names is None:
+            names = [str(v) for v in result_key]
+        numeric_result, bool_result = self.compare_fn(a_result, b_result, names)
         self.results[result_key] = numeric_result
         if not bool_result:
             raise FxNetMinimizerResultMismatchError(f"Result mismatch for {result_key}")
@@ -363,6 +367,7 @@ class _MinimizerBase:
             self._run_and_compare(
                 split_module,
                 submod_name,
+                []
             )
         except (FxNetMinimizerRunFuncError, FxNetMinimizerResultMismatchError):
             if len(nodes) == 1:
@@ -405,7 +410,7 @@ class _MinimizerBase:
             try:
                 split_module, submod_name = self._build_submodule(cur_nodes)
                 self._run_and_compare(
-                    split_module, submod_name, output_names=[node.name]
+                    split_module, submod_name, [node.name]
                 )
             except (FxNetMinimizerResultMismatchError):
                 culprits.add(node)
@@ -415,6 +420,34 @@ class _MinimizerBase:
                 culprits.update(cur_nodes)
                 if not self.settings.find_all:
                     return culprits
+
+        return culprits
+
+    def _accumulate_traverse(self, nodes: NodeList) -> NodeSet:
+        culprits: NodeSet = set()
+        nodes_to_run: NodeSet = set()
+
+        # find_all is not supported for accumulate traversal because all the
+        # ops run on NNPI. So we return after the first op that raises error.
+        if self.settings.find_all:
+            print("'Find All' mode is not supported in accumulate traversal.")
+            return culprits
+
+        for node in nodes:
+            nodes_to_run.add(node)
+
+            node_name = node.name
+            if node_name is not None and isinstance(node_name, tuple):
+                node_name = node_name[0]
+            assert node_name is not None and isinstance(node_name, str), f"minimize: node_name: {node_name}"
+
+            try:
+                split_module, submod_name = self._build_submodule(nodes_to_run)
+                self._run_and_compare(split_module, submod_name, [node_name])
+            except (FxNetMinimizerResultMismatchError,
+                    FxNetMinimizerRunFuncError):
+                culprits.add(node)
+                return culprits
 
         return culprits
 
@@ -462,8 +495,7 @@ class _MinimizerBase:
             if node in self.fusions:
                 cur_nodes.update(self.fusions[node])
 
-        output_names = None
-
+        output_names = []
         if self.settings.return_intermediate:
             output_names = [node.name for node in nodes]
 
@@ -501,5 +533,8 @@ class _MinimizerBase:
 
         if self.settings.traverse_method == "binary":
             return self._binary_traverse(nodes)
+
+        if self.settings.traverse_method == "accumulate":
+            return self._accumulate_traverse(nodes)
 
         raise RuntimeError(f"Unknow traverse method {self.settings.traverse_method}!")

--- a/torch/fx/passes/tools_common.py
+++ b/torch/fx/passes/tools_common.py
@@ -10,6 +10,7 @@ Tensors = Union[Tuple[torch.Tensor], List[torch.Tensor]]
 TensorOrTensors = Union[torch.Tensor, Tensors]
 NodeList = List[torch.fx.Node]
 NodeSet = Set[torch.fx.Node]
+Names = List[str]
 CALLABLE_NODE_OPS = {"call_module", "call_function", "call_method"}
 
 


### PR DESCRIPTION
Summary:
- Accumulate traversal : `minimizer.settings.traverse_method = "accumulate" `
   - Feature
   - net_min_tests
- Return op name to the compare function so that we can map the cosine similarity to the individual ops
- Fix the settings combinations in net_min_tests

Test Plan:
buck test glow/fb/nnpi/lowering:net_min_tests

NNPI_LOG_LEVEL=5 USE_INF_API=1 buck run mode/opt -j 12 --config fbcode//cxx.link_weight=3 --config misc.strip_binaries=debug-non-line -c glow.nnpi_project_name='fb-nnpi-nextgen' ai_codesign/video/inference:xrayvideo_2019a_eval -- --job create --model_a model_prod --device_a PTCPU --trace_a none --model_b model_v3 --device_b NNPI --trace_b fusion --replace_b true --log_level INFO --use_scrambled false --save_repro false --num_ab_runs 0 --symbolic_trace_b true --save_modified_model_b false

USE_INF_API=1 buck test glow/fb/nnpi/lowering:net_min_tests

Differential Revision: D27867010

