### PR TITLE
[ATen] Use expect_contiguous in layer_norm

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -60,24 +60,24 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_cpu(
   const Tensor& bias = *bias_maybe_owned;
 
 
-  auto inputs = _prepare_layer_norm_inputs(input, normalized_shape, weight, bias);
-  auto X = std::get<0>(inputs);
-  auto gamma = std::get<1>(inputs);
-  auto beta = std::get<2>(inputs);
-  auto M = std::get<3>(inputs);
-  auto N = std::get<4>(inputs);
+  auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
+  auto M = M_N.first;
+  auto N = M_N.second;
+  auto X = input.expect_contiguous();
+  auto gamma = weight.expect_contiguous();
+  auto beta = bias.expect_contiguous();
 
   Tensor Y = at::native::empty_like(
-      X,
+      *X,
       c10::nullopt /* dtype */,
       c10::nullopt /* layout */,
       c10::nullopt /* device */,
       c10::nullopt /* pin_memory */,
       at::MemoryFormat::Contiguous);
-  Tensor mean = at::empty({M}, X.options());
-  Tensor rstd = at::empty({M}, X.options());
+  Tensor mean = at::empty({M}, X->options());
+  Tensor rstd = at::empty({M}, X->options());
 
-  layer_norm_cpu_out(Y, mean, rstd, X, normalized_shape, gamma, beta, eps, M, N);
+  layer_norm_cpu_out(Y, mean, rstd, *X, normalized_shape, *gamma, *beta, eps, M, N);
   return std::make_tuple(std::move(Y), std::move(mean), std::move(rstd));
 }
 
@@ -86,70 +86,74 @@ std::tuple<Tensor, Tensor, Tensor> layer_norm_backward_cpu(
     const Tensor& input,
     IntArrayRef normalized_shape,
     const Tensor& mean,
-    const Tensor& rstd, const c10::optional<Tensor>& weight_opt /* optional */, const c10::optional<Tensor>& bias_opt /* optional */,
+    const Tensor& rstd,
+    const c10::optional<Tensor>& weight_opt /* optional */,
+    const c10::optional<Tensor>& bias_opt /* optional */,
     std::array<bool, 3> grad_input_mask) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> weight_maybe_owned =
+      at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& bias = c10::value_or_else(bias_opt, [] {return Tensor();});
+  c10::MaybeOwned<Tensor> bias_maybe_owned =
+      at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
 
+  auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
+  auto M = M_N.first;
+  auto N = M_N.second;
+  auto X = input.expect_contiguous();
+  auto gamma = weight.expect_contiguous();
+  auto beta = bias.expect_contiguous();
 
