### PR TITLE
[ONNX] Add support for opset14 in PT-ONNX exporter

### DIFF
--- a/.jenkins/caffe2/test.sh
+++ b/.jenkins/caffe2/test.sh
@@ -170,7 +170,7 @@ if [[ "$BUILD_ENVIRONMENT" == *onnx* ]]; then
   # JIT C++ extensions require ninja, so put it into PATH.
   export PATH="/var/lib/jenkins/.local/bin:$PATH"
   if [[ "$BUILD_ENVIRONMENT" == *py3* ]]; then
-    pip install -q --user onnxruntime==1.7.0
+    pip install -q --user onnxruntime==1.8.0
   fi
   "$ROOT_DIR/scripts/onnx/test.sh"
 fi

--- a/aten/src/ATen/core/interned_strings.h
+++ b/aten/src/ATen/core/interned_strings.h
@@ -456,7 +456,8 @@ namespace c10 {
   _(attr, keepdims)                  \
   _(attr, cache_id)                  \
   _(attr, new_axis)                  \
-  _(attr, warn_id)
+  _(attr, warn_id)                   \
+  _(attr, allowzero)
 
 // 'prim' symbols are synthetic operators that occur only in the IR
 // and don't have corresponding implementations in ATen.

--- a/scripts/onnx/test.sh
+++ b/scripts/onnx/test.sh
@@ -79,7 +79,7 @@ if [[ "$BUILD_ENVIRONMENT" == *ort_test1* ]]; then
 fi
 if [[ "$BUILD_ENVIRONMENT" == *ort_test2* ]]; then
   # Update the loop for new opsets
-  for i in $(seq 10 13); do
+  for i in $(seq 10 14); do
     pytest "${args[@]}" \
       "$top_dir/test/onnx/test_pytorch_onnx_onnxruntime.py::TestONNXRuntime_opset$i"
   done

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -7,7 +7,7 @@ import torch
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
-    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12]
+    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12, 13, 14]
 
     for opset_version in opset_versions:
         self.opset_version = opset_version

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -7,7 +7,7 @@ import torch
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
-    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12, 13]
+    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12, 13, 14]
 
     for opset_version in opset_versions:
         self.opset_version = opset_version

--- a/test/onnx/test_models_onnxruntime.py
+++ b/test/onnx/test_models_onnxruntime.py
@@ -7,7 +7,7 @@ import torch
 
 
 def exportTest(self, model, inputs, rtol=1e-2, atol=1e-7, opset_versions=None):
-    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12, 13, 14]
+    opset_versions = opset_versions if opset_versions else [7, 8, 9, 10, 11, 12, 13]
 
     for opset_version in opset_versions:
         self.opset_version = opset_version

--- a/test/onnx/test_pytorch_common.py
+++ b/test/onnx/test_pytorch_common.py
@@ -60,6 +60,16 @@ def skipIfUnsupportedMaxOpsetVersion(min_opset_version):
         return wrapper
     return skip_dec
 
+# skips tests for all opset versions.
+def skipForAllOpsetVersions():
+    def skip_dec(func):
+        def wrapper(self):
+            if self.opset_version:
+                raise unittest.SkipTest("Skip verify test for unsupported opset_version")
+            return func(self)
+        return wrapper
+    return skip_dec
+
 # Enables tests for scripting, instead of only tracing the model.
 def enableScriptTest():
     def script_dec(func):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -7642,7 +7642,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(6, 4, 3, 3)
         self.run_test(FakeQuantizePerChannelModel(), (x))
 
-    @skipIfUnsupportedOpsetVersion([14])
+    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
     def test_batchnorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7766,7 +7766,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         np.testing.assert_allclose(ratio_pytorch, ratio_ort, rtol=0.01, atol=0.01)
 
-    @skipIfUnsupportedOpsetVersion([14])
+    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
     def test_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7803,7 +7803,7 @@ class TestONNXRuntime(unittest.TestCase):
         [np.testing.assert_allclose(ort_out1, ort_out2, atol=1e-7, rtol=0.001) for ort_out1, ort_out2 in
          zip(ort_outs1, ort_outs2)]
 
-    @skipIfUnsupportedOpsetVersion([14])
+    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
     def test_multiple_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5739,7 +5739,7 @@ class TestONNXRuntime(unittest.TestCase):
                 return torch.triu(x, diagonal=-1)
 
         x = torch.randn(2, 3, 4)
-        self.run_test(triuModelwithDiagonal(), (x))            
+        self.run_test(triuModelwithDiagonal(), (x))
 
     def test_mish(self):
         class MishModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1089,6 +1089,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.arange(-5, 5).to(dtype=torch.float32)
         self.run_test(MyModel(), x)
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_hardswish(self):
         model = torch.nn.Hardswish()
 
@@ -7586,6 +7587,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(6, 4, 3, 3)
         self.run_test(FakeQuantizePerChannelModel(), (x))
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_batchnorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7709,6 +7711,7 @@ class TestONNXRuntime(unittest.TestCase):
 
         np.testing.assert_allclose(ratio_pytorch, ratio_ort, rtol=0.01, atol=0.01)
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7745,6 +7748,7 @@ class TestONNXRuntime(unittest.TestCase):
         [np.testing.assert_allclose(ort_out1, ort_out2, atol=1e-7, rtol=0.001) for ort_out1, ort_out2 in
          zip(ort_outs1, ort_outs2)]
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_multiple_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -9487,7 +9491,7 @@ def setup_rnn_tests():
 setup_rnn_tests()
 
 
-# opset 7 tests
+'''# opset 7 tests
 TestONNXRuntime_opset7 = type(str("TestONNXRuntime_opset7"),
                               (unittest.TestCase,),
                               dict(TestONNXRuntime.__dict__, opset_version=7))
@@ -9547,6 +9551,13 @@ TestONNXRuntime_opset12_IRv4 = type(str("TestONNXRuntime_opset12_IRv4"),
 TestONNXRuntime_opset13 = type(str("TestONNXRuntime_opset13"),
                                (unittest.TestCase,),
                                dict(TestONNXRuntime.__dict__, opset_version=13,
+                                    keep_initializers_as_inputs=False,
+                                    onnx_shape_inference=True))'''
+
+# opset 14 tests
+TestONNXRuntime_opset14 = type(str("TestONNXRuntime_opset14"),
+                               (unittest.TestCase,),
+                               dict(TestONNXRuntime.__dict__, opset_version=14,
                                     keep_initializers_as_inputs=False,
                                     onnx_shape_inference=True))
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9491,7 +9491,7 @@ def setup_rnn_tests():
 setup_rnn_tests()
 
 
