### PR TITLE
[PyTorch] Parallelize gelu via tensoriterator

### DIFF
--- a/aten/src/ATen/native/Activation.cpp
+++ b/aten/src/ATen/native/Activation.cpp
@@ -774,6 +774,8 @@ Tensor gelu_cpu(const Tensor& self) {
       c10::nullopt /* pin_memory */,
       LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   auto it = TensorIterator::unary_op(Y, self);
+  auto grain_size = self.numel() / at::get_num_threads();
+  it.set_grain_size_for_mt(grain_size);
   GeluKernel(kCPU, it);
   return Y;
 }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8280,6 +8280,12 @@ class TestNN(NNTestCase):
                 _test_gelu(n, m, torch.float64, True)
                 _test_gelu(n, m, torch.float64, False)
 
+        # Tesst multi threaded
+        num_threads = torch.get_num_threads()
+        torch.set_num_threads(4)
+        _test_gelu(32, 32, torch.float32, False)
+        torch.set_num_threads(num_threads)
+
 
     def test_bce_loss_always_nonnegative(self):
         target = torch.ones(5)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58947 [PyTorch] Parallelize gelu via tensoriterator**
* #58946 [DONT COMMIT] Expose interface to enable grain size on tensor iteratior

Use tensor iterator's API to set grain size in order to parallelize gelu op.

Differential Revision: [D28689819](https://our.internmc.facebook.com/intern/diff/D28689819/)