### PR TITLE
Add long tensor type to AddFakeFp16 Op

### DIFF
--- a/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
+++ b/caffe2/contrib/fakelowp/elementwise_fp16_fake_op.cc
@@ -68,7 +68,7 @@ OPERATOR_SCHEMA(SumFakeFp16).NumInputs(1, INT_MAX).NumOutputs(1, INT_MAX);
 REGISTER_CPU_OPERATOR(
     AddFakeFp16,
     BinaryElementwiseOp<
-        TensorTypes<float, int>,
+        TensorTypes<float, int, long>,
         CPUContext,
         FP16PairWiseCPUFunctor<AddFunctor<CPUContext>>>);
 OPERATOR_SCHEMA(AddFakeFp16).NumInputs(2).NumOutputs(1);


### PR DESCRIPTION
Summary:
.. to support QRT inline_CVR models to avoid failure
```
[DataPreproc] User preprocessing error: c10::Error: [enforce fail at operator.h:1307] . Unsupported type of tensor: long (Error from operator:
input: "sparse_nn_2/HistogramBinningCalibrationByFeature_2/cast_22/cast_22_5" input: "sparse_nn_2/HistogramBinningCalibrationByFeature_2/mul_5/Mul" output: "sparse_nn_2/HistogramBinningCalibrationByFeature_2/add_7/Add_2" name: "" type: "AddFakeFp16" arg { name: "broadcast" i: 1 } device_option { extra_info: "inference_split:force_merge" extra_info: "inference_split:force_merge" })
```
f273407515

Test Plan: f273692411

Reviewed By: hx89

Differential Revision: D28513550

