### PR TITLE
[package] skip failed `__import__` statements

### DIFF
--- a/test/package/test_save_load.py
+++ b/test/package/test_save_load.py
@@ -93,6 +93,14 @@ class TestSaveLoad(PackageTestCase):
         subsubpackage_0 = hi.import_module("package_b.subpackage_0.subsubpackage_0")
         self.assertEqual(subsubpackage_0.result, "subsubpackage_0")
 
+    def test_bad_dunder_imports(self):
+        """Test to ensure bad __imports__ don't cause PackageExporter to fail."""
+        buffer = BytesIO()
+        with PackageExporter(buffer, verbose=False) as e:
+            e.save_source_string(
+                "m", '__import__(these, unresolvable, "things", wont, crash, me)'
+            )
+
     def test_save_module_binary(self):
         f = BytesIO()
         with PackageExporter(f, verbose=False) as he:

--- a/torch/package/find_file_dependencies.py
+++ b/torch/package/find_file_dependencies.py
@@ -11,15 +11,19 @@ class _ExtractModuleReferences(ast.NodeVisitor):
     """
 
     @classmethod
-    def run(cls, src: str, package: str) -> List[Tuple[str, Optional[str]]]:
-        visitor = cls(package)
+    def run(
+        cls, src: str, package: str, module: str, failed_dunder_imports: List[str]
+    ) -> List[Tuple[str, Optional[str]]]:
+        visitor = cls(package, module, failed_dunder_imports)
         tree = ast.parse(src)
         visitor.visit(tree)
         return list(visitor.references.keys())
 
-    def __init__(self, package):
+    def __init__(self, package, module, failed_dunder_imports):
         super().__init__()
         self.package = package
+        self.module = module
+        self.failed_dunder_imports = failed_dunder_imports
         self.references = {}
 
     def _absmodule(self, module_name: str, level: int) -> str:
@@ -57,47 +61,53 @@ class _ExtractModuleReferences(ast.NodeVisitor):
     def visit_Call(self, node):
         # __import__ calls aren't routed to the visit_Import/From nodes
         if hasattr(node.func, "id") and node.func.id == "__import__":
-            if type(node.args[0]) not in [ast.Constant, ast.Str]:
-                # We don't want to parse dynamic uses of __import__
+            try:
+                name = self._grab_node_str(node.args[0])
+                fromlist = []
+                level = 0
+                if len(node.args) > 3:
+                    for v in node.args[3].elts:
+                        fromlist.append(self._grab_node_str(v))
+                elif hasattr(node, "keywords"):
+                    for keyword in node.keywords:
+                        if keyword.arg == "fromlist":
+                            for v in keyword.value.elts:
+                                fromlist.append(self._grab_node_str(v))
+                if len(node.args) > 4:
+                    level = self._grab_node_int(node.args[4])
+                elif hasattr(node, "keywords"):
+                    for keyword in node.keywords:
+                        if keyword.arg == "level":
+                            level = self._grab_node_int(keyword.value)
+                if fromlist == []:
+                    # the top-level package (the name up till the first dot) is returned
+                    # when the fromlist argument is empty in normal import system,
+                    # we need to include top level package to match this behavior and last
+                    # level package to capture the intended dependency of user
+                    self.references[(name, None)] = True
+                    top_name = name.rsplit(".", maxsplit=1)[0]
+                    if top_name != name:
+                        top_name = self._absmodule(top_name, level)
+                        self.references[(top_name, None)] = True
+                else:
+                    name = self._absmodule(name, level)
+                    for alias in fromlist:
+                        # fromlist args may be submodules, so we have to add the fromlist args
+                        # to the list of potential references. If import of an arg fails we
+                        # will ignore it, similar to visit_ImportFrom
+                        if alias != "*":
+                            self.references[(name, alias)] = True
+                        else:
+                            self.references[(name, None)] = True
+            except Exception as e:
+                info_string = (
+                    "module: '"
+                    + self.module
+                    + "', lineno: "
+                    + str(node.__dict__["lineno"])
+                )
+                self.failed_dunder_imports.append(info_string)
                 return
-
-            name = self._grab_node_str(node.args[0])
-            fromlist = []
-            level = 0
-            if len(node.args) > 3:
-                for v in node.args[3].elts:
-                    fromlist.append(self._grab_node_str(v))
-            elif hasattr(node, "keywords"):
-                for keyword in node.keywords:
-                    if keyword.arg == "fromlist":
-                        for v in keyword.value.elts:
-                            fromlist.append(self._grab_node_str(v))
-            if len(node.args) > 4:
-                level = self._grab_node_int(node.args[4])
-            elif hasattr(node, "keywords"):
-                for keyword in node.keywords:
-                    if keyword.arg == "level":
-                        level = self._grab_node_int(keyword.value)
-            if fromlist == []:
-                # the top-level package (the name up till the first dot) is returned
-                # when the fromlist argument is empty in normal import system,
-                # we need to include top level package to match this behavior and last
-                # level package to capture the intended dependency of user
-                self.references[(name, None)] = True
-                top_name = name.rsplit(".", maxsplit=1)[0]
-                if top_name != name:
-                    top_name = self._absmodule(top_name, level)
-                    self.references[(top_name, None)] = True
-            else:
-                name = self._absmodule(name, level)
-                for alias in fromlist:
-                    # fromlist args may be submodules, so we have to add the fromlist args
-                    # to the list of potential references. If import of an arg fails we
-                    # will ignore it, similar to visit_ImportFrom
-                    if alias != "*":
-                        self.references[(name, alias)] = True
-                    else:
-                        self.references[(name, None)] = True
 
 
 find_files_source_depends_on = _ExtractModuleReferences.run


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59330 [package] skip failed `__import__` statements**
* #59326 [package] PackageExporter verbose mode print package contents

Change our dependency resolution AST parsing code to skip `__import__` statements that are unresolvable. Additionally adds a user warning to the PackageExporter when the verbose mode is set to 'True'.

Example of package verbose mode being printed out (now prints out locations of invalid imports):
```
Package Contents:
- interned modules:
    foo__
- explicitly externed modules:
- implicitly externed modules:
    builtins
    collections
- mocked modules:
- pickles:
    <dcgan.model.pkl>
- invalid objects:
    models.DCGAN
    models.loss_criterions.ac_criterion
    models.loss_criterions.base_loss_criterions
    sentencepiece
- location of unresolvable and skipped __import__ statements:
    module: 'foo__', lineno: 8
```

Differential Revision: [D28871217](https://our.internmc.facebook.com/intern/diff/D28871217)