### PR TITLE
[DataLoader] Introduce MapMapDataPipe functional datapipe

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -8,14 +8,13 @@ import tarfile
 import zipfile
 import numpy as np
 import sys
-from PIL import Image
 from unittest import skipIf
 
 import torch
 import torch.nn as nn
 from torch.testing._internal.common_utils import (TestCase, run_tests)
 from torch.utils.data import \
-    (IterDataPipe, RandomSampler, DataLoader,
+    (IterDataPipe, MapDataPipe, RandomSampler, DataLoader,
      argument_validation, runtime_validation_disabled, runtime_validation)
 
 from typing import \
@@ -33,6 +32,13 @@ try:
 except ImportError:
     HAS_TORCHVISION = False
 skipIfNoTorchVision = skipIf(not HAS_TORCHVISION, "no torchvision")
+
+try:
+    from PIL import Image
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
+skipIfNoPIL = skipIf(not HAS_PIL, "no Pillow")
 
 
 T_co = TypeVar('T_co', covariant=True)
@@ -178,6 +184,7 @@ class TestIterableDataPipeBasic(TestCase):
             self.assertEqual(data_refs[i][1].read(), open(self.temp_files[i], 'rb').read())
 
 
+    @skipIfNoPIL
     def test_routeddecoder_iterable_datapipe(self):
         temp_dir = self.temp_dir.name
         temp_pngfile_pathname = os.path.join(temp_dir, "test_png.png")
@@ -258,6 +265,19 @@ class IDP(IterDataPipe):
             yield i
 
     def __len__(self):
+        return self.length
+
+
+class MDP(MapDataPipe):
+    def __init__(self, input_dp):
+        super().__init__()
+        self.input_dp = input_dp
+        self.length = len(input_dp)
+
+    def __getitem__(self, index):
+        return self.input_dp[index]
+
+    def __len__(self) -> int:
         return self.length
 
 
@@ -574,6 +594,65 @@ class TestFunctionalIterDataPipe(TestCase):
         self.assertEqual(list(zipped_dp), exp)
         # Reset
         self.assertEqual(list(zipped_dp), exp)
+
+
+class TestFunctionalMapDataPipe(TestCase):
+    def test_picklable(self):
+        arr = range(10)
+        picklable_datapipes: List[
+            Tuple[Type[MapDataPipe], MapDataPipe, Tuple, Dict[str, Any]]
+        ] = [
+            (dp.map.Map, MDP(arr), (), {}),
+            (dp.map.Map, MDP(arr), (_fake_fn, (0,), {'test': True}), {}),
+        ]
+        for dpipe, input_dp, dp_args, dp_kwargs in picklable_datapipes:
+            p = pickle.dumps(dpipe(input_dp, *dp_args, **dp_kwargs))  # type: ignore[call-arg]
+
+        unpicklable_datapipes: List[
+            Tuple[Type[MapDataPipe], MapDataPipe, Tuple, Dict[str, Any]]
+        ] = [
+            (dp.map.Map, MDP(arr), (lambda x: x,), {}),
+        ]
+        for dpipe, input_dp, dp_args, dp_kwargs in unpicklable_datapipes:
+            with warnings.catch_warnings(record=True) as wa:
+                datapipe = dpipe(input_dp, *dp_args, **dp_kwargs)  # type: ignore[call-arg]
+                self.assertEqual(len(wa), 1)
+                self.assertRegex(
+                    str(wa[0].message), r"^Lambda function is not supported for pickle"
+                )
+                with self.assertRaises(AttributeError):
+                    p = pickle.dumps(datapipe)
+
+    def test_map_datapipe(self):
+        arr = range(10)
+        input_dp = MDP(arr)
+
+        def fn(item, dtype=torch.float, *, sum=False):
+            data = torch.tensor(item, dtype=dtype)
+            return data if not sum else data.sum()
+
+        map_dp = input_dp.map(fn)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for index in arr:
+            self.assertEqual(
+                map_dp[index], torch.tensor(input_dp[index], dtype=torch.float)
+            )
+
+        map_dp = input_dp.map(fn=fn, fn_args=(torch.int,), fn_kwargs={'sum': True})
+        self.assertEqual(len(input_dp), len(map_dp))
+        for index in arr:
+            self.assertEqual(
+                map_dp[index], torch.tensor(input_dp[index], dtype=torch.int).sum()
+            )
+
+        from functools import partial
+
+        map_dp = input_dp.map(partial(fn, dtype=torch.int, sum=True))
+        self.assertEqual(len(input_dp), len(map_dp))
+        for index in arr:
+            self.assertEqual(
+                map_dp[index], torch.tensor(input_dp[index], dtype=torch.int).sum()
+            )
 
 
 # Metaclass conflict for Python 3.6

--- a/torch/utils/data/__init__.py
+++ b/torch/utils/data/__init__.py
@@ -3,8 +3,7 @@ from torch.utils.data.sampler import \
      SubsetRandomSampler, WeightedRandomSampler, BatchSampler)
 from torch.utils.data.dataset import \
     (Dataset, IterableDataset, TensorDataset, ConcatDataset, ChainDataset,
-     Subset, random_split)
-from torch.utils.data.dataset import IterableDataset as IterDataPipe
+     Subset, random_split, Dataset as MapDataPipe, IterableDataset as IterDataPipe)
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.dataloader import DataLoader, _DatasetKind, get_worker_info
 from torch.utils.data._decorator import \
