### PR TITLE
[release/1.9] Pin builder and xla repos (#58514)

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -62,6 +62,7 @@ popd
 
 # Clone the Builder master repo
 retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+git checkout release/1.9
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -200,7 +200,7 @@ fi
 
 # Patch required to build xla
 if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
-  git clone --recursive https://github.com/pytorch/xla.git
+  git clone --recursive -b r1.9 https://github.com/pytorch/xla.git
   ./xla/scripts/apply_patches.sh
 fi
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58601 [1.9] remove gate for beta feature (torchscript support in torch.package)
* **#58600 [release/1.9] Pin builder and xla repos (#58514)**
* #58599 [release/1.9] Fix issues regarding binary_chekcout (#58495)
* #58598 ci: Release branch specific changes

Pin builder to https://github.com/pytorch/builder/commits/release/1.9
Pin xla to https://github.com/pytorch/xla/tree/r1.9

Co-authored-by: driazati <driazati@users.noreply.github.com>