### PR TITLE
rename benchmark_cpp_extension

### DIFF
--- a/benchmarks/operator_benchmark/benchmark_pytorch.py
+++ b/benchmarks/operator_benchmark/benchmark_pytorch.py
@@ -1,7 +1,7 @@
 import time
 import json
 import torch
-import cpp_extension  # noqa: F401
+import benchmark_cpp_extension  # noqa: F401
 
 
 """PyTorch performance microbenchmarks.

--- a/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
+++ b/benchmarks/operator_benchmark/pt_extension/cpp_extension_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-import cpp_extension  # noqa: F401
+import benchmark_cpp_extension  # noqa: F401
 import torch
 
 

--- a/benchmarks/operator_benchmark/pt_extension/extension.cpp
+++ b/benchmarks/operator_benchmark/pt_extension/extension.cpp
@@ -22,7 +22,7 @@ TORCH_LIBRARY_FRAGMENT(operator_benchmark, m) {
     m.def("_consume.list", &consume_list);
 }
 
-PYBIND11_MODULE(cpp_extension, m) {
+PYBIND11_MODULE(benchmark_cpp_extension, m) {
   m.def("_consume", &consume, "consume");
   m.def("_consume_list", &consume_list, "consume_list");
 }

--- a/benchmarks/operator_benchmark/pt_extension/setup.py
+++ b/benchmarks/operator_benchmark/pt_extension/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 from torch.utils.cpp_extension import CppExtension, BuildExtension
 
-setup(name='cpp_extension',
-      ext_modules=[CppExtension('cpp_extension', ['extension.cpp'])],
+setup(name='benchmark_cpp_extension',
+      ext_modules=[CppExtension('benchmark_cpp_extension', ['extension.cpp'])],
       cmdclass={'build_ext': BuildExtension})


### PR DESCRIPTION
Currently the cpp_extension build in benchmarks is misleading as it has the same name with torch.utils.cpp_extension

Test Plan:
Run from `./benchmarks/operator_benchmark/pt_extension` folder:
```
python setup.py install
python cpp_extension_test.py
```

Note: CI doesn't matter as currently benchmarks/ folder is not compiled/test against CI