### PR TITLE
Fix hasattr support type

### DIFF
--- a/docs/source/jit_language_reference_v2.rst
+++ b/docs/source/jit_language_reference_v2.rst
@@ -1687,8 +1687,8 @@ Python Built-in Functions Support
      - None
      -
    * - ``hasattr()``
-     - Full
-     -
+     - Partial
+     - Attribute name must be string literal.
    * - ``hash()``
      - Full
      - ``Tensor``'s hash is based on identity not numeric value.


### PR DESCRIPTION
`hasattr` is partially supported. This PR fixes that. 
