### PR TITLE
.github: Add windows.8xlarge.nvidia.gpu

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -32,3 +32,8 @@ runner_types:
     os: windows
     max_available: 200
     disk_size: 256
+  windows.8xlarge.nvidia.gpu:
+    instance_type: g3.8xlarge
+    os: windows
+    max_available: 25
+    disk_size: 256


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58782 .github: Add Windows GPU workflow
* **#58781 .github: Add windows.8xlarge.nvidia.gpu**

Adds windows GPU workers to our GHA self hosted infra

[skip ci]

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28645532](https://our.internmc.facebook.com/intern/diff/D28645532)