### PR TITLE
Remove redundant code from LayerNorm Fake Op.

### DIFF
--- a/caffe2/contrib/fakelowp/ep_int8_fc_op.cc
+++ b/caffe2/contrib/fakelowp/ep_int8_fc_op.cc
@@ -1,0 +1,107 @@
+#include "ep_int8_fc_op.h"
+
+#include <functional>
+
+#include "caffe2/operators/fc_inference.h"
+
+namespace caffe2 {
+
+REGISTER_CPU_OPERATOR(EPInt8FC, EPInt8FCOp<CPUContext>);
+
+using namespace std::placeholders;
+
+OPERATOR_SCHEMA(EPInt8FC)
+    .NumInputs(3)
+    .NumOutputs(1)
+    .TensorInferenceFunction([](auto && arg1, auto && arg2) { return FCShapeInference(arg1, arg2, false); })
+    .CostInferenceFunction([](auto && arg1, auto && arg2) { return CostInferenceForFC(arg1, arg2, false); })
+    .SetDoc(R"DOC(
+The FC operator computes an output $(Y)$ as a linear combination of the input data blob $(X)$ with a weight blob $(W)$ and bias blob $(b)$. More formally,
+
+$$Y = XW^T+b$$
+
+Here, $X$ is a matrix of shape $(M,K)$, $W$ is a matrix of shape $(N,K)$, $b$ is a vector of length $N$, and $Y$ is a matrix of shape $(M,N)$. $N$ can be thought of as the number of nodes in the layer, $M$ is the batch size, and $K$ is the number of features in an input observation.
+
+*NOTE: $X$ does not need to explicitly be a 2-dimensional matrix, however, if it is not it will be coerced into one. For an arbitrary $n$-dimensional tensor $X$, e.g. $[a_0, a_1, \ldots ,a_{k-1}, a_k, \ldots , a_{n-1}]$, where $a_i$ in $N$, and $k$ is the $axis$ arg provided, then $X$ will be coerced into a 2-dimensional tensor with dimensions $[a_0 * \ldots * a_{k-1}, a_k * \ldots * a_{n-1}]$. For the default case where axis=1, this means the $X$ tensor will be coerced into a 2D tensor of dimensions $[a_0, a_1 * \ldots * a_{n-1}]$, where $a_0$ is often the batch size. In this situation, we must have $a_0 = M$ and $a_1 * \ldots * a_{n-1} = K$. Lastly, even though $b$ is a vector of length $N$, it is copied and resized to shape $(M x N)$ implicitly, then added to each vector in the batch.*
+
+<details>
+
+<summary> <b>Example</b> </summary>
+
+**Code**
+
+```
+
+// In this example, our batch size is 1 (M=1), the input observation will have
+//   6 features (K=6), and the layer will have one hidden node (N=1). The
+//   expected output is Y=7.
+workspace.ResetWorkspace()
+
+op = core.CreateOperator(
+    "EPInt8FC",
+    ["X", "W", "b"],
+    ["Y"]
+)
+
+// Create X: MxK
+data = np.array([1,2,3,4,5,6]).astype(np.float32)
+data = data[np.newaxis,:]
+
+// Create W: NxK
+weights = np.array(np.array([1,1/2.,1/3.,1/4.,1/5.,1/6.])).astype(np.float32)
+weights = weights[np.newaxis,:]
+
+// Create b: N
+bias = np.array([1.]).astype(np.float32)
+
+// Put the inputs into the workspace
+workspace.FeedBlob("X", data)
+workspace.FeedBlob("W", weights)
+workspace.FeedBlob("b", bias)
+
+// Run the operator
+workspace.RunOperatorOnce(op)
+print("Y:\n", workspace.FetchBlob("Y"))
+
+```
+
+**Result**
+
+```
+
+Y:
+ [[7.]]
+
+```
+
+</details>
+
+)DOC")
+    .Arg(
+        "axis",
+        "*(type: int; default: 1)* Describes the axis of the input data $X$. Defaults to one because in the common case when the input $X$ has shape $(M,K)$, the first axis encodes the batch size.")
+    .Arg(
+        "axis_w",
+        "*(type: int; default: 1)* Describes the axis of the input weight matrix $W$. Defaults to one because the first axis most likely describes the batch_size.")
+    .Arg(
+        "float16_compute",
+        "*(type: bool; default: False)* Whether to use float-16 compute kernel.")
+    .Input(
+        0,
+        "X",
+        "Input blob to be coerced into a 2D matrix of shape $(M,K)$, where $M$ is the batch size and $K$ is the number of features in a single observation.")
+    .Input(
+        1,
+        "W",
+        "Input blob to be coerced into a 2D matrix of shape $(N,K)$ describing a fully connected weight matrix. Here, $K$ is the number of features in a single observation and $N$ is the number of nodes in the FC layer.")
+    .Input(
+        2,
+        "b",
+        "Input blob containing vector of length $N$ which describes one bias for each node in the layer.")
+    .Output(
+        0,
+        "Y",
+        "Output blob containing a 2D output matrix of shape $(M,N)$, where $M$ is the batch size and $N$ is the number of nodes in the layer. The output is calculated as $Y=XW^T+b$.")
+    .InheritOnnxSchema("Gemm");
+
+} // namespace caffe2

