### PR TITLE
Fix usage of TORCH_INTERNAL_ASSERT with message 

### DIFF
--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -309,6 +309,7 @@ Tensor& add_relu_impl(
     max_val = std::numeric_limits<double>::max();
   } else {
     TORCH_INTERNAL_ASSERT(
+        false,
         "Unsupported datatype for add_relu:", self.dtype().name());
   }
 

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
@@ -815,6 +815,7 @@ class QEmbeddingBag final {
           include_last_offset);
     } else {
       TORCH_INTERNAL_ASSERT(
+          false,
           "Currently only support 8-bit embedding_bag quantization");
     }
   }
@@ -843,6 +844,7 @@ class QEmbedding final {
 
     } else {
       TORCH_INTERNAL_ASSERT(
+          false,
           "Currently only support 8-bit embedding quantization");
     }
     return output;

--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
@@ -131,6 +131,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
 
           if (conv_p.per_channel && conv_p.ukernel_type == pytorch_qnnp_ukernel_type_xzp_gemm) {
             TORCH_INTERNAL_ASSERT(
+              false,
               "Per channel quantized weights are not supported for XZP kernels");
           }
 
@@ -140,6 +141,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
               static_cast<pytorch_qnnp_operator_t>(calloc(1, sizeof(struct pytorch_qnnp_operator)));
           if (convolution == nullptr) {
             TORCH_INTERNAL_ASSERT(
+                false,
                 "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
                 sizeof(struct pytorch_qnnp_operator));
           }
@@ -410,7 +412,7 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
       weight_zp[i] = (uint8_t)(per_channel_zero_points[i] + 128);
     }
   } else {
-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
+    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
   }
   at:: Tensor weight_scales =
     at::empty(
@@ -431,7 +433,7 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
       weight_scales_data[i] = static_cast<float>(per_channel_scales[i]);
     }
   } else {
-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
+    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
   }
   for (int i = num_output_channels; i <  num_output_channels_padded; ++i) {
     weight_scales_data[i] = 1.f;

--- a/test/test_mobile_optimizer.py
+++ b/test/test_mobile_optimizer.py
@@ -359,6 +359,9 @@ class TestOptimizer(TestCase):
         bi_module_lint_list = generate_mobile_module_lints(bi_module)
         self.assertEqual(len(bi_module_lint_list), 0)
 
+    @unittest.skipUnless(torch.backends.xnnpack.enabled,
+                         " XNNPACK must be enabled for these tests."
+                         " Please build with USE_XNNPACK=1.")
     def test_preserve_bundled_inputs_methods(self):
         class MyBundledInputModule(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -438,7 +438,7 @@ void Module::train(bool on) {
     if (auto slot = m._ivalue()->type()->findAttributeSlot("training")) {
       m._ivalue()->setSlot(*slot, on);
     } else {
-      TORCH_INTERNAL_ASSERT("'training' attribute not found");
+      TORCH_INTERNAL_ASSERT(false, "'training' attribute not found");
     }
   }
 }

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -323,6 +323,7 @@ Node* insertEmbeddingBagOps(Node* observer, const std::string& op_name) {
     quant_fn = "quantized::embedding_bag_byte_rowwise_offsets";
   } else {
     TORCH_INTERNAL_ASSERT(
+        false,
         "Graph Mode Quantization currently supports 4-bit and 8-bit embedding bag quantization.");
   }
 

--- a/torch/csrc/jit/passes/vulkan_rewrite.cpp
+++ b/torch/csrc/jit/passes/vulkan_rewrite.cpp
@@ -234,28 +234,29 @@ script::Module vulkanOptimizeForMobile(
 
 void vulkanInsertPrePackedOps(std::shared_ptr<Graph>& graph) {
   TORCH_INTERNAL_ASSERT(
-      "Vulkan is not enabled. Please build with USE_VULKAN=1");
+      false, "Vulkan is not enabled. Please build with USE_VULKAN=1");
 }
 
 void vulkanInsertPrePackedOps(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "Vulkan is not enabled. Please build with USE_VULKAN=1");
+      false, "Vulkan is not enabled. Please build with USE_VULKAN=1");
 }
 
 void vulkanFusePrePackedConvWithClamp(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "Vulkan is not enabled. Please build with USE_VULKAN=1");
