### PR TITLE
[torch/elastic] Revise distributed run script

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -41,7 +41,7 @@ class CreateBackendTest(TestCase):
     def setUp(self) -> None:
         self._params = RendezvousParameters(
             backend="dummy_backend",
-            endpoint="localhost:29400",
+            endpoint="localhost:29300",
             run_id="dummy_run_id",
             min_nodes=1,
             max_nodes=1,
@@ -51,7 +51,7 @@ class CreateBackendTest(TestCase):
         )
 
         self._expected_endpoint_host = "localhost"
-        self._expected_endpoint_port = 29400
+        self._expected_endpoint_port = 29300
         self._expected_store_type = TCPStore
         self._expected_read_timeout = timedelta(seconds=10)
 
@@ -102,7 +102,7 @@ class CreateBackendTest(TestCase):
     def test_create_backend_returns_backend_if_endpoint_port_is_not_specified(self) -> None:
         self._params.endpoint = self._expected_endpoint_host
 
-        self._expected_endpoint_port = 29500
+        self._expected_endpoint_port = 29400
 
         self.test_create_backend_returns_backend()
 

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -121,7 +121,7 @@ class C10dRendezvousBackend(RendezvousBackend):
 
 
 def _create_tcp_store(params: RendezvousParameters) -> TCPStore:
-    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=29500)
+    host, port = parse_rendezvous_endpoint(params.endpoint, default_port=29400)
 
     cfg_is_host = params.get_as_bool("is_host")
     # If the user has explicitly specified whether our process should host the

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -6,19 +6,19 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-r"""
-This module provides similar functionality as ``torch.distributed.launch``,
-with the following additional functionalities:
+"""
+This module provides similar functionality as ``torch.distributed.launch`` with the following
+additional functionalities:
 
 1. Worker failures are handled gracefully by restarting all workers.
 
 2. Worker ``RANK`` and ``WORLD_SIZE`` are assigned automatically.
 
-3. Number of nodes is allowed to change between min and max sizes (elasticity).
+3. Number of nodes is allowed to change between minimum and maximum sizes (elasticity).
 
 **Usage:**
 
-1. Single-node multi-worker (with sidecar etcd server)
+1. Single-node multi-worker
 
 ::
 
@@ -28,7 +28,7 @@ with the following additional functionalities:
         --nproc_per_node=$NUM_TRAINERS
         YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
 
-2. Fault tolerant (fixed sized number of workers, no elasticity).:
+2. Fault tolerant (fixed sized number of workers, no elasticity):
 
 ::
 
@@ -36,9 +36,16 @@ with the following additional functionalities:
         --nnodes=$NUM_NODES
         --nproc_per_node=$NUM_TRAINERS
         --rdzv_id=$JOB_ID
-        --rdzv_backend=etcd
-        --rdzv_endpoint=$ETCD_HOST:$ETCD_PORT
+        --rdzv_backend=c10d
+        --rdzv_endpoint=$HOST_NODE_ADDR
         YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+``HOST_NODE_ADDR``, in form <host>[:<port>] (e.g. node1.example.com:29400), specifies the node and
+the port on which the C10d rendezvous backend should be instantiated and hosted. It can be any
+node in your training cluster, but ideally you should pick a node that has a high bandwidth.
+
+.. note::
+   If no port number is specified ``HOST_NODE_ADDR`` defaults to 29400.
 
 3. Elastic (``min=1``, ``max=4``):
 
@@ -48,160 +55,166 @@ with the following additional functionalities:
         --nnodes=1:4
         --nproc_per_node=$NUM_TRAINERS
         --rdzv_id=$JOB_ID
-        --rdzv_backend=etcd
-        --rdzv_endpoint=$ETCD_HOST:$ETCD_PORT
+        --rdzv_backend=c10d
+        --rdzv_endpoint=$HOST_NODE_ADDR
         YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
