### PR TITLE
[torch/elastic] Update the rendezvous docs

### DIFF
--- a/docs/source/elastic/quickstart.rst
+++ b/docs/source/elastic/quickstart.rst
@@ -1,15 +1,6 @@
 Quickstart
 ===========
 
-.. code-block:: bash
-
-   pip install torch
-
-   # start a single-node etcd server on ONE host
-   etcd --enable-v2
-        --listen-client-urls http://0.0.0.0:2379,http://127.0.0.1:4001
-        --advertise-client-urls PUBLIC_HOSTNAME:2379
-
 To launch a **fault-tolerant** job, run the following on all nodes.
 
 .. code-block:: bash
@@ -18,8 +9,8 @@ To launch a **fault-tolerant** job, run the following on all nodes.
             --nnodes=NUM_NODES
             --nproc_per_node=TRAINERS_PER_NODE
             --rdzv_id=JOB_ID
-            --rdzv_backend=etcd
-            --rdzv_endpoint=ETCD_HOST:ETCD_PORT
+            --rdzv_backend=c10d
+            --rdzv_endpoint=HOST_NODE_ADDR
             YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
 
 
@@ -32,19 +23,29 @@ and at most ``MAX_SIZE`` nodes.
             --nnodes=MIN_SIZE:MAX_SIZE
             --nproc_per_node=TRAINERS_PER_NODE
             --rdzv_id=JOB_ID
-            --rdzv_backend=etcd
-            --rdzv_endpoint=ETCD_HOST:ETCD_PORT
+            --rdzv_backend=c10d
+            --rdzv_endpoint=HOST_NODE_ADDR
             YOUR_TRAINING_SCRIPT.py (--arg1 ... train script args...)
 
+``HOST_NODE_ADDR``, in form <host>[:<port>] (e.g. node1.example.com:29400),
+specifies the node and the port on which the C10d rendezvous backend should be
+instantiated and hosted. It can be any node in your training cluster, but
+ideally you should pick a node that has a high bandwidth.
 
-.. note:: The `--standalone` option can be passed to launch a single node job with
-          a sidecar rendezvous server. You don’t have to pass —rdzv_id, —rdzv_endpoint,
-          and —rdzv_backend when the —standalone option is used
+.. note::
+   If no port number is specified ``HOST_NODE_ADDR`` defaults to 29400.
+
+.. note::
+   The ``--standalone`` option can be passed to launch a single node job with a
+   sidecar rendezvous backend. You don’t have to pass ``--rdzv_id``,
+   ``--rdzv_endpoint``, and ``--rdzv_backend`` when the ``--standalone`` option
+   is used.
 
 
-.. note:: Learn more about writing your distributed training script
-          `here <train_script.html>`_.
+.. note::
+   Learn more about writing your distributed training script
+   `here <train_script.html>`_.
 
-If ``torch.distributed.run`` does not meet your requirements
-you may use our APIs directly for more powerful customization. Start by
-taking a look at the `elastic agent <agent.html>`_ API).
+If ``torch.distributed.run`` does not meet your requirements you may use our
+APIs directly for more powerful customization. Start by taking a look at the
+`elastic agent <agent.html>`_ API).

--- a/docs/source/elastic/rendezvous.rst
+++ b/docs/source/elastic/rendezvous.rst
@@ -10,14 +10,18 @@ Below is a state diagram describing how rendezvous works.
 .. image:: etcd_rdzv_diagram.png
 
 Registry
---------------------
+--------
 
 .. autoclass:: RendezvousParameters
+   :members:
+
+.. autoclass:: RendezvousHandlerRegistry
+   :members:
 
 .. automodule:: torch.distributed.elastic.rendezvous.registry
 
 Handler
---------------------
+-------
 
 .. currentmodule:: torch.distributed.elastic.rendezvous
 
@@ -25,31 +29,77 @@ Handler
    :members:
 
 Exceptions
--------------
+----------
 .. autoclass:: RendezvousError
 .. autoclass:: RendezvousClosedError
 .. autoclass:: RendezvousTimeoutError
 .. autoclass:: RendezvousConnectionError
 .. autoclass:: RendezvousStateError
 
-Implmentations
-----------------
+Implementations
+---------------
 
