### PR TITLE
[PyTorch][Edge] Print type name in error message.

### DIFF
--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -200,8 +200,9 @@ std::pair<IValue, IValue> getFunctionTuple(
     if (type_str.find(torch_prefix) == 0) {
       TORCH_CHECK(
           type_str.find(class_prefix) == 0,
-          "__torch__ types other than torchbind (__torch__.torch.classes)"
-          "are not supported in lite interpreter. ",
+          "Type is ", type_str,
+          ". __torch__ types other than torchbind (__torch__.torch.classes)"
+          " are not supported in lite interpreter. ",
           "Workaround: instead of using arbitrary class type (class Foo()), ",
           "define a pytorch class (class Foo(torch.nn.Module)).");
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58400 [PyTorch][Edge] Print type name in error message.**
* #58353 Conservatively move all suitable prim ops from full-jit to mobile, and make them selective.

