### PR TITLE
Reimplement spectral_norm using new parametrization functionality

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -372,11 +372,22 @@ From the ``torch.nn.utils`` module
     spectral_norm
     remove_spectral_norm
 
+Parametrizations implemented using the new parametrization functionality
+in :func:`torch.nn.utils.parameterize.register_parametrization`.
+See the `Parametrizations <https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html>`__ tutorial 
+for more information on how to implement your own parametrizations.
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    parametrizations.spectral_norm
+
 Utility functions to parametrize Tensors on existing Modules.
 Note that these functions can be used to parametrize a given Parameter
 or Buffer given a specific function that maps from an input space to the
 parametrized space. They are not parameterizations that would transform
-an object into a parameter.
+an object into a parameter. 
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -374,8 +374,6 @@ From the ``torch.nn.utils`` module
 
 Parametrizations implemented using the new parametrization functionality
 in :func:`torch.nn.utils.parameterize.register_parametrization`.
-See the `Parametrizations <https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html>`__ tutorial 
-for more information on how to implement your own parametrizations.
 
 .. autosummary::
     :toctree: generated
@@ -387,7 +385,9 @@ Utility functions to parametrize Tensors on existing Modules.
 Note that these functions can be used to parametrize a given Parameter
 or Buffer given a specific function that maps from an input space to the
 parametrized space. They are not parameterizations that would transform
-an object into a parameter. 
+an object into a parameter. See the
+`Parametrizations <https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html>`__ tutorial
+for more information on how to implement your own parametrizations.
 
 .. autosummary::
     :toctree: generated

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2478,6 +2478,31 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(ValueError, "changes the dtype"):
             parametrize.remove_parametrizations(module, "weight", leave_parametrized=True)
 
+    def test_parametrization_eval_mode_on_remove(self):
+        r"""Test forward runs in eval mode when parametrization is removed"""
+        training = [True]
+        n_forward_runs = [0]
+
+        class CheckTraining(nn.Module):
+            def forward(self, X):
+                training[0] = self.training
+                n_forward_runs[0] += 1
+                return X
+
+        module = nn.Linear(4, 4)
+        module.train()
+        parametrize.register_parametrization(module, "weight", CheckTraining())
+        parametrize.remove_parametrizations(module, "weight", leave_parametrized=False)
+        self.assertEqual(n_forward_runs[0], 0)
+        self.assertTrue(training[0])
+
+        parametrize.register_parametrization(module, "weight", CheckTraining())
+        parametrize.remove_parametrizations(module, "weight", leave_parametrized=True)
+        self.assertEqual(n_forward_runs[0], 1)
+        self.assertFalse(training[0])
+        # The actual module's train/eval was not affected
+        self.assertTrue(module.training)
+
     # torch/nn/utils/prune.py
     @unittest.skipIf(not TEST_NUMPY, "numpy not found")
     def test_validate_pruning_amount_init(self):
@@ -3690,6 +3715,254 @@ class TestNN(NNTestCase):
 
                     gradcheck(fn, (m.weight_orig,))
 