-    auto inputs = _prepare_layer_norm_inputs(input, normalized_shape, weight, bias);
-    auto X = std::get<0>(inputs);
-    auto gamma = std::get<1>(inputs);
-    auto beta = std::get<2>(inputs);
-    auto M = std::get<3>(inputs);
-    auto N = std::get<4>(inputs);
-
-    Tensor dX;
-    Tensor dgamma;
-    Tensor dbeta;
-    if (grad_input_mask[0]) {
-      dX = at::native::empty_like(
-          X,
-          c10::nullopt /* dtype */,
-          c10::nullopt /* layout */,
-          c10::nullopt /* device */,
-          c10::nullopt /* pin_memory */,
-          at::MemoryFormat::Contiguous);
-    }
-    if (grad_input_mask[1]) {
-      dgamma = M > 0 ? at::native::empty_like(
-                           gamma,
-                           c10::nullopt /* dtype */,
-                           c10::nullopt /* layout */,
-                           c10::nullopt /* device */,
-                           c10::nullopt /* pin_memory */,
-                           at::MemoryFormat::Contiguous)
-                     : at::native::zeros_like(
-                           gamma,
-                           c10::nullopt /* dtype */,
-                           c10::nullopt /* layout */,
-                           c10::nullopt /* device */,
-                           c10::nullopt /* pin_memory */,
-                           at::MemoryFormat::Contiguous);
-    }
-    if (grad_input_mask[2]) {
-      dbeta = M > 0 ? at::native::empty_like(
-                          beta,
-                          c10::nullopt /* dtype */,
-                          c10::nullopt /* layout */,
-                          c10::nullopt /* device */,
-                          c10::nullopt /* pin_memory */,
-                          at::MemoryFormat::Contiguous)
-                    : at::native::zeros_like(
-                          beta,
-                          c10::nullopt /* dtype */,
-                          c10::nullopt /* layout */,
-                          c10::nullopt /* device */,
-                          c10::nullopt /* pin_memory */,
-                          at::MemoryFormat::Contiguous);
-    }
-    if (M > 0) {
-      LayerNormBackwardKernel(
-          kCPU, dY, X, mean, rstd, gamma, M, N, &dX, &dgamma, &dbeta);
-    }
-    return std::make_tuple(std::move(dX), std::move(dgamma), std::move(dbeta));
+  Tensor dX;
+  Tensor dgamma;
+  Tensor dbeta;
+  if (grad_input_mask[0]) {
+    dX = at::native::empty_like(
+        *X,
+        c10::nullopt /* dtype */,
+        c10::nullopt /* layout */,
+        c10::nullopt /* device */,
+        c10::nullopt /* pin_memory */,
+        at::MemoryFormat::Contiguous);
+  }
+  if (grad_input_mask[1]) {
+    dgamma = M > 0 ? at::native::empty_like(
+                         *gamma,
+                         c10::nullopt /* dtype */,
+                         c10::nullopt /* layout */,
+                         c10::nullopt /* device */,
+                         c10::nullopt /* pin_memory */,
+                         at::MemoryFormat::Contiguous)
+                   : at::native::zeros_like(
+                         *gamma,
+                         c10::nullopt /* dtype */,
+                         c10::nullopt /* layout */,
+                         c10::nullopt /* device */,
+                         c10::nullopt /* pin_memory */,
+                         at::MemoryFormat::Contiguous);
+  }
+  if (grad_input_mask[2]) {
+    dbeta = M > 0 ? at::native::empty_like(
+                        *beta,
+                        c10::nullopt /* dtype */,
+                        c10::nullopt /* layout */,
+                        c10::nullopt /* device */,
+                        c10::nullopt /* pin_memory */,
+                        at::MemoryFormat::Contiguous)
+                  : at::native::zeros_like(
+                        *beta,
+                        c10::nullopt /* dtype */,
+                        c10::nullopt /* layout */,
+                        c10::nullopt /* device */,
+                        c10::nullopt /* pin_memory */,
+                        at::MemoryFormat::Contiguous);
+  }
+  if (M > 0) {
+    LayerNormBackwardKernel(
+        kCPU, dY, *X, mean, rstd, *gamma, M, N, &dX, &dgamma, &dbeta);
+  }
+  return std::make_tuple(std::move(dX), std::move(dgamma), std::move(dbeta));
 }
 
 Tensor layer_norm(
@@ -160,7 +164,8 @@ Tensor layer_norm(
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& bias = c10::value_or_else(bias_opt, [] {return Tensor();});
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
 
 
   return std::get<0>(at::native_layer_norm(input, normalized_shape, weight, bias, eps));
@@ -179,15 +184,14 @@ std::tuple<Tensor, Tensor, Tensor> math_native_layer_norm(
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
-  const Tensor& bias = c10::value_or_else(bias_opt, [] {return Tensor();});
+  c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
+  const Tensor& bias = *bias_maybe_owned;
 
-  auto inputs = _prepare_layer_norm_inputs(input, normalized_shape, weight, bias);
-  auto X = std::get<0>(inputs);
-  auto gamma = std::get<1>(inputs);
-  auto beta = std::get<2>(inputs);
-  auto M = std::get<3>(inputs);
-  // NOLINTNEXTLINE(clang-diagnostic-unused-variable,clang-analyzer-deadcode.DeadStores)
-  auto N = std::get<4>(inputs);
+  auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
+  auto M = M_N.first;
+  auto X = input.expect_contiguous();
+  auto gamma = weight.expect_contiguous();
+
   auto input_shape = input.sizes();
   const auto input_ndim = input.dim();
   const int normalized_ndim = normalized_shape.size();

--- a/aten/src/ATen/native/layer_norm.h
+++ b/aten/src/ATen/native/layer_norm.h
@@ -9,7 +9,7 @@ namespace native {
 
 namespace {
 
-std::tuple<Tensor, Tensor, Tensor, int64_t, int64_t> _prepare_layer_norm_inputs(
+C10_ALWAYS_INLINE std::pair<int64_t, int64_t> _check_layer_norm_inputs(
     const Tensor& input,
     IntArrayRef normalized_shape,
     const Tensor& weight /* optional */,
@@ -58,11 +58,7 @@ std::tuple<Tensor, Tensor, Tensor, int64_t, int64_t> _prepare_layer_norm_inputs(
   const int64_t N =
       c10::multiply_integers(input_shape.cbegin() + axis, input_shape.cend());
 
-  const auto& X = input.is_contiguous() ? input : input.contiguous();
-  const auto& gamma = weight.is_contiguous() ? weight : weight.contiguous();
-  const auto& beta = bias.is_contiguous() ? bias : bias.contiguous();
-
-  return std::make_tuple(X, gamma, beta, M, N);
+  return std::make_pair(M, N);
 }
 
 } // namespace

--- a/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qnormalization.cpp
@@ -24,25 +24,25 @@ Tensor quantized_layer_norm_impl(
     double output_scale,
     int64_t output_zero_point) {
 
-  auto inputs = _prepare_layer_norm_inputs(input, normalized_shape, weight, bias);
-  auto X = std::get<0>(inputs);
-  auto gamma = std::get<1>(inputs);
-  auto beta = std::get<2>(inputs);
-  auto M = std::get<3>(inputs);
-  auto N = std::get<4>(inputs);
+  auto M_N = _check_layer_norm_inputs(input, normalized_shape, weight, bias);
+  auto M = M_N.first;
+  auto N = M_N.second;
+  auto X = input.expect_contiguous();
+  auto gamma = weight.expect_contiguous();
+  auto beta = bias.expect_contiguous();
 
   Tensor Y = at::_empty_affine_quantized(
-    X.sizes(),
-    X.scalar_type(),
+    X->sizes(),
+    X->scalar_type(),
     output_scale,
     output_zero_point,
-    X.suggest_memory_format());
+    X->suggest_memory_format());
 
   if (M > 0) {
     bool affine_per_channel = false;
     int num_channels = 1; // not relevant for LayerNorm
     int num_groups = 1; // not relevant for LayerNorm
-    quantized_normalize_stub(kCPU, X, gamma, beta, affine_per_channel,
+    quantized_normalize_stub(kCPU, *X, *gamma, *beta, affine_per_channel,
         num_channels, num_groups, M, N, eps, &Y);
   }
   return Y;

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -50,6 +50,18 @@ inline at::Tensor create_empty_from(const at::Tensor& t) {
       c10::nullopt);
 }
 
+inline at::Tensor create_empty_from(
+    at::IntArrayRef sizes,
+    const at::Tensor& t) {
+  return at::detail::empty_cpu(
+      sizes,
+      c10::typeMetaToScalarType(t.dtype()),
+      t.layout(),
+      t.device(),
+      c10::nullopt,
+      c10::nullopt);
+}
+
 inline at::Tensor create_empty(c10::ScalarType dtype) {
   return at::detail::empty_cpu(
       {0}, dtype, c10::nullopt, c10::nullopt, c10::nullopt, c10::nullopt);


### PR DESCRIPTION
Summary:
- Use expect_contiguous in layer_norm to avoid unnecessary refcount bumps when the tensors are contiguous
- Clean up some leftovers from the hacky wrappers removal cleanup: use c10::MaybeOwned<Tensor> for bias tensors
- Skip dispatcher for at::empty in the layer_norm impl in Static Runtime

Test Plan: CI

Differential Revision: D28214298

