### PR TITLE
[torch.special] Adding betainc

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -443,6 +443,7 @@ _(aten, logspace) \
 _(aten, logsumexp) \
 _(aten, xlogy) \
 _(aten, special_xlog1py) \
+_(aten, special_betainc) \
 _(aten, lstm) \
 _(aten, lstm_cell) \
 _(aten, lstsq) \

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -57,6 +57,10 @@ TORCH_META_FUNC(special_xlog1py) (const Tensor& self, const Tensor& other) {
   build_binary_float_op(maybe_get_output(), self, other);
 }
 
+TORCH_META_FUNC(special_betainc) (const Tensor& self, const Tensor& a, const Tensor& b) {
+  build_binary_float_op(maybe_get_output(), self, a, b);
+}
+
 TORCH_META_FUNC2(copysign, Tensor) (
   const Tensor& self, const Tensor& other
 ) {
@@ -195,6 +199,7 @@ DEFINE_DISPATCH(copysign_stub);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(xlogy_stub);
 DEFINE_DISPATCH(xlog1py_stub);
+DEFINE_DISPATCH(betainc_stub);
 
 TORCH_IMPL_FUNC(add_out) (
   const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& result
@@ -236,6 +241,10 @@ TORCH_IMPL_FUNC(special_xlog1py_out) (const Tensor& self, const Tensor& other, c
   xlog1py_stub(device_type(), *this);
 }
 
+TORCH_IMPL_FUNC(special_betainc_out) (const Tensor& self, const Tensor& a, const Tensor& b, const Tensor& result) {
+  betainc_stub(device_type(), *this);
+}
+
 #define CREATE_BINARY_TORCH_IMPL_FUNC(func)                                                    \
 TORCH_IMPL_FUNC(func##_out) (const Tensor& self, const Tensor& other, const Tensor& result) {  \
   func##_stub(device_type(), *this);                                                           \
@@ -266,6 +275,22 @@ Tensor& special_xlog1py_out(const Scalar& self, const Tensor& other, Tensor& res
 
 Tensor& special_xlog1py_out(const Tensor& self, const Scalar& other, Tensor& result) {
   return at::special_xlog1py_out(result, self, wrapped_scalar_tensor(other));
+}
+
+Tensor special_betainc(const Tensor& self, const Scalar& a, const Scalar& b) {
+  return at::special_betainc(self, wrapped_scalar_tensor(a), wrapped_scalar_tensor(b));
+}
+
+Tensor special_betainc(const Tensor& self, const Scalar& a, const Tensor& b) {
+  return at::special_betainc(self, wrapped_scalar_tensor(a), b);
+}
+
+Tensor& special_betainc_out(const Tensor& self, const Scalar& a, const Scalar& b, Tensor& result) {
+  return at::special_betainc_out(result, self, wrapped_scalar_tensor(a), wrapped_scalar_tensor(b));
+}
+
+Tensor& special_betainc_out(const Tensor& self, const Scalar& a, const Tensor& b, Tensor& result) {
+  return at::special_betainc_out(result, self, wrapped_scalar_tensor(a), b);
 }
 
 TORCH_IMPL_FUNC(atan2_out) (const Tensor& self, const Tensor& other, const Tensor& result) {

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -58,7 +58,17 @@ TORCH_META_FUNC(special_xlog1py) (const Tensor& self, const Tensor& other) {
 }
 
 TORCH_META_FUNC(special_betainc) (const Tensor& self, const Tensor& a, const Tensor& b) {
-  build_binary_float_op(maybe_get_output(), self, a, b);
+    TensorIteratorConfig()
+    .set_check_mem_overlap(true)
+    .allow_cpu_scalars(true)
+    .promote_inputs_to_common_dtype(true)
+    .cast_common_dtype_to_outputs(true)
+    .enforce_safe_casting_to_output(true)
+    .promote_integer_inputs_to_float(true)
+    .add_output(maybe_get_output()) // maybe try using `add_borrowed_output(maybe_get_output())` if possible
+    .add_input(self)  // similarly try using `add_borrowed_input(self)` if possible.
+    .add_input(a)  // try using `add_borrowed_input(a)` if possible.
+    .add_input(b); // try using `add_borrowed_input(b)` if possible.
 }
 
 TORCH_META_FUNC2(copysign, Tensor) (

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -58,17 +58,19 @@ TORCH_META_FUNC(special_xlog1py) (const Tensor& self, const Tensor& other) {
 }
 
 TORCH_META_FUNC(special_betainc) (const Tensor& self, const Tensor& a, const Tensor& b) {
-    TensorIteratorConfig()
-    .set_check_mem_overlap(true)
-    .allow_cpu_scalars(true)
-    .promote_inputs_to_common_dtype(true)
-    .cast_common_dtype_to_outputs(true)
-    .enforce_safe_casting_to_output(true)
-    .promote_integer_inputs_to_float(true)
-    .add_output(maybe_get_output()) // maybe try using `add_borrowed_output(maybe_get_output())` if possible
-    .add_input(self)  // similarly try using `add_borrowed_input(self)` if possible.
-    .add_input(a)  // try using `add_borrowed_input(a)` if possible.
-    .add_input(b); // try using `add_borrowed_input(b)` if possible.
+    build(
+      TensorIteratorConfig()
+      .set_check_mem_overlap(true)
+      .allow_cpu_scalars(true)
+      .promote_inputs_to_common_dtype(true)
+      .cast_common_dtype_to_outputs(true)
+      .enforce_safe_casting_to_output(true)
+      .promote_integer_inputs_to_float(true)
+      .add_output(maybe_get_output()) // maybe try using `add_borrowed_output(maybe_get_output())` if possible
+      .add_input(self)  // similarly try using `add_borrowed_input(self)` if possible.
+      .add_input(a)  // try using `add_borrowed_input(a)` if possible.
+      .add_input(b)
+      ); // try using `add_borrowed_input(b)` if possible.
 }
 
 TORCH_META_FUNC2(copysign, Tensor) (

--- a/aten/src/ATen/native/BinaryOps.cpp
+++ b/aten/src/ATen/native/BinaryOps.cpp
@@ -295,12 +295,20 @@ Tensor special_betainc(const Tensor& self, const Scalar& a, const Tensor& b) {
   return at::special_betainc(self, wrapped_scalar_tensor(a), b);
 }
 
+Tensor special_betainc(const Tensor& self, const Tensor& a, const Scalar& b) {
+  return at::special_betainc(self, a, wrapped_scalar_tensor(b));
+}
+
 Tensor& special_betainc_out(const Tensor& self, const Scalar& a, const Scalar& b, Tensor& result) {
   return at::special_betainc_out(result, self, wrapped_scalar_tensor(a), wrapped_scalar_tensor(b));
 }
 
 Tensor& special_betainc_out(const Tensor& self, const Scalar& a, const Tensor& b, Tensor& result) {
   return at::special_betainc_out(result, self, wrapped_scalar_tensor(a), b);
+}
+
+Tensor& special_betainc_out(const Tensor& self, const Tensor& a, const Scalar& b, Tensor& result) {
+  return at::special_betainc_out(result, self, a, wrapped_scalar_tensor(b));
 }
 
 TORCH_IMPL_FUNC(atan2_out) (const Tensor& self, const Tensor& other, const Tensor& result) {

--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -93,5 +93,5 @@ DECLARE_DISPATCH(structured_binary_fn, heaviside_stub);
 DECLARE_DISPATCH(structured_binary_fn, copysign_stub);
 DECLARE_DISPATCH(binary_fn, xlogy_stub);
 DECLARE_DISPATCH(structured_binary_fn, xlog1py_stub);
-
+DECLARE_DISPATCH(structured_binary_fn, betainc_stub);
 }} // namespace at::native

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1293,6 +1293,16 @@ calc_i0e(T _x) {
 inline c10::BFloat16 calc_i0e(c10::BFloat16 a) { return calc_i0e(static_cast<float>(a)); }
 
 template <typename T>
+inline C10_HOST_DEVICE T calc_betaln(T a, T b) {
+    return std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
+}
+
+template <typename T>
+inline C10_HOST_DEVICE T calc_beta(T a, T b) {
+    return std::exp(calc_betaln(a, b));
+}
+
+template <typename T>
 inline C10_HOST_DEVICE T calc_betainc(T x, T a, T b) {
   if (x < 0.0 || x > 1.0 || a < 0.0 || b < 0.0){
     return 1.0 / 0.0;
@@ -1308,8 +1318,7 @@ inline C10_HOST_DEVICE T calc_betainc(T x, T a, T b) {
   }
 
   /*Find the first part before the continued fraction.*/
-  const T lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
-  const T front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
+  const T front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - calc_betaln(a, b)) / a;
 
   /*Use Lentz's algorithm to evaluate the continued fraction.*/
   T f = 1.0, c = 1.0, d = 0.0;

--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1291,3 +1291,67 @@ calc_i0e(T _x) {
 
 // Upcast bfloat16 input to float for numerical accuracy purposes
 inline c10::BFloat16 calc_i0e(c10::BFloat16 a) { return calc_i0e(static_cast<float>(a)); }
+
+template <typename T>
+inline C10_HOST_DEVICE T calc_betainc(T x, T a, T b) {
+  if (x < 0.0 || x > 1.0 || a < 0.0 || b < 0.0){
+    return 1.0 / 0.0;
+  }
+
+  /*The continued fraction converges nicely for x < (a+1)/(a+b+2)*/
+  /*Use the fact that beta is symmetrical.*/
+  bool return_inverse = false;
+  if (x > (a + 1.0) / (a + b + 2.0)) {
+    std::swap(a, b);
+    x = 1.0 - x;
+    return_inverse = true;
+  }
+
+  /*Find the first part before the continued fraction.*/
+  const T lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
+  const T front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
+
+  /*Use Lentz's algorithm to evaluate the continued fraction.*/
+  T f = 1.0, c = 1.0, d = 0.0;
+
+  const T TINY = 1.0e-30, STOP = 1.0e-8;
+  T numerator, cd;
+  int i, m;
+  for (i = 0; i <= 200; ++i) {
+      m = i / 2;
+
+      if (i == 0) {
+          numerator = 1.0; /*First numerator is 1.0.*/
+      } else if (i % 2 == 0) {
+          numerator = (m * (b - m) * x) / ((a + 2.0 * m - 1.0) * (a + 2.0 * m)); /*Even term.*/
+      } else {
+          numerator = - ((a + m) * (a + b + m) * x) / ((a + 2.0 * m) * (a + 2.0 * m + 1)); /*Odd term.*/
+      }
+
+      /*Do an iteration of Lentz's algorithm.*/
+      d = 1.0 + numerator * d;
+      if (std::abs(d) < TINY) {
+        d = TINY;
+      }
+      d = 1.0 / d;
+
+      c = 1.0 + numerator / c;
+      if (std::abs(c) < TINY) {
+        c = TINY;
+      }
+
+      cd = c * d;
+      f *= cd;
+
+      /*Check for stop.*/
+      if (std::abs(1.0 - cd) < STOP) {
+        if (return_inverse) {
+          return 1 - front * (f - 1.0);
+        } else {
+          return front * (f - 1.0);
+        }
+      }
+  }
+
+  return 1.0 / 0.0; /*Needed more loops, did not converge.*/
+}

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -982,7 +982,7 @@ void betainc_kernel(TensorIteratorBase& iter) {
       if (x == 0){
         return 0;
       }
-      return x * 2;
+      return x;
     });
   });
 }

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -973,6 +973,20 @@ void xlog1py_kernel(TensorIteratorBase& iter) {
   });
 }
 
+void betainc_kernel(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(kBFloat16, kHalf, iter.common_dtype(), "betainc_cpu", [&]() {
+    cpu_kernel(iter, [](scalar_t x, scalar_t a, scalar_t b) -> scalar_t {
+      if (at::_isnan(x)){
+        return NAN;
+      }
+      if (x == 0){
+        return 0;
+      }
+      return x * 2;
+    });
+  });
+}
+
 } // namespace
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -1066,6 +1080,7 @@ REGISTER_DISPATCH(copysign_stub, &copysign_kernel);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_DISPATCH(xlogy_stub, &xlogy_kernel);
 REGISTER_DISPATCH(xlog1py_stub, &xlog1py_kernel);
+REGISTER_DISPATCH(betainc_stub, &betainc_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -979,8 +979,13 @@ void betainc_kernel(TensorIteratorBase& iter) {
       if (at::_isnan(x)){
         return NAN;
       }
-
-      if (x < 0.0 || x > 1.0){
+      if (at::_isnan(a)){
+        return NAN;
+      }
+      if (at::_isnan(b)){
+        return NAN;
+      }
+      if (x < 0.0 || x > 1.0 || a < 0.0 || b < 0.0){
         return NAN;
       }
 
@@ -994,13 +999,13 @@ void betainc_kernel(TensorIteratorBase& iter) {
       }
 
       /*Find the first part before the continued fraction.*/
-      const scalar_t lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a+b);
+      const scalar_t lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
       const scalar_t front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
 
       /*Use Lentz's algorithm to evaluate the continued fraction.*/
       scalar_t f = 1.0, c = 1.0, d = 0.0;
 
-      scalar_t TINY = 1.0e-30, STOP = 1.0e-7, numerator, cd;
+      scalar_t TINY = 1.0e-30, STOP = 1.0e-8, numerator, cd;
       int i, m;
       for (i = 0; i <= 200; ++i) {
           m = i / 2;

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -979,10 +979,66 @@ void betainc_kernel(TensorIteratorBase& iter) {
       if (at::_isnan(x)){
         return NAN;
       }
-      if (x == 0){
-        return 0;
+
+      if (x < 0.0 || x > 1.0){
+        return NAN;
       }
-      return x;
+
+      /*The continued fraction converges nicely for x < (a+1)/(a+b+2)*/
+      /*Use the fact that beta is symmetrical.*/
+      bool return_inverse = false;
+      if (x > (a + 1.0) / (a + b + 2.0)) {
+        std::swap(a, b);
+        x = 1.0 - x;
+        return_inverse = true;
+      }
+
+      /*Find the first part before the continued fraction.*/
+      const scalar_t lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a+b);
+      const scalar_t front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
+
+      /*Use Lentz's algorithm to evaluate the continued fraction.*/
+      scalar_t f = 1.0, c = 1.0, d = 0.0;
+
+      scalar_t TINY = 1.0e-30, STOP = 1.0e-7, numerator, cd;
+      int i, m;
+      for (i = 0; i <= 200; ++i) {
+          m = i / 2;
+          
+          if (i == 0) {
+              numerator = 1.0; /*First numerator is 1.0.*/
+          } else if (i % 2 == 0) {
+              numerator = (m * (b - m) * x) / ((a + 2.0 * m - 1.0) * (a + 2.0 * m)); /*Even term.*/
+          } else {
+              numerator = - ((a + m) * (a + b + m) * x) / ((a + 2.0 * m) * (a + 2.0 * m + 1)); /*Odd term.*/
+          }
+
+          /*Do an iteration of Lentz's algorithm.*/
+          d = 1.0 + numerator * d;
+          if (std::abs(d) < TINY) {
+            d = TINY;
+          }
+          d = 1.0 / d;
+
+          c = 1.0 + numerator / c;
+          if (std::abs(c) < TINY) {
+            c = TINY;
+          }
+
+          cd = c * d;
+          f *= cd;
+
+          /*Check for stop.*/
+          if (std::abs(1.0 - cd) < STOP) {
+            if (return_inverse) {
+              return 1 - front * (f - 1.0);
+            } else {
+              return front * (f - 1.0);
+            }
+          }
+      }
+
+      return NAN; /*Needed more loops, did not converge.*/
     });
   });
 }

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -67,11 +67,87 @@ void xlog1py_kernel_cuda(TensorIteratorBase& iter) {
   });
 }
 
