### PR TITLE
.github: Switch windows instance types

### DIFF
--- a/.github/scale-config.yml
+++ b/.github/scale-config.yml
@@ -28,12 +28,12 @@ runner_types:
     max_available: 50
     disk_size: 150
   windows.4xlarge:
-    instance_type: c5.4xlarge
+    instance_type: c5d.4xlarge
     os: windows
     max_available: 200
     disk_size: 256
   windows.8xlarge.nvidia.gpu:
-    instance_type: g3.8xlarge
+    instance_type: p3.2xlarge
     os: windows
     max_available: 25
     disk_size: 256


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59473 .github: Switch windows instance types**

Switches windows instance types to prep for usage of the AWS built
Windows AMI with pre-installed Tesla Driver.

Unforutnately neither c5.4xlarge nor g3.8xlarge is not supported by this
AMI but luckily we can swap those out with pretty comparable
alternatives like c5d.4xlarge and p3.2xlarge.

For CPU workflows this shouldn't provide any real difference since the
CPU / Memory is the same with c5d.4xlarge. For GPU workflows the GPU
with the p3.2xlarge is a Tesla V100 which should suit our needs.

<details>
<summary> nvidia-smi.exe (p3.2xlarge) </summary>

```
PS C:\Users\Administrator> & 'C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe'
Fri Jun  4 18:53:10 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 462.31       Driver Version: 462.31       CUDA Version: 11.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name            TCC/WDDM | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-SXM2...  TCC  | 00000000:00:1E.0 Off |                    0 |
| N/A   42C    P0    23W / 300W |      0MiB / 16258MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+

+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+
```

</details>

It might eventually make sense to also switch linux to these instance types but do bear in mind that p3.2xlarge for linux is ~$0.75 more expensive than g3.8xlarge

* [Price comparison for g3.8xlarge vs. p3.2xlarge](https://instances.vantage.sh/?compare_on=true&selected=p3.2xlarge,g3.8xlarge)
* [Price comparison for c5.4xlarge vs. c5d.4xlarge](https://instances.vantage.sh/?compare_on=true&selected=c5.4xlarge,c5d.4xlarge)


AMI that I'm planning on using as the new base AMI with included Tesla driver: https://aws.amazon.com/marketplace/pp/prodview-jrxucanuabmfm?qid=1622830809415&sr=0-2&ref_=srh_res_product_title#pdp-pricing

Info about c5 instances can be found here: https://aws.amazon.com/ec2/instance-types/c5/

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D28913659](https://our.internmc.facebook.com/intern/diff/D28913659)