### PR TITLE
[ONNX] Update documentation

### DIFF
--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -36,239 +36,273 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
            dynamic_axes=None, keep_initializers_as_inputs=None, custom_opsets=None,
            enable_onnx_checker=True, use_external_data_format=False):
     r"""
-    Export a model into ONNX format.  This exporter runs your model
-    once in order to get a trace of its execution to be exported;
-    at the moment, it supports a limited set of dynamic models (e.g., RNNs.)
+    Exports a model into ONNX format. If ``model`` is not a
+    :class:`torch.jit.ScriptModule` nor a :class:`torch.jit.ScriptFunction`, this runs
+    ``model`` once in order to convert it to a TorchScript graph to be exported
+    (the equivalent of :func:`torch.jit.trace`). Thus this has the same limited support
+    for dynamic control flow as :func:`torch.jit.trace`.
 
     Args:
-        model (torch.nn.Module): the model to be exported.
-        args (tuple of arguments or torch.Tensor, a dictionary consisting of named arguments (optional)):
-            a dictionary to specify the input to the corresponding named parameter:
-            - KEY: str, named parameter
-            - VALUE: corresponding input
+        model (torch.nn.Module, torch.jit.ScriptModule or torch.jit.ScriptFunction):
+            the model to be exported.
+        args (tuple or torch.Tensor):
+
             args can be structured either as:
 
-            1. ONLY A TUPLE OF ARGUMENTS or torch.Tensor::
+            1. ONLY A TUPLE OF ARGUMENTS::
 
-                "args = (x, y, z)"
+                args = (x, y, z)
 
-            The inputs to the model, e.g., such that ``model(*args)`` is a valid invocation
-            of the model. Any non-Tensor arguments will be hard-coded into the exported model;
-            any Tensor arguments will become inputs of the exported model, in the order they
-            occur in args. If args is a Tensor, this is equivalent to having
-            called it with a 1-ary tuple of that Tensor.
+            The tuple should contain model inputs such that ``model(*args)`` is a valid
+            invocation of the model. Any non-Tensor arguments will be hard-coded into the
+            exported model; any Tensor arguments will become inputs of the exported model,
+            in the order they occur in the tuple.
 
-            2. A TUPLE OF ARGUEMENTS WITH A DICTIONARY OF NAMED PARAMETERS::
+            2. A TENSOR::
 
-                "args = (x,
-                        {
-                        "y": input_y,
-                        "z": input_z
-                        })"
+                args = torch.Tensor([1])
 
-            The inputs to the model are structured as a tuple consisting of
-            non-keyword arguments and the last value of this tuple being a dictionary
-            consisting of named parameters and the corresponding inputs as key-value pairs.
-            If certain named argument is not present in the dictionary, it is assigned
-            the default value, or None if default value is not provided.
+            This is equivalent to a 1-ary tuple of that Tensor.
 
-            Cases in which an dictionary input is the last input of the args tuple
-            would cause a conflict when a dictionary of named parameters is used.
-            The model below provides such an example.
+            3. A TUPLE OF ARGUMENTS ENDING WITH A DICTIONARY OF NAMED ARGUMENTS::
 
-                class Model(torch.nn.Module):
-                    def forward(self, k, x):
-                        ...
-                        return x
+                args = (x,
+                        {'y': input_y,
+                         'z': input_z})
 
-                m = Model()
-                k = torch.randn(2, 3)
-                x = {torch.tensor(1.): torch.randn(2, 3)}
+            All but the last element of the tuple will be passed as non-keyword arguments,
+            and named arguments will be set from the last element. If a named argument is
+            not present in the dictionary, it is assigned the default value, or None if a
+            default value is not provided.
 
-                In the previous iteration, the call to export API would look like
+            .. note::
+                If a dictionary is the last element of the args tuple, it will be
+                interpreted as containing named arguments. In order to pass a dict as the
+                last non-keyword arg, provide an empty dict as the last element of the args
+                tuple. For example, instead of::
 
-                    torch.onnx.export(model, (k, x), "test.onnx")
+                    torch.onnx.export(
+                        model,
+                        (x,
+                         # WRONG: will be interpreted as named arguments
+                         {y: z}),
+                        "test.onnx.pb")
 
-                This would work as intended. However, the export function
-                would now assume that the `x` input is intended to represent the optional
-                dictionary consisting of named arguments. In order to prevent this from being
-                an issue a constraint is placed to provide an empty dictionary as the last
-                input in the tuple args in such cases. The new call would look like this.
+                Write::
 
-                    torch.onnx.export(model, (k, x, {}), "test.onnx")
+                    torch.onnx.export(
+                        model,
+                        (x,
+                         {y: z},
+                         {}),
+                        "test.onnx.pb")
 
-        f: a file-like object (has to implement fileno that returns a file descriptor)
-            or a string containing a file name.  A binary Protobuf will be written
+        f: a file-like object (such that ``f.fileno()`` returns a file descriptor)
+            or a string containing a file name.  A binary protocol buffer will be written
             to this file.
-        export_params (bool, default True): if specified, all parameters will
-            be exported.  Set this to False if you want to export an untrained model.
+        export_params (bool, default True): if True, all parameters will
+            be exported. Set this to False if you want to export an untrained model.
             In this case, the exported model will first take all of its parameters
-            as arguments, the ordering as specified by ``model.state_dict().values()``
-        verbose (bool, default False): if specified, we will print out a debug
-            description of the trace being exported.
+            as arguments, with the ordering as specified by ``model.state_dict().values()``
+        verbose (bool, default False): if True, prints a description of the
+            model being exported to stdout.
         training (enum, default TrainingMode.EVAL):
-            TrainingMode.EVAL: export the model in inference mode.
-            TrainingMode.PRESERVE: export the model in inference mode if model.training is
-            False and to a training friendly mode if model.training is True.
-            TrainingMode.TRAINING: export the model in a training friendly mode.
-        input_names(list of strings, default empty list): names to assign to the
-            input nodes of the graph, in order
-        output_names(list of strings, default empty list): names to assign to the
-            output nodes of the graph, in order
-        aten (bool, default False): [DEPRECATED. use operator_export_type] export the
-            model in aten mode. If using aten mode, all the ops original exported
-            by the functions in symbolic_opset<version>.py are exported as ATen ops.
-        export_raw_ir (bool, default False): [DEPRECATED. use operator_export_type]
-            export the internal IR directly instead of converting it to ONNX ops.
+            * ``TrainingMode.EVAL``: export the model in inference mode.
+            * ``TrainingMode.PRESERVE``: export the model in inference mode if model.training is
+              False and in training mode if model.training is True.
+            * ``TrainingMode.TRAINING``: export the model in training mode. Disables optimizations
+              which might interfere with training.
+        input_names (list of str, default empty list): names to assign to the
+            input nodes of the graph, in order.
+        output_names (list of str, default empty list): names to assign to the
+            output nodes of the graph, in order.
+        aten (bool, default False): [DEPRECATED. use operator_export_type] equivalent to
+            setting ``operator_export_type=OperatorExportTypes.ONNX_ATEN``.
+        export_raw_ir (bool, default False): [DEPRECATED. use operator_export_type] equivalent
+            to setting  ``operator_export_type=OperatorExportTypes.RAW``.
         operator_export_type (enum, default OperatorExportTypes.ONNX):
-            OperatorExportTypes.ONNX: All ops are exported as regular ONNX ops
-            (with ONNX namespace).
-            OperatorExportTypes.ONNX_ATEN: All ops are exported as ATen ops
-            (with aten namespace).
-            OperatorExportTypes.ONNX_ATEN_FALLBACK: If an ATen op is not supported
-            in ONNX or its symbolic is missing, fall back on ATen op. Registered ops
-            are exported to ONNX regularly.
-            Example graph::
+            * ``OperatorExportTypes.ONNX``: Export all ops as regular ONNX ops
+              (in the default opset domain).
+            * ``OperatorExportTypes.ONNX_FALLTHROUGH``: Try to convert all ops
+              to standard ONNX ops in the default opset domain. If unable to do so
+              (e.g. because support has not been added to convert a particular torch op to ONNX),
+              fall back to exporting the op into a custom opset domain without conversion. Applies
+              to `custom ops <https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html>`_
+              as well as ATen ops. For the exported model to be usable, the runtime must support
+              these non-standard ops.
+            * ``OperatorExportTypes.ONNX_ATEN``: All ATen ops (in the TorchScript namespace "aten")
+              are exported as ATen ops (in opset domain "org.pytorch.aten").
+              `ATen <https://pytorch.org/cppdocs/#aten>`_ is PyTorch's built-in tensor library, so
+              this instructs the runtime to use PyTorch's implementation of these ops.
 
-                graph(%0 : Float)::
+              .. warning::
+
+                Models exported this way are probably runnable only by Caffe2.
+
+              This may be useful if the numeric differences in implementations of operators are
+              causing large differences in behavior between PyTorch and Caffe2 (which is more
+              common on untrained models).
+
+            * ``OperatorExportTypes.ONNX_ATEN_FALLBACK``: Try to export each ATen op
+              (in the TorchScript namespace "aten") as a regular ONNX op. If we are unable to do so
+              (e.g. because support has not been added to convert a particular torch op to ONNX),
+              fall back to exporting an ATen op. See documentation on OperatorExportTypes.ONNX_ATEN for
+              context.
+              For example::
+
+                graph(%0 : Float):
                   %3 : int = prim::Constant[value=0]()
-                  %4 : Float = aten::triu(%0, %3) # missing op
-                  %5 : Float = aten::mul(%4, %0) # registered op
+                  # conversion unsupported
+                  %4 : Float = aten::triu(%0, %3)
+                  # conversion supported
+                  %5 : Float = aten::mul(%4, %0)
                   return (%5)
 
-            is exported as::
+              Assuming ``aten::triu`` is not supported in ONNX, this will be exported as::
 
-                graph(%0 : Float)::
+                graph(%0 : Float):
                   %1 : Long() = onnx::Constant[value={0}]()
-                  %2 : Float = aten::ATen[operator="triu"](%0, %1)  # missing op
-                  %3 : Float = onnx::Mul(%2, %0) # registered op
+                  # not converted
+                  %2 : Float = aten::ATen[operator="triu"](%0, %1)
+                  # converted
+                  %3 : Float = onnx::Mul(%2, %0)
                   return (%3)
 
-            In the above example, aten::triu is not supported in ONNX, hence
-            exporter falls back on this op.
-            OperatorExportTypes.RAW: Export raw ir.
-            OperatorExportTypes.ONNX_FALLTHROUGH: If an op is not supported
-            in ONNX, fall through and export the operator as is, as a custom
-            ONNX op. Using this mode, the op can be exported and implemented by
-            the user for their runtime backend.
-            Example graph::
+              If an op is in the TorchScript namespace "quantized", it will be exported
+              in the ONNX opset domain "caffe2". These ops are produced by
+              the modules described in
+              `Quantization <https://pytorch.org/docs/stable/quantization.html>`_.
 
-                graph(%x.1 : Long(1, strides=[1]))::
-                  %1 : None = prim::Constant()
-                  %2 : Tensor = aten::sum(%x.1, %1)
-                  %y.1 : Tensor[] = prim::ListConstruct(%2)
-                  return (%y.1)
+              .. warning::
 
-            is exported as::
+                Models exported this way are probably runnable only by Caffe2.
 
-                graph(%x.1 : Long(1, strides=[1]))::
-                  %1 : Tensor = onnx::ReduceSum[keepdims=0](%x.1)
-                  %y.1 : Long() = prim::ListConstruct(%1)
-                  return (%y.1)
+            * ``OperatorExportTypes.RAW``: Deprecated. Do not use.
 
-            In the above example, prim::ListConstruct is not supported, hence
-            exporter falls through.
-
-        opset_version (int, default is 9): by default we export the model to the
-            opset version of the onnx submodule. Since ONNX's latest opset may
-            evolve before next stable release, by default we export to one stable
-            opset version. Right now, supported stable opset version is 9.
-            The opset_version must be _onnx_main_opset or in _onnx_stable_opsets
-            which are defined in torch/onnx/symbolic_helper.py
-        do_constant_folding (bool, default False): If True, the constant-folding
-            optimization is applied to the model during export. Constant-folding
-            optimization will replace some of the ops that have all constant
-            inputs, with pre-computed constant nodes.
-        example_outputs (tuple of Tensors, list of Tensors, Tensor, int, float, bool, default None):
-            Model's example outputs being exported. 'example_outputs' must be provided when exporting
-            a ScriptModule or TorchScript Function. If there is more than one item, it should be passed
-            in tuple format, e.g.: example_outputs = (x, y, z). Otherwise, only one item should
-            be passed as the example output, e.g. example_outputs=x.
-            example_outputs must be provided when exporting a ScriptModule or TorchScript Function.
-        strip_doc_string (bool, default True): if True, strips the field
-            "doc_string" from the exported model, which information about the stack
-            trace.
+        opset_version (int, default 9):
+            Must be ``== _onnx_main_opset or in _onnx_stable_opsets``,
+            defined in torch/onnx/symbolic_helper.py.
+        do_constant_folding (bool, default False): Apply the constant-folding optimization.
+            Constant-folding will replace some of the ops that have all constant inputs
+            with pre-computed constant nodes.
+        example_outputs (T or a tuple of T, where T is Tensor or convertible to Tensor, default None):
+            Must be provided when exporting a ScriptModule or ScriptFunction, ignored otherwise.
+            Used to determine the type and shape of the outputs without tracing the execution of
+            the model. A single object is treated as equivalent to a tuple of one element.
+        strip_doc_string (bool, default True): do not include the field
+            ``doc_string``` from the exported model. Otherwise the field will mention the source
+            code locations for ``model``.
         dynamic_axes (dict<string, dict<int, string>> or dict<string, list(int)>, default empty dict):
-            a dictionary to specify dynamic axes of input/output, such that:
-            - KEY:  input and/or output names
-            - VALUE: index of dynamic axes for given key and potentially the name to be used for
-            exported dynamic axes. In general the value is defined according to one of the following
-            ways or a combination of both:
-            (1). A list of integers specifying the dynamic axes of provided input. In this scenario
-            automated names will be generated and applied to dynamic axes of provided input/output
-            during export.
-            OR (2). An inner dictionary that specifies a mapping FROM the index of dynamic axis in
-            corresponding input/output TO the name that is desired to be applied on such axis of
-            such input/output during export.
 
-            Example. if we have the following shape for inputs and outputs:
+            By default the exported model will have the shapes of all input and output tensors
+            set to exactly match those given in ``args`` (and ``example_outputs`` when that arg is
+            required). To specify axes of tensors as dynamic (i.e. known only at run-time), set
+            ``dynamic_axes`` to a dict with schema:
 
-            .. code-block:: none
+            * KEY (str): an input or output name. Each name must also be provided in ``input_names`` or
+              ``output_names``.
+            * VALUE (dict or list): If a dict, keys are axis indices and values are axis names. If a
+              list, each element is an axis index.
 
-                shape(input_1) = ("b", 3, "w", "h")
-                and shape(input_2) = ("b", 4)
-                and shape(output)  = ("b", "d", 5)
+            For example::
 
-            Then `dynamic axes` can be defined either as:
+                class SumModule(torch.nn.Module):
+                    def forward(self, x):
+                        return torch.sum(x, dim=1)
 
-            1. ONLY INDICES::
+                torch.onnx.export(SumModule(), (torch.ones(2, 2),), "onnx.pb",
+                                  input_names=["x"], output_names=["sum"])
 
-                ``dynamic_axes = {"input_1":[0, 2, 3],
-                                  "input_2":[0],
-                                  "output":[0, 1]}``
-                where automatic names will be generated for exported dynamic axes
+            Produces::
 
-            2. INDICES WITH CORRESPONDING NAMES::
+                input {
+                  name: "x"
+                  ...
+                      shape {
+                        dim {
+                          dim_value: 2  # axis 0
+                        }
+                        dim {
+                          dim_value: 2  # axis 1
+                ...
+                output {
+                  name: "sum"
+                  ...
+                      shape {
+                        dim {
+                          dim_value: 2  # axis 0
+                ...
 
-                ``dynamic_axes = {"input_1":{0:"batch",
-                                             1:"width",
-                                             2:"height"},
-                                  "input_2":{0:"batch"},
-                                  "output":{0:"batch",
-                                            1:"detections"}}``
-                where provided names will be applied to exported dynamic axes
+            While::
 
-            3. MIXED MODE OF (1) and (2)::
+                torch.onnx.export(SumModule(), (torch.ones(2, 2),), "onnx.pb",
+                                  input_names=["x"], output_names=["sum"],
+                                  dynamic_axes={
+                                      # dict value: manually named axes
+                                      "x": {0: "my_custom_axis_name"},
+                                      # list value: automatic names
+                                      "sum": [0],
+                                  })
 
-                ``dynamic_axes = {"input_1":[0, 2, 3],
-                                  "input_2":{0:"batch"},
-                                  "output":[0,1]}``
+            Produces::
+
+                input {
+                  name: "x"
+                  ...
+                      shape {
+                        dim {
+                          dim_param: "my_custom_axis_name"  # axis 0
+                        }
+                        dim {
+                          dim_value: 2  # axis 1
+                ...
+                output {
+                  name: "sum"
+                  ...
+                      shape {
+                        dim {
+                          dim_param: "sum_dynamic_axes_1"  # axis 0
+                ...
 
         keep_initializers_as_inputs (bool, default None): If True, all the
             initializers (typically corresponding to parameters) in the
             exported graph will also be added as inputs to the graph. If False,
             then initializers are not added as inputs to the graph, and only
             the non-parameter inputs are added as inputs.
+            This may allow for better optimizations (e.g. constant folding) by
+            backends/runtimes.
 
-            This may allow for better optimizations (such as constant folding
-            etc.) by backends/runtimes that execute these graphs. If
-            unspecified (default None), then the behavior is chosen
-            automatically as follows. If operator_export_type is
-            OperatorExportTypes.ONNX, the behavior is equivalent to setting
-            this argument to False. For other values of operator_export_type,
-            the behavior is equivalent to setting this argument to True. Note
-            that for ONNX opset version < 9, initializers MUST be part of graph
-            inputs. Therefore, if opset_version argument is set to a 8 or
-            lower, this argument will be ignored.
-        custom_opsets (dict<string, int>, default empty dict): A dictionary to indicate
-            custom opset domain and version at export. If model contains a custom opset,
-            it is optional to specify the domain and opset version in the dictionary:
-            - KEY: opset domain name
-            - VALUE: opset version
-            If the custom opset is not provided in this dictionary, opset version is set
-            to 1 by default.
+            If ``opset_version`` < 9, initializers MUST be part of graph
+            inputs and this argument will be ignored and the behavior will be
+            equivalent to setting this argument to True.
+
+            If None, then the behavior is chosen automatically as follows:
+
+            * If ``operator_export_type=OperatorExportTypes.ONNX``, the behavior is equivalent
+              to setting this argument to False.
+            * Else, the behavior is equivalent to setting this argument to True.
+
+        custom_opsets (dict<str, int>, default empty dict): A dictionary to indicate
+
+            A dict with schema:
+
+            * KEY (str): opset domain name
+            * VALUE (int): opset version
+
+            If a custom opset is referenced by ``model`` but not mentioned in this dictionary,
+            the opset version is set to 1.
+
         enable_onnx_checker (bool, default True): If True the onnx model checker will be run
-            as part of the export, to ensure the exported model is a valid ONNX model.
-        use_external_data_format (bool, default False): If True, then the model is exported
-            in ONNX external data format, in which case some of the model parameters are stored
-            in external binary files and not in the ONNX model file itself. See link for format
-            details:
-            https://github.com/onnx/onnx/blob/8b3f7e2e7a0f2aba0e629e23d89f07c7fc0e6a5e/onnx/onnx.proto#L423
-            Also, in this case,  argument "f" must be a string specifying the location of the model.
-            The external binary files will be stored in the same location specified by the model
-            location "f". If False, then the model is stored in regular format, i.e. model and
-            parameters are all in one file. This argument is ignored for all export types other
-            than ONNX.
+            to ensure the exported model is a valid ONNX model.
+        use_external_data_format (bool, default False): If True, then some of the model
+            parameters are stored in external data files and not in the ONNX model file itself.
+            Models larger than 2GB cannot be exported in one file because of size limits imposed
+            by Protocol Buffers.
+            For details see
+            `onnx.proto <https://github.com/onnx/onnx/blob/32c7cb66/onnx/onnx.proto#L562>`_.
+            If True,  argument ``f`` must be a string specifying the location of the model.
+            The external data files will be stored in the same directory as ``f``.
+            This argument is ignored unless ``operator_export_type=OperatorExportTypes.ONNX``.
     """
 
     from torch.onnx import utils
