### PR TITLE
Preserve custom state_dict save/load methods in TorchScript

### DIFF
--- a/test/jit/test_module_apis.py
+++ b/test/jit/test_module_apis.py
@@ -1,0 +1,76 @@
+import torch
+import os
+import sys
+from torch.testing._internal.jit_utils import JitTestCase
+from typing import Dict, Any, List
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestModuleAPIs(JitTestCase):
+    def test_default_state_dict_methods(self):
+        """Tests that default state dict methods are automatically available"""
+
+        class DefaultStateDictModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(6, 16, 5)
+                self.fc = torch.nn.Linear(16 * 5 * 5, 120)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.fc(x)
+                return x
+
+        m1 = torch.jit.script(DefaultStateDictModule())
+        m2 = torch.jit.script(DefaultStateDictModule())
+        state_dict = m1.state_dict()
+        m2.load_state_dict(state_dict)
+
+    def test_customized_state_dict_methods(self):
+        """Tests that customized state dict methods are in effect"""
+
+        class DefaultStateDictModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv2d(6, 16, 5)
+                self.fc = torch.nn.Linear(16 * 5 * 5, 120)
+                self.customized_save_state_dict_called: bool = False
+                self.customized_load_state_dict_called: bool = False
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.fc(x)
+                return x
+
+            @torch.jit.export
+            def _save_to_state_dict(self, destination: Dict[str, torch.Tensor],
+                                    prefix: str, keep_vars: bool):
+                self.customized_save_state_dict_called = True
+                return {"dummy": torch.ones(1)}
+
+            @torch.jit.export
+            def _load_from_state_dict(self,
+                                      state_dict: Dict[str, torch.Tensor],
+                                      prefix: str, local_metadata: Any,
+                                      strict: bool, missing_keys: List[str],
+                                      unexpected_keys: List[str],
+                                      error_msgs: List[str]):
+                self.customized_load_state_dict_called = True
+                return
+
+        m1 = torch.jit.script(DefaultStateDictModule())
+        self.assertFalse(m1.customized_save_state_dict_called)
+        state_dict = m1.state_dict()
+        self.assertTrue(m1.customized_save_state_dict_called)
+
+        m2 = torch.jit.script(DefaultStateDictModule())
+        self.assertFalse(m2.customized_load_state_dict_called)
+        m2.load_state_dict(state_dict)
+        self.assertTrue(m2.customized_load_state_dict_called)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -50,6 +50,7 @@ from jit.test_types import TestTypesAndAnnotation  # noqa: F401
 from jit.test_misc import TestMisc  # noqa: F401
 from jit.test_pdt import TestPDT  # noqa: F401
 from jit.test_tensor_creation_ops import TestTensorCreationOps  # noqa: F401
+from jit.test_module_apis import TestModuleAPIs  # noqa: F401
 
 # Torch
 from torch import Tensor

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -379,6 +379,17 @@ if _enabled:
                     value = value.value
                 return super(ScriptModule, self).__setattr__(attr, value)
 
+            # Do not overwrite methods that are already defined on C++
+            # ScriptModule object. This is necessary for supporting customized
+            # `_save_to_state_dict` and `load_from_state_dict`.
+            if hasattr(self._actual_script_module, attr):
+                # Temporarily limit preserving overwritable methods to those
+                # needed for customizing state_dict save/load behavior.
+                # TODO (gmagogsfm): Remove this limit once we test with other
+                # methods to make sure this BC-breaking change is safe.
+                if attr == "_save_to_state_dict" or attr == "_load_from_state_dict":
+                    return
+
             setattr(self._actual_script_module, attr, value)
 
         def define(self, src):


### PR DESCRIPTION
Previously, methods like `_save_to_state_dict` and `_load_from_state_dict` are incorrectly overwritten when we copy methods from `nn.Module` to `RecursiveScriptModule`. We should instead check if user module defines those methods and exported them to conditionally copy methods from `nn.Module` over to `RecursiveScriptModule`.

In this PR, I temporarily limit the fix to state_dict related methods to limit blast radius since this change is technically BC-breaking. 

Fixes #45225
