### PR TITLE
Support symbolic for conv_tbc (#58359)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -394,6 +394,41 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 10, 50, 100, requires_grad=True)
         self.run_test(model, (x,), rtol=1e-3, atol=1e-6)
 
+    def test_conv_tbc(self):
+        from torch.nn.modules.utils import _single
+
+        class ConvTBC(torch.nn.Module):
+            def __init__(self, in_channels, out_channels, kernel_size, padding=0):
+                super(ConvTBC, self).__init__()
+                self.in_channels = in_channels
+                self.out_channels = out_channels
+                self.kernel_size = _single(kernel_size)
+                self.padding = _single(padding)
+
+                self.weight = torch.nn.Parameter(
+                    torch.Tensor(self.kernel_size[0], in_channels, out_channels)
+                )
+                self.bias = torch.nn.Parameter(torch.Tensor(out_channels))
+
+            def reset_parameters(self):
+                torch.nn.init.xavier_normal_(self.weight)
+                torch.nn.init.zeros_(self.bias)
+
+            def conv_tbc(self, input):
+                return torch.conv_tbc(
+                    input.contiguous(), self.weight, self.bias, self.padding[0]
+                )
+
+            def forward(self, input):
+                return self.conv_tbc(input)
+
+        in_channels = 3
+        out_channels = 5
+        kernel_size = 5
+        model = ConvTBC(in_channels, out_channels, kernel_size, padding=0)
+        x = torch.randn(10, 7, in_channels, requires_grad=True)
+        self.run_test(model, (x,))
+
     def test_reshape_constant_fold(self):
         class Reshape(torch.nn.Module):
             def __init__(self, ):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58582 [ONNX] Enable support for roll() op. (#58389)
* #58581 [ONNX] handle aten::_set_item on Dict in convertInplaceOpsAndTrackAlias (#58317)
* #58580 [ONNX] use consistent quoting for string literals (#57757)
* #58579 [ONNX] Improve lower tuples and handle control flow  (#57650)
* #58578 [ONNX] Update special post process for SequenceInsert after SequenceEmpty (#56965)
* **#58577 Support symbolic for conv_tbc (#58359)**
* #58576 [ONNX] RNN scripting (#57564)
* #58575 [ONNX] Update instance_norm2 symbolic to handle track_running_stats=True (#55051)

This is a fix for exporting fairseq models, see:
```python
model = torch.hub.load(github, 'conv.wmt14.en-fr', tokenizer='moses', bpe='subword_nmt')
model = torch.hub.load(github, 'conv.wmt17.en-de', tokenizer='moses', bpe='subword_nmt')
```
With this fix, and comment out model script one line `GradMultiply`, these two models can be exported successfully with perf met.

The original PR https://github.com/pytorch/pytorch/pull/57708 has merging issue, use this one instead.

Co-authored-by: David <jiafa@microsoft.com>