### PR TITLE
Clarify .github/scripts/generate_ci_workflows.py

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -15,6 +15,9 @@ GITHUB_DIR = Path(__file__).parent.parent
 # https://github.com/python/mypy/issues/4617
 PyTorchWorkflow = Dict[str, Any]
 
+WINDOWS_CPU_TEST_RUNNER = "windows.4xlarge"
+WINDOWS_CUDA_TEST_RUNNER = "windows.8xlarge.nvidia.gpu"
+
 
 def PyTorchWindowsWorkflow(
     *,
@@ -27,6 +30,10 @@ def PyTorchWindowsWorkflow(
         "test_runner_type": test_runner_type,
         "on_pull_request": on_pull_request,
     }
+
+
+LINUX_CPU_TEST_RUNNER = "linux.2xlarge"
+LINUX_CUDA_TEST_RUNNER = "linux.8xlarge.nvidia.gpu"
 
 
 def PyTorchLinuxWorkflow(
@@ -63,7 +70,7 @@ def generate_workflow_file(
 WINDOWS_WORKFLOWS = [
     PyTorchWindowsWorkflow(
         build_environment="pytorch-win-vs2019-cpu-py3",
-        test_runner_type="windows.4xlarge",
+        test_runner_type=WINDOWS_CPU_TEST_RUNNER,
     )
 ]
 
@@ -71,119 +78,119 @@ LINUX_WORKFLOWS = [
     PyTorchLinuxWorkflow(
         build_environment="pytorch-linux-xenial-py3.6-gcc5.4",
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
-        test_runner_type="linux.2xlarge",
+        test_runner_type=LINUX_CPU_TEST_RUNNER,
         on_pull_request=True,
         enable_doc_jobs=True,
     ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-paralleltbb-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-parallelnative-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-pure_torch-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc7",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-asan",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-asan",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang7-onnx",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang7-onnx",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     PyTorchLinuxWorkflow(
         build_environment="pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7",
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
-        test_runner_type="linux.8xlarge.nvidia.gpu",
+        test_runner_type=LINUX_CUDA_TEST_RUNNER,
     ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
-    #     test_runner_type="linux.8xlarge.nvidia.gpu",
+    #     test_runner_type=LINUX_CUDA_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
-    #     test_runner_type="linux.8xlarge.nvidia.gpu",
+    #     test_runner_type=LINUX_CUDA_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-py3.6-clang9-noarch",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-xla-linux-bionic-py3.6-clang9",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-vulkan-linux-bionic-py3.6-clang9",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-py3.8-gcc9-coverage",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.8-gcc9",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-rocm3.9-py3.6",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm3.9-py3.6",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-x86_32",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-x86_64",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-arm-v7a",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-arm-v8a",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-asan",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-custom-dynamic",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-custom-static",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-code-analysis",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
-    #     test_runner_type="linux.2xlarge",
+    #     test_runner_type=LINUX_CPU_TEST_RUNNER,
     # ),
 ]
 

--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -19,17 +19,12 @@ PyTorchWorkflow = Dict[str, Any]
 def PyTorchWindowsWorkflow(
     *,
     build_environment: str,
+    test_runner_type: str,
     on_pull_request: bool = False
 ) -> PyTorchWorkflow:
-    CPU_TEST_RUNNER = "windows.4xlarge"
-    CUDA_TEST_RUNNER = "windows.8xlarge.nvidia.gpu"
     return {
         "build_environment": build_environment,
-        "test_runner_type": (
-            CUDA_TEST_RUNNER
-            if "cuda" in build_environment
-            else CPU_TEST_RUNNER
-        ),
+        "test_runner_type": test_runner_type,
         "on_pull_request": on_pull_request,
     }
 
@@ -38,19 +33,14 @@ def PyTorchLinuxWorkflow(
     *,
     build_environment: str,
     docker_image_base: str,
+    test_runner_type: str,
     on_pull_request: bool = False,
     enable_doc_jobs: bool = False,
 ) -> PyTorchWorkflow:
-    CPU_TEST_RUNNER = "linux.2xlarge"
-    CUDA_TEST_RUNNER = "linux.8xlarge.nvidia.gpu"
     return {
         "build_environment": build_environment,
         "docker_image_base": docker_image_base,
-        "test_runner_type": (
-            CUDA_TEST_RUNNER
-            if "cuda" in build_environment
-            else CPU_TEST_RUNNER
-        ),
+        "test_runner_type": test_runner_type,
         "on_pull_request": on_pull_request,
         "enable_doc_jobs": enable_doc_jobs,
     }
@@ -63,7 +53,8 @@ def generate_workflow_file(
 ) -> Path:
     output_file_path = GITHUB_DIR / f"workflows/{workflow['build_environment']}.yml"
     with open(output_file_path, "w") as output_file:
-        output_file.writelines(["# @generated DO NOT EDIT MANUALLY\n"])
+        GENERATED = "generated"
+        output_file.writelines([f"# @{GENERATED} DO NOT EDIT MANUALLY\n"])
         output_file.write(workflow_template.render(**workflow))
         output_file.write("\n")
     return output_file_path
@@ -72,6 +63,7 @@ def generate_workflow_file(
 WINDOWS_WORKFLOWS = [
     PyTorchWindowsWorkflow(
         build_environment="pytorch-win-vs2019-cpu-py3",
+        test_runner_type="windows.4xlarge",
     )
 ]
 
@@ -79,96 +71,119 @@ LINUX_WORKFLOWS = [
     PyTorchLinuxWorkflow(
         build_environment="pytorch-linux-xenial-py3.6-gcc5.4",
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
+        test_runner_type="linux.2xlarge",
         on_pull_request=True,
         enable_doc_jobs=True,
     ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-paralleltbb-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-parallelnative-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-pure_torch-linux-xenial-py3.6-gcc5.4",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc5.4",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3.6-gcc7",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-asan",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-asan",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang7-onnx",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang7-onnx",
+    #     test_runner_type="linux.2xlarge",
     # ),
     PyTorchLinuxWorkflow(
         build_environment="pytorch-linux-xenial-cuda10.2-cudnn7-py3.6-gcc7",
         docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda10.2-cudnn7-py3-gcc7",
+        test_runner_type="linux.8xlarge.nvidia.gpu",
     ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
+    #     test_runner_type="linux.8xlarge.nvidia.gpu",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-libtorch-linux-xenial-cuda11.1-cudnn8-py3.6-gcc7",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-cuda11.1-cudnn8-py3-gcc7",
+    #     test_runner_type="linux.8xlarge.nvidia.gpu",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-py3.6-clang9-noarch",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-xla-linux-bionic-py3.6-clang9",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-vulkan-linux-bionic-py3.6-clang9",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.6-clang9",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-py3.8-gcc9-coverage",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-py3.8-gcc9",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-bionic-rocm3.9-py3.6",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-bionic-rocm3.9-py3.6",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-x86_32",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-x86_64",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-arm-v7a",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-android-ndk-r19c-arm-v8a",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-asan",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-custom-dynamic",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-custom-static",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
     # PyTorchLinuxWorkflow(
     #     build_environment="pytorch-linux-xenial-py3.6-clang5-mobile-code-analysis",
     #     docker_image_base=f"{DOCKER_REGISTRY}/pytorch/pytorch-linux-xenial-py3-clang5-android-ndk-r19c",
+    #     test_runner_type="linux.2xlarge",
     # ),
 ]
 


### PR DESCRIPTION
Followup to #58491:

- use f-string to remove the literal `@generated` string from the generator script, so Phabricator no longer thinks it is a generated file
- remove the special logic for `test_runner_type` and instead explicitly specify for every workflow

**Test plan:**

```
make generate-gha-workflows
```
Also, check that Phabricator doesn't classify `.github/scripts/generate_ci_workflows.py` as "Generated changes" in this diff.