### PR TITLE
[nnc] Concat input shapes must be known to fuse

### DIFF
--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -851,11 +851,17 @@ class TensorExprFuser {
     }
     return true;
   }
+
   bool allShapesAreKnown(Node* node) {
     // TODO: Relax the checks to support dynamic shapes
     for (Value* input : node->inputs()) {
       if (!shapeIsKnown(input)) {
         return false;
+      }
+      if (input->node()->kind() == prim::ListConstruct) {
+        if (!allShapesAreKnown(input->node())) {
+          return false;
+        }
       }
     }
     for (Value* output : node->outputs()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#58974 [nnc] Concat input shapes must be known to fuse**

I don't know how we overlooked this for so long...

Differential Revision: [D28702660](https://our.internmc.facebook.com/intern/diff/D28702660/)