### PR TITLE
[local lint] Remove success checks in tests

### DIFF
--- a/tools/test/test_actions_local_runner.py
+++ b/tools/test/test_actions_local_runner.py
@@ -63,18 +63,18 @@ if sys.version_info >= (3, 8):
 
     class TestEndToEnd(unittest.TestCase):
         expected = [
-            "✓ quick-checks: Extract scripts from GitHub Actions workflows",
-            "✓ cmakelint: Run cmakelint",
-            "✓ quick-checks: Ensure no direct cub include",
-            "✓ quick-checks: Ensure no unqualified type ignore",
-            "✓ quick-checks: Ensure no unqualified noqa",
-            "✓ quick-checks: Ensure canonical include",
-            "✓ quick-checks: Ensure no non-breaking spaces",
-            "✓ quick-checks: Ensure no tabs",
-            "✓ flake8",
-            "✓ quick-checks: Ensure correct trailing newlines",
-            "✓ quick-checks: Ensure no trailing spaces",
-            "✓ quick-checks: Run ShellCheck",
+            "quick-checks: Extract scripts from GitHub Actions workflows",
+            "cmakelint: Run cmakelint",
+            "quick-checks: Ensure no direct cub include",
+            "quick-checks: Ensure no unqualified type ignore",
+            "quick-checks: Ensure no unqualified noqa",
+            "quick-checks: Ensure canonical include",
+            "quick-checks: Ensure no non-breaking spaces",
+            "quick-checks: Ensure no tabs",
+            "flake8",
+            "quick-checks: Ensure correct trailing newlines",
+            "quick-checks: Ensure no trailing spaces",
+            "quick-checks: Run ShellCheck",
         ]
 
         def test_lint(self):
@@ -85,19 +85,18 @@ if sys.version_info >= (3, 8):
             for line in self.expected:
                 self.assertIn(line, stdout)
 
-            self.assertIn("✓ mypy", stdout)
+            self.assertIn("mypy", stdout)
 
         def test_quicklint(self):
             cmd = ["make", "quicklint", "-j", str(multiprocessing.cpu_count())]
             proc = subprocess.run(cmd, cwd=actions_local_runner.REPO_ROOT, stdout=subprocess.PIPE)
             stdout = proc.stdout.decode()
 
-            # TODO: See https://github.com/pytorch/pytorch/issues/58253
-            # for line in self.expected:
-            #     self.assertIn(line, stdout)
+            for line in self.expected:
+                self.assertIn(line, stdout)
 
             # TODO: See https://github.com/pytorch/pytorch/issues/57967
-            # self.assertIn("✓ mypy (skipped typestub generation)", stdout)
+            self.assertIn("mypy (skipped typestub generation)", stdout)
 
 
     class TestQuicklint(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Testing for both that a lint job ran and that it was successful depends
on having lint pass for the PR, which can create confusion if it doesn't
(i.e. a flake8 failure also causes this job to fail, and it's not
immediately clear why). With this PR we just check for the presence of
job names to see that something ran.
