### PR TITLE
[reland] Create CUDA-aware futures in RequestCallback

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_no_python.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.cpp
@@ -602,7 +602,8 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::runJitOperator(
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
     IValue value,
     TypePtr type) const {
-  auto future = c10::make_intrusive<JitFuture>(std::move(type));
+  auto future = c10::make_intrusive<JitFuture>(
+      std::move(type), RpcAgent::getCurrentRpcAgent()->getDevices());
   future->markCompleted(std::move(value));
   return future;
 }
@@ -610,7 +611,8 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
     c10::intrusive_ptr<Message> message) const {
   auto future = c10::make_intrusive<JitFuture>(
-      at::getCustomClassType<c10::intrusive_ptr<Message>>());
+      at::getCustomClassType<c10::intrusive_ptr<Message>>(),
+      RpcAgent::getCurrentRpcAgent()->getDevices());
   std::vector<std::reference_wrapper<const at::DataPtr>> dataPtrs =
       message->getDataPtrs();
   future->markCompleted(std::move(message), std::move(dataPtrs));
@@ -619,7 +621,8 @@ c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
 
 c10::intrusive_ptr<JitFuture> RequestCallbackNoPython::asFuture(
     std::exception_ptr err) const {
-  auto future = c10::make_intrusive<JitFuture>(at::NoneType::get());
+  auto future = c10::make_intrusive<JitFuture>(
+      at::NoneType::get(), RpcAgent::getCurrentRpcAgent()->getDevices());
   future->setError(err);
   return future;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* #59211 [reland] Set and propagate devices in RRef completion future
* #59210 [reland] Set streams when invoking UDFs
* **#59209 [reland] Create CUDA-aware futures in RequestCallback**
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58426

The operations in RequestCallback can return CUDA tensors, thus the futures used to hold them must be CUDA-aware.

Differential Revision: [D28623887](https://our.internmc.facebook.com/intern/diff/D28623887/)