### PR TITLE
[docs] Clarify batch_first behavior for nn.LSTM, nn.RNN, and nn.GRU

### DIFF
--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -373,9 +373,9 @@ class RNN(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            with the batch dimension before the sequence dimension. Note that this does
-            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
-            Default: ``False``
+            as `(batch, seq, feature)` instead of `(seq, batch, feature)`.
+            Note that this does not apply to hidden or cell states. See the
+            Inputs/Outputs sections below for details.  Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             RNN layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
@@ -387,7 +387,7 @@ class RNN(RNNBase):
           the input sequence.  The input can also be a packed variable length sequence.
           See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
           :func:`torch.nn.utils.rnn.pack_sequence` for details.
-        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
+        * **h_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the initial hidden
           state for each element in the batch. Defaults to zeros if not provided.
 
         where:
@@ -397,26 +397,18 @@ class RNN(RNNBase):
                 N ={} & \text{batch size} \\
                 L ={} & \text{sequence length} \\
                 D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
-                S ={} & \text{num\_layers} * D \\
                 H_{in} ={} & \text{input\_size} \\
                 H_{out} ={} & \text{hidden\_size}
             \end{aligned}
 
     Outputs: `output, h_n`
-        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
-          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+        * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
+          :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the RNN, for each `t`. If a
           :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
           will also be a packed sequence.
-        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
+        * **h_n**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the final hidden state
           for each element in the batch.
-
-        where:
-
-        .. math::
-            \begin{aligned}
-                H_{all} ={} & D * \text{hidden\_size}
-            \end{aligned}
 
     Attributes:
         weight_ih_l[k]: the learnable input-hidden weights of the k-th layer,
@@ -523,9 +515,9 @@ class LSTM(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            with the batch dimension before the sequence dimension. Note that this does
-            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
-            Default: ``False``
+            as `(batch, seq, feature)` instead of `(seq, batch, feature)`.
+            Note that this does not apply to hidden or cell states. See the
+            Inputs/Outputs sections below for details.  Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             LSTM layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
@@ -538,11 +530,11 @@ class LSTM(RNNBase):
           the input sequence.  The input can also be a packed variable length sequence.
           See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
           :func:`torch.nn.utils.rnn.pack_sequence` for details.
-        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
-          state for each element in the batch.
+        * **h_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the
+          initial hidden state for each element in the batch.
           Defaults to zeros if `(h_0, c_0)` is not provided.
-        * **c_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial cell
-          state for each element in the batch.
+        * **c_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{cell})` containing the
+          initial cell state for each element in the batch.
           Defaults to zeros if `(h_0, c_0)` is not provided.
 
         where:
@@ -552,28 +544,21 @@ class LSTM(RNNBase):
                 N ={} & \text{batch size} \\
                 L ={} & \text{sequence length} \\
                 D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
-                S ={} & \text{num\_layers} * D \\
                 H_{in} ={} & \text{input\_size} \\
+                H_{cell} ={} & \text{hidden\_size} \\
                 H_{out} ={} & \text{proj\_size if } \text{proj\_size}>0 \text{ otherwise hidden\_size} \\
             \end{aligned}
 
     Outputs: `output, (h_n, c_n)`
-        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
-          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+        * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
+          :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the LSTM, for each `t`. If a
           :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
           will also be a packed sequence.
-        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
-          for each element in the batch.
-        * **c_n**: tensor of shape :math:`(S, N, H_{out})` containing the final cell state
-          for each element in the batch.
-
-        where:
-
-        .. math::
-            \begin{aligned}
-                H_{all} ={} & D * (\text{proj\_size if proj\_size}>0 \text{ otherwise hidden\_size})
-            \end{aligned}
+        * **h_n**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the
+          final hidden state for each element in the batch.
+        * **c_n**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{cell})` containing the
+          final cell state for each element in the batch.
 
     Attributes:
         weight_ih_l[k] : the learnable input-hidden weights of the :math:`\text{k}^{th}` layer
@@ -742,9 +727,9 @@ class GRU(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            with the batch dimension before the sequence dimension. Note that this does
-            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
-            Default: ``False``
+            as `(batch, seq, feature)` instead of `(seq, batch, feature)`.
+            Note that this does not apply to hidden or cell states. See the
+            Inputs/Outputs sections below for details.  Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             GRU layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
@@ -756,7 +741,7 @@ class GRU(RNNBase):
           the input sequence.  The input can also be a packed variable length sequence.
           See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
           :func:`torch.nn.utils.rnn.pack_sequence` for details.
-        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
+        * **h_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the initial hidden
           state for each element in the batch. Defaults to zeros if not provided.
 
         where:
@@ -766,26 +751,18 @@ class GRU(RNNBase):
                 N ={} & \text{batch size} \\
                 L ={} & \text{sequence length} \\
                 D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
-                S ={} & \text{num\_layers} * D \\
                 H_{in} ={} & \text{input\_size} \\
                 H_{out} ={} & \text{hidden\_size}
             \end{aligned}
 
     Outputs: `output, h_n`
-        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
-          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+        * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
+          :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the GRU, for each `t`. If a
           :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
           will also be a packed sequence.
-        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
+        * **h_n**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the final hidden state
           for each element in the batch.
-
-        where:
-
-        .. math::
-            \begin{aligned}
-                H_{all} ={} & D * \text{hidden\_size}
-            \end{aligned}
 
     Attributes:
         weight_ih_l[k] : the learnable input-hidden weights of the :math:`\text{k}^{th}` layer

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -373,50 +373,50 @@ class RNN(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            as `(batch, seq, feature)`. Default: ``False``
+            with the batch dimension before the sequence dimension. Note that this does
+            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
+            Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             RNN layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
-    Inputs: input, h_0
-        - **input** of shape `(seq_len, batch, input_size)`: tensor containing the features
-          of the input sequence. The input can also be a packed variable length
-          sequence. See :func:`torch.nn.utils.rnn.pack_padded_sequence`
-          or :func:`torch.nn.utils.rnn.pack_sequence`
-          for details.
-        - **h_0** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the initial hidden state for each element in the batch.
-          Defaults to zero if not provided. If the RNN is bidirectional,
-          num_directions should be 2, else it should be 1.
+    Inputs: `input, h_0`
+        * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
+          :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
+          the input sequence.  The input can also be a packed variable length sequence.
+          See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
+          :func:`torch.nn.utils.rnn.pack_sequence` for details.
+        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
+          state for each element in the batch. Defaults to zeros if not provided.
 
-    Outputs: output, h_n
-        - **output** of shape `(seq_len, batch, num_directions * hidden_size)`: tensor
-          containing the output features (`h_t`) from the last layer of the RNN,
-          for each `t`.  If a :class:`torch.nn.utils.rnn.PackedSequence` has
-          been given as the input, the output will also be a packed sequence.
+        where:
 
-          For the unpacked case, the directions can be separated
-          using ``output.view(seq_len, batch, num_directions, hidden_size)``,
-          with forward and backward being direction `0` and `1` respectively.
-          Similarly, the directions can be separated in the packed case.
-        - **h_n** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the hidden state for `t = seq_len`.
+        .. math::
+            \begin{aligned}
+                N ={} & \text{batch size} \\
+                L ={} & \text{sequence length} \\
+                D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
+                S ={} & \text{num\_layers} * D \\
+                H_{in} ={} & \text{input\_size} \\
+                H_{out} ={} & \text{hidden\_size}
+            \end{aligned}
 
-          Like *output*, the layers can be separated using
-          ``h_n.view(num_layers, num_directions, batch, hidden_size)``.
+    Outputs: `output, h_n`
+        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
+          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+          `(h_t)` from the last layer of the RNN, for each `t`. If a
+          :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
+          will also be a packed sequence.
+        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
+          for each element in the batch.
 
-    Shape:
-        - Input1: :math:`(L, N, H_{in})` tensor containing input features where
-          :math:`H_{in}=\text{input\_size}` and `L` represents a sequence length.
-        - Input2: :math:`(S, N, H_{out})` tensor
-          containing the initial hidden state for each element in the batch.
-          :math:`H_{out}=\text{hidden\_size}`
-          Defaults to zero if not provided. where :math:`S=\text{num\_layers} * \text{num\_directions}`
-          If the RNN is bidirectional, num_directions should be 2, else it should be 1.
-        - Output1: :math:`(L, N, H_{all})` where :math:`H_{all}=\text{num\_directions} * \text{hidden\_size}`
-        - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
-          for each element in the batch
+        where:
+
+        .. math::
+            \begin{aligned}
+                H_{all} ={} & D * \text{hidden\_size}
+            \end{aligned}
 
     Attributes:
         weight_ih_l[k]: the learnable input-hidden weights of the k-th layer,
@@ -432,6 +432,11 @@ class RNN(RNNBase):
     .. note::
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
+
+    .. note::
+        For bidirectional RNNs, forward and backward are directions 0 and 1 respectively.
+        Example of splitting the output layers when ``batch_first=False``:
+        ``output.view(seq_len, batch, num_directions, hidden_size)``.
 
     .. include:: ../cudnn_rnn_determinism.rst
 
@@ -518,49 +523,57 @@ class LSTM(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            as (batch, seq, feature). Default: ``False``
+            with the batch dimension before the sequence dimension. Note that this does
+            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
+            Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             LSTM layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional LSTM. Default: ``False``
         proj_size: If ``> 0``, will use LSTM with projections of corresponding size. Default: 0
 
-    Inputs: input, (h_0, c_0)
-        - **input** of shape `(seq_len, batch, input_size)`: tensor containing the features
-          of the input sequence.
-          The input can also be a packed variable length sequence.
+    Inputs: `input, (h_0, c_0)`
+        * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
+          :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
+          the input sequence.  The input can also be a packed variable length sequence.
           See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
           :func:`torch.nn.utils.rnn.pack_sequence` for details.
-        - **h_0** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the initial hidden state for each element in the batch.
-          If the LSTM is bidirectional, num_directions should be 2, else it should be 1.
-          If ``proj_size > 0`` was specified, the shape has to be
-          `(num_layers * num_directions, batch, proj_size)`.
-        - **c_0** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the initial cell state for each element in the batch.
+        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
+          state for each element in the batch.
+          Defaults to zeros if `(h_0, c_0)` is not provided.
+        * **c_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial cell
+          state for each element in the batch.
+          Defaults to zeros if `(h_0, c_0)` is not provided.
 
-          If `(h_0, c_0)` is not provided, both **h_0** and **c_0** default to zero.
+        where:
 
+        .. math::
+            \begin{aligned}
+                N ={} & \text{batch size} \\
+                L ={} & \text{sequence length} \\
+                D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
+                S ={} & \text{num\_layers} * D \\
+                H_{in} ={} & \text{input\_size} \\
+                H_{out} ={} & \text{proj\_size if } \text{proj\_size}>0 \text{ otherwise hidden\_size} \\
+            \end{aligned}
 
-    Outputs: output, (h_n, c_n)
-        - **output** of shape `(seq_len, batch, num_directions * hidden_size)`: tensor
-          containing the output features `(h_t)` from the last layer of the LSTM,
-          for each `t`. If a :class:`torch.nn.utils.rnn.PackedSequence` has been
-          given as the input, the output will also be a packed sequence. If ``proj_size > 0``
-          was specified, output shape will be `(seq_len, batch, num_directions * proj_size)`.
+    Outputs: `output, (h_n, c_n)`
+        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
+          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+          `(h_t)` from the last layer of the LSTM, for each `t`. If a
+          :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
+          will also be a packed sequence.
+        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
+          for each element in the batch.
+        * **c_n**: tensor of shape :math:`(S, N, H_{out})` containing the final cell state
+          for each element in the batch.
 
-          For the unpacked case, the directions can be separated
-          using ``output.view(seq_len, batch, num_directions, hidden_size)``,
-          with forward and backward being direction `0` and `1` respectively.
-          Similarly, the directions can be separated in the packed case.
-        - **h_n** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the hidden state for `t = seq_len`. If ``proj_size > 0``
-          was specified, ``h_n`` shape will be `(num_layers * num_directions, batch, proj_size)`.
+        where:
 
-          Like *output*, the layers can be separated using
-          ``h_n.view(num_layers, num_directions, batch, hidden_size)`` and similarly for *c_n*.
-        - **c_n** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the cell state for `t = seq_len`.
+        .. math::
+            \begin{aligned}
+                H_{all} ={} & D * (\text{proj\_size if proj\_size}>0 \text{ otherwise hidden\_size})
+            \end{aligned}
 
     Attributes:
         weight_ih_l[k] : the learnable input-hidden weights of the :math:`\text{k}^{th}` layer
@@ -580,6 +593,11 @@ class LSTM(RNNBase):
     .. note::
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
+
+    .. note::
+        For bidirectional LSTMs, forward and backward are directions 0 and 1 respectively.
+        Example of splitting the output layers when ``batch_first=False``:
+        ``output.view(seq_len, batch, num_directions, hidden_size)``.
 
     .. include:: ../cudnn_rnn_determinism.rst
 
@@ -724,49 +742,50 @@ class GRU(RNNBase):
         bias: If ``False``, then the layer does not use bias weights `b_ih` and `b_hh`.
             Default: ``True``
         batch_first: If ``True``, then the input and output tensors are provided
-            as (batch, seq, feature). Default: ``False``
+            with the batch dimension before the sequence dimension. Note that this does
+            not apply to hidden or cell states. See the Inputs/Outputs sections below for details.
+            Default: ``False``
         dropout: If non-zero, introduces a `Dropout` layer on the outputs of each
             GRU layer except the last layer, with dropout probability equal to
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional GRU. Default: ``False``
 
-    Inputs: input, h_0
-        - **input** of shape `(seq_len, batch, input_size)`: tensor containing the features
-          of the input sequence. The input can also be a packed variable length
-          sequence. See :func:`torch.nn.utils.rnn.pack_padded_sequence`
-          for details.
-        - **h_0** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the initial hidden state for each element in the batch.
-          Defaults to zero if not provided. If the RNN is bidirectional,
-          num_directions should be 2, else it should be 1.
+    Inputs: `input, h_0`
+        * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
+          :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
+          the input sequence.  The input can also be a packed variable length sequence.
+          See :func:`torch.nn.utils.rnn.pack_padded_sequence` or
+          :func:`torch.nn.utils.rnn.pack_sequence` for details.
+        * **h_0**: tensor of shape :math:`(S, N, H_{out})` containing the initial hidden
+          state for each element in the batch. Defaults to zeros if not provided.
 
-    Outputs: output, h_n
-        - **output** of shape `(seq_len, batch, num_directions * hidden_size)`: tensor
-          containing the output features h_t from the last layer of the GRU,
-          for each `t`. If a :class:`torch.nn.utils.rnn.PackedSequence` has been
-          given as the input, the output will also be a packed sequence.
-          For the unpacked case, the directions can be separated
-          using ``output.view(seq_len, batch, num_directions, hidden_size)``,
-          with forward and backward being direction `0` and `1` respectively.
+        where:
 
-          Similarly, the directions can be separated in the packed case.
-        - **h_n** of shape `(num_layers * num_directions, batch, hidden_size)`: tensor
-          containing the hidden state for `t = seq_len`
+        .. math::
+            \begin{aligned}
+                N ={} & \text{batch size} \\
+                L ={} & \text{sequence length} \\
+                D ={} & 2 \text{ if bidirectional=True otherwise } 1 \\
+                S ={} & \text{num\_layers} * D \\
+                H_{in} ={} & \text{input\_size} \\
+                H_{out} ={} & \text{hidden\_size}
+            \end{aligned}
 
-          Like *output*, the layers can be separated using
-          ``h_n.view(num_layers, num_directions, batch, hidden_size)``.
+    Outputs: `output, h_n`
+        * **output**: tensor of shape :math:`(L, N, H_{all})` when ``batch_first=False`` or
+          :math:`(N, L, H_{all})` when ``batch_first=True`` containing the output features
+          `(h_t)` from the last layer of the GRU, for each `t`. If a
+          :class:`torch.nn.utils.rnn.PackedSequence` has been given as the input, the output
+          will also be a packed sequence.
+        * **h_n**: tensor of shape :math:`(S, N, H_{out})` containing the final hidden state
+          for each element in the batch.
 
-    Shape:
-        - Input1: :math:`(L, N, H_{in})` tensor containing input features where
-          :math:`H_{in}=\text{input\_size}` and `L` represents a sequence length.
-        - Input2: :math:`(S, N, H_{out})` tensor
-          containing the initial hidden state for each element in the batch.
-          :math:`H_{out}=\text{hidden\_size}`
-          Defaults to zero if not provided. where :math:`S=\text{num\_layers} * \text{num\_directions}`
-          If the RNN is bidirectional, num_directions should be 2, else it should be 1.
-        - Output1: :math:`(L, N, H_{all})` where :math:`H_{all}=\text{num\_directions} * \text{hidden\_size}`
-        - Output2: :math:`(S, N, H_{out})` tensor containing the next hidden state
-          for each element in the batch
+        where:
+
+        .. math::
+            \begin{aligned}
+                H_{all} ={} & D * \text{hidden\_size}
+            \end{aligned}
 
     Attributes:
         weight_ih_l[k] : the learnable input-hidden weights of the :math:`\text{k}^{th}` layer
@@ -782,6 +801,11 @@ class GRU(RNNBase):
     .. note::
         All the weights and biases are initialized from :math:`\mathcal{U}(-\sqrt{k}, \sqrt{k})`
         where :math:`k = \frac{1}{\text{hidden\_size}}`
+
+    .. note::
+        For bidirectional GRUs, forward and backward are directions 0 and 1 respectively.
+        Example of splitting the output layers when ``batch_first=False``:
+        ``output.view(seq_len, batch, num_directions, hidden_size)``.
 
     .. include:: ../cudnn_persistent_rnn.rst
 

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -381,7 +381,7 @@ class RNN(RNNBase):
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional RNN. Default: ``False``
 
-    Inputs: `input, h_0`
+    Inputs: input, h_0
         * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
           :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
           the input sequence.  The input can also be a packed variable length sequence.
@@ -401,7 +401,7 @@ class RNN(RNNBase):
                 H_{out} ={} & \text{hidden\_size}
             \end{aligned}
 
-    Outputs: `output, h_n`
+    Outputs: output, h_n
         * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
           :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the RNN, for each `t`. If a
@@ -524,7 +524,7 @@ class LSTM(RNNBase):
         bidirectional: If ``True``, becomes a bidirectional LSTM. Default: ``False``
         proj_size: If ``> 0``, will use LSTM with projections of corresponding size. Default: 0
 
-    Inputs: `input, (h_0, c_0)`
+    Inputs: input, (h_0, c_0)
         * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
           :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
           the input sequence.  The input can also be a packed variable length sequence.
@@ -532,10 +532,10 @@ class LSTM(RNNBase):
           :func:`torch.nn.utils.rnn.pack_sequence` for details.
         * **h_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{out})` containing the
           initial hidden state for each element in the batch.
-          Defaults to zeros if `(h_0, c_0)` is not provided.
+          Defaults to zeros if (h_0, c_0) is not provided.
         * **c_0**: tensor of shape :math:`(D * \text{num\_layers}, N, H_{cell})` containing the
           initial cell state for each element in the batch.
-          Defaults to zeros if `(h_0, c_0)` is not provided.
+          Defaults to zeros if (h_0, c_0) is not provided.
 
         where:
 
@@ -549,7 +549,7 @@ class LSTM(RNNBase):
                 H_{out} ={} & \text{proj\_size if } \text{proj\_size}>0 \text{ otherwise hidden\_size} \\
             \end{aligned}
 
-    Outputs: `output, (h_n, c_n)`
+    Outputs: output, (h_n, c_n)
         * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
           :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the LSTM, for each `t`. If a
@@ -735,7 +735,7 @@ class GRU(RNNBase):
             :attr:`dropout`. Default: 0
         bidirectional: If ``True``, becomes a bidirectional GRU. Default: ``False``
 
-    Inputs: `input, h_0`
+    Inputs: input, h_0
         * **input**: tensor of shape :math:`(L, N, H_{in})` when ``batch_first=False`` or
           :math:`(N, L, H_{in})` when ``batch_first=True`` containing the features of
           the input sequence.  The input can also be a packed variable length sequence.
@@ -755,7 +755,7 @@ class GRU(RNNBase):
                 H_{out} ={} & \text{hidden\_size}
             \end{aligned}
 
-    Outputs: `output, h_n`
+    Outputs: output, h_n
         * **output**: tensor of shape :math:`(L, N, D * H_{out})` when ``batch_first=False`` or
           :math:`(N, L, D * H_{out})` when ``batch_first=True`` containing the output features
           `(h_t)` from the last layer of the GRU, for each `t`. If a


### PR DESCRIPTION
Fixes the high-pri doc component of #4145.

To make the input / output shapes more readable for both `batch_first` states, this PR also introduces short dim names. Opinions welcome on the readability of the restructured docs!

Screenshot for `nn.LSTM`:
<img width="791" alt="Screen Shot 2021-05-24 at 5 11 39 PM" src="https://user-images.githubusercontent.com/75754324/119408130-389e5300-bcb3-11eb-9a4f-1df96a0a4d70.png">