### PR TITLE
[DO NOT MERGE] [BENCHMARKING] make opt_for_inference noop

### DIFF
--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -165,7 +165,7 @@ def run_frozen_optimizations(mod, optimize_numerics: bool = True):
             torch._C._jit_pass_fold_frozen_conv_mul_or_div(mod.graph)
 
 def optimize_for_inference(mod: ScriptModule) -> ScriptModule:
-    # just make a copy
+    # just make a copy 2
     buffer = io.BytesIO()
     torch.jit.save(mod, buffer)
     return torch.jit.load(buffer)

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -168,5 +168,8 @@ def optimize_for_inference(mod: ScriptModule) -> ScriptModule:
     # just make a copy 3
     buffer = io.BytesIO()
     torch.jit.save(mod, buffer)
+    buffer.seek(0)
     return torch.jit.load(buffer)
 
+        
+       

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -165,7 +165,7 @@ def run_frozen_optimizations(mod, optimize_numerics: bool = True):
             torch._C._jit_pass_fold_frozen_conv_mul_or_div(mod.graph)
 
 def optimize_for_inference(mod: ScriptModule) -> ScriptModule:
-    # just make a copy 2
+    # just make a copy 3
     buffer = io.BytesIO()
     torch.jit.save(mod, buffer)
     return torch.jit.load(buffer)


### PR DESCRIPTION
Benchmarking optimized_for_inference for torchvision models

RUN_TORCHBENCH: alexnet,attention_is_all_you_need_pytorch,Background_Matting,BERT_pytorch,demucs,densenet121,dlrm,drq,fastNLP,hf_Albert,hf_Bart,hf_Bert,hf_BigBird,hf_DistilBert,hf_GPT2,hf_Longformer,hf_Reformer,hf_T5,LearningToPaint,maml,maml_omniglot,mnasnet1_0,mobilenet_v2,mobilenet_v2_quantized_qat,mobilenet_v3_large,moco,opacus_cifar10,pyhpc_equation_of_state,pyhpc_isoneutral_mixing,pytorch_CycleGAN_and_pix2pix,pytorch_stargan,pytorch_struct,resnet18,resnet50,resnext50_32x4d,shufflenet_v2_x1_0,soft_actor_critic,speech_transformer,squeezenet1_1,Super_SloMo,tacotron2,vgg16,yolov3