### PR TITLE
[paramcomms] support for in and out split sizes

### DIFF
--- a/torch/lib/c10d/ParamCommsUtils.cpp
+++ b/torch/lib/c10d/ParamCommsUtils.cpp
@@ -12,14 +12,14 @@ ParamCommsDebugInfo::ParamCommsDebugInfo(
     int inSize,
     int outSize,
     at::ScalarType dType,
-    std::vector<int64_t>&& inSplitSizes,
-    std::vector<int64_t>&& outSplitSizes) :
+    std::vector<int64_t> inSplitSizes,
+    std::vector<int64_t> outSplitSizes) :
       rank_(rank),
       columnName_(colName),
       inMessageSize_(inSize),
       outMessageSize_(outSize),
       dType_(dType),
-      inputSplitSizes_(inSplitSizes),
-      outputSplitSizes_(outSplitSizes) {}
+      inputSplitSizes_(std::move(inSplitSizes)),
+      outputSplitSizes_(std::move(outSplitSizes)) {}
 
 } // namespace torch

--- a/torch/lib/c10d/ParamCommsUtils.hpp
+++ b/torch/lib/c10d/ParamCommsUtils.hpp
@@ -20,8 +20,8 @@ class ParamCommsDebugInfo
     int inSize,
     int outSize,
     at::ScalarType dType,
-    std::vector<int64_t>&& inSplitSizes,
-    std::vector<int64_t>&& outSplitSizes);
+    std::vector<int64_t> inSplitSizes,
+    std::vector<int64_t> outSplitSizes);
 
   ~ParamCommsDebugInfo() override = default;
 
@@ -63,18 +63,16 @@ class ParamCommsDebugInfo
   std::vector<int64_t> outputSplitSizes_;
 };
 
-// TODO(jchae): handle non empty in/out split sizes
+
 #define RECORD_PARAM_COMMS(rank, colName, inSize, outSize, dType, inSplitSizes, outSplitSizes) \
