### PR TITLE
use long index type for index_add_cuda deterministic path

### DIFF
--- a/aten/src/ATen/native/cuda/Indexing.cu
+++ b/aten/src/ATen/native/cuda/Indexing.cu
@@ -495,7 +495,7 @@ Tensor& index_add_cuda_(Tensor & self, int64_t dim, const Tensor & index, const 
     for (const auto i: c10::irange(dim)) {
       indices.emplace_back();
     }
-    indices.emplace_back(index);
+    indices.emplace_back(index.to(at::kLong));
     return self.index_put_(indices, source * alpha, true);
   }
 


### PR DESCRIPTION
Summary:
index_add can take int or long index tensor whereas index_put only takes long indices tensor.

In the deterministic path of index_add_cuda, we use index_put. Hence we better convert index tensor to long.

Test Plan:
buck test mode/opt //caffe2/test:torch_cuda -- test_index_add_deterministic

    ✓ ListingSuccess: caffe2/test:torch_cuda - main (14.748)
    ✓ Pass: caffe2/test:torch_cuda - test_index_add_deterministic_cuda (test_torch.TestTorchDeviceTypeCUDA) (27.717)
    ✓ Pass: caffe2/test:torch_cuda - main (27.717)

Differential Revision: D28804038

