### PR TITLE
Ensure NativeFunctions.h codegen output is deterministic

### DIFF
--- a/tools/codegen/gen.py
+++ b/tools/codegen/gen.py
@@ -1026,7 +1026,7 @@ def main() -> None:
         'native_function_declarations': list(concatMap(
             # Convert to a set first to remove duplicate kernel names.
             # Backends are allowed to repeat kernel names; only generate the declaration once!
-            lambda f: list(set(concatMap(
+            lambda f: list(OrderedDict.fromkeys(concatMap(
                 lambda backend_idx:
                     dest.compute_native_function_declaration(f, backend_idx),
                 backend_indices.values()))),


### PR DESCRIPTION
fixes https://github.com/pytorch/pytorch/issues/58796

Planning on re-testing locally tomorrow morning to confirm, but this change should fix the non-determinism in the codegen output that was causing `ccache` not to re-use its cached output.

I built from the commit referenced in https://github.com/pytorch/pytorch/issues/58796 a few times and ran `diff -Naur` on the codegen output in `build/aten/src/ATen`. After a few tries, `NativeFunctions.h` had a few diffs. The diffs were all related to the ordering of functional/inplace/out variants of a NativeFunctionGroup, which looked non-deterministic.

That looks like it's coming from my calling `set()` to filter out duplicate NativeFunction declarations. The earlier version of the codegen also called `set()` to filter out duplicates, but it did so individually for each `NativeFunction` object, before merging the groups (I'm not too sure why this didn't introduce non-determinism before. though). With the refactor from https://github.com/pytorch/pytorch/pull/57361, we're calling `set()` on the declarations from every operator for a given DispatchKey, which is probably what introduced the nondeterminism.

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58889 Ensure NativeFunctions.h codegen output is deterministic**

Differential Revision: [D28675941](https://our.internmc.facebook.com/intern/diff/D28675941)