### PR TITLE
Enable torch::deploy GPU tests in sandcastle

### DIFF
--- a/torch/csrc/deploy/deploy.cpp
+++ b/torch/csrc/deploy/deploy.cpp
@@ -119,9 +119,9 @@ Interpreter::Interpreter(InterpreterManager* manager)
   // See comment above for fbcode vs oss behavior
   char* lib_start = nullptr;
   char* lib_end = nullptr;
+  bool cuda_available = torch::cuda::is_available();
 #ifdef FBCODE_CAFFE2
-  if (torch::cuda::is_available() &&
-      &_binary_libtorch_deployinterpreter_cuda_so_start &&
+  if (cuda_available && &_binary_libtorch_deployinterpreter_cuda_so_start &&
       &_binary_libtorch_deployinterpreter_cuda_so_end) {
     lib_start = _binary_libtorch_deployinterpreter_cuda_so_start;
     lib_end = _binary_libtorch_deployinterpreter_cuda_so_end;
@@ -135,9 +135,11 @@ Interpreter::Interpreter(InterpreterManager* manager)
   lib_start = _binary_libtorch_deployinterpreter_so_start;
   lib_end = _binary_libtorch_deployinterpreter_so_end;
 #endif // FBCODE_CAFFE2
+  std::string cuda_available_str = cuda_available ? "true" : "false";
   TORCH_CHECK(
       lib_start != nullptr && lib_end != nullptr,
-      "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.");
+      "torch::deploy requires a build-time dependency on embedded_interpreter or embedded_interpreter_cuda, neither of which were found.  torch::cuda::is_available()=" +
+          cuda_available_str);
 
   write_tmp_lib(dst, lib_start, lib_end);
   fclose(dst);

--- a/torch/csrc/deploy/test_deploy_gpu.cpp
+++ b/torch/csrc/deploy/test_deploy_gpu.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <torch/csrc/deploy/deploy.h>
+#include <torch/cuda.h>
 #include <torch/script.h>
 #include <torch/torch.h>
 #include <future>
@@ -21,6 +22,9 @@ const char* path(const char* envname, const char* path) {
 }
 
 TEST(TorchDeployGPUTest, SimpleModel) {
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP();
+  }
   const char* model_filename = path("SIMPLE", simple);
   const char* jit_filename = path("SIMPLE_JIT", simple_jit);
 


### PR DESCRIPTION
Summary:
Added GPU tests in previous diffs but had to disable them as they only
pass locally on devgpu, but not in sandcastle.

note: local testing requires mode/dev-nosan or else ASAN interferes with CUDA.

Test Plan: Verify tests passing in sandcastle.

Reviewed By: malfet

Differential Revision: D28538996

