### PR TITLE
[iOS GPU] Raise the minimum OS version support to 11.0

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNContext.mm
@@ -44,7 +44,7 @@ using namespace at::native::metal;
   if (!MPSSupportsMTLDevice(_device)) {
     return false;
   }
-  if ([UIDevice currentDevice].systemVersion.floatValue < 10.2) {
+  if ([UIDevice currentDevice].systemVersion.floatValue < 11.0) {
     return false;
   }
   if (![_device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v2]) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59310 [iOS GPU] Raise the minimum OS version support to 11.0**

We recently updated the GK to deliver GPU models to only 11.0+ devices. Will do a clean up in following diffs to clean up shader functions written for iOS 10.0.

Differential Revision: [D28805864](https://our.internmc.facebook.com/intern/diff/D28805864/)