### PR TITLE
[nnc] Enable CPU fusion inside Facebook, take 4

### DIFF
--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -18,7 +18,11 @@ namespace detail {
 
 // Note: CPU fusion is currently disabled due to test flakiness
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+#if defined(FBCODE_CAFFE2)
+bool cpu_fuser_enabled = true;
+#else
 bool cpu_fuser_enabled = false;
+#endif
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool gpu_fuser_enabled = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59430 [nnc] Infer device type from nodes if inputs are all scalars
* **#59429 [nnc] Enable CPU fusion inside Facebook, take 4**

fixed the awkward configerator initialization issue that broke some
tests.  Trying again

Differential Revision: [D28859795](https://our.internmc.facebook.com/intern/diff/D28859795/)