### PR TITLE
[c10d] Remove verbose log

### DIFF
--- a/torch/lib/c10d/ProcessGroupGloo.cpp
+++ b/torch/lib/c10d/ProcessGroupGloo.cpp
@@ -2870,8 +2870,6 @@ void ProcessGroupGloo::monitoredBarrier(
 
   auto elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - startTime);
-  LOG(INFO) << "All ranks passed monitoredBarrier in " << elapsedTime.count()
-            << " ms.";
 }
 
 void ProcessGroupGloo::setSequenceNumberForGroup() {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59070 [c10d] Remove verbose log**

This log is too verbose, especially in the case we call monitored
barrier before every collective as we do in ProcessGroupWrapper.

Differential Revision: [D28738189](https://our.internmc.facebook.com/intern/diff/D28738189/)