### PR TITLE
Warn when backward() is called with create_graph=True

### DIFF
--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -189,7 +189,8 @@ bool get_warnAlways() noexcept(true) {
   return warn_always;
 }
 
-+WarnAlways::WarnAlways(bool setting = true) : prev_setting(get_warnAlways()) {
+WarnAlways::WarnAlways(bool setting /*=true*/)
+    : prev_setting(get_warnAlways()) {
   set_warnAlways(setting);
 }
 

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -189,6 +189,14 @@ bool get_warnAlways() noexcept(true) {
   return warn_always;
 }
 
++WarnAlways::WarnAlways(bool setting = true) : prev_setting(get_warnAlways()) {
+  set_warnAlways(setting);
+}
+
+WarnAlways::~WarnAlways() {
+  set_warnAlways(prev_setting);
+}
+
 } // namespace Warning
 
 void WarningHandler::process(

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -166,6 +166,17 @@ C10_API WarningHandler* get_warning_handler() noexcept(true);
 C10_API void set_warnAlways(bool) noexcept(true);
 C10_API bool get_warnAlways(void) noexcept(true);
 
+// A RAII guard that sets warn_always (not thread-local) on
+// construction, and sets it back to the original value upon destruction.
+struct C10_API WarnAlways {
+ public:
+  explicit WarnAlways(bool);
+  ~WarnAlways();
+
+ private:
+  bool prev_setting;
+};
+
 } // namespace Warning
 
 // Used in ATen for out-of-bound indices that can reasonably only be detected

