### PR TITLE
Make torch::deploy work with or without cuda

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -1,4 +1,6 @@
+#include <c10/util/Exception.h>
 #include <torch/csrc/deploy/deploy.h>
+#include <torch/cuda.h>
 
 #include <dlfcn.h>
 #include <libgen.h>
@@ -9,8 +11,20 @@
 // it into a symbol that is then linked into libtorch_deploy.so. This enables us
 // to simply copy the contents of this symbol to disk and dlopen it to create an
 // instance of python.
-extern "C" char _binary_libtorch_deployinterpreter_so_start[];
-extern "C" char _binary_libtorch_deployinterpreter_so_end[];
+extern "C" __attribute__((
+    __weak__)) char _binary_libtorch_deployinterpreter_so_start[];
+extern "C"
+    __attribute__((__weak__)) char _binary_libtorch_deployinterpreter_so_end[];
+#ifdef FBCODE_CAFFE2
+// in fbcode, we build the interpreter version with cuda bindings explicitly and
+// side-by-side with the one without.  In OSS builds, we just build one
+// libinterpreter and it either has or doesn't have cuda depending on top-level
+// CMAKE flags
+extern "C" __attribute__((
+    __weak__)) char _binary_libtorch_deployinterpreter_cuda_so_start[];
+extern "C" __attribute__((
+    __weak__)) char _binary_libtorch_deployinterpreter_cuda_so_end[];
+#endif
 
 namespace torch {
 namespace deploy {
@@ -87,6 +101,12 @@ ReplicatedObj InterpreterSession::create_movable(Obj obj) {
   TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
+void write_tmp_lib(FILE* dst, char* lib_start, char* lib_end) {
+  TORCH_INTERNAL_ASSERT(dst);
+  size_t size = lib_end - lib_start;
+  TORCH_INTERNAL_ASSERT(size == fwrite(lib_start, 1, size, dst));
+}
+
 Interpreter::Interpreter(InterpreterManager* manager)
     : handle_(nullptr), manager_(manager) {
   // NOLINTNEXTLINE(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
@@ -95,12 +115,31 @@ Interpreter::Interpreter(InterpreterManager* manager)
   TORCH_INTERNAL_ASSERT(fd != -1, "failed to create temporary file");
   library_name_ = library_name;
   FILE* dst = fdopen(fd, "wb");
-  TORCH_INTERNAL_ASSERT(dst);
-  size_t size = _binary_libtorch_deployinterpreter_so_end -
-      _binary_libtorch_deployinterpreter_so_start;
-  TORCH_INTERNAL_ASSERT(
-      size ==
-      fwrite(_binary_libtorch_deployinterpreter_so_start, 1, size, dst));
+
+  // See comment above for fbcode vs oss behavior
+  char* lib_start = NULL;
+  char* lib_end = NULL;
+#ifdef FBCODE_CAFFE2
+  if (torch::cuda::is_available() &&
+      &_binary_libtorch_deployinterpreter_cuda_so_start &&
+      &_binary_libtorch_deployinterpreter_cuda_so_end) {
+    lib_start = _binary_libtorch_deployinterpreter_cuda_so_start;
+    lib_end = _binary_libtorch_deployinterpreter_cuda_so_end;
+  } else if (
+      &_binary_libtorch_deployinterpreter_so_start &&
+      &_binary_libtorch_deployinterpreter_so_end) {
+    lib_start = _binary_libtorch_deployinterpreter_so_start;
+    lib_end = _binary_libtorch_deployinterpreter_so_end;
+  }
+#else // FBCODE_CAFFE2
+  lib_start = _binary_libtorch_deployinterpreter_so_start;
+  lib_end = _binary_libtorch_deployinterpreter_so_end;
+#endif // FBCODE_CAFFE2
+  TORCH_CHECK(
+      lib_start != NULL && lib_end != NULL,
+      "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.");
+
+  write_tmp_lib(dst, lib_start, lib_end);
   fclose(dst);
   handle_ = dlopen(library_name, RTLD_LOCAL | RTLD_LAZY);
   if (!handle_) {

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -9,47 +9,7 @@
 #include <thread>
 #include <vector>
 
-/* Torch Deploy intentionally embeds multiple copies of c++ libraries
-   providing python bindings necessary for torch::deploy users in the same
-   process space in order to provide a multi-python environment.  As a result,
-   any exception types defined by these duplicated libraries can't be safely
-   caught or handled outside of the originating dynamic library (.so).
 
-   In practice this means that you must either
-   catch these exceptions inside the torch::deploy API boundary or risk crashing
-   the client application.
-
-   It is safe to throw exception types that are defined once in
-   the context of the client application, such as c10::Error, which is defined
-   in libtorch, which isn't duplicated in torch::deploy interpreters.
-
-   ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
-
-   For more information, see
-    https://gcc.gnu.org/wiki/Visibility (section on c++ exceptions)
-    or https://stackoverflow.com/a/14364055
-    or
-   https://stackoverflow.com/questions/14268736/symbol-visibility-exceptions-runtime-error
-    note- this may be only a serious problem on versions of gcc prior to 4.0,
-   but still seems worth sealing off.
-
-*/
-#define TORCH_DEPLOY_TRY try {
-#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                        \
-  }                                                                            \
-  catch (std::exception & err) {                                               \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Exception Caught inside torch::deploy embedded library: \n") +    \
-            err.what(),                                                        \
-        "");                                                                   \
-  }                                                                            \
-  catch (...) {                                                                \
-    throw c10::Error(                                                          \
-        std::string(                                                           \
-            "Unknown Exception Caught inside torch::deploy embedded library"), \
-        "");                                                                   \
-  }
 
 namespace torch {
 namespace deploy {

--- a/torch/csrc/deploy/interpreter/interpreter_impl.h
+++ b/torch/csrc/deploy/interpreter/interpreter_impl.h
@@ -4,6 +4,47 @@
 #include <ATen/core/ivalue.h>
 #include <caffe2/serialize/inline_container.h>
 
+/* Torch Deploy intentionally embeds multiple copies of c++ libraries
+   providing python bindings necessary for torch::deploy users in the same
+   process space in order to provide a multi-python environment.  As a result,
+   any exception types defined by these duplicated libraries can't be safely
+   caught or handled outside of the originating dynamic library (.so).
+
+   In practice this means that you must either
+   catch these exceptions inside the torch::deploy API boundary or risk crashing
+   the client application.
+
+   It is safe to throw exception types that are defined once in
+   the context of the client application, such as c10::Error, which is defined
+   in libtorch, which isn't duplicated in torch::deploy interpreters.
+
+   ==> Use TORCH_DEPLOY_TRY, _SAFE_CATCH_RETHROW around _ALL_ torch::deploy APIs
+
+   For more information, see
+    https://gcc.gnu.org/wiki/Visibility (section on c++ exceptions)
+    or https://stackoverflow.com/a/14364055
+    or
+   https://stackoverflow.com/questions/14268736/symbol-visibility-exceptions-runtime-error
+    note- this may be only a serious problem on versions of gcc prior to 4.0,
+   but still seems worth sealing off.
+
+*/
+#define TORCH_DEPLOY_TRY try {
+#define TORCH_DEPLOY_SAFE_CATCH_RETHROW                                        \
+  }                                                                            \
+  catch (std::exception & err) {                                               \
+    throw c10::Error(                                                          \
+        std::string(                                                           \
+            "Exception Caught inside torch::deploy embedded library: \n") +    \
+            err.what(),                                                        \
+        "");                                                                   \
+  }                                                                            \
+  catch (...) {                                                                \
+    throw c10::Error(                                                          \
+        std::string(                                                           \
+            "Unknown Exception Caught inside torch::deploy embedded library"), \
+        "");                                                                   \
+  }
 namespace torch {
 namespace deploy {
 
@@ -91,28 +132,40 @@ struct InterpreterImpl {
 // source file that would need to exist it both the libinterpreter.so and then
 // the libtorchpy library.
 inline at::IValue Obj::toIValue() const {
+  TORCH_DEPLOY_TRY
   return interaction_->toIValue(*this);
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::operator()(at::ArrayRef<Obj> args) {
+  TORCH_DEPLOY_TRY
   return interaction_->call(*this, args);
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::operator()(at::ArrayRef<at::IValue> args) {
+  TORCH_DEPLOY_TRY
   return interaction_->call(*this, args);
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 inline Obj Obj::call_kwargs(
     std::vector<at::IValue> args,
     std::unordered_map<std::string, c10::IValue> kwargs) {
+  TORCH_DEPLOY_TRY
   return interaction_->call_kwargs(*this, std::move(args), std::move(kwargs));
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 inline Obj Obj::call_kwargs(
     std::unordered_map<std::string, c10::IValue> kwargs) {
+  TORCH_DEPLOY_TRY
   return interaction_->call_kwargs(*this, std::move(kwargs));
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 inline Obj Obj::attr(const char* attr) {
+  TORCH_DEPLOY_TRY
   return interaction_->attr(*this, attr);
+  TORCH_DEPLOY_SAFE_CATCH_RETHROW
 }
 
 } // namespace deploy

--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include <torch/csrc/deploy/deploy.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <future>
+#include <iostream>
+#include <string>
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  return rc;
+}
+
+const char* simple = "torch/csrc/deploy/example/generated/simple";
+const char* simple_jit = "torch/csrc/deploy/example/generated/simple_jit";
+
+const char* path(const char* envname, const char* path) {
+  const char* e = getenv(envname);
+  return e ? e : path;
+}
+
+TEST(TorchDeployGPUTest, SimpleModel) {
+  const char* model_filename = path("SIMPLE", simple);
+  const char* jit_filename = path("SIMPLE_JIT", simple_jit);
+
+  // Test
+  torch::deploy::InterpreterManager m(1);
+  torch::deploy::Package p = m.load_package(model_filename);
+  auto model = p.load_pickle("model", "model.pkl");
+  {
+    auto M = model.acquire_session();
+    M.self.attr("to")({"cuda"});
+  }
+  std::vector<at::IValue> inputs;
+  {
+    auto I = p.acquire_session();
+    auto eg = I.self.attr("load_pickle")({"model", "example.pkl"}).toIValue();
+    inputs = eg.toTuple()->elements();
+    inputs[0] = inputs[0].toTensor().to("cuda");
+  }
+  at::Tensor output = model(inputs).toTensor();
+  ASSERT_TRUE(output.device().is_cuda());
+
+  // Reference
+  auto ref_model = torch::jit::load(jit_filename);
+  ref_model.to(torch::kCUDA);
+  at::Tensor ref_output = ref_model.forward(inputs).toTensor();
+
+  ASSERT_TRUE(ref_output.allclose(output, 1e-03, 1e-05));
+}

--- a/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
+++ b/torch/csrc/deploy/test_deploy_missing_interpreter.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+#include <torch/csrc/deploy/deploy.h>
+#include <torch/torch.h>
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int rc = RUN_ALL_TESTS();
+  return rc;
+}
+
+TEST(TorchDeployMissingInterpreter, Throws) {
+  EXPECT_THROW(torch::deploy::InterpreterManager(1), c10::Error);
+}


### PR DESCRIPTION
Summary:
In fbcode, we want torch::deploy to be a target that works with or without cuda, depending only on whether cuda is linked in the final binary.  To enable this, we build both flavors of libinterpreter,  and choose which to load at runtime depending on whether cuda is available in the application.  This comes at a cost to binary size, as it includes two copies of libinterpreter instead of one.  However, it does not require _loading_ two copies of libinterpreter into memory at runtime, so the memory footprint of the interpreter (which we make N copies of) is not impacted.

In oss/cmake, this change is a no-op.  cuda is already handled there by building just one libinterpreter, but building cuda or not for the whole pytorch build based on a global cmake flag.

Test Plan: test in fbcode with new gpu mode unit tests, verify existing oss CI passes

Differential Revision: D28512178