+
+``HOST_NODE_ADDR``, in form <host>[:<port>] (e.g. node1.example.com:29400), specifies the node and
+the port on which the C10d rendezvous backend should be instantiated and hosted. It can be any
+node in your training cluster, but ideally you should pick a node that has a high bandwidth.
+
+.. note::
+   If no port number is specified ``HOST_NODE_ADDR`` defaults to 29400.
 
 **Note on rendezvous backend**:
 
 For multi-node training you need to specify:
 
-1. ``--rdzv_id``: a unique job id (shared by all nodes participating in the job)
-2. ``--rdzv_backend``: an implementation of ``torch.distributed.elastic.rendevous.RendezvousHandler``
-3. ``--rdzv_endpoint``: ``host:port``-style endpoint where the rdzv backend is running.
+1. ``--rdzv_id``: A unique job id (shared by all nodes participating in the job)
+2. ``--rdzv_backend``: An implementation of
+   :py:class:`torch.distributed.elastic.rendezvous.RendezvousHandler`
+3. ``--rdzv_endpoint``: The endpoint where the rendezvous backend is running; usually in form
+   ``host:port``.
 
-Currently only ``etcd`` rdzv backend is supported out of the box.
-To use ``etcd``, setup an etcd server with the ``v2`` api enabled
-(e.g. ``--enable-v2``).
+Currently ``c10d`` (recommended), ``etcd-v2``, and ``etcd`` (legacy)  rendezvous backends are
+supported out of the box. To use ``etcd-v2`` or ``etcd``, setup an etcd server with the ``v2`` api
+enabled (e.g. ``--enable-v2``).
 
-.. warning:: ``EtcdRendezvous`` uses etcd api v2. You MUST enable the v2
-             api on the etcd server. Our tests use etcd v3.4.3.
+.. warning::
+   ``etcd-v2`` and ``etcd`` rendezvous use etcd API v2. You MUST enable the v2 API on the etcd
+   server. Our tests use etcd v3.4.3.
+
+.. warning::
+   For etcd-based rendezvous we recommend using ``etcd-v2`` over ``etcd`` which is functionally
+   equivalent, but uses a revised implementation. ``etcd`` is in maintenance mode and will be
+   removed in a future version.
 
 **Definitions:**
 
-1. ``Node`` - Physical instance or container.
-    Maps to the unit that the job manager works with.
+1. ``Node`` - A physical instance or a container; maps to the unit that the job manager works with.
 
 2. ``Worker`` - A worker in the context of distributed training.
 
-3. ``Worker Group`` - Workers that execute the same function (e.g. trainers)
+3. ``WorkerGroup`` - The set of workers that execute the same function (e.g. trainers).
 
-4. ``Local Worker Group`` - Subset of the workers in the
-    worker group running on the same Node
+4. ``LocalWorkerGroup`` - A subset of the workers in the worker group running on the same node.
 
-5. ``RANK`` - rank of the worker within a worker group.
+5. ``RANK`` - The rank of the worker within a worker group.
 
-6. ``WORLD_SIZE`` - total number of workers in a worker group.
+6. ``WORLD_SIZE`` - The total number of workers in a worker group.
 
-7. ``LOCAL_RANK`` - rank of the worker within a local worker group
+7. ``LOCAL_RANK`` - The rank of the worker within a local worker group.
 
-8. ``LOCAL_WORLD_SIZE`` - size of the local worker group
+8. ``LOCAL_WORLD_SIZE`` - The size of the local worker group.
 
-9. ``rdzv_id`` - user defined id that uniquely identifies the worker group
-      for a job. This id is used by each node to join as a member of a particular
-      worker group.
+9. ``rdzv_id`` - A user-defined id that uniquely identifies the worker group for a job. This id is
+   used by each node to join as a member of a particular worker group.
 
-9. ``rdzv_backend`` - the backend store of rendezvous (e.g. etcd). This is
-    typically a strongly consistent key-value store.
+9. ``rdzv_backend`` - The backend of the rendezvous (e.g. ``c10d``). This is typically a strongly
+   consistent key-value store.
 
