### PR TITLE
Explicitly skip master-only GHA build jobs

### DIFF
--- a/.github/templates/linux_ci_workflow.yml.in
+++ b/.github/templates/linux_ci_workflow.yml.in
@@ -3,10 +3,7 @@
 name: Linux CI (!{{ build_environment }})
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
-{%- if on_pull_request %}
   pull_request:
-{%- endif %}
   push:
     branches:
       - master
@@ -25,6 +22,9 @@ env:
 
 jobs:
   calculate-docker-image:
+    {%- if not on_pull_request %}
+    if: github.event_name != 'pull_request'
+    {%- endif %}
     runs-on: linux.2xlarge
     env:
       DOCKER_BUILDKIT: 1
@@ -247,7 +247,11 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   render_test_results:
+    {%- if on_pull_request %}
     if: always()
+    {%- else %}
+    if: always() && github.event_name != 'pull_request'
+    {%- endif %}
     needs:
       - test
     runs-on: ubuntu-18.04

--- a/.github/templates/windows_ci_workflow.yml.in
+++ b/.github/templates/windows_ci_workflow.yml.in
@@ -3,9 +3,7 @@
 name: Windows CI (!{{ build_environment }})
 
 on:
-{%- if on_pull_request %}
   pull_request:
-{%- endif %}
   push:
     branches:
       - master
@@ -27,6 +25,9 @@ env:
 
 jobs:
   build:
+    {%- if not on_pull_request %}
+    if: github.event_name != 'pull_request'
+    {%- endif %}
     runs-on: "windows.4xlarge"
     steps:
       - name: Checkout PyTorch
@@ -101,7 +102,11 @@ jobs:
             test/**/*.xml
   # TODO: Make this into a composite step
   render_test_results:
+    {%- if on_pull_request %}
     if: always()
+    {%- else %}
+    if: always() && github.event_name != 'pull_request'
+    {%- endif %}
     needs:
       - test
     runs-on: ubuntu-18.04

--- a/.github/workflows/cancel_redundant_workflows.yml
+++ b/.github/workflows/cancel_redundant_workflows.yml
@@ -6,9 +6,11 @@ on:
     # NOTE: Make sure to add to this list as you add more workflows running on 'pull_request'
     workflows:
     - Lint
+    - Linux CI (pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7)
     - Linux CI (pytorch-linux-xenial-py3.6-gcc5.4)
     - Test tools
     - TorchBench CI (pytorch-linux-py3.7-cu102)
+    - Windows CI (pytorch-win-vs2019-cpu-py3)
     - clang-format
 jobs:
   cancel:

--- a/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
+++ b/.github/workflows/pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7.yml
@@ -4,7 +4,7 @@
 name: Linux CI (pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7)
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
+  pull_request:
   push:
     branches:
       - master
@@ -23,6 +23,7 @@ env:
 
 jobs:
   calculate-docker-image:
+    if: github.event_name != 'pull_request'
     runs-on: linux.2xlarge
     env:
       DOCKER_BUILDKIT: 1
@@ -245,7 +246,7 @@ jobs:
           # Prune all of the docker images
           docker system prune -af
   render_test_results:
-    if: always()
+    if: always() && github.event_name != 'pull_request'
     needs:
       - test
     runs-on: ubuntu-18.04

--- a/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
+++ b/.github/workflows/pytorch-linux-xenial-py3.6-gcc5.4.yml
@@ -4,7 +4,6 @@
 name: Linux CI (pytorch-linux-xenial-py3.6-gcc5.4)
 
 on:
-  # TODO: Enable pull_request builds when we can verify capacity can be met by auto-scalers
   pull_request:
   push:
     branches:

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -4,6 +4,7 @@
 name: Windows CI (pytorch-win-vs2019-cpu-py3)
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -25,6 +26,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request'
     runs-on: "windows.4xlarge"
     steps:
       - name: Checkout PyTorch
@@ -99,7 +101,7 @@ jobs:
             test/**/*.xml
   # TODO: Make this into a composite step
   render_test_results:
-    if: always()
+    if: always() && github.event_name != 'pull_request'
     needs:
       - test
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This PR tries to give better visibility into what CI is _not_ being run on PRs in general, by changing the way we skip certain build workflows/configs. Specifically, now all build workflows should be triggered by the `pull_request` event, but their jobs should show up as "skipped" on the PR, to give an indicator that these will eventually be run on `master` after the PR is merged.

This is only for GHA, but if this approach makes sense, we should do the same thing for Circle as well.

**Test plan:**

The generated workflow files should be up to date with the templates:
```
make generate-gha-workflows
.github/scripts/regenerate_cancel_redundant_workflow.py
```
Also, these workflows should show up as skipped in this PR's CI:
- Linux CI (pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7)
- Windows CI (pytorch-win-vs2019-cpu-py3)