+void betainc_kernel_cuda(TensorIteratorBase& iter) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "betainc_cuda", [&]() {
+    gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, scalar_t a, scalar_t b) -> scalar_t {
+      if (at::_isnan(x)){
+        return NAN;
+      }
+      if (at::_isnan(a)){
+        return NAN;
+      }
+      if (at::_isnan(b)){
+        return NAN;
+      }
+      if (x < 0.0 || x > 1.0 || a < 0.0 || b < 0.0){
+        return NAN;
+      }
+
+      /*The continued fraction converges nicely for x < (a+1)/(a+b+2)*/
+      /*Use the fact that beta is symmetrical.*/
+      bool return_inverse = false;
+      if (x > (a + 1.0) / (a + b + 2.0)) {
+        std::swap(a, b);
+        x = 1.0 - x;
+        return_inverse = true;
+      }
+
+      /*Find the first part before the continued fraction.*/
+      const scalar_t lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
+      const scalar_t front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
+
+      /*Use Lentz's algorithm to evaluate the continued fraction.*/
+      scalar_t f = 1.0, c = 1.0, d = 0.0;
+
+      scalar_t TINY = 1.0e-30, STOP = 1.0e-8, numerator, cd;
+      int i, m;
+      for (i = 0; i <= 200; ++i) {
+          m = i / 2;
+          
+          if (i == 0) {
+              numerator = 1.0; /*First numerator is 1.0.*/
+          } else if (i % 2 == 0) {
+              numerator = (m * (b - m) * x) / ((a + 2.0 * m - 1.0) * (a + 2.0 * m)); /*Even term.*/
+          } else {
+              numerator = - ((a + m) * (a + b + m) * x) / ((a + 2.0 * m) * (a + 2.0 * m + 1)); /*Odd term.*/
+          }
+
+          /*Do an iteration of Lentz's algorithm.*/
+          d = 1.0 + numerator * d;
+          if (std::abs(d) < TINY) {
+            d = TINY;
+          }
+          d = 1.0 / d;
+
+          c = 1.0 + numerator / c;
+          if (std::abs(c) < TINY) {
+            c = TINY;
+          }
+
+          cd = c * d;
+          f *= cd;
+
+          /*Check for stop.*/
+          if (std::abs(1.0 - cd) < STOP) {
+            if (return_inverse) {
+              return 1 - front * (f - 1.0);
+            } else {
+              return front * (f - 1.0);
+            }
+          }
+      }
+
+      return NAN; /*Needed more loops, did not converge.*/
+    });
+  });
+}
+
 REGISTER_DISPATCH(smooth_l1_stub, &smooth_l1_kernel_cuda);
 REGISTER_DISPATCH(huber_stub, &huber_kernel_cuda);
 REGISTER_DISPATCH(mse_stub, &mse_kernel_cuda);
 REGISTER_DISPATCH(xlogy_stub, &xlogy_kernel_cuda);
 REGISTER_DISPATCH(xlog1py_stub, &xlog1py_kernel_cuda);
