### PR TITLE
Add no-grad inference mode note

### DIFF
--- a/docs/cpp/source/notes/inference_mode.rst
+++ b/docs/cpp/source/notes/inference_mode.rst
@@ -30,8 +30,6 @@ Inside an ``InferenceMode`` block, we make the following performance guarantees:
 - Inplace operations on inference tensors are guaranteed not to do a version bump.
 
 For more implementation details of ``InferenceMode`` please see the `RFC-0011-InferenceMode <https://github.com/pytorch/rfcs/pull/17>`_.
-Currently this guard is only available in C++ frontend, adding python frontend support
-is tracked in #56608.
 
 Migration guide from ``AutoNonVariableTypeMode``
 ------------------------------------------------

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -50,6 +50,10 @@ you can use it as ``functional.jacobian(lambda x: f(x, constant, flag=flag), inp
 Locally disabling gradient computation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+See `here <locally-disable-grad-doc_>`_ for more information on the differences
+between no-grad and inference mode as well as other related mechanisms that
+may be conflated with the two.
+
 .. autosummary::
     :toctree: generated
     :nosignatures:

--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -50,9 +50,9 @@ you can use it as ``functional.jacobian(lambda x: f(x, constant, flag=flag), inp
 Locally disabling gradient computation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See `here <locally-disable-grad-doc_>`_ for more information on the differences
+See :ref:`locally-disable-grad-doc` for more information on the differences
 between no-grad and inference mode as well as other related mechanisms that
-may be conflated with the two.
+may be confused with the two.
 
 .. autosummary::
     :toctree: generated

--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -68,7 +68,7 @@ fields.
 
 It is important to note that even though every tensor has this flag,
 *setting* it only makes sense for leaf tensors (tensors that do not have a
-``grad_fn``, e.g., a module's parameters).
+``grad_fn``, e.g., a ``nn.Module``'s parameters).
 Non-leaf tensors (tensors that do have ``grad_fn``) are tensors that have a
 backward graph associated with them. Thus their gradients will be needed
 as an intermediary result to compute the gradient for a leaf tensor that
@@ -159,6 +159,9 @@ mode. If you cannot avoid such use in your case, you can always switch back
 to no-grad mode.
 
 For details on inference mode please see
+`Inference Mode <https://pytorch.org/cppdocs/notes/inference_mode.html>`_.
+
+For implementation details of inference mode see
 `RFC-0011-InferenceMode <https://github.com/pytorch/rfcs/pull/17>`_.
 
 Evaluation Mode (``nn.Module.eval()``)

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -98,9 +98,9 @@ class no_grad(_DecoratorContextManager):
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
     .. note::
-        No-grad is one of several mechanisms that can disable gradients locally
-        see :ref:`locally-disable-grad-doc` for more information on how they
-        compare.
+        No-grad is one of several mechanisms that can enable or
+        disable gradients locally see :ref:`locally-disable-grad-doc` for
+        more information on how they compare.
 
     Example::
 
@@ -140,6 +140,10 @@ class enable_grad(_DecoratorContextManager):
 
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
+    .. note::
+        enable_grad is one of several mechanisms that can enable or
+        disable gradients locally see :ref:`locally-disable-grad-doc` for
+        more information on how they compare.
 
     Example::
 
@@ -182,6 +186,10 @@ class set_grad_enabled(object):
                      (``False``). This can be used to conditionally enable
                      gradients.
 
+    .. note::
+        set_grad_enabled is one of several mechanisms that can enable or
+        disable gradients locally see :ref:`locally-disable-grad-doc` for
+        more information on how they compare.
 
     Example::
 
@@ -227,9 +235,9 @@ class inference_mode(_DecoratorContextManager):
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
     .. note::
-        Inference mode is one of several mechanisms that can disable gradients locally
-        see :ref:`locally-disable-grad-doc` for more information on how they
-        compare.
+        Inference mode is one of several mechanisms that can enable or
+        disable gradients locally see :ref:`locally-disable-grad-doc` for
+        more information on how they compare.
 
     Args:
         mode (bool): Flag whether to enable or disable inference mode

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -97,6 +97,10 @@ class no_grad(_DecoratorContextManager):
 
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
+    .. note::
+        no-grad is one of several mechanisms that can disable gradients locally
+        see `here <locally-disable-grad-doc_>`_ for more information on how they
+        compare.
 
     Example::
 
@@ -221,6 +225,11 @@ class inference_mode(_DecoratorContextManager):
     in other threads.
 
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
+
+    .. note::
+        inference mode is one of several mechanisms that can disable gradients locally
+        see `here <locally-disable-grad-doc_>`_ for more information on how they
+        compare.
 
     Args:
         mode (bool): Flag whether to enable or disable inference mode

--- a/torch/autograd/grad_mode.py
+++ b/torch/autograd/grad_mode.py
@@ -98,8 +98,8 @@ class no_grad(_DecoratorContextManager):
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
     .. note::
-        no-grad is one of several mechanisms that can disable gradients locally
-        see `here <locally-disable-grad-doc_>`_ for more information on how they
+        No-grad is one of several mechanisms that can disable gradients locally
+        see :ref:`locally-disable-grad-doc` for more information on how they
         compare.
 
     Example::
@@ -227,8 +227,8 @@ class inference_mode(_DecoratorContextManager):
     Also functions as a decorator. (Make sure to instantiate with parenthesis.)
 
     .. note::
-        inference mode is one of several mechanisms that can disable gradients locally
-        see `here <locally-disable-grad-doc_>`_ for more information on how they
+        Inference mode is one of several mechanisms that can disable gradients locally
+        see :ref:`locally-disable-grad-doc` for more information on how they
         compare.
 
     Args:

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1651,6 +1651,9 @@ class Module:
 
         This is equivalent with :meth:`self.train(False) <torch.nn.Module.train>`.
 
+        See `here <locally-disable-grad-doc_>`_ for a comparison between
+        `.eval()` and several similar mechanisms that may be conflated with it.
+
         Returns:
             Module: self
         """
@@ -1665,6 +1668,9 @@ class Module:
 
         This method is helpful for freezing part of the module for finetuning
         or training parts of a model individually (e.g., GAN training).
+
+        See `here <locally-disable-grad-doc_>`_ for a comparison between
+        `.requires_grad_()` and several similar mechanisms that may be conflated with it.
 
         Args:
             requires_grad (bool): whether autograd should record operations on

--- a/torch/nn/modules/module.py
+++ b/torch/nn/modules/module.py
@@ -1651,8 +1651,8 @@ class Module:
 
         This is equivalent with :meth:`self.train(False) <torch.nn.Module.train>`.
 
-        See `here <locally-disable-grad-doc_>`_ for a comparison between
-        `.eval()` and several similar mechanisms that may be conflated with it.
+        See :ref:`locally-disable-grad-doc` for a comparison between
+        `.eval()` and several similar mechanisms that may be confused with it.
 
         Returns:
             Module: self
@@ -1669,8 +1669,8 @@ class Module:
         This method is helpful for freezing part of the module for finetuning
         or training parts of a model individually (e.g., GAN training).
 
-        See `here <locally-disable-grad-doc_>`_ for a comparison between
-        `.requires_grad_()` and several similar mechanisms that may be conflated with it.
+        See :ref:`locally-disable-grad-doc` for a comparison between
+        `.requires_grad_()` and several similar mechanisms that may be confused with it.
 
         Args:
             requires_grad (bool): whether autograd should record operations on

--- a/torch/nn/parameter.py
+++ b/torch/nn/parameter.py
@@ -18,7 +18,7 @@ class Parameter(torch.Tensor):
     Args:
         data (Tensor): parameter tensor.
         requires_grad (bool, optional): if the parameter requires gradient. See
-            :ref:`excluding-subgraphs` for more details. Default: `True`
+            :ref:`locally-disable-grad-doc` for more details. Default: `True`
     """
     def __new__(cls, data=None, requires_grad=True):
         if data is None:


### PR DESCRIPTION
Adds a note explaining the difference between several often conflated mechanisms in the autograd note
Also adds a link to this note from the docs in `grad_mode` and `nn.module`.