+    def test_new_spectral_norm(self):
+        input = torch.randn(3, 5)
+        m = nn.Linear(5, 7)
+        m = torch.nn.utils.parametrizations.spectral_norm(m)
+        spectral_norm_m = m.parametrizations.weight[0]
+
+        self.assertEqual(spectral_norm_m.u.size(), torch.Size([m.weight.size(0)]))
+
+        # .parametrizations.weight.original should be trainable
+        self.assertTrue(hasattr(m.parametrizations.weight, 'original'))
+        self.assertTrue('original' in m.parametrizations.weight._parameters)
+
+        # u should be just a reused buffer
+        self.assertTrue(hasattr(spectral_norm_m, 'u'))
+        self.assertTrue('u' in spectral_norm_m._buffers)
+        self.assertTrue('v' in spectral_norm_m._buffers)
+
+        # weight should be a plain attribute, not counted as a buffer or a param
+        self.assertIsNotNone(m.weight)
+        self.assertFalse('weight' in m._buffers)
+        self.assertFalse('weight' in m._parameters)
+
+        # it should also be sharing storage as `weight_orig`
+        # self.assertEqual(m.parametrizations.weight.original.storage(), m.weight.storage())
+        self.assertEqual(m.parametrizations.weight.original.size(), m.weight.size())
+        self.assertEqual(m.parametrizations.weight.original.stride(), m.weight.stride())
+
+        m = torch.nn.utils.parametrize.remove_parametrizations(m, 'weight')
+
+        # spectral_norm is the only parametrization
+        self.assertFalse(hasattr(m, 'parametrizations'))
+        self.assertTrue('weight' in m._parameters)
+
+        # We can register spectral_norm multiple times on the same parameter
+        # and on multiple parameters in the same module
+        m = torch.nn.utils.parametrizations.spectral_norm(m, 'weight')
+        m = torch.nn.utils.parametrizations.spectral_norm(m, 'weight')
+        m = torch.nn.utils.parametrizations.spectral_norm(m, 'bias')
+
+        # If we remove the parametrization on bias, weight is still parametrized
+        # Removing a parametrization runs forward in eval mode if leave_parametrized=True
+        with self.assertWarnsRegex(UserWarning, "SpectralNorm's `forward` called for the first time"):
+            m = torch.nn.utils.parametrize.remove_parametrizations(m, 'bias')
+        self.assertTrue('bias' in m._parameters)
+        self.assertTrue(hasattr(m, 'parametrizations'))
+        self.assertFalse('weight' in m._parameters)
+
+        with self.assertWarnsRegex(UserWarning, "SpectralNorm's `forward` called for the first time"):
+            m = torch.nn.utils.parametrize.remove_parametrizations(m, 'weight')
+        # Neither weight and bias are parametrized
+        self.assertFalse(hasattr(m, 'parametrizations'))
+        self.assertTrue('weight' in m._parameters)
+
+        # test correctness in training/eval modes and cpu/multi-gpu settings
+        for apply_dp in (True, False):
+            if apply_dp:
+                if not TEST_MULTIGPU:
+                    continue
+                device = torch.device('cuda:0')
+
+                def maybe_wrap(m):
+                    return torch.nn.DataParallel(m, [0, 1])
+            else:
+                device = torch.device('cpu')
+
+                def maybe_wrap(m):
+                    return m
+
+            for requires_grad in (True, False):
+                def get_modules():
+                    m = nn.Linear(3, 4).to(device)
+                    m.weight.requires_grad_(requires_grad)
+                    m = torch.nn.utils.parametrizations.spectral_norm(m)
+                    wrapped_m = maybe_wrap(m)
+                    spectral_norm_m = m.parametrizations.weight[0]
+                    return m, wrapped_m, spectral_norm_m
+
+                input = torch.randn(2, 3, device=device)
+
+                m, wrapped_m, spectral_norm_m = get_modules()
+
+                self.assertTrue(hasattr(spectral_norm_m, 'u'))
+                u0 = spectral_norm_m.u.clone()
+                v0 = spectral_norm_m.v.clone()
+
+                # TEST TRAINING BEHAVIOR
+
+                # run forward again and assert that u and v are updated
+                out = wrapped_m(input)
+                self.assertNotEqual(u0, spectral_norm_m.u)
+                self.assertNotEqual(v0, spectral_norm_m.v)
+
+                # assert that backprop reaches original weight
+                # can't use gradcheck because the function changes as we
+                # activate through it in training mode
+                if requires_grad:
+                    torch.autograd.grad(out.sum(), m.parametrizations.weight.original)
+
+                # test backward works with multiple forwards
+                # it uses training mode so we need to reset `u` and `v` vectors
+                # to same value at beginning for finite difference test to pass
+                saved_u = spectral_norm_m.u.clone()
+                saved_v = spectral_norm_m.v.clone()
+
+                def fn(input):
+                    spectral_norm_m.u.data.copy_(saved_u)
+                    spectral_norm_m.v.data.copy_(saved_v)
+                    out0 = wrapped_m(input)
+                    out1 = wrapped_m(input)
+                    return out0 + out1
+
+                gradcheck(fn, (input.clone().requires_grad_(),), check_batched_grad=False)
+
+                # test removing
+                m, wrapped_m, _ = get_modules()
+                pre_remove_out = wrapped_m(input)
+                m = torch.nn.utils.parametrize.remove_parametrizations(m, 'weight')
+                self.assertEqual(wrapped_m(input), pre_remove_out)
+
+                torch.nn.utils.parametrizations.spectral_norm(m)
+                for _ in range(3):
+                    pre_remove_out = wrapped_m(input)
+                m = torch.nn.utils.parametrize.remove_parametrizations(m, 'weight')
+                self.assertEqual(wrapped_m(input), pre_remove_out)
+
+                # TEST EVAL BEHAVIOR
+                m, wrapped_m, spectral_norm_m = get_modules()
+                wrapped_m(input)
+                last_train_out = wrapped_m(input)
+                last_train_u = spectral_norm_m.u.clone()
+                last_train_v = spectral_norm_m.v.clone()
+                wrapped_m.zero_grad()
+                wrapped_m.eval()
+
+                eval_out0 = wrapped_m(input)
+                # assert eval gives same result as last training iteration
+                self.assertEqual(eval_out0, last_train_out)
+                # assert doing more iteartion in eval don't change things
+                self.assertEqual(eval_out0, wrapped_m(input))
+                self.assertEqual(last_train_u, spectral_norm_m.u)
+                self.assertEqual(last_train_v, spectral_norm_m.v)
+
+                # FIXME: the code below is flaky when executed with DataParallel
+                # see https://github.com/pytorch/pytorch/issues/13818
+                if apply_dp:
+                    continue
+
+                # test backward works with multiple forwards in mixed training
+                # and eval modes
+                # it uses training mode so we need to reset `u` and `v` vectors
+                # to same value at beginning for finite difference test to pass
+                saved_u = spectral_norm_m.u.clone()
+                saved_v = spectral_norm_m.v.clone()
+
+                def fn(input):
+                    spectral_norm_m.u.data.copy_(saved_u)
+                    spectral_norm_m.v.data.copy_(saved_v)
+                    wrapped_m.train()
+                    out0 = wrapped_m(input)
+                    wrapped_m.eval()
+                    out1 = wrapped_m(input)
+                    wrapped_m.train()
+                    out2 = wrapped_m(input)
+                    wrapped_m.eval()
+                    out3 = wrapped_m(input)
+                    return out0 + out1 + out2 + out3
+
+                gradcheck(fn, (input.clone().requires_grad_(),))
+
+                # assert that backprop reaches weight_orig in eval
+                if requires_grad:
+                    def fn(weight):
+                        return wrapped_m(input)
+
+                    gradcheck(fn, (m.parametrizations.weight.original,))
+
+    def test_new_spectral_norm_load_state_dict(self):
+        for activate_times in (0, 3):
+            inp = torch.randn(2, 3)
+            m = nn.Linear(3, 5)
+            snm = torch.nn.utils.parametrizations.spectral_norm(m)
+            snm.train()
+
+            for _ in range(activate_times):
+                snm(inp)
+
+            state_dict = deepcopy(snm.state_dict())
+            self.assertEqual({
+                'parametrizations.weight.original',
+                'bias',
+                'parametrizations.weight.0.v',
+                'parametrizations.weight.0.u'
+            }, set(state_dict.keys()))
+
+            # test that non-strict loading works
+            non_strict_state_dict = deepcopy(state_dict)
+            non_strict_state_dict['nonsense'] = 'nonsense'
+            with self.assertRaisesRegex(RuntimeError, r'Unexpected key\(s\) in state_dict: "nonsense"'):
+                snm.load_state_dict(non_strict_state_dict, strict=True)
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict['parametrizations.weight.original']
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict['parametrizations.weight.0.u']
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict['parametrizations.weight.0.v']
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            non_strict_state_dict['weight'] = snm.weight.detach().clone()     # set W as a buffer
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict._metadata['parametrizations.weight.0']  # remove metadata info
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict['weight']                               # remove W buffer
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+            del non_strict_state_dict['bias']
+            snm.load_state_dict(non_strict_state_dict, strict=False)
+
+            # normal state_dict
+
+            # test that re-wrapping does not matter
+            m = torch.nn.utils.parametrize.remove_parametrizations(snm, 'weight')
+            snm = torch.nn.utils.parametrizations.spectral_norm(m)
+
+            snm.load_state_dict(state_dict)
+            with torch.no_grad():
+                snm.eval()
+                with self.assertWarnsRegex(UserWarning, "SpectralNorm's `forward` called for the first time"):
+                    out0_eval = snm(inp)
+                snm.train()
+                out1_train = snm(inp)
+                out2_train = snm(inp)
+                snm.eval()
+                out3_eval = snm(inp)
+
+            # test that re-wrapping does not matter
+            m = torch.nn.utils.parametrize.remove_parametrizations(snm, 'weight')
+            snm = torch.nn.utils.parametrizations.spectral_norm(m)
+
+            # Test normal loading
+            snm.load_state_dict(state_dict)
+            with torch.no_grad():
+                snm.eval()
+                with self.assertWarnsRegex(UserWarning, "SpectralNorm's `forward` called for the first time"):
+                    self.assertEqual(out0_eval, snm(inp))
+                snm.train()
+                self.assertEqual(out1_train, snm(inp))
+                self.assertEqual(out2_train, snm(inp))
+                snm.eval()
+                self.assertEqual(out3_eval, snm(inp))
+
     @skipIfNoLapack
     def test_spectral_norm_load_state_dict(self):
         inp = torch.randn(2, 3)
