### PR TITLE
[reland] Set and propagate devices in RRef completion future

### DIFF
--- a/torch/csrc/distributed/rpc/rref_context.cpp
+++ b/torch/csrc/distributed/rpc/rref_context.cpp
@@ -392,10 +392,12 @@ c10::intrusive_ptr<JitFuture> RRefContext::getOwnerRRef(
       // Note: The type passed into RRefType::create() does not matter here, as
       // the future is marked as completed with the RRef of the specific type
       // in getOrCreateOwnerRRef().
-      // Also no need to specify any devices because the RRef object itself
-      // doesn't contain any DataPtrs, it just provides means to retrieve them.
-      auto futureOwner =
-          c10::make_intrusive<JitFuture>(RRefType::create(c10::AnyType::get()));
+      // We need to set devices here, even if they won't be used by the value
+      // (an RRef object doesn't contain any tensors, it just provides means to
+      // retrieve them) because we need them to be propagated/ to child futures.
+      // This is silly and we should find a way to avoid this.
+      auto futureOwner = c10::make_intrusive<JitFuture>(
+          RRefType::create(c10::AnyType::get()), agent_->getDevices());
       pendingOwners_[rrefId] = futureOwner;
       return futureOwner;
     } else {
@@ -407,10 +409,12 @@ c10::intrusive_ptr<JitFuture> RRefContext::getOwnerRRef(
     auto owner = iter->second;
     auto rrefPtr = fromOwnerRRef(owner);
 
-    // No need to specify any devices because the RRef object itself doesn't
-    // contain any DataPtrs, it just provides means to retrieve them.
-    auto futureOwner =
-        c10::make_intrusive<JitFuture>(RRefType::create(owner->type()));
+    // We need to set devices here, even if they won't be used by the value (an
+    // RRef object doesn't contain any tensors, it just provides means to
+    // retrieve them) because we need them to be propagated/ to child futures.
+    // This is silly and we should find a way to avoid this.
+    auto futureOwner = c10::make_intrusive<JitFuture>(
+        RRefType::create(owner->type()), agent_->getDevices());
     futureOwner->markCompleted(IValue(rrefPtr));
     return futureOwner;
   }
@@ -665,7 +669,11 @@ void RRefContext::recordThreadLocalPendingRRefs() {
 }
 
 c10::intrusive_ptr<JitFuture> RRefContext::waitForThreadLocalPendingRRefs() {
-  auto jitFuturePtr = c10::make_intrusive<JitFuture>(BoolType::get());
+  // We need to set devices here, even if they won't be used by the value (it's
+  // a bool, it doesn't contain tensors!) because we need them to be propagated
+  // to child futures. This is silly and we should find a way to avoid this.
+  auto jitFuturePtr =
+      c10::make_intrusive<JitFuture>(BoolType::get(), agent_->getDevices());
   if (userTable_.empty()) {
     jitFuturePtr->markCompleted(true);
   } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* #59212 [reland] Make TP agent use streams from Future when sending response
* **#59211 [reland] Set and propagate devices in RRef completion future**
* #59210 [reland] Set streams when invoking UDFs
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58674

I found this missing parameter while debugging failures in the next PR.
I'm very unhappy about this change. I think this future, which we know for sure won't contain tensors, shouldn't have to worry about CUDA devices. And yet, it does. This means that basically any future anywhere might have to worry about it, and this just doesn't scale, and thus it's bad.

Differential Revision: [D28623886](https://our.internmc.facebook.com/intern/diff/D28623886/)