### PR TITLE
[torch/elastic] Add logging to the sanitize function of RendezvousStateHolder

### DIFF
--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -407,6 +407,14 @@ class _BackendRendezvousStateHolder(_RendezvousStateHolder):
             if last_heartbeat < expire_time
         ]
 
+        if dead_nodes and log.isEnabledFor(logging.DEBUG):
+            node_list = ", ".join(f"'{dead_node}'" for dead_node in dead_nodes)
+
+            log.debug(
+                f"The node(s) {node_list} have no heartbeat and are removed from the rendezvous "
+                f"'{self._settings.run_id}'."
+            )
+
         for dead_node in dead_nodes:
             del self._state.last_heartbeats[dead_node]
 


### PR DESCRIPTION
Summary: This PR adds logging to the `_sanitize()` function of `RendezvousStateHolder` to output the nodes that had no recent heartbeat and are considered "dead".

Test Plan: Run the existing tests.

Differential Revision: D28333394