--- a/caffe2/contrib/fakelowp/ep_int8_fc_op.h
+++ b/caffe2/contrib/fakelowp/ep_int8_fc_op.h
@@ -1,0 +1,191 @@
+#ifndef CAFFE2_OPERATORS_EP_INT8_FC_OP_H_
+#define CAFFE2_OPERATORS_EP_INT8_FC_OP_H_
+
+#include <c10/util/Optional.h>
+#include "caffe2/core/context.h"
+#include "caffe2/core/operator.h"
+#include "caffe2/utils/conversions.h"
+#include "caffe2/utils/math.h"
+
+namespace caffe2 {
+
+// This is Caffe's InnerProductOp, with a name that fits its purpose better.
+template <
+    class Context,
+    class Engine = DefaultEngine,
+    bool TransposeWeight = true>
+class EPInt8FCOp final : public Operator<Context> {
+ public:
+  USE_OPERATOR_CONTEXT_FUNCTIONS;
+  template <class... Args>
+  explicit EPInt8FCOp(Args&&... args)
+      : Operator<Context>(std::forward<Args>(args)...),
+        axis_(this->template GetSingleArgument<int32_t>("axis", 1)),
+        axis_w_(this->template GetSingleArgument<int32_t>("axis_w", 1)),
+        X_scale_(this->template GetSingleArgument<float>("X_scale", 1)),
+        X_zero_point_(this->template GetSingleArgument<int32_t>("X_zero_point", 0)),
+        W_scale_(this->template GetSingleArgument<float>("W_scale", 1)),
+        W_zero_point_(this->template GetSingleArgument<int32_t>("W_zero_point", 0)) {}
+  ~EPInt8FCOp() {}
+
+  template <
+      typename T_X,
+      typename T_W,
+      typename T_B,
+      typename T_Y,
+      typename MATH>
+  bool DoRunWithType() {
+    const auto& X = Input(0);
+    const auto& W = Input(1);
+    const auto& b = Input(2);
+
+    CAFFE_ENFORCE(b.dim() == 1, b.dim());
+    // batch size
+    const auto canonical_axis = X.canonical_axis_index(axis_);
+    const auto M = X.size_to_dim(canonical_axis);
+    const auto K = X.size_from_dim(canonical_axis);
+    const auto canonical_axis_w = W.canonical_axis_index(axis_w_);
+    const int N = TransposeWeight ? W.size_to_dim(canonical_axis_w)
+                                  : W.size_from_dim(canonical_axis_w);
+
+    auto dimErrorString = [&]() {
+      return c10::str(
+          "Dimension mismatch: ",
+          "X: ",
+          X.sizes(),
+          ", W: ",
+          W.sizes(),
+          ", b: ",
+          b.sizes(),
+          ", axis: ",
+          axis_,
+          ", M: ",
+          M,
+          ", N: ",
+          N,
+          ", K: ",
+          K);
+    };
+
+    // Error checking
+    CAFFE_ENFORCE(M == X.numel() / K, dimErrorString());
+    CAFFE_ENFORCE(K == W.numel() / N, dimErrorString());
+    CAFFE_ENFORCE(N == b.dim32(0), dimErrorString());
+    CAFFE_ENFORCE(N == b.numel(), dimErrorString());
+
+    Y_shape_cache_ = X.sizes().vec();
+    // This is an invariant of canonical_axis, so we can DCHECK.
+    DCHECK_LE(canonical_axis + 1, Y_shape_cache_.size());
+    Y_shape_cache_.resize(canonical_axis + 1);
+    Y_shape_cache_[canonical_axis] = N;
+    auto* Y = Output(0, Y_shape_cache_, at::dtype<T_Y>());
+    CAFFE_ENFORCE(M * N == Y->numel(), dimErrorString());
+
+    if (X.numel() == 0) {
+      // skip the rest of the computation if X is empty
+      Y->template mutable_data<T_Y>();
+      return true;
+    }
+
+    // default to FLOAT as math.h does.
+    TensorProto::DataType math_type = TensorProto_DataType_FLOAT;
+    if (fp16_type<MATH>()) {
+      math_type = TensorProto_DataType_FLOAT16;
+    }
+
+    // Convert X_orig to "quant 16" X matrix
+    auto X_data = X.template data<T_X>();
+    for (int i=0; i < X.numel(); ++i) {
+      auto X_tmp = X_data[i] / X_scale_ + X_zero_point_;
+      // Multiply by 2^8 before rounding to integer bascially retains 8 more bits of precision
+      X_tmp = std::nearbyint(256. * X_tmp);
+      // Now, convert back and we have this "quant 16" matrix, but in FP format
+      X_data[i] = X_scale_ * ((X_tmp / 256.) - X_zero_point_);
+    }
+    // Convert W_orig to "quant 16" W matrix
+    auto W_data = W.template data<T_X>();
+    for (int i=0; i < W.numel(); ++i) {
+      auto W_tmp = W_data[i] / W_scale_ + W_zero_point_;
+      // Multiply by 2^8 before rounding to integer bascially retains 8 more bits of precision
+      W_tmp = std::nearbyint(256. * W_tmp);
+      // Now, convert back and we have this "quant 16" matrix, but in FP format
+      W_data[i] = W_scale_ * ((W_tmp / 256.) - W_zero_point_);
+    }
+
+    // W * x
+    math::Gemm<T_X, Context, Engine>(
+        CblasNoTrans,
+        TransposeWeight ? CblasTrans : CblasNoTrans,
+        M,
+        N,
+        K,
+        1,
+        X.template data<T_X>(),
+        W.template data<T_W>(),
+        0,
+        Y->template mutable_data<T_Y>(),
+        &context_,
+        math_type);
+
+    // Add bias term
+    if (!bias_multiplier_.has_value()) {
+      bias_multiplier_ =
+          caffe2::empty({M}, at::dtype<T_B>().device(Context::GetDeviceType()));
+      math::Set<T_B, Context>(
+          M,
+          convert::To<float, T_B>(1),
+          bias_multiplier_->template mutable_data<T_B>(),
+          &context_);
+    } else if (bias_multiplier_->numel() != M) {
+      bias_multiplier_->Resize(M);
+      math::Set<T_B, Context>(
+          M,
+          convert::To<float, T_B>(1),
+          bias_multiplier_->template mutable_data<T_B>(),
+          &context_);
+    }
+
+    math::Gemm<T_B, Context, Engine>(
+        CblasNoTrans,
+        CblasNoTrans,
+        M,
+        N,
+        1,
+        1,
+        bias_multiplier_->template data<T_B>(),
+        b.template data<T_B>(),
+        1,
+        Y->template mutable_data<T_Y>(),
+        &context_,
+        math_type);
+
+    return true;
+  }
+
+  bool RunOnDevice() override {
+    return DoRunWithType<
+        float, // X
+        float, // W
+        float, // B
+        float, // Y
+        float>(); // Math
+  }
+
+ protected:
+  size_t axis_{1};
+  size_t axis_w_{1};
+  // A local vector to cache the output shape so we don't need to recreate
+  // a vector object every time we run Run().
+  vector<int64_t> Y_shape_cache_;
+  c10::optional<Tensor> bias_multiplier_;
+
+  float X_scale_;
+  int32_t X_zero_point_;
+  float W_scale_;
+  int32_t W_zero_point_;
+
+};
+
+} // namespace caffe2
+
+#endif // CAFFE2_OPERATORS_EP_INT8_FC_OP_H_


### PR DESCRIPTION
Summary: to handle elementwise_affine

Test Plan: GLOW_NNPI=1 buck run -c fbcode.platform=platform009 //caffe2/caffe2/contrib/fakelowp/test:test_layernorm_nnpi_fp16nnpi

Differential Revision: D28726804

