### PR TITLE
[ONNX] Fix the issue of converting empty list to sequence.

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9240,6 +9240,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(12)
         self.run_test(M(), (x,))
 
+        x = torch.ones(2, 0, 3)
         self.run_test(M(), (x,))
 
         x = torch.ones(0)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9245,6 +9245,36 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(0)
         self.run_test(M(), (x,))
 
+    @skipIfUnsupportedMinOpsetVersion(13)
+    def test_sequence_to_int(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                result = torch.tensor([2 for i in range(x.size()[0])], dtype=torch.int)
+                return x, result
+
+        x = torch.randn(10, 5)
+        self.run_test(M(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(13)
+    def test_sequence_to_float(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                result = torch.tensor([1.1 for i in range(x.size()[0])], dtype=torch.float)
+                return x, result
+
+        x = torch.randn(10, 5)
+        self.run_test(M(), (x,))
+
+    @skipIfUnsupportedMinOpsetVersion(13)
+    def test_sequence_to_bool(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                result = torch.tensor([False for i in range(x.size()[0])], dtype=torch.bool)
+                return x, result
+
+        x = torch.randn(10, 5)
+        self.run_test(M(), (x,))
+
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9240,7 +9240,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(12)
         self.run_test(M(), (x,))
 
-        x = torch.ones(2, 0, 3)
         self.run_test(M(), (x,))
 
         x = torch.ones(0)

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -163,24 +163,32 @@ bool isValidToTransformToONNXConcatNode(Node* lc_node) {
   return !lc_node->inputs().empty();
 }
 
-Node* transformToONNXConcatNode(Graph* g, Node* lc_node, int opset_version) {
+Node* transformToONNXConcatNode(Graph* g, Node* lc_node, bool need_new_input, int opset_version) {
   // ListConstruct Int[] output case, we need to transform to ONNX
   // Concat to ensure the output is a single tensor(dynamic) type in
   // order to be consumed as inputs
   std::vector<Value*> unsqueezed;
+  auto new_node = need_new_input ? g->return_node() : lc_node;
+
   for (auto* input : lc_node->inputs()) {
-    auto new_input = g->addInput();
-    new_input->copyMetadata(input);
+    auto new_input = need_new_input
+                     ? g->addInput()->copyMetadata(input)
+                     : input;
+
     Node* unsqueezed_node =
-        createONNXUnsqueeze(g, lc_node, new_input, 0, opset_version);
+        createONNXUnsqueeze(g, new_node, new_input, 0, opset_version);
     unsqueezed.emplace_back(unsqueezed_node->output());
   }
-  Node* concat_node = g->create(onnx::Concat, 1);
+
+  Node* concat_node = need_new_input
+                      ? g->insertNode(g->create(onnx::Concat, 1))
+                      : g->create(onnx::Concat, 1)->insertBefore(lc_node);
+
   concat_node->i_(attr::axis, 0);
   for (auto v : unsqueezed) {
     concat_node->addInput(v);
   }
-  concat_node->insertBefore(lc_node);
+
   return concat_node;
 }
 

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -175,7 +175,7 @@ Node* transformToONNXConcatNode(
   auto new_node = need_new_input ? g->return_node() : lc_node;
 
   for (auto* input : lc_node->inputs()) {
-    auto new_input = 
+    auto new_input =
         need_new_input ? g->addInput()->copyMetadata(input) : input;
 
     Node* unsqueezed_node =

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -163,11 +163,7 @@ bool isValidToTransformToONNXConcatNode(Node* lc_node) {
   return !lc_node->inputs().empty();
 }
 
-Node* transformToONNXConcatNode(
-    Graph* g,
-    Node* lc_node,
-    int opset_version) {
-
+Node* transformToONNXConcatNode(Graph* g, Node* lc_node, int opset_version) {
   // ListConstruct Int[] output case, we need to transform to ONNX
   // Concat to ensure the output is a single tensor(dynamic) type in
   // order to be consumed as inputs

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -168,6 +168,7 @@ Node* transformToONNXConcatNode(
     Node* lc_node,
     bool need_new_input,
     int opset_version) {
+
   // ListConstruct Int[] output case, we need to transform to ONNX
   // Concat to ensure the output is a single tensor(dynamic) type in
   // order to be consumed as inputs
@@ -186,7 +187,6 @@ Node* transformToONNXConcatNode(
   Node* concat_node = need_new_input
       ? g->insertNode(g->create(onnx::Concat, 1))
       : g->create(onnx::Concat, 1)->insertBefore(lc_node);
-
   concat_node->i_(attr::axis, 0);
   for (auto v : unsqueezed) {
     concat_node->addInput(v);

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -169,8 +169,10 @@ Node* transformToONNXConcatNode(Graph* g, Node* lc_node, int opset_version) {
   // order to be consumed as inputs
   std::vector<Value*> unsqueezed;
   for (auto* input : lc_node->inputs()) {
+    auto new_input = g->addInput();
+    new_input->copyMetadata(input);
     Node* unsqueezed_node =
-        createONNXUnsqueeze(g, lc_node, input, 0, opset_version);
+        createONNXUnsqueeze(g, lc_node, new_input, 0, opset_version);
     unsqueezed.emplace_back(unsqueezed_node->output());
   }
   Node* concat_node = g->create(onnx::Concat, 1);

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -163,7 +163,11 @@ bool isValidToTransformToONNXConcatNode(Node* lc_node) {
   return !lc_node->inputs().empty();
 }
 
-Node* transformToONNXConcatNode(Graph* g, Node* lc_node, bool need_new_input, int opset_version) {
+Node* transformToONNXConcatNode(
+    Graph* g,
+    Node* lc_node,
+    bool need_new_input,
+    int opset_version) {
   // ListConstruct Int[] output case, we need to transform to ONNX
   // Concat to ensure the output is a single tensor(dynamic) type in
   // order to be consumed as inputs
@@ -171,9 +175,8 @@ Node* transformToONNXConcatNode(Graph* g, Node* lc_node, bool need_new_input, in
   auto new_node = need_new_input ? g->return_node() : lc_node;
 
   for (auto* input : lc_node->inputs()) {
-    auto new_input = need_new_input
-                     ? g->addInput()->copyMetadata(input)
-                     : input;
+    auto new_input = 
+        need_new_input ? g->addInput()->copyMetadata(input) : input;
 
     Node* unsqueezed_node =
         createONNXUnsqueeze(g, new_node, new_input, 0, opset_version);
@@ -181,8 +184,8 @@ Node* transformToONNXConcatNode(Graph* g, Node* lc_node, bool need_new_input, in
   }
 
   Node* concat_node = need_new_input
-                      ? g->insertNode(g->create(onnx::Concat, 1))
-                      : g->create(onnx::Concat, 1)->insertBefore(lc_node);
+      ? g->insertNode(g->create(onnx::Concat, 1))
+      : g->create(onnx::Concat, 1)->insertBefore(lc_node);
 
   concat_node->i_(attr::axis, 0);
   for (auto v : unsqueezed) {

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -159,5 +159,32 @@ Node* createONNXUnsqueeze(
   return unsqueeze_node;
 }
 
+bool isValidToTransformToONNXConcatNode(Node* lc_node) {
+  return !lc_node->inputs().empty();
+}
+
+Node* transformToONNXConcatNode(
+    Graph* g,
+    Node* lc_node,
+    int opset_version) {
+
+  // ListConstruct Int[] output case, we need to transform to ONNX
+  // Concat to ensure the output is a single tensor(dynamic) type in
+  // order to be consumed as inputs
+  std::vector<Value*> unsqueezed;
+  for (auto* input : lc_node->inputs()) {
+    Node* unsqueezed_node =
+        createONNXUnsqueeze(g, lc_node, input, 0, opset_version);
+    unsqueezed.emplace_back(unsqueezed_node->output());
+  }
+  Node* concat_node = g->create(onnx::Concat, 1);
+  concat_node->i_(attr::axis, 0);
+  for (auto v : unsqueezed) {
+    concat_node->addInput(v);
+  }
+  concat_node->insertBefore(lc_node);
+  return concat_node;
+}
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/helper.cpp
+++ b/torch/csrc/jit/passes/onnx/helper.cpp
@@ -168,7 +168,6 @@ Node* transformToONNXConcatNode(
     Node* lc_node,
     bool need_new_input,
     int opset_version) {
-
   // ListConstruct Int[] output case, we need to transform to ONNX
   // Concat to ensure the output is a single tensor(dynamic) type in
   // order to be consumed as inputs

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -51,7 +51,7 @@ Node* createONNXUnsqueeze(
 
 bool isValidToTransformToONNXConcatNode(Node* lc_node);
 
-Node* transformToONNXConcatNode(Graph* graph, Node* lc_node, int opset_version);
+Node* transformToONNXConcatNode(Graph* graph, Node* lc_node, bool need_new_input, int opset_version);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -49,5 +49,12 @@ Node* createONNXUnsqueeze(
     int axis,
     int opset_version);
 
+bool isValidToTransformToONNXConcatNode(Node* lc_node);
+
+Node* transformToONNXConcatNode(
+    Graph* graph,
+    Node* lc_node,
+    int opset_version);
+
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -51,10 +51,7 @@ Node* createONNXUnsqueeze(
 
 bool isValidToTransformToONNXConcatNode(Node* lc_node);
 
-Node* transformToONNXConcatNode(
-    Graph* graph,
-    Node* lc_node,
-    int opset_version);
+Node* transformToONNXConcatNode(Graph* graph, Node* lc_node, int opset_version);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -51,7 +51,11 @@ Node* createONNXUnsqueeze(
 
 bool isValidToTransformToONNXConcatNode(Node* lc_node);
 
-Node* transformToONNXConcatNode(Graph* graph, Node* lc_node, bool need_new_input, int opset_version);
+Node* transformToONNXConcatNode(
+    Graph* graph,
+    Node* lc_node,
+    bool need_new_input,
+    int opset_version);
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -610,7 +610,6 @@ static void eraseListConstruct(Node* n, int opset_version) {
       auto* lc_node = input->node();
       TypePtr elem =
           lc_node->output()->type()->castRaw<ListType>()->getElementType();
-
       if (elem->cast<IntType>() &&
           isValidToTransformToONNXConcatNode(lc_node)) {
         auto concat_node = transformToONNXConcatNode(

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -610,13 +610,15 @@ static void eraseListConstruct(Node* n, int opset_version) {
       auto* lc_node = input->node();
       TypePtr elem =
           lc_node->output()->type()->castRaw<ListType>()->getElementType();
-      if (elem->cast<IntType>() && isValidToTransformToONNXConcatNode(lc_node)) {
+
+      if (elem->cast<IntType>() &&
+          isValidToTransformToONNXConcatNode(lc_node)) {
         auto concat_node = transformToONNXConcatNode(
-                        block->owningGraph(), input->node(), opset_version);
+            block->owningGraph(), input->node(), opset_version);
         // make concat node output as new input, then ListConstruct should
         // become dead
         replacements.emplace_back(
-              i, std::vector<Value*>({concat_node->output()}));
+            i, std::vector<Value*>({concat_node->output()}));
       } else {
         if (opset_version >= OPSET_VERSION_11) {
           c10::Symbol seq_node_kind = lc_node->inputs().size() > 0

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -613,7 +613,7 @@ static void eraseListConstruct(Node* n, int opset_version) {
       if (elem->cast<IntType>() &&
           isValidToTransformToONNXConcatNode(lc_node)) {
         auto concat_node = transformToONNXConcatNode(
-            block->owningGraph(), input->node(), opset_version);
+            block->owningGraph(), input->node(), false, opset_version);
         // make concat node output as new input, then ListConstruct should
         // become dead
         replacements.emplace_back(

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -610,7 +610,7 @@ static void eraseListConstruct(Node* n, int opset_version) {
       auto* lc_node = input->node();
       TypePtr elem =
           lc_node->output()->type()->castRaw<ListType>()->getElementType();
-      if (elem->cast<IntType>()) {
+      if (elem->cast<IntType>() && !lc_node->inputs().empty()) {
         // ListConstruct Int[] output case, we need to transform to ONNX
         // Concat to ensure the output is a single tensor(dynamic) type in
         // order to be consumed as inputs

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -610,29 +610,13 @@ static void eraseListConstruct(Node* n, int opset_version) {
       auto* lc_node = input->node();
       TypePtr elem =
           lc_node->output()->type()->castRaw<ListType>()->getElementType();
-      if (elem->cast<IntType>() && !lc_node->inputs().empty()) {
-        // ListConstruct Int[] output case, we need to transform to ONNX
-        // Concat to ensure the output is a single tensor(dynamic) type in
-        // order to be consumed as inputs
-        std::vector<Value*> unsqueezed;
-        Graph* g = block->owningGraph();
-        for (auto* input : lc_node->inputs()) {
-          Node* unsqueezed_node =
-              createONNXUnsqueeze(g, lc_node, input, 0, opset_version);
-          unsqueezed.emplace_back(unsqueezed_node->output());
-        }
-        Node* concat_node = g->create(onnx::Concat, 1);
-        concat_node->i_(attr::axis, 0);
-        for (auto v : unsqueezed) {
-          concat_node->addInput(v);
-        }
-        concat_node->insertBefore(lc_node);
-
+      if (elem->cast<IntType>() && isValidToTransformToONNXConcatNode(lc_node)) {
+        auto concat_node = transformToONNXConcatNode(
+                        block->owningGraph(), input->node(), opset_version);
         // make concat node output as new input, then ListConstruct should
         // become dead
         replacements.emplace_back(
-            i, std::vector<Value*>({concat_node->output()}));
-
+              i, std::vector<Value*>({concat_node->output()}));
       } else {
         if (opset_version >= OPSET_VERSION_11) {
           c10::Symbol seq_node_kind = lc_node->inputs().size() > 0

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -223,26 +223,9 @@ Value* CloneValueFromListConstruct(
   c10::optional<at::ScalarType> scalar_type = c10::nullopt;
   if (elem->cast<IntType>()) {
     scalar_type = at::kLong;
-
-    if (!v->node()->inputs().empty()) {
-      auto lc_node = v->node();
-      // ListConstruct Int[] output case, we need to transform to ONNX
-      // Concat to ensure the output is a single tensor(dynamic) type in
-      // order to be consumed as inputs
-      std::vector<Value*> unsqueezed;
-      for (auto* input : lc_node->inputs()) {
-        auto new_input = n_graph->addInput();
-        new_input->copyMetadata(input);
-        Node* unsqueezed_node = createONNXUnsqueeze(
-            n_graph.get(), n_graph->return_node(), new_input, 0, opset_version);
-        unsqueezed.emplace_back(unsqueezed_node->output());
-      }
-      Node* concat_node =
-          n_graph->insertNode(n_graph->create(::c10::onnx::Concat, 1));
-      concat_node->i_(attr::axis, 0);
-      for (auto v : unsqueezed) {
-        concat_node->addInput(v);
-      }
+    if (isValidToTransformToONNXConcatNode(v->node())) {
+      auto concat_node = transformToONNXConcatNode(
+          n_graph.get(), v->node(), opset_version);
       return concat_node->output();
     }
   } else if (elem->cast<FloatType>()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -224,25 +224,27 @@ Value* CloneValueFromListConstruct(
   if (elem->cast<IntType>()) {
     scalar_type = at::kLong;
 
-    auto lc_node = v->node();
-    // ListConstruct Int[] output case, we need to transform to ONNX
-    // Concat to ensure the output is a single tensor(dynamic) type in
-    // order to be consumed as inputs
-    std::vector<Value*> unsqueezed;
-    for (auto* input : lc_node->inputs()) {
-      auto new_input = n_graph->addInput();
-      new_input->copyMetadata(input);
-      Node* unsqueezed_node = createONNXUnsqueeze(
-          n_graph.get(), n_graph->return_node(), new_input, 0, opset_version);
-      unsqueezed.emplace_back(unsqueezed_node->output());
+    if (!v->node()->inputs().empty()) {
+      auto lc_node = v->node();
+      // ListConstruct Int[] output case, we need to transform to ONNX
+      // Concat to ensure the output is a single tensor(dynamic) type in
+      // order to be consumed as inputs
+      std::vector<Value*> unsqueezed;
+      for (auto* input : lc_node->inputs()) {
+        auto new_input = n_graph->addInput();
+        new_input->copyMetadata(input);
+        Node* unsqueezed_node = createONNXUnsqueeze(
+            n_graph.get(), n_graph->return_node(), new_input, 0, opset_version);
+        unsqueezed.emplace_back(unsqueezed_node->output());
+      }
+      Node* concat_node =
+          n_graph->insertNode(n_graph->create(::c10::onnx::Concat, 1));
+      concat_node->i_(attr::axis, 0);
+      for (auto v : unsqueezed) {
+        concat_node->addInput(v);
+      }
+      return concat_node->output();
     }
-    Node* concat_node =
-        n_graph->insertNode(n_graph->create(::c10::onnx::Concat, 1));
-    concat_node->i_(attr::axis, 0);
-    for (auto v : unsqueezed) {
-      concat_node->addInput(v);
-    }
-    return concat_node->output();
   } else if (elem->cast<FloatType>()) {
     scalar_type = at::kFloat;
   } else if (elem->cast<BoolType>()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -224,8 +224,8 @@ Value* CloneValueFromListConstruct(
   if (elem->cast<IntType>()) {
     scalar_type = at::kLong;
     if (isValidToTransformToONNXConcatNode(v->node())) {
-      auto concat_node = transformToONNXConcatNode(
-          n_graph.get(), v->node(), opset_version);
+      auto concat_node =
+          transformToONNXConcatNode(n_graph.get(), v->node(), opset_version);
       return concat_node->output();
     }
   } else if (elem->cast<FloatType>()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -224,8 +224,8 @@ Value* CloneValueFromListConstruct(
   if (elem->cast<IntType>()) {
     scalar_type = at::kLong;
     if (isValidToTransformToONNXConcatNode(v->node())) {
-      auto concat_node =
-          transformToONNXConcatNode(n_graph.get(), v->node(), true, opset_version);
+      auto concat_node = transformToONNXConcatNode(
+          n_graph.get(), v->node(), true, opset_version);
       return concat_node->output();
     }
   } else if (elem->cast<FloatType>()) {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -225,7 +225,7 @@ Value* CloneValueFromListConstruct(
     scalar_type = at::kLong;
     if (isValidToTransformToONNXConcatNode(v->node())) {
       auto concat_node =
-          transformToONNXConcatNode(n_graph.get(), v->node(), opset_version);
+          transformToONNXConcatNode(n_graph.get(), v->node(), true, opset_version);
       return concat_node->output();
     }
   } else if (elem->cast<FloatType>()) {

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -212,8 +212,11 @@ def _is_constant(value):
 def _is_tensor(x):
     return x.type().isSubtypeOf(torch._C.TensorType.get())
 
+def _is_list(x):
+    return isinstance(x.type(), torch._C.ListType)
+
 def _is_tensor_list(x):
-    return isinstance(x.type(), torch._C.ListType) and isinstance(x.type().getElementType(), torch._C.TensorType)
+    return _is_list(x) and isinstance(x.type().getElementType(), torch._C.TensorType)
 
 def _is_scalar_list(x):
     """
@@ -223,7 +226,7 @@ def _is_scalar_list(x):
     a valid ONNX data type.
     """
     element_type = str(x.type().getElementType())
-    return isinstance(x.type(), torch._C.ListType) and \
+    return _is_list(x) and \
         element_type in scalar_name_to_pytorch.keys() and \
         (scalar_name_to_pytorch[element_type] in cast_pytorch_to_onnx.keys())
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -215,6 +215,10 @@ def _is_tensor(x):
 def _is_tensor_list(x):
     return isinstance(x.type(), torch._C.ListType) and isinstance(x.type().getElementType(), torch._C.TensorType)
 
+def _is_scalar_list(x):
+    return isinstance(x.type(), torch._C.ListType) and \
+           (scalar_name_to_pytorch[str(x.type().getElementType())] in cast_pytorch_to_onnx.keys())
+
 def _get_tensor_rank(x):
     if not _is_tensor(x) or x.type() is None:
         return None

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -217,7 +217,7 @@ def _is_tensor_list(x):
 
 def _is_scalar_list(x):
     return isinstance(x.type(), torch._C.ListType) and \
-           (scalar_name_to_pytorch[str(x.type().getElementType())] in cast_pytorch_to_onnx.keys())
+        (scalar_name_to_pytorch[str(x.type().getElementType())] in cast_pytorch_to_onnx.keys())
 
 def _get_tensor_rank(x):
     if not _is_tensor(x) or x.type() is None:

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -219,7 +219,7 @@ def _is_scalar_list(x):
     """
     Check if x is a scalar list, for example: List[float], List[int].
 
-    Besides checking the type is ListType, we also check if the data type is 
+    Besides checking the type is ListType, we also check if the data type is
     a valid ONNX data type.
     """
     return isinstance(x.type(), torch._C.ListType) and \

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -216,6 +216,12 @@ def _is_tensor_list(x):
     return isinstance(x.type(), torch._C.ListType) and isinstance(x.type().getElementType(), torch._C.TensorType)
 
 def _is_scalar_list(x):
+    """
+    Check if x is a scalar list, for example: List[float], List[int].
+
+    Besides checking the type is ListType, we also check if the data type is 
+    a valid ONNX data type.
+    """
     return isinstance(x.type(), torch._C.ListType) and \
         (scalar_name_to_pytorch[str(x.type().getElementType())] in cast_pytorch_to_onnx.keys())
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -222,8 +222,10 @@ def _is_scalar_list(x):
     Besides checking the type is ListType, we also check if the data type is
     a valid ONNX data type.
     """
+    element_type = str(x.type().getElementType())
     return isinstance(x.type(), torch._C.ListType) and \
-        (scalar_name_to_pytorch[str(x.type().getElementType())] in cast_pytorch_to_onnx.keys())
+        element_type in scalar_name_to_pytorch.keys() and \
+        (scalar_name_to_pytorch[element_type] in cast_pytorch_to_onnx.keys())
 
 def _get_tensor_rank(x):
     if not _is_tensor(x) or x.type() is None:

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -745,7 +745,6 @@ def _optional_input_placeholder_tensor(g):
     return n
 
 def _handle_reduce_dim_none(g, self, op_name):
-    dim_size = _get_tensor_dim_size(self, 0)
     rank = _get_tensor_rank(self)
     if rank is not None and any([_get_tensor_dim_size(self, i) == 0 for i in range(rank)]):
         # If input tensor is empty, according to ONNX ReduceSum definition,

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1769,7 +1769,7 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
         if dtype is None:
             dtype = data.type().scalarType()
             dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
-        if sym_help._is_tensor_list(data) or sym_help._is_scalar_list(data):
+        if sym_help._is_list(data) and (sym_help._is_tensor_list(data) or sym_help._is_scalar_list(data)):
             data = g.op("ConcatFromSequence", data, axis_i=0, new_axis_i=1)
     return g.op("Cast", data, to_i=sym_help.scalar_type_to_onnx[dtype])
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1769,6 +1769,8 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
         if dtype is None:
             dtype = data.type().scalarType()
             dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
+        if sym_help._is_scalar_list(data):
+            data = g.op("ConcatFromSequence", data, axis_i=0, new_axis_i=1)
     return g.op("Cast", data, to_i=sym_help.scalar_type_to_onnx[dtype])
 
 def as_tensor(g, data, dtype=None, device=None):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1769,7 +1769,7 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
         if dtype is None:
             dtype = data.type().scalarType()
             dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
-        if sym_help._is_scalar_list(data):
+        if sym_help._is_tensor_list(data) or sym_help._is_scalar_list(data):
             data = g.op("ConcatFromSequence", data, axis_i=0, new_axis_i=1)
     return g.op("Cast", data, to_i=sym_help.scalar_type_to_onnx[dtype])
 


### PR DESCRIPTION
When we construct an empty list by python list comprehension, we need to avoid converting the node without inputs to onnx::Concat in shape_type_inference.cpp and peephole.cpp because it will create an invalid Concat node which doesn't have inputs.

In addition, update the code to avoid passing a Sequence input to an onnx::Cast node which doesn't accept Sequence data type as an input.

Add tests for the validation as well.
