### PR TITLE
[ONNX] Enable support for roll() op.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8822,6 +8822,22 @@ class TestONNXRuntime(unittest.TestCase):
                       input_names=['input_1'],
                       dynamic_axes={'input_1': [0, 1]})
 
+    def test_roll(self):
+        class M(torch.nn.Module):
+            def __init__(self, shifts, dims):
+                super(M, self).__init__()
+                self.shifts = shifts
+                self.dims = dims
+
+            def forward(self, x):
+                return torch.roll(x, self.shifts, self.dims)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(M([1, 1], [1, 0]), (x,))
+        self.run_test(M([0, 1, 2], [1, 0, 2]), (x,))
+        self.run_test(M(2, 1), (x,))
+        self.run_test(M([-1, 3], [-2, -1]), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout,
               **extra_kwargs):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3157,6 +3157,7 @@ def index_add(g, self, dim, index, other):
 
     return scatter_add(g, self, dim, expand_as(g, index, other), other)
 
+
 @parse_args('v', 'is', 'is')
 def roll(g, self, shifts, dims):
     assert len(shifts) == len(dims)


### PR DESCRIPTION
1. Add a symbolic function for aten::roll() op in symbolic_opset9.py.
2. Add a test with multiple scenarios as well.