### PR TITLE
docs: Add note about nightly versions bump

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,8 +51,13 @@ them:
   * Example: https://github.com/pytorch/pytorch/pull/40706
 * Add `release/{MAJOR}.{MINOR}` to list of branches in [`browser-extension.json`](https://github.com/pytorch/pytorch/blob/fb-config/browser-extension.json) for FaceHub integrated setups
   * Example: https://github.com/pytorch/pytorch/commit/f99fbd94d18627bae776ea2448e075ca4d5e37b2
+* A release branch should also be created in [`pytorch/builder`](https://github.com/pytorch/builder) repo and pinned in `pytorch/pytorch`
+  * Example: https://github.com/pytorch/pytorch/pull/58514
 
-> TODO: Create release branch in [`pytorch/builder`](https://github.com/pytorch/builder) repo and pin release CI to use that branch rather than HEAD of builder repo.
+These are examples of changes that should be made to the *default* branch after a release branch is cut
+
+* Nightly versions should be updated in all version files to the next MINOR release (i.e. 0.9.0 -> 0.10.0) in the default branch:
+  * Example: https://github.com/pytorch/pytorch/pull/51891
 
 ### Getting CI signal on release branches:
 Create a PR from `release/{MAJOR}.{MINOR}` to `orig/release/{MAJOR}.{MINOR}` in order to start CI testing for cherry-picks into release branch.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59324 docs: Add note about nightly versions bump**

Also updates section on pinning pytorch/builder with an example

[skip ci]

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28840049](https://our.internmc.facebook.com/intern/diff/D28840049)