### PR TITLE
[release/1.9] Fix issues regarding binary_chekcout (#58495)

### DIFF
--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -57,9 +57,9 @@ add_to_env_file() {
 }
 
 add_to_env_file "IN_CI=1"
-add_to_env_file "COMMIT_SOURCE=${CIRCLE_BRANCH:-}"
-add_to_env_file "BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
-add_to_env_file "CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}"
+add_to_env_file "COMMIT_SOURCE='${CIRCLE_BRANCH:-}'"
+add_to_env_file "BUILD_ENVIRONMENT='${BUILD_ENVIRONMENT}'"
+add_to_env_file "CIRCLE_PULL_REQUEST='${CIRCLE_PULL_REQUEST}'"
 
 
 if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58601 [1.9] remove gate for beta feature (torchscript support in torch.package)
* #58600 [release/1.9] Pin builder and xla repos (#58514)
* **#58599 [release/1.9] Fix issues regarding binary_chekcout (#58495)**
* #58598 ci: Release branch specific changes

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>