### PR TITLE
Add CUDA Vital

### DIFF
--- a/aten/src/ATen/core/Vitals.cpp
+++ b/aten/src/ATen/core/Vitals.cpp
@@ -1,15 +1,32 @@
 #include <ATen/core/Vitals.h>
 #include <cstdlib>
 
-
 namespace at {
 namespace vitals {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 APIVitals VitalsAPI;
 
+std::ostream& operator<<(std::ostream& os, TorchVital const& tv) {
+  for (const auto& m : tv.attrs) {
+    os << "[TORCH_VITAL] " << tv.name << "." << m.first << "\t\t "
+       << m.second.value << "\n";
+  }
+  return os;
+}
+
+TorchVital::~TorchVital() {
+  if (torchVitalEnabled()) {
+    std::cout << *this;
+  }
+}
+
 TorchVitalAttr& TorchVital::create(const std::string& attr) {
-  if (!torchVitalEnabled()) {
+  return create(attr, /* force = */ false);
+}
+
+TorchVitalAttr& TorchVital::create(const std::string& attr, bool force) {
+  if (!(torchVitalEnabled() || force)) {
     static TorchVitalAttr disabled;
     return disabled;
   }
@@ -31,29 +48,52 @@ bool torchVitalEnabled() {
     }
     return false;
   }();
-  return enabled;
+  if (enabled) {
+    VitalsAPI.vitals_enabled = true;
+  }
+  return VitalsAPI.vitals_enabled;
+}
+
+std::string APIVitals::readVitals() {
+  if (!torchVitalEnabled()) {
+    return "";
+  }
+
+  std::stringstream buf;
+  for (auto x : name_map_) {
+    buf << x.second;
+  }
+  return buf.str();
 }
 
 bool APIVitals::setVital(
     const std::string& vital_name,
     const std::string& attr_name,
-    const std::string& value) {
-  if (!torchVitalEnabled()) {
+    const std::string& value,
+    bool force) {
+  if (!(torchVitalEnabled() || force)) {
     return false;
   }
 
   auto iter = name_map_.find(vital_name);
-  TorchVital *vital = nullptr;
+  TorchVital* vital = nullptr;
   if (iter == name_map_.end()) {
-    auto r = name_map_.emplace(std::make_pair(vital_name, TorchVital(vital_name)));
+    auto r =
+        name_map_.emplace(std::make_pair(vital_name, TorchVital(vital_name)));
     vital = &r.first->second;
   } else {
     vital = &iter->second;
   }
 
-  vital->create(attr_name) << value;
+  vital->create(attr_name, force).write(value, force);
   return true;
 }
 
-} // namespace at
+APIVitals::APIVitals() : vitals_enabled(false), name_map_() {
+  // Set default values, force is necessary because in unit tests the env
+  // variable may not be set when global APIVitals are constructed.
+  setVital("CUDA", "used", "False", /* force = */ true);
+}
+
 } // namespace vitals
+} // namespace at

--- a/aten/src/ATen/core/Vitals.h
+++ b/aten/src/ATen/core/Vitals.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
-#include <map>
 
 #include <c10/core/impl/LocalDispatchKeySet.h>
 
@@ -25,6 +25,15 @@ struct TORCH_API TorchVitalAttr {
     }
     return *this;
   }
