### PR TITLE
[do not merge] Use testing builder branch

### DIFF
--- a/.circleci/scripts/binary_checkout.sh
+++ b/.circleci/scripts/binary_checkout.sh
@@ -64,5 +64,6 @@ popd
 retry git clone -q https://github.com/pytorch/builder.git "$BUILDER_ROOT"
 pushd "$BUILDER_ROOT"
 echo "Using builder from "
+git checkout driazati/debug_whls
 git --no-pager log --max-count 1
 popd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58684 Use testing builder branch**
* #58685 [skip ci] Move debug wheels out of package dir before test

