### PR TITLE
fx quant: remove test debug logs

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -2196,8 +2196,7 @@ class TestQuantizeFx(QuantizationTestCase):
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
             },
-            prepare_custom_config_dict=prepare_custom_config_dict,
-            print_debug_info=True)
+            prepare_custom_config_dict=prepare_custom_config_dict)
 
         # quantizeable node, quantized output
         class M2(torch.nn.Module):
@@ -2219,8 +2218,7 @@ class TestQuantizeFx(QuantizationTestCase):
             expected_node_occurrence={
                 ns.call_function(torch.quantize_per_tensor): 1,
             },
-            prepare_custom_config_dict=prepare_custom_config_dict,
-            print_debug_info=True)
+            prepare_custom_config_dict=prepare_custom_config_dict)
 
         # quantizeable node, quantized dictionary output
         class M3(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58416 fx quant: fix crash on output dicts and lists
* **#58415 fx quant: remove test debug logs**

Summary:

Removes test debugging logs which were committed, probably
someone forgot to remove before landing.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D28479947](https://our.internmc.facebook.com/intern/diff/D28479947)