### PR TITLE
[skip ci] Skip debug info on PRs

### DIFF
--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -22,5 +22,11 @@ else
   build_script='manywheel/build.sh'
 fi
 
+if [[ "$CIRCLE_BRANCH" == "master" ]] || [[ "$CIRCLE_BRANCH" == release/* ]]; then
+  export BUILD_DEBUG_INFO=1
+else
+  export BUILD_DEBUG_INFO="not building"
+fi
+
 # Build the package
 SKIP_ALL_TESTS=1 "/builder/$build_script"

--- a/.circleci/scripts/binary_linux_build.sh
+++ b/.circleci/scripts/binary_linux_build.sh
@@ -24,8 +24,6 @@ fi
 
 if [[ "$CIRCLE_BRANCH" == "master" ]] || [[ "$CIRCLE_BRANCH" == release/* ]]; then
   export BUILD_DEBUG_INFO=1
-else
-  export BUILD_DEBUG_INFO="not building"
 fi
 
 # Build the package


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58898 [do not merge] Filter CI jobs, use testing builder branch
* **#58897 [skip ci] Skip debug info on PRs**

We don't need to be building debug info on PRs since it's just filling up S3/CircleCI storage with useless 800 MB zips, this flips it so it's only run on master + release branches. See #58898 for CI signal

Also see pytorch/builder counterpart (unlike the last debuginfo PR there is no hard dependency between these two so there won't be any churn on un-rebased PRs): https://github.com/pytorch/builder/pull/778

Differential Revision: [D28689413](https://our.internmc.facebook.com/intern/diff/D28689413)