### PR TITLE
Let submodules be collected as args/kwargs

### DIFF
--- a/torch/fx/symbolic_trace.py
+++ b/torch/fx/symbolic_trace.py
@@ -193,7 +193,10 @@ class Tracer(TracerBase):
             for n_, p_ in self.root.named_buffers():
                 if a is p_:
                     return self.create_node('get_attr', n_, (), {})
-
+        elif isinstance(a, torch.nn.Module):
+            for n_, p_ in self.root.named_modules():
+                if a is p_:
+                    return self.create_node('get_attr', n_, (), {})
         # For NamedTuple instances that appear literally as args, we emit
         # a node to construct the NamedTuple and use that Node as the argument.
         if isinstance(a, tuple) and hasattr(a, '_fields'):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57840 Let submodules be collected as args/kwargs**

Differential Revision: [D28294984](https://our.internmc.facebook.com/intern/diff/D28294984)

Previously, submodules were unsupported in the `create_arg` method. This was a problem when using an fx.wrap’d function with a submodule, e.g.

```python
torch.fx.wrap("wrapped")

def wrapped(x: torch.Tensor, r: torch.nn.ReLU):
    return r(x)

class M(torch.nn.Module):

    def __init__(self):
        super(M, self).__init__()
        self.r = torch.nn.ReLU()

    def forward(self, x: torch.Tensor):
        res = wrapped(x, self.r)
        return res

"""
Throws “NotImplementedError: argument of type: <class 'torch.nn.modules.activation.ReLU’>”
"""
```

There doesn't seem to be any reason that we didn't support allowing submodules as args/kwargs before; it's just an edge case that no one thought of.

Landing this change would unblock an engineer on AI Mobile who I'm working with to trace the [DLRM model](https://github.com/facebookresearch/dlrm/blob/master/dlrm_s_pytorch.py#L1251).