### PR TITLE
[PyTorch Edge] bytecode version bump to v5 and enable share constant table

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -62,6 +62,7 @@ popd
 
 # Clone the Builder master repo
 retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
+git checkout release/1.9
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
 git --no-pager log --max-count 1

--- a/.circleci/scripts/setup_ci_environment.sh
+++ b/.circleci/scripts/setup_ci_environment.sh
@@ -57,9 +57,9 @@ add_to_env_file() {
 }
 
 add_to_env_file "IN_CI=1"
-add_to_env_file "COMMIT_SOURCE=${CIRCLE_BRANCH:-}"
-add_to_env_file "BUILD_ENVIRONMENT=${BUILD_ENVIRONMENT}"
-add_to_env_file "CIRCLE_PULL_REQUEST=${CIRCLE_PULL_REQUEST}"
+add_to_env_file "COMMIT_SOURCE='${CIRCLE_BRANCH:-}'"
+add_to_env_file "BUILD_ENVIRONMENT='${BUILD_ENVIRONMENT}'"
+add_to_env_file "CIRCLE_PULL_REQUEST='${CIRCLE_PULL_REQUEST}'"
 
 
 if [[ "${BUILD_ENVIRONMENT}" == *-build ]]; then

--- a/.jenkins/pytorch/build.sh
+++ b/.jenkins/pytorch/build.sh
@@ -200,7 +200,7 @@ fi
 
 # Patch required to build xla
 if [[ "${BUILD_ENVIRONMENT}" == *xla* ]]; then
-  git clone --recursive https://github.com/pytorch/xla.git
+  git clone --recursive -b r1.9 https://github.com/pytorch/xla.git
   ./xla/scripts/apply_patches.sh
 fi
 

--- a/.jenkins/pytorch/common_utils.sh
+++ b/.jenkins/pytorch/common_utils.sh
@@ -52,9 +52,9 @@ function get_exit_code() {
 function file_diff_from_base() {
   # The fetch may fail on Docker hosts, this fetch is necessary for GHA
   set +e
-  git fetch origin master --quiet
+  git fetch origin release/1.9 --quiet
   set -e
-  git diff --name-only "$(git merge-base origin/master HEAD)" > "$1"
+  git diff --name-only "$(git merge-base origin/release/1.9 HEAD)" > "$1"
 }
 
 function get_bazel() {

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -368,7 +368,7 @@ test_backward_compatibility() {
   python -m venv venv
   # shellcheck disable=SC1091
   . venv/bin/activate
-  pip_install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  pip_install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
   pip show torch
   python dump_all_function_schemas.py --filename nightly_schemas.txt
   deactivate

--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -65,9 +65,13 @@ constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 //  0x1L: Initial version
 //  0x2L: (Comment missing)
 //  0x3L: (Comment missing)
-//  0x4L: (Comment missing)
 //  0x4L: (update) Added schema to function tuple. Forward-compatible change.
-constexpr uint64_t kProducedBytecodeVersion = 0x4L;
+//  0x5L: (update) Update bytecode is sharing constant tensor files from torchscript, and only serialize
+//  extra tensors that are not in the torchscript constant table. Also update tensor storage schema adapting
+//  to the unify format, the root key of tensor storage is updated from {index} to
+//  {the_pointer_value_the_tensor.storage}, for example: `140245072983168.storage`
+//  Forward-compatibility change.
+constexpr uint64_t kProducedBytecodeVersion = 0x5L;
 
 static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
     "kProducedBytecodeVersion must be higher or equal to kProducedFileFormatVersion.");

--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -575,5 +575,4 @@ Utilities
     are_deterministic_algorithms_enabled
     set_warn_always
     is_warn_always_enabled
-    vmap
     _assert

--- a/test/package/common.py
+++ b/test/package/common.py
@@ -3,7 +3,6 @@ import sys
 from tempfile import NamedTemporaryFile
 
 from torch.testing._internal.common_utils import IS_WINDOWS, TestCase
-import torch.package.package_exporter
 
 
 class PackageTestCase(TestCase):
@@ -29,8 +28,6 @@ class PackageTestCase(TestCase):
         self.package_test_dir = os.path.dirname(os.path.realpath(__file__))
         self.orig_sys_path = sys.path.copy()
         sys.path.append(self.package_test_dir)
-        torch.package.package_exporter._gate_torchscript_serialization = False
-
 
     def tearDown(self):
         super().tearDown()

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -1,7 +1,8 @@
 from torch.testing._internal.common_utils import TestCase, run_tests
 import torch
 import torch.nn.functional as F
-from torch import Tensor, vmap
+from torch import Tensor
+from torch._vmap_internals import vmap
 import functools
 import itertools
 import warnings

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -740,8 +740,6 @@ del register_after_fork
 # torch.jit.script as a decorator, for instance):
 from ._lobpcg import lobpcg as lobpcg
 
-from ._vmap_internals import vmap as vmap
-
 # These were previously defined in native_functions.yaml and appeared on the
 # `torch` namespace, but we moved them to c10 dispatch to facilitate custom
 # class usage. We add these lines here to preserve backward compatibility.

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -372,7 +372,7 @@ void ScriptModuleSerializer::serialize(
         /*archive_name=*/"constants",
         /*archive_dir=*/"",
         /*tensor_dir=*/"constants/",
-        /*tensor_cdata_naming_scheme=*/false);
+        /*tensor_cdata_naming_scheme=*/true);
 
     writeByteCode(module, save_mobile_debug_info);
     writeMobileMetadata(module, extra_files);
@@ -579,8 +579,8 @@ void ScriptModuleSerializer::writeByteCode(
       telements,
       /*archive_name=*/"bytecode",
       /*archive_dir=*/"",
-      /*tensor_dir=*/"bytecode/",
-      /*tensor_cdata_naming_scheme=*/false);
+      /*tensor_dir=*/"constants/",
+      /*tensor_cdata_naming_scheme=*/true);
 
   auto debug_info_telements = Tup(std::move(debug_info_elements));
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1203,6 +1203,12 @@ class CosineEmbeddingLoss(_Loss):
             elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
             and :attr:`reduce` are in the process of being deprecated, and in the meantime,
             specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
