### PR TITLE
[fx_acc] e2e quantized resnet18

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -129,12 +129,13 @@ class TestFXExperimental(JitTestCase):
         q_tensor_channel = torch.quantize_per_channel(
             x, torch.tensor([0.1, 0.01]), torch.tensor([10, 0]), 0, torch.quint8
         )
-        result = graph_manipulation.serialize_tensor_quantization(q_tensor)
-        result2 = graph_manipulation.serialize_tensor_quantization(q_tensor_channel)
+        result, _ = graph_manipulation.serialize_tensor_quantization(q_tensor, weights={}, pcq_prefix="foo")
+        result2, per_channel_dict = graph_manipulation.serialize_tensor_quantization(q_tensor_channel, weights={}, pcq_prefix="bar")
         assert result["qscheme"] == "torch.per_tensor_affine"
         assert result["q_scale"] == 1.0
         assert result2["qscheme"] == "torch.per_channel_affine"
-        assert len(result2["q_per_channel_scales"]) == 2
+        assert result2["q_per_channel_scales"] == "bar_per_channel_scales"
+        assert per_channel_dict["bar_per_channel_zero_points"]["shape"] == "[2]"
 
     def test_find_single_partition(self):
         class TestModule(torch.nn.Module):

--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -57,22 +57,7 @@ def get_size_of_all_nodes(
     return
 
 
-def get_shape_dtype_and_stride(
-    node: Node,
-) -> Tuple[torch.Size, torch.dtype, Tuple[int]]:
-    shape: torch.Size
-    dtype: torch.dtype
-    shape, dtype = get_shape_and_dtype(node)
-    tensor_meta = node.meta.get("tensor_meta")
-    if not tensor_meta:
-        raise RuntimeError(
-            f"Node {node} has no tensor metadata associated with it! "
-            f"Check that shape propagation has run."
-        )
-    return shape, dtype, tensor_meta.stride
-
-
-def get_shape_and_dtype(node: Node) -> Any:
+def get_tensor_meta(node: Node) -> Any:
     tensor_meta = node.meta.get("tensor_meta")
 
     if not tensor_meta:
@@ -81,7 +66,7 @@ def get_shape_and_dtype(node: Node) -> Any:
             f"Check that shape propagation has run."
         )
 
-    return tensor_meta.shape, tensor_meta.dtype
+    return tensor_meta
 
 
 def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
@@ -100,10 +85,10 @@ def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
             total_num_of_elems += p.numel()
     # Don't forget the output size
     # node.shape is the shape of this node's output
-    shape, dtype = get_shape_and_dtype(node)
-    output_elem = shape.numel()
+    tensor_meta = get_tensor_meta(node)
+    output_elem = tensor_meta.shape.numel()
     total_num_of_elems += output_elem
-    size_per_elem_bytes = torch.tensor([], dtype=dtype).element_size()
+    size_per_elem_bytes = torch.tensor([], dtype=tensor_meta.dtype).element_size()
     total_size = size_per_elem_bytes * total_num_of_elems
     output_size = size_per_elem_bytes * output_elem
     return size_bytes(output_size, total_size)
@@ -117,37 +102,106 @@ def serialize_stride(stride: Tuple[int]) -> str:
     return str(list(stride))
 
 
-def serialize_tensor_quantization(tensor: torch.Tensor) -> Dict[str, Any]:
+def serialize_tensor_quantization(tensor: torch.Tensor, weights: Dict, pcq_prefix: str) -> Tuple[Dict, Dict]:
+    """
+    Args:
+        tensor: The tensor from which we try to extract quantization information.
+        weights: A dict that contains mapping from name to a tensor value.
+        pcq_prefix: A string that we would use later on as prefix for per channel quantization information. This
+            usually would be the key that we use to store info of `tensor`.
+
+    Returns:
+        scheme: Dict that stores the quantization information of `tensor`.
+        per_channel_dict: Dict that stores the information of per_channel_scales and
+            per_channel_zero_points of `tensor`. This Will be empty if `tensor` is not
+            per channel quantized.
+
+    `tensor` is per tensor quantized:
+        scheme: {
+            "qscheme": str(tensor.qscheme()),
+            "q_scale": tensor.q_scale(),
+            "q_zero_point": tensor.q_zero_point(),
+        }
+
+    `tensor` is per channel quantized:
+        scheme: {
+            "qscheme": str(tensor.qscheme()),
+            "q_per_channel_scales": {pcq_prefix}_per_channel_scales,
+            "q_per_channel_zero_points": {pcq_prefix}_per_channel_zero_points,
+            "q_per_channel_axis": tensor.q_per_channel_axis()
+        }
+        per_channel_dict: {
+            {pcq_prefix}_per_channel_scales: {
+                "dtype": dtype,
+                "shape": shape,
+                "is_quantized": is_quantized,
+                "stride": stride,
+            }
+            {pcq_prefix}_per_channel_zero_points: {
+                "dtype": dtype,
+                "shape": shape,
+                "is_quantized": is_quantized,
+                "stride": stride,
+            }
+        }
+        weights would be updated with {
+            {pcq_prefix}_per_channel_scales: tensor.q_per_channel_scales().float()
+            {pcq_prefix}_per_channel_zero_points: tensor.q_per_channel_zero_points().int()
+        }
+    """
     scheme: Dict[str, Any] = {}
