### PR TITLE
[DDP] Tests for DDP supporting multiple backwards

### DIFF
--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -46,6 +46,7 @@ Reducer::Reducer(
       gradient_as_bucket_view_(gradient_as_bucket_view),
       local_used_maps_reduced_(false),
       num_iterations_(0),
+      num_backward_calls_(0),
       num_buckets_ready_(0),
       has_rebuilt_bucket_(false),
       bucket_bytes_cap_(bucket_bytes_cap),
@@ -219,11 +220,11 @@ bool Reducer::dynamic_graph_find_unused() {
 }
 
 bool Reducer::static_graph_first_iteration() {
-  return static_graph_ && num_iterations_ == 1;
+  return static_graph_ && num_backward_calls_ == 1;
 }
 
 bool Reducer::static_graph_after_first_iteration() {
-  return static_graph_ && num_iterations_ > 1;
+  return static_graph_ && num_backward_calls_ > 1;
 }
 
 void Reducer::initialize_local_used_map() {
@@ -1170,7 +1171,7 @@ void Reducer::search_unused_parameters(
 void Reducer::prepare_for_backward(
     const std::vector<torch::autograd::Variable>& outputs) {
   std::lock_guard<std::mutex> lock(mutex_);
-
+  ++num_backward_calls_;
   cpu_timer_.backward_compute_start_time = current_time_in_nanos();
   if (should_collect_runtime_stats()) {
     record_backward_compute_start_time();

--- a/torch/lib/c10d/reducer.hpp
+++ b/torch/lib/c10d/reducer.hpp
@@ -356,7 +356,13 @@ class Reducer {
   std::vector<VariableLocator> variable_locators_;
 
   // track the number of iterations to synchronize grads in training so far.
+  // This is the number of calls to the forward pass, not necessarily equal to
+  // number of calls to backward pass.
   long num_iterations_;
+  // Number of times backward() has been called. This is mainly used for static
+  // graph training to know when to populate the map of how many times grad
+  // hooks have been triggered.
+  long num_backward_calls_;
   // track the number of buckets that have been ready for
   // communication calls like allReduce or communication hooks.
   int num_buckets_ready_;

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -135,6 +135,8 @@ class _DDPSink(Function):
                 ctx.reducer.prepare_for_backward(used_inputs)
                 ctx.reducer.set_per_iteration_param_outputs_unused(outputs_unused_indices)
             else:
+                it = ctx.state_dict['num_iterations']
+                print(f"Calling prepare_for_backward: {it}")
                 ctx.reducer.prepare_for_backward([])
         # In static graph training, enqueue delay_all_reduce for the first
         # iteration. This will allow DDP to bake in assumptions about how many

--- a/torch/nn/parallel/distributed.py
+++ b/torch/nn/parallel/distributed.py
@@ -135,8 +135,6 @@ class _DDPSink(Function):
                 ctx.reducer.prepare_for_backward(used_inputs)
                 ctx.reducer.set_per_iteration_param_outputs_unused(outputs_unused_indices)
             else:
-                it = ctx.state_dict['num_iterations']
-                print(f"Calling prepare_for_backward: {it}")
                 ctx.reducer.prepare_for_backward([])
         # In static graph training, enqueue delay_all_reduce for the first
         # iteration. This will allow DDP to bake in assumptions about how many

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -25,6 +25,7 @@ from torch.distributed.algorithms.ddp_comm_hooks import default_hooks as default
 from torch.utils.data.distributed import DistributedSampler
 from torch.nn.parallel.distributed import _dump_DDP_relevant_env_vars
 import torch.nn as nn
+import torch.optim as optim
 import torch.nn.functional as F
 from torch.nn.parallel import DistributedDataParallel
 from torch.distributed.distributed_c10d import get_world_size, _get_default_group, AllreduceOptions, GroupMember
@@ -6450,3 +6451,71 @@ class DistributedTest:
                         model.parameters(), model_static_graph.parameters()
                     ):
                         self.assertEqual(p, p_static)
+
+        def _test_ddp_bwd_with_retain_graph(self, static_graph):
+            # TODO: test with unused parameters, and different sets of unused parameters,
+            # and compare with local model.
+            # Test adapted from https://github.com/pytorch/pytorch/issues/47260.
+            class ToyModel(nn.Module):
+                def __init__(self):
+                    super(ToyModel, self).__init__()
+                    self.net1 = nn.Linear(10, 10, bias=False)
+
+                def forward(self, x):
+                    return self.net1(x)
+
+            rank = self.rank
+            torch.cuda.set_device(rank)
+            model = ToyModel().cuda(torch.cuda.current_device())
+            local_model = copy.deepcopy(model)
+            ddp_model = torch.nn.parallel.DistributedDataParallel(
+                model,
+                device_ids=[torch.cuda.current_device()]
+            )
+            if static_graph:
+                ddp_model._set_static_graph()
+
+            loss_fn = nn.MSELoss()
+            optimizer = optim.SGD(ddp_model.parameters(), lr=1)
+            local_optimizer = optim.SGD(local_model.parameters(), lr=1)
+            optimizer.zero_grad()
+            local_optimizer.zero_grad()
+
+            outputs = {}
+            outputs_local = {}
+            for i in range(3):
+                inp = torch.rand(20, 10).cuda(torch.cuda.current_device())
+                idx = str(i)
+                outputs[idx] = ddp_model(inp).sum(axis=1).unsqueeze(dim=1)
+                outputs_local[idx] = local_model(inp).sum(axis=1).unsqueeze(dim=1)
+
+            labels = torch.rand(20, 1).cuda(torch.cuda.current_device())
+
+            for i in range(3):
+                if i < 2:
+                    print(f"Starting bwd for iteration {i} rank {rank}")
+                    loss_fn(outputs[str(i)], labels).backward(retain_graph=True)
+                    print(f"Done with backward for iteration {i} rank {rank}")
+                    loss_fn(outputs_local[str(i)], labels).backward(retain_graph=True)
+                else:
+                    loss_fn(outputs[str(i)], labels).backward()
+                    loss_fn(outputs_local[str(i)], labels).backward()
+
+                # All gather grads to compare them.
+                dist_grad_tensor = torch.cat([param.grad for param in ddp_model.module.parameters()])
+                local_grad_tensor = torch.cat([param.grad for param in local_model.parameters()])
+                if self.rank == 0:
+                    self.assertEqual(dist_grad_tensor, local_grad_tensor)
+                gathered_grads = [torch.zeros_like(dist_grad_tensor) for _ in range(dist.get_world_size())]
+                dist.gather(dist_grad_tensor, gathered_grads if self.rank == 0 else None)
+                if self.rank == 0:
+                    rank_0_grad = dist_grad_tensor
+                    for grad_tensor in gathered_grads:
+                        self.assertEqual(grad_tensor, dist_grad_tensor)
+                    self.assertEqual(dist_grad_tensor, local_grad_tensor)
+
+        def test_ddp_bwd_with_retain_graph_foo(self):
+            self._test_ddp_bwd_with_retain_graph(static_graph=False)
+
+        def test_ddp_bwd_with_retain_graph_static_graph(self):
+            self._test_ddp_bwd_with_retain_graph(static_graph=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58110 [DDP] Tests for DDP supporting multiple backwards**
* #57081 [DDP] Support not all outputs used in loss calculation
* #57073 enhance DDPSink to work for general outputs

Now that prepare_for_backward is moved to the backwards() of the
_DDPSink and not at the end of the forward, we should seamlessly support
multiple bwd with retain_graph=True.

Also includes a fix for issue described in https://github.com/pytorch/pytorch/issues/58111; we now use the # of backwards call to determine `static_graph_first_iteration()` and `static_graph_after_first_iteration()`. 

Differential Revision: [D28370999](https://our.internmc.facebook.com/intern/diff/D28370999/)