### PR TITLE
[Vulkan] Fix seg fault during descriptor set allocation on some platforms

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Descriptor.cpp
+++ b/aten/src/ATen/native/vulkan/api/Descriptor.cpp
@@ -91,10 +91,12 @@ void allocate_descriptor_sets(
       descriptor_sets && (count > 0u),
       "Invalid usage!");
 
-  const std::vector<VkDescriptorSetLayout> descriptor_set_layouts{
-    count,
-    descriptor_set_layout,
-  };
+  std::vector<VkDescriptorSetLayout> descriptor_set_layouts(count);
+  fill(
+    descriptor_set_layouts.begin(),
+    descriptor_set_layouts.end(),
+    descriptor_set_layout
+  );
 
   const VkDescriptorSetAllocateInfo descriptor_set_allocate_info{
     VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57825 [Vulkan] Fix seg fault during descriptor set allocation on some platforms**

Differential Revision: [D28294939](https://our.internmc.facebook.com/intern/diff/D28294939)