+REGISTER_DISPATCH(betainc_stub, &betainc_kernel_cuda);
 
 // DO NOT ADD ANY NEW KERNELS HERE
 // CUDA compilation times grow quickly.  It's perfectly acceptable to have a file per kernel.

--- a/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
+++ b/aten/src/ATen/native/cuda/BinaryMiscOpsKernels.cu
@@ -4,6 +4,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/NumericUtils.h>
+#include <ATen/Math.h>
 
 // NOTE: CUDA on Windows requires that the enclosing function
 // of a __device__ lambda not have internal linkage.
@@ -70,74 +71,7 @@ void xlog1py_kernel_cuda(TensorIteratorBase& iter) {
 void betainc_kernel_cuda(TensorIteratorBase& iter) {
   AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, iter.common_dtype(), "betainc_cuda", [&]() {
     gpu_kernel_with_scalars(iter, []GPU_LAMBDA(scalar_t x, scalar_t a, scalar_t b) -> scalar_t {
-      if (at::_isnan(x)){
-        return NAN;
-      }
-      if (at::_isnan(a)){
-        return NAN;
-      }
-      if (at::_isnan(b)){
-        return NAN;
-      }
-      if (x < 0.0 || x > 1.0 || a < 0.0 || b < 0.0){
-        return NAN;
-      }
-
-      /*The continued fraction converges nicely for x < (a+1)/(a+b+2)*/
-      /*Use the fact that beta is symmetrical.*/
-      bool return_inverse = false;
-      if (x > (a + 1.0) / (a + b + 2.0)) {
-        std::swap(a, b);
-        x = 1.0 - x;
-        return_inverse = true;
-      }
-
-      /*Find the first part before the continued fraction.*/
-      const scalar_t lbeta_ab = std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
-      const scalar_t front = std::exp(std::log(x) * a + std::log(1.0 - x) * b - lbeta_ab) / a;
-
-      /*Use Lentz's algorithm to evaluate the continued fraction.*/
-      scalar_t f = 1.0, c = 1.0, d = 0.0;
-
-      scalar_t TINY = 1.0e-30, STOP = 1.0e-8, numerator, cd;
-      int i, m;
-      for (i = 0; i <= 200; ++i) {
-          m = i / 2;
-          
-          if (i == 0) {
-              numerator = 1.0; /*First numerator is 1.0.*/
-          } else if (i % 2 == 0) {
-              numerator = (m * (b - m) * x) / ((a + 2.0 * m - 1.0) * (a + 2.0 * m)); /*Even term.*/
-          } else {
-              numerator = - ((a + m) * (a + b + m) * x) / ((a + 2.0 * m) * (a + 2.0 * m + 1)); /*Odd term.*/
-          }
-
-          /*Do an iteration of Lentz's algorithm.*/
-          d = 1.0 + numerator * d;
-          if (std::abs(d) < TINY) {
-            d = TINY;
-          }
-          d = 1.0 / d;
-
-          c = 1.0 + numerator / c;
-          if (std::abs(c) < TINY) {
-            c = TINY;
-          }
-
-          cd = c * d;
-          f *= cd;
-
-          /*Check for stop.*/
-          if (std::abs(1.0 - cd) < STOP) {
-            if (return_inverse) {
-              return 1 - front * (f - 1.0);
-            } else {
-              return front * (f - 1.0);
-            }
-          }
-      }
-
-      return NAN; /*Needed more loops, did not converge.*/
+        return calc_betainc(x, a, b);
     });
   });
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9347,6 +9347,12 @@
   dispatch:
     CompositeExplicitAutograd: special_betainc
 
+- func: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc
+
 - func: special_betainc.out(Tensor self, Tensor a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   structured: True
@@ -9356,14 +9362,21 @@
   dispatch:
     CPU, CUDA: special_betainc_out
 
-- func: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)
+- func: special_betainc.a_scalar_out(Tensor self, Scalar a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   python_module: special
   variants: function
   dispatch:
     CompositeExplicitAutograd: special_betainc_out
 
-- func: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b, *, Tensor(a!) out) -> Tensor(a!)
+- func: special_betainc.b_scalar_out(Tensor self, Tensor a, Scalar b, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc_out
+
+- func: special_betainc.ab_scalar_out(Tensor self, Scalar a, Scalar b, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   python_module: special
   variants: function

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -9330,6 +9330,46 @@
   dispatch:
     CompositeExplicitAutograd: special_xlog1py_out
 
+- func: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
+  python_module: special
+  variants: function
+  structured_delegate: special_betainc.out
+
+- func: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc
+
+- func: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc
+
+- func: special_betainc.out(Tensor self, Tensor a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  structured: True
+  structured_inherits: TensorIteratorBase
+  python_module: special
+  variants: function
+  dispatch:
+    CPU, CUDA: special_betainc_out
+
+- func: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc_out
+
+- func: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b, *, Tensor(a!) out) -> Tensor(a!)
+  device_check: NoCheck   # TensorIterator
+  python_module: special
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: special_betainc_out
+
 - func: special_i0e(Tensor self) -> Tensor
   python_module: special
   variants: function

--- a/docs/source/special.rst
+++ b/docs/source/special.rst
@@ -29,4 +29,6 @@ Functions
 .. autofunction:: i0e
 .. autofunction:: logit
 .. autofunction:: xlog1py
+.. autofunction:: beta
+.. autofunction:: betaln
 .. autofunction:: betainc

--- a/docs/source/special.rst
+++ b/docs/source/special.rst
@@ -29,3 +29,4 @@ Functions
 .. autofunction:: i0e
 .. autofunction:: logit
 .. autofunction:: xlog1py
+.. autofunction:: betainc

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -726,6 +726,9 @@
   self: grad
   a: not_implemented("special_betainc")
 
+- name: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor
+  self: grad
+
 - name: logdet(Tensor self) -> Tensor
   self: logdet_backward(grad, self, result)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -715,16 +715,16 @@
 
 - name: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
   self: self.pow(a - 1) * (1 - self).pow(b - 1) / at::exp(at::lgamma(a) + at::lgamma(b) - at::lgamma(a + b))
-  a: not_implemented("special_betainc")
-  b: not_implemented("special_betainc")
+  a: not_implemented("special_betainc a")
+  b: not_implemented("special_betainc b")
 
 - name: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
   self: self.pow(at::scalar_to_tensor(a) - 1) * (1 - self).pow(b - 1) / at::exp(at::lgamma(at::scalar_to_tensor(a)) + at::lgamma(b) - at::lgamma(at::scalar_to_tensor(a) + b))
-  b: not_implemented("special_betainc")
+  b: not_implemented("special_betainc b")
 
 - name: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
   self: self.pow(a - 1) * (1 - self).pow(at::scalar_to_tensor(b) - 1) / at::exp(at::lgamma(a) + at::lgamma(at::scalar_to_tensor(b)) - at::lgamma(a + at::scalar_to_tensor(b)))
-  a: not_implemented("special_betainc")
+  a: not_implemented("special_betainc a")
 
 - name: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor
   self: self.pow(at::scalar_to_tensor(a) - 1) * (1 - self).pow(at::scalar_to_tensor(b) - 1) / at::exp(at::lgamma(at::scalar_to_tensor(a)) + at::lgamma(at::scalar_to_tensor(b)) - at::lgamma(at::scalar_to_tensor(a) + at::scalar_to_tensor(b)))

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -714,20 +714,20 @@
   self: grad * log1p(other.toDouble())
 
 - name: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
-  self: not_implemented("special_betainc")
+  self: self.pow(a - 1) * (1 - self).pow(b - 1) / at::exp(at::lgamma(a) + at::lgamma(b) - at::lgamma(a + b))
   a: not_implemented("special_betainc")
   b: not_implemented("special_betainc")
 
 - name: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
-  self: not_implemented("special_betainc")
+  self: self.pow(at::scalar_to_tensor(a) - 1) * (1 - self).pow(b - 1) / at::exp(at::lgamma(at::scalar_to_tensor(a)) + at::lgamma(b) - at::lgamma(at::scalar_to_tensor(a) + b))
   b: not_implemented("special_betainc")
 
 - name: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
-  self: not_implemented("special_betainc")
+  self: self.pow(a - 1) * (1 - self).pow(at::scalar_to_tensor(b) - 1) / at::exp(at::lgamma(a) + at::lgamma(at::scalar_to_tensor(b)) - at::lgamma(a + at::scalar_to_tensor(b)))
   a: not_implemented("special_betainc")
 
 - name: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor
-  self: not_implemented("special_betainc")
+  self: self.pow(at::scalar_to_tensor(a) - 1) * (1 - self).pow(at::scalar_to_tensor(b) - 1) / at::exp(at::lgamma(at::scalar_to_tensor(a)) + at::lgamma(at::scalar_to_tensor(b)) - at::lgamma(at::scalar_to_tensor(a) + at::scalar_to_tensor(b)))
 
 - name: logdet(Tensor self) -> Tensor
   self: logdet_backward(grad, self, result)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -727,7 +727,7 @@
   a: not_implemented("special_betainc")
 
 - name: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor
-  self: grad
+  self: not_implemented("special_betainc")
 
 - name: logdet(Tensor self) -> Tensor
   self: logdet_backward(grad, self, result)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -713,6 +713,19 @@
 - name: special_xlog1py.other_scalar(Tensor self, Scalar other) -> Tensor
   self: grad * log1p(other.toDouble())
 
+- name: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
+  self: grad * 1
+  a: not_implemented("special_betainc")
+  b: not_implemented("special_betainc")
+
+- name: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
+  self: grad * 1
+  b: not_implemented("special_betainc")
+
+- name: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
+  self: grad * 1
+  a: not_implemented("special_betainc")
+
 - name: logdet(Tensor self) -> Tensor
   self: logdet_backward(grad, self, result)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -714,16 +714,16 @@
   self: grad * log1p(other.toDouble())
 
 - name: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
-  self: grad
+  self: not_implemented("special_betainc")
   a: not_implemented("special_betainc")
   b: not_implemented("special_betainc")
 
 - name: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
-  self: grad
+  self: not_implemented("special_betainc")
   b: not_implemented("special_betainc")
 
 - name: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
-  self: grad
+  self: not_implemented("special_betainc")
   a: not_implemented("special_betainc")
 
 - name: special_betainc.ab_scalar(Tensor self, Scalar a, Scalar b) -> Tensor

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -714,16 +714,16 @@
   self: grad * log1p(other.toDouble())
 
 - name: special_betainc(Tensor self, Tensor a, Tensor b) -> Tensor
-  self: grad * 1
+  self: grad
   a: not_implemented("special_betainc")
   b: not_implemented("special_betainc")
 
 - name: special_betainc.a_scalar(Tensor self, Scalar a, Tensor b) -> Tensor
-  self: grad * 1
+  self: grad
   b: not_implemented("special_betainc")
 
 - name: special_betainc.b_scalar(Tensor self, Tensor a, Scalar b) -> Tensor
-  self: grad * 1
+  self: grad
   a: not_implemented("special_betainc")
 
 - name: logdet(Tensor self) -> Tensor

--- a/torch/csrc/api/include/torch/special.h
+++ b/torch/csrc/api/include/torch/special.h
@@ -182,6 +182,32 @@ inline Tensor& xlog1py_out(Tensor& result, const Tensor& self, const Scalar& oth
   return torch::special_xlog1py_out(result, self, other);
 }
 
+/// Computes betainc
+/// ```
+inline Tensor betainc(const Tensor& self, const Tensor& a, const Tensor& b) {
+  return torch::special_xlog1py(self, a, b);
+}
+
+inline Tensor betainc(const Tensor& self, const Tensor& a, const Scalar& b) {
+  return torch::special_betainc(self, a, b);
+}
+
+inline Tensor betainc(const Tensor& self, const Scalar& a, const Tensor& b) {
+  return torch::special_betainc(self, a, b);
+}
+
+inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Tensor& a, const Tensor& b) {
+  return torch::special_betainc_out(result, self, a, b);
+}
+
+inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Tensor& a, const Scalar& b) {
+  return torch::special_betainc_out(result, self, a, b);
+}
+
+inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Scalar& a, const Tensor& b) {
+  return torch::special_betainc_out(result, self, a, b);
+}
+
 /// Computes the exponentially scaled zeroth order modified Bessel function of the first kind
 /// See https://pytorch.org/docs/master/special.html#torch.special.i0e.
 ///