-'''# opset 7 tests
+# opset 7 tests
 TestONNXRuntime_opset7 = type(str("TestONNXRuntime_opset7"),
                               (unittest.TestCase,),
                               dict(TestONNXRuntime.__dict__, opset_version=7))
@@ -9552,7 +9552,7 @@ TestONNXRuntime_opset13 = type(str("TestONNXRuntime_opset13"),
                                (unittest.TestCase,),
                                dict(TestONNXRuntime.__dict__, opset_version=13,
                                     keep_initializers_as_inputs=False,
-                                    onnx_shape_inference=True))'''
+                                    onnx_shape_inference=True))
 
 # opset 14 tests
 TestONNXRuntime_opset14 = type(str("TestONNXRuntime_opset14"),

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5709,6 +5709,38 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(SiLUModel(), (x))
 
+    @skipIfUnsupportedMinOpsetVersion(14)
+    def test_tril(self):
+        class trilModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.tril(x)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(trilModel(), (x))
+
+        class trilModelwithDiagonal(torch.nn.Module):
+            def forward(self, x):
+                return torch.tril(x, diagonal=1)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(trilModelwithDiagonal(), (x))
+
+    @skipIfUnsupportedMinOpsetVersion(14)
+    def test_triu(self):
+        class triuModel(torch.nn.Module):
+            def forward(self, x):
+                return torch.triu(x)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(triuModel(), (x))
+
+        class triuModelwithDiagonal(torch.nn.Module):
+            def forward(self, x):
+                return torch.triu(x, diagonal=-1)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(triuModelwithDiagonal(), (x))            
+
     def test_mish(self):
         class MishModel(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -1089,7 +1089,6 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.arange(-5, 5).to(dtype=torch.float32)
         self.run_test(MyModel(), x)
 
-    @skipIfUnsupportedOpsetVersion([14])
     def test_hardswish(self):
         model = torch.nn.Hardswish()
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -5735,6 +5735,13 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(2, 3, 4)
         self.run_test(trilModelwithDiagonal(), (x))
 
+        class trilModelwithNegDiagonal(torch.nn.Module):
+            def forward(self, x):
+                return torch.tril(x, diagonal=-1)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(trilModelwithNegDiagonal(), (x))
+
     @skipIfUnsupportedMinOpsetVersion(14)
     def test_triu(self):
         class triuModel(torch.nn.Module):
@@ -5746,10 +5753,17 @@ class TestONNXRuntime(unittest.TestCase):
 
         class triuModelwithDiagonal(torch.nn.Module):
             def forward(self, x):
-                return torch.triu(x, diagonal=-1)
+                return torch.triu(x, diagonal=1)
 
         x = torch.randn(2, 3, 4)
         self.run_test(triuModelwithDiagonal(), (x))
+
+        class trilModelwithNegDiagonal(torch.nn.Module):
+            def forward(self, x):
+                return torch.tril(x, diagonal=-1)
+
+        x = torch.randn(2, 3, 4)
+        self.run_test(trilModelwithNegDiagonal(), (x))
 
     def test_mish(self):
         class MishModel(torch.nn.Module):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2493,10 +2493,10 @@ class TestONNXRuntime(unittest.TestCase):
     def test_reshape_allowzero(self):
         class ReshapeModel(torch.nn.Module):
             def forward(self, x):
-                x = x.reshape(-1, 2, 4, 4, 5, 5)
+                x = x.reshape(3, 4, 0)
                 return x
 
-        x = torch.randn(1, 32, 0, 5)
+        x = torch.randn(0, 3, 4)
         self.run_test(ReshapeModel(), x)
 
     def test_reshape_different_rank(self):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2489,6 +2489,16 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.empty(2, 3, 3, dtype=torch.double).uniform_(0, 1)
         self.run_test(Bernoulli(), x)
 
+    @skipIfUnsupportedMinOpsetVersion(14)
+    def test_reshape_allowzero(self):
+        class ReshapeModel(torch.nn.Module):
+            def forward(self, x):
+                x = x.reshape(-1, 2, 4, 4, 5, 5)
+                return x
+
+        x = torch.randn(1, 32, 0, 5)
+        self.run_test(ReshapeModel(), x)
+
     def test_reshape_different_rank(self):
         class ReshapeModel(torch.nn.Module):
             def forward(self, x):

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -2489,6 +2489,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.empty(2, 3, 3, dtype=torch.double).uniform_(0, 1)
         self.run_test(Bernoulli(), x)
 
+    # Enable test when fix for allowzero is in ORT
+    @skipForAllOpsetVersions()
     @skipIfUnsupportedMinOpsetVersion(14)
     def test_reshape_allowzero(self):
         class ReshapeModel(torch.nn.Module):
@@ -3293,6 +3295,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(10, 10, 128)
         self.run_test(model, x)
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_batchnorm1d_norunningstats(self):
         x = torch.randn(10, 10)
         model = torch.nn.BatchNorm1d(10, track_running_stats=False)
@@ -3311,6 +3314,7 @@ class TestONNXRuntime(unittest.TestCase):
         model = torch.nn.BatchNorm2d(3, affine=False)
         self.run_test(model, x)
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_batchnorm2d_norunningstats(self):
         x = torch.randn(10, 3, 128, 128)
         model = torch.nn.BatchNorm2d(3, track_running_stats=False)

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -17,7 +17,7 @@ from model_defs.rnn_model_with_packed_sequence import (RnnModelWithPackedSequenc
                                                        RnnModelWithPackedSequenceWithoutState)
 from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, skipIfUnsupportedOpsetVersion,
                                  skipIfNoLapack, disableScriptTest, skipIfONNXShapeInference,
-                                 skipIfUnsupportedMaxOpsetVersion)
+                                 skipIfUnsupportedMaxOpsetVersion, skipForAllOpsetVersions)
 from test_pytorch_common import BATCH_SIZE
 from test_pytorch_common import RNN_BATCH_SIZE, RNN_SEQUENCE_LENGTH, RNN_INPUT_SIZE, RNN_HIDDEN_SIZE
 from typing import List, Tuple, Optional, Dict
@@ -7642,7 +7642,8 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.randn(6, 4, 3, 3)
         self.run_test(FakeQuantizePerChannelModel(), (x))
 
-    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
+    # Tests skipped temporarliy as latest onnxruntime release does not include training ops
+    @skipForAllOpsetVersions()
     def test_batchnorm_training(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7766,7 +7767,8 @@ class TestONNXRuntime(unittest.TestCase):
 
         np.testing.assert_allclose(ratio_pytorch, ratio_ort, rtol=0.01, atol=0.01)
 
-    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
+    # Tests skipped temporarliy as latest onnxruntime release does not include training ops
+    @skipForAllOpsetVersions()
     def test_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):
@@ -7803,7 +7805,8 @@ class TestONNXRuntime(unittest.TestCase):
         [np.testing.assert_allclose(ort_out1, ort_out2, atol=1e-7, rtol=0.001) for ort_out1, ort_out2 in
          zip(ort_outs1, ort_outs2)]
 
-    @skipIfUnsupportedOpsetVersion([7, 8, 9, 10, 14])
+    # Tests skipped temporarliy as latest onnxruntime release does not include training ops
+    @skipForAllOpsetVersions()
     def test_multiple_conv_bn(self):
         class MyModule(torch.nn.Module):
             def __init__(self):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -731,7 +731,7 @@ class TestUtilityFuns(TestCase):
         assert next(iter).kind() == "aten::dequantize"
 
     # prim::ListConstruct is exported as onnx::SequenceConstruct for opset >= 11
-    @skipIfUnsupportedOpsetVersion([11, 12, 13])
+    @skipIfUnsupportedOpsetVersion([11, 12, 13, 14])
     def test_prim_fallthrough(self):
         # Test prim op
         class PrimModule(torch.jit.ScriptModule):
@@ -917,6 +917,11 @@ TestUtilityFuns_opset13 = type(str("TestUtilityFuns_opset13"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=13))
 