+
+  template <typename T>
+  void write(const T& t, bool force) {
+    if (force || torchVitalEnabled()) {
+      std::stringstream ss;
+      ss << t;
+      value = ss.str();
+    }
+  }
 };
 
 struct TORCH_API TorchVital {
@@ -35,43 +44,50 @@ struct TORCH_API TorchVital {
   TorchVital() = delete;
 
   TorchVitalAttr& create(const std::string& attr);
+  TorchVitalAttr& create(const std::string& attr, bool force);
+  friend std::ostream& operator<<(std::ostream& os, const TorchVital& dt);
 
-  ~TorchVital() {
-    for (const auto& m : attrs) {
-      std::cout << "[TORCH_VITAL] " << name << "." << m.first << "\t\t "
-                << m.second.value << "\n";
-    }
-  }
+  ~TorchVital();
 };
+
+std::ostream& operator<<(std::ostream& os, TorchVital const& tv);
 
 // A way to access vitals by string names instead of by global reference.
 // This enables access to vitals from the PythonAPI.
-class TORCH_API APIVitals
-{
-public:
-    // Set any vital sign that was added to the map.
-    bool setVital(const std::string &vital_name, const std::string &attr_name, const std::string &value);
+class TORCH_API APIVitals {
+ public:
+  bool vitals_enabled;
 
-    APIVitals(): name_map_() { }
+  // Set any vital sign that was added to the map.
+  bool setVital(
+      const std::string& vital_name,
+      const std::string& attr_name,
+      const std::string& value,
+      bool force = false);
+  std::string readVitals();
 
-    // Ensure this stays a singleton
-    APIVitals(APIVitals const& other) = delete;
-    APIVitals(APIVitals&& other) = delete;
-    APIVitals& operator=(const APIVitals&) = delete;
-    APIVitals& operator=(APIVitals&&) = delete;
+  APIVitals();
 
-private:
-    std::unordered_map<std::string, TorchVital> name_map_;
+  // Ensure this stays a singleton
+  APIVitals(APIVitals const& other) = delete;
+  APIVitals(APIVitals&& other) = delete;
+  APIVitals& operator=(const APIVitals&) = delete;
+  APIVitals& operator=(APIVitals&&) = delete;
+
+ private:
+  std::unordered_map<std::string, TorchVital> name_map_;
 };
 
 extern TORCH_API APIVitals VitalsAPI;
 
-} // namespace at
 } // namespace vitals
+} // namespace at
 
-#define TORCH_VITAL_DECLARE(name) TORCH_API at::vitals::TorchVital TorchVital_##name;
+#define TORCH_VITAL_DECLARE(name) \
+  TORCH_API at::vitals::TorchVital TorchVital_##name;
 
-#define TORCH_VITAL_DEFINE(name) TORCH_API at::vitals::TorchVital TorchVital_##name(#name);
+#define TORCH_VITAL_DEFINE(name) \
+  TORCH_API at::vitals::TorchVital TorchVital_##name(#name);
 
 #define TORCH_VITAL_BASE(name) TorchVital_##name
 

--- a/aten/src/ATen/cuda/detail/CUDAHooks.cpp
+++ b/aten/src/ATen/cuda/detail/CUDAHooks.cpp
@@ -4,6 +4,7 @@
 #include <ATen/Context.h>
 #include <ATen/DeviceGuard.h>
 #include <ATen/DynamicLibrary.h>
+#include <ATen/core/Vitals.h>
 #include <ATen/cuda/CUDAConfig.h>
 #include <ATen/cuda/CUDADevice.h>
 #include <ATen/cuda/Exceptions.h>
