### PR TITLE
To add Rectified Adam Algorithm to Optimizers

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -133,6 +133,7 @@ Algorithms
     ASGD
     LBFGS
     NAdam
+    RAdam
     RMSprop
     Rprop
     SGD

--- a/test/optim/tests.json
+++ b/test/optim/tests.json
@@ -26,6 +26,17 @@
         ]
     },
     {
+        "algorithm": "radam",
+        "config": [
+            {},
+            {"learningRate": 1e-4},
+            {"learningRate": 1e-4, "beta1": 0.92},
+            {"learningRate": 1e-4, "beta1": 0.92, "beta2": 0.96},
+            {"learningRate": 1e-4, "beta1": 0.92, "beta2": 0.96, "epsilon": 1e-3},
+            {"learningRate": 1e-4, "weightDecay": 0.1}
+        ]
+    },
+    {
         "algorithm": "adamw",
         "config": [
             {},

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -554,6 +554,29 @@ class TestOptim(TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 1: 1.0"):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
+    def test_radam(self):
+        self._test_basic_cases(
+            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3)
+        )
+        self._test_basic_cases(
+            lambda weight, bias: optim.RAdam(
+                self._build_params_dict(weight, bias, lr=1e-2),
+                lr=1e-3)
+        )
+        self._test_basic_cases(
+            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3, weight_decay=0.1)
+        )
+        self._test_basic_cases(
+            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3),
+            [lambda opt: ExponentialLR(opt, gamma=0.9),
+                lambda opt: ReduceLROnPlateau(opt)]
+        )
+        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+            optim.RAdam(None, lr=1e-2, betas=(1.0, 0.0))
+
+        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+            optim.RAdam(None, lr=1e-2, weight_decay=-1)
+
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:
             self._test_basic_cases(

--- a/torch/optim/__init__.py
+++ b/torch/optim/__init__.py
@@ -13,6 +13,7 @@ from .sparse_adam import SparseAdam
 from .adamax import Adamax
 from .asgd import ASGD
 from .sgd import SGD
+from .radam import RAdam
 from .rprop import Rprop
 from .rmsprop import RMSprop
 from .optimizer import Optimizer
@@ -29,6 +30,7 @@ del sparse_adam
 del adamax
 del asgd
 del sgd
+del radam
 del rprop
 del rmsprop
 del optimizer

--- a/torch/optim/__init__.pyi
+++ b/torch/optim/__init__.pyi
@@ -9,6 +9,7 @@ from .asgd import ASGD as ASGD
 from .lbfgs import LBFGS as LBFGS
 from .nadam import NAdam as NAdam
 from .optimizer import Optimizer as Optimizer
+from .radam import RAdam as RAdam
 from .rmsprop import RMSprop as RMSprop
 from .rprop import Rprop as Rprop
 from .sgd import SGD as SGD

--- a/torch/optim/radam.py
+++ b/torch/optim/radam.py
@@ -1,0 +1,96 @@
+import torch
+from . import _functional as F
+from .optimizer import Optimizer
+
+
+class RAdam(Optimizer):
+    r"""implements RAdam algorithm.
+
+    It has been proposed in `On the variance of the adaptive learning rate and beyond`_.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 2e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+
+    .. _On the variance of the adaptive learning rate and beyond:
+        https://arxiv.org/abs/1908.03265
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+                 weight_decay=0):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        if not 0.0 <= weight_decay:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        super(RAdam, self).__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Args:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params_with_grad = []
+            grads = []
+            exp_avgs = []
+            exp_avg_sqs = []
+            max_exp_avg_sqs = []
+            state_steps = []
+            beta1, beta2 = group['betas']
+
+            for p in group['params']:
+                if p.grad is not None:
+                    params_with_grad.append(p)
+                    if p.grad.is_sparse:
+                        raise RuntimeError('RAdam does not support sparse gradients')
+                    grads.append(p.grad)
+
+                    state = self.state[p]
+                    # Lazy state initialization
+                    if len(state) == 0:
+                        state['step'] = 0
+                        # Exponential moving average of gradient values
+                        state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+                        # Exponential moving average of squared gradient values
+                        state['exp_avg_sq'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+
+                    exp_avgs.append(state['exp_avg'])
+                    exp_avg_sqs.append(state['exp_avg_sq'])
+
+                    # update the steps for each param group update
+                    state['step'] += 1
+                    # record the step after step update
+                    state_steps.append(state['step'])
+
+            F.radam(params_with_grad,
+                    grads,
+                    exp_avgs,
+                    exp_avg_sqs,
+                    state_steps,
+                    beta1=beta1,
+                    beta2=beta2,
+                    lr=group['lr'],
+                    weight_decay=group['weight_decay'],
+                    eps=group['eps'])
+        return loss

--- a/torch/optim/radam.pyi
+++ b/torch/optim/radam.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from .optimizer import _params_t, Optimizer
+
+class RAdam(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., betas: Tuple[float, float]=..., eps: float=..., weight_decay: float=...) -> None: ...


### PR DESCRIPTION
Fixes : #24892

In the paper : https://arxiv.org/pdf/1908.03265.pdf  Liyuan Liu et al. suggested a new optimization algorithm with an essence of similar to Adam Algorithm.

It has been discussed in the paper that, without warmup heuristic, in the early stage of adaptive optimization / learning algorithms sometimes we can get undesirable large variance which can slow overall convergence process. 

Authors proposed the idea of rectification of variance of adaptive learning rate when it is expected to be high.

Differing from the paper, we selected variance tractability cut-off as 5 instead of 4. This adjustment is common practice, and could be found in the code-repository and also tensorflow swift optim library as well : 

https://github.com/LiyuanLucasLiu/RAdam/blob/2f03dd197022da442c6a15c47321f4335d113a3f/radam/radam.py#L156

https://github.com/tensorflow/swift-apis/blob/f51ee4618d652a2419e998bf9418ad80bda67454/Sources/TensorFlow/Optimizers/MomentumBased.swift#L638