### PR TITLE
Don't bind Android NNAPI on Apple platforms

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -201,6 +201,7 @@ struct NnapiCompilation : torch::jit::CustomClassHolder {
   int32_t num_outputs_;
 };
 
+#ifndef __APPLE__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto register_NnapiCompilation = [](){
   try {
@@ -214,6 +215,7 @@ static auto register_NnapiCompilation = [](){
     throw;
   }
 }();
+#endif
 
 } // namespace
 } // namespace nnapi


### PR DESCRIPTION
Summary:
Currently there is no way to run NNAPI on Apple platforms.
Disabling the binding with the preprocessor makes this easier
to enable NNAPI in the internal build without affecting iOS size.

This should be reverted soon and migrated to selective build.

Test Plan: Build Size Bot on later diff.

Reviewed By: axitkhurana

Differential Revision: D28435179

