### PR TITLE
Implementation of Mish: Self Regularized Non-Monotonic Activation Function

### DIFF
--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -6,7 +6,7 @@ from .conv import Conv1d, Conv2d, Conv3d, \
 from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
     Softmax, Softmax2d, LogSoftmax, ELU, SELU, CELU, GELU, Hardshrink, LeakyReLU, LogSigmoid, \
     Softplus, Softshrink, MultiheadAttention, PReLU, Softsign, Softmin, Tanhshrink, RReLU, GLU, \
-    Hardsigmoid, Hardswish, SiLU
+    Hardsigmoid, Hardswish, SiLU, Mish
 from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLoss, NLLLoss2d, \
     CosineEmbeddingLoss, CTCLoss, HingeEmbeddingLoss, MarginRankingLoss, \
     MultiLabelMarginLoss, MultiLabelSoftMarginLoss, MultiMarginLoss, SmoothL1Loss, HuberLoss, \
@@ -60,5 +60,5 @@ __all__ = [
     'LazyLinear', 'LazyConv1d', 'LazyConv2d', 'LazyConv3d',
     'LazyConvTranspose1d', 'LazyConvTranspose2d', 'LazyConvTranspose3d',
     'LazyBatchNorm1d', 'LazyBatchNorm2d', 'LazyBatchNorm3d',
-    'Flatten', 'Unflatten', 'Hardsigmoid', 'Hardswish', 'SiLU', 'TripletMarginWithDistanceLoss', 'ChannelShuffle'
+    'Flatten', 'Unflatten', 'Hardsigmoid', 'Hardswish', 'SiLU', 'TripletMarginWithDistanceLoss', 'ChannelShuffle', 'Mish'
 ]

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -62,6 +62,26 @@ class Threshold(Module):
             self.threshold, self.value, inplace_str
         )
 
+class Mish(Module):
+    """Implementation of Mish: Self Regularized Non-Monotonic Activation Function
+         Mish activation is defined as: f(x) = xtanh(softplus(x))
+         Paper: https://www.bmvc2020-conference.com/assets/papers/0928.pdf
+     Shape:
+         - Input: :math:`(N, *)` where `*` means, any number of additional
+           dimensions
+         - Output: :math:`(N, *)`, same shape as the input
+     Examples::
+         >>> m = nn.Mish()
+         >>> input = autograd.Variable(torch.randn(2))
+         >>> print(input)
+         >>> print(m(input))
+     """
+
+    def forward(self, input):
+        return (input * torch.tanh(torch.nn.Softplus(input).beta))
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ()'
 
 class ReLU(Module):
     r"""Applies the rectified linear unit function element-wise:


### PR DESCRIPTION
Fix for  #58375

Hey @jbschlosser @heitorschueroff I was trying to implement it, wanted to raise a PR first. Could you please check. Thank you.

Implementation of Mish: Self Regularized Non-Monotonic Activation Function
         Mish activation is defined as: f(x) = xtanh(softplus(x))
         Paper: https://www.bmvc2020-conference.com/assets/papers/0928.pdf
     Shape:
         - Input: :math:`(N, *)` where `*` means, any number of additional
           dimensions
         - Output: :math:`(N, *)`, same shape as the input
     Example Usage :
         >>> m = nn.Mish()
         >>> input = autograd.Variable(torch.randn(2))
         >>> print(input)
         >>> print(m(input))