### PR TITLE
[reland] Make TP agent use streams from Future when sending response

### DIFF
--- a/torch/csrc/distributed/rpc/tensorpipe_agent.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.h
@@ -243,7 +243,7 @@ class TensorPipeAgent : public RpcAgent {
       const std::shared_ptr<tensorpipe::Pipe>&,
       c10::intrusive_ptr<Message> message,
       std::vector<c10::Device>&& devices,
-      std::shared_ptr<LazyStreamContext> ctx,
+      std::vector<c10::Stream> streams,
       std::function<void(const tensorpipe::Error&)>) noexcept;
 
   // Callback of listener accept()
@@ -258,7 +258,7 @@ class TensorPipeAgent : public RpcAgent {
       std::shared_ptr<tensorpipe::Pipe>& pipe,
       JitFuture& futureResponseMessage,
       uint64_t messageId,
-      std::shared_ptr<LazyStreamContext> ctx);
+      std::vector<c10::Stream> stream);
 
   // Collects metrics from successful RPC calls
   void trackNetworkData(

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.h
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.h
@@ -51,7 +51,7 @@ TORCH_API std::tuple<tensorpipe::Message, TensorpipeWriteBuffers>
 tensorpipeSerialize(
     c10::intrusive_ptr<Message> rpcMessage,
     std::vector<c10::Device> devices,
-    const std::shared_ptr<LazyStreamContext>& ctx);
+    const std::vector<c10::Stream>& streams);
 
 // Allocate the buffers that will hold the incoming data. They will be managed
 // by the returned holder, which must be kept alive until the asynchronous read
@@ -60,7 +60,7 @@ tensorpipeSerialize(
 TORCH_API std::pair<tensorpipe::Allocation, TensorpipeReadBuffers>
 tensorpipeAllocate(
     const tensorpipe::Descriptor& tpDescriptor,
-    const std::shared_ptr<LazyStreamContext>& ctx);
+    const std::vector<c10::Stream>& streams);
 
 // Convert a TensorPipe message back into an RPC message. This requires the data
 // to be available and can thus only be performed once the asynchronous read has


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58753 Fix race condition in TP agent
* #56863 Ensure async_execution works with CUDAFuture
* #57355 Avoid re-doing CUDA stream sync in OwnerRRef
* **#59212 [reland] Make TP agent use streams from Future when sending response**
* #59211 [reland] Set and propagate devices in RRef completion future
* #59210 [reland] Set streams when invoking UDFs
* #59209 [reland] Create CUDA-aware futures in RequestCallback
* #59208 [reland] Provide pre-extracted DataPtrs when completing a Future with a Message
* #59207 [reland] Allow Future::then to return pre-extracted DataPtrs
* #59206 [reland] Always use intrusive_ptr for Message (2 out of 2)
* #59205 [reland] Always use intrusive_ptr for Message (1 out of 2)

Reland of https://github.com/pytorch/pytorch/pull/58428

Until now, the TP agent expected the output of a remote function to be on the same streams as the inputs. In other words, it used the lazy stream context of the inputs to synchronize the output tensors. This was true in the most common case of a synchronous remote function. However it wasn't true for async functions, for fetching RRefs, ... The more generic way is to use the CUDA events held by the Future to perform this synchronization. (These events may be on the input streams, or they may not be!).

Differential Revision: [D28623885](https://our.internmc.facebook.com/intern/diff/D28623885/)