### PR TITLE
[ONNX] Enable support for roll() op. (#58389)

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -8856,6 +8856,22 @@ class TestONNXRuntime(unittest.TestCase):
                       input_names=['input_1'],
                       dynamic_axes={'input_1': [0, 1]})
 
+    def test_roll(self):
+        class M(torch.nn.Module):
+            def __init__(self, shifts, dims):
+                super(M, self).__init__()
+                self.shifts = shifts
+                self.dims = dims
+
+            def forward(self, x):
+                return torch.roll(x, self.shifts, self.dims)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(M([1, 1], [1, 0]), (x,))
+        self.run_test(M([0, 1, 2], [1, 0, 2]), (x,))
+        self.run_test(M(2, 1), (x,))
+        self.run_test(M([-1, 3], [-2, -1]), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -14,6 +14,7 @@ import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args, _parse_arg, _unimplemented
 
 from typing import Optional
+from sys import maxsize as maxsize
 
 import numpy
 import math
@@ -3109,7 +3110,6 @@ def index_add(g, self, dim, index, other):
     warnings.warn("Warning: ONNX export does not support duplicated values in 'index' field, " +
                   "this will cause the ONNX model to be incorrect.")
     from torch.onnx.symbolic_opset9 import scatter_add
-    from sys import maxsize as maxsize
 
     dim = sym_help._maybe_get_const(dim, "i")
     if dim is None:
@@ -3160,3 +3160,27 @@ def index_add(g, self, dim, index, other):
         index = sym_help._unsqueeze_helper(g, index, [sym_help._get_tensor_rank(index)])
 
     return scatter_add(g, self, dim, expand_as(g, index, other), other)
+
+
+@parse_args('v', 'is', 'is')
+def roll(g, self, shifts, dims):
+    assert len(shifts) == len(dims)
+
+    result = self
+    for i in range(len(shifts)):
+        shapes = []
+        shape = sym_help._slice_helper(g,
+                                       result,
+                                       axes=[dims[i]],
+                                       starts=[-shifts[i]],
+                                       ends=[maxsize])
+        shapes.append(shape)
+        shape = sym_help._slice_helper(g,
+                                       result,
+                                       axes=[dims[i]],
+                                       starts=[0],
+                                       ends=[-shifts[i]])
+        shapes.append(shape)
+        result = g.op("Concat", *shapes, axis_i=dims[i])
+
+    return result


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58582 [ONNX] Enable support for roll() op. (#58389)**
* #58581 [ONNX] handle aten::_set_item on Dict in convertInplaceOpsAndTrackAlias (#58317)
* #58580 [ONNX] use consistent quoting for string literals (#57757)
* #58579 [ONNX] Improve lower tuples and handle control flow  (#57650)
* #58578 [ONNX] Update special post process for SequenceInsert after SequenceEmpty (#56965)
* #58577 Support symbolic for conv_tbc (#58359)
* #58576 [ONNX] RNN scripting (#57564)
* #58575 [ONNX] Update instance_norm2 symbolic to handle track_running_stats=True (#55051)

1. Add a symbolic function for aten::roll() op in symbolic_opset9.py.
2. Add a test with multiple scenarios as well.

Co-authored-by: fatcat-z <jiz@microsoft.com>