### PR TITLE
[PyTorch Mobile]Add light version of RandomSampler

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -578,6 +578,7 @@ if(NOT INTERN_BUILD_MOBILE OR NOT BUILD_CAFFE2_MOBILE)
        ${TORCH_SRC_DIR}/csrc/jit/mobile/nnc/context.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/nnc/registry.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/optim/sgd.cpp
+       ${TORCH_SRC_DIR}/csrc/jit/mobile/random.cpp
        ${TORCH_SRC_DIR}/csrc/jit/mobile/sequential.cpp
        )
     list(APPEND TORCH_SRCS ${MOBILE_SRCS})

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -401,6 +401,7 @@ libtorch_extra_sources = libtorch_core_jit_sources + [
     "torch/csrc/jit/mobile/module.cpp",
     "torch/csrc/jit/mobile/observer.cpp",
     "torch/csrc/jit/mobile/optim/sgd.cpp",
+    "torch/csrc/jit/mobile/random.cpp",
     "torch/csrc/jit/mobile/sequential.cpp",
     "torch/csrc/jit/mobile/nnc/context.cpp",
     "torch/csrc/jit/mobile/nnc/registry.cpp",

--- a/torch/csrc/jit/mobile/random.cpp
+++ b/torch/csrc/jit/mobile/random.cpp
@@ -1,0 +1,59 @@
+#include <torch/csrc/jit/mobile/random.h>
+#include <torch/types.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+RandomSampler::RandomSampler(int64_t size, Dtype index_dtype)
+    : indices_(torch::randperm(size, index_dtype)) {}
+
+RandomSampler::~RandomSampler() = default;
+
+void RandomSampler::reset(optional<size_t> new_size) {
+  // This allocates a new chunk of memory every time (just FYI). It should be
+  // amortized over the entire epoch hopefully.
+  const auto size = new_size.value_or(static_cast<size_t>(indices_.numel()));
+  indices_ = torch::randperm(size, indices_.options());
+  index_ = 0;
+}
+
+optional<std::vector<size_t>> RandomSampler::next(size_t batch_size) {
+  AT_ASSERT(index_ <= indices_.numel());
+  const size_t remaining_indices = indices_.numel() - index_;
+  if (remaining_indices == 0) {
+    return nullopt;
+  }
+  std::vector<size_t> index_batch(std::min(batch_size, remaining_indices));
+  auto slice = indices_.slice(/*dim=*/0, index_, index_ + index_batch.size());
+  // You may want to store your indices with 32-bit or less, but here we need
+  // to upcast to 64-bit. A batch itself won't hold too many indices, so that
+  // should be ok. Note that if this indeed results in a type promotion, there
+  // will be two allocations: one for the upcast slice, and one for the
+  // returned `index_batch` vector.
+  slice = slice.to(torch::kInt64);
+  const auto* data = slice.data_ptr<int64_t>();
+  std::copy(data, data + index_batch.size(), index_batch.begin());
+  index_ += index_batch.size();
+  return index_batch;
+}
+
+void RandomSampler::save(serialize::OutputArchive& archive) const {
+  TORCH_CHECK(false, "Serialization of RandomSampler not supported on mobile.");
+}
+
+void RandomSampler::load(serialize::InputArchive& archive) {
+  TORCH_CHECK(false, "Serialization of RandomSampler not supported on mobile.");
+}
+
+size_t RandomSampler::index() const noexcept {
+  return index_;
+}
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/mobile/random.h
+++ b/torch/csrc/jit/mobile/random.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <torch/csrc/WindowsTorchApiMacro.h>
+#include <torch/data/samplers/base.h>
+#include <torch/types.h>
+
+#include <cstddef>
+#include <vector>
+
+namespace torch {
+namespace serialize {
+class OutputArchive;
+class InputArchive;
+} // namespace serialize
+} // namespace torch
+
+namespace torch {
+namespace jit {
+namespace mobile {
+
+/// A lighter `Sampler` that returns indices randomly and cannot be
+/// serialized.
+class TORCH_API RandomSampler : public torch::data::samplers::Sampler<> {
+ public:
+  /// Constructs a `RandomSampler` with a size and dtype for the stored indices.
+  ///
+  /// The constructor will eagerly allocate all required indices, which is the
+  /// sequence `0 ... size - 1`. `index_dtype` is the data type of the stored
+  /// indices. You can change it to influence memory usage.
+  explicit RandomSampler(int64_t size, Dtype index_dtype = torch::kInt64);
+
+  ~RandomSampler() override;
+
+  /// Resets the `RandomSampler` to a new set of indices.
+  void reset(optional<size_t> new_size = nullopt) override;
+
+  /// Returns the next batch of indices.
+  optional<std::vector<size_t>> next(size_t batch_size) override;
+
+  /// Serializes the `RandomSampler` to the `archive`.
+  void save(serialize::OutputArchive& archive) const override;
+
+  /// Deserializes the `RandomSampler` from the `archive`.
+  void load(serialize::InputArchive& archive) override;
+
+  /// Returns the current index of the `RandomSampler`.
+  size_t index() const noexcept;
+
+ private:
+  at::Tensor indices_;
+  int64_t index_ = 0;
+};
+
+} // namespace mobile
+} // namespace jit
+} // namespace torch


### PR DESCRIPTION
Summary: Add light version of RandomSampler which can be used torch mobile.

Test Plan: run unit test

Differential Revision: D28364467

