### PR TITLE
Use some c10::ThreadLocal to avoid crashes on old Android toolchains

### DIFF
--- a/c10/util/ThreadLocal.h
+++ b/c10/util/ThreadLocal.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/macros/Macros.h>
+
 /**
  * Android versions with libgnustl incorrectly handle thread_local C++
  * qualifier with composite types. NDK up to r17 version is affected.

--- a/c10/util/ThreadLocalDebugInfo.cpp
+++ b/c10/util/ThreadLocalDebugInfo.cpp
@@ -1,11 +1,11 @@
+#include <c10/util/ThreadLocal.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
 
 namespace c10 {
 
-namespace {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-thread_local std::shared_ptr<ThreadLocalDebugInfo> debug_info = nullptr;
-} // namespace
+C10_DEFINE_TLS_static(std::shared_ptr<ThreadLocalDebugInfo>, tls_debug_info);
+#define debug_info (tls_debug_info.get())
 
 /* static */
 DebugInfoBase* ThreadLocalDebugInfo::get(DebugInfoKind kind) {

--- a/torch/csrc/autograd/function.cpp
+++ b/torch/csrc/autograd/function.cpp
@@ -1,5 +1,6 @@
 #include <torch/csrc/autograd/function.h>
 
+#include <c10/util/ThreadLocal.h>
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/autograd/variable.h>
 
@@ -19,7 +20,8 @@ namespace torch { namespace autograd {
 // parent of new nodes created during the evaluation of this node in anomaly
 // mode.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static thread_local std::shared_ptr<Node> current_evaluating_node = nullptr;
+C10_DEFINE_TLS_static(std::shared_ptr<Node>, tls_current_evaluating_node);
+#define current_evaluating_node (tls_current_evaluating_node.get())
 
 NodeGuard::NodeGuard(std::shared_ptr<Node> node) {
   last_evaluating_node_ = std::move(current_evaluating_node);


### PR DESCRIPTION
Summary:
See the comment in ThreadLocal.h for context.
I used a slightly dirty preprocessor hack to minimize the number of changes.
The hope is that we'll be able to revert all of these soon.

Test Plan:
CI.
Built FB4A with gnustl and saw no references to cxa_thread_atexit
in the PyTorch libraries.

Differential Revision: D28720762

