### PR TITLE
Refactor Foreach Tests: Unary Functions

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -209,12 +209,16 @@ OP_CUSTOM_FUNCTOR(floating_half_bfloat16, round, Round)
 OP_CUSTOM_FUNCTOR(floating_half_bfloat16, frac, Trunc)
 OP_CUSTOM_FUNCTOR(floating_complex_half_bfloat16, reciprocal, Reciprocal)
 
+// note(mkozuki): tensor dtype checks of `neg` kernels.
+// Since `check_foreach_api_restrictions` don't require all the tensors to have the same dtype,
+// I think it safer to check every single tensor's dtype inside negation kernels.
 std::vector<Tensor> foreach_tensor_neg_cuda(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    TORCH_CHECK(tensors[0].scalar_type() != kBool,
-                "_foreach_neg: There is a bool tensor in the passed-in TensorList. "
-                "Negation on a bool tensor is not supported. If you are trying to invert a mask, please use the `~`"
-                "or `logical_not()` operator on the individual tensors instead.");
+    for (const auto& t : tensors) {
+        TORCH_CHECK(t.scalar_type() != kBool,
+                    "Negation, the `-` operator, on a bool tensor is not supported. "
+                    "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
+    }
 
     if (!can_use_fast_route(tensors)) {
         return at::native::foreach_tensor_neg_slow(tensors);
@@ -225,10 +229,11 @@ std::vector<Tensor> foreach_tensor_neg_cuda(TensorList tensors) {
 
 void foreach_tensor_neg_cuda_(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    TORCH_CHECK(tensors[0].scalar_type() != kBool,
-                "_foreach_neg: There is a bool tensor in the passed-in TensorList. "
-                "Negation on a bool tensor is not supported. If you are trying to invert a mask, please use the `~`"
-                "or `logical_not()` operator on the individual tensors instead.");
+    for (const auto& t : tensors) {
+        TORCH_CHECK(t.scalar_type() != kBool,
+                    "Negation, the `-` operator, on a bool tensor is not supported. "
+                    "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
+    }
 
     if (!can_use_fast_route(tensors)) {
         return at::native::foreach_tensor_neg_slow_(tensors);

--- a/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachUnaryOp.cu
@@ -214,31 +214,27 @@ OP_CUSTOM_FUNCTOR(floating_complex_half_bfloat16, reciprocal, Reciprocal)
 // I think it safer to check every single tensor's dtype inside negation kernels.
 std::vector<Tensor> foreach_tensor_neg_cuda(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    for (const auto& t : tensors) {
-        TORCH_CHECK(t.scalar_type() != kBool,
-                    "Negation, the `-` operator, on a bool tensor is not supported. "
-                    "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
-    }
 
     if (!can_use_fast_route(tensors)) {
         return at::native::foreach_tensor_neg_slow(tensors);
     }
 
+    TORCH_CHECK(tensors[0].scalar_type() != kBool,
+                "Negation, the `-` operator, on a bool tensor is not supported. "
+                "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
     return all_types_half_complex_bfloat16<std::negate>(tensors);
 }
 
 void foreach_tensor_neg_cuda_(TensorList tensors) {
     check_foreach_api_restrictions(tensors);
-    for (const auto& t : tensors) {
-        TORCH_CHECK(t.scalar_type() != kBool,
-                    "Negation, the `-` operator, on a bool tensor is not supported. "
-                    "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
-    }
 
     if (!can_use_fast_route(tensors)) {
         return at::native::foreach_tensor_neg_slow_(tensors);
     }
 
+    TORCH_CHECK(tensors[0].scalar_type() != kBool,
+                "Negation, the `-` operator, on a bool tensor is not supported. "
+                "If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.");
     all_types_half_complex_bfloat16_<std::negate>(tensors);
 }
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -189,6 +189,12 @@ class TestForeach(TestCase):
             expected = ref(inputs)
             self.assertEqual(actual, expected)
 
+    # note(mkozuki): why `try-except` for both fastpath?
+    # - inputs for fastpath can be integer tensors.
+    #    - this is becase opinfo dtypes are configured for outpulace implementation
+    # - for integer inputs, trigonometric functions and exponential function returns float outputs,
+    #   which causes "result type Float can't be case to the desired type" error.
+    # Thus, `try-except` is used even if `is_fastpath` is `True`.
     def _inplace_unary_test(self, dtype, inplace, inplace_ref, inputs, is_fastpath):
         copied_inputs = [[t.clone().detach() for t in tensors] for tensors in inputs]
         try:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -194,13 +194,8 @@ class TestForeach(TestCase):
         try:
             inplace(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
-            if inplace.func == torch._foreach_neg_ and dtype == torch.bool and self.is_cuda:
-                # note(mkozuki): `foreach_neg` CUDA implementation throws a different message.
-                with self.assertRaisesRegex(type(e), "Negation, the `-` operator, on a bool tensor is not supported."):
-                    inplace_ref(copied_inputs)
-            else:
-                with self.assertRaisesRegex(type(e), re.escape(str(e))):
-                    inplace_ref(copied_inputs)
+            with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                inplace_ref(copied_inputs)
         else:
             inplace_ref(copied_inputs),
             self.assertEqual(copied_inputs, inputs)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -183,13 +183,8 @@ class TestForeach(TestCase):
         try:
             actual = op(inputs, self.is_cuda, is_fastpath)
         except RuntimeError as e:
-            if op.func == torch._foreach_neg and dtype == torch.bool and self.is_cuda:
-                # note(mkozuki): `foreach_neg` CUDA implementation throws a different message.
-                with self.assertRaisesRegex(type(e), "Negation, the `-` operator, on a bool tensor is not supported."):
-                    ref(inputs)
-            else:
-                with self.assertRaisesRegex(type(e), re.escape(str(e))):
-                    ref(inputs)
+            with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                ref(inputs)
         else:
             expected = ref(inputs)
             self.assertEqual(actual, expected)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -12,7 +12,44 @@ from torch.testing._internal.common_methods_invocations import foreach_unary_op_
 # kernel code paths.
 N_values = [20, 23] if not TEST_WITH_SLOW else [23, 30, 300]
 
+class RegularFuncWrapper:
+
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, inputs, **kwargs):
+        return [self.func(*i, **kwargs) for i in zip(*inputs)]
+
+class InplaceRefWrapper:
+
+    def __init__(self, method_name):
+        self.method_name = method_name
+
+    def __call__(self, inputs, **kwargs):
+        return [getattr(i1, self.method_name)(*rest, **kwargs) for i1, *rest in list(zip(*inputs))]
+
+class ForeachFuncWrapper:
+
+    def __init__(self, func, n_expected_cudaLaunchKernels):
+        self.func = func
+        self.n_expected_cudaLaunchKernels = n_expected_cudaLaunchKernels
+
+    def __call__(self, inputs, is_cuda, is_fastpath, **kwargs):
+        if is_cuda and torch.autograd.kineto_available():
+            with torch.profiler.profile(activities=(torch.profiler.ProfilerActivity.CPU,)) as p:
+                actual = self.func(*inputs, **kwargs)
+            for e in p.key_averages():
+                if e.key == 'cudaLaunchKernel':
+                    if is_fastpath:
+                        assert e.count == self.n_expected_cudaLaunchKernels
+                    else:
+                        assert e.count > self.n_expected_cudaLaunchKernels
+            return actual
+        else:
+            return self.func(*inputs, **kwargs)
+
 class TestForeach(TestCase):
+    # todo(mkozuki): remove this once `TestForeach` is refactored with `@op` decorator.
     bin_ops = [
         (torch._foreach_add, torch._foreach_add_, torch.add),
         (torch._foreach_sub, torch._foreach_sub_, torch.sub),
@@ -20,6 +57,22 @@ class TestForeach(TestCase):
         (torch._foreach_div, torch._foreach_div_, torch.div),
     ]
 
+    @property
+    def is_cuda(self):
+        return self.device_type == 'cuda'
+
+    # note(mkozuki): It might be the case that the expected number of `cudaLaunchKernel`s
+    # is greater than 1 once foreach functions internally separate their input `TensorList`s by
+    # devices & dtypes into vectors of tensors.
+    def _get_funcs(self, op, n_expected_cudaLaunchKernels=1):
+        return (
+            ForeachFuncWrapper(op.method_variant, n_expected_cudaLaunchKernels),
+            RegularFuncWrapper(op.ref),
+            ForeachFuncWrapper(op.inplace_variant, n_expected_cudaLaunchKernels),
+            InplaceRefWrapper(op.ref_inplace_name),
+        )
+
+    # todo(mkozuki): remove this method once `TestForeach` is refactored with `@op` decorator.
     def _get_test_data(self, device, dtype, N):
         if dtype in [torch.bfloat16, torch.bool, torch.float16]:
             tensors = [torch.randn(N, N, device=device).to(dtype) for _ in range(N)]
@@ -127,27 +180,62 @@ class TestForeach(TestCase):
             else:
                 self.assertEqual(tensors1, expected)
 
-    @ops(foreach_unary_op_db)
-    def test_unary(self, device, dtype, op):
-        for N in N_values:
-            tensors = op.sample_inputs(device, dtype, N)
-            expected = [op.ref(t) for t in tensors]
-
-            method = op.get_method()
-            inplace = op.get_inplace()
-            actual = method(tensors)
-            self.assertEqual(expected, actual)
-
-            if op.safe_casts_outputs and dtype in torch.testing.integral_types_and(torch.bool):
-                with self.assertRaisesRegex(RuntimeError, "can't be cast to the desired output type"):
-                    inplace(tensors)
-            elif dtype in [torch.complex64, torch.complex128] and inplace == torch._foreach_abs_:
-                # Special case for abs
-                with self.assertRaisesRegex(RuntimeError, r"In-place abs is not supported for complex tensors."):
-                    inplace(tensors)
+    # note(mkozuki): fastpath test uses dtypes which fastpath implementation supports.
+    # To confirm the dtypes of `OpInfo` cover the dtypes that the function support,
+    # this test does not use `try-except` for fastpath.
+    def _regular_unary_test(self, dtype, method, ref, inputs, is_fastpath):
+        if is_fastpath:
+            self.assertEqual(ref(inputs), method(inputs, self.is_cuda, is_fastpath))
+            return
+        try:
+            actual = method(inputs, self.is_cuda, is_fastpath)
+        except RuntimeError as e:
+            if method.func == torch._foreach_neg and dtype == torch.bool and self.is_cuda:
+                # note(mkozuki): `foreach_neg` CUDA implementation throws a different message.
+                with self.assertRaisesRegex(type(e), "Negation, the `-` operator, on a bool tensor is not supported."):
+                    ref(inputs)
             else:
-                inplace(tensors)
-                self.assertEqual(tensors, actual)
+                with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                    ref(inputs)
+        else:
+            expected = ref(inputs)
+            self.assertEqual(actual, expected)
+
+    def _inplace_unary_test(self, dtype, inplace, inplace_ref, inputs, is_fastpath):
+        copied_inputs = [[t.clone().detach() for t in tensors] for tensors in inputs]
+        try:
+            inplace(inputs, self.is_cuda, is_fastpath)
+        except RuntimeError as e:
+            if inplace.func == torch._foreach_neg_ and dtype == torch.bool and self.is_cuda:
+                # note(mkozuki): `foreach_neg` CUDA implementation throws a different message.
+                with self.assertRaisesRegex(type(e), "Negation, the `-` operator, on a bool tensor is not supported."):
+                    inplace_ref(copied_inputs)
+            else:
+                with self.assertRaisesRegex(type(e), re.escape(str(e))):
+                    inplace_ref(copied_inputs)
+        else:
+            inplace_ref(copied_inputs)
+        self.assertEqual(copied_inputs, inputs)
+
+    def _test_unary(self, device, dtype, op, N, is_fastpath):
+        method, ref, inplace_method, inplace_ref = self._get_funcs(op)
+        inputs = op.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
+        # note(mkozuki): Complex inputs for `_foreach_abs` go through slowpath.
+        if op.name == "_foreach_abs" and dtype in torch.testing.get_all_complex_dtypes():
+            is_fastpath = False
+        self._regular_unary_test(dtype, method, ref, inputs, is_fastpath)
+        self._inplace_unary_test(dtype, inplace_method, inplace_ref, inputs, is_fastpath)
+
+    @ops(foreach_unary_op_db)
+    def test_unary_fastpath(self, device, dtype, op):
+        for N in N_values:
+            self._test_unary(device, dtype, op, N, is_fastpath=True)
+
+    @dtypes(*torch.testing.get_all_dtypes())
+    @ops(foreach_unary_op_db)
+    def test_unary_slowpath(self, device, dtype, op):
+        for N in N_values:
+            self._test_unary(device, dtype, op, N, is_fastpath=False)
 
     #
     # Pointwise ops
@@ -828,23 +916,24 @@ class TestForeach(TestCase):
     def test_unary_op_tensors_on_different_devices(self, device, dtype, op):
         if self.device_type != 'cuda':
             self.skipTest('CUDA is necessary for tests with tensors on different devices')
+        method, ref, inplace_method, ref_inplace = self._get_funcs(op)
         # tensors: ['cuda', 'cpu]
         tensors = op.sample_inputs(device, dtype, 2)
         tensors[1] = tensors[1].to('cpu')
         try:
-            actual = op.get_method()(tensors)
+            actual = method((tensors,), False, False)
         except RuntimeError as e:
             with self.assertRaisesRegex(type(e), str(e)):
-                [op.ref(t) for t in tensors]
+                ref((tensors,))
         else:
-            expected = [op.ref(t) for t in tensors]
+            expected = ref((tensors,))
             self.assertEqual(expected, actual)
 
         try:
-            op.get_inplace()(tensors)
+            inplace_method((tensors,), False, False)
         except RuntimeError as e:
             with self.assertRaisesRegex(type(e), str(e)):
-                [getattr(t, op.ref.__name__ + '_')() for t in tensors]
+                ref_inplace((tensors,))
         else:
             self.assertEqual(expected, tensors)
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -219,6 +219,7 @@ class TestForeach(TestCase):
         self._regular_unary_test(dtype, method, ref, inputs, is_fastpath)
         self._inplace_unary_test(dtype, inplace_method, inplace_ref, inputs, is_fastpath)
 
+    @skipMeta
     @ops(foreach_unary_op_db)
     def test_unary_fastpath(self, device, dtype, op):
         for N in N_values:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -20,13 +20,6 @@ class RegularFuncWrapper:
     def __call__(self, inputs, **kwargs):
         return [self.func(*i, **kwargs) for i in zip(*inputs)]
 
-class InplaceRefWrapper:
-
-    def __init__(self, method_name):
-        self.method_name = method_name
-
-    def __call__(self, inputs, **kwargs):
-        return [getattr(i1, self.method_name)(*rest, **kwargs) for i1, *rest in list(zip(*inputs))]
 
 class ForeachFuncWrapper:
 
@@ -69,7 +62,7 @@ class TestForeach(TestCase):
             ForeachFuncWrapper(op.method_variant, n_expected_cudaLaunchKernels),
             RegularFuncWrapper(op.ref),
             ForeachFuncWrapper(op.inplace_variant, n_expected_cudaLaunchKernels),
-            InplaceRefWrapper(op.ref_inplace_name),
+            RegularFuncWrapper(op.ref_inplace),
         )
 
     # todo(mkozuki): remove this method once `TestForeach` is refactored with `@op` decorator.
@@ -214,8 +207,8 @@ class TestForeach(TestCase):
                 with self.assertRaisesRegex(type(e), re.escape(str(e))):
                     inplace_ref(copied_inputs)
         else:
-            inplace_ref(copied_inputs)
-        self.assertEqual(copied_inputs, inputs)
+            inplace_ref(copied_inputs),
+            self.assertEqual(copied_inputs, inputs)
 
     def _test_unary(self, device, dtype, op, N, is_fastpath):
         method, ref, inplace_method, inplace_ref = self._get_funcs(op)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2330,15 +2330,15 @@ def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False):
 
 def get_foreach_method_names(name):
     # get torch inplace reference function
-    method_name = "_foreach_" + name
-    method_name_inplace = "_foreach_" + name + "_"
+    op_name = "_foreach_" + name
+    inplace_op_name = "_foreach_" + name + "_"
 
-    method = getattr(torch, method_name, None)
-    method_inplace = getattr(torch, method_name_inplace, None)
+    op = getattr(torch, op_name, None)
+    inplace_op = getattr(torch, inplace_op_name, None)
 
     ref = getattr(torch, name, None)
     ref_inplace = getattr(torch.Tensor, name + "_", None)
-    return method, method_inplace, ref, ref_inplace
+    return op, inplace_op, ref, ref_inplace
 
 class ForeachFuncInfo(OpInfo):
     """Early version of a specialized OpInfo for foreach functions"""

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -4155,35 +4155,35 @@ foreach_unary_op_db: List[OpInfo] = [
         'ceil',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
         'erf',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
         'erfc',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
         'expm1',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
         'floor',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
@@ -4197,14 +4197,14 @@ foreach_unary_op_db: List[OpInfo] = [
         'round',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
         'frac',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
@@ -4225,7 +4225,7 @@ foreach_unary_op_db: List[OpInfo] = [
         'trunc',
         dtypes=floating_types(),
         dtypesIfCPU=floating_types_and(torch.bfloat16),
-        dtypesIfCUDA=floating_types_and(torch.half),
+        dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16),
     ),
 
     ForeachFuncInfo(
@@ -4234,6 +4234,7 @@ foreach_unary_op_db: List[OpInfo] = [
         dtypesIfCPU=all_types_and_complex_and(torch.bfloat16, torch.half),
         dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
         safe_casts_outputs=False,
+        supports_forward_ad=True,
     ),
 ]
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2336,9 +2336,8 @@ def get_foreach_method_names(name):
     method = getattr(torch, method_name, None)
     method_inplace = getattr(torch, method_name_inplace, None)
 
-    ref = getattr(torch.Tensor, name, None)
-
-    return method, method_inplace, ref
+    ref = getattr(torch, name, None)
+    return method, method_inplace, ref, name + "_"
 
 class ForeachFuncInfo(OpInfo):
     """Early version of a specialized OpInfo for foreach functions"""

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2323,8 +2323,8 @@ class ShapeFuncInfo(OpInfo):
                                             **kwargs)
         self.ref = ref
 
-def sample_inputs_foreach(self, device, dtype, N):
-    tensors = [make_tensor((N, N), device, dtype) for _ in range(N)]
+def sample_inputs_foreach(self, device, dtype, N, noncontiguous=False):
+    tensors = [make_tensor((N, N), device, dtype, noncontiguous=noncontiguous) for _ in range(N)]
     return tensors
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2340,8 +2340,8 @@ def get_foreach_method_names(name):
 
     return method, method_inplace, ref
 
-class ForeachUnaryFuncInfo(OpInfo):
-    """Early version of a specialized OpInfo for foreach unary functions"""
+class ForeachFuncInfo(OpInfo):
+    """Early version of a specialized OpInfo for foreach functions"""
     def __init__(self,
                  name,
                  dtypes=floating_and_complex_types(),
@@ -2351,19 +2351,22 @@ class ForeachUnaryFuncInfo(OpInfo):
                  safe_casts_outputs=True,
                  sample_inputs_func=sample_inputs_foreach,
                  **kwargs):
-        super(ForeachUnaryFuncInfo, self).__init__("_foreach_" + name,
-                                                   dtypes=dtypes,
-                                                   dtypesIfCPU=dtypesIfCPU,
-                                                   dtypesIfCUDA=dtypesIfCUDA,
-                                                   dtypesIfROCM=dtypesIfROCM,
-                                                   safe_casts_outputs=safe_casts_outputs,
-                                                   sample_inputs_func=sample_inputs_func,
-                                                   **kwargs)
+        super().__init__(
+            "_foreach_" + name,
+            dtypes=dtypes,
+            dtypesIfCPU=dtypesIfCPU,
+            dtypesIfCUDA=dtypesIfCUDA,
+            dtypesIfROCM=dtypesIfROCM,
+            safe_casts_outputs=safe_casts_outputs,
+            sample_inputs_func=sample_inputs_func,
+            **kwargs
+        )
 
-        foreach_method, foreach_method_inplace, torch_ref_method = get_foreach_method_names(name)
+        foreach_method, foreach_method_inplace, torch_ref_method, torch_ref_inplace_name = get_foreach_method_names(name)
         self.method_variant = foreach_method
         self.inplace_variant = foreach_method_inplace
         self.ref = torch_ref_method
+        self.ref_inplace_name = torch_ref_inplace_name
 
 
 def sample_inputs_linalg_cholesky_inverse(op_info, device, dtype, requires_grad=False):
@@ -4119,93 +4122,120 @@ def sample_inputs_kthvalue(op_info, device, dtype, requires_grad, **kwargs):
     return [SampleInput(tensor, args=args) for tensor, args in test_cases]
 
 foreach_unary_op_db: List[OpInfo] = [
-    ForeachUnaryFuncInfo('exp'),
-    ForeachUnaryFuncInfo('acos'),
-    ForeachUnaryFuncInfo('asin'),
-    ForeachUnaryFuncInfo('atan'),
-    ForeachUnaryFuncInfo('cos'),
-    ForeachUnaryFuncInfo('cosh'),
-    ForeachUnaryFuncInfo('log'),
-    ForeachUnaryFuncInfo('log10'),
-    ForeachUnaryFuncInfo('log2'),
-    ForeachUnaryFuncInfo('tan'),
-    ForeachUnaryFuncInfo('tanh'),
-    ForeachUnaryFuncInfo('sin'),
-    ForeachUnaryFuncInfo('sinh'),
+    ForeachFuncInfo('exp'),
+    ForeachFuncInfo('acos'),
+    ForeachFuncInfo('asin'),
+    ForeachFuncInfo('atan'),
+    ForeachFuncInfo('cos'),
+    ForeachFuncInfo('cosh'),
+    ForeachFuncInfo('log'),
+    ForeachFuncInfo('log10'),
+    ForeachFuncInfo('log2'),
+    ForeachFuncInfo('tan'),
+    ForeachFuncInfo('tanh'),
+    ForeachFuncInfo('sin'),
+    ForeachFuncInfo('sinh'),
 
-    ForeachUnaryFuncInfo('neg',
-                         dtypes=all_types_and_complex(),
-                         dtypesIfCPU=all_types_and_complex(),
-                         dtypesIfCUDA=all_types_and_complex(),
-                         sample_inputs_func=sample_inputs_foreach,
-                         safe_casts_outputs=False),
+    ForeachFuncInfo(
+        'neg',
+        dtypes=all_types_and_complex(),
+        dtypesIfCPU=all_types_and_complex(),
+        dtypesIfCUDA=all_types_and_complex(),
+        sample_inputs_func=sample_inputs_foreach,
+        safe_casts_outputs=False,
+    ),
 
-    ForeachUnaryFuncInfo('sqrt',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_and_complex_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_and_complex_types_and(torch.half)),
+    ForeachFuncInfo(
+        'sqrt',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_and_complex_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_and_complex_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('ceil',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'ceil',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('erf',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half)),
+    ForeachFuncInfo(
+        'erf',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('erfc',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'erfc',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('expm1',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'expm1',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('floor',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'floor',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('log1p',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half)),
+    ForeachFuncInfo(
+        'log1p',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('round',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'round',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('frac',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'frac',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('reciprocal',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half)),
+    ForeachFuncInfo(
+        'reciprocal',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('sigmoid',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half)),
+    ForeachFuncInfo(
+        'sigmoid',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('trunc',
-                         dtypes=floating_types(),
-                         dtypesIfCPU=floating_types_and(torch.bfloat16),
-                         dtypesIfCUDA=floating_types_and(torch.half, torch.bfloat16)),
+    ForeachFuncInfo(
+        'trunc',
+        dtypes=floating_types(),
+        dtypesIfCPU=floating_types_and(torch.bfloat16),
+        dtypesIfCUDA=floating_types_and(torch.half),
+    ),
 
-    ForeachUnaryFuncInfo('abs',
-                         dtypes=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
-                         dtypesIfCPU=all_types_and_complex_and(torch.bfloat16, torch.half),
-                         dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
-                         safe_casts_outputs=False,
-                         supports_forward_ad=True)
+    ForeachFuncInfo(
+        'abs',
+        dtypes=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
+        dtypesIfCPU=all_types_and_complex_and(torch.bfloat16, torch.half),
+        dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
+        safe_casts_outputs=False,
+    ),
 ]
 
 def reference_sign(x):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2337,7 +2337,8 @@ def get_foreach_method_names(name):
     method_inplace = getattr(torch, method_name_inplace, None)
 
     ref = getattr(torch, name, None)
-    return method, method_inplace, ref, name + "_"
+    ref_inplace = getattr(torch.Tensor, name + "_", None)
+    return method, method_inplace, ref, ref_inplace
 
 class ForeachFuncInfo(OpInfo):
     """Early version of a specialized OpInfo for foreach functions"""
@@ -2361,11 +2362,11 @@ class ForeachFuncInfo(OpInfo):
             **kwargs
         )
 
-        foreach_method, foreach_method_inplace, torch_ref_method, torch_ref_inplace_name = get_foreach_method_names(name)
+        foreach_method, foreach_method_inplace, torch_ref_method, torch_ref_inplace = get_foreach_method_names(name)
         self.method_variant = foreach_method
         self.inplace_variant = foreach_method_inplace
         self.ref = torch_ref_method
-        self.ref_inplace_name = torch_ref_inplace_name
+        self.ref_inplace = torch_ref_inplace
 
 
 def sample_inputs_linalg_cholesky_inverse(op_info, device, dtype, requires_grad=False):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2324,7 +2324,7 @@ class ShapeFuncInfo(OpInfo):
         self.ref = ref
 
 def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False):
-    tensors = [make_tensor((N, N), device, dtype, noncontiguous=noncontiguous) for i in range(N)]
+    tensors = [make_tensor((N - i, N - i), device, dtype, noncontiguous=noncontiguous) for i in range(N)]
     return tensors
 
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2323,8 +2323,8 @@ class ShapeFuncInfo(OpInfo):
                                             **kwargs)
         self.ref = ref
 
-def sample_inputs_foreach(self, device, dtype, N, noncontiguous=False):
-    tensors = [make_tensor((N, N), device, dtype, noncontiguous=noncontiguous) for _ in range(N)]
+def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False):
+    tensors = [make_tensor((N, N), device, dtype, noncontiguous=noncontiguous) for i in range(N)]
     return tensors
 
 


### PR DESCRIPTION
Related issue: #58833

__changes__
- slowpath tests: pass every dtype&device tensors and compare the behavior with regular functions including inplace
- check of #cudaLaunchKernel
- rename `ForeachUnaryFuncInfo` -> `ForeachFuncInfo`: This change is mainly for the future binary/pointwise test refactors

cc: @ngimel @ptrblck @mcarilli 