### PR TITLE
sanitize names from TS

### DIFF
--- a/test/test_jit_fuser_te.py
+++ b/test/test_jit_fuser_te.py
@@ -153,6 +153,8 @@ class TestTEFuser(JitTestCase):
         # we would compute the wrong result silently
         self.assertEqual(scripted(a, a), fused_kernel(a, a))
 
+
+    @unittest.skipIf(not RUN_CUDA, "test requires CUDA codegen")
     def test_invalid_input_names(self):
 
         code = '''
@@ -180,7 +182,7 @@ class TestTEFuser(JitTestCase):
         m(x, x, x, x)
         m(x, x, x, x)
 
-
+    @unittest.skipIf(not RUN_CUDA, "test requires CUDA codegen")
     def test_inlined_module_names(self):
         class Sub(torch.nn.Module):
             def __init__(self):

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -220,7 +220,6 @@ class TORCH_API TensorExprKernel {
   std::unordered_set<const Buf*> bufOutputs_;
   std::unordered_map<const torch::jit::Value*, const Buf*> bufs_;
   std::unordered_map<const torch::jit::Value*, VarHandle> scalars_;
-  std::unordered_map<const torch::jit::Value*, std::string> input_name_map_;
   std::unique_ptr<CodeGen> codegen_;
   at::Device device_ = at::kCPU;
   KernelArena kernelArena_;


### PR DESCRIPTION
This is to get a discussion started.
**Note,** the changes in `genInputDebugNames()` are to demonstrate that this fix covers the case with invalid input names to a fusion group as well, not just constants or intermediates. If we decide to go with this fix, I'll remove `genInputDebugNames` entirely. 

There seems to be two sources of invalid names:
1. TS where using "." is pretty common (for SSA naming and after freezing)
2. Duplicated names due to transformations in NNC. (https://github.com/pytorch/pytorch/issues/52727)
3. Technically, tensor expressions that are constructed with Python API could be another reason for invalid names, but the most of us have been conditioned to not use "." in names anyways, so this doesn't really seem to be an issue.

`1.` and `2.` seem orthogonal to me. I'd actually argue that we should be sanitizing names from TS as early as possible (maybe even before we create a kernel object) as this would result in consistent names throughout the entire NNC pipeline rather than doing it either after converting to the exprs to loop nests or in cuda codegen. 
Also, solving `1.` fixes the two test cases I added.

W.r.t. 2, I'm not sure how we should proceed here. It's not a functional bug in a sense it doesn't result in a compilation error or wrong result, rather in debuggability complications (see https://github.com/pytorch/pytorch/issues/52727) My intuition suggests that we should try keeping names consistent across the whole pipeline i.e. if we had a variable used in some loop and we peel an iteration from this loop, I'd rather the variable in the original loop to keep its name and the one in the peeled iteration to be renamed with some suffix.




