### PR TITLE
[Gradient Compression] Remove unnecessary warning on the rst file and the check on C++ version

### DIFF
--- a/docs/source/ddp_comm_hooks.rst
+++ b/docs/source/ddp_comm_hooks.rst
@@ -9,13 +9,6 @@ and users can easily apply any of these hooks to optimize communication.
 Besides, the hook interface can also support user-defined communication
 strategies for more advanced use cases.
 
-.. warning ::
-    DDP communication hook is experimental and subject to change.
-
-.. warning ::
-    DDP communication hooks can only support single process single device mode
-    on NCCL backend.
-
 How to Use a Communication Hook?
 --------------------------------
 

--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -1580,11 +1580,6 @@ void Reducer::register_builtin_comm_hook(
   TORCH_CHECK(
       comm_hook_ == nullptr,
       "register_builtin_comm_hook or register_comm_hook can only be called once.");
-  // TODO: Support GLOO and MPI backends for DDP communication hook.
-  TORCH_CHECK(
-      process_group_->getBackendName() == "nccl",
-      "register_builtin_comm_hook currently can only support NCCL backend, but the current backend is %s.",
-      process_group_->getBackendName());
 
   switch (comm_hook_type) {
     case c10d::BuiltinCommHookType::ALLREDUCE:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58170 [Gradient Compression] Remove unnecessary warning on the rst file and the check on C++ version**

Now comm hook can be supported on MPI and GLOO backends besides NCCL. No longer need these warnings and check.

Differential Revision: [D28388861](https://our.internmc.facebook.com/intern/diff/D28388861/)