### PR TITLE
Parametrizations depending on several inputs

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2156,7 +2156,9 @@ class TestNN(NNTestCase):
                 # If X is skew-symmetric it returns an orthogonal matrix
                 Id = torch.eye(X.size(0), device=X.device)
                 # We call contiguous because solve returns a tensor with strides that are Fortran-contiguous
-                # and autograd raises a performance warning
+                # and autograd raises a performance warning.
+                # This happens when we remove the parametrization with leave_parametrized=True,
+                # which does a set_ with a non-contiguous tensor while the gradient is contiguous
                 return torch.linalg.solve(Id + X, Id - X).contiguous()
 
         # Define a couple vector parametrizations
@@ -7371,7 +7373,7 @@ class TestNN(NNTestCase):
             weight = all_vars[4]
             weight_data = weight.data.clone()
             with torch.no_grad():
-                weight.set_(weight_data)
+                weight.copy_(weight_data)
 
             for _ in range(2):
                 with warnings.catch_warnings(record=True) as w:

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -203,7 +203,7 @@ class ParametrizationList(ModuleList):
                 if hasattr(module, "right_inverse"):
                     value = module.right_inverse(value)
                 # else we assume that right_inverse is the identity
-            if self.is_tensor == 1:
+            if self.is_tensor:
                 # These exceptions should only throw when a right_inverse function does not
                 # return the same dtype for every input, which should most likely be caused by a bug
                 if not isinstance(value, Tensor):
@@ -244,7 +244,7 @@ class ParametrizationList(ModuleList):
 
     def forward(self) -> Tensor:
         # Unpack the originals for the first parametrization
-        if self.is_tensor == 1:
+        if self.is_tensor:
             x = self[0](self.original)
         else:
             originals = (getattr(self, f"original{i}") for i in range(self.ntensors))
@@ -563,7 +563,7 @@ def remove_parametrizations(
     # Fetch the original tensor
     assert isinstance(module.parametrizations, ModuleDict)  # Make mypy happy
     parametrizations = module.parametrizations[tensor_name]
-    if parametrizations.is_tensor == 1:
+    if parametrizations.is_tensor:
         original = parametrizations.original
         if leave_parametrized:
             with torch.no_grad():

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -433,7 +433,7 @@ def register_parametrization(
         # Set the parametrization mechanism
         # Fetch the original buffer or parameter
         original = getattr(module, tensor_name)
-        # We create this early to check for possible errors early
+        # We create this early to check for possible errors
         parametrizations = ParametrizationList([parametrization], original)
         # Delete the previous parameter or buffer
         delattr(module, tensor_name)

--- a/torch/nn/utils/parametrize.py
+++ b/torch/nn/utils/parametrize.py
@@ -231,7 +231,7 @@ class ParametrizationList(ModuleList):
                 f"original shape: {Y.shape}\n"
                 f"new shape: {Z.shape}"
             )
-        return super().append(module)
+        return super().append(module)  # type: ignore[return-value]
 
 
 def _inject_new_class(module: Module) -> None:


### PR DESCRIPTION
Makes possible that the first register parametrization depends on a number of parameters rather than just one. Examples of these types of parametrizations are `torch.nn.utils.weight_norm` and low rank parametrizations via the multiplication of a `n x k`  tensor by a `k x m` tensor with `k <= m, n`.

Follows the plan outlined in https://github.com/pytorch/pytorch/pull/33344#issuecomment-768574924. A short summary of the idea is: we call `right_inverse` when registering a parametrization to generate the tensors that we are going to save. If `right_inverse` returns a sequence of tensors, then we save them as `original0`, `original1`...  If it returns a `Tensor` or a sequence of length 1, we save it as `original`.

We only allow to have many-to-one parametrizations in the first parametrization registered. The next parametrizations would need to be one-to-one.

There were a number of choices in the implementation:

If the `right_inverse` returns a sequence of parameters, then we unpack it in the forward. This is to allow to write code as:
```python
class Sum(nn.Module):
  def forward(self, X, Y):
    return X + Y
  def right_inverse(Z):
    return Z, torch.zeros_like(Z)
```
rather than having to unpack manually a list or a tuple within the `forward` function.

At the moment the errors are a bit all over the place. This is to avoid having to check some properties of `forward` and `right_inverse` when they are registered. I left this like this for now, but I believe it'd be better to call these functions when they are registered to make sure the invariants hold and throw errors as soon as possible.

The invariants are the following:
1. The following code should be well-formed
```python
X = module.weight
Y = param.right_inverse(X)
assert isinstance(Y, Tensor) or isinstance(Y, collections.Sequence)
Z = param(Y) if isisntance(Y, Tensor) else param(*Y)
```
in other words, if `Y` is a `Sequence` of `Tensor`s (we check also that the elements of the sequence are Tensors), then it is of the same length as the number parameters `param.forward` accepts.

2. Always: `X.dtype == Z.dtype and X.shape == Z.shape`. This is to protect the user from shooting themselves in the foot, as it's too odd for a parametrization to change the metadata of a tensor.
3. If it's one-to-one: `X.dtype == Y.dtype`. This is to be able to do `X.set_(Y)` so that if a user first instantiates the optimiser and then puts the parametrisation, then we reuse `X` and the user does not need to add a new parameter to the optimiser. Alas, this is not possible when the parametrisation is many-to-one. The current implementation of `spectral_norm` and `weight_norm` does not seem to care about this, so this would not be a regression. I left a warning in the documentation though, as this case is a bit tricky.

I'm still missing to go over the formatting of the documentation, I'll do that tomorrow.

