### PR TITLE
[1.9] remove gate for beta feature (torchscript support in torch.package)

### DIFF
--- a/test/package/common.py
+++ b/test/package/common.py
@@ -3,7 +3,6 @@ import sys
 from tempfile import NamedTemporaryFile
 
 from torch.testing._internal.common_utils import IS_WINDOWS, TestCase
-import torch.package.package_exporter
 
 
 class PackageTestCase(TestCase):
@@ -29,8 +28,6 @@ class PackageTestCase(TestCase):
         self.package_test_dir = os.path.dirname(os.path.realpath(__file__))
         self.orig_sys_path = sys.path.copy()
         sys.path.append(self.package_test_dir)
-        torch.package.package_exporter._gate_torchscript_serialization = False
-
 
     def tearDown(self):
         super().tearDown()

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -36,8 +36,6 @@ from .find_file_dependencies import find_files_source_depends_on
 from .glob_group import GlobGroup, GlobPattern
 from .importer import Importer, OrderedImporter, sys_importer
 
-_gate_torchscript_serialization = True
-
 ActionHook = Callable[["PackageExporter", str], None]
 
 
@@ -693,14 +691,6 @@ node [shape=box];
             return ("storage", storage_type, obj_key, location, obj.size())
 
         if hasattr(obj, "__reduce_package__"):
-            if _gate_torchscript_serialization and isinstance(
-                obj, torch.jit.RecursiveScriptModule
-            ):
-                raise Exception(
-                    "Serializing ScriptModules directly into a package is a beta feature. "
-                    "To use, set global "
-                    "`torch.package.package_exporter._gate_torchscript_serialization` to `False`."
-                )
             if self.serialized_reduces.get(id(obj)) is None:
                 self.serialized_reduces[id(obj)] = ("reduce_package", id(obj), *obj.__reduce_package__(self))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58601 [1.9] remove gate for beta feature (torchscript support in torch.package)**
* #58600 [release/1.9] Pin builder and xla repos (#58514)
* #58599 [release/1.9] Fix issues regarding binary_chekcout (#58495)
* #58598 ci: Release branch specific changes

To remove feature gate that is relevant for master but not for 1.9 release. This feature is still being tested for use in fbcode but since torch.package is being released as beta it is fine for this feature to be ungated for the OSS community. 