### PR TITLE
Document factory_kwargs in nn.Quantize + remove Attributes section

### DIFF
--- a/torch/nn/quantized/modules/__init__.py
+++ b/torch/nn/quantized/modules/__init__.py
@@ -20,9 +20,11 @@ class Quantize(torch.nn.Module):
      `scale`: scale of the output Quantized Tensor
      `zero_point`: zero_point of output Quantized Tensor
      `dtype`: data type of output Quantized Tensor
-
-    Attributes:
-      `scale`, `zero_point`, `dtype`
+     `factory_kwargs`: Dictionary of kwargs used for configuring initialization
+         of internal buffers. Currently, `device` and `dtype` are supported.
+         Example: `factory_kwargs={'device': 'cuda', 'dtype': torch.float64}`
+         will initialize internal buffers as type `torch.float64` on the current CUDA device.
+         Note that `dtype` only applies to floating-point buffers.
 
     Examples::
         >>> t = torch.tensor([[1., -1.], [1., -1.]])


### PR DESCRIPTION
Summary:
The `factory_kwargs` kwarg was previously undocumented in `nn.Quantize`. Further, the `Attributes` section of the docs was improperly filled in, resulting in bad formatting. This section doesn't apply since `nn.Quantize` doesn't have parameters, so it has been removed.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/59025

Reviewed By: anjali411

Differential Revision: D28723889

Pulled By: jbschlosser

fbshipit-source-id: ba86429f66d511ac35042ebd9c6cc3da7b6b5805