### PR TITLE
Switch GHA test stats S3 upload token

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.in
+++ b/.github/templates/linux_ci_workflow.yml.in
@@ -227,8 +227,8 @@ jobs:
         # tools/print_test_stats.py to natively support GitHub Actions
         env:
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_SECRET_ACCESS_KEY }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_JOB: !{{ build_environment }}
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -228,8 +228,8 @@ jobs:
         # tools/print_test_stats.py to natively support GitHub Actions
         env:
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_SECRET_ACCESS_KEY }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_JOB: pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -228,8 +228,8 @@ jobs:
         # tools/print_test_stats.py to natively support GitHub Actions
         env:
           SCRIBE_GRAPHQL_ACCESS_TOKEN: ${{ secrets.SCRIBE_GRAPHQL_ACCESS_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_UPDATE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_UPDATE_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_OSSCI_METRICS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_OSSCI_METRICS_SECRET_ACCESS_KEY }}
           CIRCLE_BRANCH: ${{ steps.parse-ref.outputs.branch }}
           CIRCLE_JOB: pytorch-linux-xenial-py3.6-gcc5.4
           CIRCLE_PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -765,10 +765,10 @@ def send_report_to_s3(head_report: Version2Report) -> None:
     job = os.environ.get('CIRCLE_JOB')
     sha1 = os.environ.get('CIRCLE_SHA1')
     branch = os.environ.get('CIRCLE_BRANCH', '')
-    if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
-        print("S3 upload only enabled on master, nightly and release branches.")
-        print(f"skipping test report on branch: {branch}")
-        return
+    # if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
+    #     print("S3 upload only enabled on master, nightly and release branches.")
+    #     print(f"skipping test report on branch: {branch}")
+    #     return
     now = datetime.datetime.utcnow().isoformat()
     key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
     obj = get_S3_object_from_bucket('ossci-metrics', key)

--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -765,10 +765,10 @@ def send_report_to_s3(head_report: Version2Report) -> None:
     job = os.environ.get('CIRCLE_JOB')
     sha1 = os.environ.get('CIRCLE_SHA1')
     branch = os.environ.get('CIRCLE_BRANCH', '')
-    # if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
-    #     print("S3 upload only enabled on master, nightly and release branches.")
-    #     print(f"skipping test report on branch: {branch}")
-    #     return
+    if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
+        print("S3 upload only enabled on master, nightly and release branches.")
+        print(f"skipping test report on branch: {branch}")
+        return
     now = datetime.datetime.utcnow().isoformat()
     key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
     obj = get_S3_object_from_bucket('ossci-metrics', key)


### PR DESCRIPTION
TODOs:

- [x] generate a temporary new token on this repo for testing purposes
- [x] change the name of the S3 secret used in the workflow YAML definitions
- [x] check the test plan
- [x] replace the temporary token with a more permanent one
- [x] check the test plan again
- [x] uncomment the `if` statement that guards against uploading PR test stats

**Test plan:**

Check the [ossci-metrics bucket](https://s3.console.aws.amazon.com/s3/buckets/ossci-metrics) after CI runs on this PR. Specifically, [this prefix](https://s3.console.aws.amazon.com/s3/buckets/ossci-metrics?region=us-east-1&prefix=test_time/a3445bfbd7efc602c28f5146fb562aa35ec50077/pytorch-linux-xenial-py3.6-gcc5.4/&showversions=false) has two objects under it.