### PR TITLE
Make GraphTask::owner_ atomic to avoid data races.

### DIFF
--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -428,7 +428,7 @@ auto Engine::thread_main(const std::shared_ptr<GraphTask>& graph_task) -> void {
     if (local_graph_task->completed()) {
       local_graph_task->mark_as_completed_and_run_post_processing();
 
-      auto base_owner = local_graph_task->owner_;
+      auto base_owner = local_graph_task->owner_.load();
       // The current worker thread finish the graph_task, but the owning thread
       // of the graph_task might be sleeping on pop() if it does not have work.
       // So we need to send a dummy function task to the owning thread just to

--- a/torch/csrc/autograd/engine.h
+++ b/torch/csrc/autograd/engine.h
@@ -116,9 +116,10 @@ struct GraphTask: std::enable_shared_from_this<GraphTask> {
 
   // The value of worker_device in the thread that created this task.
   // See Note [Reentrant backwards]
-  // Safe to read owner_ and reentrant_depth_ without synchronizaton
-  int owner_;
+  std::atomic<int> owner_;
+
   // The number of parent graph tasks for this graph task
+  // Safe to read reentrant_depth_ without synchronizaton
   const int reentrant_depth_;
 
   bool can_checkpoint() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58457 Make c10::ThreadPool::available_ atomic.
* **#58449 Make GraphTask::owner_ atomic to avoid data races.**

Several TSAN tests were failing for distributed since `owner_` was not
atomic and was being accessed by several threads. As an example:
https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/autograd/engine/dist_engine.cpp#L333.

Differential Revision: [D28496878](https://our.internmc.facebook.com/intern/diff/D28496878/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28496878/)!