### PR TITLE
use mkldnn for Linear on CPU BFloat16 dtype

### DIFF
--- a/aten/src/ATen/native/mkldnn/Linear.cpp
+++ b/aten/src/ATen/native/mkldnn/Linear.cpp
@@ -36,8 +36,62 @@ std::tuple<Tensor, Tensor, Tensor> mkldnn_linear_backward(
 #include <ATen/native/mkldnn/MKLDNNCommon.h>
 #include <ATen/native/mkldnn/Utils.h>
 
-namespace at {
-namespace native {
+namespace at { namespace native {
+
+namespace {
+
+static inline bool is_input_dtype_valid(const Tensor& t) {
+  auto st = t.scalar_type();
+  return (t.is_mkldnn() && (st == ScalarType::Float || st == ScalarType::BFloat16)) ||
+      (!t.is_mkldnn() && st == ScalarType::BFloat16);
+}
+
+// reshape input/output in 2d view, might take a memcpy
+static inline Tensor view_2d(const Tensor& t) {
+  return t.dim() == 2 ? t : t.reshape({-1, t.size(t.dim() - 1)});
+}
+
+static inline Tensor _contiguous(const Tensor& t) {
+  return t.is_mkldnn() ? t : t.contiguous();
+}
+
+} // anonymous namespace
+
+// Note on mkldnn_linear layout and dtype propagation
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// a) mkldnn_linear (e.g. mkldnn privimitive inner_product) will be used for
+//   * mkldnn layout (fp32 and bf16)
+//   * dense layout (bf16)
+//
+// b) dense layout (fp32) will still call `mkl` sgemm, reason that we skip mkl
+//    for dense layout (bf16) is that `cblas_gemm_bf16bf16f32` will have C matrix
+//    in fp32 which is against pytorch dtype propagation rule. And doing an post
+//    fp32->bf16 conversion is adverse for performance.
+//
+// c) mkldnn may choose blocked memory format for weight due to performance reasons.
+//    On mkldnn layout, weight can be prepacked to blocked to save reorder overhead
+//    for inference. Weight is always plain format (OI) for training.
+//
+// 1. mkldnn layout propagation
+//   (input, output are mkldnn layout)
+// +---------------------------------------------------------------------------+
+// | propagation          | input     | weight    | output    || weight layout |
+// |----------------------+-----------+-----------+-----------++---------------|
+// | inference prepacked  | fp32|bf16 | fp32|bf16 | fp32|bf16 || mkldnn        |
+// | training forward     | fp32|bf16 | fp32      | fp32|bf16 || dense         |
+// | training backward    | fp32|bf16 | fp32      | fp32|bf16 || dense         |
+// +---------------------------------------------------------------------------+
+//
+// 2. dense layout propagation
+//   (input, output are dense layout)
+// +---------------------------------------------------------------------------+
+// | propagation          | input     | weight    | output    || weight layout |
+// |----------------------+-----------+-----------+-----------++---------------|
+// | inference prepacked  | N/A       | N/A       | N/A       || N/A           |
+// | training forward     | bf16      | bf16      | bf16      || dense         |
+// | training backward    | bf16      | bf16      | bf16      || dense         |
+// +---------------------------------------------------------------------------+
+//
 
 Tensor mkldnn_linear(
     const Tensor& self,
@@ -45,29 +99,31 @@ Tensor mkldnn_linear(
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> bias_maybe_owned = at::borrow_from_optional_tensor(bias_opt);
   const Tensor& bias = *bias_maybe_owned;
-
   const int64_t dim = self.dim();
-  TORCH_CHECK(
-      self.dim() != 0,
+  TORCH_CHECK(self.dim() != 0,
       "mkldnn_linear: input needs to has dim at least 1, input dim ",
       self.dim());
-  TORCH_CHECK(self.is_mkldnn(),
-      "mkldnn_linear: input needs to be mkldnn layout");
+  TORCH_CHECK(is_input_dtype_valid(self),
+      "mkldnn_linear: input needs to be mkldnn layout in float32|bfloat16 or dense layout in bfloat16");
   if (self.scalar_type() == ScalarType::BFloat16) {
     TORCH_CHECK(mkldnn_bf16_device_check(),
         "mkldnn_linear: bf16 path needs the cpu support avx512bw, avx512vl and avx512dq");
   }
 
-  // reshape first if input dim != 2 and the reshape will cost a memory copy.
-  auto self_reshaped =
-      dim == 2 ? self : self.reshape({-1, self.size(self.dim() - 1)});
+  const ideep::tensor x = itensor_from_tensor(_contiguous(view_2d(self)));
+  const ideep::tensor w = itensor_from_tensor(_contiguous(weight_t));
 
-  const ideep::tensor x = itensor_from_mkldnn(self_reshaped);
-  // weight_t can be a mkldnn tensor or dense tensor.
-  const Tensor weight = (weight_t.is_mkldnn() || weight_t.is_contiguous()) ? weight_t : weight_t.contiguous();
-  const ideep::tensor w = itensor_from_tensor(weight);
+  auto input_size = self.sizes();
+  std::vector<int64_t> output_size(input_size.begin(), input_size.end() - 1);
+  output_size.push_back(weight_t.size(0));
 
+  auto output = at::empty({0}, self.options());
   ideep::tensor y;
+  if (!self.is_mkldnn()) {
+    output.resize_(output_size);
+    y = itensor_from_tensor(view_2d(output));
+  }
+
   if (bias.defined()) {
     const ideep::tensor b = itensor_from_tensor(bias);
     ideep::inner_product_forward::compute(x, w, b, y);
@@ -75,10 +131,11 @@ Tensor mkldnn_linear(
     ideep::inner_product_forward::compute(x, w, y);
   }
 
-  auto input_size = self.sizes();
-  std::vector<int64_t> output_size(input_size.begin(), input_size.end() - 1);
-  output_size.push_back(weight.size(0));
-
+  // dense layout (bfloat16)
+  if (!self.is_mkldnn()) {
+    return output;
+  }
+  // mkldnn layout (float and bfloat16)
   if (self.dim() != 2) {
     return new_with_itensor_mkldnn(std::move(y), optTypeMetaToScalarType(self.options().dtype_opt()),
                                    self.options().device_opt()).reshape(output_size);
@@ -87,29 +144,28 @@ Tensor mkldnn_linear(
                                  self.options().device_opt());
 }
 
-
 Tensor mkldnn_linear_backward_input(
-    IntArrayRef input_size, const Tensor& grad_output, const Tensor& weight_t){
-  TORCH_CHECK(grad_output.is_mkldnn(),
-      "mkldnn_linear_backward: grad_output needs to be mkldnn layout");
-  TORCH_CHECK(weight_t.device().is_cpu() && weight_t.scalar_type() == kFloat,
-      "mkldnn_linear_backward: weight_t needs to be a dense tensor");
-  auto grad_output_reshaped = grad_output.dim() > 2 ?
-    grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
+    IntArrayRef input_size, const Tensor& grad_output, const Tensor& weight){
 
-  ideep::tensor& grady = itensor_from_mkldnn(grad_output_reshaped);
-  // weight_t always dense tensor for training.
-  const Tensor weight = weight_t.is_contiguous() ? weight_t : weight_t.contiguous();
+  auto grad_output_reshaped = view_2d(grad_output);
+  const ideep::tensor grady = itensor_from_tensor(grad_output_reshaped);
+  // weight is always dense tensor for training.
   const ideep::tensor w = itensor_view_from_dense(weight);
 
-  std::vector<int64_t> input_reshaped_size;
-  input_reshaped_size.push_back(grad_output_reshaped.size(0));
-  input_reshaped_size.push_back(weight.size(1));
-
+  auto grad_input = at::empty({0}, grad_output.options());
   ideep::tensor gradx;
+  if (!grad_output.is_mkldnn()) {
+    grad_input.resize_(input_size);
+    gradx = itensor_from_tensor(view_2d(grad_input));
+  }
   ideep::inner_product_backward_data::compute(
-    grady, w, {input_reshaped_size.begin(), input_reshaped_size.end()}, gradx);
+    grady, w, {grad_output_reshaped.size(0), weight.size(1)}, gradx);
 
+  // dense layout (bfloat16)
+  if (!grad_output.is_mkldnn()) {
+    return grad_input;
+  }
+  // mkldnn layout (float and bfloat16)
   if (input_size.size() > 2) {
     return new_with_itensor_mkldnn(std::move(gradx), optTypeMetaToScalarType(grad_output.options().dtype_opt()),
                                    grad_output.options().device_opt()).reshape(input_size);
@@ -120,17 +176,9 @@ Tensor mkldnn_linear_backward_input(
 
 std::tuple<Tensor, Tensor> mkldnn_linear_backward_weights(
     const Tensor& grad_output, const Tensor& input, const Tensor& weight, bool bias_defined) {
-  TORCH_CHECK(grad_output.is_mkldnn() && input.is_mkldnn(),
-      "mkldnn_linear_backward: grad_output and input needs to be mkldnn layout");
-  TORCH_CHECK(weight.device().is_cpu() && weight.scalar_type() == kFloat,
-      "mkldnn_linear_backward: weight needs to be a dense tensor");
 
-  auto grad_output_reshaped = grad_output.dim() > 2 ?
-    grad_output.reshape({-1, grad_output.size(grad_output.dim() - 1)}) : grad_output;
-  auto input_reshaped = input.dim() > 2 ? input.reshape({-1, input.size(input.dim() - 1)}) : input;
-
-  ideep::tensor& grady = itensor_from_mkldnn(grad_output_reshaped);
-  ideep::tensor& x = itensor_from_mkldnn(input_reshaped);
+  const ideep::tensor grady = itensor_from_tensor(view_2d(grad_output));
+  const ideep::tensor x = itensor_from_tensor(view_2d(input));
   ideep::tensor gradw, gradb;
   if (bias_defined) {
     ideep::inner_product_backward_weights::compute(x, grady, gradw, gradb);
@@ -150,17 +198,39 @@ std::tuple<Tensor, Tensor> mkldnn_linear_backward_weights(
 std::tuple<Tensor, Tensor, Tensor> mkldnn_linear_backward(
     const Tensor& input, const Tensor& grad_output,
     const Tensor& weight, std::array<bool,3> output_mask) {
+  if (input.is_mkldnn()) {
+    TORCH_CHECK(grad_output.is_mkldnn(),
+        "mkldnn_linear_backward (mkldnn layout input): grad_output need to be mkldnn layout");
+    TORCH_CHECK(input.scalar_type() == grad_output.scalar_type() &&
+        (input.scalar_type() == ScalarType::Float || input.scalar_type() == ScalarType::BFloat16),
+        "mkldnn_linear_backward (mkldnn layout input): ",
+        "grad_output and input need to be the same dtype (float32 or bfloat16)");
+    TORCH_CHECK(weight.layout() == Layout::Strided && weight.scalar_type() == ScalarType::Float,
+        "mkldnn_linear_backward (mkldnn layout input): weight needs to be dense layout in float32");
+  } else {
+    TORCH_CHECK(grad_output.layout() == Layout::Strided,
+        "mkldnn_linear_backward (dense layout input): grad_output need to be dense layout");
+    TORCH_CHECK(input.scalar_type() == grad_output.scalar_type() && (input.scalar_type() == ScalarType::BFloat16),
+        "mkldnn_linear_backward (dense layout input): grad_output and input need to be bfloat16");
+    TORCH_CHECK(weight.layout() == Layout::Strided && weight.scalar_type() == ScalarType::BFloat16,
+        "mkldnn_linear_backward (dense layout input): weight needs to be dense layout in bfloat16");
+  }
+
+  Tensor input_t = _contiguous(input);
+  Tensor grad_output_t = _contiguous(grad_output);
+  // weight is always dense tensor for training.
+  Tensor weight_t = weight.contiguous();
+
   Tensor grad_input, grad_weight, grad_bias;
   if (output_mask[0]) {
-    grad_input = at::mkldnn_linear_backward_input(input.sizes(), grad_output, weight);
+    grad_input = at::mkldnn_linear_backward_input(input.sizes(), grad_output_t, weight_t);
   }
   if (output_mask[1] || output_mask[2]) {
-    std::tie(grad_weight, grad_bias) = at::mkldnn_linear_backward_weights(grad_output, input, weight, output_mask[2]);
+    std::tie(grad_weight, grad_bias) = at::mkldnn_linear_backward_weights(grad_output_t, input_t, weight_t, output_mask[2]);
   }
   return std::tuple<Tensor, Tensor, Tensor>{grad_input, grad_weight, grad_bias};
 }
 
-} // namespace native
-} // namespace at
+}} // at::native
 
 #endif // AT_MKLDNN_EBABLED

--- a/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
+++ b/aten/src/ATen/native/mkldnn/MKLDNNCommon.cpp
@@ -86,12 +86,21 @@ ideep::tensor itensor_view_from_dense(const Tensor& tensor) {
   TORCH_CHECK(
       tensor.layout() == Layout::Strided,
       "itensor_view_from_dense expects dense tensor input");
-  TORCH_CHECK(tensor.scalar_type() == ScalarType::Float,
-             "itensor_view_from_dense expects float tensor input");
+  auto data_type = tensor.scalar_type();
+  TORCH_CHECK(data_type == ScalarType::Float || data_type == ScalarType::BFloat16,
+      "itensor_view_from_dense expects float or bfloat16 tensor input");
   TORCH_INTERNAL_ASSERT(at::impl::variable_excluded_from_dispatch());
-  return {{{tensor.sizes().cbegin(), tensor.sizes().cend()},
-           ideep::tensor::data_type::f32},
-          tensor.template data_ptr<float>()};
+  if (data_type == ScalarType::Float) {
+    return {{{tensor.sizes().cbegin(), tensor.sizes().cend()},
+             ideep::tensor::data_type::f32,
+             {tensor.strides().cbegin(), tensor.strides().cend()}},
+            tensor.template data_ptr<float>()};
+  } else {
+    return {{{tensor.sizes().cbegin(), tensor.sizes().cend()},
+             ideep::tensor::data_type::bf16,
+             {tensor.strides().cbegin(), tensor.strides().cend()}},
+            tensor.template data_ptr<BFloat16>()};
+  }
 }
 
 // Helper function for getting an ideep tensor out of an aten Tensor.

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2317,19 +2317,19 @@
 - func: mkldnn_linear(Tensor self, Tensor weight, Tensor? bias=None) -> Tensor
   python_module: nn
   dispatch:
-    MkldnnCPU: mkldnn_linear
+    CompositeExplicitAutograd: mkldnn_linear
 
 - func: mkldnn_linear_backward_input(int[] input_size, Tensor grad_output, Tensor weight) -> Tensor
   dispatch:
-    MkldnnCPU: mkldnn_linear_backward_input
+    CompositeExplicitAutograd: mkldnn_linear_backward_input
 
 - func: mkldnn_linear_backward_weights(Tensor grad_output, Tensor input, Tensor weight, bool bias_defined) -> (Tensor, Tensor)
   dispatch:
-    MkldnnCPU: mkldnn_linear_backward_weights
+    CompositeExplicitAutograd: mkldnn_linear_backward_weights
 
 - func: mkldnn_linear_backward(Tensor self, Tensor grad_output, Tensor weight, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
   dispatch:
-    MkldnnCPU: mkldnn_linear_backward
+    CompositeExplicitAutograd: mkldnn_linear_backward
 
 - func: fbgemm_linear_int8_weight_fp32_activation(Tensor input, Tensor weight, Tensor packed, Tensor col_offsets, Scalar weight_scale, Scalar weight_zero_point, Tensor bias) -> Tensor
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58210 use mkldnn for Linear on CPU BFloat16 dtype**
* #56904 optimize transpose copy for float32 and bfloat16 on CPU
* #56903 add BFloat16 support for MaxPool2d on CPU
* #56902 add BFloat16 support for AdaptiveAvgPool2d on CPU
* #56372 add BFloat16 support for bernoulli and Dropout on CPU
* #55588 add bf16 support for bucketize
* #55221 optimize BFloat16 elemwise operators CPU: sigmoid, sigmoid_backward, tanh_backward, addcmul, addcdiv
* #55217 SumKernel (BFloat16): use float as accumulation type
* #55210 add BFloat16 support for LayerNorm CPU
* #55202 Optimize some redunction operators on CPU BFloat16

