### PR TITLE
[TensorExpr] Re-enable skipped tests, they seem to be working now.

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1566,7 +1566,6 @@ class TestTEFuser(JitTestCase):
                     " ".join(["Failed:", str(dtype), device])
                 )
 
-    @unittest.skipIf(not LLVM_ENABLED, "TODO: bugs in ir eval")
     def test_binary_tensor_scalar_ops(self):
         def apply_with_scalar(fn, scalar):
             return lambda x: fn(x, scalar)
@@ -1675,7 +1674,6 @@ class TestTEFuser(JitTestCase):
                     " ".join(["Failed:", str(dtype), op.__name__, device])
                 )
 
-    @unittest.skipIf(not LLVM_ENABLED, "TODO: enable in ir eval")
     def test_ternary_ops(self):
         def apply(fn):
             return lambda x, y, z: fn(x, y, z)

--- a/test/test_tensorexpr.py
+++ b/test/test_tensorexpr.py
@@ -142,7 +142,6 @@ class TestTensorExprFuser(BaseTestClass):
             c = torch.rand(M, N, device=device)
             x = traced(a, b, c)
             x = warmup_and_run_forward(traced, a, b, c)
-            print(torch.jit.last_executed_optimized_graph())
             self.assertLastGraphAllFused()
             npr = a.cpu().numpy() + b.cpu().numpy() + c.cpu().numpy()
             np.testing.assert_allclose(npr, x.cpu().numpy())
@@ -1163,7 +1162,6 @@ class TestTensorExprFuser(BaseTestClass):
         r = test(x, y, z)
         assert llvm.elapsed_value == 1 or interp.elapsed_value() > 1
 
-    @unittest.skip("no shape inference for aten::slice yet")
     def test_slice(self):
         def easy(x, y):
             a = x[0:512:2]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58207 [TensorExpr] Remove disabled tests that we do not plan to re-enable.
* **#58206 [TensorExpr] Re-enable skipped tests, they seem to be working now.**

Tested on CUDA with and without `PYTORCH_TENSOREXPR_DONT_USE_LLVM=1`.

Closes #48053.

Differential Revision: [D28403250](https://our.internmc.facebook.com/intern/diff/D28403250)