### PR TITLE
[iOS GPU] Add debug information to track memory allocation exception

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -115,6 +115,7 @@ void MPSImageWrapper::prepare() {
     _buffer = [[MPSCNNContext sharedInstance].device
         newBufferWithLength:size_bytes
                     options:MTLResourceCPUCacheModeWriteCombined];
+    TORCH_CHECK(_buffer, "Allocate GPU memory failed!");
   }
   copyToMetalBuffer(_commandBuffer, _buffer, _image);
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59113 [iOS GPU] [BE] use channel-last to transform the weights
* **#59112 [iOS GPU] Add debug information to track memory allocation exception**

Differential Revision: [D28730604](https://our.internmc.facebook.com/intern/diff/D28730604/)