### PR TITLE
[reland] Always use intrusive_ptr for Message (1 out of 2)

### DIFF
--- a/test/cpp/rpc/test_tensorpipe_serialization.cpp
+++ b/test/cpp/rpc/test_tensorpipe_serialization.cpp
@@ -21,9 +21,9 @@ TEST(TensorpipeSerialize, Base) {
   torch::distributed::rpc::MessageType mtype =
       torch::distributed::rpc::MessageType::UNKNOWN;
   int64_t mId = 100;
-  torch::distributed::rpc::Message sendingRpcMessage(
+  auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
-  sendingRpcMessage.setId(mId);
+  sendingRpcMessage->setId(mId);
   tensorpipe::Message sendingTpMessage;
   torch::distributed::rpc::TensorpipeWriteBuffers sendingTpBuffers;
   std::tie(sendingTpMessage, sendingTpBuffers) =
@@ -90,17 +90,17 @@ TEST(TensorpipeSerialize, Base) {
 
   // Mimic read() callback:
   // - Unpickle
-  torch::distributed::rpc::Message recvingRpcMessage =
+  c10::intrusive_ptr<torch::distributed::rpc::Message> recvingRpcMessage =
       torch::distributed::rpc::tensorpipeDeserialize(
           std::move(recvingTpDescriptor),
           std::move(recvingTpBuffers));
 
   // Data is ready
-  EXPECT_EQ(mtype, recvingRpcMessage.type());
-  EXPECT_EQ(payloadCopy, recvingRpcMessage.payload());
-  EXPECT_EQ(mId, recvingRpcMessage.id());
-  EXPECT_TRUE(torch::equal(t1, recvingRpcMessage.tensors()[0]));
-  EXPECT_TRUE(torch::equal(t2, recvingRpcMessage.tensors()[1]));
+  EXPECT_EQ(mtype, recvingRpcMessage->type());
+  EXPECT_EQ(payloadCopy, recvingRpcMessage->payload());
+  EXPECT_EQ(mId, recvingRpcMessage->id());
+  EXPECT_TRUE(torch::equal(t1, recvingRpcMessage->tensors()[0]));
+  EXPECT_TRUE(torch::equal(t2, recvingRpcMessage->tensors()[1]));
 }
 
 TEST(TensorpipeSerialize, RecopySparseTensors) {
@@ -117,7 +117,7 @@ TEST(TensorpipeSerialize, RecopySparseTensors) {
   std::vector<char> payload = {'1', '2', '3'};
   torch::distributed::rpc::MessageType mtype =
       torch::distributed::rpc::MessageType::UNKNOWN;
-  torch::distributed::rpc::Message sendingRpcMessage(
+  auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
 
   tensorpipe::Message sendingTpMessage;
@@ -151,7 +151,7 @@ TEST(TensorpipeSerialize, NoDeleterTensors) {
   std::vector<char> payload = {'1', '2', '3'};
   torch::distributed::rpc::MessageType mtype =
       torch::distributed::rpc::MessageType::UNKNOWN;
-  torch::distributed::rpc::Message sendingRpcMessage(
+  auto sendingRpcMessage = c10::make_intrusive<torch::distributed::rpc::Message>(
       std::move(payload), std::move(tensors), mtype);
 
   tensorpipe::Message sendingTpMessage;

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
@@ -18,7 +18,7 @@ class TORCH_API RpcWithAutograd final : public rpc::RpcCommandBase {
       rpc::worker_id_t fromWorkerId,
       rpc::MessageType messageType,
       const AutogradMetadata& autogradMetadata,
-      rpc::Message&& wrappedMessage,
+      c10::intrusive_ptr<rpc::Message> wrappedMessage,
       std::unordered_map<c10::Device, c10::Device> deviceMap = {});
 
   // Used when receiving an RPC over the wire.
@@ -80,7 +80,7 @@ class TORCH_API RpcWithAutograd final : public rpc::RpcCommandBase {
   // avoid serializing the request twice.
   // When receive rpcWithAutograd is constructed fromMessage, it is nullptr;
   // When send rpcWithAutograd is constructed before toMessage, it is valid;
-  rpc::Message wrappedMessage_;
+  c10::intrusive_ptr<rpc::Message> wrappedMessage_;
 
   // message type of the wrappedMessage, this is stored separately since
   // wrappedMessage_ is not always guaranteed to be populated.

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
@@ -15,7 +15,7 @@ class TORCH_API RpcWithProfilingReq : public rpc::RpcCommandBase {
   // For sending RPCs, invoked when client is creating this RPC command.
   RpcWithProfilingReq(
       rpc::MessageType messageType,
-      rpc::Message&& wrappedMessage,
+      c10::intrusive_ptr<rpc::Message> wrappedMessage,
       torch::autograd::profiler::ProfilerConfig&& profilerConfig,
       rpc::ProfilingId profilingKeyId);
 
@@ -50,7 +50,7 @@ class TORCH_API RpcWithProfilingReq : public rpc::RpcCommandBase {
   // message type
   const rpc::MessageType messageType_;
   // wrapped message
-  rpc::Message wrappedMessage_;
+  c10::intrusive_ptr<rpc::Message> wrappedMessage_;
   std::unique_ptr<RpcCommandBase> wrappedRpc_;
   rpc::MessageType wrappedMessageType_;
   std::vector<torch::Tensor> tensors_;

--- a/torch/csrc/distributed/autograd/utils.cpp
+++ b/torch/csrc/distributed/autograd/utils.cpp
@@ -77,8 +77,8 @@ ContextPtr addRecvRpcBackward(
   return autogradContext;
 }
 
-Message getMessageWithProfiling(
-    torch::distributed::rpc::Message&& wrappedRpcMessage,
+c10::intrusive_ptr<Message> getMessageWithProfiling(
+    c10::intrusive_ptr<torch::distributed::rpc::Message> wrappedRpcMessage,
     MessageType msgType,
     torch::autograd::profiler::ProfilerConfig&& profilerConfig) {
   auto& remoteProfilerManager =
@@ -100,9 +100,9 @@ Message getMessageWithProfiling(
   return std::move(wrappedProfilingMsg).toMessage();
 }
 
-Message getMessageWithAutograd(
+c10::intrusive_ptr<Message> getMessageWithAutograd(
     const rpc::worker_id_t dstId,
-    torch::distributed::rpc::Message&& wrappedRpcMsg,
+    c10::intrusive_ptr<torch::distributed::rpc::Message> wrappedRpcMsg,
     MessageType msgType,
     bool forceGradRecording,
     const std::unordered_map<c10::Device, c10::Device>& deviceMap) {
@@ -112,10 +112,10 @@ Message getMessageWithAutograd(
   // rpc message. otherwise, attach grad info and grad functions and send
   // rpcWithAutograd message.
   auto tensorsRequireGrad =
-      torch::autograd::compute_requires_grad(wrappedRpcMsg.tensors());
+      torch::autograd::compute_requires_grad(wrappedRpcMsg->tensors());
   if (!autogradContainer.hasValidContext() ||
       (!forceGradRecording && !tensorsRequireGrad)) {
-    return std::move(wrappedRpcMsg);
+    return wrappedRpcMsg;
   }
 
   // Retrieve the appropriate context to modify.
@@ -145,7 +145,7 @@ Message getMessageWithAutograd(
 c10::intrusive_ptr<JitFuture> sendMessageWithAutograd(
     RpcAgent& agent,
     const WorkerInfo& dst,
-    torch::distributed::rpc::Message&& wrappedRpcMsg,
+    c10::intrusive_ptr<torch::distributed::rpc::Message> wrappedRpcMsg,
     bool forceGradRecording,
     const float rpcTimeoutSeconds,
     bool forceDisableProfiling) {

--- a/torch/csrc/distributed/autograd/utils.h
+++ b/torch/csrc/distributed/autograd/utils.h
@@ -39,9 +39,9 @@ TORCH_API ContextPtr addRecvRpcBackward(
 // case, return RpcWithAutograd message; otherwise return original rpc message.
 // NB: forceGradRecording is useful when the request does not contain any tensor
 // but the corresponding response does.
-TORCH_API rpc::Message getMessageWithAutograd(
+TORCH_API c10::intrusive_ptr<rpc::Message> getMessageWithAutograd(
     const rpc::worker_id_t dstId,
-    rpc::Message&& wrappedRpcMsg,
+    c10::intrusive_ptr<rpc::Message> wrappedRpcMsg,
     rpc::MessageType msgType,
     bool forceGradRecording = false,
     const std::unordered_map<c10::Device, c10::Device>& deviceMap =
@@ -52,7 +52,7 @@ TORCH_API c10::intrusive_ptr<c10::ivalue::Future>
 sendMessageWithAutograd(
     rpc::RpcAgent& agent,
     const rpc::WorkerInfo& dst,
-    rpc::Message&& wrappedRpcMsg,
+    c10::intrusive_ptr<rpc::Message> wrappedRpcMsg,
     bool forceGradRecording = false,
     const float rpcTimeoutSeconds = torch::distributed::rpc::kUnsetRpcTimeout,
     bool forceDisableProfiling = false);

--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -91,13 +91,17 @@ void Message::setId(int64_t id) {
   id_ = id;
 }
 
-Message createExceptionResponse(const std::exception& e, int64_t id) {
+c10::intrusive_ptr<Message> createExceptionResponse(
+    const std::exception& e,
+    int64_t id) {
   return createExceptionResponse(e.what(), id);
 }
 
-Message createExceptionResponse(const std::string& exceptionStr, int64_t id) {
+c10::intrusive_ptr<Message> createExceptionResponse(
+    const std::string& exceptionStr,
+    int64_t id) {
   std::vector<char> payload(exceptionStr.begin(), exceptionStr.end());
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::vector<torch::Tensor>(),
       MessageType::EXCEPTION,

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -160,14 +160,17 @@ class TORCH_API Message final : public torch::CustomClassHolder {
 // The exception string representation will be used as the message's payload.
 // A message ID corresponding to the request that resulted in this response can
 // be provided for matching requests/responses.
-TORCH_API Message createExceptionResponse(const std::exception& e, int64_t id);
+TORCH_API c10::intrusive_ptr<Message> createExceptionResponse(
+    const std::exception& e,
+    int64_t id);
 
 // Create a response Message of type Exception.
 // The passed in string representation will be used as the message's payload.
 // A message ID corresponding to the request that resulted in this response can
 // be provided for matching requests/responses.
-TORCH_API Message
-createExceptionResponse(const std::string& exceptionStr, int64_t id);
+TORCH_API c10::intrusive_ptr<Message> createExceptionResponse(
+    const std::string& exceptionStr,
+    int64_t id);
 
 using JitFuture = c10::ivalue::Future;
 

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -268,7 +268,7 @@ void ProcessGroupAgent::shutdownImpl() {
 
 c10::intrusive_ptr<JitFuture> ProcessGroupAgent::send(
     const WorkerInfo& to,
-    Message&& message,
+    c10::intrusive_ptr<Message> message,
     const float rpcTimeoutSeconds,
     const std::unordered_map<c10::Device, c10::Device>& /* unused */) {
   // Throw if we previously encountered an exception in ::listenLoop.
@@ -287,7 +287,7 @@ c10::intrusive_ptr<JitFuture> ProcessGroupAgent::send(
         "Node ",
         RpcAgent::getWorkerInfo().id_,
         "tried to send() a message of type ",
-        message.type(),
+        message->type(),
         " but RPC is no longer running on this node.");
     throw std::runtime_error(err);
   }
@@ -300,7 +300,7 @@ c10::intrusive_ptr<JitFuture> ProcessGroupAgent::send(
 
   auto requestId = nextId();
   auto future = c10::make_intrusive<JitFuture>(at::AnyClassType::get());
-  if (message.isRequest()) {
+  if (message->isRequest()) {
     // millisecond level precision of when request started.
     auto futureStartTime = std::chrono::steady_clock::now();
     // if passed in timeout is unset, then use the currently set default timeout
@@ -339,7 +339,7 @@ c10::intrusive_ptr<JitFuture> ProcessGroupAgent::send(
       // so watchdog can acquire lock on waking up.
       futureTimeoutCV_.notify_one();
     }
-    message.setId(requestId);
+    message->setId(requestId);
     ++clientActiveCalls_;
   } else {
     future->markCompleted(IValue());
@@ -369,13 +369,13 @@ c10::intrusive_ptr<JitFuture> ProcessGroupAgent::send(
 void ProcessGroupAgent::handleSend(const SendWork& work) {
   // NOLINTNEXTLINE(clang-diagnostic-pessimizing-move)
   auto serializedPayload = std::make_unique<std::string>(std::move(
-      wireSerialize(work.message_.payload(), work.message_.tensors())));
+      wireSerialize(work.message_->payload(), work.message_->tensors())));
 
   std::vector<torch::Tensor> preamble = {torch::tensor(
       {(int64_t)pg_->getRank(),
        (int64_t)serializedPayload->length(),
-       (int64_t)work.message_.type(),
-       (int64_t)work.message_.id()},
+       (int64_t)work.message_->type(),
+       (int64_t)work.message_->id()},
       {torch::kInt64})};
 
   // ProcessGroup is not thread-safe when sending with the same tag,
@@ -429,22 +429,22 @@ void ProcessGroupAgent::handleSend(const SendWork& work) {
   }
 }
 
-void ProcessGroupAgent::sendToSelf(Message&& message) {
+void ProcessGroupAgent::sendToSelf(c10::intrusive_ptr<Message> message) {
   // NOLINTNEXTLINE(modernize-avoid-bind)
   threadPool_.run(std::bind(
-      [this](const Message& message) {
+      [this](c10::intrusive_ptr<Message> message) {
         // Unlike the other cases, need to add a tensor deleter, since the
         // data outlives the scope of this function. It's shared_ptr<> due
         // to c++11 lambda capture limitations with unique_ptr<>.
         std::unique_ptr<std::string> payload;
         try {
           payload = std::make_unique<std::string>(
-              wireSerialize(message.payload(), message.tensors()));
+              wireSerialize(message->payload(), message->tensors()));
           // only increment sendCounts when the message is indeed added into
           // local recv.
           sendCounts_.increment(pg_->getRank());
         } catch (std::exception& e) {
-          markFutureWithError(message.id(), e.what());
+          markFutureWithError(message->id(), e.what());
           return;
         }
         const char* data = payload->data();
@@ -452,8 +452,8 @@ void ProcessGroupAgent::sendToSelf(Message&& message) {
         std::string* delete_when_done = payload.release();
         enqueueRecv(RecvWork(
             getWorkerInfo(pg_->getRank()),
-            message.type(),
-            message.id(),
+            message->type(),
+            message->id(),
             torch::from_blob(
                 (void*)data,
                 len,
@@ -477,11 +477,11 @@ void ProcessGroupAgent::enqueueSend(SendWork work) {
               " on node: ",
               RpcAgent::getWorkerInfo().id_);
           auto exceptionMsg =
-              rpc::createExceptionResponse(errorStr, work.message_.id());
-          if (work.message_.isRequest()) {
+              rpc::createExceptionResponse(errorStr, work.message_->id());
+          if (work.message_->isRequest()) {
             // Mark the future with corresponding to this request with an error.
-            markFutureWithError(exceptionMsg);
-          } else if (work.message_.isResponse()) {
+            markFutureWithError(*exceptionMsg);
+          } else if (work.message_->isResponse()) {
             // Try sending the error along.
             handleSend(SendWork(work.to_, std::move(exceptionMsg)));
           }
@@ -493,13 +493,13 @@ void ProcessGroupAgent::enqueueSend(SendWork work) {
 bool ProcessGroupAgent::handleRecv(RecvWork& work) {
   torch::Tensor& payload = work.payload_;
   auto data = wireDeserialize(payload.storage().data(), payload.numel());
-  Message message(
+  auto message = c10::make_intrusive<Message>(
       std::move(data.first), std::move(data.second), work.type_, work.id_);
-  if (message.isRequest()) {
+  if (message->isRequest()) {
     ++serverActiveCalls_;
     c10::intrusive_ptr<JitFuture> futureResponse;
     try {
-      futureResponse = cb_->operator()(message, {});
+      futureResponse = cb_->operator()(*message, {});
     } catch (const std::exception& e) {
       futureResponse = c10::make_intrusive<JitFuture>(at::AnyClassType::get());
       futureResponse->setError(std::current_exception());
@@ -507,14 +507,12 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
     if (futureResponse->completed()) {
       --serverActiveCalls_;
       if (!futureResponse->hasError()) {
-        send(
-            work.from_,
-            std::move(*futureResponse->value().toCustomClass<Message>()));
+        send(work.from_, futureResponse->value().toCustomClass<Message>());
       } else {
         send(
             work.from_,
             createExceptionResponse(
-                futureResponse->tryRetrieveErrorMessage(), message.id()));
+                futureResponse->tryRetrieveErrorMessage(), message->id()));
       }
     } else {
       ++serverActiveAsyncCalls_;
@@ -529,7 +527,7 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
             if (!futureResponse.hasError()) {
               send(
                   getWorkerInfo(fromId),
-                  std::move(*futureResponse.value().toCustomClass<Message>()));
+                  futureResponse.value().toCustomClass<Message>());
             } else {
               send(
                   getWorkerInfo(fromId),
@@ -538,8 +536,8 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
             }
           });
     }
-  } else if (message.isResponse()) {
-    auto id = message.id();
+  } else if (message->isResponse()) {
+    auto id = message->id();
     c10::intrusive_ptr<JitFuture> jitFuture;
     {
       std::lock_guard<std::mutex> lock{futureMutex_};
@@ -570,16 +568,15 @@ bool ProcessGroupAgent::handleRecv(RecvWork& work) {
     }
     futureCV_.notify_all();
     --clientActiveCalls_;
-    if (message.type() == MessageType::EXCEPTION) {
+    if (message->type() == MessageType::EXCEPTION) {
       jitFuture->setError(std::make_exception_ptr(std::runtime_error(
-          std::string(message.payload().begin(), message.payload().end()))));
+          std::string(message->payload().begin(), message->payload().end()))));
     } else {
-      jitFuture->markCompleted(
-          IValue(c10::make_intrusive<Message>(std::move(message))));
+      jitFuture->markCompleted(std::move(message));
     }
   } else {
     // TODO: pass the error back to the caller instead of crashing here.
-    TORCH_INTERNAL_ASSERT(false, "unrecognized message type ", message.type());
+    TORCH_INTERNAL_ASSERT(false, "unrecognized message type ", message->type());
   }
   return true;
 }

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -169,8 +169,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processScriptCall(
 
   return future->then(
       [](JitFuture& jitFuture) {
-        return c10::make_intrusive<Message>(
-            ScriptResp(jitFuture.value()).toMessage());
+        return ScriptResp(jitFuture.value()).toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -182,8 +181,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processPythonCall(
 
   return future->then(
       [](JitFuture& future) {
-        return c10::make_intrusive<Message>(
-            PythonResp(serializePyObject(future.value())).toMessage());
+        return PythonResp(serializePyObject(future.value())).toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -230,8 +228,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processPythonRRefFetchCall(
   return future->then(
       [](JitFuture& future) {
         SerializedPyObj result = serializePyObject(future.value());
-        return c10::make_intrusive<Message>(
-            PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
+        return PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -290,7 +287,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processRRefBackward(
         PyRRef::backwardOwnerRRef(
             autogradContextId, retainGraph, future.value());
 
-        return c10::make_intrusive<Message>(RRefBackwardResp().toMessage());
+        return RRefBackwardResp().toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -145,10 +145,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::processScriptCall(
   auto future = runJitOperator(*scriptCall.op(), scriptCall.stackRef());
 
   return future->then(
-      [](JitFuture& future) {
-        return c10::make_intrusive<Message>(
-            ScriptResp(future.value()).toMessage());
-      },
+      [](JitFuture& future) { return ScriptResp(future.value()).toMessage(); },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
 
@@ -198,8 +195,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::assignOwnerRRef(
           ownerRRef->recordAllStreams(lsctx);
           ownerRRef->setValue(future.value());
         }
-        return c10::make_intrusive<Message>(
-            RemoteRet(rrefId, forkId).toMessage());
+        return RemoteRet(rrefId, forkId).toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -255,8 +251,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
 
   return future->then(
       [](JitFuture& future) {
-        return c10::make_intrusive<Message>(
-            ScriptRRefFetchRet({future.value()}).toMessage());
+        return ScriptRRefFetchRet({future.value()}).toMessage();
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -359,10 +354,9 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
         } else {
           auto msg = getMessageWithAutograd(
               fromWorkerId,
-              std::move(
-                  *wrappedRpcResponseFuture.value().toCustomClass<Message>()),
+              wrappedRpcResponseFuture.value().toCustomClass<Message>(),
               MessageType::FORWARD_AUTOGRAD_RESP);
-          return c10::make_intrusive<Message>(std::move(msg));
+          return msg;
         }
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -396,8 +390,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
         if (execFuture.hasError()) {
           std::rethrow_exception(execFuture.exception_ptr());
         } else {
-          return c10::make_intrusive<Message>(
-              PropagateGradientsResp().toMessage());
+          return PropagateGradientsResp().toMessage();
         }
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -488,8 +481,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
                     *wrappedRpcResponseFuture.value().toCustomClass<Message>()),
                 profiledEvents,
                 profilingKeyId);
-            return c10::make_intrusive<Message>(
-                std::move(*rpcWithProfilingResp).toMessage());
+            return std::move(*rpcWithProfilingResp).toMessage();
           }
         }),
         c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -578,8 +570,7 @@ c10::intrusive_ptr<Message> RequestCallbackNoPython::handleError(
       DistAutogradContainer::getInstance().getWorkerId(),
       ": ",
       e.what());
-  return c10::make_intrusive<Message>(
-      createExceptionResponse(errorMsg, messageId));
+  return createExceptionResponse(errorMsg, messageId);
 }
 
 bool RequestCallbackNoPython::cudaAvailable() const {
@@ -620,11 +611,6 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
   return asFuture(
       std::move(message),
       at::getCustomClassType<c10::intrusive_ptr<Message>>());
-}
-
-c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
-    Message message) const {
-  return asFuture(c10::make_intrusive<Message>(std::move(message)));
 }
 
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -110,8 +110,6 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
   c10::intrusive_ptr<JitFuture> asFuture(
       c10::intrusive_ptr<Message> message) const;
 
-  c10::intrusive_ptr<JitFuture> asFuture(Message message) const;
-
   c10::intrusive_ptr<JitFuture> asFuture(std::exception_ptr err) const;
 };
 

--- a/torch/csrc/distributed/rpc/rpc_agent.cpp
+++ b/torch/csrc/distributed/rpc/rpc_agent.cpp
@@ -50,7 +50,7 @@ void RpcAgent::shutdown() {
 
 c10::intrusive_ptr<JitFuture> RpcAgent::sendWithRetries(
     const WorkerInfo& to,
-    Message&& message,
+    c10::intrusive_ptr<Message> message,
     RpcRetryOptions retryOptions) {
   TORCH_CHECK(retryOptions.maxRetries >= 0, "maxRetries cannot be negative.");
   TORCH_CHECK(
@@ -64,15 +64,13 @@ c10::intrusive_ptr<JitFuture> RpcAgent::sendWithRetries(
       c10::make_intrusive<JitFuture>(at::AnyClassType::get(), getDevices());
   steady_clock_time_point newTime =
       computeNewRpcRetryTime(retryOptions, /* retryCount */ 0);
-  // Making a copy of the message so it can be retried after the first send.
-  Message msgCopy = message;
-  auto jitFuture = send(to, std::move(message));
   auto firstRetryRpc = std::make_shared<RpcRetryInfo>(
       to,
-      std::move(msgCopy),
+      message,
       originalFuture,
       /* retryCount */ 0,
       retryOptions);
+  auto jitFuture = send(to, std::move(message));
   jitFuture->addCallback([this, newTime, firstRetryRpc](JitFuture& future) {
     rpcRetryCallback(future, newTime, firstRetryRpc);
   });
@@ -122,8 +120,6 @@ void RpcAgent::retryExpiredRpcs() {
     for (auto it = earliestRpcList.begin(); it != earliestRpcList.end();
          /* no increment */) {
       auto& earliestRpc = *it;
-      // Making a copy of the message so it can be retried in the future.
-      Message msgCopy = earliestRpc->message_;
       c10::intrusive_ptr<JitFuture> jitFuture;
 
       // send() will throw an exception if an RPC is retried while the agent is
@@ -131,7 +127,7 @@ void RpcAgent::retryExpiredRpcs() {
       // with an error, since this RPC never succeeded and can no longer be
       // retried.
       try {
-        jitFuture = send(earliestRpc->to_, std::move(msgCopy));
+        jitFuture = send(earliestRpc->to_, earliestRpc->message_);
         futures.emplace_back(jitFuture, earliestRpc);
       } catch (std::exception& e) {
         // We must store the futures and exception messages here and only mark

--- a/torch/csrc/distributed/rpc/rpc_agent.h
+++ b/torch/csrc/distributed/rpc/rpc_agent.h
@@ -107,18 +107,18 @@ struct TORCH_API RpcRetryOptions {
 struct TORCH_API RpcRetryInfo {
   RpcRetryInfo(
       const WorkerInfo& to,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       c10::intrusive_ptr<JitFuture> originalFuture,
       int retryCount,
       RpcRetryOptions options)
       : to_(to),
-        message_(message),
+        message_(std::move(message)),
         originalFuture_(std::move(originalFuture)),
         retryCount_(retryCount),
         options_(options) {}
 
   const WorkerInfo& to_;
-  Message message_;
+  c10::intrusive_ptr<Message> message_;
   // Future that is returned to the caller of sendWithRetries().
   c10::intrusive_ptr<JitFuture> originalFuture_;
   // Number of send attempts completed so far.
@@ -162,7 +162,7 @@ class TORCH_API RpcAgent {
   // should be ignored by the caller.
   virtual c10::intrusive_ptr<JitFuture> send(
       const WorkerInfo& to,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       const float rpcTimeoutSeconds = kUnsetRpcTimeout,
       const std::unordered_map<c10::Device, c10::Device>& deviceMap = {}) = 0;
 
@@ -180,7 +180,7 @@ class TORCH_API RpcAgent {
   // are idempotent.
   c10::intrusive_ptr<JitFuture> sendWithRetries(
       const WorkerInfo& to,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       RpcRetryOptions retryOptions = RpcRetryOptions());
 
   // Return a reference to the ``WorkerInfo`` of this RpcAgent.

--- a/torch/csrc/distributed/rpc/rpc_command_base.h
+++ b/torch/csrc/distributed/rpc/rpc_command_base.h
@@ -12,10 +12,11 @@ class RpcCommandBase {
  public:
   // Need to override this to serialize the RPC. This should destructively
   // create a message for the RPC (Hence the &&).
-  Message toMessage() && {
+  c10::intrusive_ptr<Message> toMessage() && {
     JitRRefPickleGuard jitPickleGuard;
-    return std::move(*this).toMessageImpl();
+    return c10::make_intrusive<Message>(std::move(*this).toMessageImpl());
   }
+  // FIXME Consider changing this return type to an intrusive_ptr too.
   virtual Message toMessageImpl() && = 0;
   virtual ~RpcCommandBase() = 0;
 };

--- a/torch/csrc/distributed/rpc/rref_impl.cpp
+++ b/torch/csrc/distributed/rpc/rref_impl.cpp
@@ -169,7 +169,7 @@ IValue UserRRef::toHere(const float timeoutSeconds) const {
   // ScriptRRefFetchCall message always carries autograd context id even if
   // the message itself does not contain any tensor, because the response would
   // potentially contain tensors.
-  Message msgToSend;
+  c10::intrusive_ptr<Message> msgToSend;
 
   if (isPyObj()) {
     msgToSend = PythonRRefFetchCall(ownerId_, rrefId()).toMessage();

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -675,13 +675,13 @@ void TensorPipeAgent::pipeRead(
     const std::shared_ptr<tensorpipe::Pipe>& pipe,
     std::function<void(
         const tensorpipe::Error&,
-        Message&&,
+        c10::intrusive_ptr<Message>,
         std::shared_ptr<LazyStreamContext>)> fn) noexcept {
   pipe->readDescriptor([this, fn{std::move(fn)}, pipe](
                            const tensorpipe::Error& error,
                            tensorpipe::Descriptor tpDescriptor) mutable {
     if (error) {
-      fn(error, Message(), nullptr);
+      fn(error, c10::intrusive_ptr<Message>(), nullptr);
       return;
     }
 
@@ -698,13 +698,13 @@ void TensorPipeAgent::pipeRead(
          fn{std::move(fn)},
          ctx{std::move(ctx)}](const tensorpipe::Error& error) mutable {
           if (error) {
-            fn(error, Message(), nullptr);
+            fn(error, c10::intrusive_ptr<Message>(), nullptr);
             return;
           }
 
           // FIXME This does some unpickling, which could be a bit expensive:
           // perhaps it would be best to perform it inside the worker threads?
-          Message rpcMessage = tensorpipeDeserialize(
+          c10::intrusive_ptr<Message> rpcMessage = tensorpipeDeserialize(
               std::move(tpDescriptor), std::move(*tpBuffers));
 
           fn(error, std::move(rpcMessage), std::move(ctx));
@@ -714,7 +714,7 @@ void TensorPipeAgent::pipeRead(
 
 void TensorPipeAgent::pipeWrite(
     const std::shared_ptr<tensorpipe::Pipe>& pipe,
-    Message&& rpcMessage,
+    c10::intrusive_ptr<Message> rpcMessage,
     std::vector<c10::Device>&& devices,
     std::shared_ptr<LazyStreamContext> ctx,
     std::function<void(const tensorpipe::Error&)> fn) noexcept {
@@ -749,13 +749,13 @@ void TensorPipeAgent::sendCompletedResponseMessage(
           << pipe->getRemoteName();
 
   if (!futureResponseMessage.hasError()) {
-    Message&& responseMessage =
-        std::move(*futureResponseMessage.value().toCustomClass<Message>());
-    responseMessage.setId(messageId);
+    c10::intrusive_ptr<Message> responseMessage =
+        futureResponseMessage.value().toCustomClass<Message>();
+    responseMessage->setId(messageId);
 
     std::vector<c10::Device> devices;
     try {
-      devices = getDevicesForRemote(pipe->getRemoteName(), responseMessage);
+      devices = getDevicesForRemote(pipe->getRemoteName(), *responseMessage);
     } catch (const std::exception& e) {
       responseMessage = createExceptionResponse(e.what(), messageId);
     }
@@ -764,7 +764,7 @@ void TensorPipeAgent::sendCompletedResponseMessage(
     if (!ctxDevices.empty()) {
       // FIXME: skipping this check when ctxDevices is empty to allow
       // RRef.to_here().
-      for (const auto& tensor : responseMessage.tensors()) {
+      for (const auto& tensor : responseMessage->tensors()) {
         const auto device = tensor.device();
         if (!device.is_cpu() && ctxDevices.find(device) == ctxDevices.end()) {
           std::ostringstream oss;
@@ -834,7 +834,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
       pipe,
       [this, pipe](
           const tensorpipe::Error& error,
-          Message&& requestMessage,
+          c10::intrusive_ptr<Message> requestMessage,
           std::shared_ptr<LazyStreamContext> ctx) mutable {
         if (error) {
           if (shuttingDown_) {
@@ -851,7 +851,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
         // Arm for next read
         respond(pipe);
 
-        uint64_t messageId = requestMessage.id();
+        uint64_t messageId = requestMessage->id();
         increaseCallCount(serverActiveCalls_);
 
         VLOG(1) << "RPC agent for " << workerInfo_.name_
@@ -878,7 +878,7 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
             // `process***Call` methods to synchronize CUDA streams there
             // to make sure that we fetch the correct value from `to_here()`
             // call.
-            futureResponseMessage = cb_->operator()(requestMessage, ctx);
+            futureResponseMessage = cb_->operator()(*requestMessage, ctx);
           } catch (const std::exception& /* unused */) {
             futureResponseMessage =
                 c10::make_intrusive<JitFuture>(at::AnyClassType::get());
@@ -912,11 +912,11 @@ void TensorPipeAgent::respond(std::shared_ptr<tensorpipe::Pipe>& pipe) {
 
 c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
     const WorkerInfo& toWorkerInfo,
-    Message&& requestMessage,
+    c10::intrusive_ptr<Message> requestMessage,
     const float rpcTimeoutSeconds,
     const DeviceMap& deviceMap) {
   TORCH_CHECK(
-      requestMessage.isRequest(),
+      requestMessage->isRequest(),
       "TensorPipeAgent::send(..) is only for sending requests.");
 
   if (!rpcAgentRunning_.load()) {
@@ -924,7 +924,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
         "Node ",
         RpcAgent::getWorkerInfo().id_,
         "tried to send() a message of type ",
-        requestMessage.type(),
+        requestMessage->type(),
         " but RPC is no longer running on this node.");
     throw std::runtime_error(err);
   }
@@ -952,7 +952,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
 
   auto futureResponseMessage = std::make_shared<AtomicJitFuture>(devices_);
   uint64_t messageId = nextMessageID_++;
-  requestMessage.setId(messageId);
+  requestMessage->setId(messageId);
 
   {
     std::unique_lock<std::mutex> lock(clientPipe.mutex_);
@@ -964,11 +964,13 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
   std::vector<c10::Device> devices;
   if (deviceMap.empty()) {
     devices =
-        getDevicesForRemote(clientPipe.pipe_->getRemoteName(), requestMessage);
+        getDevicesForRemote(clientPipe.pipe_->getRemoteName(), *requestMessage);
   } else {
     // If deviceMap is specified, use that instead.
     devices = getDevicesForTensors(
-        requestMessage.tensors(), deviceMap, clientPipe.pipe_->getRemoteName());
+        requestMessage->tensors(),
+        deviceMap,
+        clientPipe.pipe_->getRemoteName());
   }
 
   futureResponseMessage->jitFuture->addCallback(
@@ -1010,7 +1012,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
 
   auto ctx = std::make_shared<LazyStreamContext>(
       devices_.empty() ? c10::kCPU : devices_[0].type());
-  ctx->waitForCurrentStreams(requestMessage.tensors());
+  ctx->waitForCurrentStreams(requestMessage->tensors());
   pipeWrite(
       clientPipe.pipe_,
       std::move(requestMessage),
@@ -1039,7 +1041,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
             clientPipe.pipe_,
             [this, &clientPipe](
                 const tensorpipe::Error& error,
-                Message&& responseMessage,
+                c10::intrusive_ptr<Message> responseMessage,
                 std::shared_ptr<LazyStreamContext> ctx) {
               if (error) {
                 if (error.isOfType<tensorpipe::PipeClosedError>() &&
@@ -1057,7 +1059,7 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
               }
 
               // Identify future response message by message ID
-              uint64_t messageId = responseMessage.id();
+              uint64_t messageId = responseMessage->id();
 
               VLOG(1) << "RPC agent for " << workerInfo_.name_
                       << " received response #" << messageId << " from "
@@ -1083,12 +1085,12 @@ c10::intrusive_ptr<JitFuture> TensorPipeAgent::send(
               // Remove entry from timeoutMap_.
               removeFromTimeoutMap(messageId);
 
-              if (responseMessage.type() == MessageType::EXCEPTION) {
+              if (responseMessage->type() == MessageType::EXCEPTION) {
                 markFutureWithError(
                     std::move(futureResponseMessage),
                     std::string(
-                        responseMessage.payload().begin(),
-                        responseMessage.payload().end()));
+                        responseMessage->payload().begin(),
+                        responseMessage->payload().end()));
               } else {
                 markFutureAsComplete(
                     std::move(futureResponseMessage),
@@ -1375,7 +1377,7 @@ void TensorPipeAgent::decreaseCallCount(int32_t& count) {
 
 void TensorPipeAgent::markFutureAsComplete(
     std::shared_ptr<AtomicJitFuture> atomicFuture,
-    Message message,
+    c10::intrusive_ptr<Message> message,
     std::shared_ptr<LazyStreamContext> ctx) {
   if (!atomicFuture->isComplete.test_and_set()) {
     // Completing the future will run its callbacks, which could execute
@@ -1387,12 +1389,11 @@ void TensorPipeAgent::markFutureAsComplete(
                      ctx{std::move(ctx)}]() mutable {
       c10::MultiStreamGuard guard(ctx->getReservedStreams());
       std::vector<std::reference_wrapper<const at::DataPtr>> data_ptrs;
-      for (const auto& tensor : message.tensors()) {
+      for (const auto& tensor : message->tensors()) {
         data_ptrs.emplace_back(tensor.storage().data_ptr());
       }
       atomicFuture->jitFuture->markCompleted(
-          IValue(c10::make_intrusive<Message>(std::move(message))),
-          std::move(data_ptrs));
+          std::move(message), std::move(data_ptrs));
       // The future's callbacks may schedule further RPCs, increasing the count.
       // Thus we must decrease it after completing the future, otherwise it may
       // briefly dip to zero and trick join into thinking all work is done.

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -176,7 +176,7 @@ class TensorPipeAgent : public RpcAgent {
 
   c10::intrusive_ptr<JitFuture> send(
       const WorkerInfo& to,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       const float rpcTimeoutSeconds = kUnsetRpcTimeout,
       const DeviceMap& deviceMap = {}) override;
 
@@ -234,14 +234,14 @@ class TensorPipeAgent : public RpcAgent {
       const std::shared_ptr<tensorpipe::Pipe>&,
       std::function<void(
           const tensorpipe::Error&,
-          Message&&,
+          c10::intrusive_ptr<Message>,
           std::shared_ptr<LazyStreamContext>)>) noexcept;
 
   // TensorPipe write function that could be used to write response
   // messages by server, and write request messages by client.
   void pipeWrite(
       const std::shared_ptr<tensorpipe::Pipe>&,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       std::vector<c10::Device>&& devices,
       std::shared_ptr<LazyStreamContext> ctx,
       std::function<void(const tensorpipe::Error&)>) noexcept;
@@ -436,7 +436,7 @@ class TensorPipeAgent : public RpcAgent {
   // Helpers to set the state of the requests.
   void markFutureAsComplete(
       std::shared_ptr<AtomicJitFuture> atomicFuture,
-      Message message,
+      c10::intrusive_ptr<Message> message,
       std::shared_ptr<LazyStreamContext> ctx);
   void markFutureWithError(
       std::shared_ptr<AtomicJitFuture> atomicFuture,

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.h
@@ -49,7 +49,7 @@ struct TensorpipeReadBuffers {
 // data that must be kept alive while the write is performed asynchronously.
 TORCH_API std::tuple<tensorpipe::Message, TensorpipeWriteBuffers>
 tensorpipeSerialize(
-    Message&& rpcMessage,
+    c10::intrusive_ptr<Message> rpcMessage,
     std::vector<c10::Device> devices,
     const std::shared_ptr<LazyStreamContext>& ctx);
 
@@ -65,7 +65,7 @@ tensorpipeAllocate(
 // Convert a TensorPipe message back into an RPC message. This requires the data
 // to be available and can thus only be performed once the asynchronous read has
 // completed. The holder can be destroyed once this function returns.
-TORCH_API Message tensorpipeDeserialize(
+TORCH_API c10::intrusive_ptr<Message> tensorpipeDeserialize(
     tensorpipe::Descriptor&& tpDescriptor,
     TensorpipeReadBuffers&& holder);
 

--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
@@ -60,19 +60,19 @@ std::unordered_map<MessageType, float, std::hash<int>> FaultyProcessGroupAgent::
 
 c10::intrusive_ptr<JitFuture> FaultyProcessGroupAgent::send(
     const WorkerInfo& to,
-    Message&& message,
+    c10::intrusive_ptr<Message> message,
     const float rpcTimeoutSeconds,
     const std::unordered_map<c10::Device, c10::Device>& /* unused */) {
   // We only fail control messages that have been specified by the test case.
   // For all other messages, we just send them without any failures.
-  if (!shouldFailMessage(message.type())) {
+  if (!shouldFailMessage(message->type())) {
     return ProcessGroupAgent::send(to, std::move(message), rpcTimeoutSeconds);
   }
   // This send function checks the failMessageCountMap_ to check whether
   // we must fail the next send. If the send must be failed, we set an error
   // on the returned future immediately and increment the counter in the map,
   // otherwise we just call the ProcessGroupAgent send.
-  const auto key = fromVec(message.payload());
+  const auto key = fromVec(message->payload());
   std::unique_lock<std::mutex> lock(failMapMutex_);
   auto it = failMessageCountMap_.find(key);
   if (it == failMessageCountMap_.end()) {
@@ -93,7 +93,7 @@ c10::intrusive_ptr<JitFuture> FaultyProcessGroupAgent::send(
 }
 
 void FaultyProcessGroupAgent::enqueueSend(SendWork work) {
-  float msgDelay = getDelayForMessage(work.message_.type());
+  float msgDelay = getDelayForMessage(work.message_->type());
   if (msgDelay != 0) {
     // Sleep for the specified delay for the message.
     std::this_thread::sleep_for(std::chrono::milliseconds(
@@ -102,8 +102,8 @@ void FaultyProcessGroupAgent::enqueueSend(SendWork work) {
   ProcessGroupAgent::enqueueSend(std::move(work));
 }
 
-void FaultyProcessGroupAgent::sendToSelf(Message&& message) {
-  float msgDelay = getDelayForMessage(message.type());
+void FaultyProcessGroupAgent::sendToSelf(c10::intrusive_ptr<Message> message) {
+  float msgDelay = getDelayForMessage(message->type());
   if (msgDelay != 0) {
     // Sleep for the specified delay for the message.
     std::this_thread::sleep_for(std::chrono::milliseconds(

--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
@@ -46,7 +46,7 @@ class FaultyProcessGroupAgent : public ProcessGroupAgent {
   // Faulty send function for this class.
   c10::intrusive_ptr<JitFuture> send(
       const WorkerInfo& to,
-      Message&& message,
+      c10::intrusive_ptr<Message> message,
       const float rpcTimeoutSeconds = torch::distributed::rpc::kUnsetRpcTimeout,
       const std::unordered_map<c10::Device, c10::Device>& deviceMap = {})
       override;
@@ -60,7 +60,7 @@ class FaultyProcessGroupAgent : public ProcessGroupAgent {
   // Overrides ProcessGroupAgent's enqueueSend to inject delays.
   void enqueueSend(SendWork work) override;
   // Override ProcessGroupAgent's sendToSelf to inject delays.
-  void sendToSelf(Message&& message) override;
+  void sendToSelf(c10::intrusive_ptr<Message> message) override;
   // This function parses the list of strings passed in by the python tests and
   // resolves the Message Types that must use the faulty send.
   std::vector<MessageType> parseMessagesToFailInput(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* #59211 [reland] Set and propagate devices in RRef completion future
* #59210 [reland] Set streams when invoking UDFs
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* **#59205 [reland] Always use intrusive_ptr for Message (1 out of 2)**

Reland of https://github.com/pytorch/pytorch/pull/58422

Similar to Future (which I tackled recently), Message is an ivalue type (a "custom class" one), and the natural way to represent it is inside an intrusive_ptr. However in the RPC code we had a mix of usages, often passing Message by value. This has undesirable consequences, as it could easily trigger a copy by accident, which I believe is why in many places we accepted _rvalue references_ to Message, in order to force the caller to move. In my experience this is non-idiomatic in C++ (normally a function signature specifies how the function consumes its arguments, and it's up to the caller to then decide whether to copy or move).

By moving to intrusive_ptr everywhere I think we eliminate and simplify many of the problems above.

In this PR I do half of the migration, by updating everything except the `toMessageImpl` methods, which will come in the next PR.

Differential Revision: [D28623891](https://our.internmc.facebook.com/intern/diff/D28623891/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28623891/)!