### PR TITLE
only forward sequential part of modules

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -135,8 +135,10 @@ class Sequential(Module):
     # TestScript.test_sequential_intermediary_types).  Cannot annotate
     # with Any as TorchScript expects a more precise type
     def forward(self, input):
-        for module in self:
-            input = module(input)
+        for name, module in self.named_children():
+            # Only forward the number indexed module
+            if name.isdigit():
+                input = module(input)
         return input
 
 


### PR DESCRIPTION
Currently, the `nn.Sequential` fails when assigned another sub-module after initialization.

Please close this PR if this is the desired behavior.

```python
linear1 = nn.Linear(1,1)
seq = nn.Sequential(linear1)
seq.linear2 = nn.Linear(2,2)
seq(torch.tensor([[0.5]]))  # raises error because it tries to forward seq.linear2 after linear1
```


This PR prevents `nn.Sequential` from forwarding the sub-modules assigned with `seq.xxx=Module`.

