### PR TITLE
Add warning about should_drop for JIT coverage plug-in

### DIFF
--- a/torch/_jit_internal.py
+++ b/torch/_jit_internal.py
@@ -647,6 +647,10 @@ def module_has_exports(mod):
                     return True
     return False
 
+
+# WARNING: should_drop is currently being used by our JIT code coverage plug-in to mark JIT'd code as covered. If you
+# rename this function, please update references in tools/coverage_plugins_package/src/coverage_plugins/jit_plugin.py to
+# allow JIT'd code to still be covered.
 def should_drop(fn) -> bool:
     attr = get_torchscript_modifier(fn)
     if attr is None:


### PR DESCRIPTION
This adds a comment above `should_drop` to prevent someone from inadvertently breaking JIT coverage by renaming the function without updating the correct references.

The current JIT plug-in uses `should_drop` to figure out which code is going to be JIT'd. If the function is named differently, the plug-in would also need to be updated. 

Question: I understand this may not be the cleanest solution. Would a cleaner solution be to create a dummy function that would simply exist for the JIT plug-in? I did not immediately do that as that may be adding unnecessary code complexity in torch.jit. 