+
+    Shape:
+        - Input1: :math:`(N, D)`, where `N` is the batch size and `D` is the embedding dimension.
+        - Input2: :math:`(N, D)`, same shape as Input1.
+        - Target: :math:`(N)`.
+        - Output: If :attr:`reduction` is ``'none'``, then :math:`(N)`, otherwise scalar.
     """
     __constants__ = ['margin', 'reduction']
     margin: float

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -36,8 +36,6 @@ from .find_file_dependencies import find_files_source_depends_on
 from .glob_group import GlobGroup, GlobPattern
 from .importer import Importer, OrderedImporter, sys_importer
 
-_gate_torchscript_serialization = True
-
 ActionHook = Callable[["PackageExporter", str], None]
 
 
@@ -693,14 +691,6 @@ node [shape=box];
             return ("storage", storage_type, obj_key, location, obj.size())
 
         if hasattr(obj, "__reduce_package__"):
-            if _gate_torchscript_serialization and isinstance(
-                obj, torch.jit.RecursiveScriptModule
-            ):
-                raise Exception(
-                    "Serializing ScriptModules directly into a package is a beta feature. "
-                    "To use, set global "
-                    "`torch.package.package_exporter._gate_torchscript_serialization` to `False`."
-                )
             if self.serialized_reduces.get(id(obj)) is None:
                 self.serialized_reduces[id(obj)] = ("reduce_package", id(obj), *obj.__reduce_package__(self))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#57888 [PyTorch Edge] bytecode version bump to v5 and enable share constant table**

As title, main change:
1. Enable share constant table and reduce model size up to 50%
2. Bump bytecode version from v4 to v5.
3. Add the unittest back. (It was partially removed because `script_module_v5.ptl` bytecode version is v5. When current runtime is v4 and try to load a v5 model, it will raise an error because version is not within the range.

As title

Differential Revision: [D28309381](https://our.internmc.facebook.com/intern/diff/D28309381/)

Differential Revision: [D28309381](https://our.internmc.facebook.com/intern/diff/D28309381)