### PR TITLE
Enable `BFloat16` for `nan_to_num` on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
+++ b/aten/src/ATen/native/cuda/UnaryOpsKernel.cu
@@ -133,7 +133,7 @@ void nan_to_num_kernel_cuda(
     c10::optional<double> nan,
     c10::optional<double> pos_inf,
     c10::optional<double> neg_inf) {
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(iter.dtype(), "nan_to_num_cuda", [&]() {
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, iter.dtype(), "nan_to_num_cuda", [&]() {
     scalar_t nan_replacement = static_cast<scalar_t>(nan.value_or(0.));
     scalar_t pos_inf_replacement = pos_inf.has_value()
         ? static_cast<scalar_t>(pos_inf.value())

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -61,6 +61,9 @@ _large_float16_vals = (-501, 501,
                        -13437.7, 13437.7)
 _large_float_vals = _large_float16_vals + (-4988429.2, 4988429.2, -1e20, 1e20)
 _float_extremals = (float('inf'), float('-inf'), float('nan'))
+_bfloat16_extremals = (torch.finfo(torch.bfloat16).max + 1.0,
+                       torch.finfo(torch.bfloat16).min - 1.0,
+                       float('nan'))
 _medium_length = 812
 _large_size = (1029, 917)
 
@@ -179,7 +182,9 @@ def generate_numeric_tensors_extremal(device, dtype, *,
         return ()
 
     vals = []
-    if dtype.is_floating_point:
+    if dtype is torch.bfloat16:
+        vals = _bfloat16_extremals
+    elif dtype.is_floating_point:
         vals = _float_extremals
     elif dtype.is_complex:
         vals = tuple(complex(x, y) for x, y in chain(product(_float_extremals, _float_extremals),

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -61,9 +61,6 @@ _large_float16_vals = (-501, 501,
                        -13437.7, 13437.7)
 _large_float_vals = _large_float16_vals + (-4988429.2, 4988429.2, -1e20, 1e20)
 _float_extremals = (float('inf'), float('-inf'), float('nan'))
-_bfloat16_extremals = (torch.finfo(torch.bfloat16).max + 1.0,
-                       torch.finfo(torch.bfloat16).min - 1.0,
-                       float('nan'))
 _medium_length = 812
 _large_size = (1029, 917)
 
@@ -182,9 +179,7 @@ def generate_numeric_tensors_extremal(device, dtype, *,
         return ()
 
     vals = []
-    if dtype is torch.bfloat16:
-        vals = _bfloat16_extremals
-    elif dtype.is_floating_point:
+    if dtype.is_floating_point:
         vals = _float_extremals
     elif dtype.is_complex:
         vals = tuple(complex(x, y) for x, y in chain(product(_float_extremals, _float_extremals),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5271,7 +5271,12 @@ op_db: List[OpInfo] = [
                    )),
     UnaryUfuncInfo('nan_to_num',
                    ref=np.nan_to_num,
-                   dtypes=all_types_and(torch.half, torch.bool)),
+                   dtypes=all_types_and(torch.half, torch.bool),
+                   dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16),
+                   skips=(
+                          # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-838013256
+                          SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
+                                   dtypes=[torch.bfloat16]),)),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5278,7 +5278,8 @@ op_db: List[OpInfo] = [
                    # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-839150556
                    sample_kwargs=lambda device, dtype, input: ({},
                                                                {'posinf': torch.finfo(torch.bfloat16).max,
-                                                                'neginf': torch.finfo(torch.bfloat16).min})),
+                                                                'neginf': torch.finfo(torch.bfloat16).min})
+                                 if dtype is torch.bfloat16 else ({}, {})),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5272,11 +5272,7 @@ op_db: List[OpInfo] = [
     UnaryUfuncInfo('nan_to_num',
                    ref=np.nan_to_num,
                    dtypes=all_types_and(torch.half, torch.bool),
-                   dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16),
-                   skips=(
-                       # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-838013256
-                       SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                dtypes=[torch.bfloat16]),)),
+                   dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16)),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5279,7 +5279,7 @@ op_db: List[OpInfo] = [
                    sample_kwargs=lambda device, dtype, input: ({},
                                                                {'posinf': torch.finfo(torch.bfloat16).max,
                                                                 'neginf': torch.finfo(torch.bfloat16).min})
-                                 if dtype is torch.bfloat16 else ({}, {})),
+                   if dtype is torch.bfloat16 else ({}, {})),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5278,8 +5278,7 @@ op_db: List[OpInfo] = [
                    # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-839150556
                    sample_kwargs=lambda device, dtype, input: ({},
                                                                {'posinf': torch.finfo(torch.bfloat16).max,
-                                                                'neginf': torch.finfo(torch.bfloat16).min})
-                  ),
+                                                                'neginf': torch.finfo(torch.bfloat16).min})),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5274,9 +5274,9 @@ op_db: List[OpInfo] = [
                    dtypes=all_types_and(torch.half, torch.bool),
                    dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16),
                    skips=(
-                          # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-838013256
-                          SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
-                                   dtypes=[torch.bfloat16]),)),
+                       # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-838013256
+                       SkipInfo('TestUnaryUfuncs', 'test_reference_numerics_extremal',
+                                dtypes=[torch.bfloat16]),)),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5272,7 +5272,14 @@ op_db: List[OpInfo] = [
     UnaryUfuncInfo('nan_to_num',
                    ref=np.nan_to_num,
                    dtypes=all_types_and(torch.half, torch.bool),
-                   dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16)),
+                   dtypesIfCUDA=all_types_and(torch.half, torch.bool, torch.bfloat16),
+                   # Passing numpy_kwargs via sample_kwargs, as numpy does comparison
+                   # with BFloat16 in float, since it currently doesn't support BFloat16.
+                   # Ref: https://github.com/pytorch/pytorch/issues/57982#issuecomment-839150556
+                   sample_kwargs=lambda device, dtype, input: ({},
+                                                               {'posinf': torch.finfo(torch.bfloat16).max,
+                                                                'neginf': torch.finfo(torch.bfloat16).min})
+                  ),
     UnaryUfuncInfo('reciprocal',
                    ref=np_unary_ufunc_integer_promotion_wrapper(np.reciprocal),
                    dtypes=all_types_and_complex_and(torch.bool, torch.half, torch.bfloat16),


### PR DESCRIPTION
Enabled BFloat16 for `nan_to_num` on CUDA. For comparison with numpy, a [workaround suggested](https://github.com/pytorch/pytorch/issues/57982#issuecomment-839150556) by @ngimel is being used - the OpInfo's `sample.kwargs` is being used to set two `numpy.kwargs`, viz. `posinf` & `neginf` for `BFloat16`.