### PR TITLE
[Release/1.9] catch exception when running print regression

### DIFF
--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -951,4 +951,7 @@ if __name__ == '__main__':
         head_json = obj
         if args.use_json:
             head_json = json.loads(Path(args.use_json).read_text())
-        print_regressions(head_json, num_prev_commits=args.num_prev_commits)
+        try:
+            print_regressions(head_json, num_prev_commits=args.num_prev_commits)
+        except Exception as e:
+            print(f"ERROR ENCOUNTERED WHEN COMPARING AGAINST S3: {e}")


### PR DESCRIPTION
Summary:
Print regression fails on release branch PRs. I cant find a good way to indicate base branch from CIRCLECI env vars. so doing a try catch for now. Also GHA job doesn't have the same issue because it merges with release branch first. 

NOTE: This cherry-pick prevents CI errors happening to #58746.

This is a cherry-pick of #58751 into release/1.9.