### PR TITLE
[ATen][Quant] Pass at::Tensor by reference

### DIFF
--- a/aten/src/ATen/core/QuantizerBase.h
+++ b/aten/src/ATen/core/QuantizerBase.h
@@ -58,12 +58,12 @@ struct TORCH_API Quantizer : public c10::intrusive_ptr_target {
   /**
    * quantize a float Tensor into a quantized Tensor.
    */
-  virtual Tensor quantize(Tensor t) = 0;
+  virtual Tensor quantize(const Tensor& t) = 0;
 
   /**
    * dequantize a quantized Tensor into a float Tensor.
    */
-  virtual Tensor dequantize(Tensor t) = 0;
+  virtual Tensor dequantize(const Tensor& t) = 0;
 
   /**
    * Compare against `other` for equality.

--- a/aten/src/ATen/native/quantized/affine_quantizer.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer.cpp
@@ -31,26 +31,31 @@ DEFINE_DISPATCH(dequantize_tensor_per_tensor_affine_sub_byte_stub);
 namespace {
 
 void checkRoundingMode(const std::string& fn_name) {
-// Disabling this warning message for now as it is printed incorrectly. Need to fix
+  // Disabling this warning message for now as it is printed incorrectly. Need
+  // to fix
 
-/*  TORCH_WARN_ONCE(
-      std::fegetround() != FE_TONEAREST,
-      fn_name,
-      " current rounding mode is not set to round-to-nearest-ties-to-even (FE_TONEAREST). This will cause accuracy issues in quantized models.");
-*/
+  /*  TORCH_WARN_ONCE(
+        std::fegetround() != FE_TONEAREST,
+        fn_name,
+        " current rounding mode is not set to round-to-nearest-ties-to-even
+     (FE_TONEAREST). This will cause accuracy issues in quantized models.");
+  */
   return;
 }
 
