### PR TITLE
Add the release testing workflow for 1.9.0 and future releases.

### DIFF
--- a/.github/scripts/monitor_proc.sh
+++ b/.github/scripts/monitor_proc.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+max() {
+    local a=$1
+    local b=$2
+    if (( $(bc <<< "${a}>${b}") )); then
+        echo "${a}"
+    else
+        echo "${b}"
+    fi
+}
+
+get_gpu_max_memory_usage_cuda() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    # Some processes might not use the GPU
+    if ! nvidia-smi pmon -s m -c 1 -o T | grep "${my_pid}" >/dev/null 2>/dev/null; then
+        echo "${max}"
+        return
+    fi
+    curr=$(nvidia-smi pmon -s m -c 1 -o T | grep "${my_pid}" | awk '{print $5}' | sort | tail -1 | grep -o "[0-9.]*")
+    max "${curr}" "${max}"
+}
+
+get_gpu_max_memory_usage_rocm() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    # Some processes might not use the GPU
+    if ! rocm-smi --showpidusedmem | grep "${my_pid}" >/dev/null 2>/dev/null; then
+        echo "${max}"
+        return
+    fi
+    curr=$(rocm-smi --showpidusedmem | grep "${my_pid}" | awk '{print $3}' | sort | tail -1 |  grep -o "[0-9.]*")
+    max "$(($curr/1000000))" "${max}"
+}
+
+get_cpu_max_rss_memory_usage() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Rss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max "${curr}" "${max}"
+    else
+        echo "${max}"
+    fi
+}
+
+get_cpu_max_pss_memory_usage() {
+    local my_pid=$1
+    local max=$2
+    local curr
+    local SMAPS_FILE="/proc/${my_pid}/smaps"
+    if [[ -f "${SMAPS_FILE}" ]]; then
+        curr=$(cat "${SMAPS_FILE}" | grep -i '^Pss' |  awk '{Total+=$2} END {print Total/1024""}' | grep -o "[0-9.]*")
+        max "${curr}" "${max}"
+    else
+        echo "${max}"
+    fi
+}
+
+get_multi_proc_ids() {
+    local my_pid=$1
+    # If a process spawns other processes this should catch that
+    ps --forest -o pid --ppid "${my_pid}" --pid "${my_pid}" | awk 'NR>1 {print}'
+}
+
+LOG_FILE=${LOG_FILE:-}
+if [[ -z "${LOG_FILE}" ]]; then
+    LOG_FILE=$(mktemp --suffix "_monitor_proc")
+fi
+
+MEM_FILE=${MEM_FILE:-}
+if [[ -z "${MEM_FILE}" ]]; then
+    MEM_FILE=${LOG_FILE}_mem
+fi
+
+COMMAND=$@
+if [[ "${COMMAND^^}" == *"ROCM"* ]]; then
+    get_gpu_max_memory_usage="get_gpu_max_memory_usage_rocm"
+    prefix=$1
+    COMMAND_TO_RUN=${COMMAND#"$prefix"}
+else
+    get_gpu_max_memory_usage="get_gpu_max_memory_usage_cuda"
+    COMMAND_TO_RUN=$@
+fi
+
+echo "Running  ${COMMAND_TO_RUN} > \"${LOG_FILE}\" 2>&1 &"
+/usr/bin/time -f "\nTotal time elapsed: %e seconds." ${COMMAND_TO_RUN} > "${LOG_FILE}" 2>&1 &
+PID_TO_WATCH=$(ps aux |  grep -v 'grep' | grep -F "${COMMAND_TO_RUN}" | grep -v "$0" | awk '{print $2}' | head -1)
+trap "kill -9 ${PID_TO_WATCH} >/dev/null 2>/dev/null || exit 0" $(seq 0 15)
+MAX_GPU_MEMORY=0
+MAX_RSS_MEMORY=0
+MAX_PSS_MEMORY=0
+
+echo "Watching PID: ${PID_TO_WATCH}"
+echo "Searching for spawned processes with"
+echo "Tail log file with: ps --forest -o pid --ppid ${PID_TO_WATCH} --pid ${PID_TO_WATCH} | awk 'NR>1 {print}'"
+echo "    tail -f ${LOG_FILE}"
+
+iteration=0
+printf "\n%-15s%-15s%s\n" "Max GPU Mem." "Max RSS Mem." "Max PSS Mem." | tee $MEM_FILE
+while kill -0 "${PID_TO_WATCH}" >/dev/null 2>/dev/null; do
+    for pid in $(get_multi_proc_ids "${PID_TO_WATCH}"); do
+        MAX_GPU_MEMORY=$("${get_gpu_max_memory_usage}" "${pid}" "${MAX_GPU_MEMORY}")
+        MAX_RSS_MEMORY=$(get_cpu_max_rss_memory_usage "${pid}" "${MAX_RSS_MEMORY}")
+        MAX_PSS_MEMORY=$(get_cpu_max_pss_memory_usage "${pid}" "${MAX_PSS_MEMORY}")
+    done
+    # Print out max every 5 seconds
+    if [[ "${iteration}" -eq "10" ]]; then
+        printf "%-15s%-15s%s\n" "${MAX_GPU_MEMORY}" "${MAX_RSS_MEMORY}" "${MAX_PSS_MEMORY}" | tee -a $MEM_FILE
+        iteration=0
+    else
+        iteration=$((iteration+1))
+    fi
+    sleep 0.5
+done
+
+printf "%-15s%-15s%s\n" "${MAX_GPU_MEMORY}" "${MAX_RSS_MEMORY}" "${MAX_PSS_MEMORY}" | tee -a $MEM_FILE

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -52,14 +52,14 @@ jobs:
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          # wget -q https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
-          # wget -q https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
-          # wget -q https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
-          # pip install ./pytorch.whl  ./torchvision.whl ./torchtext.whl
-          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
-          echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
+          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
+          # echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
+          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220425%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220425%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220425-cp38-cp38-linux_x86_64.whl
+          echo "RESULT_DIR=${HOME}/release-testing/20220425" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -69,10 +69,13 @@ jobs:
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           git clone https://github.com/pytorch/pytorch.git pytorch-src
           pushd pytorch-src
-          git checkout release/1.11
+          # commit on 20220410
+          git checkout f42bdff0166ef503c844353c32b6725391e440ac
+          # git checkout release/1.11
           python setup.py install
-          echo "RESULT_DIR=${HOME}/release-testing/1.11.0-src" >> $GITHUB_ENV
-          python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
+          echo "RESULT_DIR=${HOME}/release-testing/20220410-src" >> $GITHUB_ENV
+          popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
+          # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -52,8 +52,9 @@ jobs:
           # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc8-avx2" >> $GITHUB_ENV
+          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          conda install pytorch torchvision torchaudio cpuonly -c pytorch-test
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc9-cpuonly" >> $GITHUB_ENV
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
@@ -61,10 +62,10 @@ jobs:
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
-          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl  \
-                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220506-cp38-cp38-linux_x86_64.whl
-          echo "RESULT_DIR=${HOME}/release-testing/20220506-rc7-avx2" >> $GITHUB_ENV
+          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl  \
+          #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220506-cp38-cp38-linux_x86_64.whl
+          # echo "RESULT_DIR=${HOME}/release-testing/20220506-rc7-avx2" >> $GITHUB_ENV
           # install build deps
           # NUMPY_VERSION="1.21.2"
           # conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
@@ -103,7 +104,7 @@ jobs:
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
       - name: Run MNist HogWild
         run: |
           . activate reltest
@@ -133,7 +134,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
       - name: Run CPU WLM Transformer
         run: |
           set -x
@@ -155,7 +156,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_trans/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
+          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
       - name: Remove Conda env
         run: |
           conda env remove --name reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -56,10 +56,13 @@ jobs:
           # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
           # echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
-          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
-          echo "RESULT_DIR=${HOME}/release-testing/20220425" >> $GITHUB_ENV
+          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
+          pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/torchtext-0.11.0-cp38-cp38-linux_x86_64.whl
+          echo "RESULT_DIR=${HOME}/release-testing/1.11.0-whl" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -61,7 +61,7 @@ jobs:
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
           pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
                       https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/torchtext-0.11.0-cp38-cp38-linux_x86_64.whl
+                      https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0-whl" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -69,8 +69,8 @@ jobs:
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           git clone https://github.com/pytorch/pytorch.git pytorch-src
           pushd pytorch-src
-          # commit on 20220410
-          git checkout f42bdff0166ef503c844353c32b6725391e440ac
+          # commit on 20220401
+          git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
           # git checkout release/1.11
           git setup.py clean
           python setup.py install

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -72,6 +72,7 @@ jobs:
           # commit on 20220410
           git checkout f42bdff0166ef503c844353c32b6725391e440ac
           # git checkout release/1.11
+          git setup.py clean
           python setup.py install
           echo "RESULT_DIR=${HOME}/release-testing/20220410-src" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -70,7 +70,9 @@ jobs:
           git clone https://github.com/pytorch/pytorch.git pytorch-src
           pushd pytorch-src
           # commit on 20220401
-          git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
+          # git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
+          # commit on 20220501
+          git checkout 201ddafc22e22c387b4cd654f397e05354d73d09
           git submodule update --recursive --init
           # git checkout release/1.11
           git setup.py clean

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -71,6 +71,7 @@ jobs:
           pushd pytorch-src
           # commit on 20220401
           git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
+          git submodule update --recursive --init
           # git checkout release/1.11
           git setup.py clean
           python setup.py install

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -62,6 +62,11 @@ jobs:
           # pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
+          # install build deps
+          NUMPY_VERSION="1.21.2"
+          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
+                           setuptools cmake=3.22 cffi typing_extensions \
+                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
           git clone https://github.com/pytorch/pytorch.git pytorch-src
           pushd pytorch-src
           git checkout release/1.11

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
+          set -x
           # re-setup the cuda soft link
           if [ -e "/usr/local/cuda" ]; then
               sudo rm /usr/local/cuda
@@ -78,7 +79,7 @@ jobs:
           # git checkout release/1.11
           git setup.py clean
           python setup.py install
-          echo "RESULT_DIR=${HOME}/release-testing/20220410-src" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/20220501-src" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -53,7 +53,7 @@ jobs:
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc7-avx2" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc8-avx2" >> $GITHUB_ENV
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
@@ -102,7 +102,7 @@ jobs:
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
-          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
       - name: Run MNist HogWild
         run: |
           . activate reltest
@@ -112,7 +112,7 @@ jobs:
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
           export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
-          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest
@@ -122,7 +122,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
-          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
       - name: Run GPU WLM LSTM
         run: |
           . activate reltest
@@ -132,7 +132,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
-          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
       - name: Run CPU WLM Transformer
         run: |
           set -x
@@ -154,7 +154,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_trans/result_mem.log
-          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
       - name: Remove Conda env
         run: |
           conda env remove --name reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -61,9 +61,10 @@ jobs:
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
-          # pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
+          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl  \
+                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220506-cp38-cp38-linux_x86_64.whl
+          echo "RESULT_DIR=${HOME}/release-testing/20220506-rc7-avx2" >> $GITHUB_ENV
           # install build deps
           # NUMPY_VERSION="1.21.2"
           # conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -52,7 +52,8 @@ jobs:
           # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc7-avx2" >> $GITHUB_ENV
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
@@ -64,22 +65,22 @@ jobs:
           #             https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
           # install build deps
-          NUMPY_VERSION="1.21.2"
-          conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-                           setuptools cmake=3.22 cffi typing_extensions \
-                           future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
-          rm -rf pytorch-src || true
-          git clone https://github.com/pytorch/pytorch.git pytorch-src
-          pushd pytorch-src
+          # NUMPY_VERSION="1.21.2"
+          # conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
+          #                  setuptools cmake=3.22 cffi typing_extensions \
+          #                  future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
+          # rm -rf pytorch-src || true
+          # git clone https://github.com/pytorch/pytorch.git pytorch-src
+          # pushd pytorch-src
           # commit on 20220401
           # git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
           # commit on 20220501
-          git checkout 201ddafc22e22c387b4cd654f397e05354d73d09
-          git submodule update --recursive --init
+          # git checkout 201ddafc22e22c387b4cd654f397e05354d73d09
+          # git submodule update --recursive --init
           # git checkout release/1.11
-          git setup.py clean
-          python setup.py install
-          echo "RESULT_DIR=${HOME}/release-testing/20220501-src" >> $GITHUB_ENV
+          # git setup.py clean
+          # python setup.py install
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc7-avx2" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
@@ -143,7 +144,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_trans/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
+          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
       - name: Run GPU WLM Transformer
         run: |
           . activate reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -62,7 +62,8 @@ jobs:
           # pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
-          pushd pytorch
+          git clone https://github.com/pytorch/pytorch.git pytorch-src
+          pushd pytorch-src
           git checkout release/1.11
           python setup.py install
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0-src" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -56,9 +56,9 @@ jobs:
           # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
           # echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
-          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220425%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220425%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220425-cp38-cp38-linux_x86_64.whl
+          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
           echo "RESULT_DIR=${HOME}/release-testing/20220425" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -59,13 +59,14 @@ jobs:
           # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
           #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
-          pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
-                      https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
-          echo "RESULT_DIR=${HOME}/release-testing/1.11.0-whl" >> $GITHUB_ENV
+          # pip install https://download.pytorch.org/whl/cu113/torch-1.11.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/cu113/torchvision-0.12.0%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          #             https://download.pytorch.org/whl/torchtext-0.12.0-cp38-cp38-linux_x86_64.whl
+          pushd pytorch
+          git checkout release/1.11
+          python setup.py install
+          echo "RESULT_DIR=${HOME}/release-testing/1.11.0-src" >> $GITHUB_ENV
           python -c "import torch"
-          python -c "import torchvision"
-          python -c "import torchtext"
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -67,6 +67,7 @@ jobs:
           conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
                            setuptools cmake=3.22 cffi typing_extensions \
                            future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
+          rm -rf pytorch-src || true
           git clone https://github.com/pytorch/pytorch.git pytorch-src
           pushd pytorch-src
           # commit on 20220401

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -67,7 +67,7 @@ jobs:
           git checkout release/1.11
           python setup.py install
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0-src" >> $GITHUB_ENV
-          python -c "import torch"
+          python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -6,7 +6,7 @@ on:
       pytorch_version:
         description: "The version of PyTorch to test"
         required: true
-        default: "1.9.0"
+        default: "1.11.0"
 
 jobs:
   release-testing:
@@ -37,11 +37,13 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y cudatoolkit=10.2 numpy
-          conda install -y -c pytorch pytorch=1.9.1 torchvision
-          # conda install -y -c pytorch-test pytorch=1.10.0 torchvision
-          echo "RESULT_DIR=${HOME}/release-testing/1.9.1" >> $GITHUB_ENV
+          conda install -y cudatoolkit=11.3 numpy magma-cuda113
+          conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
+          # conda install -y -c pytorch pytorch=1.10.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           python -c "import torch"
+          python -c "import torchvision"
+          python -c "import torchtext"
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -39,8 +39,8 @@ jobs:
           . activate reltest
           conda install -y cudatoolkit=11.3 numpy
           conda install -y -c pytorch magma-cuda113
-          # conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV
           python -c "import torch"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,11 +37,10 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y cudatoolkit=10.2
+          conda install -y cudatoolkit=10.2 numpy
           conda install -y -c pytorch pytorch=1.9.1 torchvision
-          # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
-          #                                  cudatoolkit=10.2
-          # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
+          # conda install -y cudatoolkit=10.2
+          # conda install -y -c pytorch-test pytorch=1.10.0 torchvision
           python -c "import torch"
           echo "RESULT_DIR=${HOME}/release-testing/1.9.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2
-          conda install -y -c pytorch pytorch=1.9.1
+          conda install -y -c pytorch pytorch=1.9.1 torchvision
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -44,11 +44,11 @@ jobs:
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
-          conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
+          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y -c pytorch-test pytorch=1.8.1 \
+          conda install -y -c pytorch pytorch=1.8.1 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -40,11 +40,11 @@ jobs:
           conda install -y cudatoolkit=11.3
           conda install -y -c pytorch magma-cuda113
           # link: https://anaconda.org/pytorch/pytorch
-          conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
+          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -46,12 +46,14 @@ jobs:
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
+          # Check pytorch is installed
+          python -c "import torch"
       - name: Check machine tuned
         run: |
           echo "Make sure the machine is tuned."
           . activate reltest
           pushd benchmark
-          pip install -U py-cpuinfo psutil distro
+          pip install py-cpuinfo psutil distro
           sudo $HOME/anaconda3/envs/reltest/bin/python3 torchbenchmark/util/machine_config.py
           popd
       - name: Run Benchmarks

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y -c pytorch-test pytorch=1.9.0 \
+          conda install -y -c pytorch-test pytorch=1.8.1 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
-          echo "RESULT_DIR=${HOME}/release-testing/1.9.0" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.8.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -16,8 +16,8 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
       GOMP_CPU_AFFINITY: "24-47"
-      CUDA_VERSION: "11.6"
-      MAGMA_VERSION: "magma-cuda116"
+      CUDA_VERSION: "11.3"
+      MAGMA_VERSION: "magma-cuda113"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2
@@ -47,8 +47,12 @@ jobs:
           # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
+          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          wget https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
+          wget https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
+          wget https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
+          pip install ./pytorch.whl  ./torchvision.whl ./torchtext.whl
+          echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"
@@ -71,7 +75,7 @@ jobs:
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
       - name: Run MNist HogWild
         run: |
           . activate reltest
@@ -81,7 +85,7 @@ jobs:
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
           export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest
@@ -91,7 +95,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
+          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
       - name: Run GPU WLM LSTM
         run: |
           . activate reltest
@@ -101,7 +105,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
       - name: Run CPU WLM Transformer
         run: |
           . activate reltest
@@ -121,7 +125,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_trans/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
+          # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
       - name: Remove Conda env
         run: |
           conda env remove --name reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -41,7 +41,7 @@ jobs:
           conda install -y -c pytorch-test pytorch=1.10.0 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
           echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
-          # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
+          # conda install -y -c pytorch pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
@@ -54,55 +54,34 @@ jobs:
           pip install -U py-cpuinfo psutil distro
           sudo $HOME/anaconda3/envs/reltest/bin/python3 torchbenchmark/util/machine_config.py
           popd
-      - name: Run MNist
+      - name: Run Benchmarks
         run: |
           . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/mnist
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
-      - name: Run MNist HogWild
-        run: |
-          . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/mnist_hogwild
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
           export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
-      - name: Run CPU WLM LSTM
-        run: |
-          . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_cpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
-      - name: Run GPU WLM LSTM
-        run: |
-          . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
-      - name: Run CPU WLM Transformer
-        run: |
-          . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_trans/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
-      - name: Run GPU WLM Transformer
-        run: |
-          . activate reltest
-          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_gpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -61,14 +61,14 @@ jobs:
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
-      # - name: Run MNist HogWild
-      #   run: |
-      #     . activate reltest
-      #     mkdir -p ${RESULT_DIR}/mnist_hogwild
-      #     pushd examples/mnist_hogwild
-      #     export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
-      #     export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
-      #     taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+      - name: Run MNist HogWild
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/mnist_hogwild
+          pushd examples/mnist_hogwild
+          export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
+          export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=11.3 numpy
-          conda install -y -c pytorch magama-cuda113
+          conda install -y -c pytorch magma-cuda113
           conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
           # conda install -y -c pytorch pytorch=1.10.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -1,5 +1,6 @@
 name: PyTorch release testing CI (pytorch-linux-py3.8-cu102)
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       pytorch_version:
@@ -35,8 +36,10 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
+          conda install -y -c pytorch-test pytorch=1.9.0 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
+          # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
+          #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
           echo "Result dir: ${RESULT_DIR} "

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -107,3 +107,8 @@ jobs:
       - name: Remove Conda env
         run: |
           conda env remove --name reltest
+      - name: Submit GH artifacats
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: ${{ env.RESULT_DIR }}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -33,30 +33,29 @@ jobs:
           path: benchmark
       - name: Create Conda env
         run: |
-          conda create -y -n reltest python=3.7
+          conda create -y -n reltest python=3.8
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          . switch-cuda.sh 10.2
-          conda install -y -c pytorch-test pytorch=1.10.0 \
-                                           torchvision torchtext torchaudio cudatoolkit=10.2
-          echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
-          # conda install -y -c pytorch pytorch=${{ github.event.inputs.pytorch_version }} \
+          conda install -y -c cudatoolkit=10.2
+          conda install -y -c pytorch pytorch=1.10.0 \
+                              torchvision torchtext torchaudio
+          # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
+          python -c "import torch"
+          echo "RESULT_DIR=${HOME}/release-testing/1.8.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
-          # Check pytorch is installed
-          python -c "import torch"
       - name: Check machine tuned
         run: |
           echo "Make sure the machine is tuned."
           . activate reltest
           pushd benchmark
-          pip install py-cpuinfo psutil distro
+          pip install -U py-cpuinfo psutil distro
           sudo $HOME/anaconda3/envs/reltest/bin/python3 torchbenchmark/util/machine_config.py
           popd
-      - name: Run Benchmarks
+      - name: Run MNist
         run: |
           . activate reltest
           mkdir -p ${RESULT_DIR}/mnist
@@ -64,26 +63,41 @@ jobs:
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+      - name: Run MNist HogWild
+        run: |
+          . activate reltest
           mkdir -p ${RESULT_DIR}/mnist_hogwild
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
           export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+      - name: Run CPU WLM LSTM
+        run: |
+          . activate reltest
           mkdir -p ${RESULT_DIR}/wlm_cpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
+      - name: Run GPU WLM LSTM
+        run: |
+          . activate reltest
           mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+      - name: Run CPU WLM Transformer
+        run: |
+          . activate reltest
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_trans/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
+      - name: Run GPU WLM Transformer
+        run: |
+          . activate reltest
           mkdir -p ${RESULT_DIR}/wlm_gpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -41,8 +41,8 @@ jobs:
           conda install -y -c pytorch magma-cuda113
           conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
-          conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV
+          # conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -39,10 +39,10 @@ jobs:
           . activate reltest
           conda install -y cudatoolkit=11.3
           conda install -y -c pytorch magma-cuda113
-	  # link: https://anaconda.org/pytorch/pytorch
+          # link: https://anaconda.org/pytorch/pytorch
           conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
-	  # link: https://anaconda.org/pytorch-test/pytorch
+          # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -16,6 +16,8 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
       GOMP_CPU_AFFINITY: "24-47"
+      CUDA_VERSION: "11.6"
+      MAGMA_VERSION: "magma-cuda116"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2
@@ -37,8 +39,10 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y cudatoolkit=11.3
-          conda install -y -c pytorch magma-cuda113
+          . switch-cuda.sh ${CUDA_VERSION}
+          sudo ln -sf /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
+          conda install -y cudatoolkit=${CUDA_VERSION}
+          conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
           conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
@@ -61,6 +65,8 @@ jobs:
       - name: Run MNist
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/mnist
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
@@ -69,6 +75,8 @@ jobs:
       - name: Run MNist HogWild
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/mnist_hogwild
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
@@ -77,6 +85,8 @@ jobs:
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/wlm_cpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
@@ -85,6 +95,8 @@ jobs:
       - name: Run GPU WLM LSTM
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
@@ -93,6 +105,8 @@ jobs:
       - name: Run CPU WLM Transformer
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
@@ -101,6 +115,8 @@ jobs:
       - name: Run GPU WLM Transformer
         run: |
           . activate reltest
+          . switch-cuda.sh ${CUDA_VERSION}
+          nvcc --version
           mkdir -p ${RESULT_DIR}/wlm_gpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -39,7 +39,7 @@ jobs:
           . activate reltest
           conda install -y cudatoolkit=11.3 numpy
           conda install -y -c pytorch magma-cuda113
-          conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
+          conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -116,7 +116,7 @@ jobs:
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
           nvcc --version
-          pyhton -c 'import torch'
+          python -c 'import torch'
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,11 +38,10 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2 numpy
-          conda install -y -c pytorch pytorch=1.9.1 torchvision
-          # conda install -y cudatoolkit=10.2
-          # conda install -y -c pytorch-test pytorch=1.10.0 torchvision
+          # conda install -y -c pytorch pytorch=1.9.1 torchvision
+          conda install -y -c pytorch-test pytorch=1.10.0 torchvision
+          echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
           python -c "import torch"
-          echo "RESULT_DIR=${HOME}/release-testing/1.9.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,12 +37,14 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y cudatoolkit=11.3 numpy
+          conda install -y cudatoolkit=11.3
           conda install -y -c pytorch magma-cuda113
+	  # link: https://anaconda.org/pytorch/pytorch
           conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
-          # conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV
+	  # link: https://anaconda.org/pytorch-test/pytorch
+          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -40,8 +40,9 @@ jobs:
                                            torchvision torchtext torchaudio cudatoolkit=10.2
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
+          # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.9.0" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
-          echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned
         run: |
@@ -59,14 +60,14 @@ jobs:
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
           taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
-      - name: Run MNist HogWild
-        run: |
-          . activate reltest
-          mkdir -p ${RESULT_DIR}/mnist_hogwild
-          pushd examples/mnist_hogwild
-          export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
-          export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
-          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+      # - name: Run MNist HogWild
+      #   run: |
+      #     . activate reltest
+      #     mkdir -p ${RESULT_DIR}/mnist_hogwild
+      #     pushd examples/mnist_hogwild
+      #     export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
+      #     export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
+      #     taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -40,7 +40,11 @@ jobs:
         run: |
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
-          sudo ln -sf /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
+          # re-setup the cuda soft link
+          if [ -e "/usr/local/cuda" ]; then
+              sudo rm /usr/local/cuda
+              sudo ln -sf /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
+          fi
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,9 +38,9 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2 numpy
-          # conda install -y -c pytorch pytorch=1.9.1 torchvision
-          conda install -y -c pytorch-test pytorch=1.10.0 torchvision
-          echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
+          conda install -y -c pytorch pytorch=1.9.1 torchvision
+          # conda install -y -c pytorch-test pytorch=1.10.0 torchvision
+          echo "RESULT_DIR=${HOME}/release-testing/1.9.1" >> $GITHUB_ENV
           python -c "import torch"
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y cudatoolkit=11.3 numpy magma-cuda113
+          conda install -y cudatoolkit=11.3 numpy
+          conda install -y -c pytorch magama-cuda113
           conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
           # conda install -y -c pytorch pytorch=1.10.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo "Make sure the machine is tuned."
           pushd benchmark
-          pip install py-cpuinfo psutil distro
+          pip install -U py-cpuinfo psutil distro
           sudo python3 torchbenchmark/util/machine_config.py
           popd
       - name: Run MNist

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -33,7 +33,7 @@ jobs:
           path: benchmark
       - name: Create Conda env
         run: |
-          conda create -y -n reltest python=3.8
+          conda create -y -n reltest python=3.7
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,12 +38,12 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2
-          conda install -y -c pytorch-test pytorch=1.10.0
+          conda install -y -c pytorch pytorch=1.9.1
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
-          #                                  torchvision torchtext torchaudio cudatoolkit=10.2
+          #                                  cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
           python -c "import torch"
-          echo "RESULT_DIR=${HOME}/release-testing/1.8.1" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.9.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -52,10 +52,13 @@ jobs:
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          wget -q https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
-          wget -q https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
-          wget -q https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
-          pip install ./pytorch.whl  ./torchvision.whl ./torchtext.whl
+          # wget -q https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
+          # wget -q https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
+          # wget -q https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
+          # pip install ./pytorch.whl  ./torchvision.whl ./torchtext.whl
+          pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
+          	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
+                      https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
           echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -43,8 +43,8 @@ jobs:
           # re-setup the cuda soft link
           if [ -e "/usr/local/cuda" ]; then
               sudo rm /usr/local/cuda
-              sudo ln -sf /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
           fi
+          sudo ln -sf /usr/local/cuda-${CUDA_VERSION} /usr/local/cuda
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -15,6 +15,7 @@ jobs:
       GPU_FREQUENCY: "5001,900"
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
+      GOMP_CPU_AFFINITY: "24-47"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2
-          conda install -y -c pytorch pytorch=1.10.0 \
+          conda install -y -c pytorch-test pytorch=1.10.0 \
                               torchvision torchtext torchaudio
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -41,10 +41,10 @@ jobs:
           conda install -y -c pytorch magma-cuda113
           # link: https://anaconda.org/pytorch/pytorch
           conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           conda install -y -c pytorch-test pytorch=1.10.0 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
           echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
@@ -56,6 +57,7 @@ jobs:
       - name: Run MNist
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/mnist
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
@@ -64,6 +66,7 @@ jobs:
       - name: Run MNist HogWild
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/mnist_hogwild
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
@@ -72,6 +75,7 @@ jobs:
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_cpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
@@ -80,6 +84,7 @@ jobs:
       - name: Run GPU WLM LSTM
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
@@ -88,6 +93,7 @@ jobs:
       - name: Run CPU WLM Transformer
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
@@ -96,6 +102,7 @@ jobs:
       - name: Run GPU WLM Transformer
         run: |
           . activate reltest
+          . switch-cuda.sh 10.2
           mkdir -p ${RESULT_DIR}/wlm_gpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y -c pytorch pytorch=1.8.1 \
+          conda install -y -c pytorch-test pytorch=1.10.0 \
                                            torchvision torchtext torchaudio cudatoolkit=10.2
+          echo "RESULT_DIR=${HOME}/release-testing/1.10.0" >> $GITHUB_ENV
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
-          echo "RESULT_DIR=${HOME}/release-testing/1.8.1" >> $GITHUB_ENV
           sudo nvidia-smi -ac ${GPU_FREQUENCY}
           echo "Result dir: ${RESULT_DIR} "
       - name: Check machine tuned

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -49,7 +49,7 @@ jobs:
           . activate reltest
           pushd benchmark
           pip install -U py-cpuinfo psutil distro
-          sudo python3 torchbenchmark/util/machine_config.py
+          sudo $HOME/anaconda3/envs/reltest/bin/python3 torchbenchmark/util/machine_config.py
           popd
       - name: Run MNist
         run: |

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -48,9 +48,9 @@ jobs:
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
-          wget https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
-          wget https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
-          wget https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
+          wget -q https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O pytorch.whl
+          wget -q https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl -O torchvision.whl
+          wget -q https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl -O torchtext.whl
           pip install ./pytorch.whl  ./torchvision.whl ./torchtext.whl
           echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
           python -c "import torch"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2
         with:
-          path: pytorch 
+          path: pytorch
       - name: Check out pytorch/examples
         uses: actions/checkout@v2
         with:
@@ -47,6 +47,7 @@ jobs:
         run: |
           echo "Make sure the machine is tuned."
           pushd benchmark
+          pip install py-cpuinfo psutil distro
           sudo python3 torchbenchmark/util/machine_config.py
           popd
       - name: Run MNist
@@ -100,4 +101,3 @@ jobs:
       - name: Remove Conda env
         run: |
           conda env remove --name reltest
-    

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Check machine tuned
         run: |
           echo "Make sure the machine is tuned."
+          . activate reltest
           pushd benchmark
           pip install -U py-cpuinfo psutil distro
           sudo python3 torchbenchmark/util/machine_config.py

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -1,0 +1,100 @@
+name: PyTorch release testing CI (pytorch-linux-py3.8-cu102)
+on:
+  workflow_dispatch:
+    inputs:
+      pytorch_version:
+        description: "The version of PyTorch to test"
+        required: true
+        default: "1.9.0"
+
+jobs:
+  release-testing:
+    runs-on: [self-hosted, bm-runner]
+    env:
+      GPU_FREQUENCY: "5001,900"
+      CUDA_VISIBLE_DEVICES: "0"
+      CORE_LIST: "24-47"
+    steps:
+      - name: Check out pytorch/pytorch
+        uses: actions/checkout@v2
+        with:
+          path: pytorch 
+      - name: Check out pytorch/examples
+        uses: actions/checkout@v2
+        with:
+          repository: pytorch/examples
+          path: examples
+      - name: Checkout pytorch/benchmark
+        uses: actions/checkout@v2
+        with:
+          repository: pytorch/benchmark
+          path: benchmark
+      - name: Create Conda env
+        run: |
+          conda create -y -n reltest python=3.8
+      - name: Install PyTorch and setup environment
+        run: |
+          . activate reltest
+          conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
+                                           torchvision torchtext torchaudio cudatoolkit=10.2
+          sudo nvidia-smi -ac ${GPU_FREQUENCY}
+          echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV
+          echo "Result dir: ${RESULT_DIR} "
+      - name: Check machine tuned
+        run: |
+          echo "Make sure the machine is tuned."
+          pushd benchmark
+          sudo python3 torchbenchmark/util/machine_config.py
+          popd
+      - name: Run MNist
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/mnist
+          pushd examples/mnist
+          export LOG_FILE=${RESULT_DIR}/mnist/result.log
+          export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+      - name: Run MNist HogWild
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/mnist_hogwild
+          pushd examples/mnist_hogwild
+          export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
+          export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+      - name: Run CPU WLM LSTM
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/wlm_cpu_lstm
+          pushd examples/word_language_model
+          export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
+          export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
+      - name: Run GPU WLM LSTM
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
+          pushd examples/word_language_model
+          export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
+          export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+      - name: Run CPU WLM Transformer
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/wlm_cpu_trans
+          pushd examples/word_language_model
+          export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
+          export MEM_FILE=${RESULT_DIR}/wlm_cpu_trans/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
+      - name: Run GPU WLM Transformer
+        run: |
+          . activate reltest
+          mkdir -p ${RESULT_DIR}/wlm_gpu_trans
+          pushd examples/word_language_model
+          export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log
+          export MEM_FILE=${RESULT_DIR}/wlm_gpu_trans/result_mem.log
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
+      - name: Remove Conda env
+        run: |
+          conda env remove --name reltest
+    

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install PyTorch and setup environment
         run: |
           . activate reltest
-          conda install -y -c cudatoolkit=10.2
+          conda install -y cudatoolkit=10.2
           conda install -y -c pytorch pytorch=1.10.0 \
                               torchvision torchtext torchaudio
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -39,9 +39,10 @@ jobs:
           . activate reltest
           conda install -y cudatoolkit=11.3 numpy
           conda install -y -c pytorch magma-cuda113
-          conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
-          # conda install -y -c pytorch pytorch=1.10.0 torchvision torchtext
-          echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          # conda install -y -c pytorch-test pytorch=1.11.0 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          conda install -y -c pytorch pytorch=1.10.2 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.10.2" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"
           python -c "import torchtext"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -40,10 +40,10 @@ jobs:
           conda install -y cudatoolkit=11.3
           conda install -y -c pytorch magma-cuda113
           # link: https://anaconda.org/pytorch/pytorch
-          # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
+          conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
           # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
           echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           python -c "import torch"
           python -c "import torchvision"

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -112,6 +112,7 @@ jobs:
           # taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
       - name: Run CPU WLM Transformer
         run: |
+          set -x
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
           nvcc --version

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -115,6 +115,7 @@ jobs:
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
           nvcc --version
+          pyhton -c 'import torch'
           mkdir -p ${RESULT_DIR}/wlm_cpu_trans
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -38,8 +38,7 @@ jobs:
         run: |
           . activate reltest
           conda install -y cudatoolkit=10.2
-          conda install -y -c pytorch-test pytorch=1.10.0 \
-                              torchvision torchtext torchaudio
+          conda install -y -c pytorch-test pytorch=1.10.0
           # conda install -y -c pytorch-test pytorch=${{ github.event.inputs.pytorch_version }} \
           #                                  torchvision torchtext torchaudio cudatoolkit=10.2
           # echo "RESULT_DIR=${HOME}/release-testing/${{ github.event.inputs.pytorch_version }}" >> $GITHUB_ENV

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -16,8 +16,8 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
       GOMP_CPU_AFFINITY: "24-47"
-      CUDA_VERSION: "11.6"
-      MAGMA_VERSION: "magma-cuda116"
+      CUDA_VERSION: "11.3"
+      MAGMA_VERSION: "magma-cuda113"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2
@@ -49,11 +49,11 @@ jobs:
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
-          conda install -y -c pytorch pytorch=1.12.0 torchvision
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-${CUDA_VERSION}" >> $GITHUB_ENV
+          # conda install -y -c pytorch pytorch=1.12.0 torchvision
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0-${CUDA_VERSION}" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          # conda install -y -c pytorch-test pytorch=1.12.1 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.12.1-${CUDA_VERSION}" >> $GITHUB_ENV
+          conda install -y -c pytorch-test pytorch=1.12.1 torchvision
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.1-${CUDA_VERSION}" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -16,8 +16,8 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
       GOMP_CPU_AFFINITY: "24-47"
-      CUDA_VERSION: "11.3"
-      MAGMA_VERSION: "magma-cuda113"
+      CUDA_VERSION: "11.6"
+      MAGMA_VERSION: "magma-cuda116"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
-          conda install -y -c pytorch pytorch=1.12.0 torchvision torchtext
+          conda install -y -c pytorch pytorch=1.12.0 torchvision
           echo "RESULT_DIR=${HOME}/release-testing/1.12.0-${CUDA_VERSION}" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
           # conda install -y -c pytorch-test pytorch=1.12.1 torchvision torchtext

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -49,12 +49,11 @@ jobs:
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
-          # conda install -y -c pytorch pytorch=1.12.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
+          conda install -y -c pytorch pytorch=1.12.0 torchvision torchtext
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-${CUDA_VERSION}" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          conda install -y -c pytorch-test pytorch=1.12.1 torchvision torchtext
-          conda install pytorch torchvision torchaudio cpuonly -c pytorch-test
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.1" >> $GITHUB_ENV
+          # conda install -y -c pytorch-test pytorch=1.12.1 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.1-${CUDA_VERSION}" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -6,7 +6,7 @@ on:
       pytorch_version:
         description: "The version of PyTorch to test"
         required: true
-        default: "1.11.0"
+        default: "1.12.1"
 
 jobs:
   release-testing:
@@ -49,40 +49,12 @@ jobs:
           conda install -y cudatoolkit=${CUDA_VERSION}
           conda install -y -c pytorch ${MAGMA_VERSION}
           # link: https://anaconda.org/pytorch/pytorch
-          # conda install -y -c pytorch pytorch=1.11.0 torchvision torchtext
-          # echo "RESULT_DIR=${HOME}/release-testing/1.11.0" >> $GITHUB_ENV
+          # conda install -y -c pytorch pytorch=1.12.0 torchvision torchtext
+          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0" >> $GITHUB_ENV
           # link: https://anaconda.org/pytorch-test/pytorch
-          # conda install -y -c pytorch-test pytorch=1.12.0 torchvision torchtext
+          conda install -y -c pytorch-test pytorch=1.12.1 torchvision torchtext
           conda install pytorch torchvision torchaudio cpuonly -c pytorch-test
-          echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc9-cpuonly" >> $GITHUB_ENV
-          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          # 	      https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220512%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220512-cp38-cp38-linux_x86_64.whl
-          # echo "RESULT_DIR=${HOME}/release-testing/20220512" >> $GITHUB_ENV
-          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220424%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220424-cp38-cp38-linux_x86_64.whl
-          # pip install https://download.pytorch.org/whl/nightly/cu113/torch-1.12.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl  \
-          #             https://download.pytorch.org/whl/nightly/cu113/torchvision-0.13.0.dev20220506%2Bcu113-cp38-cp38-linux_x86_64.whl \
-          #             https://download.pytorch.org/whl/nightly/torchtext-0.13.0.dev20220506-cp38-cp38-linux_x86_64.whl
-          # echo "RESULT_DIR=${HOME}/release-testing/20220506-rc7-avx2" >> $GITHUB_ENV
-          # install build deps
-          # NUMPY_VERSION="1.21.2"
-          # conda install -y numpy="${NUMPY_VERSION}" requests ninja pyyaml mkl mkl-include \
-          #                  setuptools cmake=3.22 cffi typing_extensions \
-          #                  future six dataclasses pillow pytest tabulate gitpython git-lfs tqdm psutil
-          # rm -rf pytorch-src || true
-          # git clone https://github.com/pytorch/pytorch.git pytorch-src
-          # pushd pytorch-src
-          # commit on 20220401
-          # git checkout c0a6add7eef8ab3715c0f4281b3b7a2a0f1e24b5
-          # commit on 20220501
-          # git checkout 201ddafc22e22c387b4cd654f397e05354d73d09
-          # git submodule update --recursive --init
-          # git checkout release/1.11
-          # git setup.py clean
-          # python setup.py install
-          # echo "RESULT_DIR=${HOME}/release-testing/1.12.0-rc7-avx2" >> $GITHUB_ENV
+          echo "RESULT_DIR=${HOME}/release-testing/1.12.1" >> $GITHUB_ENV
           popd; python -c "import torch; print(torch.__version__); print(torch.version.git_version)"
           # install build deps
           sudo nvidia-smi -ac ${GPU_FREQUENCY}

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -101,7 +101,7 @@ jobs:
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
           nvcc --version
-          kdir -p ${RESULT_DIR}/wlm_gpu_lstm
+          mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -16,8 +16,8 @@ jobs:
       CUDA_VISIBLE_DEVICES: "0"
       CORE_LIST: "24-47"
       GOMP_CPU_AFFINITY: "24-47"
-      CUDA_VERSION: "11.3"
-      MAGMA_VERSION: "magma-cuda113"
+      CUDA_VERSION: "11.6"
+      MAGMA_VERSION: "magma-cuda116"
     steps:
       - name: Check out pytorch/pytorch
         uses: actions/checkout@v2

--- a/.github/workflows/release_testing.yml
+++ b/.github/workflows/release_testing.yml
@@ -75,7 +75,7 @@ jobs:
           pushd examples/mnist
           export LOG_FILE=${RESULT_DIR}/mnist/result.log
           export MEM_FILE=${RESULT_DIR}/mnist/result_mem.log
-          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 1
       - name: Run MNist HogWild
         run: |
           . activate reltest
@@ -85,7 +85,7 @@ jobs:
           pushd examples/mnist_hogwild
           export LOG_FILE=${RESULT_DIR}/mnist_hogwild/result.log
           export MEM_FILE=${RESULT_DIR}/mnist_hogwild/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10
       - name: Run CPU WLM LSTM
         run: |
           . activate reltest
@@ -95,17 +95,17 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_lstm/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM
       - name: Run GPU WLM LSTM
         run: |
           . activate reltest
           . switch-cuda.sh ${CUDA_VERSION}
           nvcc --version
-          mkdir -p ${RESULT_DIR}/wlm_gpu_lstm
+          kdir -p ${RESULT_DIR}/wlm_gpu_lstm
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_lstm/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_lstm/result_mem.log
-          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model LSTM --cuda
       - name: Run CPU WLM Transformer
         run: |
           set -x
@@ -117,7 +117,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_cpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_cpu_trans/result_mem.log
-          env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer
       - name: Run GPU WLM Transformer
         run: |
           . activate reltest
@@ -127,7 +127,7 @@ jobs:
           pushd examples/word_language_model
           export LOG_FILE=${RESULT_DIR}/wlm_gpu_trans/result.log
           export MEM_FILE=${RESULT_DIR}/wlm_gpu_trans/result_mem.log
-          # env ATEN_CPU_CAPABILITY=avx2 taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
+          taskset -c $CORE_LIST bash ../../pytorch/.github/scripts/monitor_proc.sh python main.py --epochs 10 --model Transformer --cuda
       - name: Remove Conda env
         run: |
           conda env remove --name reltest


### PR DESCRIPTION
This PR adds the release testing GHA workflow and the monitoring script.

Currently blocked by the RC release of domain packages (torchvision, torchtext, torchaudio)

Test Plan: CI

