### PR TITLE
Avoid 2 extra copies when reducing sparse tensors and fix result() vs inplace output discrepancy

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -1117,7 +1117,6 @@ class AsyncSparseAllreduceWork : public ProcessGroupGloo::AsyncWork {
   void run() override {
     auto output = allreduce(inputs);
 
-    // Can we avoid copy here?
     // This copy is needed when we run a multi-gpu version of reduce (multiple
     // inputs per rank).
     for (int i = 0; i < inputs.size(); ++i) {


### PR DESCRIPTION
Summary: 
* `AsyncSparseAllreduceWork` can avoid copying output tensors, since we keep all the results alive by means of modifying input vector directly
* `AsyncSparseAllreduceWork` now returns inputs back to user instead of former behavior where it returned copies of inputs. This is consistent with other operations and process group implementations
* `AsyncSparseAllreduceCUDAWork` is now copying tensors directly from CPU to input tensors avoiding extra copy `output` -> `outputs` -> `inputs`. inputs are being returned to back to user. This is consistent with other operations and process group implementations.

overall AsyncSparseAllreduceCUDAWork is now avoiding 2 extra copies (as AsyncSparseAllreduceCUDAWork is using AsyncSparseAllreduceWork's impl)



Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57822 Avoid copy when reducing sparse tensors and fix result() vs inplace output discrepancy**

Differential Revision: [D28298325](https://our.internmc.facebook.com/intern/diff/D28298325)