### PR TITLE
Enable BFloat16 for `logaddexp` & `logaddexp2` on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -10,31 +10,37 @@
 namespace at { namespace native {
 
 void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "logaddexp_cuda", [&]() {
-    gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-      if (::isinf(a) && a == b) {
-        return a;
-      }
-      else {
-        scalar_t m = ::max(a, b);
-        return m + ::log((scalar_t)(1.0) + ::exp(-::abs(a - b)));
-      }
-    });
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      ScalarType::BFloat16,
+      iter.dtype(), "logaddexp_cuda",
+      [&]() {
+        gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+          if (::isinf(a) && a == b) {
+            return a;
+          }
+          else {
+            scalar_t m = ::max(a, b);
+            return m + ::log((scalar_t)(1.0) + ::exp(-::abs(a - b)));
+          }
+        });
+      });
 }
 
 void logaddexp2_kernel_cuda(TensorIteratorBase& iter) {
-  AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "logaddexp2_cuda", [&]() {
-    gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-      if (::isinf(a) && a == b) {
-        return a;
-      }
-      else {
-        scalar_t m = ::max(a, b);
-        return m + ::log2((scalar_t)(1.0) + ::pow((scalar_t)(2.0), -::abs(a - b)));
-      }
-    });
-  });
+  AT_DISPATCH_FLOATING_TYPES_AND(
+      ScalarType::BFloat16,
+      iter.dtype(), "logaddexp2_cuda",
+      [&]() {
+        gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
+          if (::isinf(a) && a == b) {
+            return a;
+          }
+          else {
+            scalar_t m = ::max(a, b);
+            return m + ::log2((scalar_t)(1.0) + ::pow((scalar_t)(2.0), -::abs(a - b)));
+          }
+        });
+      });
 }
 
 REGISTER_DISPATCH(logaddexp_stub, &logaddexp_kernel_cuda);

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -3,6 +3,8 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
+#include <ATen/AccumulateType.h>
+
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -14,8 +16,9 @@ void logaddexp_kernel_cuda(TensorIteratorBase& iter) {
       ScalarType::BFloat16,
       iter.dtype(), "logaddexp_cuda",
       [&]() {
+        using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/true>;
         gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-          if (::isinf(a) && a == b) {
+          if (::isinf(static_cast<accscalar_t>(a)) && a == b) {
             return a;
           }
           else {
@@ -31,8 +34,9 @@ void logaddexp2_kernel_cuda(TensorIteratorBase& iter) {
       ScalarType::BFloat16,
       iter.dtype(), "logaddexp2_cuda",
       [&]() {
+        using accscalar_t = at::acc_type<scalar_t, /*is_cuda=*/true>;
         gpu_kernel(iter, [] GPU_LAMBDA (scalar_t a, scalar_t b) -> scalar_t {
-          if (::isinf(a) && a == b) {
+          if (::isinf(static_cast<accscalar_t>(a)) && a == b) {
             return a;
           }
           else {

--- a/aten/src/ATen/native/cuda/LogAddExpKernel.cu
+++ b/aten/src/ATen/native/cuda/LogAddExpKernel.cu
@@ -5,7 +5,6 @@
 #include <ATen/native/BinaryOps.h>
 #include <ATen/AccumulateType.h>
 
-
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
 

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -291,6 +291,10 @@ class TestUnaryUfuncs(TestCase):
                 # while NumPy computes in float16
                 self.assertEqualHelper(actual, expected, msg, dtype=dtype,
                                        exact_dtype=exact_dtype, rtol=1e-3, atol=1e-2)
+            elif dtype is torch.bfloat16:
+                # Ref: https://github.com/pytorch/pytorch/blob/master/torch/testing/_internal/common_utils.py#L1149
+                self.assertEqualHelper(actual, expected, msg, dtype=dtype,
+                                       exact_dtype=exact_dtype, rtol=16e-3, atol=1e-5)
             else:
                 self.assertEqualHelper(actual, expected, msg, dtype=dtype, equal_nan=equal_nan, exact_dtype=exact_dtype)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4624,11 +4624,15 @@ op_db: List[OpInfo] = [
                    )),
     OpInfo('logaddexp',
            dtypes=floating_types(),
+           dtypesIfCUDA=floating_types_and(torch.bfloat16),
+           dtypesIfROCM=floating_types_and(torch.bfloat16),
            sample_inputs_func=lambda op_info, device, dtype, requires_grad=False, **kwargs:
            (SampleInput(make_tensor((S, S), device, dtype, requires_grad=requires_grad),
                         args=(make_tensor((S, S), device, dtype, requires_grad=requires_grad),)),)),
     OpInfo('logaddexp2',
            dtypes=floating_types(),
+           dtypesIfCUDA=floating_types_and(torch.bfloat16),
+           dtypesIfROCM=floating_types_and(torch.bfloat16),
            sample_inputs_func=lambda op_info, device, dtype, requires_grad=False, **kwargs:
            (SampleInput(make_tensor((S, S), device, dtype, requires_grad=requires_grad),
                         args=(make_tensor((S, S), device, dtype, requires_grad=requires_grad),)),)),


### PR DESCRIPTION
Enabled BFloat16 for `logaddexp` & `logaddexp2` on CUDA, with a [workaround](https://github.com/pytorch/pytorch/pull/57908#issuecomment-837320532) suggested by @zasdfgbnm.