### PR TITLE
Document monitored barrier

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -419,6 +419,8 @@ Collective functions
 
 .. autofunction:: barrier
 
+.. autofunction:: monitored_barrier
+
 .. autoclass:: ReduceOp
 
 .. class:: reduce_op

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2532,7 +2532,7 @@ def barrier(group=GroupMember.WORLD,
 
 def monitored_barrier(group=GroupMember.WORLD, timeout=None, wait_all_ranks=False):
     """
-    Synchronizes all processes similar to torch.distributed.barrier, but takes
+    Synchronizes all processes similar to ``torch.distributed.barrier``, but takes
     a configurable timeout and is able to report ranks that did not pass this
     barrier within that timeout. Specifically, for non-zero ranks, will block
     until a send/recv is processed from rank 0. Rank 0 will block until all send
@@ -2544,7 +2544,7 @@ def monitored_barrier(group=GroupMember.WORLD, timeout=None, wait_all_ranks=Fals
     This collective will block all processes/ranks in the group, until the
     whole group exits the function successfully, making it useful for debugging
     and synchronizing. However, it can have a performance impact and should only
-    be used for debugging or scenarios that require full synhcronization points
+    be used for debugging or scenarios that require full synchronization points
     on the host-side. For debugging purposees, this barrier can be inserted
     before the application's collective calls to check if any ranks are
     desynchronized.


### PR DESCRIPTION
Will not land before the release, but would be good to have this function documented in master for its use in distributed debugability. 