### PR TITLE
Improve native_batch_norm_backward performance (CUDA)

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -11,7 +11,8 @@ namespace at { namespace native {
 namespace {
 
 inline bool batch_norm_use_channels_last_kernels(const at::Tensor& self) {
-  return self.is_contiguous(at::MemoryFormat::ChannelsLast) || self.ndimension() == 2;
+  return (self.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+          (self.is_contiguous() && self.strides()[1] == 1));
 }
 
 enum class Impl {
@@ -34,6 +35,15 @@ inline Impl batch_norm_choose_impl(const Tensor& self) {
   }
 
   return Impl::General;
+}
+
+inline Impl batch_norm_choose_impl(const Tensor& in1, const Tensor& in2) {
+  auto imp1 = batch_norm_choose_impl(in1);
+  if (imp1 == Impl::General) {
+    return imp1;
+  }
+  auto imp2 = batch_norm_choose_impl(in2);
+  return imp1 == imp2 ? imp1 : Impl::General;
 }
 
 void batch_norm_elementwise(
@@ -105,6 +115,125 @@ void batch_norm_elementwise(
   }
   }
 }
+
+Tensor batch_norm_elementwise_backward_train(
+    const Tensor& grad_out, const Tensor& input, const Tensor& mean, const Tensor& invstd,
+    const Tensor& weight, const Tensor& sum_dy, const Tensor& sum_dy_xmu) {
+  switch (batch_norm_choose_impl(input, grad_out)) {
+  case Impl::Contiguous: {
+    return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
+                                           "batch_norm_backward_elemt", [&] {
+      return batch_norm_backward_elemt_cuda_template<scalar_t, scalar_t, int32_t>(
+          grad_out, input, mean, invstd, weight, sum_dy, sum_dy_xmu);
+    });
+  }
+  case Impl::ChannelsLast: {
+    if ((!weight.defined() || weight.is_contiguous()) &&
+        mean.is_contiguous() && invstd.is_contiguous()) {
+      return batch_norm_backward_elemt_channels_last_cuda_template(
+          grad_out, input, mean, invstd, weight, sum_dy, sum_dy_xmu);
+    }
+    C10_FALLTHROUGH;
+  }
+  case Impl::General: {
+    const auto ndim = input.dim();
+    DimVector sizes(ndim, 1), strides(ndim, 0);
+    auto as_nd = [&](const Tensor& t) {
+      TORCH_INTERNAL_ASSERT(t.defined() && t.dim() == 1);
+      sizes[1] = t.sizes()[0];
+      strides[1] = t.strides()[0];
+      return t.as_strided(sizes, strides);
+    };
+    auto invstd_nd = as_nd(invstd);
+    auto mean_nd = as_nd(mean);
+    auto sum_dy_nd = as_nd(sum_dy);
+    auto sum_dy_xmu_nd = as_nd(sum_dy_xmu);
+    auto weight_nd = weight.defined() ? as_nd(weight) :
+        at::scalar_tensor(1.0, input.options().dtype(mean.scalar_type()));
+
+    Tensor grad_input = at::empty(input.sizes(), grad_out.options());
+    auto iter = TensorIteratorConfig()
+        .add_output(grad_input)
+        .add_input(grad_out)
+        .add_input(input)
+        .add_input(weight_nd)
+        .add_input(mean_nd)
+        .add_input(invstd_nd)
+        .add_input(sum_dy_xmu_nd)
+        .add_input(sum_dy_nd)
+        .check_all_same_dtype(false)
+        .promote_inputs_to_common_dtype(false)
+        .build();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_out.scalar_type(),
+                                    "batch_norm_eval_backward", [&]{
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      auto norm_fct = static_cast<accscalar_t>(1.0 / (input.numel() /input.size(1)) );
+      gpu_kernel(iter, [norm_fct] GPU_LAMBDA (scalar_t gO, scalar_t input, accscalar_t weight,
+                                              accscalar_t mean, accscalar_t invstd,
+                                              accscalar_t xmu, accscalar_t dy) -> scalar_t {
+        auto factor_1_c = invstd * invstd * xmu * norm_fct;
+        auto factor_2_c = weight * invstd;
+        auto m_dy_c = dy * norm_fct;
+        return (gO - m_dy_c - (input - mean) * factor_1_c) * factor_2_c;
+      });
+    });
+    return grad_input;
+  }
+  }
+  TORCH_INTERNAL_ASSERT(false);
+}
+
+Tensor batch_norm_elementwise_backward_eval(
+    const Tensor& grad_out, const Tensor& input,
+    const Tensor& invstd, const Tensor& weight) {
+  const auto ndim = input.dim();
+  DimVector shape(ndim, 1), strides(ndim, 0);
+  shape[1] = invstd.sizes()[0];
+  strides[1] = invstd.strides()[0];
+  auto invstd_nd = invstd.as_strided(shape, strides);
+  Tensor grad_input = at::empty(input.sizes(), grad_out.options());
+
+  if (weight.defined()) {
+    strides[1] = weight.strides()[0];
+    auto weight_nd = weight.as_strided(shape, strides);
+    auto iter = TensorIteratorConfig()
+        .add_output(grad_input)
+        .add_input(grad_out)
+        .add_input(invstd_nd)
+        .add_input(weight_nd)
+        .check_all_same_dtype(false)
+        .promote_inputs_to_common_dtype(false)
+        .build();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_out.scalar_type(),
+                                    "batch_norm_eval_backward", [&]{
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t gO, accscalar_t invstd, accscalar_t weight)
+                 -> scalar_t {
+          return gO * weight * invstd;
+      });
+    });
+  } else {
+    auto iter = TensorIteratorConfig()
+        .add_output(grad_input)
+        .add_input(grad_out)
+        .add_input(invstd_nd)
+        .check_all_same_dtype(false)
+        .promote_inputs_to_common_dtype(false)
+        .build();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, grad_out.scalar_type(),
+                                    "batch_norm_eval_backward", [&]{
+      using accscalar_t = at::acc_type<scalar_t, true>;
+      gpu_kernel(iter, [] GPU_LAMBDA (scalar_t gO, accscalar_t invstd) -> scalar_t {
+          return gO * invstd;
+      });
+    });
+  }
+  return grad_input;
+}
+
 
 void batch_norm_mean_var(const Tensor& self, Tensor& save_mean, Tensor& save_var) {
   // NOTE: Epsilon is only used for InvStd, not Var. The value here is ignored.
@@ -284,35 +413,72 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_cuda(const Tensor& self, const c10
   return std::make_tuple(output, save_mean, save_invstd);
 }
 
-std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda(const Tensor& grad_out, const Tensor& self, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& running_mean_opt, const c10::optional<Tensor>& running_var_opt, const c10::optional<Tensor>& save_mean_opt, const c10::optional<Tensor>& save_invstd_opt, bool train, double epsilon, std::array<bool,3> grad_input_mask) {
+std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cuda(const Tensor& grad_out, const Tensor& input, const c10::optional<Tensor>& weight_opt, const c10::optional<Tensor>& running_mean_opt, const c10::optional<Tensor>& running_var_opt, const c10::optional<Tensor>& save_mean_opt, const c10::optional<Tensor>& save_invstd_opt, bool train, double epsilon, std::array<bool,3> grad_input_mask) {
   // See [Note: hacky wrapper removal for optional tensor]
-  c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
-  const Tensor& weight = *weight_maybe_owned;
-  const Tensor& running_mean = c10::value_or_else(running_mean_opt, [] {return Tensor();});
-  const Tensor& running_var = c10::value_or_else(running_var_opt, [] {return Tensor();});
-  const Tensor& save_mean = c10::value_or_else(save_mean_opt, [] {return Tensor();});
-  const Tensor& save_invstd = c10::value_or_else(save_invstd_opt, [] {return Tensor();});
+  c10::MaybeOwned<Tensor> weight = at::borrow_from_optional_tensor(weight_opt);
+  c10::MaybeOwned<Tensor> save_mean = at::borrow_from_optional_tensor(save_mean_opt);
+  c10::MaybeOwned<Tensor> save_invstd = at::borrow_from_optional_tensor(save_invstd_opt);
+  c10::MaybeOwned<Tensor> running_mean = at::borrow_from_optional_tensor(running_mean_opt);
+  c10::MaybeOwned<Tensor> running_var = at::borrow_from_optional_tensor(running_var_opt);
 
-  return AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "batch_norm_backward_cuda", [&] {
-    auto mean_st = running_mean.dtype();
-    auto var_st = running_var.dtype();
-    TORCH_CHECK(mean_st == var_st, "running_mean and running_var need to have the same data types");
-    bool is_half_float = std::is_same<scalar_t, at::Half>::value && mean_st == at::kFloat;
-    bool is_bfloat16_float = std::is_same<scalar_t, at::BFloat16>::value && mean_st == at::kFloat;
-    if (cuda::detail::canUse32BitIndexMath(self)) {
-      if (is_half_float || is_bfloat16_float) {
-        return batch_norm_backward_cuda_template<scalar_t, float, int32_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, epsilon, grad_input_mask);
-      } else {
-        return batch_norm_backward_cuda_template<scalar_t, scalar_t, int32_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, epsilon, grad_input_mask);
-      }
+  const bool needs_reduction = train || grad_input_mask[1] || grad_input_mask[2];
+
+  // Fused reducion & elementwise kernel
+  if (needs_reduction && grad_input_mask[0] &&
+      !batch_norm_use_channels_last_kernels(input) &&
+      cuda::detail::canUse32BitIndexMath(input) &&
+      cuda::detail::canUse32BitIndexMath(grad_out)) {
+    return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(),
+                                           "batch_norm_backward_cuda", [&] {
+      return batch_norm_backward_cuda_template<scalar_t, scalar_t, int32_t>(
+          grad_out, input, *weight, *running_mean, *running_var,
+          *save_mean, *save_invstd, train, epsilon, grad_input_mask);
+    });
+  }
+
+  // NOTE: native_batch_norm always returns save_mean and save_invstd to be reused in backward.
+  // However, this is also called from cudnn_batch_norm in eval mode which doesn't give
+  // save_mean and save_invstd, so it needs recalculated.
+  const auto acc_type = at::toAccumulateType(input.scalar_type(), /*is_cuda=*/true);
+  Tensor mean;
+  if (save_mean->defined()) {
+    mean = *save_mean;
+  } else if (needs_reduction) {
+    TORCH_CHECK(running_mean->defined());
+    mean = (running_mean->scalar_type() == acc_type) ?
+        *running_mean : running_mean->to(acc_type);
+  }
+
+  Tensor invstd;
+  if (save_invstd->defined()) {
+    invstd = *save_invstd;
+  } else {
+    TORCH_CHECK(running_var->defined());
+    auto n_channels = input.sizes()[1];
+    invstd = at::empty({n_channels}, input.options().dtype(acc_type));
+    batch_norm_calc_invstd(invstd, *running_var, epsilon);
+  }
+
+  Tensor sum_dy, sum_dy_xmu, grad_weight, grad_bias;
+  if (needs_reduction) {
+    std::tie(sum_dy, sum_dy_xmu, grad_weight, grad_bias) =
+        batch_norm_backward_reduce_cuda(
+            grad_out, input, mean, invstd, *weight,
+            grad_input_mask[0], grad_input_mask[1], grad_input_mask[2]);
+  }
+
+  Tensor grad_input;
+  if (grad_input_mask[0]) {
+    if (train) {
+      grad_input = batch_norm_elementwise_backward_train(
+          grad_out, input, mean, invstd, *weight, sum_dy, sum_dy_xmu);
     } else {
-      if (is_half_float || is_bfloat16_float) {
-        return batch_norm_backward_cuda_template<scalar_t, float, int64_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, epsilon, grad_input_mask);
-      } else {
-        return batch_norm_backward_cuda_template<scalar_t, scalar_t, int64_t>(grad_out, self, weight, running_mean, running_var, save_mean, save_invstd, train, epsilon, grad_input_mask);
-      }
+      grad_input = batch_norm_elementwise_backward_eval(
+          grad_out, input, invstd, *weight);
     }
-  });
+  }
+
+  return std::make_tuple(grad_input, grad_weight, grad_bias);
 }
 
 std::tuple<Tensor, Tensor> batch_norm_stats_cuda(const Tensor& self, double epsilon) {
@@ -391,33 +557,39 @@ std::tuple<Tensor, Tensor> batch_norm_gather_stats_with_counts_cuda(
   });
 }
 
