### PR TITLE
warn appropriate warning for fn in distributed api

### DIFF
--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -86,7 +86,7 @@ class WorkerSpec:
             warnings.warn(
                 "WorkerSpec.fn will be deprecated,"
                 " please use WorkerSpec.entrypoint instead",
-                category=DeprecationWarning,
+                category=PendingDeprecationWarning,
             )
             self.entrypoint = self.fn
         assert self.entrypoint


### PR DESCRIPTION
`fn` of `WorkerSpec` in `torch.distributed.elastic.agent.server.api` is about to deprecate, not deprecated. Should have warn `PendingDeprecationWarning` instead

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang