### PR TITLE
Vectorize the softmax calculation when not along the last dim

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -703,16 +703,6 @@ Vectorized<BFloat16> inline fmadd(const Vectorized<BFloat16>& a,
   return cvtfp32_bf16(o1, o2);
 }
 
-inline std::tuple<Vectorized<float>, Vectorized<float>> convert_bfloat16_float(const Vectorized<BFloat16>& a) {
-  __m256 o1, o2;
-  cvtbf16_fp32(__m256i(a), o1, o2);
-  return std::make_tuple(o1, o2);
-}
-
-inline Vectorized<BFloat16> convert_float_bfloat16(const Vectorized<float>& a, const Vectorized<float>& b) {
- return cvtfp32_bf16(__m256(a), __m256(b));
-}
-
 #endif
 
 }}}

--- a/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_bfloat16.h
@@ -703,6 +703,16 @@ Vectorized<BFloat16> inline fmadd(const Vectorized<BFloat16>& a,
   return cvtfp32_bf16(o1, o2);
 }
 
+inline std::tuple<Vectorized<float>, Vectorized<float>> convert_bfloat16_float(const Vectorized<BFloat16>& a) {
+  __m256 o1, o2;
+  cvtbf16_fp32(__m256i(a), o1, o2);
+  return std::make_tuple(o1, o2);
+}
+
+inline Vectorized<BFloat16> convert_float_bfloat16(const Vectorized<float>& a, const Vectorized<float>& b) {
+ return cvtfp32_bf16(__m256(a), __m256(b));
+}
+
 #endif
 
 }}}

--- a/aten/src/ATen/native/SoftMax.cpp
+++ b/aten/src/ATen/native/SoftMax.cpp
@@ -132,7 +132,7 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_
   if (input.numel() == 0) {
     return output;
   }
- if (input.dim() == 0)
+  if (input.dim() == 0)
     input = input.view(1);
   TORCH_CHECK(
       dim >= 0 && dim < input.dim(),
@@ -140,9 +140,7 @@ Tensor softmax_cpu(const Tensor& input_, const int64_t dim_, const bool half_to_
   if (input.ndimension() > 0 && dim == input.ndimension() - 1) {
     softmax_lastdim_kernel(kCPU, output, input);
   } else {
-    AT_DISPATCH_FLOATING_TYPES(input.scalar_type(), "softmax", [&] {
-      host_softmax<scalar_t, false>(output, input, dim);
-    });
+    softmax_kernel(kCPU, output, input, dim);
   }
   return output;
 }
@@ -309,6 +307,8 @@ DEFINE_DISPATCH(log_softmax_lastdim_kernel);
 DEFINE_DISPATCH(softmax_backward_lastdim_kernel);
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 DEFINE_DISPATCH(log_softmax_backward_lastdim_kernel);
+
+DEFINE_DISPATCH(softmax_kernel);
 
 Tensor softmax(const Tensor& self, Dimname dim, optional<ScalarType> dtype) {
   return at::softmax(self, dimname_to_position(self, dim), dtype);

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -257,7 +257,7 @@ inline void _vec_softmax(
             // cases which will fall through this part:
             // Case 1: For the idx at the end of total chunk for each thread, there are not enough numbers for parallization.
             // Case 2: For the idx at the end of each inner_size inside thread, there are not enough numbers for parallization.
-            int64_t tail_number = ((idx+8) > end) ? (end - idx) : (inner_size - inner_idx);
+            int64_t tail_number = ((idx+8) > end) ? /*Case1*/ (end - idx) : /*Case2*/ (inner_size - inner_idx);
             for (int64_t i=0; i < tail_number; i++) {
               outer_idx = (idx + i) / inner_size;
               inner_idx = (idx + i) % inner_size;

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -223,13 +223,13 @@ inline void _vec_softmax(
       [&](int64_t begin, int64_t end) {
         int64_t idx = begin;
         while (idx < end) {
-
           int64_t outer_idx = idx / inner_size;
           int64_t inner_idx = idx % inner_size;
-
           if (((inner_idx+8) <= inner_size) && ((idx+8) <= end)) {
-            scalar_t* input_data = input_data_base + outer_idx * outer_stride + inner_idx;
-            scalar_t* output_data = output_data_base + outer_idx * outer_stride + inner_idx;
+            scalar_t* input_data =
+                input_data_base + outer_idx * outer_stride + inner_idx;
+            scalar_t* output_data =
+                output_data_base + outer_idx * outer_stride + inner_idx;
             // Step 1: Get max Score
             Vec max_m256 =  Vec::loadu(input_data);
             for (int64_t d = 1; d < dim_size; d += 1) {
@@ -250,7 +250,8 @@ inline void _vec_softmax(
             }
             idx += 8;
           } else {
-            // There are 2 kind of tail cases:
+            // Tail case is exactly same logic as host_softmax inside aten/src/ATen/native/SoftMax.cpp.
+            // There are 2 kind of cases which will fall through this tail case:
             // Case 1. For the idx at the end of each thread, there are not enough numbers for parallization
             // Case 2. For the idx at the end of the inner_size dim inside thread, there are not enough numbers for parallization
             int64_t tail_number = ((idx+8) > end) ? (end - idx) : (inner_size - inner_idx);

--- a/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
+++ b/aten/src/ATen/native/cpu/SoftMaxKernel.cpp
@@ -337,10 +337,9 @@ static void softmax_lastdim_kernel_impl(Tensor& result, const Tensor& self) {
 }
 
 static void softmax_kernel_impl(Tensor& result, const Tensor& self, int64_t dim) {
-  AT_DISPATCH_FLOATING_TYPES_AND(
-    at::ScalarType::BFloat16, self.scalar_type(),
-    "softmax_kernel_impl",
-    [&] { vec_softmax<scalar_t, false>::apply(result, self, dim); });
+  AT_DISPATCH_FLOATING_TYPES(self.scalar_type(), "softmax_kernel_impl", [&] {
+    vec_softmax<scalar_t, false>::apply(result, self, dim);
+  });
 }
 
 static void log_softmax_lastdim_kernel_impl(

--- a/aten/src/ATen/native/cpu/SoftmaxKernel.h
+++ b/aten/src/ATen/native/cpu/SoftmaxKernel.h
@@ -14,5 +14,8 @@ DECLARE_DISPATCH(forward_fn, log_softmax_lastdim_kernel);
 DECLARE_DISPATCH(backward_fn, softmax_backward_lastdim_kernel);
 DECLARE_DISPATCH(backward_fn, log_softmax_backward_lastdim_kernel);
 
+using forward_fn_with_dim = void(*)(Tensor &, const Tensor &, const int64_t);
+DECLARE_DISPATCH(forward_fn_with_dim, softmax_kernel);
+
 }
 }


### PR DESCRIPTION
Currently, if we do softmax which are not along the last dim, the calculation will fall to a [scalar version](https://github.com/pytorch/pytorch/blob/d417a094f398f1c4efd7f818b14b8471a597fbcc/aten/src/ATen/native/SoftMax.cpp#L14-L64).  And we find actually we have the chance to vectorize the calculation along the inner_size dim.

Changes we made:

- Use vectorized softmax_kernel instead of host_softmax when not along the last dim.

Performance data on 28 cores' Intel 8280 CPU when the Input size is [32, 81, 15130] and do softmax along the second dim(81).

- FP32 Baseline: 24.67 ms
- FP32 optimized: 9.2 ms