### PR TITLE
Make c10::ThreadPool::available_ atomic.

### DIFF
--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -62,7 +62,7 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
   std::condition_variable completed_;
   std::atomic_bool running_;
   bool complete_;
-  std::size_t available_;
+  std::atomic<std::size_t> available_;
   std::size_t total_;
   int numa_node_id_;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58457 Make c10::ThreadPool::available_ atomic.**
* #58449 Make GraphTask::owner_ atomic to avoid data races.

This variable had concurrent read/write access without any
synchronization. The issue was caught and reported by TSAN.

Differential Revision: [D28498116](https://our.internmc.facebook.com/intern/diff/D28498116/)