### PR TITLE
Fix device of info tensor for torch.linalg.inv_ex with MAGMA backend

### DIFF
--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1436,7 +1436,7 @@ AT_ERROR("inverse: MAGMA library not found in "
   magmaGetri<scalar_t>(
     n, self_data, lda, ipiv.data_ptr<magma_int_t>(), dwork.data_ptr<scalar_t>(), lwork, &info_getri_cpu);
   info_lu.fill_(info_lu_cpu);
-  info_getri.fill_(info_lu_cpu);
+  info_getri.fill_(info_getri_cpu);
 #endif
 }
 

--- a/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
+++ b/aten/src/ATen/native/cuda/BatchLinearAlgebra.cu
@@ -1415,7 +1415,7 @@ AT_ERROR("inverse: MAGMA library not found in "
 }
 
 template <typename scalar_t>
-static void apply_single_inverse(Tensor& self, Tensor& infos_lu, Tensor& infos_getri) {
+static void apply_single_inverse(Tensor& self, Tensor& info_lu, Tensor& info_getri) {
 #ifndef USE_MAGMA
 AT_ERROR("inverse: MAGMA library not found in "
     "compilation. Please rebuild with MAGMA.");
@@ -1425,15 +1425,18 @@ AT_ERROR("inverse: MAGMA library not found in "
   magma_int_t lda = std::max<magma_int_t>(1, n);
   magma_int_t lwork = n * magmaGetriOptimalBlocksize<scalar_t>(n);
 
-  // magmaLu and magmaGetri requires infos tensor to live on CPU
-  infos_lu = infos_lu.to(at::kCPU);
-  infos_getri = infos_getri.to(at::kCPU);
+  // magmaLu and magmaGetri requires info argument to live on CPU
+  // but info_lu and info_getri tensors are on the same device as self
+  magma_int_t info_lu_cpu = 0;
+  magma_int_t info_getri_cpu = 0;
 
   Tensor ipiv = at::empty({lda}, at::kInt);
   Tensor dwork = at::empty({lwork}, self.options());
-  magmaLu<scalar_t>(n, n, self_data, lda, ipiv.data_ptr<magma_int_t>(), infos_lu.data_ptr<magma_int_t>());
+  magmaLu<scalar_t>(n, n, self_data, lda, ipiv.data_ptr<magma_int_t>(), &info_lu_cpu);
   magmaGetri<scalar_t>(
-    n, self_data, lda, ipiv.data_ptr<magma_int_t>(), dwork.data_ptr<scalar_t>(), lwork, infos_getri.data_ptr<magma_int_t>());
+    n, self_data, lda, ipiv.data_ptr<magma_int_t>(), dwork.data_ptr<scalar_t>(), lwork, &info_getri_cpu);
+  info_lu.fill_(info_lu_cpu);
+  info_getri.fill_(info_lu_cpu);
 #endif
 }
 

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -3207,6 +3207,14 @@ class TestLinalg(TestCase):
     @skipCUDAIfNoMagmaAndNoCusolver
     @skipCPUIfNoLapack
     @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
+    def test_inv_ex_info_device(self, device, dtype):
+        A = torch.eye(3, 3, dtype=dtype, device=device)
+        info = torch.linalg.inv_ex(A).info
+        self.assertTrue(info.device == A.device)
+
+    @skipCUDAIfNoMagmaAndNoCusolver
+    @skipCPUIfNoLapack
+    @dtypes(torch.float32, torch.float64, torch.complex64, torch.complex128)
     @skipCUDAIfRocm
     def test_inv_ex_singular(self, device, dtype):
         # if the input matrix is not invertible, info with positive integer is returned


### PR DESCRIPTION
This PR fixes `torch.linalg.inv_ex` with MAGMA backend.
`info` tensor was returned on CPU device even for CUDA inputs.
Now it's on the same device as input.

Fixes https://github.com/pytorch/pytorch/issues/58769
