### PR TITLE
[nnc] Temporarily disable gelu in fuser

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -138,7 +138,8 @@ static const OperatorSet& supported_eltwise_set() {
       "aten::remainder.Tensor(Tensor self, Tensor other) -> Tensor",
       "aten::sigmoid(Tensor self) -> Tensor",
       "aten::relu(Tensor self) -> Tensor",
-      "aten::gelu(Tensor self) -> Tensor",
+      // TODO: NNC gelu occasionally produces wrong results.
+      // "aten::gelu(Tensor self) -> Tensor",
       "aten::addcmul(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor",
       "aten::neg(Tensor self) -> Tensor",
       "aten::reciprocal(Tensor self) -> Tensor",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58029 [nnc] Enable CPU fusion inside Facebook
* **#58027 [nnc] Temporarily disable gelu in fuser**
* #58028 [nnc] Handle only the first argument of aten::to
* #58026 Enable cat wo conditionals iff cpu
* #57798 [nnc] Fix float->bool conversion on cpu

Sometimes NNC gelu produces wrong results.

Differential Revision: [D28347705](https://our.internmc.facebook.com/intern/diff/D28347705/)