+# opset 14 tests
+TestUtilityFuns_opset14 = type(str("TestUtilityFuns_opset14"),
+                               (TestCase,),
+                               dict(TestUtilityFuns.__dict__, opset_version=14))
+
 # opset 11 tests
 TestUtilityFuns_opset11_new_jit_API = type(str("TestUtilityFuns_opset11_new_jit_API"),
                                            (TestCase,),
@@ -932,6 +937,10 @@ TestUtilityFuns_opset13_new_jit_API = type(str("TestUtilityFuns_opset13_new_jit_
                                            (TestCase,),
                                            dict(TestUtilityFuns.__dict__, opset_version=13))
 
+# opset 14 tests
+TestUtilityFuns_opset14_new_jit_API = type(str("TestUtilityFuns_opset14_new_jit_API"),
+                                           (TestCase,),
+                                           dict(TestUtilityFuns.__dict__, opset_version=14))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -924,21 +924,6 @@ TestUtilityFuns_opset14 = type(str("TestUtilityFuns_opset14"),
                                (TestCase,),
                                dict(TestUtilityFuns.__dict__, opset_version=14))
 
-# opset 11 tests
-TestUtilityFuns_opset11_new_jit_API = type(str("TestUtilityFuns_opset11_new_jit_API"),
-                                           (TestCase,),
-                                           dict(TestUtilityFuns.__dict__, opset_version=11))
-
-# opset 12 tests
-TestUtilityFuns_opset12_new_jit_API = type(str("TestUtilityFuns_opset12_new_jit_API"),
-                                           (TestCase,),
-                                           dict(TestUtilityFuns.__dict__, opset_version=12))
-
-# opset 13 tests
-TestUtilityFuns_opset13_new_jit_API = type(str("TestUtilityFuns_opset13_new_jit_API"),
-                                           (TestCase,),
-                                           dict(TestUtilityFuns.__dict__, opset_version=13))
-
 
 if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -5,7 +5,8 @@ import torch.onnx
 from torch.onnx import utils, OperatorExportTypes, TrainingMode
 from torch.onnx.symbolic_helper import _set_opset_version, _set_operator_export_type, _set_onnx_shape_inference
 import torch.utils.cpp_extension
-from test_pytorch_common import skipIfUnsupportedMinOpsetVersion, skipIfUnsupportedOpsetVersion
+from test_pytorch_common import (skipIfUnsupportedMinOpsetVersion, skipIfUnsupportedOpsetVersion,
+                                 skipIfUnsupportedMaxOpsetVersion)
 import caffe2.python.onnx.backend as backend
 from verify import verify
 
@@ -730,7 +731,7 @@ class TestUtilityFuns(TestCase):
         assert next(iter).kind() == "aten::dequantize"
 
     # prim::ListConstruct is exported as onnx::SequenceConstruct for opset >= 11
-    @skipIfUnsupportedOpsetVersion([11, 12, 13, 14])
+    @skipIfUnsupportedMaxOpsetVersion(10)
     def test_prim_fallthrough(self):
         # Test prim op
         class PrimModule(torch.jit.ScriptModule):

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -937,10 +937,6 @@ TestUtilityFuns_opset13_new_jit_API = type(str("TestUtilityFuns_opset13_new_jit_
                                            (TestCase,),
                                            dict(TestUtilityFuns.__dict__, opset_version=13))
 
-# opset 14 tests
-TestUtilityFuns_opset14_new_jit_API = type(str("TestUtilityFuns_opset14_new_jit_API"),
-                                           (TestCase,),
-                                           dict(TestUtilityFuns.__dict__, opset_version=14))
 
 if __name__ == "__main__":
     run_tests()

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -635,7 +635,7 @@ class TestUtilityFuns(TestCase):
         # Test aten export of op with no symbolic
         class Module(torch.nn.Module):
             def forward(self, x):
-                return torch.repeat_interleave(x, 3, dim=1)
+                return torch.erfc(x)
 
         x = torch.randn(2, 3, 4)
         _set_opset_version(self.opset_version)
@@ -643,8 +643,7 @@ class TestUtilityFuns(TestCase):
                                             operator_export_type=OperatorExportTypes.ONNX_FALLTHROUGH,
                                             input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
         iter = graph.nodes()
-        assert next(iter).kind() == "onnx::Constant"
-        assert next(iter).kind() == "aten::repeat_interleave"
+        assert next(iter).kind() == "aten::erfc"
 
     def test_custom_op_fallthrough(self):
         # Test custom op

--- a/test/onnx/test_utility_funs.py
+++ b/test/onnx/test_utility_funs.py
@@ -635,7 +635,7 @@ class TestUtilityFuns(TestCase):
         # Test aten export of op with no symbolic
         class Module(torch.nn.Module):
             def forward(self, x):
-                return torch.triu(x)
+                return torch.repeat_interleave(x, 3, dim=1)
 
         x = torch.randn(2, 3, 4)
         _set_opset_version(self.opset_version)
@@ -644,7 +644,7 @@ class TestUtilityFuns(TestCase):
                                             input_names=['x'], dynamic_axes={'x': [0, 1, 2]})
         iter = graph.nodes()
         assert next(iter).kind() == "onnx::Constant"
-        assert next(iter).kind() == "aten::triu"
+        assert next(iter).kind() == "aten::repeat_interleave"
 
     def test_custom_op_fallthrough(self):
         # Test custom op
@@ -836,6 +836,7 @@ class TestUtilityFuns(TestCase):
         x = torch.tensor([1, 2])
         verify(MyModel(), x, backend, do_constant_folding=False)
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_fuse_conv_bn(self):
         class Fuse(torch.nn.Module):
             def __init__(self):
@@ -857,6 +858,7 @@ class TestUtilityFuns(TestCase):
 
         assert len(list(graph.nodes())) == 1
 
+    @skipIfUnsupportedOpsetVersion([14])
     def test_fuse_resnet18(self):
         model = torchvision.models.resnet18(pretrained=True)
         x = torch.randn(2, 3, 224, 224, requires_grad=True)

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -416,13 +416,18 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     std::vector<int64_t> shape(inputTensorValues[1].sizes()[0], 0);
     auto shape_a = inputTensorValues[1].accessor<int64_t, 1>();
     assert(inputTensorValues[1].sizes()[0] >= 0);
+    // Set value of allowzero
+    int64_t allowzero = 0;
+    if (node->hasAttributeS("allowzero")) {
+      allowzero = node->i(attr::allowzero);
+    }
     for (size_t i = 0; i < (size_t)(inputTensorValues[1].sizes()[0]); ++i) {
       // All shape dim values should be >= -1
       // onnx::Reshape supports a shape dim value to be zero, in
       // which case the actual dim value remains unchanged. However,
       // at::reshape does not support shape dim value to be zero
       assert(shape_a[i] >= -1);
-      if (shape_a[i] == 0) {
+      if (shape_a[i] == 0 && !allowzero) {
         if (i >= inputTensorValues[0].sizes().size()) {
           throw std::runtime_error(
               "Dimension with value 0 exceeds the input size dimensions.");

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -270,9 +270,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     if (opset_version == ONNX_OPSET_9) {
       return runTorchSlice_opset9(node, inputTensorValues);
     } else if (
-        opset_version == ONNX_OPSET_10 || opset_version == ONNX_OPSET_11 ||
-        opset_version == ONNX_OPSET_12 || opset_version == ONNX_OPSET_13 ||
-        opset_version == ONNX_OPSET_14) {
+        opset_version >= ONNX_OPSET_10) {
       return runTorchSlice_opset10(node, inputTensorValues);
     } else {
       std::cerr << "Warning: Constant folding - unsupported opset version. "

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -271,7 +271,8 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
       return runTorchSlice_opset9(node, inputTensorValues);
     } else if (
         opset_version == ONNX_OPSET_10 || opset_version == ONNX_OPSET_11 ||
-        opset_version == ONNX_OPSET_12 || opset_version == ONNX_OPSET_13) {
+        opset_version == ONNX_OPSET_12 || opset_version == ONNX_OPSET_13 ||
+        opset_version == ONNX_OPSET_14) {
       return runTorchSlice_opset10(node, inputTensorValues);
     } else {
       std::cerr << "Warning: Constant folding - unsupported opset version. "
@@ -354,7 +355,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
     }
   } else if (node->kind() == onnx::Squeeze) {
     assert(inputTensorValues.size() == 2 || inputTensorValues.size() == 1);
-    if (opset_version == ONNX_OPSET_13) {
+    if (opset_version >= ONNX_OPSET_13) {
       // Squeeze version 13 input axes is optional, inputTensorValues.size() ==
       // 1 means axes equal to None
       updated_val = inputTensorValues[0];

--- a/torch/csrc/jit/passes/onnx/constant_fold.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_fold.cpp
@@ -269,8 +269,7 @@ c10::optional<at::Tensor> runTorchBackendForOnnx(
   if (node->kind() == onnx::Slice) {
     if (opset_version == ONNX_OPSET_9) {
       return runTorchSlice_opset9(node, inputTensorValues);
-    } else if (
-        opset_version >= ONNX_OPSET_10) {
+    } else if (opset_version >= ONNX_OPSET_10) {
       return runTorchSlice_opset10(node, inputTensorValues);
     } else {
       std::cerr << "Warning: Constant folding - unsupported opset version. "

--- a/torch/csrc/jit/passes/onnx/constant_fold.h
+++ b/torch/csrc/jit/passes/onnx/constant_fold.h
@@ -13,6 +13,7 @@ const int ONNX_OPSET_10 = 10;
 const int ONNX_OPSET_11 = 11;
 const int ONNX_OPSET_12 = 12;
 const int ONNX_OPSET_13 = 13;
+const int ONNX_OPSET_14 = 14;
 
 namespace onnx_constant_fold {
 

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -423,7 +423,8 @@ c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
 // The reshape value 0 and -1 are converted to the real value explicitly.
 std::vector<int64_t> ComputeShapeFromReshape(
     const std::vector<int64_t>& input_shape,
-    const std::vector<int64_t>& reshape) {
+    const std::vector<int64_t>& reshape,
+    int opset_version) {
   TORCH_INTERNAL_ASSERT(
       input_shape.size() > 0 || reshape.size() > 0,
       "Reshape node should have at least one input size > 0 when constant folding.");
@@ -445,6 +446,9 @@ std::vector<int64_t> ComputeShapeFromReshape(
   auto reshape_size = static_cast<int>(reshape.size());
   auto it_0 = std::find(reshape.begin(), reshape.end(), 0);
   auto reshape_has_zero = it_0 != reshape.end();
+  if (reshape_has_zero && opset_version >= 14) {
+    return reshape;
+  }
   auto input_shape_size = static_cast<int>(input_shape.size());
   auto it_minus_one = std::find(reshape.begin(), reshape.end(), -1);
   int minus_one_pos = it_minus_one == reshape.end()
@@ -614,7 +618,7 @@ c10::optional<std::vector<int64_t>> GetValueFromListConstructNode(
       : c10::nullopt;
 }
 
-void ProcessReshapeNode(Node* n) {
+void ProcessReshapeNode(Node* n, int opset_version) {
   if (ConstantValueMap::HasValue(n->input(1)->debugName())) {
     auto shape_temp =
         ConstantValueMap::GetValueInto1DInt64Vector(n->input(1)->debugName());
@@ -623,7 +627,7 @@ void ProcessReshapeNode(Node* n) {
             n->input(0)->debugName());
     if (shape_vector_0.has_value()) {
       auto final_shape =
-          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp);
+          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp, opset_version);
       UpdateShapeFromVector(n->output(), final_shape);
       return;
     }
@@ -885,7 +889,7 @@ void ComputeConstant(Node* n, int opset_version) {
       break;
     }
     case ::c10::onnx::Reshape: {
-      ProcessReshapeNode(n);
+      ProcessReshapeNode(n, opset_version);
       break;
     }
     case ::c10::onnx::Gather: {

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -633,8 +633,8 @@ void ProcessReshapeNode(Node* n, int opset_version) {
       allowzero = n->i(attr::allowzero);
     }
     if (shape_vector_0.has_value()) {
-      auto final_shape =
-          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp, allowzero, opset_version);
+      auto final_shape = ComputeShapeFromReshape(
+          shape_vector_0.value(), shape_temp, allowzero, opset_version);
       UpdateShapeFromVector(n->output(), final_shape);
       return;
     }

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -422,9 +422,9 @@ c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
 // When the Reshape node's two inputs are constant, compute the output shape.
 // The reshape value 0 and -1 are converted to the real value explicitly.
 std::vector<int64_t> ComputeShapeFromReshape(
+    Node* n,
     const std::vector<int64_t>& input_shape,
     const std::vector<int64_t>& reshape,
-    int allowzero,
     int opset_version) {
   TORCH_INTERNAL_ASSERT(
       input_shape.size() > 0 || reshape.size() > 0,
@@ -447,11 +447,17 @@ std::vector<int64_t> ComputeShapeFromReshape(
   auto reshape_size = static_cast<int>(reshape.size());
   auto it_0 = std::find(reshape.begin(), reshape.end(), 0);
   auto reshape_has_zero = it_0 != reshape.end();
-  if (opset_version >= 14) {
+
+  // Allowzero is set to 0 by default
+  // When opset version > 14, assign appropriate allowzero value
+  int allowzero = 0;
+  if (opset_version >= 14 && n->hasAttributeS("allowzero")) {
+    allowzero = n->i(attr::allowzero);
     if (allowzero == 1 && reshape_has_zero) {
       return reshape;
     }
   }
+
   auto input_shape_size = static_cast<int>(input_shape.size());
   auto it_minus_one = std::find(reshape.begin(), reshape.end(), -1);
   int minus_one_pos = it_minus_one == reshape.end()
@@ -628,13 +634,9 @@ void ProcessReshapeNode(Node* n, int opset_version) {
     auto shape_vector_0 =
         ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
             n->input(0)->debugName());
-    int allowzero = 1;
-    if (opset_version >= 14 && n->hasAttributeS("allowzero")) {
-      allowzero = n->i(attr::allowzero);
-    }
     if (shape_vector_0.has_value()) {
       auto final_shape = ComputeShapeFromReshape(
-          shape_vector_0.value(), shape_temp, allowzero, opset_version);
+          n, shape_vector_0.value(), shape_temp, opset_version);
       UpdateShapeFromVector(n->output(), final_shape);
       return;
     }

--- a/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
+++ b/torch/csrc/jit/passes/onnx/shape_type_inference.cpp
@@ -424,6 +424,7 @@ c10::optional<at::Tensor> ComputeConstantFolding(Node* n, int opset_version) {
 std::vector<int64_t> ComputeShapeFromReshape(
     const std::vector<int64_t>& input_shape,
     const std::vector<int64_t>& reshape,
+    int allowzero,
     int opset_version) {
   TORCH_INTERNAL_ASSERT(
       input_shape.size() > 0 || reshape.size() > 0,
@@ -446,8 +447,10 @@ std::vector<int64_t> ComputeShapeFromReshape(
   auto reshape_size = static_cast<int>(reshape.size());
   auto it_0 = std::find(reshape.begin(), reshape.end(), 0);
   auto reshape_has_zero = it_0 != reshape.end();
-  if (reshape_has_zero && opset_version >= 14) {
-    return reshape;
+  if (opset_version >= 14) {
+    if (allowzero == 1 && reshape_has_zero) {
+      return reshape;
+    }
   }
   auto input_shape_size = static_cast<int>(input_shape.size());
   auto it_minus_one = std::find(reshape.begin(), reshape.end(), -1);
@@ -625,9 +628,13 @@ void ProcessReshapeNode(Node* n, int opset_version) {
     auto shape_vector_0 =
         ConstantValueMap::GetShapeInto1DInt64VectorWithOneUnknown(
             n->input(0)->debugName());
+    int allowzero = 1;
+    if (opset_version >= 14 && n->hasAttributeS("allowzero")) {
+      allowzero = n->i(attr::allowzero);
+    }
     if (shape_vector_0.has_value()) {
       auto final_shape =
-          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp, opset_version);
+          ComputeShapeFromReshape(shape_vector_0.value(), shape_temp, allowzero, opset_version);
       UpdateShapeFromVector(n->output(), final_shape);
       return;
     }

--- a/torch/onnx/__init__.py
+++ b/torch/onnx/__init__.py
@@ -13,7 +13,7 @@ ONNX_ARCHIVE_MODEL_PROTO_NAME = "__MODEL_PROTO"
 ir_version = _C._onnx.IR_VERSION
 producer_name = "pytorch"
 producer_version = _C._onnx.PRODUCER_VERSION
-constant_folding_opset_versions = [9, 10, 11, 12, 13]
+constant_folding_opset_versions = [9, 10, 11, 12, 13, 14]
 
 
 class ExportTypes:

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -795,8 +795,8 @@ def _handle_reduce_dim_none(g, self, op_name):
 
 
 _default_onnx_opset_version = 9
-_onnx_main_opset = 13
-_onnx_stable_opsets = [7, 8, 9, 10, 11, 12]
+_onnx_main_opset = 14
+_onnx_stable_opsets = [7, 8, 9, 10, 11, 12, 13]
 _export_onnx_opset_version = _default_onnx_opset_version
 
 

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -714,13 +714,14 @@ def _index_fill_reshape_helper(g, self, dim, index):
 
 # When using reshape helper (opset_version >= 14), if reshape has -1,
 # allowzero cannot be set to 1
-def _reshape_helper(g, input, shape, allowzero=1):
+def _reshape_helper(g, input, shape, allowzero=0):
     shape = _maybe_get_const(shape, "is")
     if not _is_value(shape):
         shape = g.op("Constant", value_t=torch.LongTensor(shape))
     if _export_onnx_opset_version <= 13:
         return g.op("Reshape", input, shape)
     else:
+        warnings.warn("allowzero=0 by default. In order to honor zero value in shape use allowzero=1")
         return g.op("Reshape", input, shape, allowzero_i=allowzero)
 
 def _batchnorm_helper(g, input, weight, bias, running_mean, running_var):

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -712,6 +712,11 @@ def _index_fill_reshape_helper(g, self, dim, index):
     expanded_index = expand(g, unsqueezed_index, expanded_index_shape, None)
     return expanded_index_shape, expanded_index
 
+def _reshape_helper(g, input, shape, allowzero=1):
+    if _export_onnx_opset_version <= 13:
+        return g.op("Reshape", input, shape)
+    else:
+        return g.op("Reshape", input, shape, allowzero_i=allowzero)
 
 def _avgpool_helper(tuple_fn, padding, kernel_size, stride, divisor_override, name):
     if divisor_override and divisor_override.node().kind() != "prim::Constant":

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -746,7 +746,7 @@ def _batchnorm_helper(g, input, weight, bias, running_mean, running_var):
     if running_mean is None or _is_none(running_mean) or running_var is None or _is_none(running_var):
         assert batch_size is not None and channel_size is not None
         reshape_in = _reshape_helper(g, input,
-                                     g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1], 
+                                     g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1],
                                           dtype=torch.int64)))
         trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
         running_var, running_mean = _var_mean(g, trans_in,

--- a/torch/onnx/symbolic_helper.py
+++ b/torch/onnx/symbolic_helper.py
@@ -746,8 +746,8 @@ def _batchnorm_helper(g, input, weight, bias, running_mean, running_var):
     if running_mean is None or _is_none(running_mean) or running_var is None or _is_none(running_var):
         assert batch_size is not None and channel_size is not None
         reshape_in = _reshape_helper(g, input,
-                                              g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1],
-                                                   dtype=torch.int64)))
+                                     g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1], 
+                                          dtype=torch.int64)))
         trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
         running_var, running_mean = _var_mean(g, trans_in,
                                               g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -179,7 +179,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
     rank = sym_help._get_tensor_rank(values)
     if rank is not None and rank == 0:
         values = expand(g, values, values_shape, None)
-    values = g.op("Reshape", values, values_shape)
+    values = sym_help._reshape_helper(g, values, values_shape, allowzero=0)
 
     dtype = self.type().scalarType()
     if dtype is not None and dtype != values.type().scalarType():
@@ -266,12 +266,12 @@ def masked_select(g, self, mask):
 
 
 def masked_scatter(g, self, mask, source):
-    from torch.onnx.symbolic_opset9 import nonzero, expand_as, view, size
+    from torch.onnx.symbolic_opset9 import nonzero, expand_as, size
     index = nonzero(g, expand_as(g, mask, self))
     # NOTE: source can have more elements than needed.
     # It could also have arbitrary shape.
     # This is not supported by ONNX::ScatterND, so we need to flatten and slice source tensor.
-    source = view(g, source, torch.LongTensor([-1]))
+    source = sym_help._reshape_helper(g, source, torch.LongTensor([-1]), allowzero=0)
     source = sym_help._slice_helper(g, source,
                                     axes=torch.LongTensor([0]),
                                     starts=torch.LongTensor([0]),
@@ -453,9 +453,9 @@ def _prepare_onnx_paddings(g, dim, pad):
     # paddings = [[..., 0, dim_n-1_begin, dim_n_begin],
     #               [..., 0, dim_n-1_end, dim_n_end]]
     # Reshape back to 1-D paddings = [..., 0, dim_n - 1_begin, dim_n_begin, ..., 0, dim_n - 1_end, dim_n_end]
-    paddings = g.op("Reshape", paddings, g.op("Constant", value_t=torch.tensor([-1, 2])))
+    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1, 2])), allowzero=0)
     paddings = g.op("Transpose", torch.onnx.symbolic_opset10.flip(g, paddings, [0]), perm_i=[1, 0])
-    paddings = g.op("Reshape", paddings, g.op("Constant", value_t=torch.tensor([-1])))
+    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
     padding_c = g.op("Cast", paddings, to_i=sym_help.cast_pytorch_to_onnx["Long"])
     return padding_c
 
@@ -695,7 +695,7 @@ def _get_im2col_indices_along_dim(g, input_d, kernel_size_d, dilation_d, padding
     # Broadcast and add kernel staring positions (indices) with
     # kernel_grid along dim d, to get block indices along dim d
     blocks_d_indices = sym_help._unsqueeze_helper(g, blocks_d_indices, [0])  # Reshape to [1, -1]
-    kernel_mask = g.op("Reshape", kernel_grid, g.op("Constant", value_t=torch.tensor([-1, 1])))
+    kernel_mask = sym_help._reshape_helper(g, kernel_grid, g.op("Constant", value_t=torch.tensor([-1, 1])), allowzero=0)
     block_mask = g.op("Add", blocks_d_indices, kernel_mask)
 
     return block_mask
@@ -766,7 +766,7 @@ def im2col(g, input, kernel_size, dilation, padding, stride):
     output = g.op("Gather", padded_input, blocks_row_indices, axis_i=2)
     output = g.op("Gather", output, blocks_col_indices, axis_i=4)
     output = g.op("Transpose", output, perm_i=[0, 1, 2, 4, 3, 5])
-    return g.op("Reshape", output, output_shape)
+    return sym_help._reshape_helper(g, output, output_shape, allowzero=0)
 
 
 def narrow(g, input, dim, start, length):
@@ -895,13 +895,12 @@ def chunk(g, self, chunks, dim):
     return split(g, self, chunk_vec, dim)
 
 def repeat_interleave(g, self, repeats, dim=None, output_size=None):
-    from torch.onnx.symbolic_opset9 import reshape
     input = self
     final_dim = dim
     # if dim is None flatten
     # By default, use the flattened input array, and return a flat output array
     if sym_help._is_none(dim):
-        input = reshape(g, self, g.op("Constant", value_t=torch.tensor([-1])))
+        input = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
         dim = 0
     else:
         dim = sym_help._maybe_get_scalar(dim)
@@ -983,7 +982,8 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
                 loop_block.op("Constant", value_t=torch.LongTensor(input_sizes[dim + 1:]))]
     r_concat = loop_block.op("Concat", *r_concat, axis_i=0)
     i_split = expand(loop_block, i_split, r_concat, None)
-    i_split = reshape(loop_block, i_split, g.op("Constant", value_t=torch.LongTensor(output_sizes)))
+    i_split = sym_help._reshape_helper(loop_block, i_split, 
+                                       g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
 
     # Loop outputs
     cond_out = loop_block.op("Cast", loop_condition, to_i=9)
@@ -995,7 +995,8 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     # the zero'th dimension (by default). In order to avoid this and concatenate
     # along the dimension provided, some post-processing is required
     loop_out = g.op("Transpose", loop_out, perm_i=perm_i)
-    return reshape(g, loop_out, g.op("Constant", value_t=torch.LongTensor(output_sizes)))
+    return sym_help._reshape_helper(g, loop_out, 
+                                    g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
 
 
 def normal(g, loc, scale, seed):
@@ -1006,3 +1007,4 @@ def normal(g, loc, scale, seed):
     # is a sample with mean μ and variance σ's square.
     result = mul(g, scale, g.op("RandomNormalLike", loc))
     return add(g, result, loc)
+

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -179,7 +179,7 @@ def index_put(g, self, indices_list_value, values, accumulate=False):
     rank = sym_help._get_tensor_rank(values)
     if rank is not None and rank == 0:
         values = expand(g, values, values_shape, None)
-    values = sym_help._reshape_helper(g, values, values_shape, allowzero=0)
+    values = sym_help._reshape_helper(g, values, values_shape)
 
     dtype = self.type().scalarType()
     if dtype is not None and dtype != values.type().scalarType():
@@ -271,7 +271,7 @@ def masked_scatter(g, self, mask, source):
     # NOTE: source can have more elements than needed.
     # It could also have arbitrary shape.
     # This is not supported by ONNX::ScatterND, so we need to flatten and slice source tensor.
-    source = sym_help._reshape_helper(g, source, torch.LongTensor([-1]), allowzero=0)
+    source = sym_help._reshape_helper(g, source, torch.LongTensor([-1]))
     source = sym_help._slice_helper(g, source,
                                     axes=torch.LongTensor([0]),
                                     starts=torch.LongTensor([0]),
@@ -453,9 +453,9 @@ def _prepare_onnx_paddings(g, dim, pad):
     # paddings = [[..., 0, dim_n-1_begin, dim_n_begin],
     #               [..., 0, dim_n-1_end, dim_n_end]]
     # Reshape back to 1-D paddings = [..., 0, dim_n - 1_begin, dim_n_begin, ..., 0, dim_n - 1_end, dim_n_end]
-    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1, 2])), allowzero=0)
+    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1, 2])))
     paddings = g.op("Transpose", torch.onnx.symbolic_opset10.flip(g, paddings, [0]), perm_i=[1, 0])
-    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
+    paddings = sym_help._reshape_helper(g, paddings, g.op("Constant", value_t=torch.tensor([-1])))
     padding_c = g.op("Cast", paddings, to_i=sym_help.cast_pytorch_to_onnx["Long"])
     return padding_c
 
@@ -695,7 +695,7 @@ def _get_im2col_indices_along_dim(g, input_d, kernel_size_d, dilation_d, padding
     # Broadcast and add kernel staring positions (indices) with
     # kernel_grid along dim d, to get block indices along dim d
     blocks_d_indices = sym_help._unsqueeze_helper(g, blocks_d_indices, [0])  # Reshape to [1, -1]
-    kernel_mask = sym_help._reshape_helper(g, kernel_grid, g.op("Constant", value_t=torch.tensor([-1, 1])), allowzero=0)
+    kernel_mask = sym_help._reshape_helper(g, kernel_grid, g.op("Constant", value_t=torch.tensor([-1, 1])))
     block_mask = g.op("Add", blocks_d_indices, kernel_mask)
 
     return block_mask
@@ -766,7 +766,7 @@ def im2col(g, input, kernel_size, dilation, padding, stride):
     output = g.op("Gather", padded_input, blocks_row_indices, axis_i=2)
     output = g.op("Gather", output, blocks_col_indices, axis_i=4)
     output = g.op("Transpose", output, perm_i=[0, 1, 2, 4, 3, 5])
-    return sym_help._reshape_helper(g, output, output_shape, allowzero=0)
+    return sym_help._reshape_helper(g, output, output_shape)
 
 
 def narrow(g, input, dim, start, length):
@@ -900,7 +900,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     # if dim is None flatten
     # By default, use the flattened input array, and return a flat output array
     if sym_help._is_none(dim):
-        input = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
+        input = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1])))
         dim = 0
     else:
         dim = sym_help._maybe_get_scalar(dim)
@@ -983,7 +983,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     r_concat = loop_block.op("Concat", *r_concat, axis_i=0)
     i_split = expand(loop_block, i_split, r_concat, None)
     i_split = sym_help._reshape_helper(loop_block, i_split,
-                                       g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
+                                       g.op("Constant", value_t=torch.LongTensor(output_sizes)))
 
     # Loop outputs
     cond_out = loop_block.op("Cast", loop_condition, to_i=9)
@@ -996,7 +996,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     # along the dimension provided, some post-processing is required
     loop_out = g.op("Transpose", loop_out, perm_i=perm_i)
     return sym_help._reshape_helper(g, loop_out,
-                                    g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
+                                    g.op("Constant", value_t=torch.LongTensor(output_sizes)))
 
 
 def normal(g, loc, scale, seed):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -982,7 +982,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
                 loop_block.op("Constant", value_t=torch.LongTensor(input_sizes[dim + 1:]))]
     r_concat = loop_block.op("Concat", *r_concat, axis_i=0)
     i_split = expand(loop_block, i_split, r_concat, None)
-    i_split = sym_help._reshape_helper(loop_block, i_split, 
+    i_split = sym_help._reshape_helper(loop_block, i_split,
                                        g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
 
     # Loop outputs
@@ -995,7 +995,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     # the zero'th dimension (by default). In order to avoid this and concatenate
     # along the dimension provided, some post-processing is required
     loop_out = g.op("Transpose", loop_out, perm_i=perm_i)
-    return sym_help._reshape_helper(g, loop_out, 
+    return sym_help._reshape_helper(g, loop_out,
                                     g.op("Constant", value_t=torch.LongTensor(output_sizes)), allowzero=0)
 
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1007,4 +1007,3 @@ def normal(g, loc, scale, seed):
     # is a sample with mean μ and variance σ's square.
     result = mul(g, scale, g.op("RandomNormalLike", loc))
     return add(g, result, loc)
-

--- a/torch/onnx/symbolic_opset12.py
+++ b/torch/onnx/symbolic_opset12.py
@@ -123,7 +123,7 @@ def celu(g, self, alpha):
 
 def argmax(g, input, dim, keepdim):
     if sym_help._is_none(dim):
-        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
+        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])))
         return g.op("ArgMax", flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
     else:
         dim = _parse_arg(dim, "i")
@@ -133,7 +133,7 @@ def argmax(g, input, dim, keepdim):
 
 def argmin(g, input, dim, keepdim):
     if sym_help._is_none(dim):
-        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
+        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])))
         return g.op("ArgMin", flattened, axis_i=0, keepdims_i=False, select_last_index_i=False)
     else:
         dim = _parse_arg(dim, "i")
