### PR TITLE
[profile] Clarify record_shapes=True docstring

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -143,6 +143,9 @@ class profile(object):
 
     .. note::
         Enabling shape and stack tracing results in additional overhead.
+        When record_shapes=True is specified, profiler will temporarily hold references to the tensors;
+        that may further prevent certain optimizations that depend on the reference count and introduce
+        extra tensor copies.
 
     Examples:
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59469 [profile] Clarify record_shapes=True docstring**

Summary:
Clarify that using record_shapes=True may cause extra tensor copies.

Differential Revision: [D28905089](https://our.internmc.facebook.com/intern/diff/D28905089)