### PR TITLE
Update the default detach semantic for forward mode AD

### DIFF
--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -328,6 +328,9 @@ class Tensor(torch._C._TensorBase):
 
     The result will never require gradient.
 
+    This method also affects forward mode AD gradients and the result will never
+    have forward mode AD gradients.
+
     .. note::
 
       Returned Tensor shares the same storage with the original one.
@@ -346,6 +349,9 @@ class Tensor(torch._C._TensorBase):
     detach_ = _C._add_docstr(_C._TensorBase.detach_, r"""
     Detaches the Tensor from the graph that created it, making it a leaf.
     Views cannot be detached in-place.
+
+    This method also affects forward mode AD gradients and the result will never
+    have forward mode AD gradients.
     """)
 
     def retain_grad(self):


### PR DESCRIPTION
This makes detach both forward and backward non-differentiable by default.
You can pass the `only_backward_mode=True` argument to make it forward differentiable but backward non-differentiable.

The important side effect of this change is that, by default, detach is not tracking any view information.