### PR TITLE
Fix source path for cmake command

### DIFF
--- a/docs/cpp/source/installing.rst
+++ b/docs/cpp/source/installing.rst
@@ -94,7 +94,7 @@ using `torch.utils.cmake_prefix_path` variable. In that case CMake configuration
 
 .. code-block:: sh
 
-  cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
+  cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` ..
 
 If all goes well, it will look something like this:
 


### PR DESCRIPTION
The cmake command:
```
cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
```
needs a source directory argument (i.e. the parent directory) to be consistent with the other commands. Proposed fix:
```
cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` ..
```