### PR TITLE
various TensorIterator speed improvements

### DIFF
--- a/aten/src/ATen/MemoryOverlap.cpp
+++ b/aten/src/ATen/MemoryOverlap.cpp
@@ -8,9 +8,9 @@ MemOverlap has_internal_overlap(const Tensor& tensor) {
 }
 
 MemOverlap has_internal_overlap(TensorImpl* t) {
-  AT_ASSERT(t->layout() == kStrided);
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(t->layout() == kStrided);
 
-  if (t->is_contiguous()) {
+  if (t->is_non_overlapping_and_dense()) {
     return MemOverlap::NO;
   }
 
@@ -45,7 +45,7 @@ MemOverlapStatus get_overlap_status(TensorImpl* a, TensorImpl* b) {
   if (a->numel() == 0 || b->numel() == 0) {
     return MemOverlapStatus::NO;
   }
-  if (!a->is_contiguous() || !b->is_contiguous()) {
+  if (!a->is_non_overlapping_and_dense() || !b->is_non_overlapping_and_dense()) {
     return MemOverlapStatus::TOO_HARD;
   }
   if (!a->has_storage() || !b->has_storage()) {

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -666,10 +666,8 @@ void TensorIteratorBase::serial_for_each(loop2d_t loop, Range range) const {
     return;
   }
   auto strides = get_strides();
-  if (ndim() ==0 || is_reduction_){
-    while (strides.size() < 2U * ntensors()) {
-      strides.push_back(0);
-    }
+  while (strides.size() < 2U * ntensors()) {
+    strides.push_back(0);
   }
 
 

--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -666,6 +666,12 @@ void TensorIteratorBase::serial_for_each(loop2d_t loop, Range range) const {
     return;
   }
   auto strides = get_strides();
+  if (ndim() ==0 || is_reduction_){
+    while (strides.size() < 2U * ntensors()) {
+      strides.push_back(0);
+    }
+  }
+
 
   auto base_ptrs = get_base_ptrs();
   if (ndim() <= 1) {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2398,7 +2398,10 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
 
             # Check for zero strided, size 1 axis, in non-contiguous storage (gh-33812)
             c = torch.randn(10).as_strided([2, 1, 5], [1, 0, 2])
+            self.assertEqual(torch._debug_has_internal_overlap(c), OVERLAP_NO)
+            c = torch.randn(2, 1, 10)[::2].as_strided((2, 1, 5), (10, 0, 2))
             self.assertEqual(torch._debug_has_internal_overlap(c), OVERLAP_TOO_HARD)
+
 
         def test_allow_tensor_metadata_change(self):
             def do_test(t):


### PR DESCRIPTION
1) remove pushing back to strides vector for 1D tensors, those strides are never used in the loop anyway
2) avoid calling get_data_ptrs unless necessary
3) don't call into assert_no_partial_overlap if tensorImpls are the same (assert_no_partial_overlap has this comparison too, but after a couple of nested function calls)
4) is_non_overlapping_and_dense instead of is_contiguous in memory overlap (which, for some reason, is faster than is_contiguous, though I hoped after is_contiguous is non-virtualized, it should be the same). 

Altogether, brings instruction count down from ~110K to 102735 for the following binary inplace benchmark:
```
In [2]:  timer = Timer("m1.add_(b);", setup="at::Tensor m1=torch::empty({1}); at::Tensor b = torch::empty({1});", language="c++", timer=timeit.default_timer)
   ...:  stats=timer.collect_callgrind(number=30, repeats=3)
   ...:  print(stats[1].as_standardized().stats(inclusive=False))
```
similar improvements for unary inplace. 

Upd: returned stride packing for now, counts is now 104295, so packing is worth ~ 52 instructions, we should think about how to remove it  safely. 