--- a/torch/csrc/api/include/torch/special.h
+++ b/torch/csrc/api/include/torch/special.h
@@ -185,7 +185,7 @@ inline Tensor& xlog1py_out(Tensor& result, const Tensor& self, const Scalar& oth
 /// Computes betainc
 /// ```
 inline Tensor betainc(const Tensor& self, const Tensor& a, const Tensor& b) {
-  return torch::special_xlog1py(self, a, b);
+  return torch::special_betainc(self, a, b);
 }
 
 inline Tensor betainc(const Tensor& self, const Tensor& a, const Scalar& b) {
@@ -193,6 +193,10 @@ inline Tensor betainc(const Tensor& self, const Tensor& a, const Scalar& b) {
 }
 
 inline Tensor betainc(const Tensor& self, const Scalar& a, const Tensor& b) {
+  return torch::special_betainc(self, a, b);
+}
+
+inline Tensor betainc(const Tensor& self, const Scalar& a, const Scalar& b) {
   return torch::special_betainc(self, a, b);
 }
 
@@ -205,6 +209,10 @@ inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Tensor& a, 
 }
 
 inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Scalar& a, const Tensor& b) {
+  return torch::special_betainc_out(result, self, a, b);
+}
+
+inline Tensor& betainc_out(Tensor& result, const Tensor& self, const Scalar& a, const Scalar& b) {
   return torch::special_betainc_out(result, self, a, b);
 }
 

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -88,3 +88,6 @@ class Beta(ExponentialFamily):
 
     def _log_normalizer(self, x, y):
         return torch.lgamma(x) + torch.lgamma(y) - torch.lgamma(x + y)
