### PR TITLE
[TorchBench CI] Prune stale branches before fetching the latest ones.

### DIFF
--- a/.github/workflows/run_torchbench.yml
+++ b/.github/workflows/run_torchbench.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Update self-hosted PyTorch
         run: |
           pushd "${HOME}"/pytorch
+          git remote prune origin
           git fetch
           popd
       - name: Run TorchBench


### PR DESCRIPTION
Sometimes the `git fetch` command just fails because of staled local branch references.
Prune the local references before fetching the latest branch information from origin.

Test plan:
CI

RUN_TORCHBENCH: BERT_pytorch