### PR TITLE
[fx] Arg normalization not save output node in the node_map

### DIFF
--- a/torch/fx/experimental/normalize.py
+++ b/torch/fx/experimental/normalize.py
@@ -48,7 +48,8 @@ class NormalizeArgs(Transformer):
             out = self.call_function(n.target, args, kwargs, arg_types, kwarg_types)
         else:
             out = super().run_node(n)
-        self.node_map[out] = n
+        if n.op != "output":
+            self.node_map[out] = n
         return out
 
     def call_function(


### PR DESCRIPTION
Summary: Don't save output node in the `node_map`.

Test Plan: CI

Differential Revision: D28329580

