### PR TITLE
Remove the BETA status for torch.linalg

### DIFF
--- a/docs/source/linalg.rst
+++ b/docs/source/linalg.rst
@@ -6,10 +6,6 @@ torch.linalg
 
 Common linear algebra operations.
 
-This module is in BETA. New functions are still being added, and some
-functions may change in future PyTorch releases. See the documentation of each
-function for details.
-
 .. automodule:: torch.linalg
 .. currentmodule:: torch.linalg
 


### PR DESCRIPTION
We are ready to move to the new stage for our `torch.linalg` module, which is stable (or STABLE?).

Ref. https://github.com/pytorch/pytorch/issues/42666
