### PR TITLE
enable deterministic path for index_copy_cuda with index_put

### DIFF
--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -227,7 +227,7 @@ static void index_copy_kernel(
   int64_t self_dim_stride) {
   // See note [Writing Nondeterministic Operations]
   // Nondeterministic when index contains duplicate entries
-  at::globalContext().alertNotDeterministic("index_copy_cuda");
+  // this kernel will not be called when torch.use_deterministic_algorithms(True)
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(
     at::ScalarType::Half, at::ScalarType::Bool, at::ScalarType::BFloat16,
     iter.dtype(), "index_copy_cuda", [&] {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_device_type import (
     skipMeta,
     PYTORCH_CUDA_MEMCHECK, largeTensorTest, onlyOnCPUAndCUDA,
     expectedAlertNondeterministic)
-from typing import Dict, List
+from typing import Dict, List, Tuple
 import torch.backends.quantized
 import torch.testing._internal.data
 from torch.testing._internal.common_cuda import tf32_on_and_off, tf32_is_not_fp32
@@ -5212,56 +5212,44 @@ else:
         with self.assertRaises(IndexError):
             a.index_copy_(1, idx, c)
 
-    @onlyCPU
-    def test_index_copy_deterministic(self, device):
-        m = 6
-        n = 3
-        x = torch.zeros(m, n, device=device)
-        elems = 20000
-        src = torch.rand(elems, n, device=device)
-        index = torch.randint(m, (elems,), device=device)
-        with DeterministicGuard(True):
-            y0 = torch.index_copy(x, 0, index, src)
-            for _ in range(10):
-                y = torch.index_copy(x, 0, index, src)
-                self.assertEqual(y, y0, atol=0, rtol=0)
-
-    # Ensures that index_copy throws nondeterministic alerts in the correct cases
-    @onlyCUDA
-    @dtypes(torch.double)
-    def test_nondeterministic_alert_index_copy(self, device, dtype):
-        @expectedAlertNondeterministic('index_copy_cuda', 'cuda')
-        def test_func(slf, device, call_type):
-            S = 10
-            a = torch.randn(S, device=device)
-            b = torch.randn(S, device=device)
-            index = torch.randint(S, (S,), device=device)
-            if call_type == 'function':
-                torch.index_copy(a, 0, index, b)
-            elif call_type == 'method':
-                a.index_copy(0, index, b)
-            elif call_type == 'method inplace':
-                a.index_copy_(0, index, b)
-            else:
-                self.fail(f"'{call_type}' is not a valid call type")
-
-        test_func(self, device, 'function')
-        test_func(self, device, 'method')
-        test_func(self, device, 'method inplace')
+    def _prepare_data_for_index_copy_and_add_deterministic(
+        self, dim: int, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert (dim >= 0 and dim < 3)
+        a = [5, 4, 3]
+        a[dim] = 2000
+        x = torch.zeros(a, device=device)
+        b = a.copy()
+        elems = a[dim] * 20
+        b[dim] = elems
+        src = torch.rand(b, device=device)
+        index = torch.randint(a[dim], (elems,), device=device)
+        return (x, index, src)
 
     @onlyOnCPUAndCUDA
-    def test_index_add_deterministic(self, device):
+    def test_index_copy_deterministic(self, device: torch.device) -> None:
         for dim in range(3):
-            a = [5, 4, 3]
-            a[dim] = 1000
-            alpha = random.random() + 1
-            x = torch.zeros(a, device=device)
-            b = a.copy()
-            elems = a[dim] * 20
-            b[dim] = elems
-            src = torch.rand(b, device=device)
-            index = torch.randint(a[dim], (elems,), device=device)
+            x, index, src = self._prepare_data_for_index_copy_and_add_deterministic(dim, device)
+            with DeterministicGuard(True):
+                y0 = torch.index_copy(x, dim, index, src)
 
+            x0 = x.clone().detach()
+            index_list = index.tolist()
+            for i in range(len(index_list)):
+                if dim == 0:
+                    x0[index_list[i], :, :] = src[i, :, :]
+                elif dim == 1:
+                    x0[:, index_list[i], :] = src[:, i, :]
+                elif dim == 2:
+                    x0[:, :, index_list[i]] = src[:, :, i]
+
+            self.assertEqual(x0, y0, atol=0, rtol=0)
+
+    @onlyOnCPUAndCUDA
+    def test_index_add_deterministic(self, device: torch.device) -> None:
+        for dim in range(3):
+            x, index, src = self._prepare_data_for_index_copy_and_add_deterministic(dim, device)
+            alpha = random.random() + 1
             # on CPU it should be deterministic regardless of the deterministic mode
             with DeterministicGuard(True):
                 y0 = torch.index_add(x, dim, index, src, alpha=alpha)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -381,7 +381,7 @@ def use_deterministic_algorithms(mode):
         * :func:`torch.index_add` when called on CUDA tensor
         * :func:`torch.index_select` when attempting to differentiate a CUDA tensor
         * :func:`torch.repeat_interleave` when attempting to differentiate a CUDA tensor
-        * :func:`torch.Tensor.index_copy` when called on a CPU tensor
+        * :func:`torch.Tensor.index_copy` when called on a CPU or CUDA tensor
 
     The following normally-nondeterministic operations will throw a
     :class:`RuntimeError` when ``mode=True``:
@@ -411,7 +411,6 @@ def use_deterministic_algorithms(mode):
         * :class:`torch.nn.EmbeddingBag` when attempting to differentiate a CUDA tensor when
           ``mode='max'``
         * :func:`torch.Tensor.scatter_add_` when called on a CUDA tensor
-        * :func:`torch.Tensor.index_copy` when called on a CUDA tensor
         * :func:`torch.Tensor.put_` when ``accumulate=False``
         * :func:`torch.Tensor.put_` when ``accumulate=True`` and called on a CUDA tensor
         * :func:`torch.histc` when called on a CUDA tensor


### PR DESCRIPTION
Summary: reland D28291041 (https://github.com/pytorch/pytorch/commit/14badd9929e3fb6aad74983c6ba82658be6ab109), which was reverted due to a type error from Tuple[torch.Tensor], seems that mypy requires Tuple[torch.Tensor, torch.Tensor, torch.Tensor]

Test Plan:
buck test mode/opt //caffe2/test:torch_cuda -- test_index_copy_deterministic

    ✓ ListingSuccess: caffe2/test:torch_cuda - main (9.229)
    ✓ Pass: caffe2/test:torch_cuda - test_index_copy_deterministic_cuda (test_torch.TestTorchDeviceTypeCUDA) (25.750)
    ✓ Pass: caffe2/test:torch_cuda - main (25.750)

Differential Revision: D28383178

