### PR TITLE
Fix incorrect inplace sort in `topk` (#58314)

### DIFF
--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -300,9 +300,10 @@ TORCH_IMPL_FUNC(topk_out_cuda)
       // allocated tensors to receive the results.
 
       Tensor sortedIndices = at::empty_like(indices);
-      // FIXME: remove const_cast once sort_out cuda is ported to structured
-      sort_out_cuda(const_cast<Tensor&>(values), dim, largest, const_cast<Tensor&>(values), const_cast<Tensor&>(sortedIndices));
+      Tensor sortedValues = at::empty_like(values);
+      sort_out_cuda(values, dim, largest, sortedValues, sortedIndices);
       indices.copy_(indices.gather(dim, sortedIndices));
+      values.copy_(sortedValues);
     }
   }
 }

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -562,12 +562,15 @@ class TestSortAndSelect(TestCase):
 
     @dtypes(torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64)
     def test_topk_integral(self, device, dtype):
-        a = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max, size=(10,),
-                          dtype=dtype, device=device)
-        sort_topk = a.sort()[0][-5:].flip(0)
-        topk = a.topk(5)
-        self.assertEqual(sort_topk, topk[0])      # check values
-        self.assertEqual(sort_topk, a[topk[1]])   # check indices
+        small = 10
+        large = 4096
+        for curr_size in (small, large):
+            a = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max,
+                              size=(curr_size,), dtype=dtype, device=device)
+            sort_topk = a.sort()[0][-(curr_size//2):].flip(0)
+            topk = a.topk(curr_size//2)
+            self.assertEqual(sort_topk, topk[0])      # check values
+            self.assertEqual(sort_topk, a[topk[1]])   # check indices
 
     @dtypesIfCUDA(*torch.testing.get_all_fp_dtypes())
     @dtypes(torch.float, torch.double)

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -567,8 +567,8 @@ class TestSortAndSelect(TestCase):
         for curr_size in (small, large):
             a = torch.randint(torch.iinfo(dtype).min, torch.iinfo(dtype).max,
                               size=(curr_size,), dtype=dtype, device=device)
-            sort_topk = a.sort()[0][-(curr_size//2):].flip(0)
-            topk = a.topk(curr_size//2)
+            sort_topk = a.sort()[0][-(curr_size // 2):].flip(0)
+            topk = a.topk(curr_size // 2)
             self.assertEqual(sort_topk, topk[0])      # check values
             self.assertEqual(sort_topk, a[topk[1]])   # check indices
 


### PR DESCRIPTION
Fixes #58314

#55392 introduced a bug by not allocating a separate value tensor for sorting
CC @ngimel @zasdfgbnm 