@@ -51,6 +52,10 @@ std::function<void(void)> THCMagma_init;
 std::unique_ptr<THCState, void (*)(THCState*)> CUDAHooks::initCUDA() const {
   C10_LOG_API_USAGE_ONCE("aten.init.cuda");
   THCState* thc_state = THCState_alloc();
+
+  // Force the update to enable unit testing. This code get executed before unit tests
+  // have a chance to enable vitals.
+  at::vitals::VitalsAPI.setVital("CUDA", "used", "true", /* force = */ true);
 
   THCudaInit(thc_state);
   if (THCMagma_init)

--- a/aten/src/ATen/test/vitals.cpp
+++ b/aten/src/ATen/test/vitals.cpp
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
@@ -5,6 +6,7 @@
 #include <cstdlib>
 
 using namespace at::vitals;
+using ::testing::HasSubstr;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(Vitals, Basic) {
@@ -29,11 +31,11 @@ TEST(Vitals, Basic) {
   std::cout.rdbuf(sbuf);
 
   auto s = buffer.str();
-  ASSERT_TRUE(s.find("Testing.Attribute0\t\t 1") != std::string::npos);
-  ASSERT_TRUE(s.find("Testing.Attribute1\t\t 1") != std::string::npos);
-  ASSERT_TRUE(s.find("Testing.Attribute2\t\t 1") != std::string::npos);
-  ASSERT_TRUE(s.find("Testing.Attribute3\t\t 1") != std::string::npos);
-  ASSERT_TRUE(s.find("Testing.Attribute4\t\t  1") != std::string::npos);
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute0\t\t 1"));
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute1\t\t 1"));
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute2\t\t 1"));
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute3\t\t 1"));
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute4\t\t  1"));
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -57,8 +59,8 @@ TEST(Vitals, MultiString) {
   std::cout.rdbuf(sbuf);
 
   auto s = buffer.str();
-  ASSERT_TRUE(s.find("Testing.Attribute0\t\t 1 of 2") != std::string::npos);
-  ASSERT_TRUE(s.find("Testing.Attribute1\t\t 1 of 2") != std::string::npos);
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute0\t\t 1 of 2"));
+  ASSERT_THAT(s, HasSubstr("Testing.Attribute1\t\t 1 of 2"));
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -113,5 +115,5 @@ TEST(Vitals, APIVitals) {
 
   auto s = buffer.str();
   ASSERT_TRUE(rvalue);
-  ASSERT_TRUE(s.find("TestingSetVital.TestAttr\t\t TestValue") != std::string::npos);
+  ASSERT_THAT(s, HasSubstr("TestingSetVital.TestAttr\t\t TestValue"));
 }

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2919,21 +2919,27 @@ def torch_vital_set(value):
 
 
 # Tests Vital Signs for Torch
-class TestVitalSigns(TestCase):
+class TestBasicVitalSigns(TestCase):
     def test_basic_vitals(self):
         with torch_vital_set(''):
             self.assertFalse(torch.vitals_enabled())
         with torch_vital_set('ON'):
             self.assertTrue(torch.vitals_enabled())
 
-    def test_write_vital(self):
+    def test_basic_vitals_read_write(self):
         with torch_vital_set('ON'):
             self.assertTrue(torch.vitals_enabled())
             # This tests the code path of setting a vital
-            self.assertTrue(torch.set_vital('Dataloader', 'basic_unit_test', 'TEST'))
-            # Ideally we would have a read test for vitals, though because the the C++ design
-            # pattern of loggers we use, we can't know the whole list of vitals until the
-            # global C++ namespace is destructed.
+            self.assertTrue(torch.set_vital('Dataloader', 'basic_unit_test', 'TEST_VALUE_STRING'))
+            self.assertIn('TEST_VALUE_STRING', torch.read_vitals())
+            self.assertIn('CUDA.used', torch.read_vitals())
+
+
+class TestVitalSignsCuda(TestCase):
+    @onlyCUDA
+    def test_cuda_vitals_gpu_only(self, device):
+        with torch_vital_set('ON'):
+            self.assertIn('CUDA.used\t\t true', torch.read_vitals())
 
 
 # Device-generic tests. Instantiated below and not run directly.
@@ -8135,6 +8141,7 @@ class TestTensorDeviceOps(TestCase):
 # pytest will fail.
 add_neg_dim_tests()
 instantiate_device_type_tests(TestViewOps, globals())
+instantiate_device_type_tests(TestVitalSignsCuda, globals())
 instantiate_device_type_tests(TestTensorDeviceOps, globals())
 instantiate_device_type_tests(TestTorchDeviceType, globals())
 instantiate_device_type_tests(TestDevicePrecision, globals(), except_for='cpu')

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -954,6 +954,9 @@ PyObject* initModule() {
   py_module.def("set_vital", [](const std::string &vital, const std::string &attr, const std::string value){
     return at::vitals::VitalsAPI.setVital(vital, attr, value);
   });
+  py_module.def("read_vitals", [](){
+    return at::vitals::VitalsAPI.readVitals();
+  });
 
   py_module.def(
     "init_num_threads",

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -201,6 +201,7 @@ def get_ignored_functions() -> Set[Callable]:
         torch.set_warn_always,
         torch.vitals_enabled,
         torch.set_vital,
+        torch.read_vitals,
         Tensor.__delitem__,
         Tensor.__dir__,
         Tensor.__getattribute__,


### PR DESCRIPTION
Summary: Add CUDA.used vital sign which is true only if CUDA was "used" which technically means the context was created.

Test Plan: buck test mode/dbg caffe2/test:torch -- --regex basic_vitals

Differential Revision: D28357615

