### PR TITLE
[package] silently skip failed `__import__` statements

### DIFF
--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -93,6 +93,12 @@ class TestSaveLoad(PackageTestCase):
         subsubpackage_0 = hi.import_module("package_b.subpackage_0.subsubpackage_0")
         self.assertEqual(subsubpackage_0.result, "subsubpackage_0")
 
+    def test_bad_dunder_imports(self):
+        """Test to ensure bad __imports__ don't cause PackageExporter to fail."""
+        buffer = BytesIO()
+        with PackageExporter(buffer, verbose=False) as e:
+            e.save_source_string('m',  '__import__("these", dont, have, to, be, contants)')
+
     def test_save_module_binary(self):
         f = BytesIO()
         with PackageExporter(f, verbose=False) as he:

--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -97,7 +97,9 @@ class TestSaveLoad(PackageTestCase):
         """Test to ensure bad __imports__ don't cause PackageExporter to fail."""
         buffer = BytesIO()
         with PackageExporter(buffer, verbose=False) as e:
-            e.save_source_string('m',  '__import__("these", dont, have, to, be, contants)')
+            e.save_source_string(
+                "m", '__import__(these, unresolvable, "things", wont, crash, me)'
+            )
 
     def test_save_module_binary(self):
         f = BytesIO()

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -57,47 +57,47 @@ class _ExtractModuleReferences(ast.NodeVisitor):
     def visit_Call(self, node):
         # __import__ calls aren't routed to the visit_Import/From nodes
         if hasattr(node.func, "id") and node.func.id == "__import__":
-            if type(node.args[0]) not in [ast.Constant, ast.Str]:
-                # We don't want to parse dynamic uses of __import__
+            try:
+                name = self._grab_node_str(node.args[0])
+                fromlist = []
+                level = 0
+                if len(node.args) > 3:
+                    for v in node.args[3].elts:
+                        fromlist.append(self._grab_node_str(v))
+                elif hasattr(node, "keywords"):
+                    for keyword in node.keywords:
+                        if keyword.arg == "fromlist":
+                            for v in keyword.value.elts:
+                                fromlist.append(self._grab_node_str(v))
+                if len(node.args) > 4:
+                    level = self._grab_node_int(node.args[4])
+                elif hasattr(node, "keywords"):
+                    for keyword in node.keywords:
+                        if keyword.arg == "level":
+                            level = self._grab_node_int(keyword.value)
+                if fromlist == []:
+                    # the top-level package (the name up till the first dot) is returned
+                    # when the fromlist argument is empty in normal import system,
+                    # we need to include top level package to match this behavior and last
+                    # level package to capture the intended dependency of user
+                    self.references[(name, None)] = True
+                    top_name = name.rsplit(".", maxsplit=1)[0]
+                    if top_name != name:
+                        top_name = self._absmodule(top_name, level)
+                        self.references[(top_name, None)] = True
+                else:
+                    name = self._absmodule(name, level)
+                    for alias in fromlist:
+                        # fromlist args may be submodules, so we have to add the fromlist args
+                        # to the list of potential references. If import of an arg fails we
+                        # will ignore it, similar to visit_ImportFrom
+                        if alias != "*":
+                            self.references[(name, alias)] = True
+                        else:
+                            self.references[(name, None)] = True
+            except Exception as e:
+                # TODO: add info-warning when PackageExporter's verbose mode is cleaned up
                 return
-
-            name = self._grab_node_str(node.args[0])
-            fromlist = []
-            level = 0
-            if len(node.args) > 3:
-                for v in node.args[3].elts:
-                    fromlist.append(self._grab_node_str(v))
-            elif hasattr(node, "keywords"):
-                for keyword in node.keywords:
-                    if keyword.arg == "fromlist":
-                        for v in keyword.value.elts:
-                            fromlist.append(self._grab_node_str(v))
-            if len(node.args) > 4:
-                level = self._grab_node_int(node.args[4])
-            elif hasattr(node, "keywords"):
-                for keyword in node.keywords:
-                    if keyword.arg == "level":
-                        level = self._grab_node_int(keyword.value)
-            if fromlist == []:
-                # the top-level package (the name up till the first dot) is returned
-                # when the fromlist argument is empty in normal import system,
-                # we need to include top level package to match this behavior and last
-                # level package to capture the intended dependency of user
-                self.references[(name, None)] = True
-                top_name = name.rsplit(".", maxsplit=1)[0]
-                if top_name != name:
-                    top_name = self._absmodule(top_name, level)
-                    self.references[(top_name, None)] = True
-            else:
-                name = self._absmodule(name, level)
-                for alias in fromlist:
-                    # fromlist args may be submodules, so we have to add the fromlist args
-                    # to the list of potential references. If import of an arg fails we
-                    # will ignore it, similar to visit_ImportFrom
-                    if alias != "*":
-                        self.references[(name, alias)] = True
-                    else:
-                        self.references[(name, None)] = True
 
 
 find_files_source_depends_on = _ExtractModuleReferences.run


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59110 [package] silently skip failed `__import__` statements**

When our AST parsing code fails to determine the meaning of an `__import__` statement, skip the statement instead of failing.

Differential Revision: [D28761637](https://our.internmc.facebook.com/intern/diff/D28761637)