### PR TITLE
Remove unused python2 shebang

### DIFF
--- a/caffe2/python/caffe_translator.py
+++ b/caffe2/python/caffe_translator.py
@@ -1,6 +1,5 @@
 ## @package caffe_translator
 # Module caffe2.python.caffe_translator
-#!/usr/bin/env python2
 
 import argparse
 import copy


### PR DESCRIPTION
This is the only line (not in `third_party`) matching the regex `^#!.*python2`, and [it is not the first line of its file](https://github.com/koalaman/shellcheck/wiki/SC1128), so it has no effect. As a followup to #58275, this PR removes that shebang to reduce confusion, so now all Python shebangs in this repo are `python3`.