### PR TITLE
[caffe2] Add support for int32 lengths in BatchSparseToDense

### DIFF
--- a/caffe2/operators/batch_sparse_to_dense_op.cc
+++ b/caffe2/operators/batch_sparse_to_dense_op.cc
@@ -3,16 +3,17 @@
 namespace caffe2 {
 
 template <>
+template <typename TLen, typename TInd>
 void BatchSparseToDenseOp<float, CPUContext>::FillInDenseValues(
     const int64_t batch_size,
     const int64_t indice_lengths,
-    const int64_t* lengths_data,
-    const int64_t* indices_data,
+    const TLen* lengths_data,
+    const TInd* indices_data,
     const float* values_data,
     float* output_data,
     CPUContext* /*context*/) {
-  int64_t lengths_sum = 0;
-  math::Sum<int64_t, CPUContext>(
+  TLen lengths_sum = 0;
+  math::Sum<TLen, CPUContext>(
       batch_size, lengths_data, &lengths_sum, &context_);
   CAFFE_ENFORCE_EQ(lengths_sum, indice_lengths);
 
@@ -33,16 +34,17 @@ void BatchSparseToDenseOp<float, CPUContext>::FillInDenseValues(
 }
 
 template <>
+template <typename TLen, typename TInd>
 void BatchDenseToSparseOp<float, CPUContext>::FillInSparseValues(
     const int64_t batch_size,
     const int64_t indice_lengths,
-    const int64_t* lengths_data,
-    const int64_t* indices_data,
+    const TLen* lengths_data,
+    const TInd* indices_data,
     const float* dense_data,
     float* output_data,
     CPUContext* /*context*/) {
-  int64_t lengths_sum = 0;
-  math::Sum<int64_t, CPUContext>(
+  TLen lengths_sum = 0;
+  math::Sum<TLen, CPUContext>(
       batch_size, lengths_data, &lengths_sum, &context_);
   CAFFE_ENFORCE_EQ(lengths_sum, indice_lengths);
 

--- a/caffe2/operators/batch_sparse_to_dense_op.cu
+++ b/caffe2/operators/batch_sparse_to_dense_op.cu
@@ -8,8 +8,9 @@ namespace caffe2 {
 
 namespace {
 
+template <typename TLen>
 void array_prefix_sum_inclusive(
-    const int64_t* dev_array,
+    const TLen* dev_array,
     const int num_items,
     Tensor& prefix_buffer,
     Tensor& prefix_sum,
@@ -21,32 +22,33 @@ void array_prefix_sum_inclusive(
       nullptr,
       temp_storage_bytes,
       dev_array,
-      prefix_sum.mutable_data<int64_t>(),
+      prefix_sum.mutable_data<TLen>(),
       num_items,
       context.cuda_stream());
 
   // Allocate temporary storage
-  auto buffer_size = (temp_storage_bytes + sizeof(int64_t)) / sizeof(int64_t);
+  auto buffer_size = (temp_storage_bytes + sizeof(TLen)) / sizeof(TLen);
   prefix_buffer.Resize(buffer_size);
   void* dev_temp_storage =
-      static_cast<void*>(prefix_buffer.mutable_data<int64_t>());
+      static_cast<void*>(prefix_buffer.mutable_data<TLen>());
 
   // Inclusive sum
   cub::DeviceScan::InclusiveSum(
       dev_temp_storage,
       temp_storage_bytes,
       dev_array,
-      prefix_sum.mutable_data<int64_t>(),
+      prefix_sum.mutable_data<TLen>(),
       num_items,
       context.cuda_stream());
 }
 
+template <typename TLen, typename TInd>
 __global__ void FillInDenseValuesKernel(
     const int64_t batch_size,
     const int64_t dense_last_dim,
-    const int64_t* indices_data,
+    const TInd* indices_data,
     const float* values_data,
-    const int64_t* L_cum_sum_data,
+    const TLen* L_cum_sum_data,
     float* output_data) {
   CUDA_1D_KERNEL_LOOP(idx, batch_size) {
     int offset_start = idx == 0 ? 0 : L_cum_sum_data[idx - 1];
@@ -60,12 +62,13 @@ __global__ void FillInDenseValuesKernel(
   }
 }
 
+template <typename TLen, typename TInd>
 __global__ void FillInSparseValuesKernel(
     const int64_t batch_size,
     const int64_t dense_last_dim,
-    const int64_t* indices_data,
+    const TInd* indices_data,
     const float* dense_data,
-    const int64_t* L_cum_sum_data,
+    const TLen* L_cum_sum_data,
     float* output_data) {
   CUDA_1D_KERNEL_LOOP(idx, batch_size) {
     int offset_start = idx == 0 ? 0 : L_cum_sum_data[idx - 1];
@@ -81,21 +84,22 @@ __global__ void FillInSparseValuesKernel(
 } // namespace
 
 template <>
+template <typename TLen, typename TInd>
 void BatchSparseToDenseOp<float, CUDAContext>::FillInDenseValues(
     const int64_t batch_size,
     const int64_t indice_lengths,
-    const int64_t* lengths_data,
-    const int64_t* indices_data,
+    const TLen* lengths_data,
+    const TInd* indices_data,
     const float* values_data,
     float* output_data,
     CUDAContext* context) {
   // calculate the prefix sum of the length array
-  array_prefix_sum_inclusive(
+  array_prefix_sum_inclusive<TLen>(
       lengths_data, batch_size, len_prefix_tmp_, len_prefix_sum_, context_);
 
   // launch the gpu kernel for to fill in dense values
   const int64_t min_size = 1;
-  FillInDenseValuesKernel<<<
+  FillInDenseValuesKernel<TLen, TInd><<<
       CAFFE_GET_BLOCKS(std::max(batch_size, min_size)),
       CAFFE_CUDA_NUM_THREADS,
       0,
@@ -104,27 +108,28 @@ void BatchSparseToDenseOp<float, CUDAContext>::FillInDenseValues(
       dense_last_dim_,
       indices_data,
       values_data,
-      len_prefix_sum_.data<int64_t>(),
+      len_prefix_sum_.data<TLen>(),
       output_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template <>
+template <typename TLen, typename TInd>
 void BatchDenseToSparseOp<float, CUDAContext>::FillInSparseValues(
     const int64_t batch_size,
     const int64_t indice_lengths,
-    const int64_t* lengths_data,
-    const int64_t* indices_data,
+    const TLen* lengths_data,
+    const TInd* indices_data,
     const float* dense_data,
     float* output_data,
     CUDAContext* context) {
   // calculate the prefix sum of the length array
-  array_prefix_sum_inclusive(
+  array_prefix_sum_inclusive<TLen>(
       lengths_data, batch_size, len_prefix_tmp_, len_prefix_sum_, context_);
 
   // launch the gpu kernel for to fill in sparse values
   const int64_t min_size = 1;
-  FillInSparseValuesKernel<<<
+  FillInSparseValuesKernel<TLen, TInd><<<
       CAFFE_GET_BLOCKS(std::max(batch_size, min_size)),
       CAFFE_CUDA_NUM_THREADS,
       0,
@@ -133,7 +138,7 @@ void BatchDenseToSparseOp<float, CUDAContext>::FillInSparseValues(
       dense_last_dim_,
       indices_data,
       dense_data,
-      len_prefix_sum_.data<int64_t>(),
+      len_prefix_sum_.data<TLen>(),
       output_data);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/caffe2/python/operator_test/batch_sparse_to_dense_op_test.py
+++ b/caffe2/python/operator_test/batch_sparse_to_dense_op_test.py
@@ -69,6 +69,9 @@ class TestBatchSparseToDense(serial.SerializedTestCase):
         self.assertDeviceChecks(dc, op2, [L, I, V, S], [0])
         self.assertReferenceChecks(gc, op2, [L, I, V, S], batch_sparse_to_dense_ref)
         self.assertGradientChecks(gc, op2, [L, I, V, S], 2, [0])
+        self.assertDeviceChecks(dc, op, [L.astype(np.int32), I, V], [0])
+        self.assertReferenceChecks(gc, op, [L.astype(np.int32), I, V], batch_sparse_to_dense_ref)
+        self.assertGradientChecks(gc, op, [L.astype(np.int32), I, V], 2, [0])
 
     @given(
         batch_size=st.integers(5, 10),
@@ -106,3 +109,6 @@ class TestBatchSparseToDense(serial.SerializedTestCase):
         self.assertDeviceChecks(dc, op, [L, I, D], [0])
         self.assertReferenceChecks(gc, op, [L, I, D], batch_dense_to_sparse_ref)
         self.assertGradientChecks(gc, op, [L, I, D], 2, [0])
+        self.assertDeviceChecks(dc, op, [L.astype(np.int32), I, D], [0])
+        self.assertReferenceChecks(gc, op, [L.astype(np.int32), I, D], batch_dense_to_sparse_ref)
+        self.assertGradientChecks(gc, op, [L.astype(np.int32), I, D], 2, [0])


### PR DESCRIPTION
Summary: Make templated function to make sure BatchSparseToDense supports int32 lengths/indices

Test Plan:
```buck test //caffe2/caffe2/python/operator_test:batch_sparse_to_dense_op_test
```

Differential Revision: D28271423

