### PR TITLE
[skip ci] Move debug wheels out of package dir before test

### DIFF
--- a/.circleci/scripts/binary_linux_test.sh
+++ b/.circleci/scripts/binary_linux_test.sh
@@ -38,6 +38,10 @@ if [[ "$DESIRED_CUDA" == "cu112" ]]; then
   EXTRA_CONDA_FLAGS="-c=conda-forge"
 fi
 
+# Move debug wheels out of the the package dir so they don't get installed
+mkdir -p /tmp/debug_final_pkgs
+mv /final_pkgs/debug-*.zip /tmp/debug_final_pkgs
+
 # Install the package
 # These network calls should not have 'retry's because they are installing
 # locally and aren't actually network calls


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58684 [do not merge] Use testing builder branch
* **#58685 [skip ci] Move debug wheels out of package dir before test**

This moves debug packages out of the artifacts dir before running tests (as a counterpart to https://github.com/pytorch/builder/pull/770). Doing it this way allows us to keep the CI configs simple since there's one directory to use for artifacts / upload to S3.

See #58684 for actual CI signals (the ones on this PR are all cancelled since it depends on the builder branch set in the next PR up the stack)

Differential Revision: [D28646995](https://our.internmc.facebook.com/intern/diff/D28646995)