### PR TITLE
Remove unnecessary indirection through torch::autograd::impl::pyobj/set_pyobj

### DIFF
--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -78,8 +78,15 @@ PyObject* pyobj(const Variable& self) {
   return it == impl_to_pyobj.end() ? nullptr : it->second;
 }
 #else
-using torch::autograd::impl::pyobj;
-using torch::autograd::impl::set_pyobj;
+void set_pyobj(const Variable& self, PyObject* pyobj) {
+  TORCH_CHECK(self.defined(), "cannot call set_pyobj() on undefined tensor");
+  self.unsafeGetTensorImpl()->set_pyobj(pyobj);
+}
+
+PyObject* pyobj(const Variable& self) {
+  TORCH_CHECK(self.defined(), "cannot call pyobj() on undefined tensor");
+  return self.unsafeGetTensorImpl()->pyobj();
+}
 #endif
 
 // Creates a new Python object for a Variable. The Variable must not already

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -317,16 +317,6 @@ namespace impl {
   // Miscellaneous
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  void set_pyobj(const Variable& self, PyObject* pyobj) {
-    TORCH_CHECK(self.defined(), "cannot call set_pyobj() on undefined tensor");
-    self.unsafeGetTensorImpl()->set_pyobj(pyobj);
-  }
-
-  PyObject* pyobj(const Variable& self) {
-    TORCH_CHECK(self.defined(), "cannot call pyobj() on undefined tensor");
-    return self.unsafeGetTensorImpl()->pyobj();
-  }
-
   AutogradMeta* get_autograd_meta(const Variable& self) {
     // NB: could return nullptr
     TORCH_CHECK(self.defined(), "cannot call get_autograd_meta() on undefined tensor");

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -169,9 +169,6 @@ namespace impl {
   /// Retrieves this `Variable`s version counter.
   TORCH_API const c10::VariableVersion& version_counter(const Variable&);
 
-  TORCH_API PyObject* pyobj(const Variable&);
-  TORCH_API void set_pyobj(const Variable&, PyObject* pyobj);
-
   TORCH_API void set_name(const Variable&, const std::string& name);
 
   TORCH_API void add_hook(const Variable&, std::shared_ptr<FunctionPreHook> hook);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57733 Remove unnecessary indirection through torch::autograd::impl::pyobj/set_pyobj**

I'm going to be modifying the APIs here, so the less API surface
covering these functions the better.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28289082](https://our.internmc.facebook.com/intern/diff/D28289082)