### PR TITLE
[Don't Review] Enforce stream synchornization after optim.step

### DIFF
--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 import logging
 
+import torch
 import torch.distributed.rpc as rpc
 import torch.optim as optim
 import torch.jit as jit
@@ -63,6 +64,9 @@ class _ScriptLocalOptimizer(nn.Module):
 
         self.optim.step(grads)
 
+        if len(all_local_grads) > 0:
+            torch.cuda.current_stream(list(all_local_grads.items())[0][0].device).synchronize()
+
 
 # TODO (wanchaol): remove/merge this with ScriptLocalOptimizer once
 # we have converted all to functional optimizer in distributed.optim
@@ -91,6 +95,9 @@ class _LocalOptimizer(object):
                 param.grad = grad
             self.optim.step()
 
+        if len(all_local_grads) > 0:
+            torch.cuda.current_stream(all_local_grads[0].device()).synchronize()
+
 
 def _new_local_optimizer(optim_cls, local_params_rref, *args, **kwargs):
     return rpc.RRef(
@@ -110,6 +117,7 @@ def _new_script_local_optimizer(optim_cls, local_params_rref, *args, **kwargs):
         script_optim = jit.script(optim)
         return rpc.RRef(
             script_optim, _ScriptLocalOptimizerInterface)
+
 
 @jit.script
 def _script_local_optimizer_step(

--- a/torch/distributed/optim/optimizer.py
+++ b/torch/distributed/optim/optimizer.py
@@ -96,7 +96,7 @@ class _LocalOptimizer(object):
             self.optim.step()
 
         if len(all_local_grads) > 0:
-            torch.cuda.current_stream(all_local_grads[0].device()).synchronize()
+            torch.cuda.current_stream(list(all_local_grads.items())[0][0].device).synchronize()
 
 
 def _new_local_optimizer(optim_cls, local_params_rref, *args, **kwargs):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57958 [Don't Review] Enforce stream synchornization after optim.step**
* #57918 [WIP] Fix distributed autograd gradient accumulation
* #57917 [WIP] Fix Raw RPC/RRef Micro-batch-based Pipelining
* #57896 Revert "Make RRefContext get devices from RPC agent when creating OwnerRRef (#57443)"
* #57926 Use RPC context streams to cover serde ops

Differential Revision: [D28327488](https://our.internmc.facebook.com/intern/diff/D28327488)