### PR TITLE
[Error-reporting] Set upper boundary on border element

### DIFF
--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -244,6 +244,9 @@ class ChildFailedError(Exception):
             else:
                 other_failures_fmt.append(fmt)
 
+        # upper boundary on width
+        width = max(width, 250)
+
         return Template(_MSG_FORMAT_TEMPLATE).substitute(
             boarder=boarder_delim * width,
             title=title.center(width),


### PR DESCRIPTION
Summary: The diff sets the upper boundary on border element when presenting the error message. This is required in order to avoid unnecessary log contamination

Test Plan: Example of log contamination: https://www.internalfb.com/fblearner/details/276849996/operator/2942475685?tab=try_27021599785797968

Reviewed By: d4l3k

Differential Revision: D28812745

