### PR TITLE
[deploy] Make load_library a no-op inside a package

### DIFF
--- a/torch/_ops.py
+++ b/torch/_ops.py
@@ -96,6 +96,9 @@ class _Ops(types.ModuleType):
         Args:
             path (str): A path to a shared library to load.
         """
+        if sys.executable == "torch_deploy":
+            return
+
         path = torch._utils_internal.resolve_library_path(path)
         with dl_open_guard():
             # Import the shared library into the process, thus running its

--- a/torch/csrc/deploy/example/examples.py
+++ b/torch/csrc/deploy/example/examples.py
@@ -11,6 +11,8 @@ class Simple(torch.nn.Module):
 
 import torch.nn as nn
 
+def load_library():
+    torch.ops.load_library("my_so.so")
 
 def conv1x1(in_planes, out_planes, stride=1):
     """1x1 convolution"""

--- a/torch/csrc/deploy/example/generate_examples.py
+++ b/torch/csrc/deploy/example/generate_examples.py
@@ -8,9 +8,9 @@ import torch
 from torch.package import PackageExporter
 
 try:
-    from .examples import Simple, resnet18, MultiReturn, multi_return_metadata
+    from .examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library
 except ImportError:
-    from examples import Simple, resnet18, MultiReturn, multi_return_metadata
+    from examples import Simple, resnet18, MultiReturn, multi_return_metadata, load_library
 
 
 def save(name, model, model_jit, eg, featurestore_meta=None):
@@ -49,3 +49,8 @@ if __name__ == "__main__":
 
     multi_return = MultiReturn()
     save("multi_return", multi_return, torch.jit.script(multi_return), (torch.rand(10, 20),), multi_return_metadata)
+
+    with PackageExporter(str(p / "load_library")) as e:
+        e.mock("iopath.**")
+        e.intern("**")
+        e.save_pickle("fn", "fn.pkl", load_library)

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -42,6 +42,14 @@ const char* path(const char* envname, const char* path) {
   return e ? e : path;
 }
 
+TEST(TorchpyTest, LoadLibrary) {
+  torch::deploy::InterpreterManager m(1);
+  torch::deploy::Package p = m.load_package(
+      path("LOAD_LIBRARY", "torch/csrc/deploy/example/generated/load_library"));
+  auto model = p.load_pickle("fn", "fn.pkl");
+  model({});
+}
+
 TEST(TorchpyTest, SimpleModel) {
   compare_torchpy_jit(path("SIMPLE", simple), path("SIMPLE_JIT", simple_jit));
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58933 [deploy] Make load_library a no-op inside a package**

**Summary**
This commit makes load_library calls no-ops inside packages run with
deploy. Libraries containing custom C++ operators and classes are statically linked in C++
and don't need to be loaded. This commit takes advantage of the fact that sys.executable is
set to torch_deploy in deploy and uses that to exit early in load_library if
the program is running inside deploy.

**Test Plan**
This commit adds a test to `generate_examples`/`test_deploy` that
packages and runs a function that calls `load_library`. The library
doesn't exist, but that's okay because the function should be a no-op
anyway.

Differential Revision: [D28687159](https://our.internmc.facebook.com/intern/diff/D28687159)