### PR TITLE
[nnc] Fix output restriding of size-1 dimensions

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -1963,5 +1963,13 @@ class TestTEFuser(JitTestCase):
         script = self.checkScript(eager, (x,))
         self.assertAllFused(script.graph_for(x))
 
+    def test_dims(self):
+        def eager(x, y):
+            return x / (y + 0.0001)
+        x = torch.linspace(-1, 1, 768, dtype=torch.float32).as_strided((1, 1, 768), (768, 1, 1))
+        y = torch.tensor([[[2.0]]], dtype=torch.float32)
+        script = self.checkScript(eager, (x, y))
+        self.assertAllFused(script.graph_for(x, y))
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -3043,9 +3043,12 @@ Tensor* TensorExprKernel::convertOutputToCorrectStrides(torch::jit::Value* v) {
         std::vector<ExprHandle> new_axes(sorted_stride_indices.size());
         for (size_t stride_index : sorted_stride_indices) {
           auto stride = strides[stride_index];
+          auto size = sizes[stride_index];
           auto index = Div::make(absolute_position, IntImm::make(stride));
-          absolute_position =
+          if (size != 1) {
+            absolute_position =
               Mod::make(absolute_position, IntImm::make(stride));
+          }
           new_axes[stride_index] = index;
         }
         // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58029 [nnc] Enable CPU fusion inside Facebook
* **#58256 [nnc] Fix output restriding of size-1 dimensions**
* #58028 [nnc] Handle only the first argument of aten::to
* #58026 Enable cat wo conditionals iff cpu

Size-1 dims mess up our output restriding logic, because they're
technically "dense" no matter what stride the dimension has.  In this example a
size-1 dim has stride 1, which causes all the indices to be taken mod 1 (i.e.,
all indices become 0).  We work around this peculiar case by skipping size-1 in
our layout logic, since it has no impact on the rest of the tensor's indexing.

Differential Revision: [D28424388](https://our.internmc.facebook.com/intern/diff/D28424388/)