@@ -281,6 +315,9 @@ def export(model, args, f, export_params=True, verbose=False, training=TrainingM
 
 
 def export_to_pretty_string(*args, **kwargs):
+    r"""
+    Same as :func:`export`, but returns a text representation of the exported model.
+    """
     from torch.onnx import utils
     return utils.export_to_pretty_string(*args, **kwargs)
 
@@ -297,11 +334,13 @@ def _optimize_trace(graph, operator_export_type):
 
 def select_model_mode_for_export(model, mode):
     r"""
-    A context manager to temporarily set the training mode of "model"
-    to "mode", resetting it when we exit the with-block.  A no-op if
+    A context manager to temporarily set the training mode of ``model``
+    to ``mode``, resetting it when we exit the with-block.  A no-op if
     mode is None.
 
-    In version 1.6 changed to this from set_training
+    Args:
+      model: Same type and meaning as ``model`` arg to :func:`export`.
+      mode: Same type and meaning as ``training`` arg to :func:`export`.
     """
 
     from torch.onnx import utils
@@ -320,9 +359,7 @@ def _run_symbolic_method(*args, **kwargs):
 
 def is_in_onnx_export():
     r"""
-    Check whether it's in the middle of the ONNX export.
-    This function returns True in the middle of torch.onnx.export().
-    torch.onnx.export should be executed with single thread.
+    Returns True iff :func:`export` is running in the current thread
     """
 
     from torch.onnx import utils
@@ -330,5 +367,17 @@ def is_in_onnx_export():
 
 
 def register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version):
