### PR TITLE
Deprecate QR

### DIFF
--- a/aten/src/ATen/native/BatchLinearAlgebra.cpp
+++ b/aten/src/ATen/native/BatchLinearAlgebra.cpp
@@ -1685,6 +1685,7 @@ std::tuple<Tensor, Tensor> geqrf(const Tensor& input) {
   For further details, please see the LAPACK documentation for GEQRF and ORGQR.
 */
 void linalg_qr_out_helper(const Tensor& input, const Tensor& Q, const Tensor& R, bool compute_q, bool reduced_mode) {
+
   TORCH_INTERNAL_ASSERT(input.dim() >= 2);
 
   TORCH_INTERNAL_ASSERT(input.scalar_type() == Q.scalar_type());
@@ -1816,11 +1817,25 @@ std::tuple<Tensor&,Tensor&> linalg_qr_out(const Tensor& self, std::string mode, 
 }
 
 std::tuple<Tensor,Tensor> qr(const Tensor& self, bool some) {
+  TORCH_WARN_ONCE(
+    "torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.\n",
+    "The boolean parameter 'some' has been replaced with a string parameter 'mode'.\n",
+    "Q, R = torch.qr(A, some)\n",
+    "should be replaced with\n",
+    "Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete')"
+  );
   std::string mode = some ? "reduced" : "complete";
   return at::linalg_qr(self, mode);
 }
 
 std::tuple<Tensor&,Tensor&> qr_out(const Tensor& self, bool some, Tensor& Q, Tensor& R) {
+  TORCH_WARN_ONCE(
+    "torch.qr is deprecated in favor of torch.linalg.qr and will be removed in a future PyTorch release.\n",
+    "The boolean parameter 'some' has been replaced with a string parameter 'mode'.\n",
+    "Q, R = torch.qr(A, some)\n",
+    "should be replaced with\n",
+    "Q, R = torch.linalg.qr(A, 'reduced' if some else 'complete')"
+  );
   std::string mode = some ? "reduced" : "complete";
   return at::linalg_qr_out(Q, R, self, mode);
 }

--- a/test/jit/test_export_modes.py
+++ b/test/jit/test_export_modes.py
@@ -71,7 +71,7 @@ class TestExportModes(JitTestCase):
         class ModelWithAtenNotONNXOp(nn.Module):
             def forward(self, x, y):
                 abcd = x + y
-                defg = torch.qr(abcd)
+                defg = torch.linalg.qr(abcd)
                 return defg
 
         x = torch.rand(3, 4)

--- a/test/typing/reveal/namedtuple.py
+++ b/test/typing/reveal/namedtuple.py
@@ -9,7 +9,7 @@ t_sort.indices[0, 0] == 1   # noqa: B015
 t_sort.values[0, 0] == 1.5  # noqa: B015
 reveal_type(t_sort)  # E: Tuple[{Tensor}, {Tensor}, fallback=torch._C.namedtuple_values_indices]
 
-t_qr = torch.qr(t)
+t_qr = torch.linalg.qr(t)
 t_qr[0].shape == [2, 2]     # noqa: B015
 t_qr.Q.shape == [2, 2]      # noqa: B015
 reveal_type(t_qr)  # E: Tuple[{Tensor}, {Tensor}, fallback=torch._C._VariableFunctions.namedtuple_Q_R]

--- a/torch/_linalg_utils.py
+++ b/torch/_linalg_utils.py
@@ -82,7 +82,7 @@ def basis(A):
     """
     if A.is_cuda:
         # torch.orgqr is not available in CUDA
-        Q, _ = torch.qr(A, some=True)
+        Q = torch.linalg.qr(A).Q
     else:
         Q = torch.orgqr(*torch.geqrf(A))
     return Q

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -64,6 +64,8 @@ def get_approximate_basis(A: Tensor,
 
     R = torch.randn(n, q, dtype=dtype, device=A.device)
 
+    # The following code could be made faster using torch.geqrf + torch.ormqr
+    # but geqrf is not differentiable
     A_H = _utils.transjugate(A)
     if M is None:
         Q = torch.linalg.qr(matmul(A, R)).Q

--- a/torch/_lowrank.py
+++ b/torch/_lowrank.py
@@ -66,16 +66,16 @@ def get_approximate_basis(A: Tensor,
 
     A_H = _utils.transjugate(A)
     if M is None:
-        (Q, _) = matmul(A, R).qr()
+        Q = torch.linalg.qr(matmul(A, R)).Q
         for i in range(niter):
-            (Q, _) = matmul(A_H, Q).qr()
-            (Q, _) = matmul(A, Q).qr()
+            Q = torch.linalg.qr(matmul(A_H, Q)).Q
+            Q = torch.linalg.qr(matmul(A, Q)).Q
     else:
         M_H = _utils.transjugate(M)
-        (Q, _) = (matmul(A, R) - matmul(M, R)).qr()
+        Q = torch.linalg.qr(matmul(A, R) - matmul(M, R)).Q
         for i in range(niter):
-            (Q, _) = (matmul(A_H, Q) - matmul(M_H, Q)).qr()
-            (Q, _) = (matmul(A, Q) - matmul(M, Q)).qr()
+            Q = torch.linalg.qr(matmul(A_H, Q) - matmul(M_H, Q)).Q
+            Q = torch.linalg.qr(matmul(A, Q) - matmul(M, Q)).Q
 
     return Q
 

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7002,18 +7002,23 @@ with :math:`Q` being an orthogonal matrix or batch of orthogonal matrices and
 If :attr:`some` is ``True``, then this function returns the thin (reduced) QR factorization.
 Otherwise, if :attr:`some` is ``False``, this function returns the complete QR factorization.
 
-.. warning:: ``torch.qr`` is deprecated. Please use :func:`torch.linalg.qr`
-             instead.
+.. warning::
 
-             **Differences with** ``torch.linalg.qr``:
+    :func:`torch.qr` is deprecated in favor of :func:`torch.linalg.qr`
+    and will be removed in a future PyTorch release. The boolean parameter :attr:`some` has been
+    replaced with a string parameter :attr:`mode`.
 
-             * ``torch.linalg.qr`` takes a string parameter ``mode`` instead of ``some``:
+    ``Q, R = torch.qr(A)`` should be replaced with
 
-               - ``some=True`` is equivalent of ``mode='reduced'``: both are the
-                 default
+    .. code:: python
 
-               - ``some=False`` is equivalent of ``mode='complete'``.
+        Q, R = torch.linalg.qr(A)
 
+    ``Q, R = torch.qr(A, some=False)`` should be replaced with
+
+    .. code:: python
+
+        Q, R = torch.linalg.qr(A, mode="complete")
 
 .. warning::
           If you plan to backpropagate through QR, note that the current backward implementation

--- a/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.py
@@ -12,8 +12,10 @@ def _orthogonalize(matrix, epsilon=0):
     """
     Applies Gram-Schmidt procedure to orthogonalize a given 2D tensor.
     If epsilon is 0, this is equivalent to `torch.qr(matrix, out=(matrix, _))`,
-    but `torch.qr` is very slow, probably because it is not optimized for a matrix that has a small number of columns.
     """
+    # TODO Consider using Q = torch.orgqr(*torch.geqrf(A)) to compute the Q of the QR _much_ faster
+    # and more reliably.
+    # Works on FP32/64 or complex numbers (does not work for half precision)
     num_cols = matrix.shape[1]
     for i in range(num_cols):
         # Normalize the i'th column.

--- a/torch/nn/init.py
+++ b/torch/nn/init.py
@@ -458,7 +458,7 @@ def orthogonal_(tensor, gain=1):
         flattened.t_()
 
     # Compute the qr factorization
-    q, r = torch.qr(flattened)
+    q, r = torch.linalg.qr(flattened)
     # Make Q uniform according to https://arxiv.org/pdf/math-ph/0609050.pdf
     d = torch.diag(r, 0)
     ph = d.sign()


### PR DESCRIPTION
**BC-breaking note:**

This PR deprecates the torch.qr function in favor of torch.linalg.qr. An upgarde guide is added to the documentation for torch.qr.

Note that it DOES NOT remove torch.qr, but torch.qr will be removed in a future PyTorch release.