### PR TITLE
[TensorExpr] Fix a condition when we use a native depthwise conv2d lowering.

### DIFF
--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1511,7 +1511,7 @@ Tensor* computeConv2d(
   auto bInfo = getTensorInfo(b);
   // Generate TE for depthwise convolutions.
   if (inpInfo && wInfo && bInfo &&
-      !conv2dIsSupported(
+      conv2dIsSupported(
           *inpInfo, *wInfo, *bInfo, strides, padding, dilation, groups)) {
     return conv2d_depthwise(inp, w, b, strides[0], padding[0], groups);
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57906 [TensorExpr] Fix a condition when we use a native depthwise conv2d lowering.**

I think it was accidentally flipped in #56875.

Differential Revision: [D28312947](https://our.internmc.facebook.com/intern/diff/D28312947)