### PR TITLE
VaryingShape<Strides>::isComplete() needs to consider whether each Stride is complete

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -186,6 +186,10 @@ struct TORCH_API Stride {
         stride_ == b.stride_;
   }
 
+  bool isComplete() const {
+    return stride_index_ && contiguous_ && stride_;
+  }
+
   c10::optional<size_t> stride_index_;
   c10::optional<bool> contiguous_;
   c10::optional<size_t> stride_;
@@ -351,6 +355,17 @@ struct TORCH_API SymbolicShape {
     c10::optional<std::vector<ShapeSymbol>> dims_;
 };
 
+namespace detail {
+inline bool isComplete(const Stride& s) {
+  return s.isComplete();
+}
+
+template<typename T>
+inline bool isComplete(const T& t) {
+  return true;
+}
+}
+
 template <typename T>
 struct VaryingShape {
   using ListOfOptionalElements = std::vector<c10::optional<T>>;
@@ -414,7 +429,7 @@ struct VaryingShape {
       return false;
     }
     for (auto d : *dims_) {
-      if(!d) {
+      if (!d || !detail::isComplete(*d)) {
         return false;
       }
     }

--- a/test/cpp/jit/test_jit_type.cpp
+++ b/test/cpp/jit/test_jit_type.cpp
@@ -8,6 +8,20 @@
 namespace torch {
 namespace jit {
 
+TEST(JitTypeTest, IsComplete) {
+  auto tt = c10::TensorType::create(
+      at::kFloat,
+      at::kCPU,
+      c10::SymbolicShape(std::vector<c10::optional<int64_t>>({1, 49})),
+      std::vector<c10::Stride>(
+          {c10::Stride{2, true, 1},
+           c10::Stride{1, true, 1},
+           c10::Stride{0, true, c10::nullopt}}),
+      false);
+  TORCH_INTERNAL_ASSERT(!tt->isComplete());
+  TORCH_INTERNAL_ASSERT(!tt->strides().isComplete());
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(JitTypeTest, UnifyTypes) {
   auto bool_tensor = TensorType::get()->withScalarType(at::kBool);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58347 [nnc] Enable CPU fusion inside Facebook, take 2
* **#58510 VaryingShape<Strides>::isComplete() needs to consider whether each Stride is complete**
* #58346 [nnc] Do not fuse unsqueeze with variable dim

In some case that I don't fully understand we're getting a stride that is:
```
{2:1, 1:1, 0:*}
```
(in this debug output, M:N means stride index M, stride value N).  This shape
should be considered incomplete, since we don't actually know the values of the
stride, but VaryingShape::isComplete considers it complete because it only
checks the presence of elements in the vector, not whether those elements are
themselves complete.

Differential Revision: [D28520062](https://our.internmc.facebook.com/intern/diff/D28520062/)