### PR TITLE
[ONNX] use consistent quoting for string literals (#57757)

### DIFF
--- a/test/onnx/debug_embed_params.py
+++ b/test/onnx/debug_embed_params.py
@@ -9,11 +9,11 @@ import caffe2.python.onnx.backend as c2
 from test_pytorch_common import flatten
 
 
-torch.set_default_tensor_type('torch.FloatTensor')
+torch.set_default_tensor_type("torch.FloatTensor")
 try:
     import torch
 except ImportError:
-    print('Cannot import torch, hence caffe2-torch test will not run.')
+    print("Cannot import torch, hence caffe2-torch test will not run.")
     sys.exit(0)
 
 
@@ -23,9 +23,9 @@ def run_embed_params(proto, model, input, state_dict=None, use_gpu=True):
     case as well on pytorch front
     This should likely be removed from the release version of the code
     """
-    device = 'CPU'
+    device = "CPU"
     if use_gpu:
-        device = 'CUDA'
+        device = "CUDA"
     model_def = onnx.ModelProto.FromString(proto)
     onnx.checker.check_model(model_def)
     prepared = c2.prepare(model_def, device=device)

--- a/test/onnx/export_onnx_tests_filter.py
+++ b/test/onnx/export_onnx_tests_filter.py
@@ -57,11 +57,11 @@ def collect_generated_testcases(root_dir=test_onnx_common.pytorch_converted_dir,
     print("Failed {} testcases are moved to {}.".format(total_fail, _fail_test_dir))
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Check and filter the failed test cases.')
-    parser.add_argument('-v', action="store_true", default=False, help="verbose")
-    parser.add_argument('--delete', action="store_true", default=False, help="delete failed test cases")
-    parser.add_argument('--no-expect', action="store_true", default=False, help="generate expect txt files")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Check and filter the failed test cases.")
+    parser.add_argument("-v", action="store_true", default=False, help="verbose")
+    parser.add_argument("--delete", action="store_true", default=False, help="delete failed test cases")
+    parser.add_argument("--no-expect", action="store_true", default=False, help="generate expect txt files")
     args = parser.parse_args()
     verbose = args.v
     delete = args.delete

--- a/test/onnx/export_onnx_tests_generator.py
+++ b/test/onnx/export_onnx_tests_generator.py
@@ -135,6 +135,6 @@ def convert_tests(testcases, sets=1):
     print("PyTorch converted cases are stored in {}.".format(test_onnx_common.pytorch_converted_dir))
     print_stats(FunctionalModule_nums, nn_module)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     testcases = module_tests + new_module_tests
     convert_tests(testcases)

--- a/test/onnx/pytorch_helper.py
+++ b/test/onnx/pytorch_helper.py
@@ -48,7 +48,7 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
     """
     if prefix_name is None:
         global _next_idx
-        prefix_name = 'pytorch_import_' + str(_next_idx) + '/'
+        prefix_name = "pytorch_import_" + str(_next_idx) + "/"
         _next_idx += 1
 
     # TODO: handle the case where model cannot be exported
@@ -65,7 +65,7 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
         onnx_model.graph.input) if x.name not in initialized}
 
     if(len(uninitialized_inputs) != len(caffe2_inputs)):
-        raise ValueError('Expected {} inputs but found {}'.format(
+        raise ValueError("Expected {} inputs but found {}".format(
             len(uninitialized_inputs), len(caffe2_inputs)))
 
     def remap_blob_name(name):
@@ -74,10 +74,10 @@ def PyTorchModule(helper, model, sample_arguments, caffe2_inputs, prefix_name=No
             return str(caffe2_inputs[idx])
         return prefix_name + name
 
-    predict_net = Net(predict_net).Clone('anon', _FakeDict(remap_blob_name))
+    predict_net = Net(predict_net).Clone("anon", _FakeDict(remap_blob_name))
     helper.net.AppendNet(predict_net)
 
-    init_net = Net(init_net).Clone('anon', _FakeDict(remap_blob_name))
+    init_net = Net(init_net).Clone("anon", _FakeDict(remap_blob_name))
     helper.param_init_net.AppendNet(init_net)
 
     results = tuple([BlobReference(remap_blob_name(x.name), helper.net)

--- a/test/onnx/test_caffe2_common.py
+++ b/test/onnx/test_caffe2_common.py
@@ -8,7 +8,7 @@ from onnx import numpy_helper
 
 def load_tensor_as_numpy_array(f):
     tensor = onnx.TensorProto()
-    with open(f, 'rb') as file:
+    with open(f, "rb") as file:
         tensor.ParseFromString(file.read())
     return tensor
 
@@ -19,7 +19,7 @@ def assert_similar(ref, real):
         np.testing.assert_allclose(ref[i], real[i], rtol=1e-3)
 
 
-def run_generated_test(model_file, data_dir, device='CPU'):
+def run_generated_test(model_file, data_dir, device="CPU"):
     model = onnx.load(model_file)
     input_num = len(glob.glob(os.path.join(data_dir, "input_*.pb")))
     inputs = []

--- a/test/onnx/test_custom_ops.py
+++ b/test/onnx/test_custom_ops.py
@@ -37,10 +37,10 @@ class TestCustomOps(unittest.TestCase):
                 return torch.ops.custom_namespace.custom_add(a, b)
 
         def symbolic_custom_add(g, self, other):
-            return g.op('Add', self, other)
+            return g.op("Add", self, other)
 
         from torch.onnx import register_custom_op_symbolic
-        register_custom_op_symbolic('custom_namespace::custom_add', symbolic_custom_add, 9)
+        register_custom_op_symbolic("custom_namespace::custom_add", symbolic_custom_add, 9)
 
         x = torch.randn(2, 3, 4, requires_grad=False)
         y = torch.randn(2, 3, 4, requires_grad=False)
@@ -110,7 +110,7 @@ class TestCustomAutogradFunction(unittest.TestCase):
                 return h
 
         def symbolic_pythonop(g, n, *args, **kwargs):
-            name = kwargs['name']
+            name = kwargs["name"]
             if name == "MyClip":
                 return g.op("Clip", args[0], min_f=args[1])
             elif name == "MyRelu":
@@ -119,11 +119,11 @@ class TestCustomAutogradFunction(unittest.TestCase):
                 return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
 
         from torch.onnx import register_custom_op_symbolic
-        register_custom_op_symbolic('::prim_PythonOp', symbolic_pythonop, 1)
+        register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 1)
 
         x = torch.randn(2, 3, 4, requires_grad=True)
         model = MyModule()
         run_model_test(self, model, input=(x, ))
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_models.py
+++ b/test/onnx/test_models.py
@@ -129,7 +129,7 @@ class TestModels(TestCase):
 
     @unittest.skip("This model takes too much memory")
     def test_vgg19_bn(self):
-        # VGG 19-layer model (configuration 'E') with batch normalization
+        # VGG 19-layer model (configuration "E") with batch normalization
         x = Variable(torch.randn(BATCH_SIZE, 3, 224, 224).fill_(1.0))
         self.exportTest(toC(vgg19_bn()), toC(x))
 
@@ -263,5 +263,5 @@ class TestModels(TestCase):
         self.exportTest(toC(r2plus1d_18()), toC(x), rtol=1e-3, atol=1e-5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -39,5 +39,5 @@ TestModels_new_jit_API = type(str("TestModels_new_jit_API"),
                                    onnx_shape_inference=True))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_onnx_opset.py
+++ b/test/onnx/test_onnx_opset.py
@@ -31,9 +31,9 @@ def check_onnx_opset_operator(model, ops, opset_version=_export_onnx_opset_versi
     # specified as well
     assert len(ops) == len(graph.node)
     for i in range(0, len(ops)):
-        assert graph.node[i].op_type == ops[i]['op_name']
+        assert graph.node[i].op_type == ops[i]["op_name"]
         if "attributes" in ops[i] :
-            attributes = ops[i]['attributes']
+            attributes = ops[i]["attributes"]
             assert len(attributes) == len(graph.node[i].attribute)
             for j in range(0, len(attributes)):
                 for attribute_field in attributes[j].keys():
@@ -60,7 +60,7 @@ class TestONNXOpset(TestCase):
 
         ops = [{"op_name" : "IsNaN"}]
         ops = {9 : ops, 10 : ops}
-        x = torch.tensor([1.0, float('nan'), 2.0])
+        x = torch.tensor([1.0, float("nan"), 2.0])
         check_onnx_opsets_operator(MyModule(), x, ops, opset_versions=[9, 10])
 
     def test_topk(self):
@@ -133,7 +133,7 @@ class TestONNXOpset(TestCase):
             def forward(self, x):
                 size = [v * 2 for v in x.size()[2:]]
                 size = [int(i) for i in size]
-                return torch.nn.functional.interpolate(x, size=size, mode='nearest')
+                return torch.nn.functional.interpolate(x, size=size, mode="nearest")
 
         module = MyModule()
         ops8 = [{"op_name" : "Upsample", "attributes" : [{"name": "mode", "s": ("nearest").encode(), "type": 3},
@@ -258,7 +258,7 @@ class TestONNXOpset(TestCase):
                 size = [v * 2 for v in x.size()[2:]]
                 return torch.nn.functional.interpolate(x,
                                                        size=size,
-                                                       mode='nearest')
+                                                       mode="nearest")
         ops_9 = [{"op_name" : "Shape"},
                  {"op_name" : "Constant"},
                  {"op_name" : "Gather"},
@@ -320,7 +320,7 @@ class TestONNXOpset(TestCase):
                 size = [int(i) for i in size]
                 return torch.nn.functional.interpolate(x,
                                                        size=size,
-                                                       mode='nearest')
+                                                       mode="nearest")
         ops_9 = [{"op_name" : "Constant"},
                  {"op_name" : "Upsample",
                   "attributes" :
@@ -334,5 +334,5 @@ class TestONNXOpset(TestCase):
         check_onnx_opsets_operator(MyDynamicModel(), x, ops, opset_versions=[9, 10])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_operators.py
+++ b/test/onnx/test_operators.py
@@ -61,7 +61,7 @@ class TestOperators(TestCase):
             m = FuncModule(f, params)
         m.eval()
         onnx_model_pbtxt = export_to_pbtxt(m, args, **kwargs)
-        subname = kwargs.pop('subname', None)
+        subname = kwargs.pop("subname", None)
         self.assertExpected(onnx_model_pbtxt, subname)
         if _onnx_dep:
             onnx_model_pb = export_to_pb(m, args, **kwargs)
@@ -80,7 +80,7 @@ class TestOperators(TestCase):
                 #     2) only one assertONNX in each test, otherwise will override the data.
                 assert not os.path.exists(output_dir), "{} should not exist!".format(output_dir)
                 os.makedirs(output_dir)
-                with open(os.path.join(output_dir, "model.onnx"), 'wb') as file:
+                with open(os.path.join(output_dir, "model.onnx"), "wb") as file:
                     file.write(model_def.SerializeToString())
                 data_dir = os.path.join(output_dir, "test_data_set_0")
                 os.makedirs(data_dir)
@@ -88,14 +88,14 @@ class TestOperators(TestCase):
                     args = (args,)
                 for index, var in enumerate(flatten(args)):
                     tensor = onnx.numpy_helper.from_array(var.data.numpy())
-                    with open(os.path.join(data_dir, "input_{}.pb".format(index)), 'wb') as file:
+                    with open(os.path.join(data_dir, "input_{}.pb".format(index)), "wb") as file:
                         file.write(tensor.SerializeToString())
                 outputs = m(*args)
                 if isinstance(outputs, Variable):
                     outputs = (outputs,)
                 for index, var in enumerate(flatten(outputs)):
                     tensor = onnx.numpy_helper.from_array(var.data.numpy())
-                    with open(os.path.join(data_dir, "output_{}.pb".format(index)), 'wb') as file:
+                    with open(os.path.join(data_dir, "output_{}.pb".format(index)), "wb") as file:
                         file.write(tensor.SerializeToString())
 
     def assertONNXRaises(self, err, f, args, params=None, **kwargs):
@@ -278,8 +278,8 @@ class TestOperators(TestCase):
         model = torch.nn.Conv2d(3, 2, 3)
         y = model(x)
 
-        dynamic_axes = {'input_1': [0, 2, 3], 'output_1': {0: 'output_1_variable_dim_0', 1: 'output_1_variable_dim_1'}}
-        model_proto_name = 'conv2d.onnx'
+        dynamic_axes = {"input_1": [0, 2, 3], "output_1": {0: "output_1_variable_dim_0", 1: "output_1_variable_dim_1"}}
+        model_proto_name = "conv2d.onnx"
         torch.onnx.export(model, x, model_proto_name, verbose=True, input_names=["input_1"], output_names=["output_1"],
                           example_outputs=y, dynamic_axes=dynamic_axes)
 
@@ -385,12 +385,12 @@ class TestOperators(TestCase):
 
     def test_mean_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::mean',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::mean",
                                    lambda x: torch.mean(x, dtype=torch.double), x)
 
     def test_reduced_mean_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::mean',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::mean",
                                    lambda x: torch.mean(x, dim=0, dtype=torch.double), x)
 
     def test_sum(self):
@@ -399,12 +399,12 @@ class TestOperators(TestCase):
 
     def test_sum_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::sum',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::sum",
                                    lambda x: torch.sum(x, dtype=torch.double), x)
 
     def test_reduced_sum_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::sum',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::sum",
                                    lambda x: torch.sum(x, dim=0, dtype=torch.double), x)
 
     def test_reduced_sum(self):
@@ -429,12 +429,12 @@ class TestOperators(TestCase):
 
     def test_prod_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::prod',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::prod",
                                    lambda x: torch.prod(x, dtype=torch.double), x)
 
     def test_reduced_prod_dtype(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNXRaisesRegex(RuntimeError, 'Couldn\'t export operator aten::prod',
+        self.assertONNXRaisesRegex(RuntimeError, "Couldn't export operator aten::prod",
                                    lambda x: torch.prod(x, dim=0, dtype=torch.double), x)
 
     def test_sqrt(self):
@@ -527,7 +527,7 @@ class TestOperators(TestCase):
         self.assertONNX(lambda x: torch.flatten(x, 1), x)
 
     def test_isnan(self):
-        x = torch.tensor([1, float('nan'), 2])
+        x = torch.tensor([1, float("nan"), 2])
         self.assertONNX(lambda x: torch.isnan(x), x)
 
     def test_argmax(self):
@@ -570,16 +570,16 @@ class TestOperators(TestCase):
     def test_upsample_nearest_scale(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: nn.functional.interpolate(x, scale_factor=2.,
-                        mode='nearest', recompute_scale_factor=False), x)
+                        mode="nearest", recompute_scale_factor=False), x)
 
     def test_upsample_nearest_scale_default_scale_factor(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         self.assertONNX(lambda x: nn.functional.interpolate(x, scale_factor=2.,
-                        mode='nearest'), x)
+                        mode="nearest"), x)
 
     def test_upsample_nearest_size(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        self.assertONNX(lambda x: nn.functional.interpolate(x, size=16, mode='nearest'), x)
+        self.assertONNX(lambda x: nn.functional.interpolate(x, size=16, mode="nearest"), x)
 
     def test_unsqueeze(self):
         x = torch.randn(3, 4, requires_grad=True)
@@ -766,7 +766,7 @@ class TestOperators(TestCase):
         im_info = torch.ones(img_count, 3, dtype=torch.float32)
         anchors = torch.ones(A, 4, dtype=torch.float32)
         inputs = (scores, bbox_deltas, im_info, anchors)
-        self.assertONNX(model, inputs, custom_opsets={'org.pytorch._caffe2': 0})
+        self.assertONNX(model, inputs, custom_opsets={"org.pytorch._caffe2": 0})
 
     def test_dict(self):
         class MyModel(torch.nn.Module):
@@ -873,7 +873,7 @@ class TestOperators(TestCase):
 
     @skipIfNoLapack
     def test_det(self):
-        x = torch.randn(2, 3, 5, 5, device=torch.device('cpu'))
+        x = torch.randn(2, 3, 5, 5, device=torch.device("cpu"))
         self.assertONNX(lambda x: torch.det(x), x, opset_version=11)
         self.assertONNX(lambda x: torch.linalg.det(x), x, opset_version=11)
 
@@ -900,19 +900,19 @@ class TestOperators(TestCase):
     def test_softmaxcrossentropy_3d_none(self):
         x = torch.randn(3, 5, 2)
         y = torch.empty(3, 2, dtype=torch.long).random_(5)
-        self.assertONNX(torch.nn.CrossEntropyLoss(reduction='none'), (x, y), opset_version=12)
+        self.assertONNX(torch.nn.CrossEntropyLoss(reduction="none"), (x, y), opset_version=12)
 
     def test_softmaxcrossentropy_4d(self):
         x = torch.randn(3, 5, 2, 1)
         y = torch.empty(3, 2, 1, dtype=torch.long).random_(5)
         self.assertONNX(torch.nn.CrossEntropyLoss(), (x, y), opset_version=12)
 
-if __name__ == '__main__':
-    no_onnx_dep_flag = '--no-onnx'
+if __name__ == "__main__":
+    no_onnx_dep_flag = "--no-onnx"
     _onnx_dep = no_onnx_dep_flag not in common.UNITTEST_ARGS
     if no_onnx_dep_flag in common.UNITTEST_ARGS:
         common.UNITTEST_ARGS.remove(no_onnx_dep_flag)
-    onnx_test_flag = '--produce-onnx-test-data'
+    onnx_test_flag = "--produce-onnx-test-data"
     _onnx_test = onnx_test_flag in common.UNITTEST_ARGS
     if onnx_test_flag in common.UNITTEST_ARGS:
         common.UNITTEST_ARGS.remove(onnx_test_flag)

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -10,7 +10,7 @@ sys.path.insert(-1, pytorch_test_dir)
 
 from torch.testing._internal.common_utils import *  # noqa: F401,F403
 
-torch.set_default_tensor_type('torch.FloatTensor')
+torch.set_default_tensor_type("torch.FloatTensor")
 
 BATCH_SIZE = 2
 
@@ -32,10 +32,10 @@ def _skipper(condition, reason):
 
 
 skipIfNoCuda = _skipper(lambda: not torch.cuda.is_available(),
-                        'CUDA is not available')
+                        "CUDA is not available")
 
-skipIfTravis = _skipper(lambda: os.getenv('TRAVIS'),
-                        'Skip In Travis')
+skipIfTravis = _skipper(lambda: os.getenv("TRAVIS"),
+                        "Skip In Travis")
 
 # skips tests for all versions below min_opset_version.
 # if exporting the op is only supported after a specific version,

--- a/test/onnx/test_pytorch_helper.py
+++ b/test/onnx/test_pytorch_helper.py
@@ -38,9 +38,9 @@ class TestCaffe2Backend(unittest.TestCase):
                 return x
 
             def _initialize_weights(self):
-                init.orthogonal(self.conv1.weight, init.calculate_gain('relu'))
-                init.orthogonal(self.conv2.weight, init.calculate_gain('relu'))
-                init.orthogonal(self.conv3.weight, init.calculate_gain('relu'))
+                init.orthogonal(self.conv1.weight, init.calculate_gain("relu"))
+                init.orthogonal(self.conv2.weight, init.calculate_gain("relu"))
+                init.orthogonal(self.conv3.weight, init.calculate_gain("relu"))
                 init.orthogonal(self.conv4.weight)
 
         torch_model = SuperResolutionNet(upscale_factor=3)
@@ -49,13 +49,13 @@ class TestCaffe2Backend(unittest.TestCase):
 
         # use ModelHelper to create a C2 net
         helper = ModelHelper(name="test_model")
-        start = helper.Sigmoid(['the_input'])
+        start = helper.Sigmoid(["the_input"])
         # Embed the ONNX-converted pytorch net inside it
         toutput, = PyTorchModule(helper, torch_model, (fake_input,), [start])
         output = helper.Sigmoid(toutput)
 
         workspace.RunNetOnce(helper.InitProto())
-        workspace.FeedBlob('the_input', fake_input.data.numpy())
+        workspace.FeedBlob("the_input", fake_input.data.numpy())
         # print([ k for k in workspace.blobs ])
         workspace.RunNetOnce(helper.Proto())
         c2_out = workspace.FetchBlob(str(output))
@@ -65,5 +65,5 @@ class TestCaffe2Backend(unittest.TestCase):
         np.testing.assert_almost_equal(torch_out.data.cpu().numpy(), c2_out, decimal=3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_caffe2.py
+++ b/test/onnx/test_pytorch_onnx_caffe2.py
@@ -90,27 +90,27 @@ def do_export(model, inputs, *args, **kwargs):
     return f.getvalue(), out
 
 
-torch.set_default_tensor_type('torch.FloatTensor')
+torch.set_default_tensor_type("torch.FloatTensor")
 try:
     import torch
 except ImportError:
-    print('Cannot import torch, hence caffe2-torch test will not run.')
+    print("Cannot import torch, hence caffe2-torch test will not run.")
     sys.exit(0)
 
 
 model_urls = {
-    'alexnet': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/alexnet-owt-4df8aa71.pth',
-    'dcgan_b': 'https://s3.amazonaws.com/pytorch/test_data/export/netG_bedroom_epoch_1-0649e76b.pth',
-    'dcgan_f': 'https://s3.amazonaws.com/pytorch/test_data/export/netG_faces_epoch_49-d86035a6.pth',
-    'densenet121': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/densenet121-d66d3027.pth',
-    'inception_v3_google': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/inception_v3_google-1a9a5a14.pth',
-    'resnet50': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/resnet50-19c8e357.pth',
-    'srresNet': 'https://s3.amazonaws.com/pytorch/demos/srresnet-e10b2039.pth',
-    'super_resolution': 'https://s3.amazonaws.com/pytorch/test_data/export/superres_epoch100-44c6958e.pth',
-    'squeezenet1_0': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/squeezenet1_0-a815701f.pth',
-    'squeezenet1_1': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/squeezenet1_1-f364aa15.pth',
-    'vgg16': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/vgg16-397923af.pth',
-    'vgg19': 'https://s3.amazonaws.com/download.caffe2.ai/test_data/vgg19-dcbb9e9d.pth',
+    "alexnet": "https://s3.amazonaws.com/download.caffe2.ai/test_data/alexnet-owt-4df8aa71.pth",
+    "dcgan_b": "https://s3.amazonaws.com/pytorch/test_data/export/netG_bedroom_epoch_1-0649e76b.pth",
+    "dcgan_f": "https://s3.amazonaws.com/pytorch/test_data/export/netG_faces_epoch_49-d86035a6.pth",
+    "densenet121": "https://s3.amazonaws.com/download.caffe2.ai/test_data/densenet121-d66d3027.pth",
+    "inception_v3_google": "https://s3.amazonaws.com/download.caffe2.ai/test_data/inception_v3_google-1a9a5a14.pth",
+    "resnet50": "https://s3.amazonaws.com/download.caffe2.ai/test_data/resnet50-19c8e357.pth",
+    "srresNet": "https://s3.amazonaws.com/pytorch/demos/srresnet-e10b2039.pth",
+    "super_resolution": "https://s3.amazonaws.com/pytorch/test_data/export/superres_epoch100-44c6958e.pth",
+    "squeezenet1_0": "https://s3.amazonaws.com/download.caffe2.ai/test_data/squeezenet1_0-a815701f.pth",
+    "squeezenet1_1": "https://s3.amazonaws.com/download.caffe2.ai/test_data/squeezenet1_1-f364aa15.pth",
+    "vgg16": "https://s3.amazonaws.com/download.caffe2.ai/test_data/vgg16-397923af.pth",
+    "vgg19": "https://s3.amazonaws.com/download.caffe2.ai/test_data/vgg19-dcbb9e9d.pth",
 }
 
 
@@ -252,7 +252,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         # but also the parameters. This test checks that the model can be loaded and
         # executed in Caffe2 backend correctly.
         torch.onnx._export(model, input, f, verbose=True, export_type=ExportTypes.ZIP_ARCHIVE,
-                           input_names=['input1', 'parameter1', 'parameter2'],
+                           input_names=["input1", "parameter1", "parameter2"],
                            keep_initializers_as_inputs=True)
 
         f.seek(0)
@@ -279,7 +279,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         # This test checks that given this edge condition, the model can be loaded and executed
         # in Caffe2 backend correctly.
         torch.onnx._export(model, input, f, verbose=True, export_type=ExportTypes.ZIP_ARCHIVE,
-                           input_names=['input1', 'fc1.bias'], _retain_param_name=False,
+                           input_names=["input1", "fc1.bias"], _retain_param_name=False,
                            keep_initializers_as_inputs=True)
 
         f.seek(0)
@@ -301,11 +301,11 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         self.run_model_test(model, train=False, batch_size=BATCH_SIZE, input=(input, h0), use_gpu=False)
 
     def _dispatch_rnn_test(self, name, *args, **kwargs):
-        if name == 'elman':
+        if name == "elman":
             self._elman_rnn_test(*args, **kwargs)
-        if name == 'lstm':
+        if name == "lstm":
             self._lstm_test(*args, **kwargs)
-        if name == 'gru':
+        if name == "gru":
             self._gru_test(*args, **kwargs)
 
     def _elman_rnn_test(self, layers, nonlinearity, bidirectional,
@@ -457,7 +457,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         mp = onnx.ModelProto.FromString(do_export(model, input, export_params=self.embed_params,
                                                   keep_initializers_as_inputs=True,
                                                   do_constant_folding=False)[0])
-        prepared = c2.prepare(mp, device='CPU')
+        prepared = c2.prepare(mp, device="CPU")
         if self.embed_params:
             assert len(prepared.init_net.op) == 879
             assert len(prepared.predict_net.op) == 133
@@ -466,7 +466,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             assert len(prepared.predict_net.op) == 1000
 
     def test_alexnet(self):
-        state_dict = model_zoo.load_url(model_urls['alexnet'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["alexnet"], progress=False)
         self.run_model_test(alexnet(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict, atol=1e-3)
 
@@ -486,8 +486,8 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
         netG = dcgan._netG(1)
         netG.apply(dcgan.weights_init)
-        state_dict = model_zoo.load_url(model_urls['dcgan_b'], progress=False)
-        # state_dict = model_zoo.load_url(model_urls['dcgan_f'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["dcgan_b"], progress=False)
+        # state_dict = model_zoo.load_url(model_urls["dcgan_f"], progress=False)
         noise = torch.randn(BATCH_SIZE, dcgan.nz, 1, 1).normal_(0, 1)
         self.run_model_test(netG, train=False, batch_size=BATCH_SIZE,
                             input=noise, state_dict=state_dict, rtol=1e-2, atol=1e-6)
@@ -495,7 +495,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     @unittest.skipIf(not torch.cuda.is_available(),
                      "model on net has cuda in it, awaiting fix")
     def test_densenet(self):
-        state_dict = model_zoo.load_url(model_urls['densenet121'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["densenet121"], progress=False)
         self.run_model_test(densenet121(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict, atol=1e-7)
 
@@ -503,31 +503,31 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     # TODO: figure out the numerical instabilities
     def test_inception(self):
         x = torch.randn(BATCH_SIZE, 3, 299, 299, requires_grad=True)
-        # state_dict = model_zoo.load_url(model_urls['inception_v3_google'], progress=False)
+        # state_dict = model_zoo.load_url(model_urls["inception_v3_google"], progress=False)
         state_dict = None
         self.run_model_test(inception_v3(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict, input=x)
 
     @skipIfNoEmbed
     def test_resnet(self):
-        state_dict = model_zoo.load_url(model_urls['resnet50'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["resnet50"], progress=False)
         self.run_model_test(resnet50(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict, atol=1e-5)
 
     def test_squeezenet(self):
         sqnet_v1_1 = SqueezeNet(version=1.1)
-        state_dict = model_zoo.load_url(model_urls['squeezenet1_1'], progress=False)
-        # state_dict = model_zoo.load_url(model_urls['squeezenet1_0'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["squeezenet1_1"], progress=False)
+        # state_dict = model_zoo.load_url(model_urls["squeezenet1_0"], progress=False)
         self.run_model_test(sqnet_v1_1, train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
-    # @skip('takes long to run, LAPACK needed for gpu')
+    # @skip("takes long to run, LAPACK needed for gpu")
     @skipIfNoLapack
     @unittest.skip("This model takes too much memory")
     def test_srresnet(self):
         super_resolution_net = SRResNet(
             rescale_factor=4, n_filters=64, n_blocks=8)
-        state_dict = model_zoo.load_url(model_urls['srresNet'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["srresNet"], progress=False)
         x = torch.randn(1, 3, 224, 224, requires_grad=True)
         self.run_model_test(super_resolution_net, train=False,
                             batch_size=1, state_dict=state_dict,
@@ -538,7 +538,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     @skipIfNoCuda
     def test_super_resolution(self):
         super_resolution_net = SuperResolutionNet(upscale_factor=3)
-        state_dict = model_zoo.load_url(model_urls['super_resolution'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["super_resolution"], progress=False)
         x = torch.randn(1, 1, 224, 224, requires_grad=True)
         self.run_model_test(super_resolution_net, train=False,
                             batch_size=BATCH_SIZE, state_dict=state_dict,
@@ -546,7 +546,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     @unittest.skip("This model takes too much memory")
     def test_vgg16(self):
-        state_dict = model_zoo.load_url(model_urls['vgg16'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["vgg16"], progress=False)
         self.run_model_test(vgg16(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
@@ -557,7 +557,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     @skip("disable to run tests faster...")
     def test_vgg19(self):
-        state_dict = model_zoo.load_url(model_urls['vgg19'], progress=False)
+        state_dict = model_zoo.load_url(model_urls["vgg19"], progress=False)
         self.run_model_test(vgg19(), train=False, batch_size=BATCH_SIZE,
                             state_dict=state_dict)
 
@@ -768,12 +768,12 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             input = torch.empty(BATCH_SIZE, 10, 10).uniform_()
             self.run_model_test(MyModel(), train=False, input=input, batch_size=BATCH_SIZE)
 
-        test_func('cos')
-        test_func('sin')
-        test_func('tan')
-        test_func('acos')
-        test_func('asin')
-        test_func('atan')
+        test_func("cos")
+        test_func("sin")
+        test_func("tan")
+        test_func("acos")
+        test_func("asin")
+        test_func("atan")
 
     def test_addconstant(self):
         class MyModel(torch.nn.Module):
@@ -1017,7 +1017,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     def test_sum(self):
         shape = (3, 4, 5)
-        for params in [{}] + [{'dim': i} for i in range(len(shape))]:
+        for params in [{}] + [{"dim": i} for i in range(len(shape))]:
             class MyModel(torch.nn.Module):
                 def __init__(self):
                     super(MyModel, self).__init__()
@@ -1029,7 +1029,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     def test_cumsum(self):
         shape = (3, 4, 5)
-        for params in [{'dim': i} for i in range(len(shape))]:
+        for params in [{"dim": i} for i in range(len(shape))]:
             class MyModel(torch.nn.Module):
                 def __init__(self):
                     super(MyModel, self).__init__()
@@ -1116,7 +1116,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
     @skipIfUnsupportedOpsetVersion([10])
     def test_upsample(self):
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
-        model = nn.Upsample(size=[v * 2 for v in x.size()[2:]], mode='nearest')
+        model = nn.Upsample(size=[v * 2 for v in x.size()[2:]], mode="nearest")
         self.run_model_test(model, train=False, input=(x),
                             batch_size=BATCH_SIZE, use_gpu=False)
 
@@ -1132,7 +1132,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 size = [int(i) for i in size]
                 return nn.functional.interpolate(x,
                                                  size=size,
-                                                 mode='nearest')
+                                                 mode="nearest")
 
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         model = MyModel()
@@ -1149,7 +1149,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
                 size = [v * 2 for v in x.size()[2:]]
                 return nn.functional.interpolate(x,
                                                  size=size,
-                                                 mode='nearest')
+                                                 mode="nearest")
 
         x = torch.randn(1, 2, 3, 4, requires_grad=True)
         model = MyModel()
@@ -1181,7 +1181,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 
     def test_mean(self):
         shape = (3, 4, 5)
-        for params in [{}] + [{'dim': i} for i in range(len(shape))]:
+        for params in [{}] + [{"dim": i} for i in range(len(shape))]:
             class MyModel(torch.nn.Module):
                 def __init__(self):
                     super(MyModel, self).__init__()
@@ -1349,7 +1349,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         x = torch.randn(3, 4, 5, 6, 7)
         self.run_model_test(NegSlice(), train=False, input=(x,), batch_size=BATCH_SIZE, use_gpu=False)
 
-    @unittest.skip('https://github.com/pytorch/pytorch/issues/10984')
+    @unittest.skip("https://github.com/pytorch/pytorch/issues/10984")
     @skipIfUnsupportedOpsetVersion([10])
     def test_neg_slice_large_negone(self):
         class NegSlice(torch.nn.Module):
@@ -1470,8 +1470,8 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
         class TensorFactory(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
-                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
+                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
                 return zeros + ones
 
         x = torch.randn(2, 3, 4)
@@ -1600,7 +1600,7 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
             def forward(self, input):
                 return torch.isnan(input)
 
-        x = torch.tensor([1.0, float('nan'), 2.0])
+        x = torch.tensor([1.0, float("nan"), 2.0])
         self.run_model_test(IsNaNModel(), train=False, input=x, batch_size=BATCH_SIZE, use_gpu=False)
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -2411,8 +2411,8 @@ class TestCaffe2Backend_opset9(unittest.TestCase):
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout,
               **extra_kwargs):
-    test_name = str('_'.join([
-        'test', name, layer[1],
+    test_name = str("_".join([
+        "test", name, layer[1],
         bidirectional[1], initial_state[1],
         variable_length[1], dropout[1]
     ]))
@@ -2435,25 +2435,25 @@ def make_test(name, base, layer, bidirectional, initial_state,
 
 def setup_rnn_tests():
     layers_opts = [
-        (1, 'unilayer'),
-        (3, 'trilayer')
+        (1, "unilayer"),
+        (3, "trilayer")
     ]
     bidirectional_opts = [
-        (False, 'forward'),
-        (True, 'bidirectional')
+        (False, "forward"),
+        (True, "bidirectional")
     ]
     initial_state_opts = [
-        (True, 'with_initial_state'),
-        (False, 'no_initial_state')
+        (True, "with_initial_state"),
+        (False, "no_initial_state")
     ]
     variable_length_opts = [
-        (0, 'without_sequence_lengths'),
-        (1, 'with_variable_length_sequences'),
-        (2, 'with_batch_first_sequence_lengths')
+        (0, "without_sequence_lengths"),
+        (1, "with_variable_length_sequences"),
+        (2, "with_batch_first_sequence_lengths")
     ]
     dropout_opts = [
-        (0.2, 'with_dropout'),
-        (0.0, 'without_dropout')
+        (0.2, "with_dropout"),
+        (0.0, "without_dropout")
     ]
     test_count = 0
     for (layer, bidirectional, initial_state, variable_length, dropout) in \
@@ -2466,10 +2466,10 @@ def setup_rnn_tests():
     ):
 
         for base, name, extra_kwargs in (
-                ('elman', 'elman_relu', {'nonlinearity': u'relu'}),
-                ('elman', 'elman_tanh', {'nonlinearity': u'tanh'}),
-                ('lstm', 'lstm', {}),
-                ('gru', 'gru', {})
+                ("elman", "elman_relu", {"nonlinearity": u"relu"}),
+                ("elman", "elman_tanh", {"nonlinearity": u"tanh"}),
+                ("lstm", "lstm", {}),
+                ("gru", "gru", {})
         ):
             make_test(name, base, layer, bidirectional, initial_state,
                       variable_length, dropout,
@@ -2524,5 +2524,5 @@ TestCaffe2BackendEmbed_opset9_new_jit_API = type(str("TestCaffe2BackendEmbed_ops
                                                  (unittest.TestCase,),
                                                  dict(TestCaffe2Backend_opset9.__dict__, embed_params=True))
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_caffe2_quantized.py
+++ b/test/onnx/test_pytorch_onnx_caffe2_quantized.py
@@ -14,7 +14,7 @@ class TestQuantizedOps(unittest.TestCase):
     def generic_test(self, model, sample_inputs, input_names=None, decimal=3, relaxed_check=False):
         torch.backends.quantized.engine = "qnnpack"
         pt_inputs = tuple(torch.from_numpy(x) for x in sample_inputs)
-        model.qconfig = torch.quantization.get_default_qconfig('qnnpack')
+        model.qconfig = torch.quantization.get_default_qconfig("qnnpack")
         q_model = torch.quantization.prepare(model, inplace=False)
         q_model = torch.quantization.convert(q_model, inplace=False)
 
@@ -174,7 +174,7 @@ class TestQuantizedOps(unittest.TestCase):
                 self.dequant = torch.quantization.DeQuantStub()
 
             def forward(self, x):
-                res = torch.nn.quantized.functional.interpolate(self.quant1(x), size=[6, 8], mode='nearest')
+                res = torch.nn.quantized.functional.interpolate(self.quant1(x), size=[6, 8], mode="nearest")
                 return self.dequant(res)
 
         x = np.random.rand(1, 2, 3, 4).astype("float32")
@@ -318,14 +318,14 @@ class TestQuantizedOps(unittest.TestCase):
                 return x
 
         model = ModelWithClassifierHead().eval()
-        torch.quantization.fuse_modules(model, [['conv1', 'relu1'] ,
-                                                ['features.0.0', 'features.0.1', 'features.0.2'],
-                                                ['features.1.0', 'features.1.1', 'features.1.2'],
-                                                ['features.2.0', 'features.2.1', 'features.2.2']], inplace=True)
+        torch.quantization.fuse_modules(model, [["conv1", "relu1"] ,
+                                                ["features.0.0", "features.0.1", "features.0.2"],
+                                                ["features.1.0", "features.1.1", "features.1.2"],
+                                                ["features.2.0", "features.2.1", "features.2.2"]], inplace=True)
 
 
         x = np.random.rand(1, 3, 10, 10).astype("float32")
         self.generic_test(model, (x,), input_names=["x"], relaxed_check=True)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -195,7 +195,7 @@ def _init_test_roi_heads_faster_rcnn():
     box_detections_per_img = 100
 
     box_roi_pool = ops.MultiScaleRoIAlign(
-        featmap_names=['0', '1', '2', '3'],
+        featmap_names=["0", "1", "2", "3"],
         output_size=7,
         sampling_ratio=2)
 
@@ -235,7 +235,7 @@ class TestONNXRuntime(unittest.TestCase):
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(0)
         np.random.seed(seed=0)
-        os.environ['ALLOW_RELEASED_ONNX_OPSET_ONLY'] = '0'
+        os.environ["ALLOW_RELEASED_ONNX_OPSET_ONLY"] = "0"
         self.is_script_test_enabled = True
 
     def run_test(self, model, input, rtol=1e-3, atol=1e-7, do_constant_folding=True,
@@ -276,7 +276,7 @@ class TestONNXRuntime(unittest.TestCase):
 
             # export the model to ONNX
             with tempfile.TemporaryDirectory() as tmpdirname:
-                model_file_name = os.path.join(tmpdirname, 'model.onnx')
+                model_file_name = os.path.join(tmpdirname, "model.onnx")
                 input_copy = copy.deepcopy(input)
                 torch.onnx.export(model, input_copy, model_file_name,
                                   opset_version=self.opset_version,
@@ -479,7 +479,7 @@ class TestONNXRuntime(unittest.TestCase):
         data_dir = get_writable_path(os.path.join(os.path.dirname(__file__)))
         path = os.path.join(data_dir, filename)
         data = request.urlopen(url, timeout=15).read()
-        with open(path, 'wb') as f:
+        with open(path, "wb") as f:
             f.write(data)
         image = Image.open(path).convert("RGB")
 
@@ -620,7 +620,7 @@ class TestONNXRuntime(unittest.TestCase):
         test_inputs = torch.randn(3, 3, 224, 224, requires_grad=True)
         self.run_test(model, (dummy_input,), test_with_inputs=[(dummy_input,), (test_inputs,)],
                       input_names=["input_images"], output_names=["outputs"],
-                      dynamic_axes={"input_images": {0: 'batch_size'}, "output": {0: 'batch_size'}},
+                      dynamic_axes={"input_images": {0: "batch_size"}, "output": {0: "batch_size"}},
                       rtol=1e-3, atol=1e-5)
 
     @disableScriptTest()
@@ -827,10 +827,10 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(MixedModel(), (x, y, None))
         self.run_test(MixedModel(), (x, None, z))
         # With optional arguments dictionary
-        self.run_test(MixedModel(), (x, {'y': y, 'z': None}))
-        self.run_test(MixedModel(), (x, {'y': None, 'z': z}))
-        self.run_test(MixedModel(), (x, {'z': z}))
-        self.run_test(MixedModel(), (x, {'y': y}))
+        self.run_test(MixedModel(), (x, {"y": y, "z": None}))
+        self.run_test(MixedModel(), (x, {"y": None, "z": z}))
+        self.run_test(MixedModel(), (x, {"z": z}))
+        self.run_test(MixedModel(), (x, {"y": y}))
 
     @disableScriptTest()
     def test_optional_inputs_with_all_optionals(self):
@@ -845,7 +845,7 @@ class TestONNXRuntime(unittest.TestCase):
         # Without optional arguments dictionary
         self.run_test(AllOptionalModel(), (y, None))
         # With optional arguments dictionary
-        self.run_test(AllOptionalModel(), {'y': y, 'z': None})
+        self.run_test(AllOptionalModel(), {"y": y, "z": None})
 
     @disableScriptTest()
     def test_input_names_with_optional_args(self):
@@ -855,7 +855,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         # Without empty optional arguments dictionary
         x = torch.randn(2, 3)
-        self.run_test(NoOptionalModel(), (x,), input_names=['input_x'])
+        self.run_test(NoOptionalModel(), (x,), input_names=["input_x"])
         # With empty optional arguments dictionary
         y = torch.randn(2, 3)
         self.run_test(NoOptionalModel(), (y, {}))
@@ -872,12 +872,12 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(2, 3)
         z = torch.randn(2, 3)
         # Without optional arguments dictionary
-        self.run_test(MixedModel(), (x, y, None), input_names=['input_x', 'input_y'])
-        self.run_test(MixedModel(), (x, None, z), input_names=['input_x', 'input_z'])
+        self.run_test(MixedModel(), (x, y, None), input_names=["input_x", "input_y"])
+        self.run_test(MixedModel(), (x, None, z), input_names=["input_x", "input_z"])
 
         # With optional arguments dictionary
-        self.run_test(MixedModel(), (x, {'y': y, 'z': None}), input_names=['input_x', 'input_y'])
-        self.run_test(MixedModel(), (x, {'y': None, 'z': z}), input_names=['input_x', 'input_z'])
+        self.run_test(MixedModel(), (x, {"y": y, "z": None}), input_names=["input_x", "input_y"])
+        self.run_test(MixedModel(), (x, {"y": None, "z": z}), input_names=["input_x", "input_z"])
 
         class AllOptionalModel(torch.nn.Module):
             def forward(self, y=None, z=None):
@@ -889,11 +889,11 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(2, 3)
         z = torch.randn(2, 3)
         # Without optional arguments dictionary
-        self.run_test(AllOptionalModel(), (y, None), input_names=['input_y'])
-        self.run_test(AllOptionalModel(), (None, z), input_names=['input_z'])
+        self.run_test(AllOptionalModel(), (y, None), input_names=["input_y"])
+        self.run_test(AllOptionalModel(), (None, z), input_names=["input_z"])
         # With optional arguments dictionary
-        self.run_test(AllOptionalModel(), {'y': y, 'z': None}, input_names=['input_y'])
-        self.run_test(AllOptionalModel(), {'y': None, 'z': z}, input_names=['input_z'])
+        self.run_test(AllOptionalModel(), {"y": y, "z": None}, input_names=["input_y"])
+        self.run_test(AllOptionalModel(), {"y": None, "z": z}, input_names=["input_z"])
 
     def test_input_as_output(self):
         class Model(torch.nn.Module):
@@ -902,7 +902,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3)
         y = torch.randn(3, 4)
-        self.run_test(Model(), (x, y), input_names=['x', 'y'], output_names=['x_out', 'y_out'])
+        self.run_test(Model(), (x, y), input_names=["x", "y"], output_names=["x_out", "y_out"])
 
     @disableScriptTest()
     def test_none_as_input(self):
@@ -1003,8 +1003,8 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(7, 8, 9)
         model = test()
         self.run_test(model, x, test_with_inputs=[y],
-                      input_names=['input_1'],
-                      dynamic_axes={'input_1': [0, 1, 2]})
+                      input_names=["input_1"],
+                      dynamic_axes={"input_1": [0, 1, 2]})
 
     def test_tensor(self):
         class ScalarInputModel(torch.jit.ScriptModule):
@@ -1224,8 +1224,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(20, 16, 50, 100)
         self.run_test(Model(), x, atol=10e-5,
-                      input_names=['x'],
-                      dynamic_axes={'x': [0]})
+                      input_names=["x"],
+                      dynamic_axes={"x": [0]})
 
     def test_conv_transpose(self):
         class TraceModel(torch.nn.Module):
@@ -1260,8 +1260,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(32, 3, 64, 64)
         y = torch.randn(16, 3, 8, 64)
-        self.run_test(TransposeModule(), x, input_names=['x'],
-                      dynamic_axes={'x': [0, 2]},
+        self.run_test(TransposeModule(), x, input_names=["x"],
+                      dynamic_axes={"x": [0, 2]},
                       test_with_inputs=[y])
 
     def squeeze_model_tests(self, d, x1, x2):
@@ -1279,7 +1279,7 @@ class TestONNXRuntime(unittest.TestCase):
         x2 = [] if x2 is None else [x2]
         if len(x2) > 0:
             self.run_test(Squeeze(d), x1,
-                          input_names=['input'], dynamic_axes={'input': {0: '0', 1: '1', 2: '2'}},
+                          input_names=["input"], dynamic_axes={"input": {0: "0", 1: "1", 2: "2"}},
                           test_with_inputs=x2)
         else:
             self.run_test(Squeeze(d), x1)
@@ -1358,8 +1358,8 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.AdaptiveMaxPool1d((5), return_indices=False)
         x = torch.randn(20, 16, 50, requires_grad=True)
         y = torch.randn(32, 16, 50, requires_grad=True)
-        self.run_test(model, x, input_names=['x'],
-                      dynamic_axes={'x' : [0]},
+        self.run_test(model, x, input_names=["x"],
+                      dynamic_axes={"x" : [0]},
                       test_with_inputs=[y])
 
     def test_maxpool_2d(self):
@@ -1423,8 +1423,8 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.AvgPool3d(3, 2, ceil_mode=True)
         x = torch.randn(20, 16, 50, 44, 31)
         y = torch.randn(32, 8, 50, 44, 31)
-        self.run_test(model, x, input_names=['x'],
-                      dynamic_axes={'x' : [0, 1]},
+        self.run_test(model, x, input_names=["x"],
+                      dynamic_axes={"x" : [0, 1]},
                       test_with_inputs=[y])
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -1725,13 +1725,13 @@ class TestONNXRuntime(unittest.TestCase):
 
         class TruncDivModule(torch.nn.Module):
             def forward(self, x, y):
-                return (x.div(y, rounding_mode='trunc'),
-                        torch.div(x, y, rounding_mode='trunc'))
+                return (x.div(y, rounding_mode="trunc"),
+                        torch.div(x, y, rounding_mode="trunc"))
 
         class FloorDivModule(torch.nn.Module):
             def forward(self, x, y):
-                return (x.div(y, rounding_mode='floor'),
-                        torch.div(x, y, rounding_mode='floor'))
+                return (x.div(y, rounding_mode="floor"),
+                        torch.div(x, y, rounding_mode="floor"))
 
         modules = [TrueDivModule(), TruncDivModule()]
         if self.opset_version >= 9:
@@ -1809,10 +1809,10 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.rand(5, 5, 5)
         y = torch.randn(6, 7, 8)
         self.run_test(DynamicSliceExportMod(), x, test_with_inputs=[y],
-                      input_names=['input_1'],
-                      output_names=['output_1'],
-                      dynamic_axes={'input_1': [0, 1, 2],
-                                    'output_1': [0, 1, 2]})
+                      input_names=["input_1"],
+                      output_names=["output_1"],
+                      dynamic_axes={"input_1": [0, 1, 2],
+                                    "output_1": [0, 1, 2]})
 
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_slice_dynamic_script(self):
@@ -1845,8 +1845,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.rand(5, 5, 5)
         self.run_test(DynamicSliceExportMod(), x,
-                      dynamic_axes={'input_1': [0, 1, 2],
-                                    'output_1': [0, 1, 2]})
+                      dynamic_axes={"input_1": [0, 1, 2],
+                                    "output_1": [0, 1, 2]})
 
     def test_square(self):
         class Square(torch.nn.Module):
@@ -1867,15 +1867,15 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(5, 3, 2)
         y = torch.randn(8, 3, 2)
         self.run_test(ArangeModel(), x, test_with_inputs=[y],
-                      input_names=['input_1'],
-                      output_names=['output_1', 'output_2', 'output_3'],
-                      dynamic_axes={'input_1': [0],
-                                    'output_1': [0]})
+                      input_names=["input_1"],
+                      output_names=["output_1", "output_2", "output_3"],
+                      dynamic_axes={"input_1": [0],
+                                    "output_1": [0]})
         self.run_test(torch.jit.script(ArangeModel()), x,
-                      test_with_inputs=[y], input_names=['input_1'],
-                      output_names=['output_1', 'output_2', 'output_3'],
-                      dynamic_axes={'input_1': [0],
-                                    'output_1': [0]})
+                      test_with_inputs=[y], input_names=["input_1"],
+                      output_names=["output_1", "output_2", "output_3"],
+                      dynamic_axes={"input_1": [0],
+                                    "output_1": [0]})
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_dynamic_arange_out(self):
@@ -2182,8 +2182,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(6, 2)
         y = torch.randn(4, 1)
-        self.run_test(ScriptModel(), x, input_names=['x'],
-                      dynamic_axes={'x': {0: 'seq_length', 1: 'batch_size'}}, test_with_inputs=[y])
+        self.run_test(ScriptModel(), x, input_names=["x"],
+                      dynamic_axes={"x": {0: "seq_length", 1: "batch_size"}}, test_with_inputs=[y])
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_copy_(self):
@@ -2372,7 +2372,7 @@ class TestONNXRuntime(unittest.TestCase):
 
     def _interpolate(self, x, mode, use_size, is_upsample, align_corners=False):
         class MyModel(torch.nn.Module):
-            __constants__ = ['mode', 'use_size', 'is_upsample', 'size', 'scale', 'size_array', 'scale_array', 'align_corners']
+            __constants__ = ["mode", "use_size", "is_upsample", "size", "scale", "size_array", "scale_array", "align_corners"]
 
             def __init__(self, mode, use_size, is_upsample, align_corners):
                 super(MyModel, self).__init__()
@@ -2440,14 +2440,14 @@ class TestONNXRuntime(unittest.TestCase):
                         continue
                 self._interpolate(xi, mode_i, True, is_upsample)
                 # test with align_corners if supported
-                if mode != 'nearest':
+                if mode != "nearest":
                     self._interpolate(xi, mode_i, True, is_upsample, True)
                 # the following cases, require dynamic sizes/scales,
                 # which which is not supported for opset_version < 9
                 if self.opset_version >= 9:
                     self._interpolate(xi, mode_i, True, is_upsample)
                     # test with align_corners if supported
-                    if mode != 'nearest':
+                    if mode != "nearest":
                         self._interpolate(xi, mode_i, False, is_upsample, True)
                     self._interpolate(xi, mode_i, False, is_upsample)
 
@@ -3643,7 +3643,7 @@ class TestONNXRuntime(unittest.TestCase):
         input = torch.randn(RNN_SEQUENCE_LENGTH, 1, RNN_INPUT_SIZE)
         # verify with different input of different batch size
         input2 = torch.randn(RNN_SEQUENCE_LENGTH, BATCH_SIZE, RNN_INPUT_SIZE)
-        self.run_test(model, input, input_names=["input.1"], dynamic_axes={'input.1' : {0 : 'seq', 1 : 'batch'}},
+        self.run_test(model, input, input_names=["input.1"], dynamic_axes={"input.1" : {0 : "seq", 1 : "batch"}},
                       test_with_inputs=[input2])
 
     def test_lstm_constant_folding(self):
@@ -4165,7 +4165,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2, 4], [3, 4, 7]])
         another_x = torch.tensor([[7, 8], [5, 6]])
         self.run_test(SingleDynamicModel(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1' : {1 : 'w'}})
+                      input_names=["input_1"], dynamic_axes={"input_1" : {1 : "w"}})
 
         class NegDynamicModel(torch.nn.Module):
             def forward(self, x):
@@ -4175,7 +4175,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2, 4], [3, 4, 7]])
         another_x = torch.tensor([[7, 8], [5, 6]])
         self.run_test(NegDynamicModel(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1' : {1 : 'w'}})
+                      input_names=["input_1"], dynamic_axes={"input_1" : {1 : "w"}})
 
         class SingleDynamicModel2(torch.nn.Module):
             def forward(self, x):
@@ -4185,7 +4185,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2], [3, 4]])
         another_x = torch.tensor([[7, 8], [5, 6]])
         self.run_test(SingleDynamicModel2(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1' : {0 : 'h'}})
+                      input_names=["input_1"], dynamic_axes={"input_1" : {0 : "h"}})
 
         class AllDynamicModel(torch.nn.Module):
             def forward(self, x):
@@ -4195,7 +4195,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.tensor([[1, 2, 4, 16], [3, 9, 27, 81], [2, 3, 5, 7]])
         another_x = torch.tensor([[7, 8], [5, 6]])
         self.run_test(AllDynamicModel(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1' : {0 : 'h', 1 : 'w'}})
+                      input_names=["input_1"], dynamic_axes={"input_1" : {0 : "h", 1 : "w"}})
 
     def test_view(self):
         class ViewModel(torch.nn.Module):
@@ -4223,7 +4223,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(2)
         another_x = torch.empty((0,))
         self.run_test(ViewModel(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1': [0, ]})
+                      input_names=["input_1"], dynamic_axes={"input_1": [0, ]})
 
     def test_view_as(self):
         class ViewModel(torch.nn.Module):
@@ -4284,7 +4284,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(1, 1, 5, requires_grad=True)
         self.run_test(model, x)
 
-        model = torch.nn.utils.weight_norm(torch.nn.Conv1d(3, 6, 3), name='weight')
+        model = torch.nn.utils.weight_norm(torch.nn.Conv1d(3, 6, 3), name="weight")
         x = torch.randn(3, 3, 5, requires_grad=True)
         self.run_test(model, x)
 
@@ -4335,10 +4335,10 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(5, 5, 4, 5)
         model = MyModule()
         self.run_test(model, x, test_with_inputs=[y],
-                      input_names=['input'],
-                      output_names=['output'],
-                      dynamic_axes={'input' : {0 : 'batch_size'},
-                                    'output' : {0 : 'batch_size'}})
+                      input_names=["input"],
+                      output_names=["output"],
+                      dynamic_axes={"input" : {0 : "batch_size"},
+                                    "output" : {0 : "batch_size"}})
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_getitem(self):
@@ -4411,7 +4411,7 @@ class TestONNXRuntime(unittest.TestCase):
                 return len(input.unbind()) + input
 
         x = torch.randn(4, 5)
-        self.run_test(LenModel(), x, input_names=['input'], dynamic_axes={'input': {0: 'seq'}},
+        self.run_test(LenModel(), x, input_names=["input"], dynamic_axes={"input": {0: "seq"}},
                       test_with_inputs=(torch.randn(5, 5),))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -4566,12 +4566,12 @@ class TestONNXRuntime(unittest.TestCase):
         for dim_size_ in range(13, 16):
             y = torch.randn(1, dim_size_)
             self.run_test(model, x, test_with_inputs=[y],
-                          input_names=['x'],
-                          dynamic_axes={'x': {0: 'batch_size', 1: 'dims'}})
+                          input_names=["x"],
+                          dynamic_axes={"x": {0: "batch_size", 1: "dims"}})
 
             self.run_test(model_neg_dim, x, test_with_inputs=[y],
-                          input_names=['x'],
-                          dynamic_axes={'x': {0: 'batch_size', 1: 'dims'}})
+                          input_names=["x"],
+                          dynamic_axes={"x": {0: "batch_size", 1: "dims"}})
 
     def test_concat(self):
         class ConcatModel(torch.nn.Module):
@@ -4914,8 +4914,8 @@ class TestONNXRuntime(unittest.TestCase):
         class TensorFactory(torch.jit.ScriptModule):
             @torch.jit.script_method
             def forward(self, x):
-                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
-                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
+                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
                 return zeros + ones
 
         x = torch.randn(2, 3, 4)
@@ -4932,7 +4932,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         another_x = torch.randn(5, 6, 7)
         self.run_test(TensorFactory(), x, test_with_inputs=[another_x],
-                      input_names=['input_1'], dynamic_axes={'input_1': [0, 1, 2]})
+                      input_names=["input_1"], dynamic_axes={"input_1": [0, 1, 2]})
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_inplace_zero(self):
@@ -5410,8 +5410,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(4, 2, 3, requires_grad=True)
         y = torch.randn(2, 1, 3, requires_grad=True)
         self.run_test(UnfoldModel(), x,
-                      dynamic_axes={'x': [0, 1]},
-                      input_names=['x'],
+                      dynamic_axes={"x": [0, 1]},
+                      input_names=["x"],
                       test_with_inputs=[y])
 
     @skipIfONNXShapeInference(False)
@@ -5470,8 +5470,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 4, 5)
-        self.run_test(PReluModel(), x, input_names=['x'],
-                      dynamic_axes={'x': [1, 2]},
+        self.run_test(PReluModel(), x, input_names=["x"],
+                      dynamic_axes={"x": [1, 2]},
                       test_with_inputs=[y])
 
     def test_silu(self):
@@ -5606,17 +5606,17 @@ class TestONNXRuntime(unittest.TestCase):
     @disableScriptTest()  # error in propagate as assign input shape
     @skipIfUnsupportedMinOpsetVersion(10)
     def test_embedding_bag(self):
-        model = torch.nn.EmbeddingBag(10, 5, mode='sum', scale_grad_by_freq=True)
+        model = torch.nn.EmbeddingBag(10, 5, mode="sum", scale_grad_by_freq=True)
         input = torch.randint(10, (7,))
         offset = torch.tensor([0, 2, 5, 6])
         self.run_test(model, (input, offset))
 
-        model = torch.nn.EmbeddingBag(10, 5, mode='sum', include_last_offset=True)
+        model = torch.nn.EmbeddingBag(10, 5, mode="sum", include_last_offset=True)
         input = torch.randint(10, (7,))
         offset = torch.tensor([0, 2, 5, 6])
         self.run_test(model, (input, offset))
 
-        model = torch.nn.EmbeddingBag(10, 5, mode='max')
+        model = torch.nn.EmbeddingBag(10, 5, mode="max")
         input = torch.randint(10, (7, 5))
         self.run_test(model, (input))
 
@@ -5625,7 +5625,7 @@ class TestONNXRuntime(unittest.TestCase):
         class EmbeddingModel(torch.nn.Module):
             def forward(self, embedding_matrix, input, offset, weights):
                 return torch.nn.functional.embedding_bag(input, embedding_matrix, offsets=offset,
-                                                         mode='sum', per_sample_weights=weights)
+                                                         mode="sum", per_sample_weights=weights)
 
         model = EmbeddingModel()
         x = torch.randint(7, (6,))
@@ -5639,7 +5639,7 @@ class TestONNXRuntime(unittest.TestCase):
         class EmbeddingModel(torch.nn.Module):
             def forward(self, embedding_matrix, input, weights):
                 return torch.nn.functional.embedding_bag(input, embedding_matrix,
-                                                         mode='sum', per_sample_weights=weights)
+                                                         mode="sum", per_sample_weights=weights)
 
         embedding_matrix = torch.rand(10, 15)
         model = EmbeddingModel()
@@ -5654,7 +5654,7 @@ class TestONNXRuntime(unittest.TestCase):
         class EmbeddingModel1D(torch.nn.Module):
             def forward(self, embedding_matrix, input, weights, offsets):
                 return torch.nn.functional.embedding_bag(input, embedding_matrix, offsets=offsets,
-                                                         mode='sum', per_sample_weights=weights)
+                                                         mode="sum", per_sample_weights=weights)
 
         model = EmbeddingModel1D()
         x = torch.randint(7, (6,))
@@ -5667,13 +5667,13 @@ class TestONNXRuntime(unittest.TestCase):
         offsets2 = torch.tensor([0, ], dtype=torch.long)
         self.run_test(model, (embedding_matrix, x, w, offsets),
                       test_with_inputs=[(embedding_matrix2, x2, w2, offsets2)],
-                      input_names=['embedding_matrix', 'x', 'offsets', 'w'],
-                      dynamic_axes={'embedding_matrix': [0, 1], 'x': [0], 'offsets': [0], 'w': [0]})
+                      input_names=["embedding_matrix", "x", "offsets", "w"],
+                      dynamic_axes={"embedding_matrix": [0, 1], "x": [0], "offsets": [0], "w": [0]})
 
         class EmbeddingModel2D(torch.nn.Module):
             def forward(self, embedding_matrix, input, weights):
                 return torch.nn.functional.embedding_bag(input, embedding_matrix,
-                                                         mode='sum', per_sample_weights=weights)
+                                                         mode="sum", per_sample_weights=weights)
 
         model = EmbeddingModel2D()
         x = torch.randint(7, (2, 3))
@@ -5684,8 +5684,8 @@ class TestONNXRuntime(unittest.TestCase):
         embedding_matrix2 = torch.rand(12, 25)
         self.run_test(model, (embedding_matrix, x, w),
                       test_with_inputs=[(embedding_matrix2, x2, w2)],
-                      input_names=['embedding_matrix', 'x', 'w'],
-                      dynamic_axes={'embedding_matrix': [0, 1], 'x': [0, 1], 'w': [0, 1]})
+                      input_names=["embedding_matrix", "x", "w"],
+                      dynamic_axes={"embedding_matrix": [0, 1], "x": [0, 1], "w": [0, 1]})
 
     @skipIfUnsupportedMinOpsetVersion(8)
     def test_meshgrid(self):
@@ -5874,8 +5874,8 @@ class TestONNXRuntime(unittest.TestCase):
             run()
 
         the_exception = cm.exception
-        self.assertEqual('Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. ' +
-                         'Please try opset version 11.', the_exception.args[0])
+        self.assertEqual("Unsupported: ONNX export of Pad in opset 9. The sizes of the padding must be constant. " +
+                         "Please try opset version 11.", the_exception.args[0])
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_if_fold(self):
@@ -6025,8 +6025,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones((3, 4), dtype=torch.int)
         y = torch.ones((6, 7), dtype=torch.int)
         self.run_test(UninitializedModel(), x, test_with_inputs=[y],
-                      input_names=['input_1'],
-                      dynamic_axes={'input_1': [0, 1]})
+                      input_names=["input_1"],
+                      dynamic_axes={"input_1": [0, 1]})
 
     def test_reflection_pad(self):
         model = torch.nn.ReflectionPad1d(2)
@@ -6131,7 +6131,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_einsum(self):
         class EinsumModelBatchDiagonal(torch.nn.Module):
             def forward(self, x):
-                eqn = '...ii ->...i'
+                eqn = "...ii ->...i"
                 return torch.einsum(eqn, x)
 
         x = torch.randn(3, 5, 5)
@@ -6139,7 +6139,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class EinsumModelBatchMatmul(torch.nn.Module):
             def forward(self, x, y):
-                eqn = 'bij, bjk -> bik'
+                eqn = "bij, bjk -> bik"
                 return torch.einsum(eqn, x, y)
 
         x = torch.randn(5, 2, 3)
@@ -6148,7 +6148,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class EinsumModelInnerProd(torch.nn.Module):
             def forward(self, x, y):
-                eqn = 'i,i'
+                eqn = "i,i"
                 return torch.einsum(eqn, x, y)
 
         x = torch.randn(5)
@@ -6157,7 +6157,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class EinsumModelTranspose(torch.nn.Module):
             def forward(self, x):
-                eqn = 'ij->ji'
+                eqn = "ij->ji"
                 return torch.einsum(eqn, x)
 
         x = torch.randn(3, 4)
@@ -6187,9 +6187,9 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, ignore_index):
                 super(CrossEntropyLossNone, self).__init__()
                 if ignore_index == -100:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='none')
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="none")
                 else:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='none', ignore_index=ignore_index)
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="none", ignore_index=ignore_index)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6200,9 +6200,9 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, ignore_index):
                 super(CrossEntropyLossNoneWeight, self).__init__()
                 if ignore_index == -100:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='none', weight=torch.randn(5))
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="none", weight=torch.randn(5))
                 else:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='none', weight=torch.randn(5), ignore_index=ignore_index)
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="none", weight=torch.randn(5), ignore_index=ignore_index)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6213,9 +6213,9 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, ignore_index):
                 super(CrossEntropyLossSum, self).__init__()
                 if ignore_index == -100:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='sum')
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="sum")
                 else:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='sum', ignore_index=ignore_index)
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="sum", ignore_index=ignore_index)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6226,9 +6226,9 @@ class TestONNXRuntime(unittest.TestCase):
             def __init__(self, ignore_index):
                 super(CrossEntropyLossSumWeight, self).__init__()
                 if ignore_index == -100:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='sum', weight=torch.randn(5))
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="sum", weight=torch.randn(5))
                 else:
