### PR TITLE
Adding GPU support for per_channel quant/dequant

### DIFF
--- a/aten/src/ATen/native/quantized/affine_quantizer.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer.cpp
@@ -180,7 +180,7 @@ Tensor quantize_tensor_per_channel_float_qparams(
 
   checkRoundingMode(fn_name);
   checkFloatTensor(fn_name, rtensor);
-  checkCPUTensor(fn_name, rtensor);
+  //checkCPUTensor(fn_name, rtensor);
   checkSameDevice(fn_name, rtensor, qtensor);
   checkSameSize(fn_name, qtensor, rtensor);
 
@@ -277,7 +277,7 @@ Tensor dequantize_tensor_per_channel_float_qparams(
   static const auto fn_name = "dequantize_tensor_per_channel_affine";
 
   checkFloatTensor(fn_name, rtensor);
-  checkCPUTensor(fn_name, rtensor);
+  //checkCPUTensor(fn_name, rtensor);
   checkSameDevice(fn_name, rtensor, qtensor);
   checkSameSize(fn_name, qtensor, rtensor);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58246 Adding GPU support for per_channel quant/dequant**
* #58245 Adding support for cuda for quantized tensors

Summary:

This is a draft, I haven't finished testing, but the logic for the quant/dequant ops seems subtle so I wanted to show what I had sooner rather than later.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: