### PR TITLE
To add Rectified Adam algorithm for multi-tensor optimizers API

### DIFF
--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -132,10 +132,7 @@ Algorithms
     Adamax
     ASGD
     LBFGS
-<<<<<<< HEAD
     NAdam
-=======
->>>>>>> fa9595dbb7 (To add Rectified Adam Algorithm to Optim package)
     RAdam
     RMSprop
     Rprop

--- a/docs/source/optim.rst
+++ b/docs/source/optim.rst
@@ -132,7 +132,10 @@ Algorithms
     Adamax
     ASGD
     LBFGS
+<<<<<<< HEAD
     NAdam
+=======
+>>>>>>> fa9595dbb7 (To add Rectified Adam Algorithm to Optim package)
     RAdam
     RMSprop
     Rprop

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -320,6 +320,8 @@ class TestOptim(TestCase):
             ((optim.AdamW, optim._multi_tensor.AdamW), dict(weight_decay=0., amsgrad=False)),
             ((optim.SGD, optim._multi_tensor.SGD), dict(lr=0.2, momentum=1, dampening=0, weight_decay=1, nesterov=True)),
             ((optim.SGD, optim._multi_tensor.SGD), dict(lr=0.2, momentum=1, dampening=0.5, weight_decay=1, nesterov=False)),
+            ((optim.RAdam, optim._multi_tensor.RAdam), dict(weight_decay=0)),
+            ((optim.RAdam, optim._multi_tensor.RAdam), dict(weight_decay=1)),
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=True)),
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=0, centered=True)),
             ((optim.RMSprop, optim._multi_tensor.RMSprop), dict(weight_decay=1, momentum=1, centered=False)),
@@ -555,27 +557,28 @@ class TestOptim(TestCase):
                 optimizer(None, lr=1e-2, betas=(0.0, 1.0))
 
     def test_radam(self):
-        self._test_basic_cases(
-            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3)
-        )
-        self._test_basic_cases(
-            lambda weight, bias: optim.RAdam(
-                self._build_params_dict(weight, bias, lr=1e-2),
-                lr=1e-3)
-        )
-        self._test_basic_cases(
-            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3, weight_decay=0.1)
-        )
-        self._test_basic_cases(
-            lambda weight, bias: optim.RAdam([weight, bias], lr=1e-3),
-            [lambda opt: ExponentialLR(opt, gamma=0.9),
-                lambda opt: ReduceLROnPlateau(opt)]
-        )
-        with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
-            optim.RAdam(None, lr=1e-2, betas=(1.0, 0.0))
+        for optimizer in [optim.RAdam, optim_mt.RAdam]:
+            self._test_basic_cases(
+                lambda weight, bias: optimizer([weight, bias], lr=1e-3)
+            )
+            self._test_basic_cases(
+                lambda weight, bias: optimizer(
+                    self._build_params_dict(weight, bias, lr=1e-2),
+                    lr=1e-3)
+            )
+            self._test_basic_cases(
+                lambda weight, bias: optimizer([weight, bias], lr=1e-3, weight_decay=0.1)
+            )
+            self._test_basic_cases(
+                lambda weight, bias: optimizer([weight, bias], lr=1e-3),
+                [lambda opt: ExponentialLR(opt, gamma=0.9),
+                    lambda opt: ReduceLROnPlateau(opt)]
+            )
+            with self.assertRaisesRegex(ValueError, "Invalid beta parameter at index 0: 1.0"):
+                optimizer(None, lr=1e-2, betas=(1.0, 0.0))
 
-        with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
-            optim.RAdam(None, lr=1e-2, weight_decay=-1)
+            with self.assertRaisesRegex(ValueError, "Invalid weight_decay value: -1"):
+                optimizer(None, lr=1e-2, weight_decay=-1)
 
     def test_rmsprop(self):
         for optimizer in [optim.RMSprop, optim_mt.RMSprop]:

--- a/torch/optim/_multi_tensor/__init__.py
+++ b/torch/optim/_multi_tensor/__init__.py
@@ -8,6 +8,7 @@ future.
 from .adam import Adam
 from .adamw import AdamW
 from .sgd import SGD
+from .radam import RAdam as RAdam
 from .rmsprop import RMSprop
 from .rprop import Rprop
 from .asgd import ASGD
