### PR TITLE
Add docstring for is_inference_mode_enabled and is_grad_enabled

### DIFF
--- a/docs/source/torch.rst
+++ b/docs/source/torch.rst
@@ -253,7 +253,9 @@ Examples::
     no_grad
     enable_grad
     set_grad_enabled
+    is_grad_enabled
     inference_mode
+    is_inference_mode_enabled
 
 Math operations
 ---------------

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -4179,6 +4179,18 @@ Args:
     {input}
 """.format(**common_args))
 
+add_docstr(torch.is_grad_enabled, r"""
+is_grad_enabled() -> (bool)
+
+Returns True if grad mode is currently enabled.
+""".format(**common_args))
+
+add_docstr(torch.is_inference_mode_enabled, r"""
+is_inference_mode_enabled() -> (bool)
+
+Returns True if inference mode is currently enabled.
+""".format(**common_args))
+
 add_docstr(torch.is_nonzero, r"""
 is_nonzero(input) -> (bool)
 


### PR DESCRIPTION
Summary:
Add docstring for is_inference_mode_enabled and is_grad_enabled

Pull Request resolved: https://github.com/pytorch/pytorch/pull/59047

Reviewed By: ailzhang

Differential Revision: D28726991

Pulled By: soulitzer

fbshipit-source-id: c117c7d73e551a1b5f0e215f2aed528bf558ef7c

Fixes #{issue number}
