### PR TITLE
initial try to add benchmark to the build script

### DIFF
--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -359,7 +359,7 @@ if [[ "$BUILD_ENVIRONMENT" == *cuda* && "$BUILD_ENVIRONMENT" != *nogpu* ]]; then
   SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
   mkdir -p "$BENCHMARK_BUILD"
   pushd "$BENCHMARK_BUILD"
-  cmake "../" -DCMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" -DPYTHON_EXECUTABLE="$(which python)"
+  cmake "../" -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS $SITE_PACKAGES/torch/include" -DCMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" -DPYTHON_EXECUTABLE="$(which python)"
   make VERBOSE=1
   popd
   assert_git_not_dirty

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -349,3 +349,18 @@ if [[ "$BUILD_ENVIRONMENT" != *libtorch* && "$BUILD_ENVIRONMENT" != *bazel* ]]; 
   # don't do this for libtorch as libtorch is C++ only and thus won't have python tests run on its build
   python test/run_test.py --export-past-test-times
 fi
+
+if [[ "$BUILD_ENVIRONMENT" == *cuda* && "$BUILD_ENVIRONMENT" != *nogpu* ]]; then
+  BENCHMARK_BUILD_DIR=${BENCHMARK_BUILD_DIR:-${PWD}/benchmarks/cpp}
+  mkdir -pv "${BENCHMARK_BUILD_DIR}"
+  # Build benchmark
+  BENCHMARK_BUILD="${BENCHMARK_BUILD_DIR}/build"
+  python --version
+  SITE_PACKAGES="$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')"
+  mkdir -p "$BENCHMARK_BUILD"
+  pushd "$BENCHMARK_BUILD"
+  cmake "../" -DCMAKE_PREFIX_PATH="$SITE_PACKAGES/torch" -DPYTHON_EXECUTABLE="$(which python)"
+  make VERBOSE=1
+  popd
+  assert_git_not_dirty
+fi

--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -64,7 +64,9 @@ file(GLOB mkl_cpp "mkl/*.cpp")
 file(GLOB mkldnn_cpp "mkldnn/*.cpp")
 
 file(GLOB native_cpp "native/*.cpp")
+file(GLOB native_mkl_h "native/mkl/*.h")
 file(GLOB native_mkl_cpp "native/mkl/*.cpp")
+file(GLOB native_mkldnn_h "native/mkldnn/*.h")
 file(GLOB native_mkldnn_cpp "native/mkldnn/*.cpp")
 file(GLOB vulkan_cpp "vulkan/*.cpp")
 file(GLOB native_vulkan_cpp "native/vulkan/*.cpp" "native/vulkan/api/*.cpp" "native/vulkan/ops/*.cpp")
@@ -433,7 +435,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake-exports/ATenConfig.cmake"
 
 set(INSTALL_HEADERS ${base_h} ${ATen_CORE_HEADERS})
 if(NOT INTERN_BUILD_MOBILE)
-  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_ao_sparse_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h})
+  list(APPEND INSTALL_HEADERS ${native_h} ${native_cpu_h} ${native_ao_sparse_h} ${native_quantized_h} ${cuda_h} ${native_cuda_h} ${native_hip_h} ${cudnn_h} ${hip_h} ${miopen_h} ${native_mkldnn_h})
 else()
   if(USE_PYTORCH_METAL)
     if(IOS)

--- a/benchmarks/cpp/CMakeLists.txt
+++ b/benchmarks/cpp/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(tensorexpr)
 add_executable(convolution_bench convolution.cpp)
 target_link_libraries(convolution_bench PRIVATE torch_library benchmark)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1325,9 +1325,9 @@ if(USE_GLOO)
 
     # Temporarily override variables to avoid building Gloo tests/benchmarks
     set(__BUILD_TEST ${BUILD_TEST})
-    set(__BUILD_BENCHMARK ${BUILD_BENCHMARK})
+    set(__GLOO_BUILD_BENCHMARK ${GLOO_BUILD_BENCHMARK})
     set(BUILD_TEST OFF)
-    set(BUILD_BENCHMARK OFF)
+    set(GLOO_BUILD_BENCHMARK OFF)
     if(USE_ROCM)
       set(ENV{GLOO_ROCM_ARCH} "${PYTORCH_ROCM_ARCH}")
     endif()
@@ -1348,7 +1348,7 @@ if(USE_GLOO)
     include_directories(BEFORE SYSTEM ${CMAKE_CURRENT_LIST_DIR}/../third_party/gloo)
     include_directories(BEFORE SYSTEM ${PROJECT_BINARY_DIR}/third_party/gloo)
     set(BUILD_TEST ${__BUILD_TEST})
-    set(BUILD_BENCHMARK ${__BUILD_BENCHMARK})
+    set(GLOO_BUILD_BENCHMARK ${__GLOO_BUILD_BENCHMARK})
 
     # Add explicit dependency since NCCL is built from third_party.
     # Without dependency, make -jN with N>1 can fail if the NCCL build


### PR DESCRIPTION
benchmarks folder is not fully tested/used during CI. adding first step to build cpp benchmarks to ensure build failure doesn't occur. 

Tests will be added in separate PR