+    per_channel_dict: Dict[str, Dict] = {}
+
+    if not tensor.is_quantized:
+        return scheme, per_channel_dict
+
+    scheme["qscheme"] = str(tensor.qscheme())
+
+    # For per tensor scheme, we stores scale and zero_point.
+    if tensor.qscheme() in {torch.per_tensor_affine, torch.per_tensor_symmetric}:
+        scheme["q_scale"] = tensor.q_scale()
+        scheme["q_zero_point"] = tensor.q_zero_point()
+
+    # For per channel scheme, per_channel_scales and per_channel_zero_points are tensors.
+    # We store their tensor value into `weights` and store the name into `scheme`.
+    if tensor.qscheme() in {
+        torch.per_channel_affine,
+        torch.per_channel_affine_float_qparams,
+        torch.per_channel_symmetric,
+    }:
+        # per_channel_scales is float64. Here we save it as float32.
+        weights[f"{pcq_prefix}_per_channel_scales"] = tensor.q_per_channel_scales().float()
+        scheme["q_per_channel_scales"] = f"{pcq_prefix}_per_channel_scales"
+        per_channel_dict.update(
+            serialize_weight(weights[f"{pcq_prefix}_per_channel_scales"], weights, f"{pcq_prefix}_per_channel_scales")
+        )
+
+        # per_channel_zero_point is int64. Here we save it as int32.
+        weights[f"{pcq_prefix}_per_channel_zero_points"] = tensor.q_per_channel_zero_points().int()
+        scheme[
+            "q_per_channel_zero_points"
+        ] = f"{pcq_prefix}_per_channel_zero_points"
+        per_channel_dict.update(
+            serialize_weight(weights[f"{pcq_prefix}_per_channel_zero_points"], weights, f"{pcq_prefix}_per_channel_zero_points")
+        )
+
+        scheme["q_per_channel_axis"] = tensor.q_per_channel_axis()
+    return scheme, per_channel_dict
+
+
+def serialize_weight(tensor: torch.Tensor, weights: Dict, name: str) -> Dict:
+    weight_dict: Dict[str, Dict] = {name: {}}
+    weight_dict[name]["dtype"] = str(tensor.dtype)
+    weight_dict[name]["shape"] = serialize_shape(tensor.shape)
+    weight_dict[name]["is_quantized"] = tensor.is_quantized
+    weight_dict[name]["stride"] = serialize_stride(tensor.stride())
+
     if tensor.is_quantized:
-        scheme["qscheme"] = str(tensor.qscheme())
+        quantization_info, per_channel_dict = serialize_tensor_quantization(tensor, weights, name)
+        weight_dict[name].update(quantization_info)
+        weight_dict.update(per_channel_dict)
 
