### PR TITLE
[NNC] Fix the uninitialized pointer in loopnest.fuse_loops

### DIFF
--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -479,8 +479,7 @@ void initTensorExprBindings(PyObject* module) {
       .def_static(
           "fuse_loops",
           [](const std::vector<For*>& loops) {
-            // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-            For* fused_loop;
+            For* fused_loop = nullptr;
             LoopNest::fuseLoops(loops, &fused_loop);
             return fused_loop;
           },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59411 [NNC] Fix the uninitialized pointer in loopnest.fuse_loops**
* #59350 [NNC] Add python bindings for Compute2
* #59348 [NNC] Fix BufHandle arguments in loopnest python API

Bug: the uninitialized For* caused a casting error in pybind11.

Differential Revision: [D28882635](https://our.internmc.facebook.com/intern/diff/D28882635)