### PR TITLE
[metal] Add reflection_pad2d for metal

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
@@ -105,13 +105,13 @@ using namespace at::native::metal;
   }
   MTLFunctionConstantValues* constantValues = [MTLFunctionConstantValues new];
   NSUInteger ushortArgIndex = 0;
-  NSUInteger floatArgIndex = 10;
+  NSUInteger floatArgIndex = 12;
   for (auto i = 0; i < constants.count; ++i) {
     NSNumber* constant = constants[i];
     const char* type = constant.objCType;
     if (strcmp(type, @encode(NSUInteger)) == 0 ||
         strcmp(type, @encode(NSInteger)) == 0) {
-      TORCH_CHECK(ushortArgIndex <= 10);
+      TORCH_CHECK(ushortArgIndex <= 12);
       ushort value = ushort([constant unsignedIntegerValue]);
       [constantValues setConstantValue:&value
                                   type:MTLDataTypeUShort
@@ -120,7 +120,7 @@ using namespace at::native::metal;
     }
     if (strcmp(type, @encode(float)) == 0 ||
         strcmp(type, @encode(double)) == 0) {
-      TORCH_CHECK(floatArgIndex <= 12);
+      TORCH_CHECK(floatArgIndex <= 14);
       float value = [constant floatValue];
       [constantValues setConstantValue:&value
                                   type:MTLDataTypeFloat

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.h
@@ -52,5 +52,6 @@ bool test_mean_dim3();
 bool test_chunk();
 bool test_chunk2();
 bool test_chunk3();
+bool test_reflection_pad2d();
 
 #endif

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -791,6 +791,17 @@ bool test_reshape() {
   });
 }
 
+bool test_reflection_pad2d() {
+  __block std::vector<int64_t> size{2, 3, 47, 63};
+  return TEST(size, __PRETTY_FUNCTION__, ^bool {
+    auto X1 = at::rand(size, at::TensorOptions(at::kCPU).dtype(at::kFloat));
+    auto X2 = X1.metal();
+    auto Y1 = at::reflection_pad2d(X1, {2,4,7,9});
+    auto Y2 = at::reflection_pad2d(X2, {2,4,7,9}).cpu();
+    return almostEqual(Y1, Y2);
+  });
+}
+
 bool test_hardtanh_() {
 #if TARGET_OS_IPHONE
   __block std::vector<int64_t> size{1, 32, 112, 112};

--- a/aten/src/ATen/native/metal/ops/MetalPadding.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPadding.mm
@@ -1,0 +1,95 @@
+#import <ATen/native/metal/MetalCommandBuffer.h>
+#import <ATen/native/metal/MetalTensorImpl.h>
+#import <ATen/native/metal/MetalTensorImplStorage.h>
+#import <ATen/native/metal/MetalUtils.h>
+#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
+#import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
+#import <ATen/native/metal/mpscnn/MPSImageUtils.h>
+
+#include <torch/library.h>
+
+namespace at {
+namespace native {
+namespace metal {
+
+// API_AVAILABLE(ios(10.0), macos(10.13))
+Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
+  TORCH_CHECK(input.is_metal());
+
+  const int pad_dim = padding.size();
+  const IntArrayRef input_size = input.sizes();
+  const int input_dim = input_size.size();
+
+  TORCH_CHECK(pad_dim == 1 || pad_dim == 4, "Padding sizes must be a 1-tuple or 4-tuple!");
+  TORCH_CHECK(input_dim >= 2, "Input tensor must have dim >= 2!");
+
+  NSUInteger pad_left = padding[0];
+  NSUInteger pad_right = padding[0];
+  NSUInteger pad_top = padding[0];
+  NSUInteger pad_bottom = padding[0];
+  if (pad_dim == 4) {
+    pad_right = padding[1];
+    pad_top = padding[2];
+    pad_bottom = padding[3];
+  }
+
+  std::vector<int64_t> output_size(input_dim);
+  for (size_t d = 0; d < input_dim; ++d) {
+    if (d == input_dim - 1) {
+      output_size[d] = input_size[d] + pad_right + pad_left;
+    }
+    else if (d == input_dim - 2) {
+      output_size[d] = input_size[d] + pad_top + pad_bottom;
+    }
+    else {
+      output_size[d] = input_size[d];
+    }
+  }
+
+  MPSImage* X = imageFromTensor(input);
+  MetalCommandBuffer* commandBuffer = getCommandBufferFromTensor(input);
+  MetalTensorImplStorage mt{output_size};
+  mt.texture()->allocateTemporaryStorage(output_size, commandBuffer);
+  MPSImage* Y = mt.texture()->image();
+
+  id<MTLComputeCommandEncoder> encoder =
+      [commandBuffer.buffer computeCommandEncoder];
+  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+      specializedPipelineState:"reflection_pad2d"
+                     Constants:@[
+                       @(Y.height),
+                       @(Y.width),
+                       @(Y.featureChannels),
+                       @(Y.numberOfImages),
+                       @(X.height),
+                       @(X.width),
+                       @(X.featureChannels),
+                       @(X.numberOfImages),
+                       @(pad_left),
+                       @(pad_right),
+                       @(pad_top),
+                       @(pad_bottom)
+                     ]];
+
+  [encoder setComputePipelineState:state];
+  [encoder setTexture:[X texture] atIndex:0];
+  [encoder setTexture:[Y texture] atIndex:1];
+
+  const auto& launchParams =
+      metal::mpscnn::spatialPointwiseKernelLaunchParams(state, Y);
+  [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
+          threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
+  [encoder endEncoding];
+  [X markRead];
+  auto output = makeTensor(std::move(mt), input.options());
+  return output;
+}
+
+TORCH_LIBRARY_IMPL(aten, Metal, m) {
+  m.impl("reflection_pad2d", TORCH_FN(reflection_pad2d));
+};
+
+}
+}
+}


### PR DESCRIPTION
Summary: Add the `reflection_pad2d` op in preparation for newer xirp models.

Test Plan:
Test on device:
```
arc focus2 pp-ios
```
Test on mac
```
buck test pp-macos
```

Reviewed By: xta0

Differential Revision: D27047892

