### PR TITLE
Symbolic for ReLu6

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5474,6 +5474,21 @@ class TestONNXRuntime(unittest.TestCase):
                       dynamic_axes={"x": [1, 2]},
                       test_with_inputs=[y])
 
+    def test_relu6(self):
+        class Relu6Model(torch.nn.Module):
+            def __init__(self):
+                super(Relu6Model, self).__init__()
+                self.relu6 = torch.nn.ReLU6()
+
+            def forward(self, x):
+                return self.relu6(x)
+
+        x = torch.randn(2, 3, 4) * 100.0
+        y = torch.randn(2, 4, 5) * 100.0
+        self.run_test(Relu6Model(), x, input_names=['x'],
+                      dynamic_axes={'x': [1, 2]},
+                      test_with_inputs=[y])
+
     def test_silu(self):
         class SiLUModel(torch.nn.Module):
             def __init__(self):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -75,6 +75,18 @@ def clamp_max(g, self, max):
         return g.op("Min", self, max)
 
 
+def relu6(g, input):
+    relu = g.op("Relu", input)
+    dtype = input.type().scalarType()
+    if dtype is None:
+        dtype = 6  # float
+    else:
+        dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
+    min_val = g.op("Constant", value_t=torch.tensor(0, dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
+    max_val = g.op("Constant", value_t=torch.tensor(6, dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
+    return clamp(g, relu, min_val, max_val)
+
+
 # Opset 11 gather accepts negative indices
 @parse_args("v", "i", "v")
 def select(g, self, dim, index):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -727,6 +727,9 @@ def silu(g, input):
 def relu(g, input):
     return g.op("Relu", input)
 
+def relu6(g, input):
+    relu = g.op("Relu", input)
+    return clamp_max(g, relu, 6)
 
 def ceil(g, input):
     return g.op("Ceil", input)


### PR DESCRIPTION
Four mealv2 models can export in torch 1.8.1, but fails when torch master introduces relu6 a few months back.