+    r"""
+    Registers ``symbolic_fn`` to handle ``symbolic_name``. See
+    "Custom Operators" in the module documentation for an example usage.
+
+    Args:
+      symbolic_name (str): The name of the custom operator in "<domain>::<op>"
+        format.
+      symbolic_fn (Callable): A function that takes in the ONNX graph and
+        the input arguments to the current operator, and returns new
+        operator nodes to add to the graph.
+      opset_version (int): The ONNX opset version in which to register.
+    """
     from torch.onnx import utils
-    return utils.register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version)
+    utils.register_custom_op_symbolic(symbolic_name, symbolic_fn, opset_version)

--- a/torch/onnx/utils.py
+++ b/torch/onnx/utils.py
@@ -18,7 +18,7 @@ from torch._six import string_classes
 from torch.jit import _unique_state_dict
 from torch.onnx import ONNX_ARCHIVE_MODEL_PROTO_NAME, ExportTypes, OperatorExportTypes, TrainingMode
 from torch._C import ListType, OptionalType, _propagate_and_assign_input_shapes, _check_onnx_proto
-from typing import Union, Tuple, List
+from typing import List, Tuple, Union
 
 
 # the flag to tell the user whether it's in the middle of ONNX export or not
@@ -445,6 +445,17 @@ def _model_to_graph(model, args, verbose=False,
                     _retain_param_name=False, do_constant_folding=True,
                     _disable_torch_constant_prop=False, fixed_batch_size=False,
                     training=None, dynamic_axes=None):
