### PR TITLE
[PyTorch Edge] Use stream as backport_vi_to_vi-1 interface

### DIFF
--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -659,29 +659,31 @@ void backportAllVersionCheck(
   constexpr int64_t minimum_to_version = 4;
   int64_t current_to_version = from_version - 1;
 
-  std::ostringstream oss;
   // Verify all candidate to_version work as expected. All backport to version
   // larger than minimum_to_version should success.
   while (current_to_version >= minimum_to_version) {
-    oss.clear();
+    // Do not declare std::stringstream oss outside of the while loop and use
+    // oss.clear() oss.clear() only clears out error state flag in stringstream,
+    // while the content is the same. It's cleaner to just declare a new one and
+    // swap
+    std::stringstream oss;
     bool backPortSuccess =
         _backport_for_mobile(test_model_file_stream, oss, current_to_version);
     AT_ASSERT(backPortSuccess);
 
     // Check backport model version
-    std::stringstream iss(oss.str());
-    auto backport_version = _get_model_bytecode_version(iss);
+    auto backport_version = _get_model_bytecode_version(oss);
     AT_ASSERT(backport_version == current_to_version);
 
     // Load and run the backport model, then compare the result with expect
     // result
     runAndCheckBytecodeModel(
-        iss, input_data, expect_result_list, current_to_version);
+        oss, input_data, expect_result_list, current_to_version);
 
     current_to_version--;
   }
   //  backport to minimum version - 1 should fail
-  oss.clear();
+  std::stringstream oss;
   bool backPortSuccess =
       _backport_for_mobile(test_model_file_stream, oss, minimum_to_version - 1);
   AT_ASSERT(!backPortSuccess);

--- a/torch/csrc/jit/mobile/backport.h
+++ b/torch/csrc/jit/mobile/backport.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Export.h>
 #include <istream>
 #include <memory>
 

--- a/torch/csrc/jit/mobile/backport_manager.cpp
+++ b/torch/csrc/jit/mobile/backport_manager.cpp
@@ -6,8 +6,11 @@
 #include <torch/csrc/jit/mobile/import.h>
 #include <torch/csrc/jit/mobile/model_compatibility.h>
 #include <torch/csrc/jit/mobile/module.h>
+#include <torch/csrc/jit/serialization/export.h>
+#include <torch/csrc/jit/serialization/import.h>
 #include <torch/csrc/jit/serialization/pickler.h>
 #include <cstddef>
+#include <sstream>
 
 namespace torch {
 namespace jit {
@@ -103,14 +106,50 @@ bool check_bytecode_version(
   return true;
 }
 
+// Copy all content from reader to stringstream
+void get_model_stream(PyTorchStreamReader& reader, std::stringstream& out) {
+  auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
+    out.write(static_cast<const char*>(buf), nbytes);
+    return !out ? 0 : nbytes;
+  };
+  PyTorchStreamWriter writer(writer_func);
+  selective_copy(
+      reader,
+      writer,
+      std::unordered_set<std::string>({"version"}),
+      std::unordered_set<std::string>());
+}
+
 } // namespace
 
