### PR TITLE
Clarifies cholesky_ex role and makes batched support a common string

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -30,14 +30,20 @@ the **Cholesky decomposition** of a complex Hermitian or real symmetric positive
 where :math:`L` is a lower triangular matrix and
 :math:`L^{\text{H}}` is the conjugate transpose when :math:`L` is complex, and the transpose when :math:`L` is real-valued.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 """ + fr"""
 .. note:: {common_notes["sync_note"]}
 """ + r"""
 
 .. seealso::
+
+        :func:`torch.linalg.cholesky_ex` for a version of this operation that
+        skips the (slow) error checking by default and instead returns the debug
+        information. This makes it a faster way to check if a matrix is
+        positive-definite.
 
         :func:`torch.linalg.eigh` for a different decomposition of a Hermitian matrix.
         The eigenvalue decomposition gives more information about the matrix but it
@@ -97,17 +103,23 @@ Examples::
 """)
 
 cholesky_ex = _add_docstr(_linalg.linalg_cholesky_ex, r"""
-linalg.cholesky_ex(input, *, check_errors=False, out=None) -> (Tensor, Tensor)
+linalg.cholesky_ex(A, *, check_errors=False, out=None) -> (Tensor, Tensor)
 
-Computes the Cholesky decomposition of a complex Hermitian or real symmetric positive-definite matrix.
+Computes the Cholesky decomposition of a complex Hermitian or real
+symmetric positive-definite matrix.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+This function skips the (slow) error checking and error message construction
+of :func:`torch.linalg.cholesky`, instead directly returning the LAPACK
+error codes as part of a named tuple ``(L, info)``. This makes this function
+a faster way to check if a matrix is positive-definite, and it provides an
+opportunity to handle decomposition errors more gracefully or performantly
+than :func:`torch.linalg.cholesky` does.
 
-Returns a namedtuple ``(L,info)``. ``L`` contains the result of the Cholesky decomposition.
-``info`` stores the LAPACK error codes.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
-If :attr:`input` is not a Hermitian positive-definite matrix, or if it's a batch of matrices
+If :attr:`A` is not a Hermitian positive-definite matrix, or if it's a batch of matrices
 and one or more of them is not a Hermitian positive-definite matrix,
 then ``info`` stores a positive integer for the corresponding matrix.
 The positive integer indicates the order of the leading minor that is not positive-definite,
@@ -115,7 +127,7 @@ and the decomposition could not be completed.
 ``info`` filled with zeros indicates that the decomposition was successful.
 If ``check_errors=True`` and ``info`` contains positive integers, then a RuntimeError is thrown.
 
-.. note:: Given inputs on a CUDA device, this function may synchronize that device with the CPU.
+.. note:: If :attr:`A` is on a CUDA device, this function may synchronize that device with the CPU.
 
 .. warning:: This function is "experimental" and it may change in a future PyTorch release.
 
@@ -123,7 +135,7 @@ If ``check_errors=True`` and ``info`` contains positive integers, then a Runtime
         :func:`torch.linalg.cholesky` is a NumPy compatible variant that always checks for errors.
 
 Args:
-    input (Tensor): the Hermitian `n \times n` matrix or the batch of such matrices of size
+    A (Tensor): the Hermitian `n \times n` matrix or the batch of such matrices of size
                     `(*, n, n)` where `*` is one or more batch dimensions.
     check_errors (bool, optional): controls whether to check the content of ``infos``. Default: `False`.
 
@@ -165,8 +177,9 @@ where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
 The inverse matrix exists if and only if :math:`A` is `invertible`_. In this case,
 the inverse is unique.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices
+then the output has the same batch dimensions.
 
 """ + fr"""
 .. note:: {common_notes["sync_note"]}
@@ -230,24 +243,27 @@ Examples::
 """)
 
 inv_ex = _add_docstr(_linalg.linalg_inv_ex, r"""
-linalg.inv_ex(input, *, check_errors=False, out=None) -> (Tensor, Tensor)
+linalg.inv_ex(A, *, check_errors=False, out=None) -> (Tensor, Tensor)
 
 Computes the inverse of a square matrix if it is invertible.
 
-Returns a namedtuple ``(inverse,info)``. ``inverse`` contains the result of inverting the input matrix.
-``info`` stores the LAPACK error codes.
+Returns a namedtuple ``(inverse, info)``. ``inverse`` contains the result of
+inverting :attr:`A` and ``info`` stores the LAPACK error codes.
 
