### PR TITLE
[reland] Always use intrusive_ptr for Message (2 out of 2)

### DIFF
--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.cpp
@@ -13,12 +13,12 @@ int64_t CleanupAutogradContextReq::getContextId() {
   return context_id_;
 }
 
-rpc::Message CleanupAutogradContextReq::toMessageImpl() && {
+c10::intrusive_ptr<rpc::Message> CleanupAutogradContextReq::toMessageImpl() && {
   // pickle context_id using JIT pickler.
   std::vector<torch::Tensor> tensorTable;
   std::vector<char> payload =
       jit::pickle(at::IValue(context_id_), &tensorTable);
-  return rpc::Message(
+  return c10::make_intrusive<rpc::Message>(
       std::move(payload),
       std::move(tensorTable),
       rpc::MessageType::CLEANUP_AUTOGRAD_CONTEXT_REQ);

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_req.h
@@ -13,7 +13,7 @@ class TORCH_API CleanupAutogradContextReq : public rpc::RpcCommandBase {
  public:
   explicit CleanupAutogradContextReq(int64_t context_id);
   // Serialization and deserialization methods.
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<CleanupAutogradContextReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.cpp
@@ -4,10 +4,10 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
-rpc::Message CleanupAutogradContextResp::toMessageImpl() && {
+c10::intrusive_ptr<rpc::Message> CleanupAutogradContextResp::toMessageImpl() && {
   std::vector<torch::Tensor> tensors;
   std::vector<char> payload;
-  return rpc::Message(
+  return c10::make_intrusive<rpc::Message>(
       std::move(payload),
       std::move(tensors),
       rpc::MessageType::CLEANUP_AUTOGRAD_CONTEXT_RESP);

--- a/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/cleanup_autograd_context_resp.h
@@ -13,7 +13,7 @@ class TORCH_API CleanupAutogradContextResp : public rpc::RpcCommandBase {
  public:
   CleanupAutogradContextResp() = default;
   // Serialization and deserialization methods.
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<CleanupAutogradContextResp> fromMessage(
       const rpc::Message& message);
 };

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.cpp
@@ -18,7 +18,7 @@ PropagateGradientsReq::PropagateGradientsReq(
       grads_(std::move(grads)),
       retainGraph_(retainGraph) {}
 
-Message PropagateGradientsReq::toMessageImpl() && {
+c10::intrusive_ptr<Message> PropagateGradientsReq::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   // Add all the grad tensors.
   for (const auto& grad : grads_) {
@@ -37,7 +37,7 @@ Message PropagateGradientsReq::toMessageImpl() && {
   std::vector<char> payload =
       jit::pickle(c10::ivalue::Tuple::create(std::move(ivalues)), &tensorTable);
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensorTable),
       MessageType::BACKWARD_AUTOGRAD_REQ);

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_req.h
@@ -24,7 +24,7 @@ class TORCH_API PropagateGradientsReq : public rpc::RpcCommandBase {
   const std::vector<torch::autograd::Variable>& getGrads();
 
   // Serialization and deserialization methods.
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<PropagateGradientsReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.cpp
@@ -4,8 +4,11 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
-rpc::Message PropagateGradientsResp::toMessageImpl() && {
-  return rpc::Message({}, {}, rpc::MessageType::BACKWARD_AUTOGRAD_RESP);
+c10::intrusive_ptr<rpc::Message> PropagateGradientsResp::toMessageImpl() && {
+  return c10::make_intrusive<rpc::Message>(
+      std::vector<char>{},
+      std::vector<torch::Tensor>{},
+      rpc::MessageType::BACKWARD_AUTOGRAD_RESP);
 }
 
 std::unique_ptr<PropagateGradientsResp> PropagateGradientsResp::fromMessage(

--- a/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/propagate_gradients_resp.h
@@ -14,7 +14,7 @@ namespace autograd {
 class TORCH_API PropagateGradientsResp : public rpc::RpcCommandBase {
  public:
   PropagateGradientsResp() = default;
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<PropagateGradientsResp> fromMessage(
       const rpc::Message& message);
 };

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_autograd.h
@@ -31,7 +31,7 @@ class TORCH_API RpcWithAutograd final : public rpc::RpcCommandBase {
       std::vector<torch::Tensor> tensors,
       std::unordered_map<c10::Device, c10::Device> deviceMap = {});
 
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
 
   static std::unique_ptr<RpcWithAutograd> fromMessage(
       const rpc::Message& message);

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.cpp
@@ -59,7 +59,7 @@ void RpcWithProfilingReq::setWrappedRpc(
   wrappedRpc_ = std::move(wrappedRpc);
 }
 
-rpc::Message RpcWithProfilingReq::toMessageImpl() && {
+c10::intrusive_ptr<rpc::Message> RpcWithProfilingReq::toMessageImpl() && {
   // save the original message ID and type before moving it.
   auto wrappedMsgId = wrappedMessage_->id();
   auto wrappedMsgType = wrappedMessage_->type();
@@ -80,7 +80,7 @@ rpc::Message RpcWithProfilingReq::toMessageImpl() && {
   // add the profiling payload to the wrapped payload
   rpc::writeWrappedPayload(wrappedPayload, profilingPayload);
   // Put the wrapped payload into a message to return.
-  auto returnMsg = rpc::Message(
+  auto returnMsg = c10::make_intrusive<rpc::Message>(
       std::move(wrappedPayload),
       std::move(tensors_),
       messageType_,
@@ -128,19 +128,19 @@ std::unique_ptr<RpcWithProfilingReq> RpcWithProfilingReq::fromMessage(
   rpc::ProfilingId profilerId = rpc::ProfilingId::fromIValue(tupleElements[2]);
 
   // Create new message type and build wrapped RPC
-  rpc::Message wrappedMessage(
+  auto wrappedMessage = c10::make_intrusive<rpc::Message>(
       std::move(payload), std::move(tensors), wrappedMsgType, msgId);
   TORCH_INTERNAL_ASSERT(
-      wrappedMessage.isRequest(),
+      wrappedMessage->isRequest(),
       "Messages wrapped with profiling requests must be requests.");
   std::unique_ptr<RpcCommandBase> wrappedRpc =
-      deserializeRequest(wrappedMessage);
+      deserializeRequest(*wrappedMessage);
 
   return std::make_unique<RpcWithProfilingReq>(
       origMsgType,
       std::move(wrappedRpc),
       wrappedMsgType,
-      std::move(wrappedMessage.tensors()),
+      std::move(wrappedMessage->tensors()),
       // NOLINTNEXTLINE(performance-move-const-arg)
       std::move(cfg),
       profilerId);

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_req.h
@@ -30,7 +30,7 @@ class TORCH_API RpcWithProfilingReq : public rpc::RpcCommandBase {
       rpc::ProfilingId profilingKeyId);
 
   // Convert this RPC Command to a Message that can be sent over the wire.
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<RpcWithProfilingReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.cpp
@@ -12,18 +12,18 @@ constexpr auto kProfileEventsStartIdx = 3;
 // it as a message over the wire.
 RpcWithProfilingResp::RpcWithProfilingResp(
     rpc::MessageType messageType,
-    rpc::Message&& wrappedMessage,
+    c10::intrusive_ptr<rpc::Message> wrappedMessage,
     std::vector<torch::autograd::profiler::LegacyEvent> profiledEvents,
     rpc::ProfilingId profilingId)
     : messageType_(messageType),
       wrappedMessage_(std::move(wrappedMessage)),
       profiledEvents_(std::move(profiledEvents)),
       profilingId_(profilingId) {
-  tensors_ = wrappedMessage_.tensors();
+  tensors_ = wrappedMessage_->tensors();
   TORCH_INTERNAL_ASSERT(
       messageType_ == rpc::MessageType::RUN_WITH_PROFILING_RESP,
       "Incorrect Message type");
-  wrappedMessageType_ = wrappedMessage_.type();
+  wrappedMessageType_ = wrappedMessage_->type();
 }
 // this constructor is called in fromMessage() which is called when
 // reconstructing this RPC command when processing a message of this type
@@ -66,10 +66,10 @@ void RpcWithProfilingResp::setWrappedRpc(
   wrappedRpc_ = std::move(wrappedRpc);
 }
 
-rpc::Message RpcWithProfilingResp::toMessageImpl() && {
-  auto wrappedMsgId = wrappedMessage_.id();
-  auto wrappedMsgType = wrappedMessage_.type();
-  auto wrappedPayload = std::move(wrappedMessage_).movePayload();
+c10::intrusive_ptr<rpc::Message> RpcWithProfilingResp::toMessageImpl() && {
+  auto wrappedMsgId = wrappedMessage_->id();
+  auto wrappedMsgType = wrappedMessage_->type();
+  auto wrappedPayload = std::move(*wrappedMessage_).movePayload();
   // Wrapped payload should not be empty
   TORCH_INTERNAL_ASSERT(
       !wrappedPayload.empty(), "Wrapped payload cannot be empty");
@@ -86,7 +86,7 @@ rpc::Message RpcWithProfilingResp::toMessageImpl() && {
       jit::pickle(c10::ivalue::Tuple::create(std::move(ivalues)), &tensorTable);
   rpc::writeWrappedPayload(wrappedPayload, profilingPayload);
 
-  auto returnMsg = rpc::Message(
+  auto returnMsg = c10::make_intrusive<rpc::Message>(
       std::move(wrappedPayload),
       std::move(tensors_),
       messageType_,
@@ -132,18 +132,18 @@ std::unique_ptr<RpcWithProfilingResp> RpcWithProfilingResp::fromMessage(
     remoteEvents.push_back(std::move(fromIvalueEvent));
   }
 
-  rpc::Message wrappedMessage(
+  auto wrappedMessage = c10::make_intrusive<rpc::Message>(
       std::move(payload), std::move(tensors), wrappedMsgType, msgId);
   TORCH_INTERNAL_ASSERT(
-      wrappedMessage.isResponse(),
+      wrappedMessage->isResponse(),
       "Messages wrapped with profiling response must be responses.");
   std::unique_ptr<RpcCommandBase> wrappedRpc =
-      deserializeResponse(wrappedMessage, wrappedMsgType);
+      deserializeResponse(*wrappedMessage, wrappedMsgType);
   return std::make_unique<RpcWithProfilingResp>(
       origMsgType,
       std::move(wrappedRpc),
       wrappedMsgType,
-      std::move(wrappedMessage.tensors()),
+      std::move(wrappedMessage->tensors()),
       std::move(remoteEvents),
       profilingId);
 }

--- a/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rpc_with_profiling_resp.h
@@ -14,7 +14,7 @@ class TORCH_API RpcWithProfilingResp : public rpc::RpcCommandBase {
   // For sending RPCs over the wire
   RpcWithProfilingResp(
       rpc::MessageType messageType,
-      rpc::Message&& wrappedMessage,
+      c10::intrusive_ptr<rpc::Message> wrappedMessage,
       std::vector<torch::autograd::profiler::LegacyEvent> profiledEvents,
       rpc::ProfilingId profilingId);
 
@@ -27,7 +27,7 @@ class TORCH_API RpcWithProfilingResp : public rpc::RpcCommandBase {
       std::vector<torch::Tensor> tensors,
       std::vector<torch::autograd::profiler::LegacyEvent> profiledEvents,
       rpc::ProfilingId profilingId);
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<RpcWithProfilingResp> fromMessage(
       const rpc::Message& message);
   // Retrieve remote Events
@@ -47,7 +47,7 @@ class TORCH_API RpcWithProfilingResp : public rpc::RpcCommandBase {
   // message type
   const rpc::MessageType messageType_;
   // wrapped message
-  rpc::Message wrappedMessage_;
+  c10::intrusive_ptr<rpc::Message> wrappedMessage_;
   std::unique_ptr<RpcCommandBase> wrappedRpc_;
   rpc::MessageType wrappedMessageType_;
   std::vector<torch::Tensor> tensors_;

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.cpp
@@ -17,7 +17,7 @@ RRefBackwardReq::RRefBackwardReq(
       autogradContextId_(autogradContextId),
       retainGraph_(retainGraph) {}
 
-Message RRefBackwardReq::toMessageImpl() && {
+c10::intrusive_ptr<Message> RRefBackwardReq::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
 
   // Add all the fields.
@@ -30,7 +30,7 @@ Message RRefBackwardReq::toMessageImpl() && {
   std::vector<char> payload =
       jit::pickle(c10::ivalue::Tuple::create(std::move(ivalues)), &tensorTable);
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensorTable),
       MessageType::RREF_BACKWARD_REQ);

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_req.h
@@ -24,7 +24,7 @@ class TORCH_API RRefBackwardReq : public rpc::RpcCommandBase {
   bool retainGraph() const;
 
   // Serialization and deserialization methods.
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<RRefBackwardReq> fromMessage(
       const rpc::Message& message);
 

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.cpp
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.cpp
@@ -4,8 +4,11 @@ namespace torch {
 namespace distributed {
 namespace autograd {
 
-rpc::Message RRefBackwardResp::toMessageImpl() && {
-  return rpc::Message({}, {}, rpc::MessageType::RREF_BACKWARD_RESP);
+c10::intrusive_ptr<rpc::Message> RRefBackwardResp::toMessageImpl() && {
+  return c10::make_intrusive<rpc::Message>(
+      std::vector<char>{},
+      std::vector<torch::Tensor>{},
+      rpc::MessageType::RREF_BACKWARD_RESP);
 }
 
 std::unique_ptr<RRefBackwardResp> RRefBackwardResp::fromMessage(

--- a/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.h
+++ b/torch/csrc/distributed/autograd/rpc_messages/rref_backward_resp.h
@@ -11,7 +11,7 @@ namespace autograd {
 class TORCH_API RRefBackwardResp : public rpc::RpcCommandBase {
  public:
   RRefBackwardResp() = default;
-  rpc::Message toMessageImpl() && override;
+  c10::intrusive_ptr<rpc::Message> toMessageImpl() && override;
   static std::unique_ptr<RRefBackwardResp> fromMessage(
       const rpc::Message& message);
 };

--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -22,31 +22,6 @@ Message::Message(
       type_(type),
       id_(id) {}
 
-Message::Message(const Message& other) = default;
-
-Message::Message(Message&& other) noexcept = default;
-
-Message& Message::operator=(Message const& rhs) & {
-  auto payload = rhs.payload_;
-  auto tensors = rhs.tensors_;
-  Message(std::move(payload), std::move(tensors), rhs.type_, rhs.id_)
-      .swap(*this);
-  return *this;
-}
-
-Message& Message::operator=(Message&& rhs) & {
-  Message(std::move(rhs.payload_), std::move(rhs.tensors_), rhs.type_, rhs.id_)
-      .swap(*this);
-  return *this;
-}
-
-void Message::swap(Message& rhs) noexcept {
-  std::swap(payload_, rhs.payload_);
-  std::swap(tensors_, rhs.tensors_);
-  std::swap(type_, rhs.type_);
-  std::swap(id_, rhs.id_);
-}
-
 std::vector<char>&& Message::movePayload() && {
   return std::move(payload_);
 }

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -109,7 +109,9 @@ enum MessageType {
 // and PythonResp into a Message, and it is up to the RpcAgent
 // implementation to determine how to serialize a message.
 class TORCH_API Message final : public torch::CustomClassHolder {
- public:
+ private:
+  // Keep these private in order to force users to go through make_intrusive and
+  // thus prevent creating a Message that's not held by an intrusive_ptr.
   Message();
 
   Message(
@@ -123,11 +125,13 @@ class TORCH_API Message final : public torch::CustomClassHolder {
       MessageType type,
       int64_t id);
 
-  Message(const Message& other);
-  Message(Message&& other) noexcept;
-  Message& operator=(Message const& rhs) &;
-  Message& operator=(Message&& rhs) &;
-  void swap(Message& rhs) noexcept;
+  friend c10::intrusive_ptr<Message>;
+
+ public:
+  Message(const Message& other) = delete;
+  Message(Message&& other) = delete;
+  Message& operator=(Message const& rhs) = delete;
+  Message& operator=(Message&& rhs) = delete;
 
   // Destructively retrieves the payload.
   std::vector<char>&& movePayload() &&;

--- a/torch/csrc/distributed/rpc/python_call.cpp
+++ b/torch/csrc/distributed/rpc/python_call.cpp
@@ -10,7 +10,7 @@ PythonCall::PythonCall(SerializedPyObj&& serializedPyObj, bool isAsyncExecution)
     : serializedPyObj_(std::move(serializedPyObj)),
       isAsyncExecution_(isAsyncExecution) {}
 
-Message PythonCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> PythonCall::toMessageImpl() && {
   std::vector<char> payload;
   payload.reserve(serializedPyObj_.payload_.length() + 1);
   payload.push_back(isAsyncExecution_ ? 1 : 0);
@@ -19,7 +19,7 @@ Message PythonCall::toMessageImpl() && {
       serializedPyObj_.payload_.begin(),
       serializedPyObj_.payload_.end());
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(serializedPyObj_.tensors_),
       MessageType::PYTHON_CALL);

--- a/torch/csrc/distributed/rpc/python_call.h
+++ b/torch/csrc/distributed/rpc/python_call.h
@@ -12,7 +12,7 @@ class TORCH_API PythonCall final : public RpcCommandBase {
  public:
   PythonCall(SerializedPyObj&& serializedPyObj, bool isAsyncExecution);
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
 
   static std::unique_ptr<PythonCall> fromMessage(const Message& message);
 

--- a/torch/csrc/distributed/rpc/python_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/python_remote_call.cpp
@@ -16,7 +16,7 @@ PythonRemoteCall::PythonRemoteCall(
       retForkId_(std::move(retForkId)),
       isAsyncExecution_(isAsyncExecution) {}
 
-Message PythonRemoteCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> PythonRemoteCall::toMessageImpl() && {
   std::vector<IValue> ivalues = std::move(serializedPyObj_).toIValues();
   ivalues.emplace_back(retRRefId_);
   ivalues.emplace_back(retForkId_);
@@ -26,7 +26,7 @@ Message PythonRemoteCall::toMessageImpl() && {
   auto payload =
       jit::pickle(c10::ivalue::Tuple::create(ivalues), &tensor_table);
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensor_table),
       MessageType::PYTHON_REMOTE_CALL);

--- a/torch/csrc/distributed/rpc/python_remote_call.h
+++ b/torch/csrc/distributed/rpc/python_remote_call.h
@@ -34,7 +34,7 @@ class TORCH_API PythonRemoteCall : public RpcCommandBase {
     return isAsyncExecution_;
   }
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<PythonRemoteCall> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/python_resp.cpp
+++ b/torch/csrc/distributed/rpc/python_resp.cpp
@@ -9,10 +9,10 @@ namespace rpc {
 PythonResp::PythonResp(SerializedPyObj&& serializedPyObj)
     : serializedPyObj_(std::move(serializedPyObj)) {}
 
-Message PythonResp::toMessageImpl() && {
+c10::intrusive_ptr<Message> PythonResp::toMessageImpl() && {
   auto payload = std::vector<char>(
       serializedPyObj_.payload_.begin(), serializedPyObj_.payload_.end());
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(serializedPyObj_.tensors_),
       MessageType::PYTHON_RET);

--- a/torch/csrc/distributed/rpc/python_resp.h
+++ b/torch/csrc/distributed/rpc/python_resp.h
@@ -12,7 +12,7 @@ class TORCH_API PythonResp final : public RpcCommandBase {
  public:
   explicit PythonResp(SerializedPyObj&& serializedPyObj);
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
 
   static std::unique_ptr<PythonResp> fromMessage(const Message& message);
 

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -477,8 +477,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
                 profiledEvents, profilingConfig, event_lists);
             auto rpcWithProfilingResp = std::make_unique<RpcWithProfilingResp>(
                 MessageType::RUN_WITH_PROFILING_RESP,
-                std::move(
-                    *wrappedRpcResponseFuture.value().toCustomClass<Message>()),
+                wrappedRpcResponseFuture.value().toCustomClass<Message>(),
                 profiledEvents,
                 profilingKeyId);
             return std::move(*rpcWithProfilingResp).toMessage();

--- a/torch/csrc/distributed/rpc/rpc_command_base.h
+++ b/torch/csrc/distributed/rpc/rpc_command_base.h
@@ -14,10 +14,9 @@ class RpcCommandBase {
   // create a message for the RPC (Hence the &&).
   c10::intrusive_ptr<Message> toMessage() && {
     JitRRefPickleGuard jitPickleGuard;
-    return c10::make_intrusive<Message>(std::move(*this).toMessageImpl());
+    return std::move(*this).toMessageImpl();
   }
-  // FIXME Consider changing this return type to an intrusive_ptr too.
-  virtual Message toMessageImpl() && = 0;
+  virtual c10::intrusive_ptr<Message> toMessageImpl() && = 0;
   virtual ~RpcCommandBase() = 0;
 };
 

--- a/torch/csrc/distributed/rpc/rref_proto.cpp
+++ b/torch/csrc/distributed/rpc/rref_proto.cpp
@@ -28,11 +28,14 @@ std::vector<IValue> toIValues(const Message& message, MessageType type) {
   return value.toTuple()->elements();
 }
 
-Message fromIValues(std::vector<IValue> ivalues, MessageType type) {
+c10::intrusive_ptr<Message> fromIValues(
+    std::vector<IValue> ivalues,
+    MessageType type) {
   std::vector<torch::Tensor> tensor_table;
   auto payload = jit::pickle(
       c10::ivalue::Tuple::create(std::move(ivalues)), &tensor_table);
-  return Message(std::move(payload), std::move(tensor_table), type);
+  return c10::make_intrusive<Message>(
+      std::move(payload), std::move(tensor_table), type);
 }
 
 } // namespace
@@ -43,7 +46,7 @@ const RRefId& RRefMessageBase::rrefId() {
   return rrefId_;
 }
 
-Message RRefMessageBase::toMessageImpl() && {
+c10::intrusive_ptr<Message> RRefMessageBase::toMessageImpl() && {
   return fromIValues({rrefId_.toIValue()}, type_);
 }
 
@@ -63,7 +66,7 @@ const ForkId& ForkMessageBase::forkId() {
   return forkId_;
 }
 
-Message ForkMessageBase::toMessageImpl() && {
+c10::intrusive_ptr<Message> ForkMessageBase::toMessageImpl() && {
   return fromIValues({rrefId_.toIValue(), forkId_.toIValue()}, type_);
 }
 
@@ -81,7 +84,7 @@ std::pair<RRefId, ForkId> ForkMessageBase::fromMessage(
 
 /////////////////////////// RRef Protocol //////////////////////////////////
 
-Message ScriptRRefFetchCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> ScriptRRefFetchCall::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
@@ -103,7 +106,7 @@ std::unique_ptr<ScriptRRefFetchCall> ScriptRRefFetchCall::fromMessage(
       worker_id_t(id), RRefId::fromIValue(values[0]));
 }
 
-Message PythonRRefFetchCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> PythonRRefFetchCall::toMessageImpl() && {
   std::vector<at::IValue> ivalues;
   ivalues.reserve(2);
   ivalues.emplace_back(rrefId_.toIValue());
@@ -129,12 +132,8 @@ const std::vector<at::IValue>& RRefFetchRet::values() {
   return values_;
 }
 
-Message RRefFetchRet::toMessageImpl() && {
-  std::vector<at::IValue> ivalues = values_;
-  std::vector<torch::Tensor> tensor_table;
-  auto payload =
-      jit::pickle(c10::ivalue::Tuple::create(ivalues), &tensor_table);
-  return Message(std::move(payload), std::move(tensor_table), type_);
+c10::intrusive_ptr<Message> RRefFetchRet::toMessageImpl() && {
+  return fromIValues(values_, type_);
 }
 
 std::unique_ptr<ScriptRRefFetchRet> ScriptRRefFetchRet::fromMessage(
@@ -170,7 +169,7 @@ const ForkId& RRefChildAccept::forkId() const {
   return forkId_;
 }
 
-Message RRefChildAccept::toMessageImpl() && {
+c10::intrusive_ptr<Message> RRefChildAccept::toMessageImpl() && {
   return fromIValues({forkId_.toIValue()}, MessageType::RREF_CHILD_ACCEPT);
 }
 
@@ -189,8 +188,9 @@ std::unique_ptr<RRefForkRequest> RRefForkRequest::fromMessage(
   return std::make_unique<RRefForkRequest>(pair.first, pair.second);
 }
 
-Message RRefAck::toMessageImpl() && {
-  return Message({}, {}, MessageType::RREF_ACK);
+c10::intrusive_ptr<Message> RRefAck::toMessageImpl() && {
+  return c10::make_intrusive<Message>(
+      std::vector<char>{}, std::vector<torch::Tensor>{}, MessageType::RREF_ACK);
 }
 
 std::unique_ptr<RRefAck> RRefAck::fromMessage(const Message& message) {

--- a/torch/csrc/distributed/rpc/rref_proto.h
+++ b/torch/csrc/distributed/rpc/rref_proto.h
@@ -24,7 +24,7 @@ class TORCH_API RRefMessageBase : public RpcCommandBase {
   const RRefId& rrefId();
 
   // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual Message toMessageImpl() && override;
+  virtual c10::intrusive_ptr<Message> toMessageImpl() && override;
   static at::IValue fromMessage(const Message& message, MessageType type);
 
  protected:
@@ -45,7 +45,7 @@ class TORCH_API ForkMessageBase : public RRefMessageBase {
   const ForkId& forkId();
 
   // NOLINTNEXTLINE(modernize-use-override,cppcoreguidelines-explicit-virtual-functions)
-  virtual Message toMessageImpl() && override;
+  virtual c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::pair<RRefId, ForkId> fromMessage(
       const Message& message,
       MessageType type);
@@ -66,7 +66,7 @@ class TORCH_API ScriptRRefFetchCall final : public RRefMessageBase {
     return fromWorkerId_;
   }
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<ScriptRRefFetchCall> fromMessage(
       const Message& message);
 
@@ -80,7 +80,7 @@ class TORCH_API PythonRRefFetchCall final : public RRefMessageBase {
       : RRefMessageBase(rrefId, MessageType::PYTHON_RREF_FETCH_CALL),
         fromWorkerId_(fromWorkerId) {}
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<PythonRRefFetchCall> fromMessage(
       const Message& message);
 
@@ -95,7 +95,7 @@ class TORCH_API RRefFetchRet : public RpcCommandBase {
       : values_(std::move(values)), type_(type) {}
 
   const std::vector<at::IValue>& values();
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
 
  private:
   std::vector<at::IValue> values_;
@@ -146,7 +146,7 @@ class TORCH_API RRefChildAccept final : public RpcCommandBase {
 
   const ForkId& forkId() const;
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<RRefChildAccept> fromMessage(const Message& message);
 
  private:
@@ -167,7 +167,7 @@ class TORCH_API RRefAck final : public RpcCommandBase {
   // NOLINTNEXTLINE(modernize-use-equals-default)
   RRefAck() {}
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<RRefAck> fromMessage(const Message& message);
 };
 

--- a/torch/csrc/distributed/rpc/script_call.cpp
+++ b/torch/csrc/distributed/rpc/script_call.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<ScriptCall> ScriptCall::fromIValues(
   }
 }
 
-Message ScriptCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> ScriptCall::toMessageImpl() && {
   std::vector<IValue> ivalues;
   toIValues(ivalues);
 
@@ -116,7 +116,7 @@ Message ScriptCall::toMessageImpl() && {
   auto payload = jit::pickle(
       c10::ivalue::Tuple::create(std::move(ivalues)), &tensor_table);
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload), std::move(tensor_table), MessageType::SCRIPT_CALL);
 }
 

--- a/torch/csrc/distributed/rpc/script_call.h
+++ b/torch/csrc/distributed/rpc/script_call.h
@@ -39,7 +39,7 @@ class TORCH_API ScriptCall : public RpcCommandBase {
     return isAsyncExecution_;
   }
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<ScriptCall> fromMessage(const Message& message);
 
   // NOLINTNEXTLINE(modernize-use-override)

--- a/torch/csrc/distributed/rpc/script_remote_call.cpp
+++ b/torch/csrc/distributed/rpc/script_remote_call.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<ScriptRemoteCall> ScriptRemoteCall::fromIValues(
   }
 }
 
-Message ScriptRemoteCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> ScriptRemoteCall::toMessageImpl() && {
   std::vector<IValue> ivalues;
   ScriptCall::toIValues(ivalues);
   ivalues.emplace_back(retRRefId_.toIValue());
@@ -60,7 +60,7 @@ Message ScriptRemoteCall::toMessageImpl() && {
   auto payload = jit::pickle(
       c10::ivalue::Tuple::create(std::move(ivalues)), &tensor_table);
 
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload),
       std::move(tensor_table),
       MessageType::SCRIPT_REMOTE_CALL);

--- a/torch/csrc/distributed/rpc/script_remote_call.h
+++ b/torch/csrc/distributed/rpc/script_remote_call.h
@@ -44,7 +44,7 @@ class TORCH_API ScriptRemoteCall final : public ScriptCall {
   static std::unique_ptr<ScriptRemoteCall> fromIValues(
       std::vector<at::IValue>& ivalues);
 
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<ScriptRemoteCall> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/script_resp.cpp
+++ b/torch/csrc/distributed/rpc/script_resp.cpp
@@ -22,10 +22,10 @@ const at::IValue& ScriptResp::value() {
   return value_;
 }
 
-Message ScriptResp::toMessageImpl() && {
+c10::intrusive_ptr<Message> ScriptResp::toMessageImpl() && {
   std::vector<torch::Tensor> tensor_table;
   auto payload = jit::pickle(value_, &tensor_table);
-  return Message(
+  return c10::make_intrusive<Message>(
       std::move(payload), std::move(tensor_table), MessageType::SCRIPT_RET);
 }
 

--- a/torch/csrc/distributed/rpc/script_resp.h
+++ b/torch/csrc/distributed/rpc/script_resp.h
@@ -14,7 +14,7 @@ class TORCH_API ScriptResp final : public RpcCommandBase {
   explicit ScriptResp(at::IValue&& values);
 
   const at::IValue& value();
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   static std::unique_ptr<ScriptResp> fromMessage(const Message& message);
 
  private:

--- a/torch/csrc/distributed/rpc/unpickled_python_call.cpp
+++ b/torch/csrc/distributed/rpc/unpickled_python_call.cpp
@@ -25,7 +25,7 @@ UnpickledPythonCall::~UnpickledPythonCall() {
   pythonUdf_.ptr() = nullptr;
 }
 
-Message UnpickledPythonCall::toMessageImpl() && {
+c10::intrusive_ptr<Message> UnpickledPythonCall::toMessageImpl() && {
   TORCH_INTERNAL_ASSERT(
       false, "UnpickledPythonCall does not support toMessage().");
 }

--- a/torch/csrc/distributed/rpc/unpickled_python_call.h
+++ b/torch/csrc/distributed/rpc/unpickled_python_call.h
@@ -24,7 +24,7 @@ class TORCH_API UnpickledPythonCall : public RpcCommandBase {
 
   // toMessage() method is not implemented, as objects of this class should
   // never be directly converted into a Message object.
-  Message toMessageImpl() && override;
+  c10::intrusive_ptr<Message> toMessageImpl() && override;
   const py::object& pythonUdf() const;
 
   inline bool isAsyncExecution() const {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* #59211 [reland] Set and propagate devices in RRef completion future
* #59210 [reland] Set streams when invoking UDFs
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* **#59206 [reland] Always use intrusive_ptr for Message (2 out of 2)**
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58423

This is part 2 of the previous PR. Here we address the remaining occurrences of "raw" Message, namely the ones within toMessageImpl. And since they're the last ones, we make the constructor of Message private, to prevent new usages from emerging.

Differential Revision: [D28623892](https://our.internmc.facebook.com/intern/diff/D28623892/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D28623892/)!