### PR TITLE
[nnc] Add strides to Buf and use it to support output restriding

### DIFF
--- a/test/cpp/tensorexpr/test_loopnest.cpp
+++ b/test/cpp/tensorexpr/test_loopnest.cpp
@@ -1959,14 +1959,14 @@ TEST(LoopNest, Reduce2dComputeAt) {
 # CHECK:   Allocate(temp); // dtype=int, dims=[2, W + 1]
 # CHECK:   for (int idx0 = 0; idx0 < 2; idx0++) {
 # CHECK:     for (int idx1 = 0; idx1 < W + 1; idx1++) {
-# CHECK:       temp[(0 + idx0 * (1 * (W + 1))) + idx1 * 1] = (idx0 + cy) * (idx1 + 0);
+# CHECK:       temp[(0 + idx0 * ((W + 1) * 1)) + idx1 * 1] = (idx0 + cy) * (idx1 + 0);
 # CHECK:     }
 # CHECK:   }
 # CHECK:   for (int cx = 0; cx < W; cx++) {
-# CHECK:     cons[(0 + cy * (1 * W)) + cx * 1] = int(0);
+# CHECK:     cons[(0 + cy * (W * 1)) + cx * 1] = int(0);
 # CHECK:     for (int r = 0; r < 2; r++) {
 # CHECK:       for (int s = 0; s < 2; s++) {
-# CHECK:         cons[(0 + cy * (1 * W)) + cx * 1] = (cons[(0 + cy * (1 * W)) + cx * 1]) + (temp[(0 + r * (1 * (W + 1))) + (s + cx) * 1]);
+#: CHECK:         cons[(0 + cy * (W * 1)) + cx * 1] = (cons[(0 + cy * (W * 1)) + cx * 1]) + (temp[(0 + r * ((W + 1) * 1)) + (s + cx) * 1]);
 # CHECK:       }
 # CHECK:     }
 # CHECK:   }
@@ -1995,13 +1995,13 @@ TEST(LoopNest, Reduce2dComputeAt) {
 # CHECK:     Allocate(temp); // dtype=int, dims=[2, 2]
 # CHECK:     for (int idx0 = 0; idx0 < 2; idx0++) {
 # CHECK:       for (int idx1 = 0; idx1 < 2; idx1++) {
-# CHECK:         temp[(0 + idx0 * (1 * 2)) + idx1 * 1] = (cy + idx0) * (cx + idx1);
+# CHECK:         temp[
 # CHECK:       }
 # CHECK:     }
-# CHECK:     cons[(0 + cy * (1 * W)) + cx * 1] = 0;
+# CHECK:     cons[
 # CHECK:     for (int r = 0; r < 2; r++) {
 # CHECK:       for (int s = 0; s < 2; s++) {
-# CHECK:         cons[(0 + cy * (1 * W)) + cx * 1] = (cons[(0 + cy * (1 * W)) + cx * 1]) + (temp[(0 + r * (1 * 2)) + s * 1]);
+# CHECK:         cons[
 # CHECK:       }
 # CHECK:     }
 # CHECK:     Free(temp);

--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1963,5 +1963,13 @@ class TestTEFuser(JitTestCase):
         script = self.checkScript(eager, (x,))
         self.assertAllFused(script.graph_for(x))
 
+    def test_dims(self):
+        def eager(x, y):
+            return x / (y + 0.0001)
+        x = torch.linspace(-1, 1, 768, dtype=torch.float32).as_strided((1, 1, 768), (768, 1, 1))
+        y = torch.tensor([[[2.0]]], dtype=torch.float32)
+        script = self.checkScript(eager, (x, y))
+        self.assertAllFused(script.graph_for(x, y))
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -615,7 +615,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     }
     void* ptr = iter->second;
 
-    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
+    const Expr* flat_idx =
+        flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
     flat_idx->accept(this);
     std::vector<int> index = value().as_vec<int>();
     ScalarType v_sdtype = v->dtype().scalar_type();
@@ -645,7 +646,8 @@ class SimpleIREvaluatorImpl : public IRVisitor {
 
     void* ptr = iter->second;
 
-    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
+    const Expr* flat_idx =
+        flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
     flat_idx->accept(this);
     std::vector<int> index = value().as_vec<int>();
     ScalarType v_sdtype = v->value()->dtype().scalar_type();

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -615,7 +615,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     }
     void* ptr = iter->second;
 
-    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->indices());
+    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
     flat_idx->accept(this);
     std::vector<int> index = value().as_vec<int>();
     ScalarType v_sdtype = v->dtype().scalar_type();
@@ -645,7 +645,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
 
     void* ptr = iter->second;
 