-If :attr:`input` is not an invertible matrix, or if it's a batch of matrices
+If :attr:`A` is not an invertible matrix, or if it's a batch of matrices
 and one or more of them is not an invertible matrix,
 then ``info`` stores a positive integer for the corresponding matrix.
-The positive integer indicates the diagonal element of the LU decomposition of the input matrix that is exactly zero.
+The positive integer indicates the diagonal element of the LU decomposition of
+the input matrix that is exactly zero.
 ``info`` filled with zeros indicates that the inversion was successful.
 If ``check_errors=True`` and ``info`` contains positive integers, then a RuntimeError is thrown.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
-.. note:: Given inputs on a CUDA device, this function may synchronize that device with the CPU.
+.. note:: If :attr:`A` is on a CUDA device then this function may synchronize
+that device with the CPU.
 
 .. warning:: This function is "experimental" and it may change in a future PyTorch release.
 
@@ -256,7 +272,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
         :func:`torch.linalg.inv` is a NumPy compatible variant that always checks for errors.
 
 Args:
-    input (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
+    A (Tensor): tensor of shape `(*, n, n)` where `*` is zero or more batch dimensions
                     consisting of square matrices.
     check_errors (bool, optional): controls whether to check the content of ``info``. Default: `False`.
 
@@ -285,8 +301,9 @@ linalg.det(A, *, out=None) -> Tensor
 
 Computes the determinant of a square matrix.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 """ + fr"""
 .. note:: This function is computed using :func:`torch.lu`.
@@ -343,8 +360,9 @@ Computes the sign and natural logarithm of the absolute value of the determinant
 For complex :attr:`A`, it returns the angle and the natural logarithm of the modulus of the
 determinant, that is, a logarithmic polar decomposition of the determinant.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 """ + fr"""
 .. note:: This function is computed using :func:`torch.lu`.
@@ -403,8 +421,9 @@ the **eigenvalue decomposition** of a square matrix
 This decomposition exists if and only if :math:`A` is `diagonalizable`_.
 This is the case when all its eigenvalues are different.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 .. note:: The eigenvalues and eigenvectors of a real matrix may be complex.
 
@@ -497,8 +516,9 @@ as the roots (counted with multiplicity) of the polynomial `p` of degree `n` giv
 
 where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 .. note:: The eigenvalues of a real matrix may be complex, as the roots of a real polynomial may be complex.
 
@@ -548,8 +568,9 @@ the **eigenvalue decomposition** of a complex Hermitian or real symmetric matrix
 where :math:`Q^{\text{H}}` is the conjugate transpose when :math:`Q` is complex, and the transpose when :math:`Q` is real-valued.
 :math:`Q` is orthogonal in the real case and unitary in the complex case.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 :attr:`A` is assumed to be Hermitian (resp. symmetric), but this is not checked internally, instead:
 
@@ -658,8 +679,9 @@ are defined as the roots (counted with multiplicity) of the polynomial `p` of de
 where :math:`\mathrm{I}_n` is the `n`-dimensional identity matrix.
 The eigenvalues of a real symmetric or complex Hermitian matrix are always real.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 The eigenvalues are returned in ascending order.
 
@@ -738,7 +760,8 @@ where :math:`\mathrm{I}_m` is the `m`-dimensional identity matrix and
 See `Representation of Orthogonal or Unitary Matrices`_ for further details.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Also supports batches of matrices, and if the inputs are batches of matrices then
+the output has the same batch dimensions.
 
 .. note:: This function only uses the values strictly below the main diagonal of :attr:`A`.
           The other values are ignored.
@@ -804,7 +827,8 @@ the **least squares problem** for a linear system :math:`AX = B` with
 where :math:`\|-\|_F` denotes the Frobenius norm.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Also supports batches of matrices, and if the inputs are batches of matrices then
+the output has the same batch dimensions.
 
 :attr:`driver` chooses the LAPACK/MAGMA function that will be used.
 For CPU inputs the valid values are `'gels'`, `'gelsy'`, `'gelsd`, `'gelss'`.
@@ -904,8 +928,9 @@ matrix_power(A, n, *, out=None) -> Tensor
 
 Computes the `n`-th power of a square matrix for an integer `n`.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 If :attr:`n`\ `= 0`, it returns the identity matrix (or batch) of the same shape
 as :attr:`A`. If :attr:`n` is negative, it returns the inverse of each matrix
@@ -969,8 +994,9 @@ The matrix rank is computed as the number of singular values
 (or eigenvalues in absolute value when :attr:`hermitian`\ `= True`)
 that are greater than the specified :attr:`tol` threshold.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 If :attr:`hermitian`\ `= True`, :attr:`A` is assumed to be Hermitian if complex or
 symmetric if real, but this is not checked internally. Instead, just the lower
@@ -1043,12 +1069,13 @@ Examples::
 norm = _add_docstr(_linalg.linalg_norm, r"""
 linalg.norm(A, ord=None, dim=None, keepdim=False, *, out=None, dtype=None) -> Tensor
 
-Computes a vector or a matrix norm.
+Computes a vector or matrix norm.
 
 If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+
+Whether this function computes a vector or matrix norm is determined as follows:
 
 - If :attr:`dim` is an `int`, the vector norm will be computed.
 - If :attr:`dim` is a `2`-`tuple`, the matrix norm will be computed.
@@ -1061,7 +1088,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 ======================     =========================  ========================================================
 :attr:`ord`                norm for matrices          norm for vectors
 ======================     =========================  ========================================================
-`None` (default)           Frobenius norm             `2`-norm
+`None` (default)           Frobenius norm             `2`-norm (see below)
 `'fro'`                    Frobenius norm             -- not supported --
 `'nuc'`                    nuclear norm               -- not supported --
 `inf`                      `max(sum(abs(x), dim=1))`  `max(abs(x))`
@@ -1071,7 +1098,7 @@ Also supports batched inputs, and, if the input is batched, the output is batche
 `-1`                       `min(sum(abs(x), dim=0))`  as below
 `2`                        largest singular value     as below
 `-2`                       smallest singular value    as below
-other `int` or `float`     -- not supported --        `sum(abs(x)**\ `:attr:`ord`\ `)**(1./\ `:attr:`ord`\ `)`
+other `int` or `float`     -- not supported --        `sum(abs(x)^{ord})^{(1 / ord)}`
 ======================     =========================  ========================================================
 
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
@@ -1181,29 +1208,38 @@ Computes a vector norm.
 
 If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+
+This function does not necessarily treat multidimensonal attr:`A` as a batch of
+vectors, instead:
 
 - If :attr:`dim`\ `= None`, :attr:`A` will be flattened before the norm is computed.
 - If :attr:`dim` is an `int` or a `tuple`, the norm will be computed over these dimensions
   and the other dimensions will be treated as batch dimensions.
+
+This behavior is for consistency with :func:`torch.linalg.norm`.
 
 :attr:`ord` defines the vector norm that is computed. The following norms are supported:
 
 ======================   ========================================================
 :attr:`ord`              vector norm
 ======================   ========================================================
-`2` (default)            `2`-norm
+`2` (default)            `2`-norm (see below)
 `inf`                    `max(abs(x))`
 `-inf`                   `min(abs(x))`
 `0`                      `sum(x != 0)`
-other `int` or `float`   `sum(abs(x)**\ `:attr:`ord`\ `)**(1./\ `:attr:`ord`\ `)`
+other `int` or `float`   `sum(abs(x)^{ord})^{(1 / ord)}`
 ======================   ========================================================
 
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
+.. seealso::
+
+        :func:`torch.linalg.matrix_norm` computes a matrix norm.
+
 Args:
-    A (Tensor): tensor of shape `(*, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor, flattened by default, but this behavior can be
+        controlled using :attr:`dim`.
     ord (int, float, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `2`
     dim (int, Tuple[int], optional): dimensions over which to compute
         the norm. See above for the behavior when :attr:`dim`\ `= None`.
@@ -1244,11 +1280,10 @@ Computes a matrix norm.
 
 If :attr:`A` is complex valued, it computes the norm of :attr:`A`\ `.abs()`
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
-
-The norm will be computed over the dimensions specified by the 2-tuple :attr:`dim`
-and the other dimensions will be treated as batch dimensions.
+Support input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices: the norm will be computed over the
+dimensions specified by the 2-tuple :attr:`dim` and the other dimensions will
+be treated as batch dimensions. The output will have the same batch dimensions.
 
 :attr:`ord` defines the matrix norm that is computed. The following norms are supported:
 
@@ -1268,7 +1303,9 @@ and the other dimensions will be treated as batch dimensions.
 where `inf` refers to `float('inf')`, NumPy's `inf` object, or any equivalent object.
 
 Args:
-    A (Tensor): tensor of shape `(*, m, n)` where `*` is zero or more batch dimensions.
+    A (Tensor): tensor with two or more dimensions. By default its
+        shape is interpreted as `(*, m, n)` where `*` is zero or more
+        batch dimensions, but this behavior can be controlled using :attr:`dim`.
     ord (int, inf, -inf, 'fro', 'nuc', optional): order of norm. Default: `'fro'`
     dim (Tuple[int, int], optional): dimensions over which to compute the norm. Default: `(-2, -1)`
     keepdim (bool, optional): If set to `True`, the reduced dimensions are retained
@@ -1318,6 +1355,7 @@ the fewest arithmetic operations are performed.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
 This function does not support batched inputs.
+
 Every tensor in :attr:`tensors` must be 2D, except for the first and last which
 may be 1D. If the first tensor is a 1D vector of shape `(n,)` it is treated as a row vector
 of shape `(1, n)`, similarly if the last tensor is a 1D vector of shape `(n,)` it is treated
@@ -1408,8 +1446,9 @@ When `m > n` (resp. `m < n`) we can drop the last `m - n` (resp. `n - m`) column
 where :math:`\operatorname{diag}(S) \in \mathbb{K}^{k \times k}`.
 In this case, :math:`U` and :math:`V` also have orthonormal columns.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 The returned decomposition is a named tuple `(U, S, Vh)`
 which corresponds to :math:`U`, :math:`S`, :math:`V^{\text{H}}` above.
@@ -1524,8 +1563,9 @@ linalg.svdvals(A, *, out=None) -> Tensor
 
 Computes the singular values of a matrix.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 The singular values are returned in descending order.
 
@@ -1579,8 +1619,9 @@ the **condition number** :math:`\kappa` of a matrix
 The condition number of :attr:`A` measures the numerical stability of the linear system `AX = B`
 with respect to a matrix norm.
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 :attr:`p` defines the matrix norm that is computed. The following norms are supported:
 
@@ -1704,8 +1745,9 @@ Computes the pseudoinverse (Moore-Penrose inverse) of a matrix.
 The pseudoinverse may be `defined algebraically`_
 but it is more computationally convenient to understand it `through the SVD`_
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 If :attr:`hermitian`\ `= True`, :attr:`A` is assumed to be Hermitian if complex or
 symmetric if real, but this is not checked internally. Instead, just the lower
@@ -1831,7 +1873,8 @@ This system of linear equations has one solution if and only if :math:`A` is `in
 This function assumes that :math:`A` is invertible.
 
 Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Also supports batches of matrices, and if the inputs are batches of matrices then
+the output has the same batch dimensions.
 
 Letting `*` be zero or more batch dimensions,
 
@@ -1914,7 +1957,7 @@ If this is the case, it computes a tensor `X` such that
 
     X.shape == A.shape[ind:] + A.shape[:ind]
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
+Supports input of float, double, cfloat and cdouble dtypes.
 
 .. note:: When :attr:`A` is a `2`-dimensional tensor and :attr:`ind`\ `= 1`,
           this function computes the (multiplicative) inverse of :attr:`A`
@@ -2052,8 +2095,9 @@ In this case, we can drop the last `m - n` columns of `Q` to form the
 
 The reduced QR decomposition agrees with the full QR decomposition when `n >= m` (wide matrix).
 
-Supports inputs of float, double, cfloat and cdouble dtypes.
-Also supports batched inputs, and, if the input is batched, the output is batched with the same dimensions.
+Supports input of float, double, cfloat and cdouble dtypes.
+Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
+the output has the same batch dimensions.
 
 The parameter :attr:`mode` chooses between the full and reduced QR decomposition.
 If :attr:`A` has shape `(*, m, n)`, denoting `k = min(m, n)`

--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -262,8 +262,9 @@ Supports input of float, double, cfloat and cdouble dtypes.
 Also supports batches of matrices, and if :attr:`A` is a batch of matrices then
 the output has the same batch dimensions.
 
-.. note:: If :attr:`A` is on a CUDA device then this function may synchronize
-that device with the CPU.
+.. note::
+    If :attr:`A` is on a CUDA device then this function may synchronize
+    that device with the CPU.
 
 .. warning:: This function is "experimental" and it may change in a future PyTorch release.
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/34272

Also updates and creates a common string for when the linear algebra operations support batching