-10. ``rdzv_endpoint`` - rdzv backend server endpoint in ``host:port`` format.
+10. ``rdzv_endpoint`` - The rendezvous backend endpoint; usually in form ``<host>:<port>``.
 
-A ``Node`` runs ``LOCAL_WORLD_SIZE`` workers which comprise a ``LocalWorkerGroup``.
-The union of all ``LocalWorkerGroups`` in the nodes in the job comprise the
-``WorkerGroup``.
+A ``Node`` runs ``LOCAL_WORLD_SIZE`` workers which comprise a ``LocalWorkerGroup``. The union of
+all ``LocalWorkerGroups`` in the nodes in the job comprise the ``WorkerGroup``.
 
 **Environment Variables:**
 
-The following environment variables are made available to you in your
-script:
+The following environment variables are made available to you in your script:
 
-1. ``LOCAL_RANK`` -  local rank
+1. ``LOCAL_RANK`` -  The local rank.
 
-2. ``RANK`` -  global rank
+2. ``RANK`` -  The global rank.
 
-3. ``GROUP_RANK`` - rank of the worker group. A number between 0 - ``max_nnodes``.
-        When running a single worker group per node, this is the rank of the node.
+3. ``GROUP_RANK`` - The rank of the worker group. A number between 0 and ``max_nnodes``. When
+   running a single worker group per node, this is the rank of the node.
 
-4. ``ROLE_RANK`` -  the rank of the worker across all the workers tha have the same
-        role. The role of the worker is specified in the ``WorkerSpec``.
+4. ``ROLE_RANK`` -  The rank of the worker across all the workers that have the same role. The role
+   of the worker is specified in the ``WorkerSpec``.
 
-5. ``LOCAL_WORLD_SIZE`` - local world size (e.g. number of workers running locally).
-       Equal to ``--nproc_per_node`` specified on ``torch.distributed.run``.
+5. ``LOCAL_WORLD_SIZE`` - The local world size (e.g. number of workers running locally); equals to
+   ``--nproc_per_node`` specified on ``torch.distributed.run``.
 
-6. ``WORLD_SIZE`` - world size (total number of workers in the job).
+6. ``WORLD_SIZE`` - The world size (total number of workers in the job).
 
-7. ``ROLE_WORLD_SIZE`` - the total number of workers that was launched with the same
-        role specified in ``WorkerSpec``.
+7. ``ROLE_WORLD_SIZE`` - The total number of workers that was launched with the same role specified
+   in ``WorkerSpec``.
 
-8. ``MASTER_ADDR`` - fqdn of the host that is running worker with rank 0.
-   Used to initialize torch distributed backend.
+8. ``MASTER_ADDR`` - The FQDN of the host that is running worker with rank 0; used to initialize
+   the Torch Distributed backend.
 
-9. ``MASTER_PORT`` - port on the ``MASTER_ADDR`` that can be used to
-   host the tcp ``c10d`` store.
+9. ``MASTER_PORT`` - The port on the ``MASTER_ADDR`` that can be used to host the C10d TCP store.
 
-10. ``TORCHELASTIC_RESTART_COUNT`` - number of worker group restarts so far.
+10. ``TORCHELASTIC_RESTART_COUNT`` - The number of worker group restarts so far.
 
-11. ``TORCHELASTIC_MAX_RESTARTS`` - configured max number of restarts.
+11. ``TORCHELASTIC_MAX_RESTARTS`` - The configured maximum number of restarts.
 
-12. ``TORCHELASTIC_RUN_ID`` - equal to rdzv run_id (e.g. unique job id).
+12. ``TORCHELASTIC_RUN_ID`` - Equal to the rendezvous ``run_id`` (e.g. unique job id).
 
 **Deployment:**
 
-1. Start the rdzv backend server and get the endpoint
-   (to be passed as ``--rdzv_endpoint`` to the launcher script)
+1. (Not needed for the C10d backend) Start the rendezvous backend server and get the endpoint (to be
+   passed as ``--rdzv_endpoint`` to the launcher script)
 
