### PR TITLE
Modify argument parsing process for tensorlist by disabling eager typechecking error to adjust the process similar to other type of lists

### DIFF
--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1155,7 +1155,7 @@ class TestTensorCreation(TestCase):
         self.assertEqual(z.size(), (21, SIZE, SIZE))
 
         self.assertRaises(RuntimeError, lambda: torch.cat([]))
-        self.assertRaisesRegex(TypeError, 'got None', lambda: torch.cat([x, None]))
+        self.assertRaises(TypeError, lambda: torch.cat([x, None]))
 
     @onlyCPU
     def test_cat_scalars(self, device):

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -1172,8 +1172,7 @@ void initJITBindings(PyObject* module) {
                   is_tensor_list_and_append_overloaded(
                       args[i].ptr(),
                       &overloaded_args,
-                      static_cast<int>(total_arg_num),
-                      false /* throw_error */);
+                      static_cast<int>(total_arg_num));
                 }
                 // NB: for kwargs, we cannot guarantee the order of appending
                 // is the same as the argument order in operator's schema.
@@ -1185,10 +1184,7 @@ void initJITBindings(PyObject* module) {
                   is_tensor_and_append_overloaded(
                       item.second.ptr(), &overloaded_args);
                   is_tensor_list_and_append_overloaded(
-                      item.second.ptr(),
-                      &overloaded_args,
-                      total_arg_num,
-                      false /* throw_error */);
+                      item.second.ptr(), &overloaded_args, total_arg_num);
                 }
                 if (overloaded_args.size() > 0) {
                   std::vector<py::object> overloaded_types;

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -1021,10 +1021,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
   for (const auto& arg : args) {
     is_tensor_and_append_overloaded(arg.ptr(), &overloaded_args);
     is_tensor_list_and_append_overloaded(
-        arg.ptr(),
-        &overloaded_args,
-        static_cast<int>(total_arg_num),
-        false /* throw_error */);
+        arg.ptr(), &overloaded_args, static_cast<int>(total_arg_num));
   }
   // NB: for kwargs, we cannot guarantee the order of appending
   // is the same as the argument order in operator's schema.
@@ -1035,10 +1032,7 @@ inline c10::optional<py::object> maybeTorchFunctionDispatch(
   for (auto item : kwargs) {
     is_tensor_and_append_overloaded(item.second.ptr(), &overloaded_args);
     is_tensor_list_and_append_overloaded(
-        item.second.ptr(),
-        &overloaded_args,
-        total_arg_num,
-        false /* throw_error */);
+        item.second.ptr(), &overloaded_args, total_arg_num);
   }
   if (overloaded_args.size() > 0) {
     return pybind11::reinterpret_steal<py::object>(

--- a/torch/csrc/utils/python_arg_parser.cpp
+++ b/torch/csrc/utils/python_arg_parser.cpp
@@ -393,7 +393,7 @@ bool is_scalar_list(PyObject* obj) {
   return true;
 }
 
-bool is_tensor_list_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args, int argnum, bool throw_error) {
+bool is_tensor_list_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args, int argnum) {
   auto tuple = six::isTuple(obj);
   if (!(tuple || PyList_Check(obj))) {
     return false;
@@ -403,10 +403,6 @@ const   auto size = tuple ? PyTuple_GET_SIZE(obj) : PyList_GET_SIZE(obj);
   for (long idx = 0; idx < size; idx++) {
     PyObject* iobj = tuple ? PyTuple_GET_ITEM(obj, idx) : PyList_GET_ITEM(obj, idx);
     if (!is_tensor_and_append_overloaded(iobj, overloaded_args)) {
-      if (throw_error) {
-        throw TypeError("expected Tensor as element %d in argument %d, but got %s",
-            static_cast<int>(idx), argnum, Py_TYPE(iobj)->tp_name);
-      }
       return false;
     }
   }
@@ -491,7 +487,7 @@ auto FunctionParameter::check(PyObject* obj, std::vector<py::handle> &overloaded
       return size == 1 && THPUtils_checkDimname(obj);
     }
     case ParameterType::TENSOR_LIST: {
-      return is_tensor_list_and_append_overloaded(obj, &overloaded_args, argnum, true /* throw_error */);
+      return is_tensor_list_and_append_overloaded(obj, &overloaded_args, argnum);
     }
     case ParameterType::INT_LIST: return is_int_list(obj, size);
     case ParameterType::FLOAT_LIST: return is_float_or_complex_list(obj);

--- a/torch/csrc/utils/python_arg_parser.h
+++ b/torch/csrc/utils/python_arg_parser.h
@@ -801,6 +801,6 @@ bool is_tensor_and_append_overloaded(PyObject* obj, std::vector<py::handle>* ove
  * 'throw_error': whether throw error if any element in the list or tuple is
  *                not tensor type or overloaded.
  */
-bool is_tensor_list_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args, int argnum, bool throw_error);
+bool is_tensor_list_and_append_overloaded(PyObject* obj, std::vector<py::handle>* overloaded_args, int argnum);
 
 } // namespace torch


### PR DESCRIPTION
Fixes #58087

As it has been pointed out in the issue, in argument parsing process, type checking wants to handle TensorLists parameters proactively, and throws error in a position where we would just hope to return false.

In this PR, we are removing the corresponding code piece to throwing error, and enabling return false and to observe what will be its result in overall.