### PR TITLE
Fix UB in library.h

### DIFF
--- a/test/cpp_extensions/torch_library.cu
+++ b/test/cpp_extensions/torch_library.cu
@@ -6,4 +6,10 @@ TORCH_LIBRARY(torch_library, m) {
   m.def("logical_and", &logical_and);
 }
 
+struct CuaevComputer : torch::CustomClassHolder {};
+
+TORCH_LIBRARY(cuaev, m) {
+  m.class_<CuaevComputer>("CuaevComputer");
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {}

--- a/torch/library.h
+++ b/torch/library.h
@@ -658,7 +658,7 @@ public:
   }
 
   template <class CurClass>
-  inline class_<CurClass> class_(const std::string& className);
+  inline torch::class_<CurClass> class_(const std::string& className);
 
 private:
   Kind kind_;


### PR DESCRIPTION
The function name and return type both are called `class_`, therefore they are ambiguous and this is UB and does not work on NVCC. See the tests for the failure case.
 
Thanks for the help of Thibaut Lutz from NVIDIA's compiler team.

cc: @yueyericardo @ptrblck 