### PR TITLE
[package] allow non-package modules to import module attributes for externed modules

### DIFF
--- a/test/package/package_b/__init__.py
+++ b/test/package/package_b/__init__.py
@@ -3,6 +3,7 @@ __import__("subpackage_0.subsubpackage_0", globals(), fromlist=[""], level=1)
 __import__("subpackage_2", globals=globals(), locals=locals(), fromlist=["*"], level=1)
 
 result = "package_b"
+import os.path
 
 class PackageBObject:
     __slots__ = ["obj"]

--- a/torch/package/package_importer.py
+++ b/torch/package/package_importer.py
@@ -491,7 +491,6 @@ class PackageImporter(Importer):
                 return node
             if isinstance(node, _ModuleNode):
                 name = ".".join(atoms[:i])
-                print(f"full name: {atoms}")
                 raise ImportError(
                     f"inconsistent module structure. module {name} is not a package, but has submodules"
                 )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57954 [package] allow non-package modules to import module attributes**

Allow non-package modules to import module attributes. When users manipulate `sys.modules` modules, they can add modules as attributes on modules that aren't packages:
```
# my_module.py
import other_module.sub_module as oops 
import sys

sys.modules['my_module.oops'] = oops
```
Another .py file can call `import my_module.oops` and access `other_module.sub_module` via `my_module.oops`.

`PackageExporter` handles this behavior in `_get_source_of_module` by writing out the contents of `other_module/sub_module.py` as `my_module/oops.py` in the package.

