### PR TITLE
[Static Runtime] Fix bug in aten::clone

### DIFF
--- a/benchmarks/static_runtime/test_scripts.h
+++ b/benchmarks/static_runtime/test_scripts.h
@@ -163,6 +163,16 @@ const auto flatten_script_2 = R"JIT(
       return torch.flatten(b, start_dim, end_dim)
 )JIT";
 
+const auto clone_script_0 = R"JIT(
+  def forward(self, input):
+      return torch.clone(input)
+)JIT";
+
+const auto clone_script_1 = R"JIT(
+  def forward(self, input: Tensor, memory_format: int):
+      return torch.clone(input, memory_format=memory_format)
+)JIT";
+
 const auto aten_sum = R"JIT(
   def forward(self, input):
       return torch.sum(input)

--- a/benchmarks/static_runtime/test_static_runtime.cc
+++ b/benchmarks/static_runtime/test_static_runtime.cc
@@ -90,6 +90,8 @@ void testStaticRuntime(
   } else if (expect.isList()) {
     compareTensorLists(expect.toTensorVector(), actual.toTensorVector());
   } else {
+    VLOG(2) << "expect " << expect.toTensor() << std::endl;
+    VLOG(2) << "output " << actual.toTensor() << std::endl;
     EXPECT_TRUE(expect.toTensor().equal(actual.toTensor()));
   }
   // make sure inputs were not modified
@@ -115,7 +117,7 @@ TEST(StaticRuntime, InPlace) {
 }
 
 TEST(StaticRuntime, UnaryOps) {
-  auto a = at::ones({2, 3});
+  auto a = at::randn({2, 3});
 
   std::vector<IValue> args{a};
 
@@ -125,6 +127,18 @@ TEST(StaticRuntime, UnaryOps) {
   testStaticRuntime(aten_sum_1, args);
   testStaticRuntime(aten_sum_0_true, args);
   testStaticRuntime(aten_sum_1_true, args);
+}
+
+TEST(StaticRuntime, Clone) {
+  auto a = at::randn({2, 3});
+  auto b = at::empty_strided({3, 2}, {1, 3});
+
+  std::vector<IValue> args_0{b, c10::MemoryFormat::Contiguous};
+  std::vector<IValue> args_1{b, c10::MemoryFormat::Preserve};
+
+  testStaticRuntime(clone_script_0, {a});
+  testStaticRuntime(clone_script_1, args_0);
+  testStaticRuntime(clone_script_1, args_1);
 }
 
 TEST(StaticRuntime, Logit) {
@@ -140,7 +154,7 @@ TEST(StaticRuntime, Logit) {
 }
 
 TEST(StaticRuntime, EmbeddingBag) {
-  at::Tensor weight = torch::ones({3, 11}, at::ScalarType::Float);
+  at::Tensor weight = torch::randn({3, 11}, at::ScalarType::Float);
   at::Tensor input = torch::tensor({0, 1, 0, 2});
   at::Tensor offset = torch::tensor({0, 2, 4});
 

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -82,6 +82,18 @@ inline at::Tensor create_empty_from(const at::Tensor& t, c10::Device device) {
       c10::nullopt);
 }
 
+inline at::Tensor create_empty_from(
+    const at::Tensor& t,
+    c10::MemoryFormat memory_format) {
+  return at::detail::empty_cpu(
+      {0},
+      c10::typeMetaToScalarType(t.dtype()),
+      t.layout(),
+      t.device(),
+      c10::nullopt,
+      memory_format);
+}
+
 inline bool checkResizedDataPtr(at::Tensor& t) {
   auto const prev_data_ptr = t.data_ptr();
   t.resize_({0});


### PR DESCRIPTION
Summary: aten::clone has a second arg, memory_format, which was not previously supported.

Reviewed By: ajyu

Differential Revision: D28347171