@@ -3797,12 +4070,40 @@ class TestNN(NNTestCase):
         # check that u refers to the same dimension
         self.assertEqual(m.weight_u.shape, m.weight_orig[0, :, 0, 0].shape)
 
+    def test_new_spectral_norm_dim(self):
+        inp = torch.randn(2, 3, 10, 12)
+        m = nn.ConvTranspose2d(3, 4, (5, 6))
+        m = torch.nn.utils.parametrizations.spectral_norm(m)
+        snm = m.parametrizations.weight[0]
+        # this should not run into incompatible shapes
+        x = m(inp)
+        # check that u refers to the same dimension
+        self.assertEqual(snm.u.shape, m.parametrizations.weight.original[0, :, 0, 0].shape)
+
     def test_spectral_norm_forward(self):
         input = torch.randn(3, 5)
         m = nn.Linear(5, 7)
         m = torch.nn.utils.spectral_norm(m)
         # naive forward
         _weight, _bias, _u = m.weight_orig, m.bias, m.weight_u
+        _weight_mat = _weight.view(_weight.size(0), -1)
+        _v = torch.mv(_weight_mat.t(), _u)
+        _v = F.normalize(_v, dim=0, eps=1e-12)
+        _u = torch.mv(_weight_mat, _v)
+        _u = F.normalize(_u, dim=0, eps=1e-12)
+        _weight.data /= torch.dot(_u, torch.matmul(_weight_mat, _v))
+        out_hat = torch.nn.functional.linear(input, _weight, _bias)
+        expect_out = m(input)
+        self.assertEqual(expect_out, out_hat)
+
+    def test_new_spectral_norm_forward(self):
+        input = torch.randn(3, 5)
+        m = nn.Linear(5, 7)
+        m = torch.nn.utils.parametrizations.spectral_norm(m)
+        snm = m.parametrizations.weight[0]
+        # naive forward
+        _weight = m.parametrizations.weight.original
+        _bias, _u = m.bias, snm.u
         _weight_mat = _weight.view(_weight.size(0), -1)
         _v = torch.mv(_weight_mat.t(), _u)
         _v = F.normalize(_v, dim=0, eps=1e-12)

