### PR TITLE
T90561249: Enforce kernel launch checks

### DIFF
--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -603,7 +603,7 @@ static void _launch_kernel(int total_n_elems, func_t f) {
   auto stream = at::cuda::getCurrentCUDAStream();
   _elementwise_kernel<n_threads, n_elems_per_thread, func_t>
     <<<grid, block, 0, stream>>>(total_n_elems, f);
-  AT_CUDA_CHECK(cudaGetLastError());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 void _unpack_pivots_internal_kernel(

--- a/test/test_kernel_launch_checks.py
+++ b/test/test_kernel_launch_checks.py
@@ -39,10 +39,8 @@ some_function_call<TemplateArg><<<1,2,0,stream>>> ( arg1 , arg2 , arg3 ) ;
         """))
 
     def test_check_cuda_launches(self):
-        check_cuda_kernel_launches()
-        # TODO: Enable this after warning messages have been dealt with.
-        self.assertTrue(True)
-        # self.assertTrue(check_cuda_kernel_launches() == 0)
+        unsafeLaunchesCount = check_cuda_kernel_launches()
+        self.assertTrue(unsafeLaunchesCount == 0)
 
 
 if __name__ == '__main__':

--- a/torch/testing/_check_kernel_launches.py
+++ b/torch/testing/_check_kernel_launches.py
@@ -74,8 +74,11 @@ def check_file(filename):
     """
     if not (filename.endswith(".cu") or filename.endswith(".cuh")):
         return 0
-    contents = open(filename, "r").read()
-    return check_code_for_cuda_kernel_launches(contents, filename)
+    fo = open(filename, "r")
+    contents = fo.read()
+    unsafeCount = check_code_for_cuda_kernel_launches(contents, filename)
+    fo.close()
+    return unsafeCount
 
 
 def check_cuda_kernel_launches():


### PR DESCRIPTION
Summary: https://www.internalfb.com/T90561249: change the test to enforce

Test Plan:
buck test //caffe2/test:kernel_launch_checks

before fixing LinearAlgebra.cu and file close: https://www.internalfb.com/intern/testinfra/testconsole/testrun/1970324893386017/

after: https://www.internalfb.com/intern/testinfra/testconsole/testrun/2814749824394650/

Differential Revision: D28390166

