### PR TITLE
[RPC Framework] Add a link to the tutorial in RemoteModule docstring

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -486,6 +486,10 @@ class RemoteModule(_RemoteModule):
         >>>
         >>> rpc.init_rpc("worker1", rank=1, world_size=2)
         >>> rpc.shutdown()
+
+        Furthermore, a more practical example that is combined with
+        `DistributedDataParallel <https://pytorch.org/docs/stable/nn.html#torch.nn.parallel.DistributedDataParallel>`__ (DDP)
+        can be found in this `tutorial <https://pytorch.org/tutorials/advanced/rpc_ddp_tutorial.html>`__.
     """
 
     def __init__(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57876 [RPC Framework] Update rpc.rst
* **#57875 [RPC Framework] Add a link to the tutorial in RemoteModule docstring**
* #57695 [RPC Framework] Support passing RemoteModule as an arg

This tutorial combines DDP and RemoteModule.

Differential Revision: [D28305382](https://our.internmc.facebook.com/intern/diff/D28305382/)