+    r"""Converts model into an ONNX graph.
+
+    Returns:
+      graph (torch._C.Graph): A TorchScript IR Graph with ONNX nodes.
+      params_dict (Dict[str, torch.Tensor]): Dict from input param name to param value.
+      torch_out (Union[NoneType, torch.Tensor, Tuple[torch.Tensor], List[torch.Tensor]]):
+        The output tensors resulting from the trace of ``model``.
+        If ``model`` is a :class:`torch.jit.ScriptModule` or :class:`torch.jit.ScriptFunction`,
+        this will be None, since we are not doing any tracing.
+    """
+    # TODO: can we simplify this to always return a tuple of Tensor or None?
     from torch.onnx.symbolic_helper import _export_onnx_opset_version
     # Special case for common case of passing a single Tensor
     if isinstance(args, (torch.Tensor, int, float, bool)):
@@ -626,10 +637,6 @@ def _find_missing_ops_onnx_export(model, args, f, verbose=False, training=Traini
             unsupported_ops.append(node.kind())
     return graph, unsupported_ops
 
-# NOTE: the output `torch_out` will contain the output tensors resulting from
-# the trace of a Module. In the case that a torch.nn.ScriptModule is passed in,
-# this output will be None, since we are not doing any tracing but rather
-# directly extracting the graph.
 def _export(model, args, f, export_params=True, verbose=False, training=None,
             input_names=None, output_names=None, operator_export_type=None,
             export_type=ExportTypes.PROTOBUF_FILE, example_outputs=None,
@@ -950,7 +957,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
         from torch.onnx.symbolic_helper import _export_onnx_opset_version as opset_version
         import torch.onnx.symbolic_registry as sym_registry
 
-        sym_registry.register_version('', opset_version)
+        sym_registry.register_version("", opset_version)
 
         # Quantized op symbolics are registered for opset 9 only.
         if operator_export_type == OperatorExportTypes.ONNX_ATEN_FALLBACK and opset_version == 9:
@@ -973,7 +980,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                 return g.op(op_name, *inputs, **attrs, outputs=n.outputsSize())
 
         elif ns == "aten":
-            is_exportable_aten_op = sym_registry.is_registered_op(op_name, '', opset_version)
+            is_exportable_aten_op = sym_registry.is_registered_op(op_name, "", opset_version)
             is_onnx_aten_export = operator_export_type == OperatorExportTypes.ONNX_ATEN
             is_aten_fallback_export = operator_export_type == OperatorExportTypes.ONNX_ATEN_FALLBACK
             if is_onnx_aten_export or (not is_exportable_aten_op and is_aten_fallback_export):
@@ -984,7 +991,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                 return _graph_at(g, op_name, *inputs, aten=True, **attrs)
             else:
                 # Export it regularly
-                domain = ''
+                domain = ""
                 symbolic_fn = _find_symbolic_in_registry(domain, op_name, opset_version, operator_export_type)
                 if symbolic_fn is None:
                     return None
@@ -1093,7 +1100,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                     return new_op_outputs
             else:
                 symbolic_name = "prim_" + op_name
-                domain = ''
+                domain = ""
                 symbolic_fn = _find_symbolic_in_registry(domain, symbolic_name, opset_version,
                                                          operator_export_type)
                 if symbolic_fn is None:
@@ -1104,7 +1111,7 @@ def _run_symbolic_function(g, block, n, inputs, env, operator_export_type=Operat
                 return symbolic_fn(g, *inputs, **attrs)
 
         elif ns == "quantized":
-            domain = ''
+            domain = ""
             if operator_export_type == OperatorExportTypes.ONNX_ATEN_FALLBACK:
                 domain = "caffe2"
             symbolic_fn = _find_symbolic_in_registry(domain, op_name, opset_version, operator_export_type)


### PR DESCRIPTION
[ONNX] Update documentation

* Add introductory paragraph explaining what ONNX is and what the
  torch.onnx module does.
* In examples change file extension from ".onnx" to ".onnx.pb". ".pb"
  is a common extension for binary-format protocol buffer files.
* In "Tracing vs Scripting" and doc-string for torch.onnx.export(),
  clarify that exporting always happens on ScriptModules and that
  tracing and scripting are the two ways to produce a ScriptModule.
* Remove examples of using Caffe2 to run exported models.
  Caffe2's website says it's deprecated, so it's probably best not to
  encourage people to use it by including it in examples.
* Remove a lot of content that's redundant:
  * The example of how to mix tracing and scripting, and instead
  link to Introduction to TorchScript, which includes very similar
  content.
  * "Type annotations" section. Link to TorchScript docs which explain
  that in more detail.
  * "Using dictionaries to handle Named Arguments as model inputs"
  section. It's redundant with the description of the `args` argument
  to `export()`, which appears on the same page once the HTML
  is generated.
  * Remove the list of supported Tensor indexing patterns. If it's not
  in the list of unsupported patterns, users can assume it's
  supported, so having both is redundant.
  * "Operator Export Type" section. It's redundant with the description
  of the `operator_export_type` arg to to `export()`, which appears on
  the same page once the HTML is generated.
* Move the content about different operator implementations producing
  different results from the "Limitations" section into the doc for the
  `operator_export_type` arg.
* Document "quantized" -> "caffe2" behavior of
  OperatorExportTypes.ONNX_ATEN_FALLBACK.
* Combing the text about using torch.Tensor.item() and the text about
  using NumPy types into a section titled
  "Avoid NumPy and built-in Python types", since they're both
  fundamentally about the same issue.
* Rename "Write PyTorch model in Torch way" to "Avoiding Pitfalls".
* Lots of minor fixes: spelling, grammar, brevity, fixing links, adding
  links.
* Clarify limitation on input and output types. Phrasing it in terms of
  PyTorch types is much more accessible than in terms of TorchScript
  types. Also clarify what actually happens when dict and str are used
  as inputs and outputs.
* In Supported operators, use torch function and class names and link
  to them. This is more user friendly than using the internal aten
  op names.
* Remove references to VariableType.h, which doesn't appear to contain
  the information that it once did. Instead refer to the generated
  .pyi files.
* Remove the text in the FAQ about appending to lists within loops.
  I think this limitation is no longer present
  (perhaps since https://github.com/pytorch/pytorch/pull/51577).
* Minor fixes to some code I read along the way.