### PR TITLE
Small fix type hints in mobile optimizer

### DIFF
--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -5,7 +5,7 @@ This module contains utility method for mobile model optimization and lint.
 import torch
 from enum import Enum
 from torch._C import MobileOptimizerType
-from typing import Set, List, AnyStr
+from typing import Optional, Set, List, AnyStr
 
 class LintCode(Enum):
     BUNDLED_INPUT = 1
@@ -14,9 +14,9 @@ class LintCode(Enum):
     BATCHNORM = 4
 
 def optimize_for_mobile(
-        script_module,
-        optimization_blocklist: Set[MobileOptimizerType] = None,
-        preserved_methods: List[AnyStr] = None,
+        script_module: torch.jit.ScriptModule,
+        optimization_blocklist: Optional[Set[MobileOptimizerType]] = None,
+        preserved_methods: Optional[List[AnyStr]] = None,
         backend: str = 'CPU'):
     """
     Args:

--- a/torch/utils/mobile_optimizer.py
+++ b/torch/utils/mobile_optimizer.py
@@ -17,7 +17,7 @@ def optimize_for_mobile(
         script_module: torch.jit.ScriptModule,
         optimization_blocklist: Optional[Set[MobileOptimizerType]] = None,
         preserved_methods: Optional[List[AnyStr]] = None,
-        backend: str = 'CPU'):
+        backend: str = 'CPU') -> torch.jit.RecursiveScriptModule:
     """
     Args:
         script_module: An instance of torch script module with type of ScriptModule.


### PR DESCRIPTION
Adjusts type hints for optimize_for_mobile to be consistent with the default. Right now using optimize_for_mobile and only passing a script_module gives me a type error complaining about preserved_methods can't be None.