### PR TITLE
[FX] Make stack trace testing less strict

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1949,9 +1949,9 @@ class TestFX(JitTestCase):
             with self.assertRaises(TypeError):
                 traced(5)
 
-        self.assertIn("Call using an FX-traced Module, line 4 of the "
-                      "traced Module's generated forward function:",
-                      captured[0])
+        self.assertRegex(captured[0],
+                         r"Call using an FX-traced Module, line .* of the "
+                         r"traced Module's generated forward function:")
 
     def test_custom_traceback_not_raised_when_exception_source_is_submodule(self):
         class M(torch.nn.Module):
@@ -1971,9 +1971,9 @@ class TestFX(JitTestCase):
         except RuntimeError:
             captured = traceback.format_exc()
 
-        self.assertNotIn("Call using an FX-traced Module, line 4 of the"
-                         " traced Module's generated forward function:",
-                         captured)
+        self.assertNotRegex(captured,
+                            r"Call using an FX-traced Module, line .* of the "
+                            r"traced Module's generated forward function:")
 
     def test_ast_rewriter_rewrites_assert(self):
         class M(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58061 [WIP][FX] Fix retracing wrapped functions
* **#58088 [FX] Make stack trace testing less strict**

These tests triggered false-positive failures when making an unrelated serialization change. This patch makes it so that we test against a regex where the line number is wildcard-ed out

Differential Revision: [D28365398](https://our.internmc.facebook.com/intern/diff/D28365398)