### PR TITLE
[Release-1.9] Disable failing ROCM-4.2 tests

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5467,6 +5467,7 @@ class TestNN(NNTestCase):
 
     # For https://github.com/pytorch/pytorch/pull/1273
     # Almost identical to the above `test_Conv2d_naive_groups`
+    @skipIfRocm
     def test_Conv2d_groups_nobias(self):
         dev_dtypes = [("cpu", torch.float)]
         if TEST_CUDA:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5505,6 +5505,7 @@ class TestNN(NNTestCase):
     # Covering special case when group > 1, input-channel / group < 16 and output-channel is multiple of 16
     # See also https://github.com/pytorch/pytorch/pull/18463#issuecomment-476563686
     # and https://github.com/pytorch/pytorch/pull/18463#issuecomment-477001024
+    @skipIfRocm
     def test_Conv2d_groups_nobias_v2(self):
         torch.manual_seed(123)
         dev_dtypes = [("cpu", torch.float)]


### PR DESCRIPTION
- [ROCm] disable test test_Conv2d_groups_nobias for ROCm (#59158)
- [ROCm] disable test test_Conv2d_groups_nobias_v2 for ROCm (#58701)
