### PR TITLE
Add Int32 support for NNAPI

### DIFF
--- a/aten/src/ATen/nnapi/nnapi_bind.cpp
+++ b/aten/src/ATen/nnapi/nnapi_bind.cpp
@@ -191,6 +191,13 @@ struct NnapiCompilation : torch::jit::CustomClassHolder {
       operand->zeroPoint = t.q_zero_point();
       return;
     }
+    if (t.scalar_type() == c10::kInt) {
+      operand->type = ANEURALNETWORKS_TENSOR_INT32;
+      operand->scale = 0;
+      operand->zeroPoint = 0;
+      return;
+    }
+
     // TODO: Support more dtypes.
     CAFFE_THROW("Bad dtype");
   }

--- a/torch/backends/_nnapi/serializer.py
+++ b/torch/backends/_nnapi/serializer.py
@@ -369,6 +369,8 @@ class _NnapiSerializer(object):
         zero_point = 0
         if dtype == "float32":
             op_type = NNAPI_OperandCode.TENSOR_FLOAT32
+        elif dtype == "int32":
+            op_type = NNAPI_OperandCode.TENSOR_INT32
         elif dtype == "quint8":
             op_type = NNAPI_OperandCode.TENSOR_QUANT8_ASYMM
             scale = tensor.q_scale()


### PR DESCRIPTION
Summary: Support Int32 tensors in NNAPI converter

Test Plan: Some local testing with FB prod models. Need to add automated testing.

Differential Revision: D28687383