-Etcd Rendezvous
-****************
+Dynamic Rendezvous
+******************
+
+.. currentmodule:: torch.distributed.elastic.rendezvous.dynamic_rendezvous
+
+.. autofunction:: create_handler
+
+.. autoclass:: DynamicRendezvousHandler()
+   :members: from_backend
+
+.. autoclass:: RendezvousBackend
+   :members:
+
+.. autoclass:: RendezvousTimeout
+   :members:
+
+C10d Backend
+^^^^^^^^^^^^
+
+.. currentmodule:: torch.distributed.elastic.rendezvous.c10d_rendezvous_backend
+
+.. autofunction:: create_backend
+
+.. autoclass:: C10dRendezvousBackend
+   :members:
+
+Etcd Backend
+^^^^^^^^^^^^
+
+.. currentmodule:: torch.distributed.elastic.rendezvous.etcd_rendezvous_backend
+
+.. autofunction:: create_backend
+
+.. autoclass:: EtcdRendezvousBackend
+   :members:
+
+Etcd Rendezvous (Legacy)
+************************
+
+.. warning::
+    The ``DynamicRendezvousHandler`` class supersedes the ``EtcdRendezvousHandler``
+    class, and is recommended for most users. ``EtcdRendezvousHandler`` is in
+    maintenance mode and will be deprecated in the future.
 
 .. currentmodule:: torch.distributed.elastic.rendezvous.etcd_rendezvous
 
 .. autoclass:: EtcdRendezvousHandler
 
-.. autoclass:: EtcdRendezvous
-   :members:
+Etcd Store
+**********
+
+The ``EtcdStore`` is the C10d ``Store`` instance type returned by
+``next_rendezvous()`` when etcd is used as the rendezvous backend.
+
+.. currentmodule:: torch.distributed.elastic.rendezvous.etcd_store
 
 .. autoclass:: EtcdStore
    :members:
 
 Etcd Server
-*************
+***********
 
 The ``EtcdServer`` is a convenience class that makes it easy for you to
 start and stop an etcd server on a subprocess. This is useful for testing

--- a/docs/source/elastic/train_script.rst
+++ b/docs/source/elastic/train_script.rst
@@ -8,7 +8,7 @@ working with ``torch.distributed.run`` with these differences:
    ``MASTER_ADDR``, and ``MASTER_PORT``.
 
 2. ``rdzv_backend`` and ``rdzv_endpoint`` must be provided. For most users
-   this will be set to ``etcd`` (see `rendezvous <rendezvous.html>`_).
+   this will be set to ``c10d`` (see `rendezvous <rendezvous.html>`_).
 
 3. Make sure you have a ``load_checkpoint(path)`` and
    ``save_checkpoint(path)`` logic in your script. When workers fail

--- a/torch/distributed/elastic/rendezvous/__init__.py
+++ b/torch/distributed/elastic/rendezvous/__init__.py
@@ -1,104 +1,131 @@
-# -*- coding: utf-8 -*-
-
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-""" Rendezvous
-
-In the context of torchelastic we use the term ``rendezvous`` to refer to
-a particular functionality that combines a **distributed
+"""
+In the context of Torch Distributed Elastic we use the term *rendezvous* to
+refer to a particular functionality that combines a **distributed
 synchronization** primitive with **peer discovery**.
 
-It is used by torchelastic to gather participants of a training job
-(i.e. workers) such that they all agree on the same list of participants
-and everyone’s roles, as well as make a consistent collective decision
-on when training can begin/resume.
+It is used by Torch Distributed Elastic to gather participants of a training
+job (i.e. nodes) such that they all agree on the same list of participants and
+everyone's roles, as well as make a consistent collective decision on when
+training can begin/resume.
 
-Torchelastic Rendezvous provides the following critical functionalities:
+Torch Distributed Elastic rendezvous provides the following critical
+functionalities:
 
 **Barrier**:
 
-Workers performing rendezvous will all block until the rendezvous is
-considered complete - this happens when at least ``min`` total number of
-workers have joined the rendezvous barrier (for the same job). This also
-implies the barrier is not necessarily of fixed size.
+Nodes performing rendezvous will all block until the rendezvous is considered
+complete - this happens when at least ``min`` total number of nodes have joined
+the rendezvous barrier (for the same job). This also implies the barrier is not
+necessarily of fixed size.
 
-There’s an additional small waiting time after reaching ``min`` number
-of workers - this is used to ensure the rendezvous is not completed “too
-quickly” (which could potentially exclude additional workers attempting
-to join at approximately the same time).
+There's an additional small waiting time after reaching ``min`` number of
+nodes - this is used to ensure the rendezvous is not completed "too quickly"
+(which could potentially exclude additional nodes attempting to join at
+approximately the same time).
 
-If ``max`` number of workers is gathered at the barrier, the rendezvous
-is completed immediately.
+If ``max`` number of nodes is gathered at the barrier, the rendezvous is
+completed immediately.
 
