### PR TITLE
Define the SYCL device version __assert_fail when the NDEBUG defined.

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -333,6 +333,13 @@ __host__ __device__
 #else // __APPLE__, _MSC_VER
 #if defined(NDEBUG)
 extern "C" {
+#if defined(__SYCL_DEVICE_ONLY__)
+extern SYCL_EXTERNAL void __assert_fail(
+    const char* expr,
+    const char* file,
+    unsigned int line,
+    const char* func);
+#else // __SYCL_DEVICE_ONLY__
 #if (defined(__CUDA_ARCH__) && !(defined(__clang__) && defined(__CUDA__))) || \
     defined(__HIP_ARCH__) || defined(__HIP__)
 __host__ __device__
@@ -343,6 +350,7 @@ __host__ __device__
         const char* file,
         unsigned int line,
         const char* function) throw();
+#endif
 }
 #endif // NDEBUG
 #define CUDA_KERNEL_ASSERT(cond)                                         \


### PR DESCRIPTION
## Motivation
The utils in namespace  `c10` require the `__assert_fail` when the NDEBUG is defined in kernel code.

The `__assert_fail` declaration in pytorch is not compatible to the SYCL‘s specification.

This causes compile error when use these utils in SYCL kernels.

## Solution
Add the `__assert_fail` declaration for SYCL kernels to pytorch when compiling the SYCL kernels with `c10` utils.

## Additional context
`__assert_fail` in SYCL kernel

`extern SYCL_EXTERNAL void __assert_fail(const char *expr, const char *file, unsigned int line, const char *func);`