--- a/torch/nn/utils/__init__.py
+++ b/torch/nn/utils/__init__.py
@@ -5,3 +5,4 @@ from .convert_parameters import parameters_to_vector, vector_to_parameters
 from .spectral_norm import spectral_norm, remove_spectral_norm
 from .fusion import fuse_conv_bn_eval, fuse_conv_bn_weights
 from .memory_format import convert_conv2d_weight_memory_format
+from . import parametrizations

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -137,8 +137,14 @@ def spectral_norm(module: Module,
 
     .. note::
         This function is implemented using the new parametrization functionality
-        in :func:`torch.nn.utils.parameterize.register_parametrization`. It is a
+        in :func:`torch.nn.utils.parametrize.register_parametrization`. It is a
         reimplementation of :func:`torch.nn.utils.spectral_norm`.
+
+    .. note::
+        If the `SpectralNorm` module, i.e., `module.parametrization.weight[idx]`,
+        is in training mode on removal, it will perform another power iteration.
+        If you'd like to avoid this iteration, set the module to eval mode
+        before its removal.
 
     Example::
 

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -5,7 +5,7 @@ from .. import functional as F
 
 from typing import Optional
 
-class SpectralNorm(Module):
+class _SpectralNorm(Module):
     def __init__(
         self,
         weight: torch.Tensor,
@@ -141,7 +141,7 @@ def spectral_norm(module: Module,
         reimplementation of :func:`torch.nn.utils.spectral_norm`.
 
     .. note::
-        If the `SpectralNorm` module, i.e., `module.parametrization.weight[idx]`,
+        If the `_SpectralNorm` module, i.e., `module.parametrization.weight[idx]`,
         is in training mode on removal, it will perform another power iteration.
         If you'd like to avoid this iteration, set the module to eval mode
         before its removal.
@@ -154,7 +154,7 @@ def spectral_norm(module: Module,
         in_features=20, out_features=40, bias=True
         (parametrizations): ModuleDict(
             (weight): ParametrizationList(
-            (0): SpectralNorm()
+            (0): _SpectralNorm()
             )
         )
         )
@@ -176,5 +176,5 @@ def spectral_norm(module: Module,
             dim = 1
         else:
             dim = 0
-    parametrize.register_parametrization(module, name, SpectralNorm(weight, n_power_iterations, dim, eps))
+    parametrize.register_parametrization(module, name, _SpectralNorm(weight, n_power_iterations, dim, eps))
     return module

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -1,0 +1,181 @@
+import warnings
+
+import torch
+from ..utils import parametrize
+from ..modules import Module
+from .. import functional as F
+
+from typing import Optional
+
+class SpectralNorm(Module):
+    def __init__(
+        self,
+        weight: torch.Tensor,
+        n_power_iterations: int = 1,
+        dim: int = 0,
+        eps: float = 1e-12
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        if n_power_iterations <= 0:
+            raise ValueError('Expected n_power_iterations to be positive, but '
+                             'got n_power_iterations={}'.format(n_power_iterations))
+        self.n_power_iterations = n_power_iterations
+        self.eps = eps
+        # randomly initialize `u` and `v`
+        with torch.no_grad():
+            weight_mat = self._reshape_weight_to_matrix(weight)
+            h, w = weight_mat.size()
+            u = F.normalize(weight.new_empty(h).normal_(0, 1), dim=0, eps=self.eps)
+            v = F.normalize(weight.new_empty(w).normal_(0, 1), dim=0, eps=self.eps)
+        self.register_buffer('u', u)
+        self.register_buffer('v', v)
+        self.buffers_initialized = False
+
+    def _reshape_weight_to_matrix(self, weight: torch.Tensor) -> torch.Tensor:
+        weight_mat = weight
+        if self.dim != 0:
+            # permute dim to front
+            weight_mat = weight_mat.permute(self.dim,
+                                            *[d for d in range(weight_mat.dim()) if d != self.dim])
+        height = weight_mat.size(0)
+        return weight_mat.reshape(height, -1)
+
+    def forward(self, weight: torch.Tensor) -> torch.Tensor:
+        # See original note at torch/nn/utils/spectral_norm.py
+        # NB: If `do_power_iteration` is set, the `u` and `v` vectors are
+        #     updated in power iteration **in-place**. This is very important
+        #     because in `DataParallel` forward, the vectors (being buffers) are
+        #     broadcast from the parallelized module to each module replica,
+        #     which is a new module object created on the fly. And each replica
+        #     runs its own spectral norm power iteration. So simply assigning
+        #     the updated vectors to the module this function runs on will cause
+        #     the update to be lost forever. And the next time the parallelized
+        #     module is replicated, the same randomly initialized vectors are
+        #     broadcast and used!
+        #
+        #     Therefore, to make the change propagate back, we rely on two
+        #     important behaviors (also enforced via tests):
+        #       1. `DataParallel` doesn't clone storage if the broadcast tensor
+        #          is already on correct device; and it makes sure that the
+        #          parallelized module is already on `device[0]`.
+        #       2. If the out tensor in `out=` kwarg has correct shape, it will
+        #          just fill in the values.
+        #     Therefore, since the same power iteration is performed on all
+        #     devices, simply updating the tensors in-place will make sure that
+        #     the module replica on `device[0]` will update the _u vector on the
+        #     parallized module (by shared storage).
+        #
+        #    However, after we update `u` and `v` in-place, we need to **clone**
+        #    them before using them to normalize the weight. This is to support
+        #    backproping through two forward passes, e.g., the common pattern in
+        #    GAN training: loss = D(real) - D(fake). Otherwise, engine will
+        #    complain that variables needed to do backward for the first forward
+        #    (i.e., the `u` and `v` vectors) are changed in the second forward.
+        weight_mat = self._reshape_weight_to_matrix(weight)
+
+        if self.training:
+            self.buffers_initialized = True
+            with torch.no_grad():
+                for _ in range(self.n_power_iterations):
+                    # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
+                    # are the first left and right singular vectors.
+                    # This power iteration produces approximations of `u` and `v`.
+                    self.v = F.normalize(torch.mv(weight_mat.t(), self.u),  # type: ignore[has-type]
+                                         dim=0, eps=self.eps, out=self.v)   # type: ignore[has-type]
+                    self.u = F.normalize(torch.mv(weight_mat, self.v),
+                                         dim=0, eps=self.eps, out=self.u)   # type: ignore[has-type]
+                # See above on why we need to clone
+                self.u = self.u.clone(memory_format=torch.contiguous_format)
+                self.v = self.v.clone(memory_format=torch.contiguous_format)
+        else:
+            # https://github.com/pytorch/pytorch/issues/51800
+            if not self.buffers_initialized:
+                warnings.warn("SpectralNorm's `forward` called for the first time, but "
+                              "is in eval mode. SpectralNorm may need to be computed "
+                              "at least once in training mode for its buffers to "
+                              "initialize.")
+
+        sigma = torch.dot(self.u, torch.mv(weight_mat, self.v))
+        return weight / sigma
+
+    def right_inverse(self, value: torch.Tensor) -> torch.Tensor:
+        # we may want to assert here that the passed value already
+        # satisfies constraints
+        return value
+
+
+def spectral_norm(module: Module,
+                  name: str = 'weight',
+                  n_power_iterations: int = 1,
+                  eps: float = 1e-12,
+                  dim: Optional[int] = None) -> Module:
+    r"""Applies spectral normalization to a parameter in the given module.
+
+    .. math::
+        \mathbf{W}_{SN} = \dfrac{\mathbf{W}}{\sigma(\mathbf{W})},
+        \sigma(\mathbf{W}) = \max_{\mathbf{h}: \mathbf{h} \ne 0} \dfrac{\|\mathbf{W} \mathbf{h}\|_2}{\|\mathbf{h}\|_2}
+
+    Spectral normalization stabilizes the training of discriminators (critics)
+    in Generative Adversarial Networks (GANs) by rescaling the weight tensor
+    with spectral norm :math:`\sigma` of the weight matrix calculated using
+    power iteration method. If the dimension of the weight tensor is greater
+    than 2, it is reshaped to 2D in power iteration method to get spectral
+    norm.
+
+    See `Spectral Normalization for Generative Adversarial Networks`_ .
+
+    .. _`Spectral Normalization for Generative Adversarial Networks`: https://arxiv.org/abs/1802.05957
+
+    Args:
+        module (nn.Module): containing module
+        name (str, optional): name of weight parameter
+        n_power_iterations (int, optional): number of power iterations to
+            calculate spectral norm
+        eps (float, optional): epsilon for numerical stability in
+            calculating norms
+        dim (int, optional): dimension corresponding to number of outputs,
+            the default is ``0``, except for modules that are instances of
+            ConvTranspose{1,2,3}d, when it is ``1``
+
+    Returns:
+        The original module with a new parametrization registered to the specified
+        weight
+
+    .. note::
+        This function is implemented using the new parametrization functionality
+        in :func:`torch.nn.utils.parameterize.register_parametrization`. It is a
+        reimplementation of :func:`torch.nn.utils.spectral_norm`.
+
+    Example::
+
+        >>> snm = spectral_norm(nn.Linear(20, 40))
+        >>> snm
+        ParametrizedLinear(
+        in_features=20, out_features=40, bias=True
+        (parametrizations): ModuleDict(
+            (weight): ParametrizationList(
+            (0): SpectralNorm()
+            )
+        )
+        )
+        >>> snm.parametrizations.weight[0].u.size()
+        torch.Size([40])
+    """
+    if not hasattr(module, name):
+        raise ValueError(
+            "Module '{}' has no attribute with name '{}'".format(module, name)
+        )
+    # getattr should get the correct parametrized weight if there
+    # is already an parametrization registered
+    weight = getattr(module, name)
+
+    if dim is None:
+        if isinstance(module, (torch.nn.ConvTranspose1d,
+                               torch.nn.ConvTranspose2d,
+                               torch.nn.ConvTranspose3d)):
+            dim = 1
+        else:
+            dim = 0
+    parametrize.register_parametrization(module, name, SpectralNorm(weight, n_power_iterations, dim, eps))
+    return module

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -205,6 +205,9 @@ def register_parametrization(
     Parametrizations may be concatenated by registering several parametrizations
     on the same attribute.
 
+    The training mode of the registered parametrizations are updated on registration
+    if necessary to match the training mode of the host module
+
     Parametrized parameters and buffers have an inbuilt caching system that can be activated
     using the context manager :func:`cached`.
 
@@ -256,6 +259,7 @@ def register_parametrization(
         >>> print(torch.allclose(m.weight, A))
         True
     """
+    parametrization.train(module.training)
     if is_parametrized(module, tensor_name):
         # Just add the new parametrization to the parametrization list
         module.parametrizations[tensor_name].append(parametrization)  # type: ignore[index, union-attr]

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -347,7 +347,8 @@ def remove_parametrizations(
     # Fetch the original tensor
     original = module.parametrizations[tensor_name].original  # type: ignore[index, union-attr]
     if leave_parametrized:
-        t = getattr(module, tensor_name)
+        with torch.no_grad():
+            t = getattr(module, tensor_name)
         # If they have the same dtype, we reuse the original tensor.
         # We do this so that the parameter does not to change the id()
         # This way the user does not need to update the optimizer

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -341,17 +341,9 @@ def remove_parametrizations(
         )
 
     # Fetch the original tensor
-    parametrizations = module.parametrizations[tensor_name]  # type: ignore[index, union-attr]
-    original = parametrizations.original  # type: ignore[union-attr]
+    original = module.parametrizations[tensor_name].original  # type: ignore[index, union-attr]
     if leave_parametrized:
-        # Call getattr in eval mode so that parametrizations that
-        # compute weight iteratively won't perform another iteration
-        training = parametrizations.training   # type: ignore[union-attr]
-        parametrizations.eval()  # type: ignore[union-attr]
-        with torch.no_grad():
-            t = getattr(module, tensor_name)
-        parametrizations.train(training)  # type: ignore[union-attr]
-
+        t = getattr(module, tensor_name)
         # If they have the same dtype, we reuse the original tensor.
         # We do this so that the parameter does not to change the id()
         # This way the user does not need to update the optimizer

--- a/torch/nn/utils/spectral_norm.py
+++ b/torch/nn/utils/spectral_norm.py
@@ -251,6 +251,14 @@ def spectral_norm(module: T_module,
     Returns:
         The original module with the spectral norm hook
 
+    .. note::
+        This function has been reimplemented as
+        :func:`torch.nn.utils.parametrizations.spectral_norm` using the new
+        parametrization functionality in
+        :func:`torch.nn.utils.parametrize.register_parametrization`. Please use
+        the newer version. This function will be deprecated in a future version
+        of PyTorch.
+
     Example::
 
         >>> m = spectral_norm(nn.Linear(20, 40))


### PR DESCRIPTION
Adds a new file under `torch/nn/utils/parametrizations.py` which should contain all the parametrization implementations

For spectral_norm we add the `SpectralNorm` module which can be registered using `torch.nn.utils.parametrize.register_parametrization` or using a wrapper: `spectral_norm`, the same API the old implementation provided.

Most of the logic is borrowed from the old implementation:
 - Just like the old implementation, there should be cases when retrieving the weight should perform another power iteration (thus updating the weight) and cases where it shouldn't. For example in eval mode `self.training=True`, we do not perform power iteration.

There are also some differences/difficulties with the new implementation:
 - Using new parametrization functionality as-is there doesn't seem to be a good way to tell whether a 'forward' call was the result of parametrizations are unregistered (and leave_parametrizations=True) or when the injected property's getter was invoked. The issue is that we want perform power iteration in the latter case but not the former, but we don't have this control as-is. So, in this PR I modified the parametrization functionality to change the module to eval mode before triggering their forward call
 - Updates the vectors based on weight on initialization to fix https://github.com/pytorch/pytorch/issues/51800 (this avoids silently update weights in eval mode). This also means that we perform twice any many power iterations by the first forward.
 - right_inverse is just the identity for now, but maybe it should assert that the passed value already satisfies the constraints
 - So far, all the old spectral_norm tests have been cloned, but maybe we don't need so much testing now that the core functionality is already well tested