### PR TITLE
Fixes: register_full_backward_hook crash if first argument don't require a gradient (#57944)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -622,6 +622,16 @@ class TestNN(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "where no input requires gradient"):
             mod(inp).sum().backward()
 
+    def test_hook_last_arg_requires_grad(self):
+        mod = nn.L1Loss()
+        inp = torch.rand(1, requires_grad=True)
+        mod.register_full_backward_hook(lambda m, gI, gO: None)
+
+        try:
+            mod(inp.detach(), inp)
+        except Exception as ex:
+            self.fail("Unexpected exception: %s" % ex)
+
     def test_hook_extra_input(self):
         class MyModule(nn.Module):
             def forward(self, non_tensor, tensor):

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -136,12 +136,13 @@ class BackwardHook(object):
         new_tensors = torch.nn.modules._functions.BackwardHookFunction.apply(*tensors)
         if len(new_tensors) == 0:
             raise RuntimeError("Cannot set Module backward hook for a Module with no input Tensors.")
-        grad_fn = new_tensors[0].grad_fn
-        if not grad_fn.name() == "BackwardHookFunctionBackward":
+
+        grad_fns = [t.grad_fn for t in new_tensors if t.grad_fn is not None and t.grad_fn.name() == "BackwardHookFunctionBackward"]
+        if len(grad_fns) == 0:
             raise RuntimeError("Error while setting up backward hooks. Please open "
                                "an issue with a code sample to reproduce this.")
 
-        fn(grad_fn)
+        fn(grad_fns[0])
 
         arg_list = list(args)
         for idx, val in zip(tensors_idx, new_tensors):


### PR DESCRIPTION


Fixes #57944