+      false, "Vulkan is not enabled. Please build with USE_VULKAN=1");
 }
 
 void vulkanFoldPrePackingOps(script::Module& m) {
   TORCH_INTERNAL_ASSERT(
-      "Vulkan is not enabled. Please build with USE_VULKAN=1");
+      false, "Vulkan is not enabled. Please build with USE_VULKAN=1");
 }
 
 script::Module vulkanOptimizeForMobile(
     const script::Module& module,
     const std::vector<std::string>& preserved_methods) {
   TORCH_INTERNAL_ASSERT(
+      false,
       "Mobile optimizaiton only available with Vulkan at the moment. "
       "Vulkan is not enabled. Please build with USE_VULKAN=1");
   return module;

--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
@@ -425,22 +425,22 @@ script::Module optimizeForMobile(
 
 void insertPrePackedOps(std::shared_ptr<Graph>& graph) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void insertPrePackedOps(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void fusePrePackedLinearConvWithClamp(script::Module& module) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 void FoldPrePackingOps(script::Module& m) {
   TORCH_INTERNAL_ASSERT(
-      "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+      false, "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
 }
 
 script::Module optimizeForMobile(
@@ -448,6 +448,7 @@ script::Module optimizeForMobile(
     const std::set<MobileOptimizerType>& blocklist,
     const std::vector<std::string>& preserved_methods) {
   TORCH_INTERNAL_ASSERT(
+      false,
       "Mobile optimization only available with XNNPACK at the moment. "
       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
   return module;

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -796,7 +796,7 @@ void GraphExecutor::debugFlushCompilationCache() {
     ppImpl->debugFlushCompilationCache();
   } else {
     // we are deprecating legacy executor
-    TORCH_INTERNAL_ASSERT("Not Implemented for Legacy Executor");
+    TORCH_INTERNAL_ASSERT(false, "Not Implemented for Legacy Executor");
   }
 }
 

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -195,7 +195,8 @@ IValue tensorToListRecursive(
     } else if (inner_result.isBool()) {
       result.emplace_back(inner_result.toBool());
     } else {
-      TORCH_INTERNAL_ASSERT("Unknown return type for tensorToListRecursive");
+      TORCH_INTERNAL_ASSERT(
+          false, "Unknown return type for tensorToListRecursive");
     }
 
     data += strides[cur_dim] * element_size;

--- a/torch/lib/c10d/ProcessGroup.cpp
+++ b/torch/lib/c10d/ProcessGroup.cpp
@@ -42,7 +42,7 @@ std::string opTypeToString(OpType opType) {
     case OpType::UNKNOWN:
       return "UNKNOWN";
     default:
-      TORCH_INTERNAL_ASSERT("Unknown op type!");
+      TORCH_INTERNAL_ASSERT(false, "Unknown op type!");
   }
   return "UNKNOWN";
 }


### PR DESCRIPTION
Using only a string as the argument for TORCH_INTERNAL_ASSERT will never trigger a failure as a string is always a truethy value.
This hides actual bugs and makes users and devs think all worked while it did not.
Change to use `TORCH_INTERNAL_ASSERT(false, "msg")`

I found this because on PPC (where there is no XNNPACK) one of the tests failed:

```
FAIL: test_preserve_bundled_inputs_methods (__main__.TestOptimizer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mobile_optimizer.py", line 328, in test_preserve_bundled_inputs_methods
    self.assertFalse(hasattr(incomplete_bi_module_optim, 'get_all_bundled_inputs'))
AssertionError: True is not false
```

This happens because the assertion is not fired and the module is returned unchanged: https://github.com/pytorch/pytorch/compare/master...Flamefire:assert_fix?expand=1#diff-5d18cdc66f45034594ef1f12d8ed1e9e21c21ae75fb55eb88713f26e49f8eb74R266

cc @pietern @mrshenli @pritamdamania87 @zhaojuanmao @satgera @rohan-varma @gqchen @aazzolini @osalpekar @jiayisuse @SciPioneer @H-Huang