### PR TITLE
[2/n] [torch/elastic] Rename etcd-/c10d-experimental rdzv backends to etcd-v2 and c10d

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -59,7 +59,7 @@ class CreateBackendTest(TestCase):
 
         self.assertIsInstance(backend.store, self._expected_store_type)
 
-        self.assertEqual(backend.name, "c10d-experimental")
+        self.assertEqual(backend.name, "c10d")
         self.assertEqual(backend.key, "torch.rendezvous." + self._params.run_id)
 
         store = backend.store

--- a/test/distributed/elastic/rendezvous/etcd_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_rendezvous_backend_test.py
@@ -77,7 +77,7 @@ class CreateBackendTest(TestCase):
     def test_create_backend_returns_backend(self) -> None:
         backend = create_backend(self._params)
 
-        self.assertEqual(backend.name, "etcd-experimental")
+        self.assertEqual(backend.name, "etcd-v2")
         self.assertEqual(backend.key, "/torch/elastic/rendezvous/" + self._params.run_id)
         self.assertEqual(backend.ttl, 7200)
         self.assertEqual(backend.client.host, self._server.get_host())

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -56,7 +56,7 @@ class C10dRendezvousBackend(RendezvousBackend):
     @property
     def name(self) -> str:
         """See base class."""
-        return "c10d-experimental"
+        return "c10d"
 
     @property
     def store(self) -> Store:

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.py
@@ -68,7 +68,7 @@ class EtcdRendezvousBackend(RendezvousBackend):
     @property
     def name(self) -> str:
         """See base class."""
-        return "etcd-experimental"
+        return "etcd-v2"
 
     @property
     def client(self) -> EtcdClient:

--- a/torch/distributed/elastic/rendezvous/registry.py
+++ b/torch/distributed/elastic/rendezvous/registry.py
@@ -9,27 +9,13 @@ from .api import rendezvous_handler_registry as handler_registry
 from .dynamic_rendezvous import create_handler
 
 
-def _create_static_handler(params: RendezvousParameters) -> RendezvousHandler:
-    from . import static_tcp_rendezvous
-
-    return static_tcp_rendezvous.create_rdzv_handler(params)
-
-
-def _create_etcd_handler(params: RendezvousParameters) -> RendezvousHandler:
+def _create_etcd_v1_handler(params: RendezvousParameters) -> RendezvousHandler:
     from . import etcd_rendezvous
 
     return etcd_rendezvous.create_rdzv_handler(params)
 
 
-def _create_c10d_handler(params: RendezvousParameters) -> RendezvousHandler:
-    from .c10d_rendezvous_backend import create_backend
-
-    backend = create_backend(params)
-
-    return create_handler(backend.store, backend, params)
-
-
-def _create_expr_etcd_handler(params: RendezvousParameters) -> RendezvousHandler:
+def _create_etcd_v2_handler(params: RendezvousParameters) -> RendezvousHandler:
     from .etcd_rendezvous_backend import create_backend
     from .etcd_store import EtcdStore
 
@@ -40,10 +26,24 @@ def _create_expr_etcd_handler(params: RendezvousParameters) -> RendezvousHandler
     return create_handler(store, backend, params)
 
 
+def _create_c10d_handler(params: RendezvousParameters) -> RendezvousHandler:
+    from .c10d_rendezvous_backend import create_backend
+
+    backend = create_backend(params)
+
+    return create_handler(backend.store, backend, params)
+
+
+def _create_static_handler(params: RendezvousParameters) -> RendezvousHandler:
+    from . import static_tcp_rendezvous
+
+    return static_tcp_rendezvous.create_rdzv_handler(params)
+
+
 def _register_default_handlers() -> None:
-    handler_registry.register("etcd", _create_etcd_handler)
-    handler_registry.register("c10d-experimental", _create_c10d_handler)
-    handler_registry.register("etcd-experimental", _create_expr_etcd_handler)
+    handler_registry.register("etcd", _create_etcd_v1_handler, aliases=["etcd-v1"])
+    handler_registry.register("etcd-v2", _create_etcd_v2_handler)
+    handler_registry.register("c10d", _create_c10d_handler)
     handler_registry.register("static", _create_static_handler)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57738 [2/n] [torch/elastic] Rename etcd-/c10d-experimental rdzv backends to etcd-v2 and c10d**
* #57737 [1/n] [torch/elastic] Add alias support to RendezvousHandlerRegistry

As discussed offline this PR renames `etcd-experimental` backend to `etcd-v2` and `c10d-experimental` backend to `c10d`. In order to have consistency in naming it also adds an `etcd-v1` alias to the original `etcd` backend.

Differential Revision: [D28255813](https://our.internmc.facebook.com/intern/diff/D28255813/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28255813/)!