### PR TITLE
[reland] Provide pre-extracted DataPtrs when completing a Future with a Message

### DIFF
--- a/torch/csrc/distributed/rpc/message.cpp
+++ b/torch/csrc/distributed/rpc/message.cpp
@@ -66,6 +66,16 @@ void Message::setId(int64_t id) {
   id_ = id;
 }
 
+std::vector<std::reference_wrapper<const at::DataPtr>> Message::getDataPtrs()
+    const {
+  std::vector<std::reference_wrapper<const at::DataPtr>> dataPtrs;
+  dataPtrs.reserve(tensors_.size());
+  for (const auto& tensor : tensors_) {
+    dataPtrs.emplace_back(tensor.storage().data_ptr());
+  }
+  return dataPtrs;
+}
+
 c10::intrusive_ptr<Message> createExceptionResponse(
     const std::exception& e,
     int64_t id) {

--- a/torch/csrc/distributed/rpc/message.h
+++ b/torch/csrc/distributed/rpc/message.h
@@ -153,6 +153,8 @@ class TORCH_API Message final : public torch::CustomClassHolder {
   int64_t id() const;
   void setId(int64_t id);
 
+  std::vector<std::reference_wrapper<const at::DataPtr>> getDataPtrs() const;
+
  private:
   std::vector<char> payload_;
   std::vector<torch::Tensor> tensors_;
@@ -175,6 +177,14 @@ TORCH_API c10::intrusive_ptr<Message> createExceptionResponse(
 TORCH_API c10::intrusive_ptr<Message> createExceptionResponse(
     const std::string& exceptionStr,
     int64_t id);
+
+inline std::tuple<
+    c10::intrusive_ptr<Message>,
+    std::vector<std::reference_wrapper<const at::DataPtr>>>
+withDataPtrs(c10::intrusive_ptr<Message> message) {
+  auto dataPtrs = message->getDataPtrs();
+  return std::make_tuple(std::move(message), std::move(dataPtrs));
+}
 
 using JitFuture = c10::ivalue::Future;
 

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -169,7 +169,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processScriptCall(
 
   return future->then(
       [](JitFuture& jitFuture) {
-        return ScriptResp(jitFuture.value()).toMessage();
+        return withDataPtrs(ScriptResp(jitFuture.value()).toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -181,7 +181,8 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processPythonCall(
 
   return future->then(
       [](JitFuture& future) {
-        return PythonResp(serializePyObject(future.value())).toMessage();
+        return withDataPtrs(
+            PythonResp(serializePyObject(future.value())).toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -228,7 +229,8 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processPythonRRefFetchCall(
   return future->then(
       [](JitFuture& future) {
         SerializedPyObj result = serializePyObject(future.value());
-        return PythonRRefFetchRet(std::move(result).toIValues()).toMessage();
+        return withDataPtrs(
+            PythonRRefFetchRet(std::move(result).toIValues()).toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -287,7 +289,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processRRefBackward(
         PyRRef::backwardOwnerRRef(
             autogradContextId, retainGraph, future.value());
 
-        return RRefBackwardResp().toMessage();
+        return withDataPtrs(RRefBackwardResp().toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }

--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -113,7 +113,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::processMessage(
           c10::intrusive_ptr<Message> message =
               future.value().toCustomClass<Message>();
           message->setId(id);
-          return message;
+          return withDataPtrs(message);
         },
         c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 
@@ -145,7 +145,9 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::processScriptCall(
   auto future = runJitOperator(*scriptCall.op(), scriptCall.stackRef());
 
   return future->then(
-      [](JitFuture& future) { return ScriptResp(future.value()).toMessage(); },
+      [](JitFuture& future) {
+        return withDataPtrs(ScriptResp(future.value()).toMessage());
+      },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
 
@@ -195,7 +197,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::assignOwnerRRef(
           ownerRRef->recordAllStreams(lsctx);
           ownerRRef->setValue(future.value());
         }
-        return RemoteRet(rrefId, forkId).toMessage();
+        return withDataPtrs(RemoteRet(rrefId, forkId).toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -251,7 +253,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
 
   return future->then(
       [](JitFuture& future) {
-        return ScriptRRefFetchRet({future.value()}).toMessage();
+        return withDataPtrs(ScriptRRefFetchRet({future.value()}).toMessage());
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
 }
@@ -356,7 +358,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
               fromWorkerId,
               wrappedRpcResponseFuture.value().toCustomClass<Message>(),
               MessageType::FORWARD_AUTOGRAD_RESP);
-          return msg;
+          return withDataPtrs(std::move(msg));
         }
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -390,7 +392,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
         if (execFuture.hasError()) {
           std::rethrow_exception(execFuture.exception_ptr());
         } else {
-          return PropagateGradientsResp().toMessage();
+          return withDataPtrs(PropagateGradientsResp().toMessage());
         }
       },
       c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -480,7 +482,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::
                 wrappedRpcResponseFuture.value().toCustomClass<Message>(),
                 profiledEvents,
                 profilingKeyId);
-            return std::move(*rpcWithProfilingResp).toMessage();
+            return withDataPtrs(std::move(*rpcWithProfilingResp).toMessage());
           }
         }),
         c10::getCustomClassType<c10::intrusive_ptr<Message>>());
@@ -607,9 +609,12 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
 
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
     c10::intrusive_ptr<Message> message) const {
-  return asFuture(
-      std::move(message),
+  auto future = c10::make_intrusive<JitFuture>(
       at::getCustomClassType<c10::intrusive_ptr<Message>>());
+  std::vector<std::reference_wrapper<const at::DataPtr>> dataPtrs =
+      message->getDataPtrs();
+  future->markCompleted(std::move(message), std::move(dataPtrs));
+  return future;
 }
 
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -1388,10 +1388,8 @@ void TensorPipeAgent::markFutureAsComplete(
                      message{std::move(message)},
                      ctx{std::move(ctx)}]() mutable {
       c10::MultiStreamGuard guard(ctx->getReservedStreams());
-      std::vector<std::reference_wrapper<const at::DataPtr>> data_ptrs;
-      for (const auto& tensor : message->tensors()) {
-        data_ptrs.emplace_back(tensor.storage().data_ptr());
-      }
+      std::vector<std::reference_wrapper<const at::DataPtr>> data_ptrs =
+          message->getDataPtrs();
       atomicFuture->jitFuture->markCompleted(
           std::move(message), std::move(data_ptrs));
       // The future's callbacks may schedule further RPCs, increasing the count.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* #59211 [reland] Set and propagate devices in RRef completion future
* #59210 [reland] Set streams when invoking UDFs
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* **#59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message**
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58425

Now that callbacks can provide pre-extracted DataPtrs, let's do so. This will become of crucial importance in the next PR, where some of these futures will become CUDA-aware, and thus they will try to extract DataPtrs on their own, but they would fail to do so here because Message isn't "inspectable".

Differential Revision: [D28623888](https://our.internmc.facebook.com/intern/diff/D28623888/)