### PR TITLE
Increase mimimum number of warmup runs to 2

### DIFF
--- a/torch/utils/benchmark/utils/timer.py
+++ b/torch/utils/benchmark/utils/timer.py
@@ -259,7 +259,7 @@ class Timer(object):
         """
         with common.set_torch_threads(self._task_spec.num_threads):
             # Warmup
-            self._timer.timeit(number=max(int(number // 100), 1))
+            self._timer.timeit(number=max(int(number // 100), 2))
 
             return common.Measurement(
                 number_per_run=number,


### PR DESCRIPTION
The JIT will typically need two warmup runs to do profiling and optimization.
This is not the perfect solution but it will substantially reduce the number of surprised people when the docs say torch.utils.benchmark.Timer takes care of warmup.
