### PR TITLE
fix lint?

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -19,7 +19,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Union,
 )
 from urllib.parse import quote


### PR DESCRIPTION
Getting CI errors about `Tuple` not being used in `package_exporter.py`