@@ -17,9 +16,10 @@ __all__ = ['Sampler', 'SequentialSampler', 'RandomSampler',
            'DistributedSampler', 'Dataset', 'IterableDataset', 'TensorDataset',
            'ConcatDataset', 'ChainDataset', 'Subset', 'random_split',
            'DataLoader', '_DatasetKind', 'get_worker_info',
-           'IterDataPipe', 'functional_datapipe', 'guaranteed_datapipes_determinism',
-           'non_deterministic', 'argument_validation',
-           'runtime_validation_disabled', 'runtime_validation']
+           'IterDataPipe', 'MapDataPipe', 'functional_datapipe',
+           'guaranteed_datapipes_determinism', 'non_deterministic',
+           'argument_validation', 'runtime_validation_disabled',
+           'runtime_validation']
 
 
 ################################################################################

--- a/torch/utils/data/_decorator.py
+++ b/torch/utils/data/_decorator.py
@@ -1,7 +1,7 @@
 import inspect
 from functools import wraps
 from typing import Any, Callable, Optional, Type, Union, get_type_hints
-from torch.utils.data import IterDataPipe
+from torch.utils.data import IterDataPipe, MapDataPipe
 from torch.utils.data._typing import _DataPipeMeta
 
 
@@ -15,16 +15,20 @@ class functional_datapipe(object):
         self.name = name
 
     def __call__(self, cls):
-        if isinstance(cls, Type):  # type: ignore[arg-type]
-            if not isinstance(cls, _DataPipeMeta):
-                raise TypeError('`functional_datapipe` can only decorate IterDataPipe')
-        # with non_deterministic decorator
-        else:
-            if not isinstance(cls, non_deterministic) and \
-                not (hasattr(cls, '__self__') and
-                     isinstance(cls.__self__, non_deterministic)):
-                raise TypeError('`functional_datapipe` can only decorate IterDataPipe')
-        IterDataPipe.register_datapipe_as_function(self.name, cls)
+        if issubclass(cls, IterDataPipe):
+            if isinstance(cls, Type):  # type: ignore[arg-type]
+                if not isinstance(cls, _DataPipeMeta):
+                    raise TypeError('`functional_datapipe` can only decorate IterDataPipe')
+            # with non_deterministic decorator
+            else:
+                if not isinstance(cls, non_deterministic) and \
+                    not (hasattr(cls, '__self__') and
+                         isinstance(cls.__self__, non_deterministic)):
+                    raise TypeError('`functional_datapipe` can only decorate IterDataPipe')
+            IterDataPipe.register_datapipe_as_function(self.name, cls)
+        elif issubclass(cls, MapDataPipe):
+            MapDataPipe.register_datapipe_as_function(self.name, cls)
+
         return cls
 
 

--- a/torch/utils/data/datapipes/__init__.py
+++ b/torch/utils/data/datapipes/__init__.py
@@ -1,1 +1,2 @@
 from . import iter
+from . import map

--- a/torch/utils/data/datapipes/map/__init__.py
+++ b/torch/utils/data/datapipes/map/__init__.py
@@ -1,0 +1,5 @@
+# Functional DataPipe
+from torch.utils.data.datapipes.map.callable import MapMapDataPipe as Map
+
+
+__all__ = ["Map"]

