### PR TITLE
Remove master documentation from being indexable by search engines

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,6 +1,16 @@
 {% extends "!layout.html" %}
 <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html" />
 
+{% block extrahead %}
+{% if release == "master" %}
+<!--
+  Search engines should not index the master version of documentation.
+  Stable documentation are built without release == 'master'.
+-->
+<meta name="robots" content="noindex">
+{% endif %}
+{% endblock %}
+
 {% block menu %}
 {% if release == "master" %}
 <div>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58092 Adds an aten::_ops namespace with unambiguous function names
* **#58056 Remove master documentation from being indexable by search engines**

This PR addresses an action item in #3428: disabling search engine
indexing of master documentation. This is desireable because we want to
direct users to our stable documentation (instead of master
documentation) because they are more likely to have a stable version of
PyTorch installed.

Test Plan:
1. run `make html`, check that the noindex tags are there
2. run `make html-stable, check that the noindex tags aren't there

Differential Revision: [D28490504](https://our.internmc.facebook.com/intern/diff/D28490504)