### PR TITLE
Catch KeyboardInterrupt in tools/test_history.py

### DIFF
--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -341,4 +341,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
Currently, interrupting `tools/test_history.py` with `^C` gives a very long traceback:
```
$ tools/test_history.py --mode=multiline --ref=594a66 --sha-length=8 --test=test_set_dir --job pytorch_linux_xenial_py3_6_gcc5_4_test --job pytorch_linux_xenial_py3_6_gcc7_test
2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc7_test 0.449s
2021-02-10 10:09:14Z 602434bc pytorch_linux_xenial_py3_6_gcc5_4_test 0.361s
2021-02-10 10:09:14Z 602434bc pytorch_linux_xenial_py3_6_gcc7_test 0.454s
2021-02-10 10:09:10Z 2e35fe95 (no reports in S3)
2021-02-10 10:09:07Z ff73be7e (no reports in S3)
2021-02-10 10:05:39Z 74082f0d (no reports in S3)
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc5_4_test 0.414s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc5_4_test 0.476s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc7_test 0.377s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc7_test 0.326s
2021-02-10 07:27:53Z 33afb5f1 pytorch_linux_xenial_py3_6_gcc5_4_test 0.381s
2021-02-10 07:27:53Z 33afb5f1 pytorch_linux_xenial_py3_6_gcc7_test 0.294s
^CTraceback (most recent call last):
  File "tools/test_history.py", line 344, in <module>
    main()
  File "tools/test_history.py", line 339, in main
    for line in run(sys.argv[1:]):
  File "tools/test_history.py", line 143, in history_lines
    summaries = get_test_stats_summaries(sha=sha, jobs=jobs)
  File "/Users/sestep/github/pytorch/pytorch/tools/stats_utils/s3_stat_parser.py", line 161, in get_test_stats_summaries
    return _parse_s3_summaries(summaries, jobs=list(jobs or []))
  File "/Users/sestep/github/pytorch/pytorch/tools/stats_utils/s3_stat_parser.py", line 147, in _parse_s3_summaries
    for summary in summaries:
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/boto3/resources/collection.py", line 83, in __iter__
    for page in self.pages():
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/boto3/resources/collection.py", line 166, in pages
    for page in pages:
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/client.py", line 662, in _make_api_call
    http, parsed_response = self._make_request(
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/client.py", line 682, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/endpoint.py", line 102, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/endpoint.py", line 134, in _send_request
    success_response, exception = self._get_response(
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/endpoint.py", line 166, in _get_response
    success_response, exception = self._do_get_response(
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/endpoint.py", line 200, in _do_get_response
    http_response = self._send(request)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/endpoint.py", line 269, in _send
    return self.http_session.send(request)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/botocore/httpsession.py", line 308, in send
    urllib_response = conn.urlopen(
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/urllib3/connectionpool.py", line 699, in urlopen
    httplib_response = self._make_request(
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/http/client.py", line 1347, in getresponse
    response.begin()
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/http/client.py", line 307, in begin
    version, status, reason = self._read_status()
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/http/client.py", line 268, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/socket.py", line 669, in readinto
    return self._sock.recv_into(b)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/Users/sestep/miniconda3/envs/pytorch/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
KeyboardInterrupt
```
This PR eliminates that traceback using a technique from `tools/actions_local_runner.py`.

**Test plan:**

```
$ tools/test_history.py --mode=multiline --ref=594a66 --sha-length=8 --test=test_set_dir --job pytorch_linux_xenial_py3_6_gcc5_4_test --job pytorch_linux_xenial_py3_6_gcc7_test
2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc5_4_test 0.36s
2021-02-10 11:13:34Z 594a66d7 pytorch_linux_xenial_py3_6_gcc7_test 0.573s errored
2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc5_4_test 0.819s
2021-02-10 10:13:25Z 9c0caf03 pytorch_linux_xenial_py3_6_gcc7_test 0.449s
2021-02-10 10:09:14Z 602434bc pytorch_linux_xenial_py3_6_gcc5_4_test 0.361s
2021-02-10 10:09:14Z 602434bc pytorch_linux_xenial_py3_6_gcc7_test 0.454s
2021-02-10 10:09:10Z 2e35fe95 (no reports in S3)
2021-02-10 10:09:07Z ff73be7e (no reports in S3)
2021-02-10 10:05:39Z 74082f0d (no reports in S3)
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc5_4_test 0.414s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc5_4_test 0.476s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc7_test 0.377s
2021-02-10 07:42:29Z 0620c96f pytorch_linux_xenial_py3_6_gcc7_test 0.326s
2021-02-10 07:27:53Z 33afb5f1 pytorch_linux_xenial_py3_6_gcc5_4_test 0.381s
2021-02-10 07:27:53Z 33afb5f1 pytorch_linux_xenial_py3_6_gcc7_test 0.294s
^C
```