### PR TITLE
[nccl] log rank when communicator is aborted

### DIFF
--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -112,6 +112,7 @@ class NCCLComm {
     C10D_NCCL_CHECK(
         ncclCommInitRank(&(comm->ncclComm_), numRanks, commId, rank));
     comm->ncclId_ = commId;
+    comm->rank_ = rank;
     return comm;
   }
 
@@ -139,7 +140,8 @@ class NCCLComm {
   ncclComm_t getNcclComm() {
     std::unique_lock<std::mutex> lock(mutex_);
     if (aborted_) {
-      throw std::runtime_error("NCCL communicator was aborted.");
+      throw std::runtime_error(
+          "NCCL communicator was aborted on rank ", rank_, ".");
     }
     return ncclComm_;
   }
@@ -192,6 +194,8 @@ class NCCLComm {
   bool aborted_;
   ncclResult_t ncclAsyncErr_;
   mutable std::mutex mutex_;
+  // Rank that this communicator corresponds to.
+  int rank_;
 };
 
 } // namespace c10d

--- a/torch/lib/c10d/NCCLUtils.hpp
+++ b/torch/lib/c10d/NCCLUtils.hpp
@@ -9,8 +9,8 @@
 #include <nccl.h>
 
 namespace {
-  // Provides additional detail into NCCL error codes based on when these are
-  // thrown in the NCCL codebase.
+// Provides additional detail into NCCL error codes based on when these are
+// thrown in the NCCL codebase.
 const inline char* getNcclErrorDetailStr(ncclResult_t error) {
   switch (error) {
     case ncclUnhandledCudaError:
@@ -50,7 +50,7 @@ const inline char* getNcclErrorDetailStr(ncclResult_t error) {
 // Macro to throw on a non-successful NCCL return value.
 #define C10D_NCCL_CHECK(cmd)                                                  \
   do {                                                                        \
-    ncclResult_t result = cmd; \
+    ncclResult_t result = cmd;                                                \
     if (result != ncclSuccess) {                                              \
       std::string err = "NCCL error in: " + std::string(__FILE__) + ":" +     \
           std::to_string(__LINE__) + ", " + ncclGetErrorWithVersion(result) + \
@@ -141,7 +141,8 @@ class NCCLComm {
     std::unique_lock<std::mutex> lock(mutex_);
     if (aborted_) {
       throw std::runtime_error(
-          "NCCL communicator was aborted on rank ", rank_, ".");
+          "NCCL communicator was aborted on rank " + std::to_string(rank_) +
+          ".");
     }
     return ncclComm_;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57974 [nccl] log rank when communicator is aborted**

We see this error quite a bit in internal workflows, would be useful
to have this additional logging information here.

Differential Revision: [D28331693](https://our.internmc.facebook.com/intern/diff/D28331693/)