-void checkCPUTensor(const std::string& fn_name, Tensor t) {
+void checkCPUTensor(const std::string& fn_name, const Tensor& t) {
   TORCH_CHECK(
       t.device().type() == kCPU, fn_name, " only supports CPU device type.");
 }
 
-void checkFloatTensor(const std::string& fn_name, Tensor t) {
+void checkFloatTensor(const std::string& fn_name, const Tensor& t) {
   TORCH_CHECK(t.scalar_type() == kFloat, fn_name, " expects a Float Tensor.");
 }
 
-void checkSameDevice(const std::string& fn_name, Tensor t1, Tensor t2) {
+void checkSameDevice(
+    const std::string& fn_name,
+    const Tensor& t1,
+    const Tensor& t2) {
   TORCH_CHECK(
       t1.device() == t2.device(),
       fn_name,
@@ -58,7 +63,7 @@ void checkSameDevice(const std::string& fn_name, Tensor t1, Tensor t2) {
 }
 
 template <typename T>
-void checkQuantizedTensor(const std::string& fn_name, Tensor t) {
+void checkQuantizedTensor(const std::string& fn_name, const Tensor& t) {
   TORCH_CHECK(t.is_quantized(), fn_name, " expects a quantized Tensor.");
   TORCH_CHECK(
       t.scalar_type() == caffe2::TypeMeta::Make<T>(),
@@ -86,7 +91,7 @@ void checkZeroPoint(const std::string& fn_name, int64_t zero_point) {
 }
 
 template <typename T>
-void checkZeroPoints(const std::string& fn_name, Tensor zero_points) {
+void checkZeroPoints(const std::string& fn_name, const Tensor& zero_points) {
   auto zero_points_data = zero_points.data_ptr<int64_t>();
   // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   for (size_t i = 0; i < zero_points.numel(); ++i) {
@@ -94,7 +99,10 @@ void checkZeroPoints(const std::string& fn_name, Tensor zero_points) {
   }
 }
 
-void checkSameSize(const std::string& fn_name, Tensor qt, Tensor rt) {
+void checkSameSize(
+    const std::string& fn_name,
+    const Tensor& qt,
+    const Tensor& rt) {
   TORCH_CHECK(
       qt.sizes().equals(rt.sizes()),
       fn_name,
@@ -103,12 +111,12 @@ void checkSameSize(const std::string& fn_name, Tensor qt, Tensor rt) {
 
 } // anonymous namespace
 
-Tensor quantize_tensor_per_tensor_affine(
-    Tensor rtensor,
-    Tensor qtensor,
+Tensor& quantize_tensor_per_tensor_affine(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     double scale,
     int64_t zero_point) {
-  static const auto fn_name = "quantize_tensor_per_tensor_affine";
+  static const std::string fn_name = "quantize_tensor_per_tensor_affine";
 
   checkRoundingMode(fn_name);
   checkFloatTensor(fn_name, rtensor);
@@ -125,22 +133,21 @@ Tensor quantize_tensor_per_tensor_affine(
   // Can move this into the fbgemm::Quantize op.
   if (qtensor.scalar_type() == at::ScalarType::QUInt4x2) {
     quantize_tensor_per_tensor_affine_sub_byte_stub(
-      rtensor.device().type(), rtensor, qtensor, scale, zero_point);
-  }
-  else {
+        rtensor.device().type(), rtensor, qtensor, scale, zero_point);
+  } else {
     quantize_tensor_per_tensor_affine_stub(
-      rtensor.device().type(), rtensor, qtensor, scale, zero_point);
+        rtensor.device().type(), rtensor, qtensor, scale, zero_point);
   }
   return qtensor;
 }
 
-Tensor quantize_tensor_per_channel_affine(
-    Tensor rtensor,
-    Tensor qtensor,
+Tensor& quantize_tensor_per_channel_affine(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis) {
-  static const auto fn_name = "quantize_tensor_per_channel_affine";
+  static const std::string fn_name = "quantize_tensor_per_channel_affine";
 
   checkRoundingMode(fn_name);
   checkFloatTensor(fn_name, rtensor);
@@ -156,7 +163,10 @@ Tensor quantize_tensor_per_channel_affine(
   TORCH_CHECK(
       0 <= axis && axis < rtensor.dim(),
       "Channel axis out of range in per channel affine quantization. Got: ",
-      axis, "Expected: [0, ", rtensor.dim(), ")");
+      axis,
+      "Expected: [0, ",
+      rtensor.dim(),
+      ")");
   int64_t channel = rtensor.size(axis);
   TORCH_CHECK(
       channel == int64_t(scales.numel()),
@@ -170,13 +180,14 @@ Tensor quantize_tensor_per_channel_affine(
   return qtensor;
 }
 
-Tensor quantize_tensor_per_channel_float_qparams(
-    Tensor rtensor,
-    Tensor qtensor,
+Tensor& quantize_tensor_per_channel_float_qparams(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis) {
-  static const auto fn_name = "quantize_tensor_per_channel_float_qparams";
+  static const std::string fn_name =
+      "quantize_tensor_per_channel_float_qparams";
 
   checkRoundingMode(fn_name);
   checkFloatTensor(fn_name, rtensor);
@@ -192,7 +203,10 @@ Tensor quantize_tensor_per_channel_float_qparams(
   TORCH_CHECK(
       0 <= axis && axis < rtensor.dim(),
       "Channel axis out of range in per channel float qparams quantization. Got: ",
-      axis, "Expected: [0, ", rtensor.dim(), ")");
+      axis,
+      "Expected: [0, ",
+      rtensor.dim(),
+      ")");
   int64_t channel = rtensor.size(axis);
   TORCH_CHECK(
       channel == int64_t(scales.numel()),
@@ -204,15 +218,14 @@ Tensor quantize_tensor_per_channel_float_qparams(
   quantize_tensor_per_channel_float_qparams_stub(
       rtensor.device().type(), rtensor, qtensor, scales, zero_points, axis);
   return qtensor;
-
 }
 
-Tensor dequantize_tensor_per_tensor_affine(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_tensor_affine(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     double scale,
     int64_t zero_point) {
-  static const auto fn_name = "dequantize_tensor_per_tensor_affine";
+  static const std::string fn_name = "dequantize_tensor_per_tensor_affine";
   checkFloatTensor(fn_name, rtensor);
   checkSameDevice(fn_name, rtensor, qtensor);
   checkSameSize(fn_name, qtensor, rtensor);
@@ -233,13 +246,13 @@ Tensor dequantize_tensor_per_tensor_affine(
   return rtensor;
 }
 
-Tensor dequantize_tensor_per_channel_affine(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_channel_affine(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis) {
-  static const auto fn_name = "dequantize_tensor_per_channel_affine";
+  static const std::string fn_name = "dequantize_tensor_per_channel_affine";
 
   checkFloatTensor(fn_name, rtensor);
   checkCPUTensor(fn_name, rtensor);
@@ -254,7 +267,10 @@ Tensor dequantize_tensor_per_channel_affine(
   TORCH_CHECK(
       0 <= axis && axis < qtensor.dim(),
       "Channel axis out of range in per channel affine dequantization. Got:",
-      axis, " Expected: [0, ", qtensor.dim(), ")");
+      axis,
+      " Expected: [0, ",
+      qtensor.dim(),
+      ")");
   int64_t channel = qtensor.size(axis);
   TORCH_CHECK(
       channel == int64_t(scales.numel()),
@@ -268,13 +284,13 @@ Tensor dequantize_tensor_per_channel_affine(
   return rtensor;
 }
 
-Tensor dequantize_tensor_per_channel_float_qparams(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_channel_float_qparams(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis) {
-  static const auto fn_name = "dequantize_tensor_per_channel_affine";
+  static const std::string fn_name = "dequantize_tensor_per_channel_affine";
 
   checkFloatTensor(fn_name, rtensor);
   checkCPUTensor(fn_name, rtensor);
@@ -289,7 +305,10 @@ Tensor dequantize_tensor_per_channel_float_qparams(
   TORCH_CHECK(
       0 <= axis && axis < qtensor.dim(),
       "Channel axis out of range in per channel float qparams dequantization. Got:",
-      axis, " Expected: [0, ", qtensor.dim(), ")");
+      axis,
+      " Expected: [0, ",
+      qtensor.dim(),
+      ")");
   int64_t channel = qtensor.size(axis);
   TORCH_CHECK(
       channel == int64_t(scales.numel()),

--- a/aten/src/ATen/native/quantized/affine_quantizer.h
+++ b/aten/src/ATen/native/quantized/affine_quantizer.h
@@ -7,82 +7,82 @@
 namespace at {
 namespace native {
 
-Tensor quantize_tensor_per_tensor_affine(
-    Tensor rtensor,
-    Tensor qtensor,
+Tensor& quantize_tensor_per_tensor_affine(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     double scale,
     int64_t zero_point);
-Tensor quantize_tensor_per_channel_affine(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& quantize_tensor_per_channel_affine(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis);
 
-Tensor quantize_tensor_per_channel_float_qparams(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& quantize_tensor_per_channel_float_qparams(
+    const Tensor& rtensor,
+    Tensor& qtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis);
 
-Tensor dequantize_tensor_per_tensor_affine(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_tensor_affine(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     double scale,
     int64_t zero_point);
-Tensor dequantize_tensor_per_channel_affine(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_channel_affine(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis);
-Tensor dequantize_tensor_per_channel_float_qparams(
-    Tensor qtensor,
-    Tensor rtensor,
+Tensor& dequantize_tensor_per_channel_float_qparams(
+    const Tensor& qtensor,
+    Tensor& rtensor,
     Tensor scales,
     Tensor zero_points,
     int64_t axis);
 
 using quantize_tensor_per_tensor_affine_fn =
-    void (*)(Tensor rtensor, Tensor qtensor, double scale, int64_t zero_point);
+    void (*)(const Tensor& rtensor, Tensor& qtensor, double scale, int64_t zero_point);
 
 using quantize_tensor_per_channel_affine_fn = void (*)(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis);
 
 using quantize_tensor_per_channel_float_qparams_fn = void (*)(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis);
 
 using dequantize_tensor_per_tensor_affine_fn =
-    void (*)(Tensor qtensor, Tensor rtensor, double scale, int64_t zero_point);
+    void (*)(const Tensor& qtensor, Tensor& rtensor, double scale, int64_t zero_point);
 
 using dequantize_tensor_per_channel_affine_fn = void (*)(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& qtensor,
+    Tensor& rtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis);
 
 using dequantize_tensor_per_channel_float_qparams_fn = void (*)(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& qtensor,
+    Tensor& rtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis);
 
 using quantize_tensor_per_tensor_affine_sub_byte_fn =
-    void (*)(Tensor rtensor, Tensor qtensor, float scale, float zero_point);
+    void (*)(const Tensor& rtensor, Tensor& qtensor, float scale, float zero_point);
 
 using dequantize_tensor_per_tensor_affine_sub_byte_fn =
-    void (*)(Tensor qtensor, Tensor rtensor, float scale, float zero_point);
+    void (*)(const Tensor& qtensor, Tensor& rtensor, float scale, float zero_point);
 
 DECLARE_DISPATCH(
     quantize_tensor_per_tensor_affine_fn,

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -2429,8 +2429,8 @@ void quantized_normalize_kernel(
 
 #ifdef USE_FBGEMM
 void quantize_tensor_per_tensor_affine_cpu(
-    Tensor rtensor,
-    Tensor qtensor,
+    const Tensor& rtensor,
+    Tensor& qtensor,
     double scale,
     int64_t zero_point) {
   AT_DISPATCH_QINT_TYPES(
@@ -2462,8 +2462,8 @@ void quantize_tensor_per_tensor_affine_cpu(
 }
 
 void dequantize_tensor_per_tensor_affine_cpu(
-    Tensor qtensor,
-    Tensor rtensor,
+    const Tensor& qtensor,
+    Tensor& rtensor,
     double scale,
     int64_t zero_point) {
   AT_DISPATCH_QINT_TYPES(
@@ -2502,7 +2502,7 @@ void dequantize_tensor_per_tensor_affine_cpu(
 template <typename T>
 void quantize_tensor_arm(
     const float* in,
-    Tensor qtensor,
+    Tensor& qtensor,
     const int64_t N,
     const float scale,
     const int32_t zero_point) {
@@ -2521,7 +2521,7 @@ void quantize_tensor_arm(
 template <>
 void quantize_tensor_arm<c10::quint8>(
     const float* in,
-    Tensor qtensor,
+    Tensor& qtensor,
     const int64_t N,
     const float scale,
     const int32_t zero_point) {
@@ -2589,8 +2589,8 @@ void quantize_tensor_arm<c10::quint8>(
 #endif // defined(__ARM_NEON__) || defined(__aarch64__)
 
 void quantize_tensor_per_tensor_affine_cpu(
-    Tensor rtensor,
-    Tensor qtensor,
+    const Tensor& rtensor,
+    Tensor& qtensor,
     double scale,
     int64_t zero_point) {
 #if defined(__ARM_NEON__) || defined(__aarch64__)
@@ -2617,8 +2617,8 @@ void quantize_tensor_per_tensor_affine_cpu(
 }
 
 void dequantize_tensor_per_tensor_affine_cpu(
-    Tensor qtensor,
-    Tensor rtensor,
+    const Tensor& qtensor,
+    Tensor& rtensor,
     double scale,
     int64_t zero_point) {
   AT_DISPATCH_QINT_TYPES(
@@ -2638,10 +2638,10 @@ void dequantize_tensor_per_tensor_affine_cpu(
 // Generic template defaults to naive quantize implementation
 template <typename T>
 void quantize_tensor_per_channel_impl(
-    Tensor rtensor,
-    Tensor qtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   // TODO: channels last kernel can be made faster.
   // For contiguous tensors, e.g. NCHW, arbitrary axis can be used.
@@ -2697,10 +2697,10 @@ void quantize_tensor_per_channel_impl(
 // (int8, int32).
 template <>
 void quantize_tensor_per_channel_impl<c10::quint8>(
-    Tensor rtensor,
-    Tensor qtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   int64_t batches = size_to_dim_(axis, rtensor.sizes());
   int64_t elements_per_channel = size_from_dim_(axis + 1, rtensor.sizes());
@@ -2883,10 +2883,10 @@ void quantize_tensor_per_channel_impl<c10::quint8>(
 #endif // defined(__ARM_NEON__) || defined(__aarch64__)
 
 void quantize_tensor_per_channel_affine_cpu(
-    Tensor rtensor,
-    Tensor qtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   TORCH_CHECK(
       rtensor.is_contiguous() || (axis <= 1),
@@ -2902,10 +2902,10 @@ void quantize_tensor_per_channel_affine_cpu(
 
 template<typename T, typename N, typename Q>
 void dequantize_per_channel_affine_kernel(
-      Tensor qtensor,
-      Tensor rtensor,
-      Tensor scales,
-      Tensor zero_points,
+      const Tensor& qtensor,
+      Tensor& rtensor,
+      const Tensor& scales,
+      const Tensor& zero_points,
       int64_t axis,
       int bit_width=8) {
 
@@ -2967,10 +2967,10 @@ void dequantize_per_channel_affine_kernel(
 }
 
 void dequantize_tensor_per_channel_affine_cpu(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& qtensor,
+    Tensor& rtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   AT_DISPATCH_QINT_TYPES(
       qtensor.scalar_type(), "dequantize_tensor_per_channel_affine_cpu", [&]() {
@@ -2980,10 +2980,10 @@ void dequantize_tensor_per_channel_affine_cpu(
 
 // quantize stubs for floating point scale and zero_point.
 void quantize_tensor_per_channel_float_qparams_cpu(
-    Tensor rtensor,
-    Tensor qtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& rtensor,
+    Tensor& qtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   // For contiguous tensors, e.g. NCHW, arbitrary axis can be used.
   // For channels_last/3d however axis == 0 or 1.
@@ -3045,10 +3045,10 @@ void quantize_tensor_per_channel_float_qparams_cpu(
 }
 
 void dequantize_tensor_per_channel_float_qparams_cpu(
-    Tensor qtensor,
-    Tensor rtensor,
-    Tensor scales,
-    Tensor zero_points,
+    const Tensor& qtensor,
+    Tensor& rtensor,
+    const Tensor& scales,
+    const Tensor& zero_points,
     int64_t axis) {
   // NOLINTNEXTLINE(clang-diagnostic-unused-variable)
   AT_DISPATCH_QINT_AND_SUB_BYTE_TYPES(
@@ -3058,8 +3058,8 @@ void dequantize_tensor_per_channel_float_qparams_cpu(
 }
 
 void quantize_tensor_per_tensor_affine_sub_byte_cpu(
-    Tensor rtensor,
-    Tensor qtensor,
+    const Tensor& rtensor,
+    Tensor& qtensor,
     float scale,
     float zero_point) {
   // TODO Use fbgemm kernel to pack values
@@ -3089,8 +3089,8 @@ void quantize_tensor_per_tensor_affine_sub_byte_cpu(
 }
 
 void dequantize_tensor_per_tensor_affine_sub_byte_cpu(
-    Tensor qtensor,
-    Tensor rtensor,
+    const Tensor& qtensor,
+    Tensor& rtensor,
     float scale,
     float zero_point) {
   // TODO Use fbgemm kernel to pack values

--- a/aten/src/ATen/native/quantized/cuda/affine_quantizer.cu
+++ b/aten/src/ATen/native/quantized/cuda/affine_quantizer.cu
@@ -9,8 +9,8 @@ namespace native {
 namespace {
 
 void quantize_tensor_per_tensor_affine_cuda(
-    Tensor rtensor,
-    Tensor qtensor,
+    const Tensor& rtensor,
+    Tensor& qtensor,
     double scale,
     int64_t zero_point) {
   AT_DISPATCH_QINT_TYPES(
@@ -39,8 +39,8 @@ void quantize_tensor_per_tensor_affine_cuda(
 }
 
 void dequantize_tensor_per_tensor_affine_cuda(
-    Tensor qtensor,
-    Tensor rtensor,
+    const Tensor& qtensor,
+    Tensor& rtensor,
     double scale,
     int64_t zero_point) {
   AT_DISPATCH_QINT_TYPES(

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -130,7 +130,7 @@ inline Tensor new_qtensor(
   return tensor;
 }
 
-Tensor PerTensorAffineQuantizer::quantize(Tensor rtensor) {
+Tensor PerTensorAffineQuantizer::quantize(const Tensor& rtensor) {
   TORCH_CHECK(
       rtensor.scalar_type() == kFloat, "quantize only works on Float Tensor.");
   // Here we need a std::intrusive_ptr<Quantizer>.. but actually "this" is the
@@ -142,25 +142,25 @@ Tensor PerTensorAffineQuantizer::quantize(Tensor rtensor) {
           .memory_format(rtensor.suggest_memory_format()),
       intrusive_from_this());
 
-  rtensor = rtensor.contiguous(rtensor.suggest_memory_format());
+  auto rtensor_contig = rtensor.expect_contiguous(rtensor.suggest_memory_format());
   native::quantize_tensor_per_tensor_affine(
-      rtensor, qtensor, scale_, zero_point_);
+      *rtensor_contig, qtensor, scale_, zero_point_);
   return qtensor;
 }
 
-Tensor PerTensorAffineQuantizer::dequantize(Tensor qtensor) {
+Tensor PerTensorAffineQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(
       qtensor.sizes(),
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  qtensor = qtensor.contiguous(qtensor.suggest_memory_format());
+  auto qtensor_contig = qtensor.expect_contiguous(qtensor.suggest_memory_format());
   native::dequantize_tensor_per_tensor_affine(
-      qtensor, rtensor, scale_, zero_point_);
+      *qtensor_contig, rtensor, scale_, zero_point_);
   return rtensor;
 }
 
-Tensor PerChannelAffineQuantizer::quantize(Tensor rtensor) {
+Tensor PerChannelAffineQuantizer::quantize(const Tensor& rtensor) {
   // Here we need a std::intrusive_ptr<Quantizer>.. but actually "this" is the
   // quantizer that can be reused, so I'm using intrusive_from_this here
   Tensor qtensor = new_qtensor(
@@ -169,42 +169,42 @@ Tensor PerChannelAffineQuantizer::quantize(Tensor rtensor) {
           .dtype(scalar_type_)
           .memory_format(rtensor.suggest_memory_format()),
       intrusive_from_this());
-  rtensor = rtensor.contiguous(rtensor.suggest_memory_format());
+  auto rtensor_contig = rtensor.expect_contiguous(rtensor.suggest_memory_format());
   native::quantize_tensor_per_channel_affine(
-      rtensor, qtensor, scales_, zero_points_, axis_);
+      *rtensor_contig, qtensor, scales_, zero_points_, axis_);
   return qtensor;
 }
 
-Tensor PerChannelAffineQuantizer::dequantize(Tensor qtensor) {
+Tensor PerChannelAffineQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(
       qtensor.sizes(),
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  qtensor = qtensor.contiguous(qtensor.suggest_memory_format());
+  auto qtensor_contig = qtensor.expect_contiguous(qtensor.suggest_memory_format());
   native::dequantize_tensor_per_channel_affine(
-      qtensor, rtensor, scales_, zero_points_, axis_);
+      *qtensor_contig, rtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 
-Tensor PerChannelAffineFloatQParamsQuantizer::quantize(Tensor rtensor) {
+Tensor PerChannelAffineFloatQParamsQuantizer::quantize(const Tensor& rtensor) {
  TORCH_CHECK(
       rtensor.scalar_type() == kFloat, "quantize only works on Float Tensor.");
  Tensor qtensor = new_qtensor(
       rtensor.sizes(),
       rtensor.options().dtype(scalar_type_),
       intrusive_from_this());
- rtensor = rtensor.contiguous();
+ auto rtensor_contig = rtensor.expect_contiguous();
  native::quantize_tensor_per_channel_float_qparams(
-   rtensor, qtensor, scales_, zero_points_, axis_);
+   *rtensor_contig, qtensor, scales_, zero_points_, axis_);
   return qtensor;
 }
 
-Tensor PerChannelAffineFloatQParamsQuantizer::dequantize(Tensor qtensor) {
+Tensor PerChannelAffineFloatQParamsQuantizer::dequantize(const Tensor& qtensor) {
   Tensor rtensor = at::empty(qtensor.sizes(), qtensor.options().dtype(at::kFloat));
-  qtensor = qtensor.contiguous();
+  auto qtensor_contig = qtensor.expect_contiguous();
   native::dequantize_tensor_per_channel_float_qparams(
-    qtensor, rtensor, scales_, zero_points_, axis_);
+    *qtensor_contig, rtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -64,8 +64,8 @@ struct TORCH_API PerTensorAffineQuantizer : public AffineQuantizer {
         scale_(scale),
         zero_point_(zero_point) {}
 
-  Tensor quantize(Tensor tensor) override;
-  Tensor dequantize(Tensor tensor) override;
+  Tensor quantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& tensor) override;
 
   QScheme qscheme() const override {
     return kPerTensorAffine;
@@ -134,8 +134,8 @@ struct TORCH_API PerChannelAffineQuantizer : public AffineQuantizer {
     return axis_;
   }
 
-  Tensor quantize(Tensor tensor) override;
-  Tensor dequantize(Tensor tensor) override;
+  Tensor quantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& tensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffine) {
@@ -184,8 +184,8 @@ struct TORCH_API PerChannelAffineFloatQParamsQuantizer : public PerChannelAffine
     return kPerChannelAffineFloatQParams;
   }
 
-  Tensor quantize(Tensor tensor) override;
-  Tensor dequantize(Tensor tensor) override;
+  Tensor quantize(const Tensor& tensor) override;
+  Tensor dequantize(const Tensor& tensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffineFloatQParams) {


### PR DESCRIPTION
Summary: Passing at::Tensor by value can incur a lot of refcount bumps overhead. Passing-by-reference is much more efficient.

Differential Revision: D28432300