-                    self.loss = torch.nn.CrossEntropyLoss(reduction='sum', weight=torch.randn(5), ignore_index=ignore_index)
+                    self.loss = torch.nn.CrossEntropyLoss(reduction="sum", weight=torch.randn(5), ignore_index=ignore_index)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6280,7 +6280,7 @@ class TestONNXRuntime(unittest.TestCase):
         class KLDivLossNone(torch.nn.Module):
             def __init__(self):
                 super(KLDivLossNone, self).__init__()
-                self.loss = torch.nn.KLDivLoss(reduction='none', log_target=True)
+                self.loss = torch.nn.KLDivLoss(reduction="none", log_target=True)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6290,7 +6290,7 @@ class TestONNXRuntime(unittest.TestCase):
         class KLDivLossMean(torch.nn.Module):
             def __init__(self):
                 super(KLDivLossMean, self).__init__()
-                self.loss = torch.nn.KLDivLoss(reduction='mean', log_target=False)
+                self.loss = torch.nn.KLDivLoss(reduction="mean", log_target=False)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6300,7 +6300,7 @@ class TestONNXRuntime(unittest.TestCase):
         class KLDivLossSum(torch.nn.Module):
             def __init__(self):
                 super(KLDivLossSum, self).__init__()
-                self.loss = torch.nn.KLDivLoss(reduction='sum', log_target=True)
+                self.loss = torch.nn.KLDivLoss(reduction="sum", log_target=True)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6310,7 +6310,7 @@ class TestONNXRuntime(unittest.TestCase):
         class KLDivLossBatchMean(torch.nn.Module):
             def __init__(self):
                 super(KLDivLossBatchMean, self).__init__()
-                self.loss = torch.nn.KLDivLoss(reduction='batchmean', log_target=False)
+                self.loss = torch.nn.KLDivLoss(reduction="batchmean", log_target=False)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6320,7 +6320,7 @@ class TestONNXRuntime(unittest.TestCase):
         class KLDivLossMiniBatchMean(torch.nn.Module):
             def __init__(self):
                 super(KLDivLossMiniBatchMean, self).__init__()
-                self.loss = torch.nn.KLDivLoss(reduction='batchmean', size_average=False, log_target=True)
+                self.loss = torch.nn.KLDivLoss(reduction="batchmean", size_average=False, log_target=True)
 
             def forward(self, input, target):
                 return self.loss(input, target)
@@ -6332,7 +6332,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='none')
+                self.loss = torch.nn.NLLLoss(reduction="none")
                 self.m = torch.nn.LogSoftmax(dim=1)
 
             def forward(self, input, target):
@@ -6352,7 +6352,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='none')
+                self.loss = torch.nn.NLLLoss(reduction="none")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6373,7 +6373,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='mean')
+                self.loss = torch.nn.NLLLoss(reduction="mean")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6394,7 +6394,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='sum')
+                self.loss = torch.nn.NLLLoss(reduction="sum")
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6415,7 +6415,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='mean', weight=torch.randn(C))
+                self.loss = torch.nn.NLLLoss(reduction="mean", weight=torch.randn(C))
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6436,7 +6436,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='mean', ignore_index=1)
+                self.loss = torch.nn.NLLLoss(reduction="mean", ignore_index=1)
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6454,7 +6454,7 @@ class TestONNXRuntime(unittest.TestCase):
         class NLLModel(torch.nn.Module):
             def __init__(self):
                 super(NLLModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='mean', weight=torch.randn(C), ignore_index=1)
+                self.loss = torch.nn.NLLLoss(reduction="mean", weight=torch.randn(C), ignore_index=1)
                 self.conv = torch.nn.Conv2d(16, C, (3, 3))
                 self.m = torch.nn.LogSoftmax(dim=1)
 
@@ -6492,55 +6492,55 @@ class TestONNXRuntime(unittest.TestCase):
     def _bce_logits(self, x, y):
         class BCEWithLogitsLossNone(torch.nn.Module):
             def forward(self, input, target):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction='none')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction="none")
 
         self.run_test(BCEWithLogitsLossNone(), input=(x, y))
 
         class BCEWithLogitsLossMean(torch.nn.Module):
             def forward(self, input, target):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction='mean')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction="mean")
 
         self.run_test(BCEWithLogitsLossMean(), input=(x, y))
 
         class BCEWithLogitsLossSum(torch.nn.Module):
             def forward(self, input, target):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction='sum')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, reduction="sum")
 
         self.run_test(BCEWithLogitsLossSum(), input=(x, y))
 
     def _bce_logits_wegiht(self, x, y, weight):
         class BCEWithLogitsLossWegihtNone(torch.nn.Module):
             def forward(self, input, target, weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction='none')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction="none")
         self.run_test(BCEWithLogitsLossWegihtNone(), input=(x, y, weight))
 
         class BCEWithLogitsLossWegihtMean(torch.nn.Module):
             def forward(self, input, target, weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction='mean')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction="mean")
 
         self.run_test(BCEWithLogitsLossWegihtMean(), input=(x, y, weight))
 
         class BCEWithLogitsLossWegihtSum(torch.nn.Module):
             def forward(self, input, target, weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction='sum')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight, reduction="sum")
 
         self.run_test(BCEWithLogitsLossWegihtSum(), input=(x, y, weight))
 
     def _bce_logits_posweight(self, x, y, pos_weight):
         class BCEWithLogitsLossPosWegihtNone(torch.nn.Module):
             def forward(self, input, target, pos_weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction='none')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction="none")
         self.run_test(BCEWithLogitsLossPosWegihtNone(), input=(x, y, pos_weight))
 
         class BCEWithLogitsLossPosWegihtMean(torch.nn.Module):
             def forward(self, input, target, pos_weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction='mean')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction="mean")
 
         self.run_test(BCEWithLogitsLossPosWegihtMean(), input=(x, y, pos_weight))
 
         class BCEWithLogitsLossPosWegihtSum(torch.nn.Module):
             def forward(self, input, target, pos_weight):
-                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction='sum')
+                return torch.nn.functional.binary_cross_entropy_with_logits(input, target, pos_weight=pos_weight, reduction="sum")
 
         self.run_test(BCEWithLogitsLossPosWegihtSum(), input=(x, y, pos_weight))
 
@@ -6548,21 +6548,21 @@ class TestONNXRuntime(unittest.TestCase):
         class BCEWithLogitsLossWeightPosweightNone(torch.nn.Module):
             def forward(self, input, target, weight, pos_weight):
                 return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight,
-                                                                            pos_weight=pos_weight, reduction='none')
+                                                                            pos_weight=pos_weight, reduction="none")
 
         self.run_test(BCEWithLogitsLossWeightPosweightNone(), input=(x, y, weight, pos_weight))
 
         class BCEWithLogitsLossWeightPosweightMean(torch.nn.Module):
             def forward(self, input, target, weight, pos_weight):
                 return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight,
-                                                                            pos_weight=pos_weight, reduction='mean')
+                                                                            pos_weight=pos_weight, reduction="mean")
 
         self.run_test(BCEWithLogitsLossWeightPosweightMean(), input=(x, y, weight, pos_weight))
 
         class BCEWithLogitsLossWeightPosweightSum(torch.nn.Module):
             def forward(self, input, target, weight, pos_weight):
                 return torch.nn.functional.binary_cross_entropy_with_logits(input, target, weight=weight,
-                                                                            pos_weight=pos_weight, reduction='sum')
+                                                                            pos_weight=pos_weight, reduction="sum")
 
         self.run_test(BCEWithLogitsLossWeightPosweightSum(), input=(x, y, weight, pos_weight))
 
@@ -6607,7 +6607,7 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x):
                 return x.isinf()
 
-        x = torch.tensor([[1, 2, float('inf')], [2, float('nan'), float('inf')]])
+        x = torch.tensor([[1, 2, float("inf")], [2, float("nan"), float("inf")]])
         self.run_test(M(), (x, ))
 
     @skipIfUnsupportedMinOpsetVersion(9)  # ONNX IsNaN op is added in opset 9.
@@ -6616,7 +6616,7 @@ class TestONNXRuntime(unittest.TestCase):
             def forward(self, x):
                 return x.isnan()
 
-        x = torch.tensor([[1, 2, float('inf')], [2, float('nan'), float('inf')]])
+        x = torch.tensor([[1, 2, float("inf")], [2, float("nan"), float("inf")]])
         self.run_test(M(), (x, ))
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -6900,8 +6900,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3)
         self.run_test(torch.jit.script(IfModel()), x,
-                      output_names=['output_1'],
-                      dynamic_axes={'output_1': [0, 1]})
+                      output_names=["output_1"],
+                      dynamic_axes={"output_1": [0, 1]})
 
     @skipIfONNXShapeInference(False)
     @skipIfUnsupportedMinOpsetVersion(13)
