### PR TITLE
Add kMaxSupportedBytecodeVersion for Lite Interpreter

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -76,11 +76,13 @@ constexpr uint64_t kProducedBytecodeVersion = 0x5L;
 static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
     "kProducedBytecodeVersion must be higher or equal to kProducedFileFormatVersion.");
 
-// Introduce kMinSupportedBytecodeVersion for limited backward compatibility
-// support of bytecode. If
-// kMinSupportedBytecodeVersion <= model_version <= kProducedBytecodeVersion (in loader),
+// Introduce kMinSupportedBytecodeVersion and kMaxSupportedBytecodeVersion
+// for limited backward/forward compatibility support of bytecode. If
+// kMinSupportedBytecodeVersion <= model_version <= kMaxSupportedBytecodeVersion (in loader),
 // we should support this model_version. For example, we provide a wrapper to
 // handle an updated operator.
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
+constexpr uint64_t kMaxSupportedBytecodeVersion = 0x5L;
+
 } // namespace serialize
 } // namespace caffe2

--- a/test/cpp/jit/test_lite_interpreter.cpp
+++ b/test/cpp/jit/test_lite_interpreter.cpp
@@ -610,7 +610,8 @@ TEST(LiteInterpreterTest, TwoSubmodulesModuleInfo) {
 TEST(LiteInterpreterTest, GetRuntimeByteCodeVersion) {
   auto runtime_bytecode_version = _get_runtime_bytecode_version();
   AT_ASSERT(
-      runtime_bytecode_version == caffe2::serialize::kProducedBytecodeVersion);
+      runtime_bytecode_version ==
+      caffe2::serialize::kMaxSupportedBytecodeVersion);
 }
 
 TEST(LiteInterpreterTest, GetByteCodeVersion) {

--- a/torch/csrc/jit/mobile/import.cpp
+++ b/torch/csrc/jit/mobile/import.cpp
@@ -310,12 +310,12 @@ void BytecodeDeserializer::parseMethods(
       // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
       caffe2::serialize::kMinSupportedBytecodeVersion <= model_version &&
           // NOLINTNEXTLINE(clang-diagnostic-sign-compare)
-          model_version <= caffe2::serialize::kProducedBytecodeVersion,
+          model_version <= caffe2::serialize::kMaxSupportedBytecodeVersion,
       "Lite Interpreter verson number does not match. ",
       "The model version must be between ",
       caffe2::serialize::kMinSupportedBytecodeVersion,
       " and ",
-      caffe2::serialize::kProducedBytecodeVersion,
+      caffe2::serialize::kMaxSupportedBytecodeVersion,
       "But the model version is ",
       model_version);
 

--- a/torch/csrc/jit/mobile/runtime_compatibility.cpp
+++ b/torch/csrc/jit/mobile/runtime_compatibility.cpp
@@ -7,7 +7,7 @@ namespace torch {
 namespace jit {
 
 uint64_t _get_runtime_bytecode_version() {
-  return caffe2::serialize::kProducedBytecodeVersion;
+  return caffe2::serialize::kMaxSupportedBytecodeVersion;
 }
 
 /*


### PR DESCRIPTION
Summary:
Previously, the lite interpreter would refuse to load any model
with a version greater than kProducedBytecodeVersion.  Now, we're
able to independently advance the loading and saving code, so we
can roll out changes without breaking forward compatibility.

Test Plan:
CI.
Loaded a bytecode v5 model even with setting kProducedBytecodeVersion
to v4.

Reviewed By: raziel

Differential Revision: D28904350

