### PR TITLE
Convert floating-point constants to T in Bessel functions

### DIFF
--- a/aten/src/ATen/native/Math.h
+++ b/aten/src/ATen/native/Math.h
@@ -1353,18 +1353,17 @@ static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 calc_i0(T _x) {
   T x = std::abs(_x);
 
-  if (x <= 8.0) {
+  if (x <= T{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i0e_A<T>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    T y = (x / 2.0) - 2.0;
+    T y = (x / T{2.0}) - T{2.0};
     return static_cast<T>(std::exp(x) * chbevl(y, A, len));
   }
   auto coeff_pair = chebyshev_coefficients_i0e_B<T>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  return static_cast<T>(
-      std::exp(x) * chbevl(static_cast<T>(32.0 / x - 2.0), B, len) / std::sqrt(x));
+  return std::exp(x) * chbevl(T{32.0} / x - T{2.0}, B, len) / std::sqrt(x);
 }
 
 // Upcast bfloat16 input to float for numerical accuracy purposes
@@ -1384,19 +1383,18 @@ static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 calc_i0e(T _x) {
   T x = std::abs(_x);
 
-  if (x <= 8.0) {
+  if (x <= T{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i0e_A<T>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    T y = (x / 2.0) - 2.0;
-    return static_cast<T>(chbevl(y, A, len));
+    T y = (x / T{2.0}) - T{2.0};
+    return chbevl(y, A, len);
   }
 
   auto coeff_pair = chebyshev_coefficients_i0e_B<T>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  return static_cast<T>(
-      chbevl(static_cast<T>(32.0 / x - 2.0), B, len) / std::sqrt(x));
+  return chbevl(T{32.0} / x - T{2.0}, B, len) / std::sqrt(x);
 }
 
 // Upcast bfloat16 input to float for numerical accuracy purposes
@@ -1416,20 +1414,19 @@ static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 calc_i1(T _x) {
   T x = std::abs(_x);
 
-  if (x <= 8.0) {
+  if (x <= T{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<T>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    T y = (x / 2.0) - 2.0;
-    const T out = static_cast<T>(std::exp(x) * x * chbevl(y, A, len));
-    return (_x < 0.0) ? -out : out;
+    T y = (x / T{2.0}) - T{2.0};
+    const T out = std::exp(x) * x * chbevl(y, A, len);
+    return (_x < T{0.0}) ? -out : out;
   }
   auto coeff_pair = chebyshev_coefficients_i1e_B<T>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  const auto out = static_cast<T>(
-      (std::exp(x) * chbevl(static_cast<T>(32.0 / x - 2.0), B, len)) / std::sqrt(x));
-  return (_x < 0.0) ? -out : out;
+  const T out = (std::exp(x) * chbevl(T{32.0} / x - T{2.0}, B, len)) / std::sqrt(x);
+  return (_x < T{0.0}) ? -out : out;
 }
 
 /*
@@ -1446,18 +1443,17 @@ static inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 calc_i1e(T _x) {
   T x = std::abs(_x);
 
-  if (x <= 8.0) {
+  if (x <= T{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<T>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    T y = (x / 2.0) - 2.0;
-    const auto out = static_cast<T>(chbevl(y, A, len) * x);
-    return (_x < 0.0) ? -out : out;
+    T y = (x / T{2.0}) - T{2.0};
+    const T out = chbevl(y, A, len) * x;
+    return (_x < T{0.0}) ? -out : out;
   }
   auto coeff_pair = chebyshev_coefficients_i1e_B<T>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  const auto out =
-      static_cast<T>(chbevl(static_cast<T>(32.0 / x - 2.0), B, len) / std::sqrt(x));
-  return (_x < 0.0) ? -out : out;
+  const auto out = chbevl(T{32.0} / x - T{2.0}, B, len) / std::sqrt(x);
+  return (_x < T{0.0}) ? -out : out;
 }

--- a/aten/src/ATen/native/cuda/Math.cuh
+++ b/aten/src/ATen/native/cuda/Math.cuh
@@ -388,18 +388,18 @@ static inline C10_HOST_DEVICE scalar_t calc_i0(scalar_t _x) {
   // Needed for accurate results if input is bfloat16 or float16
   accscalar_t x = ::abs(static_cast<accscalar_t>(_x));
 
-  if (x <= 8.0) {
+  if (x <= accscalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i0e_A<accscalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    accscalar_t y = static_cast<accscalar_t>((x / 2.0) - 2.0);
+    accscalar_t y = (x / accscalar_t{2.0}) - accscalar_t{2.0};
     return static_cast<scalar_t>(::exp(x) * chbevl(y, A, len));
   }
 
   auto coeff_pair = chebyshev_coefficients_i0e_B<accscalar_t>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  return static_cast<scalar_t>(::exp(x) * chbevl(static_cast<accscalar_t>(32.0 / x - 2.0), B, len) / ::sqrt(x));
+  return static_cast<scalar_t>(::exp(x) * chbevl(accscalar_t{32.0} / x - accscalar_t{2.0}, B, len) / ::sqrt(x));
 }
 
 template <typename scalar_t>
@@ -410,58 +410,56 @@ static inline C10_HOST_DEVICE scalar_t calc_i0e(scalar_t _x) {
   // Needed for accurate results if input is bfloat16 or float16
   accscalar_t x = ::abs(static_cast<accscalar_t>(_x));
 
-  if (x <= 8.0) {
+  if (x <= accscalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i0e_A<accscalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    accscalar_t y = static_cast<accscalar_t>((x / 2.0) - 2.0);
+    accscalar_t y = (x / accscalar_t{2.0}) - accscalar_t{2.0};
     return static_cast<scalar_t>(chbevl(y, A, len));
   }
 
   auto coeff_pair = chebyshev_coefficients_i0e_B<accscalar_t>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  return static_cast<scalar_t>(chbevl(static_cast<accscalar_t>(32.0 / x - 2.0), B, len) / ::sqrt(x));
+  return static_cast<scalar_t>(chbevl(accscalar_t{32.0} / x - accscalar_t{2.0}, B, len) / ::sqrt(x));
 }
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_i1(scalar_t _x) {
   const auto x = ::abs(_x);
-  if (x <= 8.0) {
+  if (x <= scalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<scalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    auto y = static_cast<scalar_t>((x / 2.0) - 2.0);
-    const auto out = static_cast<scalar_t>(::exp(x) * x * chbevl(y, A, len));
-    return (_x < 0.0) ? -out : out;
+    scalar_t y = x / scalar_t{2.0} - scalar_t{2.0};
+    const scalar_t out = ::exp(x) * x * chbevl(y, A, len);
+    return (_x < scalar_t{0.0}) ? -out : out;
   }
 
   auto coeff_pair = chebyshev_coefficients_i1e_B<scalar_t>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  const auto out = static_cast<scalar_t>(
-      (::exp(x) * chbevl(static_cast<scalar_t>(32.0 / x - 2.0), B, len)) / ::sqrt(x));
-  return (_x < 0.0) ? -out : out;
+  const scalar_t out = (::exp(x) * chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len)) / ::sqrt(x);
+  return (_x < scalar_t{0.0}) ? -out : out;
 }
 
 template <typename scalar_t>
 static inline C10_HOST_DEVICE scalar_t calc_i1e(scalar_t _x) {
   const auto x = ::abs(_x);
-  if (x <= 8.0) {
+  if (x <= scalar_t{8.0}) {
     auto coeff_pair = chebyshev_coefficients_i1e_A<scalar_t>();
     auto A = std::get<0>(coeff_pair);
     auto len = std::get<1>(coeff_pair);
-    const auto y = static_cast<scalar_t>((x / 2.0) - 2.0);
-    const auto out = static_cast<scalar_t>(chbevl(y, A, len) * x);
-    return (_x < 0.0) ? -out : out;
+    const scalar_t y = x / scalar_t{2.0} - scalar_t{2.0};
+    const scalar_t out = chbevl(y, A, len) * x;
+    return (_x < scalar_t{0.0}) ? -out : out;
   }
 
   auto coeff_pair = chebyshev_coefficients_i1e_B<scalar_t>();
   auto B = std::get<0>(coeff_pair);
   auto len = std::get<1>(coeff_pair);
-  const auto out = static_cast<scalar_t>(
-      chbevl(static_cast<scalar_t>(32.0 / x - 2.0), B, len) / ::sqrt(x));
-  return (_x < 0.0) ? -out : out;
+  const scalar_t out = chbevl(scalar_t{32.0} / x - scalar_t{2.0}, B, len) / ::sqrt(x);
+  return (_x < scalar_t{0.0}) ? -out : out;
 }
 
 } // namespace native


### PR DESCRIPTION
If T is float, many of the computations are more expensive than
expected. Compilers may be reluctant to optimize because they often lead
to different outcome. Converting many constants to T before using them
to clear any doubt.

Benchmark: (Debian 11, no turbo, Release build, Intel(R) Xeon(R) E-2136 CPU @ 3.30GHz, gcc 10.2.1)

```python
import timeit
for dtype in ('torch.float',):
    for func in ('i0', 'i0e', 'i1', 'i1e'):
        for n, t in [(10_000, 10000),
                    (100_000, 1000)]:
            print(f'torch.special.{func}(torch.arange(n, dtype=torch.float32)), n = {n} for {t} times, dtype={dtype}')
            print(timeit.timeit(f'torch.special.{func}(a)', setup=f'import torch; a = torch.arange({n}, dtype=torch.float32)', number=t))
```

Before:

```
torch.special.i0(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
1.539132010017056
torch.special.i0(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.9613071230123751
torch.special.i0e(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
4.32450835997588
torch.special.i0e(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
1.5751779029960744
torch.special.i1(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
1.0810036820184905
torch.special.i1(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.5314770240220241
torch.special.i1e(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
0.41711462699458934
torch.special.i1e(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.1759720179834403
```

After:

```
torch.special.i0(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
1.337154256994836
torch.special.i0(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.8640981369826477
torch.special.i0e(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
4.308618158014724
torch.special.i0e(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
1.5217605629877653
torch.special.i1(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
0.9398589830088895
torch.special.i1(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.4667845010117162
torch.special.i1e(torch.arange(n, dtype=torch.float32)), n = 10000 for 10000 times, dtype=torch.float
0.3658539849857334
torch.special.i1e(torch.arange(n, dtype=torch.float32)), n = 100000 for 1000 times, dtype=torch.float
0.15680673700990155
```
