### PR TITLE
[FX Splitter] dump final graph and print operator stats via to_glow API

### DIFF
--- a/torch/csrc/jit/backends/backend_init.cpp
+++ b/torch/csrc/jit/backends/backend_init.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/jit/backends/backend_init.h>
 
+#include <pybind11/iostream.h>
 #include <torch/csrc/jit/backends/backend_detail.h>
 #include <torch/csrc/jit/backends/backend_resolver.h>
 #include <torch/csrc/jit/frontend/code_template.h>
@@ -147,6 +148,10 @@ void initJitBackendBindings(PyObject* module) {
       [=](const std::string& backend_name,
           py::handle orig_module,
           const py::dict& method_compile_spec) {
+        py::scoped_ostream_redirect cerr(
+            std::cerr, py::module_::import("sys").attr("stderr"));
+        py::scoped_ostream_redirect cout(
+            std::cout, py::module_::import("sys").attr("stdout"));
         return py::module::import("torch.jit._recursive")
             .attr("wrap_cpp_module")(codegen_func(
                 backend_name,
@@ -159,6 +164,10 @@ void initJitBackendBindings(PyObject* module) {
       [=](py::handle orig_module,
           const py::function& to_backend,
           const std::vector<std::string>& modules_to_lower) {
+        py::scoped_ostream_redirect cerr(
+            std::cerr, py::module_::import("sys").attr("stderr"));
+        py::scoped_ostream_redirect cout(
+            std::cout, py::module_::import("sys").attr("stdout"));
         if (auto original_module =
                 as_module(py::cast<py::object>(orig_module))) {
           // Clone the Module to avoid editing types that are shared with


### PR DESCRIPTION
Summary:
- dump final graph in glow
- print operator stats via to_glow API
   - 1) node stats for final glow graph
   - 2) operator stats in TorchGlowBackend for torch::jit::graph to lower

Reviewed By: khabinov

Differential Revision: D28444501

