### PR TITLE
Back out "[PyTorch Edge] Reuse constant table from ts in bytecode"

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -33,9 +33,6 @@
 namespace torch {
 namespace jit {
 
-static constexpr const char* kArchiveNameConstants = "constants";
-static constexpr const char* kArchiveNameBytecode = "bytecode";
-
 char const* toString(OpCode op);
 
 namespace {
@@ -195,7 +192,7 @@ std::pair<IValue, IValue> getFunctionTuple(
   auto codeTable = Table(
       {{"instructions", Tup(instructions)},
        {"operators", Tup(operators)},
-       {kArchiveNameConstants, Tup(constants)},
+       {"constants", Tup(constants)},
        {"types", Tup(types)},
        {"register_size", register_size}});
 
@@ -350,8 +347,7 @@ class ScriptModuleSerializer {
     // so loading the code does not depend on loading the data
     std::vector<IValue> ivalue_constants(
         constant_table_.begin(), constant_table_.end());
-    writeArchive(
-        kArchiveNameConstants, c10::ivalue::Tuple::create(ivalue_constants));
+    writeArchive("constants", c10::ivalue::Tuple::create(ivalue_constants));
     if (bytecode_format) {
       writeByteCode(module, save_mobile_debug_info);
       writeMobileMetadata(module, extra_files);
@@ -364,10 +360,7 @@ class ScriptModuleSerializer {
   }
 
  private:
-  void writeArchive(
-      const std::string& archive_name,
-      const IValue& value,
-      bool use_tensors_archive_table = false) {
+  void writeArchive(const std::string& archive_name, const IValue& value) {
     std::vector<char> data;
     // Vector to capture the run-time class types during pickling the IValues
     std::vector<c10::ClassTypePtr> memoizedClassTypes;
@@ -380,48 +373,15 @@ class ScriptModuleSerializer {
           return type_name_uniquer_.getUniqueName(t);
         },
         &memoizedClassTypes);
-    if (use_tensors_archive_table && !tensors_archive_table_.empty()) {
-      data_pickle.updateTensorsArchiveTable(tensors_archive_table_);
-    }
     data_pickle.protocol();
     data_pickle.pushIValue(value);
     data_pickle.stop();
     size_t i = 0;
     std::string prefix = archive_name + "/";
-
-    // TODO: currently there exists logic only for archive constant and
-    // bytecode, to avoid exporting duplicate tensors. The logic can be more
-    // generic such that it can be used by other tensors from other archive, to
-    // avoid deduplicating tensors among different archives.
-
-    // Store all tensors from archives `constants` to tensors_archive_table_
-    if (archive_name == kArchiveNameConstants) {
-      const auto tensor_candidates = data_pickle.tensorData();
-      for (size_t tensor_index = 0; tensor_index < tensor_candidates.size();
-           tensor_index++) {
-        tensors_archive_table_[tensor_candidates[tensor_index]] =
-            std::make_pair(kArchiveNameConstants, tensor_index);
-      }
-    }
-
-    // Export deduplicate tensors only if use_tensors_archive_table is set to
-    // true and archive name is `bytecode`
-    bool can_use_tensors_archive_table =
-        (use_tensors_archive_table && archive_name == kArchiveNameBytecode);
-
     for (const auto& td : data_pickle.tensorData()) {
       WriteableTensorData writable_td = getWriteableTensorData(td);
       std::string fname = prefix + c10::to_string(i++);
-      if (can_use_tensors_archive_table) {
-        const auto found = tensors_archive_table_.find(td);
-        if (found == tensors_archive_table_.end()) {
-          writer_.writeRecord(
-              fname, writable_td.data(), writable_td.sizeInBytes());
-        }
-      } else {
-        writer_.writeRecord(
-            fname, writable_td.data(), writable_td.sizeInBytes());
-      }
+      writer_.writeRecord(fname, writable_td.data(), writable_td.sizeInBytes());
     }
     std::string fname = archive_name + ".pkl";
     writer_.writeRecord(fname, data.data(), data.size());
@@ -542,7 +502,7 @@ class ScriptModuleSerializer {
     moduleMethodsTuple(
         module, elements, debug_info_elements, debug_handle_manager);
     auto telements = Tup(std::move(elements));
-    writeArchive("bytecode", telements, false);
+    writeArchive("bytecode", telements);
     auto debug_info_telements = Tup(std::move(debug_info_elements));
 
     // At the moment keeping this feature experimental
@@ -610,10 +570,6 @@ class ScriptModuleSerializer {
 
   caffe2::serialize::PyTorchStreamWriter writer_;
   std::vector<at::IValue> constant_table_;
-
-  // key: tensor, value: pair(arhive_name, index)
-  TensorIndexMap tensors_archive_table_;
-
   std::unordered_set<c10::NamedTypePtr> converted_types_;
   PrintDepsTable class_deps_;
   TypeNameUniquer type_name_uniquer_;

--- a/torch/csrc/jit/serialization/import_read.cpp
+++ b/torch/csrc/jit/serialization/import_read.cpp
@@ -29,33 +29,10 @@ IValue readArchiveAndTensors(
     return len;
   };
 
-  static const char slash = '/';
+  std::string archive_name_plus_slash = archive_name + "/";
   auto read_record = [&](const std::string& name) {
-    std::size_t found = name.find(slash);
-    std::stringstream ss;
-    // In bytecode version 4, the tensor root_key doesn't include the parent
-    // path To support backward compatibility, when the name doesn't include
-    // slash assume it's version 4 and attach the archive_name_plus_slash The
-    // example tensor format is: torch._utils._rebuild_tensor_v2(
-    //     pers.obj(('storage', torch.FloatStorage, '17', 'cpu', 22736),),
-    //     0,
-    //     (1, 464, 7, 7),
-    //     (22736, 49, 7, 1),
-    //     False,
-    //     collections.OrderedDict())
-    if (found == std::string::npos) {
-      ss << archive_name << slash << name;
-      return std::get<0>(stream_reader.getRecord(ss.str()));
-    }
-
-    // In bytecode version 4+, the tensor root_key in bytecode will include the
-    // parent path. The example tensor format is:
-    // torch._utils._rebuild_tensor_v2(
-    //     pers.obj(('storage', torch.FloatStorage, 'constants/17', 'cpu',
-    //     22736),), 0, (1, 464, 7, 7), (22736, 49, 7, 1), False,
-    //     collections.OrderedDict())
-    ss << name;
-    return std::get<0>(stream_reader.getRecord(ss.str()));
+    std::string ss = archive_name_plus_slash + name;
+    return std::get<0>(stream_reader.getRecord(ss));
   };
 
   Unpickler unpickler(

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -295,18 +295,7 @@ void Pickler::pushStorageOfTensor(const at::Tensor& tensor) {
       std::string(toString(tensor.scalar_type())).append("Storage");
   pushGlobal("torch", data_type);
   // root_key
-  // if tensors_archive_table_ includes the tensor, root_key will be,
-  // for example: constants/0, such that it refers to the existing tensor
-  // archive/index.
-  const auto& found = tensors_archive_table_.find(tensor);
-  std::string root_key;
-  if (found != tensors_archive_table_.end()) {
-    std::string archive_name_slash = found->second.first + "/";
-    root_key = archive_name_slash + c10::to_string(found->second.second);
-  } else {
-    root_key = c10::to_string(tensor_data_.size());
-  }
-  pushString(root_key);
+  pushString(c10::to_string(tensor_data_.size()));
   // location
   pushString(tensor.device().str());
   // size

--- a/torch/csrc/jit/serialization/pickler.h
+++ b/torch/csrc/jit/serialization/pickler.h
@@ -14,27 +14,6 @@
 namespace torch {
 namespace jit {
 
-struct tensor_value_hash {
-  std::size_t operator()(const at::Tensor& tensor) const {
-    at::IValue iv(tensor);
-    return at::IValue::hash(iv);
-  }
-};
-
-struct tensor_value_equal {
-  bool operator()(const at::Tensor& a, const at::Tensor& b) const {
-    at::IValue iv_a(a);
-    at::IValue iv_b(b);
-    return at::IValue::hash(iv_a) == at::IValue::hash(iv_b);
-  }
-};
-
-using TensorIndexMap = std::unordered_map<
-    at::Tensor,
-    std::pair<std::string, int>,
-    tensor_value_hash,
-    tensor_value_equal>;
-
 // See Python's pickletools.py for a detailed description of each of these codes
 enum class PickleOpCode : char {
   MARK = '(',
@@ -173,11 +152,6 @@ class TORCH_API Pickler {
     return tensor_data_;
   }
 
-  void updateTensorsArchiveTable(const TensorIndexMap& tensors_archive_table) {
-    tensors_archive_table_.insert(
-        tensors_archive_table.begin(), tensors_archive_table.end());
-  }
-
   void pushEmptyDict();
   void pushDict(const IValue& ivalue);
   void pushInt(int64_t value);
@@ -289,14 +263,6 @@ class TORCH_API Pickler {
   // similar to ivalues, they are memoized using BINPUT
   std::vector<at::Tensor> tensor_data_;
   std::unordered_map<const void*, uint32_t> memoized_storage_map_;
-
-  // tensors_archive_table_ is a map of (tensor) => (archive_name, index)
-  // when the tensor exists in the map, it is available under the corresponding
-  // archive, and there is no need to rewrite the tensor. It will just update
-  // archive_name.pkl with the corresponding archive path, for example:
-  // constants/0. Currently, this map is only used for bytecode archive
-  // referring constant archive.
-  TensorIndexMap tensors_archive_table_;
 
   std::unordered_map<std::string, uint32_t> memoized_globals_map_;
   std::unordered_map<std::string, uint32_t> memoized_strings_map_;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58099 Back out "[PyTorch Edge] Reuse constant table from ts in bytecode"**

Original commit changeset: 34e0cb814901

Differential Revision: [D28369142](https://our.internmc.facebook.com/intern/diff/D28369142/)