### PR TITLE
Predicate uses of RPC APIs on `torch.distributed.rpc.is_available()`

### DIFF
--- a/torch/csrc/jit/python/python_sugared_value.cpp
+++ b/torch/csrc/jit/python/python_sugared_value.cpp
@@ -1102,6 +1102,9 @@ std::shared_ptr<SugaredValue> toSugaredValue(
     }
   }
 
+  bool isRpcAvailable = py::cast<bool>(
+      py::module::import("torch.distributed.rpc").attr("is_available")());
+
   if (auto callee = as_function(obj)) {
     return std::make_shared<FunctionValue>(callee->function_);
   } else if (py::isinstance<py::module>(obj)) {
@@ -1125,17 +1128,20 @@ std::shared_ptr<SugaredValue> toSugaredValue(
 #ifdef USE_RPC
     // RPC module is only avaialble when build flag "USE_DISTRIBUTED" is on.
   } else if (
+      isRpcAvailable &&
       obj.ptr() ==
-      py::module::import("torch.distributed.rpc").attr("rpc_async").ptr()) {
+          py::module::import("torch.distributed.rpc").attr("rpc_async").ptr()) {
     return SpecialFormValue::create(prim::rpc_async);
   } else if (
+      isRpcAvailable &&
       obj.ptr() ==
-      py::module::import("torch.distributed.rpc").attr("rpc_sync").ptr()) {
+          py::module::import("torch.distributed.rpc").attr("rpc_sync").ptr()) {
     return SpecialFormValue::create(prim::rpc_sync);
   } else if (
+      isRpcAvailable &&
       // RPC module is only avaialble  when build flag "USE_DISTRIBUTED" is on.
       obj.ptr() ==
-      py::module::import("torch.distributed.rpc").attr("remote").ptr()) {
+          py::module::import("torch.distributed.rpc").attr("remote").ptr()) {
     return SpecialFormValue::create(prim::rpc_remote);
 #endif
   } else if (auto callee = as_module(obj)) {


### PR DESCRIPTION
Summary:
There are some callsites of `torch.distributed.rpc.XXX` APIs that are compiled
or not based on `USE_RPC`. However, `torch::deploy`, at least for now,
is compiled with `USE_RPC=1`, but the `torch.distributed.rpc.XXX` APIs used by
the aforementioned pieces of code are not available (i.e.
`torch.distributed.rpc.is_available()` returns `False`). This can cause
Torchscript compilation to fail, even if the code being compiled doesn't use
RPC.

This commit fixes this problem (at least temporarily) by predicating the use
all thse `torch.distributed.rpc` APIs on the value of
`torch.distributed.rpc.is_available()`.

Test Plan: Ran packaged XLM-R model with C++ benchmark.

Differential Revision: D28660925

