### PR TITLE
Fix pthreadpool guard test

### DIFF
--- a/aten/src/ATen/test/test_thread_pool_guard.cpp
+++ b/aten/src/ATen/test/test_thread_pool_guard.cpp
@@ -33,29 +33,19 @@ TEST(TestThreadPoolGuard, TestThreadPoolGuard) {
 TEST(TestThreadPoolGuard, TestRunWithGuard) {
   const std::vector<int64_t> array = {1, 2, 3};
 
-  // Run via pthreadpool_parallelize_1d
-  int64_t outer = 0;
-  auto fn1 = [&array, &outer](const size_t task_id) {
-    outer += array[task_id];
-  };
   auto pool = caffe2::pthreadpool();
-  pool->run(fn1, 3);
-
   int64_t inner = 0;
   {
     // Run on same thread
     caffe2::_NoPThreadPoolGuard g1;
-    auto fn2 = [&array, &inner](const size_t task_id) {
+    auto fn = [&array, &inner](const size_t task_id) {
       inner += array[task_id];
     };
-    pool->run(fn2, 3);
+    pool->run(fn, 3);
 
     // confirm the guard is on
-    auto threadpool_ptr1 = caffe2::pthreadpool_();
-    ASSERT_EQ(threadpool_ptr1, nullptr);
+    auto threadpool_ptr = caffe2::pthreadpool_();
+    ASSERT_EQ(threadpool_ptr, nullptr);
   }
-  ASSERT_NE(outer, 0);
-  ASSERT_NE(inner, 0);
-  ASSERT_EQ(outer, 6);
   ASSERT_EQ(inner, 6);
 }


### PR DESCRIPTION
Summary:
* Test was flaky as part of it ran async
* Remove async part to test only the functionality added

Test Plan:
regular test:

`buck test mode/dev //caffe2/aten:test_thread_pool_guard -- --exact 'caffe2/aten:test_thread_pool_guard - TestThreadPoolGuard.TestRunWithGuard' --run-disabled`

stress test:

`buck test mode/dev //caffe2/aten:test_thread_pool_guard -- --exact 'caffe2/aten:test_thread_pool_guard - TestThreadPoolGuard.TestRunWithGuard' --run-disabled --jobs 18 --stress-runs 10 --record-results`

Differential Revision: D28703064