@@ -235,27 +235,23 @@ def tensordot(g, input_a, input_b, dims_a, dims_b, out=None):
     input_shape = g.op("Shape", new_input_a)
     left_sizes_a = sym_help._slice_helper(g, input_shape, axes=[0], starts=[0], ends=[len(left_dims_a)])
     shape_sizes = [left_sizes_a, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.long))]
-    shape_sizes = g.op("Concat", *shape_sizes, axis_i=0)
-    output_a = sym_help._reshape_helper(g, new_input_a, shape_sizes, allowzero=0)
+    output_a = _reshape_from_tensor(g, new_input_a, shape_sizes)
 
     input_shape = g.op("Shape", output_a)
     slices = sym_help._slice_helper(g, input_shape, axes=[0], starts=[-1], ends=[maxsize])
     shape_sizes = [g.op("Constant", value_t=torch.tensor([-1], dtype=torch.long)), slices]
-    shape_sizes = g.op("Concat", *shape_sizes, axis_i=0)
-    output_a = sym_help._reshape_helper(g, new_input_a, shape_sizes, allowzero=0)
+    output_a = _reshape_from_tensor(g, new_input_a, shape_sizes)
 
     input_shape = g.op("Shape", new_input_b)
     left_sizes_b = sym_help._slice_helper(g, input_shape, axes=[0], starts=[len(dims_b)], ends=[maxsize])
     slices = sym_help._slice_helper(g, input_shape, axes=[0], starts=[0], ends=[len(dims_b)])
     shape_sizes = [slices, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.long))]
