### PR TITLE
[static runtime] quantize_per_tensor out variant

### DIFF
--- a/aten/src/ATen/core/QuantizerBase.h
+++ b/aten/src/ATen/core/QuantizerBase.h
@@ -66,6 +66,11 @@ struct TORCH_API Quantizer : public c10::intrusive_ptr_target {
   virtual Tensor dequantize(Tensor t) = 0;
 
   /**
+   * dequantize a quantized Tensor into a float Tensor, out= variant
+   */
+  virtual Tensor& dequantize_out(Tensor& out, const Tensor& t) = 0;
+
+  /**
    * Compare against `other` for equality.
    */
   virtual bool equalTo(QuantizerPtr other) = 0;

--- a/aten/src/ATen/core/QuantizerBase.h
+++ b/aten/src/ATen/core/QuantizerBase.h
@@ -61,6 +61,11 @@ struct TORCH_API Quantizer : public c10::intrusive_ptr_target {
   virtual Tensor quantize(Tensor t) = 0;
 
   /**
+   * quantize a float Tensor into a quantized Tensor, out= variant
+   */
+  virtual Tensor& quantize_out(Tensor& out, const Tensor& t) = 0;
+
+  /**
    * dequantize a quantized Tensor into a float Tensor.
    */
   virtual Tensor dequantize(Tensor t) = 0;

--- a/aten/src/ATen/quantized/Quantizer.cpp
+++ b/aten/src/ATen/quantized/Quantizer.cpp
@@ -150,13 +150,20 @@ Tensor PerTensorAffineQuantizer::quantize(Tensor rtensor) {
 
 Tensor PerTensorAffineQuantizer::dequantize(Tensor qtensor) {
   Tensor rtensor = at::empty(
-      qtensor.sizes(),
+      {0},
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  qtensor = qtensor.contiguous(qtensor.suggest_memory_format());
+  return dequantize_out(rtensor, qtensor);
+}
+
+Tensor& PerTensorAffineQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  const auto qtensor_contig =
+    qtensor.expect_contiguous(qtensor.suggest_memory_format());
   native::dequantize_tensor_per_tensor_affine(
-      qtensor, rtensor, scale_, zero_point_);
+      *qtensor_contig, rtensor, scale_, zero_point_);
   return rtensor;
 }
 
@@ -177,13 +184,20 @@ Tensor PerChannelAffineQuantizer::quantize(Tensor rtensor) {
 
 Tensor PerChannelAffineQuantizer::dequantize(Tensor qtensor) {
   Tensor rtensor = at::empty(
-      qtensor.sizes(),
+      {0},
       qtensor.options()
           .dtype(at::kFloat)
           .memory_format(qtensor.suggest_memory_format()));
-  qtensor = qtensor.contiguous(qtensor.suggest_memory_format());
+  return dequantize_out(rtensor, qtensor);
+}
+
+Tensor& PerChannelAffineQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  const auto qtensor_contig =
+    qtensor.expect_contiguous(qtensor.suggest_memory_format());
   native::dequantize_tensor_per_channel_affine(
-      qtensor, rtensor, scales_, zero_points_, axis_);
+      *qtensor_contig, rtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 
@@ -201,10 +215,16 @@ Tensor PerChannelAffineFloatQParamsQuantizer::quantize(Tensor rtensor) {
 }
 
 Tensor PerChannelAffineFloatQParamsQuantizer::dequantize(Tensor qtensor) {
-  Tensor rtensor = at::empty(qtensor.sizes(), qtensor.options().dtype(at::kFloat));
-  qtensor = qtensor.contiguous();
+  Tensor rtensor = at::empty({0}, qtensor.options().dtype(at::kFloat));
+  return dequantize_out(rtensor, qtensor);
+}
+
+Tensor& PerChannelAffineFloatQParamsQuantizer::dequantize_out(
+    Tensor& rtensor, const Tensor& qtensor) {
+  rtensor.resize_(qtensor.sizes());
+  const auto qtensor_contig = qtensor.expect_contiguous();
   native::dequantize_tensor_per_channel_float_qparams(
-    qtensor, rtensor, scales_, zero_points_, axis_);
+    *qtensor_contig, rtensor, scales_, zero_points_, axis_);
   return rtensor;
 }
 

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -65,6 +65,7 @@ struct TORCH_API PerTensorAffineQuantizer : public AffineQuantizer {
         zero_point_(zero_point) {}
 
   Tensor quantize(Tensor tensor) override;
+  Tensor& quantize_out(Tensor& qtensor, const Tensor& tensor) override;
   Tensor dequantize(Tensor tensor) override;
   Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 
@@ -136,6 +137,7 @@ struct TORCH_API PerChannelAffineQuantizer : public AffineQuantizer {
   }
 
   Tensor quantize(Tensor tensor) override;
+  Tensor& quantize_out(Tensor& qtensor, const Tensor& tensor) override;
   Tensor dequantize(Tensor tensor) override;
   Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 
@@ -187,6 +189,7 @@ struct TORCH_API PerChannelAffineFloatQParamsQuantizer : public PerChannelAffine
   }
 
   Tensor quantize(Tensor tensor) override;
+  Tensor& quantize_out(Tensor& qtensor, const Tensor& tensor) override;
   Tensor dequantize(Tensor tensor) override;
   Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 

--- a/aten/src/ATen/quantized/Quantizer.h
+++ b/aten/src/ATen/quantized/Quantizer.h
@@ -66,6 +66,7 @@ struct TORCH_API PerTensorAffineQuantizer : public AffineQuantizer {
 
   Tensor quantize(Tensor tensor) override;
   Tensor dequantize(Tensor tensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 
   QScheme qscheme() const override {
     return kPerTensorAffine;
@@ -136,6 +137,7 @@ struct TORCH_API PerChannelAffineQuantizer : public AffineQuantizer {
 
   Tensor quantize(Tensor tensor) override;
   Tensor dequantize(Tensor tensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffine) {
@@ -186,6 +188,7 @@ struct TORCH_API PerChannelAffineFloatQParamsQuantizer : public PerChannelAffine
 
   Tensor quantize(Tensor tensor) override;
   Tensor dequantize(Tensor tensor) override;
+  Tensor& dequantize_out(Tensor& rtensor, const Tensor& tensor) override;
 
   bool equalTo(QuantizerPtr other) override {
     if (!other.get() || other->qscheme() != kPerChannelAffineFloatQParams) {

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -106,6 +106,14 @@ inline at::Tensor create_empty_from(
       memory_format);
 }
 
+inline at::Tensor create_empty_from(
+    const at::Tensor& t,
+    c10::ScalarType dtype,
+    c10::MemoryFormat memory_format) {
+  return at::detail::empty_cpu(
+      {0}, dtype, t.layout(), t.device(), c10::nullopt, memory_format);
+}
+
 inline bool checkResizedDataPtr(at::Tensor& t) {
   auto const prev_data_ptr = t.data_ptr();
   t.resize_({0});

--- a/torch/csrc/jit/runtime/static/passes.cpp
+++ b/torch/csrc/jit/runtime/static/passes.cpp
@@ -378,6 +378,7 @@ TORCH_LIBRARY_FRAGMENT(static_runtime, m) {
       "static_runtime::to_copy.prim_dtype(Tensor self, int? dtype=None, bool non_blocking=False, bool copy=False) -> Tensor");
   m.def(
       "static_runtime::to_copy.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor");
+  m.def("static_runtime::dequantize_copy.self(Tensor self) -> Tensor");
 }
 
 bool HasInplaceOp(std::shared_ptr<Graph>& graph, const AliasDb& alias_db) {
@@ -413,7 +414,9 @@ void ReplaceWithCopy(std::shared_ptr<torch::jit::Graph>& graph) {
       {c10::Symbol::fromQualString("aten::reshape"),
        c10::Symbol::fromQualString("static_runtime::reshape_copy")},
       {c10::Symbol::fromQualString("aten::flatten"),
-       c10::Symbol::fromQualString("static_runtime::flatten_copy")}};
+       c10::Symbol::fromQualString("static_runtime::flatten_copy")},
+      {c10::Symbol::fromQualString("aten::dequantize"),
+       c10::Symbol::fromQualString("static_runtime::dequantize_copy")}};
 
   // for ops that have overloads, match the schema
   const std::vector<std::pair<c10::FunctionSchema, c10::Symbol>> supported_schema = {


### PR DESCRIPTION
Summary: Out variant for quantize_per_tensor

Test Plan:
V0514 13:06:39.758564 1155947 impl.cpp:1233] Switch to out variant for node: %quantize_per_tensor.1 : Tensor = aten::quantize_per_tensor(%main_module_impl_impl_dense_arch_dense_transform_gating_after_prep_reducesum_module.1, %729, %648, %730)

Run inline_cvr local model
```
MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 numactl -m 0 -C 3 ./buck-out/opt/gen/caffe2/caffe2/fb/predictor/ptvsc2_predictor_bench --scripted_model=/data/users/ansha/tmp/adfinder/dec_6x/266377643_shrunk.predictor.disagg.local.regenerated.pt --pt_inputs=/data/users/ansha/tmp/adfinder/dec_6x/local_inputs --pt_enable_static_runtime=1 --pt_cleanup_activations=1 --pt_enable_out_variant=1 --compare_results=1 --iters=5000 --warmup_iters=5000 --num_threads=1 --do_profile=0 --do_benchmark=1 --adsfinder_compatibility=1
```

Differential Revision: D28450857

