### PR TITLE
[ROCm] disable test test_Conv2d_groups_nobias_v2 for ROCm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5504,6 +5504,7 @@ class TestNN(NNTestCase):
     # Covering special case when group > 1, input-channel / group < 16 and output-channel is multiple of 16
     # See also https://github.com/pytorch/pytorch/pull/18463#issuecomment-476563686
     # and https://github.com/pytorch/pytorch/pull/18463#issuecomment-477001024
+    @skipIfRocm
     def test_Conv2d_groups_nobias_v2(self):
         torch.manual_seed(123)
         dev_dtypes = [("cpu", torch.float)]


### PR DESCRIPTION
Disable test_Conv2d_groups_nobias_v2 test because it is failing on ROCm 4.2