### PR TITLE
Fix cmake_minimum_require in libshm

### DIFF
--- a/torch/lib/libshm/CMakeLists.txt
+++ b/torch/lib/libshm/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(libshm C CXX)
-cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
-cmake_policy(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_policy(VERSION 2.8.12)
 
 set(TORCH_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../)
 include(${TORCH_ROOT}/cmake/public/threads.cmake)


### PR DESCRIPTION
Deprecation warning reported by cmake:

```
CMake Deprecation Warning at CMakeLists.txt (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This is the only place that requires bumping min version. There're two others but only in `third_party` folder.