### PR TITLE
Deprecate torch.eig

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -2579,6 +2579,19 @@ Tensor linalg_eigvals(const Tensor& input) {
 DEFINE_DISPATCH(eig_stub);
 
 std::tuple<Tensor&, Tensor&> eig_out(const Tensor& self, bool eigenvectors, Tensor& e, Tensor& v) {
+  TORCH_WARN_ONCE(
+    "torch.eig is deprecated in favor of torch.linalg.eig and will be removed in a future ",
+    "PyTorch release.\n",
+    "torch.linalg.eig returns complex tensors of dtype cfloat or cdouble rather than real tensors ",
+    "mimicking complex tensors.\n",
+    "L, _ = torch.eig(A)\n",
+    "should be replaced with\n",
+    "L_complex = torch.linalg.eigvals(A)\n",
+    "and\n",
+    "L, V = torch.eig(A, eigenvectors=True)\n",
+    "should be replaced with\n",
+    "L_complex, V_complex = torch.linalg.eig(A)"
+  );
   TORCH_CHECK(self.dim() == 2, "input should be 2 dimensional");
   TORCH_CHECK(self.size(0) == self.size(1), "input should be square");
   TORCH_CHECK(self.isfinite().all().item<bool>(), "input should not contain infs or NaNs");

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3769,7 +3769,7 @@ class TestAutograd(TestCase):
     def test_eig_complex_eigenvalues(self):
         A = torch.tensor([[0., -1.], [1., 0.]], dtype=torch.float32, requires_grad=True)
         w, v = torch.eig(A, eigenvectors=True)
-        with self.assertRaisesRegex(RuntimeError, 'is not differentiable'):
+        with self.assertRaisesRegex(RuntimeError, 'does not support complex eigenvalues'):
             torch.autograd.backward([w, v], [torch.ones_like(w), torch.ones_like(v)])
 
     @skipIfNoLapack

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -3762,14 +3762,14 @@ class TestAutograd(TestCase):
     def test_eig_no_eigenvectors(self):
         A = torch.tensor([[1., 2.], [2., 4.]], dtype=torch.float32, requires_grad=True)
         w, v = torch.eig(A, eigenvectors=False)
-        with self.assertRaisesRegex(RuntimeError, 'cannot compute backward'):
+        with self.assertRaisesRegex(RuntimeError, 'is not differentiable'):
             torch.autograd.backward([w, v], [torch.ones_like(w), torch.ones_like(v)])
 
     @skipIfNoLapack
     def test_eig_complex_eigenvalues(self):
         A = torch.tensor([[0., -1.], [1., 0.]], dtype=torch.float32, requires_grad=True)
         w, v = torch.eig(A, eigenvectors=True)
-        with self.assertRaisesRegex(RuntimeError, 'does not support complex eigenvalues'):
+        with self.assertRaisesRegex(RuntimeError, 'is not differentiable'):
             torch.autograd.backward([w, v], [torch.ones_like(w), torch.ones_like(v)])
 
     @skipIfNoLapack

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3001,6 +3001,25 @@ Computes the eigenvalues and eigenvectors of a real square matrix.
     When :attr:`input` is on CUDA, :func:`torch.eig() <torch.eig>` causes
     host-device synchronization.
 
+.. warning::
+
+    :func:`torch.eig` is deprecated in favor of :func:`torch.linalg.eig`
+    and will be removed in a future PyTorch release.
+    :func:`torch.linalg.eig` returns complex tensors of dtype `cfloat` or `cdouble`
+    rather than real tensors mimicking complex tensors.
+
+    ``L, _ = torch.eig(A)`` should be replaced with
+
+    .. code :: python
+
+        L_complex = torch.linalg.eigvals(A)
+
+    ``L, V = torch.eig(A, eigenvectors=True)`` should be replaced with
+
+    .. code :: python
+
+        L_complex, V_complex = torch.linalg.eig(A)
+
 Args:
     input (Tensor): the square matrix of shape :math:`(n \times n)` for which the eigenvalues and eigenvectors
         will be computed

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2198,8 +2198,8 @@ Tensor svd_backward(const std::vector<torch::autograd::Variable> &grads, const T
 Tensor eig_backward(const std::vector<torch::autograd::Variable> &grads, const Tensor& self,
                     bool is_eigvec_tensor_nonempty, const Tensor& eigenvalues, const Tensor& eigenvectors) {
   TORCH_CHECK(is_eigvec_tensor_nonempty,
-           "eig_backward: Setting eigenvectors to false in torch.eig doesn't compute eigenvectors ",
-           "and hence we cannot compute backward. Please use torch.linalg.eig(A)");
+           "eig_backward: torch.eig(eigenvalues=False) is not differentiable. ",
+           "Please use torch.linalg.eigvals");
 
   // variable names correspond to the ones in the reference document
   auto D = eigenvalues;

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -2199,7 +2199,7 @@ Tensor eig_backward(const std::vector<torch::autograd::Variable> &grads, const T
                     bool is_eigvec_tensor_nonempty, const Tensor& eigenvalues, const Tensor& eigenvectors) {
   TORCH_CHECK(is_eigvec_tensor_nonempty,
            "eig_backward: Setting eigenvectors to false in torch.eig doesn't compute eigenvectors ",
-           "and hence we cannot compute backward. Please use torch.eig(eigenvectors=True)");
+           "and hence we cannot compute backward. Please use torch.linalg.eig(A)");
 
   // variable names correspond to the ones in the reference document
   auto D = eigenvalues;


### PR DESCRIPTION
**BC-Breaking Note:**

This deprecates the torch.eig function in favor of the torch.linalg.eig function, which always returns two complex tensors instead of two real-valued tensors. See the documentation for torch.eig for details on how to migrate to torch.linalg.eig.

It DOES NOT remove torch.eig. But torch.eig will throw a warning (once) when called, and direct users to use torch.linalg.eig.