### PR TITLE
Only use actually mismatched elements for reporting in `torch.testing`

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -1003,6 +1003,17 @@ class TestAsserts(TestCase):
                 fn()
 
     @onlyCPU
+    def test_mismatching_values_zero_div_zero(self, device):
+        actual = torch.tensor([1.0, 0.0], device=device)
+        expected = torch.tensor([2.0, 0.0], device=device)
+
+        for fn in self.assert_fns_with_inputs(actual, expected):
+            # Although it looks complicated, this regex just makes sure that the word 'nan' is not part of the error
+            # message. That would happen if the 0 / 0 is used for the mismatch computation although it matches.
+            with self.assertRaisesRegex(AssertionError, "((?!nan).)*"):
+                fn()
+
+    @onlyCPU
     def test_mismatching_values_msg_complex_real(self, device):
         actual = torch.tensor(complex(0, 1), device=device)
         expected = torch.tensor(complex(1, 1), device=device)

--- a/torch/testing/_asserts.py
+++ b/torch/testing/_asserts.py
@@ -222,11 +222,16 @@ def _trace_mismatches(actual: Tensor, expected: Tensor, mismatches: Tensor) -> D
     dtype = torch.float64 if actual.dtype.is_floating_point else torch.int64
     a_flat = actual.flatten().to(dtype)
     b_flat = expected.flatten().to(dtype)
+    matches_flat = ~mismatches.flatten()
 
     abs_diff = torch.abs(a_flat - b_flat)
+    # Ensure that only mismatches are used for the max_abs_diff computation
+    abs_diff[matches_flat] = 0
     max_abs_diff, max_abs_diff_flat_idx = torch.max(abs_diff, 0)
 
     rel_diff = abs_diff / torch.abs(b_flat)
+    # Ensure that only mismatches are used for the max_rel_diff computation
+    rel_diff[matches_flat] = 0
     max_rel_diff, max_rel_diff_flat_idx = torch.max(rel_diff, 0)
 
     return SimpleNamespace(


### PR DESCRIPTION
Redo of #57135 out of stack

---

Currently all values are used for the reported absolute and relative differences. This usually works fine, but breaks down for the extremals:

```python
torch.testing.assert_close(torch.tensor([1.0, 0.0]), torch.tensor([2.0, 0.0]))
```

```
[...]
Greatest absolute difference: 1.0 at 0 (up to 1e-05 allowed)
Greatest relative difference: nan at 1 (up to 1.3e-06 allowed)
```

Although the second element is matching it is listed as offender for the greatest relative difference. The `NaN` stems from the `0 / 0` division.

To overcome this, we should only use the values that were considered a mismatch for the reported stats.
