### PR TITLE
[ONNX] Add linspace symbolic

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1960,7 +1960,9 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)
-        self.run_test(ArangeModelStep(), (x, y))
+        self.run_test(ArangeModelStep(), (x, y), input_names=["x", "y"],
+                      dynamic_axes={"x": [0, 1, 2]})
+        self.run_test(ArangeModelStep(), (x, y), remained_onnx_input_idx=[1])
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_arange_with_floats(self):
@@ -1977,7 +1979,19 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)
-        self.run_test(ArangeModelStep(), (x, y))
+        self.run_test(ArangeModelStep(), (x, y), input_names=["x", "y"],
+                      dynamic_axes={"x": [0, 1, 2]})
+        self.run_test(ArangeModelStep(), (x, y), remained_onnx_input_idx=[1])
+
+        class ArangeModelStepNeg(torch.nn.Module):
+            def forward(self, start, end):
+                return torch.arange(end, start.size(0), -1.5)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelStepNeg(), (x, y), input_names=["x", "y"],
+                      dynamic_axes={"x": [0, 1, 2]})
+        self.run_test(ArangeModelStepNeg(), (x, y), remained_onnx_input_idx=[1])
 
         class ArangeModelStart(torch.nn.Module):
             def forward(self, start, end):
@@ -1985,7 +1999,9 @@ class TestONNXRuntime(unittest.TestCase):
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)
-        self.run_test(ArangeModelStart(), (x, y))
+        self.run_test(ArangeModelStart(), (x, y), input_names=["x", "y"],
+                      dynamic_axes={"x": [0, 1, 2]})
+        self.run_test(ArangeModelStart(), (x, y), remained_onnx_input_idx=[1])
 
     @skipIfUnsupportedMinOpsetVersion(9)
     def test_arange_with_floats_override(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1962,6 +1962,7 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.tensor(8.5, dtype=torch.float)
         self.run_test(ArangeModelStep(), (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_arange_with_floats(self):
         class ArangeModelEnd(torch.nn.Module):
             def forward(self, end):
@@ -1986,6 +1987,7 @@ class TestONNXRuntime(unittest.TestCase):
         y = torch.tensor(8.5, dtype=torch.float)
         self.run_test(ArangeModelStart(), (x, y))
 
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_arange_with_floats_override(self):
         class ArangeModelEnd(torch.nn.Module):
             def forward(self, end):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1947,9 +1947,7 @@ class TestONNXRuntime(unittest.TestCase):
     def test_arange(self):
         class ArangeModel(torch.nn.Module):
             def forward(self, start, end):
-                out = torch.arange(start.size(0), end, 1.5, dtype=torch.int64)
-                print(out)
-                return out
+                return torch.arange(start.size(0), end, 1.5, dtype=torch.int64)
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1932,28 +1932,77 @@ class TestONNXRuntime(unittest.TestCase):
                       input_names=["x", "y"], dynamic_axes={"x": [0, 1, 2]})
         self.run_test(ArangeStartOutModel(), (x, y), remained_onnx_input_idx=[1])
 
-    @skipIfUnsupportedMinOpsetVersion(11)
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_linspace(self):
         class LinspaceModel(torch.nn.Module):
             def forward(self, start, end, steps):
                 return torch.linspace(start, end, steps)
-        
+
         x = torch.tensor(3, dtype=torch.float)
         y = torch.tensor(10, dtype=torch.float)
         z = torch.tensor(5, dtype=torch.int)
         self.run_test(LinspaceModel(), (x, y, z))
 
-    @skipIfUnsupportedMinOpsetVersion(11)
-    def test_arange(self):
-        class ArangeModel(torch.nn.Module):
+    @skipIfUnsupportedMinOpsetVersion(9)
+    def test_arange_with_floats_out(self):
+        class ArangeModelEnd(torch.nn.Module):
+            def forward(self, end):
+                out_t = torch.tensor([1], dtype=torch.float)
+                return torch.arange(end, out=out_t)
+
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelEnd(), (y))
+
+        class ArangeModelStep(torch.nn.Module):
+            def forward(self, start, end):
+                out_t = torch.tensor([1], dtype=torch.float)
+                return torch.arange(start.size(0), end, 1.5, out=out_t)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelStep(), (x, y))
+
+    def test_arange_with_floats(self):
+        class ArangeModelEnd(torch.nn.Module):
+            def forward(self, end):
+                return torch.arange(end)
+
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelEnd(), (y))
+
+        class ArangeModelStep(torch.nn.Module):
+            def forward(self, start, end):
+                return torch.arange(start.size(0), end, 1.5)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelStep(), (x, y))
+
+        class ArangeModelStart(torch.nn.Module):
+            def forward(self, start, end):
+                return torch.arange(start.size(0), end)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelStart(), (x, y))
+
+    def test_arange_with_floats_override(self):
+        class ArangeModelEnd(torch.nn.Module):
+            def forward(self, end):
+                return torch.arange(end, dtype=torch.int64)
+
+        y = torch.tensor(8.5, dtype=torch.float)
+        self.run_test(ArangeModelEnd(), (y))
+
+        class ArangeModelStep(torch.nn.Module):
             def forward(self, start, end):
                 return torch.arange(start.size(0), end, 1.5, dtype=torch.int64)
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)
-        self.run_test(ArangeModel(), (x, y), input_names=["x", "y"],
+        self.run_test(ArangeModelStep(), (x, y), input_names=["x", "y"],
                       dynamic_axes={"x": [0, 1, 2]})
-        self.run_test(ArangeModel(), (x, y), remained_onnx_input_idx=[1])
+        self.run_test(ArangeModelStep(), (x, y), remained_onnx_input_idx=[1])
 
     @skipIfUnsupportedMinOpsetVersion(11)
     def test_arange_out(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1933,10 +1933,23 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(ArangeStartOutModel(), (x, y), remained_onnx_input_idx=[1])
 
     @skipIfUnsupportedMinOpsetVersion(11)
+    def test_linspace(self):
+        class LinspaceModel(torch.nn.Module):
+            def forward(self, start, end, steps):
+                return torch.linspace(start, end, steps)
+        
+        x = torch.tensor(3, dtype=torch.float)
+        y = torch.tensor(10, dtype=torch.float)
+        z = torch.tensor(5, dtype=torch.int)
+        self.run_test(LinspaceModel(), (x, y, z))
+
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_arange(self):
         class ArangeModel(torch.nn.Module):
             def forward(self, start, end):
-                return torch.arange(start.size(0), end, 1.5, dtype=torch.int64)
+                out = torch.arange(start.size(0), end, 1.5, dtype=torch.int64)
+                print(out)
+                return out
 
         x = torch.randn(2, 3, 4)
         y = torch.tensor(8.5, dtype=torch.float)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -661,13 +661,12 @@ def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
     step = g.op("Cast", step, to_i=scalar_type_to_onnx[type]) if step else None
     return type, end, start, step
 
-def _linspace_helper(g, start, end, step, dtype):
+def _arange_helper(g, *args):
     if _export_onnx_opset_version <= 10:
         from torch.onnx.symbolic_opset9 import arange
-        return arange(g, start, end, step, dtype, None, None, None)
     else:
-        type, end, start, step = _arange_cast_helper(g, start=start, end=end, step=step, dtype=dtype)
-        return g.op("Range", start, end, step)
+        from torch.onnx.symbolic_opset11 import arange
+    return arange(g, *args)
 
 def _size_helper(g, self, dim):
     full_shape = g.op("Shape", self)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -661,6 +661,13 @@ def _arange_cast_helper(g, end, start=None, step=None, dtype=None):
     step = g.op("Cast", step, to_i=scalar_type_to_onnx[type]) if step else None
     return type, end, start, step
 
+def _linspace_helper(g, start, end, step, dtype):
+    if _export_onnx_opset_version <= 10:
+        from torch.onnx.symbolic_opset9 import arange
+        return arange(g, start, end, step, dtype, None, None, None)
+    else:
+        type, end, start, step = _arange_cast_helper(g, start=start, end=end, step=step, dtype=dtype)
+        return g.op("Range", start, end, step)
 
 def _size_helper(g, self, dim):
     full_shape = g.op("Shape", self)

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -665,7 +665,7 @@ def _arange_helper(g, *args):
     if _export_onnx_opset_version <= 10:
         from torch.onnx.symbolic_opset9 import arange
     else:
-        from torch.onnx.symbolic_opset11 import arange
+        from torch.onnx.symbolic_opset11 import arange  # type: ignore[no-redef]
     return arange(g, *args)
 
 def _size_helper(g, self, dim):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -531,10 +531,11 @@ def arange(g, *args):
     return arange_tensor
 
 def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
+    dtype = sym_help._maybe_get_const(dtype, "i")
     step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
-    type, end, start, step = sym_help._arange_cast_helper(g, start=start, end=end, step=step, dtype=dtype)
-    range_tensor = g.op("Range", start, end, step)
-    return range_tensor
+    end_epsilon = g.op("Add", step, end)
+    type, end, start, step = sym_help._arange_cast_helper(g, start=start, end=end_epsilon, step=step, dtype=dtype)
+    return g.op("Range", start, end, step)
 
 @parse_args("v", "i")
 def _dim_arange(g, like, dim):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -7,7 +7,7 @@ import warnings
 import numpy
 
 from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list
-from torch.onnx.symbolic_opset9 import expand, unused, div, sub
+from torch.onnx.symbolic_opset9 import expand, unused
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
 
@@ -530,12 +530,6 @@ def arange(g, *args):
         raise NotImplementedError("Unknown aten::arange signature taking " + str(len(args)) + " arguments.")
     return arange_tensor
 
-def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
-    dtype = sym_help._maybe_get_const(dtype, "i")
-    step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
-    end_epsilon = g.op("Add", step, end)
-    type, end, start, step = sym_help._arange_cast_helper(g, start=start, end=end_epsilon, step=step, dtype=dtype)
-    return g.op("Range", start, end, step)
 
 @parse_args("v", "i")
 def _dim_arange(g, like, dim):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -7,7 +7,7 @@ import warnings
 import numpy
 
 from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list
-from torch.onnx.symbolic_opset9 import expand, unused
+from torch.onnx.symbolic_opset9 import expand, unused, div, sub
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
 
@@ -530,6 +530,11 @@ def arange(g, *args):
         raise NotImplementedError("Unknown aten::arange signature taking " + str(len(args)) + " arguments.")
     return arange_tensor
 
+def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
+    step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
+    type, end, start, step = sym_help._arange_cast_helper(g, start=start, end=end, step=step, dtype=dtype)
+    range_tensor = g.op("Range", start, end, step)
+    return range_tensor
 
 @parse_args("v", "i")
 def _dim_arange(g, like, dim):

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2744,7 +2744,7 @@ def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
     dtype = sym_help._maybe_get_const(dtype, "i")
     step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
     end_epsilon = g.op("Add", step, end)
-    return arange(g, start, end_epsilon, step, dtype, None, None, None)
+    return sym_help._linspace_helper(g, start, end_epsilon, step, dtype)
 
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2741,10 +2741,9 @@ def arange(g, *args):
         raise NotImplementedError("Unknown aten::arange signature taking " + str(len(args)) + " arguments.")
 
 def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
-    dtype = sym_help._maybe_get_const(dtype, "i")
     step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
     end_epsilon = g.op("Add", step, end)
-    return sym_help._linspace_helper(g, start, end_epsilon, step, dtype)
+    return sym_help._arange_helper(g, start, end_epsilon, step, dtype, None, None, None)
 
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2694,53 +2694,57 @@ def arange(g, *args):
 
     def _get_arange_dtype(dtype):
         dtype = sym_help._maybe_get_const(dtype, "i")
-        if sym_help._is_value(dtype):
-            dtype = 4  # default to int64
         return dtype
 
-    if len(args) == 2:
-        # aten::arange(Scalar end, Tensor out)
-        end = sym_help._unsqueeze_helper(g, args[0], [0])
-        dtype = 4  # default to int64
-        arange_tensor = sym_help._squeeze_helper(g, nonzero(g, ones(g, end, dtype, None, None)), [1])
+    def _float_step_convert(range_tensor):
+        if sym_help._is_fp(range_tensor):
+            range_tensor = g.op("Cast", g.op("Ceil", range_tensor), to_i=sym_help.scalar_type_to_onnx[4])
+        return range_tensor
+
+    if len(args) == 2 or len(args) == 5:
+        if len(args) == 2:
+            # aten::arange(Scalar end, Tensor out)
+            dtype = None
+        else:
+            # aten::arange(Scalar end, ScalarType dtype, Layout, Device, bool pin_memory)
+            dtype = _get_arange_dtype(args[1])
+        dtype, end, start, step = sym_help._arange_cast_helper(g, end=args[0], dtype=dtype)
+        end = sym_help._unsqueeze_helper(g, end, [0])
+        range_tensor = _float_step_convert(end)
+        arange_tensor = sym_help._squeeze_helper(g, nonzero(g, ones(g, range_tensor, dtype, None, None)), [1])
         return g.op("Cast", arange_tensor, to_i=sym_help.scalar_type_to_onnx[dtype])
-    elif len(args) == 4:
-        # aten::arange(Scalar start, Scalar end, Scalar step, Tensor out)
-        dtype = 4  # default to int64
-        step = sym_help._unsqueeze_helper(g, args[2], [0])
-        end = sym_help._unsqueeze_helper(g, args[1], [0])
-        start = sym_help._unsqueeze_helper(g, args[0], [0])
-        range_tensor = g.op("Div", g.op("Sub", end, start), step)
+    elif len(args) == 4 or len(args) == 7:
+        if len(args) == 4:
+            # aten::arange(Scalar start, Scalar end, Scalar step, Tensor out)
+            dtype = None
+        else:
+            # aten::arange(Scalar start, Scalar end, Scalar step, ScalarType dtype, Layout, Device, bool pin_memory)
+            dtype = _get_arange_dtype(args[3])
+        dtype, end, start, step = sym_help._arange_cast_helper(g, start=args[0], end=args[1], step=args[2], dtype=dtype)
+        step = sym_help._unsqueeze_helper(g, step, [0])
+        end = sym_help._unsqueeze_helper(g, end, [0])
+        start = sym_help._unsqueeze_helper(g, start, [0])
+        range_tensor = _float_step_convert(g.op("Div", g.op("Sub", end, start), step))
         arange_tensor = sym_help._squeeze_helper(g, nonzero(g, ones(g, range_tensor, None, None, None)), [1])
         arange_tensor = g.op("Add", g.op("Mul", arange_tensor, step), start)
-        return g.op("Cast", arange_tensor, to_i=sym_help.scalar_type_to_onnx[dtype])
-    elif len(args) == 5:
-        # aten::arange(Scalar end, ScalarType dtype, Layout, Device, bool pin_memory)
-        dtype = _get_arange_dtype(args[1])
-        end = sym_help._unsqueeze_helper(g, args[0], [0])
-        arange_tensor = sym_help._squeeze_helper(g, nonzero(g, ones(g, end, dtype, *(args[2:]))), [1])
         return g.op("Cast", arange_tensor, to_i=sym_help.scalar_type_to_onnx[dtype])
     elif len(args) == 6:
         # aten::arange(Scalar start, Scalar end, ScalarType dtype, Layout, Device, bool pin_memory)
         dtype = _get_arange_dtype(args[2])
-        end = sym_help._unsqueeze_helper(g, args[1], [0])
-        start = sym_help._unsqueeze_helper(g, args[0], [0])
-        range_tensor = g.op("Sub", end, start)
+        dtype, end, start, step = sym_help._arange_cast_helper(g, start=args[0], end=args[1], dtype=dtype)
+        end = sym_help._unsqueeze_helper(g, end, [0])
+        start = sym_help._unsqueeze_helper(g, start, [0])
+        range_tensor = _float_step_convert(g.op("Sub", end, start))
         arange_tensor = g.op("Add", sym_help._squeeze_helper(g, nonzero(g, ones(g, range_tensor, dtype, *(args[3:]))), [1]), start)
-        return g.op("Cast", arange_tensor, to_i=sym_help.scalar_type_to_onnx[dtype])
-    elif len(args) == 7:
-        # aten::arange(Scalar start, Scalar end, Scalar step, ScalarType dtype, Layout, Device, bool pin_memory)
-        dtype = _get_arange_dtype(args[3])
-        step = sym_help._unsqueeze_helper(g, args[2], [0])
-        end = sym_help._unsqueeze_helper(g, args[1], [0])
-        start = sym_help._unsqueeze_helper(g, args[0], [0])
-        range_tensor = g.op("Div", g.op("Sub", end, start), step)
-        arange_tensor = sym_help._squeeze_helper(g, nonzero(g, ones(g, range_tensor, dtype, *(args[4:]))), [1])
-        arange_tensor = g.op("Add", g.op("Mul", arange_tensor, step), start)
         return g.op("Cast", arange_tensor, to_i=sym_help.scalar_type_to_onnx[dtype])
     else:
         raise NotImplementedError("Unknown aten::arange signature taking " + str(len(args)) + " arguments.")
 
+def linspace(g, start, end, steps, dtype, layout, device, pin_memory):
+    dtype = sym_help._maybe_get_const(dtype, "i")
+    step = div(g, sub(g, end, start), sub(g, steps, g.op("Constant", value_t=torch.tensor(1, dtype=torch.int64))))
+    end_epsilon = g.op("Add", step, end)
+    return arange(g, start, end_epsilon, step, dtype, None, None, None)
 
 def masked_fill(g, self, mask, value):
     mask = _cast_Bool(g, mask, False)  # type: ignore[name-defined]


### PR DESCRIPTION
* Adds support for linspace op 
* Modifies arange symbolic in opset 9 to replicate the same behavior in which dtype is determined (similar to opset 11) as in https://pytorch.org/docs/stable/generated/torch.arange.html
* Enabled some arange unit tests which were disabled for opset 9
