### PR TITLE
Adding support for normalization of __is__ op

### DIFF
--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -217,3 +217,12 @@ class TestPeephole(JitTestCase):
             self.run_pass("inline", conv_dim.graph)
             self.run_pass("peephole", conv_dim.graph)
             FileCheck().check("conv").check("dim").run(conv_dim.graph)
+
+    def test_normalized_is_op(self):
+        print("test_start")
+        @torch.jit.script
+        def convertible_is_op(x:bool, y:bool):
+            return x is True, False is x, x is y
+
+        FileCheck().check_count("aten::eq", 3, exactly=True).run(convertible_is_op.graph)
+        FileCheck().check_count("aten::__is__", 0, exactly=True).run(convertible_is_op.graph)

--- a/test/jit/test_peephole.py
+++ b/test/jit/test_peephole.py
@@ -219,7 +219,7 @@ class TestPeephole(JitTestCase):
             FileCheck().check("conv").check("dim").run(conv_dim.graph)
 
     def test_normalized_is_op(self):
-        def convertible_is_op(x:bool, y:bool):
+        def convertible_is_op(x: bool, y: bool):
             return x is True, False is x, x is y
 
         self.checkScript(convertible_is_op, (True, False))
@@ -229,7 +229,7 @@ class TestPeephole(JitTestCase):
         FileCheck().check_count("aten::__is__", 0, exactly=True).run(op_graph)
 
     def test_normalized_isnot_op(self):
-        def convertible_isnot_op(x:bool, y:bool):
+        def convertible_isnot_op(x: bool, y: bool):
             return x is not True, False is not x, x is not y
 
         self.checkScript(convertible_isnot_op, (True, False))

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -1,7 +1,7 @@
 #include <torch/csrc/jit/passes/normalize_ops.h>
 
-#include <c10/util/Exception.h>
 #include <ATen/core/interned_strings.h>
+#include <c10/util/Exception.h>
 #include <jit/ir/graph_node_list.h>
 #include <jit/ir/ir.h>
 
@@ -23,19 +23,21 @@ bool normalizeOpAliases(graph_node_list_iterator& iter) {
   return false;
 }
 
-// Normalizes a `__is__` comparison with a bool to `eq` (and same with `__isnot__`)
+// Normalizes a `__is__` comparison with a bool to `eq` (and same with
+// `__isnot__`)
 bool normalizeIsBool(graph_node_list_iterator& iter) {
   ArrayRef<Value*> args = iter->inputs();
-  if(args.size() == 2 && args[0]->type() == BoolType::get() && args[1]->type() == BoolType::get()){
-    if(iter->kind() == aten::__is__){
-        iter->replaceWithNewSymbol(aten::eq);
-        iter.destroyCurrent();
-        return true;
-      }
-    if(iter->kind() == aten::__isnot__){
-        iter->replaceWithNewSymbol(aten::ne);
-        iter.destroyCurrent();
-        return true;
+  if (args.size() == 2 && args[0]->type() == BoolType::get() &&
+      args[1]->type() == BoolType::get()) {
+    if (iter->kind() == aten::__is__) {
+      iter->replaceWithNewSymbol(aten::eq);
+      iter.destroyCurrent();
+      return true;
+    }
+    if (iter->kind() == aten::__isnot__) {
+      iter->replaceWithNewSymbol(aten::ne);
+      iter.destroyCurrent();
+      return true;
     }
   }
   return false;

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -1,9 +1,9 @@
 #include <torch/csrc/jit/passes/normalize_ops.h>
 
 #include <c10/util/Exception.h>
-#include "ATen/core/interned_strings.h"
-#include "jit/ir/graph_node_list.h"
-#include "jit/ir/ir.h"
+#include <ATen/core/interned_strings.h>
+#include <jit/ir/graph_node_list.h>
+#include <jit/ir/ir.h>
 
 namespace torch {
 namespace jit {
@@ -23,14 +23,19 @@ bool normalizeOpAliases(graph_node_list_iterator& iter) {
   return false;
 }
 
-// Normalizes a __is__ comparison with a bool to `eq`
+// Normalizes a `__is__` comparison with a bool to `eq` (and same with `__isnot__`)
 bool normalizeIsBool(graph_node_list_iterator& iter) {
-  if(iter->kind() == aten::__is__){
-    ArrayRef<Value*> args = iter->inputs();
-    if(args[0]->type() == BoolType::get() && args[1]->type() == BoolType::get()){
-      iter->replaceWithNewSymbol(aten::eq);
-      iter.destroyCurrent();
-      return true;
+  ArrayRef<Value*> args = iter->inputs();
+  if(args.size() == 2 && args[0]->type() == BoolType::get() && args[1]->type() == BoolType::get()){
+    if(iter->kind() == aten::__is__){
+        iter->replaceWithNewSymbol(aten::eq);
+        iter.destroyCurrent();
+        return true;
+      }
+    if(iter->kind() == aten::__isnot__){
+        iter->replaceWithNewSymbol(aten::ne);
+        iter.destroyCurrent();
+        return true;
     }
   }
   return false;

--- a/torch/csrc/jit/passes/normalize_ops.cpp
+++ b/torch/csrc/jit/passes/normalize_ops.cpp
@@ -1,9 +1,6 @@
 #include <torch/csrc/jit/passes/normalize_ops.h>
 
-#include <ATen/core/interned_strings.h>
 #include <c10/util/Exception.h>
-#include <jit/ir/graph_node_list.h>
-#include <jit/ir/ir.h>
 
 namespace torch {
 namespace jit {

--- a/torch/testing/_internal/jit_utils.py
+++ b/torch/testing/_internal/jit_utils.py
@@ -425,6 +425,10 @@ class JitTestCase(JitCommonTestCase):
                     profiling=ProfilingMode.PROFILING,
                     atol=None,
                     rtol=None):
+        """
+        Checks that a given script generates the same output as the Python
+        version using the given inputs.
+        """
         with torch.jit.optimized_execution(optimize):
             with enable_profiling_mode_for_profiling_tests():
                 extra_profile_runs = any(isinstance(x, torch.Tensor) and x.requires_grad for x in inputs)


### PR DESCRIPTION
Summary:
normalizing `__is__` to `eq`, and `__isnot__` to `ne` in the case of bools.

Test Plan:
```
python test/test_jit.py TestPeephole
```
11 Tests, 1 skipped, no failures

Reviewers:
@eellison 

Subscribers:

Tasks:

Tags:

Fixes #57387
