### PR TITLE
Fix test reporting regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,8 +637,6 @@ jobs:
           echo "(cat docker_commands.sh | docker exec -u jenkins -i "$id" bash) 2>&1" > command.sh
           unbuffer bash command.sh | ts
 
-          echo "Retrieving test reports"
-          docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
               echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
@@ -655,6 +653,10 @@ jobs:
         no_output_timeout: "5m"
         command: |
           set -e
+          # Retrieving test results should be done as very first step as command never fails
+          # But is always executed if previous step fails for some reason
+          echo "Retrieving test reports"
+          docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           docker stats --all --no-stream
 
           cat >docker_commands.sh \<<EOL

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -181,8 +181,6 @@ jobs:
           echo "(cat docker_commands.sh | docker exec -u jenkins -i "$id" bash) 2>&1" > command.sh
           unbuffer bash command.sh | ts
 
-          echo "Retrieving test reports"
-          docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           if [[ ${BUILD_ENVIRONMENT} == *"coverage"* ]]; then
               echo "Retrieving C++ coverage report"
               docker cp $id:/var/lib/jenkins/workspace/build/coverage.info ./test
@@ -199,6 +197,10 @@ jobs:
         no_output_timeout: "5m"
         command: |
           set -e
+          # Retrieving test results should be done as very first step as command never fails
+          # But is always executed if previous step fails for some reason
+          echo "Retrieving test reports"
+          docker cp $id:/var/lib/jenkins/workspace/test/test-reports ./ || echo 'No test reports found!'
           docker stats --all --no-stream
 
           cat >docker_commands.sh \<<EOL


### PR DESCRIPTION
Here is why another move of this single line is needed:
 - Regardless of whether test-run failed or succeeded it's good to
   report number of tests executed
 - `docker cp || echo` always succeeds so could safely be executed
   before any other step in "Report test results"
 - This command should not be part of "Run tests" step, otherwise it would not get executed if any of the test failed (if it must be part of "Run tests" step, it should be prefixed with [trap](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html) command and defined before `docker exec` step

This fixes "regression" introduced by https://github.com/pytorch/pytorch/pull/56725 although real culprit here is lack of documentation

Here is an example of PR where test results are not reported back due to
the failure: https://app.circleci.com/pipelines/github/pytorch/pytorch/317199/workflows/584a658b-c742-4cbb-8f81-6bb4718a0c04/jobs/13209736/steps
