### PR TITLE
[tsm] add support for jetter to Role (base_image) for mast launches

### DIFF
--- a/test/distributed/launcher/run_test.py
+++ b/test/distributed/launcher/run_test.py
@@ -358,6 +358,28 @@ class ElasticLaunchTest(unittest.TestCase):
         )
 
     @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test incompatible with tsan")
+    def test_launch_run_path(self):
+        nnodes = 1
+        nproc_per_node = 4
+        world_size = nnodes * nproc_per_node
+        args = [
+            "--run_path",
+            f"--nnodes={nnodes}",
+            f"--nproc_per_node={nproc_per_node}",
+            "--monitor_interval=1",
+            "--start_method=fork",
+            path("bin/test_script.py"),
+            f"--touch_file_dir={self.test_dir}",
+        ]
+        launch.main(args)
+
+        # make sure all the workers ran
+        # each worker touches a file with its global rank as the name
+        self.assertSetEqual(
+            {str(i) for i in range(world_size)}, set(os.listdir(self.test_dir))
+        )
+
+    @unittest.skipIf(TEST_WITH_ASAN or TEST_WITH_TSAN, "test incompatible with tsan")
     def test_launch_elastic_multiple_agents(self):
         run_id = str(uuid.uuid4().int)
         min_nodes = 1

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -235,7 +235,7 @@ import os
 import sys
 import uuid
 from argparse import REMAINDER, ArgumentParser
-from typing import List, Tuple
+from typing import Callable, List, Tuple, Union
 
 import torch
 from torch.distributed.argparse_util import check_env, env
@@ -359,6 +359,14 @@ def get_args_parser() -> ArgumentParser:
         action=check_env,
         help="Skip prepending the training script with 'python' - just execute it directly. Useful "
         "when the script is not a Python script.",
+    )
+
+    parser.add_argument(
+        "--run_path",
+        action=check_env,
+        help="Run the training script with runpy.run_path in the same interpreter."
+        " Script must be provided as an abs path (e.g. /abs/path/script.py)."
+        " Takes precedence over --no_python.",
     )
     parser.add_argument(
         "--log_dir",
@@ -503,7 +511,7 @@ def get_rdzv_endpoint(args):
     return args.rdzv_endpoint
 
 
-def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
+def config_from_args(args) -> Tuple[LaunchConfig, Union[Callable, str], List[str]]:
     # If ``args`` not passed, defaults to ``sys.argv[:1]``
     min_nodes, max_nodes = parse_min_max_nnodes(args.nnodes)
     assert 0 < min_nodes <= max_nodes
@@ -548,31 +556,51 @@ def config_from_args(args) -> Tuple[LaunchConfig, List[str]]:
     )
 
     with_python = not args.no_python
-    cmd = []
-    if with_python:
-        cmd = [sys.executable, "-u"]
-        if args.module:
-            cmd.append("-m")
+    cmd: Union[Callable, str]
+    cmd_args = []
+    if args.run_path:
+        cmd = run_script_path
+        cmd_args.append(args.training_script)
     else:
-        if not args.use_env:
-            raise ValueError(
-                "When using the '--no_python' flag,"
-                " you must also set the '--use_env' flag."
-            )
-        if args.module:
-            raise ValueError(
-                "Don't use both the '--no_python' flag"
-                " and the '--module' flag at the same time."
-            )
-    cmd.append(args.training_script)
+        if with_python:
+            cmd = sys.executable
+            cmd_args.append("-u")
+            if args.module:
+                cmd_args.append("-m")
+            cmd_args.append(args.training_script)
+        else:
+            if not args.use_env:
+                raise ValueError(
+                    "When using the '--no_python' flag,"
+                    " you must also set the '--use_env' flag."
+                )
+            if args.module:
+                raise ValueError(
+                    "Don't use both the '--no_python' flag"
+                    " and the '--module' flag at the same time."
+                )
+            cmd = args.training_script
     if not args.use_env:
         log.warning(
-            "`torch.distributed.launch` is Deprecated. Use torch.distributed.run"
+            "--use_env is deprecated and will be removed in future releases.\n"
+            " Please read local_rank from `os.environ('LOCAL_RANK')` instead."
         )
-        cmd.append(f"--local_rank={macros.local_rank}")
-    cmd.extend(args.training_script_args)
+        cmd_args.append(f"--local_rank={macros.local_rank}")
+    cmd_args.extend(args.training_script_args)
 
-    return config, cmd
+    return config, cmd, cmd_args
+
+
+def run_script_path(training_script: str, *training_script_args: str):
+    """
+    Runs the provided `training_script` from within this interpreter.
+    Usage: `script_as_function("/abs/path/to/script.py", "--arg1", "val1")`
+    """
+    import runpy
+    import sys
+
+    sys.argv = [training_script] + [*training_script_args]
+    runpy.run_path(sys.argv[0], run_name="__main__")
 
 
 def run(args):
@@ -589,9 +617,11 @@ def run(args):
             f"**************************************\n"
         )
 
-    config, cmd = config_from_args(args)
-
-    elastic_launch(config=config, entrypoint=cmd[0],)(*cmd[1:])
+    config, cmd, cmd_args = config_from_args(args)
+    elastic_launch(
+        config=config,
+        entrypoint=cmd,
+    )(*cmd_args)
 
 
 def main(args=None):


### PR DESCRIPTION
Summary:
1. Adds `ml_image` buck macro
2. Adds `--run_path` option to `torch.distributed.run`
3. Adds `tsm/driver/fb/test/patched/foo` (for unittesting)
4. Changes to `distributed_sum` to use `ml_image` (see Test plan for how this was tested in local and mast)

NOTE: need to enable jetter for flow and local schedulers (will do this on a separate diff since this diff is already really big)

Test Plan:
## Local Testing
```
# build the two fbpkgs (base and main)
buck run //pytorch/elastic/examples/distributed_sum/fb:torchx.examples.dist_sum.base
buck run //pytorch/elastic/examples/distributed_sum/fb:torchx.examples.dist_sum

# fetch the fbpkgs
cd ~/tmp

fbpkg fetch --symlink-tags  -o -d . jetter:prod
fbpkg fetch --symlink-tags  -o -d . torchx.examples.dist_sum.base
fbpkg fetch --symlink-tags  -o -d . torchx.examples.dist_sum

jetter/LAST/jetter apply-and-run \
  torchx.examples.dist_sum.base/LAST/torchrun \
  torchx.examples.dist_sum/LAST \
  -- \
  --as_function \
  --rdzv_id foobar \
  --nnodes 1 \
  --nproc_per_node 2 \
  --max_restarts 0 \
  --role worker \
  --no_python \
~/torchx.examples.dist_sum/LAST/pytorch/elastic/examples/distributed_sum/fb/main.py
```

## Mast Testing
```
buck-out/gen/pytorch/elastic/torchelastic/tsm/fb/cli/tsm.par run_ddp \
  --scheduler mast
  --base_fbpkg torchx.examples.dist_sum.base:78f01b5 \
  --fbpkg torchx.examples.dist_sum:f38ab46 \
  --run_cfg hpcClusterUuid=MastNaoTestCluster,hpcIdentity=pytorch_r2p,hpcJobOncall=pytorch_r2p \
  --nnodes 2 \
  --resource T1 \
  --nproc_per_node 4 \
  --name kiuk_jetter_test \
 pytorch/elastic/examples/distributed_sum/fb/main.py
```
Runs successfully: https://www.internalfb.com/mast/job/tsm_kiuk-kiuk_jetter_test_34c9f0fa?

Differential Revision: D28421033

