### PR TITLE
Change a number of PyTorch loops to use irange

### DIFF
--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -15,6 +15,7 @@
 #include <ATen/core/Vitals.h>
 #include <TH/TH.h>
 #include <c10/util/Logging.h>
+#include <c10/util/irange.h>
 #include <cstdlib>
 #include <libshm.h>
 #include <pybind11/pybind11.h>
@@ -587,7 +588,7 @@ PyObject *THPModule_supportedQEngines(PyObject *_unused, PyObject *noargs)
 {
   auto qengines = at::globalContext().supportedQEngines();
   auto list = THPObjectPtr(PyList_New(qengines.size()));
-  for (size_t i = 0; i < qengines.size(); ++i) {
+  for (const auto i : c10::irange(qengines.size())) {
     PyObject *i64 = THPUtils_packInt64(static_cast<int>(qengines[i]));
     if (!i64) {
       throw python_error();

--- a/torch/csrc/Size.cpp
+++ b/torch/csrc/Size.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/Size.h>
 
 #include <string>
@@ -22,7 +23,7 @@ PyObject * THPSize_New(const torch::autograd::Variable& var)
   auto self = THPObjectPtr(THPSizeType.tp_alloc(&THPSizeType, var.dim()));
   if (!self) throw python_error();
 
-  for (int64_t i = 0; i < var.dim(); ++i) {
+  for (const auto i : c10::irange(var.dim())) {
     PyObject *py_size_tensor = THPVariable_Wrap(torch::jit::tracer::getSizeOf(var, i));
     if (!py_size_tensor) throw python_error();
     PyTuple_SET_ITEM(self.get(), i, py_size_tensor);

--- a/torch/csrc/api/include/torch/data/dataloader/base.h
+++ b/torch/csrc/api/include/torch/data/dataloader/base.h
@@ -12,6 +12,7 @@
 #include <torch/csrc/utils/variadic.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <cstddef>
 #include <exception>
@@ -84,7 +85,8 @@ class DataLoaderBase {
     // Send one 'quit' message per worker. Since a worker dies (exits its
     // thread) after receiving this message, each `QuitWorker()` message will be
     // read by exactly one worker.
-    for (size_t w = 0; w < options_.workers; ++w) {
+    for (const auto w : c10::irange(options_.workers)) {
+      (void)w; // Suppress unused variable warning
       push_job(QuitWorker());
     }
     for (auto& worker : workers_) {
@@ -148,7 +150,8 @@ class DataLoaderBase {
   /// Schedules `requested_jobs` many new batches to be fetched. The actual
   /// number of jobs scheduled may be less if the DataLoader exhausts.
   void prefetch(size_t requested_jobs) {
-    for (size_t r = 0; r < requested_jobs; ++r) {
+    for (const auto r : c10::irange(requested_jobs)) {
+      (void)r; // Suppress unused variable
       if (auto batch_request = get_batch_request()) {
         this->push_job(std::move(*batch_request));
       } else {

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/arg.h>
 #include <torch/csrc/utils/memory.h>
 #include <torch/data/datasets/stateful.h>
@@ -399,7 +400,7 @@ class ChunkDataset final
 
     AT_ASSERT(running_preloaders_ == 0);
     running_preloaders_ = options_.preloader_count();
-    for (size_t i = 0; i < options_.preloader_count(); ++i) {
+    for (const auto i : c10::irange(options_.preloader_count())) {
       preload_threads_.emplace_back([this, i]() { this->preloader(i); });
     }
   }
@@ -441,7 +442,7 @@ class ChunkDataset final
           }
         }
         UnwrappedBatchType data = chunk_reader_.read_chunk(chunk_idx[0]);
-        for (size_t i = 1; i < chunk_idx.size(); ++i) {
+        for (const auto i : c10::irange(1, chunk_idx.size())) {
           auto chunk_data = chunk_reader_.read_chunk(chunk_idx[i]);
           std::move(
               chunk_data.begin(), chunk_data.end(), std::back_inserter(data));

--- a/torch/csrc/api/include/torch/nn/functional/pooling.h
+++ b/torch/csrc/api/include/torch/nn/functional/pooling.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/nn/functional/activation.h>
 #include <torch/nn/options/pooling.h>
 #include <torch/nn/modules/utils.h>
@@ -599,7 +600,7 @@ inline std::vector<int64_t> _unpool_output_size(const Tensor& input,
   const IntArrayRef& padding, const c10::optional<std::vector<int64_t>>& output_size) {
   auto input_size = input.sizes();
   std::vector<int64_t> default_size;
-  for (size_t d = 0; d < kernel_size.size(); d++) {
+  for (const auto d : c10::irange(kernel_size.size())) {
     default_size.push_back((input_size[d + 2] - 1) * stride[d] +
                             kernel_size[d] - 2 * padding[d]);
   }
@@ -616,7 +617,7 @@ inline std::vector<int64_t> _unpool_output_size(const Tensor& input,
                   " elements, but it has a length of '",
                   output_size_.size(), "'");
     }
-    for (size_t d = 0; d < kernel_size.size(); d++) {
+    for (const auto d : c10::irange(kernel_size.size())) {
       const auto min_size = default_size[d] - stride[d];
       const auto max_size = default_size[d] + stride[d];
       if (!(min_size <= output_size_[d] && output_size_[d] <= max_size)) {

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/nn/functional/pooling.h>
 #include <torch/nn/options/upsampling.h>
 
@@ -62,7 +63,7 @@ inline std::vector<int64_t> _interp_output_size(
   }
 
   std::vector<int64_t> ret;
-  for (int64_t i = 0; i < dim; i++) {
+  for (const auto i : c10::irange(dim)) {
     ret.emplace_back(static_cast<int64_t>(floor(input.size(i + 2) * scale_factors[i])));
   }
   return ret;

--- a/torch/csrc/api/include/torch/nn/modules/common.h
+++ b/torch/csrc/api/include/torch/nn/modules/common.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <c10/util/irange.h>
+
 /// This macro enables a module with default arguments in its forward method
 /// to be used in a Sequential module.
 ///
@@ -83,7 +85,7 @@
     TORCH_INTERNAL_ASSERT(arguments.size() >= _forward_num_required_args() && arguments.size() <= num_all_args); \
     std::vector<torch::nn::AnyValue> ret; \
     ret.reserve(num_all_args); \
-    for (size_t i = 0; i < arguments.size(); i++) { \
+    for (const auto i : c10::irange(arguments.size())) { \
       ret.emplace_back(std::move(arguments[i])); \
     } \
     for (auto& arg_info : args_info) { \

--- a/torch/csrc/api/include/torch/nn/modules/conv.h
+++ b/torch/csrc/api/include/torch/nn/modules/conv.h
@@ -1,5 +1,7 @@
 #pragma once
 
+
+#include <c10/util/irange.h>
 #include <c10/util/overloaded.h>
 
 #include <torch/expanding_array.h>
@@ -43,13 +45,13 @@ class ConvNdImpl : public torch::nn::Cloneable<Derived> {
           std::fill_n(_reversed_padding_repeated_twice.begin(), 2 * D, 0);
         },
         [&](enumtype::kSame) {
-          for (size_t i = 0; i < D; ++i) {
+          for (const auto i : c10::irange(D)) {
             const auto stride = (*options.stride())[i];
             TORCH_CHECK(stride == 1, "padding='same' is not supported for strided convolutions");
           }
 
           _reversed_padding_repeated_twice.resize(2 * D);
-          for (size_t i = 0; i < D; ++i) {
+          for (const auto i : c10::irange(D)) {
             const auto dilation = (*options.dilation())[i];
             const auto kernel_size = (*options.kernel_size())[i];
             const auto total_padding = dilation * (kernel_size - 1);

--- a/torch/csrc/api/include/torch/nn/modules/utils.h
+++ b/torch/csrc/api/include/torch/nn/modules/utils.h
@@ -2,6 +2,7 @@
 
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <vector>
 
@@ -20,7 +21,8 @@ inline std::vector<int64_t> _reverse_repeat_vector(at::ArrayRef<int64_t> t, int6
   std::vector<int64_t> ret;
   ret.reserve(t.size() * n);
   for (auto rit = t.rbegin(); rit != t.rend(); ++rit) {
-    for (int64_t i = 0; i < n; i++) {
+    for (const auto i : c10::irange(n)) {
+      (void)i; // Suppress unused variable
       ret.emplace_back(*rit);
     }
   }
@@ -34,7 +36,7 @@ inline std::vector<int64_t> _list_with_default(
     "Input dimension should be at least ", out_size.size() + 1);
   std::vector<int64_t> ret;
   torch::IntArrayRef defaults_slice = defaults.slice(defaults.size() - out_size.size(), out_size.size());
-  for (size_t i = 0; i < out_size.size(); i++) {
+  for (const auto i : c10::irange(out_size.size())) {
     auto v = out_size.at(i);
     auto d = defaults_slice.at(i);
     ret.emplace_back(v.has_value() ? v.value() : d);

--- a/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
+++ b/torch/csrc/api/include/torch/nn/parallel/data_parallel.h
@@ -13,6 +13,7 @@
 #include <ATen/Parallel.h>
 #include <c10/core/TensorOptions.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <cstddef>
 #include <exception>
@@ -104,7 +105,7 @@ void replicate_grad_edges(
     auto grad_fn = std::make_shared<ReduceAdd>((*parameter).device());
     grad_fn->set_next_edges(autograd::collect_next_edges(*parameter));
 
-    for (size_t i = 0; i < devices.size(); ++i) {
+    for (const auto i : c10::irange(devices.size())) {
       autograd::set_history(replicas[i]->parameters_[parameter.key()], grad_fn);
     }
   }
@@ -114,7 +115,7 @@ void replicate_grad_edges(
       auto grad_fn = std::make_shared<ReduceAdd>((*buffer).device());
       grad_fn->set_next_edges(autograd::collect_next_edges(*buffer));
 
-      for (size_t i = 0; i < devices.size(); ++i) {
+      for (const auto i : c10::irange(devices.size())) {
         autograd::set_history(replicas[i]->buffers_[buffer.key()], grad_fn);
       }
     }
@@ -255,7 +256,7 @@ Tensor data_parallel(
         device_count > 0, "Expected at least one CUDA device to be available");
     devices = std::vector<Device>();
     devices->reserve(device_count);
-    for (size_t index = 0; index < device_count; ++index) {
+    for (const auto index : c10::irange(device_count)) {
       devices->emplace_back(kCUDA, static_cast<torch::DeviceIndex>(index));
     }
   }

--- a/torch/csrc/api/include/torch/nn/utils/rnn.h
+++ b/torch/csrc/api/include/torch/nn/utils/rnn.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/types.h>
 
 namespace torch {
@@ -303,7 +304,7 @@ inline Tensor pad_sequence(
 ///     a `PackedSequence` object
 inline PackedSequence pack_sequence(ArrayRef<Tensor> sequences, bool enforce_sorted = true) {
   Tensor lengths = torch::empty({(int64_t)sequences.size()}, kInt64);
-  for (size_t i = 0; i < sequences.size(); i++) {
+  for (const auto i : c10::irange(sequences.size())) {
     lengths[i] = sequences[i].size(0);
   }
   return pack_padded_sequence(

--- a/torch/csrc/api/include/torch/serialize.h
+++ b/torch/csrc/api/include/torch/serialize.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/serialize/archive.h>
 #include <torch/serialize/tensor.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
@@ -66,7 +67,7 @@ template <typename... SaveToArgs>
 void save(const std::vector<torch::Tensor>& tensor_vec, SaveToArgs&&... args) {
   serialize::OutputArchive archive(
       std::make_shared<jit::CompilationUnit>());
-  for (size_t i = 0; i < tensor_vec.size(); i++) {
+  for (const auto i : c10::irange(tensor_vec.size())) {
     auto& value = tensor_vec[i];
     archive.write(c10::to_string(i), value);
   }

--- a/torch/csrc/api/src/cuda.cpp
+++ b/torch/csrc/api/src/cuda.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/Context.h>
 #include <c10/core/DeviceGuard.h>
+#include <c10/util/irange.h>
 
 #include <cstddef>
 
@@ -40,7 +41,7 @@ void manual_seed(uint64_t seed) {
 /// Sets the seed for all available GPUs.
 void manual_seed_all(uint64_t seed) {
   auto num_gpu = device_count();
-  for (size_t i = 0; i < num_gpu; ++i) {
+  for (const auto i : c10::irange(num_gpu)) {
     auto gen = at::detail::getCUDAHooks().getDefaultCUDAGenerator(i);
     {
       // See Note [Acquire lock when using random generators]

--- a/torch/csrc/api/src/data/samplers/distributed.cpp
+++ b/torch/csrc/api/src/data/samplers/distributed.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/data/samplers/distributed.h>
 #include <torch/serialize/archive.h>
 #include <torch/types.h>
@@ -57,7 +58,7 @@ void DistributedRandomSampler::populate_indices() {
       num_replicas_ == 1 ? size_ : num_local_samples * num_replicas_;
   all_indices_.resize(sample_count);
   std::iota(std::begin(all_indices_), std::end(all_indices_), 0);
-  for (size_t i = size_; i < sample_count; ++i) {
+  for (const auto i : c10::irange(size_, sample_count)) {
     // we may have added duplicate samples to make all
     // replicas to have the same number of samples.
     all_indices_[i] = i - size_;

--- a/torch/csrc/api/src/nn/init.cpp
+++ b/torch/csrc/api/src/nn/init.cpp
@@ -5,6 +5,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <cmath>
@@ -82,7 +83,7 @@ Tensor dirac_(Tensor tensor) {
   const auto min_dim = std::min(sizes[0], sizes[1]);
 
   tensor.zero_();
-  for (int64_t d = 0; d < min_dim; ++d) {
+  for (const auto d : c10::irange(min_dim)) {
     switch (tensor.ndimension()) {
       case 3: // Temporal convolution
         tensor[d][d][sizes[2] / 2] = 1;
@@ -159,7 +160,7 @@ Tensor sparse_(Tensor tensor, double sparsity, double std) {
   const auto columns = tensor.size(1);
   const int64_t num_zeros = std::ceil(sparsity * rows);
   tensor.normal_(0, std);
-  for (int64_t column = 0; column < columns; ++column) {
+  for (const auto column : c10::irange(columns)) {
     auto row_indices = torch::randperm(rows, tensor.options().dtype(kLong));
     auto zero_indices =
         row_indices.slice(/*dim=*/0, /*start=*/0, /*end=*/num_zeros);

--- a/torch/csrc/api/src/nn/modules/_functions.cpp
+++ b/torch/csrc/api/src/nn/modules/_functions.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/nn/modules/_functions.h>
 
 using namespace torch::autograd;
@@ -44,7 +45,7 @@ Variable CrossMapLRN2d::forward(
   scale_first.zero_();
 
   /// compute first feature map normalization
-  for (int64_t c = 0; c < pre_pad_crop; ++c) {
+  for (const auto c : c10::irange(pre_pad_crop)) {
     scale_first.add_(input_square.select(1, c));
   }
 
@@ -52,7 +53,7 @@ Variable CrossMapLRN2d::forward(
   /// by adding the next feature map and removing the previous
   torch::Tensor scale_previous, scale_current, square_next, square_previous;
 
-  for (int64_t c = 1; c < channels; ++c) {
+  for (const auto c : c10::irange(1, channels)) {
     scale_previous = ctx->saved_data["scale"].toTensor().select(1, c - 1);
     scale_current = ctx->saved_data["scale"].toTensor().select(1, c);
     scale_current.copy_(scale_previous);
@@ -103,14 +104,14 @@ variable_list CrossMapLRN2d::backward(AutogradContext *ctx, variable_list grad_o
   padded_ratio.zero_();
   auto padded_ratio_center = padded_ratio.narrow(0, inversePrePad, channels);
 
-  for (int64_t n = 0; n < batch_size; ++n) {
+  for (const auto n : c10::irange(batch_size)) {
     torch::mul_out(padded_ratio_center, grad_output[n], output[n]);
     padded_ratio_center.div_(ctx->saved_data["scale"].toTensor()[n]);
     torch::sum_out(
         accum_ratio,
         padded_ratio.narrow(0, 0, ctx->saved_data["size"].toInt() - 1),
         0, /*keepdim=*/false);
-    for (int64_t c = 0; c < channels; ++c) {
+    for (const auto c : c10::irange(channels)) {
       accum_ratio.add_(padded_ratio[c + ctx->saved_data["size"].toInt() - 1]);
       grad_input[n][c].addcmul_(input[n][c], accum_ratio, -cache_ratio_value);
       accum_ratio.add_(padded_ratio[c], -1);

--- a/torch/csrc/api/src/nn/modules/transformer.cpp
+++ b/torch/csrc/api/src/nn/modules/transformer.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/nn/init.h>
 #include <torch/nn/modules/transformerlayer.h>
 #include <torch/nn/modules/transformercoder.h>
@@ -201,7 +202,7 @@ TransformerEncoderImpl::TransformerEncoderImpl(
 
 void TransformerEncoderImpl::reset() {
   layers = this->register_module("layers", ModuleList());
-  for (int64_t i = 0; i < options.num_layers(); ++i) {
+  for (const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.encoder_layer()->clone());
   }
 
@@ -218,7 +219,7 @@ void TransformerEncoderImpl::reset_parameters() {
     "TransformerEncoder should have", options.num_layers(), " encoder layers, but got ", layers->size());
 
   size_t num_layers = layers->size();
-  for (size_t i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     layers->at<TransformerEncoderLayerImpl>(i).reset_parameters();
   }
   // a. No way to know whether module in AnyModule has api to reset_parameters, so replace instead
@@ -243,7 +244,7 @@ Tensor TransformerEncoderImpl::forward(
   if (num_layers > 0) {
     output = layers->at<TransformerEncoderLayerImpl>(0).forward(src, src_mask, src_key_padding_mask);
   }
-  for (size_t i = 1; i < num_layers; ++i) {
+  for (const auto i : c10::irange(1, num_layers)) {
     output = layers->at<TransformerEncoderLayerImpl>(i).forward(output, src_mask, src_key_padding_mask);
   }
 
@@ -263,7 +264,7 @@ TransformerDecoderImpl::TransformerDecoderImpl(
 void TransformerDecoderImpl::reset() {
 
   layers = this->register_module("layers", ModuleList());
-  for (int64_t i = 0; i < options.num_layers(); ++i) {
+  for (const auto i : c10::irange(options.num_layers())) {
     layers->push_back(options.decoder_layer()->clone());
   }
 
@@ -281,7 +282,7 @@ void TransformerDecoderImpl::reset_parameters() {
     " decoder layers, but got ", layers->size());
 
   size_t num_layers = layers->size();
-  for (size_t i = 0; i < num_layers; ++i) {
+  for (const auto i : c10::irange(num_layers)) {
     layers->at<TransformerDecoderLayerImpl>(i).reset_parameters();
   }
   // a. No way to know whether module in AnyModule has api to reset_parameters, so replace instead
@@ -315,7 +316,7 @@ Tensor TransformerDecoderImpl::forward(
       tgt_key_padding_mask,
       memory_key_padding_mask);
   }
-  for (size_t i = 1; i < num_layers; ++i) {
+  for (const auto i : c10::irange(1, num_layers)) {
     output = layers->at<TransformerDecoderLayerImpl>(i).forward(
       output,
       memory,

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -586,7 +586,7 @@ std::vector<Tensor> cat_tensors_backward(const Tensor & grad, const std::vector<
   if (grad_is_complex) {
     grad_ = at::real(grad);
   }
-  for (size_t i = 0; i < sizes.size(); ++i) {
+  for (const auto i : c10::irange(sizes.size())) {
     Tensor grad_val;
     if (!at::isComplexType(dtypes[i]) && grad_is_complex) {
       // R -> C
@@ -827,12 +827,12 @@ Tensor repeat_backward(Tensor grad, IntArrayRef repeats, IntArrayRef input_shape
   }
   const auto input_dims = input_shape.size();
   int64_t num_unsqueezed = grad.dim() - input_dims;
-  for (int64_t i = 0; i < num_unsqueezed; ++i) {
+  for (const auto i : c10::irange(num_unsqueezed)) {
     grad = grad.sum(0, false);
   }
 
   at::DimVector grad_size, sum_dims;
-  for (size_t dim = 0; dim < input_dims; ++dim) {
+  for (const auto dim : c10::irange(input_dims)) {
     int64_t repeat = repeats[dim + num_unsqueezed];
     // Reshape gradient (repeat > 1)
     // Index:      [..., dim    , ...]    [..., dim   ,  dim+1        , ...]
@@ -1040,7 +1040,7 @@ Tensor split_with_sizes_backward(const std::vector<torch::autograd::Variable> &g
   // it's possible some of the grads are not defined (represents tensors of all 0s).
   // Since at::cat can't handle those, let's define them
   std::vector<Tensor> grads_all_defined(grads.size());
-  for (size_t j = 0; j < grads.size(); ++j) {
+  for (const auto j : c10::irange(grads.size())) {
     if (grads[j].defined()) {
       grads_all_defined[j] = grads[j];
     } else {

--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -71,7 +71,7 @@ Tensor unpack_opt(const Tensor & t, const char * name, int pos) {
 
 std::vector<at::Tensor> unpack(at::TensorList tl, const char *name, int pos) {
   std::vector<at::Tensor> ret(tl.size());
-  for (size_t i = 0; i < tl.size(); ++i) {
+  for (const auto i : c10::irange(tl.size())) {
     const auto &t = tl[i];
     if (!t.defined()) {
       continue;

--- a/torch/csrc/autograd/VariableTypeUtils.h
+++ b/torch/csrc/autograd/VariableTypeUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/generated/VariableType.h>
 
 #include <torch/csrc/autograd/variable.h>
@@ -341,7 +342,7 @@ inline std::vector<SavedVariable> make_saved_variable_list(const c10::List<c10::
 
 inline std::vector<std::vector<int64_t>> to_args_sizes(TensorList tensors) {
   std::vector<std::vector<int64_t>> args_sizes(tensors.size());
-  for (size_t i = 0; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(tensors.size())) {
     args_sizes[i] = tensors[i].sizes().vec();
   }
   return args_sizes;
@@ -349,7 +350,7 @@ inline std::vector<std::vector<int64_t>> to_args_sizes(TensorList tensors) {
 
 inline std::vector<ScalarType> to_args_scalartypes(TensorList tensors) {
   std::vector<ScalarType> args_scalartypes(tensors.size());
-  for (size_t i = 0; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(tensors.size())) {
     args_scalartypes[i] = tensors[i].scalar_type();
   }
   return args_scalartypes;

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -40,7 +40,7 @@ variable_list _make_grads(
         "gradients",
         num_tensors,
         num_gradients);
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       const Variable& output = outputs[i];
       const Variable& grad_output = grad_outputs[i];
       if (!grad_output.defined()) {
@@ -89,7 +89,7 @@ variable_list run_backward(
   if (!inputs.empty()) {
     size_t num_inputs = inputs.size();
     output_edges.reserve(num_inputs);
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       const Variable& input = inputs[i];
       const auto output_nr = input.output_nr();
       auto grad_fn = input.grad_fn();
@@ -119,7 +119,7 @@ variable_list run_backward(
   // check if grad_inputs contains None or not base on the allow_unused flag
   if (!inputs.empty() && !allow_unused) {
     size_t num_inputs = inputs.size();
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       TORCH_CHECK(
           grad_inputs[i].defined(),
           "One of the "

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/variable.h>
 
 namespace torch {
@@ -76,7 +77,7 @@ namespace {
     if (base.dim() != other.dim()) {
       return false;
     }
-    for (int64_t i=0; i<base.dim(); ++i) {
+    for (const auto i : c10::irange(base.dim())) {
       if (base.sizes()[i] != other.sizes()[i]) {
         return false;
       }

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/autograd.h>
@@ -110,7 +111,7 @@ std::vector<c10::optional<Variable>> _wrap_outputs(const variable_list &input_va
   int num_diff_outputs = 0;
 
 
-  for (auto i = 0; i < num_outputs; ++i) {
+  for (const auto i : c10::irange(num_outputs)) {
     // For outputs that are not tensors, put a placeholder undefined input.
     if (!raw_outputs[i].has_value()) {
       if (cdata) {

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -4,6 +4,7 @@
 #include <torch/csrc/autograd/variable.h>
 #include <ATen/core/ivalue.h>
 #include <c10/util/flat_hash_map.h>
+#include <c10/util/irange.h>
 #include <vector>
 
 namespace torch { namespace autograd {
@@ -287,7 +288,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
   int num_inputs = inputs.size();
   variable_list backward_inputs;
   backward_inputs.reserve(num_inputs);
-  for (int i = 0 ; i < num_inputs; ++i) {
+  for (const auto i : c10::irange(num_inputs)) {
     if (inputs[i].defined() || !ctx_.materialize_grads_) {
       backward_inputs.emplace_back(inputs[i]);
     } else {
@@ -310,7 +311,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
   // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
   if (num_outputs > num_forward_inputs) {
     bool all_undef = true;
-    for (size_t i = num_forward_inputs; i < num_outputs; ++i) {
+    for (const auto i : c10::irange(num_forward_inputs, num_outputs)) {
       all_undef &= (!outputs[i].defined());
     }
     if (all_undef) {
@@ -331,7 +332,7 @@ variable_list CppNode<T>::apply(variable_list&& inputs) {
   variable_list results;
   results.reserve(num_outputs);
   // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-  for (int i = 0; i < num_outputs; ++i) {
+  for (const auto i : c10::irange(num_outputs)) {
     if (!is_variable_input_[i]) {
       if (outputs[i].defined()) {
         std::string msg("function ");

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -536,7 +536,7 @@ void GraphTask::exec_post_processing() {
   // WARNING: Don't use a range-for loop here because more callbacks may be
   // added in between callback calls, so iterators may become invalidated.
   // NOLINTNEXTLINE(modernize-loop-convert)
-  for (size_t i = 0; i < final_callbacks_.size(); ++i) {
+  for (const auto i : c10::irange(final_callbacks_.size())) {
     cb_lock.unlock();
     final_callbacks_[i]();
     cb_lock.lock();
@@ -782,7 +782,7 @@ void Engine::evaluate_function(
 
   if (AnomalyMode::is_enabled()) {
     AutoGradMode grad_mode(false);
-    for (int i = 0; i < num_outputs; ++i) {
+    for (const auto i : c10::irange(num_outputs)) {
       auto& output = outputs[i];
       at::OptionalDeviceGuard guard(device_of(output));
       if (output.defined() && isnan(output).any().item<uint8_t>()) {
@@ -795,7 +795,7 @@ void Engine::evaluate_function(
 
   // Lock mutex for the accesses to GraphTask dependencies_, not_ready_ and cpu_ready_queue_ below
   std::lock_guard<std::mutex> lock(graph_task->mutex_);
-  for (int i = 0; i < num_outputs; ++i) {
+  for (const auto i : c10::irange(num_outputs)) {
     auto& output = outputs[i];
     const auto& next = fn.next_edge(i);
 
@@ -1141,7 +1141,7 @@ auto Engine::start_device_threads() -> void {
 
   thread_pool_shared_ = std::make_shared<ThreadPoolShared>();
 
-  for (int i = 0; i < num_devices; ++i) {
+  for (const auto i : c10::irange(num_devices)) {
     std::thread t(&Engine::thread_init, this, i, device_ready_queues_[i], true);
     t.detach();
   }

--- a/torch/csrc/autograd/functions/init.cpp
+++ b/torch/csrc/autograd/functions/init.cpp
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/accumulate_grad.h>
 #include <torch/csrc/autograd/functions/basic_ops.h>
 #include <torch/csrc/autograd/functions/pybind.h>
@@ -62,7 +63,7 @@ PyObject* getTupleAttr(PyObject* obj, void* _unused)
   auto num_elems = arr.size();
   THPObjectPtr py_tuple(PyTuple_New(num_elems));
   if (!py_tuple) return nullptr;
-  for (size_t i = 0; i < num_elems; ++i) {
+  for (const auto i : c10::irange(num_elems)) {
     PyTuple_SET_ITEM(py_tuple.get(), i, Convert(arr[i]));
   }
   return py_tuple.release();

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -56,7 +56,7 @@ CopySlices::CopySlices(
   const auto num_outputs = fn->num_outputs();
   next_edges_.reserve(num_outputs);
   add_next_edge(impl::gradient_edge(base_var));
-  for (size_t i = 1; i < num_outputs; i++) {
+  for (const auto i : c10::irange(1, num_outputs)) {
     add_next_edge(fn->next_edge(i));
   }
 }

--- a/torch/csrc/autograd/functions/utils.cpp
+++ b/torch/csrc/autograd/functions/utils.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/functions/utils.h>
 
 #include <torch/csrc/autograd/edge.h>
@@ -47,7 +48,7 @@ void check_input_variables(const char* name, const variable_list& inputs, int ar
     ss << ")";
     throw std::runtime_error(ss.str());
   }
-  for (int i = 0; i < required_args; ++i) {
+  for (const auto i : c10::irange(required_args)) {
     if (!inputs[i].defined() && !allow_undefined) {
       std::stringstream ss;
       ss << name << ": expected Tensor at argument " << i << " (got None)";

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/profiler_kineto.h>
 
 #include <torch/csrc/jit/frontend/tracer.h>
@@ -309,7 +310,7 @@ void pushProfilingCallbacks() {
 std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes) {
   std::ostringstream oss;
   oss << "[";
-  for (size_t t_idx = 0; t_idx < shapes.size(); ++t_idx) {
+  for (const auto t_idx : c10::irange(shapes.size())) {
     if (t_idx > 0) {
       oss << ", ";
     }

--- a/torch/csrc/autograd/profiler_legacy.cpp
+++ b/torch/csrc/autograd/profiler_legacy.cpp
@@ -18,6 +18,7 @@
 #include <ATen/record_function.h>
 #include <c10/core/Allocator.h>
 #include <c10/util/ThreadLocalDebugInfo.h>
+#include <c10/util/irange.h>
 
 #include <iostream>
 
@@ -319,7 +320,7 @@ std::string ProfilerThreadLocalState::getNvtxStr(
     }
     if (shapes.size() > 0) {
       s << ", sizes = [";
-      for (size_t idx = 0; idx < shapes.size(); ++idx) {
+      for (const auto idx : c10::irange(shapes.size())) {
         if (shapes[idx].size() > 0) {
           s << "[";
           for (size_t dim = 0; dim < shapes[idx].size(); ++dim) {
@@ -594,7 +595,7 @@ void LegacyEvent::record(bool record_cuda) {
   auto shapeList = shapeListIValue.toList();
   std::vector<std::vector<int64_t>> shapes;
   shapes.reserve(shapeList.size());
-  for (size_t i = 0 ; i < shapeList.size(); ++i) {
+  for (const auto i : c10::irange(shapeList.size())) {
     std::vector<int64_t> s;
     auto shapeIValue = shapeList.get(i);
     TORCH_INTERNAL_ASSERT(
@@ -602,7 +603,7 @@ void LegacyEvent::record(bool record_cuda) {
         "Expected each profiler shape element to contain shapes of type c10::impl::GenericList.")
     auto curShapesList = shapeIValue.toList();
     s.reserve(curShapesList.size());
-    for (size_t j = 0; j < curShapesList.size(); ++j) {
+    for (const auto j : c10::irange(curShapesList.size())) {
       s.emplace_back(curShapesList.get(j).toInt());
     }
     shapes.emplace_back(s);

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/python_cpp_function.h>
 
 #include <torch/csrc/python_headers.h>
@@ -108,7 +109,7 @@ PyObject* THPCppFunction_next_functions(THPCppFunction* self, PyObject* hook)
   const auto num_next = self->cdata->num_outputs();
   THPObjectPtr py_functions(PyTuple_New(num_next));
   if (!py_functions) return nullptr;
-  for (size_t i = 0; i < num_next; ++i) {
+  for (const auto i : c10::irange(num_next)) {
     auto& c_tuple = self->cdata->next_edge(i);
     THPObjectPtr tuple(PyTuple_New(2));
     if (!tuple) return nullptr;

--- a/torch/csrc/autograd/python_engine.cpp
+++ b/torch/csrc/autograd/python_engine.cpp
@@ -222,7 +222,7 @@ PyObject *THPEngine_run_backward(PyObject *self, PyObject *args, PyObject *kwarg
   if (inputs != nullptr) {
     int num_inputs = PyTuple_GET_SIZE(inputs);
     output_edges.reserve(num_inputs);
-    for (int i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       PyObject *input = PyTuple_GET_ITEM(inputs, i);
       THPUtils_assert(THPVariable_Check(input),
           "all inputs have to be Tensors, but got %s", THPUtils_typename(input));

--- a/torch/csrc/autograd/python_function.cpp
+++ b/torch/csrc/autograd/python_function.cpp
@@ -67,7 +67,7 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   THPObjectPtr pyInputs(PyTuple_New(num_inputs));
   if (!pyInputs) throw_python_error();
   auto& output_info = py_fn->output_info;
-  for (size_t i = 0; i < num_inputs; ++i) {
+  for (const auto i : c10::irange(num_inputs)) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     PyObject* input;
     if (inputs[i].defined() || !py_fn->materialize_grads) {
@@ -92,7 +92,7 @@ auto PyNode::apply(variable_list&& inputs) -> variable_list {
   // Truncate the result tuple in that case.
   if (num_outputs > num_forward_inputs) {
     bool all_none = true;
-    for (int i = num_forward_inputs; i < num_outputs; i++) {
+    for (const auto i : c10::irange(num_forward_inputs, num_outputs)) {
       all_none &= PyTuple_GET_ITEM(r.get(), i) == Py_None;
     }
     if (all_none) {
@@ -318,7 +318,7 @@ static void _wrap_outputs(const std::shared_ptr<PyNode>& cdata, THPFunction *sel
 
   std::vector<c10::optional<Variable>> raw_output_vars;
   raw_output_vars.reserve(num_outputs);
-  for(int i = 0; i < num_outputs; ++i){
+  for (const auto i : c10::irange(num_outputs)) {
     PyObject* obj = PyTuple_GET_ITEM(raw_output, i);
     // Only process tensors as outputs for autograd purposes.
     if (THPVariable_Check(obj)) {
@@ -507,7 +507,7 @@ static void _trace_post_record(
     auto unpacked = graph->createTupleUnpack(node->output())->insertAfter(node);
     node = unpacked;
   }
-  for (int i = 0; i < num_outputs; ++i) {
+  for (const auto i : c10::irange(num_outputs)) {
     PyObject* obj = PyTuple_GET_ITEM(output_objects, i);
     if (THPVariable_Check(obj)) {
       Value* value = node->outputs()[i];
@@ -615,7 +615,7 @@ PyObject *THPFunction_apply(PyObject *cls, PyObject *inputs)
   if (!ctx_input_tuple) return nullptr;
   Py_INCREF(ctx);
   PyTuple_SET_ITEM(ctx_input_tuple.get(), 0, (PyObject*)ctx);
-  for (int i = 0; i < num_args; ++i) {
+  for (const auto i : c10::irange(num_args)) {
     PyObject *arg = PyTuple_GET_ITEM(unpacked_input.input_tuple.get(), i);
     Py_INCREF(arg);
     PyTuple_SET_ITEM(ctx_input_tuple.get(), i + 1, arg);
@@ -760,7 +760,7 @@ PyObject *THPFunction_next_functions(THPFunction *self, void *_unused)
   THPObjectPtr result(PyTuple_New(num_outputs));
   if (!result)
     return nullptr;
-  for (uint32_t i = 0; i < num_outputs; i++) {
+  for (const auto i : c10::irange(num_outputs)) {
     THPObjectPtr fn_tuple(PyTuple_New(2));
     if (!fn_tuple) return nullptr;
     const auto& edge = cdata->next_edge(i);

--- a/torch/csrc/autograd/python_hook.cpp
+++ b/torch/csrc/autograd/python_hook.cpp
@@ -104,7 +104,7 @@ static PyObject *wrap_variables(const variable_list& c_variables)
   size_t num_vars = c_variables.size();
   THPObjectPtr tuple(PyTuple_New(num_vars));
   if (!tuple) throw python_error();
-  for (size_t i = 0; i < num_vars; ++i) {
+  for (const auto i : c10::irange(num_vars)) {
     THPObjectPtr var(THPVariable_Wrap(c_variables[i]));
     if (!var) throw python_error();
     PyTuple_SET_ITEM(tuple.get(), i, var.release());
@@ -148,7 +148,7 @@ static void check_result(PyObject* prev, PyObject* result, PyObject* hook) {
     throw std::runtime_error(ss.str());
   }
 
-  for (auto i = 0; i < prev_size; i++) {
+  for (const auto i : c10::irange(prev_size)) {
     check_single_result(PyTuple_GET_ITEM(prev, i), PyTuple_GET_ITEM(result, i), hook);
   }
 }

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -28,6 +28,7 @@
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <ATen/NamedTensorUtils.h>
 #include <c10/util/DeadlockDetection.h>
+#include <c10/util/irange.h>
 
 #include <ATen/ATen.h>
 #include <pybind11/pybind11.h>
@@ -551,7 +552,7 @@ PyObject *THPVariable_get_names(PyObject *self, void *unused)
   if (!tuple) throw python_error();
 
   const auto dimnames = tensor.names();
-  for (size_t i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     PyObject* str;
     if (dimnames[i].type() == at::NameType::WILDCARD) {

--- a/torch/csrc/autograd/utils/wrap_outputs.h
+++ b/torch/csrc/autograd/utils/wrap_outputs.h
@@ -3,6 +3,7 @@
 // Wrap tensor operation outputs as PyObject*
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/python_headers.h>
 #include <tuple>
 
@@ -189,7 +190,7 @@ inline PyObject* wrap(std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor,
 inline PyObject* wrap(at::TensorList tl) {
   auto r = THPObjectPtr{PyTuple_New(tl.size())};
   if (!r) throw python_error();
-  for (size_t i = 0; i < tl.size(); ++i) {
+  for (const auto i : c10::irange(tl.size())) {
     PyTuple_SET_ITEM(r.get(), i, wrap(tl[i]));
   }
   return r.release();
@@ -198,7 +199,7 @@ inline PyObject* wrap(at::TensorList tl) {
 inline PyObject* wrap(at::IntArrayRef list) {
   auto r = THPObjectPtr{PyTuple_New(list.size())};
   if (!r) throw python_error();
-  for (size_t i = 0; i < list.size(); ++i) {
+  for (const auto i : c10::irange(list.size())) {
     PyTuple_SET_ITEM(r.get(), i, wrap(list[i]));
   }
   return r.release();

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -349,7 +349,7 @@ PyObject * THCPModule_memoryStats(PyObject *_unused, PyObject *arg)
       "all", "small_pool", "large_pool"
     };
     py::dict dict;
-    for (size_t i = 0; i < statTypeNames.size(); ++i) {
+    for (const auto i : c10::irange(statTypeNames.size())) {
       dict[statTypeNames[i]] = statToDict(statArray[i]);
     }
     return dict;

--- a/torch/csrc/cuda/comm.cpp
+++ b/torch/csrc/cuda/comm.cpp
@@ -332,7 +332,7 @@ std::vector<at::Tensor> scatter(
       ? tensor.split_with_sizes(/*split_sizes=*/*chunk_sizes, /*dim=*/dim)
       : tensor.chunk(/*chunks=*/devices.size(), /*dim=*/dim);
   at::cuda::OptionalCUDAStreamGuard cuda_guard;
-  for (size_t i = 0; i < chunks.size(); ++i) {
+  for (const auto i : c10::irange(chunks.size())) {
     const auto device_index = static_cast<int16_t>(devices[i]);
     if (device_index != tensor.get_device()) {
       if (i < (streams ? streams->size() : 0U) && (*streams)[i]) {
@@ -417,7 +417,7 @@ at::Tensor& gather_out(
         expected_size.size(),
         ")");
     expected_size[dim] = tensor.size(dim);
-    for (size_t dimension = 0; dimension < expected_size.size(); ++dimension) {
+    for (const auto dimension : c10::irange(expected_size.size())) {
       TORCH_CHECK(
           expected_size[dimension] == tensor.size(dimension),
           "Input tensor at index ",
@@ -471,7 +471,7 @@ at::Tensor gather(
         expected_size.size(),
         ")");
     expected_size[dim] = tensor.size(dim);
-    for (size_t dimension = 0; dimension < expected_size.size(); ++dimension) {
+    for (const auto dimension : c10::irange(expected_size.size())) {
       TORCH_CHECK(
           expected_size[dimension] == tensor.size(dimension),
           "Input tensor at index ",

--- a/torch/csrc/deploy/deploy.h
+++ b/torch/csrc/deploy/deploy.h
@@ -1,6 +1,7 @@
 #pragma once
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <assert.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/deploy/interpreter/interpreter_impl.h>
 #include <torch/csrc/jit/serialization/import.h>
 #include <fstream>
@@ -108,7 +109,7 @@ struct TORCH_API LoadBalancer {
 struct TORCH_API InterpreterManager {
   InterpreterManager(size_t n_interp = 2) : resources_(n_interp) {
     TORCH_DEPLOY_TRY
-    for (size_t i = 0; i < n_interp; ++i) {
+    for (const auto i : c10::irange(n_interp)) {
       instances_.emplace_back(this);
       auto I = instances_.back().acquire_session();
       // make torch.version.interp be the interpreter id

--- a/torch/csrc/deploy/example/benchmark.cpp
+++ b/torch/csrc/deploy/example/benchmark.cpp
@@ -13,6 +13,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/TypeDefault.h>
+#include <c10/util/irange.h>
 
 #include <torch/script.h>
 
@@ -131,7 +132,7 @@ struct RunJIT {
     if (!cuda) {
       models_.push_back(torch::jit::load(file_to_run + "_jit"));
     } else {
-      for (int i = 0; i < 2; ++i) {
+      for (const auto i : c10::irange(2)) {
         auto d = torch::Device(torch::DeviceType::CUDA, i);
         std::stringstream qualified;
         qualified << file_to_run << "_jit_" << i;
@@ -208,7 +209,7 @@ struct Benchmark {
 
     std::vector<std::vector<double>> latencies(n_threads_);
 
-    for (size_t i = 0; i < n_threads_; ++i) {
+    for (const auto i : c10::irange(n_threads_)) {
       threads_.emplace_back([this, &latencies, i] {
         torch::NoGradGuard guard;
         // do initial work
@@ -301,7 +302,7 @@ int main(int argc, char* argv[]) {
   }
 
   auto n_threads = {1, 2, 4, 8, 16, 32, 40};
-  for (int i = 4; i < argc; ++i) {
+  for (const auto i : c10::irange(4, argc)) {
     std::string model_file = argv[i];
     for (int n_thread : n_threads) {
       if (n_thread > max_thread) {

--- a/torch/csrc/deploy/test_deploy.cpp
+++ b/torch/csrc/deploy/test_deploy.cpp
@@ -127,7 +127,7 @@ TEST(TorchpyTest, ThreadedSimpleModel) {
   for (const auto i : c10::irange(nthreads)) {
     futures.push_back(std::async(std::launch::async, [&model]() {
       auto input = torch::ones({10, 20});
-      for (int i = 0; i < 100; ++i) {
+      for (const auto i : c10::irange(100)) {
         model({input.alias()}).toTensor();
       }
       auto result = model({input.alias()}).toTensor();
@@ -198,12 +198,12 @@ TEST(TorchpyTest, TaggingRace) {
   constexpr int64_t trials = 4;
   constexpr int64_t nthreads = 16;
   torch::deploy::InterpreterManager m(nthreads);
-  for (int64_t n = 0; n < trials; n++) {
+  for (const auto n : c10::irange(trials)) {
     at::Tensor t = torch::empty(2);
     std::atomic<int64_t> success(0);
     std::atomic<int64_t> failed(0);
     at::parallel_for(0, nthreads, 1, [&](int64_t begin, int64_t end) {
-      for (int64_t i = begin; i < end; i++) {
+      for (const auto i : c10::irange(begin, end)) {
         auto I = m.all_instances()[i].acquire_session();
         try {
           I.from_ivalue(t);

--- a/torch/csrc/distributed/rpc/process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/process_group_agent.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/distributed/rpc/process_group_agent.h>
 
 #include <c10/util/C++17.h>
+#include <c10/util/irange.h>
 #include <c10d/ProcessGroup.hpp>
 #include <fmt/format.h>
 #include <torch/csrc/distributed/rpc/agent_utils.h>
@@ -175,7 +176,7 @@ bool ProcessGroupAgent::hasPendingMessage() {
   // allgather both send and recv messages in one shot
   std::vector<std::vector<torch::Tensor>> outputSnapshots(1);
 
-  for (int i = 0; i < worldSize; ++i) {
+  for (const auto i : c10::irange(worldSize)) {
     outputSnapshots[0].emplace_back(
         torch::zeros({2, worldSize}, {torch::kInt64}));
   }
@@ -185,8 +186,8 @@ bool ProcessGroupAgent::hasPendingMessage() {
   // loop through all send/recv pairs to make sure that all sent messages are
   // processed.
   const auto& peerCounts = outputSnapshots[0];
-  for (int from = 0; from < worldSize; ++from) {
-    for (int to = 0; to < worldSize; ++to) {
+  for (const auto from : c10::irange(worldSize)) {
+    for (const auto to : c10::irange(worldSize)) {
       // peerCounts[x][0] is recv counts, and peerCounts[x][1] is send counts
 
       const auto& sentCnt = peerCounts[from][1][to].data_ptr<int64_t>()[0];

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/distributed/rpc/utils.h>
 
 #include <c10/core/StreamGuard.h>
+#include <c10/util/irange.h>
 
 #if TENSORPIPE_HAS_SHM_TRANSPORT
 // Needed for ::getpid(), which is used to create a unique address.
@@ -318,7 +319,7 @@ constexpr static int kNumUvThreads = 16;
 std::unique_ptr<ChannelRegistration> makeMultiplexedUvChannel() {
   std::vector<std::shared_ptr<tensorpipe::transport::Context>> contexts;
   std::vector<std::shared_ptr<tensorpipe::transport::Listener>> listeners;
-  for (int laneIdx = 0; laneIdx < kNumUvThreads; ++laneIdx) {
+  for (const auto laneIdx : c10::irange(kNumUvThreads)) {
     auto context = tensorpipe::transport::uv::create();
     std::string address = TensorPipeAgent::guessAddress();
     contexts.push_back(std::move(context));

--- a/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_utils.cpp
@@ -7,6 +7,7 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <c10/util/irange.h>
 #endif
 
 #include <tensorpipe/tensorpipe.h>
@@ -103,7 +104,7 @@ std::tuple<tensorpipe::Message, TensorpipeWriteBuffers> tensorpipeSerialize(
   tpMessage.payloads.push_back(tensorpipe::Message::Payload{
       buffers.pickle.data(), buffers.pickle.size()});
   const auto& tensorDataVec = pickler.tensorData();
-  for (size_t i = 0; i < tensorDataVec.size(); ++i) {
+  for (const auto i : c10::irange(tensorDataVec.size())) {
     // This is different from jit::getWriteableTensorData as it avoids copying
     // tensor to CPU.
     const auto& tensorData =
@@ -215,7 +216,7 @@ std::pair<tensorpipe::Allocation, TensorpipeReadBuffers> tensorpipeAllocate(
 
   size_t numTensors = tpDescriptor.tensors.size();
   tpAllocation.tensors.resize(numTensors);
-  for (size_t tensorIdx = 0; tensorIdx < numTensors; ++tensorIdx) {
+  for (const auto tensorIdx : c10::irange(numTensors)) {
     const tensorpipe::Descriptor::Tensor& tensor =
         tpDescriptor.tensors[tensorIdx];
     TORCH_INTERNAL_ASSERT(tensor.targetDevice.has_value());
@@ -284,7 +285,7 @@ c10::intrusive_ptr<Message> tensorpipeDeserialize(
     tensors.emplace_back(std::move(t));
   }
 
-  for (size_t i = 0; i < tpDescriptor.tensors.size(); ++i) {
+  for (const auto i : c10::irange(tpDescriptor.tensors.size())) {
     auto& tensor = tpDescriptor.tensors[i];
     if (tensor.targetDevice.has_value() &&
         tensor.targetDevice->type == tensorpipe::kCudaDeviceType) {

--- a/torch/csrc/jit/api/function_impl.cpp
+++ b/torch/csrc/jit/api/function_impl.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/passes/inliner.h>
 
@@ -14,13 +15,13 @@ c10::FunctionSchema defaultSchemaFor(const Function& function) {
   std::vector<c10::Argument> returns;
   Graph& g = *function.graph();
   size_t num_inputs = function.num_inputs();
-  for (size_t i = 0; i < num_inputs; ++i) {
+  for (const auto i : c10::irange(num_inputs)) {
     const Value* v = g.inputs().at(i);
     std::string name = v->hasDebugName() ? v->debugNameBase()
                                          : ("argument_" + c10::to_string(i));
     args.emplace_back(std::move(name), unshapedType(g.inputs()[i]->type()));
   }
-  for (size_t i = 0; i < g.outputs().size(); ++i) {
+  for (const auto i : c10::irange(g.outputs().size())) {
     returns.emplace_back("", unshapedType(g.outputs()[i]->type()));
   }
   return {function.name(), "", std::move(args), std::move(returns)};

--- a/torch/csrc/jit/api/module.cpp
+++ b/torch/csrc/jit/api/module.cpp
@@ -2,6 +2,7 @@
 #include <ATen/record_function.h>
 #include <c10/util/Exception.h>
 #include <c10/util/StringUtil.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/frontend/error_report.h>
@@ -365,7 +366,7 @@ Module Module::clone_impl(
 
   // Copy slots. If a slot is a module - recursively clone it.
   size_t N = type()->numAttributes();
-  for (size_t i = 0; i < N; ++i) {
+  for (const auto i : c10::irange(N)) {
     IValue s = _ivalue()->getSlot(i);
     std::string attr_name = type()->getAttributeName(i);
 

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -18,6 +18,7 @@
 #include <ATen/core/qualified_name.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <functional>
 #include <memory>
@@ -566,7 +567,7 @@ struct NamedPolicy {
       name = (cursors.back().i_ == -1) ? "" : nameFragment(cursors.back());
     } else {
       std::ostringstream ss;
-      for (size_t i = 0; i < cursors.size(); ++i) {
+      for (const auto i : c10::irange(cursors.size())) {
         if (i > 0) {
           ss << ".";
         }

--- a/torch/csrc/jit/codegen/cuda/codegen.cpp
+++ b/torch/csrc/jit/codegen/cuda/codegen.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/codegen.h>
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
@@ -157,7 +158,7 @@ class CudaKernelGenerator : private OptInConstDispatch {
   }
 
   std::ostream& indent() {
-    for (int i = 0; i < block_nest_level_; ++i) {
+    for (const auto i : c10::irange(block_nest_level_)) {
       code_ << kTab;
     }
     return code_;

--- a/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_kernel_arg.cpp
@@ -1,4 +1,5 @@
 #include <ATen/CUDAGeneratorImpl.h>
+#include <c10/util/irange.h>
 
 // Extract size and strides
 #include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
@@ -39,7 +40,7 @@ void KernelArgumentHolder::push(const at::Tensor& tensor) {
   c10::ScalarType dtype = tensor.scalar_type();
   std::unique_ptr<TensorArgAbstract> tensor_arg = getTensorArg(dtype, nDims);
   tensor_arg->setPointer(tensor.data_ptr());
-  for (int i = 0; i < nDims; i++) {
+  for (const auto i : c10::irange(nDims)) {
     tensor_arg->setSize(i, tensor.sizes()[i]);
     tensor_arg->setStride(i, tensor.strides()[i]);
   }

--- a/torch/csrc/jit/codegen/cuda/executor_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/executor_utils.cpp
@@ -182,7 +182,7 @@ void validateKernelInputs(
 
   std::stringstream msg;
   bool mismatch = false;
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     const IValue& arg = inputs[i];
     const Val* param = fusion->inputs()[i];
     mismatch = !validateKernelArg(arg, param, device, msg) || mismatch;
@@ -207,7 +207,7 @@ void validateKernelOutputs(
 
   std::stringstream msg;
   bool mismatch = false;
-  for (size_t i = 0; i < outputs.size(); ++i) {
+  for (const auto i : c10::irange(outputs.size())) {
     const at::Tensor& arg = outputs[i];
     const Val* param = fusion->outputs()[i];
     mismatch = !validateKernelArg(arg, param, device, msg) || mismatch;

--- a/torch/csrc/jit/codegen/cuda/ir_iostream.h
+++ b/torch/csrc/jit/codegen/cuda/ir_iostream.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <torch/csrc/jit/codegen/cuda/dispatch.h>
@@ -22,7 +23,7 @@ class TORCH_CUDA_CU_API IrPrinter : public OptInConstDispatch {
 
   // Indent the generated code
   void indent() {
-    for (int i = 0; i < indent_size_; i++) {
+    for (const auto i : c10::irange(indent_size_)) {
       os_ << "  ";
     }
   }

--- a/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_cache.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_cache.h>
 
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
@@ -134,7 +135,7 @@ at::DimVector getPermutationPerSortedStride(const TensorTypePtr& type) {
   std::set<int> ordered_axes;
 
   // TODO: this does not support broadcast yet;
-  for (int i = 0; i < rank; i++) {
+  for (const auto i : c10::irange(rank)) {
     if ((*stride_properties)[i].has_value() &&
         (*stride_properties)[i]->stride_index_.has_value()) {
       ordered_axes.insert((*stride_properties)[i]->stride_index_.value());
@@ -190,13 +191,13 @@ at::DimVector inversePermutation(
     }
 
     at::DimVector permutation(red_rank, -1);
-    for (int i = 0; i < red_rank; i++) {
+    for (const auto i : c10::irange(red_rank)) {
       permutation[adjusted_permutation[i]] = i;
     }
     return permutation;
   } else {
     at::DimVector permutation(rank, -1);
-    for (int i = 0; i < rank; i++) {
+    for (const auto i : c10::irange(rank)) {
       permutation[permuted[i]] = i;
     }
     return permutation;
@@ -456,7 +457,7 @@ void GraphCache::createFusion(const std::shared_ptr<Graph>& graph) {
 
       std::vector<c10::ShapeSymbol> permuted_vec_ss;
       std::vector<c10::optional<c10::Stride>> permuted_vec_optional_stride;
-      for (int i = 0; i < rank; i++) {
+      for (const auto i : c10::irange(rank)) {
         permuted_vec_ss.emplace_back(
             vec_shape_symbol[this->input_permutation_[i]]);
         // permutation doesn't change contiguity info, nor does it change
@@ -464,7 +465,7 @@ void GraphCache::createFusion(const std::shared_ptr<Graph>& graph) {
         if (vec_optional_stride[i].has_value()) {
           c10::optional<size_t> index = vec_optional_stride[i]->stride_index_;
           if (index.has_value()) {
-            for (int j = 0; j < rank; j++) {
+            for (const auto j : c10::irange(rank)) {
               // follow the permutation to resolve the new stride_index;
               if (this->input_permutation_[j] == (long)index.value()) {
                 index = j;

--- a/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
+++ b/torch/csrc/jit/codegen/cuda/kernel_ir_printer.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/kernel_ir_printer.h>
 
 #include <torch/csrc/jit/codegen/cuda/instrumentation.h>
@@ -49,7 +50,7 @@ void IrPrinter::printKernel(const Kernel* kernel) {
 }
 
 std::ostream& IrPrinter::indent() {
-  for (int i = 0; i < indent_level_; ++i) {
+  for (const auto i : c10::irange(indent_level_)) {
     os_ << kTab;
   }
   return os_;

--- a/torch/csrc/jit/codegen/cuda/lower_index.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_index.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/arith.h>
 #include <torch/csrc/jit/codegen/cuda/index_compute.h>
 #include <torch/csrc/jit/codegen/cuda/ir_iostream.h>
@@ -211,7 +212,7 @@ void IndexLowering::handle(ReductionOp* rop) {
 
     Val* buffer_size =
         buffer_ids.empty() ? new Int(1) : buffer_ids[0]->rawExtent();
-    for (size_t i = 1; i < buffer_ids.size(); i++) {
+    for (const auto i : c10::irange(1, buffer_ids.size())) {
       buffer_size = mul(buffer_size, buffer_ids[i]->rawExtent());
     }
 
@@ -226,7 +227,7 @@ void IndexLowering::handle(ReductionOp* rop) {
         sync_ids.end());
 
     Val* sync_size = sync_ids.empty() ? new Int(1) : sync_ids[0]->rawExtent();
-    for (size_t i = 1; i < sync_ids.size(); i++) {
+    for (const auto i : c10::irange(1, sync_ids.size())) {
       sync_size = mul(sync_size, sync_ids[i]->rawExtent());
     }
 

--- a/torch/csrc/jit/codegen/cuda/lower_loops.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_loops.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/cuda/lower_loops.h>
 
 #include <torch/csrc/jit/codegen/cuda/arith.h>
@@ -66,7 +67,7 @@ Expr* LoopNestGenerator::pushAlloc(TensorView* tv) {
     size = ir_builder_.create<kir::Int>(1);
   } else {
     size = GpuLower::lowerValue(alloc_dims[0]);
-    for (size_t i = 1; i < alloc_dims.size(); i++) {
+    for (const auto i : c10::irange(1, alloc_dims.size())) {
       size = ir_builder_.mulExpr(size, GpuLower::lowerValue(alloc_dims[i]));
     }
   }

--- a/torch/csrc/jit/codegen/cuda/lower_utils.cpp
+++ b/torch/csrc/jit/codegen/cuda/lower_utils.cpp
@@ -210,7 +210,7 @@ class ReplaceExprsInScope : public OptOutDispatch {
       : replacement_map_(std::move(replacement_map)) {}
 
   void handleScope(kir::Scope& scope) {
-    for (size_t i = 0; i < scope.size(); ++i) {
+    for (const auto i : c10::irange(scope.size())) {
       const auto it = replacement_map_.find(scope[i]);
       if (it == replacement_map_.end()) {
         handle(scope[i]);

--- a/torch/csrc/jit/codegen/cuda/manager.cpp
+++ b/torch/csrc/jit/codegen/cuda/manager.cpp
@@ -15,6 +15,7 @@
 
 #include <ATen/DimVector.h>
 #include <c10/core/DeviceType.h>
+#include <c10/util/irange.h>
 
 #include <torch/csrc/jit/codegen/cuda/manager.h>
 
@@ -133,7 +134,7 @@ class CudaFusionManager {
   at::DimVector restorePermutation(at::DimVector permuted) {
     int rank = static_cast<int>(permuted.size());
     at::DimVector permutation(rank, -1);
-    for (int i = 0; i < rank; i++) {
+    for (const auto i : c10::irange(rank)) {
       permutation[permuted[i]] = i;
     }
     return permutation;
@@ -156,7 +157,7 @@ class CudaFusionManager {
     std::set<int> ordered_axes;
 
     // TODO: this does not support broadcast yet;
-    for (int i = 0; i < rank; i++) {
+    for (const auto i : c10::irange(rank)) {
       if ((*stride_properties)[i].has_value() &&
           (*stride_properties)[i]->stride_index_.has_value()) {
         ordered_axes.insert((*stride_properties)[i]->stride_index_.value());

--- a/torch/csrc/jit/codegen/fuser/codegen.cpp
+++ b/torch/csrc/jit/codegen/fuser/codegen.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/fuser/compiler.h>
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/codegen/fuser/tensor_info.h>
@@ -517,7 +518,7 @@ std::string generateKernel(
         env.s(
             "load4",
             format(
-                "for(int i = 0; i<4; i++) t${formal}_buf[i] = t${formal}.data[t${formal}_offset + i]",
+                "for (const auto i : c10::irange(4))t${formal}_buf[i] = t${formal}.data[t${formal}_offset + i]",
                 env));
       }
       load << format("${load4};\n", env);
@@ -631,7 +632,7 @@ std::string generateKernel(
       env.s(
           "store4",
           format(
-              "for(int i = 0; i<4; i++) t${formal}.data[t${formal}_offset + i] = t${formal}_buf[i]",
+              "for (const auto i : c10::irange(4))t${formal}.data[t${formal}_offset + i] = t${formal}_buf[i]",
               env));
     }
     store << format("${store4};\n", env);

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/jit/frontend/code_template.h>
 
@@ -88,7 +89,7 @@ constexpr auto rand_support_literal = R"(
       if(STATE == 0) {
         uint4 counter_ = counter;
         uint2 key_ = key;
-        for(int i = 0; i < 9; i++) {
+        for (const auto i : c10::irange(9)) {
           counter_ = single_round(counter_, key_);
           key_.x += (kPhilox10A); key_.y += (kPhilox10B);
         }
@@ -189,7 +190,7 @@ void ${kernelName}(IndexType totalElements, ${formals} ${RandParam}) {
       // load 4 at a time
       ${kernelLoad}
       #pragma unroll 4
-      for (int i=0; i<4; i++) {
+      for (const auto i : c10::irange(4)) {
         // calculate the results
         ${kernelBody_vec4}
       }

--- a/torch/csrc/jit/codegen/fuser/executor.cpp
+++ b/torch/csrc/jit/codegen/fuser/executor.cpp
@@ -104,7 +104,7 @@ static bool expandArgs(
     std::vector<int64_t>& map_size,
     bool dry_run) {
   bool has_broadcast = false;
-  for (size_t i = 0; i < args.size(); ++i) {
+  for (const auto i : c10::irange(args.size())) {
     auto& arg = args[i];
     const auto& pdesc = spec.inputChunks()[i];
     if (pdesc.nSubTensors() == 1) {
@@ -271,7 +271,7 @@ void launchFusion(
   };
 
   // Adds (flattened) input arguments
-  for (size_t i = 0; i < fusion.inputDesc().size(); ++i) {
+  for (const auto i : c10::irange(fusion.inputDesc().size())) {
     const auto& chunk = fusion.chunkDesc()[i];
     const at::Tensor& tensor = inputs[i];
     if (chunk.isNoop()) {
@@ -280,7 +280,7 @@ void launchFusion(
       size_t chunk_offset = map_size[chunk.dim()] * tensor.stride(chunk.dim()) *
           elementSize(tensor.scalar_type());
       char* data_ptr = reinterpret_cast<char*>(tensor.data_ptr());
-      for (size_t chunks = 0; chunks < chunk.nSubTensors(); ++chunks) {
+      for (const auto chunks : c10::irange(chunk.nSubTensors())) {
         addTensorInfoRaw(
             *chunk.subTensorDesc(), data_ptr, map_size, tensor.strides());
         data_ptr += chunk_offset;
@@ -295,7 +295,7 @@ void launchFusion(
   // Adds (flattened) output arguments
   outputs.reserve(fusion.outputDesc().size());
   const auto& ref_options = inputs[0].options();
-  for (size_t i = 0; i < fusion.outputDesc().size(); ++i) {
+  for (const auto i : c10::irange(fusion.outputDesc().size())) {
     const auto& c = fusion.concatDesc()[i];
     if (c.isNoop()) {
       outputs.push_back(at::empty(
@@ -308,7 +308,7 @@ void launchFusion(
       outputs.push_back(at::empty(concat_size, ref_options));
       const auto& o = outputs[i];
       size_t offset = 0;
-      for (size_t j = 0; j < c.nSubTensors(); ++j) {
+      for (const auto j : c10::irange(c.nSubTensors())) {
         // because the concatenated_output stays live, the underlying data
         // in this view remains live through the end of this function
         // so there is not need to hold onto this tensor

--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/jit/codegen/fuser/kernel_cache.h>
 
 #include <c10/util/Flags.h>
+#include <c10/util/irange.h>
 #include <stdexcept>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -62,10 +63,10 @@ std::vector<at::Tensor> debugLaunchGraph(
   Node* fusion_group = wrapper_graph->insertNode(
       wrapper_graph->createWithSubgraph(prim::FusionGroup));
   fusion_group->g_(attr::Subgraph, graph.copy());
-  for (size_t i = 0; i < graph.inputs().size(); ++i) {
+  for (const auto i : c10::irange(graph.inputs().size())) {
     fusion_group->addInput(wrapper_graph->addInput());
   }
-  for (size_t i = 0; i < graph.outputs().size(); ++i) {
+  for (const auto i : c10::irange(graph.outputs().size())) {
     wrapper_graph->registerOutput(fusion_group->addOutput());
   }
 
@@ -84,10 +85,10 @@ std::string debugGetFusedKernelCode(
   Node* fusion_group = wrapper_graph->insertNode(
       wrapper_graph->createWithSubgraph(prim::FusionGroup));
   fusion_group->g_(attr::Subgraph, graph.copy());
-  for (size_t i = 0; i < graph.inputs().size(); ++i) {
+  for (const auto i : c10::irange(graph.inputs().size())) {
     fusion_group->addInput(wrapper_graph->addInput());
   }
-  for (size_t i = 0; i < graph.outputs().size(); ++i) {
+  for (const auto i : c10::irange(graph.outputs().size())) {
     wrapper_graph->registerOutput(fusion_group->addOutput());
   }
 

--- a/torch/csrc/jit/codegen/fuser/tensor_desc.h
+++ b/torch/csrc/jit/codegen/fuser/tensor_desc.h
@@ -4,6 +4,7 @@
 #include <ATen/core/jit_type.h>
 #include <c10/util/Exception.h>
 #include <c10/util/hash.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 #include <algorithm>
@@ -64,7 +65,7 @@ struct TORCH_API TensorDesc {
       const at::IntArrayRef& strides) {
     AT_ASSERT(sizes.size() == strides.size());
     std::vector<bool> cont(sizes.size());
-    for (size_t i = 0; i < sizes.size(); ++i) {
+    for (const auto i : c10::irange(sizes.size())) {
       const auto expected_stride =
           (i + 1 < sizes.size()) ? sizes[i + 1] * strides[i + 1] : 1;
       cont[i] = (strides[i] == expected_stride);

--- a/torch/csrc/jit/frontend/code_template.h
+++ b/torch/csrc/jit/frontend/code_template.h
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <c10/util/irange.h>
+
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -190,7 +193,7 @@ struct CodeTemplate {
       bool comma_after) const {
     if (comma_before && strings.size() > 0)
       out << ", ";
-    for (size_t i = 0; i < strings.size(); ++i) {
+    for (const auto i : c10::irange(strings.size())) {
       if (i > 0)
         out << ", ";
       out << strings[i];
@@ -203,7 +206,7 @@ struct CodeTemplate {
   // or trailing newlines. It's the responsibility of the calling function
   // to indent correctly in the context.
   void emitIndent(std::ostream& out, size_t indent) const {
-    for (size_t i = 0; i < indent; ++i) {
+    for (const auto i : c10::irange(indent)) {
       out << " ";
     }
   }
@@ -222,7 +225,7 @@ struct CodeTemplate {
       std::stringstream& out,
       size_t indent,
       const string_list& strings) const {
-    for (size_t i = 0; i < strings.size(); ++i) {
+    for (const auto i : c10::irange(strings.size())) {
       if (i > 0)
         emitIndent(out, indent);
       emitStringWithIndents(out, indent, strings[i]);

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/frontend/exit_transforms.h>
 
 #include <ATen/core/jit_type.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/error_report.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/ir_views.h>
@@ -148,7 +149,7 @@ struct ExitTransformer {
     IfView if_view(n);
     registerBlockOutputs(if_view.thenBlock(), true_outs);
     registerBlockOutputs(if_view.elseBlock(), false_outs);
-    for (size_t i = 0; i < true_outs.size(); ++i) {
+    for (const auto i : c10::irange(true_outs.size())) {
       auto out_type =
           unifyTypes(true_outs.at(i)->type(), false_outs.at(i)->type());
       n->addOutput()->setType(*out_type);
@@ -550,7 +551,7 @@ bool inlineConsecutiveIfs(Node* node) {
   bool then_value = maybe_then_value->toBool();
   bool else_value = maybe_else_value->toBool();
 
-  for (auto i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
     Block* first_if_block;
     // NOLINTNEXTLINE(cppcoreguidelines-init-variables)

--- a/torch/csrc/jit/frontend/ir_emitter.cpp
+++ b/torch/csrc/jit/frontend/ir_emitter.cpp
@@ -1858,7 +1858,7 @@ struct to_ir {
     // a module which returns a Tensor,
     // we do not push a new environment frame because if we did all intermediary
     // values would have to subtype the input type.
-    for (int64_t i = 0; i < len; ++i) {
+    for (const auto i : c10::irange(len)) {
       auto index =
           materializeConstant(i, *method.graph(), loc, integral_constants);
       auto sugared_value = iterable->getitem(loc, method, index);
@@ -3669,7 +3669,7 @@ struct to_ir {
         AT_ASSERT(key_trees.size() == value_trees.size());
         std::vector<Value*> keys, values;
 
-        for (size_t i = 0; i < key_trees.size(); ++i) {
+        for (const auto i : c10::irange(key_trees.size())) {
           keys.push_back(emitExpr(Expr(key_trees[i])));
           values.push_back(emitExpr(Expr(value_trees[i])));
         }
@@ -4667,7 +4667,7 @@ bool meaningfulName(const std::string& name) {
     return false;
   if (name[0] != '_')
     return true;
-  for (size_t i = 1; i < name.size(); ++i) {
+  for (const auto i : c10::irange(1, name.size())) {
     if (!isdigit(name[i]))
       return true;
   }

--- a/torch/csrc/jit/frontend/schema_matching.cpp
+++ b/torch/csrc/jit/frontend/schema_matching.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/frontend/schema_matching.h>
 
 #include <ATen/core/jit_type.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/builtin_functions.h>
 #include <torch/csrc/jit/frontend/error_report.h>
 #include <torch/csrc/jit/runtime/operator.h>
@@ -221,7 +222,7 @@ static Value* tryMatchArgument(
 c10::optional<size_t> findInputWithName(
     const std::string& name,
     at::ArrayRef<NamedValue> kwargs) {
-  for (size_t i = 0; i < kwargs.size(); ++i) {
+  for (const auto i : c10::irange(kwargs.size())) {
     if (kwargs[i].name() == name)
       return i;
   }
@@ -329,7 +330,7 @@ static c10::optional<MatchedSchema> tryMatchSchema(
 
   // if we finish the loop will we have consumed all arguments?
   size_t used_args = 0;
-  for (size_t schema_i = 0; schema_i < schema.arguments().size(); ++schema_i) {
+  for (const auto schema_i : c10::irange(schema.arguments().size())) {
     const auto& arg = schema.arguments()[schema_i];
     c10::optional<NamedValue> actual_named_value;
     if (arg.name() == "self" && self) {
@@ -429,7 +430,7 @@ static c10::optional<MatchedSchema> tryMatchSchema(
     return c10::nullopt;
   }
   // check for unused kwargs
-  for (size_t i = 0; i < kwargs.size(); ++i) {
+  for (const auto i : c10::irange(kwargs.size())) {
     const auto& nv = kwargs[i];
     if (!used_kwarg[i]) {
       if (failure_messages) {
@@ -533,7 +534,7 @@ std::pair<size_t, MatchedSchema> matchSchemas(
   for (bool allow_conversions : {false, true}) {
     // clear previous error messages
     failure_messages.str("");
-    for (size_t i = 0; i < schemas.size(); ++i) {
+    for (const auto i : c10::irange(schemas.size())) {
       const auto matched_schema = tryMatchSchema(
           *schemas[i],
           loc,

--- a/torch/csrc/jit/frontend/source_range.cpp
+++ b/torch/csrc/jit/frontend/source_range.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/source_range.h>
 #include <torch/csrc/jit/serialization/source_range_serialization.h>
 
@@ -164,7 +165,7 @@ C10_EXPORT void SourceRange::print_with_context(
       AT_ASSERT(hightlight_begin == 0 || str[hightlight_begin - 1] == '\n');
       AT_ASSERT(highlight_end == range_end || str[highlight_end] == '\n');
       // determine amount of empty space vs highlighted space
-      for (size_t i = hightlight_begin; i < highlight_end; i++) {
+      for (const auto i : c10::irange(hightlight_begin, highlight_end)) {
         if (str[i] == ' ' || i < start()) {
           empty_space++;
         } else {

--- a/torch/csrc/jit/frontend/sugared_value.cpp
+++ b/torch/csrc/jit/frontend/sugared_value.cpp
@@ -467,7 +467,7 @@ RangeValue::RangeValue(
     Function& m,
     std::vector<Value*> inputs,
     c10::optional<int64_t> static_len) {
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     auto typ = inputs[i]->type();
     if (!typ->cast<IntType>()) {
       throw ErrorReport(loc)

--- a/torch/csrc/jit/frontend/tracer.cpp
+++ b/torch/csrc/jit/frontend/tracer.cpp
@@ -79,7 +79,7 @@ void delValueTrace(const IValue& var) {
   getTracingState()->delValue(var);
 }
 void TracingState::delValue(const IValue& var) {
-  for (size_t i = 0; i < env_stack.size(); ++i) {
+  for (const auto i : c10::irange(env_stack.size())) {
     auto& value_map = env_stack.at(env_stack.size() - 1 - i);
     auto it = value_map.find(var);
     if (it == value_map.end()) {
@@ -145,7 +145,7 @@ Value* TracingState::getValue(const IValue& var) {
       Node* n = graph->createNone();
       return graph->insertNode(n)->output();
     }
-    for (size_t i = 0; i < env_stack.size(); ++i) {
+    for (const auto i : c10::irange(env_stack.size())) {
       auto& value_map = env_stack.at(env_stack.size() - 1 - i);
       auto it = value_map.find(var);
       if (it == value_map.end()) {
@@ -177,7 +177,7 @@ Value* TracingState::getValue(const IValue& var) {
     auto it = env_stack.back().emplace(var, constant);
     return it.first->second;
   } else if (var.isFuture() || var.isObject()) {
-    for (size_t i = 0; i < env_stack.size(); ++i) {
+    for (const auto i : c10::irange(env_stack.size())) {
       auto& future_map = env_stack.at(env_stack.size() - 1 - i);
       auto it = future_map.find(var);
       if (it == future_map.end()) {
@@ -193,7 +193,7 @@ Value* TracingState::getValue(const IValue& var) {
       auto custom_class_type = getCustomClass(qualname->qualifiedName());
       if (custom_class_type) {
         auto capsule = var.toObject()->getAttr("capsule");
-        for (size_t i = 0; i < env_stack.size(); ++i) {
+        for (const auto i : c10::irange(env_stack.size())) {
           auto& value_map = env_stack.at(env_stack.size() - 1 - i);
           auto it = value_map.find(capsule);
           if (it == value_map.end()) {
@@ -352,7 +352,7 @@ static IValue addInput(
     size_t num_elems = elems.size();
     AT_ASSERT(
         elem_values.size() == num_elems && elem_types.size() == num_elems);
-    for (size_t i = 0; i < num_elems; ++i) {
+    for (const auto i : c10::irange(num_elems)) {
       elems[i] = addInput(state, elems.at(i), elem_types[i], elem_values[i]);
     }
     return tuple;
@@ -543,20 +543,20 @@ void TracingState::setValue(const IValue& v, Value* value) {
     auto outputs = v.toTensorList();
     Node* unpack_node =
         graph->insertNode(graph->createListUnpack(value, outputs.size()));
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       setValue(outputs.get(i), unpack_node->outputs()[i]);
     }
   } else if (v.isTuple()) {
     auto outputs = v.toTuple()->elements();
     Node* unpack_node = graph->insertNode(graph->createTupleUnpack(value));
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       setValue(outputs[i], unpack_node->outputs()[i]);
     }
   } else if (v.isList()) {
     auto elements = v.toListRef();
     Node* unpack_node =
         graph->insertNode(graph->createListUnpack(value, elements.size()));
-    for (size_t i = 0; i < elements.size(); ++i) {
+    for (const auto i : c10::irange(elements.size())) {
       setValue(elements[i], unpack_node->outputs()[i]);
     }
   } else if (isCustomClass(v)) {
@@ -765,7 +765,7 @@ void addInputs(Node* n, const char* name, at::IntArrayRef value) {
       : ArgumentStash::IntArrayRefTrace(value.size());
 
   auto& g = getTracingState()->graph;
-  for (size_t i = 0; i < info.size(); ++i) {
+  for (const auto i : c10::irange(info.size())) {
     if (info[i] != nullptr)
       continue;
     info[i] = g->insertConstant(value[i]);
@@ -831,7 +831,7 @@ void addOutput(Node* node, const std::vector<at::Tensor>& outputs) {
   Graph* graph = node->owningGraph();
   Node* unpack_node = graph->insertNode(
       graph->create(prim::ListUnpack, {value}, outputs.size()));
-  for (size_t i = 0; i < outputs.size(); ++i) {
+  for (const auto i : c10::irange(outputs.size())) {
     Value* output_val = unpack_node->outputs()[i];
     output_val->inferTypeFrom(outputs[i]);
     setValueTrace(outputs[i], output_val);

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -1046,7 +1046,7 @@ void AliasDb::analyzeBroadcastingChunk(Node* node) {
   auto inputs = node->inputs();
   auto outputs = node->outputs();
   auto nchunks = node->i(attr::chunks);
-  for (size_t index = 0; index < inputs.size(); ++index) {
+  for (const auto index : c10::irange(inputs.size())) {
     // Each inputs[i] is aliased by exactly `nchunks` distinct output tensors:
     // inputs[i] produces chunks outputs[i * nchunks + k] for k in [0..nchunks)
     auto output_begin = outputs.begin() + index * nchunks;

--- a/torch/csrc/jit/ir/attributes.cpp
+++ b/torch/csrc/jit/ir/attributes.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/attributes.h>
 #include <torch/csrc/jit/ir/ir.h>
 
@@ -10,7 +11,7 @@ AttributeValue::Ptr GraphAttr::clone() const {
 
 std::unique_ptr<AttributeValue> GraphsAttr::clone() const {
   std::vector<std::shared_ptr<Graph>> copy(value_.size());
-  for (size_t i = 0; i < value_.size(); ++i) {
+  for (const auto i : c10::irange(value_.size())) {
     copy[i] = value_.at(i)->copy();
   }
   return Ptr(new GraphsAttr(name, std::move(copy)));

--- a/torch/csrc/jit/ir/ir_views.h
+++ b/torch/csrc/jit/ir/ir_views.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
 
 namespace torch {
@@ -149,7 +150,7 @@ struct LoopView {
       const std::vector<size_t>& index_ordering) {
     std::vector<size_t> adjusted;
     adjusted.reserve(adjust + index_ordering.size());
-    for (size_t i = 0; i < adjust; ++i) {
+    for (const auto i : c10::irange(adjust)) {
       adjusted.push_back(i);
     }
     for (auto index : index_ordering) {

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -7,6 +7,7 @@
 #include <ATen/core/interned_strings.h>
 #include <c10/util/Exception.h>
 #include <c10/util/hash.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/node_hashing.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 
@@ -30,7 +31,7 @@ bool typeListEqual(
     const std::vector<TypePtr>& rhs) {
   if (lhs.size() != rhs.size())
     return false;
-  for (size_t i = 0; i < lhs.size(); ++i) {
+  for (const auto i : c10::irange(lhs.size())) {
     if (*lhs[i] != *rhs[i]) {
       return false;
     }
@@ -61,7 +62,7 @@ bool attributesEqual(at::ArrayRef<IValue> a1, at::ArrayRef<IValue> a2) {
   if (a1.size() != a2.size()) {
     return false;
   }
-  for (size_t i = 0; i < a1.size(); ++i) {
+  for (const auto i : c10::irange(a1.size())) {
     if (!ivaluesEqual(a1[i], a2[i])) {
       return false;
     }
@@ -244,7 +245,7 @@ bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {
   auto rhs_outputs = rhs->outputs();
   if (lhs_outputs.size() != rhs_outputs.size())
     return false;
-  for (size_t i = 0; i < lhs_outputs.size(); ++i) {
+  for (const auto i : c10::irange(lhs_outputs.size())) {
     if (*lhs_outputs[i]->type() != *rhs_outputs[i]->type())
       return false;
   }

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/util/ScopeExit.h>
+#include <c10/util/irange.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/compilation_unit.h>
 #include <torch/csrc/jit/mobile/interpreter.h>
@@ -169,7 +170,7 @@ c10::intrusive_ptr<c10::ivalue::Object> objLoaderMobile(
     size_t ndict = dict.size();
     auto obj = c10::ivalue::Object::create(type, ndict);
     auto it = dict.begin();
-    for (size_t i = 0; i < ndict; ++i) {
+    for (const auto i : c10::irange(ndict)) {
       std::stringstream name;
       name << it->key();
       cls->addOrCheckAttribute(name.str(), it->key().type());
@@ -327,7 +328,7 @@ void BytecodeDeserializer::parseMethods(
   }
 
   // Process all methods in this mobile module.
-  for (size_t i = method_i_start; i < vals.size(); ++i) {
+  for (const auto i : c10::irange(method_i_start, vals.size())) {
     const auto& element = vals[i];
     const auto& m_tuple = element.toTuple()->elements();
     const std::string& function_name = m_tuple[0].toStringRef();
@@ -385,7 +386,7 @@ void BytecodeDeserializer::parseMethods(
           "The numbers of instructions and debug handles strings do not match.");
     }
 
-    for (size_t i = 0; i < ins_list.size(); ++i) {
+    for (const auto i : c10::irange(ins_list.size())) {
       auto ins_item = ins_list[i].toTuple()->elements();
       TORCH_CHECK(
           ins_item.size() == 3,

--- a/torch/csrc/jit/mobile/import_data.cpp
+++ b/torch/csrc/jit/mobile/import_data.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/mobile/import_data.h>
 
 #include <ATen/core/ivalue.h>
+#include <c10/util/irange.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/compilation_unit.h>
 #include <torch/csrc/jit/mobile/observer.h>
@@ -127,7 +128,7 @@ c10::IValue BytecodeDeserializer::readArchive(
       size_t ndict = dict.size();
       auto obj = c10::ivalue::Object::create(type, ndict);
       auto it = dict.begin();
-      for (size_t i = 0; i < ndict; ++i) {
+      for (const auto i : c10::irange(ndict)) {
         std::stringstream name;
         name << it->key();
         cls->addOrCheckAttribute(name.str(), it->key().type());

--- a/torch/csrc/jit/mobile/interpreter.cpp
+++ b/torch/csrc/jit/mobile/interpreter.cpp
@@ -8,6 +8,7 @@
 #include <torch/csrc/jit/runtime/vararg_functions.h>
 
 #include <ATen/record_function.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/mobile/observer.h>
 
 #include <torch/csrc/jit/backends/backend_exception.h>
@@ -170,7 +171,7 @@ bool InterpreterState::run(Stack& stack) {
             ++pc;
           } else {
             size_t n_loop_carried = inst.N - 2;
-            for (size_t i = 0; i < n_loop_carried; ++i) {
+            for (const auto i : c10::irange(n_loop_carried)) {
               frame[i] = std::move(frame[i + 3]);
             }
             drop(stack, 3); // iteration_count, max_iter, cond

--- a/torch/csrc/jit/mobile/model_compatibility.cpp
+++ b/torch/csrc/jit/mobile/model_compatibility.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/ivalue.h>
+#include <c10/util/irange.h>
 #include <caffe2/serialize/file_adapter.h>
 #include <caffe2/serialize/inline_container.h>
 #include <torch/csrc/jit/api/compilation_unit.h> // removed after using simple type_resolver/obj_loader
@@ -147,7 +148,7 @@ std::unordered_map<std::string, OperatorInfo> _get_model_ops_and_info(
     return result;
   }
   // loop over all the functions in the bytecode
-  for (int i = 1; i < bytecode_ivalues.size(); i++) {
+  for (const auto i : c10::irange(1, bytecode_ivalues.size())) {
     // descend to the operators list
     auto method_tuple = bytecode_ivalues.at(i).toTuple()->elements();
     auto operators_tuple = method_tuple.at(1).toTuple()->elements()[1];

--- a/torch/csrc/jit/mobile/module.cpp
+++ b/torch/csrc/jit/mobile/module.cpp
@@ -7,6 +7,7 @@
 #include <exception>
 
 #include <ATen/record_function.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace jit {
@@ -76,7 +77,7 @@ void slot_named_params_recurse(
     const std::string& parent_name) {
   auto slots = obj->slots();
   size_t nslots = slots.size();
-  for (size_t i = 0; i < nslots; ++i) {
+  for (const auto i : c10::irange(nslots)) {
     auto slot = slots[i];
     std::string name =
         parent_name.size() == 0 ? parent_name : parent_name + ".";

--- a/torch/csrc/jit/mobile/nnc/context.cpp
+++ b/torch/csrc/jit/mobile/nnc/context.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Functions.h>
 #include <ATen/core/functional.h>
 #include <c10/core/CPUAllocator.h>
+#include <c10/util/irange.h>
 
 #include <torch/csrc/jit/mobile/nnc/registry.h>
 
@@ -188,7 +189,7 @@ c10::impl::GenericList Function::run(
       input_specs_.size(),
       " actual: ",
       inputs.size());
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     const c10::IValue& input = inputs[i];
     const auto& input_tensor = input.toTensor();
     TORCH_CHECK(
@@ -199,7 +200,7 @@ c10::impl::GenericList Function::run(
   // Preallocate and fill in output tensors.
   c10::List<at::Tensor> outputs;
   outputs.reserve(output_specs_.size());
-  for (size_t i = 0; i < output_specs_.size(); ++i) {
+  for (const auto i : c10::irange(output_specs_.size())) {
     at::Tensor output = output_specs_[i].allocate();
     outputs.emplace_back(output);
     args[inputs.size() + i] = output.data_ptr();

--- a/torch/csrc/jit/passes/canonicalize_graph_fuser_ops.cpp
+++ b/torch/csrc/jit/passes/canonicalize_graph_fuser_ops.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/canonicalize_graph_fuser_ops.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 
@@ -27,7 +28,7 @@ static c10::optional<std::vector<ChunkOutput>> getChunkOutputs(Node* chunk) {
         return c10::nullopt;
       }
       auto unpack_outputs = list_use.user->outputs();
-      for (size_t i = 0; i < unpack_outputs.size(); ++i) {
+      for (const auto i : c10::irange(unpack_outputs.size())) {
         outputs.emplace_back(unpack_outputs[i], i);
       }
     } else {

--- a/torch/csrc/jit/passes/constant_propagation.cpp
+++ b/torch/csrc/jit/passes/constant_propagation.cpp
@@ -3,6 +3,7 @@
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/constants.h>
@@ -162,7 +163,7 @@ struct ConstantPropagator {
     }
     auto graph = n->owningGraph();
     WithInsertPoint guard(n);
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       auto new_output = tryInsertConstant(*graph, outputs[i]);
       if (new_output) {
         made_change_ = true;

--- a/torch/csrc/jit/passes/dead_code_elimination.cpp
+++ b/torch/csrc/jit/passes/dead_code_elimination.cpp
@@ -61,7 +61,7 @@ class DeadCodeEliminator {
         continue;
       }
       Graph& g = *node->g(attr::Subgraph);
-      for (size_t i = 0; i < g.inputs().size(); ++i) {
+      for (const auto i : c10::irange(g.inputs().size())) {
         if (!g.inputs().at(i)->hasUses()) {
           GRAPH_UPDATE(
               "Dead ",

--- a/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
+++ b/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
@@ -459,7 +459,7 @@ void inlineScopeBlocks(Block* b) {
       const auto& old_outputs = n->outputs();
 
       AT_ASSERT(new_outputs.size() == old_outputs.size());
-      for (size_t i = 0; i < old_outputs.size(); ++i) {
+      for (const auto i : c10::irange(old_outputs.size())) {
         old_outputs[i]->replaceAllUsesWith(new_outputs[i]);
       }
       n->destroy();

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -645,7 +645,7 @@ class AttributePropagator {
     auto it2 = preservedScalarAttrs_.find(module._ivalue());
     SharedTypeSubModules_[type].insert(module._ivalue());
     attrsToKeep_[type].insert({});
-    for (size_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       auto name = type->getAttributeName(i);
       auto attr = module.attr(name);
       auto attrTy = attr.type();
@@ -692,7 +692,7 @@ class AttributePropagator {
       if (it.second.count(N)) {
         continue;
       }
-      for (size_t i = 0; i < N; ++i) {
+      for (const auto i : c10::irange(N)) {
         if (it.second.count(i) == 0) {
           attrsToRemove.push_back(type->getAttributeName(i));
         }

--- a/torch/csrc/jit/passes/frozen_conv_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_folding.cpp
@@ -2,6 +2,7 @@
 #include <c10/core/ScalarType.h>
 #include <c10/util/Exception.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/constants.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -302,7 +303,7 @@ void FoldFrozenConvMulOrDiv(Block* b) {
       // channels-out resize it to the shape that will broadcast to
       // weight_tensor when the op is run so we dont change weight size
       std::vector<int64_t> weight_compatible_size = {out_channels};
-      for (int64_t i = 1; i < weight_tensor.ndimension(); ++i) {
+      for (const auto i : c10::irange(1, weight_tensor.ndimension())) {
         weight_compatible_size.push_back(1);
       }
 

--- a/torch/csrc/jit/passes/graph_fuser.cpp
+++ b/torch/csrc/jit/passes/graph_fuser.cpp
@@ -267,7 +267,7 @@ struct GraphFuser {
     std::unordered_map<Value*, Value*> inner_to_outer;
     auto inner_inputs = producer_subgraph->inputs();
     auto outer_inputs = producer_group->inputs();
-    for (size_t i = 0; i < inner_inputs.size(); ++i) {
+    for (const auto i : c10::irange(inner_inputs.size())) {
       inner_to_outer[inner_inputs[i]] = outer_inputs[i];
     }
 
@@ -279,14 +279,14 @@ struct GraphFuser {
       temporary_nodes.emplace_back(outer);
       auto inner_outputs = inner->outputs();
       auto outer_outputs = outer->outputs();
-      for (size_t i = 0; i < inner_outputs.size(); ++i) {
+      for (const auto i : c10::irange(inner_outputs.size())) {
         inner_to_outer[inner_outputs[i]] = outer_outputs[i];
       }
     }
 
     // Replace uses of producer_group outputs and destroy the producer
     auto subgraph_outputs = producer_subgraph->outputs();
-    for (size_t i = 0; i < subgraph_outputs.size(); ++i) {
+    for (const auto i : c10::irange(subgraph_outputs.size())) {
       auto outer_output = inner_to_outer.at(subgraph_outputs[i]);
       producer_group->outputs()[i]->replaceAllUsesWith(outer_output);
       // new producer outputs have same aliasing properties as outer_output
@@ -304,7 +304,7 @@ struct GraphFuser {
       Node* merged = mergeNodeIntoGroup(consumer_group, node);
       // If any of the outputs are still used then we need to add them
       auto outputs = node->outputs();
-      for (size_t i = 0; i < outputs.size(); ++i) {
+      for (const auto i : c10::irange(outputs.size())) {
         auto output = outputs[i];
         if (output->uses().size() == 0)
           continue;
@@ -632,7 +632,7 @@ struct GraphFuser {
     Node* bchunk =
         chunk->owningGraph()->create(prim::BroadcastingChunk, nchunks);
     bchunk->addInput(chunk->input());
-    for (size_t i = 0; i < nchunks; ++i) {
+    for (const auto i : c10::irange(nchunks)) {
       auto* old_output = chunk->outputs().at(i);
       auto* new_output = bchunk->outputs().at(i);
       new_output->copyMetadata(old_output);
@@ -777,7 +777,7 @@ struct GraphFuser {
       if (it != bchunk_inputs.end()) {
         chunked_inputs.emplace_back();
         auto input_index = std::distance(bchunk_inputs.begin(), it);
-        for (size_t chunk = 0; chunk < nchunks; ++chunk) {
+        for (const auto chunk : c10::irange(nchunks)) {
           chunked_inputs.back().push_back(
               bchunk->outputs().at(nchunks * input_index + chunk));
         }
@@ -909,8 +909,7 @@ struct GraphFuser {
         Node* new_chunk =
             graph->insertNode(graph->create(prim::ConstantChunk, input, 0));
         new_chunk->copyAttributes(*bchunk);
-        for (size_t output_offset = 0; output_offset < nchunks;
-             output_offset++) {
+        for (const auto output_offset : c10::irange(nchunks)) {
           auto new_output = new_chunk->addOutput();
           auto old_output =
               bchunk->outputs().at(input_offset * nchunks + output_offset);
@@ -936,7 +935,7 @@ struct GraphFuser {
     auto inputs = fusion_group->inputs();
     auto sinputs = subgraph->inputs();
     AT_ASSERT(inputs.size() == sinputs.size());
-    for (size_t i = 0; i < inputs.size(); ++i) {
+    for (const auto i : c10::irange(inputs.size())) {
       if (inputs[i]->type()->isSubtypeOf(TensorType::get())) {
         Value* soutput = graph->insert(aten::size, {inputs[i]});
         aliasDb_->createValue(soutput);
@@ -951,7 +950,7 @@ struct GraphFuser {
     auto outputs = fusion_group->outputs();
     auto soutputs = subgraph->outputs();
     AT_ASSERT(outputs.size() == soutputs.size());
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       if (usedOnlyInSize(outputs[i]))
         continue;
       Value* soutput = graph->insert(aten::size, {outputs[i]});

--- a/torch/csrc/jit/passes/loop_unrolling.cpp
+++ b/torch/csrc/jit/passes/loop_unrolling.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/interned_strings.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <torch/csrc/jit/ir/constants.h>
 #include <torch/csrc/jit/ir/ir_views.h>
@@ -128,7 +129,7 @@ void repeatBody(Block* body, size_t times, Block* dest) {
   std::vector<Value*> io = dest->inputs().vec();
   TORCH_INTERNAL_ASSERT(
       !body->inputs().at(0)->hasUses(), "loop counter should be unused");
-  for (size_t i = 0; i < times; ++i) {
+  for (const auto i : c10::irange(times)) {
     io[0] = body->inputs().at(0);
     io = insertBlockCopy(*graph, body, io);
   }

--- a/torch/csrc/jit/passes/metal_rewrite.cpp
+++ b/torch/csrc/jit/passes/metal_rewrite.cpp
@@ -1,4 +1,5 @@
 #include <ATen/core/jit_type.h>
+#include <c10/util/irange.h>
 
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
@@ -269,7 +270,7 @@ void metalFusePrePackedConvWithClamp(script::Module& module) {
 void metalInsertCopyOps(script::Module& module) {
   auto graph = module.get_method("forward").graph();
   auto&& outputs = graph->outputs();
-  for (size_t i = 0; i < outputs.size(); ++i) {
+  for (const auto i : c10::irange(outputs.size())) {
     Value* output = outputs[i];
     auto namedValue = NamedValue("", output);
     if (namedValue.type()->kind() == TypeKind::TensorType) {

--- a/torch/csrc/jit/passes/onnx.cpp
+++ b/torch/csrc/jit/passes/onnx.cpp
@@ -259,7 +259,7 @@ void NodeToONNX(
     const ParamMap empty_params_dict = {};
     auto opset_version =
         py::cast<int>(onnx_symbolic.attr("_export_onnx_opset_version"));
-    for (size_t i = 0; i < num_old_outputs; ++i) {
+    for (const auto i : c10::irange(num_old_outputs)) {
       auto old = old_outputs[i];
       if (outputs[i]) {
         // Allow symbolic() to skip specifying the type of the return node.

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/passes/onnx/helper.h>
 
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 #include <algorithm>
 
 namespace torch {
@@ -88,7 +89,7 @@ c10::optional<at::Tensor> runTorchSlice_opset9(
     std::iota(axesAttr.begin(), axesAttr.end(), 0);
   }
   auto updated_val = inputTensorValues[0];
-  for (size_t i = 0; i < axesAttr.size(); ++i) {
+  for (const auto i : c10::irange(axesAttr.size())) {
     // ONNX slice accepts negative starts and ends values.
     int64_t axis = axesAttr[i], start = startsAttr[i], end = endsAttr[i];
     // ONNX slice accepts negative axis, fix this for aten op

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/onnx/constant_map.h>
 
 #include <torch/csrc/jit/jit_log.h>
@@ -139,7 +140,7 @@ std::vector<int64_t> ConstantValueMap::GetValueInto1DInt64Vector(
   std::vector<int64_t> value_vector;
   value_vector.reserve(value_int64_t.size(0));
   auto value_size_a = value_int64_t.accessor<int64_t, 1>();
-  for (auto i = 0; i < value_int64_t.size(0); i++) {
+  for (const auto i : c10::irange(value_int64_t.size(0))) {
     value_vector.emplace_back(static_cast<int64_t>(value_size_a[i]));
   }
   return value_vector;

--- a/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
+++ b/torch/csrc/jit/passes/onnx/fixup_onnx_controlflow.cpp
@@ -165,7 +165,7 @@ std::vector<Value*> ConvertSequenceDependencies(Node* node, int opset_version) {
   }
 
   // Remove sequence outputs, and replace with scan outputs.
-  for (size_t i = 0; i < idx_to_remove.size(); ++i) {
+  for (const auto i : c10::irange(idx_to_remove.size())) {
     size_t idx = idx_to_remove[i] - i;
 
     sub_block->eraseInput(idx);
@@ -359,7 +359,7 @@ void ONNXFixupUninitializedOutput(Node* node) {
       std::vector<::c10::ShapeSymbol> dims;
       if (then_shape.rank() && else_shape.rank() &&
           then_shape.rank() == else_shape.rank()) {
-        for (size_t j = 0; j < then_shape.rank().value(); ++j) {
+        for (const auto j : c10::irange(then_shape.rank().value())) {
           if (then_shape[j] == else_shape[j]) {
             dims.emplace_back(then_shape[j]);
           } else {

--- a/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
+++ b/torch/csrc/jit/passes/onnx/pattern_conversion/pattern_conversion.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/erase_number_types.h>
 #include <torch/csrc/jit/passes/onnx.h>
@@ -183,7 +184,7 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
   size_t min_index_dim = dim_index_map.size();
   size_t max_index_dim = 0;
   size_t tensor_ind_count = 0;
-  for (size_t i = 0; i < dim_index_map.size(); ++i) {
+  for (const auto i : c10::irange(dim_index_map.size())) {
     auto index_i = dim_index_map.find(i);
     AT_ASSERT(index_i != dim_index_map.end());
     if (index_i->second.orig_node_kind == aten::index) {
@@ -203,7 +204,7 @@ std::vector<Value*> ReshapeToAdvancedIndexingFormat(
 
   size_t tensor_ind_offset = tensor_ind_count == 0 ? 0 : tensor_ind_count - 1;
   WithInsertPoint guard(index_put_node);
-  for (size_t i = 0; i < dim_index_map.size(); ++i) {
+  for (const auto i : c10::irange(dim_index_map.size())) {
     size_t ind_size = 0;
     auto index_i = dim_index_map.find(i);
     AT_ASSERT(index_i != dim_index_map.end());

--- a/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
+++ b/torch/csrc/jit/passes/onnx/scalar_type_analysis.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/onnx/scalar_type_analysis.h>
 
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
@@ -88,7 +89,7 @@ static c10::optional<c10::ScalarType> PromoteScalarTypes(
     return c10::nullopt;
   }
   auto st = types[0];
-  for (size_t i = 1; i < types.size(); ++i) {
+  for (const auto i : c10::irange(1, types.size())) {
     st = c10::promoteTypes(st, types[i]);
   }
   return st;

--- a/torch/csrc/jit/passes/peephole_non_tensor.cpp
+++ b/torch/csrc/jit/passes/peephole_non_tensor.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/peephole.h>
 
 #include <ATen/core/jit_type.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir_views.h>
 #include <torch/csrc/jit/jit_log.h>
 
@@ -45,7 +46,7 @@ struct PeepholeOptimizeNonTensorImpl {
         IfView n(node);
         // this handles redundant short circuits like "x and True" or "x or
         // False"
-        for (size_t i = 0; i < n.outputs().size(); ++i) {
+        for (const auto i : c10::irange(n.outputs().size())) {
           if (n.outputs().at(i)->type() != BoolType::get()) {
             continue;
           }

--- a/torch/csrc/jit/passes/quantization/insert_observers.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_observers.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/quantization/insert_observers.h>
 
 #include <torch/csrc/jit/frontend/schema_matching.h>
@@ -124,7 +125,7 @@ class ModuleCloneHelper {
     }
     // Copy slots. If a slot is a module - recursively clone it.
     size_t N = type->numAttributes();
-    for (size_t i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       IValue s = module._ivalue()->getSlot(i);
       std::string attr_name = type->getAttributeName(i);
       TypePtr attr_type = type->getAttribute(i);

--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/quantization/insert_quant_dequant.h>
 
 #include <c10/core/QScheme.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/constant_propagation.h>
@@ -126,7 +127,7 @@ std::vector<Value*> insertDeQuantForAllUse(
   // and changing the graph will also change the uses() list
   const std::vector<Use> uses = original_val->uses();
   std::vector<Value*> outputs;
-  for (size_t i = 0; i < uses.size(); ++i) {
+  for (const auto i : c10::irange(uses.size())) {
     auto* user = uses[i].user;
     // Insert dequantize node right before use node, because
     // we want to make sure use node and dequantize node reside
@@ -658,7 +659,7 @@ void checkCalculateQParamsResult(const IValue& qparams) {
       "Tuple of size 2, got Tuple of size ",
       tp->elements().size());
   // Expect first two elements of the tuple to be Tensor
-  for (size_t i = 0; i < 2; ++i) {
+  for (const auto i : c10::irange(2)) {
     TORCH_CHECK(
         tp->elements()[i].isTensor(),
         "Element of Tuple is expected to be Tensor, but element ",
@@ -1412,7 +1413,7 @@ void InsertQuantDeQuantHelper::run(
   // point is the beginning of graph node. This also safe guards against
   // observing a potentially mutated value due to some in-place operation
   std::vector<Value*> input_values;
-  for (size_t idx = 1; idx < method.num_inputs(); ++idx) {
+  for (const auto idx : c10::irange(1, method.num_inputs())) {
     auto& v = graph->inputs()[idx];
     if (v->type()->isSubtypeOf(TensorType::get())) {
       input_values.push_back(v);

--- a/torch/csrc/jit/passes/quantization/quantization_patterns.h
+++ b/torch/csrc/jit/passes/quantization/quantization_patterns.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/ir/subgraph_matcher.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -71,7 +72,7 @@ std::string getQuantizeForScalar(const std::string& value) {
           )" +
       value + "_tensor : Tensor = aten::scalar_tensor(" + value + ", " + value +
       "_float_scalar_type";
-  for (auto i = 0; i < 3; ++i) {
+  for (const auto i : c10::irange(3)) {
     quantize_pattern += ", " + value + "_none";
   }
   quantize_pattern += ")";

--- a/torch/csrc/jit/passes/remove_inplace_ops.cpp
+++ b/torch/csrc/jit/passes/remove_inplace_ops.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/remove_inplace_ops.h>
 
 namespace torch {
@@ -59,7 +60,7 @@ void RemoveInplaceOps(Block* block) {
             static_cast<int>(newNode->inputs().size());
       }
 
-      for (int i = 0; i < additionalInputCount; ++i) {
+      for (const auto i : c10::irange(additionalInputCount)) {
         auto noneNode = graph->createNone();
         noneNode->insertBefore(newNode);
         newNode->addInput(noneNode->output());

--- a/torch/csrc/jit/passes/requires_grad_analysis.cpp
+++ b/torch/csrc/jit/passes/requires_grad_analysis.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/passes/requires_grad_analysis.h>
 
 #include <ATen/core/jit_type.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/autograd.h>
 #include <torch/csrc/jit/ir/constants.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -27,7 +28,7 @@ void setRequiresGrad(
     at::ArrayRef<Value*> outputs,
     const std::vector<bool>& values) {
   AT_ASSERT(outputs.size() == values.size());
-  for (size_t i = 0; i < values.size(); ++i) {
+  for (const auto i : c10::irange(values.size())) {
     setRequiresGrad(outputs[i], values[i]);
   }
 }
@@ -38,7 +39,7 @@ void setRequiresGrad(Node* node, const std::vector<bool>& values) {
 
 std::vector<bool> bitwiseOr(std::vector<bool> a, const std::vector<bool>& b) {
   AT_ASSERT(a.size() == b.size());
-  for (size_t i = 0; i < a.size(); ++i) {
+  for (const auto i : c10::irange(a.size())) {
     a[i] = a[i] || b[i];
   }
   return a;

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -195,7 +195,7 @@ class ShapePropagator {
     if (schema.is_vararg()) {
       return c10::nullopt;
     }
-    for (size_t i = 0; i < args.size(); ++i) {
+    for (const auto i : c10::irange(args.size())) {
       if (args[i].type()->isSubtypeOf(ListType::ofTensors())) {
         return c10::nullopt;
       } else if (args[i].type()->isSubtypeOf(TensorType::get())) {
@@ -276,7 +276,7 @@ class ShapePropagator {
       ArrayRef<Value*> outputs) {
     AT_ASSERT(lhs.size() == rhs.size() && rhs.size() == outputs.size());
     bool changed = false;
-    for (size_t i = 0; i < lhs.size(); ++i) {
+    for (const auto i : c10::irange(lhs.size())) {
       auto old_output_type = outputs[i]->type();
       auto new_type =
           unifyTypes(lhs[i]->type(), rhs[i]->type(), /*default_to_any=*/true);
@@ -413,7 +413,7 @@ class ShapePropagator {
     op(&stack);
 
     AT_ASSERT(stack.size() == node->outputs().size());
-    for (size_t i = 0; i < stack.size(); ++i) {
+    for (const auto i : c10::irange(stack.size())) {
       // some ops may have mixed tensor/primitive outputs
       // for primitives, we don't need to change the type because it is already
       // its most constrained form.
@@ -456,7 +456,7 @@ class ShapePropagator {
         auto tp_sizes = tp->sizes().concrete_sizes().value();
         if (sizes.size() != tp_sizes.size())
           return false;
-        for (int64_t i = 0; i < ndim; ++i) {
+        for (const auto i : c10::irange(ndim)) {
           if (sizes[i] != tp_sizes[i] && i != dim) {
             return false;
           }
@@ -570,7 +570,7 @@ class ShapePropagator {
         // propagate loop-carried input types to block inputs
         auto loop_carried_inputs = node->inputs().slice(2); // skip max, cond
         auto loop_carried_block = body_block->inputs().slice(1); // skip trip
-        for (size_t i = 0; i < loop_carried_inputs.size(); ++i) {
+        for (const auto i : c10::irange(loop_carried_inputs.size())) {
           loop_carried_block[i]->setType(loop_carried_inputs[i]->type());
         }
         auto loop_carried_outputs = body_block->outputs().slice(1); // skip cond
@@ -585,7 +585,7 @@ class ShapePropagator {
         // now that the types are stable, we can insert the expands
         PropagateShapeOnBlock(body_block, /*insert_expands=*/true);
 
-        for (size_t i = 0; i < loop_carried_inputs.size(); ++i) {
+        for (const auto i : c10::irange(loop_carried_inputs.size())) {
           node->outputs()[i]->setType(loop_carried_block[i]->type());
         }
         return;
@@ -1590,7 +1590,7 @@ class ShapePropagator {
         } else {
           auto outputs = node->outputs();
           AT_ASSERT(types.size() == outputs.size());
-          for (size_t i = 0; i < types.size(); ++i) {
+          for (const auto i : c10::irange(types.size())) {
             AT_ASSERT(outputs[i]->type()->isSubtypeOf(TensorType::get()));
             outputs[i]->setType(types[i]);
           }
@@ -2069,7 +2069,7 @@ class ShapePropagator {
       // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
       size_t inferred_idx;
       int64_t size_product = 1;
-      for (size_t i = 0; i < sizes.size(); ++i) {
+      for (const auto i : c10::irange(sizes.size())) {
         if (sizes.get(i) == -1) {
           if (inferred)
             throw propagation_error();

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -120,10 +120,10 @@ struct AutogradZeroSpecializer {
   void replaceBlockInputsWithGraphInputs(Block* b) {
     TORCH_INTERNAL_ASSERT(graph_->inputs().size() == b->inputs().size());
     size_t num_inputs = graph_->inputs().size();
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       b->inputs().at(i)->replaceAllUsesWith(graph_->inputs().at(i));
     }
-    for (size_t i = 0; i < num_inputs; ++i) {
+    for (const auto i : c10::irange(num_inputs)) {
       b->eraseInput(num_inputs - (1 + i));
     }
   }

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -1,5 +1,6 @@
 #include <ATen/core/interned_strings.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/ir/constants.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -122,7 +123,7 @@ struct SymbolicShapeAnalyzer {
   c10::SymbolicShape run() {
     // TODO: only run while the last iteration has made a change
     size_t num_optimization_iters = 6;
-    for (size_t i = 0; i < num_optimization_iters; i++) {
+    for (const auto i : c10::irange(num_optimization_iters)) {
       // XXX: we cannot substitute symbolic dims before passes like constant
       // propagation, or we might inadvertently use them in arithmetic or
       // other operators
@@ -228,10 +229,10 @@ struct SymbolicShapeAnalyzer {
 
     // there are ways to compute this more efficiently but typically number of
     // Values for each symbolic set is low and this is cheap to run
-    for (size_t i = 0; i < symbolic_set.size(); ++i) {
+    for (const auto i : c10::irange(symbolic_set.size())) {
       Value* v = symbolic_set[i];
       Value* dominating_value = v;
-      for (size_t j = 0; j < symbolic_set.size(); ++j) {
+      for (const auto j : c10::irange(symbolic_set.size())) {
         if (dominating_value->node()->isDominatedBy(symbolic_set[j]->node())) {
           dominating_value = symbolic_set[j];
         }

--- a/torch/csrc/jit/passes/tensorexpr_fuser.cpp
+++ b/torch/csrc/jit/passes/tensorexpr_fuser.cpp
@@ -4,6 +4,7 @@
 #include <ATen/core/interned_strings.h>
 #include <ATen/record_function.h>
 #include <c10/util/FunctionRef.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/codegen/fuser/interface.h>
 #include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -478,7 +479,7 @@ class TensorExprFuser {
     auto inputs = fusion_group->inputs();
     auto sinputs = subgraph->inputs();
     AT_ASSERT(inputs.size() == sinputs.size());
-    for (size_t i = 0; i < inputs.size(); ++i) {
+    for (const auto i : c10::irange(inputs.size())) {
       if (inputs[i]->type()->isSubtypeOf(TensorType::get())) {
         Value* soutput = graph->insert(aten::size, {inputs[i]});
         aliasDb_->createValue(soutput);
@@ -498,7 +499,7 @@ class TensorExprFuser {
     auto outputs = fusion_group->outputs();
     auto soutputs = subgraph->outputs();
     AT_ASSERT(outputs.size() == soutputs.size());
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       if (usedOnlyInSize(outputs[i]))
         continue;
       Value* soutput = graph->insert(aten::size, {outputs[i]});
@@ -724,7 +725,7 @@ class TensorExprFuser {
     Node* prev_fusion_group =
         initial_fusion_groups.size() ? initial_fusion_groups[0] : nullptr;
 
-    for (size_t i = 1; i < initial_fusion_groups.size(); ++i) {
+    for (const auto i : c10::irange(1, initial_fusion_groups.size())) {
       // Try merging the just created fusion group into the previous one.
       // If it did not work, then put the previous fusion group into
       // fusion_groups vector - we will not touch it anymore in this loop.

--- a/torch/csrc/jit/passes/value_refinement_utils.cpp
+++ b/torch/csrc/jit/passes/value_refinement_utils.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/passes/value_refinement_utils.h>
 
 namespace torch {
@@ -113,7 +114,7 @@ void joinIfRefinements(
     }
     Block* non_throwing_block =
         true_block_throws ? if_node->blocks().at(1) : if_node->blocks().at(0);
-    for (size_t i = 0; i < if_n.outputs().size(); ++i) {
+    for (const auto i : c10::irange(if_n.outputs().size())) {
       if (boolean_value_refinements.count(
               non_throwing_block->outputs().at(i))) {
         boolean_value_refinements[if_node->outputs().at(i)] =
@@ -123,7 +124,7 @@ void joinIfRefinements(
     return;
   }
 
-  for (size_t i = 0; i < if_n.outputs().size(); ++i) {
+  for (const auto i : c10::irange(if_n.outputs().size())) {
     if (!(if_n.outputs().at(i)->type() == BoolType::get())) {
       return;
     }

--- a/torch/csrc/jit/python/init.cpp
+++ b/torch/csrc/jit/python/init.cpp
@@ -98,6 +98,7 @@
 #include <torch/csrc/jit/tensorexpr/tensorexpr_init.h>
 
 #include <c10/macros/Export.h>
+#include <c10/util/irange.h>
 #include <c10/util/signal_handler.h>
 #include <caffe2/serialize/inline_container.h>
 
@@ -474,7 +475,7 @@ void initJITBindings(PyObject* module) {
             // we want full shape specialization. The alternative would be to
             // have a "complete type inference" function in ArguemntSpecCreator.
             auto g_inputs = graph->inputs();
-            for (size_t i = 0; i < inputs.size(); ++i) {
+            for (const auto i : c10::irange(inputs.size())) {
               if (stack[i].isTensor()) {
                 g_inputs[i]->setType(stack[i].type());
               }
@@ -490,7 +491,7 @@ void initJITBindings(PyObject* module) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             auto g_inputs = graph->inputs();
-            for (size_t i = 0; i < inputs.size(); ++i) {
+            for (const auto i : c10::irange(inputs.size())) {
               if (stack[i].isTensor()) {
                 g_inputs[i]->setType(stack[i].type());
               }
@@ -1164,7 +1165,7 @@ void initJITBindings(PyObject* module) {
               [operations, symbol](py::args args, py::kwargs kwargs) {
                 std::vector<py::handle> overloaded_args;
                 size_t total_arg_num = args.size() + kwargs.size();
-                for (size_t i = 0; i < args.size(); ++i) {
+                for (const auto i : c10::irange(args.size())) {
                   is_tensor_and_append_overloaded(
                       args[i].ptr(), &overloaded_args);
                   is_tensor_list_and_append_overloaded(
@@ -1380,7 +1381,7 @@ void initJITBindings(PyObject* module) {
     py::function f = py::cast<py::function>(args[0]);
     py::tuple args_tup(args.size() - 1);
 
-    for (size_t i = 1; i < args.size(); ++i) {
+    for (const auto i : c10::irange(1, args.size())) {
       args_tup[i - 1] = args[i];
     }
 

--- a/torch/csrc/jit/python/pybind.h
+++ b/torch/csrc/jit/python/pybind.h
@@ -4,6 +4,7 @@
 
 #include <ATen/core/interned_strings.h>
 #include <ATen/core/ivalue.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/variable.h>
@@ -214,7 +215,7 @@ namespace jit {
 
 static inline py::tuple tuple_tail(const py::tuple& tup) {
   py::tuple r(tup.size() - 1);
-  for (size_t i = 1; i < tup.size(); i++) {
+  for (const auto i : c10::irange(1, tup.size())) {
     r[i - 1] = tup[i];
   }
   return r;

--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -80,7 +80,7 @@ IValue toIValue(py::handle obj, const TypePtr& type, c10::optional<int32_t> N) {
       }
       std::vector<IValue> values;
       values.reserve(tuple_size);
-      for (size_t i = 0; i < tuple_size; ++i) {
+      for (const auto i : c10::irange(tuple_size)) {
         values.push_back(toIValue(tuple[i], elem_types[i]));
       }
       return tuple_type->name()

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -39,6 +39,7 @@
 #endif
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -707,7 +708,7 @@ inline py::object toPyObject(IValue ivalue) {
   } else if (ivalue.isList()) {
     auto list = std::move(ivalue).toList();
     py::list t{list.size()};
-    for (size_t i = 0; i < list.size(); ++i) {
+    for (const auto i : c10::irange(list.size())) {
       t[i] = toPyObject(IValue{list.get(i)});
     }
     return std::move(t);
@@ -715,7 +716,7 @@ inline py::object toPyObject(IValue ivalue) {
     auto tuple = std::move(ivalue).toTuple();
     const auto& elements = tuple->elements();
     py::tuple t{elements.size()};
-    for (size_t i = 0; i < elements.size(); ++i) {
+    for (const auto i : c10::irange(elements.size())) {
       t[i] = toPyObject(IValue{elements.at(i)});
     }
     if (tuple->type() && tuple->type()->schema() &&
@@ -765,7 +766,7 @@ inline py::object toPyObject(IValue ivalue) {
 
     const auto numAttrs = classType->numAttributes();
 
-    for (size_t slot = 0; slot < numAttrs; slot++) {
+    for (const auto slot : c10::irange(numAttrs)) {
       const auto& attrName = classType->getAttributeName(slot);
       IValue v = obj->getSlot(slot);
       py::setattr(pyObj, attrName.c_str(), toPyObject(std::move(v)));
@@ -898,7 +899,7 @@ inline py::object createPyObjectForStack(Stack&& stack) {
 
   // If there is more than one return value, pop them into a py::tuple.
   py::tuple return_values(stack.size());
-  for (size_t ret = 0; ret < return_values.size(); ++ret) {
+  for (const auto ret : c10::irange(return_values.size())) {
     return_values[ret] = toPyObject(std::move(stack[ret]));
   }
 
@@ -917,7 +918,7 @@ inline Stack evilDeprecatedBadCreateStackDoNotUse(
   }
   Stack result;
   result.reserve(tuple.size() + reserve_extra_space);
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     result.push_back(toIValue(std::move(tuple[i]), inputs[i]->type()));
   }
   return result;

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/python/python_arg_flatten.h>
 #include <torch/csrc/utils/python_strings.h>
 #include <torch/csrc/utils/six.h>
@@ -33,7 +34,7 @@ template <typename T>
 py::object cast_handle_sequence(std::vector<py::handle> objs) {
   auto num_objs = objs.size();
   T sequence{num_objs};
-  for (size_t i = 0; i < num_objs; ++i)
+  for (const auto i : c10::irange(num_objs))
     sequence[i] = py::reinterpret_borrow<py::object>(objs[i]);
   return sequence;
 }
@@ -109,7 +110,7 @@ template <typename T>
 py::object cast_sequence(std::vector<py::object> objs) {
   auto num_objs = objs.size();
   T sequence{num_objs};
-  for (size_t i = 0; i < num_objs; ++i)
+  for (const auto i : c10::irange(num_objs))
     sequence[i] = std::move(objs[i]);
   return std::move(sequence);
 }
@@ -117,7 +118,7 @@ py::object cast_sequence(std::vector<py::object> objs) {
 py::object cast_dict(std::vector<py::object> objs) {
   auto num_objs = objs.size();
   py::dict sequence = {};
-  for (size_t i = 0; i < num_objs; ++i) {
+  for (const auto i : c10::irange(num_objs)) {
     py::tuple obj = py::reinterpret_borrow<py::tuple>(objs[i]);
     sequence[obj[0]] = obj[1];
   }

--- a/torch/csrc/jit/python/python_arg_flatten.h
+++ b/torch/csrc/jit/python/python_arg_flatten.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <c10/util/hash.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/python/pybind.h>
 
@@ -75,7 +76,7 @@ static inline std::ostream& operator<<(
     out << ", device=" << meta_device.index();
   }
   out << ") {";
-  for (size_t i = 0; i < meta.sizes.size(); ++i) {
+  for (const auto i : c10::irange(meta.sizes.size())) {
     if (i > 0)
       out << ", ";
     out << meta.sizes[i];
@@ -89,7 +90,7 @@ static inline std::ostream& operator<<(
     const IODescriptor& desc) {
   out << desc.structure << "\n";
   out << "  with grad_enabled=" << desc.grad_enabled << "\n";
-  for (size_t i = 0; i < desc.metadata.size(); ++i) {
+  for (const auto i : c10::irange(desc.metadata.size())) {
     out << "  with v" << i << " having type " << desc.metadata[i] << "\n";
   }
   return out;

--- a/torch/csrc/jit/python/python_tracer.cpp
+++ b/torch/csrc/jit/python/python_tracer.cpp
@@ -10,6 +10,7 @@
 #include <torch/csrc/utils/python_strings.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <sstream>
 
@@ -89,7 +90,7 @@ std::pair<std::shared_ptr<Graph>, Stack> createGraphByTracing(
       [&func](Stack inputs) -> Stack {
         size_t num_func_inputs = inputs.size();
         py::tuple py_inputs(num_func_inputs);
-        for (size_t i = 0; i < num_func_inputs; ++i) {
+        for (const auto i : c10::irange(num_func_inputs)) {
           py_inputs[i] = py::cast(inputs[i]);
         }
         auto out = func(*py_inputs);

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/jit/testing/file_check.h>
 
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/parser.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/constants.h>
@@ -171,7 +172,7 @@ void checkOverloadDecl(const Decl& new_decl, const Decl& old_decl) {
       "Overload must have same number of parameters\n",
       new_decl.range(),
       old_decl.range());
-  for (size_t i = 0; i < new_decl.params().size(); ++i) {
+  for (const auto i : c10::irange(new_decl.params().size())) {
     TORCH_INTERNAL_ASSERT(
         new_params[i].ident().name() == old_params[i].ident().name(),
         "Overload parameters must have the same names\n",
@@ -307,7 +308,7 @@ static Decl mergeDefaultsAndExtraParametersToOverloadDecl(
       overload_decl.range(),
       impl_decl.range());
 
-  for (size_t i = 0; i < overload_params.size(); ++i) {
+  for (const auto i : c10::irange(overload_params.size())) {
     auto overload_name = overload_params[i].ident().name();
     auto impl_name = impl_params[i].ident().name();
     if (overload_name != impl_name) {
@@ -582,7 +583,7 @@ bool ivalue_tags_match(const Module& lhs, const Module& rhs) {
     } else if (item.a.isList()) {
       auto al = item.a.toList();
       auto bl = item.b.toList();
-      for (size_t i = 0; i < al.size(); ++i) {
+      for (const auto i : c10::irange(al.size())) {
         work.emplace_back(Work{al.get(i), bl.get(i)});
       }
     } else if (item.a.isGenericDict()) {

--- a/torch/csrc/jit/runtime/argument_spec.cpp
+++ b/torch/csrc/jit/runtime/argument_spec.cpp
@@ -1,4 +1,5 @@
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 
 namespace torch {
@@ -270,7 +271,7 @@ void ArgumentSpecCreator::specializeTypes(
   //        to investigate the uses of the inputs in detail to change the
   //        accesses/ unwrapping
   auto inputs = graph.inputs();
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     auto t = result_stack.back()[i];
     if (auto ot = t->cast<OptionalType>()) {
       // if an optional input hasn't been specialized above, it is None

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -3,6 +3,7 @@
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
 #include <c10/util/hash.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/jit/ir/ir.h>
@@ -237,7 +238,7 @@ struct CompleteArgumentSpec {
       : hash_code(0), ninputs(inputs.size()) {
     int32_t all_dims = 0;
     const int32_t num_inputs = inputs.size();
-    for (int32_t i = 0; i < num_inputs; i++) {
+    for (const auto i : c10::irange(num_inputs)) {
       if (!inputs[i].isTensor())
         continue;
       auto& tensor = inputs[i].toTensor();
@@ -250,7 +251,7 @@ struct CompleteArgumentSpec {
     auto* pods = reinterpret_cast<CompleteArgumentInfoPOD*>(data.data());
     int64_t* next_dim = sizes_strides();
     int32_t total_dims = 0;
-    for (int32_t i = 0; i < num_inputs; i++) {
+    for (const auto i : c10::irange(num_inputs)) {
       auto& pod = pods[i];
       pod.is_tensor = static_cast<uint32_t>(inputs[i].isTensor());
       if (pod.is_tensor) {
@@ -400,13 +401,13 @@ inline std::ostream& operator<<(std::ostream& out, const ArgumentInfo& info) {
 
 inline std::ostream& operator<<(std::ostream& out, const ArgumentSpec& spec) {
   out << "{";
-  for (size_t i = 0; i < spec.numTensors(); ++i) {
+  for (const auto i : c10::irange(spec.numTensors())) {
     if (i > 0)
       out << ", ";
     out << spec.tensorAt(i);
   }
   out << "; ";
-  for (size_t i = 0; i < spec.numOptionals(); ++i) {
+  for (const auto i : c10::irange(spec.numOptionals())) {
     if (i > 0)
       out << ", ";
     out << spec.isPresent(i);
@@ -431,7 +432,7 @@ inline std::ostream& operator<<(
     std::ostream& out,
     const CompleteArgumentSpec& spec) {
   out << "{";
-  for (size_t i = 0; i < spec.size(); ++i) {
+  for (const auto i : c10::irange(spec.size())) {
     if (i > 0)
       out << ", ";
     out << spec.at(i);

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/functional.h>
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/ir_emitter.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
@@ -157,7 +158,7 @@ static c10::optional<std::vector<Value*>> build_script_grad(
     new_outputs = unpackOutputs(new_outputs);
     auto outputs = node->outputs();
     AT_ASSERT(new_outputs.size() == outputs.size() + 1);
-    for (size_t i = 0; i < outputs.size(); ++i) {
+    for (const auto i : c10::irange(outputs.size())) {
       new_outputs.at(i)->setType(outputs[i]->type());
       outputs[i]->replaceAllUsesWith(new_outputs.at(i));
     }

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -441,7 +441,7 @@ struct DifferentiableGraphOp {
       v = IValue(detach(std::move(v).toTensor()));
     } else if (v.isTensorList()) {
       c10::List<at::Tensor> lst = std::move(v).toTensorList();
-      for (size_t i = 0; i < lst.size(); ++i) {
+      for (const auto i : c10::irange(lst.size())) {
         lst.set(i, detach(lst.extract(i)));
       }
       v = std::move(lst);
@@ -454,7 +454,7 @@ struct DifferentiableGraphOp {
     // ourselves.
     const int64_t stack_size = stack.size();
     const int64_t stack_offset = stack_size - num_inputs;
-    for (int64_t i = stack_offset; i < stack_size; ++i) {
+    for (const auto i : c10::irange(stack_offset, stack_size)) {
       detach(stack[i]);
     }
   }

--- a/torch/csrc/jit/runtime/instruction.cpp
+++ b/torch/csrc/jit/runtime/instruction.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/runtime/instruction.h>
 #include <cstring>
 #include <iostream>
@@ -64,7 +65,7 @@ static constexpr const char* strOpCode[] = {
 
 OpCode parseOpCode(const char* str) {
   const int n = sizeof(strOpCode) / sizeof(strOpCode[0]);
-  for (int i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     if (strcmp(strOpCode[i], str) == 0)
       return (OpCode)i;
   }

--- a/torch/csrc/jit/runtime/interpreter.cpp
+++ b/torch/csrc/jit/runtime/interpreter.cpp
@@ -319,7 +319,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
               ++frame.pc;
             } else {
               size_t n_loop_carried = inst.N - 2;
-              for (size_t i = 0; i < n_loop_carried; ++i) {
+              for (const auto i : c10::irange(n_loop_carried)) {
                 fr[i] = std::move(fr[i + 3]);
               }
               drop(stack, 3); // iteration_count, max_iter, cond
@@ -510,7 +510,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
             size_t base_pointer = frame.base_pointer;
             TORCH_INTERNAL_ASSERT(stack.size() >= num_inputs);
             size_t inputs_start = stack.size() - num_inputs;
-            for (size_t i = 0; i < num_inputs; ++i) {
+            for (const auto i : c10::irange(num_inputs)) {
               stack.at(base_pointer + i) =
                   std::move(stack.at(inputs_start + i));
             }
@@ -692,7 +692,7 @@ struct InterpreterStateImpl : c10::intrusive_ptr_target {
  public:
   std::vector<StackEntry> callstack() const {
     std::vector<StackEntry> entries;
-    for (size_t i = 0; i < frames.size(); ++i) {
+    for (const auto i : c10::irange(frames.size())) {
       const Frame& frame = frames[i];
       std::string previous_fn_name = frame.function->function_name_;
       size_t pc = frame.pc;

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/jit_log.h>
@@ -162,8 +163,7 @@ struct CodeImpl {
 
   void request_bailout(size_t index) {
     auto count = index;
-    for (size_t instr_index = 0; instr_index < instructions_.size();
-         instr_index++) {
+    for (const auto instr_index : c10::irange(instructions_.size())) {
       if (instructions_[instr_index].op == GUARD ||
           instructions_[instr_index].op == FAIL_GUARD) {
         if (count-- == 0) {
@@ -405,7 +405,7 @@ struct CodeImpl {
     // Emit the expected type.
     size_t types_start = type_table_.size();
     auto types = node->tys(attr::types);
-    for (size_t i = 0; i < num_inputs; i++) {
+    for (const auto i : c10::irange(num_inputs)) {
       emitType(types[i]);
     }
     insertInstruction(TYPECHECK, types_start, num_inputs);
@@ -702,7 +702,7 @@ struct CodeImpl {
 
   void dump(std::ostream& out) const {
     out << *graph_ << "\n";
-    for (size_t i = 0; i < instructions_.size(); ++i) {
+    for (const auto i : c10::irange(instructions_.size())) {
       dump(out, i);
     }
   }

--- a/torch/csrc/jit/runtime/operator.cpp
+++ b/torch/csrc/jit/runtime/operator.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/alias_info.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/edit_distance.h>
 
 #include <queue>
@@ -406,7 +407,7 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
   out.push_back('(');
 
   bool seen_kwarg_only = false;
-  for (size_t i = 0; i < schema.arguments().size(); ++i) {
+  for (const auto i : c10::irange(schema.arguments().size())) {
     if (i > 0) {
       out += ", ";
     }
@@ -425,7 +426,7 @@ std::string canonicalSchemaString(const FunctionSchema& schema) {
     out += schema.returns().at(0).type()->str();
   } else if (schema.returns().size() > 1) {
     out.push_back('(');
-    for (size_t i = 0; i < schema.returns().size(); ++i) {
+    for (const auto i : c10::irange(schema.returns().size())) {
       if (i > 0) {
         out += ", ";
       }

--- a/torch/csrc/jit/runtime/register_c10_ops.cpp
+++ b/torch/csrc/jit/runtime/register_c10_ops.cpp
@@ -1,6 +1,7 @@
 #include <ATen/core/ATenOpList.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <ATen/record_function.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/tracer.h>
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/runtime/operator.h>
@@ -88,8 +89,7 @@ Operator createOperatorFromC10_withTracingHandledHere(
             // doubles in the list are constants
             auto value = iter->toDoubleVector();
             std::vector<Value*> info(value.size());
-            for (size_t value_index = 0; value_index < value.size();
-                 ++value_index) {
+            for (const auto value_index : c10::irange(value.size())) {
               info[value_index] = graph->insertConstant(value[value_index]);
               tracer::recordSourceLocation(info[value_index]->node());
             }

--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
+++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
@@ -336,7 +336,7 @@ void listExtend(Stack* stack) {
   c10::List<IValue> a = pop(stack).to<c10::List<IValue>>();
 
   a.reserve(a.size() + b.size());
-  for (size_t i = 0; i < b.size(); ++i) {
+  for (const auto i : c10::irange(b.size())) {
     a.push_back(b.get(i));
   }
 }
@@ -397,7 +397,7 @@ void listMulIntLeftInPlace(Stack* stack) {
     list.clear();
   } else if (n > 1) {
     size_t list_size = list.size();
-    for (int64_t i = 1; i < n; i++) {
+    for (const auto i : c10::irange(1, n)) {
       for (const auto j : c10::irange(list_size)) {
         list.push_back(list.get(j));
       }
@@ -467,7 +467,7 @@ void listSlice(Stack* stack) {
   sliced_list.reserve(num_values);
 
   int i = start;
-  for (int j = 0; j < num_values; ++j) {
+  for (const auto j : c10::irange(num_values)) {
     sliced_list.push_back(list.get(i));
     i += step;
   }

--- a/torch/csrc/jit/runtime/register_ops_utils.h
+++ b/torch/csrc/jit/runtime/register_ops_utils.h
@@ -30,6 +30,7 @@
 #include <ATen/core/ivalue.h>
 #include <c10/core/thread_pool.h>
 #include <c10/util/SmallVector.h>
+#include <c10/util/irange.h>
 #include <c10/util/math_compat.h>
 #include <c10/util/string_utils.h>
 
@@ -196,7 +197,7 @@ void minList(Stack* stack) {
   c10::List<T> b = pop(stack).to<c10::List<T>>();
 
   size_t min_size = std::min(a.size(), b.size());
-  for (size_t i = 0; i < min_size; i++) {
+  for (const auto i : c10::irange(min_size)) {
     if (a[i] == b[i]) {
       continue;
     }
@@ -214,7 +215,7 @@ void maxList(Stack* stack) {
   c10::List<T> b = pop(stack).to<c10::List<T>>();
 
   size_t min_size = std::min(a.size(), b.size());
-  for (size_t i = 0; i < min_size; i++) {
+  for (const auto i : c10::irange(min_size)) {
     if (a[i] == b[i]) {
       continue;
     }
@@ -259,7 +260,7 @@ void listMin(Stack* stack) {
   }
 
   T min_elem = list[0];
-  for (size_t i = 1; i < list_size; ++i) {
+  for (const auto i : c10::irange(1, list_size)) {
     T elem = list[i];
     min_elem = elem < min_elem ? elem : min_elem;
   }
@@ -276,7 +277,7 @@ void listMax(Stack* stack) {
   }
 
   T max_elem = list[0];
-  for (size_t i = 1; i < list_size; ++i) {
+  for (const auto i : c10::irange(1, list_size)) {
     T elem = list[i];
     max_elem = elem > max_elem ? elem : max_elem;
   }
@@ -345,7 +346,7 @@ inline bool tensor_list_equal(
     return false;
   }
 
-  for (size_t i = 0; i < a.size(); ++i) {
+  for (const auto i : c10::irange(a.size())) {
     at::Tensor a_element = a[i];
     at::Tensor b_element = b[i];
     // This preserves Python's semantics, which uses eq() to compare two

--- a/torch/csrc/jit/runtime/register_prim_ops.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops.cpp
@@ -175,7 +175,7 @@ RegisterOperators reg(
                  "Output annotation list dimension and runtime tensor dimension must match for tolist()");
 
              // Wrap out_ty in a ListType dim times.
-             for (int i = 0; i < dim_val; ++i) {
+             for (const auto i : c10::irange(dim_val)) {
                out_ty = ListType::create(out_ty);
              }
 
@@ -1884,7 +1884,7 @@ TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
 
         std::stringstream ss;
         ss << string;
-        for (auto i = 0; i < to_append; ++i) {
+        for (const auto i : c10::irange(to_append)) {
           ss << fillchar;
         }
 
@@ -1903,7 +1903,7 @@ TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
             std::max(int64_t(0), width - static_cast<int64_t>(string.size()));
 
         std::stringstream ss;
-        for (auto i = 0; i < to_append; ++i) {
+        for (const auto i : c10::irange(to_append)) {
           ss << fillchar;
         }
         ss << string;
@@ -1917,7 +1917,7 @@ TORCH_LIBRARY_IMPL(aten, CatchAll, m) {
             std::max(int64_t(0), width - static_cast<int64_t>(string.size()));
 
         std::stringstream ss;
-        for (auto i = 0; i < to_append; ++i) {
+        for (const auto i : c10::irange(to_append)) {
           ss << '0';
         }
         ss << string;
@@ -2056,7 +2056,7 @@ RegisterOperators reg1(
            pop(stack, n);
            c10::List<int64_t> elems;
            elems.reserve(n);
-           for (int i = 0; i < n; i++) {
+           for (const auto i : c10::irange(n)) {
              elems.push_back(i);
            }
            push(stack, std::move(elems));
@@ -2251,7 +2251,7 @@ RegisterOperators reg1(
            auto num_inputs = pop(stack).toInt();
            std::vector<int64_t> size;
            size.reserve(8);
-           for (auto i = 0; i < num_inputs; ++i) {
+           for (const auto i : c10::irange(num_inputs)) {
              size =
                  at::infer_size(size, peek(stack, i, num_inputs).toIntVector());
            }
@@ -2288,7 +2288,7 @@ RegisterOperators reg1(
            auto sizes_tensor = torch::empty(
                {static_cast<int64_t>(sizes.size())}, at::dtype(at::kLong));
            auto accessor = sizes_tensor.accessor<int64_t, 1>();
-           for (size_t i = 0; i < sizes.size(); ++i) {
+           for (const auto i : c10::irange(sizes.size())) {
              accessor[i] = sizes[i];
            }
            stack->emplace_back(sizes_tensor);
@@ -2760,7 +2760,7 @@ RegisterOperators reg2({
           pop(stack, t);
           c10::List<int64_t> elems;
           elems.reserve(t.size(0));
-          for (int i = 0; i < t.size(0); i++) {
+          for (const auto i : c10::irange(t.size(0))) {
             elems.push_back(*t[i].data_ptr<int32_t>());
           }
           push(stack, std::move(elems));
@@ -2772,7 +2772,7 @@ RegisterOperators reg2({
           c10::List<int64_t> l = pop(stack).toIntList();
           auto t = torch::empty(
               {static_cast<int64_t>(l.size())}, at::dtype(at::kInt));
-          for (size_t i = 0; i < l.size(); i++) {
+          for (const auto i : c10::irange(l.size())) {
             t[i] = l.get(i);
           }
           push(stack, std::move(t));
@@ -2805,7 +2805,7 @@ RegisterOperators reg2({
         [](Stack* stack) {
           c10::List<c10::complex<double>> l = pop(stack).toComplexDoubleList();
           c10::complex<double> sum = 0.0;
-          for (int i = 0; i < l.size(); i++) {
+          for (const auto i : c10::irange(l.size())) {
             sum = sum + l.extract(i);
           }
           push(stack, sum);

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/runtime/register_ops_utils.h>
 
 #include <ATen/core/ivalue.h>
+#include <c10/util/irange.h>
 #include <algorithm>
 #include <bitset>
 #include <cctype>
@@ -111,7 +112,7 @@ RegisterOperators reg(
                      " outputs, but got ",
                      num_results);
                }
-               for (int64_t i = num_results; i < chunks; ++i) {
+               for (const auto i : c10::irange(num_results, chunks)) {
                  TORCH_CHECK(
                      !outputs_used[i],
                      "Expected chunk to return at least ",
@@ -423,7 +424,7 @@ bool isSortableListOfObjectsOrTuples(
   // best sorting methods. If in the future we need to support heterogenous
   // types inside list, then sorting needs to have runtime sortable checks.
   const size_t n = ivalues.size();
-  for (size_t i = 0; i < n; ++i) {
+  for (const auto i : c10::irange(n)) {
     const IValue& v = ivalues.get(i);
     auto curr_type = v.type();
     if (*curr_type != *type) {
@@ -517,7 +518,7 @@ std::vector<int64_t> _output_size(
     scale_repeated = scale_factors.toDoubleVector();
   }
   std::vector<int64_t> ret;
-  for (size_t i = 0; i < dim; ++i) {
+  for (const auto i : c10::irange(dim)) {
     ret.push_back(std::floor(input.size(i + 2) * scale_repeated[i]));
   }
   return ret;

--- a/torch/csrc/jit/runtime/static/fusion.cpp
+++ b/torch/csrc/jit/runtime/static/fusion.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/runtime/static/fusion.h>
 
 #include <ATen/core/interned_strings.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/canonicalize.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
@@ -295,7 +296,7 @@ void createFusionGroups(Block* block, AliasDb* aliasDb, size_t min_size) {
   Node* prev_fusion_group =
       initial_fusion_groups.size() ? initial_fusion_groups[0] : nullptr;
 
-  for (size_t i = 1; i < initial_fusion_groups.size(); ++i) {
+  for (const auto i : c10::irange(1, initial_fusion_groups.size())) {
     // Try merging the just created fusion group into the previous one.
     // If it did not work, then put the previous fusion group into
     // fusion_groups vector - we will not touch it anymore in this loop.

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1114,7 +1114,7 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       // put output back
       DCHECK_EQ(stack.size(), num_outputs);
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-      for (auto i = 0; i < num_outputs; i++) {
+      for (const auto i : c10::irange(num_outputs)) {
         p_node->Output(i) = std::move(stack[i]);
       }
     };

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/runtime/vararg_functions.h>
 
 #include <ATen/ATen.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace jit {
@@ -264,7 +265,7 @@ void tupleSlice(Stack& stack, size_t begin, size_t end) {
   auto tuple = pop(stack).toTuple();
   std::vector<IValue> output_elems;
   output_elems.reserve(end - begin);
-  for (size_t i = begin; i < end; ++i) {
+  for (const auto i : c10::irange(begin, end)) {
     output_elems.emplace_back(tuple->elements()[i]);
   }
   push(stack, c10::ivalue::Tuple::create(std::move(output_elems)));

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/jit/serialization/export.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/backends/backend_debug_handler.h>
 #include <torch/csrc/jit/backends/backend_debug_info.h>
 #include <torch/csrc/jit/frontend/source_range.h>
@@ -84,7 +85,7 @@ std::pair<IValue, IValue> getFunctionTuple(
   std::vector<c10::OperatorName> opnames;
   std::vector<std::string> method_names;
   std::vector<int64_t> op_debug_handles;
-  for (size_t i = 0; i < instructions_copy.size(); ++i) {
+  for (const auto i : c10::irange(instructions_copy.size())) {
     Instruction ins = instructions_copy[i];
     if (ins.op == OP || ins.op == OPN) {
       auto node = code->instructions_source()[i];
@@ -583,7 +584,7 @@ void ScriptModuleSerializer::updateSourceRangeTags(
 
 void ScriptModuleSerializer::convertTypes(const at::NamedTypePtr& root_type) {
   class_deps_.add(root_type);
-  for (size_t i = 0; i < class_deps_.size(); ++i) {
+  for (const auto i : c10::irange(class_deps_.size())) {
     // note: convertNameType may extend class_deps_, so re-checking .size() is
     // necessary
     convertNamedType(class_deps_[i]);

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -159,7 +159,7 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
     } else {
       auto dict = std::move(input).toGenericDict();
       auto obj = c10::ivalue::Object::create(type, n);
-      for (size_t i = 0; i < n; ++i) {
+      for (const auto i : c10::irange(n)) {
         obj->setSlot(i, dict.at(cls->getAttributeName(i)));
       }
       return obj;

--- a/torch/csrc/jit/serialization/import_legacy.cpp
+++ b/torch/csrc/jit/serialization/import_legacy.cpp
@@ -292,12 +292,12 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
   }
   auto module =
       Module(c10::QualifiedName(LEGACY_moduleStack_), compilation_unit_);
-  for (int i = 0; i < module_def.submodules_size(); ++i) {
+  for (const auto i : c10::irange(module_def.submodules_size())) {
     const torch::ModuleDef& sub_def = module_def.submodules(i);
     auto submodule = LEGACY_convertModule(sub_def);
     module.register_module(sub_def.name(), submodule);
   }
-  for (int i = 0; i < module_def.parameters_size(); ++i) {
+  for (const auto i : c10::irange(module_def.parameters_size())) {
     const torch::ParameterDef& param_def = module_def.parameters(i);
     at::Tensor tensor = constant_table_.at(param_def.tensor_id()).toTensor();
     if (param_def.is_buffer()) {
@@ -308,7 +308,7 @@ Module ScriptModuleDeserializer::LEGACY_convertModule(
   }
   ScriptTypeParser typeParser(
       std::make_shared<ClassResolver>(source_importer_));
-  for (int i = 0; i < module_def.attributes_size(); ++i) {
+  for (const auto i : c10::irange(module_def.attributes_size())) {
     const torch::AttributeDef& attr_def = module_def.attributes(i);
     if (module.hasattr(attr_def.name())) {
       // this attribute was already registered as a buffer above.

--- a/torch/csrc/jit/serialization/onnx.cpp
+++ b/torch/csrc/jit/serialization/onnx.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/serialization/onnx.h>
 #include <torch/csrc/onnx/onnx.h>
 
@@ -24,14 +25,14 @@ std::string nlidt(size_t indent) {
 
 void dump(const onnx::TensorProto& tensor, std::ostream& stream) {
   stream << "TensorProto shape: [";
-  for (int i = 0; i < tensor.dims_size(); ++i) {
+  for (const auto i : c10::irange(tensor.dims_size())) {
     stream << tensor.dims(i) << (i == tensor.dims_size() - 1 ? "" : " ");
   }
   stream << "]";
 }
 
 void dump(const onnx::TensorShapeProto& shape, std::ostream& stream) {
-  for (int i = 0; i < shape.dim_size(); ++i) {
+  for (const auto i : c10::irange(shape.dim_size())) {
     auto& dim = shape.dim(i);
     if (dim.has_dim_value()) {
       stream << dim.dim_value();
@@ -108,19 +109,19 @@ void dump(
     dump(attr.t(), stream);
   } else if (attr.floats_size()) {
     stream << "floats, values: [";
-    for (int i = 0; i < attr.floats_size(); ++i) {
+    for (const auto i : c10::irange(attr.floats_size())) {
       stream << attr.floats(i) << (i == attr.floats_size() - 1 ? "" : " ");
     }
     stream << "]";
   } else if (attr.ints_size()) {
     stream << "ints, values: [";
-    for (int i = 0; i < attr.ints_size(); ++i) {
+    for (const auto i : c10::irange(attr.ints_size())) {
       stream << attr.ints(i) << (i == attr.ints_size() - 1 ? "" : " ");
     }
     stream << "]";
   } else if (attr.strings_size()) {
     stream << "strings, values: [";
-    for (int i = 0; i < attr.strings_size(); ++i) {
+    for (const auto i : c10::irange(attr.strings_size())) {
       stream << "'" << attr.strings(i) << "'"
              << (i == attr.strings_size() - 1 ? "" : " ");
     }
@@ -145,15 +146,15 @@ void dump(
 
 void dump(const onnx::NodeProto& node, std::ostream& stream, size_t indent) {
   stream << "Node {type: \"" << node.op_type() << "\", inputs: [";
-  for (int i = 0; i < node.input_size(); ++i) {
+  for (const auto i : c10::irange(node.input_size())) {
     stream << node.input(i) << (i == node.input_size() - 1 ? "" : ",");
   }
   stream << "], outputs: [";
-  for (int i = 0; i < node.output_size(); ++i) {
+  for (const auto i : c10::irange(node.output_size())) {
     stream << node.output(i) << (i == node.output_size() - 1 ? "" : ",");
   }
   stream << "], attributes: [";
-  for (int i = 0; i < node.attribute_size(); ++i) {
+  for (const auto i : c10::irange(node.attribute_size())) {
     dump(node.attribute(i), stream, indent + 1);
     stream << (i == node.attribute_size() - 1 ? "" : ",");
   }
@@ -163,27 +164,27 @@ void dump(const onnx::NodeProto& node, std::ostream& stream, size_t indent) {
 void dump(const onnx::GraphProto& graph, std::ostream& stream, size_t indent) {
   stream << idt(indent) << "GraphProto {" << nlidt(indent + 1) << "name: \""
          << graph.name() << "\"" << nlidt(indent + 1) << "inputs: [";
-  for (int i = 0; i < graph.input_size(); ++i) {
+  for (const auto i : c10::irange(graph.input_size())) {
     dump(graph.input(i), stream);
     stream << (i == graph.input_size() - 1 ? "" : ",");
   }
   stream << "]" << nlidt(indent + 1) << "outputs: [";
-  for (int i = 0; i < graph.output_size(); ++i) {
+  for (const auto i : c10::irange(graph.output_size())) {
     dump(graph.output(i), stream);
     stream << (i == graph.output_size() - 1 ? "" : ",");
   }
   stream << "]" << nlidt(indent + 1) << "value_infos: [";
-  for (int i = 0; i < graph.value_info_size(); ++i) {
+  for (const auto i : c10::irange(graph.value_info_size())) {
     dump(graph.value_info(i), stream);
     stream << (i == graph.value_info_size() - 1 ? "" : ",");
   }
   stream << "]" << nlidt(indent + 1) << "initializers: [";
-  for (int i = 0; i < graph.initializer_size(); ++i) {
+  for (const auto i : c10::irange(graph.initializer_size())) {
     dump(graph.initializer(i), stream);
     stream << (i == graph.initializer_size() - 1 ? "" : ",");
   }
   stream << "]" << nlidt(indent + 1) << "nodes: [" << nlidt(indent + 2);
-  for (int i = 0; i < graph.node_size(); ++i) {
+  for (const auto i : c10::irange(graph.node_size())) {
     dump(graph.node(i), stream, indent + 2);
     if (i != graph.node_size() - 1) {
       stream << "," << nlidt(indent + 2);

--- a/torch/csrc/jit/serialization/pickler.cpp
+++ b/torch/csrc/jit/serialization/pickler.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/distributed/rpc/rref_context.h>
 #endif
 #include <aten/src/ATen/quantized/Quantizer.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/api/function_impl.h>
 #include <torch/csrc/jit/serialization/pickler.h>
 #include <string>
@@ -460,7 +461,7 @@ static inline double swapDouble(double value) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   double flipped;
   char* out_bytes = reinterpret_cast<char*>(&flipped);
-  for (size_t i = 0; i < sizeof(double); ++i) {
+  for (const auto i : c10::irange(sizeof(double))) {
     out_bytes[i] = bytes[sizeof(double) - i - 1];
   }
   return *reinterpret_cast<double*>(out_bytes);

--- a/torch/csrc/jit/serialization/python_print.cpp
+++ b/torch/csrc/jit/serialization/python_print.cpp
@@ -27,7 +27,7 @@ static bool isValidIdentifierChar(char c, size_t pos) {
 static bool isValidIdentifier(const std::string& name) {
   if (name.size() == 0)
     return false;
-  for (size_t i = 0; i < name.size(); ++i) {
+  for (const auto i : c10::irange(name.size())) {
     if (!isValidIdentifierChar(name[i], i))
       return false;
   }
@@ -315,7 +315,7 @@ struct PythonPrintImpl {
     // We will probably need to optimize this at some point using hashing.
     if (val.isTensor()) {
       auto& t = val.toTensor();
-      for (size_t i = 0; i < constant_table_.size(); ++i) {
+      for (const auto i : c10::irange(constant_table_.size())) {
         if (!constant_table_[i].isTensor()) {
           continue;
         }
@@ -431,7 +431,7 @@ struct PythonPrintImpl {
   size_t level = 0;
   // indent to the current indent level
   TaggedStringStream& indent() {
-    for (size_t i = 0; i < level; ++i) {
+    for (const auto i : c10::irange(level)) {
       body_ << "  ";
     }
     return body_;
@@ -521,7 +521,7 @@ struct PythonPrintImpl {
   void printAnnotatedAssignment(
       at::ArrayRef<Value*> lhs,
       at::ArrayRef<Value*> rhs) {
-    for (size_t i = 0; i < lhs.size(); ++i) {
+    for (const auto i : c10::irange(lhs.size())) {
       indent();
       body_ << useOf(lhs[i]);
       if (requiresAnnotation(lhs[i], rhs[i])) {
@@ -1163,7 +1163,7 @@ struct PythonPrintImpl {
         // details.
         size_t necessary_args =
             CalculateNecessaryArgs(schema.arguments(), node->inputs());
-        for (size_t i = 0; i < necessary_args; ++i) {
+        for (const auto i : c10::irange(necessary_args)) {
           if (i > 0)
             stmt << ", ";
           auto v = useOf(node->inputs().at(i));
@@ -1204,7 +1204,7 @@ struct PythonPrintImpl {
   IValue createBroadList(dtype value, const int64_t& N) {
     c10::List<dtype> repeated;
     repeated.reserve(N);
-    for (int i = 0; i < N; ++i) {
+    for (const auto i : c10::irange(N)) {
       repeated.push_back(value);
     }
     return repeated;

--- a/torch/csrc/jit/tensorexpr/bounds_inference.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_inference.cpp
@@ -40,7 +40,7 @@ BoundsInfo mergeTensorAccesses(
       if (!distinctAccessKinds || kind == TABI.kind) {
         TORCH_INTERNAL_ASSERT(TABI.start.size() == access->bounds().size());
         TORCH_INTERNAL_ASSERT(TABI.stop.size() == access->bounds().size());
-        for (size_t i = 0; i < TABI.start.size(); ++i) {
+        for (const auto i : c10::irange(TABI.start.size())) {
           TABI.start[i] = IRSimplifier::simplify(
               new Min(TABI.start[i], access->bounds()[i].start, true));
           TABI.stop[i] = IRSimplifier::simplify(
@@ -182,7 +182,7 @@ std::vector<const Expr*> getBoundExtents(
   }
 
   std::vector<const Expr*> extents;
-  for (size_t i = 0; i < starts.size(); ++i) {
+  for (const auto i : c10::irange(starts.size())) {
     const Expr* dim = IRSimplifier::simplify(
         new Add(new Sub(stops[i], starts[i]), new IntImm(1)));
 
@@ -200,7 +200,7 @@ BoundSet convertBounds(
   BoundSet ret;
   for (auto& TABI : bounds) {
     if (filter == kMutate || TABI.kind == filter) {
-      for (size_t i = 0; i < TABI.start.size(); ++i) {
+      for (const auto i : c10::irange(TABI.start.size())) {
         ret.insert(Bound(TABI.start[i], TABI.stop[i]));
       }
     }
@@ -279,7 +279,7 @@ IndexBounds getIndexBounds(const TensorAccessBoundsInfo& tabi) {
   if (tabi.start.empty()) {
     return ret;
   }
-  for (size_t i = 0; i < tabi.start.size(); ++i) {
+  for (const auto i : c10::irange(tabi.start.size())) {
     ret[i] = Bound(tabi.start[i], tabi.stop[i]);
   }
   return ret;
@@ -322,8 +322,8 @@ bool hasConflictingOverlap(
     auto bIndexBounds = bIndexBoundsInfo[bIt->first];
     auto aTABIs = aBound.second;
     auto bTABIs = bIt->second;
-    for (size_t i = 0; i < aTABIs.size(); ++i) {
-      for (size_t j = 0; j < bTABIs.size(); ++j) {
+    for (const auto i : c10::irange(aTABIs.size())) {
+      for (const auto j : c10::irange(bTABIs.size())) {
         auto aTABI = aTABIs[i];
         auto bTABI = bTABIs[j];
         if (aTABI.kind == kLoad && bTABI.kind == kLoad) {

--- a/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
+++ b/torch/csrc/jit/tensorexpr/bounds_overlap.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/bounds_overlap.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 
@@ -67,7 +68,7 @@ Bound flattenBounds(const IndexBounds& a) {
   }
   Bound ret = a[0];
 
-  for (size_t i = 1; i < a.size(); ++i) {
+  for (const auto i : c10::irange(1, a.size())) {
     ret.start = new Mul(ret.start, a[i].start);
     ret.end = new Mul(ret.end, a[i].end);
   }
@@ -90,7 +91,7 @@ OverlapKind overlaps(const IndexBounds& a, const IndexBounds& b) {
   TORCH_INTERNAL_ASSERT(a.size() == b.size());
 
   OverlapKind overlap = boundOverlap(a[0], b[0]);
-  for (size_t i = 1; i < a.size(); ++i) {
+  for (const auto i : c10::irange(1, a.size())) {
     OverlapKind bOverlap = boundOverlap(a[i], b[i]);
     if (bOverlap == NoOverlap) {
       return NoOverlap;
@@ -199,7 +200,7 @@ std::vector<IndexBounds> subtractIndicesBounds(
   std::vector<IndexBounds> boundSlices;
   std::vector<Bound> remainingOuterBounds;
 
-  for (size_t i = 0; i < A.size(); ++i) {
+  for (const auto i : c10::irange(A.size())) {
     auto slices = subtractBound(A[i], B[i]);
 
     Bound remaining = A[i];
@@ -209,7 +210,7 @@ std::vector<IndexBounds> subtractIndicesBounds(
       newRegion.reserve(A.size());
       TORCH_INTERNAL_ASSERT(remainingOuterBounds.size() == i);
 
-      for (size_t j = 0; j < i; ++j) {
+      for (const auto j : c10::irange(i)) {
         newRegion.push_back(remainingOuterBounds[j]);
       }
       newRegion.push_back(slice);

--- a/torch/csrc/jit/tensorexpr/eval.cpp
+++ b/torch/csrc/jit/tensorexpr/eval.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 
 #include <torch/csrc/jit/tensorexpr/external_functions_registry.h>
@@ -434,7 +435,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
   std::vector<DstType> castValues(const Dtype& src_dtype, const Value& v) {
     const std::vector<SrcType>& src_values = v.as_vec<SrcType>();
     std::vector<DstType> dst_values(src_values.size());
-    for (int i = 0; i < src_dtype.lanes(); ++i) {
+    for (const auto i : c10::irange(src_dtype.lanes())) {
       // NOLINTNEXTLINE(bugprone-signed-char-misuse)
       dst_values[i] = static_cast<DstType>(src_values[i]);
     }
@@ -485,7 +486,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
   std::vector<DstType> bitcastValues(const Dtype& src_dtype, const Value& v) {
     const std::vector<SrcType>& src_values = v.as_vec<SrcType>();
     std::vector<DstType> dst_values(src_values.size());
-    for (int i = 0; i < src_dtype.lanes(); ++i) {
+    for (const auto i : c10::irange(src_dtype.lanes())) {
       dst_values[i] = raw_bitcast<DstType>(src_values[i]);
     }
     return dst_values;
@@ -542,7 +543,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
       throw malformed_input("could not find var_node in For context", v);
     }
 
-    for (int i = start; i < stop; i++) {
+    for (const auto i : c10::irange(start, stop)) {
       eval_context_[var_node] = Value(i);
       if (v->body()) {
         v->body()->accept(this);
@@ -559,7 +560,7 @@ class SimpleIREvaluatorImpl : public IRVisitor {
     int lanes = v->lanes();
 
     std::vector<int> values(lanes);
-    for (int i = 0; i < lanes; i++) {
+    for (const auto i : c10::irange(lanes)) {
       values[i] = base + i * stride;
     }
 
@@ -975,7 +976,7 @@ SimpleIREvaluator::~SimpleIREvaluator() = default;
 
 void SimpleIREvaluator::call(const std::vector<CallArg>& args) {
   std::vector<void*> raw_args(args.size());
-  for (size_t i = 0; i < args.size(); i++) {
+  for (const auto i : c10::irange(args.size())) {
     auto const& bufferArg = buffer_args()[i];
     auto const& callArg = args[i];
     raw_args[i] = argToPtr(bufferArg, callArg);

--- a/torch/csrc/jit/tensorexpr/ir.cpp
+++ b/torch/csrc/jit/tensorexpr/ir.cpp
@@ -90,7 +90,7 @@ const Expr* flatten_index(
   // stride[i] = stride[i+1]*dims[i+1], i < ndim-1
   // stride[i] = 1,                     i = ndim-1
   strides[ndim - 1] = new IntImm(1);
-  for (size_t i = 1; i < ndim; i++) {
+  for (const auto i : c10::irange(1, ndim)) {
     strides[ndim - 1 - i] = new Mul(strides[ndim - i], dims[ndim - i]);
   }
 

--- a/torch/csrc/jit/tensorexpr/ir.h
+++ b/torch/csrc/jit/tensorexpr/ir.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include <c10/util/string_utils.h>
 #include <torch/csrc/jit/tensorexpr/exceptions.h>
 #include <torch/csrc/jit/tensorexpr/expr.h>
@@ -644,7 +645,7 @@ class TORCH_API Intrinsics : public ExprNode<Intrinsics> {
       IntrinsicsOp op_type,
       const std::vector<ExprHandle>& params) {
     std::vector<const Expr*> params_nodes(params.size());
-    for (size_t i = 0; i < params.size(); i++) {
+    for (const auto i : c10::irange(params.size())) {
       params_nodes[i] = params[i].node();
     }
     return ExprHandle(new Intrinsics(op_type, params_nodes));

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/ir_simplifier.h>
 
 namespace torch {
@@ -2179,7 +2180,7 @@ const Expr* TermExpander::mutate(const MaxTerm* v) {
   } else {
     max = variables[0];
   }
-  for (size_t i = 1; i < variables.size(); i++) {
+  for (const auto i : c10::irange(1, variables.size())) {
     max = new Max(max, variables[i], v->propagate_nans());
   }
   return max->accept_mutator(this);
@@ -2202,7 +2203,7 @@ const Expr* TermExpander::mutate(const MinTerm* v) {
   } else {
     min = variables[0];
   }
-  for (size_t i = 1; i < variables.size(); i++) {
+  for (const auto i : c10::irange(1, variables.size())) {
     min = new Min(min, variables[i], v->propagate_nans());
   }
   return min->accept_mutator(this);

--- a/torch/csrc/jit/tensorexpr/ir_verifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_verifier.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/ir_verifier.h>
 
 #include <torch/csrc/jit/tensorexpr/ir.h>
@@ -77,7 +78,7 @@ void IRVerifier::visit(const Load* v) {
 
   Dtype index_dtype = indices.size() ? indices.at(0)->dtype() : kInt;
   if (indices.size() > 1) {
-    for (size_t i = 1; i < indices.size(); ++i) {
+    for (const auto i : c10::irange(1, indices.size())) {
       if (indices.at(i)->dtype() != index_dtype) {
         throw malformed_ir("dtype mismatch in Load indices");
       }
@@ -120,7 +121,7 @@ void IRVerifier::visit(const Store* v) {
 
   Dtype index_dtype = indices.size() ? indices.at(0)->dtype() : kInt;
   if (indices.size() > 1) {
-    for (size_t i = 1; i < indices.size(); ++i) {
+    for (const auto i : c10::irange(1, indices.size())) {
       if (indices.at(i)->dtype() != index_dtype) {
         throw malformed_ir("dtype mismatch in Store indices");
       }

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 
 namespace torch {
@@ -99,7 +100,7 @@ class TORCH_API LoopNest {
   // This corresponds to the conditional format that is generated to handle
   // `aten::cat` op.
   //
-  //   for (int i = 0; i < 20; i++) {
+  //   for (const auto i : c10::irange(20)) {
   //     A[i] = IfThenElse(i<5 ? 1 : 0, B[i], C[i-5])
   //   }
   //
@@ -119,17 +120,17 @@ class TORCH_API LoopNest {
   // added after the given loop.
   //
   // For example, consider the following code:
-  //   for (int i = 0; i < 100; ++i) {
+  //   for (const auto i : c10::irange(100)) {
   //     A[i] =
   //   }
   //
   // splitWithTail(i, 8, ...) will result in:
-  //   for (int i_outer = 0; i_outer < 12; ++i_outer) {
-  //     for (int i_inner = 0; i_inner < 8; ++i_inner) {
+  //   for (const auto i_outer : c10::irange(12)) {
+  //     for (const auto i_inner : c10::irange(8)) {
   //       A[i_outer * 8 + i_inner] =
   //     }
   //   }
-  //   for (int i_tail = 0; i_tail < 4; ++i_tail) {
+  //   for (const auto i_tail : c10::irange(4)) {
   //     A[i_tail + 96] =
   //   }
   //
@@ -148,13 +149,13 @@ class TORCH_API LoopNest {
   // iterations appropriately.
   //
   // For example, consider the following code:
-  //   for (int i = 0; i < 100; ++i) {
+  //   for (const auto i : c10::irange(100)) {
   //     A[i] =
   //   }
   //
   // splitWithMask(i, 8, ...) will result in:
-  //   for (int i_outer = 0; i_outer < 13; ++i_outer) {
-  //     for (int i_inner = 0; i_inner < 8; ++i_inner) {
+  //   for (const auto i_outer : c10::irange(13)) {
+  //     for (const auto i_inner : c10::irange(8)) {
   //       if (i_outer * 8 + i_inner < 100) {
   //         A[i_outer * 8 + i_inner] =
   //       }
@@ -308,11 +309,11 @@ class TORCH_API LoopNest {
   // Compresses the given buffer based on its use in the given Stmts.
   // For example, given the input:
   //
-  // for (int i = 0; i < 100; ++i) {
-  //   for (int j = 0; j < 200; ++j) {
+  // for (const auto i : c10::irange(100)) {
+  //   for (const auto j : c10::irange(200)) {
   //     A[i,j] = sin(i*j)
   //   }
-  //   for (int j = 0; j < 199; ++j) {
+  //   for (const auto j : c10::irange(199)) {
   //     B[i,j] = A[i,j] + A[i, j+1]
   //   }
   // }
@@ -320,11 +321,11 @@ class TORCH_API LoopNest {
   // compressBuffer(A, ...) will compress buffer A from
   // [100, 200] to [1, 200] and modify the code as follows:
   //
-  // for (int i = 0; i < 100; ++i) {
-  //   for (int j = 0; j < 200; ++j) {
+  // for (const auto i : c10::irange(100)) {
+  //   for (const auto j : c10::irange(200)) {
   //     A[0,j] = sin(i*j)
   //   }
-  //   for (int j = 0; j < 199; ++j) {
+  //   for (const auto j : c10::irange(199)) {
   //     B[i,j] = A[0,j] + A[0, j+1]
   //   }
   // }

--- a/torch/csrc/jit/tensorexpr/registerizer.cpp
+++ b/torch/csrc/jit/tensorexpr/registerizer.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <torch/csrc/jit/tensorexpr/registerizer.h>
 
 namespace torch {
@@ -74,7 +75,7 @@ bool AccessInfo::overlaps(const std::shared_ptr<AccessInfo>& other) {
   // They don't overlap if there is a guaranteed difference in any
   // dimension.
   bool overlap = true;
-  for (size_t i = 0; i < indices_.size(); ++i) {
+  for (const auto i : c10::irange(indices_.size())) {
     const Expr* diff = new Sub(indices_[i], other_indices[i]);
     diff = IRSimplifier::simplify(diff);
 

--- a/torch/csrc/jit/tensorexpr/registerizer.h
+++ b/torch/csrc/jit/tensorexpr/registerizer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <c10/core/ScalarType.h>
+#include <c10/util/irange.h>
 #include <torch/csrc/WindowsTorchApiMacro.h>
 #include <vector>
 
@@ -21,7 +22,7 @@ For example it can replace:
 
 {
   A[0] = 0;
-  for (int x = 0; x < 10; x++) {
+  for (const auto x : c10::irange(10)) {
     A[0] = (A[0]) + x;
   }
 }
@@ -30,7 +31,7 @@ with:
 
 {
   int A_ = 0;
-  for (int x = 0; x < 10; x++) {
+  for (const auto x : c10::irange(10)) {
     A_ = x + A_;
   }
   A[0] = A_;

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <pybind11/functional.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
@@ -609,7 +610,7 @@ void initTensorExprBindings(PyObject* module) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             auto g_inputs = self.graph()->inputs();
-            for (size_t i = 0; i < inputs.size(); ++i) {
+            for (const auto i : c10::irange(inputs.size())) {
               if (stack[i].isTensor()) {
                 g_inputs[i]->setType(stack[i].type());
               }
@@ -626,7 +627,7 @@ void initTensorExprBindings(PyObject* module) {
               stack.push_back(toTypeInferredIValue(obj));
             }
             auto g_inputs = self.graph()->inputs();
-            for (size_t i = 0; i < inputs.size(); ++i) {
+            for (const auto i : c10::irange(inputs.size())) {
               if (stack[i].isTensor()) {
                 g_inputs[i]->setType(stack[i].type());
               }

--- a/torch/csrc/jit/testing/file_check.cpp
+++ b/torch/csrc/jit/testing/file_check.cpp
@@ -346,8 +346,8 @@ struct FileCheckImpl {
       }
 
       bool found_highlight = true;
-      for (auto pos = highlight_start_offset; pos < highlight_end_offset;
-           ++pos) {
+      for (const auto pos :
+           c10::irange(highlight_start_offset, highlight_end_offset)) {
         if (source->text()[pos] != '~') {
           found_highlight = false;
         }

--- a/torch/csrc/utils/tensor_new.cpp
+++ b/torch/csrc/utils/tensor_new.cpp
@@ -155,7 +155,7 @@ ScalarType infer_scalar_type(PyObject *obj) {
     if (length < 0) throw python_error();
     // match NumPy semantics, except use default tensor type instead of double.
     if (length == 0) return torch::tensors::get_default_scalar_type();
-    for (int i = 0; i < length; ++i) {
+    for (const auto i : c10::irange(length)) {
       THPObjectPtr handle(PySequence_GetItem(obj, i));
       if (!handle) throw python_error();
       auto cur_item = handle.get();

--- a/torch/csrc/utils/throughput_benchmark-inl.h
+++ b/torch/csrc/utils/throughput_benchmark-inl.h
@@ -8,6 +8,7 @@
 #include <torch/csrc/utils/pybind.h>
 
 #include <aten/src/ATen/Parallel.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 namespace throughput_benchmark {
@@ -37,8 +38,7 @@ BenchmarkExecutionStats BenchmarkHelper<Input, Output, Model>::benchmark(
         "Did you forget to call add_input()? ");
     std::uniform_int_distribution<int> dist(0, inputs_.size() - 1);
 
-    for (int thread_id = 0; thread_id < config.num_calling_threads;
-         ++thread_id) {
+    for (const auto thread_id : c10::irange(config.num_calling_threads)) {
       // Just in case we generate num_iters inputs for each of the threads
       // This was if one thread does all the work we will be fine
       for (int i = 0; i < config.num_iters + config.num_warmup_iters; ++i) {
@@ -58,13 +58,12 @@ BenchmarkExecutionStats BenchmarkHelper<Input, Output, Model>::benchmark(
   std::atomic<int64_t> num_attempted_iters{0};
   std::vector<std::thread> callers;
 
-  for (auto thread_id = 0; thread_id < config.num_calling_threads;
-       ++thread_id) {
+  for (const auto thread_id : c10::irange(config.num_calling_threads)) {
     // NOLINTNEXTLINE(performance-inefficient-vector-operation)
     callers.emplace_back([&, thread_id]() {
       // We use conditional variable as a barrier to make sure each thread
       // performs required warmeup iterations before we start measuring
-      for (auto j = 0; j < config.num_warmup_iters; ++j) {
+      for (const auto j : c10::irange(config.num_warmup_iters)) {
         runOnce(std::move(thread_inputs[thread_id][input_iters[thread_id]]));
         ++input_iters[thread_id];
       }

--- a/torch/custom_class_detail.h
+++ b/torch/custom_class_detail.h
@@ -4,6 +4,7 @@
 #include <ATen/core/function.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/TypeTraits.h>
+#include <c10/util/irange.h>
 
 namespace torch {
 
@@ -157,7 +158,7 @@ inline bool validIdent(size_t i, char n) {
 }
 
 inline void checkValidIdent(const std::string& str, const char *type) {
-  for (size_t i = 0; i < str.size(); ++i) {
+  for (const auto i : c10::irange(str.size())) {
     TORCH_CHECK(validIdent(i, str[i]),
       type,
       " must be a valid Python/C++ identifier."

--- a/torch/lib/c10d/ProcessGroupMPI.cpp
+++ b/torch/lib/c10d/ProcessGroupMPI.cpp
@@ -4,6 +4,7 @@
 #include <map>
 
 #include <c10/core/DeviceGuard.h>
+#include <c10/util/irange.h>
 
 #if defined(OPEN_MPI) && OPEN_MPI
 #include <mpi-ext.h> // Needed for CUDA-aware check
@@ -265,7 +266,7 @@ c10::intrusive_ptr<ProcessGroupMPI> ProcessGroupMPI::createProcessGroupMPI(
       constexpr int kMaxNumRetries = 3;
       bool groupComm_updated = false;
       MPI_Barrier(MPI_COMM_WORLD);
-      for (int i = 0; i < kMaxNumRetries; ++i) {
+      for (const auto i : c10::irange(kMaxNumRetries)) {
         if (MPI_Comm_create(MPI_COMM_WORLD, ranksGroup, &groupComm)) {
           groupComm_updated = true;
           break;
@@ -493,7 +494,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::allgather(
             mpiDatatype.at(data.scalar_type()),
             pgComm_));
 
-        for (size_t i = 0; i < outputDataVec.size(); ++i) {
+        for (const auto i : c10::irange(outputDataVec.size())) {
           outputDataVec[i].copy_(flatOutputTensor[i]);
         }
       };
@@ -564,7 +565,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::gather(
         if (rank_ == opts.rootRank) {
           const std::vector<at::Tensor>& outputDataVec = entry->dst;
           // copy the flattened output tensors to the outputs
-          for (size_t i = 0; i < outputDataVec.size(); ++i) {
+          for (const auto i : c10::irange(outputDataVec.size())) {
             outputDataVec.at(i).copy_(flatOutputTensor[i]);
           }
         }
@@ -624,7 +625,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::scatter(
           sendbuf = flatInputTensor.data_ptr();
 
           // copy the input tensors to the flatten large send buffer
-          for (size_t i = 0; i < inputDataVec.size(); ++i) {
+          for (const auto i : c10::irange(inputDataVec.size())) {
             flatInputTensor[i].copy_(inputDataVec.at(i));
           }
         }
@@ -783,7 +784,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
         at::Tensor dstFlatData = at::empty({dst_len}, dstdata[0].options());
         auto srcFlatDataSplits =
             srcFlatData.split_with_sizes(c10::IntArrayRef(send_lengthsL), 0);
-        for (int i = 0; i < size_; i++) {
+        for (const auto i : c10::irange(size_)) {
           srcFlatDataSplits[i].copy_(srcdata[i].view({-1}));
         }
         c10::DeviceGuard guard1(srcdata[0].device());
@@ -801,7 +802,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupMPI::alltoall(
 
         auto dstFlatDataSplits =
             dstFlatData.split_with_sizes(c10::IntArrayRef(recv_lengthsL), 0);
-        for (int i = 0; i < size_; i++) {
+        for (const auto i : c10::irange(size_)) {
           dstdata[i].view({-1}).copy_(dstFlatDataSplits[i]);
         }
       };

--- a/torch/lib/c10d/ProcessGroupNCCL.cpp
+++ b/torch/lib/c10d/ProcessGroupNCCL.cpp
@@ -151,7 +151,7 @@ void syncStreams(
     const std::vector<at::Device>& devices,
     std::vector<at::cuda::CUDAEvent>& ncclEvents,
     std::vector<at::cuda::CUDAStream>& ncclStreams) {
-  for (size_t i = 0; i < devices.size(); ++i) {
+  for (const auto i : c10::irange(devices.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams[i];
     at::cuda::CUDAEvent& ncclEvent = ncclEvents[i];
     ncclEvent.record(at::cuda::getCurrentCUDAStream(devices[i].index()));
@@ -296,7 +296,7 @@ bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecution() {
 }
 
 bool ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal() const {
-  for (size_t i = 0; i < devices_.size(); ++i) {
+  for (const auto i : c10::irange(devices_.size())) {
     // Checking the work's corresponding CUDA events' status
     if (!(*cudaEvents_)[i].query()) {
       return false;
@@ -337,7 +337,7 @@ void ProcessGroupNCCL::WorkNCCL::synchronize() {
 }
 
 void ProcessGroupNCCL::WorkNCCL::synchronizeStreams() {
-  for (size_t i = 0; i < devices_.size(); ++i) {
+  for (const auto i : c10::irange(devices_.size())) {
     auto currentStream = at::cuda::getCurrentCUDAStream(devices_[i].index());
     // Block the current stream on the NCCL stream
     (*cudaEvents_)[i].block(currentStream);
@@ -873,14 +873,14 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
   // to "close" all active nccl groups to ensure nccl communicator is actually
   // created before encountering any communication calls. This is why we need
   // the following for loop.
-  for (size_t i = 0; i < ncclActiveGroupCounter_; ++i) {
+  for (const auto i : c10::irange(ncclActiveGroupCounter_)) {
     C10D_NCCL_CHECK(ncclGroupEnd());
   }
 
   // [Note 1] Create the NCCL communicators for each GPU
   C10D_NCCL_CHECK(ncclGroupStart());
 
-  for (size_t i = 0; i < devices.size(); ++i) {
+  for (const auto i : c10::irange(devices.size())) {
     // GPU world size and GPU rank
     int numRanks, rank;
 
@@ -912,7 +912,7 @@ std::vector<std::shared_ptr<NCCLComm>>& ProcessGroupNCCL::getNCCLComm(
   C10D_NCCL_CHECK(ncclGroupEnd());
 
   // See [Group Start/End Note]
-  for (size_t i = 0; i < ncclActiveGroupCounter_; ++i) {
+  for (const auto i : c10::irange(ncclActiveGroupCounter_)) {
     C10D_NCCL_CHECK(ncclGroupStart());
   }
 
@@ -1107,7 +1107,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
 
   pre(ncclStreams_[key]);
 
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     gpuGuard.set_index(devices[i].index());
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
 
@@ -1125,7 +1125,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
 
   {
     AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < inputs.size(); ++i) {
+    for (const auto i : c10::irange(inputs.size())) {
       gpuGuard.set_index(devices[i].index());
       at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
       C10D_NCCL_CHECK(
@@ -1136,7 +1136,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::collective(
   post(ncclStreams_[key]);
 
   // Event should only be recorded after the ncclGroupEnd()
-  for (size_t i = 0; i < inputs.size(); ++i) {
+  for (const auto i : c10::irange(inputs.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
     (*work->cudaEvents_)[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
@@ -1208,7 +1208,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
 
   pre(ncclStreams_[key]);
 
-  for (size_t i = 0; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(tensors.size())) {
     gpuGuard.set_index(devices[i].index());
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
 
@@ -1223,7 +1223,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
 
   {
     AutoNcclGroup nccl_group_guard;
-    for (size_t i = 0; i < tensors.size(); ++i) {
+    for (const auto i : c10::irange(tensors.size())) {
       gpuGuard.set_index(devices[i].index());
       at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
       // For point-to-point communication, NCCL ranks can only
@@ -1237,7 +1237,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::pointToPoint(
   post(ncclStreams_[key]);
 
   // Event should only be recorded after the ncclGroupEnd()
-  for (size_t i = 0; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(tensors.size())) {
     at::cuda::CUDAStream& ncclStream = ncclStreams_[key][i];
     (*work->cudaEvents_)[i].record(ncclStream);
     work->ncclComms_[i] = ncclComms[i];
@@ -1460,7 +1460,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::allgather(
       [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {},
       [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {
         // Copy the flattened output tensors to the outputs.
-        for (size_t i = 0; i < outputTensors.size(); ++i) {
+        for (const auto i : c10::irange(outputTensors.size())) {
           at::cuda::CUDAStreamGuard guard(ncclStreams[i]);
           for (size_t j = 0; j < outputTensors[0].size(); ++j) {
             // See [Sync Streams].
@@ -1525,7 +1525,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupNCCL::reduce_scatter(
       },
       [&](std::vector<at::cuda::CUDAStream>& ncclStreams) {
         // Copy the input tensors to the flattened inputs.
-        for (size_t i = 0; i < inputTensors.size(); ++i) {
+        for (const auto i : c10::irange(inputTensors.size())) {
           at::cuda::CUDAStreamGuard guard(ncclStreams[i]);
           for (size_t j = 0; j < inputTensors[0].size(); ++j) {
             // See [Sync Streams].

--- a/torch/lib/c10d/ProcessGroupWrapper.cpp
+++ b/torch/lib/c10d/ProcessGroupWrapper.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 #include <c10/util/intrusive_ptr.h>
+#include <c10/util/irange.h>
 #include <c10d/ProcessGroup.hpp>
 #include <c10d/ProcessGroupGloo.hpp>
 #include <c10d/ProcessGroupWrapper.hpp>
@@ -69,7 +70,7 @@ struct CollectiveFingerPrint {
     // Allgather tensor shapes.
     pg->allgather(output_tensors, shape_tensors)->wait();
     // Verify equivalence
-    for (int i = 0; i < output_tensors.size(); ++i) {
+    for (const auto i : c10::irange(output_tensors.size())) {
       auto world_tensor_shapes = output_tensors[i];
       auto reference_shape_tensor = shape_tensors[i];
       for (const auto& rank_tensor_shape : world_tensor_shapes) {

--- a/torch/lib/c10d/TCPStore.cpp
+++ b/torch/lib/c10d/TCPStore.cpp
@@ -780,7 +780,7 @@ void TCPStore::wait(
     const std::chrono::milliseconds& timeout) {
   std::vector<std::string> regKeys;
   regKeys.resize(keys.size());
-  for (size_t i = 0; i < keys.size(); ++i) {
+  for (const auto i : c10::irange(keys.size())) {
     regKeys[i] = regularPrefix_ + keys[i];
   }
   waitHelper_(regKeys, timeout);

--- a/torch/lib/c10d/Utils.hpp
+++ b/torch/lib/c10d/Utils.hpp
@@ -2,6 +2,7 @@
 
 #include <ATen/ATen.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/irange.h>
 #include <c10d/Types.hpp>
 
 #ifdef _WIN32
@@ -55,7 +56,7 @@ std::vector<at::Tensor> getTensorShapes(const std::vector<at::Tensor>& tensors);
 inline std::string toString(at::IntArrayRef l) {
   std::stringstream ss;
   ss << "(";
-  for (size_t i = 0; i < l.size(); i++) {
+  for (const auto i : c10::irange(l.size())) {
     if (i > 0) {
       ss << ", ";
     }
@@ -74,7 +75,7 @@ inline std::string toString(const c10::Layout& layout) {
 inline void assertSameType(
     const at::DeprecatedTypeProperties& type,
     const std::vector<at::Tensor>& tensors) {
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     if (!tensors[i].options().type_equal(type.options())) {
       const std::string expected = type.toString();
       const std::string actual = tensors[i].toString();
@@ -109,7 +110,7 @@ inline bool parseEnvVarFlag(const char* envVarName) {
 inline void assertSameSizes(
     const at::IntArrayRef& sizes,
     const std::vector<at::Tensor>& tensors) {
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     if (!tensors[i].sizes().equals(sizes)) {
       const auto expected = toString(sizes);
       const auto actual = toString(tensors[i].sizes());
@@ -128,7 +129,7 @@ inline void assertSameSizeAndType(const std::vector<at::Tensor>& tensors) {
   // Ensure all tensors have identical type and shape
   auto options = tensors[0].options();
   auto sizes = tensors[0].sizes();
-  for (size_t i = 1; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     if (!tensors[i].options().type_equal(options)) {
       const auto expected = toString(options);
       const auto actual = toString(tensors[i].options());
@@ -195,7 +196,7 @@ inline void assertLayoutMatch(
     std::function<void(const std::string&)> fn,
     const at::ArrayRef<at::Tensor> tensors) {
   const auto& layout = tensors[0].layout();
-  for (size_t i = 1; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     assertLayoutMatch(fn, layout, tensors, i);
   }
 }
@@ -275,7 +276,7 @@ inline void assertSameDevice(
     return;
   }
   const auto& device = tensors[0].device();
-  for (int i = 1; i < tensors.size(); ++i) {
+  for (const auto i : c10::irange(1, tensors.size())) {
     if (tensors[i].device() != device) {
       fn("tensors should be on the same device");
     }
@@ -287,7 +288,7 @@ inline void assertTypeAndSizesMatch(
     const at::ArrayRef<at::Tensor> tensors,
     const at::DeprecatedTypeProperties& type,
     const at::IntArrayRef& sizes) {
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     assertTypeMatch(fn, type, tensors, i);
     assertSizesMatch(fn, sizes, tensors, i);
   }
@@ -298,7 +299,7 @@ inline void assertTypeAndSizesMatch(
     const at::ArrayRef<at::Tensor> tensors,
     const at::TensorOptions& options,
     const at::IntArrayRef& sizes) {
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     assertTypeMatch(fn, options, tensors, i);
     assertSizesMatch(fn, sizes, tensors, i);
   }
@@ -374,7 +375,7 @@ inline at::Tensor newLikeFlat(std::vector<at::Tensor>& tensors) {
 inline std::vector<std::vector<int64_t>> getSizes(
     const std::vector<at::Tensor>& tensors) {
   std::vector<std::vector<int64_t>> sizes(tensors.size());
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     sizes[i] = tensors[i].sizes().vec();
   }
   return sizes;
@@ -383,7 +384,7 @@ inline std::vector<std::vector<int64_t>> getSizes(
 inline std::vector<int> getDevices(const std::vector<at::Tensor>& tensors) {
   std::vector<int> devices(tensors.size(), -1);
   if (tensors[0].device().is_cuda()) {
-    for (size_t i = 0; i < tensors.size(); i++) {
+    for (const auto i : c10::irange(tensors.size())) {
       devices[i] = tensors[i].storage().device().index();
     }
   }
@@ -404,7 +405,7 @@ inline T* getDataPointer(const at::Tensor& tensor) {
 template <typename T>
 std::vector<T*> getDataPointers(const std::vector<at::Tensor>& tensors) {
   std::vector<T*> ptrs(tensors.size());
-  for (size_t i = 0; i < tensors.size(); i++) {
+  for (const auto i : c10::irange(tensors.size())) {
     ptrs[i] = getDataPointer<T>(tensors[i]);
   }
   return ptrs;
@@ -447,7 +448,7 @@ size_t computeLengthsAndOffsets(
     equal_splits = true;
     split_size = tensor.size(0) / group_size;
   }
-  for (int i = 0; i < group_size; i++) {
+  for (const auto i : c10::irange(group_size)) {
     size_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
     TORCH_INTERNAL_ASSERT(
         length <= std::numeric_limits<int>::max() &&
@@ -467,7 +468,7 @@ size_t computeLengthsAndOffsets(
     std::vector<T>* offsets) {
   size_t group_size = lengths->size();
   size_t offset = 0;
-  for (int i = 0; i < group_size; i++) {
+  for (const auto i : c10::irange(group_size)) {
     size_t length = tensors[i].numel();
     TORCH_INTERNAL_ASSERT(
         length <= std::numeric_limits<int>::max() &&

--- a/torch/lib/c10d/comm.cpp
+++ b/torch/lib/c10d/comm.cpp
@@ -91,7 +91,7 @@ std::vector<at::Tensor> GradBucket::getPerParameterTensors() const {
   std::vector<at::Tensor> per_parameter_tensors;
   size_t num_parameters = offsets_.size();
   per_parameter_tensors.reserve(num_parameters);
-  for (size_t i = 0; i < num_parameters; ++i) {
+  for (const auto i : c10::irange(num_parameters)) {
     per_parameter_tensors.push_back(
         tensor_.slice(0, offsets_[i], offsets_[i] + lengths_[i])
             .view(sizes_vec_[i]));

--- a/torch/lib/c10d/example/allreduce.cpp
+++ b/torch/lib/c10d/example/allreduce.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <c10d/FileStore.hpp>
 #include <c10d/ProcessGroupGloo.hpp>
 
@@ -12,7 +13,7 @@ int main(int argc, char** argv) {
   // Create some tensors
   const auto ntensors = 10;
   std::vector<at::Tensor> tensors;
-  for (auto i = 0; i < ntensors; i++) {
+  for (const auto i : c10::irange(ntensors)) {
     auto x =
         at::ones({1000, 16 * (i + 1)}, at::TensorOptions(at::CPU(at::kFloat)));
     tensors.push_back(x);
@@ -20,7 +21,7 @@ int main(int argc, char** argv) {
 
   // Kick off work
   std::vector<c10::intrusive_ptr<ProcessGroup::Work>> pending;
-  for (auto i = 0; i < ntensors; i++) {
+  for (const auto i : c10::irange(ntensors)) {
     std::vector<at::Tensor> tmp = {tensors[i]};
     pending.push_back(pg.allreduce(tmp));
   }

--- a/torch/lib/c10d/reducer.cpp
+++ b/torch/lib/c10d/reducer.cpp
@@ -113,8 +113,7 @@ Reducer::Reducer(
     size_t replica_index = 0;
     const auto variable_count = replicas_[replica_index].size();
     grad_accumulators_[replica_index].resize(variable_count);
-    for (size_t variable_index = 0; variable_index < variable_count;
-         variable_index++) {
+    for (const auto variable_index : c10::irange(variable_count)) {
       auto& variable = replicas_[replica_index][variable_index];
 
       // The gradient accumulator function is lazily initialized once.
@@ -434,8 +433,7 @@ void Reducer::push_rebuilt_params_for_all_indices() {
   }
   const auto replica_count = replicas_.size();
   const auto variable_count = replicas_[0].size();
-  for (size_t variable_index = 0; variable_index < variable_count;
-       ++variable_index) {
+  for (const auto variable_index : c10::irange(variable_count)) {
     push_rebuilt_params(variable_index);
   }
 }
@@ -1273,8 +1271,7 @@ std::vector<std::string> Reducer::getUnmarkedParamsForIteration() {
 std::vector<size_t> Reducer::getUnmarkedParamIndicesForIteration() {
   std::vector<size_t> unmarked_param_indices;
   const auto variable_count = replicas_[0].size();
-  for (size_t variable_index = 0; variable_index < variable_count;
-       variable_index++) {
+  for (const auto variable_index : c10::irange(variable_count)) {
     if (perIterationReadyParams_.find(variable_index) ==
         perIterationReadyParams_.end()) {
       unmarked_param_indices.push_back(variable_index);
@@ -1287,9 +1284,7 @@ std::vector<size_t> Reducer::getUnmarkedParamIndicesForIteration() {
 void Reducer::finalize_bucket_dense(Bucket& bucket) {
   size_t replica_index = 0;
   auto& replica = bucket.replicas[replica_index];
-  for (size_t intra_bucket_index = 0;
-       intra_bucket_index < replica.variables.size();
-       intra_bucket_index++) {
+  for (const auto intra_bucket_index : c10::irange(replica.variables.size())) {
     auto& variable = replica.variables[intra_bucket_index];
     const auto offset = replica.offsets[intra_bucket_index];
     const auto length = replica.lengths[intra_bucket_index];
@@ -1323,7 +1318,7 @@ void Reducer::finalize_bucket_dense(Bucket& bucket) {
         // Wait for local_used_maps reduction to complete.
         local_used_work_->wait();
         // D2H from local_used_maps_dev_ to local_used_maps_
-        for (size_t i = 0; i < local_used_maps_.size(); i++) {
+        for (const auto i : c10::irange(local_used_maps_.size())) {
           // Blocking copy, if local_used_maps_dev_ is cuda
           local_used_maps_[i].copy_(local_used_maps_dev_[i]);
         }

--- a/torch/lib/c10d/sequence_num.hpp
+++ b/torch/lib/c10d/sequence_num.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <c10/util/Optional.h>
+#include <c10/util/irange.h>
 
 namespace c10d {
 const int kUnsetSeqNum = 0;
@@ -16,7 +17,7 @@ inline std::vector<T> toVec(uint64_t num, int numBytes) {
   std::vector<T> values;
   // Read off bytes from right to left, pushing them into
   // char array.
-  for (int i = 0; i < numBytes; ++i) {
+  for (const auto i : c10::irange(numBytes)) {
     uint8_t x = (num >> (kByteOffset * i)) & 0xff;
     values.push_back(static_cast<T>(x));
   }
@@ -28,7 +29,7 @@ template <typename T>
 inline uint64_t fromVec(const std::vector<T>& values) {
   uint64_t num = 0;
   // Set each byte at the correct location on num
-  for (int i = 0; i < values.size(); ++i) {
+  for (const auto i : c10::irange(values.size())) {
     uint8_t x = static_cast<uint8_t>(values[i]);
     num |= (static_cast<int64_t>(x) << (kByteOffset * i));
   }

--- a/torch/lib/c10d/test/FileStoreTest.cpp
+++ b/torch/lib/c10d/test/FileStoreTest.cpp
@@ -1,3 +1,5 @@
+
+#include <c10/util/irange.h>
 #include <c10d/test/StoreTestCommon.hpp>
 
 #ifndef _WIN32
@@ -79,14 +81,14 @@ void stressTestStore(std::string path, std::string prefix = "") {
   std::vector<std::thread> threads;
   c10d::test::Semaphore sem1, sem2;
 
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     threads.push_back(std::thread([&] {
       auto fileStore =
           c10::make_intrusive<c10d::FileStore>(path, numThreads + 1);
       c10d::PrefixStore store(prefix, fileStore);
       sem1.post();
       sem2.wait();
-      for (auto j = 0; j < numIterations; j++) {
+      for (const auto j : c10::irange(numIterations)) {
         store.add("counter", 1);
       }
     }));

--- a/torch/lib/c10d/test/HashStoreTest.cpp
+++ b/torch/lib/c10d/test/HashStoreTest.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <c10d/test/StoreTestCommon.hpp>
 
 #include <unistd.h>
@@ -61,11 +62,11 @@ void stressTestStore(std::string prefix = "") {
   auto hashStore = c10::make_intrusive<c10d::HashStore>();
   c10d::PrefixStore store(prefix, hashStore);
 
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     threads.push_back(std::thread([&] {
       sem1.post();
       sem2.wait();
-      for (auto j = 0; j < numIterations; j++) {
+      for (const auto j : c10::irange(numIterations)) {
         store.add("counter", 1);
       }
     }));

--- a/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooAsyncTest.cpp
@@ -15,12 +15,12 @@ using c10d::ProcessGroup;
 template <typename T, typename... Args>
 std::vector<T> initialize(const std::string& path, int N, Args&&... args) {
   std::vector<T> tests;
-  for (auto i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     tests.push_back(std::move(T(path, std::forward<Args>(args)...)));
   }
 
   std::vector<std::thread> threads;
-  for (auto i = 0; i < N; i++) {
+  for (const auto i : c10::irange(N)) {
     threads.push_back(std::thread([i, N, &tests] { tests[i].start(i, N); }));
   }
 
@@ -71,7 +71,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
         state_(::at::globalContext().lazyInitCUDA()) {
     // Allocate inputs on available devices in a round robin fashion.
     inputs_.resize(numTensors_);
-    for (auto i = 0; i < numTensors_; i++) {
+    for (const auto i : c10::irange(numTensors_)) {
       inputs_[i] = at::empty(
           {16, 16},
           at::device(
@@ -87,7 +87,7 @@ class AsyncInputIsOutputTest : public AsyncTest {
     //
     at::cuda::OptionalCUDAGuard deviceGuard;
     streams_.reserve(numDevices_);
-    for (auto i = 0; i < numDevices_; i++) {
+    for (const auto i : c10::irange(numDevices_)) {
       deviceGuard.set_index(i);
       streams_.push_back(at::cuda::getStreamFromPool());
     }
@@ -136,13 +136,13 @@ class AsyncAllreduceTest : public AsyncInputIsOutputTest {
 
     // Launch sleep on every stream
     at::cuda::OptionalCUDAGuard deviceGuard;
-    for (auto i = 0; i < numDevices_; i++) {
+    for (const auto i : c10::irange(numDevices_)) {
       deviceGuard.set_index(i);
       cudaSleep(streams_[i], 10 * 1000 * 1000);
     }
 
     // Launch value initialization for every tensor
-    for (auto i = 0; i < numTensors_; i++) {
+    for (const auto i : c10::irange(numTensors_)) {
       deviceGuard.set_index(i % numDevices_);
       inputs_[i].fill_(pg_->getRank() * numTensors_ + i);
     }
@@ -162,13 +162,13 @@ class AsyncBroadcastTest : public AsyncInputIsOutputTest {
 
     // Launch sleep on every stream
     at::cuda::OptionalCUDAGuard deviceGuard;
-    for (auto i = 0; i < numDevices_; i++) {
+    for (const auto i : c10::irange(numDevices_)) {
       deviceGuard.set_index(i);
       cudaSleep(streams_[i], 10 * 1000 * 1000);
     }
 
     // Launch value initialization for every tensor
-    for (auto i = 0; i < numTensors_; i++) {
+    for (const auto i : c10::irange(numTensors_)) {
       deviceGuard.set_index(i % numDevices_);
       inputs_[i].fill_(pg_->getRank() * numTensors_ + i);
     }
@@ -212,7 +212,7 @@ void runAsyncAllreduceTest(
 
       EXPECT_EQ(tensor.numel(), result_tensor.numel());
 
-      for (auto k = 0; k < tensor.numel(); k++) {
+      for (const auto k : c10::irange(tensor.numel())) {
         EXPECT_EQ(data[k], expected);
         EXPECT_EQ(result_data[k], expected);
       }

--- a/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupGlooTest.cpp
@@ -16,6 +16,7 @@
 #include <torch/csrc/autograd/profiler.h>
 #include <torch/cuda.h>
 
+#include <c10/util/irange.h>
 #include <c10d/FileStore.hpp>
 #include <c10d/ProcessGroupGloo.hpp>
 #include <c10d/test/TestUtils.hpp>
@@ -125,12 +126,12 @@ class CollectiveTest {
       int num,
       bool delayed = false) {
     std::vector<CollectiveTest> tests;
-    for (auto i = 0; i < num; i++) {
+    for (const auto i : c10::irange(num)) {
       tests.push_back(CollectiveTest(path));
     }
 
     std::vector<std::thread> threads;
-    for (auto i = 0; i < num; i++) {
+    for (const auto i : c10::irange(num)) {
       threads.push_back(std::thread(
           [i, &tests, delayed] { tests[i].start(i, tests.size(), delayed); }));
     }
@@ -256,7 +257,7 @@ void testAllreduce(const std::string& path, const at::DeviceType b) {
   std::vector<std::vector<at::Tensor>> inputs(size);
   std::vector<std::vector<int64_t>> allShapes;
   std::vector<int64_t> shapes = {16, 16};
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     auto tensor = at::ones(shapes, b) * i;
     std::vector<int64_t> shapesVec = shapes;
     allShapes.emplace_back(std::move(shapesVec));
@@ -268,7 +269,7 @@ void testAllreduce(const std::string& path, const at::DeviceType b) {
   const char* GLOO_ALLREDUCE_STR = "gloo:all_reduce";
   enableProfilerLegacy(ProfilerConfig(
       ProfilerState::CPU, /* report_input_shapes */ true, false));
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     work[i] = tests[i].getProcessGroup().allreduce(inputs[i]);
   }
   // Wait for work to complete
@@ -280,10 +281,10 @@ void testAllreduce(const std::string& path, const at::DeviceType b) {
 
   // Verify outputs
   const auto expected = (size * (size - 1)) / 2;
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     auto& tensor = outputs[i][0];
     auto data = tensor.data_ptr<float>();
-    for (auto j = 0; j < tensor.numel(); j++) {
+    for (const auto j : c10::irange(tensor.numel())) {
       EXPECT_EQ(data[j], expected);
     }
   }
@@ -299,7 +300,7 @@ void testAllreduceUsingWorkAPI(const std::string& path, const at::DeviceType b) 
   std::vector<std::vector<at::Tensor>> inputs(size);
   std::vector<std::vector<int64_t>> allShapes;
   std::vector<int64_t> shapes = {16, 16};
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     auto tensor = at::ones(shapes, b) * i;
     std::vector<int64_t> shapesVec = shapes;
     allShapes.emplace_back(std::move(shapesVec));
@@ -311,7 +312,7 @@ void testAllreduceUsingWorkAPI(const std::string& path, const at::DeviceType b) 
   const char* GLOO_ALLREDUCE_STR = "gloo:all_reduce";
   enableProfilerLegacy(ProfilerConfig(
       ProfilerState::CPU, /* report_input_shapes */ true, false));
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     work[i] = tests[i].getProcessGroup().allreduce(inputs[i]);
   }
   // Wait for work to complete
@@ -323,10 +324,10 @@ void testAllreduceUsingWorkAPI(const std::string& path, const at::DeviceType b) 
 
   // Verify outputs
   const auto expected = (size * (size - 1)) / 2;
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     auto& tensor = outputs[i][0];
     auto data = tensor.data_ptr<float>();
-    for (auto j = 0; j < tensor.numel(); j++) {
+    for (const auto j : c10::irange(tensor.numel())) {
       EXPECT_EQ(data[j], expected);
     }
   }
@@ -340,17 +341,17 @@ void testBroadcast(const std::string& path, const at::DeviceType b) {
   std::vector<std::vector<at::Tensor>> inputs(size);
   std::vector<int64_t> shapes = {16, 16};
   // Try every permutation of root rank and root tensor
-  for (auto i = 0; i < size; i++) {
-    for (auto j = 0; j < stride; j++) {
+  for (const auto i : c10::irange(size)) {
+    for (const auto j : c10::irange(stride)) {
       std::vector<std::vector<int64_t>> allShapes;
       // Initialize inputs
-      for (auto k = 0; k < size; k++) {
+      for (const auto k : c10::irange(size)) {
         std::vector<int64_t> shapesVec = shapes;
         allShapes.emplace_back(std::move(shapesVec));
         inputs[k].resize(stride);
         // This won't work if we ever support sparse CUDA
         at::OptionalDeviceGuard deviceGuard;
-        for (auto l = 0; l < stride; l++) {
+        for (const auto l : c10::irange(stride)) {
           if (b == at::DeviceType::CUDA) {
             deviceGuard.reset_device(at::Device(at::kCUDA, l));
           }
@@ -368,7 +369,7 @@ void testBroadcast(const std::string& path, const at::DeviceType b) {
           ProfilerState::CPU, /* report_input_shapes */ true, false));
       std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> work(size);
 
-      for (auto i = 0; i < size; i++) {
+      for (const auto i : c10::irange(size)) {
         work[i] = tests[i].getProcessGroup().broadcast(inputs[i], options);
       }
 
@@ -381,11 +382,11 @@ void testBroadcast(const std::string& path, const at::DeviceType b) {
 
       // Verify outputs
       const auto expected = (i * stride + j);
-      for (auto k = 0; k < size; k++) {
-        for (auto l = 0; l < stride; l++) {
+      for (const auto k : c10::irange(size)) {
+        for (const auto l : c10::irange(stride)) {
           auto& tensor = outputs[k][l];
           auto data = tensor.data_ptr<float>();
-          for (auto n = 0; n < tensor.numel(); n++) {
+          for (const auto n : c10::irange(tensor.numel())) {
             EXPECT_EQ(data[n], expected);
           }
         }
@@ -406,7 +407,7 @@ void testAlltoall(const std::string& path, const at::DeviceType b) {
       {20, 21, 22, 23, 24},
       {30, 31, 32, 33, 34, 35, 36},
   };
-  for (auto rank = 0; rank < size; rank++) {
+  for (const auto rank : c10::irange(size)) {
     const std::vector<int32_t>& blob = blobs[rank];
     inputs[rank] = at::from_blob((int32_t*)(blob.data()), blob.size()).to(b);
   }
@@ -414,7 +415,7 @@ void testAlltoall(const std::string& path, const at::DeviceType b) {
   // Allocate outputs
   std::vector<at::Tensor> outputs(size);
   std::vector<int> outputLengths = {9, 7, 6, 5};
-  for (auto rank = 0; rank < size; rank++) {
+  for (const auto rank : c10::irange(size)) {
     outputs[rank] =
         at::empty(outputLengths[rank], c10::TensorOptions(at::kInt).device(b));
   }
@@ -447,13 +448,13 @@ void testAlltoall(const std::string& path, const at::DeviceType b) {
   }
   enableProfilerLegacy(ProfilerConfig(
           ProfilerState::CPU, /* report_input_shapes */ true, false));
-  for (auto rank = 0; rank < size; rank++) {
+  for (const auto rank : c10::irange(size)) {
     work[rank] = tests[rank].getProcessGroup().alltoall_base(
         outputs[rank], inputs[rank], outputSplits[rank], inputSplits[rank]);
   }
 
   // Wait for work to complete
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     work[i]->wait();
   }
 
@@ -467,11 +468,11 @@ void testAlltoall(const std::string& path, const at::DeviceType b) {
       {4, 15, 16, 23, 34, 35},
       {5, 17, 18, 24, 36},
   };
-  for (auto rank = 0; rank < size; rank++) {
+  for (const auto rank : c10::irange(size)) {
     at::Tensor tensor = outputs[rank].cpu();
     EXPECT_EQ(tensor.numel(), expected[rank].size());
     auto data = tensor.data_ptr<int32_t>();
-    for (auto j = 0; j < tensor.numel(); j++) {
+    for (const auto j : c10::irange(tensor.numel())) {
       EXPECT_EQ(data[j], expected[rank][j]);
     }
   }
@@ -485,7 +486,7 @@ void testBarrier(const std::string& path) {
   enableProfilerLegacy(ProfilerConfig(
           ProfilerState::CPU, /* report_input_shapes */ true, false));
   std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> work(size);
-  for (auto i = 0; i < size; i++) {
+  for (const auto i : c10::irange(size)) {
     work[i] = tests[i].getProcessGroup().barrier();
   }
 
@@ -509,7 +510,7 @@ void testMonitoredBarrier(const std::string& path) {
   };
   std::vector<std::thread> threads;
   threads.reserve(size);
-  for (int r = 0; r < size; r++) {
+  for (const auto r : c10::irange(size)) {
     threads.emplace_back(std::thread([=]() { runMonitoredBarrier(r); }));
   }
   for (auto & t : threads) {
@@ -530,7 +531,7 @@ void testMonitoredBarrier(const std::string& path) {
       }
   };
   threads.clear();
-  for (int r = 0; r < size; r++) {
+  for (const auto r : c10::irange(size)) {
       threads.emplace_back(std::thread([=]() { runMonitoredBarrierWithException(r); }));
   }
   for (auto & t : threads) {
@@ -541,12 +542,12 @@ void testMonitoredBarrier(const std::string& path) {
 void testSequenceNumInit(const std::string& path) {
   const auto size = 4;
   auto tests = CollectiveTest::initialize(path, size);
-  for (int i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     tests[i].getProcessGroup().setSequenceNumberForGroup();
   }
 
   std::unordered_set<uint64_t> nums;
-  for (int i = 0; i < size; ++i) {
+  for (const auto i : c10::irange(size)) {
     auto seqNum = tests[i].getProcessGroup().getSequenceNumberForGroup();
     nums.insert(seqNum);
   }
@@ -826,7 +827,7 @@ TEST(ProcessGroupGlooTest, testBackendName) {
     const auto size = 2;
     auto tests = CollectiveTest::initialize(file.path, size);
 
-    for (auto i = 0; i < size; i++) {
+    for (const auto i : c10::irange(size)) {
       EXPECT_EQ(
           tests[i].getProcessGroup().getBackendName(),
           std::string(c10d::GLOO_BACKEND_NAME));

--- a/torch/lib/c10d/test/ProcessGroupMPITest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupMPITest.cpp
@@ -1,12 +1,13 @@
+#include <unistd.h>
+
+#include <c10/util/irange.h>
+#include <c10d/ProcessGroupMPI.hpp>
+
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <thread>
-
-#include <unistd.h>
-
-#include <c10d/ProcessGroupMPI.hpp>
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -58,7 +59,7 @@ void testAllreduce(int iter = 1000) {
 
   // Generate inputs
   std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensor = at::ones({16, 16}) * i;
     std::vector<at::Tensor> tensors = {tensor};
 
@@ -74,7 +75,7 @@ void testAllreduce(int iter = 1000) {
   auto worldSize = pg->getSize();
 
   // Verify outputs
-  for (int i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     const auto expected = worldSize * i;
     auto data = outputTensors[i][0].data_ptr<float>();
     for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
@@ -88,7 +89,7 @@ void testAllreduce(int iter = 1000) {
 void testBroadcast(int iter = 10000) {
   auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
   std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensors = std::vector<at::Tensor>();
     if (pg->getRank() == 0) {
       auto tensor = at::ones({16, 16}) * i;
@@ -107,7 +108,7 @@ void testBroadcast(int iter = 10000) {
   auto outputTensors = waitFuture(pg, works);
 
   // Verify outputs
-  for (int i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     const auto expected = i;
     auto data = outputTensors[i][0].data_ptr<float>();
     for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
@@ -121,7 +122,7 @@ void testBroadcast(int iter = 10000) {
 void testReduce(int iter = 10000) {
   auto pg = c10d::ProcessGroupMPI::createProcessGroupMPI();
   std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensor = at::ones({16, 16}) * i;
     auto tensors = std::vector<at::Tensor>({tensor});
 
@@ -137,7 +138,7 @@ void testReduce(int iter = 10000) {
 
   if (pg->getRank() == 0) {
     // Verify outputs
-    for (int i = 0; i < iter; ++i) {
+    for (const auto i : c10::irange(iter)) {
       const auto expected = worldSize * i;
       auto data = outputTensors[i][0].data_ptr<float>();
       for (auto j = 0; j < outputTensors[i][0].numel(); ++j) {
@@ -158,12 +159,12 @@ void testAllgather(int iter = 10000) {
   auto rank = pg->getRank();
 
   // Generate inputs
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensor = at::ones({16, 16}) * i * rank;
     auto tensors = std::vector<at::Tensor>({tensor});
     auto outputs = std::vector<std::vector<at::Tensor>>(1);
     outputs[0].resize(worldSize);
-    for (auto j = 0; j < worldSize; ++j) {
+    for (const auto j : c10::irange(worldSize)) {
       outputs[0][j] = at::zeros({16, 16});
     }
 
@@ -176,8 +177,8 @@ void testAllgather(int iter = 10000) {
   auto outputTensors = waitFuture(pg, works);
 
   // Verify outputs
-  for (int i = 0; i < iter; ++i) {
-    for (int j = 0; j < worldSize; ++j) {
+  for (const auto i : c10::irange(iter)) {
+    for (const auto j : c10::irange(worldSize)) {
       const auto expected = i * j;
       auto data = outputTensors[i][j].data_ptr<float>();
       for (auto k = 0; k < outputTensors[i][j].numel(); ++k) {
@@ -198,14 +199,14 @@ void testGather(int iter = 10000) {
   auto rank = pg->getRank();
 
   // Generate inputs
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensor = at::ones({16, 16}) * i * rank;
     auto tensors = std::vector<at::Tensor>({tensor});
     auto outputs = std::vector<std::vector<at::Tensor>>(0);
     if (rank == 0) {
       outputs = std::vector<std::vector<at::Tensor>>(1);
       outputs[0].resize(worldSize);
-      for (auto j = 0; j < worldSize; ++j) {
+      for (const auto j : c10::irange(worldSize)) {
         outputs[0][j] = at::zeros({16, 16});
       }
     }
@@ -220,8 +221,8 @@ void testGather(int iter = 10000) {
 
   // Verify outputs
   if (rank == 0) {
-    for (int i = 0; i < iter; ++i) {
-      for (int j = 0; j < worldSize; ++j) {
+    for (const auto i : c10::irange(iter)) {
+      for (const auto j : c10::irange(worldSize)) {
         const auto expected = i * j;
         auto data = outputTensors[i][j].data_ptr<float>();
         for (auto k = 0; k < outputTensors[i][j].numel(); ++k) {
@@ -232,7 +233,7 @@ void testGather(int iter = 10000) {
       }
     }
   } else {
-    for (int i = 0; i < iter; ++i) {
+    for (const auto i : c10::irange(iter)) {
       if (outputTensors[i].size() != 0) {
         throw std::runtime_error("BOOM!");
       }
@@ -249,14 +250,14 @@ void testScatter(int iter = 1) {
   auto rank = pg->getRank();
 
   // Generate inputs
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     auto tensor = at::zeros({16, 16});
     auto tensors = std::vector<at::Tensor>({tensor});
     auto inputs = std::vector<std::vector<at::Tensor>>(0);
     if (rank == 0) {
       inputs = std::vector<std::vector<at::Tensor>>(1);
       inputs[0].resize(worldSize);
-      for (auto j = 0; j < worldSize; ++j) {
+      for (const auto j : c10::irange(worldSize)) {
         inputs[0][j] = at::ones({16, 16}) * i * j;
       }
     }
@@ -270,8 +271,8 @@ void testScatter(int iter = 1) {
   auto outputTensors = waitFuture(pg, works);
 
   // Verify outputs
-  for (int i = 0; i < iter; ++i) {
-    for (int j = 0; j < worldSize; ++j) {
+  for (const auto i : c10::irange(iter)) {
+    for (const auto j : c10::irange(worldSize)) {
       const auto expected = i * j;
       auto data = outputTensors[i][0].data_ptr<float>();
       for (auto k = 0; k < outputTensors[i][0].numel(); ++k) {
@@ -291,7 +292,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
   // pg->send does not keep sent tensors alive, so we need to.
   std::vector<std::vector<at::Tensor>> sendTensors(iter);
   auto rank = pg->getRank();
-  for (auto i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     if (rank == 0) {
       auto tensor = at::ones({16, 16}) * i;
       sendTensors[i] = std::vector<at::Tensor>({tensor});
@@ -330,7 +331,7 @@ void testSendRecv(bool recvAnysource, int iter = 10000) {
   }
 
   // Verify outputs
-  for (int i = 0; i < iter; ++i) {
+  for (const auto i : c10::irange(iter)) {
     if (recvAnysource && srcRanks[i] != 0) {
       throw std::runtime_error("src rank is wrong for recvAnysource");
     }

--- a/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
+++ b/torch/lib/c10d/test/ProcessGroupNCCLErrorsTest.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 
+#include <c10/util/irange.h>
 #include <c10d/FileStore.hpp>
 #include <c10d/ProcessGroupNCCL.hpp>
 #include <c10d/test/CUDATest.hpp>
@@ -157,7 +158,7 @@ class ProcessGroupNCCLErrorsTest : public ::testing::Test {
 
     at::cuda::OptionalCUDAGuard deviceGuard;
     tensors_.resize(numDevices);
-    for (auto i = 0; i < numDevices; ++i) {
+    for (const auto i : c10::irange(numDevices)) {
       deviceGuard.set_index(i);
       tensors_[i] = at::ones({3, 3}, at::kCUDA);
     }

--- a/torch/lib/c10d/test/TCPStoreTest.cpp
+++ b/torch/lib/c10d/test/TCPStoreTest.cpp
@@ -1,3 +1,4 @@
+#include <c10/util/irange.h>
 #include <c10d/test/StoreTestCommon.hpp>
 
 #include <cstdlib>
@@ -82,7 +83,7 @@ void testHelper(const std::string& prefix = "") {
   // Each thread will have a client store to send/recv data
   std::vector<c10::intrusive_ptr<c10d::TCPStore>> clientTCPStores;
   std::vector<c10::intrusive_ptr<c10d::PrefixStore>> clientStores;
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     clientTCPStores.push_back(c10::make_intrusive<c10d::TCPStore>(
         "127.0.0.1", serverTCPStore->getPort(), numWorkers, false));
     clientStores.push_back(
@@ -92,7 +93,7 @@ void testHelper(const std::string& prefix = "") {
   std::string expectedCounterRes =
       std::to_string(numThreads * numIterations + 1);
 
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     threads.emplace_back(std::thread([&sem1,
                                       &sem2,
                                       &clientStores,
@@ -100,12 +101,12 @@ void testHelper(const std::string& prefix = "") {
                                       &expectedCounterRes,
                                       &numIterations,
                                       &numThreads] {
-      for (auto j = 0; j < numIterations; j++) {
+      for (const auto j : c10::irange(numIterations)) {
         clientStores[i]->add("counter", 1);
       }
       // Let each thread set and get key on its client store
       std::string key = "thread_" + std::to_string(i);
-      for (auto j = 0; j < numIterations; j++) {
+      for (const auto j : c10::irange(numIterations)) {
         std::string val = "thread_val_" + std::to_string(j);
         c10d::test::set(*clientStores[i], key, val);
         c10d::test::check(*clientStores[i], key, val);
@@ -116,7 +117,7 @@ void testHelper(const std::string& prefix = "") {
       // Check the counter results
       c10d::test::check(*clientStores[i], "counter", expectedCounterRes);
       // Now check other threads' written data
-      for (auto j = 0; j < numThreads; j++) {
+      for (const auto j : c10::irange(numThreads)) {
         if (j == i) {
           continue;
         }
@@ -144,7 +145,7 @@ void testHelper(const std::string& prefix = "") {
   c10d::test::check(*serverStore, "counter", expectedCounterRes);
 
   // Check that each threads' written data from the main thread
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     std::string key = "thread_" + std::to_string(i);
     std::string val = "thread_val_" + std::to_string(numIterations - 1);
     c10d::test::check(*serverStore, key, val);
@@ -179,7 +180,7 @@ void testWatchKeyCallback(const std::string& prefix = "") {
   // Each thread will have a client store to send/recv data
   std::vector<c10::intrusive_ptr<c10d::TCPStore>> clientTCPStores;
   std::vector<c10::intrusive_ptr<c10d::PrefixStore>> clientStores;
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     clientTCPStores.push_back(c10::make_intrusive<c10d::TCPStore>(
         "127.0.0.1", serverTCPStore->getPort(), numWorkers, false));
     clientStores.push_back(
@@ -189,7 +190,7 @@ void testWatchKeyCallback(const std::string& prefix = "") {
   // Start watching key on server and client stores
   std::string internalKey = "internalKey";
   std::string internalKeyCount = "internalKeyCount";
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     serverStore->watchKey(internalKey + std::to_string(i), callback);
     serverStore->watchKey(internalKeyCount + std::to_string(i), callback);
     clientStores[i]->watchKey(internalKey + std::to_string(i), callback);
@@ -198,7 +199,7 @@ void testWatchKeyCallback(const std::string& prefix = "") {
 
   std::vector<std::thread> threads;
   std::atomic<int> keyChangeOperationCount{0};
-  for (auto i = 0; i < numThreads; i++) {
+  for (const auto i : c10::irange(numThreads)) {
     threads.emplace_back(std::thread([&clientStores,
                                       &internalKey,
                                       &internalKeyCount,

--- a/torch/utils/benchmark/utils/timeit_template.cpp
+++ b/torch/utils/benchmark/utils/timeit_template.cpp
@@ -10,6 +10,7 @@ sections with user provided statements.
 #include <chrono>
 
 #include <pybind11/pybind11.h>
+#include <c10/util/irange.h>
 #include <torch/extension.h>
 
 // Global setup. (e.g. #includes)
@@ -28,7 +29,7 @@ double timeit(int n) {
 
     // Main loop
     auto start_time = std::chrono::high_resolution_clock::now();
-    for (int loop_idx = 0; loop_idx < n; loop_idx++) {
+    for (const auto loop_idx : c10::irange(n)) {
         // STMT_TEMPLATE_LOCATION
     }
     auto end_time = std::chrono::high_resolution_clock::now();

--- a/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
+++ b/torch/utils/benchmark/utils/valgrind_wrapper/timer_callgrind_template.cpp
@@ -11,6 +11,7 @@ sections with user provided statements.
 #include <string>
 
 #include <callgrind.h>
+#include <c10/util/irange.h>
 #include <torch/torch.h>
 
 // Global setup. (e.g. #includes)
@@ -42,15 +43,15 @@ int main(int argc, char* argv[]) {
     // SETUP_TEMPLATE_LOCATION
 
     // Warmup
-    for (int i = 0; i < number_warmup; i++) {
+    for (const auto i : c10::irange(number_warmup)) {
         // STMT_TEMPLATE_LOCATION
     }
 
     // Main loop
-    for (int repeat = 0; repeat < repeats; repeat++) {
+    for (const auto repeat : c10::irange(repeats)) {
         CALLGRIND_TOGGLE_COLLECT;
 
-        for (int i = 0; i < number; i++) {
+        for (const auto i : c10::irange(number)) {
         // STMT_TEMPLATE_LOCATION
         }
 


### PR DESCRIPTION
Summary: Uses D28874212 to codemod PyTorch to use the `c10::irange` example

Differential Revision: D28876623

