### PR TITLE
.circleci: Disable USE_GOLD_LINKER for CUDA 10.2

### DIFF
--- a/.circleci/scripts/binary_populate_env.sh
+++ b/.circleci/scripts/binary_populate_env.sh
@@ -68,6 +68,11 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
   fi
 fi
 
+USE_GOLD_LINKER="ON"
+if [[ ${DESIRED_CUDA} = "cu102" ]]; then
+  USE_GOLD_LINKER="OFF"
+fi
+
 # Default to nightly, since that's where this normally uploads to
 PIP_UPLOAD_FOLDER='nightly/'
 # We put this here so that OVERRIDE_PACKAGE_VERSION below can read from it
@@ -169,7 +174,7 @@ export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-}"
 export CIRCLE_BRANCH="$CIRCLE_BRANCH"
 export CIRCLE_WORKFLOW_ID="$CIRCLE_WORKFLOW_ID"
 
-export USE_GOLD_LINKER=1
+export USE_GOLD_LINKER="${USE_GOLD_LINKER}"
 export USE_GLOO_WITH_OPENSSL=1
 # =================== The above code will be executed inside Docker container ===================
 EOL


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59414 DO NOT MERGE, testing disabling gold linker for cuda 10.2
* **#59413 .circleci: Disable USE_GOLD_LINKER for CUDA 10.2**

For CUDA 10.2 builds linked with the gold linker we were observing
crashes when exceptions were being raised

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28888054](https://our.internmc.facebook.com/intern/diff/D28888054)