### PR TITLE
Merge CreationMeta MULTI_OUTPUT_SAFE with MULTI_OUTPUT_NODE

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8268,7 +8268,7 @@ class TestAutogradDeviceType(TestCase):
             a = torch.randn(3, 3, device=device, requires_grad=True)
             b = a + a
             s1, s2, s3 = f(b)
-            error_msg = 'This view is an output of a function that returns multiple views.'
+            error_msg = 'This view is the output of a function that returns multiple views.'
             with self.assertRaisesRegex(RuntimeError, error_msg):
                 s1.mul_(s2)
 

--- a/tools/autograd/gen_inplace_or_view_type.py
+++ b/tools/autograd/gen_inplace_or_view_type.py
@@ -63,13 +63,6 @@ VIEW_FUNCTIONS = {
 for key in VIEW_FUNCTIONS_WITH_METADATA_CHANGE:
     VIEW_FUNCTIONS[key] = 'self'
 
-# Functions for which we use CreationMeta::MULTI_OUTPUT_SAFE. I.e., the ones for
-# which inplace modification of outputs is being gradually deprecated.
-MULTI_OUTPUT_SAFE_FUNCTIONS = {
-    'split',
-    'split_with_sizes',
-}
-
 # note: some VIEW_FUNCTIONS are just compositions of the view functions above
 # this list contains both the root view functions and any that are purely composed
 # of viewing functions, and is used by the JIT to determine when an operator
@@ -302,10 +295,7 @@ def emit_view_body(fn: NativeFunctionWithDifferentiabilityInfo, var: str) -> Tup
         # If we are in a no grad block, raise a warning
         # See NOTE [ View + Inplace detection ] for more details about this logic
         if is_tensor_list_type(return_info.type):
-            if base_name in MULTI_OUTPUT_SAFE_FUNCTIONS:
-                creation_meta = get_creation_meta_in_mode('CreationMeta::MULTI_OUTPUT_SAFE')
-            else:
-                creation_meta = get_creation_meta_in_mode('CreationMeta::MULTI_OUTPUT_NODE')
+            creation_meta = get_creation_meta_in_mode('CreationMeta::MULTI_OUTPUT_NODE')
             call += (f'as_view(/* base */ {view_info}, /* output */ {var}, /* is_bw_differentiable */ true, '
                      '/* is_fw_differentiable */ true, '
                      f'/* creation_meta */ {creation_meta});')

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -214,22 +214,13 @@ Tensor & detach_(c10::DispatchKeySet ks, Tensor & self) {
     // NB: is_view() ==> get_autograd_meta()
     auto diff_view_meta = static_cast<torch::autograd::DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(self));
     // See NOTE [ View + Inplace detection ]
-    if (diff_view_meta->get_creation_meta() == CreationMeta::MULTI_OUTPUT_SAFE) {
-        TORCH_WARN("This view is an output of a function that "
-                   "returns multiple views. Detaching such views inplace "
-                   "is being deprecated and will be forbidden "
-                   "starting from version 1.8. Consider using detach() instead "
-                   "of detach_(). Alternatively, create this view with an "
-                   "`unsafe_` version of the function that produced it.");
-    } else {
-      AT_ERROR("Can't detach views in-place. Use detach() instead. "
-               "If you are using DistributedDataParallel (DDP) for training, "
-               "and gradient_as_bucket_view is set as True, gradients are "
-               "views of DDP buckets, and hence detach_() cannot be called "
-               "on these gradients. To fix this error, please refer to the "
-               "Optimizer.zero_grad() function in torch/optim/optimizer.py "
-               "as the solution.");
-    }
+    AT_ERROR("Can't detach views in-place. Use detach() instead. "
+              "If you are using DistributedDataParallel (DDP) for training, "
+              "and gradient_as_bucket_view is set as True, gradients are "
+              "views of DDP buckets, and hence detach_() cannot be called "
+              "on these gradients. To fix this error, please refer to the "
+              "Optimizer.zero_grad() function in torch/optim/optimizer.py "
+              "as the solution.");
   }
   // I think the choice here is conservative.  In principle, doing
   // an in-place detach should give us the ability to just clear

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -211,8 +211,6 @@ Tensor detach(c10::DispatchKeySet ks, const Tensor & self) {
 Tensor & detach_(c10::DispatchKeySet ks, Tensor & self) {
   RECORD_FUNCTION("detach_", std::vector<c10::IValue>({self}));
   if (self.is_view()) {
-    // NB: is_view() ==> get_autograd_meta()
-    auto diff_view_meta = static_cast<torch::autograd::DifferentiableViewMeta*>(torch::autograd::impl::get_autograd_meta(self));
     // See NOTE [ View + Inplace detection ]
     AT_ERROR("Can't detach views in-place. Use detach() instead. "
               "If you are using DistributedDataParallel (DDP) for training, "

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -218,7 +218,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // backward differentiable view
       if (diff_view_meta->has_bw_view()) {
         TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::NO_GRAD_MODE || creation_meta == CreationMeta::INFERENCE_MODE ||
-            creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
+            creation_meta == CreationMeta::MULTI_OUTPUT_NODE,
             "Functions that result multiple view must have a creation meta reflecting this behavior or more restrictive.");
       }
       creation_meta = propagate_creation_meta(diff_view_meta->get_creation_meta(), creation_meta);
@@ -248,7 +248,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
       // TODO: fix fb internal use-case so that it doesn't trigger this internal assert when the base is not a view.
       // In this code, the assert should be outside of the if statement.
       TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::NO_GRAD_MODE || creation_meta == CreationMeta::INFERENCE_MODE ||
-          creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
+          creation_meta == CreationMeta::MULTI_OUTPUT_NODE,
           "Functions that result multiple view must have a creation meta reflecting this behavior or more restrictive.");
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed
@@ -266,7 +266,7 @@ inline std::vector<Tensor> as_view(const Tensor & base, std::vector<Tensor>& ten
     if (diff_view_meta && diff_view_meta->has_fw_view()) {
       const auto& base_fw_info = diff_view_meta->get_forward_view();
       TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::NO_GRAD_MODE || creation_meta == CreationMeta::INFERENCE_MODE ||
-          creation_meta == CreationMeta::MULTI_OUTPUT_NODE || creation_meta == CreationMeta::MULTI_OUTPUT_SAFE,
+          creation_meta == CreationMeta::MULTI_OUTPUT_NODE,
           "Functions that result multiple view must have a creation meta reflecting this behavior or more restrictive.");
       // It is ok to create a ViewInfo where only the base is correct in this case as inplace operations on such views are
       // not allowed

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -149,9 +149,7 @@ namespace impl {
       // See NOTE [ View + Inplace detection ]
       auto creation_meta = diff_view_meta->get_creation_meta();
       // Do not use handle_view_on_rebase here as check_inplace should have been called before this
-      // and either throw an error or clear the warning
-      // Temporary error message as a full fix is too risky for now
-      // Should be an internal assert again
+      // and either throw an error
       TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::DEFAULT);
       TORCH_INTERNAL_ASSERT(gradient_edge.input_nr == 0);
       TORCH_INTERNAL_ASSERT(gradient_edge.function);
@@ -647,7 +645,7 @@ void handle_view_on_rebase(DifferentiableViewMeta* diff_view_meta, bool indirect
     } else if (creation_meta == CreationMeta::NO_GRAD_MODE) {
       TORCH_INTERNAL_ASSERT(!grad_fn);
       msg = c10::str(msg, " Given that this use case is ambiguous and error-prone, it is forbidden."
-                      " You can clarify your code and remove this warning by moving both the view and the inplace either both"
+                      " You can clarify your code by moving both the view and the inplace either both"
                       " inside the no_grad block (if you don't want the inplace to be tracked) or both outside (if you want"
                       " the inplace to be tracked).");
     } else if (creation_meta == CreationMeta::INFERENCE_MODE) {
@@ -660,7 +658,7 @@ void handle_view_on_rebase(DifferentiableViewMeta* diff_view_meta, bool indirect
     } else if (creation_meta == CreationMeta::IN_CUSTOM_FUNCTION) {
       msg = c10::str(msg, " This view was created inside a custom Function (or because an input was returned as-is) and the"
                       " autograd logic to handle view+inplace would override the custom backward associated with the custom"
-                      " Function, leading to incorrect gradients. This behavior is forbidden. You can remove this warning by"
+                      " Function, leading to incorrect gradients. This behavior is forbidden. You can fix this by"
                       " cloning the output of the custom Function.");
     } else {
       TORCH_INTERNAL_ASSERT(false, "Invalid CreationMeta state");

--- a/torch/csrc/autograd/variable.cpp
+++ b/torch/csrc/autograd/variable.cpp
@@ -148,25 +148,23 @@ namespace impl {
     if (diff_view_meta && diff_view_meta->has_bw_view()) {
       // See NOTE [ View + Inplace detection ]
       auto creation_meta = diff_view_meta->get_creation_meta();
-      if (creation_meta != CreationMeta::MULTI_OUTPUT_SAFE) {
-        // Do not use handle_view_on_rebase here as check_inplace should have been called before this
-        // and either throw an error or clear the warning
-        // Temporary error message as a full fix is too risky for now
-        // Should be an internal assert again
-        TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::DEFAULT);
-        TORCH_INTERNAL_ASSERT(gradient_edge.input_nr == 0);
-        TORCH_INTERNAL_ASSERT(gradient_edge.function);
-        TORCH_CHECK(
-            gradient_edge.function->num_inputs() == 1,
-            "Functions which modify views in-place must return a single Variable");
-        auto view_info = diff_view_meta->get_backward_view();
-        diff_view_meta->output_nr_ = gradient_edge.input_nr;
-        auto copy_slices = std::make_shared<CopySlices>(
-            view_info.base_, at::TensorGeometry(self), view_info.view_fn_, std::move(gradient_edge.function));
-        set_gradient_edge(view_info.base_, {std::move(copy_slices), 0});
-        self.grad_fn(); // trigger an update to the view's grad_fn
-        return;
-      }
+      // Do not use handle_view_on_rebase here as check_inplace should have been called before this
+      // and either throw an error or clear the warning
+      // Temporary error message as a full fix is too risky for now
+      // Should be an internal assert again
+      TORCH_INTERNAL_ASSERT(creation_meta == CreationMeta::DEFAULT);
+      TORCH_INTERNAL_ASSERT(gradient_edge.input_nr == 0);
+      TORCH_INTERNAL_ASSERT(gradient_edge.function);
+      TORCH_CHECK(
+          gradient_edge.function->num_inputs() == 1,
+          "Functions which modify views in-place must return a single Variable");
+      auto view_info = diff_view_meta->get_backward_view();
+      diff_view_meta->output_nr_ = gradient_edge.input_nr;
+      auto copy_slices = std::make_shared<CopySlices>(
+          view_info.base_, at::TensorGeometry(self), view_info.view_fn_, std::move(gradient_edge.function));
+      set_gradient_edge(view_info.base_, {std::move(copy_slices), 0});
+      self.grad_fn(); // trigger an update to the view's grad_fn
+      return;
     }
 
     set_gradient_edge(self, std::move(gradient_edge));
@@ -536,63 +534,61 @@ const std::shared_ptr<torch::autograd::Node>& VariableHooks::grad_fn(const Tenso
   auto diff_view_meta = torch::autograd::impl::get_view_autograd_meta(self);
   if (diff_view_meta && diff_view_meta->has_bw_view()) {
     // See NOTE [ View + Inplace detection ]
-    if (diff_view_meta->get_creation_meta() != CreationMeta::MULTI_OUTPUT_SAFE) {
-      std::lock_guard<std::mutex> lock(diff_view_meta->mutex_);
-      auto view_info = diff_view_meta->get_backward_view();
-      if (!diff_view_meta->grad_fn_ && !view_info.base_.requires_grad()) {
-        return diff_view_meta->grad_fn_;
-      }
-      auto current_version = self._version();
-      if (diff_view_meta->get_attr_version() != current_version) {
-        // This is an indirect rebase_history due to another view or the base being modified inplace
-        handle_view_on_rebase(diff_view_meta, /* indirect */ true);
-        TORCH_INTERNAL_ASSERT(diff_view_meta->output_nr_ == 0);
-        // Note [View + Inplace update for view tensor]
-        // An inplace update happened on Tensor `self` (which is a view).
-        // For example:
-        //   view_1 = view_op_1(diff_view_meta->base_)
-        //   view_2 = view_op_2(view_1)
-        //   ...
-        //   self = view_op_n(view_n-1)
-        //   self = inplace_op(self)
-        //
-        // For CPU/CUDA backends, we employ one AsStridedBackward Node to represent the chain of
-        // view backward ops for effienciency.
-        //
-        // However in XLA backend we don't have full support of AsStridedBackward, we instead run a full
-        // forward pass with a tensor that requires gradient to get proper grad_fn setup,
-        // then save it to DifferentiableViewMeta for future use.
-        // This is fairly cheap for XLA lazy tensor approach (but would be really expensive for CPU/CUDA).
-        // XLA Tensor only run thorugh VariableType dispatch and lower the forward pass to a XLA HLO graph,
-        // then we take grad_fn and never materialize the tensor content.
-        // So we only construct the graph but not execute it, which is a fairly cheap operation to do.
-        //
-        // See Note [View + Inplace update for base tensor] for what we do to base tensor when
-        // an in-place operation happens.
-        //
-        // TODO: Potentially the following logic can be replaced by special logic in VariableType_x.cpp
-        //       that would provide a way to recreate the grad_fn chain.
-        if (view_info.has_view_fn()) {
-          auto view_fn = view_info.view_fn();
-          auto diff_view = view_fn(view_info.base_);
-          diff_view_meta->grad_fn_ = diff_view.grad_fn();
-        } else {
-          auto fn = std::make_shared<torch::autograd::generated::AsStridedBackward>();
-          fn->self_geometry = at::TensorGeometry(view_info.base_);
-          fn->size = self.sizes().vec();
-          fn->stride = self.strides().vec();
-          fn->storage_offset = self.storage_offset();
-          fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
-          fn->add_input_metadata(
-            view_info.base_.options(),
-            self.sizes(), // Note: sizes(), not base_.sizes(), is intentional
-            view_info.base_.device());
-          diff_view_meta->grad_fn_ = std::move(fn);
-        }
-        diff_view_meta->set_attr_version(current_version);
-      }
+    std::lock_guard<std::mutex> lock(diff_view_meta->mutex_);
+    auto view_info = diff_view_meta->get_backward_view();
+    if (!diff_view_meta->grad_fn_ && !view_info.base_.requires_grad()) {
       return diff_view_meta->grad_fn_;
     }
+    auto current_version = self._version();
+    if (diff_view_meta->get_attr_version() != current_version) {
+      // This is an indirect rebase_history due to another view or the base being modified inplace
+      handle_view_on_rebase(diff_view_meta, /* indirect */ true);
+      TORCH_INTERNAL_ASSERT(diff_view_meta->output_nr_ == 0);
+      // Note [View + Inplace update for view tensor]
+      // An inplace update happened on Tensor `self` (which is a view).
+      // For example:
+      //   view_1 = view_op_1(diff_view_meta->base_)
+      //   view_2 = view_op_2(view_1)
+      //   ...
+      //   self = view_op_n(view_n-1)
+      //   self = inplace_op(self)
+      //
+      // For CPU/CUDA backends, we employ one AsStridedBackward Node to represent the chain of
+      // view backward ops for effienciency.
+      //
+      // However in XLA backend we don't have full support of AsStridedBackward, we instead run a full
+      // forward pass with a tensor that requires gradient to get proper grad_fn setup,
+      // then save it to DifferentiableViewMeta for future use.
+      // This is fairly cheap for XLA lazy tensor approach (but would be really expensive for CPU/CUDA).
+      // XLA Tensor only run thorugh VariableType dispatch and lower the forward pass to a XLA HLO graph,
+      // then we take grad_fn and never materialize the tensor content.
+      // So we only construct the graph but not execute it, which is a fairly cheap operation to do.
+      //
+      // See Note [View + Inplace update for base tensor] for what we do to base tensor when
+      // an in-place operation happens.
+      //
+      // TODO: Potentially the following logic can be replaced by special logic in VariableType_x.cpp
+      //       that would provide a way to recreate the grad_fn chain.
+      if (view_info.has_view_fn()) {
+        auto view_fn = view_info.view_fn();
+        auto diff_view = view_fn(view_info.base_);
+        diff_view_meta->grad_fn_ = diff_view.grad_fn();
+      } else {
+        auto fn = std::make_shared<torch::autograd::generated::AsStridedBackward>();
+        fn->self_geometry = at::TensorGeometry(view_info.base_);
+        fn->size = self.sizes().vec();
+        fn->stride = self.strides().vec();
+        fn->storage_offset = self.storage_offset();
+        fn->set_next_edges(torch::autograd::collect_next_edges(view_info.base_));
+        fn->add_input_metadata(
+          view_info.base_.options(),
+          self.sizes(), // Note: sizes(), not base_.sizes(), is intentional
+          view_info.base_.device());
+        diff_view_meta->grad_fn_ = std::move(fn);
+      }
+      diff_view_meta->set_attr_version(current_version);
+    }
+    return diff_view_meta->grad_fn_;
   }
 
   if (torch::autograd::impl::get_autograd_meta(self)) {
@@ -645,44 +641,32 @@ void handle_view_on_rebase(DifferentiableViewMeta* diff_view_meta, bool indirect
     }
 
     if (creation_meta == CreationMeta::MULTI_OUTPUT_NODE) {
-      TORCH_CHECK(false, msg, " This view is the output of a function that returns multiple views. Such functions do not"
-                         " allow the output views to be modified inplace. You should replace the inplace operation by an"
-                         " out-of-place one.");
-    } else {
-      if (creation_meta == CreationMeta::NO_GRAD_MODE) {
-        TORCH_INTERNAL_ASSERT(!grad_fn);
-        msg = c10::str(msg, " Given that this use case is ambiguous and error-prone, it is forbidden."
-                       " You can clarify your code and remove this warning by moving both the view and the inplace either both"
-                       " inside the no_grad block (if you don't want the inplace to be tracked) or both outside (if you want"
-                       " the inplace to be tracked).");
-      } else if (creation_meta == CreationMeta::INFERENCE_MODE) {
-        TORCH_INTERNAL_ASSERT(!grad_fn);
-        msg = c10::str(msg, " Given that this use case is ambiguous and error-prone, it is forbidden."
-                       " You can clarify your code by moving both the view and the inplace either both"
-                       " inside the inference_mode block (if you don't want the inplace to be tracked) or both outside (if you want"
-                       " the inplace to be tracked).");
-        TORCH_CHECK(false, msg);
-      } else if (creation_meta == CreationMeta::IN_CUSTOM_FUNCTION) {
-        msg = c10::str(msg, " This view was created inside a custom Function (or because an input was returned as-is) and the"
-                       " autograd logic to handle view+inplace would override the custom backward associated with the custom"
-                       " Function, leading to incorrect gradients. This behavior is forbidden. You can remove this warning by"
-                       " cloning the output of the custom Function.");
-      } else if (creation_meta == CreationMeta::MULTI_OUTPUT_SAFE) {
-        msg = c10::str(msg, " This view is an output of a function that "
-                       "returns multiple views. Inplace operators on such "
-                       "views is forbidden. You should replace the inplace "
-                       "operation by an out-of-place one.");
-      } else {
-        TORCH_INTERNAL_ASSERT(false, "Invalid CreationMeta state");
-      }
-
+      msg = c10::str(msg, " This view is the output of a function that returns multiple views. Such functions do not"
+                     " allow the output views to be modified inplace. You should replace the inplace operation by an"
+                     " out-of-place one.");
+    } else if (creation_meta == CreationMeta::NO_GRAD_MODE) {
+      TORCH_INTERNAL_ASSERT(!grad_fn);
+      msg = c10::str(msg, " Given that this use case is ambiguous and error-prone, it is forbidden."
+                      " You can clarify your code and remove this warning by moving both the view and the inplace either both"
+                      " inside the no_grad block (if you don't want the inplace to be tracked) or both outside (if you want"
+                      " the inplace to be tracked).");
+    } else if (creation_meta == CreationMeta::INFERENCE_MODE) {
+      TORCH_INTERNAL_ASSERT(!grad_fn);
+      msg = c10::str(msg, " Given that this use case is ambiguous and error-prone, it is forbidden."
+                      " You can clarify your code by moving both the view and the inplace either both"
+                      " inside the inference_mode block (if you don't want the inplace to be tracked) or both outside (if you want"
+                      " the inplace to be tracked).");
       TORCH_CHECK(false, msg);
+    } else if (creation_meta == CreationMeta::IN_CUSTOM_FUNCTION) {
+      msg = c10::str(msg, " This view was created inside a custom Function (or because an input was returned as-is) and the"
+                      " autograd logic to handle view+inplace would override the custom backward associated with the custom"
+                      " Function, leading to incorrect gradients. This behavior is forbidden. You can remove this warning by"
+                      " cloning the output of the custom Function.");
+    } else {
+      TORCH_INTERNAL_ASSERT(false, "Invalid CreationMeta state");
     }
 
-    // We warn only once per view
-    // Note that if a Tensor is modified inplace from two threads at the same time, this is not thread safe and can warn
-    // multiple time. This is ok as it should be a rare event.
-    diff_view_meta->set_creation_meta(CreationMeta::DEFAULT);
+    TORCH_CHECK(false, msg);
   }
 }
 

--- a/torch/csrc/autograd/variable.h
+++ b/torch/csrc/autograd/variable.h
@@ -494,15 +494,10 @@ struct TORCH_API ViewInfo {
 /// - NO_GRAD_MODE should be set when a view in created when GradMode is disabled
 /// - MULTI_OUTPUT_NODE should be set when a Node created by codegen code returns
 ///   multiple differentiable views
-/// - MULTI_OUTPUT_SAFE should be set when a view was returned by a function
-///   that returns multiple views, and unsafe_* version of that function
-///   exists. These are note considered as views for now for the view+inplace
-///   logic! The graph won't be rewritten when an inplace is done, only a
-///   warning will be thrown.
 /// - Inference_MODE should be set when a view of normal tensor is created in InferenceMode.
 /// - DEFAULT is for all other cases
 enum class CreationMeta: uint8_t { DEFAULT, IN_CUSTOM_FUNCTION, MULTI_OUTPUT_NODE,
-                                   NO_GRAD_MODE, MULTI_OUTPUT_SAFE, INFERENCE_MODE};
+                                   NO_GRAD_MODE, INFERENCE_MODE};
 
 /// Handles correctly propagating CreationMeta when a new view is created from a previous view.
 /// In general, we don't want the new view to be _less_ restrictive than the previous view


### PR DESCRIPTION
Fixes #57679

##### Release Notes
This is part of the end of the deprecation of inplace/view:
- `detach_` will now raise an error when invoked on any view created by `split`, `split_with_sizes`, or `chunk`. You should use the non-inplace `detach` instead.
- The error message for when an in-place operation (that is not detach) is performed on a view created by `split`, `split_with_size`, and `chunk` has been changed from  "This view is **an** output of a function..." to "This view is **the** output of a function...".