### PR TITLE
[reland] Set streams when invoking UDFs

### DIFF
--- a/torch/csrc/distributed/rpc/request_callback_impl.h
+++ b/torch/csrc/distributed/rpc/request_callback_impl.h
@@ -16,13 +16,16 @@ class TORCH_API RequestCallbackImpl : public RequestCallbackNoPython {
       const MessageType& messageType) const override;
 
   c10::intrusive_ptr<JitFuture> processPythonCall(
-      RpcCommandBase& rpc) const override;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const override;
 
   c10::intrusive_ptr<JitFuture> processScriptCall(
-      RpcCommandBase& rpc) const override;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const override;
 
   c10::intrusive_ptr<JitFuture> processScriptRemoteCall(
-      RpcCommandBase& rpc) const override;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const override;
 
   c10::intrusive_ptr<JitFuture> processPythonRemoteCall(
       RpcCommandBase& rpc,
@@ -49,10 +52,12 @@ class TORCH_API RequestCallbackImpl : public RequestCallbackNoPython {
   c10::intrusive_ptr<JitFuture> runJitFunction(
       const c10::QualifiedName& name,
       std::vector<at::IValue>& stack,
+      std::shared_ptr<LazyStreamContext> lsctx,
       bool isAsyncExecution) const;
 
   c10::intrusive_ptr<JitFuture> runPythonFunction(
       const py::object& function,
+      std::shared_ptr<LazyStreamContext> lsctx,
       bool isAsyncExecution) const;
 };
 

--- a/torch/csrc/distributed/rpc/request_callback_no_python.h
+++ b/torch/csrc/distributed/rpc/request_callback_no_python.h
@@ -24,10 +24,12 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       const MessageType& messageType) const;
 
   virtual c10::intrusive_ptr<JitFuture> processScriptCall(
-      RpcCommandBase& rpc) const;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const;
 
   virtual c10::intrusive_ptr<JitFuture> processPythonCall(
-      RpcCommandBase& rpc) const;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const;
 
   c10::intrusive_ptr<JitFuture> assignOwnerRRef(
       const RRefId& rrefId,
@@ -36,7 +38,8 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
       std::shared_ptr<LazyStreamContext> lsctx) const;
 
   virtual c10::intrusive_ptr<JitFuture> processScriptRemoteCall(
-      RpcCommandBase& rpc) const;
+      RpcCommandBase& rpc,
+      std::shared_ptr<LazyStreamContext> lsctx) const;
 
   virtual c10::intrusive_ptr<JitFuture> processPythonRemoteCall(
       RpcCommandBase& rpc,
@@ -101,7 +104,8 @@ class TORCH_API RequestCallbackNoPython : public RequestCallback {
 
   c10::intrusive_ptr<JitFuture> runJitOperator(
       const jit::Operator& op,
-      std::vector<at::IValue>& stack) const;
+      std::vector<at::IValue>& stack,
+      std::shared_ptr<LazyStreamContext> lsctx) const;
 
   // Helpers to convert various kinds of objects into already-completed futures.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* #59211 [reland] Set and propagate devices in RRef completion future
* **#59210 [reland] Set streams when invoking UDFs**
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58427

Running the UDF (be it Python or JIT) is the first step of (most?) RPC calls, which is where the inputs are consumed. The lazy stream context contains the streams used by the inputs, thus it must be made current before any UDF call. I opt to do this as "close" as possible to the place the UDF is invoked, to make the relationship as explicit as possible.

Differential Revision: [D28623889](https://our.internmc.facebook.com/intern/diff/D28623889/)