+    
+    def cdf(self, x):
+        return torch.special.betainc(x, self.concentration1, self.concentration0)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -87,7 +87,7 @@ class Beta(ExponentialFamily):
         return (self.concentration1, self.concentration0)
 
     def _log_normalizer(self, x, y):
-        return torch.special.beta(x, y)
+        return torch.special.betaln(x, y)
     
     def cdf(self, x):
         return torch.special.betainc(x, self.concentration1, self.concentration0)

--- a/torch/distributions/beta.py
+++ b/torch/distributions/beta.py
@@ -87,7 +87,7 @@ class Beta(ExponentialFamily):
         return (self.concentration1, self.concentration0)
 
     def _log_normalizer(self, x, y):
-        return torch.lgamma(x) + torch.lgamma(y) - torch.lgamma(x + y)
+        return torch.special.beta(x, y)
     
     def cdf(self, x):
         return torch.special.betainc(x, self.concentration1, self.concentration0)

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -293,4 +293,40 @@ Example::
 
 betainc = _add_docstr(_special.special_betainc,
                   r"""
+betainc(input, a, b, out=None) -> Tensor
+
+Computes the regularized incomplete Beta function (as defined below)
+for each element of :attr:`input`,  :attr:`a`, :attr:`b`.
+
+.. math::
+    \frac{1}{\Beta(a,b)} \int_0^x t^{a-1}\,(1-t)^{b-1}\,dt
+
+Similar to SciPy's `scipy.special.betainc`.
+
+""" + r"""
+
+Args:
+    input (Tensor) : the upper limit of integration (:attr:`0 < input < 1`)
+    a (Number or Tensor) : (:attr:`a > 0`)
+    b (Number or Tensor) : (:attr:`b > 0`)
+
+Keyword args:
+    {out}
+
+Example::
+
+    >>> x = torch.tensor([-1, 0, 1, float('inf'), float('nan')])
+    >>> torch.special.betainc(x, 1, 2)
+    tensor([nan, 0., 1., nan, nan])
+    >>> x = torch.tensor([0.15, 0.34, 0.99])
+    >>> a = torch.tensor([1, 2, 3.1])
+    >>> b = torch.tensor([2, 4, 1.4])
+    >>> torch.special.betainc(x, a, b)
+    tensor([0.2775, 0.5522, 0.9933])
+    >>> torch.special.betainc(x, a, 2)
+    tensor([0.2775, 0.2682, 0.9994])
+    >>> torch.special.betainc(x, 2, b)
+    tensor([0.0607, 0.5522, 0.9962])
+    >>> torch.special.betainc(x, 2, 1)
+    tensor([0.0225, 0.1156, 0.9801])           
 """.format(**common_args))

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -330,3 +330,67 @@ Example::
     >>> torch.special.betainc(x, 2, 1)
     tensor([0.0225, 0.1156, 0.9801])           
 """.format(**common_args))
+
+def betaln(a, b):
+    r"""
+    betainc(input, a, b, out=None) -> Tensor
+    
+    Computes the natural logarithm of absolute value of Beta function (as defined below)
+    for each element of :attr:`input`,  :attr:`a`, :attr:`b`.
+
+    .. math::
+        \log\,|\,\Beta(a,b)\,|
+
+    Similar to SciPy's `scipy.special.betaln`.
+
+    """ + r"""
+
+    Args:
+        a (Tensor) : (:attr:`a > 0`)
+        b (Tensor) : (:attr:`b > 0`)
+
+    Keyword args:
+        {out}
+
+    Example::
+
+        >>> torch.special.betaln( torch.tensor([-1, 0, 1, float('inf'), float('nan')]), torch.tensor(9))
+        tensor([    inf,     inf, -2.1972,     nan,     nan])
+        >>> torch.special.betaln(torch.tensor([2, 4, 5]), torch.tensor(9))
+        tensor([-4.4998, -7.5909, -8.7695])
+        >>> torch.special.betaln(torch.tensor(6), torch.tensor(9))
+        tensor(-9.7991)
+    """
+    return torch.lgamma(a) + torch.lgamma(b) - torch.lgamma(a + b)
+
+def beta(a, b):
+    r"""
+    betainc(input, a, b, out=None) -> Tensor
+    
+    Computes the Beta function (as defined below)
+    for each element of :attr:`input`,  :attr:`a`, :attr:`b`.
+
+    .. math::
+        \frac{\Gamma(a) * \Gamma(b)}{\Gamma(a + b)}
+
+    Similar to SciPy's `scipy.special.beta`.
+
+    """ + r"""
+
+    Args:
+        a (Tensor) : (:attr:`a > 0`)
+        b (Tensor) : (:attr:`b > 0`)
+
+    Keyword args:
+        {out}
+
+    Example::
+
+        >>> torch.special.beta( torch.tensor([-1, 0, 1, float('inf'), float('nan')]), torch.tensor(9))
+        tensor([   inf,    inf, 0.1111,    nan,    nan])
+        >>> torch.special.beta(torch.tensor([2, 4, 5]), torch.tensor(9))
+        tensor([0.0111, 0.0005, 0.0002])
+        >>> torch.special.beta(torch.tensor(6), torch.tensor(9))
+        tensor(5.5500e-05)
+    """
+    return torch.exp(betaln(a, b))

--- a/torch/special/__init__.py
+++ b/torch/special/__init__.py
@@ -290,3 +290,7 @@ Example::
     >>> torch.special.i0e(torch.arange(5, dtype=torch.float32))
     tensor([1.0000, 0.4658, 0.3085, 0.2430, 0.2070])
 """.format(**common_args))
