### PR TITLE
Fix failing torch deploy tests and reenable.

### DIFF
--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -430,10 +430,9 @@ test_vec256() {
 }
 
 test_torch_deploy() {
-  true;
-  # python torch/csrc/deploy/example/generate_examples.py
-  # build/bin/test_deploy
-  # assert_git_not_dirty
+  python torch/csrc/deploy/example/generate_examples.py
+  build/bin/test_deploy
+  assert_git_not_dirty
 }
 
 if ! [[ "${BUILD_ENVIRONMENT}" == *libtorch* || "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -75,11 +75,11 @@ TEST(TorchpyTest, MultiSerialSimpleModel) {
   std::vector<at::Tensor> outputs;
 
   for (size_t i = 0; i < ninterp; i++) {
-    outputs.push_back(model({input}).toTensor());
+    outputs.push_back(model({input.alias()}).toTensor());
   }
 
   // Generate reference
-  auto ref_output = ref_model.forward({input}).toTensor();
+  auto ref_output = ref_model.forward({input.alias()}).toTensor();
 
   // Compare all to reference
   for (size_t i = 0; i < ninterp; i++) {
@@ -117,9 +117,9 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
     futures.push_back(std::async(std::launch::async, [&model]() {
       auto input = torch::ones({10, 20});
       for (int i = 0; i < 100; ++i) {
-        model({input}).toTensor();
+        model({input.alias()}).toTensor();
       }
-      auto result = model({input}).toTensor();
+      auto result = model({input.alias()}).toTensor();
       return result;
     }));
   }
@@ -128,7 +128,7 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   }
 
   // Generate reference
-  auto ref_output = ref_model.forward({input}).toTensor();
+  auto ref_output = ref_model.forward({input.alias()}).toTensor();
 
   // Compare all to reference
   for (size_t i = 0; i < nthreads; i++) {


### PR DESCRIPTION
Fix is simple; alias inputs before feeding them to distinct
torchdeploy interpreters.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Fixes #58832
