### PR TITLE
Make torch.Tensor(torch.tensor(1.0)) work

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -8209,6 +8209,10 @@ class TestTensorDeviceOps(TestCase):
 class TestTorch(AbstractTestCases._TestTorchMixin):
     exact_dtype = True
 
+    def test_tensor_ctor_scalar(self):
+        x = torch.Tensor(torch.tensor(1.0))
+        self.assertEqual(x, torch.tensor(1.0))
+
     def test_deepcopy_gradient(self):
         from copy import deepcopy
         a = torch.zeros(10)

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -88,7 +88,7 @@ Tensor new_with_tensor(c10::TensorOptions options, at::ScalarType scalar_type, c
   options = options.dtype(scalar_type);
   TORCH_CHECK_TYPE(other.options().type_equal(options), "expected ",
                    options, " (got ", other.options(), ")");
-  return other.slice();
+  return other.alias();
 }
 
 std::vector<int64_t> compute_sizes(PyObject* seq) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58885 Make torch.Tensor(torch.tensor(1.0)) work**

Fixes #58884

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28687510](https://our.internmc.facebook.com/intern/diff/D28687510)