### PR TITLE
Open json config file in context manager

### DIFF
--- a/benchmarks/distributed/rpc/parameter_server/launcher.py
+++ b/benchmarks/distributed/rpc/parameter_server/launcher.py
@@ -215,14 +215,9 @@ def run_benchmark(rank, model, data, config):
 
 
 def get_json_config(file_name, id):
-    f = open(
-        os.path.join(
-            Path(__file__).parent, file_name
-        ),
-        "r"
-    )
-    json_config = json.load(f)[id]
-    f.close()
+    with open(os.path.join(Path(__file__).parent, file_name), "r") as f:
+        json_config = json.load(f)[id]
+
     return json_config
 
 


### PR DESCRIPTION
* Open json config file safely using a context manager (using a with block).
* This will make sure that the file closed even if an exception is raised.