### PR TITLE
[package] add mock/extern hooks

### DIFF
--- a/test/package/test_dependency_hooks.py
+++ b/test/package/test_dependency_hooks.py
@@ -1,0 +1,101 @@
+from io import BytesIO
+
+from torch.package import (
+    PackageExporter,
+)
+from torch.testing._internal.common_utils import run_tests
+
+try:
+    from .common import PackageTestCase
+except ImportError:
+    # Support the case where we run this file directly.
+    from common import PackageTestCase
+
+
+class TestDependencyHooks(PackageTestCase):
+    """Dependency management hooks API tests.
+    - register_mock_hook()
+    - register_extern_hook()
+    """
+
+    def test_single_hook(self):
+        buffer = BytesIO()
+
+        my_externs = set()
+
+        def my_extern_hook(package_exporter, module_name):
+            my_externs.add(module_name)
+
+        with PackageExporter(buffer, verbose=False) as exporter:
+            exporter.extern(["package_a.subpackage", "module_a"])
+            exporter.register_extern_hook(my_extern_hook)
+            exporter.save_source_string("foo", "import module_a")
+
+        self.assertEqual(my_externs, set(["module_a"]))
+
+    def test_multiple_hooks(self):
+        buffer = BytesIO()
+
+        my_externs = set()
+
+        def my_extern_hook(package_exporter, module_name):
+            my_externs.add(module_name)
+
+        def my_extern_hook2(package_exporter, module_name):
+            my_externs.remove(module_name)
+
+        with PackageExporter(buffer, verbose=False) as exporter:
+            exporter.extern(["package_a.subpackage", "module_a"])
+            exporter.register_extern_hook(my_extern_hook)
+            exporter.register_extern_hook(my_extern_hook2)
+            exporter.save_source_string("foo", "import module_a")
+
+        self.assertEqual(my_externs, set())
+
+    def test_remove_hooks(self):
+        buffer = BytesIO()
+
+        my_externs = set()
+        my_externs2 = set()
+
+        def my_extern_hook(package_exporter, module_name):
+            my_externs.add(module_name)
+
+        def my_extern_hook2(package_exporter, module_name):
+            my_externs2.add(module_name)
+
+        with PackageExporter(buffer, verbose=False) as exporter:
+            exporter.extern(["package_a.subpackage", "module_a"])
+            handle = exporter.register_extern_hook(my_extern_hook)
+            exporter.register_extern_hook(my_extern_hook2)
+            handle.remove()
+            exporter.save_source_string("foo", "import module_a")
+
+        self.assertEqual(my_externs, set())
+        self.assertEqual(my_externs2, set(["module_a"]))
+
+    def test_extern_and_mock_hook(self):
+        buffer = BytesIO()
+
+        my_externs = set()
+        my_mocks = set()
+
+        def my_extern_hook(package_exporter, module_name):
+            my_externs.add(module_name)
+
+        def my_mock_hook(package_exporter, module_name):
+            my_mocks.add(module_name)
+
+        with PackageExporter(buffer, verbose=False) as exporter:
+            exporter.extern("module_a")
+            exporter.mock("package_a")
+            exporter.register_extern_hook(my_extern_hook)
+            exporter.register_mock_hook(my_mock_hook)
+            exporter.save_source_string("foo", "import module_a; import package_a")
+
+        self.assertEqual(my_externs, set(["module_a"]))
+        self.assertEqual(my_mocks, set(["package_a"]))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -397,6 +397,8 @@ node [shape=box];
 
             hook(exporter: PackageExporter, module_name: str) -> None
 
+        Hooks will be called in order of registration.
+
         Returns:
             :class:`torch.utils.hooks.RemovableHandle`:
                 a handle that can be used to remove the added hook by calling
@@ -415,6 +417,8 @@ node [shape=box];
         It should have the following signature::
 
             hook(exporter: PackageExporter, module_name: str) -> None
+
+        Hooks will be called in order of registration.
 
         Returns:
             :class:`torch.utils.hooks.RemovableHandle`:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #57341 [package] Add an intern keyword
* **#58000 [package] add mock/extern hooks**

Directly overriding save_extern and save_mock may mess with our
invariants in weird ways. This is less pronounced now, but once we
switch to graph-based dependency management things will get broken
subtly if people fail to call `super()`.

Better to add hook support to reflect that really you can only do a side
effect. Also has the bonus that people are likely familiar with it from
`nn.Module` hooks.

Differential Revision: [D28339191](https://our.internmc.facebook.com/intern/diff/D28339191)