### PR TITLE
[nnc] Enable CPU fusion inside Facebook, take 2

### DIFF
--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -8,8 +8,13 @@
 #include <c10/util/Flags.h>
 #include <stdexcept>
 
+#ifdef FBCODE_CAFFE2
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+C10_DEFINE_bool(torch_jit_enable_cpu_fusion, true, "enable cpu fusion");
+#else
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(torch_jit_enable_cpu_fusion, false, "enable cpu fusion");
+#endif
 
 namespace torch {
 namespace jit {
@@ -46,6 +51,7 @@ bool canFuseOnGPU() {
 
 void overrideCanFuseOnCPU(bool value) {
   detail::cpu_fuser_enabled = value;
+  FLAGS_torch_jit_enable_cpu_fusion = value;
 }
 
 void overrideCanFuseOnGPU(bool value) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58347 [nnc] Enable CPU fusion inside Facebook, take 2**
* #58510 VaryingShape<Strides>::isComplete() needs to consider whether each Stride is complete
* #58346 [nnc] Do not fuse unsqueeze with variable dim

Back out "Revert D27652484: [nnc] Enable CPU fusion inside Facebook"
Original commit changeset: ecfef3ee1e71

Differential Revision: [D28461013](https://our.internmc.facebook.com/intern/diff/D28461013/)