### PR TITLE
Fix mismatch in README.md Docker Image section

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ should increase shared memory size either with `--ipc=host` or `--shm-size` comm
 
 **NOTE:** Must be built with a docker version > 18.06
 
-The `Dockerfile` is supplied to build images with Cuda support and cuDNN v7.
+The `Dockerfile` is supplied to build images with CUDA 11.1 support and cuDNN v8.
 You can pass `PYTHON_VERSION=x.y` make variable to specify which Python version is to be used by Miniconda, or leave it
 unset to use the default.
 ```bash


### PR DESCRIPTION
docker.Makefile has CUDNN_VERSION=8 as the defaults, but README.md states cuDNN v7