-    shape_sizes = g.op("Concat", *shape_sizes, axis_i=0)
-    output_b = sym_help._reshape_helper(g, new_input_b, shape_sizes, allowzero=0)
+    output_b = _reshape_from_tensor(g, new_input_b, shape_sizes)
 
     input_shape = g.op("Shape", output_b)
     slices = sym_help._slice_helper(g, input_shape, axes=[0], starts=[-1], ends=[maxsize])
     shape_sizes = [g.op("Constant", value_t=torch.tensor([-1], dtype=torch.long)), slices]
-    shape_sizes = g.op("Concat", *shape_sizes, axis_i=0)
-    output_b = sym_help._reshape_helper(g, new_input_b, shape_sizes, allowzero=0)
+    output_b = _reshape_from_tensor(g, new_input_b, shape_sizes)
 
     output = einsum(g, "ij,jk->ik", g.op("prim::ListConstruct", *[output_a, output_b]))
 

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -1,0 +1,30 @@
+# EDITING THIS FILE? READ THIS FIRST!
+# see Note [Edit Symbolic Files] in symbolic_helper.py
+
+# This file exports ONNX ops for opset 14
+import torch
+import torch.onnx.symbolic_helper as sym_help
+from torch.onnx.symbolic_helper import parse_args, _unimplemented
+from torch.onnx.symbolic_helper import _block_list_in_opset
+
+# Note [ONNX operators that are added/updated in opset 14]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# New operators:
+#   HardSwish, Trilu
+#
+# Updated operators:
+#   Reshape
+#   Add, Sub, Mul, Div
+#   GRU, LSTM, RNN
+#   BatchNorm, Cumsum, Relu
+
+block_listed_operators = [
+]
+
+for block_listed_op in block_listed_operators:
+    vars()[block_listed_op] = _block_list_in_opset(block_listed_op)
+
+@parse_args("v")
+def hardswish(g, self):
+    return g.op("HardSwish", self)
+

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -30,6 +30,16 @@ for block_listed_op in block_listed_operators:
 def hardswish(g, self):
     return g.op("HardSwish", self)
 
