### PR TITLE
Add UninitializedBuffer to nn docs

### DIFF
--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -22,6 +22,7 @@ These are the basic building blocks for graphs:
 
     ~parameter.Parameter
     ~parameter.UninitializedParameter
+    ~parameter.UninitializedBuffer
 
 Containers
 ----------------------------------


### PR DESCRIPTION
The `UninitializedBuffer` class was previously left out of `nn.rst`, so it was not included in the generated documentation.
