### PR TITLE
Enable NNAPI in internal build

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -201,6 +201,7 @@ struct NnapiCompilation : torch::jit::CustomClassHolder {
   int32_t num_outputs_;
 };
 
+#ifndef __APPLE__
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static auto register_NnapiCompilation = [](){
   try {
@@ -214,6 +215,7 @@ static auto register_NnapiCompilation = [](){
     throw;
   }
 }();
+#endif
 
 } // namespace
 } // namespace nnapi

--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -1032,6 +1032,9 @@ aten_native_source_non_codegen_list = [
     # "aten/src/ATen/TensorIndexing.cpp",
     "aten/src/ATen/TensorIterator.cpp",
     "aten/src/ATen/LegacyTHFunctionsCPU.cpp",
+    "aten/src/ATen/nnapi/nnapi_bind.cpp",
+    "aten/src/ATen/nnapi/nnapi_wrapper.cpp",
+    "aten/src/ATen/nnapi/nnapi_model_loader.cpp",
 ]
 
 # 1. Files in ATen/native with a few exceptions


### PR DESCRIPTION
Test Plan: Build Size Bot.  Segmentation in Spark Player.

Reviewed By: axitkhurana

Differential Revision: D28435176

