### PR TITLE
remove redundant getDispatchKeySetUnboxed(eligibleKeys)

### DIFF
--- a/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
+++ b/aten/src/ATen/core/dispatch/DispatchKeyExtractor.h
@@ -139,10 +139,10 @@ public:
   }
 
   template<class... Args>
-  DispatchKeySet getDispatchKeySetUnboxed(DispatchKeySet eligibleKeys, const Args&... args) const {
+  DispatchKeySet getDispatchKeySetUnboxed(const Args&... args) const {
     auto ks = detail::multi_dispatch_key_set(args...);
     // Keys that are fallthrough should be skipped
-    return impl::computeDispatchKeySet(ks, nonFallthroughKeys_ & eligibleKeys);
+    return impl::computeDispatchKeySet(ks, nonFallthroughKeys_);
   }
 
   void setOperatorHasFallthroughForKey(DispatchKey k, bool has_fallthrough);

--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -509,10 +509,7 @@ template<class Return, class... Args>
 C10_DISPATCHER_INLINE_UNLESS_MOBILE Return Dispatcher::call(const TypedOperatorHandle<Return(Args...)>& op, Args... args) const {
   detail::unused_arg_(args...);  // workaround for a false-positive warning about unused parameters in gcc 5
   auto dispatchKeySet = op.operatorDef_->op.dispatchKeyExtractor()
-    .template getDispatchKeySetUnboxed<Args...>(
-      DispatchKeySet::FULL,
-      args...
-    );
+    .template getDispatchKeySetUnboxed<Args...>(args...);
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(!c10::isAliasDispatchKey(dispatchKeySet.highestPriorityTypeId()));
   const KernelFunction& kernel = op.operatorDef_->op.lookup(dispatchKeySet.highestPriorityTypeId());
 #ifndef PYTORCH_DISABLE_PER_OP_PROFILING


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58535 remove redundant getDispatchKeySetUnboxed(eligibleKeys)**

Removes the `eligibleKeys` param from `getDispatchKeySetUnboxed()`. In the current evolution of the dispatcher this always took the value `DispatchKeySet::FULL`, meaning all keys were eligible. No instruction count change on a quick check - just for the cleanup.

Differential Revision: [D28531377](https://our.internmc.facebook.com/intern/diff/D28531377)