### PR TITLE
Deprecate matrix_rank

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -408,10 +408,20 @@ Tensor linalg_matrix_rank(const Tensor& input, optional<double> tol, bool hermit
 }
 
 Tensor matrix_rank(const Tensor& self, double tol, bool symmetric) {
+  TORCH_WARN_ONCE(
+    "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was ",
+    "renamed in torch.linalg.matrix_rank to 'hermitian'."
+  );
   return at::linalg_matrix_rank(self, optional<double>(tol), symmetric);
 }
 
 Tensor matrix_rank(const Tensor& self, bool symmetric) {
+  TORCH_WARN_ONCE(
+    "torch.matrix_rank is deprecated in favor of torch.linalg.matrix_rank",
+    "and will be removed in a future PyTorch release. The parameter 'symmetric' was ",
+    "renamed in torch.linalg.matrix_rank to 'hermitian'."
+  );
   return at::linalg_matrix_rank(self, c10::nullopt, symmetric);
 }
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -5086,8 +5086,11 @@ specified, :attr:`tol` is set to ``S.max() * max(S.size()) * eps`` where `S` is 
 singular values (or the eigenvalues when :attr:`symmetric` is ``True``), and ``eps``
 is the epsilon value for the datatype of :attr:`input`.
 
-.. note:: :func:`torch.matrix_rank` is deprecated. Please use :func:`torch.linalg.matrix_rank` instead.
-          The parameter :attr:`symmetric` was renamed in :func:`torch.linalg.matrix_rank` to ``hermitian``.
+.. warning::
+
+    :func:`torch.matrix_rank` is deprecated in favor of :func:`torch.linalg.matrix_rank`
+    and will be removed in a future PyTorch release. The parameter :attr:`symmetric` was
+    renamed in :func:`torch.linalg.matrix_rank` to :attr:`hermitian`.
 
 Args:
     input (Tensor): the input 2-D tensor


### PR DESCRIPTION
This one's straightforward


**BC-breaking Note**

This PR deprecates matrix_rank in favor of linalg.matrix_rank. An upgrade guide from matrix_rank to linalg.matrix_rank is provided in the documentation of matrix_rank.

It DOES NOT remove matrix_rank.