### PR TITLE
[release/1.9] Fix issues regarding binary_chekcout

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -57,9 +57,9 @@ add_to_env_file() {
 }
 
 add_to_env_file "IN_CI=1"
-add_to_env_file "COMMIT_SOURCE=${CIRCLE_BRANCH:-}"
-add_to_env_file "BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
-add_to_env_file "CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}"
+add_to_env_file "COMMIT_SOURCE='${CIRCLE_BRANCH:-}'"
+add_to_env_file "BUILD_ENVIRONMENT='${BUILD_ENVIRONMENT}'"
+add_to_env_file "CIRCLE_PULL_REQUEST='${CIRCLE_PULL_REQUEST}'"
 
 
 if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then


### PR DESCRIPTION
Fixes issues where things included in the `BASH_ENV` were not properly getting set due to lacking quotes around variables.

See: https://app.circleci.com/pipelines/github/pytorch/pytorch/323635/workflows/7759eb83-70b8-403e-9e4f-258034999335/jobs/13536054