### PR TITLE
Overwrite with `ln` if libc10.so already exists

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -173,10 +173,10 @@ test_aten() {
       SUDO=sudo
     fi
 
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libc10* build/bin || true
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libcaffe2* build/bin || true
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libmkldnn* build/bin || true
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libnccl* build/bin || true
+    ${SUDO} ln -sf "$TORCH_LIB_PATH"/libc10* build/bin
+    ${SUDO} ln -sf "$TORCH_LIB_PATH"/libcaffe2* build/bin
+    ${SUDO} ln -sf "$TORCH_LIB_PATH"/libmkldnn* build/bin
+    ${SUDO} ln -sf "$TORCH_LIB_PATH"/libnccl* build/bin
 
     ls build/bin
     aten/tools/run_tests.sh build/bin

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -173,10 +173,10 @@ test_aten() {
       SUDO=sudo
     fi
 
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libc10* build/bin
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libcaffe2* build/bin
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libmkldnn* build/bin
-    ${SUDO} ln -s "$TORCH_LIB_PATH"/libnccl* build/bin
+    ${SUDO} ln -s "$TORCH_LIB_PATH"/libc10* build/bin || true
+    ${SUDO} ln -s "$TORCH_LIB_PATH"/libcaffe2* build/bin || true
+    ${SUDO} ln -s "$TORCH_LIB_PATH"/libmkldnn* build/bin || true
+    ${SUDO} ln -s "$TORCH_LIB_PATH"/libnccl* build/bin || true
 
     ls build/bin
     aten/tools/run_tests.sh build/bin


### PR DESCRIPTION
This should fix the issue noted in https://github.com/pytorch/pytorch/pull/57622#issuecomment-840612300 and demonstrated in [this run](https://github.com/pytorch/pytorch/runs/2566809365). Please review this PR carefully, because I do not know enough context to know whether this is the right thing to do.

**Test plan:**

n/a