### PR TITLE
[PyTorch] Set a cap for number of threads in thread pool for Windows

### DIFF
--- a/caffe2/utils/threadpool/ThreadPool.cc
+++ b/caffe2/utils/threadpool/ThreadPool.cc
@@ -19,7 +19,8 @@ C10_DEFINE_int(caffe2_threadpool_android_cap, true, "");
 C10_DEFINE_int(caffe2_threadpool_ios_cap, true, "");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int(caffe2_threadpool_macos_cap, true, "");
-
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+C10_DEFINE_int(caffe2_threadpool_win_cap, true, "");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 C10_DEFINE_int(pthreadpool_size, 0, "Override the default thread pool size.");
 
@@ -36,6 +37,8 @@ size_t getDefaultNumThreads() {
   applyCap = FLAGS_caffe2_threadpool_ios_cap;
 #elif defined(TARGET_OS_MAC)
   applyCap = FLAGS_caffe2_threadpool_macos_cap;
+#elif defined(_MSC_VER)
+  applyCap = FLAGS_caffe2_threadpool_win_cap;
 #endif
 
   if (applyCap) {


### PR DESCRIPTION
Summary:
Same idea and purpose as D27578871 (https://github.com/pytorch/pytorch/commit/f1a0b817f063250d76aa3bddba6d0d5772a77bf3). We are seeing PyTorch model running on Windows to be performing worse than caffe2 models. We discovered that # threads = # cpu core and we are spending most of the time waiting on each threads (See image below).
{F617484428}

Here I'm setting a cap for number of threads we are using in thread pool.

Test Plan:
see screenshot showing that CPU usage is lower.

{F617484598}

Differential Revision: D28557091

