### PR TITLE
Added fix for missing ops aten::sorted.str

### DIFF
--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -790,6 +790,10 @@ RegisterOperators reg(
          TORCH_SELECTIVE_SCHEMA("aten::dequantize.any(Any tensors) -> Any"),
          [](Stack* stack) { dequantize(*stack); },
          aliasAnalysisFromSchema()),
+     OperatorGenerator(
+         TORCH_SELECTIVE_SCHEMA("aten::sorted.str(str[](a) input) -> (str[])"),
+         listCopyAndSort<std::string>,
+         aliasAnalysisFromSchema()),
      DEFINE_UNARY_OP_WITH_COMPLEX(aten::log, std::log(a), float, float),
      DEFINE_STRING_OP(aten::add, a + b, str),
      DEFINE_COMPARISON_OP_WITH_COMPLEX(aten::eq, a == b),

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -800,10 +800,6 @@ RegisterOperators reg2({
         listCopyAndSort<bool>,
         aliasAnalysisFromSchema()),
     Operator(
-        "aten::sorted.str(str[](a) input) -> (str[])",
-        listCopyAndSort<std::string>,
-        aliasAnalysisFromSchema()),
-    Operator(
         "aten::eq.float_list(float[] a, float[] b) -> bool",
         listEq<double>,
         aliasAnalysisFromSchema()),


### PR DESCRIPTION
Summary: The operator was present as part of full_jit ops but wasn't included for mobile. The diff copies it for mobile

Test Plan: buck run xplat/langtech/mobile:giga5_bin -- --voice /data/users/prabhavag/experiments/embedded_new_stateful_conv_may6/nicole_batch.giga5 --frontend /data/users/prabhavag/experiments/tools_pkg/en_US.embedded.frontend.titan --icudata xplat/third-party/icu/stubdata/reduced/icudt55l.dat --text "haha"

Reviewed By: iseeyuan

Differential Revision: D28452179

