### PR TITLE
fixed numerical instability in beta_grad_alpha_mid

### DIFF
--- a/aten/src/ATen/native/Distributions.h
+++ b/aten/src/ATen/native/Distributions.h
@@ -426,7 +426,7 @@ C10_DEVICE static inline scalar_t _beta_grad_alpha_mid(accscalar_t x, accscalar_
   const accscalar_t total = alpha + beta;
   const accscalar_t mean = alpha / total;
   const accscalar_t std = compat_sqrt(alpha * beta / (total + 1)) / total;
-  if (mean - 0.1 * std <= x && x <= mean + 0.1 * std) {
+  if (mean - 0.2 * std <= x && x <= mean + 0.2 * std) {
     // Avoid the singularity at x = mean.
     const accscalar_t poly = 47 * x * (beta * beta) * (beta * beta) + alpha * (
                            (43 + 20 * (16 + 27 * beta) * x) * (beta * beta) * beta + alpha * (
@@ -445,12 +445,12 @@ C10_DEVICE static inline scalar_t _beta_grad_alpha_mid(accscalar_t x, accscalar_
   const accscalar_t axbx = alpha * (x - 1) + beta * x;
   const accscalar_t term1_den = compat_sqrt(2 * alpha / beta) * compat_pow(total, static_cast<accscalar_t>(1.5f)) * axbx * axbx;
   const accscalar_t term1 = term1_num / term1_den;
-  const accscalar_t term2 = 0.5f * compat_log(alpha / (total * x));
+  const accscalar_t term2 = 0.5f * (compat_log(alpha) - compat_log((total * x)));
   const accscalar_t term3_num = compat_sqrt(8 * alpha * beta / total);
   const accscalar_t term3_den = beta * x + alpha * (x - 1);
   const accscalar_t term3 = term3_num / term3_den;
-  const accscalar_t term4_base = beta * compat_log(beta / (total * (1 - x))) +
-                               alpha * compat_log(alpha / (total * x));
+  const accscalar_t term4_base = beta * (compat_log(beta)  - compat_log(total * (1 - x))) +
+                                alpha * (compat_log(alpha) - compat_log(total * x));
   const accscalar_t term4 = compat_pow(term4_base, static_cast<accscalar_t>(-1.5f));
   const accscalar_t term1234 = term1 + term2 * (term3 + (x < mean ? term4 : -term4));
   return static_cast<scalar_t>(stirling * prefactor * term1234);

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3044,17 +3044,17 @@ class TestRsample(TestCase):
             ]))
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA not found")
-     def test_dirichlet_grad_consistency(self):
-         # Fix for https://github.com/pytorch/pytorch/issues/57447
-         dtype = torch.float32
-         x = torch.tensor([0.15497829020023346, 0.845021665096283], dtype=dtype)
-         c = torch.tensor([14539.8583984375, 79369.6484375], dtype=dtype)
-         t = torch.tensor([93909.5078125, 93909.5078125], dtype=dtype)
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_dirichlet_grad_consistency(self):
+        # Fix for https://github.com/pytorch/pytorch/issues/57447
+        dtype = torch.float32
+        x = torch.tensor([0.15497829020023346, 0.845021665096283], dtype=dtype)
+        c = torch.tensor([14539.8583984375, 79369.6484375], dtype=dtype)
+        t = torch.tensor([93909.5078125, 93909.5078125], dtype=dtype)
 
-         expected = torch._dirichlet_grad(x, c, t)
-         actual = torch._dirichlet_grad(x.to('cuda'), c.to('cuda'), t.to('cuda'))
-         self.assertAlmostEqual(expected, actual, 4) 
+        expected = torch._dirichlet_grad(x, c, t)
+        actual = torch._dirichlet_grad(x.to('cuda'), c.to('cuda'), t.to('cuda'))
+        self.assertAlmostEqual(expected, actual, 4) 
 
     def test_dirichlet_tangent_field(self):
         num_samples = 20

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -3053,7 +3053,7 @@ class TestRsample(TestCase):
         t = torch.tensor([93909.5078125, 93909.5078125], dtype=dtype)
 
         expected = torch._dirichlet_grad(x, c, t)
-        actual = torch._dirichlet_grad(x.to('cuda'), c.to('cuda'), t.to('cuda'))
+        actual = torch._dirichlet_grad(x.to('cuda'), c.to('cuda'), t.to('cuda')).cpu()
         self.assertAlmostEqual(expected, actual, 4) 
 
     def test_dirichlet_tangent_field(self):

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -1,5 +1,4 @@
-"""
-Note [Randomized statistical tests]
+""" Note [Randomized statistical tests]
 -----------------------------------
 
 This note describes how to maintain tests in this file as random sources
@@ -3043,6 +3042,19 @@ class TestRsample(TestCase):
                 "actual_grad: %.5g" % actual_grad,
                 "error = %.2g" % torch.abs(expected_grad - actual_grad).max(),
             ]))
+
+
+@unittest.skipIf(not TEST_CUDA, "CUDA not found")
+     def test_dirichlet_grad_consistency(self):
+         # Fix for https://github.com/pytorch/pytorch/issues/57447
+         dtype = torch.float32
+         x = torch.tensor([0.15497829020023346, 0.845021665096283], dtype=dtype)
+         c = torch.tensor([14539.8583984375, 79369.6484375], dtype=dtype)
+         t = torch.tensor([93909.5078125, 93909.5078125], dtype=dtype)
+
+         expected = torch._dirichlet_grad(x, c, t)
+         actual = torch._dirichlet_grad(x.to('cuda'), c.to('cuda'), t.to('cuda'))
+         self.assertAlmostEqual(expected, actual, 4) 
 
     def test_dirichlet_tangent_field(self):
         num_samples = 20


### PR DESCRIPTION
Fixes #57447

While increasing precision can work, it's always best to fix numerical instability algorithmically. Changing the log(x/y) operations to log(x)-log(y) is an easy fix that seems to work for this case, and has almost no downsides. However, the root problem here is that there is a singularity at x=mean (where mean is alpha/total) when alpha and beta are large. There is a block of code at line 429 designed to deal with this, when x is within 0.1 std of the mean. The NaN issue can also be fixed by casting a wider net around the mean (e.g., 0.2 std).
