### PR TITLE
[1/n] [torch/elastic] Add alias support to RendezvousHandlerRegistry

### DIFF
--- a/test/distributed/elastic/rendezvous/api_test.py
+++ b/test/distributed/elastic/rendezvous/api_test.py
@@ -252,6 +252,18 @@ class RendezvousHandlerRegistryTest(TestCase):
 
         self.assertIs(handler.params, self._params)
 
+    def test_create_handler_returns_handler_if_backend_name_is_an_alias(self) -> None:
+        self._registry.register("dummy_backend", self._create_handler, aliases=["dummy_alias"])
+
+        self._params.backend = "dummy_alias"
+
+        handler = self._registry.create_handler(self._params)
+
+        self.assertIsInstance(handler, _DummyRendezvousHandler)
+
+        self.assertIs(handler.params, self._params)
+
+
     def test_create_handler_raises_error_if_backend_is_not_registered(self) -> None:
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57738 [2/n] [torch/elastic] Rename etcd-/c10d-experimental rdzv backends to etcd-v2 and c10d
* **#57737 [1/n] [torch/elastic] Add alias support to RendezvousHandlerRegistry**

This PR adds support for aliases in `RendezvousHandlerRegistry`. Due to backwards compatibility requirements we have to preserve the original backend names; therefore in order to have consistency between new and old backend names we use aliases.

Differential Revision: [D28255808](https://our.internmc.facebook.com/intern/diff/D28255808/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28255808/)!