### PR TITLE
Run pthreadpool with _NoPThreadPoolGuard on the same thread

### DIFF
--- a/aten/src/ATen/test/test_thread_pool_guard.cpp
+++ b/aten/src/ATen/test/test_thread_pool_guard.cpp
@@ -3,7 +3,6 @@
 #include <caffe2/utils/threadpool/thread_pool_guard.h>
 #include <caffe2/utils/threadpool/pthreadpool-cpp.h>
 
-
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(TestThreadPoolGuard, TestThreadPoolGuard) {
   auto threadpool_ptr = caffe2::pthreadpool_();
@@ -29,4 +28,34 @@ TEST(TestThreadPoolGuard, TestThreadPoolGuard) {
   auto threadpool_ptr4 = caffe2::pthreadpool_();
   ASSERT_NE(threadpool_ptr4, nullptr);
   ASSERT_EQ(threadpool_ptr4, threadpool_ptr);
+}
+
+TEST(TestThreadPoolGuard, TestRunWithGuard) {
+  const std::vector<int64_t> array = {1, 2, 3};
+
+  // Run via pthreadpool_parallelize_1d
+  int64_t outer = 0;
+  auto fn1 = [&array, &outer](const size_t task_id) {
+    outer += array[task_id];
+  };
+  auto pool = caffe2::pthreadpool();
+  pool->run(fn1, 3);
+
+  int64_t inner = 0;
+  {
+    // Run on same thread
+    caffe2::_NoPThreadPoolGuard g1;
+    auto fn2 = [&array, &inner](const size_t task_id) {
+      inner += array[task_id];
+    };
+    pool->run(fn2, 3);
+
+    // confirm the guard is on
+    auto threadpool_ptr1 = caffe2::pthreadpool_();
+    ASSERT_EQ(threadpool_ptr1, nullptr);
+  }
+  ASSERT_NE(outer, 0);
+  ASSERT_NE(inner, 0);
+  ASSERT_EQ(outer, 6);
+  ASSERT_EQ(inner, 6);
 }

--- a/caffe2/utils/threadpool/pthreadpool-cpp.cc
+++ b/caffe2/utils/threadpool/pthreadpool-cpp.cc
@@ -45,8 +45,17 @@ void PThreadPool::set_thread_count(const size_t thread_count) {
 void PThreadPool::run(
     const std::function<void(size_t)>& fn,
     const size_t range) {
+  // Run on same thread if _NoPThreadPoolGuard guard is enabled
+  if (caffe2::_NoPThreadPoolGuard::is_enabled()) {
+    for (size_t i = 0; i < range; ++i) {
+      fn(i);
+    }
+    return;
+  }
+
   std::lock_guard<std::mutex> lock{mutex_};
 
+  TORCH_INTERNAL_ASSERT(!caffe2::_NoPThreadPoolGuard::is_enabled(), "Inside a threadpool guard!");
   TORCH_INTERNAL_ASSERT(threadpool_.get(), "Invalid threadpool!");
 
   struct Context final {


### PR DESCRIPTION
Summary:
* Makes `pthreadpool()->run` respect `_NoPThreadPoolGuard`
   Runs tasks on the same thread instead of parallelizing when guard is present

Test Plan:
buck build //xplat/caffe2:aten_test_test_thread_pool_guard
./buck-out/last/aten_test_test_thread_pool_guard

Differential Revision: D28597425

