### PR TITLE
[flake8] install flake8-quotes

### DIFF
--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -2,6 +2,7 @@ flake8==3.8.2
 flake8-bugbear==20.1.4
 flake8-comprehensions==3.3.0
 flake8-executable==2.0.4
+flake8-quotes==3.2.0
 git+https://github.com/malfet/flake8-coding.git
 flake8-pyi==20.5.0
 mccabe


### PR DESCRIPTION
This should be a no-op given the existing .flake8 config file because
it is not enabled by default.
It will facilitate gradually bringing the code into compliance with
PEP8's guidance on string quotes: "Pick a rule and stick to it." [1]

The plan is to enable this one directory at a time until the entire
code base is compliant, and then enable it in the root .flake8 config.

Starting with:
https://github.com/pytorch/pytorch/pull/57757

[1] https://www.python.org/dev/peps/pep-0008/#string-quotes