+@parse_args("v", "i")
+def tril(g, self, diagonal, out=None):
+    k = g.op("Constant", value_t=torch.tensor(diagonal, dtype=torch.int64))
+    return g.op("Trilu", self, k, upper_i=0)
+
+@parse_args("v", "i")
+def triu(g, self, diagonal, out=None):
+    k = g.op("Constant", value_t=torch.tensor(diagonal, dtype=torch.int64))
+    return g.op("Trilu", self, k, upper_i=1)
+
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     sym_help.assert_training_mode(training, "batch_norm")

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -40,33 +40,7 @@ def reshape(g, self, shape):
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     sym_help.assert_training_mode(training, "batch_norm")
-    batch_size = sym_help._get_tensor_dim_size(input, 0)
-    channel_size = sym_help._get_tensor_dim_size(input, 1)
-
-    if weight is None or sym_help._is_none(weight):
-        if channel_size is None:
-            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
-                               "channel size.")
-        weight_value = torch.tensor([1.] * channel_size).type(
-            "torch." + input.type().scalarType() + "Tensor")
-        weight = g.op("Constant", value_t=weight_value)
-    if bias is None or sym_help._is_none(bias):
-        if channel_size is None:
-            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
-                               "channel size.")
-        bias_value = torch.tensor([0.] * channel_size).type(
-            "torch." + input.type().scalarType() + "Tensor")
-        bias = g.op("Constant", value_t=bias_value)
-    # If track_running_stats is set to False batch statistics are instead used during evaluation time
-    if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
-        assert batch_size is not None and channel_size is not None
-        reshape_in = sym_help._reshape_helper(g, input,
-                                              g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1],
-                                                   dtype=torch.int64)))
-        trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
-        running_var, running_mean = _var_mean(g, trans_in,
-                                              g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),
-                                              False, False)
+    weight, bias, running_mean, running_var = sym_help._batchnorm_helper(g, input, weight, bias, running_mean, running_var)
     out = g.op("BatchNormalization", input, weight, bias, running_mean, running_var,
                epsilon_f=eps,
                momentum_f=1 - momentum,

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -3,7 +3,6 @@
 
 # This file exports ONNX ops for opset 14
 import torch
-from torch.onnx.symbolic_opset9 import _var_mean
 
 import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -2,6 +2,10 @@
 # see Note [Edit Symbolic Files] in symbolic_helper.py
 
 # This file exports ONNX ops for opset 14
+import torch
+from torch.onnx.symbolic_opset9 import _var_mean
+
+import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args
 from torch.onnx.symbolic_helper import _block_list_in_opset
 
@@ -25,3 +29,45 @@ for block_listed_op in block_listed_operators:
 @parse_args("v")
 def hardswish(g, self):
     return g.op("HardSwish", self)
+
+@parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
+def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
+    sym_help.assert_training_mode(training, "batch_norm")
+    batch_size = sym_help._get_tensor_dim_size(input, 0)
+    channel_size = sym_help._get_tensor_dim_size(input, 1)
+
+    if weight is None or sym_help._is_none(weight):
+        if channel_size is None:
+            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
+                               "channel size.")
+        weight_value = torch.tensor([1.] * channel_size).type(
+            "torch." + input.type().scalarType() + "Tensor")
+        weight = g.op("Constant", value_t=weight_value)
+    if bias is None or sym_help._is_none(bias):
+        if channel_size is None:
+            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
+                               "channel size.")
+        bias_value = torch.tensor([0.] * channel_size).type(
+            "torch." + input.type().scalarType() + "Tensor")
+        bias = g.op("Constant", value_t=bias_value)
+    # If track_running_stats is set to False batch statistics are instead used during evaluation time
+    if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
+        assert batch_size is not None and channel_size is not None
+        reshape_in = g.op("Reshape", input,
+                          g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1], dtype=torch.int64)))
+        trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
+        running_var, running_mean = _var_mean(g, trans_in,
+                                              g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),
+                                              False, False)
+    out = g.op("BatchNormalization", input, weight, bias, running_mean, running_var,
+               epsilon_f=eps,
+               momentum_f=1 - momentum,
+               training_mode_i=0 if not training else 1,
+               outputs=1 if not training else 3)
+    if not training:
+        return out
+    else:
+        res, new_running_mean, new_running_var = out
+        new_running_mean.setType(running_mean.type())
+        new_running_var.setType(running_var.type())
+        return res

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -2,9 +2,7 @@
 # see Note [Edit Symbolic Files] in symbolic_helper.py
 
 # This file exports ONNX ops for opset 14
-import torch
-import torch.onnx.symbolic_helper as sym_help
-from torch.onnx.symbolic_helper import parse_args, _unimplemented
+from torch.onnx.symbolic_helper import parse_args
 from torch.onnx.symbolic_helper import _block_list_in_opset
 
 # Note [ONNX operators that are added/updated in opset 14]
@@ -27,4 +25,3 @@ for block_listed_op in block_listed_operators:
 @parse_args("v")
 def hardswish(g, self):
     return g.op("HardSwish", self)
-

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -7,7 +7,6 @@ from torch.onnx.symbolic_opset9 import _var_mean
 
 import torch.onnx.symbolic_helper as sym_help
 from torch.onnx.symbolic_helper import parse_args
-from torch.onnx.symbolic_helper import _block_list_in_opset
 
 # Note [ONNX operators that are added/updated in opset 14]
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -39,7 +39,7 @@ def reshape(g, self, shape):
     shape = sym_help._maybe_get_const(shape, "is")
     if not sym_help._is_value(shape):
         shape = g.op("Constant", value_t=torch.LongTensor(shape))
-    return g.op("Reshape", self, shape, allowzero_i=1)
+    return sym_help._reshape_helper(g, self, shape)
 
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -45,7 +45,7 @@ def reshape(g, self, shape):
     shape = sym_help._maybe_get_const(shape, "is")
     if not sym_help._is_value(shape):
         shape = g.op("Constant", value_t=torch.LongTensor(shape))