-There’s also an overall timeout which causes the rendezvous to fail if
-``min`` number of workers is never reached – this is meant to be a
-simple fail-safe to help release partially allocated job resources, in
-case there’s a problem with the resource manger, and is meant to be
-interpreted as non-retryable.
+There's also an overall timeout which causes the rendezvous to fail if ``min``
+number of nodes is never reached - this is meant to be a simple fail-safe to
+help release partially allocated job resources, in case there's a problem with
+the resource manager, and is meant to be interpreted as non-retryable.
 
 **Exclusivity**:
 
-A simple distributed barrier would not be sufficient, as we also need to
-ensure that only one group of workers exists at any given time (for a
-given job). In other words, new workers (i.e. joining late) should not
-be able to form a parallel independent group of workers for the same
-job.
+A simple distributed barrier would not be sufficient, as we also need to ensure
+that only one group of nodes exists at any given time (for a given job). In
+other words, new nodes (i.e. joining late) should not be able to form a parallel
+independent group of workers for the same job.
 
-Torchelastic rendezvous ensures that if a group of workers has already
-completed a rendezvous (and hence might already be training), then
-additional “late” workers attempting to rendezvous will only announce
-themselves as waiting, and will have to wait until the (previously
-completed) existing rendezvous is destroyed first.
+Torch Distributed Elastic rendezvous ensures that if a group of nodes has
+already completed a rendezvous (and hence might already be training), then
+additional "late" nodes attempting to rendezvous will only announce themselves
+as waiting, and will have to wait until the (previously completed) existing
+rendezvous is destroyed first.
 
 **Consistency**:
 
+When a rendezvous is completed, all its members will agree on the job membership
+and everyone's role in it. This role is represented using an integer, called
+rank, that is between between 0 and world size.
 
-When a rendezvous is completed, all its members will agree on the job
-membership and everyone’s role in it. This role is represented using an
-integer, called rank, that is between between 0 and world size.
-
-Note that ranks are *not stable*, in the sense that the same worker
-process can be assigned a different rank in the next (re-)rendezvous.
+Note that ranks are *not stable*, in the sense that the same node can be
+assigned a different rank in the next (re-)rendezvous.
 
 **Fault-tolerance**:
 
-Torchelastic rendezvous is designed to tolerate worker failures during
-the rendezvous process. Should a process crash (or lose network
-connectivity, etc), between joining the rendezvous and it being
-completed, then a re-rendezvous with remaining healthy workers will
-happen automatically.
+Torch Distributed Elastic rendezvous is designed to tolerate node failures
+during the rendezvous process. Should a process crash (or lose network
+connectivity, etc), between joining the rendezvous and it being completed, then
+a re-rendezvous with remaining healthy nodes will happen automatically.
 
-A worker can also fail *after* it has completed (or *has been
-observered* by other workers to have completed) the rendezvous - this
-scenario will be handled by the torchelastic ``train_loop`` instead
-(where it will also trigger a re-rendezvous).
+A node can also fail *after* it has completed (or *has been observered* by other
+nodes to have completed) the rendezvous - this scenario will be handled by the
+Torch Distributed Elastic ``train_loop`` instead (where it will also trigger a
+re-rendezvous).
 
 **Shared key-value store**:
 
-When the rendezvous is completed, a shared key-value store is created
-and returned. This store implements a ``torch.distributed.Store`` API
-(see `distributed communication
-docs <https://pytorch.org/docs/stable/distributed.html>`__).
+When the rendezvous is completed, a shared key-value store is created and
+returned. This store implements a ``torch.distributed.Store`` API (see
+`distributed communication docs
+<https://pytorch.org/docs/stable/distributed.html>`__).
 
 This store is only shared by the members of the completed rendezvous. It
-is intended to be used by torchelastic to exchange information necessary
-to initialize job control and data-planes.
+is intended to be used by Torch Distributed Elastic to exchange information
+necessary to initialize job control and data-planes.
 
 **Waiting workers and rendezvous closing**:
 
-Torchelastic rendezvous handler object provides additional
-functionalities, which are technically not part of the rendezvous
-process:
+Torch Distributed Elastic rendezvous handler object provides additional
+functionalities, which are technically not part of the rendezvous process:
 
-1. Querying how many workers arrived late at the barrier, who
-   can participate in *next* rendezvous.
+1. Querying how many workers arrived late at the barrier, who can participate in
+   *next* rendezvous.
 