-2. Single-node multi-worker - start the launcher on the host to start
-   the agent process which creates and monitors a local worker group.
+2. Single-node multi-worker: Start the launcher on the host to start the agent process which
+   creates and monitors a local worker group.
 
-3. Multi-node multi-worker - Start the launcher with the same arguments
-   on all the nodes participating in training.
+3. Multi-node multi-worker: Start the launcher with the same arguments on all the nodes
+   participating in training.
 
-When using a job/cluster manager the entry point command to the multi-node
-job is invoking this launcher.
+When using a job/cluster manager the entry point command to the multi-node job should be this
+launcher.
 
 **Failure Modes:**
 
-1. Worker failure - For a training job with ``n`` workers, if ``k <= n`` workers fail
-   all workers are stopped and restarted up to ``max_restarts``.
+1. Worker failure: For a training job with ``n`` workers, if ``k<=n`` workers fail all workers
+   are stopped and restarted up to ``max_restarts``.
 
-2. Agent failure - An agent failure results in local worker group failure,
-   it is up to the job manager to fail the entire job (gang semantics) or attempt
-   to replace the node. Both behaviors are supported by the agent.
+2. Agent failure: An agent failure results in a local worker group failure. It is up to the job
+   manager to fail the entire job (gang semantics) or attempt to replace the node. Both behaviors
+   are supported by the agent.
 
-3. Node failure - Same as agent failure.
+3. Node failure: Same as agent failure.
 
 **Membership Changes:**
 
-1. Node departure (scale-down) - agent is notified of the departure,
-   all existing workers are stopped, a new ``Worker Group`` is formed and all
-   workers are started with a new ``RANK`` and ``WORLD_SIZE``.
+1. Node departure (scale-down): The agent is notified of the departure, all existing workers are
+   stopped, a new ``WorkerGroup`` is formed, and all workers are started with a new ``RANK`` and
+   ``WORLD_SIZE``.
 
-2. Node arrival (scale-up) - the new node is admitted to the job,
-   all existing workers are stopped, a new ``Worker Group`` is formed and all
-   workers are started with a new ``RANK`` and ``WORLD_SIZE``.
-
+2. Node arrival (scale-up): The new node is admitted to the job, all existing workers are stopped,
+   a new ``WorkerGroup`` is formed, and all workers are started with a new ``RANK`` and
+   ``WORLD_SIZE``.
 
 **Important Notices:**
 
-1. All the items in the important notices section of ``torch.distributed.launch``
-   apply to this module as well
+1. All the items in the important notices section of ``torch.distributed.launch`` apply to this
+   module as well.
 
-2. The environment variables necessary to initialize a torch process group
-   are provided to you by this module, no need for you to pass ``RANK`` manually.
-   To initialize a process group in your training script, simply run
+2. The environment variables necessary to initialize a Torch process group are provided to you by
+   this module, no need for you to pass ``RANK`` manually.  To initialize a process group in your
+   training script, simply run:
 
 ::
 
  >>> import torch.distributed as dist
  >>> dist.init_process_group(backend="gloo|nccl")
 
-3. On failures or membership changes ALL surviving workers are killed
-   immediately. Make sure to checkpoint your progress. The frequency of
-   checkpoints should depend on your job's tolerance for lost work.
+3. On failures or membership changes ALL surviving workers are killed immediately. Make sure to
+   checkpoint your progress. The frequency of checkpoints should depend on your job's tolerance
+   for lost work.
 
-4. This module only supports homogeneous ``LOCAL_WORLD_SIZE``. That is,
-   it is assumed that all nodes run the same number of local workers (per role).
+4. This module only supports homogeneous ``LOCAL_WORLD_SIZE``. That is, it is assumed that all
+   nodes run the same number of local workers (per role).
 
