### PR TITLE
[ONNX] Set correct name for inputs of new Conv node after fused Conv and Bat…

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2403,6 +2403,17 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(RandLike(), x)
 
+    def test_bernoulli(self):
+        class Bernoulli(torch.nn.Module):
+            def forward(self, x):
+                return torch.mul(x, torch.bernoulli(x).size(0))
+
+        x = torch.empty(3, 3).uniform_(0, 1)
+        self.run_test(Bernoulli(), x)
+
+        x = torch.empty(2, 3, 3, dtype=torch.double).uniform_(0, 1)
+        self.run_test(Bernoulli(), x)
+
     def test_reshape_different_rank(self):
         class ReshapeModel(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5882,6 +5882,21 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(model, (x, y))
 
     @skipIfUnsupportedMinOpsetVersion(9)
+    def test_type_as(self):
+        class MyModule(torch.nn.Module):
+            def forward(self, x):
+                y = torch.tensor([1.0])
+                return x.type_as(y)
+
+        a = torch.tensor([True, False], dtype=torch.bool)
+        b = torch.randn(3, 4, dtype=torch.double)
+        c = torch.ones((2, 2), dtype=torch.int64)
+        model = MyModule()
+        self.run_test(model, a)
+        self.run_test(model, b)
+        self.run_test(model, c)
+
+    @skipIfUnsupportedMinOpsetVersion(9)
     def test_ones_bool(self):
         class MyModule(torch.nn.Module):
             def forward(self, input):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9041,6 +9041,17 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(M(2, 1), (x,))
         self.run_test(M([-1, 3], [-2, -1]), (x,))
 
+    def test_sum_empty_tensor(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return x[0:0].sum()
+
+        x = torch.ones(12)
+        self.run_test(M(), (x,))
+
+        x = torch.ones(2, 0, 3)
+        self.run_test(M(), (x,))
+
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,
               **extra_kwargs):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5558,6 +5558,21 @@ class TestONNXRuntime(unittest.TestCase):
                       dynamic_axes={"x": [1, 2]},
                       test_with_inputs=[y])
 