-        if tensor.qscheme() in {torch.per_tensor_affine, torch.per_tensor_symmetric}:
-            scheme["q_scale"] = tensor.q_scale()
-            scheme["q_zero_point"] = tensor.q_zero_point()
-        if tensor.qscheme() in {
-            torch.per_channel_affine,
-            torch.per_channel_affine_float_qparams,
-            torch.per_channel_symmetric,
-        }:
-            scheme["q_per_channel_scales"] = tensor.q_per_channel_scales().tolist()
-            scheme[
-                "q_per_channel_zero_points"
-            ] = tensor.q_per_channel_zero_points().tolist()
-            scheme["q_per_channel_axis"] = tensor.q_per_channel_axis()
-
-    return scheme
-
-
-def serialize_weight(tensor: torch.Tensor) -> Dict:
-    weight: Dict[str, Any] = {}
-    weight["dtype"] = str(tensor.dtype)
-    weight["is_quantized"] = tensor.is_quantized
-    if tensor.is_quantized:
-        weight.update(serialize_tensor_quantization(tensor))
-    weight["shape"] = serialize_shape(tensor.shape)
-    weight["stride"] = serialize_stride(tensor.stride())
-    return weight
+    return weight_dict
 
 
 def serialize_leaf_module(
@@ -157,7 +211,7 @@ def serialize_leaf_module(
 
     for p_name, p_value in node.attrs_for_lowering.items():  # type: ignore[attr-defined]
         if isinstance(p_value, torch.Tensor):
-            weights_metadata[f"{name_prefix}.{p_name}"] = serialize_weight(p_value)
+            weights_metadata.update(serialize_weight(p_value, weights, f"{name_prefix}.{p_name}"))
             weights[f"{name_prefix}.{p_name}"] = p_value
         else:
             parameters[p_name] = str(p_value)
@@ -215,25 +269,19 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
         for name, p in named_tensors:
             if name.startswith("parent.") or not isinstance(p, torch.Tensor):
                 continue
-            weight = serialize_weight(p)
-            serialized_dict["weights"][prefix + name] = weight
+            weight_dict = serialize_weight(p, weights, prefix + name)
+            serialized_dict["weights"].update(weight_dict)
             weights[prefix + name] = p
 
     add_weight_tensors(fx_module.named_parameters())
     add_weight_tensors(fx_module.named_buffers())
 
     def get_node_info(node):
-        shape, dtype, stride = get_shape_dtype_and_stride(node)
-        tensor_meta = node.meta.get("tensor_meta")
-        if not tensor_meta:
-            raise RuntimeError(
-                f"Node {node} has no tensor metadata! Ensure shape "
-                f"propagation has been run!"
-            )
+        tensor_meta = get_tensor_meta(node)
         node_rep = {
-            "shape": serialize_shape(shape),
-            "dtype": str(dtype),
-            "stride": serialize_stride(stride),
+            "shape": serialize_shape(tensor_meta.shape),
+            "dtype": str(tensor_meta.dtype),
+            "stride": serialize_stride(tensor_meta.stride),
             "is_quantized": tensor_meta.is_quantized,
         }
 
@@ -289,11 +337,11 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
         if node.op == "get_attr":
             # If we are targeting a parent constant we update the target.
             if node.target.startswith("parent."):
-                stripped_name = node.target[len("parent.") :]
+                stripped_name = node.target[len("parent."):]
                 node.name = stripped_name
                 node_rep["target"] = stripped_name
-                weight = serialize_weight(weights[stripped_name])
-                serialized_dict["weights"][stripped_name] = weight
+                weight = serialize_weight(weights[stripped_name], weights, node.target[len("parent."):])
+                serialized_dict["weights"].update(weight)
             else:
                 # Find the actual target parameter/buffer from the fx_module.
                 submod_path, _, target_name = node.target.rpartition(".")
@@ -306,8 +354,8 @@ def serialize_module(fx_module: GraphModule, weights: Dict, name_prefix="") -> D
                 qualname = prefix + node.target
                 # Check that the target is a tensor, and that we haven't added it already from a leaf module.
                 if isinstance(target, torch.Tensor) and qualname not in weights:
-                    weight = serialize_weight(target)
-                    serialized_dict["weights"][qualname] = weight
+                    weight = serialize_weight(target, weights, qualname)
+                    serialized_dict["weights"].update(weight)
                     weights[qualname] = target
 
         node_rep["op_code"] = node.op

--- a/torch/fx/experimental/graph_manipulation.py
+++ b/torch/fx/experimental/graph_manipulation.py
@@ -88,7 +88,11 @@ def get_size_of_node(fx_module: GraphModule, node: Node) -> size_bytes:
     tensor_meta = get_tensor_meta(node)
     output_elem = tensor_meta.shape.numel()
     total_num_of_elems += output_elem
-    size_per_elem_bytes = torch.tensor([], dtype=tensor_meta.dtype).element_size()
+    # Assume for now if it's quantized then it's qint8 or quint8
+    if tensor_meta.is_quantized:
+        size_per_elem_bytes = torch._empty_affine_quantized([], dtype=tensor_meta.dtype).element_size()
+    else:
+        size_per_elem_bytes = torch.tensor([], dtype=tensor_meta.dtype).element_size()
     total_size = size_per_elem_bytes * total_num_of_elems
     output_size = size_per_elem_bytes * output_elem
     return size_bytes(output_size, total_size)

--- a/torch/fx/passes/shape_prop.py
+++ b/torch/fx/passes/shape_prop.py
@@ -56,6 +56,7 @@ def extract_tensor_metadata(result : torch.Tensor) -> TensorMetadata:
     return TensorMetadata(
         shape, dtype, stride, memory_format, is_quantized, qscheme, q_scale, q_zero_point)
 
+
 class ShapeProp(torch.fx.Interpreter):
     """
     Execute an FX graph Node-by-Node and


### PR DESCRIPTION
Summary: E2E quantized ResNet18 via accelerated graph module. Accuracy matches

Test Plan: `buck test glow/fb/fx/fx_glow:test_fx_glow -- test_fx_glow_binding_quantized_resnet`

Differential Revision: D27717265

