### PR TITLE
[RPC Framework] Support creating a RemoteModule by RRef

### DIFF
--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 import collections
+import io
 import sys
 import types
 from typing import (
@@ -111,9 +112,10 @@ class _RemoteModule(nn.Module):
     def __init__(
         self,
         remote_device: str,
-        module_cls: Type[nn.Module],
+        module_cls: Type[nn.Module] = None,
         args: Tuple = None,
         kwargs: Dict[str, Any] = None,
+        module_rref: rpc.RRef[nn.Module] = None,
         _module_interface_cls: Any = None,
     ):
         """
@@ -170,6 +172,10 @@ class _RemoteModule(nn.Module):
                 >>> module_cls = MyModule
             args (Sequence, optional): args to be passed to ``module_cls``.
             kwargs (Dict, optional): kwargs to be passed to ``module_cls``.
+            module_rref (RRef[nn.Module], optional): If provided, no new module will be actually created,
+                and only reuses a module reference possibly shared by other another remote module.
+                This alternate construction can help save memory footprint by not creating an underlying module.
+                For this case, the other 3 args ``module_cls``, ``args``, and ``kwargs`` will be disregarded.
             _module_interface_cls (type, optional): The TorchScript interface type for the module
                 to be created. The type object should be decorated by @torch.jit.interface.
                 If not provided, the generated RemoteModule is not torchscript-able.
@@ -177,7 +183,7 @@ class _RemoteModule(nn.Module):
 
         Returns:
             A remote module instance which wraps the :class:`~nn.Module` created by the
-            user-provided ``module_cls``, it has a blocking ``forward`` method and an
+            user-provided ``module_cls`` or ``module_rref``, it has a blocking ``forward`` method and an
             asynchronous ``forward_async`` method that returns a future of the ``forward`` call
             on the user-provided module on the remote side.
 
@@ -208,6 +214,10 @@ class _RemoteModule(nn.Module):
         """
         super().__init__()
 
+        assert (
+            module_cls is not None or module_rref is not None
+        ), "module_cls and module_rref cannot be both None."
+
         # NOTE: if a new attribute is added to this class, also need to add it
         # to ``_REMOTE_MODULE_PICKLED_ATTRIBUTES`` for pickling/unpickling.
 
@@ -235,12 +245,13 @@ class _RemoteModule(nn.Module):
             # Users reply on this field to know if this generated RemoteModule is TorchScript-able.
             self.is_scriptable = True
 
-            # Instantiate template on remote side.
-            fut = rpc.rpc_async(
-                self.on,
-                _instantiate_template,
-                (_module_interface_cls, enable_moving_cpu_tensors_to_cuda),
-            )
+            if module_rref is None:
+                # Instantiate template on remote side.
+                fut = rpc.rpc_async(
+                    self.on,
+                    _instantiate_template,
+                    (_module_interface_cls, enable_moving_cpu_tensors_to_cuda),
+                )
 
             # Instantiate template on local side.
             generated_module = (
@@ -250,28 +261,41 @@ class _RemoteModule(nn.Module):
             )
             self.generated_methods = generated_module._generated_methods
 
-            # Create the module on the remote side.
-            fut.wait()  # Ensure remote_module_cls is available on remote side.
+            if module_rref is None:
+                # Instantiate template on remote side.
+                fut = rpc.rpc_async(
+                    self.on,
+                    _instantiate_template,
+                    (_module_interface_cls, enable_moving_cpu_tensors_to_cuda),
+                )
 
-            # TODO: We need to change this to rpc.remote, and make it async (see the else branch below).
-            # For that we need to be able to apply _module_interface_cls to the RRef returned by rpc.remote
-            # See https://github.com/pytorch/pytorch/issues/58098 for more context.
-            self.module_rref = rpc.rpc_sync(
-                self.on,
-                _create_module_with_interface,
-                (module_cls, args, kwargs, self.device, _module_interface_cls),
-            )
+                # Create the module on the remote side.
+                fut.wait()  # Ensure remote_module_cls is available on remote side.
+
+                # TODO: We need to change this to rpc.remote, and make it async (see the else branch below).
+                # For that we need to be able to apply _module_interface_cls to the RRef returned by rpc.remote
+                # See https://github.com/pytorch/pytorch/issues/58098 for more context.
+                self.module_rref = rpc.rpc_sync(
+                    self.on,
+                    _create_module_with_interface,
+                    (module_cls, args, kwargs, self.device, _module_interface_cls),
+                )
+            else:
+                self.module_rref = module_rref
         else:
             self.is_scriptable = False
             self.generated_methods = (
                 _NON_SCRIPTABLE_REMOTE_MODULE_MODULE._generated_methods
             )
-            # Create the module on the remote side.
-            self.module_rref = rpc.remote(
-                self.on,
-                _create_module,
-                (module_cls, args, kwargs, self.device),
-            )
+            if module_rref is None:
+                # Create the module on the remote side.
+                self.module_rref = rpc.remote(
+                    self.on,
+                    _create_module,
+                    (module_cls, args, kwargs, self.device),
+                )
+            else:
+                self.module_rref = module_rref
 
         # Install generated methods.
         for method in self.generated_methods:
@@ -518,11 +542,12 @@ class RemoteModule(_RemoteModule):
     def __init__(
         self,
         remote_device: str,
-        module_cls: Type[nn.Module],
+        module_cls: Type[nn.Module] = None,
         args: Tuple = None,
         kwargs: Dict[str, Any] = None,
+        module_rref: rpc.RRef[nn.Module] = None,
     ):
-        super().__init__(remote_device, module_cls, args, kwargs)
+        super().__init__(remote_device, module_cls, args, kwargs, module_rref)
 
 
 def _remote_module_receiver(
@@ -565,7 +590,9 @@ def _remote_module_reducer(remote_module):
             print(
                 "The new attribute ``{}`` of RemoteModule is ignored during RPC pickling. "
                 "To pickle this attribute, please add it to ``_REMOTE_MODULE_PICKLED_ATTRIBUTES``. "
-                "Otherwise, please explicitly add it to ``_REMOTE_MODULE_ATTRIBUTES_IGNORE_FOR_PICKLING``.".format(k),
+                "Otherwise, please explicitly add it to ``_REMOTE_MODULE_ATTRIBUTES_IGNORE_FOR_PICKLING``.".format(
+                    k
+                ),
                 file=sys.stderr,
             )
 
@@ -574,4 +601,35 @@ def _remote_module_reducer(remote_module):
         tuple(pickled_attrs.values()),
     )
 
+
+def _recursive_script_module_receiver(
+    recursive_script_module_serialized,
+):
+    """
+    Deserializes a RecursiveScirptModule that does not contain a script RemoteModule.
+    """
+    f = io.BytesIO(recursive_script_module_serialized)
+    m = torch.jit.load(f)
+    return m
+
+
+def _recursive_script_module_reducer(recursive_script_module):
+    """
+    Serializes a RecursiveScirptModule that does not contain a script RemoteModule,
+    and raises an error otherwise.
+    """
+    if hasattr(recursive_script_module._c, "module_rref"):
+        raise RuntimeError(
+            "Passing a script RemoteModule over RPC is not supported. Please create a RemoteModule in the sender, "
+            "send the `module_rref` to the receiver, and create a new instance on the receiver end by passing this `module_rref`."
+        )
+
+    f = io.BytesIO()
+    torch.jit.save(recursive_script_module, f)
+    return (_recursive_script_module_receiver, (f.getvalue(),))
+
+
 _internal_rpc_pickler._register_reducer(RemoteModule, _remote_module_reducer)
+_internal_rpc_pickler._register_reducer(
+    torch.jit.RecursiveScriptModule, _recursive_script_module_reducer
+)

--- a/torch/distributed/rpc/internal.py
+++ b/torch/distributed/rpc/internal.py
@@ -118,12 +118,6 @@ class _InternalRPCPickler:
             # Ignore type error because dispatch_table is defined in third-party package
             p.dispatch_table[obj.__class__] = self._script_module_reducer  # type: ignore[index]
 
-        # TODO(58274): This reducer will be triggered when a script RemoteModule is sent over RPC.
-        # Although `RecursiveScriptModule` is a subclass of `ScriptModule`, the above line somehow
-        # cannot trigger the reducer.
-        # Ignore type error because dispatch_table is defined in third-party package
-        p.dispatch_table[torch.jit.RecursiveScriptModule] = self._script_module_reducer  # type: ignore[index]
-
         # Install customized picklers.
         for class_name in self._class_reducer_dict.keys():
             p.dispatch_table[class_name] = self._class_reducer_dict[class_name]  # type: ignore[index]

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import enum
-import unittest
+import pickle
 from typing import Tuple
 
 import torch
@@ -42,6 +42,11 @@ def remote_forward_async(remote_module, args):
     # Since future cannot be pickled and sent over the RPC layer,
     # have to wait and behave just like ``forward_sync``.
     return remote_module.forward_async(*args).wait()
+
+
+# RPC handler for creating a remote module by module rref on the destination worker.
+def create_remote_module_by_module_rref(remote_device, module_rref):
+    return RemoteModule(remote_device=remote_device, module_rref=module_rref)
 
 
 class ModuleCreationMode(enum.Enum):
@@ -424,7 +429,9 @@ class RemoteModuleTest(CommonRemoteModuleTest):
             new_attr_name = "new_attr"
             setattr(remote_module, new_attr_name, 1)
 
-            attrs = rpc.rpc_sync(dst_worker_name, remote_module_attributes, (remote_module,))
+            attrs = rpc.rpc_sync(
+                dst_worker_name, remote_module_attributes, (remote_module,)
+            )
             self.assertNotIn(new_attr_name, attrs)
 
     @dist_utils.dist_init
@@ -443,9 +450,6 @@ class RemoteModuleTest(CommonRemoteModuleTest):
                 ):
                     torch.save(remote_module, fname)
 
-    @unittest.skip(
-        "Script RemoteModule cannot be sent over RPC at this time. See #57865"
-    )
     @dist_utils.dist_init
     def test_remote_module_py_pickle_not_supported_script(self):
         if self.rank != 0:
@@ -456,10 +460,7 @@ class RemoteModuleTest(CommonRemoteModuleTest):
             dst_worker_name, modes=[ModuleCreationMode.MODULE_CTOR_WITH_INTERFACE]
         ):
             with TemporaryFileName() as fname:
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "Cannot pickle RemoteModule in python pickler. RemoteModule can only be pickled when using RPC",
-                ):
+                with self.assertRaises(pickle.PickleError):
                     torch.save(remote_module, fname)
 
 
@@ -506,11 +507,8 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
             )
             self.assertEqual(ret2, tuple(reversed(args)))
 
-    @unittest.skip(
-        "Script RemoteModule cannot be sent over RPC at this time. See #57865"
-    )
     @dist_utils.dist_init
-    def test_send_remote_module_over_the_wire_script(self):
+    def test_send_remote_module_over_the_wire_script_not_supported(self):
         if self.rank != 0:
             return
         dst_worker1_name = dist_utils.worker_name((self.rank + 1) % self.world_size)
@@ -522,30 +520,43 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
         expected_unpickled_attrs.append("forward_async")
         expected_unpickled_attrs.append("forward")
 
-        # Create a remote module on worker1 and then pass it to worker2 over the RPC layer.
-        for remote_module in self._create_remote_module_iter(
-            dst_worker1_name, modes=[ModuleCreationMode.MODULE_CTOR_WITH_INTERFACE]
+        with self.assertRaisesRegex(
+            RuntimeError, "Passing a script RemoteModule over RPC is not supported."
         ):
-            # Test querying some simple attributes from worker2.
-            attrs = rpc.rpc_sync(
-                dst_worker2_name, remote_module_attributes, (remote_module,)
-            )
-            self.assertListEqual(list(attrs.keys()), expected_unpickled_attrs)
-            self.assertEqual(attrs["on"], "worker1")
-            self.assertEqual(attrs["device"], "cpu")
-            self.assertFalse(attrs["is_device_map_set"])
-            self.assertFalse(attrs["is_scriptable"])
+            # Create a remote module on worker1 and then pass it to worker2 over the RPC layer.
+            for remote_module in self._create_remote_module_iter(
+                dst_worker1_name, modes=[ModuleCreationMode.MODULE_CTOR_WITH_INTERFACE]
+            ):
+                # Test querying some simple attributes from worker2.
+                attrs = rpc.rpc_sync(
+                    dst_worker2_name, remote_module_attributes, (remote_module,)
+                )
 
-            # Test the installed methods on worker1's can be initiated by worker2 over RPC layer.
-            # NOTE: In practice a remote module should be directly stored on the worker that runs ``forward``` or ``forward_async``,
-            # not have another worker to initiate forward over the RPC layer.
-            args = (torch.ones(1), 2, "3")
-            ret1 = rpc.rpc_sync(dst_worker2_name, remote_forward, (remote_module, args))
-            self.assertEqual(ret1, tuple(reversed(args)))
-            ret2 = rpc.rpc_sync(
-                dst_worker2_name, remote_forward_async, (remote_module, args)
+    @dist_utils.dist_init
+    def test_create_remote_module_by_module_rref(self):
+        if self.rank != 0:
+            return
+        dst_worker1_name = dist_utils.worker_name((self.rank + 1) % self.world_size)
+        dst_worker2_name = dist_utils.worker_name((self.rank + 2) % self.world_size)
+
+        # Create a remote module on worker1 and then pass its `module_rref` to worker2 over the RPC layer.
+        for remote_module in self._create_remote_module_iter(
+            dst_worker1_name, modes=[ModuleCreationMode.MODULE_CTOR]
+        ):
+            remote_module2 = rpc.rpc_sync(
+                dst_worker2_name,
+                create_remote_module_by_module_rref,
+                ("{}/cuda:0".format(dst_worker2_name), remote_module.module_rref),
             )
-            self.assertEqual(ret2, tuple(reversed(args)))
+
+            args = (torch.ones(1), 2, "3")
+            ret1 = rpc.rpc_sync(
+                dst_worker1_name, remote_forward, (remote_module, args)
+            )
+            ret2 = rpc.rpc_sync(
+                dst_worker2_name, remote_forward, (remote_module2, args)
+            )
+            self.assertEqual(ret2, ret2)
 
 
 class CudaRemoteModuleTest(CommonRemoteModuleTest):
@@ -588,8 +599,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             r"Expected one of .+ device type at start of device string",
         ):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "{}/foo".format(dst_worker_name),
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -599,8 +610,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             RuntimeError, r"CUDA error: invalid device ordinal"
         ):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "{}/cuda:100".format(dst_worker_name),
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -608,8 +619,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
 
         with self.assertRaisesRegex(RuntimeError, r"Invalid device string: 'cpu2'"):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "{}/cpu2".format(dst_worker_name),
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -617,8 +628,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
 
         with self.assertRaisesRegex(RuntimeError, r"Device string must not be empty"):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "{}/".format(dst_worker_name),
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -629,8 +640,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             r"Could not parse remote_device: worker1/cuda:0/cuda:1. The valid format is '<workername>/<device>'",
         ):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "{}/cuda:0/cuda:1".format(dst_worker_name),
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -641,8 +652,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             r"Could not parse remote_device: /. The valid format is '<workername>/<device>'",
         ):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "/",
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )
@@ -653,8 +664,8 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
             r"Could not parse remote_device: /cuda:0. The valid format is '<workername>/<device>'",
         ):
             list(
-                m.forward() for m in
-                self._create_remote_module_iter(
+                m.forward()
+                for m in self._create_remote_module_iter(
                     "/cuda:0",
                     modes=[ModuleCreationMode.MODULE_CTOR],
                 )

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -546,7 +546,7 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
             remote_module2 = rpc.rpc_sync(
                 dst_worker2_name,
                 create_remote_module_by_module_rref,
-                ("{}/cuda:0".format(dst_worker2_name), remote_module.module_rref),
+                (dst_worker2_name, remote_module.get_module_rref()),
             )
 
             args = (torch.ones(1), 2, "3")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59242 [RPC Framework] Support creating a RemoteModule by RRef**

#Oringal PR Issue: https://github.com/pytorch/pytorch/issues/58274

This can be a workaround: Instead of passing a script `RemoteModule` over RPC, pass its `module_rref` field over RPC, and then construct a new `RemoteModule` on the receiver end.

Differential Revision: [D28794905](https://our.internmc.facebook.com/intern/diff/D28794905/)