+    def test_relu6(self):
+        class Relu6Model(torch.nn.Module):
+            def __init__(self):
+                super(Relu6Model, self).__init__()
+                self.relu6 = torch.nn.ReLU6()
+
+            def forward(self, x):
+                return self.relu6(x)
+
+        x = torch.randn(2, 3, 4) * 100.0
+        y = torch.randn(2, 4, 5) * 100.0
+        self.run_test(Relu6Model(), x, input_names=['x'],
+                      dynamic_axes={'x': [1, 2]},
+                      test_with_inputs=[y])
+
     def test_silu(self):
         class SiLUModel(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/passes/onnx/eval_peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/eval_peephole.cpp
@@ -119,12 +119,26 @@ static void fuseConvBatchNorm(Block* b, ValueToParamPairMap& valsToParamsMap) {
       valsToParamsMap.insert(
           {conv_W, std::make_pair(conv_W->debugName(), w_conv)});
       conv_W->inferTypeFrom(w_conv);
+      for (int j = 0; j < it->inputs().size(); j++) {
+        if (it->inputs()[j]->debugName().find("weight") != std::string::npos) {
+          conv_W->setDebugName(it->inputs()[j]->debugName().c_str());
+          break;
+        }
+      }
+
       convNode->addInput(conv_W);
 
       auto conv_B = b->addInput();
       valsToParamsMap.insert(
           {conv_B, std::make_pair(conv_B->debugName(), b_conv)});
       conv_B->inferTypeFrom(b_conv);
+      for (int j = 0; j < bnNode->inputs().size(); j++) {
+        if (bnNode->inputs()[j]->debugName().find("bias") != std::string::npos) {
+          conv_B->setDebugName(bnNode->inputs()[j]->debugName().c_str());
+          break;
+        }
+      }
+
       convNode->addInput(conv_B);
 
       bnNode->replaceAllUsesWith(convNode);

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -738,6 +738,13 @@ def _optional_input_placeholder_tensor(g):
     n.setType(OptionalType.ofTensor())
     return n
 
+def _handle_reduce_dim_none(g, self, op_name):
+    dim_size = _get_tensor_dim_size(self, 0)
+    if dim_size is None or dim_size == 0:
+        # If input tensor is empty, according to ONNX ReduceSum definition,
+        # set keepdims=1 so that the resulted tensor has the same rank as the input.
+        return g.op(op_name, self, keepdims_i=1)
+    return g.op(op_name, self, keepdims_i=0)
 
 # ---------------------------------------------------------------------
 # ONNX operator version

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -75,6 +75,18 @@ def clamp_max(g, self, max):
         return g.op("Min", self, max)
 
 
+def relu6(g, input):
+    relu = g.op("Relu", input)
+    dtype = input.type().scalarType()
+    if dtype is None:
+        dtype = 6  # float
+    else:
+        dtype = sym_help.scalar_type_to_onnx.index(sym_help.cast_pytorch_to_onnx[dtype])
+    min_val = g.op("Constant", value_t=torch.tensor(0, dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
+    max_val = g.op("Constant", value_t=torch.tensor(6, dtype=sym_help.scalar_type_to_pytorch_type[dtype]))
+    return clamp(g, relu, min_val, max_val)
+
+
 # Opset 11 gather accepts negative indices
 @parse_args("v", "i", "v")
 def select(g, self, dim, index):

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -147,9 +147,9 @@ def _reduce_op_symbolic(onnx_op_name):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
             # all-reduce path
-            return g.op(onnx_op_name, self, keepdims_i=0)
+            return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
-            keepdim = sym_help._get_const(keepdim, "i", "keepdim")
+            keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1526,8 +1526,9 @@ def type_as(g, self, other):
             # We don't know the type of other, bail by emitting ATen
             return g.op("ATen", self, other, operator_s="type_as")
         else:
-            raise RuntimeError("Unsupported: ONNX export of type_as for tensor "
-                               "of unknown dtype.")
+            raise RuntimeError('Unsupported: ONNX export of type_as for tensor '
+                               'of unknown dtype. Please check if the dtype of the '
+                               'parameter passed to the type_as function is correct.')
 
 
 @parse_args("v", "v", "i", "f")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -729,6 +729,9 @@ def mish(g, input):
 def relu(g, input):
     return g.op("Relu", input)
 
+def relu6(g, input):
+    relu = g.op("Relu", input)
+    return clamp_max(g, relu, 6)
 
 def ceil(g, input):
     return g.op("Ceil", input)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -368,7 +368,7 @@ def _reduce_op_symbolic(onnx_op_name, allow_multi_dim_support=True):
         self = _maybe_cast_reduce_op_input(g, self)
         if dim is None:
             # all-reduce path
-            return g.op(onnx_op_name, self, keepdims_i=0)
+            return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
             # dim-reduce path
             desc = "is" if allow_multi_dim_support else "i"

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2412,7 +2412,21 @@ def rrelu(g, input, lower, upper, training, generator):
     return g.op("PRelu", input, p)
 
 
-@parse_args("v")
+def bernoulli(g, input, generator=None, out=None):
+    if out is not None:
+        _unimplemented("Bernoulli", "out parameter is not supported for bernoulli")
+    if generator is not None and not sym_help._is_none(generator):
+        _unimplemented("Bernoulli", "generator is not supported for bernoulli")
+
+    dtype = sym_help._try_get_scalar_type(input)
+    if dtype is None:
+        return _unimplemented("Bernoulli", "input dtype not accessible")
+    p = g.op('RandomUniformLike', input, high_f=1.0, low_f=0.0, dtype_i=sym_help.cast_pytorch_to_onnx[dtype])
+    output = g.op('Less', p, input)
+    return g.op("Cast", output, to_i=sym_help.cast_pytorch_to_onnx[dtype])
+
+
+@parse_args('v')
 def log_sigmoid(g, input):
     p = g.op("Sigmoid", input)
     return g.op("Log", p)


### PR DESCRIPTION
After fused Conv and BatchNorm ops in some scenarios, we will add 2 new inputs for the final new Conv op. We don't set the value of the names of these inputs explicitly so the names are always some numbers. This usually works until we set export_params=False and keep_initializers_as_inputs=True in ORTModule.

ORTModule is now working in this way:

After it exports a module with above settings. It will then find out all inputs names via the PyTorch script module. Then ORTModule will prepare values for these inputs and pass them to the generated ONNX file as parameters for inference. But in the ONNX file, the inputs names are all numbers which don't exist in the inputs list passed by ORTModule. So it will throw out an error like:

RuntimeError: Input is present in ONNX graph but not provided: 195. 

where 195 is the name of one input of new fused Conv op in ONNX file.

This fix tends to update the input names of new fused Conv op so that its value could be found in the inputs list prepared by ORTModule. Then the issue is gone.