### PR TITLE
Add check_env, getenv api

### DIFF
--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/util/Exception.h>
+#include <c10/util/Optional.h>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -8,13 +9,13 @@
 namespace c10 {
 namespace utils {
 // Reads an environment variable and returns
-// - true,              if set equal to "1"
-// - false,             if set equal to "0"
-// - `default_value`,   otherwise
+// - optional<true>,              if set equal to "1"
+// - optional<false>,             if set equal to "0"
+// - nullopt,   otherwise
 //
 // NB:
 // Issues a warning if the value of the environment variable is not 0 or 1.
-bool check_env_bool(const char* name, bool default_value = false) {
+optional<bool> check_env_bool(const char* name) {
   auto envar = std::getenv(name);
   if (envar) {
     if (strcmp(envar, "0") == 0) {
@@ -30,45 +31,7 @@ bool check_env_bool(const char* name, bool default_value = false) {
         envar,
         "valid values are 0 or 1.");
   }
-  return default_value;
-}
-
-// Reads an environment variable and returns
-// - its value,         if it is set and is a valid value
-// - `default_value`,   otherwise
-//
-// You can optionally pass in a list of valid values (default: empty list,
-// which is interpreted as "all values accepted")
-std::string check_env(
-    const char* name,
-    const char* default_value = "UNSET",
-    const std::vector<std::string> valid_values = std::vector<std::string>()) {
-  auto envar = std::getenv(name);
-
-  // Check if envar is in the set of valid values (if any)
-  bool found = false;
-  for (auto& val : valid_values) {
-    if (val.compare(envar) == 0) {
-      found = true;
-    }
-  }
-
-  // Issue a warning if an invalid value was passed in
-  if (valid_values.size() > 0 && !found) {
-    std::stringstream ss;
-    ss << "Ignoring invalid value for flag " << name << ": " << envar << ". ";
-    ss << "Valid values are: ";
-    for (auto& val : valid_values) {
-      ss << val << ", ";
-    }
-    ss << ". Using default value " << default_value << "instead.";
-
-    TORCH_WARN(ss.str());
-
-    return default_value;
-  }
-
-  return envar;
+  return {};
 }
 } // namespace utils
 } // namespace c10

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <torch/csrc/Exceptions.h>
+#include <c10/util/Exception.h>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -55,8 +55,6 @@ std::string check_env(
 
   // Issue a warning if an invalid value was passed in
   if (valid_values.size() > 0 && !found) {
-    std::string valid_values_str;
-
     std::stringstream ss;
     ss << "Ignoring invalid value for flag " << name << ": " << envar << ". ";
     ss << "Valid values are: ";

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -15,7 +15,7 @@ namespace utils {
 //
 // NB:
 // Issues a warning if the value of the environment variable is not 0 or 1.
-optional<bool> check_env_bool(const char* name) {
+optional<bool> check_env(const char* name) {
   auto envar = std::getenv(name);
   if (envar) {
     if (strcmp(envar, "0") == 0) {

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -35,7 +35,7 @@ namespace utils {
   //
   // You can optionally pass in a list of valid values (default: empty list,
   // which is interpreted as "all values accepted")
-  std::string getenv(const char *name,
+  std::string check_env(const char *name,
       const char *default_value = "UNSET",
       const std::vector<std::string> valid_values= std::vector<std::string>()) {
     auto envar = std::getenv(name);

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -1,71 +1,76 @@
 #pragma once
 
 #include <torch/csrc/Exceptions.h>
+#include <cstring>
 #include <iostream>
 #include <sstream>
-#include <cstring>
 
 namespace c10 {
 namespace utils {
-  // Reads an environment variable and returns
-  // - true,              if set equal to "1"
-  // - false,             if set equal to "0"
-  // - `default_value`,   otherwise
-  //
-  // NB:
-  // Issues a warning if the value of the environment variable is not 0 or 1.
-  bool check_env(const char *name, bool default_value = false) {
-    auto envar = std::getenv(name);
-    if (envar) {
-      if (strcmp(envar, "0") == 0) {
-        return false;
-      }
-      if (strcmp(envar, "1") == 0) {
-        return true;
-      }
-      TORCH_WARN("Ignoring invalid value for boolean flag ", name, ": ", envar,
-          "valid values are 0 or 1.");
+// Reads an environment variable and returns
+// - true,              if set equal to "1"
+// - false,             if set equal to "0"
+// - `default_value`,   otherwise
+//
+// NB:
+// Issues a warning if the value of the environment variable is not 0 or 1.
+bool check_env(const char* name, bool default_value = false) {
+  auto envar = std::getenv(name);
+  if (envar) {
+    if (strcmp(envar, "0") == 0) {
+      return false;
     }
+    if (strcmp(envar, "1") == 0) {
+      return true;
+    }
+    TORCH_WARN(
+        "Ignoring invalid value for boolean flag ",
+        name,
+        ": ",
+        envar,
+        "valid values are 0 or 1.");
+  }
+  return default_value;
+}
+
+// Reads an environment variable and returns
+// - its value,         if it is set and is a valid value
+// - `default_value`,   otherwise
+//
+// You can optionally pass in a list of valid values (default: empty list,
+// which is interpreted as "all values accepted")
+std::string check_env(
+    const char* name,
+    const char* default_value = "UNSET",
+    const std::vector<std::string> valid_values = std::vector<std::string>()) {
+  auto envar = std::getenv(name);
+
+  // Check if envar is in the set of valid values (if any)
+  bool found = false;
+  for (auto& val : valid_values) {
+    if (val.compare(envar) == 0) {
+      found = true;
+    }
+  }
+
+  // Issue a warning if an invalid value was passed in
+  if (valid_values.size() > 0 && !found) {
+    std::string valid_values_str;
+
+    std::stringstream ss;
+    ss << "Ignoring invalid value for flag " << name << ": " << envar << ". ";
+    ss << "Valid values are: ";
+    for (auto& val : valid_values) {
+      ss << val << ", ";
+    }
+    ss << ". Using default value " << default_value << "instead.";
+
+    TORCH_WARN(ss.str());
+
     return default_value;
   }
 
-  // Reads an environment variable and returns
-  // - its value,         if it is set and is a valid value
-  // - `default_value`,   otherwise
-  //
-  // You can optionally pass in a list of valid values (default: empty list,
-  // which is interpreted as "all values accepted")
-  std::string check_env(const char *name,
-      const char *default_value = "UNSET",
-      const std::vector<std::string> valid_values= std::vector<std::string>()) {
-    auto envar = std::getenv(name);
-
-    // Check if envar is in the set of valid values (if any)
-    bool found = false;
-    for (auto &val: valid_values) {
-      if (val.compare(envar) == 0) {
-        found = true;
-      }
-    }
-
-    // Issue a warning if an invalid value was passed in
-    if (valid_values.size() > 0 && !found) {
-      std::string valid_values_str;
-
-      std::stringstream ss;
-      ss << "Ignoring invalid value for flag " << name << ": " << envar << ". ";
-      ss << "Valid values are: ";
-      for (auto &val: valid_values) {
-        ss << val << ", ";
-      }
-      ss << ". Using default value " << default_value << "instead.";
-
-      TORCH_WARN(ss.str());
-
-      return default_value;
-    }
-
-    return envar;
-  }
-} // namespace util
+  return envar;
+}
+} // namespace utils
 } // namespace c10

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -14,7 +14,7 @@ namespace utils {
 //
 // NB:
 // Issues a warning if the value of the environment variable is not 0 or 1.
-bool check_env(const char* name, bool default_value = false) {
+bool check_env_bool(const char* name, bool default_value = false) {
   auto envar = std::getenv(name);
   if (envar) {
     if (strcmp(envar, "0") == 0) {

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <torch/csrc/Exceptions.h>
+#include <iostream>
+#include <sstream>
+#include <cstring>
+
+namespace c10 {
+namespace utils {
+  // Reads an environment variable and returns
+  // - true,              if set equal to "1"
+  // - false,             if set equal to "0"
+  // - `default_value`,   otherwise
+  //
+  // NB:
+  // Issues a warning if the value of the environment variable is not 0 or 1.
+  bool check_env(const char *name, bool default_value = false) {
+    auto envar = std::getenv(name);
+    if (envar) {
+      if (strcmp(envar, "0") == 0) {
+        return false;
+      }
+      if (strcmp(envar, "1") == 0) {
+        return true;
+      }
+      TORCH_WARN("Ignoring invalid value for boolean flag ", name, ": ", envar,
+          "valid values are 0 or 1.");
+    }
+    return default_value;
+  }
+
+  // Reads an environment variable and returns
+  // - its value,         if it is set and is a valid value
+  // - `default_value`,   otherwise
+  //
+  // You can optionally pass in a list of valid values (default: empty list,
+  // which is interpreted as "all values accepted")
+  std::string getenv(const char *name,
+      const char *default_value = "UNSET",
+      const std::vector<std::string> valid_values= std::vector<std::string>()) {
+    auto envar = std::getenv(name);
+
+    // Check if envar is in the set of valid values (if any)
+    bool found = false;
+    for (auto &val: valid_values) {
+      if (val.compare(envar) == 0) {
+        found = true;
+      }
+    }
+
+    // Issue a warning if an invalid value was passed in
+    if (valid_values.size() > 0 && !found) {
+      std::string valid_values_str;
+
+      std::stringstream ss;
+      ss << "Ignoring invalid value for flag " << name << ": " << envar << ". ";
+      ss << "Valid values are: ";
+      for (auto &val: valid_values) {
+        ss << val << ", ";
+      }
+      ss << ". Using default value " << default_value << "instead.";
+
+      TORCH_WARN(ss.str());
+
+      return default_value;
+    }
+
+    return envar;
+  }
+} // namespace util
+} // namespace c10

--- a/c10/util/env.h
+++ b/c10/util/env.h
@@ -3,8 +3,6 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 #include <cstring>
-#include <iostream>
-#include <sstream>
 
 namespace c10 {
 namespace utils {
@@ -31,7 +29,7 @@ optional<bool> check_env(const char* name) {
         envar,
         "valid values are 0 or 1.");
   }
-  return {};
+  return c10::nullopt;
 }
 } // namespace utils
 } // namespace c10


### PR DESCRIPTION
Related Issue: #57691

Summary:
This PR introduces an API for checking environment variables:

```c++
optional<bool> check_env(const char *name)
```
Reads the environment variable name and returns
- `optional<true>`,                       if set equal to "1"
- `optional<false>`,                      if set equal to "0"
- `nullopt`,   otherwise

Issues a warning if the environment variable was set to any value other than 0 or 1

Test Plan:
Manually run the following test case:

- Apply this diff to the repo
```
diff --git a/torch/csrc/Exceptions.cpp b/torch/csrc/Exceptions.cpp
index d008643f70..990d254f0d 100644
--- a/torch/csrc/Exceptions.cpp
+++ b/torch/csrc/Exceptions.cpp
@@ -9,6 +9,9 @@

 #include <torch/csrc/THP.h>

+#include <c10/util/Optional.h>
+#include <c10/util/env.h>
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 PyObject *THPException_FatalError;

@@ -23,18 +26,7 @@ bool THPException_init(PyObject *module)
 namespace torch {

 static bool compute_cpp_stack_traces_enabled() {
-  auto envar = std::getenv("TORCH_SHOW_CPP_STACKTRACES");
-  if (envar) {
-    if (strcmp(envar, "0") == 0) {
-      return false;
-    }
-    if (strcmp(envar, "1") == 0) {
-      return true;
-    }
-    TORCH_WARN("ignoring invalid value for TORCH_SHOW_CPP_STACKTRACES: ", envar,
-               " valid values are 0 or 1.");
-  }
-  return false;
+ return c10::utils::check_env("TORCH_SHOW_CPP_STACKTRACES").value_or(false);
 }

 bool get_cpp_stacktraces_enabled() {
```
This patch replaces the prior `std::getenv` usage in `torch/csrc/Exceptions.cpp` to use the new api.
- Run the following python3 script
```python
import torch

print(torch.__version__) # should print local version (not release)

a1 = torch.tensor([1,2,3])
a2 = torch.tensor([2])

a1 @ a2
```
using the following commands
```bash
python3 test.py # should not output CPP trace
TORCH_SHOW_CPP_STACKTRACES=1 python3 test.py # should output CPP trace
```