### PR TITLE
fx quant: fix crash on output dicts and lists

### DIFF
--- a/test/quantization/test_quantize_fx.py
+++ b/test/quantization/test_quantize_fx.py
@@ -2261,6 +2261,24 @@ class TestQuantizeFx(QuantizationTestCase):
         m2 = copy.deepcopy(m)
         self.assertTrue(hasattr(m2, "attr"))
 
+    def test_output_lists_and_dicts(self):
+        """Verify that specifying complicated output types does not crash.
+        """
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(1, 1, 1)
+
+            def forward(self, x):
+                x = self.conv(x)
+                return {'foo': [x]}, [{'foo': [[x]]}]
+
+        m = M().eval()
+        qconfig_dict = {'': torch.quantization.default_qconfig}
+        mp = prepare_fx(m, qconfig_dict)
+        mc = convert_fx(mp)
+
+
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):
     """Unit tests for individual ops

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -476,7 +476,7 @@ def maybe_insert_observers_before_graph_output(
 ) -> None:
     """
     If the output needs to be quantized and there are any nodes
-    in the output which are not already observed, inserts obserervers
+    in the output which are not already observed, inserts observers
     for those nodes.
     """
 

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -475,8 +475,11 @@ def maybe_insert_observers_before_graph_output(
     graph: Graph,
 ) -> None:
     """
-
+    If the output needs to be quantized and there are any nodes
+    in the output which are not already observed, inserts obserervers
+    for those nodes.
     """
+
     # TODO(future PR): update the output_quantized_idxs API to match
     # arbitrary data structures. There is always a single output, and
     # that output can have arbitrary nesting of values. List[int] is
@@ -492,14 +495,14 @@ def maybe_insert_observers_before_graph_output(
     output_target_dtype = torch.quint8
 
     def _recursive_maybe_replace_node_with_obs(
-        maybe_node: Any,
+        maybe_node: Argument,
         target_dtype: torch.dtype,
         node_name_to_target_dtype: Dict[str, torch.dtype],
         qconfig_map: Dict[str, QConfigAny],
         model: torch.nn.Module,
         modules: Dict[str, torch.nn.Module],
         graph: Graph,
-    ) -> Any:
+    ) -> Argument:
         """
         Navigate an arbitrary data structure of lists, tuples, dicts.
         For each container type, recurse on all inputs. Once any Node

