### PR TITLE
Wrap torch::deploy API functions in safe rethrow macros

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -9,6 +9,47 @@
 #include <thread>
 #include <vector>
 
+/* Torch Deploy intentionally embeds multiple copies of c++ libraries in the
+   same process space in order to provide a multi-python environment.  As a
+   result, any exception types defined by these duplicated libraries can't be
+   safely caught or handled outside of the originating dynamic library (.so).
+
+   In practice this means that you must either
+   catch these exceptions inside the torch::deploy API boundary or risk crashing
+   the client application.
+
+   It is safe to throw exception types that are defined once in
+   the context of the client application, such as c10::Error, which is defined
+   in libtorch, which isn't duplicated in torch::deploy interpreters.
+
+   ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
+
+   For more information, see
+    https://gcc.gnu.org/wiki/Visibility (section on c++ exceptions)
+    or https://stackoverflow.com/a/14364055
+    or
+   https://stackoverflow.com/questions/14268736/symbol-visibility-exceptions-runtime-error
+    note- this may be only a serious problem on versions of gcc prior to 4.0,
+   but still seems worth sealing off.
+
+*/
+#define TORCH_DEPLOY_TRY try {
+#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                        \
+  }                                                                            \
+  catch (std::exception & err) {                                               \
+    throw c10::Error(                                                          \
+        std::string(                                                           \
+            "Exception Caught inside torch::deploy embedded library: \n") +    \
+            err.what(),                                                        \
+        "");                                                                   \
+  }                                                                            \
+  catch (...) {                                                                \
+    throw c10::Error(                                                          \
+        std::string(                                                           \
+            "Unknown Exception Caught inside torch::deploy embedded library"), \
+        "");                                                                   \
+  }
+
 namespace torch {
 namespace deploy {
 
@@ -26,10 +67,14 @@ struct TORCH_API InterpreterSession {
   InterpreterSession(InterpreterSession&&) noexcept = default;
   ~InterpreterSession();
   Obj global(const char* module, const char* name) {
+    TORCH_DEPLOY_TRY
     return impl_->global(module, name);
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   Obj from_ivalue(at::IValue ivalue) {
+    TORCH_DEPLOY_TRY
     return impl_->from_ivalue(std::move(ivalue));
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   ReplicatedObj create_movable(Obj obj);
   Obj from_movable(const ReplicatedObj& obj);
@@ -55,7 +100,9 @@ class TORCH_API Interpreter {
  public:
   Interpreter(InterpreterManager* manager);
   InterpreterSession acquire_session() const {
+    TORCH_DEPLOY_TRY
     return InterpreterSession(pImpl_->acquire_session(), manager_);
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   ~Interpreter();
   Interpreter(Interpreter&& rhs) noexcept
@@ -63,7 +110,9 @@ class TORCH_API Interpreter {
         handle_(rhs.handle_),
         pImpl_(std::move(rhs.pImpl_)),
         manager_(rhs.manager_) {
+    TORCH_DEPLOY_TRY
     rhs.handle_ = nullptr;
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   Interpreter(const Interpreter&) = delete;
@@ -75,13 +124,17 @@ class TORCH_API Interpreter {
 struct Package;
 
 struct TORCH_API LoadBalancer {
-  LoadBalancer(size_t n) : uses_(new uint64_t[8 * n]), allocated_(n), n_(n) {
+  explicit LoadBalancer(size_t n) : uses_(new uint64_t[8 * n]), allocated_(n), n_(n) {
+    TORCH_DEPLOY_TRY
     // 8*... to avoid false sharing of atomics on the same cache line
     memset(uses_.get(), 0, 8 * n_ * sizeof(uint64_t));
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   void setResourceLimit(size_t n) {
+    TORCH_DEPLOY_TRY
     TORCH_INTERNAL_ASSERT(n <= allocated_);
     n_ = n;
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   int acquire();
   void free(int where);
@@ -96,6 +149,7 @@ struct TORCH_API LoadBalancer {
 
 struct TORCH_API InterpreterManager {
   InterpreterManager(size_t n_interp = 2) : resources_(n_interp) {
+    TORCH_DEPLOY_TRY
     for (size_t i = 0; i < n_interp; ++i) {
       instances_.emplace_back(this);
       auto I = instances_.back().acquire_session();
@@ -104,24 +158,31 @@ struct TORCH_API InterpreterManager {
       I.global("torch", "version").attr("__setattr__")({"interp", int(i)});
       // std::cerr << "Interpreter " << i << " initialized\n";
     }
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   // get a free model, guarenteed that no other user of acquire_one has the same
   // model. It _is_ possible that other users will be using the interpreter.
   InterpreterSession acquire_one() {
+    TORCH_DEPLOY_TRY
     int where = resources_.acquire();
     InterpreterSession I = instances_[where].acquire_session();
     I.notify_idx_ = where;
     return I;
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   // use to make sure something gets run on all interpreters, such as loading or
   // unloading a model eagerly
   at::ArrayRef<Interpreter> all_instances() {
+    TORCH_DEPLOY_TRY
     return instances_;
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   void debugLimitInterpreters(size_t N) {
+    TORCH_DEPLOY_TRY
     AT_ASSERT(N <= instances_.size());
     resources_.setResourceLimit(N);
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
   Package load_package(const std::string& uri);
   Package load_package(
@@ -157,21 +218,27 @@ struct TORCH_API ReplicatedObj {
   InterpreterSession acquire_session(
       const Interpreter* on_this_interpreter = nullptr) const;
   at::IValue operator()(at::ArrayRef<at::IValue> args) const {
+    TORCH_DEPLOY_TRY
     auto I = acquire_session();
     return I.self(args).toIValue();
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
-  at::IValue call_kwargs(
+  [[nodiscard]] at::IValue call_kwargs(
       std::vector<at::IValue> args,
       std::unordered_map<std::string, c10::IValue> kwargs) const {
+    TORCH_DEPLOY_TRY
     auto I = acquire_session();
     return I.self.call_kwargs(std::move(args), std::move(kwargs)).toIValue();
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   [[nodiscard]] at::IValue call_kwargs(
       std::unordered_map<std::string, c10::IValue> kwargs) const {
+    TORCH_DEPLOY_TRY
     auto I = acquire_session();
     return I.self.call_kwargs(std::move(kwargs)).toIValue();
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   void unload(const Interpreter* on_this_interpreter = nullptr);
@@ -190,22 +257,28 @@ struct TORCH_API Package {
   ReplicatedObj load_pickle(
       const std::string& module,
       const std::string& file) {
+    TORCH_DEPLOY_TRY
     auto I = acquire_session();
     auto loaded = I.self.attr("load_pickle")({module, file});
     return I.create_movable(loaded);
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   std::string load_text(const std::string& module, const std::string& file) {
+    TORCH_DEPLOY_TRY
     auto I = acquire_session();
     auto loaded = I.self.attr("load_text")({module, file});
     return loaded.toIValue().toStringRef();
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
   InterpreterSession acquire_session() {
+    TORCH_DEPLOY_TRY
     auto I = manager_->acquire_one();
     I.self = I.impl_->create_or_get_package_importer_from_container_file(
         container_file_);
     return I;
+    TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
  private:

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -134,3 +134,15 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
     ASSERT_TRUE(ref_output.equal(outputs[i]));
   }
 }
+
+TEST(TorchpyTest, ThrowsSafely) {
+  // See explanation in deploy.h
+  torch::deploy::InterpreterManager manager(3);
+  EXPECT_THROW(manager.load_package("some garbage path"), c10::Error);
+
+  torch::deploy::Package p = manager.load_package(path("SIMPLE", simple));
+  EXPECT_THROW(p.load_pickle("some other", "garbage path"), c10::Error);
+
+  auto model = p.load_pickle("model", "model.pkl");
+  EXPECT_THROW(model(at::IValue("unexpected input")), c10::Error);
+}


### PR DESCRIPTION
Summary:
Exceptions thrown by deploy internals need to be sanitized
for application safety.

See commment in deploy.h for detailed explanation.

Test Plan: Added unit test

Reviewed By: suo

Differential Revision: D28371127

