### PR TITLE
Prevent lock inversions with GIL in Future

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -360,13 +360,10 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
       IValue value,
       c10::optional<std::vector<std::reference_wrapper<const at::DataPtr>>>
           data_ptrs = c10::nullopt) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    TORCH_CHECK(
-        !completed(),
-        "Attempting to mark a completed Future as complete again. Note that "
-        "a Future can only be marked completed once.");
-
     // Start by performing all steps that can throw, before setting any field.
+    // Do this before even acquiring the mutex, because extractDataPtrs might
+    // acquire the GIL, which could lead to a lock inversion with our mutex.
+    // See https://github.com/pytorch/pytorch/issues/58239.
     std::vector<std::reference_wrapper<const at::DataPtr>> actualDataPtrs;
     std::vector<c10::Device> usedDevices;
     try {
@@ -382,9 +379,15 @@ struct C10_EXPORT ivalue::Future final : c10::intrusive_ptr_target {
         ensureIsSubsetOfDevices(usedDevices, devices_);
       }
     } catch (const std::exception&) {
-      setErrorInternal(std::current_exception(), lock);
+      setError(std::current_exception());
       return;
     }
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    TORCH_CHECK(
+        !completed(),
+        "Attempting to mark a completed Future as complete again. Note that "
+        "a Future can only be marked completed once.");
 
     // Only set value_ and completed_ flag once all checks and preparation steps
     // have returned successfully to allow for proper error propagation.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58391 Prevent lock inversions with GIL in Future**
* #58382 Fix deadlock due to lock inversion with GIL

An additional (and hopefully more robust) way of fixing the same problem https://github.com/pytorch/pytorch/pull/58382 fixed.

Differential Revision: [D28474154](https://our.internmc.facebook.com/intern/diff/D28474154/)