### PR TITLE
[JIT] Also fold NaiveSyncBatchNorm when folding batch norm

### DIFF
--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -783,11 +783,17 @@ bool is_conv_transpose2d_module(
 bool is_batchnorm2d_module(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap) {
-  return is_module(
-      match,
-      vmap,
-      "batchnorm",
-      "__torch__.torch.nn.modules.batchnorm.BatchNorm2d");
+   bool regnorm = is_module(
+       match,
+       vmap,
+       "batchnorm",
+       "__torch__.torch.nn.modules.batchnorm.BatchNorm2d");
+   bool naivenorm = is_module(
+       match,
+       vmap,
+       "batchnorm",
+       "__torch__.mobile_cv.arch.layers.batch_norm.NaiveSyncBatchNorm");
+   return (regnorm || naivenorm);
 }
 
 bool is_batchnorm3d_module(

--- a/torch/csrc/jit/passes/quantization/helper.cpp
+++ b/torch/csrc/jit/passes/quantization/helper.cpp
@@ -783,17 +783,17 @@ bool is_conv_transpose2d_module(
 bool is_batchnorm2d_module(
     const Match& match,
     const std::unordered_map<std::string, Value*>& vmap) {
-   bool regnorm = is_module(
-       match,
-       vmap,
-       "batchnorm",
-       "__torch__.torch.nn.modules.batchnorm.BatchNorm2d");
-   bool naivenorm = is_module(
-       match,
-       vmap,
-       "batchnorm",
-       "__torch__.mobile_cv.arch.layers.batch_norm.NaiveSyncBatchNorm");
-   return (regnorm || naivenorm);
+  bool regnorm = is_module(
+      match,
+      vmap,
+      "batchnorm",
+      "__torch__.torch.nn.modules.batchnorm.BatchNorm2d");
+  bool naivenorm = is_module(
+      match,
+      vmap,
+      "batchnorm",
+      "__torch__.mobile_cv.arch.layers.batch_norm.NaiveSyncBatchNorm");
+  return (regnorm || naivenorm);
 }
 
 bool is_batchnorm3d_module(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57823 [JIT] Also fold NaiveSyncBatchNorm when folding batch norm**

Some models use the `NaiveSyncBatchNorm` instead of `BatchNorm2d`, but during inference they behave the same. This change is to ensure that `NaiveSyncBatchNorm` gets folded into convs during optimization passes, particularly `FoldConvBatchNorm`.

Differential Revision: [D28291709](https://our.internmc.facebook.com/intern/diff/D28291709)