-    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->indices());
+    const Expr* flat_idx = flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices());
     flat_idx->accept(this);
     std::vector<int> index = value().as_vec<int>();
     ScalarType v_sdtype = v->value()->dtype().scalar_type();

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -369,6 +369,17 @@ ExprHandle Buf::make(const std::vector<ExprHandle>& dims, Dtype dtype) {
   return Buf::make("", dims, dtype);
 }
 
+std::vector<const Expr*> Buf::compute_strides(const std::vector<const Expr*>& dims) const {
+  std::vector<const Expr*> strides;
+  ExprHandle stride = IntImm::make(1);
+  for (auto it = crbegin(dims); it != crend(dims); it++) {
+    strides.push_back(stride.node());
+    stride = ExprHandle(*it) * stride;
+  }
+  std::reverse(strides.begin(), strides.end());
+  return strides;
+}
+
 std::vector<ExprHandle> BufHandle::dims() const {
   return ExprVectorToExprHandleVector(node()->dims());
 }

--- a/torch/csrc/jit/tensorexpr/expr.cpp
+++ b/torch/csrc/jit/tensorexpr/expr.cpp
@@ -369,7 +369,8 @@ ExprHandle Buf::make(const std::vector<ExprHandle>& dims, Dtype dtype) {
   return Buf::make("", dims, dtype);
 }
 
