### PR TITLE
[nnc] Enable CPU fuser inside FB, take 5

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -164,6 +164,9 @@ class TestTEFuser(JitTestCase):
             scripted = self.checkScript(func, (a,))
             self.assertLastGraphAllFused()
 
+    def test_nop(self):
+        pass
+
     def test_sum_dim(self):
         def func(x):
             return x.sum((0, )) * 2

--- a/torch/csrc/jit/codegen/fuser/interface.cpp
+++ b/torch/csrc/jit/codegen/fuser/interface.cpp
@@ -18,7 +18,11 @@ namespace detail {
 
 // Note: CPU fusion is currently disabled due to test flakiness
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+#if defined(FBCODE_CAFFE2)
+bool cpu_fuser_enabled = true;
+#else
 bool cpu_fuser_enabled = false;
+#endif
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 bool gpu_fuser_enabled = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59461 [nnc] Enable CPU fuser inside FB, take 5**
* #59430 [nnc] Infer device type from nodes if inputs are all scalars

long tail test failues

Differential Revision: [D28892885](https://our.internmc.facebook.com/intern/diff/D28892885/)