### PR TITLE
Prefer accurate reciprocal on ARMv8

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -479,33 +479,12 @@ public:
         vsqrtq_f32(values.val[1]));
   }
   Vectorized<float> reciprocal() const {
-#ifndef C10_MOBILE
     auto r0 = vdivq_f32(vdupq_n_f32(1.0f), values.val[0]);
     auto r1 = vdivq_f32(vdupq_n_f32(1.0f), values.val[1]);
     return Vectorized<float>(r0, r1);
-#else
-    float32x4_t r0 = vrecpeq_f32(values.val[0]);
-    float32x4_t r1 = vrecpeq_f32(values.val[1]);
-    // Run two more Netwon's method iterations to get more accurate results
-    r0 = vmulq_f32(vrecpsq_f32(values.val[0], r0), r0);
-    r0 = vmulq_f32(vrecpsq_f32(values.val[0], r0), r0);
-    r1 = vmulq_f32(vrecpsq_f32(values.val[1], r1), r1);
-    r1 = vmulq_f32(vrecpsq_f32(values.val[1], r1), r1);
-    return Vectorized<float>(r0, r1);
-#endif
   }
   Vectorized<float> rsqrt() const {
-#ifndef C10_MOBILE
     return this->sqrt().reciprocal();
-#else
-    float32x4_t r0 =  vrsqrteq_f32(values.val[0]);
-    float32x4_t r1 =  vrsqrteq_f32(values.val[1]);
-    r0 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[0], r0), r0), r0);
-    r0 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[0], r0), r0), r0);
-    r1 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[1], r1), r1), r1);
-    r1 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[1], r1), r1), r1);
-    return Vectorized<float>(r0, r1);
-#endif
   }
   Vectorized<float> pow(const Vectorized<float> &exp) const {
     __at_align32__ float tmp[size()];

--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -479,6 +479,11 @@ public:
         vsqrtq_f32(values.val[1]));
   }
   Vectorized<float> reciprocal() const {
+#ifndef C10_MOBILE
+    auto r0 = vdivq_f32(vdupq_n_f32(1.0f), values.val[0]);
+    auto r1 = vdivq_f32(vdupq_n_f32(1.0f), values.val[1]);
+    return Vectorized<float>(r0, r1);
+#else
     float32x4_t r0 = vrecpeq_f32(values.val[0]);
     float32x4_t r1 = vrecpeq_f32(values.val[1]);
     // Run two more Netwon's method iterations to get more accurate results
@@ -487,8 +492,12 @@ public:
     r1 = vmulq_f32(vrecpsq_f32(values.val[1], r1), r1);
     r1 = vmulq_f32(vrecpsq_f32(values.val[1], r1), r1);
     return Vectorized<float>(r0, r1);
+#endif
   }
   Vectorized<float> rsqrt() const {
+#ifndef C10_MOBILE
+    return this->sqrt().reciprocal();
+#else
     float32x4_t r0 =  vrsqrteq_f32(values.val[0]);
     float32x4_t r1 =  vrsqrteq_f32(values.val[1]);
     r0 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[0], r0), r0), r0);
@@ -496,6 +505,7 @@ public:
     r1 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[1], r1), r1), r1);
     r1 = vmulq_f32(vrsqrtsq_f32(vmulq_f32(values.val[1], r1), r1), r1);
     return Vectorized<float>(r0, r1);
+#endif
   }
   Vectorized<float> pow(const Vectorized<float> &exp) const {
     __at_align32__ float tmp[size()];


### PR DESCRIPTION
Default NEON accelerated implementation of reciprocal uses vrecpeq_f32 which yield  Newton-Raphson approximation rather than actual value
Use regular NEON accelerated division for reciprocal and reciprocal square root operations.

This fixes `test_reference_numerics_hard_frac_cpu_float32`, `test_reference_numerics_normal_rsqrt_cpu_float32` etc
