### PR TITLE
[PyTorch Edge] Add proper error message when loading incompatible model with lite interpreter

### DIFF
--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -662,6 +662,13 @@ mobile::Module _load_for_mobile_impl(
   }
   const size_t model_size = rai != nullptr ? rai->size() : 0;
   auto reader = torch::make_unique<PyTorchStreamReader>(std::move(rai));
+
+  TORCH_CHECK(
+      reader->hasRecord("bytecode.pkl"),
+      "The model is not generated from the api _save_for_lite_interpreter. "
+      "Please regenerate the module by scripted_module._save_for_lite_interpreter('model.ptl'). "
+      "Refer to https://pytorch.org/tutorials/prototype/lite_interpreter.html for more details.");
+
   BytecodeDeserializer deserializer(std::move(reader), module_load_options);
   std::string error_message;
   auto guard = c10::make_scope_exit([&]() {

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -666,7 +666,7 @@ mobile::Module _load_for_mobile_impl(
   TORCH_CHECK(
       reader->hasRecord("bytecode.pkl"),
       "The model is not generated from the api _save_for_lite_interpreter. "
-      "Please regenerate the module by scripted_module._save_for_lite_interpreter('model.ptl'). "
+      "Please regenerate the module by running: module._save_for_lite_interpreter('model.ptl'). "
       "Refer to https://pytorch.org/tutorials/prototype/lite_interpreter.html for more details.");
 
   BytecodeDeserializer deserializer(std::move(reader), module_load_options);


### PR DESCRIPTION
Check if the model has `bytecode.pkl` and provide proper error message before loading model. Test it by loading a model.pt and model.ptl.
```
>>> from torch.jit.mobile import _load_for_lite_interpreter
>>> _load_for_lite_interpreter("/Users/chenlai/Documents/pytorch/data/mobilenet_v2.pt")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chenlai/pytorch/torch/jit/mobile/__init__.py", line 48, in _load_for_lite_interpreter
    cpp_module = torch._C._load_for_lite_interpreter(f, map_location)  # type: ignore[attr-defined]
RuntimeError: The model is not generated from the api _save_for_lite_interpreter. Please regenerate the module by scripted_module._save_for_lite_interpreter('model.ptl'). Refer to https://pytorch.org/tutorials/prototype/lite_interpreter.html for more details.
```

iOS:
![image](https://user-images.githubusercontent.com/16430979/120593077-cbe23180-c3f3-11eb-9745-ee2b04b78c6c.png)

Android:
![image](https://user-images.githubusercontent.com/16430979/120594357-af46f900-c3f5-11eb-9fb0-500a038148e3.png)


Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59354 [PyTorch Edge] Add proper error message when loading incompatible model with lite interpreter**

Differential Revision: [D28856713](https://our.internmc.facebook.com/intern/diff/D28856713)