@@ -6935,8 +6935,8 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.randn(2, 16, 8)
         cond = torch.tensor(1, dtype=torch.bool)
         self.run_test(torch.jit.script(IfModel()), (x, y, cond),
-                      output_names=['output_1'],
-                      dynamic_axes={'output_1': [1]})
+                      output_names=["output_1"],
+                      dynamic_axes={"output_1": [1]})
 
     def test_onnx_proto_checker(self):
         class Model(torch.nn.Module):
@@ -7040,11 +7040,11 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (x,))
 
     def _dispatch_rnn_test(self, name, *args, **kwargs):
-        if name == 'elman':
+        if name == "elman":
             self._elman_rnn_test(*args, **kwargs)
-        if name == 'lstm':
+        if name == "lstm":
             self._lstm_test(*args, **kwargs)
-        if name == 'gru':
+        if name == "gru":
             self._gru_test(*args, **kwargs)
 
     def _elman_rnn_test(self, layers, nonlinearity, bidirectional,
@@ -7501,7 +7501,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class MyModule(torch.nn.Module):
             __annotations__ = {
-                'box_coder': BoxCoder,
+                "box_coder": BoxCoder,
             }
 
             def __init__(self):
@@ -7546,10 +7546,10 @@ class TestONNXRuntime(unittest.TestCase):
         actual_list = [p.name for p in loaded_model.graph.initializer]
         assert actual_list == state_dict_list, \
             "Initializers' sequence is not as same as state_dict(). Expected: (" \
-            + ', '.join(state_dict_list) + "). Actual:(" + ', '.join(actual_list) + ")."
+            + ", ".join(state_dict_list) + "). Actual:(" + ", ".join(actual_list) + ")."
         assert actual_list == named_params_list, \
             "Initializers' sequence is not as same as named_parameters(). Expected: (" \
-            + ', '.join(named_params_list) + "). Actual:(" + ', '.join(actual_list) + ")."
+            + ", ".join(named_params_list) + "). Actual:(" + ", ".join(actual_list) + ")."
 
     def test_initializer_sequence_script_model(self):
         def list_is_expected(short_list, long_list) -> bool:
@@ -7596,10 +7596,10 @@ class TestONNXRuntime(unittest.TestCase):
         actual_list = [p.name for p in loaded_model.graph.initializer]
         assert list_is_expected(state_dict_list, actual_list), \
             "ScriptModel - Initializers' sequence is not as same as state_dict(). Expected: (" \
-            + ', '.join(state_dict_list) + "). Actual:(" + ', '.join(actual_list) + ")."
+            + ", ".join(state_dict_list) + "). Actual:(" + ", ".join(actual_list) + ")."
         assert list_is_expected(named_params_list, actual_list), \
             "ScriptModel - Initializers' sequence is not as same as named_parameters(). Expected: (" \
-            + ', '.join(named_params_list) + "). Actual:(" + ', '.join(actual_list) + ")."
+            + ", ".join(named_params_list) + "). Actual:(" + ", ".join(actual_list) + ")."
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_nms(self):
@@ -7705,11 +7705,11 @@ class TestONNXRuntime(unittest.TestCase):
     def get_features(self, images):
         s0, s1 = images.shape[-2:]
         features = [
-            ('0', torch.rand(2, 256, s0 // 4, s1 // 4)),
-            ('1', torch.rand(2, 256, s0 // 8, s1 // 8)),
-            ('2', torch.rand(2, 256, s0 // 16, s1 // 16)),
-            ('3', torch.rand(2, 256, s0 // 32, s1 // 32)),
-            ('4', torch.rand(2, 256, s0 // 64, s1 // 64)),
+            ("0", torch.rand(2, 256, s0 // 4, s1 // 4)),
+            ("1", torch.rand(2, 256, s0 // 8, s1 // 8)),
+            ("2", torch.rand(2, 256, s0 // 16, s1 // 16)),
+            ("3", torch.rand(2, 256, s0 // 32, s1 // 32)),
+            ("4", torch.rand(2, 256, s0 // 64, s1 // 64)),
         ]
         features = OrderedDict(features)
         return features
@@ -7751,7 +7751,7 @@ class TestONNXRuntime(unittest.TestCase):
         class TransformModule(torch.nn.Module):
             def __init__(self):
                 super(TransformModule, self).__init__()
-                self.model = ops.MultiScaleRoIAlign(['feat1', 'feat2'], 3, 2)
+                self.model = ops.MultiScaleRoIAlign(["feat1", "feat2"], 3, 2)
                 self.image_sizes = [(512, 512)]
 
             def forward(self, input, boxes):
@@ -7759,14 +7759,14 @@ class TestONNXRuntime(unittest.TestCase):
                 return self.model(input, boxes, self.image_sizes)
 
         i = OrderedDict()
-        i['feat1'] = torch.rand(1, 5, 64, 64)
-        i['feat2'] = torch.rand(1, 5, 16, 16)
+        i["feat1"] = torch.rand(1, 5, 64, 64)
+        i["feat2"] = torch.rand(1, 5, 16, 16)
         boxes = torch.rand(6, 4) * 256
         boxes[:, 2:] += boxes[:, :2]
 
         i1 = OrderedDict()
-        i1['feat1'] = torch.rand(1, 5, 64, 64)
-        i1['feat2'] = torch.rand(1, 5, 16, 16)
+        i1["feat1"] = torch.rand(1, 5, 64, 64)
+        i1["feat2"] = torch.rand(1, 5, 16, 16)
         boxes1 = torch.rand(6, 4) * 256
         boxes1[:, 2:] += boxes1[:, :2]
 
@@ -8135,8 +8135,8 @@ class TestONNXRuntime(unittest.TestCase):
         empty_tensor = torch.tensor([], dtype=torch.float).view(0, 0, 0, 0, 0)
         random_state = torch.rand((1, 1, 10, 30, 30))
         self.run_test(model, (random_data, empty_tensor),
-                      input_names=['data', 'state'],
-                      dynamic_axes={'state': [0, 1, 2, 3, 4]},
+                      input_names=["data", "state"],
+                      dynamic_axes={"state": [0, 1, 2, 3, 4]},
                       test_with_inputs=[(random_data, random_state)])
 
     @skipIfUnsupportedMinOpsetVersion(11)
@@ -8411,7 +8411,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = ChunkModel()
         model.eval()
         x = torch.randn(1, 18)
-        self.run_test(model, x, input_names=['x'])
+        self.run_test(model, x, input_names=["x"])
 
     def test_symbolic_shape_inference(self):
         # ConstantOfShape is tested in test_embedding_bag
@@ -8419,7 +8419,7 @@ class TestONNXRuntime(unittest.TestCase):
         # test Shape, Reshape, Transpose, Gather
         class ShapeModel(torch.nn.Module):
             def forward(self, x, y):
-                shape = x.size()[:3] + (-1,)  # shape [4], ('batch', 3, 4, -1)
+                shape = x.size()[:3] + (-1,)  # shape [4], ("batch", 3, 4, -1)
                 y = y.reshape(shape)  # batch, 3, 4, 10/batch
                 return y.transpose(1, 2)
 
@@ -8475,8 +8475,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randint(5, (M, C, K, N))
         y = torch.randint(5, (M, C + 1, K + 1, N + 1))
         self.run_test(model, x)
-        self.run_test(model, x, input_names=['x'],
-                      dynamic_axes={'x' : [0, 1, 2, 3]}, test_with_inputs=[(x,), (y,)])
+        self.run_test(model, x, input_names=["x"],
+                      dynamic_axes={"x" : [0, 1, 2, 3]}, test_with_inputs=[(x,), (y,)])
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_symbolic_shape_inference_box(self):
@@ -8494,8 +8494,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(2, 4)
         y = torch.ones(3, 5)
         self.run_test(model, x)
-        self.run_test(model, x, input_names=['x'],
-                      dynamic_axes={'x' : [0, 1]}, test_with_inputs=[(x,), (y,)])
+        self.run_test(model, x, input_names=["x"],
+                      dynamic_axes={"x" : [0, 1]}, test_with_inputs=[(x,), (y,)])
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_symbolic_shape_inference_box_if(self):
@@ -8535,7 +8535,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_symbolic_shape_inference_nonzero(self):
         class OneLikeModel(torch.nn.Module):
             def forward(self, x):
-                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                ones = torch.ones_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
                 return torch.nonzero(ones)
 
         x = torch.randn(2)
@@ -8545,7 +8545,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         class ZeroLikeModel(torch.nn.Module):
             def forward(self, x):
-                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device('cpu'))
+                zeros = torch.zeros_like(x, dtype=torch.float, layout=torch.strided, device=torch.device("cpu"))
                 return torch.nonzero(zeros)
 
         x = torch.randn(2)
@@ -8602,14 +8602,14 @@ class TestONNXRuntime(unittest.TestCase):
         h0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
         c0 = torch.randn(1, BATCH_SIZE, RNN_HIDDEN_SIZE)
         model_lstm = torch.nn.LSTM(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False)
-        self.run_test(model_lstm, (input, (h0, c0)), input_names=['x', 'y'],
-                      dynamic_axes={'x' : [0, 1]})
+        self.run_test(model_lstm, (input, (h0, c0)), input_names=["x", "y"],
+                      dynamic_axes={"x" : [0, 1]})
         model_gru = torch.nn.GRU(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False, bias=False)
-        self.run_test(model_gru, (input, h0), input_names=['x', 'y'],
-                      dynamic_axes={'x' : [0, 1]})
+        self.run_test(model_gru, (input, h0), input_names=["x", "y"],
+                      dynamic_axes={"x" : [0, 1]})
         model_rnn = torch.nn.RNN(RNN_INPUT_SIZE, RNN_HIDDEN_SIZE, 1, bidirectional=False, bias=False)
-        self.run_test(model_rnn, (input, h0), input_names=['x', 'y'],
-                      dynamic_axes={'x' : [0, 1]})
+        self.run_test(model_rnn, (input, h0), input_names=["x", "y"],
+                      dynamic_axes={"x" : [0, 1]})
 
     def test_symbolic_shape_inference_dynamic_axes(self):
         class M(torch.nn.Module):
@@ -8618,8 +8618,8 @@ class TestONNXRuntime(unittest.TestCase):
                 input_ids = input_ids.view(-1, input_shape[-1])
                 return input_ids.transpose(0, 1)
         x = torch.randn(3, 16)
-        self.run_test(M(), (x,), input_names=['input_ids'],
-                      dynamic_axes={'input_ids': {0: 'batch', 1: 'sequence'}})
+        self.run_test(M(), (x,), input_names=["input_ids"],
+                      dynamic_axes={"input_ids": {0: "batch", 1: "sequence"}})
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_hann_window_periodic(self):
@@ -8715,8 +8715,8 @@ class TestONNXRuntime(unittest.TestCase):
         new_y = torch.randint(6, (2, 5, 3, 4))
 
         self.run_test(M(), (x, y), test_with_inputs=[(new_x, new_y)],
-                      input_names=['input_x', 'input_y'],
-                      dynamic_axes={'input_x': [0, 1, 2, 3], 'input_y': [0, 1, 2, 3]})
+                      input_names=["input_x", "input_y"],
+                      dynamic_axes={"input_x": [0, 1, 2, 3], "input_y": [0, 1, 2, 3]})
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_to_device(self):
@@ -8859,13 +8859,13 @@ class TestONNXRuntime(unittest.TestCase):
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):
-    test_name = str('_'.join([
-        'test', name, layer[1],
+    test_name = str("_".join([
+        "test", name, layer[1],
         bidirectional[1], initial_state[1],
         variable_length[1], dropout[1]
     ]))
 
-    # Cannot export with older opsets because of 'ConstantFill' op
+    # Cannot export with older opsets because of "ConstantFill" op
     # ConstantFill was a temp op removed at opset 8. This is no longer supported by onnxruntime
     # There are still some issues prevent us from enabling script test for these scenarios:
     # test_gru_*:
@@ -8891,25 +8891,25 @@ def make_test(name, base, layer, bidirectional, initial_state,
 
 def setup_rnn_tests():
     layers_opts = [
-        (1, 'unilayer'),
-        (3, 'trilayer')
+        (1, "unilayer"),
+        (3, "trilayer")
     ]
     bidirectional_opts = [
-        (False, 'forward'),
-        (True, 'bidirectional')
+        (False, "forward"),
+        (True, "bidirectional")
     ]
     initial_state_opts = [
-        (True, 'with_initial_state'),
-        (False, 'no_initial_state')
+        (True, "with_initial_state"),
+        (False, "no_initial_state")
     ]
     variable_length_opts = [
-        (0, 'without_sequence_lengths'),
-        (1, 'with_variable_length_sequences'),
-        (2, 'with_batch_first_sequence_lengths')
+        (0, "without_sequence_lengths"),
+        (1, "with_variable_length_sequences"),
+        (2, "with_batch_first_sequence_lengths")
     ]
     dropout_opts = [
-        (0.2, 'with_dropout'),
-        (0.0, 'without_dropout')
+        (0.2, "with_dropout"),
+        (0.0, "without_dropout")
     ]
     test_count = 0
     for (layer, bidirectional, initial_state, variable_length, dropout) in \
@@ -8921,10 +8921,10 @@ def setup_rnn_tests():
                 dropout_opts,):
 
         for base, name, extra_kwargs in (
-                ('elman', 'elman_relu', {'nonlinearity': u'relu'}),
-                ('elman', 'elman_tanh', {'nonlinearity': u'tanh'}),
-                ('lstm', 'lstm', {}),
-                ('gru', 'gru', {})
+                ("elman", "elman_relu", {"nonlinearity": u"relu"}),
+                ("elman", "elman_tanh", {"nonlinearity": u"tanh"}),
+                ("lstm", "lstm", {}),
+                ("gru", "gru", {})
         ):
             # Need Add between list of tensors
             script_test_min_opset_version = 11
@@ -8950,7 +8950,7 @@ def setup_rnn_tests():
     # make sure no one accidentally disables all the tests without
     # noticing
     if test_count != 192:
-        raise ValueError('Expected 192 tests but found {}'.format(test_count))
+        raise ValueError("Expected 192 tests but found {}".format(test_count))
 
 setup_rnn_tests()
 
@@ -9018,5 +9018,5 @@ TestONNXRuntime_opset13 = type(str("TestONNXRuntime_opset13"),
                                     keep_initializers_as_inputs=False,
                                     onnx_shape_inference=True))
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime_cuda.py
@@ -22,7 +22,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
             def forward(self, x):
                 return torch.nn.functional.gelu(x)
 
-        x = torch.randn(2, 4, 5, 6, requires_grad=True, dtype=torch.float16, device=torch.device('cuda'))
+        x = torch.randn(2, 4, 5, 6, requires_grad=True, dtype=torch.float16, device=torch.device("cuda"))
         self.run_test(GeluModel(), x, rtol=1e-3, atol=1e-5)
 
     @skipIfUnsupportedMinOpsetVersion(9)
@@ -36,7 +36,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
             def forward(self, x):
                 return self.layer_norm(x)
 
-        x = torch.randn(20, 5, 10, 10, requires_grad=True, dtype=torch.float16, device=torch.device('cuda'))
+        x = torch.randn(20, 5, 10, 10, requires_grad=True, dtype=torch.float16, device=torch.device("cuda"))
         self.run_test(LayerNormModel(), x, rtol=1e-3, atol=1e-5)
 
 
@@ -46,7 +46,7 @@ class TestONNXRuntime_cuda(unittest.TestCase):
         class FusionModel(torch.nn.Module):
             def __init__(self):
                 super(FusionModel, self).__init__()
-                self.loss = torch.nn.NLLLoss(reduction='none')
+                self.loss = torch.nn.NLLLoss(reduction="none")
                 self.m = torch.nn.LogSoftmax(dim=1)
 
             @autocast()
@@ -55,8 +55,8 @@ class TestONNXRuntime_cuda(unittest.TestCase):
                 return output
 
         N, C = 5, 4
-        input = torch.randn(N, 16, dtype=torch.float16, device=torch.device('cuda'))
-        target = torch.empty(N, dtype=torch.long, device=torch.device('cuda')).random_(0, C)
+        input = torch.randn(N, 16, dtype=torch.float16, device=torch.device("cuda"))
+        target = torch.empty(N, dtype=torch.long, device=torch.device("cuda")).random_(0, C)
 
         # using test data containing default ignore_index=-100
         target[target == 1] = -100
@@ -65,5 +65,5 @@ class TestONNXRuntime_cuda(unittest.TestCase):
 TestONNXRuntime_cuda.setUp = TestONNXRuntime.setUp
 TestONNXRuntime_cuda.run_test = TestONNXRuntime.run_test
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(TestONNXRuntime_cuda())

--- a/test/onnx/test_pytorch_onnx_shape_inference.py
+++ b/test/onnx/test_pytorch_onnx_shape_inference.py
@@ -38,7 +38,7 @@ class TestONNXShapeInference(unittest.TestCase):
         g = self.create_empty_graph()
         input = g.addInput()
         cast_out = g.op("Cast", input, to_i=1)
-        self.run_test(g, cast_out.node(), expect_tensor('Float'))
+        self.run_test(g, cast_out.node(), expect_tensor("Float"))
 
     def test_constant_of_shape(self):
         # Test ConstantOfShape with input of onnx::Shape node.
@@ -46,7 +46,7 @@ class TestONNXShapeInference(unittest.TestCase):
         constant = self.insert_tensor_constant(g, torch.ones(1, 2, 3, 4))
         shape = g.op("Shape", constant)
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(1, 2, 3, 4)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor("Float", shape=(1, 2, 3, 4)))
 
     def test_constant_of_shape_static(self):
         # Test ConstantOfShape with input of prim::ListConstruct of static tensor
@@ -56,7 +56,7 @@ class TestONNXShapeInference(unittest.TestCase):
         shape = g.op("prim::ListConstruct", *constants)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(1, 2, 3, 4)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor("Float", shape=(1, 2, 3, 4)))
 
     def test_constant_of_shape_dynamic(self):
         # Test ConstantOfShape with input of prim::ListConstruct of dynamic tensor
@@ -66,26 +66,26 @@ class TestONNXShapeInference(unittest.TestCase):
         shape = g.op("prim::ListConstruct", *inputs)
         shape.setType(torch._C.ListType.ofInts())
         constant_of_shape = g.op("ConstantOfShape", shape, value_t=torch.tensor([2.0]))
-        self.run_test(g, constant_of_shape.node(), expect_tensor('Float', shape=(None, None, None, None)))
+        self.run_test(g, constant_of_shape.node(), expect_tensor("Float", shape=(None, None, None, None)))
 
     def test_reshape(self):
         g = self.create_empty_graph()
         constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 5))
         constant_2 = self.insert_tensor_constant(g, torch.tensor([2, 0, -1]))
         shape = g.op("Reshape", constant, constant_2)
-        self.run_test(g, shape.node(), expect_tensor('Float', shape=(2, 16, 25)))
+        self.run_test(g, shape.node(), expect_tensor("Float", shape=(2, 16, 25)))
 
         g = self.create_empty_graph()
         constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 4))
         constant_2 = self.insert_tensor_constant(g, torch.tensor([-1, 0, 4]))
         shape = g.op("Reshape", constant, constant_2)
-        self.run_test(g, shape.node(), expect_tensor('Float', shape=(10, 16, 4)))
+        self.run_test(g, shape.node(), expect_tensor("Float", shape=(10, 16, 4)))
 
         g = self.create_empty_graph()
         constant = self.insert_tensor_constant(g, torch.ones(2, 16, 5, 4))
         constant_2 = self.insert_tensor_constant(g, torch.tensor([-1, 0, 0]))
         shape = g.op("Reshape", constant, constant_2)
-        self.run_test(g, shape.node(), expect_tensor('Float', shape=(8, 16, 5)))
+        self.run_test(g, shape.node(), expect_tensor("Float", shape=(8, 16, 5)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -62,9 +62,9 @@ class TestUtilityFuns(TestCase):
         import warnings
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            utils._validate_dynamic_axes({'input1': {}, 'output': {},
-                                         'invalid_name1': {}, 'invalid_name2': {}},
-                                         None, ['input1', 'input2'], ['output'])
+            utils._validate_dynamic_axes({"input1": {}, "output": {},
+                                         "invalid_name1": {}, "invalid_name2": {}},
+                                         None, ["input1", "input2"], ["output"])
             messages = [str(warning.message) for warning in w]
         assert "Provided key invalid_name1 for dynamic axes is not a valid input/output name" in messages
         assert "Provided key invalid_name2 for dynamic axes is not a valid input/output name" in messages
@@ -361,7 +361,7 @@ class TestUtilityFuns(TestCase):
         if self.opset_version <= 12:
             assert len(list(graph.nodes())) == 3
         else:
-            # Unsqueeze op parameter 'axes' as an input instead of as an attribute when opset version >= 13
+            # Unsqueeze op parameter "axes" as an input instead of as an attribute when opset version >= 13
             assert len(list(graph.nodes())) == 4
 
     def test_constant_fold_transpose_matmul(self):
@@ -554,9 +554,9 @@ class TestUtilityFuns(TestCase):
         x = torch.randn(1, 2, 3, 4)
         f = io.BytesIO()
         with self.assertRaisesRegex(ValueError,
-                                    'torch.nn.DataParallel is not supported by ONNX '
-                                    'exporter, please use \'attribute\' module to '
-                                    'unwrap model from torch.nn.DataParallel. Try '):
+                                    "torch.nn.DataParallel is not supported by ONNX "
+                                    "exporter, please use 'attribute' module to "
+                                    "unwrap model from torch.nn.DataParallel. Try "):
             torch.onnx.export(model, x, f, opset_version=self.opset_version)
 
     def test_export_mode(self):
@@ -602,7 +602,7 @@ class TestUtilityFuns(TestCase):
         assert next(iter).kind() == "prim::Constant"
         assert next(iter).kind() == "aten::cumsum"
         assert len(unsupported_ops) == 1
-        assert unsupported_ops == ['aten::cumsum']
+        assert unsupported_ops == ["aten::cumsum"]
 
     def test_aten_fallthrough(self):
         # Test aten export of op with no symbolic
@@ -722,7 +722,7 @@ class TestUtilityFuns(TestCase):
         class CustomFunction(torch.autograd.Function):
             @staticmethod
             def symbolic(g, input):
-                return g.op('CustomNamespace::Custom', input, outputs=2)
+                return g.op("CustomNamespace::Custom", input, outputs=2)
 
             @staticmethod
             def forward(ctx, input):
@@ -890,5 +890,5 @@ TestUtilityFuns_opset13_new_jit_API = type(str("TestUtilityFuns_opset13_new_jit_
                                            dict(TestUtilityFuns.__dict__, opset_version=13))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_verify.py
+++ b/test/onnx/test_verify.py
@@ -103,5 +103,5 @@ class TestVerify(TestCase):
         self.assertVerifyExpectFail(MyModel(), x, backend, test_args=[(y,)])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run_tests()

--- a/test/onnx/verify.py
+++ b/test/onnx/verify.py
@@ -53,17 +53,17 @@ class Errors(object):
         Test that x and y are nearly equal (equal within self.rtol
         precision), but continue execution even if they are not equal.
 
-        To prevent error cascades, you should remember to call 'failIfErrs'
+        To prevent error cascades, you should remember to call "failIfErrs"
         at some later point in time.
         """
         self.almostEqualAndThen(x, y, msg, self.addErr)
 
     def almostEqualAndThen(self, x, y, msg, k):
         """
-        Helper for implementing 'requireAlmostEqual' and 'checkAlmostEqual'.
-        Upon failure, invokes continuation 'k' with the error message.
+        Helper for implementing "requireAlmostEqual" and "checkAlmostEqual".
+        Upon failure, invokes continuation "k" with the error message.
 
-        At the moment, only tests on 'numpy.ndarray' are supported.
+        At the moment, only tests on "numpy.ndarray" are supported.
         """
         if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
             try:
@@ -85,7 +85,7 @@ class Errors(object):
         """
         Test that x and y are equal, but continue execution even if they are not equal.
 
-        To prevent error cascades, you should remember to call 'failIfErrs'
+        To prevent error cascades, you should remember to call "failIfErrs"
         at some later point in time.
         """
         self.equalAndThen(x, y, msg, self.addErr)
@@ -93,8 +93,8 @@ class Errors(object):
     # Bit-for-bit accuracy test
     def equalAndThen(self, x, y, msg, k):
         """
-        Helper for implementing 'requireEqual' and 'checkEqual'.  Upon failure,
-        invokes continuation 'k' with the error message.
+        Helper for implementing "requireEqual" and "checkEqual".  Upon failure,
+        invokes continuation "k" with the error message.
         """
         if isinstance(x, onnx.TensorProto) and isinstance(y, onnx.TensorProto):
             self.equalAndThen(x.name, y.name, msg, k)
@@ -114,7 +114,7 @@ class Errors(object):
                 # TODO: Better algorithm for lists
                 sx = str(x)
                 sy = str(y)
-                if len(sx) > 40 or len(sy) > 40 or '\n' in sx or '\n' in sy:
+                if len(sx) > 40 or len(sy) > 40 or "\n" in sx or "\n" in sy:
                     # long form
                     l = "=" * 50
                     k("\n{}The value\n{}\n{}\n{}\n\ndoes not equal\n\n{}\n{}\n{}"
@@ -131,8 +131,8 @@ class Errors(object):
 
     def multiLineEqualAndThen(self, x, y, msg, k):
         """
-        Helper for implementing 'requireMultiLineEqual'.  Upon failure,
-        invokes continuation 'k' with the error message.
+        Helper for implementing "requireMultiLineEqual".  Upon failure,
+        invokes continuation "k" with the error message.
         """
         if msg is None:
             msg = "Strings are not equal"
@@ -155,7 +155,7 @@ class Errors(object):
         """
         Immediately fail and short-circuit to the next recovery context.
 
-        NB: It is an error to 'fail' without having added any errors to
+        NB: It is an error to "fail" without having added any errors to
         the error context.
         """
         raise self.exc_class()
@@ -220,7 +220,7 @@ class Errors(object):
     def __exit__(self, exc_type, exc_value, traceback):
         if self.errors:
             errors_msg = "\n\n".join("ERROR: " + x for x in self.errors)
-            final_msg = "{}\n{}\n{}".format(self.msg, '-' * 70, errors_msg)
+            final_msg = "{}\n{}\n{}".format(self.msg, "-" * 70, errors_msg)
             raise AssertionError(final_msg)
         if exc_type == self.exc_class:
             raise RuntimeError("ShortCircuit was raised, but no errors were recorded")
@@ -378,7 +378,7 @@ def verify(model, args, backend, verbose=False, training=torch.onnx.TrainingMode
                     msg += "\n(To get more information, run torch.onnx.verify(..., verbose=True))"
                 with Errors(msg, rtol=rtol, atol=atol) as errs:
                     # First, check if we have the same number of parameters, and
-                    # that they're the same order.  If they don't, something has *really* gone wrong.
+                    # that they"re the same order.  If they don"t, something has *really* gone wrong.
                     initializer_order_hint = ("This is really strange! The second time I exported your model,\n"
                                               "it had a different set of parameters.  Are you assigning Parameters\n"
                                               "in the forward() of your model definition?")

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -62,8 +62,8 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
                 "args = (x,
                         {
-                        'y': input_y,
-                        'z': input_z
+                        "y": input_y,
+                        "z": input_z
                         })"
 
             The inputs to the model are structured as a tuple consisting of
@@ -87,7 +87,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
                 In the previous iteration, the call to export API would look like
 
-                    torch.onnx.export(model, (k, x), 'test.onnx')
+                    torch.onnx.export(model, (k, x), "test.onnx")
 
                 This would work as intended. However, the export function
                 would now assume that the `x` input is intended to represent the optional
@@ -95,7 +95,7 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
                 an issue a constraint is placed to provide an empty dictionary as the last
                 input in the tuple args in such cases. The new call would look like this.
 
-                    torch.onnx.export(model, (k, x, {}), 'test.onnx')
+                    torch.onnx.export(model, (k, x, {}), "test.onnx")
 
         f: a file-like object (has to implement fileno that returns a file descriptor)
             or a string containing a file name.  A binary Protobuf will be written
@@ -205,34 +205,34 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
             .. code-block:: none
 
-                shape(input_1) = ('b', 3, 'w', 'h')
-                and shape(input_2) = ('b', 4)
-                and shape(output)  = ('b', 'd', 5)
+                shape(input_1) = ("b", 3, "w", "h")
+                and shape(input_2) = ("b", 4)
+                and shape(output)  = ("b", "d", 5)
 
             Then `dynamic axes` can be defined either as:
 
             1. ONLY INDICES::
 
-                ``dynamic_axes = {'input_1':[0, 2, 3],
-                                  'input_2':[0],
-                                  'output':[0, 1]}``
+                ``dynamic_axes = {"input_1":[0, 2, 3],
+                                  "input_2":[0],
+                                  "output":[0, 1]}``
                 where automatic names will be generated for exported dynamic axes
 
             2. INDICES WITH CORRESPONDING NAMES::
 
-                ``dynamic_axes = {'input_1':{0:'batch',
-                                             1:'width',
-                                             2:'height'},
-                                  'input_2':{0:'batch'},
-                                  'output':{0:'batch',
-                                            1:'detections'}}``
+                ``dynamic_axes = {"input_1":{0:"batch",
+                                             1:"width",
+                                             2:"height"},
+                                  "input_2":{0:"batch"},
+                                  "output":{0:"batch",
+                                            1:"detections"}}``
                 where provided names will be applied to exported dynamic axes
 
             3. MIXED MODE OF (1) and (2)::
 
-                ``dynamic_axes = {'input_1':[0, 2, 3],
-                                  'input_2':{0:'batch'},
-                                  'output':[0,1]}``
+                ``dynamic_axes = {"input_1":[0, 2, 3],
+                                  "input_2":{0:"batch"},
+                                  "output":[0,1]}``
 
         keep_initializers_as_inputs (bool, default None): If True, all the
             initializers (typically corresponding to parameters) in the
@@ -264,9 +264,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
             in external binary files and not in the ONNX model file itself. See link for format
             details:
             https://github.com/onnx/onnx/blob/8b3f7e2e7a0f2aba0e629e23d89f07c7fc0e6a5e/onnx/onnx.proto#L423
-            Also, in this case,  argument 'f' must be a string specifying the location of the model.
+            Also, in this case,  argument "f" must be a string specifying the location of the model.
             The external binary files will be stored in the same location specified by the model
-            location 'f'. If False, then the model is stored in regular format, i.e. model and
+            location "f". If False, then the model is stored in regular format, i.e. model and
             parameters are all in one file. This argument is ignored for all export types other
             than ONNX.
     """
@@ -297,8 +297,8 @@ def _optimize_trace(graph, operator_export_type):
 
 def select_model_mode_for_export(model, mode):
     r"""
-    A context manager to temporarily set the training mode of 'model'
-    to 'mode', resetting it when we exit the with-block.  A no-op if
+    A context manager to temporarily set the training mode of "model"
+    to "mode", resetting it when we exit the with-block.  A no-op if
     mode is None.
 
     In version 1.6 changed to this from set_training

--- a/torch/onnx/symbolic_caffe2.py
+++ b/torch/onnx/symbolic_caffe2.py
@@ -6,18 +6,18 @@ from inspect import getmembers, isfunction
 
 def register_quantized_ops(domain, version):
     # Register all the non-quantized ops
-    sym_registry.register_version('', version)
+    sym_registry.register_version("", version)
     # Register all quantized ops
-    module = importlib.import_module('torch.onnx.symbolic_caffe2')
-    sym_registry._symbolic_versions['caffe2'] = module
-    quant_version_ops = getmembers(sym_registry._symbolic_versions['caffe2'])
+    module = importlib.import_module("torch.onnx.symbolic_caffe2")
+    sym_registry._symbolic_versions["caffe2"] = module
+    quant_version_ops = getmembers(sym_registry._symbolic_versions["caffe2"])
     for op in quant_version_ops:
         if isfunction(op[1]) and not sym_registry.is_registered_op(op[0], domain, version):
-            aten_q_ops = ['relu', '_empty_affine_quantized', 'dequantize',
-                          'quantize_per_tensor', 'upsample_nearest2d', 'avg_pool2d',
-                          'reshape', 'slice', 'cat', 'max_pool2d', 'sigmoid']
+            aten_q_ops = ["relu", "_empty_affine_quantized", "dequantize",
+                          "quantize_per_tensor", "upsample_nearest2d", "avg_pool2d",
+                          "reshape", "slice", "cat", "max_pool2d", "sigmoid"]
             if op[0] in aten_q_ops:
-                sym_registry.register_op(op[0], op[1], '', version)
+                sym_registry.register_op(op[0], op[1], "", version)
             sym_registry.register_op(op[0], op[1], domain, version)
 
 def _permute_helper(g, input, axes):
@@ -46,7 +46,7 @@ def linear_prepack(g, weight, bias):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'v', 'v', 'f', 'i')
+@parse_args("v", "v", "v", "f", "i")
 def linear(g, input, weight, bias, scale, zero_point):
     kwargs = {
         "Y_scale_f": scale,
@@ -64,7 +64,7 @@ def conv_prepack(g, input, weight, bias, stride, padding, dilation, groups):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'f', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "f", "i")
 def conv2d(g, input, weight, bias, stride, padding, dilation, groups, scale, zero_point):
     kernel_size = weight.node()["shape"][1:3]
     kwargs = {
@@ -81,7 +81,7 @@ def conv2d(g, input, weight, bias, stride, padding, dilation, groups, scale, zer
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'f', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "f", "i")
 def conv2d_relu(g, input, weight, bias, stride, padding, dilation, groups, scale, zero_point):
     kernel_size = weight.node()["shape"][1:3]
     kwargs = {
@@ -98,7 +98,7 @@ def conv2d_relu(g, input, weight, bias, stride, padding, dilation, groups, scale
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'v', 'f', 'i')
+@parse_args("v", "v", "f", "i")
 def add(g, input_a, input_b, scale, zero_point):
     kwargs = {
         "Y_scale_f": scale,
@@ -108,7 +108,7 @@ def add(g, input_a, input_b, scale, zero_point):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v')
+@parse_args("v")
 def relu(g, input):
     if input not in sym_help._quantized_ops:
         from torch.onnx.symbolic_opset9 import relu
@@ -121,7 +121,7 @@ def relu(g, input):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'f', 'i', 't')
+@parse_args("v", "f", "i", "t")
 def quantize_per_tensor(g, input, scale, zero_point, dtype):
     kwargs = {
         "Y_scale_f": scale,
@@ -131,11 +131,11 @@ def quantize_per_tensor(g, input, scale, zero_point, dtype):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v')
+@parse_args("v")
 def dequantize(g, input):
     return g.op("_caffe2::Int8Dequantize", input)
 
-@parse_args('v', 't', 't', 't', 't', 't', 't', 't')
+@parse_args("v", "t", "t", "t", "t", "t", "t", "t")
 def _empty_affine_quantized(g, input, shape, scale, zero_point, dtype, pin_memory, memory_format, layout):
     return input
 
@@ -144,7 +144,7 @@ def upsample_nearest2d(g, input, output_size, align_corners=None, scales_h=None,
         from torch.onnx.symbolic_opset9 import upsample_nearest2d as upsample_nearest2d_impl
         return upsample_nearest2d_impl(g, input, output_size, align_corners)
 
-    output_size = sym_help._parse_arg(output_size, 'is')
+    output_size = sym_help._parse_arg(output_size, "is")
     kwargs = {
         "output_size_i": output_size,
         "Y_scale_f": input.node()["Y_scale"],
@@ -155,7 +155,7 @@ def upsample_nearest2d(g, input, output_size, align_corners=None, scales_h=None,
     output = nhwc2nchw(g, output)
     sym_help._quantized_ops.add(output)
     return output
-@parse_args('v', 'is', 'is', 'is', 'is', 'i')
+@parse_args("v", "is", "is", "is", "is", "i")
 def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     if input not in sym_help._quantized_ops:
         from torch.onnx.symbolic_opset9 import max_pool2d
@@ -174,7 +174,7 @@ def max_pool2d(g, input, kernel_size, stride, padding, dilation, ceil_mode):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
+@parse_args("v", "is", "is", "is", "i", "i", "none")
 def avg_pool2d(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
     if input not in sym_help._quantized_ops:
         from torch.onnx.symbolic_opset9 import avg_pool2d
@@ -206,7 +206,7 @@ def reshape(g, input, shape):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v', 'v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "v", "i")
 def slice(g, input, dim, start, end, step):
     if input not in sym_help._quantized_ops:
         from torch.onnx.symbolic_opset9 import slice
@@ -214,9 +214,9 @@ def slice(g, input, dim, start, end, step):
 
     if step != 1:
         raise RuntimeError("ONNX quantized slice export only works for step 1.")
-    start = sym_help._parse_arg(start, 'i')
-    end = sym_help._parse_arg(end, 'i')
-    dim = sym_help._parse_arg(dim, 'i')
+    start = sym_help._parse_arg(start, "i")
+    end = sym_help._parse_arg(end, "i")
+    dim = sym_help._parse_arg(dim, "i")
 
     kwargs = {
         "start_idx_i": start,
@@ -236,7 +236,7 @@ def cat(g, tensor_list, dim, scale=None, zero_point=None):
         from torch.onnx.symbolic_opset9 import cat
         return cat(g, tensor_list, dim)
 
-    dim = sym_help._parse_arg(dim, 'i')
+    dim = sym_help._parse_arg(dim, "i")
     kwargs = {
         "Y_scale_f": tensors[0].node()["Y_scale"],
         "Y_zero_point_i": tensors[0].node()["Y_zero_point"],
@@ -245,7 +245,7 @@ def cat(g, tensor_list, dim, scale=None, zero_point=None):
     sym_help._quantized_ops.add(output)
     return output
 
-@parse_args('v')
+@parse_args("v")
 def sigmoid(g, input):
     if input not in sym_help._quantized_ops:
         from torch.onnx.symbolic_opset9 import sigmoid

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -26,7 +26,7 @@ from torch._C import OptionalType
 #   dispatch is done with keyword arguments.
 # - Looking for inplace ops?  They're detected by the trailing underscore, and
 #   transparently dispatched to their non inplace versions in
-#   'run_symbolic_function'.   See Note [Export inplace]
+#   "run_symbolic_function".   See Note [Export inplace]
 #
 # ----------------------------------------------------------------------------------
 # A note on Tensor types
@@ -52,38 +52,38 @@ _sum = sum
 
 
 def _parse_arg(value, desc, arg_name=None, node_name=None):
-    if desc == 'none':
+    if desc == "none":
         return value
-    if desc == 'v' or not _is_value(value):
+    if desc == "v" or not _is_value(value):
         return value
     if value.node().mustBeNone():
         return None
-    if value.node().kind() == 'onnx::Constant':
-        tval = value.node()['value']
-        if desc == 'i':
+    if value.node().kind() == "onnx::Constant":
+        tval = value.node()["value"]
+        if desc == "i":
             return int(tval)
-        elif desc == 'f':
+        elif desc == "f":
             return float(tval)
-        elif desc == 'b':
+        elif desc == "b":
             return bool(tval)
-        elif desc == 's':
+        elif desc == "s":
             return str(tval)
-        elif desc == 't':
+        elif desc == "t":
             return tval
-        elif desc == 'is':
+        elif desc == "is":
             return [int(v) for v in tval]
-        elif desc == 'fs':
+        elif desc == "fs":
             return [float(v) for v in tval]
         else:
             raise RuntimeError("ONNX symbolic doesn't know to interpret Constant node")
-    elif value.node().kind() == 'prim::ListConstruct':
-        if desc == 'is':
+    elif value.node().kind() == "prim::ListConstruct":
+        if desc == "is":
             for v in value.node().inputs():
-                if v.node().kind() != 'onnx::Constant':
+                if v.node().kind() != "onnx::Constant":
                     raise RuntimeError("Failed to export an ONNX attribute '" + v.node().kind() +
                                        "', since it's not constant, please try to make "
                                        "things (e.g., kernel size) static if possible")
-            return [int(v.node()['value']) for v in value.node().inputs()]
+            return [int(v.node()["value"]) for v in value.node().inputs()]
         else:
             raise RuntimeError("ONNX symbolic doesn't know to interpret ListConstruct node")
 
@@ -95,13 +95,13 @@ def _parse_arg(value, desc, arg_name=None, node_name=None):
 
 
 def _maybe_get_const(value, desc):
-    if _is_value(value) and value.node().kind() == 'onnx::Constant':
+    if _is_value(value) and value.node().kind() == "onnx::Constant":
         return _parse_arg(value, desc)
     return value
 
 
 def _maybe_get_scalar(value):
-    value_t = _maybe_get_const(value, 't')
+    value_t = _maybe_get_const(value, "t")
     if isinstance(value_t, torch.Tensor) and value_t.shape == ():
         return value_t
     return value
@@ -168,7 +168,7 @@ def parse_args(*arg_descriptors):
             # only support _outputs in kwargs
             assert len(kwargs) <= 1
             if len(kwargs) == 1:
-                assert '_outputs' in kwargs
+                assert "_outputs" in kwargs
             return fn(g, *args, **kwargs)
 
         return wrapper
@@ -225,10 +225,10 @@ def _get_tensor_sizes(x, allow_nonstatic=True):
         return None
     if allow_nonstatic:
         # Each individual symbol is returned as None.
-        # e.g. [1, 'a', 'b'] -> [1, None, None]
+        # e.g. [1, "a", "b"] -> [1, None, None]
         return x.type().varyingSizes()
     # returns None, if exists any symbol in sizes.
-    # e.g. [1, 'a', 'b'] -> None
+    # e.g. [1, "a", "b"] -> None
     return x.type().sizes()
 
 def _get_tensor_dim_size(x, dim):
@@ -244,17 +244,17 @@ def _unimplemented(op, msg):
 
 
 def _onnx_unsupported(op_name):
-    raise RuntimeError('Unsupported: ONNX export of operator {}. '
-                       'Please feel free to request support or submit a pull request on PyTorch GitHub.'.format(op_name))
+    raise RuntimeError("Unsupported: ONNX export of operator {}. "
+                       "Please feel free to request support or submit a pull request on PyTorch GitHub.".format(op_name))
 
 
 def _onnx_opset_unsupported(op_name, current_opset, supported_opset):
-    raise RuntimeError('Unsupported: ONNX export of {} in '
-                       'opset {}. Please try opset version {}.'.format(op_name, current_opset, supported_opset))
+    raise RuntimeError("Unsupported: ONNX export of {} in "
+                       "opset {}. Please try opset version {}.".format(op_name, current_opset, supported_opset))
 
 def _onnx_opset_unsupported_detailed(op_name, current_opset, supported_opset, reason):
-    raise RuntimeError('Unsupported: ONNX export of {} in '
-                       'opset {}. {}. Please try opset version {}.'.format(op_name, current_opset, reason, supported_opset))
+    raise RuntimeError("Unsupported: ONNX export of {} in "
+                       "opset {}. {}. Please try opset version {}.".format(op_name, current_opset, reason, supported_opset))
 
 
 def _block_list_in_opset(name):
@@ -286,7 +286,7 @@ def _select_helper(g, self, dim, index, apply_reshape=True):
             index = g.op("Reshape", index, g.op("Constant", value_t=torch.LongTensor([1])))
 
     index_scalar_type = index.type().scalarType()
-    if index_scalar_type is None or index_scalar_type not in ['Long', 'Int']:
+    if index_scalar_type is None or index_scalar_type not in ["Long", "Int"]:
         index = g.op("Cast", index, to_i=cast_pytorch_to_onnx["Long"])
     return g.op("Gather", self, index, axis_i=dim)
 
@@ -311,12 +311,12 @@ def _is_fp(value):
     if value:
         if isinstance(value, torch.Tensor):
             type = value.dtype
-            return (type == 'torch.float32') or (type == 'torch.float64') or (type == 'torch.float16')
+            return (type == "torch.float32") or (type == "torch.float64") or (type == "torch.float16")
         else:
             type = value.type().scalarType()
             if type is None:
                 warnings.warn("Type cannot be inferred, which might cause exported graph to produce incorrect results.")
-            return (type == 'Float') or (type == 'Double') or (type == 'Half')
+            return (type == "Float") or (type == "Double") or (type == "Half")
     return False
 
 def _dtype_is_fp(type_value):
@@ -377,7 +377,7 @@ def _interpolate_warning(interpolate_mode):
                   "ONNX's Upsample/Resize operator did not match Pytorch's Interpolation until opset 11. "
                   "Attributes to determine how to transform the input were added in onnx:Resize in opset 11 "
                   "to support Pytorch's behavior (like coordinate_transformation_mode and nearest_mode).\n"
-                  "We recommend using opset 11 and above for models using this operator. ")
+                  "We recommend using opset 11 and above for models using this operator.")
 
 def _unsqueeze_helper(g, input, axes_i):
     if _export_onnx_opset_version >= 13:
@@ -394,7 +394,7 @@ def _squeeze_helper(g, input, axes_i):
         return g.op("Squeeze", input, axes_i=axes_i)
 
 def _reducesum_helper(g, input, axes_i=None, keepdims_i=1, noop_with_empty_axes_i=0):
-    keepdims_i = _maybe_get_const(keepdims_i, 'i')
+    keepdims_i = _maybe_get_const(keepdims_i, "i")
     if _export_onnx_opset_version >= 13:
         if axes_i:
             if not _is_value(axes_i):
@@ -405,7 +405,7 @@ def _reducesum_helper(g, input, axes_i=None, keepdims_i=1, noop_with_empty_axes_
         return g.op("ReduceSum", input, axes_i=axes_i, keepdims_i=keepdims_i)
 
 def _interpolate_size_to_scales(g, input, output_size, dim):
-    output_size = _maybe_get_const(output_size, 'is')
+    output_size = _maybe_get_const(output_size, "is")
     if _is_value(output_size):
         offset = 2
         offsets = g.op("Constant", value_t=torch.ones(offset, dtype=torch.float32))
@@ -423,19 +423,19 @@ def _interpolate_size_to_scales(g, input, output_size, dim):
 
 
 def _interpolate_get_scales_if_available(g, scales):
-    available_scales = _maybe_get_const(scales[0], 'fs') != -1 and not _is_none(scales[0])
+    available_scales = _maybe_get_const(scales[0], "fs") != -1 and not _is_none(scales[0])
 
     if not available_scales:
         return None
 
     offsets = g.op("Constant", value_t=torch.ones(2, dtype=torch.float32))
-    scales_list = g.op("Constant", value_t=torch.tensor(_maybe_get_const(scales[0], 'fs')))
+    scales_list = g.op("Constant", value_t=torch.tensor(_maybe_get_const(scales[0], "fs")))
     scales = g.op("Concat", offsets, scales_list, axis_i=0)
     return scales
 
 
 def _get_interpolate_attributes(g, mode, args):
-    if mode == 'nearest':
+    if mode == "nearest":
         align_corners = None
         scales = args[0:]
     else:
@@ -458,14 +458,14 @@ def _interpolate_get_scales(g, scale_factor, dim):
 
 
 def _interpolate_get_scales_and_mode(g, input, size, scale_factor, mode , align_corners):
-    mode = _maybe_get_const(mode, 's')
-    if 'linear' in mode:
-        mode = 'linear'
-    if 'cubic' in mode:
-        mode = 'cubic'
+    mode = _maybe_get_const(mode, "s")
+    if "linear" in mode:
+        mode = "linear"
+    if "cubic" in mode:
+        mode = "cubic"
     _interpolate_warning(mode)
 
-    align_corners = _maybe_get_const(align_corners, 'b')
+    align_corners = _maybe_get_const(align_corners, "b")
     if isinstance(align_corners, bool) and align_corners:
         return _unimplemented("interpolate", "align_corners == True")
 
@@ -477,7 +477,7 @@ def _interpolate_get_scales_and_mode(g, input, size, scale_factor, mode , align_
         scale_factor = _interpolate_get_scales(g, scale_factor, dim)
     elif not _is_none(size):
         if not _is_packed_list(size):
-            is_scalar = ((_maybe_get_const(size, 't').dim() == 0))
+            is_scalar = ((_maybe_get_const(size, "t").dim() == 0))
             if is_scalar:
                 size = _unsqueeze_helper(g, size, [0])
                 size = [size for i in range(dim - 2)]
@@ -498,7 +498,7 @@ def _interpolate_helper(name, dim, interpolate_mode):
         if scales is None:
             input_size = g.op("Shape", input)
             input_size_beg = _slice_helper(g, input_size, axes=[0], ends=[2], starts=[0])
-            output_size = g.op("Cast", output_size, to_i=cast_pytorch_to_onnx['Long'])
+            output_size = g.op("Cast", output_size, to_i=cast_pytorch_to_onnx["Long"])
             output_size = g.op("Concat", input_size_beg, output_size, axis_i=0)
 
             if _export_onnx_opset_version >= 13:
@@ -535,12 +535,12 @@ def _interpolate_helper(name, dim, interpolate_mode):
 
 
 def __interpolate_helper(g, input, size, scale_factor, mode, align_corners, recompute_scale_factor):
-    mode = _maybe_get_const(mode, 's')
-    if 'linear' in mode:
-        mode = 'linear'
-    if 'cubic' in mode:
-        mode = 'cubic'
-    align_corners = _maybe_get_const(align_corners, 'b')
+    mode = _maybe_get_const(mode, "s")
+    if "linear" in mode:
+        mode = "linear"
+    if "cubic" in mode:
+        mode = "cubic"
+    align_corners = _maybe_get_const(align_corners, "b")
     align_corners = False if not isinstance(align_corners, bool) else align_corners
     coordinate_transformation_mode = "asymmetric" if mode == "nearest" \
         else "align_corners" if align_corners else "pytorch_half_pixel"
@@ -549,11 +549,11 @@ def __interpolate_helper(g, input, size, scale_factor, mode, align_corners, reco
         input_size = g.op("Shape", input)
         input_size = _slice_helper(g, input_size, axes=[0], ends=[2], starts=[0])
         # in some cases size is not a packed list but size is a scalar
-        # We need to also verify that (_maybe_get_const(size, 't').dim() == 0)
+        # We need to also verify that (_maybe_get_const(size, "t").dim() == 0)
         # but this information is not always available. Try to get the dim,
         # and if not assume that it is not a scalar.
         try:
-            is_scalar = not _is_packed_list(size) and ((_maybe_get_const(size, 't').dim() == 0))
+            is_scalar = not _is_packed_list(size) and ((_maybe_get_const(size, "t").dim() == 0))
         except AttributeError:
             is_scalar = not _is_packed_list(size)
             if not is_scalar:
@@ -568,7 +568,7 @@ def __interpolate_helper(g, input, size, scale_factor, mode, align_corners, reco
             size = _unsqueeze_helper(g, size, [0])
             size = [size for i in range(rank - 2)]
             size = g.op("Concat", *size, axis_i=0)
-        size = g.op("Cast", size, to_i=cast_pytorch_to_onnx['Long'])
+        size = g.op("Cast", size, to_i=cast_pytorch_to_onnx["Long"])
         size = g.op("Concat", input_size, size, axis_i=0)
 
         if _export_onnx_opset_version >= 13:
@@ -638,13 +638,13 @@ def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
     def _is_all_integral(scalars):
         for scalar in scalars:
             try:
-                if scalar.type().scalarType() != 'Long':
+                if scalar.type().scalarType() != "Long":
                     return False
             except Exception:
                 pass
         return True
 
-    # This logic is based on torch.arange docs. If 'dtype' is provided,
+    # This logic is based on torch.arange docs. If "dtype" is provided,
     # infer input types from dtype. If not, then check if any of start, stop,
     # or step are floating point, and infer the type from get_default.
     # Otherwise, the dtype is inferred to be torch.int64.
@@ -684,7 +684,7 @@ def _index_fill_reshape_helper(g, self, dim, index):
     if self.type().dim() is None:
         return _unimplemented("index_fill", "input rank not accesible")
     self_dim = self.type().dim()
-    dim_value = _parse_arg(dim, 'i')
+    dim_value = _parse_arg(dim, "i")
     unsqueezed_index = _unsqueeze_helper(g, index, [i for i in range(self_dim) if i != dim_value])
     expanded_index_shape = scatter(g, g.op("Shape", self), 0,
                                    _unsqueeze_helper(g, dim, [0]), g.op("Shape", index))
@@ -693,7 +693,7 @@ def _index_fill_reshape_helper(g, self, dim, index):
 
 
 def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, name):
-    if divisor_override and divisor_override.node().kind() != 'prim::Constant':
+    if divisor_override and divisor_override.node().kind() != "prim::Constant":
         return _unimplemented(name, "divisor_override")
     if not stride:
         stride = kernel_size
@@ -729,7 +729,7 @@ def _flatten_helper(g, input, start_dim, end_dim, dim):
 def _is_split_static(split_size_or_sizes, _outputs):
     if _outputs is None:
         return False
-    if _is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() != 'onnx::Constant':
+    if _is_value(split_size_or_sizes) and split_size_or_sizes.node().kind() != "onnx::Constant":
         return False
     return True
 
@@ -800,37 +800,37 @@ def _set_onnx_shape_inference(onnx_shape_inference):
 
 # Metaprogram symbolics for each ATen native specialized cast operator.
 # For e.g. we specify a function named `_cast_uint8_t` that instantiates an
-# ONNX cast node with `to` attribute 'UINT8'
+# ONNX cast node with `to` attribute "UINT8"
 #
 # TODO: remove these once we support Type's in the JIT IR and we can once again
 # use the unified toType operator
 cast_pytorch_to_onnx = {
-    'Byte': torch.onnx.TensorProtoDataType.UINT8,
-    'Char': torch.onnx.TensorProtoDataType.INT8,
-    'Double': torch.onnx.TensorProtoDataType.DOUBLE,
-    'Float': torch.onnx.TensorProtoDataType.FLOAT,
-    'Half': torch.onnx.TensorProtoDataType.FLOAT16,
-    'Int': torch.onnx.TensorProtoDataType.INT32,
-    'Long': torch.onnx.TensorProtoDataType.INT64,
-    'Short': torch.onnx.TensorProtoDataType.INT16,
-    'Bool': torch.onnx.TensorProtoDataType.BOOL,
-    'ComplexFloat': torch.onnx.TensorProtoDataType.COMPLEX64,
-    'ComplexDouble': torch.onnx.TensorProtoDataType.COMPLEX128,
-    'Undefined': torch.onnx.TensorProtoDataType.UNDEFINED,
+    "Byte": torch.onnx.TensorProtoDataType.UINT8,
+    "Char": torch.onnx.TensorProtoDataType.INT8,
+    "Double": torch.onnx.TensorProtoDataType.DOUBLE,
+    "Float": torch.onnx.TensorProtoDataType.FLOAT,
+    "Half": torch.onnx.TensorProtoDataType.FLOAT16,
+    "Int": torch.onnx.TensorProtoDataType.INT32,
+    "Long": torch.onnx.TensorProtoDataType.INT64,
+    "Short": torch.onnx.TensorProtoDataType.INT16,
+    "Bool": torch.onnx.TensorProtoDataType.BOOL,
+    "ComplexFloat": torch.onnx.TensorProtoDataType.COMPLEX64,
+    "ComplexDouble": torch.onnx.TensorProtoDataType.COMPLEX128,
+    "Undefined": torch.onnx.TensorProtoDataType.UNDEFINED,
 }
 
 scalar_name_to_pytorch = {
-    'uint8_t': 'Byte',
-    'int8_t': 'Char',
-    'double': 'Double',
-    'float': 'Float',
-    'half': 'Half',
-    'int': 'Int',
-    'int64_t': 'Long',
-    'int16_t': 'Short',
-    'bool': 'Bool',
-    'complex64': 'ComplexFloat',
-    'complex128': 'ComplexDouble'
+    "uint8_t": "Byte",
+    "int8_t": "Char",
+    "double": "Double",
+    "float": "Float",
+    "half": "Half",
+    "int": "Int",
+    "int64_t": "Long",
+    "int16_t": "Short",
+    "bool": "Bool",
+    "complex64": "ComplexFloat",
+    "complex128": "ComplexDouble"
 }
 
 

--- a/torch/onnx/symbolic_opset10.py
+++ b/torch/onnx/symbolic_opset10.py
@@ -27,9 +27,9 @@ def div(g, self, other, *args):
         return _div_rounding_mode(g, self, other, *args)
 
 
-@parse_args('v', 'v', 's')
+@parse_args("v", "v", "s")
 def _div_rounding_mode(g, self, other, rounding_mode):
-    if rounding_mode == 'floor':
+    if rounding_mode == "floor":
         return _floor_divide(g, self, other)
     else:
         return torch.onnx.symbolic_opset9._div_rounding_mode(g, self, other, rounding_mode)
@@ -38,49 +38,49 @@ def _div_rounding_mode(g, self, other, rounding_mode):
 def _floor_divide(g, self, other):
     if sym_help._is_fp(self) or sym_help._is_fp(other):
         out = torch.onnx.symbolic_opset9.true_divide(g, self, other)
-        return g.op('Floor', out)
+        return g.op("Floor", out)
     else:
         # Integer division does trunction rounding
-        div = g.op('Div', self, other)
+        div = g.op("Div", self, other)
         # Division is negative if: self < 0 != other < 0
-        zero = g.op('Constant', value_t=torch.tensor(0, dtype=torch.int64))
-        negative = g.op('Xor',
-                        g.op('Less', self, zero),
-                        g.op('Less', other, zero))
+        zero = g.op("Constant", value_t=torch.tensor(0, dtype=torch.int64))
+        negative = g.op("Xor",
+                        g.op("Less", self, zero),
+                        g.op("Less", other, zero))
 
         # For negative numbers with self % other != 0, subtract 1 to round down instead of up
-        mod = g.op('Mod', self, other, fmod_i=0)
-        fixup_mask = g.op('And', negative,
-                          g.op('Not', g.op('Equal', mod, zero)))
+        mod = g.op("Mod", self, other, fmod_i=0)
+        fixup_mask = g.op("And", negative,
+                          g.op("Not", g.op("Equal", mod, zero)))
 
-        one = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
-        fixup = g.op('Sub', div, one)
-        return g.op('Where', fixup_mask, fixup, div)
+        one = g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))
+        fixup = g.op("Sub", div, one)
+        return g.op("Where", fixup_mask, fixup, div)
 
 
-@parse_args('v', 'i', 'i', 'none')
+@parse_args("v", "i", "i", "none")
 def sort(g, self, dim, decending, out=None):
     return sym_help._sort_helper(g, self, dim, decending=decending, out=out)
 
 
-@parse_args('v', 'v', 'i', 'i', 'i', 'none')
+@parse_args("v", "v", "i", "i", "i", "none")
 def topk(g, self, k, dim, largest, sorted, out=None):
     return sym_help._topk_helper(g, self, k, dim, largest=largest, sorted=sorted, out=out)
 
 
 def _max_pool(name, tuple_fn, ndims, return_indices):
-    @parse_args('v', 'is', 'is', 'is', 'is', 'i')
+    @parse_args("v", "is", "is", "is", "is", "i")
     def symbolic_fn(g, input, kernel_size, stride, padding, dilation, ceil_mode):
         if not stride:
             stride = kernel_size
         kwargs = {
-            'kernel_shape_i': tuple_fn(kernel_size),
-            'pads_i': tuple_fn(padding) * 2,
-            'strides_i': tuple_fn(stride),
-            'ceil_mode_i': ceil_mode,
+            "kernel_shape_i": tuple_fn(kernel_size),
+            "pads_i": tuple_fn(padding) * 2,
+            "strides_i": tuple_fn(stride),
+            "ceil_mode_i": ceil_mode,
         }
         if set(tuple_fn(dilation)) != {1}:
-            kwargs['dilations_i'] = tuple_fn(dilation)
+            kwargs["dilations_i"] = tuple_fn(dilation)
         # easy but hacky way to get flattened indices values
         # to be used to convert the indices values to non-flattened.
         # In ONNX the indices are computed as a flatten 1-D tensor,
@@ -121,7 +121,7 @@ max_pool3d_with_indices = _max_pool("max_pool3d_with_indices", _triple, 3, retur
 
 
 def _avg_pool(name, tuple_fn):
-    @parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
+    @parse_args("v", "is", "is", "is", "i", "i", "none")
     def symbolic_fn(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
         if not stride:
             stride = kernel_size
@@ -129,7 +129,7 @@ def _avg_pool(name, tuple_fn):
         if count_include_pad:
             input = g.op("Pad", input,
                          pads_i=((0,) * 2 + padding) * 2,
-                         mode_s='constant',
+                         mode_s="constant",
                          value_f=0.)
             padding = (0,) * len(padding)
         output = g.op("AveragePool", input,
@@ -141,9 +141,9 @@ def _avg_pool(name, tuple_fn):
     return symbolic_fn
 
 
-avg_pool1d = _avg_pool('avg_pool1d', _single)
-avg_pool2d = _avg_pool('avg_pool2d', _pair)
-avg_pool3d = _avg_pool('avg_pool3d', _triple)
+avg_pool1d = _avg_pool("avg_pool1d", _single)
+avg_pool2d = _avg_pool("avg_pool2d", _pair)
+avg_pool3d = _avg_pool("avg_pool3d", _triple)
 
 
 def _interpolate(name, dim, interpolate_mode):
@@ -159,12 +159,12 @@ def _interpolate(name, dim, interpolate_mode):
     return symbolic_fn
 
 
-upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
-upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
-upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
-upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
-upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
-upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
+upsample_nearest1d = _interpolate("upsample_nearest1d", 3, "nearest")
+upsample_nearest2d = _interpolate("upsample_nearest2d", 4, "nearest")
+upsample_nearest3d = _interpolate("upsample_nearest3d", 5, "nearest")
+upsample_linear1d = _interpolate("upsample_linear1d", 3, "linear")
+upsample_bilinear2d = _interpolate("upsample_bilinear2d", 4, "linear")
+upsample_trilinear3d = _interpolate("upsample_trilinear3d", 5, "linear")
 
 def __interpolate(g, input, size, scale_factor, mode , align_corners, recompute_scale_factor):
     scales, mode = sym_help._interpolate_get_scales_and_mode(g, input, size, scale_factor,
@@ -205,28 +205,28 @@ def slice(g, self, *args):
         dim = 0
     else:
         raise NotImplementedError("Unknown aten::slice signature")
-    is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == 'NoneType'
-    is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == 'NoneType'
-    is_start_onnx_const = start.node().kind() == 'onnx::Constant'
-    is_end_onnx_const = end.node().kind() == 'onnx::Constant'
+    is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == "NoneType"
+    is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == "NoneType"
+    is_start_onnx_const = start.node().kind() == "onnx::Constant"
+    is_end_onnx_const = end.node().kind() == "onnx::Constant"
     step = sym_help._parse_arg(step, 'i')
     if (not is_start_none and not is_start_onnx_const) or \
        (not isinstance(end, int) and not is_end_none and not is_end_onnx_const) or \
-       (not isinstance(dim, int) and dim.node().kind() != 'onnx::Constant'):
+       (not isinstance(dim, int) and dim.node().kind() != "onnx::Constant"):
         dynamic_slice = True
         if is_start_none:
             start = g.op("Constant", value_t=torch.tensor(0))
         if is_end_none:
             end = g.op("Constant", value_t=torch.tensor(9223372036854775807))
     else:
-        start = [0 if is_start_none else sym_help._parse_arg(start, 'i')]
-        end = [9223372036854775807 if is_end_none else sym_help._parse_arg(end, 'i')]
-        dim = [sym_help._parse_arg(dim, 'i')]
+        start = [0 if is_start_none else sym_help._parse_arg(start, "i")]
+        end = [9223372036854775807 if is_end_none else sym_help._parse_arg(end, "i")]
+        dim = [sym_help._parse_arg(dim, "i")]
         dynamic_slice = False
     return sym_help._slice_helper(g, self, axes=dim, starts=start, ends=end, steps=[step], dynamic_slice=dynamic_slice)
 
 
-@parse_args('v', 'is')
+@parse_args("v", "is")
 def flip(g, input, dims):
     return sym_help._slice_helper(g, input, axes=dims,
                                   starts=[-1] * len(dims),
@@ -238,7 +238,7 @@ def fmod(g, input, other):
     return g.op("Mod", input, other, fmod_i=1)
 
 
-@parse_args('v', 'v', 'v', 'i', 'i', 'i', 'v', 'i', 'i')
+@parse_args("v", "v", "v", "i", "i", "i", "v", "i", "i")
 def embedding_bag(g,
                   embedding_matrix,
                   indices,
@@ -250,9 +250,9 @@ def embedding_bag(g,
                   include_last_offset,
                   padding_idx):
     if scale_grad_by_freq and sym_help._training_mode:
-        return sym_help._onnx_unsupported('embedding_bag with scale_grad_by_freq for training mode')
+        return sym_help._onnx_unsupported("embedding_bag with scale_grad_by_freq for training mode")
     if padding_idx is not None and padding_idx >= 0:
-        raise RuntimeError('embedding_bag with padding_idx')
+        raise RuntimeError("embedding_bag with padding_idx")
     from torch.onnx.symbolic_opset9 import select
     import warnings
     warnings.warn("Export of embedding_bag with dynamic input/offsets shape is not supported in opset 10. "
@@ -293,11 +293,11 @@ def embedding_bag(g,
         # But the last three outputs are not used in torch.nn.EmbeddingBag or torch.nn.functional.embedding_bag.
         return output, None, None, None
     else:
-        return sym_help._onnx_unsupported('embedding_bag with unknown shape of offsets for opset 10 is not supported. '
-                                          'please use opset 11 or higher.')
+        return sym_help._onnx_unsupported("embedding_bag with unknown shape of offsets for opset 10 is not supported. "
+                                          "please use opset 11 or higher.")
 
 
-@parse_args('v', 't', 'i', 'i', 'i')
+@parse_args("v", "t", "i", "i", "i")
 def fake_quantize_per_tensor_affine(g, inputs, scale, zero_point, quant_min=-128, quant_max=127):
     if quant_min not in [0, -128] or quant_max not in [127, 255]:
         raise RuntimeError(

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -17,7 +17,7 @@ from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_blo
 # This file exports ONNX ops for opset 11
 
 
-@parse_args('v', 'f', 'f')
+@parse_args("v", "f", "f")
 def hardtanh(g, self, min_val, max_val):
     dtype = self.type().scalarType()
     if dtype is None:
@@ -76,7 +76,7 @@ def clamp_max(g, self, max):
 
 
 # Opset 11 gather accepts negative indices
-@parse_args('v', 'i', 'v')
+@parse_args("v", "i", "v")
 def select(g, self, dim, index):
     return g.op("Gather", self, index, axis_i=dim)
 
@@ -88,10 +88,10 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         indices_list = [indices_list_value]
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         args = [self] + indices_list + [values, accumulate]
-        return g.op("ATen", *args, operator_s='index_put')
+        return g.op("ATen", *args, operator_s="index_put")
 
     from torch.onnx.symbolic_opset9 import add, expand
-    accumulate = sym_help._parse_arg(accumulate, 'b')
+    accumulate = sym_help._parse_arg(accumulate, "b")
 
     if len(indices_list) == 0:
         return values
@@ -150,7 +150,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
         #   return (%33)
         index = indices_list[0]
         bool_inp = index
-        if bool_inp.type() is not None and bool_inp.type().scalarType() == 'Bool':
+        if bool_inp.type() is not None and bool_inp.type().scalarType() == "Bool":
             rank = sym_help._get_tensor_rank(values)
             if rank is not None and rank == 0:
                 from torch.onnx.symbolic_opset9 import masked_fill
@@ -183,7 +183,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
     return result
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def pixel_shuffle(g, self, upscale_factor):
     rank = sym_help._get_tensor_rank(self)
     if rank is not None and rank != 4:
@@ -195,28 +195,28 @@ def _interpolate(name, dim, interpolate_mode):
     return sym_help._interpolate_helper(name, dim, interpolate_mode)
 
 
-upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
-upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
-upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
-upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
-upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
-upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
-upsample_bicubic2d = _interpolate('upsample_bicubic2d', 4, "cubic")
+upsample_nearest1d = _interpolate("upsample_nearest1d", 3, "nearest")
+upsample_nearest2d = _interpolate("upsample_nearest2d", 4, "nearest")
+upsample_nearest3d = _interpolate("upsample_nearest3d", 5, "nearest")
+upsample_linear1d = _interpolate("upsample_linear1d", 3, "linear")
+upsample_bilinear2d = _interpolate("upsample_bilinear2d", 4, "linear")
+upsample_trilinear3d = _interpolate("upsample_trilinear3d", 5, "linear")
+upsample_bicubic2d = _interpolate("upsample_bicubic2d", 4, "cubic")
 
 
 def __interpolate(g, input, size, scale_factor, mode, align_corners, recompute_scale_factor):
     return sym_help.__interpolate_helper(g, input, size, scale_factor, mode, align_corners, recompute_scale_factor)
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def gather(g, self, dim, index, sparse_grad=False):
-    if sym_help._maybe_get_const(sparse_grad, 'i'):
+    if sym_help._maybe_get_const(sparse_grad, "i"):
         return _unimplemented("gather", "sparse_grad == True")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", self, dim, index, sparse_grad, operator_s="gather")
     return g.op("GatherElements", self, index, axis_i=dim)
 
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def scatter(g, self, dim, index, src):
     from torch.onnx.symbolic_opset9 import expand_as
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
@@ -226,18 +226,18 @@ def scatter(g, self, dim, index, src):
     if sym_help._is_value(src):
         return g.op("ScatterElements", self, index, src, axis_i=dim)
     else:
-        # Check if scalar 'src' has same type as self (PyTorch allows different
+        # Check if scalar "src" has same type as self (PyTorch allows different
         # type for scalar src (but not when src is tensor)). If not, insert Cast node.
         if self.type().scalarType() != src_type:
             src = g.op("Cast", src, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
         return g.op("ScatterElements", self, index, expand_as(g, src, index), axis_i=dim)
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def cumsum(g, self, dim, dtype=None):
     dim_tensor = g.op("Constant", value_t=torch.tensor(dim, dtype=torch.int))
-    if dtype and dtype.node().kind() != 'prim::Constant':
-        parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    if dtype and dtype.node().kind() != "prim::Constant":
+        parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
         cast = g.op("Cast", self, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
     else:
         cast = self
@@ -248,7 +248,7 @@ def cumsum(g, self, dim, dtype=None):
 def masked_select(g, self, mask):
     from torch.onnx.symbolic_opset9 import nonzero, expand_as
     index = nonzero(g, expand_as(g, mask, self))
-    return g.op('GatherND', self, index)
+    return g.op("GatherND", self, index)
 
 
 def masked_scatter(g, self, mask, source):
@@ -263,7 +263,7 @@ def masked_scatter(g, self, mask, source):
                                     starts=torch.LongTensor([0]),
                                     ends=size(g, index, torch.LongTensor([0])),
                                     dynamic_slice=True)
-    return g.op('ScatterND', self, index, source)
+    return g.op("ScatterND", self, index, source)
 
 
 def _len(g, self):
@@ -317,7 +317,7 @@ def cat(g, tensor_list, dim):
         from torch.onnx.symbolic_opset9 import cat as cat_opset9
         return cat_opset9(g, tensor_list, dim)
     else:
-        dim = sym_help._get_const(dim, 'i', 'dim')
+        dim = sym_help._get_const(dim, "i", "dim")
         return g.op("ConcatFromSequence", tensor_list, axis_i=dim)
 
 
@@ -326,25 +326,25 @@ def stack(g, tensor_list, dim):
         from torch.onnx.symbolic_opset9 import stack as stack_opset9
         return stack_opset9(g, tensor_list, dim)
     else:
-        dim = sym_help._get_const(dim, 'i', 'dim')
+        dim = sym_help._get_const(dim, "i", "dim")
         return g.op("ConcatFromSequence", tensor_list, axis_i=dim, new_axis_i=1)
 
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def _unique2(g, self, sorted, return_inverse, return_counts):
     u, indices, inverse_indices, counts = g.op("Unique", self, sorted_i=sorted, outputs=4)
     return u, inverse_indices, counts
 
 
 def _avg_pool(name, tuple_fn):
-    @parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
+    @parse_args("v", "is", "is", "is", "i", "i", "none")
     def symbolic_fn(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
         padding = sym_help._avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, name)
         if not stride:
             stride = kernel_size
         if count_include_pad:
             input = g.op("Pad", input,
-                         g.op("Constant", value_t=torch.tensor(((0,) * 2 + padding) * 2)), mode_s='constant')
+                         g.op("Constant", value_t=torch.tensor(((0,) * 2 + padding) * 2)), mode_s="constant")
             padding = (0,) * len(padding)
         output = g.op("AveragePool", input,
                       kernel_shape_i=tuple_fn(kernel_size),
@@ -355,23 +355,23 @@ def _avg_pool(name, tuple_fn):
     return symbolic_fn
 
 
-avg_pool1d = _avg_pool('avg_pool1d', _single)
-avg_pool2d = _avg_pool('avg_pool2d', _pair)
-avg_pool3d = _avg_pool('avg_pool3d', _triple)
+avg_pool1d = _avg_pool("avg_pool1d", _single)
+avg_pool2d = _avg_pool("avg_pool2d", _pair)
+avg_pool3d = _avg_pool("avg_pool3d", _triple)
 
 
-@parse_args('v', 'i', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i", "i")
 def unique_dim(g, self, dim, sorted, return_inverse, return_counts):
     u, indices, inverse_indices, counts = g.op("Unique", self, axis_i=dim, sorted_i=sorted, outputs=4)
     return u, inverse_indices, counts
 
 
-@parse_args('v', 'v', 'i', 'i', 'i', 'none')
+@parse_args("v", "v", "i", "i", "i", "none")
 def topk(g, self, k, dim, largest, sorted, out=None):
     return sym_help._topk_helper(g, self, k, dim, largest=largest, sorted=sorted, out=out)
 
 
-@parse_args('v', 'i', 'i', 'none')
+@parse_args("v", "i", "i", "none")
 def sort(g, self, dim, decending, out=None):
     return sym_help._sort_helper(g, self, dim, decending=decending, out=out)
 
@@ -380,7 +380,7 @@ def round(g, self):
     return g.op("Round", self)
 
 
-@parse_args('v', 'v', 'i', 'i')
+@parse_args("v", "v", "i", "i")
 def split(g, self, split_size_or_sizes, dim, _outputs=None):
     if not sym_help._is_split_static(split_size_or_sizes, _outputs):
         split_out = g.op("SplitToSequence", self, split_size_or_sizes, axis_i=dim)
@@ -403,12 +403,12 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         return torch.onnx.symbolic_opset9.split(g, self, split_size_or_sizes, dim, _outputs)
 
 
-@parse_args('v', 'v', 'i', 'i')
+@parse_args("v", "v", "i", "i")
 def split_with_sizes(g, self, split_sizes, dim, _outputs=None):
     return split(g, self, split_sizes, dim, _outputs)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def unbind(g, self, dim=0, _outputs=None):
     if _outputs is None:
         return g.op("SplitToSequence", self, g.op("Constant", value_t=torch.tensor(1, dtype=torch.long)), axis_i=dim, keepdims_i=0)
@@ -433,7 +433,7 @@ def _prepare_onnx_paddings(g, dim, pad):
                      g.op("Constant", value_t=torch.tensor(2, dtype=torch.int64))), pad_len)
     # Concat pad with extension: paddings = [dim_n_begin, dim_n_end, dim_n-1_begin, dim_n-1_end, 0, 0, ... ]
     # Currently ONNX only supports int64 type for Pad
-    pad = g.op("Cast", pad, to_i=sym_help.cast_pytorch_to_onnx['Long'])
+    pad = g.op("Cast", pad, to_i=sym_help.cast_pytorch_to_onnx["Long"])
     paddings = g.op("Concat", pad, g.op("ConstantOfShape", extension, value_t=torch.tensor([0], dtype=torch.int64)), axis_i=0)
     # Reshape and reverse order and collate first beginnings and then ends
     # paddings = [[..., 0, dim_n-1_begin, dim_n_begin],
@@ -442,7 +442,7 @@ def _prepare_onnx_paddings(g, dim, pad):
     paddings = g.op("Reshape", paddings, g.op("Constant", value_t=torch.tensor([-1, 2])))
     paddings = g.op("Transpose", torch.onnx.symbolic_opset10.flip(g, paddings, [0]), perm_i=[1, 0])
     paddings = g.op("Reshape", paddings, g.op("Constant", value_t=torch.tensor([-1])))
-    padding_c = g.op("Cast", paddings, to_i=sym_help.cast_pytorch_to_onnx['Long'])
+    padding_c = g.op("Cast", paddings, to_i=sym_help.cast_pytorch_to_onnx["Long"])
     return padding_c
 
 
@@ -485,7 +485,7 @@ def logdet(g, input):
 
 def arange(g, *args):
     def _get_arange_dtype(dtype):
-        dtype = sym_help._maybe_get_const(dtype, 'i')
+        dtype = sym_help._maybe_get_const(dtype, "i")
         return dtype
 
     if len(args) == 2 or len(args) == 5:
@@ -519,9 +519,9 @@ def arange(g, *args):
     return arange_tensor
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def _dim_arange(g, like, dim):
-    like_shape = g.op('Shape', like)
+    like_shape = g.op("Shape", like)
     stop = g.op("Gather", like_shape, g.op("Constant", value_t=torch.tensor(dim)), axis_i=0)
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("_caffe2::Range", stop)
@@ -538,7 +538,7 @@ def squeeze(g, self, dim=None):
     if dim is None:
         return g.op("Squeeze", self)
 
-    dim = sym_help._get_const(dim, 'i', 'dim')
+    dim = sym_help._get_const(dim, "i", "dim")
 
     input_rank = sym_help._get_tensor_rank(self)
     adjusted_dim = dim
@@ -548,12 +548,12 @@ def squeeze(g, self, dim=None):
     if (dim < 0 and input_rank is None) or dim_size is None:
         # If onnx shape inference is not on, export always as dynamic.
         # Because we cannot tell if observed static shape is also static at runtime.
-        # create 'cond' node (condition is shape[i]==1)
+        # create "cond" node (condition is shape[i]==1)
         dim_constant = g.op("Constant", value_t=torch.tensor([dim]))
         size = sym_help._size_helper(g, self, dim_constant)
         const_one = g.op("Constant", value_t=torch.ones(1, dtype=torch.int64))
         cond = g.op("Equal", size, const_one)
-        # create the 'If' node and add the 'then' and 'else' blocks to it.
+        # create the "If" node and add the "then" and "else" blocks to it.
         if_node_outputs = g.op("If", cond)
         if_node = if_node_outputs.node()
         if_block = torch.onnx.utils._add_block(if_node)
@@ -575,7 +575,7 @@ def squeeze(g, self, dim=None):
     return sym_help._squeeze_helper(g, self, [dim])
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def unsqueeze(g, self, dim):
     return sym_help._unsqueeze_helper(g, self, [dim])
 
@@ -598,13 +598,13 @@ def index(g, self, index):
         if not sym_help._is_none(index) and (index.type().scalarType() == "Bool" or index.type().scalarType() == "Byte"):
             from torch.onnx.symbolic_opset9 import nonzero
             index = nonzero(g, index)
-            return g.op('GatherND', self, index)
+            return g.op("GatherND", self, index)
     from torch.onnx.symbolic_opset9 import index as index_opset9
     return index_opset9(g, self, index)
 
 
 def index_fill(g, self, dim, index, value):
-    dim_value = sym_help._parse_arg(dim, 'i')
+    dim_value = sym_help._parse_arg(dim, "i")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", self, index, value, dim_i=dim_value, operator_s="index_fill")
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -615,7 +615,7 @@ def index_fill(g, self, dim, index, value):
 
 
 def index_copy(g, self, dim, index, source):
-    dim_value = sym_help._parse_arg(dim, 'i')
+    dim_value = sym_help._parse_arg(dim, "i")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", self, index, source, dim_i=dim_value, operator_s="index_copy")
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -628,16 +628,16 @@ def __rshift_(g, self, other):
     if other.type().scalarType() != self.type().scalarType():
         other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
 
-    if self.type().scalarType() == 'Byte':
-        return g.op('BitShift', self, other, direction_s="RIGHT")
+    if self.type().scalarType() == "Byte":
+        return g.op("BitShift", self, other, direction_s="RIGHT")
 
-    two = g.op('Constant', value_t=torch.tensor(2, dtype=torch.float32))
+    two = g.op("Constant", value_t=torch.tensor(2, dtype=torch.float32))
     # exponent (same type as self) has to be float or double in onnx::Pow
     if not sym_help._is_fp(self):
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    two_pow = g.op('Pow', two, other)
-    two_pow = g.op('Cast', two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
-    rshift = g.op('Div', self, two_pow)
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+    two_pow = g.op("Pow", two, other)
+    two_pow = g.op("Cast", two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+    rshift = g.op("Div", self, two_pow)
     return rshift
 
 
@@ -647,16 +647,16 @@ def __lshift_(g, self, other):
     if other.type().scalarType() != self.type().scalarType():
         other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
 
-    if self.type().scalarType() == 'Byte':
-        return g.op('BitShift', self, other, direction_s="LEFT")
+    if self.type().scalarType() == "Byte":
+        return g.op("BitShift", self, other, direction_s="LEFT")
 
-    two = g.op('Constant', value_t=torch.tensor(2, dtype=torch.float32))
+    two = g.op("Constant", value_t=torch.tensor(2, dtype=torch.float32))
     # exponent (same type as self) has to be float or double in onnx::Pow
     if not sym_help._is_fp(self):
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    two_pow = g.op('Pow', two, other)
-    two_pow = g.op('Cast', two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
-    lshift = g.op('Mul', self, two_pow)
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+    two_pow = g.op("Pow", two, other)
+    two_pow = g.op("Cast", two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+    lshift = g.op("Mul", self, two_pow)
     return lshift
 
 
@@ -681,7 +681,7 @@ def _get_im2col_indices_along_dim(g, input_d, kernel_size_d, dilation_d, padding
     # Broadcast and add kernel staring positions (indices) with
     # kernel_grid along dim d, to get block indices along dim d
     blocks_d_indices = sym_help._unsqueeze_helper(g, blocks_d_indices, [0])  # Reshape to [1, -1]
-    kernel_mask = g.op('Reshape', kernel_grid, g.op('Constant', value_t=torch.tensor([-1, 1])))
+    kernel_mask = g.op("Reshape", kernel_grid, g.op("Constant", value_t=torch.tensor([-1, 1])))
     block_mask = g.op("Add", blocks_d_indices, kernel_mask)
 
     return block_mask
@@ -707,7 +707,7 @@ def _get_im2col_output_shape(g, input, kernel_h, kernel_w):
                 g.op("Constant", value_t=torch.tensor([-1])), axis_i=0)
 
 
-@parse_args('v', 'is', 'is', 'is', 'is')
+@parse_args("v", "is", "is", "is", "is")
 def im2col(g, input, kernel_size, dilation, padding, stride):
     # Input is always 4-D tensor (N, C, H, W)
     # All other args are int[2]
@@ -761,7 +761,7 @@ def narrow(g, input, dim, start, length):
     return _slice_helper(g, input, axes=dim, starts=start, ends=end, dynamic_slice=True)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)
     # use ONNX's Flatten operator for cases where the output shape is 2D
@@ -782,7 +782,7 @@ def flatten(g, input, start_dim, end_dim):
     return sym_help._flatten_helper(g, input, start_dim, end_dim, dim)
 
 
-@parse_args('v', 'v', 'v', 'i', 'i', 'i', 'v', 'i', 'i')
+@parse_args("v", "v", "v", "i", "i", "i", "v", "i", "i")
 def embedding_bag(g,
                   embedding_matrix,
                   indices,
@@ -794,9 +794,9 @@ def embedding_bag(g,
                   include_last_offset,
                   padding_idx):
     if scale_grad_by_freq and sym_help._training_mode:
-        return sym_help._onnx_unsupported('embedding_bag with scale_grad_by_freq for training mode')
+        return sym_help._onnx_unsupported("embedding_bag with scale_grad_by_freq for training mode")
     if padding_idx is not None and padding_idx >= 0:
-        raise RuntimeError('embedding_bag with padding_idx')
+        raise RuntimeError("embedding_bag with padding_idx")
 
     loop_condition = g.op("Constant", value_t=torch.tensor(1))
     loop_condition = g.op("Cast", loop_condition, to_i=9)
@@ -885,14 +885,14 @@ def repeat_interleave(g, self, repeats, dim=None):
     repeats_sizes = sym_help._get_tensor_sizes(repeats)
     input_sizes = sym_help._get_tensor_sizes(input)
     if repeats_dim is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'repeats rank.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "repeats rank.")
     if repeats_sizes is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'repeats size.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "repeats size.")
     if input_sizes is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'input size.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "input size.")
     # Handle cases where dim is negative
     if dim < 0:
         dim += len(input_sizes)

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -11,19 +11,19 @@ from torch.onnx.symbolic_opset9 import permute, _reshape_from_tensor
 
 # This file exports ONNX ops for opset 12
 
-@parse_args('s', 'v')
+@parse_args("s", "v")
 def einsum(g, equation, tensor_list):
     tensors = sym_help._unpack_list(tensor_list)
     return g.op("Einsum", *tensors, equation_s=equation)
 
-@parse_args('v', 'v')
+@parse_args("v", "v")
 def outer(g, input, other):
     # make sure to cast other to self's type
     if other.type().scalarType() != input.type().scalarType():
         other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[input.type().scalarType()])
-    return g.op("Einsum", input, other, equation_s='i,j->ij')
+    return g.op("Einsum", input, other, equation_s="i,j->ij")
 
-@parse_args('v', 'f', 'i')
+@parse_args("v", "f", "i")
 def dropout(g, input, p, train):
     sym_help.assert_training_mode(train, "dropout")
     # in eval mode, dropout is non-op - if the node's train param is set to False, dropout is non-op
@@ -40,13 +40,13 @@ def nll_loss(g, self, target, weight, reduction, ignore_index):
     # none reduction : onnx::Constant[value={0}]
     # mean reduction : onnx::Constant[value={1}]
     # sum reduction : onnx::Constant[value={2}]
-    reduction = sym_help._maybe_get_const(reduction, 'i')
-    reduction_vals = ['none', 'mean', 'sum']
+    reduction = sym_help._maybe_get_const(reduction, "i")
+    reduction_vals = ["none", "mean", "sum"]
     reduction = reduction_vals[reduction]
 
     # in onnx NegativeLogLikelihoodLoss specification, ignore_index is optional without default value.
     # therefore we need to set ignore_index attribute even if it is not specified (e.g. ignore_index=-100).
-    ignore_index = sym_help._maybe_get_const(ignore_index, 'i')
+    ignore_index = sym_help._maybe_get_const(ignore_index, "i")
     if weight.node().mustBeNone():
         nllloss = g.op("NegativeLogLikelihoodLoss", self, target, reduction_s=reduction, ignore_index_i=ignore_index)
     else:
@@ -67,13 +67,13 @@ def cross_entropy_loss(g, self, target, weight, reduction, ignore_index):
     # none reduction : onnx::Constant[value={0}]
     # mean reduction : onnx::Constant[value={1}]
     # sum reduction : onnx::Constant[value={2}]
-    reduction = sym_help._maybe_get_const(reduction, 'i')
-    reduction_vals = ['none', 'mean', 'sum']
+    reduction = sym_help._maybe_get_const(reduction, "i")
+    reduction_vals = ["none", "mean", "sum"]
     reduction = reduction_vals[reduction]
 
     # in onnx SoftmaxCrossEntropyLoss specification, ignore_index is optional without default value.
     # therefore we need to set ignore_index attribute even if it is not specified (e.g. ignore_index=-100).
-    ignore_index = sym_help._maybe_get_const(ignore_index, 'i')
+    ignore_index = sym_help._maybe_get_const(ignore_index, "i")
     if weight.node().mustBeNone():
         celoss = g.op("SoftmaxCrossEntropyLoss", self, target, reduction_s=reduction, ignore_index_i=ignore_index)
     else:
@@ -82,7 +82,7 @@ def cross_entropy_loss(g, self, target, weight, reduction, ignore_index):
     return celoss
 
 
-@parse_args('v', 'v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "v", "i")
 def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduction):
     from torch.onnx.symbolic_opset9 import sigmoid, log, sub, neg, mul, add
     p = g.op("Constant", value_t=torch.tensor([1]))
@@ -99,7 +99,7 @@ def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduc
     if weight is not None and not sym_help._is_none(weight):
         output = mul(g, weight, output)
 
-    reduction = sym_help._maybe_get_const(reduction, 'i')
+    reduction = sym_help._maybe_get_const(reduction, "i")
     if reduction == 0:
         return output
     elif reduction == 1:
@@ -111,12 +111,12 @@ def binary_cross_entropy_with_logits(g, input, target, weight, pos_weight, reduc
 
 
 def celu(g, self, alpha):
-    alpha = sym_help._maybe_get_const(alpha, 'f')
+    alpha = sym_help._maybe_get_const(alpha, "f")
     # if the input is of type double cast it to float
-    if self.type().scalarType() == 'Double':
-        self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+    if self.type().scalarType() == "Double":
+        self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx["Float"])
         out = g.op("Celu", self, alpha_f=alpha)
-        return g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx['Double'])
+        return g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx["Double"])
 
     return g.op("Celu", self, alpha_f=alpha)
 
@@ -125,37 +125,37 @@ def argmax(g, input, dim, keepdim):
     if sym_help._is_none(dim):
         from torch.onnx.symbolic_opset9 import reshape
         flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
-        return g.op('ArgMax', flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
+        return g.op("ArgMax", flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
     else:
-        dim = _parse_arg(dim, 'i')
-        keepdim = _parse_arg(keepdim, 'i')
-        return g.op('ArgMax', input, axis_i=dim, keepdims_i=keepdim, select_last_index_i=False)
+        dim = _parse_arg(dim, "i")
+        keepdim = _parse_arg(keepdim, "i")
+        return g.op("ArgMax", input, axis_i=dim, keepdims_i=keepdim, select_last_index_i=False)
 
 
 def argmin(g, input, dim, keepdim):
     if sym_help._is_none(dim):
         from torch.onnx.symbolic_opset9 import reshape
         flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
-        return g.op('ArgMin', flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
+        return g.op("ArgMin", flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
     else:
-        dim = _parse_arg(dim, 'i')
-        keepdim = _parse_arg(keepdim, 'i')
-        return g.op('ArgMin', input, axis_i=dim, keepdims_i=keepdim, select_last_index_i=False)
+        dim = _parse_arg(dim, "i")
+        keepdim = _parse_arg(keepdim, "i")
+        return g.op("ArgMin", input, axis_i=dim, keepdims_i=keepdim, select_last_index_i=False)
 
 
 def pow(g, self, exponent):
     return g.op("Pow", self, exponent)
 
 def ge(g, input, other):
-    return g.op('GreaterOrEqual', input, other)
+    return g.op("GreaterOrEqual", input, other)
 
 def le(g, input, other):
-    return g.op('LessOrEqual', input, other)
+    return g.op("LessOrEqual", input, other)
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def unfold(g, input, dimension, size, step):
-    const_size = sym_help._maybe_get_const(size, 'i')
-    const_step = sym_help._maybe_get_const(step, 'i')
+    const_size = sym_help._maybe_get_const(size, "i")
+    const_step = sym_help._maybe_get_const(step, "i")
     if not sym_help._is_value(const_size) and not sym_help._is_value(const_step):
         from torch.onnx.symbolic_opset9 import unfold as _unfold
         return _unfold(g, input, dimension, const_size, const_step)
@@ -212,18 +212,18 @@ def unfold(g, input, dimension, size, step):
     else:
         return _unimplemented("Unfold", "input size not accessible")
 
-@parse_args('v', 'v', 'is', 'is', 'v')
+@parse_args("v", "v", "is", "is", "v")
 def tensordot(g, input_a, input_b, dims_a, dims_b, out=None):
     if out is not None:
         _unimplemented("Tensordot", "Out parameter is not supported for tensordot.")
 
     dim_count_a = sym_help._get_tensor_rank(input_a)
     if dim_count_a is None:
-        raise RuntimeError('Unsupported: ONNX export of tensordot for tensor(input_a) of unknown rank.')
+        raise RuntimeError("Unsupported: ONNX export of tensordot for tensor(input_a) of unknown rank.")
 
     dim_count_b = sym_help._get_tensor_rank(input_b)
     if dim_count_b is None:
-        raise RuntimeError('Unsupported: ONNX export of tensordot for tensor(input_b) of unknown rank.')
+        raise RuntimeError("Unsupported: ONNX export of tensordot for tensor(input_b) of unknown rank.")
 
     dims_a = [(dims_a[i] + dim_count_a) if (dims_a[i] < 0) else dims_a[i] for i in range(len(dims_a))]
     dims_b = [(dims_b[i] + dim_count_b) if (dims_b[i] < 0) else dims_b[i] for i in range(len(dims_b))]
@@ -255,7 +255,7 @@ def tensordot(g, input_a, input_b, dims_a, dims_b, out=None):
     shape_sizes = [g.op("Constant", value_t=torch.tensor([-1], dtype=torch.long)), slices]
     output_b = _reshape_from_tensor(g, new_input_b, shape_sizes)
 
-    output = einsum(g, 'ij,jk->ik', g.op("prim::ListConstruct", *[output_a, output_b]))
+    output = einsum(g, "ij,jk->ik", g.op("prim::ListConstruct", *[output_a, output_b]))
 
     shape_sizes = [left_sizes_a, left_sizes_b]
     return _reshape_from_tensor(g, output, shape_sizes)

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -14,36 +14,36 @@ from torch.onnx.symbolic_opset9 import overload_by_arg_count, _maybe_cast_reduce
 # This file exports ONNX ops for opset 13
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def softmax(g, input, dim, dtype=None):
-    softmax = g.op('Softmax', input, axis_i=dim)
-    if dtype and dtype.node().kind() != 'prim::Constant':
-        parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    softmax = g.op("Softmax", input, axis_i=dim)
+    if dtype and dtype.node().kind() != "prim::Constant":
+        parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
         softmax = g.op("Cast", softmax, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
 
     return softmax
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def log_softmax(g, input, dim, dtype=None):
     return_op = g.op("LogSoftmax", input, axis_i=dim)
-    if dtype and dtype.node().kind() != 'prim::Constant':
-        parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    if dtype and dtype.node().kind() != "prim::Constant":
+        parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
         return_op = g.op("Cast", return_op, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
     return return_op
 
 
-@parse_args('v', 'v', 'i')
+@parse_args("v", "v", "i")
 def frobenius_norm(g, self, dim=None, keepdim=False):
-    dim_val = sym_help._maybe_get_const(dim, 'is')
+    dim_val = sym_help._maybe_get_const(dim, "is")
     if not sym_help._is_value(dim_val) and len(dim_val) == 0:
         return g.op("ReduceL2", self, keepdims_i=0)
-    sqr = g.op('Mul', self, self)
+    sqr = g.op("Mul", self, self)
     sumsqr = sym_help._reducesum_helper(g, sqr, dim, keepdims_i=keepdim)
-    return g.op('Sqrt', sumsqr)
+    return g.op("Sqrt", sumsqr)
 
 
-@parse_args('v', 'v', 'i', 'i')
+@parse_args("v", "v", "i", "i")
 def split(g, self, split_size_or_sizes, dim, _outputs=None):
     if not sym_help._is_split_static(split_size_or_sizes, _outputs):
         split_out = g.op("SplitToSequence", self, split_size_or_sizes, axis_i=dim)
@@ -65,17 +65,17 @@ def split(g, self, split_size_or_sizes, dim, _outputs=None):
         return [g.op("SequenceAt", split_out, g.op("Constant", value_t=torch.tensor([i], dtype=torch.long)))
                 for i in range(_outputs)]
 
-    split_val = split_size_or_sizes.node()['value']
+    split_val = split_size_or_sizes.node()["value"]
     if split_val.dim() > 0:
         return g.op("Split", self, split_size_or_sizes, axis_i=dim, outputs=_outputs)
-    split_size = sym_help._get_const(split_size_or_sizes, 'i', 'split_size')
+    split_size = sym_help._get_const(split_size_or_sizes, "i", "split_size")
 
     size = sym_help._get_tensor_dim_size(self, dim)
     if size is None:
         if _outputs is not None:
             size = split_size * _outputs
         else:
-            raise RuntimeError('Unknown dimension size not supported')
+            raise RuntimeError("Unknown dimension size not supported")
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:
@@ -96,7 +96,7 @@ def unsafe_split_with_sizes(g, self, split_sizes, dim, _outputs=None):
     return split_with_sizes(g, self, split_sizes, dim, _outputs)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def unbind(g, self, dim=0, _outputs=None):
     if _outputs is None:
         return g.op("SplitToSequence",
@@ -116,17 +116,17 @@ def nonzero_numpy(g, input, _outputs=None):
     return unbind(g, nonzero(g, input), 1, _outputs=_outputs)
 
 
-@parse_args('v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "i")
 def where(g, condition, self=None, other=None, _outputs=None):
     # Assumes that torch.where's first argument takes only Bool and Byte tensors.
-    if condition.type().scalarType() != 'Bool':
-        condition = g.op("Cast", condition, to_i=sym_help.cast_pytorch_to_onnx['Bool'])
+    if condition.type().scalarType() != "Bool":
+        condition = g.op("Cast", condition, to_i=sym_help.cast_pytorch_to_onnx["Bool"])
     if self is None:
         condition = nonzero(g, condition)
         return sym_help._unbind_helper(g, condition, g.op("Constant", value_t=torch.tensor(1)), _outputs)
     return g.op("Where", condition, self, other)
 
-@parse_args('v', 'v', 'v', 'i', 'i', 'i')
+@parse_args("v", "v", "v", "i", "i", "i")
 def fake_quantize_per_channel_affine(g, inputs, scale, zero_point, axis, quant_min=-128, quant_max=127):
     if quant_min not in [0, -128] or quant_max not in [127, 255]:
         raise RuntimeError(
@@ -134,9 +134,9 @@ def fake_quantize_per_channel_affine(g, inputs, scale, zero_point, axis, quant_m
 
     # ONNX defines zero_point to be int8 or uint8
     if quant_min == 0:
-        zero_point = g.op("Cast", zero_point, to_i=sym_help.cast_pytorch_to_onnx['Byte'])
+        zero_point = g.op("Cast", zero_point, to_i=sym_help.cast_pytorch_to_onnx["Byte"])
     else:
-        zero_point = g.op("Cast", zero_point, to_i=sym_help.cast_pytorch_to_onnx['Char'])
+        zero_point = g.op("Cast", zero_point, to_i=sym_help.cast_pytorch_to_onnx["Char"])
     return g.op(
         "DequantizeLinear",
         g.op("QuantizeLinear", inputs, scale, zero_point, axis_i=axis),
@@ -149,7 +149,7 @@ def _reduce_op_symbolic(onnx_op_name):
             # all-reduce path
             return g.op(onnx_op_name, self, keepdims_i=0)
         else:
-            keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
+            keepdim = sym_help._get_const(keepdim, "i", "keepdim")
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic
 
@@ -158,23 +158,23 @@ def _reduce_with_dtype(onnx_op, name):
 
     @overload_by_arg_count
     def reduce(g, *args, **kwargs):
-        @parse_args('v', 'none')
+        @parse_args("v", "none")
         def reduce_nodim(g, self, dtype):
-            if dtype.node().kind() != 'prim::Constant':
+            if dtype.node().kind() != "prim::Constant":
                 return _unimplemented(name, "dtype")
             return symbolic(g, self)
 
-        @parse_args('v', 'v', 'i', 'none')
+        @parse_args("v", "v", "i", "none")
         def reduce_dim(g, self, dim, keepdim, dtype):
-            if dtype.node().kind() != 'prim::Constant':
+            if dtype.node().kind() != "prim::Constant":
                 return _unimplemented(name, "dtype")
             return symbolic(g, self, dim, keepdim)
         return reduce_nodim, reduce_dim
     return reduce
 
-sum = _reduce_with_dtype('ReduceSum', 'sum')
+sum = _reduce_with_dtype("ReduceSum", "sum")
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def unsafe_chunk(g, self, chunks, dim, _outputs=None):
     if _outputs is None:
         return g.op("SplitToSequence",
@@ -184,14 +184,14 @@ def unsafe_chunk(g, self, chunks, dim, _outputs=None):
 
     size = sym_help._get_tensor_dim_size(self, dim)
     if size is None:
-        return _unimplemented('unsafe_chunk', 'unknown dimension size')
+        return _unimplemented("unsafe_chunk", "unknown dimension size")
     split_size = (size + chunks - 1) // chunks
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:
         splits.append(leftover)
 
-    # TODO: So far we don't have a module using this method. We'll keep
+    # TODO: So far we don"t have a module using this method. We"ll keep
     # this as a constant unless we see a request of dynamics in any
     # user's modules.
     splits = g.op("Constant", value_t=torch.tensor(splits, dtype=torch.long))

--- a/torch/onnx/symbolic_opset7.py
+++ b/torch/onnx/symbolic_opset7.py
@@ -51,9 +51,9 @@ def div(g, self, other, *args):
         return _div_rounding_mode(g, self, other, *args)
 
 
-@parse_args('v', 'v', 's')
+@parse_args("v", "v", "s")
 def _div_rounding_mode(g, self, other, rounding_mode):
-    if rounding_mode == 'floor':
+    if rounding_mode == "floor":
         return _floor_divide(g, self, other)
     else:
         return sym_opset9._div_rounding_mode(g, self, other, rounding_mode)
@@ -62,9 +62,9 @@ def _div_rounding_mode(g, self, other, rounding_mode):
 def _floor_divide(g, self, other):
     if sym_help._is_fp(self) or sym_help._is_fp(other):
         out = sym_opset9.true_divide(g, self, other)
-        return g.op('Floor', out)
+        return g.op("Floor", out)
     else:
-        raise RuntimeError('Integer floor division requires ONNX opset 9 or greater')
+        raise RuntimeError("Integer floor division requires ONNX opset 9 or greater")
 
 
 for block_listed_op in block_listed_operators:

--- a/torch/onnx/symbolic_opset8.py
+++ b/torch/onnx/symbolic_opset8.py
@@ -58,7 +58,7 @@ def _interpolate(name, dim, interpolate_mode):
         align_corners = sym_help._maybe_get_scalar(align_corners)
         if align_corners:
             return _unimplemented(name, "align_corners == True")
-        output_size = sym_help._maybe_get_const(output_size, 'is')
+        output_size = sym_help._maybe_get_const(output_size, "is")
         if sym_help._is_value(output_size):
             return _unimplemented(name, "torch._C.Value (output_size) indexing")
         if scales is None:
@@ -69,16 +69,16 @@ def _interpolate(name, dim, interpolate_mode):
     return symbolic_fn
 
 
-upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
-upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
-upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
-upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
-upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
-upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
+upsample_nearest1d = _interpolate("upsample_nearest1d", 3, "nearest")
+upsample_nearest2d = _interpolate("upsample_nearest2d", 4, "nearest")
+upsample_nearest3d = _interpolate("upsample_nearest3d", 5, "nearest")
+upsample_linear1d = _interpolate("upsample_linear1d", 3, "linear")
+upsample_bilinear2d = _interpolate("upsample_bilinear2d", 4, "linear")
+upsample_trilinear3d = _interpolate("upsample_trilinear3d", 5, "linear")
 
 
 def __interpolate(g, input, size, scale_factor, mode, align_corners, recompute_scale_factor):
-    align_corners = sym_help._maybe_get_const(align_corners, 'b')
+    align_corners = sym_help._maybe_get_const(align_corners, "b")
     if not sym_help._is_none(align_corners) and align_corners:
         return _unimplemented("interpolate", "align_corners == True")
 
@@ -97,7 +97,7 @@ def __interpolate(g, input, size, scale_factor, mode, align_corners, recompute_s
 #       issue for "cast" operators. Some symbolic functions depend on shape information of input tensor, which
 #       is lost after casting.
 def _try_cast_integer_to_float(g, *args):
-    floating_scalar_types = ['Half', 'Float', 'Double']
+    floating_scalar_types = ["Half", "Float", "Double"]
     old_type = None
     # Cast the input tensor to Float if its scalarType is known and is not floating number.
     # If casting is performed, return the old scalarType, otherwise return None.
@@ -118,7 +118,7 @@ def _try_cast_integer_to_float(g, *args):
 def _cast_to_type(g, input, to_type):
     if to_type is None:
         return input
-    return getattr(sym_opset9, '_cast_{}'.format(to_type))(g, input, False)
+    return getattr(sym_opset9, "_cast_{}".format(to_type))(g, input, False)
 
 
 def _comparison_operator(g, input, other, op_name):
@@ -173,7 +173,7 @@ def mm(g, self, other):
         return g.op("Gemm", self, other, C, beta_f=0.0, alpha_f=1.0)
 
 
-@parse_args('v', 'v', 'v', 't', 't')
+@parse_args("v", "v", "v", "t", "t")
 def addmm(g, self, mat1, mat2, beta, alpha):
     if _try_get_scalar_type(self):
         old_type, self, mat1, mat2 = _try_cast_integer_to_float(g, self, mat1, mat2)
@@ -185,8 +185,8 @@ def addmm(g, self, mat1, mat2, beta, alpha):
 
 
 def flatten(g, input, start_dim, end_dim):
-    start_dim_i = sym_help._get_const(start_dim, 'i', 'start_dim')
-    end_dim_i = sym_help._get_const(end_dim, 'i', 'end_dim')
+    start_dim_i = sym_help._get_const(start_dim, "i", "start_dim")
+    end_dim_i = sym_help._get_const(end_dim, "i", "end_dim")
 
     dim = input.type().dim()
     if end_dim_i < 0 :
@@ -218,49 +218,49 @@ def _constant_fill(g, sizes, dtype, const_value):
     else:
         return g.op("ConstantFill", sizes, dtype_i=sym_help.scalar_type_to_onnx[dtype], input_as_shape_i=1, value_f=const_value)
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def empty(g, sizes, dtype, layout, device, pin_memory=False, memory_format=None):
     return zeros(g, sizes, dtype, layout, device, pin_memory)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def empty_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
     return zeros_like(g, input, dtype, layout, device, pin_memory)
 
-@parse_args('v', 'i', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v")
 def zeros(g, sizes, dtype, layout, device, pin_memory=False):
     # NOTE: no way to set device and layout in ONNX, so we ignore it
     return _constant_fill(g, sizes, dtype, 0)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def zeros_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     return _constant_fill(g, shape, dtype, 0)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v")
 def ones(g, sizes, dtype, layout, device, pin_memory=False):
     return _constant_fill(g, sizes, dtype, 1)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def ones_like(g, input, dtype, layout, device, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     return _constant_fill(g, shape, dtype, 1)
 
 
 def full(g, sizes, value, dtype, layout, device, pin_memory=False):
-    const_value = sym_help._maybe_get_const(value, 't')
+    const_value = sym_help._maybe_get_const(value, "t")
     if sym_help._is_value(const_value):
         tmp = zeros(g, sizes, dtype, layout, device)
         return sym_opset9.add(g, tmp, value, g.op("Constant", value_t=torch.tensor(1)))
     else:
-        dtype = sym_help._get_const(dtype, 'i', 'dtype')
+        dtype = sym_help._get_const(dtype, "i", "dtype")
         return _constant_fill(g, sizes, dtype, const_value)
 
 
-@parse_args('v', 'f', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "f", "i", "v", "v", "v", "v")
 def full_like(g, input, fill_value, dtype, layout, device, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     return _constant_fill(g, shape, dtype, fill_value)
@@ -272,7 +272,7 @@ def repeat(g, self, repeats):
     if sym_help._is_packed_list(repeats):
         repeat_size_len = len(sym_help._unpack_list(repeats))
     else:
-        const_repeats = sym_help._maybe_get_const(repeats, 'is')
+        const_repeats = sym_help._maybe_get_const(repeats, "is")
         repeat_size_len = len(const_repeats)
     if self.isCompleteTensor():
         sizes = self.type().sizes()

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -63,13 +63,13 @@ def unused(g):
     return n
 
 def _shape_as_tensor(g, input):
-    return g.op('Shape', input)
+    return g.op("Shape", input)
 
 
 def _reshape_from_tensor(g, input, shape):
     if (isinstance(shape, list)):
         shape = g.op("Concat", *shape, axis_i=0)
-    return g.op('Reshape', input, shape)
+    return g.op("Reshape", input, shape)
 
 
 def reshape(g, self, shape):
@@ -77,13 +77,13 @@ def reshape(g, self, shape):
 
 
 def reshape_as(g, self, other):
-    shape = g.op('Shape', other)
+    shape = g.op("Shape", other)
     return reshape(g, self, shape)
 
 
 def add(g, self, other, alpha=None):
     if sym_help._is_value(self) and sym_help._is_tensor_list(self):
-        return sym_help._onnx_opset_unsupported_detailed('Add', 9, 11, 'Add between list of tensors not supported')
+        return sym_help._onnx_opset_unsupported_detailed("Add", 9, 11, "Add between list of tensors not supported")
 
     # default alpha arg is to allow no-alpha add (aten add st overload no alpha)
     if alpha and sym_help._scalar(sym_help._maybe_get_scalar(alpha)) != 1:
@@ -113,30 +113,30 @@ def div(g, self, other, *args):
         return _div_rounding_mode(g, self, other, *args)
 
 
-@parse_args('v', 'v', 's')
+@parse_args("v", "v", "s")
 def _div_rounding_mode(g, self, other, rounding_mode):
     if rounding_mode is None:
         return true_divide(g, self, other)
-    elif rounding_mode == 'floor':
+    elif rounding_mode == "floor":
         return _floor_divide(g, self, other)
-    elif rounding_mode == 'trunc':
+    elif rounding_mode == "trunc":
         return _trunc_divide(g, self, other)
     else:
         raise RuntimeError(f'Unsupported rounding mode: "{rounding_mode}". Expected None, "floor" or "trunc"')
 
 
 def _trunc_divide(g, self, other):
-    out = g.op('Div', self, other)
+    out = g.op("Div", self, other)
     # the correct operation is truncate, which is not supported in ONNX,
     # we cannot call floor since it will behave differently for negative numbers
     # (eg. -0.1 should become -0 )
     # - if scalar_type information are not available, assume that
     # we need to call floor (treat as float)
-    out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx['Long'])
+    out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx["Long"])
 
     # Matching PyTorch's behavior:
     # - if self is fp the output's type is self's type
-    # - if self is not fp and other is fp, the output is of type 'Float'
+    # - if self is not fp and other is fp, the output is of type "Float"
     # - self is not fp and other is not fp, the output's type is self's output type
     # - the output type defaults to Float
     scalar_type = self.type().scalarType()
@@ -145,35 +145,35 @@ def _trunc_divide(g, self, other):
         if not sym_help._is_fp(self) and \
            other.type().scalarType() is not None and \
            sym_help._is_fp(other):
-            out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+            out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx["Float"])
         else:
             out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx[scalar_type])
     else:
-        out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+        out = g.op("Cast", out, to_i=sym_help.cast_pytorch_to_onnx["Float"])
     return out
 
 
 def _floor_divide(g, self, other):
     if sym_help._is_fp(self) or sym_help._is_fp(other):
         out = true_divide(g, self, other)
-        return g.op('Floor', out)
+        return g.op("Floor", out)
     else:
         # Integer division does trunction rounding
-        div = g.op('Div', self, other)
+        div = g.op("Div", self, other)
         # Division is negative if: self < 0 != other < 0
-        zero = g.op('Constant', value_t=torch.tensor(0, dtype=torch.int64))
-        negative = g.op('Xor',
-                        g.op('Less', self, zero),
-                        g.op('Less', other, zero))
+        zero = g.op("Constant", value_t=torch.tensor(0, dtype=torch.int64))
+        negative = g.op("Xor",
+                        g.op("Less", self, zero),
+                        g.op("Less", other, zero))
 
         # For negative numbers with self % other != 0, subtract 1 to round down instead of up
-        mod = g.op('Sub', self, g.op('Mul', div, other))
-        fixup_mask = g.op('And', negative,
-                          g.op('Not', g.op('Equal', mod, zero)))
+        mod = g.op("Sub", self, g.op("Mul", div, other))
+        fixup_mask = g.op("And", negative,
+                          g.op("Not", g.op("Equal", mod, zero)))
 
-        one = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
-        fixup = g.op('Sub', div, one)
-        return g.op('Where', fixup_mask, fixup, div)
+        one = g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))
+        fixup = g.op("Sub", div, one)
+        return g.op("Where", fixup_mask, fixup, div)
 
 
 def floor_divide(g, self, other):
@@ -209,10 +209,10 @@ def true_divide(g, self, other):
     # Case 4: neither is floating
     # Casts both inputs to the default scalar type
     scalar_type = torch.get_default_dtype()
-    onnx_scalar_type = sym_help.cast_pytorch_to_onnx['Float']
+    onnx_scalar_type = sym_help.cast_pytorch_to_onnx["Float"]
     assert scalar_type is torch.float or scalar_type is torch.double
     if torch.get_default_dtype() is torch.double:
-        onnx_scalar_type = sym_help.cast_pytorch_to_onnx['Double']
+        onnx_scalar_type = sym_help.cast_pytorch_to_onnx["Double"]
 
     self = g.op("Cast", self, to_i=onnx_scalar_type)
     other = g.op("Cast", other, to_i=onnx_scalar_type)
@@ -223,13 +223,13 @@ def reciprocal(g, self):
     return g.op("Div", torch.ones(1), self)
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def cat(g, tensor_list, dim):
     tensors = sym_help._unpack_list(tensor_list)
     return g.op("Concat", *tensors, axis_i=dim)
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def stack(g, tensor_list, dim):
     unsqueezed = [sym_help._unsqueeze_helper(g, t, [dim]) for t in sym_help._unpack_list(tensor_list)]
     return g.op("Concat", *unsqueezed, axis_i=dim)
@@ -254,7 +254,7 @@ def matmul(g, self, other):
     return g.op("MatMul", self, other)
 
 
-@parse_args('v', 'v', 'v', 't', 't')
+@parse_args("v", "v", "v", "t", "t")
 def addmm(g, self, mat1, mat2, beta, alpha):
     dtype = None
     self_dtype = sym_help._try_get_scalar_type(self)
@@ -357,7 +357,7 @@ def _maybe_cast_reduce_op_input(g, self):
     # This check only covers traced modules where dtype is present
     if dtype is not None:
         # pytorch reduce-ops cast all other integral types to int64
-        if not sym_help._is_fp(self) and not (dtype == 'Long'):
+        if not sym_help._is_fp(self) and not (dtype == "Long"):
             self = _cast_Long(g, self, False)  # type: ignore[name-defined]
     return self
 
@@ -370,8 +370,8 @@ def _reduce_op_symbolic(onnx_op_name, allow_multi_dim_support=True):
             return g.op(onnx_op_name, self, keepdims_i=0)
         else:
             # dim-reduce path
-            desc = 'is' if allow_multi_dim_support else 'i'
-            dim, keepdim = sym_help._get_const(dim, desc, 'dim'), sym_help._get_const(keepdim, 'i', 'keepdim')
+            desc = "is" if allow_multi_dim_support else "i"
+            dim, keepdim = sym_help._get_const(dim, desc, "dim"), sym_help._get_const(keepdim, "i", "keepdim")
             dim_list = dim if allow_multi_dim_support else [dim]
             return g.op(onnx_op_name, self, axes_i=dim_list, keepdims_i=keepdim)
     return symbolic
@@ -396,56 +396,56 @@ def _reduce_with_dtype(onnx_op, name, allow_multi_dim_support=True):
 
     @overload_by_arg_count
     def reduce(g, *args, **kwargs):
-        @parse_args('v', 'none')
+        @parse_args("v", "none")
         def reduce_nodim(g, self, dtype):
-            if dtype.node().kind() != 'prim::Constant':
+            if dtype.node().kind() != "prim::Constant":
                 return _unimplemented(name, "dtype")
             return symbolic(g, self)
 
-        dim_desc = 'is' if allow_multi_dim_support else 'i'
+        dim_desc = "is" if allow_multi_dim_support else "i"
 
-        @parse_args('v', dim_desc, 'i', 'none')
+        @parse_args("v", dim_desc, "i", "none")
         def reduce_dim(g, self, dim, keepdim, dtype):
-            if dtype.node().kind() != 'prim::Constant':
+            if dtype.node().kind() != "prim::Constant":
                 return _unimplemented(name, "dtype")
             return symbolic(g, self, dim, keepdim)
         return reduce_nodim, reduce_dim
     return reduce
 
 
-sum = _reduce_with_dtype('ReduceSum', 'sum')
-mean = _reduce_with_dtype('ReduceMean', 'mean')
-prod = _reduce_with_dtype('ReduceProd', 'prod', allow_multi_dim_support=False)  # torch.prod does not support multidimensional 'dim'
+sum = _reduce_with_dtype("ReduceSum", "sum")
+mean = _reduce_with_dtype("ReduceMean", "mean")
+prod = _reduce_with_dtype("ReduceProd", "prod", allow_multi_dim_support=False)  # torch.prod does not support multidimensional "dim"
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def cumsum(g, input, dim, dtype):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
-        if dtype.node().kind() != 'prim::Constant':
+        if dtype.node().kind() != "prim::Constant":
             return _unimplemented(name, "dtype")
         return g.op("ATen", input, operator_s="cumsum", dim_i=dim)
     else:
-        sym_help._onnx_opset_unsupported('cumsum', 9, 11)
+        sym_help._onnx_opset_unsupported("cumsum", 9, 11)
 
 
 def _sample_dirichlet(g, self, generator):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         if not sym_help._is_none(generator):
-            return _unimplemented('_sample_dirichlet',
-                                  'We are not able to export generator')
+            return _unimplemented("_sample_dirichlet",
+                                  "We are not able to export generator")
         return g.op("ATen", self, operator_s="_sample_dirichlet")
     else:
-        return sym_help._onnx_unsupported('_sample_dirichlet')
+        return sym_help._onnx_unsupported("_sample_dirichlet")
 
 
 def _standard_gamma(g, self, generator):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         if not sym_help._is_none(generator):
-            return _unimplemented('_standard_gamma',
-                                  'We are not able to export generator')
+            return _unimplemented("_standard_gamma",
+                                  "We are not able to export generator")
         return g.op("ATen", self, operator_s="_standard_gamma")
     else:
-        return sym_help._onnx_unsupported('_standard_gamma')
+        return sym_help._onnx_unsupported("_standard_gamma")
 
 
 def t(g, self):
@@ -453,7 +453,7 @@ def t(g, self):
 
 
 def expand(g, self, size, implicit):
-    size = sym_help._maybe_get_const(size, 'is')
+    size = sym_help._maybe_get_const(size, "is")
     if not sym_help._is_value(size):
         size = g.op("Constant", value_t=torch.LongTensor(size))
     elif sym_help._is_packed_list(size):
@@ -473,20 +473,20 @@ def expand_as(g, self, other):
     return g.op("Expand", self, shape)
 
 
-@parse_args('v', 'v', 'i', 'b', 'v')
+@parse_args("v", "v", "i", "b", "v")
 def embedding(g, weight, indices, padding_idx, scale_grad_by_freq, sparse):
     if scale_grad_by_freq and sym_help._training_mode:
-        raise RuntimeError('Unsupported: ONNX export of embedding with scale_grad_by_freq=True '
-                           'for training mode. ONNX does not support scaling the gradients.')
+        raise RuntimeError("Unsupported: ONNX export of embedding with scale_grad_by_freq=True "
+                           "for training mode. ONNX does not support scaling the gradients.")
     if padding_idx >= 0 and sym_help._training_mode:
-        warnings.warn('Warning: ONNX export of embedding with padding_idx >= 0 '
-                      'for training mode. '
-                      'ONNX does not support not updating the embedding vector at padding_idx during training.')
+        warnings.warn("Warning: ONNX export of embedding with padding_idx >= 0 "
+                      "for training mode. "
+                      "ONNX does not support not updating the embedding vector at padding_idx during training.")
 
     return g.op("Gather", weight, indices)
 
 
-@parse_args('v', 'v', 'v', 'i', 'i', 'i', 'v', 'i', 'i')
+@parse_args("v", "v", "v", "i", "i", "i", "v", "i", "i")
 def embedding_bag(g,
                   embedding_matrix,
                   indices,
@@ -498,7 +498,7 @@ def embedding_bag(g,
                   include_last_offset,
                   padding_idx):
     if not sym_help._is_none(per_sample_weights):
-        return sym_help._onnx_unsupported('embedding_bag  with per_sample_weights')
+        return sym_help._onnx_unsupported("embedding_bag  with per_sample_weights")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen",
                     embedding_matrix,
@@ -512,21 +512,21 @@ def embedding_bag(g,
                     include_last_offset_i=include_last_offset,
                     padding_idx_i=padding_idx)
     else:
-        return sym_help._onnx_unsupported('embedding_bag')
+        return sym_help._onnx_unsupported("embedding_bag")
 
 
 def size(g, self, dim=None):
     if dim is None:
         return g.op("Shape", self)
-    if sym_help._maybe_get_const(dim, 'i') < 0:
+    if sym_help._maybe_get_const(dim, "i") < 0:
         rank = sym_help._get_tensor_rank(self)
         if rank is not None:
-            dim = sym_help._maybe_get_const(dim, 'i') + rank
+            dim = sym_help._maybe_get_const(dim, "i") + rank
             dim = g.op("Constant", value_t=torch.tensor(dim))
     return sym_help._size_helper(g, self, dim)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def transpose(g, self, dim0, dim1):
     if dim0 == dim1:  # micro-optimization
         return self
@@ -543,11 +543,11 @@ def transpose(g, self, dim0, dim1):
         if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
             return g.op("ATen", self, operator_s="transpose", dim0_i=dim0, dim1_i=dim1)
         else:
-            raise RuntimeError('Unsupported: ONNX export of transpose for tensor '
-                               'of unknown rank.')
+            raise RuntimeError("Unsupported: ONNX export of transpose for tensor "
+                               "of unknown rank.")
 
 
-@parse_args('v', 'is')
+@parse_args("v", "is")
 def permute(g, self, dims):
     if dims == list(range(0, len(dims))):
         return self
@@ -555,7 +555,7 @@ def permute(g, self, dims):
 
 
 def view(g, self, size):
-    size = sym_help._maybe_get_const(size, 'is')
+    size = sym_help._maybe_get_const(size, "is")
     if sym_help._is_value(size):
         shape = size
     else:
@@ -571,7 +571,7 @@ def view_as(g, self, other):
 def prim_ConstantSplit(g, self, split_size, dim):
     size = sym_help._get_tensor_dim_size(self, dim)
     if size is None:
-        return _unimplemented('prim::ConstantSplit', 'unknown dimension size')
+        return _unimplemented("prim::ConstantSplit", "unknown dimension size")
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:
@@ -586,18 +586,18 @@ def prim_ConstantSplit(g, self, split_size, dim):
 def prim_ConstantChunk(g, self, chunks, dim):
     dim_size = sym_help._get_tensor_dim_size(self, dim)
     if dim_size is None:
-        return _unimplemented('prim::ConstantChunk', 'unknown dimension size')
+        return _unimplemented("prim::ConstantChunk", "unknown dimension size")
     split_size = (dim_size + chunks - 1) // chunks
     return prim_ConstantSplit(g, self, split_size, dim)
 
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def unsafe_chunk(g, self, chunks, dim, _outputs=None):
     if _outputs is None:
-        return sym_help._onnx_opset_unsupported_detailed('unsafe_chunk', 9, 11, 'Dynamic number of outputs not supported')
+        return sym_help._onnx_opset_unsupported_detailed("unsafe_chunk", 9, 11, "Dynamic number of outputs not supported")
     size = sym_help._get_tensor_dim_size(self, dim)
     if size is None:
-        return _unimplemented('unsafe_chunk', 'unknown dimension size')
+        return _unimplemented("unsafe_chunk", "unknown dimension size")
     split_size = (size + chunks - 1) // chunks
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
@@ -606,22 +606,22 @@ def unsafe_chunk(g, self, chunks, dim, _outputs=None):
     return g.op("Split", self, split_i=splits, axis_i=dim, outputs=_outputs)
 
 
-@parse_args('v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "i")
 def split(g, self, split_size_or_sizes, dim, _outputs=None):
     if not sym_help._is_split_static(split_size_or_sizes, _outputs):
-        return sym_help._onnx_opset_unsupported_detailed('split', 9, 11, 'Dynamic number of outputs not supported')
-    split_val = split_size_or_sizes.node()['value']
+        return sym_help._onnx_opset_unsupported_detailed("split", 9, 11, "Dynamic number of outputs not supported")
+    split_val = split_size_or_sizes.node()["value"]
     if split_val.dim() > 0:
         return split_with_sizes(g, self, split_size_or_sizes, dim, _outputs)
-    split_size = sym_help._get_const(split_size_or_sizes, 'i', 'split_size')
-    dim = sym_help._get_const(dim, 'i', 'dim')
+    split_size = sym_help._get_const(split_size_or_sizes, "i", "split_size")
+    dim = sym_help._get_const(dim, "i", "dim")
 
     size = sym_help._get_tensor_dim_size(self, dim)
     if size is None:
         if _outputs is not None:
             size = split_size * _outputs
         else:
-            return sym_help._onnx_opset_unsupported_detailed('split', 9, 11, 'Unknown dimension size not supported')
+            return sym_help._onnx_opset_unsupported_detailed("split", 9, 11, "Unknown dimension size not supported")
     splits = [split_size] * (size // split_size)
     leftover = size % split_size
     if leftover:
@@ -633,10 +633,10 @@ def unsafe_split(g, self, split_size_or_sizes, dim, _outputs=None):
     return split(g, self, split_size_or_sizes, dim, _outputs)
 
 
-@parse_args('v', 'is', 'i', 'i')
+@parse_args("v", "is", "i", "i")
 def split_with_sizes(g, self, split_sizes, dim, _outputs=None):
     if not sym_help._is_split_static(split_sizes, _outputs):
-        return sym_help._onnx_opset_unsupported_detailed('split_with_sizes', 9, 11, 'Dynamic number of outputs not supported')
+        return sym_help._onnx_opset_unsupported_detailed("split_with_sizes", 9, 11, "Dynamic number of outputs not supported")
     return g.op("Split", self, split_i=split_sizes, axis_i=dim, outputs=_outputs)
 
 
@@ -644,10 +644,10 @@ def unsafe_split_with_sizes(g, self, split_sizes, dim, _outputs=None):
     return split_with_sizes(g, self, split_sizes, dim, _outputs)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def unbind(g, self, dim=0, _outputs=None):
     if _outputs is None:
-        return sym_help._onnx_opset_unsupported_detailed('unbind', 9, 11, 'Dynamic number of outputs not supported')
+        return sym_help._onnx_opset_unsupported_detailed("unbind", 9, 11, "Dynamic number of outputs not supported")
 
     outputs = g.op("Split", self, split_i=[1] * _outputs, axis_i=dim, outputs=_outputs)
     outputs = [outputs] if _outputs == 1 else outputs
@@ -655,7 +655,7 @@ def unbind(g, self, dim=0, _outputs=None):
     return squeezed_outputs
 
 
-@parse_args('v', 'i', 'v')
+@parse_args("v", "i", "v")
 def select(g, self, dim, index):
     index = sym_help._maybe_get_scalar(index)
     if (not sym_help._is_value(index)) and (index < 0):
@@ -677,7 +677,7 @@ def squeeze(g, self, dim=None):
     if dim is None:
         return g.op("Squeeze", self)
 
-    squeeze_dim = sym_help._get_const(dim, 'i', 'dim')
+    squeeze_dim = sym_help._get_const(dim, "i", "dim")
     # Handle negative dims
     if squeeze_dim < 0:
         rank = sym_help._get_tensor_rank(self)
@@ -690,7 +690,7 @@ def squeeze(g, self, dim=None):
                           "Passing an tensor of different rank in execution will be incorrect.")
             squeeze_dim += rank
         else:
-            return _unimplemented('squeeze', 'negative axis with unknown input rank')
+            return _unimplemented("squeeze", "negative axis with unknown input rank")
 
     dim_size = sym_help._get_tensor_dim_size(self, squeeze_dim)
     if dim_size is None:
@@ -720,7 +720,7 @@ def prelu(g, self, weight):
 
 
 def silu(g, input):
-    return g.op('Mul', input, g.op('Sigmoid', input))
+    return g.op("Mul", input, g.op("Sigmoid", input))
 
 
 def relu(g, input):
@@ -740,7 +740,7 @@ def _len(g, self):
     return sym_help._squeeze_helper(g, sz_0, [0])
 
 
-@parse_args('v', 't', 't')
+@parse_args("v", "t", "t")
 def threshold(g, self, threshold, value):
     # See Note [Export inplace]
     if sym_help._scalar(threshold) != 0:
@@ -751,23 +751,23 @@ def threshold(g, self, threshold, value):
 
 
 def leaky_relu(g, input, negative_slope, inplace=False):
-    negative_slope = sym_help._get_const(negative_slope, 't', 'negative_slope')
+    negative_slope = sym_help._get_const(negative_slope, "t", "negative_slope")
     # See Note [Export inplace]
     # TODO: Talk to ONNX about unconditional cast of scalar to float
     return g.op("LeakyRelu", input, alpha_f=sym_help._scalar(negative_slope))
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def glu(g, input, dim):
     dim_size = sym_help._get_tensor_dim_size(input, dim)
     if dim_size is not None:
         assert dim_size % 2 == 0
 
-    first, second = g.op('Split', input, axis_i=dim, outputs=2)
-    return g.op('Mul', first, g.op('Sigmoid', second))
+    first, second = g.op("Split", input, axis_i=dim, outputs=2)
+    return g.op("Mul", first, g.op("Sigmoid", second))
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def softmax(g, input, dim, dtype=None):
     # Softmax does normalization at vector level.
     # PyTorch and ONNX use different strategies to split the input tensor into vectors.
@@ -803,9 +803,9 @@ def softmax(g, input, dim, dtype=None):
             input = g.op("Transpose", input, perm_i=axes)
             dim = input_dim - 1
 
-        softmax = g.op('Softmax', input, axis_i=dim)
-        if dtype and dtype.node().kind() != 'prim::Constant':
-            parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+        softmax = g.op("Softmax", input, axis_i=dim)
+        if dtype and dtype.node().kind() != "prim::Constant":
+            parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
             softmax = g.op("Cast", softmax, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
 
         if is_transpose_required:
@@ -813,21 +813,21 @@ def softmax(g, input, dim, dtype=None):
         return softmax
 
     # Apply max normalization.
-    input = g.op('Sub', input, g.op('ReduceMax', input, axes_i=[dim], keepdims_i=1))
+    input = g.op("Sub", input, g.op("ReduceMax", input, axes_i=[dim], keepdims_i=1))
 
-    exp = g.op('Exp', input)
+    exp = g.op("Exp", input)
     sum = sym_help._reducesum_helper(g, exp, axes_i=[dim])
-    softmax = g.op('Div', exp, sum)
-    if dtype and dtype.node().kind() != 'prim::Constant':
-        parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    softmax = g.op("Div", exp, sum)
+    if dtype and dtype.node().kind() != "prim::Constant":
+        parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
         softmax = g.op("Cast", softmax, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
     return softmax
 
-@parse_args('v', 't', 'v')
+@parse_args("v", "t", "v")
 def softplus(g, self, beta, threshold):
     if beta != 1:
         return _unimplemented("beta", "has to be 1")
-    return g.op('Softplus', self)
+    return g.op("Softplus", self)
 
 
 def get_pool_ceil_padding(input, kernel_size, stride, padding):
@@ -857,7 +857,7 @@ def get_pool_ceil_padding(input, kernel_size, stride, padding):
 
 
 def _max_pool(name, tuple_fn, ndims, return_indices):
-    @parse_args('v', 'is', 'is', 'is', 'is', 'i')
+    @parse_args("v", "is", "is", "is", "is", "i")
     def symbolic_fn(g, input, kernel_size, stride, padding, dilation, ceil_mode):
         if set(tuple_fn(dilation)) != {1}:
             return _unimplemented(name, "dilation")
@@ -870,9 +870,9 @@ def _max_pool(name, tuple_fn, ndims, return_indices):
         else:
             padding = padding * 2
         kwargs = {
-            'kernel_shape_i': tuple_fn(kernel_size),
-            'pads_i': padding,
-            'strides_i': tuple_fn(stride),
+            "kernel_shape_i": tuple_fn(kernel_size),
+            "pads_i": padding,
+            "strides_i": tuple_fn(stride),
         }
         # easy but hacky way to get flattened indices values
         # to be used to convert the indices values to non-flattened.
@@ -913,7 +913,7 @@ max_pool3d_with_indices = _max_pool("max_pool3d_with_indices", _triple, 3, retur
 
 
 def _avg_pool(name, tuple_fn):
-    @parse_args('v', 'is', 'is', 'is', 'i', 'i', 'none')
+    @parse_args("v", "is", "is", "is", "i", "i", "none")
     def symbolic_fn(g, input, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override=None):
         if not stride:
             stride = kernel_size
@@ -923,7 +923,7 @@ def _avg_pool(name, tuple_fn):
         if count_include_pad:
             input = g.op("Pad", input,
                          pads_i=((0,) * 2 + padding) * 2,
-                         mode_s='constant',
+                         mode_s="constant",
                          value_f=0.)
             padding = (0,) * len(padding)
         if ceil_mode:
@@ -938,9 +938,9 @@ def _avg_pool(name, tuple_fn):
     return symbolic_fn
 
 
-avg_pool1d = _avg_pool('avg_pool1d', _single)
-avg_pool2d = _avg_pool('avg_pool2d', _pair)
-avg_pool3d = _avg_pool('avg_pool3d', _triple)
+avg_pool1d = _avg_pool("avg_pool1d", _single)
+avg_pool2d = _avg_pool("avg_pool2d", _pair)
+avg_pool3d = _avg_pool("avg_pool3d", _triple)
 
 
 def _adaptive_pool(name, type, tuple_fn, fn=None):
@@ -955,9 +955,9 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
         # (input is not a complete tensor or output size not factor of input size)
         # then we call GlobalAveragePool and return None for the indices
         try:
-            output_size = _parse_arg(output_size, 'is')
+            output_size = _parse_arg(output_size, "is")
         except Exception:
-            return sym_help._onnx_unsupported('adaptive pooling, since output_size is not constant.')
+            return sym_help._onnx_unsupported("adaptive pooling, since output_size is not constant.")
         if output_size == [1] * len(output_size) and type == "AveragePool":
             return g.op("GlobalAveragePool", input)
         sizes = sym_help._get_tensor_sizes(input)
@@ -968,16 +968,16 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
         if dim is None or any([i is None for i in dim]):
             if output_size == [1] * len(output_size):
                 return g.op("GlobalMaxPool", input), None
-            return _unimplemented(name, 'input size not accessible')
+            return _unimplemented(name, "input size not accessible")
         # verify if output size % input size = 0 for all dim
         mod = [dim[i] % output_size[i] for i in range(0, len(dim))]
         if mod != [0] * len(mod):
             if output_size == [1] * len(output_size):
                 return g.op("GlobalMaxPool", input), None
             if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
-                return _unimplemented(name, 'output size that are not factor of input size')
+                return _unimplemented(name, "output size that are not factor of input size")
             else:
-                return sym_help._onnx_unsupported(name + ', since output size is not factor of input size')
+                return sym_help._onnx_unsupported(name + ", since output size is not factor of input size")
         k = [int(dim[i] / output_size[i]) for i in range(0, len(dim))]
         # call max_poolxd_with_indices to get indices in the output
         if type == "MaxPool":
@@ -989,13 +989,13 @@ def _adaptive_pool(name, type, tuple_fn, fn=None):
     return symbolic_fn
 
 
-adaptive_avg_pool1d = _adaptive_pool('adaptive_avg_pool1d', "AveragePool", _single)
-adaptive_avg_pool2d = _adaptive_pool('adaptive_avg_pool2d', "AveragePool", _pair)
-adaptive_avg_pool3d = _adaptive_pool('adaptive_avg_pool3d', "AveragePool", _triple)
+adaptive_avg_pool1d = _adaptive_pool("adaptive_avg_pool1d", "AveragePool", _single)
+adaptive_avg_pool2d = _adaptive_pool("adaptive_avg_pool2d", "AveragePool", _pair)
+adaptive_avg_pool3d = _adaptive_pool("adaptive_avg_pool3d", "AveragePool", _triple)
 
-adaptive_max_pool1d = _adaptive_pool('adaptive_max_pool1d', "MaxPool", _single, max_pool1d_with_indices)
-adaptive_max_pool2d = _adaptive_pool('adaptive_max_pool2d', "MaxPool", _pair, max_pool2d_with_indices)
-adaptive_max_pool3d = _adaptive_pool('adaptive_max_pool3d', "MaxPool", _triple, max_pool3d_with_indices)
+adaptive_max_pool1d = _adaptive_pool("adaptive_max_pool1d", "MaxPool", _single, max_pool1d_with_indices)
+adaptive_max_pool2d = _adaptive_pool("adaptive_max_pool2d", "MaxPool", _pair, max_pool2d_with_indices)
+adaptive_max_pool3d = _adaptive_pool("adaptive_max_pool3d", "MaxPool", _triple, max_pool3d_with_indices)
 
 
 # Generate paddings in ONNX order based on pad in pytorch.
@@ -1015,21 +1015,21 @@ def _prepare_onnx_paddings(dim, pad):
     return paddings
 
 def _convert_padding_node(padding):
-    padding = sym_help._maybe_get_const(padding, 'is')
+    padding = sym_help._maybe_get_const(padding, "is")
     if sym_help._is_value(padding) and sym_help._is_packed_list(padding):
         input_list = sym_help._unpack_list(padding)
         try:
-            padding = [sym_help._get_const(v, 'i', 'padding') for v in input_list]
+            padding = [sym_help._get_const(v, "i", "padding") for v in input_list]
         except Exception:
-            return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The sizes of the padding must be constant')
+            return sym_help._onnx_opset_unsupported_detailed("Pad", 9, 11, "The sizes of the padding must be constant")
     return padding
 
 def constant_pad_nd(g, input, padding, value):
     mode = "constant"
     try:
-        value = sym_help._get_const(value, 'f', 'value')
+        value = sym_help._get_const(value, "f", "value")
     except Exception:
-        return sym_help._onnx_opset_unsupported_detailed('Pad', 9, 11, 'The value for the padding must be constant')
+        return sym_help._onnx_opset_unsupported_detailed("Pad", 9, 11, "The value for the padding must be constant")
 
     padding = _convert_padding_node(padding)
     paddings = _prepare_onnx_paddings(sym_help._get_tensor_rank(input), padding)
@@ -1071,12 +1071,12 @@ def _interpolate(name, dim, interpolate_mode):
     return symbolic_fn
 
 
-upsample_nearest1d = _interpolate('upsample_nearest1d', 3, "nearest")
-upsample_nearest2d = _interpolate('upsample_nearest2d', 4, "nearest")
-upsample_nearest3d = _interpolate('upsample_nearest3d', 5, "nearest")
-upsample_linear1d = _interpolate('upsample_linear1d', 3, "linear")
-upsample_bilinear2d = _interpolate('upsample_bilinear2d', 4, "linear")
-upsample_trilinear3d = _interpolate('upsample_trilinear3d', 5, "linear")
+upsample_nearest1d = _interpolate("upsample_nearest1d", 3, "nearest")
+upsample_nearest2d = _interpolate("upsample_nearest2d", 4, "nearest")
+upsample_nearest3d = _interpolate("upsample_nearest3d", 5, "nearest")
+upsample_linear1d = _interpolate("upsample_linear1d", 3, "linear")
+upsample_bilinear2d = _interpolate("upsample_bilinear2d", 4, "linear")
+upsample_trilinear3d = _interpolate("upsample_trilinear3d", 5, "linear")
 
 
 def __interpolate(g, input, size, scale_factor, mode , align_corners, recompute_scale_factor):
@@ -1084,9 +1084,9 @@ def __interpolate(g, input, size, scale_factor, mode , align_corners, recompute_
                                                              mode , align_corners)
     return g.op("Upsample", input, scales, mode_s=mode)
 
-@parse_args('v')
+@parse_args("v")
 def bitwise_not(g, inp):
-    if inp.type().scalarType() != 'Bool':
+    if inp.type().scalarType() != "Bool":
         return _unimplemented("bitwise_not", "non-bool tensor")
     return g.op("Not", inp)
 
@@ -1102,7 +1102,7 @@ def wrap_logical_op_with_cast_to(to_type):
 def wrap_logical_op_with_cast_to_and_from(to_type):
     def decorator(fn):
         def wrap_with_cast(g, input, other):
-            to_cast_func = globals()['_cast_{}'.format(to_type)]
+            to_cast_func = globals()["_cast_{}".format(to_type)]
             from_cast_func = wrap_logical_op_with_cast_to(input.type().scalarType())(fn)
             return from_cast_func(g, to_cast_func(g, input, False), to_cast_func(g, other, False))
         return wrap_with_cast
@@ -1133,10 +1133,10 @@ def gt(g, input, other):
 
 
 def gt_impl(g, input, other):
-    if input.type().scalarType() is not None and input.type().scalarType() == 'Bool' and \
-            other.type().scalarType() is not None and other.type().scalarType() == 'Bool':
-        input = g.op("Cast", input, to_i=sym_help.cast_pytorch_to_onnx['Int'])
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Int'])
+    if input.type().scalarType() is not None and input.type().scalarType() == "Bool" and \
+            other.type().scalarType() is not None and other.type().scalarType() == "Bool":
+        input = g.op("Cast", input, to_i=sym_help.cast_pytorch_to_onnx["Int"])
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Int"])
     return g.op("Greater", input, other)
 
 
@@ -1145,10 +1145,10 @@ def lt(g, input, other):
 
 
 def lt_impl(g, input, other):
-    if input.type().scalarType() is not None and input.type().scalarType() == 'Bool' and \
-            other.type().scalarType() is not None and other.type().scalarType() == 'Bool':
-        input = g.op("Cast", input, to_i=sym_help.cast_pytorch_to_onnx['Int'])
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Int'])
+    if input.type().scalarType() is not None and input.type().scalarType() == "Bool" and \
+            other.type().scalarType() is not None and other.type().scalarType() == "Bool":
+        input = g.op("Cast", input, to_i=sym_help.cast_pytorch_to_onnx["Int"])
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Int"])
     return g.op("Less", input, other)
 
 
@@ -1162,29 +1162,29 @@ def le(g, input, other):
     return gt_impl(g, input, other)
 
 
-@wrap_logical_op_with_cast_to_and_from('Bool')
+@wrap_logical_op_with_cast_to_and_from("Bool")
 def __and_(g, input, other):
-    return g.op('And', input, other)
+    return g.op("And", input, other)
 
 
-@wrap_logical_op_with_cast_to_and_from('Bool')
+@wrap_logical_op_with_cast_to_and_from("Bool")
 def __or_(g, input, other):
-    return g.op('Or', input, other)
+    return g.op("Or", input, other)
 
 
-@wrap_logical_op_with_cast_to_and_from('Bool')
+@wrap_logical_op_with_cast_to_and_from("Bool")
 def logical_and(g, input, other):
-    return g.op('And', input, other)
+    return g.op("And", input, other)
 
 
-@wrap_logical_op_with_cast_to_and_from('Bool')
+@wrap_logical_op_with_cast_to_and_from("Bool")
 def logical_or(g, input, other):
-    return g.op('Or', input, other)
+    return g.op("Or", input, other)
 
 
-@wrap_logical_op_with_cast_to_and_from('Bool')
+@wrap_logical_op_with_cast_to_and_from("Bool")
 def logical_xor(g, input, other):
-    return g.op('Xor', input, other)
+    return g.op("Xor", input, other)
 
 
 def __rshift_(g, self, other):
@@ -1193,13 +1193,13 @@ def __rshift_(g, self, other):
     if other.type().scalarType() != self.type().scalarType():
         other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
 
-    two = g.op('Constant', value_t=torch.tensor(2, dtype=torch.float32))
+    two = g.op("Constant", value_t=torch.tensor(2, dtype=torch.float32))
     # exponent (same type as self) has to be float or double in onnx::Pow
     if not sym_help._is_fp(self):
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    two_pow = g.op('Pow', two, other)
-    two_pow = g.op('Cast', two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
-    rshift = g.op('Div', self, two_pow)
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+    two_pow = g.op("Pow", two, other)
+    two_pow = g.op("Cast", two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+    rshift = g.op("Div", self, two_pow)
     return rshift
 
 
@@ -1209,28 +1209,28 @@ def __lshift_(g, self, other):
     if other.type().scalarType() != self.type().scalarType():
         other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
 
-    two = g.op('Constant', value_t=torch.tensor(2, dtype=torch.float32))
+    two = g.op("Constant", value_t=torch.tensor(2, dtype=torch.float32))
     # exponent (same type as self) has to be float or double in onnx::Pow
     if not sym_help._is_fp(self):
-        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    two_pow = g.op('Pow', two, other)
-    two_pow = g.op('Cast', two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
-    lshift = g.op('Mul', self, two_pow)
+        other = g.op("Cast", other, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+    two_pow = g.op("Pow", two, other)
+    two_pow = g.op("Cast", two_pow, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
+    lshift = g.op("Mul", self, two_pow)
     return lshift
 
 
-@parse_args('v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "i")
 def where(g, condition, self=None, other=None, _outputs=None):
     # Assumes that torch.where's first argument takes only Bool and Byte tensors.
-    if condition.type().scalarType() != 'Bool':
-        condition = g.op("Cast", condition, to_i=sym_help.cast_pytorch_to_onnx['Bool'])
+    if condition.type().scalarType() != "Bool":
+        condition = g.op("Cast", condition, to_i=sym_help.cast_pytorch_to_onnx["Bool"])
     if self is None:
         condition = torch.onnx.symbolic_opset9.nonzero(g, condition)
         return sym_help._unbind_helper(g, condition, g.op("Constant", value_t=torch.tensor(1)), _outputs)
     return g.op("Where", condition, self, other)
 
 
-@parse_args('v', 'i', 'none')
+@parse_args("v", "i", "none")
 def log_softmax(g, input, dim, dtype=None):
     # PyTorch dim and ONNX axis have different meanings.
     # See Softmax comment for details.
@@ -1250,15 +1250,15 @@ def log_softmax(g, input, dim, dtype=None):
         input = g.op("Transpose", input, perm_i=axes)
         dim = input_dim - 1
     return_op = g.op("LogSoftmax", input, axis_i=dim)
-    if dtype and dtype.node().kind() != 'prim::Constant':
-        parsed_dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    if dtype and dtype.node().kind() != "prim::Constant":
+        parsed_dtype = sym_help._get_const(dtype, "i", "dtype")
         return_op = g.op("Cast", return_op, to_i=sym_help.scalar_type_to_onnx[parsed_dtype])
     if is_transpose_required:
         return_op = g.op("Transpose", return_op, perm_i=axes)
     return return_op
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'is', 'i', 'i', 'i', 'i', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "is", "i", "i", "i", "i", "i")
 def _convolution(g, input, weight, bias, stride, padding, dilation,
                  transposed, output_padding, groups, benchmark, deterministic, cudnn_enabled, allow_tf32):
     weight_size = sym_help._get_tensor_sizes(weight)
@@ -1268,8 +1268,8 @@ def _convolution(g, input, weight, bias, stride, padding, dilation,
         kernel_shape = None
 
     if kernel_shape is None or any([i is None for i in kernel_shape]):
-        raise RuntimeError('Unsupported: ONNX export of convolution for kernel '
-                           'of unknown shape.')
+        raise RuntimeError("Unsupported: ONNX export of convolution for kernel "
+                           "of unknown shape.")
 
     args = [input, weight]
     # ONNX only supports 1D bias
@@ -1300,37 +1300,37 @@ def _convolution(g, input, weight, bias, stride, padding, dilation,
         return n
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i")
 def conv1d(g, input, weight, bias, stride, padding, dilation, groups):
     return _convolution(g, input, weight, bias, stride, padding, dilation, False, (), groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i")
 def conv2d(g, input, weight, bias, stride, padding, dilation, groups):
     return _convolution(g, input, weight, bias, stride, padding, dilation, False, (), groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i')
+@parse_args("v", "v", "v", "is", "is", "is", "i")
 def conv3d(g, input, weight, bias, stride, padding, dilation, groups):
     return _convolution(g, input, weight, bias, stride, padding, dilation, False, (), groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'is')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "is")
 def conv_transpose1d(g, input, weight, bias, stride, padding, output_padding, groups, dilation):
     return _convolution(g, input, weight, bias, stride, padding, dilation, True, output_padding, groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'is')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "is")
 def conv_transpose2d(g, input, weight, bias, stride, padding, output_padding, groups, dilation):
     return _convolution(g, input, weight, bias, stride, padding, dilation, True, output_padding, groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'is', 'is', 'is', 'i', 'is')
+@parse_args("v", "v", "v", "is", "is", "is", "i", "is")
 def conv_transpose3d(g, input, weight, bias, stride, padding, output_padding, groups, dilation):
     return _convolution(g, input, weight, bias, stride, padding, dilation, True, output_padding, groups, None, None, None, None)
 
 
-@parse_args('v', 'v', 'v', 'v', 'v', 'i', 'f', 'f', 'i')
+@parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     sym_help.assert_training_mode(training, "batch_norm")
     batch_size = sym_help._get_tensor_dim_size(input, 0)
@@ -1338,24 +1338,24 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
 
     if weight is None or sym_help._is_none(weight):
         if channel_size is None:
-            raise RuntimeError('Unsupported: ONNX export of batch_norm for unknown '
-                               'channel size.')
+            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
+                               "channel size.")
         weight_value = torch.tensor([1.] * channel_size).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            "torch." + input.type().scalarType() + "Tensor")
         weight = g.op("Constant", value_t=weight_value)
     if bias is None or sym_help._is_none(bias):
         if channel_size is None:
-            raise RuntimeError('Unsupported: ONNX export of batch_norm for unknown '
-                               'channel size.')
+            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
+                               "channel size.")
         bias_value = torch.tensor([0.] * channel_size).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            "torch." + input.type().scalarType() + "Tensor")
         bias = g.op("Constant", value_t=bias_value)
     # If track_running_stats is set to False batch statistics are instead used during evaluation time
     if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
         assert batch_size is not None and channel_size is not None
         reshape_in = g.op("Reshape", input,
                           g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1], dtype=torch.int64)))
-        trans_in = g.op('Transpose', reshape_in, perm_i=[0, 2, 1])
+        trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
         running_var, running_mean = _var_mean(g, trans_in,
                                               g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),
                                               False, False)
@@ -1374,7 +1374,7 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
         return res
 
 
-@parse_args('v', 'is', 'v', 'v', 'f', 'i')
+@parse_args("v", "is", "v", "v", "f", "i")
 def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, weight, bias, normalized_shape_i=normalized_shape,
@@ -1401,23 +1401,23 @@ def layer_norm(g, input, normalized_shape, weight, bias, eps, cudnn_enable):
     return layer_norm
 
 
-@parse_args('v', 'v', 'v', 'v', 'v', 'i', 'f', 'f', 'i')
+@parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled):
     if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
         channel_size = sym_help._get_tensor_dim_size(input, 1)
         if weight is None or sym_help._is_none(weight):
             if channel_size is None:
-                raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                                   'channel size.')
+                raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
+                                   "channel size.")
             weight_value = torch.tensor([1.] * channel_size).type(
-                'torch.' + input.type().scalarType() + 'Tensor')
+                "torch." + input.type().scalarType() + "Tensor")
             weight = g.op("Constant", value_t=weight_value)
         if bias is None or sym_help._is_none(bias):
             if channel_size is None:
-                raise RuntimeError('Unsupported: ONNX export of instance_norm for unknown '
-                                   'channel size.')
+                raise RuntimeError("Unsupported: ONNX export of instance_norm for unknown "
+                                   "channel size.")
             bias_value = torch.tensor([0.] * channel_size).type(
-                'torch.' + input.type().scalarType() + 'Tensor')
+                "torch." + input.type().scalarType() + "Tensor")
             bias = g.op("Constant", value_t=bias_value)
         return g.op("InstanceNormalization", input, weight, bias, epsilon_f=eps)
     else:
@@ -1426,7 +1426,7 @@ def instance_norm(g, input, weight, bias, running_mean, running_var, use_input_s
         return batch_norm(g, input, weight, bias, running_mean, running_var, use_input_stats, momentum, eps, cudnn_enabled)
 
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def unfold(g, input, dimension, size, step):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, operator_s="unfold", dimension_i=dimension, size_i=size, step_i=step)
@@ -1449,7 +1449,7 @@ def unfold(g, input, dimension, size, step):
         return _unimplemented("Unfold", "input size not accessible")
 
 
-@parse_args('v', 't', 't', 't')
+@parse_args("v", "t", "t", "t")
 def elu(g, input, alpha, scale, input_scale):
     if scale and scale != 1.:
         return _unimplemented("scale", "does not support scale in Elu")
@@ -1463,7 +1463,7 @@ def selu(g, input):
     return g.op("Selu", input)
 
 
-@parse_args('v', 'i', 'v')
+@parse_args("v", "i", "v")
 def index_select(g, self, dim, index):
     # In case of a scalar index, index_select returns a tensor with the same rank as the input.
     # To match this behavior in ONNX, we make index a 1D tensor so that the following gather
@@ -1478,9 +1478,9 @@ def index_put(g, self, indices_list_value, values, accumulate):
         indices_list = [indices_list_value]
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         args = [self] + indices_list + [values, accumulate]
-        return g.op("ATen", *args, operator_s='index_put')
+        return g.op("ATen", *args, operator_s="index_put")
 
-    accumulate = sym_help._parse_arg(accumulate, 'b')
+    accumulate = sym_help._parse_arg(accumulate, "b")
 
     if len(indices_list) == 0:
         if accumulate:
@@ -1488,11 +1488,11 @@ def index_put(g, self, indices_list_value, values, accumulate):
         else:
             return values
     else:
-        sym_help._onnx_opset_unsupported('index_put', 9, 11)
+        sym_help._onnx_opset_unsupported("index_put", 9, 11)
 
 
 def index_fill(g, self, dim, index, value):
-    dim_value = sym_help._parse_arg(dim, 'i')
+    dim_value = sym_help._parse_arg(dim, "i")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", self, index, value, dim_i=dim_value, operator_s="index_fill")
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -1504,7 +1504,7 @@ def index_fill(g, self, dim, index, value):
 
 
 def index_copy(g, self, dim, index, source):
-    dim_value = sym_help._parse_arg(dim, 'i')
+    dim_value = sym_help._parse_arg(dim, "i")
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", self, index, source, dim_i=dim_value, operator_s="index_copy")
     expanded_index_shape, expanded_index = sym_help._index_fill_reshape_helper(g, self, dim, index)
@@ -1523,16 +1523,16 @@ def type_as(g, self, other):
             # We don't know the type of other, bail by emitting ATen
             return g.op("ATen", self, other, operator_s="type_as")
         else:
-            raise RuntimeError('Unsupported: ONNX export of type_as for tensor '
-                               'of unknown dtype.')
+            raise RuntimeError("Unsupported: ONNX export of type_as for tensor "
+                               "of unknown dtype.")
 
 
-@parse_args('v', 'v', 'i', 'f')
+@parse_args("v", "v", "i", "f")
 def cosine_similarity(g, x1, x2, dim, eps):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", x1, x2, dim_i=dim, eps_f=eps, operator_s="cosine_similarity")
     else:
-        return sym_help._onnx_unsupported('cosine_similarity')
+        return sym_help._onnx_unsupported("cosine_similarity")
 
 
 # ignore clone operators that are inserted by PyTorch autograd
@@ -1555,7 +1555,7 @@ def log1p(g, self):
 def pow(g, self, exponent):
     f_dtype = self_dtype = self.type().scalarType()
     if not sym_help._is_fp(self):
-        f_dtype = 'Float'
+        f_dtype = "Float"
         self = g.op("Cast", self, to_i=sym_help.cast_pytorch_to_onnx[f_dtype])
     if not sym_help._is_fp(exponent):
         exponent = g.op("Cast", exponent, to_i=sym_help.cast_pytorch_to_onnx[f_dtype])
@@ -1572,7 +1572,7 @@ def clamp(g, self, min, max):
         return clamp_min(g, self, min)
     else:
         if sym_help._is_constant(min) and sym_help._is_constant(max):
-            return g.op("Clip", self, min_f=_parse_arg(min, 'f'), max_f=_parse_arg(max, 'f'))
+            return g.op("Clip", self, min_f=_parse_arg(min, "f"), max_f=_parse_arg(max, "f"))
         else:
             return clamp_max(g, clamp_min(g, self, min), max)
 
@@ -1587,7 +1587,7 @@ def clamp_min(g, self, min):
         return g.op("Max", self, min)
 
 
-@parse_args('v', 'v')
+@parse_args("v", "v")
 def clamp_max(g, self, max):
     if sym_help._is_constant(max):
         return g.op("Clip", self, max_f=_parse_arg(max, 'f'))
@@ -1608,10 +1608,10 @@ def max(g, self, dim_or_y=None, keepdim=None):
         return g.op("Max", self, dim_or_y)
     # torch.max(input, dim, keepdim)
     else:
-        dim = sym_help._get_const(dim_or_y, 'i', 'dim')
-        keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
+        dim = sym_help._get_const(dim_or_y, "i", "dim")
+        keepdim = sym_help._get_const(keepdim, "i", "keepdim")
         max = g.op("ReduceMax", self, axes_i=[dim], keepdims_i=keepdim)
-        indices = g.op('ArgMax', self, axis_i=dim, keepdims_i=keepdim)
+        indices = g.op("ArgMax", self, axis_i=dim, keepdims_i=keepdim)
         return max, indices
 
 
@@ -1624,10 +1624,10 @@ def min(g, self, dim_or_y=None, keepdim=None):
         return g.op("Min", self, dim_or_y)
     # torch.min(input, dim, keepdim)
     else:
-        dim = sym_help._get_const(dim_or_y, 'i', 'dim')
-        keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
+        dim = sym_help._get_const(dim_or_y, "i", "dim")
+        keepdim = sym_help._get_const(keepdim, "i", "keepdim")
         min = g.op("ReduceMin", self, axes_i=[dim], keepdims_i=keepdim)
-        indices = g.op('ArgMin', self, axis_i=dim, keepdims_i=keepdim)
+        indices = g.op("ArgMin", self, axis_i=dim, keepdims_i=keepdim)
         return min, indices
 
 
@@ -1635,7 +1635,7 @@ def exp(g, self):
     return g.op("Exp", self)
 
 
-@parse_args('v', 'f', 'i')
+@parse_args("v", "f", "i")
 def dropout(g, input, p, train):
     sym_help.assert_training_mode(train, "dropout")
     # in eval mode, dropout is non-op - if the node's train param is set to False, dropout is non-op
@@ -1648,7 +1648,7 @@ def dropout(g, input, p, train):
 
 
 def _unsupported_dropout(name):
-    @parse_args('v', 'f', 'i')
+    @parse_args("v", "f", "i")
     def feature_dropout(g, input, p, train):
         # NB: In inference mode, FeatureDropout is exported as an identity op.
         if train:
@@ -1668,7 +1668,7 @@ alpha_dropout_ = alpha_dropout
 feature_alpha_dropout_ = feature_alpha_dropout
 
 
-@parse_args('v', 't', 'is', 'i')
+@parse_args("v", "t", "is", "i")
 def norm(g, self, p, dim, keepdim):
     if p == 1:
         f = _reduce_op_symbolic("ReduceL1")
@@ -1679,7 +1679,7 @@ def norm(g, self, p, dim, keepdim):
     return f(g, self, dim=dim, keepdim=keepdim)
 
 
-@parse_args('v', 'v', 'v', 'i')
+@parse_args("v", "v", "v", "i")
 def conv_tbc(g, input, weight, bias, pad):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, weight, bias, operator_s="conv_tbc", pad_i=pad)
@@ -1695,36 +1695,36 @@ def conv_tbc(g, input, weight, bias, pad):
         return g.op("Transpose", conv, perm_i=[2, 0, 1])
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def _unique(g, input, sorted, return_inverse):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, operator_s="_unique", sorted_i=sorted,
                     return_inverse_i=return_inverse, outputs=2)
     else:
-        return sym_help._onnx_unsupported('_unique')
+        return sym_help._onnx_unsupported("_unique")
 
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def _unique2(g, input, sorted, return_inverse, return_counts):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, operator_s="_unique2", sorted_i=sorted,
                     return_inverse_i=return_inverse, return_counts_i=return_counts,
                     outputs=3)
     else:
-        sym_help._onnx_opset_unsupported('_unique2', 9, 11)
+        sym_help._onnx_opset_unsupported("_unique2", 9, 11)
 
 
 for k, v in sym_help.cast_pytorch_to_onnx.items():
-    name = '_cast_{}'.format(k)
-    globals()[name] = parse_args('v', 'i')(partial(sym_help._cast_func_template, v))
+    name = "_cast_{}".format(k)
+    globals()[name] = parse_args("v", "i")(partial(sym_help._cast_func_template, v))
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def empty(g, sizes, dtype, layout, device, pin_memory=False, memory_format=None):
     return zeros(g, sizes, dtype, layout, device, pin_memory)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def empty_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     return zeros_like(g, input, dtype, layout, device, pin_memory)
 
@@ -1738,7 +1738,7 @@ def new_empty(g, self, sizes, dtype, layout, device, pin_memory=False):
 
 
 def scalar_tensor(g, scalar, dtype, *options):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if dtype is None:
         dtype = 6  # float
     scalar = g.op("Cast", scalar, to_i=sym_help.scalar_type_to_onnx[dtype])
@@ -1746,7 +1746,7 @@ def scalar_tensor(g, scalar, dtype, *options):
 
 
 def tensor(g, data, dtype=None, device=None, requires_grad=False):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if sym_help._is_packed_list(data):
         if dtype is None:
             dtype = sym_help._unpack_list(data)[0].type().scalarType()
@@ -1767,7 +1767,7 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
 def as_tensor(g, data, dtype=None, device=None):
     return tensor(g, data, dtype, device)
 
-@parse_args('v', 'i', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v")
 def zeros(g, sizes, dtype, layout, device, pin_memory=False):
     # NOTE: no way to set device, layout and pin_memory in ONNX, so we ignore it
     if dtype is None:
@@ -1776,7 +1776,7 @@ def zeros(g, sizes, dtype, layout, device, pin_memory=False):
                 value_t=torch.tensor([0], dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def zeros_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     if dtype is None:
@@ -1793,7 +1793,7 @@ def new_zeros(g, self, sizes, dtype, layout, device, pin_memory=False):
     return zeros(g, sizes, dtype, layout, device, pin_memory)
 
 
-@parse_args('v', 'i', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v")
 def ones(g, sizes, dtype, layout, device, pin_memory=False):
     if dtype is None:
         dtype = 6  # float
@@ -1801,7 +1801,7 @@ def ones(g, sizes, dtype, layout, device, pin_memory=False):
                 value_t=torch.tensor([1], dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
 
 
-@parse_args('v', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "i", "v", "v", "v", "v")
 def ones_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
     shape = g.op("Shape", input)
     if dtype is None:
@@ -1811,21 +1811,21 @@ def ones_like(g, input, dtype=None, layout=None, device=None, pin_memory=False, 
 
 
 def full(g, sizes, value, dtype, layout, device, pin_memory=False):
-    const_value = sym_help._maybe_get_const(value, 't')
+    const_value = sym_help._maybe_get_const(value, "t")
     if sym_help._is_value(const_value):
         dtype = 6 if dtype is None else dtype
         tmp = zeros(g, sizes, dtype, layout, device)
         return add(g, tmp, value, g.op("Constant", value_t=torch.tensor(1)))
     else:
-        dtype = sym_help._get_const(dtype, 'i', 'dtype')
+        dtype = sym_help._get_const(dtype, "i", "dtype")
         dtype = 6 if dtype is None else dtype
         return g.op("ConstantOfShape", sizes,
                     value_t=torch.tensor([const_value], dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
 
 
 def full_like(g, input, fill_value, dtype=None, layout=None, device=None, pin_memory=False, memory_format=None):
-    fill_value = sym_help._maybe_get_const(fill_value, 'f')
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    fill_value = sym_help._maybe_get_const(fill_value, "f")
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     dtype = 6 if dtype is None else dtype
     if sym_help._is_value(fill_value):
         tmp = zeros_like(g, input, dtype, layout, device)
@@ -1867,68 +1867,68 @@ def slice(g, self, *args):
     if len(args) == 4:
         # aten::slice(Tensor self, int dim, int start, int end, int step) -> Tensor
         dim, start, end, step = args
-        step = _parse_arg(step, 'i')
+        step = _parse_arg(step, "i")
         if step != 1:
             raise RuntimeError("step!=1 is currently not supported")
-        is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == 'NoneType'
-        is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == 'NoneType'
-        is_start_onnx_const = start.node().kind() == 'onnx::Constant'
-        is_end_onnx_const = end.node().kind() == 'onnx::Constant'
+        is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == "NoneType"
+        is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == "NoneType"
+        is_start_onnx_const = start.node().kind() == "onnx::Constant"
+        is_end_onnx_const = end.node().kind() == "onnx::Constant"
         if ((not is_start_none) and (not is_start_onnx_const)) or \
            ((not is_end_none) and (not is_end_onnx_const)) or \
-           dim.node().kind() != 'onnx::Constant':
+           dim.node().kind() != "onnx::Constant":
             if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX:
-                raise RuntimeError('Unsupported: ONNX export of Slice with dynamic inputs. DynamicSlice '
-                                   'is a deprecated experimental op. Please use statically allocated '
-                                   'variables or export to a higher opset version.')
+                raise RuntimeError("Unsupported: ONNX export of Slice with dynamic inputs. DynamicSlice "
+                                   "is a deprecated experimental op. Please use statically allocated "
+                                   "variables or export to a higher opset version.")
             else:
                 start_unsqueezed = sym_help._unsqueeze_helper(g, start, [0])
                 end_unsqueezed = sym_help._unsqueeze_helper(g, end, [0])
                 dim_unsqueezed = sym_help._unsqueeze_helper(g, dim, [0])
                 return g.op("DynamicSlice", self, start_unsqueezed, end_unsqueezed, dim_unsqueezed)
         else:
-            start = 0 if is_start_none else _parse_arg(start, 'i')
-            end = 9223372036854775807 if is_end_none else _parse_arg(end, 'i')
-            dim = _parse_arg(dim, 'i')
+            start = 0 if is_start_none else _parse_arg(start, "i")
+            end = 9223372036854775807 if is_end_none else _parse_arg(end, "i")
+            dim = _parse_arg(dim, "i")
             return sym_help._slice_helper(g, self, axes=[dim], starts=[start], ends=[end])
     elif len(args) == 3:
         # aten::slice(t[] l, int start, int end, int step) -> t[]
         start, end, step = args
         dim = 0
-        is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == 'NoneType'
-        is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == 'NoneType'
-        start = 0 if is_start_none else _parse_arg(start, 'i')
-        end = 9223372036854775807 if is_end_none else _parse_arg(end, 'i')
+        is_start_none = start.node().kind() == "prim::Constant" and start.type().kind() == "NoneType"
+        is_end_none = end.node().kind() == "prim::Constant" and end.type().kind() == "NoneType"
+        start = 0 if is_start_none else _parse_arg(start, "i")
+        end = 9223372036854775807 if is_end_none else _parse_arg(end, "i")
         return sym_help._slice_helper(g, self, axes=[dim], starts=[start], ends=[end])
     else:
         raise NotImplementedError("Unknown aten::slice signature")
 
 
-@parse_args('v', 'f', 'f')
+@parse_args("v", "f", "f")
 def hardtanh(g, self, min_val, max_val):
     return g.op("Clip", self, min_f=min_val, max_f=max_val)
 
 
-@parse_args('v')
+@parse_args("v")
 def hardswish(g, self):
-    input = g.op("Add", self, g.op('Constant', value_t=torch.tensor(3, dtype=torch.float)))
+    input = g.op("Add", self, g.op("Constant", value_t=torch.tensor(3, dtype=torch.float)))
     hardtanh_ = sym_help._hardtanh_helper(g, input,
-                                          g.op('Constant', value_t=torch.tensor(0, dtype=torch.float)),
-                                          g.op('Constant', value_t=torch.tensor(6, dtype=torch.float)))
-    hardtanh_ = g.op("Div", hardtanh_, g.op('Constant', value_t=torch.tensor(6, dtype=torch.float)))
+                                          g.op("Constant", value_t=torch.tensor(0, dtype=torch.float)),
+                                          g.op("Constant", value_t=torch.tensor(6, dtype=torch.float)))
+    hardtanh_ = g.op("Div", hardtanh_, g.op("Constant", value_t=torch.tensor(6, dtype=torch.float)))
     return g.op("Mul", self, hardtanh_)
 
 
-@parse_args('v')
+@parse_args("v")
 def hardsigmoid(g, self):
-    return g.op('HardSigmoid', self, alpha_f=1 / 6)
+    return g.op("HardSigmoid", self, alpha_f=1 / 6)
 
 
 def alias(g, self):
     return self
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def unsqueeze(g, self, dim):
     # Handle negative dim
     if dim < 0:
@@ -1942,12 +1942,12 @@ def unsqueeze(g, self, dim):
                           "Passing an tensor of different rank in execution will be incorrect.")
             dim = dim + rank + 1
         else:
-            return _unimplemented('unsqueeze', 'negative axis with unknown input rank')
+            return _unimplemented("unsqueeze", "negative axis with unknown input rank")
 
     return sym_help._unsqueeze_helper(g, self, axes_i=[dim])
 
 
-@parse_args('v', 'i', 'i', 'none')
+@parse_args("v", "i", "i", "none")
 def sort(g, self, dim, decending, out=None):
     if out is not None:
         _unimplemented("Sort", "Out parameter is not supported for sort")
@@ -1968,7 +1968,7 @@ def numel(g, self):
     return g.op("ReduceProd", shape, keepdims_i=0)
 
 
-@parse_args('v', 'i', 'i', 'i', 'i', 'none')
+@parse_args("v", "i", "i", "i", "i", "none")
 def topk(g, self, k, dim, largest, sorted, out=None):
     if out is not None:
         _unimplemented("TopK", "Out parameter is not supported for topk")
@@ -1981,11 +1981,11 @@ def topk(g, self, k, dim, largest, sorted, out=None):
 def to(g, self, *args):
     # ONNX doesn't have a concept of a device, so we ignore device casts
     if len(args) == 4:
-        if args[0].node().kind() == 'prim::device' or args[0].type().isSubtypeOf(ListType.ofInts()):
+        if args[0].node().kind() == "prim::device" or args[0].type().isSubtypeOf(ListType.ofInts()):
             # aten::to(Tensor, Device, bool, bool, memory_format)
             return self
         else:
-            dtype = sym_help._maybe_get_const(args[0], 'i')
+            dtype = sym_help._maybe_get_const(args[0], "i")
             if sym_help._is_value(dtype):
                 # aten::to(Tensor, Tensor, bool, bool, memory_format)
                 other = args[0]
@@ -1997,17 +1997,17 @@ def to(g, self, *args):
                 return g.op("Cast", self, to_i=sym_help.scalar_type_to_onnx[dtype])
     elif len(args) == 5:
         # aten::to(Tensor, Device, ScalarType, bool, bool, memory_format)
-        dtype = sym_help._get_const(args[1], 'i', 'dtype')
+        dtype = sym_help._get_const(args[1], "i", "dtype")
         # memory_format is ignored
         return g.op("Cast", self, to_i=sym_help.scalar_type_to_onnx[dtype])
     elif len(args) == 6:
         # aten::to(Tensor, ScalarType, Layout, Device, bool, bool, memory_format) -> Tensor
-        dtype = sym_help._get_const(args[0], 'i', 'dtype')
+        dtype = sym_help._get_const(args[0], "i", "dtype")
         # Layout, device and memory_format are ignored
         return g.op("Cast", self, to_i=sym_help.scalar_type_to_onnx[dtype])
     elif len(args) == 7:
         # aten::to(Tensor, ScalarType, Layout, Device, bool, bool, bool, memory_format) -> Tensor
-        dtype = sym_help._get_const(args[0], 'i', 'dtype')
+        dtype = sym_help._get_const(args[0], "i", "dtype")
         # Layout, device and memory_format are ignored
         return g.op("Cast", self, to_i=sym_help.scalar_type_to_onnx[dtype])
     else:
@@ -2035,14 +2035,14 @@ def repeat_interleave(g, self, repeats, dim=None):
     repeats_sizes = sym_help._get_tensor_sizes(repeats)
     input_sizes = sym_help._get_tensor_sizes(input)
     if repeats_dim is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'repeats rank.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "repeats rank.")
     if repeats_sizes is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'repeats size.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "repeats size.")
     if input_sizes is None:
-        raise RuntimeError('Unsupported: ONNX export of repeat_interleave for unknown '
-                           'input size.')
+        raise RuntimeError("Unsupported: ONNX export of repeat_interleave for unknown "
+                           "input size.")
 
     input_sizes_temp = input_sizes.copy()
     for idx, input_size in enumerate(input_sizes):
@@ -2054,8 +2054,8 @@ def repeat_interleave(g, self, repeats, dim=None):
         if not sym_help._is_tensor(repeats):
             repeats = g.op("Constant", value_t=torch.LongTensor(repeats))
         if input_sizes[dim] == 0:
-            return sym_help._onnx_opset_unsupported_detailed('repeat_interleave', 9, 11,
-                                                             'Unsupported along dimension with unknown input size')
+            return sym_help._onnx_opset_unsupported_detailed("repeat_interleave", 9, 11,
+                                                             "Unsupported along dimension with unknown input size")
         else:
             reps = input_sizes[dim]
             repeats = expand(g, repeats, g.op("Constant", value_t=torch.tensor([reps])), None)
@@ -2063,8 +2063,8 @@ def repeat_interleave(g, self, repeats, dim=None):
     # Cases where repeats is a 1 dim Tensor
     elif repeats_dim == 1:
         if input_sizes[dim] == 0:
-            return sym_help._onnx_opset_unsupported_detailed('repeat_interleave', 9, 11,
-                                                             'Unsupported along dimension with unknown input size')
+            return sym_help._onnx_opset_unsupported_detailed("repeat_interleave", 9, 11,
+                                                             "Unsupported along dimension with unknown input size")
         assert repeats_sizes[0] == input_sizes[dim], "repeats must have the same size as input along dim"
         reps = repeats_sizes[0]
     else:
@@ -2086,7 +2086,7 @@ def repeat_interleave(g, self, repeats, dim=None):
     return g.op("Concat", *final_splits, axis_i=dim)
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def pixel_shuffle(g, self, upscale_factor):
     dims = sym_help._get_tensor_sizes(self)
     if len(dims) != 4:
@@ -2111,24 +2111,24 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
                   "Make sure to save the model with a batch size of 1, " +
                   "or define the initial states (h0/c0) as inputs of the model. ")
 
-    onnxActivations = ['Relu', 'Tanh', 'Sigmoid', 'Affine', 'LeakyRelu', 'ThresholdedRelu',
-                       'ScaledTanh', 'HardSigmoid', 'Elu', 'Softsign', 'Softplus']
+    onnxActivations = ["Relu", "Tanh", "Sigmoid", "Affine", "LeakyRelu", "ThresholdedRelu",
+                       "ScaledTanh", "HardSigmoid", "Elu", "Softsign", "Softplus"]
     variantToOnnxActivationMap = dict(zip([act_fun.lower() for act_fun in onnxActivations], onnxActivations))
     weights_per_layer = 4 if has_biases else 2
     # this means that projections are used inside LSTM, so need to tell user that it's not supported
-    if variant == 'LSTM' and len(all_weights) != num_layers * weights_per_layer * (1 + bidirectional):
+    if variant == "LSTM" and len(all_weights) != num_layers * weights_per_layer * (1 + bidirectional):
         return _unimplemented("LSTM", "LSTMs with projections")
     assert len(all_weights) == num_layers * weights_per_layer * (1 + bidirectional)
     layer_weights = [all_weights[i:i + weights_per_layer] for i in range(0, len(all_weights), weights_per_layer)]
     if batch_first:
         # batch, seq, feat -> seq, batch, feat
-        input = g.op('Transpose', input, perm_i=[1, 0, 2])
+        input = g.op("Transpose", input, perm_i=[1, 0, 2])
     if dropout and train:
         return _unimplemented("RNN/GRU/LSTM", "dropout in training mode")
 
-    if variant.startswith('RNN'):
+    if variant.startswith("RNN"):
         nonlinearity = variantToOnnxActivationMap[variant[4:].lower()]
-        variant = 'RNN'
+        variant = "RNN"
 
     w_hh = all_weights[1]
     hidden_size = sym_help._get_tensor_dim_size(w_hh, 1)
@@ -2140,44 +2140,44 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
     prev_output = input
 
     h_outs = []
-    if variant == 'RNN' or variant == 'GRU':
+    if variant == "RNN" or variant == "GRU":
         h0 = initial_states
-    elif variant == 'LSTM':
+    elif variant == "LSTM":
         h0, c0 = initial_states
         c_outs = []
 
     sequence_lens = unused(g) if batch_sizes is None else batch_sizes
 
-    if variant == 'GRU':
+    if variant == "GRU":
         # pytorch is reset, input, hidden
         # onnx is    input, reset, hidden
         reform_permutation = [(1, 2), (0, 1), (2, 3)]
-    elif variant == 'LSTM':
+    elif variant == "LSTM":
         # pytorch is input, forget, cell, output.
         # onnx is    input, output, forget, cell.
         reform_permutation = [(0, 1), (3, 4), (1, 3)]
 
     def reform_weights(g, w, n, intervals):
         slices = [sym_help._slice_helper(g, w, axes=[0], starts=[x * n], ends=[y * n]) for x, y in intervals]
-        return g.op('Concat', *slices, axis_i=0)
+        return g.op("Concat", *slices, axis_i=0)
 
     def transform_weights_no_bias(layer_index):
         weights = layer_weights[layer_index]
-        if variant == 'RNN':
+        if variant == "RNN":
             weight_ih, weight_hh = weights
-        elif variant == 'GRU' or variant == 'LSTM':
+        elif variant == "GRU" or variant == "LSTM":
             weight_ih, weight_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
         return tuple(sym_help._unsqueeze_helper(g, x, [0]) for x in (weight_ih, weight_hh))
 
     def transform_weights(layer_index):
         weights = layer_weights[layer_index]
-        if variant == 'RNN':
+        if variant == "RNN":
             weight_ih, weight_hh, bias_ih, bias_hh = weights
-        elif variant == 'GRU' or variant == 'LSTM':
+        elif variant == "GRU" or variant == "LSTM":
             weight_ih, weight_hh, bias_ih, bias_hh = \
                 [reform_weights(g, w, hidden_size, reform_permutation) for w in weights]
-        bias_concat = g.op('Concat', bias_ih, bias_hh, axis_i=0)
+        bias_concat = g.op("Concat", bias_ih, bias_hh, axis_i=0)
         return tuple(sym_help._unsqueeze_helper(g, x, [0]) for x in (weight_ih, weight_hh, bias_concat))
 
     def retrieve_state(x, start, end):
@@ -2196,41 +2196,41 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             if weights_per_layer == 4:
                 weight_ih_f, weight_hh_f, bias_f = transform_weights(2 * i)
                 weight_ih_b, weight_hh_b, bias_b = transform_weights(2 * i + 1)
-                bias_concat = g.op('Concat', bias_f, bias_b, axis_i=0)
+                bias_concat = g.op("Concat", bias_f, bias_b, axis_i=0)
             else:
                 weight_ih_f, weight_hh_f = transform_weights_no_bias(2 * i)
                 weight_ih_b, weight_hh_b = transform_weights_no_bias(2 * i + 1)
                 bias_concat = unused(g)
 
-            weight_ih = g.op('Concat', weight_ih_f, weight_ih_b, axis_i=0)
-            weight_hh = g.op('Concat', weight_hh_f, weight_hh_b, axis_i=0)
+            weight_ih = g.op("Concat", weight_ih_f, weight_ih_b, axis_i=0)
+            weight_hh = g.op("Concat", weight_hh_f, weight_hh_b, axis_i=0)
 
             state_indices = 2 * i, 2 * i + 2
 
         inputs = [prev_output, weight_ih, weight_hh, bias_concat, sequence_lens]
 
         inputs.append(retrieve_state(h0, *state_indices))
-        if variant == 'LSTM':
+        if variant == "LSTM":
             inputs.append(retrieve_state(c0, *state_indices))
 
-        extra_kwargs = {} if unidirectional else {'direction_s': 'bidirectional'}
-        if variant == 'RNN':
+        extra_kwargs = {} if unidirectional else {"direction_s": "bidirectional"}
+        if variant == "RNN":
             if bidirectional:
                 activation = [nonlinearity, nonlinearity]
             else:
                 activation = [nonlinearity]
 
-            prev_output, h_out = g.op('RNN', *inputs, outputs=2,
+            prev_output, h_out = g.op("RNN", *inputs, outputs=2,
                                       hidden_size_i=hidden_size,
                                       activations_s=activation,
                                       **extra_kwargs)
-        elif variant == 'GRU':
-            prev_output, h_out = g.op('GRU', *inputs, outputs=2,
+        elif variant == "GRU":
+            prev_output, h_out = g.op("GRU", *inputs, outputs=2,
                                       hidden_size_i=hidden_size,
                                       linear_before_reset_i=1,
                                       **extra_kwargs)
-        elif variant == 'LSTM':
-            prev_output, h_out, c_out = g.op('LSTM', *inputs, outputs=3,
+        elif variant == "LSTM":
+            prev_output, h_out, c_out = g.op("LSTM", *inputs, outputs=3,
                                              hidden_size_i=hidden_size,
                                              **extra_kwargs)
 
@@ -2242,36 +2242,36 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             # by first moving num_directions before hidden_size with
             # Transpose, and then combining it with hidden_size
             # with Reshape.
-            prev_output = g.op('Transpose', prev_output, perm_i=[0, 2, 1, 3])
-            prev_output = g.op('Reshape', prev_output, g.op('Constant', value_t=torch.LongTensor([0, 0, -1])))
+            prev_output = g.op("Transpose", prev_output, perm_i=[0, 2, 1, 3])
+            prev_output = g.op("Reshape", prev_output, g.op("Constant", value_t=torch.LongTensor([0, 0, -1])))
         else:
             prev_output = sym_help._squeeze_helper(g, prev_output, [1])
 
         h_outs.append(h_out)
-        if variant == 'LSTM':
+        if variant == "LSTM":
             c_outs.append(c_out)
     if batch_first:
         # seq, batch, num_directions * hidden_size -> batch, seq, num_directions * hidden_size
-        prev_output = g.op('Transpose', prev_output, perm_i=[1, 0, 2])
-    h_outs = h_out if num_layers == 1 else g.op('Concat', *h_outs, axis_i=0)
-    if variant == 'RNN' or variant == 'GRU':
+        prev_output = g.op("Transpose", prev_output, perm_i=[1, 0, 2])
+    h_outs = h_out if num_layers == 1 else g.op("Concat", *h_outs, axis_i=0)
+    if variant == "RNN" or variant == "GRU":
         return prev_output, h_outs
-    elif variant == 'LSTM':
-        c_outs = c_out if num_layers == 1 else g.op('Concat', *c_outs, axis_i=0)
+    elif variant == "LSTM":
+        c_outs = c_out if num_layers == 1 else g.op("Concat", *c_outs, axis_i=0)
         return prev_output, h_outs, c_outs
 
 
-@parse_args('v', 'v', 'v', 'i', 'i', 'f', 'i', 'i', 'i')
+@parse_args("v", "v", "v", "i", "i", "f", "i", "i", "i")
 def _lstm_full(g, input, hidden_v, weight_v, has_biases, num_layers, dropout, train, bidirectional, batch_first):
     hidden, weight = sym_help._unpack_list(hidden_v), sym_help._unpack_list(weight_v)
-    return _generic_rnn(g, 'LSTM', input, hidden, weight, has_biases, num_layers,
+    return _generic_rnn(g, "LSTM", input, hidden, weight, has_biases, num_layers,
                         dropout, train, bidirectional, batch_first)
 
 
-@parse_args('v', 'v', 'v', 'v', 'i', 'i', 'f', 'i', 'i')
+@parse_args("v", "v", "v", "v", "i", "i", "f", "i", "i")
 def _lstm_packed(g, input, batch_sizes, hidden_v, weight_v, has_biases, num_layers, dropout, train, bidirectional):
     hidden, weight = sym_help._unpack_list(hidden_v), sym_help._unpack_list(weight_v)
-    return _generic_rnn(g, 'LSTM', input, hidden, weight, has_biases, num_layers,
+    return _generic_rnn(g, "LSTM", input, hidden, weight, has_biases, num_layers,
                         dropout, train, bidirectional, batch_sizes=batch_sizes)
 
 
@@ -2283,13 +2283,13 @@ def lstm(g, *args):
 
 
 def _one_hidden_rnn(kind):
-    @parse_args('v', 'v', 'v', 'i', 'i', 'f', 'i', 'i', 'i')
+    @parse_args("v", "v", "v", "i", "i", "f", "i", "i", "i")
     def _rnn_full(g, input, hidden, weight_v, has_biases, num_layers, dropout, train, bidirectional, batch_first):
         weight = sym_help._unpack_list(weight_v)
         return _generic_rnn(g, kind, input, hidden, weight, has_biases, num_layers,
                             dropout, train, bidirectional, batch_first)
 
-    @parse_args('v', 'v', 'v', 'v', 'i', 'i', 'f', 'i', 'i')
+    @parse_args("v", "v", "v", "v", "i", "i", "f", "i", "i")
     def _rnn_packed(g, input, batch_sizes, hidden, weight_v, has_biases, num_layers, dropout, train, bidirectional):
         weight = sym_help._unpack_list(weight_v)
         return _generic_rnn(g, kind, input, hidden, weight, has_biases, num_layers,
@@ -2304,14 +2304,14 @@ def _one_hidden_rnn(kind):
     return symbolic
 
 
-gru = _one_hidden_rnn('GRU')
-rnn_tanh = _one_hidden_rnn('RNN_TANH')
-rnn_relu = _one_hidden_rnn('RNN_RELU')
+gru = _one_hidden_rnn("GRU")
+rnn_tanh = _one_hidden_rnn("RNN_TANH")
+rnn_relu = _one_hidden_rnn("RNN_RELU")
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def _dim_arange(g, like, dim):
-    like_shape = g.op('Shape', like)
+    like_shape = g.op("Shape", like)
     stop = g.op("Gather", like_shape, g.op("Constant", value_t=torch.tensor(dim)), axis_i=0)
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("_caffe2::Range", stop)
@@ -2325,97 +2325,97 @@ def detach(g, input):
     return input
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def contiguous(g, input, memory_format):
     if memory_format > 2:  # allower values are any, preserve and contiguous_format
         raise RuntimeError("onnx memory_format support is not implemented")
     return input
 
 
-@parse_args('v', 'v', 'i')
+@parse_args("v", "v", "i")
 def _pack_padded_sequence(g, input, lengths, batch_first):
     # There currently is no PackPadded operator in ONNX. We rely on an
     # optimization pass to remove this later. It is an error if all
     # PackPadded operators cannot be optimized out.
     if batch_first:
-        input = g.op('Transpose', input, perm_i=[1, 0, 2])
+        input = g.op("Transpose", input, perm_i=[1, 0, 2])
     if not lengths.type().isSubtypeOf(torch._C.TensorType.get()):
         raise RuntimeError("Lengths must be a Tensor for ONNX export")
     # We know it's a TensorType so this check is now safe.
     # It's really only necessary because those operators expand to something that
     # only works with int32 types in Caffe2...
-    if lengths.type().scalarType() != 'Int':
+    if lengths.type().scalarType() != "Int":
         lengths = _cast_Int(g, lengths, False)  # type: ignore[name-defined]
     return g.op("prim::PackPadded", input, lengths, outputs=2)
 
 
-@parse_args('v', 'v', 'i', 't', 'v')
+@parse_args("v", "v", "i", "t", "v")
 def _pad_packed_sequence(g, data, batch_sizes, batch_first, padding_value, total_length):
     # Ignore total_length as it is not supported in _symbolic_pad_packed_sequence
     # It is only useful/used when training using data_parallel model, so
     # It shouldn't be relevant for ONNX anyway
     data, lengths = g.op("prim::PadPacked", data, batch_sizes, outputs=2)
     if batch_first:
-        data = g.op('Transpose', data, perm_i=[1, 0, 2])
+        data = g.op("Transpose", data, perm_i=[1, 0, 2])
     return data, lengths
 
 
 def randn(g, shapes, dtype, *options):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if dtype is None:
         dtype = 6  # float
     shape = sym_help._maybe_get_const(shapes, "is")
     if sym_help._is_value(shape):
         shape_const = g.op("ConstantOfShape", shapes,
                            value_t=torch.tensor([0], dtype=sym_help.scalar_type_to_pytorch_type[6]))
-        return g.op('RandomNormalLike', shape_const, dtype_i=sym_help.scalar_type_to_onnx[dtype])
-    return g.op('RandomNormal', shape_i=shape)
+        return g.op("RandomNormalLike", shape_const, dtype_i=sym_help.scalar_type_to_onnx[dtype])
+    return g.op("RandomNormal", shape_i=shape)
 
 
 def rand(g, shapes, dtype, *options):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if dtype is None:
         dtype = 6  # float
     shape = sym_help._maybe_get_const(shapes, "is")
     if sym_help._is_value(shape):
         shape_const = g.op("ConstantOfShape", shapes,
                            value_t=torch.tensor([0], dtype=sym_help.scalar_type_to_pytorch_type[6]))
-        return g.op('RandomUniformLike', shape_const, dtype_i=sym_help.scalar_type_to_onnx[dtype])
-    return g.op('RandomUniform', shape_i=shape)
+        return g.op("RandomUniformLike", shape_const, dtype_i=sym_help.scalar_type_to_onnx[dtype])
+    return g.op("RandomUniform", shape_i=shape)
 
 
 def randn_like(g, self, dtype, layout=None, device=None, pin_memory=False, memory_format=None):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if dtype is None:
         dtype = 6  # float
-    return g.op('RandomNormalLike', self, dtype_i=sym_help.scalar_type_to_onnx[dtype])
+    return g.op("RandomNormalLike", self, dtype_i=sym_help.scalar_type_to_onnx[dtype])
 
 
 def rand_like(g, self, dtype, layout=None, device=None, pin_memory=False, memory_format=None):
-    dtype = sym_help._get_const(dtype, 'i', 'dtype')
+    dtype = sym_help._get_const(dtype, "i", "dtype")
     if dtype is None:
         dtype = 6  # float
-    return g.op('RandomUniformLike', self, dtype_i=sym_help.scalar_type_to_onnx[dtype])
+    return g.op("RandomUniformLike", self, dtype_i=sym_help.scalar_type_to_onnx[dtype])
 
 
-@parse_args('v', 'f', 'f', 'i', 'none')
+@parse_args("v", "f", "f", "i", "none")
 def rrelu(g, input, lower, upper, training, generator):
-    p = g.op('RandomUniformLike', input, high_f=upper, low_f=lower)
-    return g.op('PRelu', input, p)
+    p = g.op("RandomUniformLike", input, high_f=upper, low_f=lower)
+    return g.op("PRelu", input, p)
 
 
-@parse_args('v')
+@parse_args("v")
 def log_sigmoid(g, input):
-    p = g.op('Sigmoid', input)
-    return g.op('Log', p)
+    p = g.op("Sigmoid", input)
+    return g.op("Log", p)
 
 
-@parse_args('v')
+@parse_args("v")
 def erf(g, input):
-    return g.op('Erf', input)
+    return g.op("Erf", input)
 
 
-@parse_args('v', 'i', 'i')
+@parse_args("v", "i", "i")
 def flatten(g, input, start_dim, end_dim):
     dim = sym_help._get_tensor_rank(input)
     if dim is None:
@@ -2435,9 +2435,9 @@ def flatten(g, input, start_dim, end_dim):
     return sym_help._flatten_helper(g, input, start_dim, end_dim, dim)
 
 # Emitted from `torch.nonzero(x, as_tuple=False)`
-@parse_args('v')
+@parse_args("v")
 def nonzero(g, input):
-    return t(g, g.op('NonZero', input))
+    return t(g, g.op("NonZero", input))
 
 
 # Emitted from `torch.nonzero(x, as_tuple=True)`
@@ -2445,9 +2445,9 @@ def nonzero_numpy(g, input, _outputs=None):
     return unbind(g, nonzero(g, input), 1, _outputs=_outputs)
 
 
-@parse_args('v')
+@parse_args("v")
 def isnan(g, input):
-    output = g.op('IsNaN', input)
+    output = g.op("IsNaN", input)
     return output
 
 def _any(g, input):
@@ -2459,7 +2459,7 @@ def _all(g, input):
     return g.op("Not", _any(g, g.op("Not", input)))
 
 
-@parse_args('v', 'i', 'i', 'i')
+@parse_args("v", "i", "i", "i")
 def narrow(g, input, dim, start, length):
     return sym_help._slice_helper(g, input, axes=[dim], starts=[start], ends=[start + length])
 
@@ -2467,38 +2467,38 @@ def narrow(g, input, dim, start, length):
 def argmax(g, input, dim, keepdim):
     if sym_help._is_none(dim):
         flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
-        return g.op('ArgMax', flattened, axis_i=0, keepdims_i=False)
+        return g.op("ArgMax", flattened, axis_i=0, keepdims_i=False)
     else:
-        dim = _parse_arg(dim, 'i')
-        keepdim = _parse_arg(keepdim, 'i')
-        return g.op('ArgMax', input, axis_i=dim, keepdims_i=keepdim)
+        dim = _parse_arg(dim, "i")
+        keepdim = _parse_arg(keepdim, "i")
+        return g.op("ArgMax", input, axis_i=dim, keepdims_i=keepdim)
 
 
 def argmin(g, input, dim, keepdim):
     if sym_help._is_none(dim):
         flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
-        return g.op('ArgMin', flattened, axis_i=0, keepdims_i=False)
+        return g.op("ArgMin", flattened, axis_i=0, keepdims_i=False)
     else:
-        dim = _parse_arg(dim, 'i')
-        keepdim = _parse_arg(keepdim, 'i')
-        return g.op('ArgMin', input, axis_i=dim, keepdims_i=keepdim)
+        dim = _parse_arg(dim, "i")
+        keepdim = _parse_arg(keepdim, "i")
+        return g.op("ArgMin", input, axis_i=dim, keepdims_i=keepdim)
 
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def scatter(g, self, dim, index, src):
     src_type = src.type().scalarType()
     src = sym_help._maybe_get_scalar(src)
     if sym_help._is_value(src):
         return g.op("Scatter", self, index, src, axis_i=dim)
     else:
-        # Check if scalar 'src' has same type as self (PyTorch allows different
+        # Check if scalar "src" has same type as self (PyTorch allows different
         # type for scalar src (but not when src is tensor)). If not, insert Cast node.
         if self.type().scalarType() != src_type:
             src = g.op("Cast", src, to_i=sym_help.cast_pytorch_to_onnx[self.type().scalarType()])
         return g.op("Scatter", self, index, expand_as(g, src, index), axis_i=dim)
 
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def scatter_add(g, self, dim, index, src):
     dtype = sym_help._try_get_scalar_type(self)
     if dtype is None:
@@ -2517,14 +2517,14 @@ def scatter_add(g, self, dim, index, src):
 
 def log2(g, self):
     _ln2 = 0.693147180559945309
-    return g.op('Div', log(g, self), g.op('Constant', value_t=torch.tensor([_ln2])))
+    return g.op("Div", log(g, self), g.op("Constant", value_t=torch.tensor([_ln2])))
 
 
 def prim_shape(g, self):
-    return g.op('Shape', self)
+    return g.op("Shape", self)
 
 def prim_max(g, self, other):
-    return g.op('Max', self, other)
+    return g.op("Max", self, other)
 
 def prim_min(g, self, other=None):
     if not other:
@@ -2570,22 +2570,22 @@ def prim_dtype(g, self):
 # dim_val and elem_ty_val represent dimension and type annotations
 # that need to match dimension and type of the input tensor.
 def prim_tolist(g, input, dim_val, elem_ty_val):
-    dim = sym_help._maybe_get_const(dim_val, 'i')
+    dim = sym_help._maybe_get_const(dim_val, "i")
     if dim > 1:
         return _unimplemented("prim_tolist", "dim_val > 1")
     return input
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def one_hot(g, self, num_classes):
     values = g.op("Constant", value_t=torch.LongTensor([0, 1]))
     depth = g.op("Constant", value_t=torch.LongTensor([num_classes]))
     return g.op("OneHot", self, depth, values, axis_i=-1)
 
 
-@parse_args('v', 'i', 'v', 'v')
+@parse_args("v", "i", "v", "v")
 def gather(g, self, dim, index, sparse_grad=False):
-    if sym_help._maybe_get_const(sparse_grad, 'i'):
+    if sym_help._maybe_get_const(sparse_grad, "i"):
         return _unimplemented("gather", "sparse_grad == True")
     # NOTE: This workaround is needed since GatherElement is only supported
     #       since opset 11, and Gather in ONNX is not the same as torch.gather.
@@ -2597,7 +2597,7 @@ def gather(g, self, dim, index, sparse_grad=False):
     return sym_help._reducesum_helper(g, mul, axes_i=[dim], keepdims_i=0)
 
 
-@parse_args('v', 'is', 'i', 'i')
+@parse_args("v", "is", "i", "i")
 def _var_mean(g, input, dim, correction, keepdim):
     if dim is None:
         mean = g.op("ReduceMean", input, keepdims_i=0)
@@ -2618,7 +2618,7 @@ def _var_mean(g, input, dim, correction, keepdim):
     if correction is None:
         correction = 1
     if correction != 0:
-        num_elements = g.op("Cast", num_elements, to_i=sym_help.cast_pytorch_to_onnx['Float'])
+        num_elements = g.op("Cast", num_elements, to_i=sym_help.cast_pytorch_to_onnx["Float"])
         one = g.op("Constant", value_t=torch.tensor(correction, dtype=torch.float))
         mul = g.op("Mul", var, num_elements)
         var = g.op("Div", mul, g.op("Sub", num_elements, one))
@@ -2652,9 +2652,9 @@ def std_mean(g, input, *args):
     return g.op("Sqrt", var), mean
 
 
-@parse_args('v', 'is', 'i')
+@parse_args("v", "is", "i")
 def logsumexp(g, input, dim, keepdim):
-    return g.op('ReduceLogSumExp', input, axes_i=dim, keepdims_i=keepdim)
+    return g.op("ReduceLogSumExp", input, axes_i=dim, keepdims_i=keepdim)
 
 
 def arange(g, *args):
@@ -2662,7 +2662,7 @@ def arange(g, *args):
         return g.op("ATen", *args, operator_s="arange")
 
     def _get_arange_dtype(dtype):
-        dtype = sym_help._maybe_get_const(dtype, 'i')
+        dtype = sym_help._maybe_get_const(dtype, "i")
         if sym_help._is_value(dtype):
             dtype = 4  # default to int64
         return dtype
@@ -2714,7 +2714,7 @@ def arange(g, *args):
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]
     value = sym_help._maybe_get_scalar(value)
-    return g.op('Where', mask, sym_help._if_scalar_type_as(g, value, self), self)
+    return g.op("Where", mask, sym_help._if_scalar_type_as(g, value, self), self)
 
 
 def index(g, self, index):
@@ -2828,14 +2828,14 @@ def index(g, self, index):
             return g.op("Reshape", self, final_shape)
 
 
-@parse_args('v', 'is', 'i')
+@parse_args("v", "is", "i")
 def frobenius_norm(g, self, dim=None, keepdim=False):
-    sqr = g.op('Mul', self, self)
+    sqr = g.op("Mul", self, self)
     sumsqr = sym_help._reducesum_helper(g, sqr, axes_i=dim, keepdims_i=keepdim)
-    return g.op('Sqrt', sumsqr)
+    return g.op("Sqrt", sumsqr)
 
 
-@parse_args('v', 'i', 'b', 'v')
+@parse_args("v", "i", "b", "v")
 def multinomial(g, input, num_samples, replacement=False, generator=None):
     if generator is not None and not sym_help._is_none(generator):
         _unimplemented("Multinomial", "generator is not supported for multinomial")
@@ -2844,7 +2844,7 @@ def multinomial(g, input, num_samples, replacement=False, generator=None):
 
     log_input = log(g, input)
     return g.op("Multinomial", log_input,
-                dtype_i=sym_help.cast_pytorch_to_onnx['Long'],
+                dtype_i=sym_help.cast_pytorch_to_onnx["Long"],
                 sample_size_i=num_samples)
 
 
@@ -2879,11 +2879,11 @@ def remainder(g, input, other):
 
 def gelu(g, self):
     _sqrt2 = 1.4142135623730951
-    erf = g.op('Erf', g.op('Div', self, torch.tensor(_sqrt2, dtype=torch.double)))
-    erf_plusone = add(g, erf, g.op('Constant', value_t=torch.tensor(1, dtype=torch.double)))
-    return mul(g, mul(g, self, erf_plusone), g.op('Constant', value_t=torch.tensor(0.5, dtype=torch.double)))
+    erf = g.op("Erf", g.op("Div", self, torch.tensor(_sqrt2, dtype=torch.double)))
+    erf_plusone = add(g, erf, g.op("Constant", value_t=torch.tensor(1, dtype=torch.double)))
+    return mul(g, mul(g, self, erf_plusone), g.op("Constant", value_t=torch.tensor(0.5, dtype=torch.double)))
 
-@parse_args('v', 'i', 'v', 'v', 'f', 'i')
+@parse_args("v", "i", "v", "v", "f", "i")
 def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
     if sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", input, weight, bias, num_groups_i=num_groups,
@@ -2897,26 +2897,26 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
         return _unimplemented("group_norm", "unknown input rank")
     # 0 in the shape list keeps dimension value unchanged.
     shape = [0, num_groups, -1]
-    input_reshaped = g.op('Reshape', input, g.op('Constant', value_t=torch.LongTensor(shape)))
+    input_reshaped = g.op("Reshape", input, g.op("Constant", value_t=torch.LongTensor(shape)))
 
     # C is always divisible by num_groups
     # Due to shape difference. we need to apply weight and bias after
     # instance norm computation and reshape
     weight_ = g.op("Constant", value_t=torch.tensor([1.] * num_groups).type(
-        'torch.' + input.type().scalarType() + 'Tensor'))
+        "torch." + input.type().scalarType() + "Tensor"))
     bias_ = g.op("Constant", value_t=torch.tensor([0.] * num_groups).type(
-        'torch.' + input.type().scalarType() + 'Tensor'))
+        "torch." + input.type().scalarType() + "Tensor"))
 
     norm_reshaped = g.op("InstanceNormalization", input_reshaped, weight_, bias_, epsilon_f=eps)
-    norm = g.op('Reshape', norm_reshaped, g.op("Shape", input))
+    norm = g.op("Reshape", norm_reshaped, g.op("Shape", input))
 
     if weight is None or weight.node().mustBeNone():
         weight_value = torch.tensor([1.]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            "torch." + input.type().scalarType() + "Tensor")
         weight = g.op("Constant", value_t=weight_value)
     if bias is None or bias.node().mustBeNone():
         bias_value = torch.tensor([0.]).type(
-            'torch.' + input.type().scalarType() + 'Tensor')
+            "torch." + input.type().scalarType() + "Tensor")
         bias = g.op("Constant", value_t=bias_value)
 
     # Norm has shape [N, C, *] so we reshape weight and bias to [C, *]
@@ -2924,7 +2924,7 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
     return add(g, mul(g, norm, sym_help._unsqueeze_helper(g, weight, axes)), sym_help._unsqueeze_helper(g, bias, axes))
 
 
-@parse_args('v', 'v', 'i')
+@parse_args("v", "v", "i")
 def _weight_norm(g, weight_v, weight_g, dim):
     rank = sym_help._get_tensor_rank(weight_v)
     if rank is not None:
@@ -2945,15 +2945,15 @@ def _weight_norm(g, weight_v, weight_g, dim):
     elif sym_help._operator_export_type == torch.onnx.OperatorExportTypes.ONNX_ATEN_FALLBACK:
         return g.op("ATen", weight_v, weight_g, dim_i=dim, operator_s="_weight_norm")
     else:
-        raise RuntimeError('Unsupported: ONNX export of _weight_norm for tensor '
-                           'of unknown rank.')
+        raise RuntimeError("Unsupported: ONNX export of _weight_norm for tensor "
+                           "of unknown rank.")
 
 
 def dim(g, self):
-    '''Implement the dim functionality available for a pytorch tensor in ONNX'''
+    """Implement the dim functionality available for a pytorch tensor in ONNX"""
     # ONNX does not support dim directly in this opset so we can use 2 ops to get the info
-    shape = g.op('Shape', self)
-    return g.op('Size', shape)
+    shape = g.op("Shape", self)
+    return g.op("Size", shape)
 
 
 def __getitem_(g, self, i):
@@ -2965,7 +2965,7 @@ def item(g, self):
 
 
 def take(g, self, index):
-    self_flattened = g.op('Reshape', self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
+    self_flattened = g.op("Reshape", self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
     out = index_select(g, self_flattened, 0, index)
     out = reshape_as(g, out, index)
     return out
@@ -2988,7 +2988,7 @@ def _kl_div_non_log_target_impl(g, input, target):
     return output
 
 
-@parse_args('v', 'v', 'i', 'b')
+@parse_args("v", "v", "i", "b")
 def kl_div(g, input, target, reduction, log_target):
     if log_target:
         output = _kl_div_log_target_impl(g, input, target)
@@ -3005,9 +3005,9 @@ def kl_div(g, input, target, reduction, log_target):
         return sym_help._onnx_unsupported("kl_div with reduction other than none, mean, or sum.")
 
 
-@parse_args('v', 'v', 'is', 'i')
+@parse_args("v", "v", "is", "i")
 def as_strided(g, self, sizes, strides, offset=None):
-    sizes = sym_help._maybe_get_const(sizes, 'is')
+    sizes = sym_help._maybe_get_const(sizes, "is")
     rank = len(strides)
     self_1d = g.op("Reshape", self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
     ind: Optional[torch.Tensor]
@@ -3052,15 +3052,15 @@ def __derive_index(g, index, start, step):
 def __range_length(g, lo, hi, step):
     sub = g.op("Sub", hi, lo)
     div = g.op("Ceil", true_divide(g, sub, step))
-    return g.op("Cast", div, to_i=sym_help.cast_pytorch_to_onnx['Long'])
+    return g.op("Cast", div, to_i=sym_help.cast_pytorch_to_onnx["Long"])
 
 
 def linear(g, input, weight, bias):
     rank = sym_help._get_tensor_rank(input)
     weight = t(g, weight)
     if rank == 2 and not bias.node().mustBeNone():
-        alpha = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
-        beta = g.op('Constant', value_t=torch.tensor(1, dtype=torch.int64))
+        alpha = g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))
+        beta = g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))
         output = addmm(g, bias, input, weight, alpha, beta)
     else:
         output = matmul(g, input, weight)
@@ -3070,7 +3070,7 @@ def linear(g, input, weight, bias):
     return output
 
 
-@parse_args('v', 'b', 'i', 'v', 'v', 'v', 'v')
+@parse_args("v", "b", "i", "v", "v", "v", "v")
 def hann_window(g, window_length, periodic=True, dtype=None, layout=None, device=None, pin_memory=None, requires_grad=False):
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -3079,8 +3079,8 @@ def hann_window(g, window_length, periodic=True, dtype=None, layout=None, device
         dtype = sym_help.scalar_type_to_pytorch_type.index(dtype)
 
     n_array = arange(g, window_length, 4, None, None, None)
-    output = g.op('Cast', n_array, to_i=sym_help.cast_pytorch_to_onnx['Float'])
-    output = mul(g, g.op('Constant', value_t=torch.tensor(math.pi, dtype=torch.float)), output)
+    output = g.op("Cast", n_array, to_i=sym_help.cast_pytorch_to_onnx["Float"])
+    output = mul(g, g.op("Constant", value_t=torch.tensor(math.pi, dtype=torch.float)), output)
 
     if periodic is False:
         window_length = sub(g, window_length, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int)))
@@ -3111,7 +3111,7 @@ def index_add(g, self, dim, index, other):
     from torch.onnx.symbolic_opset9 import scatter_add
     from sys import maxsize as maxsize
 
-    dim = sym_help._maybe_get_const(dim, 'i')
+    dim = sym_help._maybe_get_const(dim, "i")
     if dim is None:
         raise NotImplementedError("ONNX export does NOT support exporting 'index_add_()' function with " +
                                   "unknown 'dim' value.")

--- a/torch/onnx/symbolic_registry.py
+++ b/torch/onnx/symbolic_registry.py
@@ -14,7 +14,7 @@ _registry: Dict[Tuple[str, int], Dict] = {}
 _symbolic_versions: Dict[Union[int, str], Any] = {}
 from torch.onnx.symbolic_helper import _onnx_stable_opsets, _onnx_main_opset
 for opset_version in _onnx_stable_opsets + [_onnx_main_opset]:
-    module = importlib.import_module('torch.onnx.symbolic_opset{}'.format(opset_version))
+    module = importlib.import_module("torch.onnx.symbolic_opset{}".format(opset_version))
     _symbolic_versions[opset_version] = module
 
 
@@ -28,14 +28,14 @@ def register_version(domain, version):
 def register_ops_helper(domain, version, iter_version):
     version_ops = get_ops_in_version(iter_version)
     for op in version_ops:
-        if op[0] == '_len':
-            op = ('len', op[1])
-        if op[0] == '_list':
-            op = ('list', op[1])
-        if op[0] == '_any':
-            op = ('any', op[1])
-        if op[0] == '_all':
-            op = ('all', op[1])
+        if op[0] == "_len":
+            op = ("len", op[1])
+        if op[0] == "_list":
+            op = ("list", op[1])
+        if op[0] == "_any":
+            op = ("any", op[1])
+        if op[0] == "_all":
+            op = ("all", op[1])
         if isfunction(op[1]) and not is_registered_op(op[0], domain, version):
             register_op(op[0], op[1], domain, version)
 

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -400,14 +400,14 @@ def _create_jit_graph(model, args, _retain_param_name):
             torch._C._jit_pass_onnx_function_substitution(graph)
             freezed_m = torch._C._freeze_module(model._c, preserveParameters=True)
             module, params = torch._C._jit_onnx_list_model_parameters(freezed_m)
-            method_graph = module._get_method('forward').graph
+            method_graph = module._get_method("forward").graph
             args_params = tuple(args) + tuple(params)
             param_count_list = _get_param_count_list(method_graph, args_params)
             in_vars, _ = torch.jit._flatten(args_params)
             graph = _propagate_and_assign_input_shapes(
                 method_graph, tuple(in_vars), param_count_list, False, False)
         except AttributeError as e:
-            raise RuntimeError('\'forward\' method must be a script method') from e
+            raise RuntimeError("'forward' method must be a script method") from e
         return graph, params, torch_out, module
     elif isinstance(model, torch.jit.ScriptFunction):
         params = ()
@@ -621,10 +621,10 @@ def _find_missing_ops_onnx_export(model, args, f, verbose=False, training=Traini
         args = _decide_input_format(model, args)
         graph, params_dict, torch_out = _model_to_graph(model, args, verbose, input_names,
                                                         output_names, operator_export_type)
-    # The output 'unsupported_ops' will contain the names of all the ops that are not supported in ONNX
+    # The output "unsupported_ops" will contain the names of all the ops that are not supported in ONNX
     unsupported_ops = list()
     for node in graph.nodes():
-        if node.kind().split(':')[0] not in ['onnx', 'prim']:
+        if node.kind().split(":")[0] not in ["onnx", "prim"]:
             unsupported_ops.append(node.kind())
     return graph, unsupported_ops
 
@@ -642,10 +642,10 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
             onnx_shape_inference=True):
 
     if isinstance(model, torch.nn.DataParallel):
-        raise ValueError('torch.nn.DataParallel is not supported by ONNX '
-                         'exporter, please use \'attribute\' module to '
-                         'unwrap model from torch.nn.DataParallel. Try '
-                         'torch.onnx.export(model.module, ...)')
+        raise ValueError("torch.nn.DataParallel is not supported by ONNX "
+                         "exporter, please use 'attribute' module to "
+                         "unwrap model from torch.nn.DataParallel. Try "
+                         "torch.onnx.export(model.module, ...)")
     global __IN_ONNX_EXPORT
     assert __IN_ONNX_EXPORT is False
     __IN_ONNX_EXPORT = True
@@ -719,14 +719,14 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
 
             if export_type == ExportTypes.PROTOBUF_FILE:
                 assert(len(export_map) == 0)
-                with torch.serialization._open_file_like(f, 'wb') as opened_file:
+                with torch.serialization._open_file_like(f, "wb") as opened_file:
                     opened_file.write(proto)
             elif export_type in [ExportTypes.ZIP_ARCHIVE, ExportTypes.COMPRESSED_ZIP_ARCHIVE]:
                 import zipfile
                 compression = zipfile.ZIP_DEFLATED \
                     if export_type == ExportTypes.COMPRESSED_ZIP_ARCHIVE \
                     else zipfile.ZIP_STORED
-                with zipfile.ZipFile(f, 'w', compression=compression) as z:
+                with zipfile.ZipFile(f, "w", compression=compression) as z:
                     z.writestr(ONNX_ARCHIVE_MODEL_PROTO_NAME, proto)
                     for k, v in export_map.items():
                         z.writestr(k, v)
@@ -738,15 +738,15 @@ def _export(model, args, f, export_params=True, verbose=False, training=None,
                     os.makedirs(f)
 
                 model_proto_file = os.path.join(f, ONNX_ARCHIVE_MODEL_PROTO_NAME)
-                with torch.serialization._open_file_like(model_proto_file, 'wb') as opened_file:
+                with torch.serialization._open_file_like(model_proto_file, "wb") as opened_file:
                     opened_file.write(proto)
 
                 for k, v in export_map.items():
                     weight_proto_file = os.path.join(f, k)
-                    with torch.serialization._open_file_like(weight_proto_file, 'wb') as opened_file:
+                    with torch.serialization._open_file_like(weight_proto_file, "wb") as opened_file:
                         opened_file.write(v)
             else:
-                raise RuntimeError('Unknown export type')
+                raise RuntimeError("Unknown export type")
     finally:
         assert __IN_ONNX_EXPORT
         __IN_ONNX_EXPORT = False
@@ -764,8 +764,8 @@ def _set_input_and_output_names(graph, input_names, output_names):
         for name, node in zip(name_list, node_list):
             if node.debugName() != name:
                 node.setDebugName(name)
-    set_names(list(graph.inputs()), input_names, 'input')
-    set_names(list(graph.outputs()), output_names, 'output')
+    set_names(list(graph.inputs()), input_names, "input")
+    set_names(list(graph.outputs()), output_names, "output")
 
 attr_pattern = re.compile("^(.+)_([ifstgz])$")
 
@@ -841,8 +841,8 @@ def _newNode(g, opname, outputs, *args, **kwargs):
 
 def _graph_op(g, opname, *raw_args, **kwargs):
     r"""
-    Create an ONNX operator 'opname', taking 'args' as inputs and attributes
-    'kwargs'; returning the node representing the single output of this operator
+    Create an ONNX operator "opname", taking "args" as inputs and attributes
+    "kwargs"; returning the node representing the single output of this operator
     (see the `outputs` keyword argument for multi-return nodes).
 
     The set of operators and the inputs/attributes they take
@@ -867,7 +867,7 @@ def _graph_op(g, opname, *raw_args, **kwargs):
             of output `Node`, representing each output of the ONNX operator
             in positional.
     """
-    outputs = kwargs.pop('outputs', 1)
+    outputs = kwargs.pop("outputs", 1)
 
     # Filter out None attributes, this can be convenient client side because
     # now they can pass through None attributes, and have them not show up
@@ -957,11 +957,11 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
         # Quantized op symbolics are registered for opset 9 only.
         if operator_export_type == OperatorExportTypes.ONNX_ATEN_FALLBACK and opset_version == 9:
             import torch.onnx.symbolic_caffe2
-            torch.onnx.symbolic_caffe2.register_quantized_ops('caffe2', opset_version)
+            torch.onnx.symbolic_caffe2.register_quantized_ops("caffe2", opset_version)
 
         # See Note [Export inplace]
         # TODO: I think this is not necessary anymore
-        if n.kind().endswith('_'):
+        if n.kind().endswith("_"):
             ns_op_name = n.kind()[:-1]
         else:
             ns_op_name = n.kind()
@@ -1016,7 +1016,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                 return None
             elif op_name == "device" and n.output().type().kind() == "DeviceObjType":
                 return None
-            elif op_name == 'Loop' or op_name == 'If':
+            elif op_name == "Loop" or op_name == "If":
                 new_op_outputs = g.op(op_name, *inputs, outputs=n.outputsSize())
                 new_node = new_op_outputs[0].node() if n.outputsSize() > 1 else new_op_outputs.node()
                 for b in n.blocks():
@@ -1047,7 +1047,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                     torch._C._jit_pass_onnx_node_shape_type_inference(new_node, _params_dict, opset_version)
                 return new_op_outputs
             else:
-                symbolic_name = 'prim_' + op_name
+                symbolic_name = "prim_" + op_name
                 domain = ''
                 symbolic_fn = _find_symbolic_in_registry(domain, symbolic_name, opset_version,
                                                          operator_export_type)
@@ -1061,7 +1061,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
         elif ns == "quantized":
             domain = ''
             if operator_export_type == OperatorExportTypes.ONNX_ATEN_FALLBACK:
-                domain = 'caffe2'
+                domain = "caffe2"
             symbolic_fn = _find_symbolic_in_registry(domain, op_name, opset_version, operator_export_type)
             if symbolic_fn is None:
                 return None
@@ -1154,7 +1154,7 @@ def register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version):
                            and should start with a letter and contain only \
                            alphanumerical characters"
                            .format(symbolic_name))
-    ns, op_name = symbolic_name.split('::')
+    ns, op_name = symbolic_name.split("::")
     unaccepted_domain_names = ["onnx", "aten", "prim"]
     if ns in unaccepted_domain_names:
         raise RuntimeError("Failed to register operator {}. The domain {} is already a used domain."
@@ -1171,7 +1171,7 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
     if len(dynamic_axes) == 0:
         return
 
-    if(hasattr(model, 'graph')):
+    if(hasattr(model, "graph")):
         # Extracting set of valid input/output names that shall be used for dynamic_axes
         if (input_names is None) or len(input_names) == 0:
             input_names = [x.debugName() for x in model.graph.inputs()]
@@ -1188,18 +1188,18 @@ def _validate_dynamic_axes(dynamic_axes, model, input_names, output_names):
         if key not in valid_names:
             warnings.warn("Provided key {} for dynamic axes is not a valid input/output name".format(key))
         if isinstance(value, list):
-            warnings.warn('No names were found for specified dynamic axes of provided input.'
-                          'Automatically generated names will be applied to each dynamic axes of input {}'.format(key))
+            warnings.warn("No names were found for specified dynamic axes of provided input."
+                          "Automatically generated names will be applied to each dynamic axes of input {}".format(key))
 
             value_dict = {}
             for i, x in enumerate(value):
                 if not isinstance(x, int):
                     raise ValueError("The type of axis index is expected to be an integer")
                 if x in value_dict:
-                    warnings.warn('Duplicate dynamic axis index {} was provided for input {}.'
+                    warnings.warn("Duplicate dynamic axis index {} was provided for input {}."
                                   .format(x, key))
                 else:
-                    value_dict[x] = str(key) + '_dynamic_axes_' + str(i + 1)
+                    value_dict[x] = str(key) + "_dynamic_axes_" + str(i + 1)
             dynamic_axes[key] = value_dict
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58582 [ONNX] Enable support for roll() op. (#58389)
* #58581 [ONNX] handle aten::_set_item on Dict in convertInplaceOpsAndTrackAlias (#58317)
* **#58580 [ONNX] use consistent quoting for string literals (#57757)**
* #58579 [ONNX] Improve lower tuples and handle control flow  (#57650)
* #58578 [ONNX] Update special post process for SequenceInsert after SequenceEmpty (#56965)
* #58577 Support symbolic for conv_tbc (#58359)
* #58576 [ONNX] RNN scripting (#57564)
* #58575 [ONNX] Update instance_norm2 symbolic to handle track_running_stats=True (#55051)

As PEP8 says: "Pick a rule and stick to it." [1]

[1] https://www.python.org/dev/peps/pep-0008/#string-quotes

Co-authored-by: Gary Miguel <garymiguel@microsoft.com>