### PR TITLE
Add device runtime API for the plug-in to register platform python module into torch

### DIFF
--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -752,3 +752,9 @@ from ._vmap_internals import vmap as vmap
 # class usage. We add these lines here to preserve backward compatibility.
 quantized_lstm = torch.ops.aten.quantized_lstm
 quantized_gru = torch.ops.aten.quantized_gru
+
+
+def _register_device_module(device_type, module):
+    # Make sure the device_type represent a valid device type for torch.
+    dev = torch.device(device_type)
+    setattr(sys.modules[__name__], str(dev.type), module)


### PR DESCRIPTION
## Motivation
Allow the out-of-tree Pytorch plug-in, for the device type other than CUDA, to add the runtime interface to the `torch` module. The runtime interface of the device can be referred with the device type name in the `torch` module. I.E., `torch.cuda` or `torch.xpu`.


## Solution
- Add a register interface for the plug-in to add the platform python module into `torch` module with the device type name. I.E., The `torch.xpu` can be used to refer the XPU runtime interface after the XPU runtime module is registered with `torch._register_device_module('xpu', xpu_module)` in Intel's XPU plug-in.


## Additional Context
More details about runtime has been discussed in #53707. 
