### PR TITLE
Bump Ubuntu/Python versions in ECR GC Docker image

### DIFF
--- a/.circleci/ecr_gc_docker/Dockerfile
+++ b/.circleci/ecr_gc_docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y python-pip git && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+RUN apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 ADD requirements.txt /requirements.txt
 


### PR DESCRIPTION
Should fix the ECR GC jobs that broke as a result of #58275; examples:

- https://app.circleci.com/pipelines/github/pytorch/pytorch/322385/workflows/c26788cb-2147-4279-9813-224af3c01583/jobs/13480923
- https://app.circleci.com/pipelines/github/pytorch/pytorch/322385/workflows/c26788cb-2147-4279-9813-224af3c01583/jobs/13473074
- https://app.circleci.com/pipelines/github/pytorch/pytorch/322385/workflows/c26788cb-2147-4279-9813-224af3c01583/jobs/13473077
- https://app.circleci.com/pipelines/github/pytorch/pytorch/322385/workflows/c26788cb-2147-4279-9813-224af3c01583/jobs/13473073

See also #58308.