### PR TITLE
[torch/elastic] Revise the note section of RendezvousHandler doc

### DIFF
--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -33,13 +33,10 @@ class RendezvousStateError(RendezvousError):
 class RendezvousHandler(ABC):
     """Main rendezvous interface.
 
-    .. note:: torchelastic users normally **do not** need to implement their
-              own ``RendezvousHandler``. An implementation based on
-              `etcd <https://etcd.io/>`__ is already provided, and is recommended
-              for most users, provided they can deploy it in their environment.
-
-    .. warning:: torchelastic is currently considered experimental,
-                 so the APIs may change!
+    Note:
+        TorchElastic users normally **do not** need to implement their own
+        ``RendezvousHandler``. An implementation based on C10d Store is already
+        provided, and is recommended for most users.
     """
 
     @abstractmethod


### PR DESCRIPTION
Summary:
Updated the note section of `RendezvousHandler`:

- Removed the experimental API warning.
- Recommended using the C10d Store instead of etcd for most users.

Test Plan: N/A

Differential Revision: D28253828

