### PR TITLE
[Gradient Compression] Re-enable test_ddp_hook_parity_powerSGD on Gloo backend

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -3462,10 +3462,8 @@ class DistributedTest:
             process_group = torch.distributed.new_group(gpus)
             self._test_ddp_hook_parity(state=process_group, hook=default.allreduce_hook)
 
-        # FIXME: Multi-GPU test still fails on Gloo backend.
-        # Need to re-enable it once Gloo submodule picks up https://github.com/facebookincubator/gloo/pull/309.
         @unittest.skipIf(
-            BACKEND != "nccl",
+            BACKEND != "nccl" and BACKEND != "gloo",
             "MPI backend does not support DDP communication hook on CUDA devices",
         )
         @skip_if_lt_x_gpu(int(os.environ["WORLD_SIZE"]))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58882 [Gradient Compression] Re-enable test_ddp_hook_parity_powerSGD on Gloo backend**

Re-enable this test since https://github.com/facebookincubator/gloo/pull/309 is already picked up by Gloo submodule.

Differential Revision: [D28654433](https://our.internmc.facebook.com/intern/diff/D28654433/)