### PR TITLE
simplify cpu_kernel to not have contiguous special case

### DIFF
--- a/aten/src/ATen/native/cpu/Loops.h
+++ b/aten/src/ATen/native/cpu/Loops.h
@@ -280,14 +280,7 @@ void cpu_kernel_multiple_outputs(TensorIteratorBase& iter, func_t&& op) {
   TORCH_INTERNAL_ASSERT(iter.ninputs() == traits::arity);
 
   iter.for_each([&](char** data, const int64_t* strides, int64_t n) {
-    if (is_contiguous<traits>(strides)) {
-      multiple_outputs_loop(data, strides, 0, n, std::forward<func_t>(op));
-    } else {
-      using Indices = std::make_index_sequence<traits::arity>;
-      unroll_contiguous_scalar_checks<traits>(strides, Indices{}, [&](size_t _idx) {
-        multiple_outputs_loop(data, strides, 0, n, std::forward<func_t>(op));
-      });
-    }
+    multiple_outputs_loop(data, strides, 0, n, std::forward<func_t>(op));
   });
   iter.cast_outputs();
 }
@@ -331,14 +324,7 @@ void cpu_serial_kernel(TensorIteratorBase& iter, func_t&& op, const Range& range
   TORCH_INTERNAL_ASSERT(!needs_dynamic_casting<func_t>::check(iter));
 
   iter.serial_for_each([&](char** data, const int64_t* strides, int64_t n) {
-    if (is_contiguous<traits>(strides)) {
-      basic_loop(data, strides, 0, n, std::forward<func_t>(op));
-    } else {
-      using Indices = std::make_index_sequence<traits::arity>;
-      unroll_contiguous_scalar_checks<traits>(strides, Indices{}, [&](size_t _idx) {
-        basic_loop(data, strides, 0, n, std::forward<func_t>(op));
-      });
-    }
+    basic_loop(data, strides, 0, n, std::forward<func_t>(op));
   }, range);
   iter.cast_outputs();
 }


### PR DESCRIPTION
Per title
 `unroll_contiguous_scalar_checks` tries to verify that all arguments (including outputs) are contiguous except maybe 1 scalar (with stride 0). Then it calls the passed lambda with index of the scalar arg if this verification succeeded, or 0 if args were not contiguous/there was no scalar. Depending on the value of this index (with 0=not found) a different function can be called (in vectorized kernels it’s vectorized loop if args are contiguous + scalar, and basic loop if not). It makes sense for vectorized kernel (vectorized loop can still be used in some broadcasted cases), but all other (cpu_kernel, serial_cpu_kernel, cpu_kernel_multiple_outputs) don’t even use idx argument in lambda, so regardless of what `unroll_contiguous_scalar_checks` does, they'll do the same thing. No point in calling `unroll_contiguous_scalar_checks` then. 