### PR TITLE
Use pip3 instead of pip when building ECR GC image

### DIFF
--- a/.circleci/ecr_gc_docker/Dockerfile
+++ b/.circleci/ecr_gc_docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y python3-pip git && rm -rf /var/lib/apt/
 
 ADD requirements.txt /requirements.txt
 
-RUN pip install -r /requirements.txt
+RUN pip3 install -r /requirements.txt
 
 ADD gc.py /usr/bin/gc.py
 


### PR DESCRIPTION
A followup to #58309, to fix the broken docker_for_ecr_gc_build_job:

- https://app.circleci.com/pipelines/github/pytorch/pytorch/322672/workflows/4877ddfe-eee1-4116-91ae-6ee9dd3a97ad/jobs/13486207
- https://app.circleci.com/pipelines/github/pytorch/pytorch/322710/workflows/8d33afb6-7b85-48c7-94fd-ac9176f4a16e/jobs/13488388
- https://app.circleci.com/pipelines/github/pytorch/pytorch/322759/workflows/b480989a-b39e-48f7-929d-66f1bdc50c89/jobs/13490919

**Test plan:**

Before this PR, this fails:
```
cd .circleci/ecr_gc_docker && docker build .
```
After this PR, it succeeds.