-std::vector<const Expr*> Buf::compute_strides(const std::vector<const Expr*>& dims) const {
+std::vector<const Expr*> Buf::compute_strides(
+    const std::vector<const Expr*>& dims) const {
   std::vector<const Expr*> strides;
   ExprHandle stride = IntImm::make(1);
   for (auto it = crbegin(dims); it != crend(dims); it++) {

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -200,6 +200,7 @@ class TORCH_API Buf : public ExprNode<Buf> {
       : ExprNodeBase(dtype, kPrimitive),
         base_handle_(var),
         dims_(std::move(dims)),
+        strides_(compute_strides(dims_)),
         initializer_(initializer) {
     TORCH_CHECK(var);
   }
@@ -217,8 +218,17 @@ class TORCH_API Buf : public ExprNode<Buf> {
     return dims_;
   }
   void set_dims(std::vector<const Expr*> dims) {
-    dims_ = dims;
+    dims_ = std::move(dims);
+    strides_ = compute_strides(dims_);
   };
+
+  const std::vector<const Expr*>& strides() const {
+    return strides_;
+  }
+
+  void set_strides(std::vector<const Expr*> strides) {
+    strides_ = std::move(strides);
+  }
 
   const Expr* initializer() const {
     return initializer_;
@@ -234,8 +244,11 @@ class TORCH_API Buf : public ExprNode<Buf> {
   }
 
  private:
+  std::vector<const Expr*> compute_strides(const std::vector<const Expr*>& dims) const;
+
   Var* base_handle_;
   std::vector<const Expr*> dims_;
+  std::vector<const Expr*> strides_;
   const Expr* initializer_;
 };
 

--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -244,7 +244,8 @@ class TORCH_API Buf : public ExprNode<Buf> {
   }
 
  private:
-  std::vector<const Expr*> compute_strides(const std::vector<const Expr*>& dims) const;
+  std::vector<const Expr*> compute_strides(
+      const std::vector<const Expr*>& dims) const;
 
   Var* base_handle_;
   std::vector<const Expr*> dims_;

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -71,6 +71,7 @@ Store* Store::make(
 
 const Expr* flatten_index(
     const std::vector<const Expr*>& dims,
+    const std::vector<const Expr*>& strides,
     const std::vector<const Expr*>& indices) {
   // Handle already flattened indices first
   if (indices.size() == 1) {
@@ -83,13 +84,6 @@ const Expr* flatten_index(
   }
   if (ndim == 0) {
     return new IntImm(0);
-  }
-  std::vector<const Expr*> strides(ndim);
-  // stride[i] = stride[i+1]*dims[i+1], i < ndim-1
-  // stride[i] = 1,                     i = ndim-1
-  strides[ndim - 1] = new IntImm(1);
-  for (size_t i = 1; i < ndim; i++) {
-    strides[ndim - 1 - i] = new Mul(strides[ndim - i], dims[ndim - i]);
   }
 
   const Expr* total_index = new IntImm(0);

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -810,6 +810,7 @@ TORCH_API std::vector<VarHandle> VarVectorToVarHandleVector(
     const std::vector<const Var*>&);
 TORCH_API const Expr* flatten_index(
     const std::vector<const Expr*>& dims,
+    const std::vector<const Expr*>& strides,
     const std::vector<const Expr*>& indices);
 
 } // namespace tensorexpr

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3013,8 +3013,8 @@ Tensor* TensorExprKernel::convertOutputToCorrectStrides(torch::jit::Value* v) {
   // produced by NNC onto the strided representation that we want to return.
   // So we create a new tensor with identical indexing, but restrided.
   auto dims = c10::fmap<DimArg>(sizesForValue(v));
-  auto output = Compute(
-      "output_1", dims, [&](const std::vector<VarHandle>& axes_input) {
+  auto output =
+      Compute("output_1", dims, [&](const std::vector<VarHandle>& axes_input) {
         return BufHandle(buf).load(axes_input);
       });
   std::vector<const Expr*> strideExprs;

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3009,48 +3009,20 @@ Tensor* TensorExprKernel::convertOutputToCorrectStrides(torch::jit::Value* v) {
     return new Tensor(buf, nullptr);
   }
 
+  // We need to project the contiguous form of the output that is "natively"
+  // produced by NNC onto the strided representation that we want to return.
+  // So we create a new tensor with identical indexing, but restrided.
   auto dims = c10::fmap<DimArg>(sizesForValue(v));
-  // We need to convert the output tensor so that its values are layed
-  // so that when viewed from the output strides the values are correct.
-  // A contiguous Tensor of size(2, 3) with values 0-5 is layed out as:
-  // [0] [1] [2] [3] [4] [5]
-  // The same valued tensor with strides (2, 1) would be layed out like
-  // [0] [3] [1] [4] [2] [5]
-  // When we are doing the re-ordering of values into the output tensor,
-  // we are iterating per-element of the input, and we are fixed
-  // in indexing in to the output tensor at [i, j] = val
-  // `val` we want here is equal to the indices for the output
-  // tensor that would have given the same position as the output
-  // The position is equal to the sum of stride[i] * index[i],
-  // and we can can calculate the equivalent indices in the
-  // output tensor strides by iteratively computing the index of
-  // the biggest stride:
-  // absolute = ...
-  // for stride in strides_from_largest_to_smallest:
-  //     cur_idx = absolute // stride
-  //     absolute = absolute % stride
-
-  return Compute(
+  auto output = Compute(
       "output_1", dims, [&](const std::vector<VarHandle>& axes_input) {
-        std::vector<ExprHandle> axes(axes_input.begin(), axes_input.end());
-        auto absolute_position = IntImm::make(0);
-        for (size_t i = 0; i < axes.size(); ++i) {
-          absolute_position =
-              absolute_position + (IntImm::make(default_strides[i]) * axes[i]);
-        }
-        std::vector<size_t> sorted_stride_indices =
-            reverse_sort_indices(strides);
-        std::vector<ExprHandle> new_axes(sorted_stride_indices.size());
-        for (size_t stride_index : sorted_stride_indices) {
-          auto stride = strides[stride_index];
-          auto index = Div::make(absolute_position, IntImm::make(stride));
-          absolute_position =
-              Mod::make(absolute_position, IntImm::make(stride));
-          new_axes[stride_index] = index;
-        }
-        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
-        return BufHandle(buf).load(new_axes);
+        return BufHandle(buf).load(axes_input);
       });
+  std::vector<const Expr*> strideExprs;
+  for (auto const& stride : strides) {
+    strideExprs.push_back(IntImm::make(stride).node());
+  }
+  const_cast<Buf*>(output->buf())->set_strides(std::move(strideExprs));
+  return output;
 }
 
 void TensorExprKernel::bindConstant(const torch::jit::Value* v) {

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -90,7 +90,9 @@ class IndexFlattener : public IRMutator {
       return v;
     }
     return new Load(
-        v->dtype(), v->buf(), {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())});
+        v->dtype(),
+        v->buf(),
+        {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())});
   }
 
   Stmt* mutate(const Store* v) override {
@@ -100,7 +102,9 @@ class IndexFlattener : public IRMutator {
       return (Stmt*)v;
     }
     return new Store(
-        v->buf(), {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())}, new_value);
+        v->buf(),
+        {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())},
+        new_value);
   }
 };
 

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -90,7 +90,7 @@ class IndexFlattener : public IRMutator {
       return v;
     }
     return new Load(
-        v->dtype(), v->buf(), {flatten_index(v->buf()->dims(), v->indices())});
+        v->dtype(), v->buf(), {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())});
   }
 
   Stmt* mutate(const Store* v) override {
@@ -100,7 +100,7 @@ class IndexFlattener : public IRMutator {
       return (Stmt*)v;
     }
     return new Store(
-        v->buf(), {flatten_index(v->buf()->dims(), v->indices())}, new_value);
+        v->buf(), {flatten_index(v->buf()->dims(), v->buf()->strides(), v->indices())}, new_value);
   }
 };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58029 [nnc] Enable CPU fusion inside Facebook
* **#58222 [nnc] Add strides to Buf and use it to support output restriding**
* #58028 [nnc] Handle only the first argument of aten::to
* #58026 Enable cat wo conditionals iff cpu

I encountered a bug in restriding NNC output tensors and realized life
would be simpler if NNC could directly represent striding, so, here it is.

Differential Revision: [D28407364](https://our.internmc.facebook.com/intern/diff/D28407364/)