### PR TITLE
Check memory overlap in sort for large input sizes

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -268,7 +268,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
   }
 
   TORCH_CHECK(get_overlap_status(self, values) == MemOverlapStatus::NO,
-	      "Passed output tensor that overlaps with input tensor to cuda sort");
+	      "Sort size too large for inplace sort");
 
   Tensor self_;
   if (is_non_overlapping_and_dense && self.stride(dim) == 1) {

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -295,7 +295,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
     values_tmp = at::empty_strided(self_.sizes(), self_.strides(), self_.options());
     values_ptr_ = values_tmp.data_ptr();
   } else {
-    if (get_overlap_status(self, values) == MemOverlapStatus::NO) {
+    if (self_.defined() || get_overlap_status(self, values) == MemOverlapStatus::NO) {
       values_ptr_ = values.data_ptr();
     } else {
       values_tmp = at::empty_like(values);

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -304,7 +304,6 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
       values_ptr_ = values_tmp.data_ptr();
     }
   }
-  TORCH_WARN("AFTER");
 
   if (!indices.defined()) {
     if (is_non_overlapping_and_dense) {

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -1,6 +1,7 @@
 #include <limits>
 
 #include <ATen/ATen.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/LegacyTHFunctionsCUDA.h>
 #include <ATen/core/Array.h>
@@ -265,6 +266,9 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
     sortKeyValueInplace(values, indices, dim, descending);
     return std::forward_as_tuple(values, indices);
   }
+
+  TORCH_CHECK(get_overlap_status(self, values) == MemOverlapStatus::NO,
+	      "Passed output tensor that overlaps with input tensor to cuda sort");
 
   Tensor self_;
   if (is_non_overlapping_and_dense && self.stride(dim) == 1) {

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -57,6 +57,14 @@ class TestSortAndSelect(TestCase):
             x = torch.rand(4, SIZE, device=device)
             res1val, res1ind = torch.sort(x)
 
+            # Test inplace
+            y = x.clone()
+            y_inds = torch.tensor((), dtype=torch.int64, device=device)
+            torch.sort(y, out=(y, y_inds))
+            x_vals, x_inds = torch.sort(x)
+            self.assertEqual(x_vals, y)
+            self.assertEqual(x_inds, y_inds)
+
             # Test use of result tensor
             res2val = torch.tensor((), device=device)
             res2ind = torch.tensor((), device=device, dtype=torch.long)


### PR DESCRIPTION
The downstream cub sort doesn't support inplace sorting; this PR adds a check to bail out to allocating a new tensor instead of silently corrupting the returned indices.

CC @ngimel @zasdfgbnm