### PR TITLE
[ONNX] Fix sum export with attribute keepdims

### DIFF
--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9061,16 +9061,28 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(M(2, 1), (x,))
         self.run_test(M([-1, 3], [-2, -1]), (x,))
 
+    def test_sum(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sum(x)
+
+        x = torch.ones(12, 3)
+        self.run_test(M(), (x,), input_names=['x'], dynamic_axes={'x': [0]})
+
     def test_sum_empty_tensor(self):
         class M(torch.nn.Module):
             def forward(self, x):
-                return x[0:0].sum()
+                return x[0:0].sum(), x.sum()
 
         x = torch.ones(12)
         self.run_test(M(), (x,))
 
         x = torch.ones(2, 0, 3)
         self.run_test(M(), (x,))
+
+        x = torch.ones(0)
+        self.run_test(M(), (x,))
+
 
 def make_test(name, base, layer, bidirectional, initial_state,
               variable_length, dropout, script_test_min_opset_version,

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -740,7 +740,8 @@ def _optional_input_placeholder_tensor(g):
 
 def _handle_reduce_dim_none(g, self, op_name):
     dim_size = _get_tensor_dim_size(self, 0)
-    if dim_size is None or dim_size == 0:
+    rank = _get_tensor_rank(self)
+    if rank is not None and any([_get_tensor_dim_size(self, i) == 0 for i in range(rank)]):
         # If input tensor is empty, according to ONNX ReduceSum definition,
         # set keepdims=1 so that the resulted tensor has the same rank as the input.
         return g.op(op_name, self, keepdims_i=1)


### PR DESCRIPTION
Fix after b9bdb07a0261ab5a0b1038f290fa03af6ce0415f. Improving previous fix on two aspects
* Not only checks 0 on first dimension for empty tensor.
* Do not assume empty tensor when shape is not accessible. 