### PR TITLE
`topk`: port to structured

### DIFF
--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -30,7 +30,7 @@ using namespace native;
 
     // Build the output size, which is the dim being selected set to
     // size k
-    std::vector<int64_t> topKSize = self.sizes().vec();
+    DimVector topKSize(self.sizes().vec());
     if (topKSize.size() > 0) {
       topKSize[dim] = k;
     }
@@ -351,7 +351,7 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
   checkScalarType("median", {indices, "indices", 1}, kLong);
   checkSameType("median", {values, "values", 0}, {self, "self", 2});
 
-  DimVector out_shape(self.sizes().vec());
+  std::vector<int64_t> out_shape = self.sizes().vec();
   if (self.dim() > 0) {
     if (keepdim) {
       out_shape[dim] = 1;

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -12,6 +12,34 @@
 #include <utility>
 
 namespace at {
+namespace meta {
+using namespace native;
+  TORCH_META_FUNC(topk) (
+    const Tensor& self,
+    int64_t k,
+    int64_t dim_,
+    bool largest,
+    bool sorted) {
+
+    int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
+    TORCH_CHECK(
+        k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
+        "selected index k out of range");
+    int64_t sliceSize = self.dim() == 0 ? 1 : self.size(dim);
+    TORCH_CHECK(k >= 0 && k <= sliceSize, "k not in range for dimension");
+
+    // Build the output size, which is the dim being selected set to
+    // size k
+    std::vector<int64_t> topKSize = self.sizes().vec();
+    if (topKSize.size() > 0) {
+      topKSize[dim] = k;
+    }
+
+    set_output(0, topKSize, self.options());
+    set_output(1, topKSize, self.options().dtype(at::kLong));
+  }
+} // namespace meta
+
 namespace native {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -706,40 +734,26 @@ std::tuple<Tensor, Tensor> kthvalue(
   return at::kthvalue(self, k, dimname_to_position(self, dim), keepdim);
 }
 
-std::tuple<Tensor&, Tensor&> topk_out_cpu(const Tensor& self,
+TORCH_IMPL_FUNC(topk_out_cpu)
+   (const Tensor& self,
     int64_t k,
     int64_t dim_,
     bool largest,
     bool sorted,
-    Tensor& values,
-    Tensor& indices) {
+    const Tensor& values,
+    const Tensor& indices) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   TORCH_CHECK(
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");
 
-  _allocate_or_resize_output_with_indices(values, indices, self, dim_, k);
+  _allocate_or_resize_output_with_indices(const_cast<Tensor&>(values), const_cast<Tensor&>(indices), self, dim_, k);
   if (self.dim() == 0 && self.numel() == 1) {
     values.copy_(self);
     indices.zero_();
-    return std::forward_as_tuple(values, indices);
   }
 
   topk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
-
-  return std::forward_as_tuple(values, indices);
-}
-
-std::tuple<Tensor, Tensor> topk(
-    const Tensor& self,
-    int64_t k,
-    int64_t dim,
-    bool largest,
-    bool sorted) {
-  Tensor values = at::empty({0}, self.options());
-  Tensor indices = at::empty({0}, self.options().dtype(kLong));
-  at::topk_out(values, indices, self, k, dim, largest, sorted);
-  return std::make_tuple(values, indices);
 }
 
 std::tuple<Tensor&, Tensor&> median_out_cpu(

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -287,9 +287,6 @@ std::tuple<Tensor&, Tensor&> kthvalue_out_impl_cpu(
     bool keepdim) {
   int64_t dim = maybe_wrap_dim(dim_, self.dim(), /*wrap_scalar=*/true);
   zero_numel_check_dims(self, dim, "kthvalue()");
-  TORCH_CHECK(
-      k > 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
-      "selected index k out of range");
 
   at::assert_no_overlap(self, values);
 
@@ -354,7 +351,7 @@ std::tuple<Tensor&, Tensor&> median_with_indices_impl(
   checkScalarType("median", {indices, "indices", 1}, kLong);
   checkSameType("median", {values, "values", 0}, {self, "self", 2});
 
-  std::vector<int64_t> out_shape = self.sizes().vec();
+  DimVector out_shape(self.sizes().vec());
   if (self.dim() > 0) {
     if (keepdim) {
       out_shape[dim] = 1;
@@ -746,7 +743,6 @@ TORCH_IMPL_FUNC(topk_out_cpu)
       k >= 0 && k <= (self.dim() > 0 ? self.size(dim) : 1),
       "selected index k out of range");
 
-  _allocate_or_resize_output_with_indices(const_cast<Tensor&>(values), const_cast<Tensor&>(indices), self, dim_, k);
   if (self.dim() == 0 && self.numel() == 1) {
     values.copy_(self);
     indices.zero_();

--- a/aten/src/ATen/native/Sorting.cpp
+++ b/aten/src/ATen/native/Sorting.cpp
@@ -34,7 +34,6 @@ using namespace native;
     if (topKSize.size() > 0) {
       topKSize[dim] = k;
     }
-
     set_output(0, topKSize, self.options());
     set_output(1, topKSize, self.options().dtype(at::kLong));
   }
@@ -751,9 +750,9 @@ TORCH_IMPL_FUNC(topk_out_cpu)
   if (self.dim() == 0 && self.numel() == 1) {
     values.copy_(self);
     indices.zero_();
+  } else {
+    topk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
   }
-
-  topk_stub(kCPU, values, indices, self, k, dim, largest, sorted);
 }
 
 std::tuple<Tensor&, Tensor&> median_out_cpu(

--- a/aten/src/ATen/native/Sorting.h
+++ b/aten/src/ATen/native/Sorting.h
@@ -15,7 +15,7 @@ enum class QUANTILE_INTERPOLATION_MODE : uint8_t {
 };
 
 using sort_fn = void(*)(Tensor& values, Tensor& indices, int64_t dim, bool descending, bool stable);
-using topk_fn = void(*)(Tensor&, Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
+using topk_fn = void(*)(const Tensor&, const Tensor&, const Tensor&, int64_t, int64_t, bool, bool);
 
 DECLARE_DISPATCH(sort_fn, sort_stub);
 DECLARE_DISPATCH(topk_fn, topk_stub);

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -142,8 +142,8 @@ static void sort_kernel(
 }
 
 static void topk_kernel(
-    Tensor& values,
-    Tensor& indices,
+    const Tensor& values,
+    const Tensor& indices,
     const Tensor& self,
     int64_t k,
     int64_t dim,

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -40,8 +40,8 @@ void fillSliceWithIndex(Tensor& t,int dim) {
 // In alignment with default sort on a c++ map, this function
 // will permute key and value tensors identically, and
 // in such a way that the 'key' tensor is ordered numerically
-void sortKeyValueInplace(Tensor& key,
-                         Tensor& value,
+void sortKeyValueInplace(const Tensor& key,
+                         const Tensor& value,
                          int dim, bool dir) {
   TORCH_CHECK(key.sizes() == value.sizes(),
               "Key tensor must have same size as value tensor");

--- a/aten/src/ATen/native/cuda/SortUtils.cuh
+++ b/aten/src/ATen/native/cuda/SortUtils.cuh
@@ -95,7 +95,7 @@ bitonicSortKVInPlace(at::cuda::detail::TensorInfo<K, IndexType> keys,
 }
 
 bool should_use_small_sort(const Tensor &self, int64_t dim);
-void sortKeyValueInplace(Tensor& key,
-                         Tensor& value,
+void sortKeyValueInplace(const Tensor& key,
+                         const Tensor& value,
                          int dim, bool dir);
 }} // at::native

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -157,7 +157,6 @@ TORCH_IMPL_FUNC(topk_out_cuda)
    const Tensor& indices) {
   TensorArg topK_arg{values, "topK", 1}, indices_arg{indices, "indices", 2}, input_arg{self, "self", 3};
   checkAllSameGPU("topk_out_cuda", {topK_arg, indices_arg, input_arg});
-  TORCH_CHECK(indices.dtype() == at::kLong, "expected indices to be of type ", at::kLong);
   dim = at::maybe_wrap_dim(dim, self);
 
   int numDims = self.dim();
@@ -167,14 +166,6 @@ TORCH_IMPL_FUNC(topk_out_cuda)
 
   Tensor input = self.contiguous();
 
-  // Build the output size, which is the dim being selected set to
-  // size k
-  std::vector<int64_t> topKSize = input.sizes().vec();
-  if (topKSize.size() > 0) {
-    topKSize[dim] = k;
-  }
-  at::native::resize_output(values, topKSize);
-  at::native::resize_output(indices, topKSize);
   // static_cast is required to ensure that the correct type (INDEX_T)
   // is provided to the kernel for the arguments.
 

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6779,15 +6779,15 @@
   variants: method, function
 
 - func: topk.values(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
+  structured: True
   dispatch:
     CPU: topk_out_cpu
     CUDA: topk_out_cuda
 
 - func: topk(Tensor self, int k, int dim=-1, bool largest=True, bool sorted=True) -> (Tensor values, Tensor indices)
   variants: method, function
+  structured_delegate: topk.values
   dispatch:
-    CPU: topk
-    CUDA: topk_cuda
     QuantizedCPU: topk_quantized_cpu
 
 - func: all(Tensor self) -> Tensor


### PR DESCRIPTION
#55070

There are a few places where `const_cast` is used with utility functions shared with unstructured operators.
The RFC says that assigning to the `out` tensor doesn't work, but that seems to be what e.g., `_allocate_or_resize_output_with_indices` seems to do. Does assignment "work" when the tensors are not allocated?