### PR TITLE
two hash() hash

### DIFF
--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -14,33 +14,19 @@
 namespace torch {
 namespace jit {
 
-// Example tensor_str: "Columns 1 to 26 1  1  1  1  1  1  1  1  1  1  1  1  1  1
-// 1  1  1  1  1  1  1  1  1  1  1  1\n\nColumns 27 to 52 1  1  1  1  1  1  1  1
-// 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1\n\nColumns 53 to 78 1  1
-// 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
-// 1\n\nColumns 79 to 104 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
-// 1  1  1  1  1  1  1  1\n\nColumns 105 to 115 1  1  1  1  1  1  1  1  1  1
-// 1\n[ CPULongType{1,115} ]"
 struct tensor_value_hash {
   std::size_t operator()(const at::Tensor& tensor) const {
-    std::stringstream tensor_stream;
-    tensor_stream << tensor;
-    std::string tensor_str = tensor_stream.str();
-    std::size_t h1 = std::hash<std::string>{}(tensor_str);
-    return h1;
+    at::IValue iv(tensor);
+    return at::IValue::hash(iv);
   }
 };
 
 struct tensor_value_equal {
   bool operator()(const at::Tensor& a, const at::Tensor& b) const {
-    std::stringstream a_stream;
-    a_stream << a;
-    std::string a_str = a_stream.str();
+    at::IValue iv_a(a);
+    at::IValue iv_b(b);
 
-    std::stringstream b_stream;
-    b_stream << b;
-    std::string b_str = b_stream.str();
-    return a_str == b_str;
+    return at::IValue::hash(iv_a) == at::IValue::hash(iv_b);
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57812 no cache even not export bytecode
* **#57809 two hash() hash**
* #57808 try string hash
* #56002 [PyTorch Edge] Reuse constant table from ts in bytecode
* #56802 [PyTorch Edge] Add backport to export old bytecode models

Differential Revision: [D28281083](https://our.internmc.facebook.com/intern/diff/D28281083/)