### PR TITLE
Fix dtype inference in sparse_csr_tensor_ctor

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -48,6 +48,9 @@ class TestSparseCSR(TestCase):
             self.assertEqual(torch.tensor(col_indices, dtype=index_dtype), sparse.col_indices())
             self.assertEqual(torch.tensor(values, dtype=dtype), sparse.values())
 
+        with self.assertRaises(RuntimeError):
+            torch.sparse_csr_tensor(crow_indices, torch.tensor(col_indices), values, size=(2, 10))
+
     @onlyCPU
     @dtypes(torch.double)
     def test_factory_size_check(self, device, dtype):


### PR DESCRIPTION
`NULL` return from `PyObject_GetAttrString` should never get ignored without handling the exception, as behavior of subsequent Python C API calls are undefined until `PyErr_Fetch` or `PyErr_Clear` is called. 

This accidentally leads to `list` type being incorrectly identified as `Tensor`

Fixes #58520
