### PR TITLE
enable better depthwise conv perf on cudnn 8.2+

### DIFF
--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -436,9 +436,8 @@ bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
 // simplified version for cudnn 8.2 and above
 bool check_cudnn_depthwise_workload_with_filter(const at::Tensor& input, int stride, const at::Tensor& weight) {
   // 1D conv
-  if(input.size(2) == 1){
-    // add 1d heuristic here
-    return false;
+  if(input.size(2) == 1 && stride == 1){
+    return true;
   }
 
   // 2d conv

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -432,6 +432,43 @@ bool check_cudnn_depthwise_workload(const at::Tensor& input, int stride) {
   }
   return false;
 }
+
+// simplified version for cudnn 8.2 and above
+bool check_cudnn_depthwise_workload_with_filter(const at::Tensor& input, int stride, const at::Tensor& weight) {
+  // 1D conv
+  if(input.size(2) == 1){
+    // add 1d heuristic here
+    return false;
+  }
+
+  // 2d conv
+  // only square filters
+  if (weight.size(2) != weight.size(3)) return false;
+  int filter = weight.size(3);
+  // only 1/3/5 filter
+  if (filter != 1 && filter != 3 && filter != 5) return false;
+  // we don't enforce square input but only check width to reduce heuristic space
+  if (input.size(3) < 7) return false; // min width 7
+  int w = input.size(3);
+  // only 1/2 stride, use cudnn for all stride 1
+  if (stride == 1) return true;
+  if (stride != 2) return false;
+
+  int ch = input.size(1);
+  int bs = input.size(0);
+  // special case since bs1 show good perf in lots of cases
+  if (bs == 1) {
+    if (filter == 1 && w <= 28) return true;
+    if (filter == 3 || filter == 5) return true;
+  } else {
+    if (filter == 1 && bs <= 16 && ch >= 128 && w <= 7) return true;
+    if (filter == 3 || filter == 5) {
+      if ((ch >= 512) || (ch >= 256 && w >= 28)) return true;
+    }
+  }
+  return false;
+}
+
 // Use cudnn for FP16 depthwise convolutions
 auto ConvParams::use_cudnn_depthwise(
         const at::Tensor& input, const at::Tensor& weight) const -> bool {
@@ -440,6 +477,20 @@ auto ConvParams::use_cudnn_depthwise(
   }
   if (detail::getCUDAHooks().supportsDepthwiseConvolutionWithCuDNN()) {
     long cudnn_version = detail::getCUDAHooks().versionCuDNN();
+    if (cudnn_version >= 8200) {
+      bool kernel_cond =  (use_cudnn(input, weight) &&
+                           input.scalar_type() == kHalf && // only for FP16
+                           weight.scalar_type() == kHalf &&
+                           is_depthwise(input, weight) &&
+                           input.ndimension() == 4 &&   // TODO: 5-D contiguous depthwise is not supported yet, need benchmarks
+                           !is_dilated() && // no dilation supported
+                           (stride[0] == stride[1] || stride[0] == 0) && // square or 1d
+                           input.size(1) >= 32); // min 32 channels supported)
+      if (kernel_cond) {
+        return check_cudnn_depthwise_workload_with_filter(input, stride[1], weight);
+      }
+    }
+    // keep (7600 <= cudnn < 8200) code unchanged
     bool kernel_cond =  (cudnn_version >= 7600 &&
                          use_cudnn(input, weight) &&
                          input.scalar_type() == kHalf && // only for FP16

--- a/aten/src/ATen/native/Convolution.cpp
+++ b/aten/src/ATen/native/Convolution.cpp
@@ -483,7 +483,7 @@ auto ConvParams::use_cudnn_depthwise(
                            is_depthwise(input, weight) &&
                            input.ndimension() == 4 &&   // TODO: 5-D contiguous depthwise is not supported yet, need benchmarks
                            !is_dilated() && // no dilation supported
-                           (stride[0] == stride[1] || stride[0] == 0) && // square or 1d
+                           (stride[0] == stride[1] || input.size(2) == 1) && // square or 1d
                            input.size(1) >= 32); // min 32 channels supported)
       if (kernel_cond) {
         return check_cudnn_depthwise_workload_with_filter(input, stride[1], weight);


### PR DESCRIPTION
There are multiple improvement of depthwise convolution speed in cudnn between 7.6 and 8.2, since https://github.com/pytorch/pytorch/pull/22302.
This PR aim to harvest all the new improvement by enable more cudnn kernel. The workload checking logic can also be simplified now.
To keep the change simple, I kept things before cudnn 8.2 unchanged.

Similar to https://github.com/pytorch/pytorch/pull/22302, I used a script [here](https://gist.github.com/FDecaYed/e8ba98a95cd33697df2ace86fdb44897) to benchmark. Both run are using cudnn 8.2
One enhancement I did to the script is switch to event based timing. With warmup kernels to fill the launch queue ahead, this should give us accurate kernel timing even in CPU launch bound cases.

Here is A100 and V100 result sorted by speedup.
[Book1.xlsx](https://github.com/pytorch/pytorch/files/6530371/Book1.xlsx)

Result highlights:
Newly turned on 5x5 cudnn kernel show up to 6x speedup.
Close to half of test sizes show >10% speedup.
Fixed some corner cases that previously caused 15-20x slowdown.
Only slowdown a handful of cases(~10 out of >1000)


