### PR TITLE
std::move redispatch arguments instead of copying them

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -141,6 +141,7 @@ def mk_dispatch_arg(arg: Expr) -> str:
         ConstRefCType,
         MutRefCType,
     )
+
     def dontmove(type: CType) -> bool:
         return isinstance(type, free_copy_types) or type.cpp_type() in basic_types
 

--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -21,7 +21,7 @@ from tools.codegen.model import (Argument, DispatchKey, FunctionSchema,
 from tools.codegen.api.types import (Binding, CppSignature, CppSignatureGroup,
                                      DispatcherSignature, NativeSignature,
                                      ArrayRefCType, ConstRefCType, MutRefCType,
-                                     OptionalCType, Expr)
+                                     OptionalCType, CType, Expr)
 from tools.codegen.api import cpp
 import tools.codegen.api.dispatcher as dispatcher
 import tools.codegen.api.native as native
@@ -141,7 +141,7 @@ def mk_dispatch_arg(arg: Expr) -> str:
         ConstRefCType,
         MutRefCType,
     )
-    def dontmove(type):
+    def dontmove(type: CType) -> bool:
         return isinstance(type, free_copy_types) or type.cpp_type() in basic_types
 
     if dontmove(arg.type.type) or \
@@ -265,8 +265,7 @@ class ComputeFunction:
             else:
                 sig = sig_group.signature
 
-            dispatcher_exprs = translate(sig.arguments(), dispatcher_sig.arguments())
-            dispatcher_exprs = mk_dispatch_args(dispatcher_exprs)
+            dispatcher_exprs = mk_dispatch_args(translate(sig.arguments(), dispatcher_sig.arguments()))
             if self.is_redispatching_fn:
                 dispatcher_exprs_str = ', '.join(['dispatchKeySet'] + dispatcher_exprs)
                 dispatcher_call = 'redispatch'


### PR DESCRIPTION
Some types can be copied for free, but others like std::string cannot.
We introduce std::move on arguments for which copy is non-free for a small speedup and reduction in code size.

Example output (`build/aten/src/ATen/RedispatchFunctions.cpp`):
```c++
// aten::conv1d.padding(Tensor input, Tensor weight, Tensor? bias=None, int[1] stride=1, str padding="valid", int[1] dilation=1, int groups=1) -> Tensor
at::Tensor conv1d(c10::DispatchKeySet dispatchKeySet, const at::Tensor & input, const at::Tensor & weight, const c10::optional<at::Tensor> & bias, at::IntArrayRef stride, std::string padding, at::IntArrayRef dilation, int64_t groups) {
    static auto op = c10::Dispatcher::singleton()
        .findSchemaOrThrow("aten::conv1d", "padding")
        .typed<at::Tensor (const at::Tensor &, const at::Tensor &, const c10::optional<at::Tensor> &, at::IntArrayRef, std::string, at::IntArrayRef, int64_t)>();
    return op.redispatch(dispatchKeySet, input, weight, bias, std::move(stride), std::move(padding), std::move(dilation), groups);
}
```

cc @bdhirsh @ezyang