--- a/torch/utils/data/datapipes/map/callable.py
+++ b/torch/utils/data/datapipes/map/callable.py
@@ -1,0 +1,82 @@
+import warnings
+from typing import Callable, Dict, Optional, Tuple, TypeVar
+
+from torch.utils.data import MapDataPipe, functional_datapipe
+
+try:
+    import dill
+
+    # XXX: By default, dill writes the Pickler dispatch table to inject its
+    # own logic there. This globally affects the behavior of the standard library
+    # pickler for any user who transitively depends on this module!
+    # Undo this extension to avoid altering the behavior of the pickler globally.
+    dill.extend(use_dill=False)
+    DILL_AVAILABLE = True
+except ImportError:
+    DILL_AVAILABLE = False
+
+T_co = TypeVar('T_co', covariant=True)
+
+
+# Default function to return each item directly
+# In order to keep datapipe picklable, eliminates the usage
+# of python lambda function
+def default_fn(data):
+    return data
+
+
+@functional_datapipe('map')
+class MapMapDataPipe(MapDataPipe[T_co]):
+    r""":class:`MapMapDataPipe`.
+
+    Map DataPipe to run a function over each item from the source DataPipe.
+    The function can be any regular python function or partial object. Lambda
+    function is not recommended as it is not supported by pickle.
+    args:
+        datapipe: Source Map DataPipe
+        fn: Function called over each item
+        fn_args: Positional arguments for `fn`
+        fn_kwargs: Keyword arguments for `fn`
+    """
+    datapipe: MapDataPipe
+    fn: Callable
+
+    def __init__(
+        self,
+        datapipe: MapDataPipe,
+        fn: Callable = default_fn,
+        fn_args: Optional[Tuple] = None,
+        fn_kwargs: Optional[Dict] = None,
+    ) -> None:
+        super().__init__()
+        self.datapipe = datapipe
+        # Partial object has no attribute '__name__', but can be pickled
+        if hasattr(fn, '__name__') and fn.__name__ == '<lambda>' and not DILL_AVAILABLE:
+            warnings.warn(
+                "Lambda function is not supported for pickle, please use "
+                "regular python function or functools.partial instead."
+            )
+        self.fn = fn  # type: ignore[assignment]
+        self.args = () if fn_args is None else fn_args
+        self.kwargs = {} if fn_kwargs is None else fn_kwargs
+
+    def __len__(self) -> int:
+        return len(self.datapipe)
+
+    def __getitem__(self, index) -> T_co:
+        return self.fn(self.datapipe[index], *self.args, **self.kwargs)
+
+    def __getstate__(self):
+        if DILL_AVAILABLE:
+            dill_function = dill.dumps(self.fn)
+        else:
+            dill_function = self.fn
+        state = (self.datapipe, dill_function, self.args, self.kwargs)
+        return state
+
+    def __setstate__(self, state):
+        (self.datapipe, dill_function, self.args, self.kwargs) = state
+        if DILL_AVAILABLE:
+            self.fn = dill.loads(dill_function)  # type: ignore[assignment]
+        else:
+            self.fn = dill_function  # type: ignore[assignment]

--- a/torch/utils/data/dataset.py
+++ b/torch/utils/data/dataset.py
@@ -29,6 +29,7 @@ class Dataset(Generic[T_co]):
       sampler that yields integral indices.  To make it work with a map-style
       dataset with non-integral indices/keys, a custom sampler must be provided.
     """
+    functions: Dict[str, Callable] = {}
 
     def __getitem__(self, index) -> T_co:
         raise NotImplementedError
@@ -39,6 +40,27 @@ class Dataset(Generic[T_co]):
     # No `def __len__(self)` default?
     # See NOTE [ Lack of Default `__len__` in Python Abstract Base Classes ]
     # in pytorch/torch/utils/data/sampler.py
+
+    def __getattr__(self, attribute_name):
+        if attribute_name in Dataset.functions:
+            function = functools.partial(Dataset.functions[attribute_name], self)
+            return function
+        else:
+            raise AttributeError
+
+    @classmethod
+    def register_function(cls, function_name, function):
+        cls.functions[function_name] = function
+
+    @classmethod
+    def register_datapipe_as_function(cls, function_name, cls_to_register):
+        if function_name in cls.functions:
+            raise Exception("Unable to add DataPipe function name {} as it is already taken".format(function_name))
+
+        def class_function(cls, source_dp, *args, **kwargs):
+            return cls(source_dp, *args, **kwargs)
+        function = functools.partial(class_function, cls_to_register)
+        cls.functions[function_name] = function
 
 
 class IterableDataset(Dataset[T_co], metaclass=_DataPipeMeta):
@@ -161,20 +183,6 @@ class IterableDataset(Dataset[T_co], metaclass=_DataPipeMeta):
             return function
         else:
             raise AttributeError
-
-    @classmethod
-    def register_function(cls, function_name, function):
-        IterableDataset.functions[function_name] = function
-
-    @classmethod
-    def register_datapipe_as_function(cls, function_name, cls_to_register):
-        if function_name in IterableDataset.functions:
-            raise Exception("Unable to add DataPipe function name {} as it is already taken".format(function_name))
-
-        def class_function(cls, source_dp, *args, **kwargs):
-            return cls(source_dp, *args, **kwargs)
-        function = functools.partial(class_function, cls_to_register)
-        IterableDataset.functions[function_name] = function
 
     def __reduce_ex__(self, *args, **kwargs):
         if IterableDataset.reduce_ex_hook is not None:


### PR DESCRIPTION
Summary:
As part of https://github.com/pytorch/pytorch/issues/57031, this PR adds the `MapMapDataPipe` functional datapipe for the `MapDataPipe` class.

Usage:
```
def fn(x):
    return x * 10

dp = CountingDataset(n=10)
dp.map(fn)
```

Differential Revision: D28394510

