### PR TITLE
Escape star inside regex.

### DIFF
--- a/test/test_buffer_protocol.py
+++ b/test/test_buffer_protocol.py
@@ -131,7 +131,7 @@ class TestBufferProtocol(common.TestCase):
         for first in range(len(input)):
             count = len(input) - first + 1
             with self.assertRaisesRegex(ValueError,
-                                        rf"requested buffer length \({count} * {bytes} bytes\) "
+                                        rf"requested buffer length \({count} \* {bytes} bytes\) "
                                         rf"after offset \({first * bytes} bytes\) must .*"
                                         rf"buffer length \({in_bytes} bytes\)"):
                 self._run_test(dtype, input, count=count, first=first)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59444 Escape star inside regex.**
* #59077 Implement NumPy-like `from_buffer` tensor constructor.

**IGNORE THIS PR**
Unintentionally opened this PR (forgot I was working with `ghstack`)