### PR TITLE
[RPC Framework] Move the annotation w/ bold effect out of the quotes

### DIFF
--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -312,7 +312,7 @@ to use `the profiler <https://pytorch.org/docs/stable/autograd.html#profiler>`__
 
 -  `Getting started with Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_tutorial.html>`__
 -  `Implementing a Parameter Server using Distributed RPC Framework <https://pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html>`__
--  `Combining Distributed DataParallel with Distributed RPC Framework (covers **RemoteModule** as well) <https://pytorch.org/tutorials/advanced/rpc_ddp_tutorial.html>`__
+-  `Combining Distributed DataParallel with Distributed RPC Framework <https://pytorch.org/tutorials/advanced/rpc_ddp_tutorial.html>`__ (covers **RemoteModule** as well)
 -  `Profiling RPC-based Workloads <https://pytorch.org/tutorials/recipes/distributed_rpc_profiling.html>`__
 -  `Implementing batch RPC processing <https://pytorch.org/tutorials/intermediate/rpc_async_execution.html>`__
 -  `Distributed Pipeline Parallel <https://pytorch.org/tutorials/intermediate/dist_pipeline_parallel_tutorial.html>`__


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57965 [RPC Framework] Move the annotation w/ bold effect out of the quotes**

The bold effect does not work under quotes, so move it out.

Differential Revision: [D28329694](https://our.internmc.facebook.com/intern/diff/D28329694/)