-2. Setting the rendezvous *closed* to signal all workers not
-   to participate in next rendezvous
+2. Setting the rendezvous *closed* to signal all nodes not to participate in
+   next rendezvous.
+
+**DynamicRendezvousHandler**:
+
+Torch Distributed Elastic comes with the :py:class:`.DynamicRendezvousHandler`
+class that implements the rendezvous mechanism described above. It is a backend-
+agnostic type that expects a particular :py:class:`.RendezvousBackend` instance
+to be specified during construction.
+
+Torch distributed users can either implement their own backend type or use one
+of the following implementations that come with PyTorch:
+
+- :py:class:`.C10dRendezvousBackend`: Uses a C10d store (by default
+  ``TCPStore``) as the rendezvous backend. The main advantage of using a C10d
+  store is that it requires no 3rd-party dependency (such as etcd) to establish
+  a rendezvous.
+- :py:class:`.EtcdRendezvousBackend`: Supersedes the legacy
+  :py:class:`.EtcdRendezvousHandler` class. Passing an
+  :py:class:`.EtcdRendezvousBackend` instance to
+  :py:class:`.DynamicRendezvousHandler` is functionally equivalent to
+  instantiating an :py:class:`.EtcdRendezvousHandler`.
+
+  ::
+
+     store = TCPStore("localhost")
+
+     backend = C10dRendezvousBackend(store, "my_run_id")
+
+     rdzv_handler = DynamicRendezvousHandler.from_backend(
+         run_id="my_run_id",
+         store=store,
+         backend=backend,
+         min_nodes=2,
+         max_nodes=4
+     )
 """
 
 from .api import *  # noqa: F403

--- a/torch/distributed/elastic/rendezvous/api.py
+++ b/torch/distributed/elastic/rendezvous/api.py
@@ -34,7 +34,7 @@ class RendezvousHandler(ABC):
     """Main rendezvous interface.
 
     Note:
-        TorchElastic users normally **do not** need to implement their own
+        Distributed Torch users normally **do not** need to implement their own
         ``RendezvousHandler``. An implementation based on C10d Store is already
         provided, and is recommended for most users.
     """

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -1055,6 +1055,12 @@ def create_handler(
     """Creates a new :py:class:`DynamicRendezvousHandler` from the specified
     parameters.
 
+    Args:
+        store:
+            The C10d store to return as part of the rendezvous.
+        backend:
+            The backend to use to hold the rendezvous state.
+
     +-------------------+------------------------------------------------------+
     | Parameter         | Description                                          |
     +===================+======================================================+

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -76,13 +76,13 @@ CONST_RUNID_SUBROOT_TTL = 7200  # 2 hours
 
 class EtcdRendezvousHandler(RendezvousHandler):
     """
-    Implements a :py:class:`torchelastic.rendezvous.RendezvousHandler`
-    interface backed by
-    :py:class:`torchelastic.rendezvous.etcd_rendezvous.EtcdRendezvous`.
-
-    Torchelastic uses a URL to configure the type of rendezvous to use and
-    to pass implementation specific configurations to the rendezvous module.
-    The basic etcd rendezvous configuration URL looks like the following
+    Implements a
+    :py:class:`torch.distributed.elastic.rendezvous.RendezvousHandler` interface
+    backed by
+    :py:class:`torch.distributed.elastic.rendezvous.etcd_rendezvous.EtcdRendezvous`.
+    ``EtcdRendezvousHandler`` uses a URL to configure the type of rendezvous to
+    use and to pass implementation specific configurations to the rendezvous
+    module. The basic etcd rendezvous configuration URL looks like the following
     ::
 
      etcd://<etcd_address>:<port>/<job_id>?min_workers=<min_workers>&max_workers=<max_workers>  # noqa: W605
@@ -102,9 +102,9 @@ class EtcdRendezvousHandler(RendezvousHandler):
        any string (e.g. does not need to be a number) as long as it is
        unique.
     4. ``min_workers=1`` and ``max_workers=3`` specifies a range for
-       membership size - torchelastic starts running the job as long as the
-       cluster size is greater than or equal to ``min_workers`` and admits
-       up to ``max_workers`` into the cluster.
+       membership size - Torch Distributed Elastic starts running the job as
+       long as the cluster size is greater than or equal to ``min_workers``
+       and admits up to ``max_workers`` into the cluster.
 
     Below are a full list of the parameters that can be passed to etcd
     rendezvous:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58160 [torch/elastic] Update the rendezvous docs**
* #58159 [torch/elastic] Revise distributed run script

This PR updates the Torch Distributed Elastic documentation with references to the new `c10d` backend.

Differential Revision: [D28384996](https://our.internmc.facebook.com/intern/diff/D28384996/)