+
+betainc = _add_docstr(_special.special_betainc,
+                  r"""
+""".format(**common_args))


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/issues/50345

Adding the incomplete beta function.

TODO
- [x] Bolierplace with a dummy function
- [x] Porting scipy function from https://github.com/scipy/scipy/blob/master/scipy/special/cephes/incbet.c
- [ ] Write test

I am following https://github.com/pytorch/pytorch/pull/55138 as an example of how to implement this. I have an issue: most operation in `torch` are either unary or binary and I cannot find an example of a ternary operation. Right now I have a compilation error:
```
.../pytorch/aten/src/ATen/native/BinaryOps.cpp:61:54: error: too many arguments to function call, expected 3, have 4
  build_binary_float_op(maybe_get_output(), self, a, b);
```
basically, following the implementation of `torch.special.xlog1py` that is:
```
TORCH_META_FUNC(special_xlog1py) (const Tensor& self, const Tensor& other) {
  build_binary_float_op(maybe_get_output(), self, other);
}
```

I have
```
TORCH_META_FUNC(special_betainc) (const Tensor& self, const Tensor& a, const Tensor& b) {
  build_binary_float_op(maybe_get_output(), self, a, b);
}
```
but it is clearly giving an error since it is not binary but ternary. Any suggestions on how to proceed? @kshitij12345 
