### PR TITLE
[ONNX] Handle onnx::Size in ComputeConstant folding

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -6236,6 +6236,21 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(DimModel(), empty_input)
         self.run_test(DimModel(), multi_dim_input)
 
+    @skipIfUnsupportedMinOpsetVersion(11)
+    def test_dim_1(self):
+        class M(torch.jit.ScriptModule):
+            @torch.jit.script_method
+            def forward(self, poses):
+                boxes = torch.zeros([poses.shape[0], 2, 4])
+                batch_boxes = []
+                for kp_boxes in boxes:
+                    kp_boxes = torchvision.ops.clip_boxes_to_image(kp_boxes, (2, 3))
+                    batch_boxes.append(kp_boxes)
+                return batch_boxes
+
+        dummy_inputs = torch.rand(2, 2, 3)
+        self.run_test(M(), (dummy_inputs, ), input_names=['x'], dynamic_axes={"x": [0]})
+
     @skipIfUnsupportedMinOpsetVersion(12)
     def test_outer(self):
         class Outer(torch.nn.Module):

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -13,6 +13,9 @@ const int ONNX_OPSET_12 = 12;
 const int ONNX_OPSET_13 = 13;
 
 namespace onnx_constant_fold {
+
+at::Tensor IntToTensor(int64_t value);
+
 c10::optional<at::Tensor> runTorchBackendForOnnx(
     const Node* node,
     std::vector<at::Tensor>& inputTensorValues,

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -1029,6 +1029,32 @@ void ComputeConstant(Node* n, int opset_version) {
       ProcessTimeSeriesNode(n);
       break;
     }
+    case ::c10::onnx::Size: {
+      if (ConstantValueMap::HasShape(n->input(0)->debugName())) {
+        auto input0_shape_size =
+            ConstantValueMap::GetShape(n->input(0)->debugName())
+                .value()
+                .sizes();
+        if (input0_shape_size.has_value()) {
+          auto input0_shape_value = input0_shape_size.value();
+          int64_t total_size = 1;
+          auto is_full_static = true;
+          for (auto i = 0; i < input0_shape_value.size(); i++) {
+            if (input0_shape_value[i].is_static()) {
+              total_size *= input0_shape_value[i].static_size();
+            } else {
+              is_full_static = false;
+              break;
+            }
+          }
+          if (is_full_static) {
+            auto f_final = onnx_constant_fold::IntToTensor(total_size);
+            ConstantValueMap::SetValue(n->output(0)->debugName(), f_final);
+          }
+        }
+      }
+      break;
+    }
     case ::c10::onnx::Slice: {
       ProcessSliceNode(n, opset_version);
       break;


### PR DESCRIPTION
Support export aten::dim const folding in torchvision.ops.clip_boxes_to_image.
Our traditional const folding cannot handle onnx::Size, because the case here, the input value is unknown. But the new const folding technique can do that, because shape is constant which is enough.