-// To add next backport
-// function, for example, backport_vn_to_vn-1, create an anonymous namespace
-// with a backport_vn_to_vn-1 function + other necessary customized function. If
-// a function can be reused by other backport functions, move it to the utility
-// function group. It will be easier to split out backport_manager.cpp to
-// smaller files when it grows too long.
+/*
+ To add next backport function, for example, backport_vn_to_vn-1, create an
+ anonymous namespace with a backport_vn_to_vn-1 function + other necessary
+ customized function. If a function can be reused by other backport functions,
+ move it to the utility function group. It will be easier to split out
+ backport_manager.cpp to smaller files when it grows too long.
+
+ How to add backport_v{i}_to_v{i-1} ?
+ There are two options:
+ 1) [Format change only, recommended] Constrcut a reader with the
+ input_model_stream, modify the file, and use PyTorchWriter to write it to
+ output_model_stream. See backport_v5_to_v4.
+
+ 2) [Both format and content change] ]Use torch.jit.load() to load the stream,
+ and save it to output_model_stream.
+
+ The first option is preferred, because it will be purely format change, and
+ the model doesn't need to go through inline again and model content will
+ remain the same.
+
+ A note for manipulate stringstream, it's recommend to declare a new
+ stringstream, tmp_stream, and swap it with the argument output_model_stream
+ once it's ready, output_model_stream.swap(tmp_stream). Do not use
+ output_model_stream.clear(). It only clears out error state flag
+ (https://www.cplusplus.com/reference/ios/ios/clear/), while the content is the
+ same. It's cleaner to just declare a new one and swap.
+
+*/
 
 // The functions needed for backport model from v5 to v4.
 namespace {
@@ -146,14 +185,11 @@ void writeArchiveV4(
 }
 
 bool backport_v5_to_v4(
-    PyTorchStreamReader& reader,
-    PyTorchStreamWriter& writer) {
+    std::stringstream& input_model_stream,
+    std::stringstream& ouput_model_stream) {
   // 1) read from archive `bytecode` archive
+  PyTorchStreamReader reader(&input_model_stream);
   std::vector<IValue> bytecode_values = get_bytecode_values(reader);
-  if (!check_bytecode_version(bytecode_values, kBytecodeVersionV5)) {
-    TORCH_WARN("Incorrect bytecode version for input model.");
-    return false;
-  }
   std::vector<IValue> constants_values =
       readArchive(kArchiveNameConstants, reader).toTuple()->elements();
 
@@ -169,6 +205,14 @@ bool backport_v5_to_v4(
       "constants",
       "bytecode",
   };
+
+  auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
+    ouput_model_stream.write(static_cast<const char*>(buf), nbytes);
+    return !ouput_model_stream ? 0 : nbytes;
+  };
+
+  PyTorchStreamWriter writer(writer_func);
+
   selective_copy(reader, writer, excluded_files, excluded_dirs);
 
   // 3) write `bytecode` archive
@@ -192,9 +236,8 @@ bool backport_v5_to_v4(
 // * PyTorchStreamReader has access to the input model from N bytecode version.
 // * PyTorchStreamWriter has access to the output model backported to the
 // previous N-1 bytecode version. Returns true if successful, false otherwise.
-using BytecodeBackportFunction = std::function<bool(
-    caffe2::serialize::PyTorchStreamReader&,
-    caffe2::serialize::PyTorchStreamWriter&)>;
+using BytecodeBackportFunction =
+    std::function<bool(std::stringstream&, std::stringstream&)>;
 
 BackportManager::BackportManager() {
   registerBytecodeBackportFunction(kBytecodeVersionV5, backport_v5_to_v4);
@@ -202,15 +245,11 @@ BackportManager::BackportManager() {
 
 std::unordered_map<
     int64_t,
-    std::function<bool(
-        caffe2::serialize::PyTorchStreamReader&,
-        caffe2::serialize::PyTorchStreamWriter&)>>&
+    std::function<bool(std::stringstream&, std::stringstream&)>>&
 BackportManager::bytecodeBackportFunctions() const {
   static std::unordered_map<
       int64_t,
-      std::function<bool(
-          caffe2::serialize::PyTorchStreamReader&,
-          caffe2::serialize::PyTorchStreamWriter&)>>
+      std::function<bool(std::stringstream&, std::stringstream&)>>
       backport_functions;
   return backport_functions;
 }
@@ -240,6 +279,8 @@ bool BackportManager::backport(
     PyTorchStreamWriter& final_writer,
     int64_t from_version,
     int64_t to_version) const {
+  PyTorchStreamReader start_reader(istream_adapter);
+
   if (from_version <= to_version) {
     TORCH_WARN(
         "backport donesn't support backporting model to new version. It's trying to backport from version ",
@@ -249,44 +290,71 @@ bool BackportManager::backport(
     return false;
   }
   int64_t bytecode_version = from_version;
-  std::ostringstream out;
-  auto writer_func = [&](const void* buf, size_t nbytes) -> size_t {
-    out.write(static_cast<const char*>(buf), nbytes);
-    return !out ? 0 : nbytes;
-  };
-
-  std::shared_ptr<IStreamAdapter> intermediate_istream_adapter =
-      istream_adapter;
-  std::ostringstream oss;
   bool backport_success = true;
 
-  while (bytecode_version > to_version) {
-    // Read from intermediate writer result if ostream is not empty, otherwise
-    // it means that it's the first time to backport and read from the source.
-    if (!out.str().empty()) {
-      std::istringstream iss(out.str());
-      intermediate_istream_adapter =
-          std::make_shared<caffe2::serialize::IStreamAdapter>(&iss);
-    }
-    out.clear();
+  // 1) Given an istream_adapter (an adapter with access to the input model, the
+  // model can be from istrea, file and etc), copy all model content to
+  // stringstream
+  std::stringstream oss;
+  get_model_stream(start_reader, oss);
+  std::stringstream input_model_stream(oss.str());
+  std::stringstream output_model_stream;
 
-    PyTorchStreamReader intermediate_reader(intermediate_istream_adapter);
-    PyTorchStreamWriter intermediate_writer(writer_func);
+  // 2) backport model, backport_v{i}_to_v{i-1} function's argurment is
+  // (input_model_stream and output_model_stream)
+  while (bytecode_version > to_version) {
+    // Swap input and output if it's not the first time and output_model_stream
+    // has value.
+    if (!output_model_stream.str().empty()) {
+      input_model_stream.swap(output_model_stream);
+      // reset output_model_stream
+      output_model_stream.str("");
+    }
 
     if (!hasBytecodeBackportFunction(bytecode_version)) {
       return false;
     }
 
-    // When it's the last backport process, write to the final destination
-    // otherwise, export to the intermediate ostream.
-    if (bytecode_version - 1 == to_version) {
-      backport_success &= bytecodeBackportFunctions()[bytecode_version--](
-          intermediate_reader, final_writer);
-    } else {
-      backport_success &= bytecodeBackportFunctions()[bytecode_version--](
-          intermediate_reader, intermediate_writer);
+    auto input_model_stream_version =
+        _get_model_bytecode_version(input_model_stream);
+
+    if (input_model_stream_version != bytecode_version) {
+      TORCH_WARN(
+          "The bytecode version of input model stream is supposed to be ",
+          bytecode_version,
+          ", but it gets ",
+          input_model_stream_version);
+    }
+
+    // Keep backporting till request version
+    backport_success &= bytecodeBackportFunctions()[bytecode_version--](
+        input_model_stream, output_model_stream);
+
+    auto output_model_stream_version =
+        _get_model_bytecode_version(output_model_stream);
+
+    if (output_model_stream_version != bytecode_version) {
+      TORCH_WARN(
+          "The bytecode version of output model stream is supposed to be ",
+          bytecode_version,
+          ", but it gets ",
+          output_model_stream_version);
     }
   }
+
+  // 3) Write the final output_model_stream to final_writer, final_writer has
+  // access to the final model destination (file, ostream and etc)
+  if (output_model_stream.str().empty()) {
+    TORCH_WARN("No output model from backport.");
+    return false;
+  }
+  PyTorchStreamReader last_model_reader(&output_model_stream);
+  selective_copy(
+      last_model_reader,
+      final_writer,
+      std::unordered_set<std::string>({"version"}),
+      std::unordered_set<std::string>());
+
   return backport_success;
 }
 

--- a/torch/csrc/jit/mobile/backport_manager.h
+++ b/torch/csrc/jit/mobile/backport_manager.h
@@ -30,9 +30,7 @@ class BackportManager final {
 
   std::unordered_map<
       int64_t,
-      std::function<bool(
-          caffe2::serialize::PyTorchStreamReader&,
-          caffe2::serialize::PyTorchStreamWriter&)>>&
+      std::function<bool(std::stringstream&, std::stringstream&)>>&
   bytecodeBackportFunctions() const;
 
   bool backport(
@@ -49,9 +47,8 @@ class BackportManager final {
   // Registry of backport functions.
   void registerBytecodeBackportFunction(
       const int64_t from_version,
-      const std::function<bool(
-          caffe2::serialize::PyTorchStreamReader&,
-          caffe2::serialize::PyTorchStreamWriter&)>& backport_function);
+      const std::function<bool(std::stringstream&, std::stringstream&)>&
+          backport_function);
 };
 
 } // namespace jit

--- a/torch/csrc/jit/mobile/model_compatibility.h
+++ b/torch/csrc/jit/mobile/model_compatibility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Export.h>
 #include <istream>
 #include <memory>
 

--- a/torch/csrc/jit/mobile/runtime_compatibility.h
+++ b/torch/csrc/jit/mobile/runtime_compatibility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/macros/Export.h>
 #include <memory>
 #include <unordered_map>
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58852 Enable implicit operator versioning via number of arguments
* **#58851 [PyTorch Edge] Use stream as backport_vi_to_vi-1 interface**

Three main changes:
1. Change the argument of the collection of backport_v{i}_to_v{i-1} from (reader, writer) to (input_model_stream, output_model_stream), so it's easier to backport a model in option 2.

>  2) [Both format and content change] ]Use torch.jit.load() to load the stream,
 and save it to output_model_stream.

2. Fix an issue in the test `backportAllVersionCheck`. Previous it declares `std::ostringstream oss` and uses `oss.clear()` to reset the stringstream. However, the `clear()` function doesn't reset the stream content, and causes problematic stream. As a mitigation, checks are added to prevent corrupted stream for each iteration in while loop.



Differential Revision: [D28620961](https://our.internmc.facebook.com/intern/diff/D28620961/)