### PR TITLE
[ONNX] Sum empty tensor could not be exported to ONNX successfully.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8880,6 +8880,9 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(12)
         self.run_test(M(), (x,))
 
+        x = torch.ones(2, 0, 3)
+        self.run_test(M(), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8872,6 +8872,15 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(M(2, 1), (x,))
         self.run_test(M([-1, 3], [-2, -1]), (x,))
 
+    def test_sum_empty_tensor(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                # pytorch sum over empty tensor gives 0, while onnx produce error.
+                return x[0:0].sum()
+
+        x = torch.ones(12)
+        self.run_test(M(), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8875,7 +8875,6 @@ class TestONNXRuntime(unittest.TestCase):
     def test_sum_empty_tensor(self):
         class M(torch.nn.Module):
             def forward(self, x):
-                # pytorch sum over empty tensor gives 0, while onnx produce error.
                 return x[0:0].sum()
 
         x = torch.ones(12)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -738,6 +738,13 @@ def _optional_input_placeholder_tensor(g):
     n.setType(OptionalType.ofTensor())
     return n
 
+def _handle_reduce_dim_none(g, self, op_name):
+    dim_size = _get_tensor_dim_size(self.node().output(), 0)
+    if dim_size is None or dim_size == 0:
+        # If input tensor is empty, according to ONNX ReduceSum definition, set keepdims=1 
+        # so that the resulted tensor has the same rank as the input.
+        return g.op(op_name, self, keepdims_i=1)
+    return g.op(op_name, self, keepdims_i=0)
 
 # ---------------------------------------------------------------------
 # ONNX operator version

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -741,7 +741,7 @@ def _optional_input_placeholder_tensor(g):
 def _handle_reduce_dim_none(g, self, op_name):
     dim_size = _get_tensor_dim_size(self.node().output(), 0)
     if dim_size is None or dim_size == 0:
-        # If input tensor is empty, according to ONNX ReduceSum definition, set keepdims=1 
+        # If input tensor is empty, according to ONNX ReduceSum definition, set keepdims=1
         # so that the resulted tensor has the same rank as the input.
         return g.op(op_name, self, keepdims_i=1)
     return g.op(op_name, self, keepdims_i=0)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -741,8 +741,8 @@ def _optional_input_placeholder_tensor(g):
 def _handle_reduce_dim_none(g, self, op_name):
     dim_size = _get_tensor_dim_size(self.node().output(), 0)
     if dim_size is None or dim_size == 0:
-        # If input tensor is empty, according to ONNX ReduceSum definition, set keepdims=1
-        # so that the resulted tensor has the same rank as the input.
+        # If input tensor is empty, according to ONNX ReduceSum definition,
+        # set keepdims=1 so that the resulted tensor has the same rank as the input.
         return g.op(op_name, self, keepdims_i=1)
     return g.op(op_name, self, keepdims_i=0)
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -739,7 +739,7 @@ def _optional_input_placeholder_tensor(g):
     return n
 
 def _handle_reduce_dim_none(g, self, op_name):
-    dim_size = _get_tensor_dim_size(self.node().output(), 0)
+    dim_size = _get_tensor_dim_size(self, 0)
     if dim_size is None or dim_size == 0:
         # If input tensor is empty, according to ONNX ReduceSum definition,
         # set keepdims=1 so that the resulted tensor has the same rank as the input.

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -146,10 +146,12 @@ def _reduce_op_symbolic(onnx_op_name):
     def symbolic(g, self, dim=None, keepdim=None):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
+            print('=== dim is none op_name (13): ', onnx_op_name)
             # all-reduce path
-            return g.op(onnx_op_name, self, keepdims_i=0)
+            return g.op(onnx_op_name, self, keepdims_i=1)
         else:
-            keepdim = sym_help._get_const(keepdim, "i", "keepdim")
+            print('=== op_name (13): ', onnx_op_name)
+            keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic
 

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -5,7 +5,7 @@
 import torch
 import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args, _unimplemented
-from torch.onnx.symbolic_opset9 import overload_by_arg_count, _maybe_cast_reduce_op_input, nonzero, _handle_reduce_dim_none
+from torch.onnx.symbolic_opset9 import overload_by_arg_count, _maybe_cast_reduce_op_input, nonzero
 
 
 # EDITING THIS FILE? READ THIS FIRST!
@@ -147,7 +147,7 @@ def _reduce_op_symbolic(onnx_op_name):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
             # all-reduce path
-            return _handle_reduce_dim_none(g, self, onnx_op_name)
+            return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
             keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -5,7 +5,7 @@
 import torch
 import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args, _unimplemented
-from torch.onnx.symbolic_opset9 import overload_by_arg_count, _maybe_cast_reduce_op_input, nonzero
+from torch.onnx.symbolic_opset9 import overload_by_arg_count, _maybe_cast_reduce_op_input, nonzero, _handle_reduce_dim_none
 
 
 # EDITING THIS FILE? READ THIS FIRST!
@@ -146,11 +146,9 @@ def _reduce_op_symbolic(onnx_op_name):
     def symbolic(g, self, dim=None, keepdim=None):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
-            print('=== dim is none op_name (13): ', onnx_op_name)
             # all-reduce path
-            return g.op(onnx_op_name, self, keepdims_i=1)
+            return _handle_reduce_dim_none(g, self, onnx_op_name)
         else:
-            print('=== op_name (13): ', onnx_op_name)
             keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -363,18 +363,12 @@ def _maybe_cast_reduce_op_input(g, self):
     return self
 
 
-def _handle_reduce_dim_none(g, self, op_name):
-    if len(list(self.node().inputs())) > 0:
-        return g.op(op_name, self, keepdims_i=1)
-    return g.op(op_name, self, keepdims_i=0)
-
-
 def _reduce_op_symbolic(onnx_op_name, allow_multi_dim_support=True):
     def symbolic(g, self, dim=None, keepdim=None):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
             # all-reduce path
-            return _handle_reduce_dim_none(g, self, onnx_op_name)
+            return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
             # dim-reduce path
             desc = "is" if allow_multi_dim_support else "i"

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -367,9 +367,13 @@ def _reduce_op_symbolic(onnx_op_name, allow_multi_dim_support=True):
     def symbolic(g, self, dim=None, keepdim=None):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
+            print('=== dim is none op_name (9): ', onnx_op_name)
             # all-reduce path
-            return g.op(onnx_op_name, self, keepdims_i=0)
+            # if onnx_op_name == "ReduceSum":
+            #     return g.op(onnx_op_name, self, keepdims_i=1)
+            return g.op(onnx_op_name, self, keepdims_i=1)
         else:
+            print('=== op_name (9): ', onnx_op_name)
             # dim-reduce path
             desc = "is" if allow_multi_dim_support else "i"
             dim, keepdim = sym_help._get_const(dim, desc, "dim"), sym_help._get_const(keepdim, "i", "keepdim")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -363,17 +363,19 @@ def _maybe_cast_reduce_op_input(g, self):
     return self
 
 
+def _handle_reduce_dim_none(g, self, op_name):
+    if len(list(self.node().inputs())) > 0:
+        return g.op(op_name, self, keepdims_i=1)
+    return g.op(op_name, self, keepdims_i=0)
+
+
 def _reduce_op_symbolic(onnx_op_name, allow_multi_dim_support=True):
     def symbolic(g, self, dim=None, keepdim=None):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
-            print('=== dim is none op_name (9): ', onnx_op_name)
             # all-reduce path
-            # if onnx_op_name == "ReduceSum":
-            #     return g.op(onnx_op_name, self, keepdims_i=1)
-            return g.op(onnx_op_name, self, keepdims_i=1)
+            return _handle_reduce_dim_none(g, self, onnx_op_name)
         else:
-            print('=== op_name (9): ', onnx_op_name)
             # dim-reduce path
             desc = "is" if allow_multi_dim_support else "i"
             dim, keepdim = sym_help._get_const(dim, desc, "dim"), sym_help._get_const(keepdim, "i", "keepdim")


### PR DESCRIPTION
PyTorch sum over empty tensor gives 0, while ONNX produces an error.

torch.sum will be translated into onnx::ReduceSum op. Per the definition of ReduceSum, update the keepdims attribute for this scenario.