--- a/c10/util/Exception.h
+++ b/c10/util/Exception.h
@@ -170,7 +170,7 @@ C10_API bool get_warnAlways(void) noexcept(true);
 // construction, and sets it back to the original value upon destruction.
 struct C10_API WarnAlways {
  public:
-  explicit WarnAlways(bool);
+  explicit WarnAlways(bool setting = true);
   ~WarnAlways();
 
  private:

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -856,8 +856,7 @@ TEST(CustomAutogradTest, BackwardWithNonLeafInputs) {
 }
 
 TEST(CustomAutogradTest, BackwardWithCreateGraphWarns) {
-  bool prev = c10::Warning::get_warnAlways();
-  c10::Warning::set_warnAlways(true);
+  c10::Warning::WarnAlways guard(true);
 
   torch::Tensor x = torch::randn({5,5}).set_requires_grad(true);
   auto z = x * x;
@@ -874,8 +873,6 @@ TEST(CustomAutogradTest, BackwardWithCreateGraphWarns) {
     ASSERT_TRUE(
         warnings.str().find("Using backward() with create_graph=True") != std::string::npos);
   }
-
-  c10::Warning::set_warnAlways(prev);
 }
 
 // TODO add these tests if needed

--- a/test/cpp/api/autograd.cpp
+++ b/test/cpp/api/autograd.cpp
@@ -855,6 +855,29 @@ TEST(CustomAutogradTest, BackwardWithNonLeafInputs) {
   ASSERT_THROWS_WITH(w.backward(torch::ones({5, 5}), false, false, {z}), "is not a leaf Tensor");
 }
 
+TEST(CustomAutogradTest, BackwardWithCreateGraphWarns) {
+  bool prev = c10::Warning::get_warnAlways();
+  c10::Warning::set_warnAlways(true);
+
+  torch::Tensor x = torch::randn({5,5}).set_requires_grad(true);
+  auto z = x * x;
+  {
+    WarningCapture warnings;
+    z.backward(torch::ones({5, 5}), c10::nullopt, true);
+    ASSERT_TRUE(
+        warnings.str().find("Using backward() with create_graph=True") != std::string::npos);
+  }
+
+  {
+    WarningCapture warnings;
+    torch::autograd::backward({z}, {torch::ones({5, 5})}, c10::nullopt, true);
+    ASSERT_TRUE(
+        warnings.str().find("Using backward() with create_graph=True") != std::string::npos);
+  }
+
+  c10::Warning::set_warnAlways(prev);
+}
+
 // TODO add these tests if needed
 // test_once_differentiable
 // test_sparse_backward

--- a/test/cpp/api/inference_mode.cpp
+++ b/test/cpp/api/inference_mode.cpp
@@ -610,14 +610,9 @@ TEST(InferenceModeTest, TestCustomFunction) {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InferenceModeTest, TestLegacyAutoNonVariableTypeModeWarning) {
-  bool prev = c10::Warning::get_warnAlways();
-  c10::Warning::set_warnAlways(true);
-
-  {
-    WarningCapture warnings;
-    at::AutoNonVariableTypeMode guard;
-    ASSERT_TRUE(
-      warnings.str().find("AutoNonVariableTypeMode is deprecated") != std::string::npos);
-  }
-  c10::Warning::set_warnAlways(prev);
+  c10::Warning::WarnAlways guard(true);
+  WarningCapture warnings;
+  at::AutoNonVariableTypeMode guard;
+  ASSERT_TRUE(
+    warnings.str().find("AutoNonVariableTypeMode is deprecated") != std::string::npos);
 }

--- a/test/cpp/api/inference_mode.cpp
+++ b/test/cpp/api/inference_mode.cpp
@@ -610,7 +610,7 @@ TEST(InferenceModeTest, TestCustomFunction) {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST(InferenceModeTest, TestLegacyAutoNonVariableTypeModeWarning) {
-  c10::Warning::WarnAlways guard(true);
+  c10::Warning::WarnAlways warn_always(true);
   WarningCapture warnings;
   at::AutoNonVariableTypeMode guard;
   ASSERT_TRUE(

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -1724,6 +1724,26 @@ class TestAutograd(TestCase):
         c.backward(torch.tensor([1, 1, 1], dtype=torch.double), retain_graph=True)
         c.backward(torch.tensor([1, 1, 1], dtype=torch.double))
 
+    def test_backward_create_graph_warns(self):
+        try:
+            prev = torch.is_warn_always_enabled()
+            torch.set_warn_always(True)
+
+            b = torch.randn(3, requires_grad=True, dtype=torch.double)
+            c = b * b
+            with warnings.catch_warnings(record=True) as ws:
+                c.backward(torch.ones_like(c), create_graph=True)
+            b.grad = None
+            self.assertTrue(any('Using backward() with create_graph=True' in str(w.message) for w in ws))
+
+            # Should not warn for grad
+            with warnings.catch_warnings(record=True) as ws:
+                torch.autograd.grad(c, b, torch.ones_like(c), create_graph=True)
+            self.assertFalse(any('Using backward() with create_graph=True' in str(w.message) for w in ws))
+
+        finally:
+            torch.set_warn_always(prev)
+
     def test_next_functions(self):
         x = torch.randn(5, 5, requires_grad=True)
         y = torch.randn(5, 5, requires_grad=True)

--- a/torch/csrc/autograd/engine.cpp
+++ b/torch/csrc/autograd/engine.cpp
@@ -907,7 +907,14 @@ auto Engine::execute(const edge_list& roots,
   validate_outputs(roots, const_cast<variable_list&>(inputs), [](const std::string& msg) {
     return msg;
   });
-
+  if (accumulate_grad && create_graph) {
+    TORCH_WARN_ONCE(
+      "Using backward() with create_graph=True will create a reference cycle "
+      "between the parameter and its gradient which can cause a memory leak. "
+      "We recommend using autograd.grad when creating the graph to avoid this. "
+      "If you have to use this function, make sure to reset the .grad fields of "
+      "your parameters to None after use to break the cycle and avoid the leak.");
+  }
   // A fresh first time Engine::execute call should start on the CPU device, initialize
   // a new thread local ready queue on CPU or reuse the existing one (if there is one
   // allocated already, i.e. consecutive backward calls, re-entrant backward calls),


### PR DESCRIPTION
Fixes #4661
- Add warnings in engine's `execute` function so it can be triggered through both cpp and python codepaths
- Adds an RAII guard version of `c10::Warning::set_warnAlways` and replaces all prior usages of the set_warnAlways with the new one
