### PR TITLE
Remove tmp folder when run unit test

### DIFF
--- a/test/cpp_api_parity/functional_impl_check.py
+++ b/test/cpp_api_parity/functional_impl_check.py
@@ -193,6 +193,7 @@ def write_test_to_test_class(
             device=device,
             test_instance_class=test_instance_class,
         )
+        try_remove_folder(test_params.cpp_tmp_folder)
         unit_test_name = 'test_torch_nn_functional_{}'.format(test_params.functional_variant_name)
         unit_test_class.functional_test_params_map[unit_test_name] = test_params
 

--- a/test/cpp_api_parity/module_impl_check.py
+++ b/test/cpp_api_parity/module_impl_check.py
@@ -243,6 +243,7 @@ def write_test_to_test_class(
             device=device,
             test_instance_class=test_instance_class,
         )
+        try_remove_folder(test_params.cpp_tmp_folder)
         unit_test_name = 'test_torch_nn_{}'.format(test_params.module_variant_name)
         unit_test_class.module_test_params_map[unit_test_name] = test_params
 


### PR DESCRIPTION
Fixes #57799

Remove tmp folder when run cpp_api_parity test cases one by one.