-  std::vector<int64_t> iss; \
-  std::vector<int64_t> oss; \
   auto paramCommsInfo = std::make_shared<torch::ParamCommsDebugInfo>( \
     rank, \
     colName, \
     inSize, \
     outSize, \
     dType, \
-    std::move(iss), \
-    std::move(oss)); \
+    inSplitSizes, \
+    outSplitSizes); \
   c10::DebugInfoGuard g(c10::DebugInfoKind::PARAM_COMMS_INFO, paramCommsInfo); \
   RECORD_FUNCTION(torch::kParamCommsCallName, std::vector<c10::IValue>());
 

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -415,13 +415,13 @@ void ProcessGroupNCCL::WorkNCCL::synchronizeInternal(
 // Same as calling synchronize().
 bool ProcessGroupNCCL::WorkNCCL::wait(std::chrono::milliseconds timeout) {
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "wait", // colName
-      0, // inSize
-      0, // outSize
-      at::kByte, // dType
-      {}, // inSplitSizes
-      {}); // outSplitSizes
+      rank_,                    // rank
+      "wait",                   // colName
+      0,                        // inSize
+      0,                        // outSize
+      at::kByte,                // dType
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSizes
   synchronizeInternal(timeout);
   // Always return true, because abort API is not implemented.
   return true;
@@ -1352,13 +1352,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::broadcast(
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "broadcast", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
-      tensor.scalar_type(), // dType
-      {}, // inSplitSizes
-      {}); // outSplitSizes
+      rank_,                    // rank
+      "broadcast",              // colName
+      tensor.numel(),           // inSize
+      tensor.numel(),           // outSize
+      tensor.scalar_type(),     // dType
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSizes
 
   return collective(
       tensors,
@@ -1387,13 +1387,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce(
   // @lint-ignore CLANGTIDY
   auto tensor = tensors.back();
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "reduce", // colName
-      tensor.numel(), // inSize
-      tensor.numel(), // outSize
-      tensor.scalar_type(), // dType
-      {}, // inSplitSizes
-      {}); // outSplitSizes
+      rank_,                    // rank
+      "reduce",                 // colName
+      tensor.numel(),           // inSize
+      tensor.numel(),           // outSize
+      tensor.scalar_type(),     // dType
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSizes
 
   return collective(
       tensors,
@@ -1430,14 +1430,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
   // @lint-ignore CLANGTIDY
   auto tensor = inputTensors.back();
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "all_gather", // colName
-      tensor.numel(), // inSize
-      tensor.numel() * // outSize
-          this->getSize(), // dType
-      tensor.scalar_type(), // inSplitSizes
-      {}, // outSplitSizes
-      {});
+      rank_,                    // rank
+      "all_gather",             // colName
+      tensor.numel(),           // inSize
+      tensor.numel() *          // outSize
+        this->getSize(),        // dType
+      tensor.scalar_type(),
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSize
 
   return collective(
       inputTensors,
@@ -1491,14 +1491,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
   // @lint-ignore CLANGTIDY
   auto tensor = outputTensors.back();
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "reduce_scatter", // colName
-      tensor.numel() * // inSize
-          this->getSize(), // outSize
-      tensor.numel(), // dType
-      tensor.scalar_type(), // inSplitSizes
-      {}, // outSplitSizes
-      {});
+      rank_,                    // rank
+      "reduce_scatter",         // colName
+      tensor.numel() *          // inSize
+        this->getSize(),        // outSize
+      tensor.numel(),           // dType
+      tensor.scalar_type(),
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSizes
 
   auto inputFlattened =
       flatten_for_scatter_gather(inputTensors, outputTensors, size_);
@@ -1543,13 +1543,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
 c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::barrier(
     const BarrierOptions& opts) {
   RECORD_PARAM_COMMS(
-      rank_, // rank
-      "barrier", // colName
-      0, // inSize
-      0, // outSize
-      at::kByte, // dType
-      {}, // inSplitSizes
-      {}); // outSplitSizes
+      rank_,                    // rank
+      "barrier",                // colName
+      0,                        // inSize
+      0,                        // outSize
+      at::kByte,                // dType
+      std::vector<int64_t>(),   // inSplitSizes
+      std::vector<int64_t>());  // outSplitSizes
 
   std::vector<at::Device> devices;
 
@@ -1617,13 +1617,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall_base(
     std::vector<at::Tensor> outputTensors = {outputTensor};
 
     RECORD_PARAM_COMMS(
-        rank_, // rank
-        "all_to_all", // colName
-        inputTensor.numel(), // inSize
-        outputTensor.numel(), // outSize
-        at::kByte, // dType
-        {}, // inSplitSizes
-        {}); // outSplitSizes
+        rank_,                    // rank
+        "all_to_all",             // colName
+        inputTensor.numel(),      // inSize
+        outputTensor.numel(),     // outSize
+        at::kByte,                // dType
+        std::vector<int64_t>(),   // inSplitSizes
+        std::vector<int64_t>());  // outSplitSizes
 
     return collective(
         inputTensors,
@@ -1648,13 +1648,13 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::alltoall_base(
     std::vector<at::Tensor> outputTensors = {outputTensor};
 
     RECORD_PARAM_COMMS(
-        rank_, // rank
-        "all_to_allv", // colName
-        inputTensor.numel(), // inSize
-        outputTensor.numel(), // outSize
-        at::kByte, // dType
-        std::move(inputSplitSizes), // inSplitSizes
-        std::move(outputSplitSizes)); // outSplitSizes
+        rank_,                 // rank
+        "all_to_allv",         // colName
+        inputTensor.numel(),   // inSize
+        outputTensor.numel(),  // outSize
+        at::kByte,             // dType
+        inputSplitSizes,       // inSplitSizes
+        outputSplitSizes);     // outSplitSizes
 
     return collective(
         inputTensors,


### PR DESCRIPTION
Summary:
NOTE: initial commit got reverted D28247764

Adding way to accept in and out split sizes.

Test Plan:
{F613245151}
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1620153506%2F127.0.0.1%2Flibkineto_activities_1112677.json.gz&bucket=gpu_traces
NOTE: ignore the GPU user showing up in CPU - the issue is fixed in the diff above the stack D28196723

UPDATED: now the sizes are encoded as arrays in .json
https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree%2Ftraces%2Fdynocli%2F0%2F1620259313%2F127.0.0.1%2Flibkineto_activities_3944235.json.gz&bucket=gpu_traces

Differential Revision: D28248333

