### PR TITLE
[ONNX] Improve lower tuples and handle control flow  (#57650)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -21,6 +21,7 @@ from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, skipIfUnsuppo
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 from typing import List, Tuple, Optional, Dict
+from torch import Tensor
 import model_defs.word_language_model as word_language_model
 
 import onnx
@@ -6713,6 +6714,70 @@ class TestONNXRuntime(unittest.TestCase):
 
         input = torch.randn(2, 5, 7, dtype=torch.float64)
         self.run_test(Celu(), (input,))
+
+    def test_lower_tuple(self):
+        class TupleModule(torch.nn.Module):
+            def forward(self, input1, input2, input3):
+                # type: (Tensor, Tensor, Tensor) -> Tensor
+                a = (input1, input2)
+                b = a
+                c = (input1, input2, input3)
+                for i in range(5):
+                    d = a[0]
+                    for j in range(2):
+                        e, f = a
+                        a = (d, f)
+                        f = c[2]
+                        if f.size(0) != input1.size(-1):
+                            g = b[1]
+                            b = (g, f)
+                        else:
+                            k = c[1:]
+                            b = (f, k[0])
+                    m, n = b
+                    c = (input1, n, m)
+                p, q, r = c
+                return p + q + r
+
+        input1 = torch.randn(2)
+        input2 = torch.randn(2)
+        input3 = torch.randn(2)
+        self.run_test(TupleModule(), (input1, input2, input3))
+
+    def test_lower_tuple_2(self):
+        class TupleModule(torch.nn.Module):
+            def forward(self, input1, input2):
+                # type: (Tensor, Tensor) -> Tuple[Tensor, Tensor]
+                a = (input1, input2)
+                for x in range(5):
+                    c, d = a
+                    a = (c, d)
+                return a
+
+        input1 = torch.randn(2)
+        input2 = torch.randn(2)
+        self.run_test(TupleModule(), (input1, input2))
+
+    def test_lower_tuple_3(self):
+        class TupleModule(torch.nn.Module):
+            def forward(self, input1, input2):
+                # type: (Tuple[Tensor, Tensor], Tuple[Tensor, Tensor])
+                a = input1
+                b = input2
+                for x in range(5):
+                    c, d = a
+                    e, f = b
+                    if c.shape[0] == e.shape[0]:
+                        e = e + c
+                    else:
+                        f = f + d
+                    a = (e, f)
+                    b = (c, d)
+                return a , b
+
+        input1 = (torch.randn(2), torch.randn(2))
+        input2 = (torch.randn(2), torch.randn(2))
+        self.run_test(TupleModule(), (input1, input2))
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_where(self):

--- a/torch/csrc/jit/passes/lower_tuples.cpp
+++ b/torch/csrc/jit/passes/lower_tuples.cpp
@@ -25,7 +25,74 @@ std::unordered_set<Symbol> supported_ops = {
     prim::Return,
     prim::PythonOp,
     aten::format,
-};
+    prim::Uninitialized,
+    aten::__getitem__};
+
+// Flatten block inputs and insert a tuple construct in the block
+static void flattenTupleInLoopParams(Node* n, size_t index) {
+  auto input = n->inputs().at(index);
+  TupleTypePtr tt = input->type()->cast<TupleType>();
+  TORCH_INTERNAL_ASSERT(tt);
+
+  Block* block = n->blocks().at(0);
+  Node* block_node = n;
+
+  std::vector<Value*> new_node_inputs = {};
+  auto new_construct_node =
+      block->prependNode(block->owningGraph()->create(prim::TupleConstruct));
+  for (size_t j = 0; j < tt->elements().size(); ++j) {
+    auto new_block_in = block->insertInput(index + j);
+    new_construct_node->addInput(new_block_in);
+    block_node->insertInput(index + j + 1, input->node()->inputs().at(j));
+  }
+  new_construct_node->output()->setType(block->inputs().at(index - 1)->type());
+  block->inputs().at(index - 1)->replaceAllUsesWith(
+      new_construct_node->output());
+  block->eraseInput(index - 1);
+  block_node->removeInput(index);
+}
+
+// Flatten tuple outputs of the block node and append a TupleConstruct
+// node after the block node if there is an outer block.
+static void flattenTupleInBlockReturn(Node* n, size_t index) {
+  auto input = n->inputs().at(index);
+  Block* block = n->owningBlock();
+  Node* block_node = block->owningNode();
+  Node* new_construct_node = nullptr;
+  TupleTypePtr tt = input->type()->cast<TupleType>();
+  TORCH_INTERNAL_ASSERT(tt);
+
+  // 1- Add flattened tuple to block outputs
+  for (size_t j = 0; j < tt->elements().size(); ++j) {
+    block->insertOutput(index + j + 1, input->node()->inputs().at(j));
+  }
+  block->eraseOutput(index);
+
+  if (block_node == nullptr)
+    return;
+  // 2- For uses of the block node in the outer block,
+  // flatten the blocknode outputs and insert a tuple construct
+  // to replace that.
+  // Loop block has an extra element (iter counter)
+  if (block_node->kind() == prim::Loop)
+    index = index - 1;
+  auto tuple_output = block_node->outputs().at(index);
+  // When node has multiple blocks, do not flatten outputs on the second block
+  // again
+  if (!(tuple_output->type()->cast<TupleType>()))
+    return;
+
+  new_construct_node = block->owningGraph()->create(prim::TupleConstruct);
+  new_construct_node->insertAfter(block_node);
+  for (size_t j = 0; j < tt->elements().size(); ++j) {
+    auto new_block_out = block_node->insertOutput(index + j + 1);
+    new_construct_node->addInput(new_block_out);
+  }
+  // Replace the block node with the new TupleConstruct node
+  new_construct_node->output()->setType(tuple_output->type());
+  tuple_output->replaceAllUsesWith(new_construct_node->output());
+  block_node->eraseOutput(index);
+}
 
 void removeTupleNodes(Node* n, bool must_remove_tuples) {
   if (n->kind() != prim::TupleUnpack && n->kind() != prim::TupleIndex &&
@@ -33,8 +100,8 @@ void removeTupleNodes(Node* n, bool must_remove_tuples) {
     return;
   }
   // tuple index has two inputs, tuple and index
-  auto construct = n->inputs().at(0)->node();
-  if (construct->kind() != prim::TupleConstruct) {
+  auto construct_node = n->inputs().at(0)->node();
+  if (construct_node->kind() != prim::TupleConstruct) {
     if (must_remove_tuples) {
       AT_ERROR(n->kind().toQualString(), " not matched to tuple construct");
     }
@@ -42,7 +109,7 @@ void removeTupleNodes(Node* n, bool must_remove_tuples) {
   }
   if (n->kind() == prim::TupleUnpack) {
     for (size_t i = 0; i < n->outputs().size(); ++i) {
-      n->outputs()[i]->replaceAllUsesWith(construct->inputs().at(i));
+      n->outputs()[i]->replaceAllUsesWith(construct_node->inputs().at(i));
     }
   } else if (n->kind() == prim::TupleIndex) {
     auto idx = n->inputs().at(1);
@@ -54,21 +121,21 @@ void removeTupleNodes(Node* n, bool must_remove_tuples) {
       return;
     }
     auto int_idx = *maybe_int;
-    auto len = construct->output()->type()->containedTypes().size();
+    size_t len = construct_node->output()->type()->containedTypes().size();
     if (int_idx < 0) {
       int_idx += len;
     }
     // currently, we allow non-constant tuple index if the tuple is of one type.
     // so we need to check bounds here
     if (int_idx >= 0 && static_cast<size_t>(int_idx) < len) {
-      n->output()->replaceAllUsesWith(construct->inputs().at(int_idx));
+      n->output()->replaceAllUsesWith(construct_node->inputs().at(int_idx));
     }
   } else if (n->kind() == prim::TupleSlice) {
     std::vector<Value*> values;
     int64_t beg = n->i(attr::beg);
     int64_t end = n->i(attr::end);
     for (int64_t i = beg; i < end; i += 1) {
-      values.push_back(construct->inputs().at(i));
+      values.push_back(construct_node->inputs().at(i));
     }
     auto graph = n->owningGraph();
     auto tuple_out = graph->createTuple(values);
@@ -108,57 +175,52 @@ static void RemoveTupleConstants(Node* n) {
   n->replaceAllUsesWith(tuple_construct);
 }
 
-static void VisitNode(Node* n, Node* insert_point) {
-  auto& graph = *n->owningGraph();
-
-  // tuple construction operators will become dead when the unpacks are replaced
-  if (n->kind() == prim::TupleConstruct) {
-    return;
-  }
-
-  // note: changing the second argument to false changes this pass from a
-  // complete lowering pass to one that removes tuples when possible. When
-  // tuples are first-class in the interpreter, we should still run this pass to
-  // remove extraneous uses
-
-  if (n->kind() == prim::TupleUnpack || n->kind() == prim::TupleIndex ||
-      n->kind() == prim::TupleSlice) {
-    removeTupleNodes(n, /*must_remove_tuples*/ true);
-    return;
-  }
-
+static void flattenInputs(Node* n, Node* insert_point) {
   // flatten the input list  op(a, tup, b) --> op(a, t0, t1, b)
   for (size_t i = 0; i < n->inputs().size();) {
     auto input = n->inputs()[i];
     if (TupleTypePtr tt = input->type()->cast<TupleType>()) {
       TORCH_CHECK(
-          supported_ops.count(n->kind()) > 0,
-          "tuple appears in op that does not forward tuples, ",
-          "unsupported kind: ",
+          (input->node()->kind() == prim::TupleConstruct),
+          "tuple use not matched to tuple construct. Instead found: ",
           n->kind().toQualString());
-      TORCH_CHECK(
-          input->node()->kind() == prim::TupleConstruct,
-          "tuple use not matched to tuple construct");
-      for (size_t j = 0; j < tt->elements().size(); ++j) {
-        n->insertInput(i + 1 + j, input->node()->inputs().at(j));
+      if (supported_ops.count(n->kind()) > 0) {
+        if (n->kind() == prim::Loop) {
+          // This function supports all node types with blocks that take tuple
+          // inputs.
+          flattenTupleInLoopParams(n, i);
+        } else if (n->kind() == prim::Return) {
+          flattenTupleInBlockReturn(n, i);
+        } else {
+          for (size_t j = 0; j < tt->elements().size(); ++j) {
+            n->insertInput(i + 1 + j, input->node()->inputs().at(j));
+          }
+          n->removeInput(i);
+        }
+        // note: no update to i
+        // since tuples might be nested we need to recursively scan
+        // the new flattened inputs
+      } else {
+        TORCH_WARN(
+            "tuple appears in op inputs, but this op does not forward tuples, ",
+            "unsupported kind: ",
+            n->kind().toQualString());
+        ++i;
       }
-      n->removeInput(i);
-      // note: no update to i
-      // since tuples might be nested we need to recursively scan
-      // the new flattened inputs
     } else {
       ++i;
     }
   }
-  for (auto b : n->blocks()) {
-    LowerAllTuples(b);
-  }
+}
 
+static void flattenOutputs(Node* n, Node* insert_point) {
   // flatten the outputs list
+  auto& graph = *n->owningGraph();
   for (size_t i = 0; i < n->outputs().size();) {
     Value* output = n->outputs()[i];
     if (!output->hasUses()) {
-      return;
+      ++i;
+      continue;
     }
 
     // (a, b, tup, c) -> (a, b, t0, t1, c)
@@ -166,25 +228,49 @@ static void VisitNode(Node* n, Node* insert_point) {
     //    tup = (t0, t1)
     // is placed at the current insertion point
     if (TupleTypePtr tt = output->type()->cast<TupleType>()) {
-      TORCH_CHECK(
-          supported_ops.count(n->kind()) > 0,
-          "tuple appears in op that does not forward tuples, ",
-          "unsupported kind: ",
-          n->kind().toQualString());
-      for (size_t j = 0; j < tt->elements().size(); j++) {
-        n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
+      if (supported_ops.count(n->kind()) > 0) {
+        for (size_t j = 0; j < tt->elements().size(); j++) {
+          n->insertOutput(i + 1 + j)->setType(tt->elements()[j]);
+        }
+        auto new_tup =
+            graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
+        new_tup->insertBefore(insert_point);
+        insert_point = new_tup;
+        output->replaceAllUsesWith(new_tup->output());
+        n->eraseOutput(i);
+        // note: no update to i to handle nested tuples
+      } else {
+        TORCH_WARN(
+            "tuple appears in the op outputs, but this op does not forward tuples, ",
+            "unsupported kind: ",
+            n->kind().toQualString());
+        ++i;
       }
-      auto new_tup =
-          graph.createTuple(n->outputs().slice(i + 1, tt->elements().size()));
-      new_tup->insertBefore(insert_point);
-      insert_point = new_tup;
-      output->replaceAllUsesWith(new_tup->output());
-      n->eraseOutput(i);
-      // note: no update to i to handle nested tuples
     } else {
       ++i;
     }
   }
+}
+
+static void VisitNode(Node* n, Node* insert_point) {
+  // tuple construction operators will become dead when the unpacks are replaced
+  if (n->kind() == prim::TupleConstruct) {
+    return;
+  }
+  // note: changing the second argument to false changes this pass from a
+  // complete lowering pass to one that removes tuples when possible. When
+  // tuples are first-class in the interpreter, we should still run this pass to
+  // remove extraneous uses
+  if (n->kind() == prim::TupleUnpack || n->kind() == prim::TupleIndex ||
+      n->kind() == prim::TupleSlice) {
+    removeTupleNodes(n, /*must_remove_tuples*/ true);
+    return;
+  }
+  flattenInputs(n, insert_point);
+  for (auto b : n->blocks()) {
+    LowerAllTuples(b);
+  }
+  flattenOutputs(n, insert_point);
 }
 
 static void LowerAllTuples(Block* block) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58582 [ONNX] Enable support for roll() op. (#58389)
* #58581 [ONNX] handle aten::_set_item on Dict in convertInplaceOpsAndTrackAlias (#58317)
* #58580 [ONNX] use consistent quoting for string literals (#57757)
* **#58579 [ONNX] Improve lower tuples and handle control flow  (#57650)**
* #58578 [ONNX] Update special post process for SequenceInsert after SequenceEmpty (#56965)
* #58577 Support symbolic for conv_tbc (#58359)
* #58576 [ONNX] RNN scripting (#57564)
* #58575 [ONNX] Update instance_norm2 symbolic to handle track_running_stats=True (#55051)

Improving the logic for finding tuple patterns within control flow.
Also fixes: https://github.com/pytorch/pytorch/issues/56914

Co-authored-by: neginraoof <neginmr@utexas.edu>