### PR TITLE
[DDP] Don't find tensors if static graph

### DIFF
--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -807,7 +807,8 @@ class DistributedDataParallel(Module):
                 # because we need to figure out which parameters were used during
                 # this forward pass, to ensure we short circuit reduction for any
                 # unused parameters. Only if `find_unused_parameters` is set.
-                if self.find_unused_parameters:
+                if self.find_unused_parameters and not self.static_graph:
+                    # Do not need to populate this for static graph.
                     self.reducer.prepare_for_backward(list(_find_tensors(output)))
                 else:
                     self.reducer.prepare_for_backward([])


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58105 [DDP] Don't find tensors if static graph**
* #57073 enhance DDPSink to work for general outputs

When find_unused_parameters=True but static_graph is also set, static graph handles unused parameter accounting, so this code path is not needed

Differential Revision: [D28371954](https://our.internmc.facebook.com/intern/diff/D28371954/)