-5. ``RANK`` is NOT stable. Between restarts, the local workers on a node
-   can be assgined a different range of ranks than before. NEVER hard code
-   any assumptions about the stable-ness of ranks or some correlation between
-   ``RANK`` and ``LOCAL_RANK``.
+5. ``RANK`` is NOT stable. Between restarts, the local workers on a node can be assgined a
+   different range of ranks than before. NEVER hard code any assumptions about the stable-ness of
+   ranks or some correlation between ``RANK`` and ``LOCAL_RANK``.
 
-6. When using elasticity (``min_size != max_size``) DO NOT hard code
-   assumptions about ``WORLD_SIZE`` as the world size can change as
-   nodes are allowed to leave and join.
+6. When using elasticity (``min_size!=max_size``) DO NOT hard code assumptions about
+   ``WORLD_SIZE`` as the world size can change as nodes are allowed to leave and join.
 
-7. It is recommended your script have the following structure
+7. It is recommended for your script to have the following structure:
 
 ::
 
@@ -227,7 +240,6 @@ from typing import List, Tuple
 import torch
 from torch.distributed.argparse_util import check_env, env
 from torch.distributed.elastic.multiprocessing import Std
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
 from torch.distributed.elastic.rendezvous.utils import _parse_rendezvous_config
 from torch.distributed.elastic.utils import macros
 from torch.distributed.elastic.utils.logging import get_logger
@@ -238,86 +250,87 @@ log = get_logger()
 
 
 def get_args_parser() -> ArgumentParser:
-    """
-    Helper function parsing the command line options.
-    """
+    """Helper function parsing the command line options."""
 
-    parser = ArgumentParser(description="torchelastic elastic training launcher")
+    parser = ArgumentParser(description="Torch Distributed Elastic Training Launcher")
 
-    # Arguments for the launch helper
-    # worker/node size related arguments
+    #
+    # Worker/node size related arguments.
+    #
+
     parser.add_argument(
         "--nnodes",
         action=env,
         type=str,
         default="1:1",
-        help="number of nodes or MIN_NODES:MAX_NODES",
+        help="Number of nodes, or the range of nodes in form <minimum_nodes>:<maximum_nodes>.",
     )
     parser.add_argument(
         "--nproc_per_node",
         action=env,
         type=str,
         default="auto",
-        help="number of workers per node, supported values: [auto, cpu, gpu, int]",
+        help="Number of workers per node; supported values: [auto, cpu, gpu, int].",
     )
 
-    # rendezvous related arguments
+    #
+    # Rendezvous related arguments
+    #
+
     parser.add_argument(
         "--rdzv_backend",
         action=env,
         type=str,
         default="static",
-        help="rendezvous backend",
+        help="Rendezvous backend.",
     )
     parser.add_argument(
         "--rdzv_endpoint",
         action=env,
         type=str,
         default="",
-        help="rendezvous backend server host:port",
+        help="Rendezvous backend endpoint; usually in form <host>:<port>.",
     )
     parser.add_argument(
         "--rdzv_id",
         action=env,
-        default="none",
         type=str,
-        help="user defined group id",
+        default="none",
+        help="User-defined group id.",
     )
     parser.add_argument(
         "--rdzv_conf",
         action=env,
         type=str,
         default="",
-        help="additional rdzv configuration (conf1=v1,conf2=v2,...)",
+        help="Additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).",
     )
-
-    # sidecar embed rdzv backend that defaults to etcd
     parser.add_argument(
         "--standalone",
         action=check_env,
-        help="starts a local, standalone rdzv backend that is represented by"
-        " etcd server on a random free port"
-        "using the etcd binary specified in TORCHELASTIC_ETCD_BINARY_PATH"
-        " env var or the one found in PATH."
-        " Useful when launching single-node, multi-worker job."
-        " If specified --rdzv_backend, --rdzv_endpoint, --rdzv_id"
-        " are autoassigned, any explicitly set values are ignored",
+        help="Start a local standalone rendezvous backend that is represented by a C10d TCP store "
+        "on port 29400. Useful when launching single-node, multi-worker job. If specified "
+        "--rdzv_backend, --rdzv_endpoint, --rdzv_id are auto-assigned; any explicitly set values "
+        "are ignored.",
     )
 
