### PR TITLE
[libkineto] Refactor trace activities (#206)

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -57,13 +57,24 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
       return;
     }
 
+#ifdef USE_KINETO_UPDATED
+    libkineto::GenericTraceActivity op(
+        cpu_trace->span,
+        libkineto::ActivityType::CPU_OP,
+        std::string(fn.name().str()));
+    op.device = libkineto::processId();
+    op.resource = libkineto::systemThreadId();
+    op.id = ctx->correlationId;
+#else
     libkineto::GenericTraceActivity op;
     op.activityType = libkineto::ActivityType::CPU_OP;
     op.activityName = std::string(fn.name().str());
     op.device = libkineto::processId();
+    op.sysThreadId = libkineto::systemThreadId();
+    op.correlation = ctx->correlationId;
+#endif
     op.startTime = ctx->startUs;
     op.endTime = getTimeUs();
-    op.correlation = ctx->correlationId;
     // optimization - postpone shapesToStr till finalizeCPUTrace
     // is called from disableProfiler
     // if (ctx->shapes && !ctx->shapes->empty()) {
@@ -71,7 +82,6 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
     // }
 
     libkineto::api().activityProfiler().recordThreadInfo();
-    op.sysThreadId = libkineto::systemThreadId();
 
     {
       std::lock_guard<std::mutex> guard(state_mutex_);
@@ -120,14 +130,23 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
 
       {
         std::lock_guard<std::mutex> guard(state_mutex_);
+        libkineto::api().activityProfiler().recordThreadInfo();
+#ifdef USE_KINETO_UPDATED
+        memory_events_.emplace_back(
+            cpu_trace->span,
+            libkineto::ActivityType::CPU_INSTANT_EVENT,
+            "[memory]");
+        auto& act = memory_events_.back();
+        act.device = libkineto::processId();
+        act.resource = libkineto::systemThreadId();
+#else
         memory_events_.emplace_back();
         auto& act = memory_events_.back();
         act.activityType = libkineto::ActivityType::CPU_INSTANT_EVENT;
         act.activityName = "[memory]";
-        act.startTime = getTimeUs();
-        act.device = libkineto::processId();
-        libkineto::api().activityProfiler().recordThreadInfo();
         act.sysThreadId = libkineto::systemThreadId();
+#endif
+        act.startTime = getTimeUs();
         act.addMetadata("Device Type", std::to_string((int8_t)device.type()));
         act.addMetadata("Device Id", std::to_string(device.index()));
         act.addMetadata("Bytes", std::to_string(alloc_size));
@@ -138,10 +157,13 @@ struct KinetoThreadLocalState : public ProfilerThreadLocalState {
   void addTraceEvents(libkineto::ActivityTraceInterface& trace) {
     const auto& events = *(trace.activities());
     for (const auto& ev_ptr : events) {
-      // CPU_OP and CPU_INSTANT_EVENT events are already processed
+      // These events are already processed
       if (ev_ptr->type() != libkineto::ActivityType::CPU_OP &&
           ev_ptr->type() != libkineto::ActivityType::CPU_INSTANT_EVENT
-        ) {
+#ifdef USE_KINETO_UPDATED
+          && ev_ptr->type() != libkineto::ActivityType::USER_ANNOTATION
+#endif
+      ) {
         kineto_events_.emplace_back();
         kineto_events_.back()
             .activity(*ev_ptr);
@@ -362,6 +384,10 @@ void prepareProfiler(
 
   std::set<libkineto::ActivityType> cpuTypes = {
     libkineto::ActivityType::CPU_OP,
+    libkineto::ActivityType::CPU_INSTANT_EVENT,
+#ifdef USE_KINETO_UPDATED
+    libkineto::ActivityType::USER_ANNOTATION,
+#endif
     libkineto::ActivityType::EXTERNAL_CORRELATION,
     libkineto::ActivityType::CUDA_RUNTIME,
   };
@@ -494,8 +520,14 @@ c10::DeviceType KinetoEvent::deviceType() const {
     case (uint8_t)libkineto::ActivityType::GPU_MEMCPY:
     case (uint8_t)libkineto::ActivityType::GPU_MEMSET:
     case (uint8_t)libkineto::ActivityType::CONCURRENT_KERNEL:
+#ifdef USE_KINETO_UPDATED
+    case (uint8_t)libkineto::ActivityType::GPU_USER_ANNOTATION:
+#endif
       return c10::DeviceType::CUDA;
     case (uint8_t)libkineto::ActivityType::CPU_OP:
+#ifdef USE_KINETO_UPDATED
+    case (uint8_t)libkineto::ActivityType::USER_ANNOTATION:
+#endif
     case (uint8_t)libkineto::ActivityType::EXTERNAL_CORRELATION:
     case (uint8_t)libkineto::ActivityType::CUDA_RUNTIME:
     case (uint8_t)libkineto::ActivityType::CPU_INSTANT_EVENT:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/kineto/pull/206

Replace ClientTraceActivity with GenericActivity.
In addition:
* Add a couple of new activity types for user annotations
* Simplify code for GPU-side user annotations
* Add accessor to containing trace span object in activities. Later we can replace this with a trace context / trace session object.
* Simplified MemoryTraceLogger
* Added early exit for cupti push/pop correlation ID

Reviewed By: ilia-cher

Differential Revision: D28231675

