### PR TITLE
ci: Release branch specific changes

### DIFF
--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -52,9 +52,9 @@ function get_exit_code() {
 function file_diff_from_base() {
   # The fetch may fail on Docker hosts, this fetch is necessary for GHA
   set +e
-  git fetch origin master --quiet
+  git fetch origin release/1.9 --quiet
   set -e
-  git diff --name-only "$(git merge-base origin/master HEAD)" > "$1"
+  git diff --name-only "$(git merge-base origin/release/1.9 HEAD)" > "$1"
 }
 
 function get_bazel() {

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -368,7 +368,7 @@ test_backward_compatibility() {
   python -m venv venv
   # shellcheck disable=SC1091
   . venv/bin/activate
-  pip_install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  pip_install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
   pip show torch
   python dump_all_function_schemas.py --filename nightly_schemas.txt
   deactivate


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58601 [1.9] remove gate for beta feature (torchscript support in torch.package)
* #58600 [release/1.9] Pin builder and xla repos (#58514)
* #58599 [release/1.9] Fix issues regarding binary_chekcout (#58495)
* **#58598 ci: Release branch specific changes**

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>