### PR TITLE
Mention distributed profiling in documentation

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -428,6 +428,18 @@ Collective functions
 
     :class:`~torch.distributed.ReduceOp` is recommended to use instead.
 
+Profiling Collective Communication
+-----------------------------------------
+
+Note that you can use `torch.profiler` or `torch.autograd.profiler` to profile collective communication and point-to-point communication APIs mentioned here. All out-of-the-box backends (`gloo`,
+`nccl`, `mpi`) are supported and collective communication usage will be rendered as expected in profiling output/traces. Profiling your code is the same as any regular torch operator:
+
+```
+with torch.profiler(): # or torch.autograd.profiler
+    tensor = torch.randn(20, 10)
+    dist.all_reduce(tensor)
+```
+
 Autograd-enabled communication primitives
 -----------------------------------------
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -440,6 +440,8 @@ with torch.profiler(): # or torch.autograd.profiler
     dist.all_reduce(tensor)
 ```
 
+Please refer to the `profiler documentation <https://pytorch.org/docs/stable/profiler.html>`__ for a full overview of profiler features.
+
 Autograd-enabled communication primitives
 -----------------------------------------
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -438,7 +438,6 @@ Note that you can use ``torch.profiler`` or ``torch.autograd.profiler`` to profi
 
     import torch
     import torch.distributed as dist
-    
     with torch.profiler():
         tensor = torch.randn(20, 10)
         dist.all_reduce(tensor)

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -431,7 +431,7 @@ Collective functions
 Profiling Collective Communication
 -----------------------------------------
 
-Note that you can use ``torch.profiler`` or ``torch.autograd.profiler`` to profile collective communication and point-to-point communication APIs mentioned here. All out-of-the-box backends (``gloo``,
+Note that you can use ``torch.profiler`` (recommended, only available after 1.8.1)  or ``torch.autograd.profiler`` to profile collective communication and point-to-point communication APIs mentioned here. All out-of-the-box backends (``gloo``,
 ``nccl``, ``mpi``) are supported and collective communication usage will be rendered as expected in profiling output/traces. Profiling your code is the same as any regular torch operator:
 
 ::
@@ -442,7 +442,7 @@ Note that you can use ``torch.profiler`` or ``torch.autograd.profiler`` to profi
         tensor = torch.randn(20, 10)
         dist.all_reduce(tensor)
 
-Please refer to the `profiler documentation <https://pytorch.org/docs/stable/profiler.html>`__ for a full overview of profiler features.
+Please refer to the `profiler documentation <https://pytorch.org/docs/master/profiler.html>`__ for a full overview of profiler features.
 
 Autograd-enabled communication primitives
 -----------------------------------------

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -431,14 +431,17 @@ Collective functions
 Profiling Collective Communication
 -----------------------------------------
 
-Note that you can use `torch.profiler` or `torch.autograd.profiler` to profile collective communication and point-to-point communication APIs mentioned here. All out-of-the-box backends (`gloo`,
-`nccl`, `mpi`) are supported and collective communication usage will be rendered as expected in profiling output/traces. Profiling your code is the same as any regular torch operator:
+Note that you can use ``torch.profiler`` or ``torch.autograd.profiler`` to profile collective communication and point-to-point communication APIs mentioned here. All out-of-the-box backends (``gloo``,
+``nccl``, ``mpi``) are supported and collective communication usage will be rendered as expected in profiling output/traces. Profiling your code is the same as any regular torch operator:
 
-```
-with torch.profiler(): # or torch.autograd.profiler
-    tensor = torch.randn(20, 10)
-    dist.all_reduce(tensor)
-```
+::
+
+    import torch
+    import torch.distributed as dist
+    
+    with torch.profiler():
+        tensor = torch.randn(20, 10)
+        dist.all_reduce(tensor)
 
 Please refer to the `profiler documentation <https://pytorch.org/docs/stable/profiler.html>`__ for a full overview of profiler features.
 


### PR DESCRIPTION
Added a simple section indicating distributed profiling is expected to work similar to other torch operators, and is supported for all communication backends out of the box.