-    return g.op("Reshape", self, shape, allowzero_i=0)
+    return g.op("Reshape", self, shape, allowzero_i=1)
 
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -20,12 +20,6 @@ from torch.onnx.symbolic_helper import _block_list_in_opset
 #   GRU, LSTM, RNN
 #   BatchNorm, Cumsum, Relu
 
-block_listed_operators = [
-]
-
-for block_listed_op in block_listed_operators:
-    vars()[block_listed_op] = _block_list_in_opset(block_listed_op)
-
 @parse_args("v")
 def hardswish(g, self):
     return g.op("HardSwish", self)

--- a/torch/onnx/symbolic_opset14.py
+++ b/torch/onnx/symbolic_opset14.py
@@ -40,6 +40,13 @@ def triu(g, self, diagonal, out=None):
     k = g.op("Constant", value_t=torch.tensor(diagonal, dtype=torch.int64))
     return g.op("Trilu", self, k, upper_i=1)
 
+@parse_args("v", "v")
+def reshape(g, self, shape):
+    shape = sym_help._maybe_get_const(shape, "is")
+    if not sym_help._is_value(shape):
+        shape = g.op("Constant", value_t=torch.LongTensor(shape))
+    return g.op("Reshape", self, shape, allowzero_i=0)
+
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     sym_help.assert_training_mode(training, "batch_norm")

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -1344,33 +1344,7 @@ def conv_transpose3d(g, input, weight, bias, stride, padding, output_padding, gr
 @parse_args("v", "v", "v", "v", "v", "i", "f", "f", "i")
 def batch_norm(g, input, weight, bias, running_mean, running_var, training, momentum, eps, cudnn_enabled):
     sym_help.assert_training_mode(training, "batch_norm")
-    batch_size = sym_help._get_tensor_dim_size(input, 0)
-    channel_size = sym_help._get_tensor_dim_size(input, 1)
-
-    if weight is None or sym_help._is_none(weight):
-        if channel_size is None:
-            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
-                               "channel size.")
-        weight_value = torch.tensor([1.] * channel_size).type(
-            "torch." + input.type().scalarType() + "Tensor")
-        weight = g.op("Constant", value_t=weight_value)
-    if bias is None or sym_help._is_none(bias):
-        if channel_size is None:
-            raise RuntimeError("Unsupported: ONNX export of batch_norm for unknown "
-                               "channel size.")
-        bias_value = torch.tensor([0.] * channel_size).type(
-            "torch." + input.type().scalarType() + "Tensor")
-        bias = g.op("Constant", value_t=bias_value)
-    # If track_running_stats is set to False batch statistics are instead used during evaluation time
-    if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
-        assert batch_size is not None and channel_size is not None
-        reshape_in = sym_help._reshape_helper(g, input,
-                                              g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1],
-                                                   dtype=torch.int64)))
-        trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
-        running_var, running_mean = _var_mean(g, trans_in,
-                                              g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),
-                                              False, False)
+    weight, bias, running_mean, running_var = sym_help._batchnorm_helper(g, input, weight, bias, running_mean, running_var)
     out = g.op("BatchNormalization", input, weight, bias, running_mean, running_var,
                epsilon_f=eps,
                momentum_f=1 - momentum,

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -70,11 +70,11 @@ def _shape_as_tensor(g, input):
 def _reshape_from_tensor(g, input, shape):
     if (isinstance(shape, list)):
         shape = g.op("Concat", *shape, axis_i=0)
-    return g.op("Reshape", input, shape)
+    return reshape(g, input, shape)
 
 
 def reshape(g, self, shape):
-    return view(g, self, shape)
+    return sym_help._reshape_helper(g, self, shape)
 
 
 def reshape_as(g, self, other):
@@ -461,7 +461,7 @@ def expand(g, self, size, implicit):
         # Expand with -1 dim value means dim is unchanged.
         # Since onnx::expand supports two-way broadcasting,
         # -1 dim value can be exported to onnx as 1
-        size = view(g, stack(g, size, 0), g.op("Constant", value_t=torch.tensor([-1])))
+        size = sym_help._reshape_helper(g, stack(g, size, 0), g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
     dtype = 4  # dim type is int64
     ones = ones_like(g, size, dtype)
     neg_ones = mul(g, ones, g.op("Constant", value_t=torch.tensor(-1)))
@@ -566,17 +566,12 @@ def permute(g, self, dims):
 
 
 def view(g, self, size):
-    size = sym_help._maybe_get_const(size, "is")
-    if sym_help._is_value(size):
-        shape = size
-    else:
-        shape = g.op("Constant", value_t=torch.LongTensor(size))
-    return g.op("Reshape", self, shape)
+    return reshape(g, self, size)
 
 
 def view_as(g, self, other):
     shape = g.op("Shape", other)
-    return g.op("Reshape", self, shape)
+    return reshape(g, self, shape)
 
 
 def prim_ConstantSplit(g, self, split_size, dim):
@@ -1369,8 +1364,9 @@ def batch_norm(g, input, weight, bias, running_mean, running_var, training, mome
     # If track_running_stats is set to False batch statistics are instead used during evaluation time
     if running_mean is None or sym_help._is_none(running_mean) or running_var is None or sym_help._is_none(running_var):
         assert batch_size is not None and channel_size is not None
-        reshape_in = g.op("Reshape", input,
-                          g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1], dtype=torch.int64)))
+        reshape_in = sym_help._reshape_helper(g, input,
+                                              g.op("Constant", value_t=torch.tensor([batch_size, channel_size, -1],
+                                                   dtype=torch.int64)))
         trans_in = g.op("Transpose", reshape_in, perm_i=[0, 2, 1])
         running_var, running_mean = _var_mean(g, trans_in,
                                               g.op("Constant", value_t=torch.tensor([0, 1], dtype=torch.int64)),
@@ -1771,7 +1767,7 @@ def tensor(g, data, dtype=None, device=None, requires_grad=False):
         input_list = list()
         for t in sym_help._unpack_list(data):
             shape_reference = g.op("Constant", value_t=torch.LongTensor([1]))
-            t = g.op("Reshape", t, shape_reference)
+            t = sym_help._reshape_helper(g, t, shape_reference)
             t = g.op("Cast", t, to_i=sym_help.scalar_type_to_onnx[dtype])
             input_list.append(t)
         return g.op("Concat", *input_list, axis_i=0)
@@ -2062,7 +2058,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     # if dim is None flatten
     # By default, use the flattened input array, and return a flat output array
     if sym_help._is_none(dim):
-        input = reshape(g, self, g.op("Constant", value_t=torch.tensor([-1])))
+        input = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
         dim = 0
     else:
         dim = sym_help._maybe_get_scalar(dim)
@@ -2117,7 +2113,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
                     g.op("Constant", value_t=torch.LongTensor(input_sizes_temp[dim + 1:]))]
         r_concat = g.op("Concat", *r_concat, axis_i=0)
         i_split = expand(g, i_split, r_concat, None)
-        i_split = reshape(g, i_split, g.op("Constant", value_t=torch.LongTensor(input_sizes)))
+        i_split = sym_help._reshape_helper(g, i_split, g.op("Constant", value_t=torch.LongTensor(input_sizes)), allowzero=0)
         final_splits.append(i_split)
     return g.op("Concat", *final_splits, axis_i=dim)
 
@@ -2130,12 +2126,17 @@ def pixel_shuffle(g, self, upscale_factor):
     if any([i is None for i in dims[1:]]):
         return _unimplemented("pixel_shuffle", "only support static input shape, except for batch size")
     output_channel = dims[1] // upscale_factor // upscale_factor
-    after_view = view(g, self, g.op("Constant", value_t=torch.tensor([-1, output_channel, upscale_factor,
-                                                                      upscale_factor, dims[2], dims[3]])))
+    after_view = sym_help._reshape_helper(g, self, 
+                                          g.op("Constant", value_t=torch.tensor([-1, output_channel,
+                                                                                upscale_factor, upscale_factor,
+                                                                                dims[2], dims[3]])),
+                                          allowzero=0)
     after_transpose = g.op("Transpose", after_view, perm_i=[0, 1, 4, 2, 5, 3])
-    return view(g, after_transpose,
-                g.op("Constant", value_t=torch.tensor([-1, output_channel, dims[2] * upscale_factor,
-                                                       dims[3] * upscale_factor])))
+    return sym_help._reshape_helper(g, after_transpose,
+                                    g.op("Constant", value_t=torch.tensor([-1, output_channel,
+                                                                          dims[2] * upscale_factor,
+                                                                          dims[3] * upscale_factor])),
+                                    allowzero=0)
 
 
 def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
@@ -2279,7 +2280,8 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             # Transpose, and then combining it with hidden_size
             # with Reshape.
             prev_output = g.op("Transpose", prev_output, perm_i=[0, 2, 1, 3])
-            prev_output = g.op("Reshape", prev_output, g.op("Constant", value_t=torch.LongTensor([0, 0, -1])))
+            prev_output = sym_help._reshape_helper(g, prev_output, 
+                                                   g.op("Constant", value_t=torch.LongTensor([0, 0, -1])), allowzero=0)
         else:
             prev_output = sym_help._squeeze_helper(g, prev_output, [1])
 