-std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_cuda(const Tensor& self, const Tensor& input, const Tensor& mean, const Tensor& invstd, const c10::optional<Tensor>& weight_opt, bool input_g, bool weight_g, bool bias_g) {
+std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_cuda(const Tensor& grad_output, const Tensor& input, const Tensor& mean, const Tensor& invstd, const c10::optional<Tensor>& weight_opt, bool input_g, bool weight_g, bool bias_g) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
 
-  // self is grad_output
-  if (at::cuda::detail::canUse32BitIndexMath(self) && batch_norm_use_channels_last_kernels(self)){
-    return batch_norm_backward_reduce_cuda_channels_last_template(self, input, mean, invstd, weight, input_g, weight_g, bias_g);
+  if (at::cuda::detail::canUse32BitIndexMath(grad_output) &&
+      batch_norm_use_channels_last_kernels(grad_output) &&
+      batch_norm_use_channels_last_kernels(input) &&
+      (!weight.defined() || weight.is_contiguous()) &&
+      mean.is_contiguous() && invstd.is_contiguous()){
+    return batch_norm_backward_reduce_cuda_channels_last_template(
+        grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g);
   }
 
-  return AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "batch_norm_backward_reduce", [&] {
+  return AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, grad_output.scalar_type(), "batch_norm_backward_reduce", [&] {
     auto mean_st = mean.dtype();
     auto invstd_st = invstd.dtype();
     TORCH_CHECK(mean_st == invstd_st, "mean and invstd need to have the same data types");
-    bool is_half_float = std::is_same<scalar_t, at::Half>::value && mean_st == at::kFloat;
-    bool is_bfloat16_float = std::is_same<scalar_t, at::BFloat16>::value && mean_st == at::kFloat;
-    if (cuda::detail::canUse32BitIndexMath(self)) {
-      if (is_half_float || is_bfloat16_float) {
-        return batch_norm_backward_reduce_cuda_template<scalar_t, float, int32_t>(self, input, mean, invstd, weight, input_g, weight_g, bias_g);
+    const bool is_half_float = weight.defined() &&
+        weight.scalar_type() != input.scalar_type();
+    using accscalar_t = at::acc_type<scalar_t, true>;
+
+    if (cuda::detail::canUse32BitIndexMath(grad_output)) {
+      if (is_half_float) {
+        return batch_norm_backward_reduce_cuda_template<scalar_t, accscalar_t, int32_t>(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g);
       } else {
-        return batch_norm_backward_reduce_cuda_template<scalar_t, scalar_t, int32_t>(self, input, mean, invstd, weight, input_g, weight_g, bias_g);
+        return batch_norm_backward_reduce_cuda_template<scalar_t, scalar_t, int32_t>(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g);
       }
     } else {
-      if (is_half_float || is_bfloat16_float) {
-        return batch_norm_backward_reduce_cuda_template<scalar_t, float, int64_t>(self, input, mean, invstd, weight, input_g, weight_g, bias_g);
+      if (is_half_float) {
+        return batch_norm_backward_reduce_cuda_template<scalar_t, accscalar_t, int64_t>(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g);
       } else {
-        return batch_norm_backward_reduce_cuda_template<scalar_t, scalar_t, int64_t>(self, input, mean, invstd, weight, input_g, weight_g, bias_g);
+        return batch_norm_backward_reduce_cuda_template<scalar_t, scalar_t, int64_t>(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g);
       }
     }
   });

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -413,8 +413,7 @@ __global__ void batch_norm_backward_kernel(
   // 1. Sum(grad_output)
   // 2. DotProduct(input - mean, grad_output)
   GradOp<input_scalar_t, stat_accscalar_t, GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t>> g(mean, input, grad_output);
-  Float2<input_scalar_t, stat_accscalar_t> res = reduce<Float2<input_scalar_t, stat_accscalar_t>, GradOp<input_scalar_t, stat_accscalar_t,
-                                                                                   GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t>> >(g, grad_output, plane);
+  auto res = reduce<Float2<input_scalar_t, stat_accscalar_t>>(g, grad_output, plane);
 
   stat_accscalar_t grad_output_sum = res.v1;
   stat_accscalar_t dot_p = res.v2;
@@ -514,8 +513,7 @@ __global__ void batch_norm_backward_reduce_kernel(
   stat_accscalar_t factor = invstd[plane];
 
   GradOp<input_scalar_t, stat_accscalar_t, GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t>> g(r_mean, input, grad_output);
-  Float2<input_scalar_t, stat_accscalar_t> res = reduce<Float2<input_scalar_t, stat_accscalar_t>, GradOp<input_scalar_t, stat_accscalar_t,
-                                                                                   GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t>> >(g, grad_output, plane);
+  auto res = reduce<Float2<input_scalar_t, stat_accscalar_t>>(g, grad_output, plane);
 
   if (threadIdx.x == 0) {
     if (grad_weight.size(0) > 0) {
@@ -534,7 +532,7 @@ __global__ void batch_norm_backward_reduce_kernel(
 }
 
 template <typename input_scalar_t, typename stat_scalar_t, typename stat_accscalar_t, typename index_t>
-__global__ void batch_norm_backward_elemt_kernel(
+__device__ __forceinline__ void batch_norm_backward_elemt_kernel_impl(
     const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> input,
     const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_output,
     const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> mean,
@@ -543,13 +541,7 @@ __global__ void batch_norm_backward_elemt_kernel(
     const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy,
     const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy_xmu,
     GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_input,
-    const int* __restrict__ numel, const int world_size) {
-
-  int64_t div = 0;
-  for (int i = 0; i < world_size; i ++) {
-    div += numel[i];
-  }
-
+    const stat_accscalar_t norm_fct) {
   index_t plane = blockIdx.x;
 
   if (plane >= input.size(1)) {
@@ -557,11 +549,11 @@ __global__ void batch_norm_backward_elemt_kernel(
   }
 
   stat_accscalar_t m_c = mean[plane];
-  stat_accscalar_t m_dy_c = sum_dy[plane] / div;
+  stat_accscalar_t m_dy_c = sum_dy[plane] * norm_fct;
   stat_accscalar_t factor_1_c = invstd[plane];
   stat_accscalar_t factor_2_c = weight.size(0) > 0 ? static_cast<stat_accscalar_t>(weight[plane]) : stat_accscalar_t(1);
   factor_2_c *= factor_1_c;
-  factor_1_c = factor_1_c * factor_1_c * sum_dy_xmu[plane] / div;
+  factor_1_c = factor_1_c * factor_1_c * sum_dy_xmu[plane] * norm_fct;
 
   index_t bs = input.size(0);
   index_t fs = input.size(2);
@@ -575,6 +567,43 @@ __global__ void batch_norm_backward_elemt_kernel(
       g_i[feature] = static_cast<input_scalar_t>((g_o[feature] - m_dy_c - (i[feature] - m_c) * factor_1_c) * factor_2_c);
     }
   }
+}
+
+template <typename input_scalar_t, typename stat_scalar_t, typename stat_accscalar_t, typename index_t>
+__global__ void batch_norm_backward_elemt_kernel(
+    const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> input,
+    const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_output,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> mean,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> invstd,
+    const GenericPackedTensorAccessor<stat_scalar_t, 1, DefaultPtrTraits, index_t> weight,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy_xmu,
+    GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_input,
+    const int* __restrict__ numel, const int world_size) {
+  int64_t total_numel = 0;
+  for (int i = 0; i < world_size; i ++) {
+    total_numel += numel[i];
+  }
+
+  const stat_accscalar_t norm_fct =
+      static_cast<stat_accscalar_t>(1) / static_cast<stat_accscalar_t>(total_numel);
+  batch_norm_backward_elemt_kernel_impl(
+      input, grad_output, mean, invstd, weight, sum_dy, sum_dy_xmu, grad_input, norm_fct);
+}
+
+template <typename input_scalar_t, typename stat_scalar_t, typename stat_accscalar_t, typename index_t>
+__global__ void batch_norm_backward_elemt_kernel(
+    const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> input,
+    const GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_output,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> mean,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> invstd,
+    const GenericPackedTensorAccessor<stat_scalar_t, 1, DefaultPtrTraits, index_t> weight,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy,
+    const GenericPackedTensorAccessor<stat_accscalar_t, 1, DefaultPtrTraits, index_t> sum_dy_xmu,
+    GenericPackedTensorAccessor<input_scalar_t, 3, DefaultPtrTraits, index_t> grad_input,
+    const stat_accscalar_t norm_fct) {
+  batch_norm_backward_elemt_kernel_impl(
+      input, grad_output, mean, invstd, weight, sum_dy, sum_dy_xmu, grad_input, norm_fct);
 }
 
 template <typename scalar_t, int64_t dim, template <typename U> class PtrTraits = DefaultPtrTraits, typename index_t = int64_t>
@@ -644,8 +673,6 @@ void batch_norm_stats_cuda_template(
   Tensor dummy_var_;
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
 
-  auto bs = input_reshaped.size(0);
-  auto features = input_reshaped.size(2);
   auto input = input_reshaped.generic_packed_accessor<scalar_t, 3, RestrictPtrTraits, index_t>();
   TORCH_INTERNAL_ASSERT(out_invstd.dim() == 1 && out_invstd.is_contiguous() &&
                         out_invstd.sizes()[0]);
@@ -673,8 +700,6 @@ void batch_norm_elemt_cuda_template(const Tensor& output_, const Tensor& input_,
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
   auto output_reshaped = output_.view({input_.size(0), input_.size(1), -1});
 
-  auto bs = input_reshaped.size(0);
-  auto features = input_reshaped.size(2);
   auto input = input_reshaped.generic_packed_accessor<input_scalar_t, 3, RestrictPtrTraits, index_t>();
   auto output = output_reshaped.generic_packed_accessor<input_scalar_t, 3, RestrictPtrTraits, index_t>();
   auto weight = packed_accessor_or_dummy<stat_scalar_t, 1, RestrictPtrTraits, index_t>(weight_);
@@ -791,16 +816,13 @@ std::tuple<Tensor, Tensor, Tensor, Tensor> batch_norm_backward_reduce_cuda_templ
 template<typename input_scalar_t, typename stat_scalar_t, typename index_t>
 Tensor batch_norm_backward_elemt_cuda_template(const Tensor& grad_out_, const Tensor& input_,
                                                const Tensor& mean_, const Tensor& invstd_,
-                                               const Tensor& weight_, const Tensor& sum_dy_, const Tensor& sum_dy_xmu_, const Tensor& count) {
+                                               const Tensor& weight_, const Tensor& sum_dy_, const Tensor& sum_dy_xmu_) {
 
   using stat_accscalar_t = at::acc_type<stat_scalar_t, true>;
   int64_t n_input = input_.size(1);
   auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
   auto grad_output_reshaped = grad_out_.reshape(input_reshaped.sizes());
   auto grad_input_reshaped = at::empty_like(input_reshaped, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-
-  auto bs = input_reshaped.size(0);
-  auto features = input_reshaped.size(2);
 
   auto input = input_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
   auto grad_input = grad_input_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
@@ -822,6 +844,50 @@ Tensor batch_norm_backward_elemt_cuda_template(const Tensor& grad_out_, const Te
   int tb = std::max<int>(64/tf, 1);
   dim3 blocks_trans(input.size(1), std::max<int>(1, std::min<int>((256*1024)/input.size(1),
                                                                   (input.size(0)+tb-1)/tb)));
+  blocks_trans.y = std::min(blocks_trans.y, MAX_GRID_SIZE);
+  dim3 threads_trans(tf, tb);
+  auto reduction_size = input_.numel() / n_input;
+  auto norm_fct = static_cast<stat_accscalar_t>(1.0 / reduction_size);
+  batch_norm_backward_elemt_kernel<input_scalar_t, stat_scalar_t, stat_accscalar_t, index_t>
+      <<<blocks_trans, threads_trans, 0, stream>>>
+      (input, grad_output, mean, invstd, weight, sum_dy, sum_dy_xmu, grad_input, norm_fct);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return grad_input_reshaped.view(input_.sizes());
+}
+
+template<typename input_scalar_t, typename stat_scalar_t, typename index_t>
+Tensor batch_norm_backward_elemt_cuda_template(const Tensor& grad_out_, const Tensor& input_,
+                                               const Tensor& mean_, const Tensor& invstd_,
+                                               const Tensor& weight_, const Tensor& sum_dy_, const Tensor& sum_dy_xmu_, const Tensor& count) {
+
+  using stat_accscalar_t = at::acc_type<stat_scalar_t, true>;
+  int64_t n_input = input_.size(1);
+  auto input_reshaped = input_.reshape({input_.size(0), input_.size(1), -1}); // internally we merge the feature dimensions
+  auto grad_output_reshaped = grad_out_.reshape(input_reshaped.sizes());
+  auto grad_input_reshaped = at::empty_like(input_reshaped, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+
+  auto input = input_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
+  auto grad_input = grad_input_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
+  auto grad_output = grad_output_reshaped.generic_packed_accessor<input_scalar_t, 3, DefaultPtrTraits, index_t>();
+  auto mean = packed_accessor_or_dummy<stat_accscalar_t, 1, DefaultPtrTraits, index_t>(mean_);
+  auto invstd = packed_accessor_or_dummy<stat_accscalar_t, 1, DefaultPtrTraits, index_t>(invstd_);
+  auto weight = packed_accessor_or_dummy<stat_scalar_t, 1, DefaultPtrTraits, index_t>(weight_);
+  auto sum_dy = packed_accessor_or_dummy<stat_accscalar_t, 1, DefaultPtrTraits, index_t>(sum_dy_);
+  auto sum_dy_xmu = packed_accessor_or_dummy<stat_accscalar_t, 1, DefaultPtrTraits, index_t>(sum_dy_xmu_);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  // The kernel is pointwise, but we need to balance reading parameters (save_var/mean,
+  // weight/bias) - which we only do once and have a for loop afterwards - with having many threads and blocks
+  // and good occupancy. Quiet likely, we could go with even more blocks than 1024.
+  // The various planes are independent, so we use blocks for them.
+  int tf = std::max<int>(getNumThreads(input.size(2)/4),
+                         std::min<int>(getNumThreads(input.size(2)), 64));
+  int tb = std::max<int>(64/tf, 1);
+  dim3 blocks_trans(input.size(1), std::max<int>(1, std::min<int>((256*1024)/input.size(1),
+                                                                  (input.size(0)+tb-1)/tb)));
+  blocks_trans.y = std::min(blocks_trans.y, MAX_GRID_SIZE);
   dim3 threads_trans(tf, tb);
   batch_norm_backward_elemt_kernel<input_scalar_t, stat_scalar_t, stat_accscalar_t, index_t> <<<blocks_trans, threads_trans, 0, stream>>>
     (input, grad_output, mean, invstd, weight, sum_dy, sum_dy_xmu, grad_input, count.data_ptr<int>(), count.numel());
@@ -1052,11 +1118,11 @@ __device__ __forceinline__ void merge_block_vertical_backward(T& sum_dy,
 
 // batchnorm backward kernel for c last tensor
 // original apex name: reduce_bn_c_last_kernel
-template
-   <typename scalar_t,
+template <
+    int PARALLEL_LOADS,
+    typename scalar_t,
     typename accscalar_t,
-    typename layerscalar_t,
-    int PARALLEL_LOADS>
+    typename layerscalar_t>
 __global__ void batch_norm_backward_reduce_channels_last_kernel(
       const scalar_t* __restrict__ input,
       const scalar_t* __restrict__ grad_output,
@@ -1206,11 +1272,11 @@ __global__ void batch_norm_backward_reduce_channels_last_kernel(
 // elementwise BN kernel
 // original apex name: batchnorm_backward_c_last_kernel
 template <
+    int PARALLEL_LOADS,
     typename scalar_t,
     typename accscalar_t,
-    typename layerscalar_t,
-    int PARALLEL_LOADS>
-__global__ void batch_norm_backward_elemt_channels_last_kernel(
+    typename layerscalar_t>
+__device__ __forceinline__ void batch_norm_backward_elemt_channels_last_kernel_impl(
       const scalar_t* __restrict__ grad_output,
       const scalar_t* __restrict__ input,
       const accscalar_t* __restrict__ mean,
@@ -1218,15 +1284,10 @@ __global__ void batch_norm_backward_elemt_channels_last_kernel(
       const layerscalar_t* __restrict__ weight,
       const accscalar_t* __restrict__ sum_dy,
       const accscalar_t* __restrict__ sum_dy_xmu,
-      const int* __restrict__ numel,
       scalar_t* __restrict__ grad_input,
-      const int64_t world_size,
+      const accscalar_t norm_fct,
       const int reduction_size,
       const int stride) {
-  int64_t div = 0;
-  for (int i = 0; i < world_size; i++) {
-    div += numel[i];
-  }
   // tensor dimension (m,c)
   // loop along m dimension
   int inner_loop_stride = blockDim.y * gridDim.y;
@@ -1236,10 +1297,10 @@ __global__ void batch_norm_backward_elemt_channels_last_kernel(
   int c_offset = blockIdx.x * blockDim.x + threadIdx.x;
 
   auto m_c = mean[c_offset];
-  auto m_dy_c = sum_dy[c_offset] / div;
+  auto m_dy_c = sum_dy[c_offset] * norm_fct;
   auto factor_1_c = inv_std[c_offset];
   auto factor_2_c = (weight == nullptr? accscalar_t(1.0) : static_cast<accscalar_t>(weight[c_offset])) * factor_1_c;
-  factor_1_c = factor_1_c * factor_1_c * sum_dy_xmu[c_offset] / div;
+  factor_1_c = factor_1_c * factor_1_c * sum_dy_xmu[c_offset] * norm_fct;
 
   int loop_count = 1 + (reduction_size - 1) / (inner_loop_stride * PARALLEL_LOADS);
   int address_base = m_offset * stride + c_offset;
@@ -1258,6 +1319,58 @@ __global__ void batch_norm_backward_elemt_channels_last_kernel(
       address_base += address_increment;
     }
   }
+}
+
+template <
+    int PARALLEL_LOADS,
+    typename scalar_t,
+    typename accscalar_t,
+    typename layerscalar_t>
+__global__ void batch_norm_backward_elemt_channels_last_kernel(
+      const scalar_t* __restrict__ grad_output,
+      const scalar_t* __restrict__ input,
+      const accscalar_t* __restrict__ mean,
+      const accscalar_t* __restrict__ inv_std,
+      const layerscalar_t* __restrict__ weight,
+      const accscalar_t* __restrict__ sum_dy,
+      const accscalar_t* __restrict__ sum_dy_xmu,
+      const int* __restrict__ numel,
+      scalar_t* __restrict__ grad_input,
+      const int64_t world_size,
+      const int reduction_size,
+      const int stride) {
+
+  int64_t total_numel = 0;
+  for (int i = 0; i < world_size; i++) {
+    total_numel += numel[i];
+  }
+
+  auto norm_fct = static_cast<accscalar_t>(1) / static_cast<accscalar_t>(total_numel);
+  batch_norm_backward_elemt_channels_last_kernel_impl<PARALLEL_LOADS>(
+      grad_output, input, mean, inv_std, weight, sum_dy, sum_dy_xmu,
+      grad_input, norm_fct, reduction_size, stride);
+}
+
+template <
+    int PARALLEL_LOADS,
+    typename scalar_t,
+    typename accscalar_t,
+    typename layerscalar_t>
+__global__ void batch_norm_backward_elemt_channels_last_kernel(
+      const scalar_t* __restrict__ grad_output,
+      const scalar_t* __restrict__ input,
+      const accscalar_t* __restrict__ mean,
+      const accscalar_t* __restrict__ inv_std,
+      const layerscalar_t* __restrict__ weight,
+      const accscalar_t* __restrict__ sum_dy,
+      const accscalar_t* __restrict__ sum_dy_xmu,
+      scalar_t* __restrict__ grad_input,
+      const accscalar_t norm_fct,
+      const int reduction_size,
+      const int stride) {
+  batch_norm_backward_elemt_channels_last_kernel_impl<PARALLEL_LOADS>(
+      grad_output, input, mean, inv_std, weight, sum_dy, sum_dy_xmu,
+      grad_input, norm_fct, reduction_size, stride);
 }
 
 template<typename scalar_t, typename VarTransform>
@@ -1399,7 +1512,7 @@ batch_norm_backward_reduce_cuda_channels_last_template(const at::Tensor& grad_ou
       using accscalar_t = at::acc_type<scalar_t, true>;
       accscalar_t* staging_data_ptr = grid.y > 1 ? staging_data.data_ptr<accscalar_t>() : nullptr;
       int* semaphores_ptr = grid.y > 1 ? semaphores.data_ptr<int>() : nullptr;
-      batch_norm_backward_reduce_channels_last_kernel<scalar_t, accscalar_t, accscalar_t, ELEMENTS_PER_ITER>
+      batch_norm_backward_reduce_channels_last_kernel<ELEMENTS_PER_ITER>
           <<<grid, block, 0, stream>>>(
           input.data_ptr<scalar_t>(),
           grad_output.data_ptr<scalar_t>(),
@@ -1424,7 +1537,7 @@ batch_norm_backward_reduce_cuda_channels_last_template(const at::Tensor& grad_ou
       using accscalar_t = at::acc_type<scalar_t, true>;
       accscalar_t* staging_data_ptr = grid.y > 1 ? staging_data.data_ptr<accscalar_t>() : nullptr;
       int* semaphores_ptr = grid.y > 1 ? semaphores.data_ptr<int>() : nullptr;
-      batch_norm_backward_reduce_channels_last_kernel<scalar_t, accscalar_t, scalar_t, ELEMENTS_PER_ITER>
+      batch_norm_backward_reduce_channels_last_kernel<ELEMENTS_PER_ITER>
           <<<grid, block, 0, stream>>>(
           input.data_ptr<scalar_t>(),
           grad_output.data_ptr<scalar_t>(),
@@ -1468,7 +1581,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_cuda_template(
   if (input.scalar_type() == at::kHalf && weight.defined() && weight.scalar_type() == at::kFloat) {
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "batchnorm_backward_element", [&] {
       using accscalar_t = at::acc_type<scalar_t, true>;
-      batch_norm_backward_elemt_channels_last_kernel<scalar_t, accscalar_t, accscalar_t, ELEMENTS_PER_ITER>
+      batch_norm_backward_elemt_channels_last_kernel<ELEMENTS_PER_ITER>
           <<<grid, block, 0, stream>>>(
           grad_output.data_ptr<scalar_t>(),
           input.data_ptr<scalar_t>(),
@@ -1491,7 +1604,7 @@ at::Tensor batch_norm_backward_elemt_channels_last_cuda_template(
     }
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "batchnorm_backward_element", [&] {
       using accscalar_t = at::acc_type<scalar_t, true>;
-      batch_norm_backward_elemt_channels_last_kernel<scalar_t, accscalar_t, scalar_t, ELEMENTS_PER_ITER>
+      batch_norm_backward_elemt_channels_last_kernel<ELEMENTS_PER_ITER>
           <<<grid, block, 0, stream>>>(
           grad_output.data_ptr<scalar_t>(),
           input.data_ptr<scalar_t>(),
@@ -1508,6 +1621,64 @@ at::Tensor batch_norm_backward_elemt_channels_last_cuda_template(
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     });
   }
+
+  return grad_input;
+}
+
+at::Tensor batch_norm_backward_elemt_channels_last_cuda_template(
+    const at::Tensor& grad_output,
+    const at::Tensor& input,
+    const at::Tensor& mean,
+    const at::Tensor& inv_std,
+    const at::Tensor& weight,
+    const at::Tensor& sum_dy,
+    const at::Tensor& sum_dy_xmu) {
+  const auto stride = input.sizes()[1];
+  const auto reduction_size = input.numel() / stride;
+  auto norm_fct = 1.0 / reduction_size;
+
+  at::Tensor grad_input = at::empty_like(input, input.suggest_memory_format());
+
+  dim3 block;
+  dim3 grid;
+  flexible_launch_configs(reduction_size, stride, block, grid);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "batchnorm_backward_element", [&] {
+    using accscalar_t = at::acc_type<scalar_t, true>;
+
+    if (weight.defined() && weight.scalar_type() != input.scalar_type()) {
+      batch_norm_backward_elemt_channels_last_kernel<ELEMENTS_PER_ITER>
+          <<<grid, block, 0, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          mean.data_ptr<accscalar_t>(),
+          inv_std.data_ptr<accscalar_t>(),
+          weight.defined() ? weight.data_ptr<accscalar_t>() : nullptr,
+          sum_dy.data_ptr<accscalar_t>(),
+          sum_dy_xmu.data_ptr<accscalar_t>(),
+          grad_input.data_ptr<scalar_t>(),
+          static_cast<accscalar_t>(norm_fct),
+          reduction_size,
+          stride);
+    } else {
+      batch_norm_backward_elemt_channels_last_kernel<ELEMENTS_PER_ITER>
+          <<<grid, block, 0, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          mean.data_ptr<accscalar_t>(),
+          inv_std.data_ptr<accscalar_t>(),
+          weight.defined() ? weight.data_ptr<scalar_t>() : nullptr,
+          sum_dy.data_ptr<accscalar_t>(),
+          sum_dy_xmu.data_ptr<accscalar_t>(),
+          grad_input.data_ptr<scalar_t>(),
+          static_cast<accscalar_t>(norm_fct),
+          reduction_size,
+          stride);
+    }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  });
 
   return grad_input;
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14715,8 +14715,9 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(gradcheck(F.hardswish, (inputs,)))
 
 
-    def _test_batchnorm_eval(self, device, dtype=torch.float):
-        module = nn.BatchNorm1d(3).to(device, dtype)
+    def _test_batchnorm_eval(self, device, dtype, module_dtype=None):
+        module_dtype = module_dtype or dtype
+        module = nn.BatchNorm1d(3).to(device, module_dtype)
         module.eval()
 
         data = torch.rand(4, 3, device=device, dtype=dtype, requires_grad=True)
@@ -14738,7 +14739,7 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(grad1, grad2)
 
         # track_running_stats=False
-        module = nn.BatchNorm1d(3, track_running_stats=False).to(device, dtype)
+        module = nn.BatchNorm1d(3, track_running_stats=False).to(device, module_dtype)
 
         data = torch.rand(4, 3, device=device, dtype=dtype, requires_grad=True)
         grad = torch.rand(4, 3, device=device, dtype=dtype)
@@ -14761,21 +14762,30 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(res1, res2)
         self.assertEqual(grad1, grad2)
 
-    def test_batchnorm_eval(self, device):
-        self._test_batchnorm_eval(device)
+    @dtypes(torch.float)
+    @dtypesIfCUDA(torch.float, torch.bfloat16)
+    def test_batchnorm_eval(self, device, dtype):
+        self._test_batchnorm_eval(device, dtype)
 
         if self.device_type == 'cuda' and self.has_cudnn():
             with torch.backends.cudnn.flags(enabled=False):
-                self._test_batchnorm_eval(device)
+                self._test_batchnorm_eval(device, dtype)
 
     @onlyCUDA
-    def test_batchnorm_eval_bfloat16(self, device):
-        self._test_batchnorm_eval(device, torch.bfloat16)
+    @dtypes(torch.bfloat16, torch.half)
+    def test_batchnorm_eval_mixed(self, device, dtype):
+        # Test bfloat16 input with float module
+        self._test_batchnorm_eval(device, dtype, torch.float)
 
-    def _test_batchnorm_simple_average(self, device, dtype):
-        module = nn.BatchNorm1d(3, momentum=None).to(dtype=dtype, device=device)
-        zeros = torch.zeros(3, dtype=dtype, device=device)
-        ones = torch.ones(3, dtype=dtype, device=device)
+        if self.device_type == 'cuda' and self.has_cudnn():
+            with torch.backends.cudnn.flags(enabled=False):
+                self._test_batchnorm_eval(device, dtype, torch.float)
+
+    def _test_batchnorm_simple_average(self, device, dtype, module_dtype=None):
+        module_dtype = module_dtype or dtype
+        module = nn.BatchNorm1d(3, momentum=None).to(dtype=module_dtype, device=device)
+        zeros = torch.zeros(3, dtype=module_dtype, device=device)
+        ones = torch.ones(3, dtype=module_dtype, device=device)
         self.assertEqual(module.running_mean, zeros)
         self.assertEqual(module.running_var, ones)
 
@@ -14815,12 +14825,22 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(module.running_var, (running_var1 + running_var2) / 2)
 
     @dtypes(torch.float)
+    @dtypesIfCUDA(torch.float, torch.bfloat16)
     def test_batchnorm_simple_average(self, device, dtype):
         self._test_batchnorm_simple_average(device, dtype)
 
         if self.device_type == 'cuda' and self.has_cudnn():
             with torch.backends.cudnn.flags(enabled=False):
                 self._test_batchnorm_simple_average(device, dtype)
+
+    @onlyCUDA
+    @dtypes(torch.bfloat16, torch.half)
+    def test_batchnorm_simple_average_mixed(self, device, dtype):
+        self._test_batchnorm_simple_average(device, dtype, torch.float)
+
+        if self.device_type == 'cuda' and self.has_cudnn():
+            with torch.backends.cudnn.flags(enabled=False):
+                self._test_batchnorm_simple_average(device, dtype, torch.float)
 
     def _test_maxpool_indices(self, num_dim, adaptive=False, device="cpu", dtype=torch.float):
         def expected_indices(dim):


### PR DESCRIPTION
Fixes  #38915

The original code uses a single kernel to do both the reduction and the elementwise backward calculations. Whereas the  `SyncBatchNorm` kernels are split, which makes them slightly slower in some cases. I try to use the fused kernel when it's beneficial, but otherwise choose the optimized channels last split kernels. There is also eval mode, where the reduction is sometimes unnecessary in which case split kernels are a win even without channels last.

Benchmarks on my system show significant speedups for channels last reductions and eval mode, with only a few minor slowdowns in training mode. These slowdowns are for 2 x 2048 shape in training, which is a small channels last inputs. But for larger batches or channels, the channels last kernels are much faster.


|N   |C   |L   |training|backward|old   |new   |cudnn |
|----|----|----|--------|--------|------|------|------|
|1   |256 |3136|TRUE    |all     |70.25 |64.93 |68.90 |
|    |    |    |TRUE    |self    |69.77 |64.61 |69.42 |
|    |    |    |FALSE   |all     |70.10 |51.12 |x     |
|    |    |    |FALSE   |self    |70.17 |51.17 |x     |
|3136|256 |    |TRUE    |all     |554.08|76.63 |549.88|
|    |    |    |TRUE    |self    |553.34|78.19 |552.36|
|    |    |    |FALSE   |all     |565.40|55.09 |x     |
|    |    |    |FALSE   |self    |565.71|54.84 |x     |
|2   |8192|1   |TRUE    |all     |155.47|47.26 |202.26|
|    |    |    |TRUE    |self    |155.46|48.36 |203.72|
|    |    |    |FALSE   |all     |178.28|40.90 |x     |
|    |    |    |FALSE   |self    |178.21|40.69 |x     |
|2   |2048|1   |TRUE    |all     |43.50 |48.21 |57.47 |
|    |    |    |TRUE    |self    |43.63 |47.24 |55.22 |
|    |    |    |FALSE   |all     |49.36 |39.27 |x     |
|    |    |    |FALSE   |self    |49.25 |42.02 |x     |
|128 |8192|1   |TRUE    |all     |762.70|106.45|336.52|
|    |    |    |TRUE    |self    |765.79|107.04|337.32|
|    |    |    |FALSE   |all     |792.68|74.94 |x     |
|    |    |    |FALSE   |self    |793.86|74.83 |x     |
|128 |2048|1   |TRUE    |all     |188.37|46.20 |85.02 |
|    |    |    |TRUE    |self    |188.47|47.57 |85.04 |
|    |    |    |FALSE   |all     |191.57|40.44 |x     |
|    |    |    |FALSE   |self    |190.13|41.55 |x     |
|2   |8192|    |TRUE    |all     |156.03|43.01 |155.19|
|    |    |    |TRUE    |self    |156.24|46.59 |156.93|
|    |    |    |FALSE   |all     |179.34|40.06 |x     |
|    |    |    |FALSE   |self    |179.20|41.85 |x     |
|2   |2048|    |TRUE    |all     |44.05 |50.15 |44.21 |
|    |    |    |TRUE    |self    |44.10 |48.97 |44.11 |
|    |    |    |FALSE   |all     |49.72 |40.95 |x     |
|    |    |    |FALSE   |self    |49.87 |43.43 |x     |
|128 |8192|    |TRUE    |all     |775.19|96.60 |777.64|
|    |    |    |TRUE    |self    |776.20|96.85 |774.21|
|    |    |    |FALSE   |all     |797.64|68.01 |x     |
|    |    |    |FALSE   |self    |806.25|68.05 |x     |
|128 |2048|    |TRUE    |all     |188.49|48.10 |188.97|
|    |    |    |TRUE    |self    |188.07|46.97 |187.98|
|    |    |    |FALSE   |all     |192.32|43.78 |x     |
|    |    |    |FALSE   |self    |193.72|40.82 |x     |