--- a/torch/quantization/fx/quantize.py
+++ b/torch/quantization/fx/quantize.py
@@ -465,6 +465,103 @@ def maybe_insert_output_observer_for_node(
 
     return None
 
+def maybe_insert_observers_before_graph_output(
+    graph_output_node: Node,
+    output_quantized_idxs: List[int],
+    node_name_to_target_dtype: Dict[str, torch.dtype],
+    qconfig_map: Dict[str, QConfigAny],
+    model: torch.nn.Module,
+    modules: Dict[str, torch.nn.Module],
+    graph: Graph,
+) -> None:
+    """
+
+    """
+    # TODO(future PR): update the output_quantized_idxs API to match
+    # arbitrary data structures. There is always a single output, and
+    # that output can have arbitrary nesting of values. List[int] is
+    # not the right data type for this.
+    assert output_quantized_idxs == [0] or output_quantized_idxs == [], \
+        'unrecognized format of output_quantized_idxs'
+
+    # Currently dequants are inserted in the convert step. So, we only
+    # have to do anything if the output is hardcoded to be quantized
+    if output_quantized_idxs == []:
+        return
+    # TODO(future PR): support more dtypes in model outputs, if necessary
+    output_target_dtype = torch.quint8
+
+    def _recursive_maybe_replace_node_with_obs(
+        maybe_node: Any,
+        target_dtype: torch.dtype,
+        node_name_to_target_dtype: Dict[str, torch.dtype],
+        qconfig_map: Dict[str, QConfigAny],
+        model: torch.nn.Module,
+        modules: Dict[str, torch.nn.Module],
+        graph: Graph,
+    ) -> Any:
+        """
+        Navigate an arbitrary data structure of lists, tuples, dicts.
+        For each container type, recurse on all inputs. Once any Node
+        is found, insert an observer if needed and do not recurse further.
+
+        For example, given a structure of
+
+          {'foo1': [[bar1]], 'foo2': {'foo3': [[[bar3]]]}}
+
+        we recurse down to bar1 and bar3, observe them if necessary,
+        and if we inserted an observer then replace the original node
+        with its observer.
+
+        Returns the data structure with all nodes needing observation being
+        replaced by their observers.
+        """
+        if isinstance(maybe_node, Node):
+            # check dtype of this node
+            this_node_dtype = node_name_to_target_dtype[maybe_node.name]
+            if this_node_dtype != target_dtype:
+                # insert observer
+                qconfig = qconfig_map.get(maybe_node.name)
+                # TODO(future PR): see if we need to allow specifying qconfig
+                #   on output nodes, to remove the restriction below.
+                assert qconfig is not None, \
+                    'Quantizing the output node without a qconfig is not supported'
+                observer_mod = qconfig.activation()
+                observer_node = insert_observer(
+                    maybe_node, observer_mod, model, modules, graph)
+                return observer_node
+            else:
+                return maybe_node
+        elif isinstance(maybe_node, (list, tuple)):
+            results = []
+            for inner_node in maybe_node:
+                results.append(_recursive_maybe_replace_node_with_obs(
+                    inner_node, target_dtype, node_name_to_target_dtype,
+                    qconfig_map, model, modules, graph))
+            if isinstance(maybe_node, list):
+                return results
+            else:
+                return tuple(results)
+        elif isinstance(maybe_node, dict):
+            results_dict = {}
+            for k, inner_v in maybe_node.items():
+                results_dict[k] = _recursive_maybe_replace_node_with_obs(
+                    inner_v, target_dtype, node_name_to_target_dtype,
+                    qconfig_map, model, modules, graph)
+            return results_dict
+        else:
+            return results
+
+    new_args = []
+    for old_arg in graph_output_node.args:
+        new_args.append(
+            _recursive_maybe_replace_node_with_obs(
+                old_arg, output_target_dtype, node_name_to_target_dtype,
+                qconfig_map, model, modules, graph))
+
+    graph_output_node.args = new_args  # type: ignore[assignment]
+
+
 def maybe_propagate_dtype_for_node(
     node: Node,
     target_dtype: torch.dtype,
@@ -717,26 +814,10 @@ def insert_observers_for_model(
                                 adjust_observers_for_cat(node, model, modules)
 
                 else:  # output
-                    prev_node = node.args[0]
-                    if isinstance(prev_node, Node):
-                        if is_activation_post_process_node(prev_node, modules):
-                            prev_node = prev_node.args[0]
-                    elif isinstance(prev_node, dict):
-                        # get first value
-                        prev_node = list(prev_node.items())[0][1]
-                        assert isinstance(prev_node, Node)
-                        if is_activation_post_process_node(prev_node, modules):
-                            prev_node = prev_node.args[0]
-
-                    # we check for node again because some graphs can return
-                    # None
-                    if isinstance(prev_node, Node):
-                        prev_node_qconfig = qconfig_map.get(prev_node.name, None)
-                        # this modifies node inplace
-                        maybe_insert_input_observers_for_node(
-                            node, prev_node_qconfig, model, modules, graph,
-                            node_name_to_target_dtype,
-                            qhandler, prepare_custom_config_dict)
+                    maybe_insert_observers_before_graph_output(
+                        node, output_quantized_idxs,
+                        node_name_to_target_dtype, qconfig_map,
+                        model, modules, graph)
 
         #
         # After this point, the current node has input and output observers


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58416 fx quant: fix crash on output dicts and lists**
* #58415 fx quant: remove test debug logs

Summary:

https://github.com/pytorch/pytorch/pull/57519 had a regression not
caught by CI, it added an assertion which failed on various model
output types.

This PR removes the assertion and adds the logic to observe graph
outputs in a way that supports arbitrary output formats.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_output_lists_and_dicts
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D28479946](https://our.internmc.facebook.com/intern/diff/D28479946)