### PR TITLE
Added OperatorMap for mapping Operator to any template <T>

### DIFF
--- a/test/cpp/jit/test_ir.cpp
+++ b/test/cpp/jit/test_ir.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "test/cpp/jit/test_utils.h"
-#include "torch/csrc/jit/ir/irparser.h"
+#include <test/cpp/jit/test_utils.h>
+#include <torch/csrc/jit/ir/irparser.h>
 
 namespace torch {
 namespace jit {
@@ -157,6 +157,59 @@ graph(%x : Tensor,
       ASSERT_EQ(blocks_from_graph_block, ref_blocks_from_graph[i][j]);
     }
   }
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+TEST(IRTest, OperatorMap) {
+  OperatorMap<int> op_map;
+  const char* literal1 =
+      "aten::dropout(Tensor input, float p, bool train) -> Tensor";
+  const char* literal2 =
+      "aten::bernoulli(Tensor self, *, Generator? generator) -> Tensor";
+  const char* literal3 =
+      "aten::bernoulli(Tensor self, float p, *, Generator? generator) -> Tensor";
+  const char* literal4 =
+      "aten::normal(Tensor mean, Tensor std, *, Generator? generator) -> Tensor";
+  const char* literal5 =
+      "aten::normal(float mean, Tensor std, *, Generator? generator) -> Tensor";
+  const char* literal6 =
+      "aten::normal(Tensor mean, float std, *, Generator? generator) -> Tensor";
+  std::shared_ptr<Operator> op1 = getOperatorForLiteral(literal1);
+  std::shared_ptr<Operator> op2 = getOperatorForLiteral(literal2);
+  std::shared_ptr<Operator> op3 = getOperatorForLiteral(literal3);
+  std::shared_ptr<Operator> op4 = getOperatorForLiteral(literal4);
+  std::shared_ptr<Operator> op5 = getOperatorForLiteral(literal5);
+  std::shared_ptr<Operator> op6 = getOperatorForLiteral(literal6);
+  op_map.insert(op1, 1);
+  op_map.insert({{op2, 2}, {op3, 3}});
+  op_map.insert({{op4, 4}, {op5, 5}});
+  op_map.insert(op6, 6);
+  ASSERT_TRUE(op_map.contains(*op1));
+  ASSERT_TRUE(op_map.contains(*op2));
+  ASSERT_TRUE(op_map.contains(*op3));
+  ASSERT_TRUE(op_map.contains(*op4));
+  ASSERT_TRUE(op_map.contains(*op5));
+  ASSERT_TRUE(op_map.contains(*op6));
+  op_map.erase(op6);
+  op_map.erase(op3);
+  op_map.erase(op1);
+  ASSERT_FALSE(op_map.contains(*op1));
+  ASSERT_FALSE(op_map.contains(*op3));
+  ASSERT_FALSE(op_map.contains(*op6));
+  op_map.insert(op1, 1);
+  ASSERT_TRUE(op_map.contains(*op1));
+  c10::optional<int> o1 = op_map.find(*op1);
+  ASSERT_TRUE(o1.has_value());
+  c10::optional<int> o2 = op_map.find(*op2);
+  ASSERT_TRUE(o2.has_value());
+  c10::optional<int> o3 = op_map.find(*op3);
+  ASSERT_FALSE(o3.has_value());
+  c10::optional<int> o4 = op_map.find(*op4);
+  ASSERT_TRUE(o4.has_value());
+  c10::optional<int> o5 = op_map.find(*op5);
+  ASSERT_TRUE(o5.has_value());
+  c10::optional<int> o6 = op_map.find(*op6);
+  ASSERT_FALSE(o6.has_value());
 }
 
 } // namespace jit

--- a/torch/csrc/jit/ir/ir.h
+++ b/torch/csrc/jit/ir/ir.h
@@ -149,6 +149,8 @@ using topo_position_t = int64_t;
 using ValueSet = std::unordered_set<const Value*>;
 
 struct OperatorSet;
+template <typename T>
+struct OperatorMap;
 
 // This is a wrapper to allow invalidating the Python object
 // safely when the C++ object for a Node/Value/Block is deleted
@@ -716,6 +718,19 @@ struct TORCH_API Node {
       at::ArrayRef<Symbol> const_inputs = {}) const;
 
   bool isMemberOf(const OperatorSet& os) const;
+  template <typename T>
+  bool isMemberOf(const OperatorMap<T>& om) const {
+    auto it = om.map.find(kind());
+    if (it == om.map.end()) {
+      return false;
+    }
+    for (auto& op : it->second) {
+      if (matches(op.first->schema())) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   const FunctionSchema& schema() const;
   const FunctionSchema* maybeSchema() const;
@@ -1510,6 +1525,80 @@ struct OperatorSet {
  private:
   friend struct Node;
   std::unordered_map<Symbol, std::vector<std::shared_ptr<Operator>>> ops;
+};
+
+template <typename T>
+struct OperatorMap {
+  // Type aliasing
+  using OpMapType = typename std::pair<std::shared_ptr<Operator>, T>;
+  using ValueType = std::vector<OpMapType>;
+  using MapType = std::unordered_map<Symbol, ValueType>;
+
+  OperatorMap() = default;
+  explicit OperatorMap(
+      std::initializer_list<std::pair<std::shared_ptr<Operator>, T>> init) {
+    insert(init);
+  }
+
+  void insert(const std::shared_ptr<Operator>& op, T val) {
+    // Remove if exists before insert
+    erase(op);
+    map[Symbol::fromQualString(op->schema().name())].emplace_back(
+        std::make_pair(op, val));
+  }
+
+  void insert(
+      std::initializer_list<std::pair<std::shared_ptr<Operator>, T>> v) {
+    for (auto& el : v) {
+      insert(el.first, el.second);
+    }
+  }
+
+  void erase(const std::shared_ptr<Operator>& op) {
+    auto it = map.find(Symbol::fromQualString(op->schema().name()));
+    if (it == map.end()) {
+      return;
+    }
+    for (auto vit = it->second.begin(); vit != it->second.end(); ++vit) {
+      if (vit->first->schema() == op->schema()) {
+        it->second.erase(vit);
+        break;
+      }
+    }
+    if (it->second.size() == 0) {
+      map.erase(Symbol::fromQualString(op->schema().name()));
+    }
+  }
+
+  bool contains(const Operator& op) const {
+    const auto it = map.find(Symbol::fromQualString(op.schema().name()));
+    if (it == map.end()) {
+      return false;
+    }
+    for (auto vit = it->second.begin(); vit != it->second.end(); ++vit) {
+      if (vit->first->schema() == op.schema()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  c10::optional<T> find(const Operator& op) {
+    const auto it = map.find(Symbol::fromQualString(op.schema().name()));
+    if (it == map.end()) {
+      return c10::nullopt;
+    }
+    for (auto vit = it->second.begin(); vit != it->second.end(); ++vit) {
+      if (vit->first->schema() == op.schema()) {
+        return vit->second;
+      }
+    }
+    return c10::nullopt;
+  }
+
+ private:
+  friend struct Node;
+  MapType map;
 };
 
 } // namespace jit


### PR DESCRIPTION
Summary: Generic way to check if Operator belongs to predefined map, and if so via public method(s) access to map value. In general value can be anything for example Operator's schema.

Test Plan: buck test caffe2/test/cpp/jit:jit -- OperatorMap

Differential Revision: D28357933