@@ -17,6 +18,7 @@ from .adadelta import Adadelta
 del adam
 del adamw
 del sgd
+del radam
 del rmsprop
 del rprop
 del asgd

--- a/torch/optim/_multi_tensor/__init__.pyi
+++ b/torch/optim/_multi_tensor/__init__.pyi
@@ -1,6 +1,7 @@
 from .adam import Adam as Adam
 from .adamw import AdamW as AdamW
 from .sgd import SGD as SGD
+from .radam import RAdam as RAdam
 from .rmsprop import RMSprop as RMSprop
 from .rprop import Rprop as Rprop
 from .asgd import ASGD as ASGD

--- a/torch/optim/_multi_tensor/_functional.py
+++ b/torch/optim/_multi_tensor/_functional.py
@@ -110,3 +110,51 @@ def asgd(params: List[Tensor],
         state['eta'] = (lr /
                         math.pow((1 + lambd * lr * state['step']), alpha))
         state['mu'] = 1 / max(1, state['step'] - t0)
+
+
+def radam(params: List[Tensor],
+          grads: List[Tensor],
+          exp_avg: List[Tensor],
+          exp_avg_sq: List[Tensor],
+          states: List[Dict],
+          *,
+          beta1: float,
+          beta2: float,
+          lr: float,
+          weight_decay: float,
+          eps: float):
+    r"""Functional API that performs Adam algorithm computation.
+
+    See :class:`~torch.optim.Adam` for details.
+    """
+
+    # maximum length of the approximated SMA
+    rho_inf = 2 / (1 - beta2) - 1
+    # compute the length of the approximated SMA
+    rho_t_list = [rho_inf - 2 * state['step'] * (beta2 ** state['step']) / (1 - beta2 ** state['step']) for state in states]
+
+    bias_correction1 = [1 - beta1 ** state['step'] for state in states]
+    bias_correction2 = [1 - beta2 ** state['step'] for state in states]
+    if weight_decay != 0:
+        torch._foreach_add_(grads, params, alpha=weight_decay)
+
+    # Decay the first and second moment running average coefficient
+    torch._foreach_mul_(exp_avg, beta1)
+    torch._foreach_add_(exp_avg, grads, alpha=1 - beta1)
+
+    torch._foreach_mul_(exp_avg_sq, beta2)
+    torch._foreach_addcmul_(exp_avg_sq, grads, grads, 1 - beta2)
+
+    rect = [math.sqrt((rho_t - 4) * (rho_t - 2) * rho_inf / ((rho_inf - 4) * (rho_inf - 2) * rho_t))
+            if rho_t > 5 else 0 for rho_t in rho_t_list]
+    unrectified = [0 if rect > 0 else 1. for rect in rect]
+
+    exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sq)
+    bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
+    denom = torch._foreach_div(exp_avg_sq_sqrt, bias_correction_sqrt)
+    step_size = [(lr * rect / bc) * -1 for rect, bc in zip(rect, bias_correction1)]
+    torch._foreach_addcdiv_(params, exp_avg, denom, step_size)
+
+    denom = [torch.ones_like(exp_av, memory_format=torch.preserve_format) for exp_av in exp_avg]
+    step_size = [(lr * rect / bc) * -1 for rect, bc in zip(unrectified, bias_correction1)]
+    torch._foreach_addcdiv_(params, exp_avg, denom, step_size)

