### PR TITLE
avoid explicitly casting low precision inputs to fp32 in norm

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -2325,7 +2325,11 @@ static Tensor& linalg_vector_norm_impl(const Tensor& self, const Scalar& scalar_
   TORCH_CHECK(!result.defined() || out_dtype == result.scalar_type(),
     "linalg.vector_norm expected out tensor dtype ", out_dtype,
     " but got: ", result.scalar_type());
-  auto iter = make_reduction("vector_norm", result, self_, dim, keepdim, in_dtype, out_dtype);
+  // omit in_dtype in the following call, to avoid make_reduction explicitly casting input to out_dtype
+  auto iter = isComplexType(self.scalar_type()) ?
+      make_reduction("vector_norm", result, self_, dim, keepdim, in_dtype, out_dtype) :
+      make_reduction("vector_norm", result, self_, dim, keepdim, out_dtype);
+
   linalg_vector_norm_stub(iter.device_type(), iter, ord);
   return result;
 }

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1032,7 +1032,7 @@ static Tensor& norm_out(Tensor &result, const Tensor &self, const optional<Scala
 
 // omit in_dtype in the following call, to avoid make_reduction explicitly casting input to out_dtype
   auto iter = isComplexType(self.scalar_type()) ?
-      make_reduction("vector_norm", result, self, dim, keepdim, in_dtype, out_dtype) :
+      make_reduction("norm", result, self, dim, keepdim, in_dtype, out_dtype) :
       make_reduction("norm", result, self, dim, keepdim, out_dtype);
 
   if (iter.numel() == 0) {

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -1030,7 +1030,10 @@ static Tensor& norm_out(Tensor &result, const Tensor &self, const optional<Scala
 
   ScalarType out_dtype = result.defined() ? result.scalar_type() : (opt_dtype.has_value() ? opt_dtype.value() : toValueType(self.scalar_type()));
 
-  auto iter = make_reduction("norm", result, self, dim, keepdim, in_dtype, out_dtype);
+// omit in_dtype in the following call, to avoid make_reduction explicitly casting input to out_dtype
+  auto iter = isComplexType(self.scalar_type()) ?
+      make_reduction("vector_norm", result, self, dim, keepdim, in_dtype, out_dtype) :
+      make_reduction("norm", result, self, dim, keepdim, out_dtype);
 
   if (iter.numel() == 0) {
     result.zero_();

--- a/aten/src/ATen/native/ReduceOpsUtils.h
+++ b/aten/src/ATen/native/ReduceOpsUtils.h
@@ -210,9 +210,9 @@ static TensorIterator make_reduction(
   // efficiency.
   // not generalize this to common mismatched input/output types to avoid cross
   // product of templated kernel launches.
-  const bool gpu_f16_to_f32 = (
-    self.is_cuda() && self.scalar_type() == kHalf && out_dtype == kFloat);
-  auto in_dtype = gpu_f16_to_f32 ? self.scalar_type() : out_dtype;
+  const bool gpu_lowp_to_f32 = (
+    self.is_cuda() && (self.scalar_type() == kHalf || self.scalar_type() == kBFloat16) && out_dtype == kFloat);
+  auto in_dtype = gpu_lowp_to_f32 ? self.scalar_type() : out_dtype;
   return make_reduction(name, result, self, dim, keepdim, in_dtype, out_dtype);
 }
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1562,6 +1562,23 @@ class TestLinalg(TestCase):
                 for ord in ord_settings:
                     run_test_case(input, ord, dim, keepdim)
 
+
+    @onlyCUDA
+    @dtypes(torch.bfloat16, torch.float16)
+    def test_norm_fused_type_promotion(self, device, dtype):
+        x = torch.randn(10, device=device, dtype=dtype)
+        def profile_and_check(fn, x, kwargs, fn_name):
+            with torch.profiler.profile(activities=(torch.profiler.ProfilerActivity.CPU,)) as p:
+                fn(x, **kwargs, dtype=torch.float)
+            # smoke check that profiler returned some events
+            self.assertTrue(fn_name in map(lambda e: e.name, p.events()))
+            # test that there was no explicit copy
+            self.assertFalse("aten::to" in map(lambda e: e.name, p.events()))
+
+        for f, kwargs, fn_name in zip((torch.norm, torch.linalg.vector_norm), ({"p":2}, {}),
+                                       ("aten::norm", "aten::linalg_vector_norm")):
+            profile_and_check(f, x, kwargs, fn_name)
+
     @skipMeta  # https://github.com/pytorch/pytorch/issues/53739
     @skipCPUIfNoLapack
     @skipCUDAIfNoMagma

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -1567,6 +1567,7 @@ class TestLinalg(TestCase):
     @dtypes(torch.bfloat16, torch.float16)
     def test_norm_fused_type_promotion(self, device, dtype):
         x = torch.randn(10, device=device, dtype=dtype)
+
         def profile_and_check(fn, x, kwargs, fn_name):
             with torch.profiler.profile(activities=(torch.profiler.ProfilerActivity.CPU,)) as p:
                 fn(x, **kwargs, dtype=torch.float)
@@ -1575,8 +1576,8 @@ class TestLinalg(TestCase):
             # test that there was no explicit copy
             self.assertFalse("aten::to" in map(lambda e: e.name, p.events()))
 
-        for f, kwargs, fn_name in zip((torch.norm, torch.linalg.vector_norm), ({"p":2}, {}),
-                                       ("aten::norm", "aten::linalg_vector_norm")):
+        for f, kwargs, fn_name in zip((torch.norm, torch.linalg.vector_norm), ({"p" : 2}, {}),
+                                      ("aten::norm", "aten::linalg_vector_norm")):
             profile_and_check(f, x, kwargs, fn_name)
 
     @skipMeta  # https://github.com/pytorch/pytorch/issues/53739


### PR DESCRIPTION
Per title. Now `norm` with fp16/bfloat16 inputs and fp32 outputs on cuda won't do explicit cast
