### PR TITLE
allow structured ops to not specify a dispatch table and default to composite

### DIFF
--- a/tools/codegen/model.py
+++ b/tools/codegen/model.py
@@ -348,7 +348,7 @@ class NativeFunction:
                 f"unexpected name for singleton CompositeImplicitAutograd dispatch entry: expected {cpp.name(func)} " \
                 f"but got {dispatch[DispatchKey.CompositeImplicitAutograd]}.  Rename your implementation to the expected " \
                 "name, then delete the dispatch table"
-        elif not structured and structured_delegate is None:
+        elif structured_delegate is None:
             dispatch[DispatchKey.CompositeImplicitAutograd] = cpp.name(func)
 
         assert not (DispatchKey.CompositeExplicitAutograd in dispatch and DispatchKey.CompositeImplicitAutograd in dispatch), \


### PR DESCRIPTION
cc @ezyang. Right now if an operator doesn't include a dispatch entry in `native_functions.yaml`, we assume that the operator is composite (registered to the `CompositeImplicitAutograd` key) if the operator is **unstructured**; but if it's structured, we don't do that. I think the original reason for this is because it's completely valid for `structured_delegate` ops to not have any dispatch entries, since their CPU/CUDA implementations will call into the `out` variant of the operator. But I'm pretty sure that we want to allow this behavior for `structured` (out) operators. This came up in a [port of torch.square() to structured](https://github.com/pytorch/pytorch/pull/58266), which is a mathematically composite operator.


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58336 allow structured ops to not specify a dispatch table and default to composite**

Differential Revision: [D28458390](https://our.internmc.facebook.com/intern/diff/D28458390)