### PR TITLE
don't copy indices to the self device in dispatch_index

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -274,13 +274,8 @@ static inline void recordTensorIndex(const Tensor& tensor, std::vector<Tensor>& 
 static inline c10::List<c10::optional<Tensor>> typeConvertIndices(const Tensor& self, std::vector<Tensor>&& indices) {
   c10::List<c10::optional<Tensor>> converted_inds;
   converted_inds.reserve(indices.size());
-  for (size_t i = 0; i < indices.size(); ++i) {
-    const auto &ind = indices[i];
-    if (ind.defined()) {
-      converted_inds.push_back(ind.to(ind.options().device(self.device())));
-    } else {
-      converted_inds.push_back(std::move(indices[i]));
-    }
+  for (const auto &i: indices){
+    converted_inds.push_back(std::move(i));
   }
   return converted_inds;
 }

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1077,6 +1077,18 @@ class TestIndexing(TestCase):
         for accumulate in [True, False]:
             self.assertRaises(RuntimeError, lambda: torch.index_put_(b, (idx,), c, accumulate=accumulate))
 
+    @onlyCUDA
+    def test_cpu_indices(self, device):
+        idx = torch.tensor([0, 1])
+        b = torch.zeros(2, device=device)
+        x = torch.ones(10, device=device)
+        x[idx] = b  # index_put_
+        ref = torch.ones(10, device=device)
+        ref[:2] = 0
+        self.assertEqual(x, ref, atol=0, rtol=0)
+        out = x[idx]  # index
+        self.assertEqual(out, torch.zeros(2, device=device), atol=0, rtol=0)
+
     @dtypes(torch.long, torch.float32)
     def test_take_along_dim(self, device, dtype):
         def _test_against_numpy(t, indices, dim):


### PR DESCRIPTION
Let index/index_put implementation in aten take care of moving the indices to the correct device, don't make python wrapper do that. 