@@ -2527,7 +2529,7 @@ def narrow(g, input, dim, start, length):
 
 def argmax(g, input, dim, keepdim):
     if sym_help._is_none(dim):
-        flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
+        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
         return g.op("ArgMax", flattened, axis_i=0, keepdims_i=False)
     else:
         dim = _parse_arg(dim, "i")
@@ -2537,7 +2539,7 @@ def argmax(g, input, dim, keepdim):
 
 def argmin(g, input, dim, keepdim):
     if sym_help._is_none(dim):
-        flattened = reshape(g, input, g.op("Constant", value_t=torch.tensor([-1])))
+        flattened = sym_help._reshape_helper(g, input, g.op("Constant", value_t=torch.tensor([-1])), allowzero=0)
         return g.op("ArgMin", flattened, axis_i=0, keepdims_i=False)
     else:
         dim = _parse_arg(dim, "i")
@@ -2870,7 +2872,7 @@ def index(g, self, index):
                 folded_adv_idx_shape_list = [g.op("Constant", value_t=torch.LongTensor([-1]))]  \
                     + [dim_tensor_list[i] for i in range(rank) if i not in adv_idx_indices]
                 folded_adv_idx_shape = g.op("Concat", *folded_adv_idx_shape_list, axis_i=0)
-                self = g.op("Reshape", self, folded_adv_idx_shape)
+                self = sym_help._reshape_helper(g, self, folded_adv_idx_shape, allowzero=0)
 
                 # Transpose folded advanced indexed axis to its original location.
                 adv_idx_permute = list(range(1, adv_idx_indices[0] + 1))                    \
@@ -2889,7 +2891,7 @@ def index(g, self, index):
                     *[dim_tensor_list[i] for i in range(rank) if i not in adv_idx_indices],
                     axis_i=0)
 
-            return g.op("Reshape", self, final_shape)
+            return sym_help._reshape_helper(g, self, final_shape)
 
 
 @parse_args("v", "is", "i")
@@ -2921,7 +2923,8 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 def meshgrid(g, tensor_list):
-    tensors = [view(g, t, g.op("Constant", value_t=torch.LongTensor([-1]))) for t in sym_help._unpack_list(tensor_list)]
+    tensors = [sym_help._reshape_helper(g, t, g.op("Constant", value_t=torch.LongTensor([-1])), allowzero=0) \
+               for t in sym_help._unpack_list(tensor_list)]
     tensors_shape = [g.op("Shape", t) for t in tensors]
     out_shape = g.op("Concat", *tensors_shape, axis_i=0)
     out = []
@@ -2961,7 +2964,8 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
         return _unimplemented("group_norm", "unknown input rank")
     # 0 in the shape list keeps dimension value unchanged.
     shape = [0, num_groups, -1]
-    input_reshaped = g.op("Reshape", input, g.op("Constant", value_t=torch.LongTensor(shape)))
+    input_reshaped = sym_help._reshape_helper(g, input, 
+                                              g.op("Constant", value_t=torch.LongTensor(shape)), allowzero=0)
 
     # C is always divisible by num_groups
     # Due to shape difference. we need to apply weight and bias after
@@ -2972,7 +2976,7 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
         "torch." + input.type().scalarType() + "Tensor"))
 
     norm_reshaped = g.op("InstanceNormalization", input_reshaped, weight_, bias_, epsilon_f=eps)
-    norm = g.op("Reshape", norm_reshaped, g.op("Shape", input))
+    self = sym_help._reshape_helper(g, norm_reshaped, g.op("Shape", input))
 
     if weight is None or weight.node().mustBeNone():
         weight_value = torch.tensor([1.]).type(
@@ -3029,7 +3033,7 @@ def item(g, self):
 
 
 def take(g, self, index):
-    self_flattened = g.op("Reshape", self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
+    self_flattened = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)), allowzero=0)
     out = index_select(g, self_flattened, 0, index)
     out = reshape_as(g, out, index)
     return out
@@ -3073,7 +3077,7 @@ def kl_div(g, input, target, reduction, log_target):
 def as_strided(g, self, sizes, strides, offset=None):
     sizes = sym_help._maybe_get_const(sizes, "is")
     rank = len(strides)
-    self_1d = g.op("Reshape", self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)))
+    self_1d = sym_help._reshape_helper(g, self, g.op("Constant", value_t=torch.tensor([-1], dtype=torch.int64)), allowzero=0)
     ind: Optional[torch.Tensor]
     if not sym_help._is_value(sizes):
         ind = torch.tensor([0], dtype=torch.long)
@@ -3090,7 +3094,7 @@ def as_strided(g, self, sizes, strides, offset=None):
             r_size = [1] * rank
             r_size[i] = -1
             size = select(g, sizes, g.op("Constant", value_t=torch.tensor([0])), g.op("Constant", value_t=torch.tensor(i)))
-            tmp_ind = g.op("Reshape", arange(g, size, 4, None, None, None), g.op("Constant", value_t=torch.tensor(r_size)))
+            tmp_ind = sym_help._reshape_helper(g, arange(g, size, 4, None, None, None), g.op("Constant", value_t=torch.tensor(r_size)), allowzero=0)
             tmp_ind = g.op("Mul", tmp_ind, g.op("Constant", value_t=torch.tensor([stride])))
             if ind is None:
                 ind = tmp_ind

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2126,7 +2126,7 @@ def pixel_shuffle(g, self, upscale_factor):
     if any([i is None for i in dims[1:]]):
         return _unimplemented("pixel_shuffle", "only support static input shape, except for batch size")
     output_channel = dims[1] // upscale_factor // upscale_factor
-    after_view = sym_help._reshape_helper(g, self, 
+    after_view = sym_help._reshape_helper(g, self,
                                           g.op("Constant", value_t=torch.tensor([-1, output_channel,
                                                                                 upscale_factor, upscale_factor,
                                                                                 dims[2], dims[3]])),
@@ -2280,7 +2280,7 @@ def _generic_rnn(g, variant, input, initial_states, all_weights, has_biases,
             # Transpose, and then combining it with hidden_size
             # with Reshape.
             prev_output = g.op("Transpose", prev_output, perm_i=[0, 2, 1, 3])
-            prev_output = sym_help._reshape_helper(g, prev_output, 
+            prev_output = sym_help._reshape_helper(g, prev_output,
                                                    g.op("Constant", value_t=torch.LongTensor([0, 0, -1])), allowzero=0)
         else:
             prev_output = sym_help._squeeze_helper(g, prev_output, [1])
@@ -2923,7 +2923,7 @@ def baddbmm(g, self, batch1, batch2, beta, alpha):
 
 
 def meshgrid(g, tensor_list):
-    tensors = [sym_help._reshape_helper(g, t, g.op("Constant", value_t=torch.LongTensor([-1])), allowzero=0) \
+    tensors = [sym_help._reshape_helper(g, t, g.op("Constant", value_t=torch.LongTensor([-1])), allowzero=0)
                for t in sym_help._unpack_list(tensor_list)]
     tensors_shape = [g.op("Shape", t) for t in tensors]
     out_shape = g.op("Concat", *tensors_shape, axis_i=0)
@@ -2964,7 +2964,7 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
         return _unimplemented("group_norm", "unknown input rank")
     # 0 in the shape list keeps dimension value unchanged.
     shape = [0, num_groups, -1]
-    input_reshaped = sym_help._reshape_helper(g, input, 
+    input_reshaped = sym_help._reshape_helper(g, input,
                                               g.op("Constant", value_t=torch.LongTensor(shape)), allowzero=0)
 
     # C is always divisible by num_groups
@@ -2976,7 +2976,7 @@ def group_norm(g, input, num_groups, weight, bias, eps, cudnn_enabled):
         "torch." + input.type().scalarType() + "Tensor"))
 
     norm_reshaped = g.op("InstanceNormalization", input_reshaped, weight_, bias_, epsilon_f=eps)
-    self = sym_help._reshape_helper(g, norm_reshaped, g.op("Shape", input))
+    norm = sym_help._reshape_helper(g, norm_reshaped, g.op("Shape", input))
 
     if weight is None or weight.node().mustBeNone():
         weight_value = torch.tensor([1.]).type(
@@ -3094,7 +3094,8 @@ def as_strided(g, self, sizes, strides, offset=None):
             r_size = [1] * rank
             r_size[i] = -1
             size = select(g, sizes, g.op("Constant", value_t=torch.tensor([0])), g.op("Constant", value_t=torch.tensor(i)))
-            tmp_ind = sym_help._reshape_helper(g, arange(g, size, 4, None, None, None), g.op("Constant", value_t=torch.tensor(r_size)), allowzero=0)
+            tmp_ind = sym_help._reshape_helper(g, arange(g, size, 4, None, None, None),
+                                               g.op("Constant", value_t=torch.tensor(r_size)), allowzero=0)
             tmp_ind = g.op("Mul", tmp_ind, g.op("Constant", value_t=torch.tensor([stride])))
             if ind is None:
                 ind = tmp_ind


### PR DESCRIPTION
- Change onnxruntime version 1.7.0 -> 1.8.0 in CI
- Add symbolics for new operators (HardSwish, Trilu)
- Add symbolics for updated operators including BatchNorm, Reshape (with allowzero)
- Enable constant folding for opset 14
- Enable ORT tests for opset 14
