### PR TITLE
Fix some tensor operators to return `NotImplemented` for invalid inputs

### DIFF
--- a/test/onnx/expect/TestOperators.test_rsub.expect
+++ b/test/onnx/expect/TestOperators.test_rsub.expect
@@ -17,14 +17,14 @@ graph {
   }
   node {
     input: "1"
-    input: "x"
+    input: "0"
     output: "2"
     name: "Sub_1"
     op_type: "Sub"
   }
   name: "torch-jit-export"
   input {
-    name: "x"
+    name: "0"
     type {
       tensor_type {
         elem_type: 11

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2759,25 +2759,23 @@ tensor_binary_ops = [
     '__eq__', '__ne__',
 
     '__add__', '__radd__', '__iadd__',
-    '__sub__', '__isub__',
+    '__sub__', '__rsub__', '__isub__',
     '__mul__', '__rmul__', '__imul__',
-    '__matmul__',
-    '__truediv__', '__itruediv__',
+    '__matmul__', '__rmatmul__',
+    '__truediv__', '__rtruediv__', '__itruediv__',
     '__floordiv__', '__rfloordiv__', '__ifloordiv__',
     '__mod__', '__imod__',
-    '__rpow__', '__ipow__',
+    '__pow__', '__rpow__', '__ipow__',
     '__lshift__', '__ilshift__',
     '__rshift__', '__irshift__',
     '__and__', '__iand__',
     '__xor__', '__ixor__',
     '__or__', '__ior__',
 
-    # Attribute does not exist
-    # '__rmatmul__', '__rmod__', '__divmod__', '__rdivmod__', '__idivmod__',
-    # '__pow__', '__rand__', '__ror__', '__rxor__', '__rlshift__', '__rrshift__',
-
-    # Attribute exists, but `NotImplemented` is not returned.
-    # '__rsub__', '__imatmul__', '__rtruediv__',
+    # Unsupported operators
+    # '__rmod__', '__imatmul__',
+    # '__divmod__', '__rdivmod__', '__idivmod__',
+    # '__rand__', '__ror__', '__rxor__', '__rlshift__', '__rrshift__',
 ]
 
 # Test that binary math operations return NotImplemented for unknown types.

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2437,7 +2437,8 @@ class TestOperatorSignatures(JitTestCase):
                            '__rsub__',
                            '__rmul__',
                            '__rdiv__',
-                           '__rpow__'}
+                           '__rpow__',
+                           '__rmatmul__'}
 
         try:
             sample_inputs_itr = op.sample_inputs(device, dtype, requires_grad=False)

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -1321,7 +1321,8 @@ class TestNormalizeOperators(JitTestCase):
                    '__rsub__',
                    '__rmul__',
                    '__rdiv__',
-                   '__rpow__'}
+                   '__rpow__',
+                   '__rmatmul__'}
 
         # Unsupported input types
         if op.name in op_skip:

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -1164,7 +1164,6 @@ PyMethodDef variable_methods[] = {
   {"__nonzero__", THPVariable_bool_scalar, METH_NOARGS, NULL},
   {"__invert__", THPVariable_invert, METH_NOARGS, NULL},
   {"__matmul__", castPyCFunctionWithKeywords(TypeError_to_NotImplemented_<THPVariable_matmul>), METH_VARARGS | METH_KEYWORDS, NULL},
-  {"__rmatmul__", castPyCFunctionWithKeywords(TypeError_to_NotImplemented_<THPVariable_matmul>), METH_VARARGS | METH_KEYWORDS, NULL},
   {"_is_view", THPVariable__is_view, METH_NOARGS, NULL},
   {"apply_", THPVariable_apply_, METH_O, NULL},
   {"bfloat16", castPyCFunctionWithKeywords(THPVariable_bfloat16), METH_VARARGS | METH_KEYWORDS, NULL},

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -1164,6 +1164,7 @@ PyMethodDef variable_methods[] = {
   {"__nonzero__", THPVariable_bool_scalar, METH_NOARGS, NULL},
   {"__invert__", THPVariable_invert, METH_NOARGS, NULL},
   {"__matmul__", castPyCFunctionWithKeywords(TypeError_to_NotImplemented_<THPVariable_matmul>), METH_VARARGS | METH_KEYWORDS, NULL},
+  {"__rmatmul__", castPyCFunctionWithKeywords(TypeError_to_NotImplemented_<THPVariable_matmul>), METH_VARARGS | METH_KEYWORDS, NULL},
   {"_is_view", THPVariable__is_view, METH_NOARGS, NULL},
   {"apply_", THPVariable_apply_, METH_O, NULL},
   {"bfloat16", castPyCFunctionWithKeywords(THPVariable_bfloat16), METH_VARARGS | METH_KEYWORDS, NULL},

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -538,11 +538,13 @@ class Tensor(torch._C._TensorBase):
             )
         return torch.unique_consecutive(self, return_inverse=return_inverse, return_counts=return_counts, dim=dim)
 
+    @_wrap_type_error_to_not_implemented
     def __rsub__(self, other):
         if has_torch_function_variadic(self, other):
             return handle_torch_function(Tensor.__rsub__, (self, other), self, other)
         return _C._VariableFunctions.rsub(self, other)
 
+    @_wrap_type_error_to_not_implemented
     def __rdiv__(self, other):
         if has_torch_function_variadic(self, other):
             return handle_torch_function(Tensor.__rdiv__, (self, other), self, other)
@@ -551,7 +553,7 @@ class Tensor(torch._C._TensorBase):
     __rtruediv__ = __rdiv__
     __itruediv__ = _C._TensorBase.__idiv__
 
-    __pow__ = _C._TensorBase.pow
+    __pow__ = _wrap_type_error_to_not_implemented(_C._TensorBase.pow)
 
     def __format__(self, format_spec):
         if has_torch_function_unary(self):

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -580,6 +580,12 @@ class Tensor(torch._C._TensorBase):
     def __rfloordiv__(self, other):
         return torch.floor_divide(other, self)
 
+    @_wrap_type_error_to_not_implemented
+    def __rmatmul__(self, other):
+        if has_torch_function_variadic(self, other):
+            return handle_torch_function(Tensor.__rmatmul__, (self, other), self, other)
+        return torch.matmul(other, self)
+
     __pos__ = _C._TensorBase.positive
     __neg__ = _C._TensorBase.neg
     __abs__ = _C._TensorBase.abs

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2919,7 +2919,12 @@ def sample_inputs_matmul(op_info, device, dtype, requires_grad):
     for lhs_shape, rhs_shape in test_cases:
         lhs = make_tensor(lhs_shape, device, dtype, low=None, high=None, requires_grad=requires_grad)
         rhs = make_tensor(rhs_shape, device, dtype, low=None, high=None, requires_grad=requires_grad)
-        sample_inputs.append(SampleInput(lhs, args=(rhs,)))
+        if op_info.name == 'matmul':
+            sample_inputs.append(SampleInput(lhs, args=(rhs,)))
+        elif op_info.name == '__rmatmul__':
+            sample_inputs.append(SampleInput(rhs, args=(lhs,)))
+        else:
+            raise RuntimeError("`op_info.name` must be 'matmul' or '__rmatmul__'")
     return tuple(sample_inputs)
 
 
@@ -5088,6 +5093,20 @@ op_db: List[OpInfo] = [
            skips=(SkipInfo('TestCommon', 'test_variant_consistency_jit',),),
            assert_autodiffed=True,
            autodiff_nonfusible_nodes=['aten::mul'],),
+    OpInfo('__rmatmul__',
+           op=torch.Tensor.__rmatmul__,
+           dtypes=floating_types(),
+           dtypesIfCPU=all_types_and_complex(),
+           dtypesIfCUDA=floating_types_and(torch.float16, torch.complex64, torch.complex128),
+           dtypesIfROCM=floating_types_and(torch.half),
+           assert_autodiffed=True,
+           sample_inputs_func=sample_inputs_matmul,
+           supports_out=False,
+           skips=(
+               SkipInfo('TestCommon', 'test_variant_consistency_jit',),
+               # https://github.com/pytorch/pytorch/issues/55755
+               SkipInfo('TestOpInfo', 'test_unsupported_dtypes',
+                        device_type='cpu', dtypes=(torch.float16,)),)),
     OpInfo('__rpow__',
            op=torch.Tensor.__rpow__,
            dtypes=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),


### PR DESCRIPTION
Fixes #57719.

This PR fixes `torch.Tensor{__rsub__, __rdiv__, __rtruediv__, __pow__, __rmatmul__}` to return `NotImplemented` instead of raising a `TypeError`.

cc/ @mruberry: The first commit of this PR is the same as https://github.com/pytorch/pytorch/pull/56997/commits/1d209db1cc624fbbe99eee5c82b7b68273c1666e excepts the commit message.