### PR TITLE
Fix arange functions for VSX specializations of Vec256

### DIFF
--- a/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_double_vsx.h
@@ -141,7 +141,8 @@ class Vec256<double> {
         vec_sel(a._vec0, b._vec0, mask._vecb0),
         vec_sel(a._vec1, b._vec1, mask._vecb1)};
   }
-  static Vec256<double> arange(double base = 0., double step = 1.) {
+  template <typename step_t>
+  static Vec256<double> arange(double base = 0., step_t step = static_cast<step_t>(1)) {
     return Vec256<double>(base, base + step, base + 2 * step, base + 3 * step);
   }
 

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_float_vsx.h
@@ -135,7 +135,8 @@ class Vec256<float> {
         vec_sel(a._vec1, b._vec1, mask._vecb1)};
   }
 
-  static Vec256<float> arange(float base = 0.f, float step = 1.f) {
+  template <typename step_t>
+  static Vec256<float> arange(float base = 0.f, step_t step = static_cast<step_t>(1)) {
     return Vec256<float>(
         base,
         base + step,

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int16_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int16_vsx.h
@@ -201,7 +201,8 @@ class Vec256<int16_t> {
         vec_sel(a._vec1, b._vec1, mask._vecb1)};
   }
 
-  static Vec256<int16_t> arange(int16_t base = 0, int16_t step = 1) {
+  template <typename step_t>
+  static Vec256<int16_t> arange(int16_t base = 0, step_t step = static_cast<step_t>(1)) {
     return Vec256<int16_t>(
         base,
         base + step,

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int32_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int32_vsx.h
@@ -154,7 +154,8 @@ class Vec256<int32_t> {
         vec_sel(a._vec1, b._vec1, mask._vecb1)};
   }
 
-  static Vec256<int32_t> arange(int32_t base = 0.f, int32_t step = 1.f) {
+  template <typename step_t>
+  static Vec256<int32_t> arange(int32_t base = 0.f, step_t step = static_cast<step_t>(1)) {
     return Vec256<int32_t>(
         base,
         base + step,

--- a/aten/src/ATen/cpu/vec256/vsx/vec256_int64_vsx.h
+++ b/aten/src/ATen/cpu/vec256/vsx/vec256_int64_vsx.h
@@ -116,7 +116,8 @@ class Vec256<int64_t> {
         vec_sel(a._vec0, b._vec0, mask._vecb0),
         vec_sel(a._vec1, b._vec1, mask._vecb1)};
   }
-  static Vec256<int64_t> arange(int64_t base = 0., int64_t step = 1.) {
+  template <typename step_t>
+  static Vec256<int64_t> arange(int64_t base = 0., step_t step = static_cast<step_t>(1)) {
     return Vec256<int64_t>(base, base + step, base + 2 * step, base + 3 * step);
   }
 


### PR DESCRIPTION
Need a templated 2nd parameter to support e.g. double steps even for int vectors.

This extends https://github.com/pytorch/pytorch/pull/34555 x86 specific fix to VSX instruction set.

Fixes #58551