-    # user-code launch related arguments
+    #
+    # User-code launch related arguments.
+    #
+
     parser.add_argument(
         "--max_restarts",
         action=env,
         type=int,
         default=3,
-        help="max number of worker group restarts before failing",
+        help="Maximum number of worker group restarts before failing.",
     )
     parser.add_argument(
         "--monitor_interval",
         action=env,
         type=float,
         default=5,
-        help="interval (in seconds) to monitor the state of workers",
+        help="Interval, in seconds, to monitor the state of workers.",
     )
     parser.add_argument(
         "--start_method",
@@ -325,118 +338,117 @@ def get_args_parser() -> ArgumentParser:
         type=str,
         default="spawn",
         choices=["spawn", "fork", "forkserver"],
-        help="multiprocessing start_method to use when creating workers",
+        help="Multiprocessing start method to use when creating workers.",
     )
     parser.add_argument(
         "--role",
         action=env,
         type=str,
         default="default",
-        help="user-defined role for the workers",
+        help="User-defined role for the workers.",
     )
     parser.add_argument(
         "-m",
         "--module",
         action=check_env,
-        help="Changes each process to interpret the launch script "
-        "as a python module, executing with the same behavior as"
-        "'python -m'.",
+        help="Change each process to interpret the launch script as a Python module, executing "
+        "with the same behavior as 'python -m'.",
     )
     parser.add_argument(
         "--no_python",
         action=check_env,
-        help='Do not prepend the training script with "python" - just exec '
-        "it directly. Useful when the script is not a Python script.",
+        help="Skip prepending the training script with 'python' - just execute it directly. Useful "
+        "when the script is not a Python script.",
     )
-
     parser.add_argument(
         "--log_dir",
         action=env,
         type=str,
         default=None,
-        help="base dir to use for log files (e.g. /var/log/torchelastic)"
-        " can reuse the same dir for multiple runs "
-        "(a unique job-level subdir is created with rdzv_id as the prefix)",
+        help="Base directory to use for log files (e.g. /var/log/torch/elastic). The same "
+        "directory is re-used for multiple runs (a unique job-level sub-directory is created with "
+        "rdzv_id as the prefix).",
     )
-
     parser.add_argument(
         "-r",
         "--redirects",
         action=env,
         type=str,
         default="0",
-        help="std streams to redirect into a log file in the log_dir"
-        " (e.g. [-r 3] redirects both stdout+stderr for all workers,"
-        " [-r 0:1,1:2] redirects stdout for local rank 0 and stderr for local rank 1)",
+        help="Redirect std streams into a log file in the log directory (e.g. [-r 3] redirects "
+        "both stdout+stderr for all workers, [-r 0:1,1:2] redirects stdout for local rank 0 and "
+        "stderr for local rank 1).",
     )
-
     parser.add_argument(
         "-t",
         "--tee",
         action=env,
         type=str,
         default="0",
-        help="tee std streams into a log file and also to console (see --redirects for format)",
+        help="Tee std streams into a log file and also to console (see --redirects for format).",
     )
 
-    # backwards compatible params with caffe2.distributed.launch
+    #
+    # Backwards compatible parameters with caffe2.distributed.launch.
+    #
 
     parser.add_argument(
         "--node_rank",
         type=int,
         action=env,
         default=0,
-        help="The rank of the node for multi-node distributed " "training",
+        help="Rank of the node for multi-node distributed training.",
     )
