### PR TITLE
[pkg] Catch exceptions where dependency resolution gets invalid imports (#58573)

### DIFF
--- a/test/package/test_dependency_api.py
+++ b/test/package/test_dependency_api.py
@@ -273,6 +273,25 @@ class TestDependencyAPI(PackageTestCase):
         else:
             self.fail("PackagingError should have been raised")
 
+    def test_invalid_import(self):
+        """An incorrectly-formed import should raise a PackagingError."""
+        buffer = BytesIO()
+        with self.assertRaises(PackagingError) as e:
+            with PackageExporter(buffer, verbose=False) as exporter:
+                # This import will fail to load.
+                exporter.save_source_string("foo", "from ........ import lol")
+
+        self.assertEqual(
+            str(e.exception),
+            dedent(
+                """
+                * Dependency resolution failed.
+                    foo
+                      Context: attempted relative import beyond top-level package
+                """
+            ),
+        )
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -253,7 +253,16 @@ class PackageExporter:
         package_name = (
             module_name if is_package else module_name.rsplit(".", maxsplit=1)[0]
         )
-        dep_pairs = find_files_source_depends_on(src, package_name)
+        try:
+            dep_pairs = find_files_source_depends_on(src, package_name)
+        except Exception as e:
+            self.dependency_graph.add_node(
+                module_name,
+                error=PackagingErrorReason.DEPENDENCY_RESOLUTION_FAILED,
+                error_context=str(e),
+            )
+            return []
+
         # Use a dict to get uniquing but also deterministic order
         dependencies = {}
         for dep_module_name, dep_module_obj in dep_pairs:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/58573

Users can create invalid imports, like:
```
HG: in a top-level package
if False:
  from .. import foo
```

Since this code is never executed, it will not cause the module to fail to
load. But our dependency analysis walks every `import` statement in the AST,
and will attempt to resolve the (incorrectly formed) import, throwing an exception.

For posterity, the code that triggered this: https://git.io/JsCgM

Differential Revision: D28543980

Test Plan: Added a unit test

Reviewed By: Chillee

Pulled By: suo

fbshipit-source-id: 03b7e274633945b186500fab6f974973ef8c7c7d