### PR TITLE
[DataLoader] Fix missing argument bug for metatype

### DIFF
--- a/torch/utils/data/_typing.py
+++ b/torch/utils/data/_typing.py
@@ -248,24 +248,24 @@ class _DataPipeMeta(GenericMeta):
     """
     type: _DataPipeType
 
-    def __new__(cls, name, bases, namespace, **kargs):
+    def __new__(cls, name, bases, namespace, **kwargs):
         # For Python > 3.6
         cls.__origin__ = None
         # Need to add _is_protocol for Python 3.7 _ProtocolMeta
         if '_is_protocol' not in namespace:
             namespace['_is_protocol'] = True
         if 'type' in namespace:
-            return super().__new__(cls, name, bases, namespace)
+            return super().__new__(cls, name, bases, namespace, **kwargs)
 
         namespace['__type_class__'] = False
         # For plain derived class without annotation
         for base in bases:
             if isinstance(base, _DataPipeMeta):
-                return super().__new__(cls, name, bases, namespace)
+                return super().__new__(cls, name, bases, namespace, **kwargs)
 
         namespace.update({'type': _DEFAULT_TYPE,
                           '__init_subclass__': _dp_init_subclass})
-        return super().__new__(cls, name, bases, namespace)
+        return super().__new__(cls, name, bases, namespace, **kwargs)
 
     @_tp_cache
     def __getitem__(self, param):

--- a/torch/utils/data/_typing.py
+++ b/torch/utils/data/_typing.py
@@ -255,17 +255,17 @@ class _DataPipeMeta(GenericMeta):
         if '_is_protocol' not in namespace:
             namespace['_is_protocol'] = True
         if 'type' in namespace:
-            return super().__new__(cls, name, bases, namespace, **kwargs)
+            return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
         namespace['__type_class__'] = False
         # For plain derived class without annotation
         for base in bases:
             if isinstance(base, _DataPipeMeta):
-                return super().__new__(cls, name, bases, namespace, **kwargs)
+                return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
         namespace.update({'type': _DEFAULT_TYPE,
                           '__init_subclass__': _dp_init_subclass})
-        return super().__new__(cls, name, bases, namespace, **kwargs)
+        return super().__new__(cls, name, bases, namespace, **kwargs)  # type: ignore[call-overload]
 
     @_tp_cache
     def __getitem__(self, param):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #56066 [DataLoader] Add option to reinforce type during runtime validation for DP instance
* **#58236 [DataLoader] Fix bug for metaclass**

Forward `**kwargs` to parent type class.