### PR TITLE
Expose interface to enable grain size on tensor iteratior

### DIFF
--- a/aten/src/ATen/TensorIterator.cpp
+++ b/aten/src/ATen/TensorIterator.cpp
@@ -640,6 +640,9 @@ int TensorIteratorBase::num_reduce_dims() const {
 
 void TensorIteratorBase::for_each(loop2d_t loop, int64_t grain_size) {
   int64_t numel = this->numel();
+  // If grain size is set differently via TensorIterator API
+  // set_grain_size_for_mt then use that value.
+  grain_size = (grain_size_for_mt_ == std::numeric_limits<int64_t>::max()) ? grain_size : grain_size_for_mt_;
   if (numel == 0) {
     return;
   } else if (numel < grain_size || at::get_num_threads() == 1) {

--- a/aten/src/ATen/TensorIterator.h
+++ b/aten/src/ATen/TensorIterator.h
@@ -343,6 +343,9 @@ public:
 
   void build_binary_float_op(const Tensor& out, const Tensor& a, const Tensor& b);
   void build_borrowing_binary_float_op(const Tensor& out, const Tensor& a, const Tensor& b);
+  void set_grain_size_for_mt(int64_t grain_size) { grain_size_for_mt_ = grain_size;}
+  int64_t get_grain_size_for_mt() { return grain_size_for_mt_;}
+
   void build_binary_op(const Tensor& out, const Tensor& a, const Tensor& b);
   void build_borrowing_binary_op(const Tensor& out, const Tensor& a, const Tensor& b);
   void build_unary_float_op(const Tensor& out, const Tensor& a);
@@ -457,6 +460,8 @@ protected:
 
   /// Set by populate_operands(), says if we're handling meta tensors
   bool is_meta_ = false;
+
+  int64_t grain_size_for_mt_ = std::numeric_limits<int64_t>::max();
 };
 
 struct TORCH_API TensorIterator final : public TensorIteratorBase {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58947 [PyTorch] Parallelize gelu via tensoriterator
* **#58946 [DONT COMMIT] Expose interface to enable grain size on tensor iteratior**

To parallelize ops grain size setting is exposed at for_each level.
This is too far deep in the stack cpu_kernel_vec which does not know what the
op is. You would want to parallelize op depending on the op type. Non trivial
ops can benefit from threads even when the # of elements in tensor is not high.
This API exposes setting grain size at tensor iterator level so that operator
creating it can have control over it.

Differential Revision: [D26857523](https://our.internmc.facebook.com/intern/diff/D26857523/)