### PR TITLE
use stream as backport function interface

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -670,7 +670,7 @@ void backportAllVersionCheck(
 
     // Check backport model version
     std::stringstream iss(oss.str());
-    auto backport_version = _get_model_bytecode_version(iss);
+    auto backport_version = _get_model_bytecode_version(oss.str());
     AT_ASSERT(backport_version == current_to_version);
 
     // Load and run the backport model, then compare the result with expect

--- a/torch/csrc/jit/mobile/backport.cpp
+++ b/torch/csrc/jit/mobile/backport.cpp
@@ -39,6 +39,19 @@ bool _backport_for_mobile(
 }
 
 bool _backport_for_mobile(
+    std::stringstream& in,
+    std::stringstream& out,
+    const int64_t to_version) {
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
+    out.write(static_cast<const char*>(buf), nbytes);
+    return !out ? 0 : nbytes;
+  };
+  PyTorchStreamWriter writer(writer_func);
+  return _backport_for_mobile_impl(std::move(rai), writer, to_version);
+}
+
+bool _backport_for_mobile(
     std::istream& in,
     const std::string& output_filename,
     const int64_t to_version) {

--- a/torch/csrc/jit/mobile/backport.h
+++ b/torch/csrc/jit/mobile/backport.h
@@ -19,6 +19,11 @@ TORCH_API bool _backport_for_mobile(
     const int64_t to_version);
 
 TORCH_API bool _backport_for_mobile(
+    std::stringstream& in,
+    std::stringstream& out,
+    const int64_t to_version);
+
+TORCH_API bool _backport_for_mobile(
     std::istream& in,
     const std::string& output_filename,
     const int64_t to_version);

--- a/torch/csrc/jit/mobile/backport_manager.h
+++ b/torch/csrc/jit/mobile/backport_manager.h
@@ -31,8 +31,8 @@ class BackportManager final {
   std::unordered_map<
       int64_t,
       std::function<bool(
-          caffe2::serialize::PyTorchStreamReader&,
-          caffe2::serialize::PyTorchStreamWriter&)>>&
+          std::istringstream&,
+          std::ostringstream&)>>&
   bytecodeBackportFunctions() const;
 
   bool backport(
@@ -50,8 +50,8 @@ class BackportManager final {
   void registerBytecodeBackportFunction(
       const int64_t from_version,
       const std::function<bool(
-          caffe2::serialize::PyTorchStreamReader&,
-          caffe2::serialize::PyTorchStreamWriter&)>& backport_function);
+          std::istringstream&,
+          std::ostringstream&)>& backport_function);
 };
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/backport_manager.h
+++ b/torch/csrc/jit/mobile/backport_manager.h
@@ -31,8 +31,8 @@ class BackportManager final {
   std::unordered_map<
       int64_t,
       std::function<bool(
-          std::istringstream&,
-          std::ostringstream&)>>&
+          std::stringstream&,
+          std::stringstream&)>>&
   bytecodeBackportFunctions() const;
 
   bool backport(
@@ -50,8 +50,8 @@ class BackportManager final {
   void registerBytecodeBackportFunction(
       const int64_t from_version,
       const std::function<bool(
-          std::istringstream&,
-          std::ostringstream&)>& backport_function);
+          std::stringstream&,
+          std::stringstream&)>& backport_function);
 };
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -64,6 +64,11 @@ int64_t _get_model_bytecode_version(std::istream& in) {
   return _get_model_bytecode_version(std::move(rai));
 }
 
+int64_t _get_model_bytecode_version(std::stringstream& in) {
+  std::unique_ptr<IStreamAdapter> rai = std::make_unique<IStreamAdapter>(&in);
+  return _get_model_bytecode_version(std::move(rai));
+}
+
 int64_t _get_model_bytecode_version(const std::string& filename) {
   std::unique_ptr<FileAdapter> rai = std::make_unique<FileAdapter>(filename);
   return _get_model_bytecode_version(std::move(rai));

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -70,11 +70,11 @@ int64_t _get_model_bytecode_version(const std::string& filename) {
 }
 
 int64_t _get_model_bytecode_version(std::shared_ptr<ReadAdapterInterface> rai) {
-//  if (!check_zip_file(rai)) {
-//    TORCH_WARN(
-//        "The input model might not be generated from _save_for_mobile()");
-//    return -1;
-//  }
+  //  if (!check_zip_file(rai)) {
+  //    TORCH_WARN(
+  //        "The input model might not be generated from _save_for_mobile()");
+  //    return -1;
+  //  }
   PyTorchStreamReader reader(rai);
   auto bytecode_values = get_bytecode_values(reader);
   return _get_model_bytecode_version(bytecode_values);

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -16,6 +16,8 @@ namespace jit {
 // The family of methods below to get bytecode version from a model
 TORCH_API int64_t _get_model_bytecode_version(std::istream& in);
 
+TORCH_API int64_t _get_model_bytecode_version(std::stringstream& in);
+
 TORCH_API int64_t _get_model_bytecode_version(const std::string& filename);
 
 TORCH_API int64_t _get_model_bytecode_version(

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -376,7 +376,7 @@ void ScriptModuleSerializer::serialize(
         /*archive_name=*/"constants",
         /*archive_dir=*/"",
         /*tensor_dir=*/"constants/",
-        /*tensor_cdata_naming_scheme=*/false);
+        /*tensor_cdata_naming_scheme=*/true);
 
     writeByteCode(module, save_mobile_debug_info);
     writeMobileMetadata(module, extra_files);
@@ -569,9 +569,8 @@ void ScriptModuleSerializer::writeByteCode(
     const bool save_mobile_debug_info) {
   std::vector<c10::IValue> elements;
   BackendDebugHandleManager debug_handle_manager;
-  if(BytecodeWriteVersion.has_value()) {
-    elements.emplace_back(
-        static_cast<int64_t>(BytecodeWriteVersion.value()));
+  if (BytecodeWriteVersion.has_value()) {
+    elements.emplace_back(static_cast<int64_t>(BytecodeWriteVersion.value()));
   } else {
     elements.emplace_back(
         static_cast<int64_t>(caffe2::serialize::kProducedBytecodeVersion));
@@ -588,8 +587,8 @@ void ScriptModuleSerializer::writeByteCode(
       telements,
       /*archive_name=*/"bytecode",
       /*archive_dir=*/"",
-      /*tensor_dir=*/"bytecode/",
-      /*tensor_cdata_naming_scheme=*/false);
+      /*tensor_dir=*/"constants/",
+      /*tensor_cdata_naming_scheme=*/true);
 
   auto debug_info_telements = Tup(std::move(debug_info_elements));
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58738 use stream as backport function interface**
* #58680 Enable implicit operator versioning through number of arguments