-
     parser.add_argument(
         "--master_addr",
         default="127.0.0.1",
         type=str,
         action=env,
-        help="Master node (rank 0)'s address, should be either "
-        "the IP address or the hostname of node 0, for "
-        "single node multi-proc training, the "
-        "--master_addr can simply be 127.0.0.1"
-        "IPV6 should have the following pattern: `[0:0:0:0:0:0:0:1]`",
+        help="Address of the master node (rank 0). It should be either the IP address or the "
+        "hostname of rank 0. For single node multi-proc training the --master_addr can simply be "
+        "127.0.0.1; IPv6 should have the pattern `[0:0:0:0:0:0:0:1]`.",
     )
     parser.add_argument(
         "--master_port",
         default=29500,
         type=int,
         action=env,
-        help="Master node (rank 0)'s free port that needs to "
-        "be used for communication during distributed "
-        "training",
+        help="Port on the master node (rank 0) to be used for communication during distributed "
+        "training.",
     )
 
-    # positional
+    #
+    # Positional arguments.
+    #
+
     parser.add_argument(
         "training_script",
         type=str,
-        help="The full path to the single GPU training "
-        "program/script to be launched in parallel, "
-        "followed by all the arguments for the "
-        "training script",
+        help="Full path to the (single GPU) training program/script to be launched in parallel, "
+        "followed by all the arguments for the training script.",
     )
 
-    # rest from the training program
+    # Rest from the training program.
     parser.add_argument("training_script_args", nargs=REMAINDER)
+
     return parser
-    # return parser.parse_args(args)
 
 
 def parse_args(args):
     parser = get_args_parser()
+
+    #
+    # Legacy arguments.
+    #
+
     parser.add_argument(
         "--use_env",
         default=True,
         action="store_true",
-        help="Use environment variable to pass "
-        "'local rank'. For legacy reasons, the default value is False. "
-        "If set to True, the script will not pass "
-        "--local_rank as argument, and will instead set LOCAL_RANK.",
+        help="Use environment variable to pass local rank. If set to True (default), the script "
+        "will NOT pass --local_rank as argument, and will instead set LOCAL_RANK.",
     )
+
     return parser.parse_args(args)
 
 
@@ -486,10 +498,9 @@ def determine_local_world_size(nproc_per_node: str):
 
 
 def get_rdzv_endpoint(args):
-    if args.rdzv_backend == "static":
+    if args.rdzv_backend == "static" and not args.rdzv_endpoint:
         return f"{args.master_addr}:{args.master_port}"
-    else:
-        return args.rdzv_endpoint
+    return args.rdzv_endpoint
 
 
 def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
@@ -566,10 +577,8 @@ def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
 
 def run(args):
     if args.standalone:
-        etcd_server = EtcdServer()
-        etcd_server.start()
-        args.rdzv_backend = "etcd"
-        args.rdzv_endpoint = etcd_server.get_endpoint()
+        args.rdzv_backend = "c10d"
+        args.rdzv_endpoint = "localhost:29400"
         args.rdzv_id = str(uuid.uuid4())
         log.info(
             f"\n**************************************\n"
@@ -582,14 +591,7 @@ def run(args):
 
     config, cmd = config_from_args(args)
 
-    try:
-        elastic_launch(
-            config=config,
-            entrypoint=cmd[0],
-        )(*cmd[1:])
-    finally:
-        if args.standalone:
-            etcd_server.stop()
+    elastic_launch(config=config, entrypoint=cmd[0],)(*cmd[1:])
 
 
 def main(args=None):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58160 [torch/elastic] Update the rendezvous docs
* **#58159 [torch/elastic] Revise distributed run script**

This PR includes the following changes:

- The `--standalone` option of `torch.distributed.run` now uses the `c10d` backend instead of `etcd` backend.

- The `import` statement for `EtcdServer` has been removed from the run script.

- The docstrings and parameter descriptions of the run script have been revised and improved.

- The default port number of `EtcdRendezvousBackend` has been changed from 29500 to 29400 to improve the user experience when used along with the run script which uses the port 29500 for the distributed job store (a.k.a. `MASTER_PORT`) by default.

Differential Revision: [D28383681](https://our.internmc.facebook.com/intern/diff/D28383681/)