--- a/torch/optim/_multi_tensor/radam.py
+++ b/torch/optim/_multi_tensor/radam.py
@@ -1,0 +1,140 @@
+import math
+import torch
+from ..optimizer import Optimizer
+from collections import defaultdict
+
+class RAdam(Optimizer):
+    r"""Implements RAdam algorithm with multi tensor APIs.
+
+    It has been proposed in `On the variance of the adaptive learning rate and beyond`_.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        lr (float, optional): learning rate (default: 2e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+
+    .. _On the variance of the adaptive learning rate and beyond:
+        https://arxiv.org/pdf/1908.03265.pdf
+    """
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+                 weight_decay=0):
+        if not 0.0 <= lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 <= eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError("Invalid beta parameter at index 1: {}".format(betas[1]))
+        if not 0.0 <= weight_decay:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        super(RAdam, self).__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Args:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params_with_grad = []
+            grads = []
+            exp_avg = []
+            exp_avg_sq = []
+            states = []
+
+            for p in group['params']:
+                if p.grad is not None:
+                    if p.grad.is_sparse:
+                        raise RuntimeError('RAdam does not support sparse gradients')
+                    params_with_grad.append(p)
+                    grads.append(p.grad)
+
+            for p in params_with_grad:
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p, memory_format=torch.preserve_format)
+
+                exp_avg.append(state['exp_avg'])
+                exp_avg_sq.append(state['exp_avg_sq'])
+
+                state['step'] += 1
+                states.append(state)
+
+            beta1, beta2 = group['betas']
+
+            # maximum length of the approximated SMA
+            rho_inf = 2 / (1 - beta2) - 1
+            # compute the length of the approximated SMA
+            rho_t_list = [rho_inf - 2 * state['step'] * (beta2 ** state['step']) / (1 - beta2 ** state['step']) for state in states]
+
+            bias_correction1 = [1 - beta1 ** state['step'] for state in states]
+            bias_correction2 = [1 - beta2 ** state['step'] for state in states]
+            if group['weight_decay'] != 0:
+                grads = torch._foreach_add(grads, params_with_grad, alpha=group['weight_decay'])
+
+            # Decay the first and second moment running average coefficient
+            torch._foreach_mul_(exp_avg, beta1)
+            torch._foreach_add_(exp_avg, grads, alpha=1 - beta1)
+
+            torch._foreach_mul_(exp_avg_sq, beta2)
+            torch._foreach_addcmul_(exp_avg_sq, grads, grads, 1 - beta2)
+
+            rect = [math.sqrt((rho_t - 4) * (rho_t - 2) * rho_inf / ((rho_inf - 4) * (rho_inf - 2) * rho_t))
+                    if rho_t > 5 else 0 for rho_t in rho_t_list]
+            unrectified = [0 if rect > 0 else 1. for rect in rect]
+
+            exp_avg_sq_sqrt = torch._foreach_sqrt(exp_avg_sq)
+            bias_correction_sqrt = [math.sqrt(bc) for bc in bias_correction2]
+            denom = torch._foreach_div(exp_avg_sq_sqrt, bias_correction_sqrt)
+            step_size = [(group['lr'] * rect / bc) * -1 for rect, bc in zip(rect, bias_correction1)]
+            torch._foreach_addcdiv_(params_with_grad, exp_avg, denom, step_size)
+
+            denom = [torch.ones_like(exp_av, memory_format=torch.preserve_format) for exp_av in exp_avg]
+            step_size = [(group['lr'] * rect / bc) * -1 for rect, bc in zip(unrectified, bias_correction1)]
+            torch._foreach_addcdiv_(params_with_grad, exp_avg, denom, step_size)
+
+        return loss
+
+    # TODO: refactor to a base class once foreach ops are in a good shape.
+    def zero_grad(self, set_to_none: bool = False):
+        per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is not None:
+                    if set_to_none:
+                        p.grad = None
+                    else:
+                        if p.grad.grad_fn is not None:
+                            p.grad.detach_()
+                        else:
+                            p.grad.requires_grad_(False)
+
+                        if p.grad.is_sparse:
+                            p.grad.zero_()
+                        else:
+                            per_device_and_dtype_grads[p.grad.device][p.grad.dtype].append(p.grad)
+
+            for _, per_dtype_grads in per_device_and_dtype_grads.items():
+                for grads in per_dtype_grads.values():
+                    torch._foreach_zero_(grads)

--- a/torch/optim/_multi_tensor/radam.pyi
+++ b/torch/optim/_multi_tensor/radam.pyi
@@ -1,0 +1,5 @@
+from typing import Tuple
+from ..optimizer import _params_t, Optimizer
+
+class RAdam(Optimizer):
+    def __init__(self, params: _params_t, lr: float=..., betas: Tuple[float, float]=..., eps: float=..., weight_decay: float=...) -> None: ...


### PR DESCRIPTION
Previously in the PR: #58968 we added RAdam to Optimizers. Here in this PR we are proposing multi-tensor version of RAdam for PyTorch.

Radam has been proposed in the paper https://arxiv.org/pdf/1908.03265.pdf Liyuan Liu et al. 

It has been one of the most used algorithm in Deep Learning community.

Differing from the paper, we selected variance tractability cut-off as 5 instead of 4 as it is the common practice.