### PR TITLE
Add Deploy to PredictorContainer

### DIFF
--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -222,14 +222,6 @@ struct TORCH_API Package {
     TORCH_DEPLOY_SAFE_CATCH_RETHROW
   }
 
-  std::string load_text(const std::string& module, const std::string& file) {
-    TORCH_DEPLOY_TRY
-    auto I = acquire_session();
-    auto loaded = I.self.attr("load_text")({module, file});
-    return loaded.toIValue().toStringRef();
-    TORCH_DEPLOY_SAFE_CATCH_RETHROW
-  }
-
   InterpreterSession acquire_session() {
     TORCH_DEPLOY_TRY
     auto I = manager_->acquire_one();

--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -110,3 +110,130 @@ class ResNet(nn.Module):
 
 def resnet18():
     return ResNet(BasicBlock, [2, 2, 2, 2])
+
+
+class MultiReturn(torch.nn.Module):
+    def __init__(self):
+        super(MultiReturn, self).__init__()
+
+    def forward(self, t):
+        # type: (Tuple[Tensor, Tensor]) -> Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]
+        a, b = t
+        result = ((a.masked_fill_(b, 0.1), b), (torch.ones_like(a), b))
+        return result
+
+
+multi_return_metadata = r"""
+{
+ "metadata_container": {
+  "forward": {
+   "named_input_metadata": {
+    "t": {
+     "argument_type": {
+      "tuple": {
+       "tuple_elements": [
+        {
+         "tensor": 1
+        },
+        {
+         "tensor": 6
+        }
+       ]
+      }
+     },
+     "optional_argument": false,
+     "metadata": {
+      "dense_features": {
+       "feature_desc": [
+        {
+          "feature_name": "test_feature_1",
+          "feature_id": 1
+        }
+       ],
+       "expected_shape": {
+        "dims": [
+         -1,
+         1
+        ],
+        "unknown_rank": false
+       },
+       "data_type": 1,
+       "feature_store_feature_type": 0
+      }
+     }
+    }
+   },
+   "positional_output_metadata": [
+    {
+     "argument_type": {
+      "tuple": {
+       "tuple_elements": [
+        {
+         "tensor": 1
+        },
+        {
+         "tensor": 6
+        }
+       ]
+      }
+     },
+     "optional_argument": false,
+     "metadata": {
+      "dense_features": {
+       "feature_desc": [
+        {
+          "feature_name": "test_feature_1",
+          "feature_id": 1
+        }
+       ],
+       "expected_shape": {
+        "dims": [
+         -1,
+         1
+        ],
+        "unknown_rank": false
+       },
+       "data_type": 1,
+       "feature_store_feature_type": 0
+      }
+     }
+    },
+    {
+     "argument_type": {
+      "tuple": {
+       "tuple_elements": [
+        {
+         "tensor": 1
+        },
+        {
+         "tensor": 6
+        }
+       ]
+      }
+     },
+     "optional_argument": false,
+     "metadata": {
+      "dense_features": {
+       "feature_desc": [
+        {
+          "feature_name": "test_feature_3",
+          "feature_id": 3
+        }
+       ],
+       "expected_shape": {
+        "dims": [
+         -1,
+         1
+        ],
+        "unknown_rank": false
+       },
+       "data_type": 1,
+       "feature_store_feature_type": 0
+      }
+     }
+    }
+   ]
+  }
+ }
+}
+"""

--- a/torch/csrc/deploy/example/generate_examples.py
+++ b/torch/csrc/deploy/example/generate_examples.py
@@ -1,24 +1,29 @@
 """
 Generate the example files that torchpy_test uses.
 """
-from pathlib import Path
-import torch
 import argparse
+from pathlib import Path
 
+import torch
 from torch.package import PackageExporter
 
 try:
-    from .examples import Simple, resnet18
+    from .examples import Simple, resnet18, MultiReturn, multi_return_metadata
 except ImportError:
-    from examples import Simple, resnet18
+    from examples import Simple, resnet18, MultiReturn, multi_return_metadata
 
-def save(name, model, model_jit, eg):
+
+def save(name, model, model_jit, eg, featurestore_meta=None):
     with PackageExporter(str(p / name)) as e:
-        e.mock('iopath.**')
-        e.intern('**')
-        e.save_pickle('model', 'model.pkl', model)
-        e.save_pickle('model', 'example.pkl', eg)
-    model_jit.save(str(p / (name + '_jit')))
+        e.mock("iopath.**")
+        e.intern("**")
+        e.save_pickle("model", "model.pkl", model)
+        e.save_pickle("model", "example.pkl", eg)
+        if featurestore_meta:
+            # TODO(whc) can this name come from buck somehow,
+            # so it's consistent with predictor_config_constants::METADATA_FILE_NAME()?
+            e.save_text("extra_files", "metadata.json", featurestore_meta)
+    model_jit.save(str(p / (name + "_jit")))
 
 
 parser = argparse.ArgumentParser(description="Generate Examples")
@@ -37,7 +42,10 @@ if __name__ == "__main__":
     resnet.eval()
     resnet_eg = torch.rand(1, 3, 224, 224)
     resnet_traced = torch.jit.trace(resnet, resnet_eg)
-    save('resnet', resnet, resnet_traced, (resnet_eg,))
+    save("resnet", resnet, resnet_traced, (resnet_eg,))
 
     simple = Simple(10, 20)
-    save('simple', simple, torch.jit.script(simple), (torch.rand(10, 20),))
+    save("simple", simple, torch.jit.script(simple), (torch.rand(10, 20),))
+
+    multi_return = MultiReturn()
+    save("multi_return", multi_return, torch.jit.script(multi_return), (torch.rand(10, 20),), multi_return_metadata)


### PR DESCRIPTION
Summary: add gflags to force using deploy for torchscript models

Test Plan: Add parametrization to PredictorContainer test to exercise gflag override and test deploy codepath.  Add test case to exercise new torch.package codepath.

Reviewed By: suo

Differential Revision: D28246793

