### PR TITLE
remove syncs in one_hot

### DIFF
--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -18,19 +18,19 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     }
 
     // non-empty tensor
-    if (self.device() != at::kCUDA) {
+    if (self.device().type() != at::kCUDA) {
       //for cuda, rely on device assert thrown by scatter
       TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
     }
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        if (self.device() != at::kCUDA) {
+        if (self.device().type() != at::kCUDA) {
           //rely on device asserts from scatter to avoid sync here
           TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
         } else {
             //for cuda, assert that num_classes is at least 1
-            TORCH_CHECK(num_classes >= 1);
+            TORCH_CHECK(num_classes >= 1, "num_classes should be positive");
         }
     }
 

--- a/aten/src/ATen/native/Onehot.cpp
+++ b/aten/src/ATen/native/Onehot.cpp
@@ -18,11 +18,20 @@ Tensor one_hot(const Tensor &self, int64_t num_classes) {
     }
 
     // non-empty tensor
-    TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
+    if (self.device() != at::kCUDA) {
+      //for cuda, rely on device assert thrown by scatter
+      TORCH_CHECK(self.min().item().toLong() >= 0, "Class values must be non-negative.");
+    }
     if (num_classes == -1) {
         num_classes = self.max().item().toLong() + 1;
     } else {
-        TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
+        if (self.device() != at::kCUDA) {
+          //rely on device asserts from scatter to avoid sync here
+          TORCH_CHECK(num_classes > self.max().item().toLong(), "Class values must be smaller than num_classes.");
+        } else {
+            //for cuda, assert that num_classes is at least 1
+            TORCH_CHECK(num_classes >= 1);
+        }
     }
 
     shape.push_back(num_classes);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12539,11 +12539,12 @@ class TestNNDeviceType(NNTestCase):
         self._test_module_empty_input(mod, inp)
 
     def test_one_hot(self, device):
-        with self.assertRaises(RuntimeError):
-            torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
+        if self.device_type != 'cuda':  # cuda throws device assert for invalid data
+            with self.assertRaises(RuntimeError):
+                torch.nn.functional.one_hot(torch.tensor([3, 4, -1, 0], device=device), -1)
 
-        with self.assertRaises(RuntimeError):
-            torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device), 3)
+            with self.assertRaises(RuntimeError):
+                torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device), 3)
 
         t = torch.nn.functional.one_hot(torch.tensor([3, 4, 1, 0], device=device))
         expected = torch.tensor([[0, 0, 0, 1, 0],


### PR DESCRIPTION
Fixes #55579
Now on cuda one-hot relies on device-side asserts thrown by scatter
