### PR TITLE
Added full form for acronym RNG.

### DIFF
--- a/torch/random.py
+++ b/torch/random.py
@@ -64,7 +64,7 @@ _fork_rng_warned_already = False
 @contextlib.contextmanager
 def fork_rng(devices=None, enabled=True, _caller="fork_rng", _devices_kw="devices"):
     """
-    Forks the RNG, so that when you return, the RNG is reset
+    Forks the RNG(Random Number Generator), so that when you return, the RNG is reset
     to the state that it was previously in.
 
     Args:


### PR DESCRIPTION
Since the changed line is the first line in the documentation page, added full form for acronym RNG so that line is more understandable and will make it easier to interpret.
![Screenshot (124)](https://user-images.githubusercontent.com/51470622/117577590-082db500-b108-11eb-99ba-fddfcbe9f17e.png)


