### PR TITLE
Fix TP agent not recording outgoing tensors with caching allocator

### DIFF
--- a/torch/csrc/distributed/rpc/utils.h
+++ b/torch/csrc/distributed/rpc/utils.h
@@ -104,7 +104,8 @@ struct TORCH_API LazyStreamContext {
   void waitForCurrentStreams(const std::vector<torch::Tensor>& tensors = {}) {
     for (const auto& tensor : tensors) {
       if (tensor.is_cuda()) {
-        getStream(tensor.device());
+        c10::Stream stream = getStream(tensor.device());
+        impl_.recordDataPtrOnStream(tensor.storage().data_ptr(), stream);
       }
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58384 Fix TP agent not recording outgoing tensors with caching allocator**

When the caller send tensors within a request, it does so on fresh streams it obtained from the caching allocator. However it wasn't recording those tensors with the caching allocator. This carried the risk that, if those tensors were deleted before the async CUDA ops were done, the caching allocator could reuse the storage and thus overwrite the previous data while it was still being used.

Differential Revision: [D28473429](https://our.internmc.facebook.com/intern/diff/D28473429/)