### PR TITLE
[nnc] Use int64 to compute matmul flops heuristic

### DIFF
--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -8,8 +8,13 @@
 #include <c10/util/Flags.h>
 #include <stdexcept>
 
+#ifdef FBCODE_CAFFE2
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+C10_DEFINE_bool(torch_jit_enable_cpu_fusion, true, "enable cpu fusion");
+#else
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_bool(torch_jit_enable_cpu_fusion, false, "enable cpu fusion");
+#endif
 
 namespace torch {
 namespace jit {
@@ -46,6 +51,7 @@ bool canFuseOnGPU() {
 
 void overrideCanFuseOnCPU(bool value) {
   detail::cpu_fuser_enabled = value;
+  FLAGS_torch_jit_enable_cpu_fusion = value;
 }
 
 void overrideCanFuseOnGPU(bool value) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1466,8 +1466,11 @@ Tensor* computeMatmul(
 
   auto size_a = a.dims();
   auto size_b = b.dims();
-  const IntImm* total_size = dynamic_cast<const IntImm*>(
-      IRSimplifier::simplify((size_a[0] * size_a[1] * size_b[1])).node());
+  auto total_size = dynamic_cast<LongImm*>(
+      IRSimplifier::simplify(
+          cast<int64_t>(size_a[0]) * cast<int64_t>(size_a[1]) *
+          cast<int64_t>(size_b[1]))
+          .node());
 
   // For small sizes, where N*M*K < 1000, lower matmul to a naive 3-level
   // loopnest. The number is not tuned very carefully, and in future we should


### PR DESCRIPTION
Summary:
We only generate asm for small matmuls, but we were computing the # of
flops using an int32, which is too small.

Test Plan:
```
buck test mode/dev //caffe2/test:static_runtime -- --exact 'caffe2/test:static_runtime - test_mlp (test_static_runtime.TestStaticModule)'
```

Reviewed By: navahgar

Differential Revision: D28562157

