### PR TITLE
[BE] Use __func__ as checkAllSameGPU() 1st arg

### DIFF
--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -432,7 +432,7 @@ namespace {
   {
     TensorArg input_arg{ input, "input", 1 },
               output_arg{ output, "output", 2 };
-    checkAllSameGPU("cudnn_adaptive_avg_pooling2d", {input_arg, output_arg});
+    checkAllSameGPU(__func__, {input_arg, output_arg});
 
     for (int64_t i = 0; i < input.ndimension(); i++) {
       TORCH_CHECK(input.size(i) > 0,
@@ -583,8 +583,7 @@ namespace {
     TensorArg grad_input_arg{ gradInput, "gradInput", 1 },
               grad_output_arg{ gradOutput_, "gradOutput_", 2 },
               input_arg{ input, "input", 3 };
-    checkAllSameGPU("cudnn_adaptive_avg_pooling2d_out",
-                    {grad_input_arg, grad_output_arg, input_arg});
+    checkAllSameGPU(__func__, {grad_input_arg, grad_output_arg, input_arg});
 
     switch (input.suggest_memory_format()) {
       case at::MemoryFormat::ChannelsLast: {

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling2d.cu
@@ -203,7 +203,7 @@ const Tensor& indices) {
   TensorArg input_arg{input, "input", 3};
 
   checkAllSameGPU(
-      "adaptive_max_pool2d_cuda", {output_arg, indices_arg, input_arg});
+      __func__, {output_arg, indices_arg, input_arg});
 
   int64_t osizeH = output_size[0];
   int64_t osizeW = output_size[1];
@@ -309,7 +309,7 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_cuda)
   TensorArg indices_arg{indices, "indices", 4};
 
   checkAllSameGPU(
-      "adaptive_max_pool2d_backward_cuda",
+      __func__,
       {grad_input_arg, grad_output_arg, input_arg, indices_arg});
 
   bool atomic =

--- a/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveMaxPooling3d.cu
@@ -304,7 +304,7 @@ TORCH_IMPL_FUNC(adaptive_max_pool3d_out_cuda)
   TensorArg input_arg{input, "input", 3};
 
   checkAllSameGPU(
-      "adaptive_max_pool3d_cuda", {output_arg, indices_arg, input_arg});
+      __func__, {output_arg, indices_arg, input_arg});
 
   int64_t osizeT = output_size[0];
   int64_t osizeH = output_size[1];
@@ -378,7 +378,7 @@ TORCH_IMPL_FUNC(adaptive_max_pool3d_backward_out_cuda)
   TensorArg indices_arg{indices, "indices", 4};
 
   checkAllSameGPU(
-      "adaptive_max_pool3d_backward_cuda",
+      __func__,
       {grad_input_arg, grad_output_arg, input_arg, indices_arg});
 
   const Tensor gradOutput_ = gradOutput.contiguous();

--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -343,7 +343,7 @@ void avg_pool3d_out_cuda_template(
   TensorArg output_arg{ output, "output", 1 };
   TensorArg input_arg{ input, "input", 2 };
 
-  checkAllSameGPU("avg_pool3d_out_cuda", {output_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, input_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?
   TORCH_CHECK(kernel_size.size() == 1 || kernel_size.size() == 3,
@@ -472,7 +472,7 @@ void avg_pool3d_backward_out_cuda_template(
   TensorArg gradOutput_arg{ gradOutput, "gradOutput", 2 };
   TensorArg input_arg{ input, "input", 3 };
 
-  checkAllSameGPU("avg_pool3d_backward_out_cuda",
+  checkAllSameGPU(__func__,
                   {gradInput_arg, gradOutput_arg, input_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?

--- a/aten/src/ATen/native/cuda/Col2Im.cu
+++ b/aten/src/ATen/native/cuda/Col2Im.cu
@@ -25,7 +25,7 @@ void col2im_out_cuda_template(
     IntArrayRef stride) {
   TensorArg input_arg{input_, "input", 1};
   TensorArg output_arg{output, "output", 2};
-  checkAllSameGPU("col2im_out_cuda", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   TORCH_CHECK(
       output_size.size() == 2,

--- a/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool2d.cu
@@ -300,8 +300,7 @@ const Tensor& indices) {
   TensorArg indices_arg{ indices, "indices", 2 };
   TensorArg input_arg{ input_, "input_", 3 };
 
-  checkAllSameGPU("max_pool2d_with_indices_out_cuda",
-                  {output_arg, indices_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, indices_arg, input_arg});
 
   const int kH = safe_downcast<int, int64_t>(kernel_size[0]);
   const int kW = kernel_size.size() == 1 ? kH : safe_downcast<int, int64_t>(kernel_size[1]);
@@ -423,7 +422,7 @@ const Tensor& gradInput) {
   TensorArg input_arg{ input_, "input_", 3 };
   TensorArg indices_arg{ indices, "indices", 4 };
 
-  checkAllSameGPU("max_pool2d_with_indices_out_cuda",
+  checkAllSameGPU(__func__,
                   {gradInput_arg, gradOutput_arg, input_arg, indices_arg});
 
   const int kH = safe_downcast<int, int64_t>(kernel_size[0]);

--- a/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
+++ b/aten/src/ATen/native/cuda/DilatedMaxPool3d.cu
@@ -199,7 +199,7 @@ void max_pool3d_with_indices_out_cuda_template(
   TensorArg indices_arg{ indices, "indices", 2 };
   TensorArg input_arg{ input, "input", 3 };
 
-  checkAllSameGPU("max_pool3d_with_indices_out_cuda",
+  checkAllSameGPU(__func__,
                   {output_arg, indices_arg, input_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?
@@ -307,7 +307,7 @@ void max_pool3d_with_indices_backward_out_cuda_template(
   TensorArg input_arg{ input, "input", 3 };
   TensorArg indices_arg{ indices, "indices", 4 };
 
-  checkAllSameGPU("max_pool3d_with_indices_backward_out_cuda",
+  checkAllSameGPU(__func__,
                   {gradInput_arg, gradOutput_arg, input_arg, indices_arg});
 
   // #20866, #22032: Guarantee this for the official C++ API?

--- a/aten/src/ATen/native/cuda/Im2Col.cu
+++ b/aten/src/ATen/native/cuda/Im2Col.cu
@@ -53,7 +53,7 @@ static void im2col_out_cuda_template(
 
   TensorArg input_arg{input_, "input", 1};
   TensorArg output_arg{output, "output", 2};
-  checkAllSameGPU("im2col_cuda", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   im2col_shape_check(
       input_,

--- a/aten/src/ATen/native/cuda/IndexKernel.cu
+++ b/aten/src/ATen/native/cuda/IndexKernel.cu
@@ -447,7 +447,7 @@ Tensor & masked_scatter__cuda(Tensor& self, const Tensor& mask, const Tensor& so
   TensorArg self_arg{self, "self", 1};
   TensorArg mask_arg{mask, "mask", 2};
   TensorArg source_arg{source, "source", 3};
-  checkAllSameGPU("masked_scatter_", {self_arg, mask_arg, source_arg});
+  checkAllSameGPU(__func__, {self_arg, mask_arg, source_arg});
 
   c10::MaybeOwned<Tensor> b_mask = expand_inplace(self, mask, "masked_scatter_");
 

--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -462,7 +462,7 @@ Tensor& index_add_cuda_(Tensor & self, int64_t dim, const Tensor & index, const 
   dim = maybe_wrap_dim(dim, self.dim());
 
   TensorArg self_arg{self, "self", 1}, index_arg{index, "index", 3}, source_arg{source, "source", 4};
-  checkAllSameGPU("index_add", {self_arg, index_arg, source_arg});
+  checkAllSameGPU(__func__, {self_arg, index_arg, source_arg});
 
   TORCH_CHECK_INDEX(index.dim() <= 1, "index_add_(): Index is supposed to be a vector");
   TORCH_CHECK(index.scalar_type() == ScalarType::Long || index.scalar_type() == ScalarType::Int, "index_add_(): Expected dtype int32/int64 for index");

--- a/aten/src/ATen/native/cuda/LinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/LinearAlgebra.cu
@@ -78,7 +78,7 @@ Tensor& addmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& ma
   TORCH_CHECK(mat1.dim() == 2 && mat2.dim() == 2, "tensors must be 2-D");
 
   TensorArg args[]{{result, "out", 0}, {self, "self", 1}, {mat1, "mat1", 2}, {mat2, "mat2", 3}};
-  checkAllSameGPU("addmm", args);
+  checkAllSameGPU(__func__, args);
 
   IntArrayRef mat1_sizes = mat1.sizes();
   IntArrayRef mat2_sizes = mat2.sizes();
@@ -178,7 +178,7 @@ Tensor& baddbmm_out_cuda_impl(Tensor& result, const Tensor& self, const Tensor& 
   TORCH_CHECK(batch2.dim() == 3, "batch2 must be a 3D tensor");
 
   TensorArg args[]{{result, "out", 0}, {self, "self", 1}, {batch1, "batch1", 2}, {batch2, "batch2", 3}};
-  checkAllSameGPU("baddbmm", args);
+  checkAllSameGPU(__func__, args);
 
   IntArrayRef batch1_sizes = batch1.sizes();
   IntArrayRef batch2_sizes = batch2.sizes();

--- a/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
+++ b/aten/src/ATen/native/cuda/NaiveConvolutionTranspose2d.cu
@@ -174,7 +174,7 @@ void slow_conv_transpose2d_out_cuda_template(
       columns_arg{columns_, "columns", 5}, ones_arg{ones_, "ones", 6};
 
   checkAllSameGPU(
-      "slow_conv_transpose2d_out_cuda",
+      __func__,
       {input_arg, output_arg, weight_arg, bias_arg, columns_arg, ones_arg});
 
   int n_input_plane = weight_.size(0);
@@ -389,7 +389,7 @@ static void slow_conv_transpose2d_backward_out_cuda_template(
       grad_input_arg{grad_input, "grad_input", 5};
 
   checkAllSameGPU(
-      "slow_conv_transpose2d_backward_out_cuda",
+      __func__,
       {input_arg,
        grad_output_arg,
        weight_arg,
@@ -577,7 +577,7 @@ void slow_conv_transpose2d_acc_grad_parameters_cuda_template(
       columns_arg{columns_, "columns", 5}, ones_arg{ones_, "ones", 6};
 
   checkAllSameGPU(
-      "slow_conv_transpose2d_acc_grad_parameters_cuda",
+      __func__,
       {input_arg,
        grad_output_arg,
        grad_weight_arg,

--- a/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
+++ b/aten/src/ATen/native/cuda/NaiveDilatedConvolution.cu
@@ -136,6 +136,7 @@ void col2hvol(
    check tensor data locations
 */
 void slow_conv_dilated_location_check(
+    CheckedFrom c,
     const Tensor& input,
     const Tensor& weight,
     const Tensor& bias,
@@ -143,13 +144,12 @@ void slow_conv_dilated_location_check(
   // checking data locations of user-provided tensor arguments
   TensorArg input_arg{input, "input", 2}, weight_arg{weight, "weight", 3},
       bias_arg{bias, "bias", 4}, grad_output_arg{grad_output, "grad_output", 5};
-  checkAllSameGPU("slow_conv_dilated_all_cuda_template", {input_arg, weight_arg});
+  checkAllSameGPU(c, {input_arg, weight_arg});
   if (bias.defined()) {
-    checkAllSameGPU("slow_conv_dilated_all_cuda_template", {input_arg, bias_arg});
+    checkAllSameGPU(c, {input_arg, bias_arg});
   }
   if (grad_output.defined()) {
-    checkAllSameGPU(
-        "slow_conv_dilated_all_cuda_template", {input_arg, grad_output_arg});
+    checkAllSameGPU(c, {input_arg, grad_output_arg});
   }
   // we are not checking the data locations of other tensor
   // arguments such as output, grad_input, etc because of these are
@@ -178,7 +178,7 @@ void slow_conv_dilated_all_cuda_template(
     IntArrayRef stride_size,
     IntArrayRef pad_size,
     IntArrayRef dilation_size) {
-  slow_conv_dilated_location_check(input, weight, bias, grad_output);
+  slow_conv_dilated_location_check(__func__, input, weight, bias, grad_output);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   auto options = input.options();
   // The rear part of input tensor sizes:

--- a/aten/src/ATen/native/cuda/ScanKernels.cu
+++ b/aten/src/ATen/native/cuda/ScanKernels.cu
@@ -233,7 +233,7 @@ void cummax_helper_cuda(const Tensor& self, Tensor& values, Tensor& indices, int
   TensorArg output_arg{ values, "output", 1 };
   TensorArg indices_arg{ indices, "indices", 2 };
   TensorArg input_arg{ self, "input", 3 };
-  checkAllSameGPU("cummax", {output_arg, indices_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, indices_arg, input_arg});
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
     self.scalar_type(), "cummax_cuda", [&]() {
     scalar_t init = self.is_floating_point() ? (-1*std::numeric_limits<scalar_t>::infinity()) : std::numeric_limits<scalar_t>::lowest();
@@ -245,7 +245,7 @@ void cummin_helper_cuda(const Tensor& self, Tensor& values, Tensor& indices, int
   TensorArg output_arg{ values, "output", 1 };
   TensorArg indices_arg{ indices, "indices", 2 };
   TensorArg input_arg{ self, "input", 3 };
-  checkAllSameGPU("cummin", {output_arg, indices_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, indices_arg, input_arg});
   AT_DISPATCH_ALL_TYPES_AND2(at::ScalarType::Bool, at::ScalarType::Half,
     self.scalar_type(), "cummin_cuda", [&]() {
     scalar_t init = self.is_floating_point() ? std::numeric_limits<scalar_t>::infinity() : std::numeric_limits<scalar_t>::max();
@@ -557,7 +557,7 @@ Tensor& _logcumsumexp_out_cuda(const Tensor& self, int64_t dim, Tensor& result) 
 
   TensorArg output_arg{ result, "output", 1 };
   TensorArg input_arg{ self, "input", 2 };
-  checkAllSameGPU("logcumsumexp", {output_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, input_arg});
 
   AT_DISPATCH_FLOATING_TYPES_AND(at::ScalarType::Half,
     self.scalar_type(), "logcumsumexp_cuda", [&]() {
@@ -588,7 +588,7 @@ Tensor _logcumsumexp_cuda(const Tensor& self, int64_t dim) {
 Tensor& _cumsum_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
   TensorArg output_arg{result, "output", 1};
   TensorArg input_arg{self, "input", 2};
-  checkAllSameGPU("cumsum", {output_arg, input_arg});
+  checkAllSameGPU(__func__, {output_arg, input_arg});
   checkSameType("cumsum", output_arg, input_arg);
 
   at::native::resize_output(result, self.sizes());
@@ -624,8 +624,8 @@ Tensor _cumsum_cuda(const Tensor& self, int64_t dim) {
 Tensor& _cumprod_out_cuda(const Tensor& self, int64_t dim, Tensor& result) {
   TensorArg output_arg{result, "output", 1};
   TensorArg input_arg{self, "input", 2};
-  checkAllSameGPU("cumprod", {output_arg, input_arg});
-  checkSameType("cumprod", output_arg, input_arg);
+  checkAllSameGPU(__func__, {output_arg, input_arg});
+  checkSameType(__func__, output_arg, input_arg);
 
   at::native::resize_output(result, self.sizes());
   if (self.dim() == 0) {

--- a/aten/src/ATen/native/cuda/Sort.cu
+++ b/aten/src/ATen/native/cuda/Sort.cu
@@ -206,7 +206,7 @@ std::tuple<Tensor &,Tensor &> sort_out_stable_cuda(const Tensor & self, c10::opt
   // this algorithm is always stable
   TORCH_INTERNAL_ASSERT(stable.has_value(), "sort_out(): c10::optional<bool> for stable has to have value.");
   TensorArg self_arg{self, "self", 1}, values_arg{values, "values", 2}, indices_arg{indices, "indices", 3};
-  checkAllSameGPU("small_sort", {self_arg, values_arg, indices_arg});
+  checkAllSameGPU(__func__, {self_arg, values_arg, indices_arg});
 
   bool is_non_overlapping_and_dense = self.is_non_overlapping_and_dense();
   int64_t numel = self.numel();

--- a/aten/src/ATen/native/cuda/TensorTopK.cu
+++ b/aten/src/ATen/native/cuda/TensorTopK.cu
@@ -156,7 +156,7 @@ TORCH_IMPL_FUNC(topk_out_cuda)
    const Tensor& values,
    const Tensor& indices) {
   TensorArg topK_arg{values, "topK", 1}, indices_arg{indices, "indices", 2}, input_arg{self, "self", 3};
-  checkAllSameGPU("topk_out_cuda", {topK_arg, indices_arg, input_arg});
+  checkAllSameGPU(__func__, {topK_arg, indices_arg, input_arg});
   dim = at::maybe_wrap_dim(dim, self);
 
   int numDims = self.dim();

--- a/aten/src/ATen/native/cuda/TriangularOps.cu
+++ b/aten/src/ATen/native/cuda/TriangularOps.cu
@@ -150,8 +150,8 @@ Tensor& apply_diag(Tensor& result, const Tensor& self, int64_t dimension) {
 
   TensorArg result_arg{result, "result", 1};
   TensorArg self_arg{self, "self", 2};
-  checkAllSameGPU("diag", {result_arg, self_arg});
-  checkSameType("diag", result_arg, self_arg);
+  checkAllSameGPU(__func__, {result_arg, self_arg});
+  checkSameType(__func__, result_arg, self_arg);
 
   int nDimension = self.dim();
   if (nDimension == 2) {

--- a/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBicubic2d.cu
@@ -165,7 +165,7 @@ static void upsample_bicubic2d_out_cuda_template(
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
   TensorArg input_arg{input, "input", 1}, output_arg{output, "output", 2};
-  checkAllSameGPU("upsample_bicubic2d_out", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   int output_height = output_size[0];
   int output_width = output_size[1];
@@ -222,9 +222,7 @@ static void upsample_bicubic2d_backward_out_cuda_template(
     c10::optional<double> scales_w) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
-  checkAllSameGPU(
-      "upsample_bicubic2d_backward_out_cuda",
-      {grad_output_arg, grad_input_arg});
+  checkAllSameGPU(__func__, {grad_output_arg, grad_input_arg});
 
   int output_height = output_size[0];
   int output_width = output_size[1];

--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -159,7 +159,7 @@ static void upsample_bilinear2d_out_cuda_template(
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
   TensorArg input_arg{input, "input", 1}, output_arg{output, "output", 2};
-  checkAllSameGPU("upsample_bilinear2d_out_cuda", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   int output_height = output_size[0];
   int output_width = output_size[1];
@@ -206,9 +206,7 @@ static void upsample_bilinear2d_backward_out_cuda_template(
     c10::optional<double> scales_w) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
-  checkAllSameGPU(
-      "upsample_bilinear2d_backward_out_cuda",
-      {grad_output_arg, grad_input_arg});
+  checkAllSameGPU(__func__, {grad_output_arg, grad_input_arg});
 
   int output_height = output_size[0];
   int output_width = output_size[1];

--- a/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleLinear1d.cu
@@ -115,7 +115,7 @@ static void upsample_linear1d_out_cuda_template(
     bool align_corners,
     c10::optional<double> scales) {
   TensorArg input_arg{input, "input", 1}, output_arg{output, "output", 2};
-  checkAllSameGPU("upsample_linear1d_out_cuda", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   int output_width = output_size[0];
 
@@ -160,8 +160,7 @@ static void upsample_linear1d_backward_out_cuda_template(
     c10::optional<double> scales) {
   TensorArg grad_output_arg{grad_output_, "grad_output_", 1},
       grad_input_arg{grad_input, "grad_input", 2};
-  checkAllSameGPU(
-      "upsample_linear1d_backward_out_cuda", {grad_output_arg, grad_input_arg});
+  checkAllSameGPU(__func__, {grad_output_arg, grad_input_arg});
 
   int output_width = output_size[0];
 

--- a/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest2d.cu
@@ -118,8 +118,7 @@ static void upsample_nearest2d_out_cuda_template(
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
   TensorArg input_arg{input_, "input_", 1}, output_arg{output, "output", 2};
-  checkAllSameGPU(
-      "upsample_nearest2d_out_cuda_template", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   // TODO: remove this when the cuda kernel is updated to support the channels_last memory format.
   // This is a temporary hack to prevent a silence correctness issue when calling this kernel
@@ -210,9 +209,7 @@ static void upsample_nearest2d_backward_out_cuda_template(
     c10::optional<double> scales_w) {
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
-  checkAllSameGPU(
-      "upsample_nearest2d_backward_out_cuda",
-      {grad_output_arg, grad_input_arg});
+  checkAllSameGPU(__func__, {grad_output_arg, grad_input_arg});
 
   int output_height = output_size[0];
   int output_width = output_size[1];

--- a/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleNearest3d.cu
@@ -128,7 +128,7 @@ static void upsample_nearest3d_out_cuda_template(
     c10::optional<double> scales_h,
     c10::optional<double> scales_w) {
   TensorArg input_arg{input_, "input_", 1}, output_arg{output, "output", 2};
-  checkAllSameGPU("upsample_nearest3d_out_cuda", {input_arg, output_arg});
+  checkAllSameGPU(__func__, {input_arg, output_arg});
 
   // TODO: remove this when the cuda kernel is updated to support the channels_last memory format.
   // This is a temporary hack to prevent a silence correctness issue when calling this kernel
@@ -203,7 +203,7 @@ static void upsample_nearest3d_backward_out_cuda_template(
   TensorArg grad_input_arg{grad_input, "grad_input", 1},
       grad_output_arg{grad_output_, "grad_output_", 2};
   checkAllSameGPU(
-      "upsample_nearest3d_backward_out_cuda",
+      __func__,
       {grad_output_arg, grad_input_arg});
 
   int output_depth = output_size[0];


### PR DESCRIPTION
Hardcoded names often get out of date, for example in AdaptiveAverafePooling those names contained cudnn_ prefix