### PR TITLE
fix render_test_result step dependency

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.in
+++ b/.github/templates/linux_ci_workflow.yml.in
@@ -241,7 +241,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   render_test_results:
-    if: always()
+    if: always() && jobs.calculate-docker-image.outcome == 'success' && jobs.build.outcome == 'success'
     needs:
       - test
     runs-on: ubuntu-18.04

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -242,7 +242,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   render_test_results:
-    if: always()
+    if: always() && jobs.calculate-docker-image.outcome == 'success' && jobs.build.outcome == 'success'
     needs:
       - test
     runs-on: ubuntu-18.04

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -242,7 +242,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   render_test_results:
-    if: always()
+    if: always() && jobs.calculate-docker-image.outcome == 'success' && jobs.build.outcome == 'success'
     needs:
       - test
     runs-on: ubuntu-18.04


### PR DESCRIPTION
render_test_results should depend on successful steps of:
- calculate-docker-image
- build

If either of the step above failed it should not re run. 

The goal here is:
1. Reduce CI cost - even the step only runs for around 1min with just the checkout step and artifact download before failing, we still spend unnecessary time/cost
2. render_test_results failure contributes to "failing" count to the PR page signal hub - which is misleading when debugging failures