### PR TITLE
[ttk] Store float64 in tensorboard instead of float32

### DIFF
--- a/torch/utils/tensorboard/summary.py
+++ b/torch/utils/tensorboard/summary.py
@@ -230,7 +230,7 @@ def hparams(hparam_dict=None, metric_dict=None, hparam_domain_discrete=None):
     return exp, ssi, sei
 
 
-def scalar(name, scalar, collections=None, new_style=False):
+def scalar(name, scalar, collections=None, new_style=False, double_precision=False):
     """Outputs a `Summary` protocol buffer containing a single scalar value.
     The generated Summary has a Tensor.proto containing the input Tensor.
     Args:
@@ -248,15 +248,20 @@ def scalar(name, scalar, collections=None, new_style=False):
     """
     scalar = make_np(scalar)
     assert scalar.squeeze().ndim == 0, "scalar should be 0D"
+    # python float is double precision in numpy
     scalar = float(scalar)
     if new_style:
+        tensor = TensorProto(float_val=[scalar], dtype="DT_FLOAT")
+        if double_precision:
+            tensor = TensorProto(double_val=[scalar], dtype="DT_DOUBLE")
+
         plugin_data = SummaryMetadata.PluginData(plugin_name="scalars")
         smd = SummaryMetadata(plugin_data=plugin_data)
         return Summary(
             value=[
                 Summary.Value(
                     tag=name,
-                    tensor=TensorProto(float_val=[scalar], dtype="DT_FLOAT"),
+                    tensor=tensor,
                     metadata=smd,
                 )
             ]

--- a/torch/utils/tensorboard/writer.py
+++ b/torch/utils/tensorboard/writer.py
@@ -313,7 +313,13 @@ class SummaryWriter(object):
                 w_hp.add_scalar(k, v)
 
     def add_scalar(
-        self, tag, scalar_value, global_step=None, walltime=None, new_style=False
+        self,
+        tag,
+        scalar_value,
+        global_step=None,
+        walltime=None,
+        new_style=False,
+        double_precision=False,
     ):
         """Add scalar data to summary.
 
@@ -345,7 +351,9 @@ class SummaryWriter(object):
             from caffe2.python import workspace
             scalar_value = workspace.FetchBlob(scalar_value)
 
-        summary = scalar(tag, scalar_value, new_style=new_style)
+        summary = scalar(
+            tag, scalar_value, new_style=new_style, double_precision=double_precision
+        )
         self._get_file_writer().add_summary(summary, global_step, walltime)
 
     def add_scalars(self, main_tag, tag_scalar_dict, global_step=None, walltime=None):


### PR DESCRIPTION
Summary: Sometimes we need to compare 10+ digits. Currenlty tensorboard only saves float32. Provide an option to save float64

Reviewed By: yuguo68

Differential Revision: D28856352

