### PR TITLE
Adding run-specified-test-cases option in run_test.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ coverage.xml
 .hypothesis
 .mypy_cache
 /.extracted_scripts/
-**/.pytorch-test-times
-**/.pytorch-slow-tests
+**/.pytorch-test-times.json
+**/.pytorch-slow-tests.json
 */*.pyc
 */*.so*
 */**/__pycache__

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -119,6 +119,6 @@ python setup.py install --cmake && sccache --show-stats && (
     7z a %TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\torch %CONDA_PARENT_DIR%\Miniconda3\Lib\site-packages\caffe2 && copy /Y "%TMP_DIR_WIN%\%IMAGE_COMMIT_TAG%.7z" "%PYTORCH_FINAL_PACKAGE_DIR%\"
 
     :: export test times so that potential sharded tests that'll branch off this build will use consistent data
-    python test/run_test.py --export-past-test-times %PYTORCH_FINAL_PACKAGE_DIR%/.pytorch-test-times
+    python test/run_test.py --export-past-test-times %PYTORCH_FINAL_PACKAGE_DIR%/.pytorch-test-times.json
   )
 )

--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -1,7 +1,7 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 echo Copying over test times file
-copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
 pushd test
 

--- a/.jenkins/pytorch/win-test-helpers/test_python_jit_legacy.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_jit_legacy.bat
@@ -1,7 +1,7 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 echo Copying over test times file
-copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
 pushd test
 

--- a/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_second_shard.bat
@@ -1,7 +1,7 @@
 call %SCRIPT_HELPERS_DIR%\setup_pytorch_env.bat
 
 echo Copying over test times file
-copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times" "%TEST_DIR_WIN%"
+copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
 cd test && python run_test.py --exclude-jit-executor --shard 2 2 --verbose --determine-from="%1" && cd ..
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -339,7 +339,7 @@ TARGET_DET_LIST = [
 ]
 
 # the JSON file to store the S3 test stats
-TEST_TIMES_FILE = '.pytorch-test-times'
+TEST_TIMES_FILE = '.pytorch-test-times.json'
 
 # if a test file takes longer than 5 min, we add it to TARGET_DET_LIST
 SLOW_TEST_THRESHOLD = 300
@@ -388,6 +388,21 @@ JIT_EXECUTOR_TESTS = [
     'test_jit_legacy',
     'test_jit_fuser_legacy',
 ]
+
+# Dictionary matching test modules (in TESTS) to lists of test cases (within that test_module) that would be run when
+# options.run_specified_test_cases is enabled.
+# For example:
+# {
+#   test_nn -> ([test_doubletensor_avg_pool3d, test_share_memory, test_hook_requires_grad]),
+#   ...
+# }
+# For test_nn.py, we would ONLY run test_doubletensor_avg_pool3d, test_share_memory, and test_hook_requires_grad.
+SPECIFIED_TEST_CASES_DICT: Dict[str, List[str]] = {}
+
+# The file from which the SPECIFIED_TEST_CASES_DICT will be filled, a CSV of test cases that would be run when
+# options.run_specified_test_cases is enabled.
+SPECIFIED_TEST_CASES_FILE: str = '.pytorch_specified_test_cases.csv'
+
 
 def print_to_stderr(message):
     print(message, file=sys.stderr)
@@ -515,6 +530,23 @@ def get_slow_tests_based_on_S3() -> List[str]:
     return slow_tests
 
 
+def get_test_case_args(test_module, using_pytest) -> List[str]:
+    if test_module not in SPECIFIED_TEST_CASES_DICT:
+        print('Warning! This should not happen as this should be checked before entering the function.')
+        return
+    args = []
+
+    if using_pytest:
+        args.append('-k')
+        args.append(' or '.join(SPECIFIED_TEST_CASES_DICT[test_module]))
+    else:
+        for test in SPECIFIED_TEST_CASES_DICT[test_module]:
+            args.append('-k')
+            args.append(test)
+
+    return args
+
+
 def get_executable_command(options, allow_pytest, disable_coverage=False):
     if options.coverage and not disable_coverage:
         executable = ['coverage', 'run', '--parallel-mode', '--source=torch']
@@ -542,10 +574,6 @@ def run_test(test_module, test_directory, options, launcher_cmd=None, extra_unit
     if options.pytest:
         unittest_args = [arg if arg != '-f' else '-x' for arg in unittest_args]
 
-    # Can't call `python -m unittest test_*` here because it doesn't run code
-    # in `if __name__ == '__main__': `. So call `python test_*.py` instead.
-    argv = [test_module + '.py'] + unittest_args
-
     # Multiprocessing related tests cannot run with coverage.
     # Tracking issue: https://github.com/pytorch/pytorch/issues/50661
     disable_coverage = sys.platform == 'win32' and test_module in WINDOWS_COVERAGE_BLOCKLIST
@@ -553,6 +581,15 @@ def run_test(test_module, test_directory, options, launcher_cmd=None, extra_unit
     # Extra arguments are not supported with pytest
     executable = get_executable_command(options, allow_pytest=not extra_unittest_args,
                                         disable_coverage=disable_coverage)
+
+    # The following logic for running specified tests will only run for non-distributed tests, as those are dispatched
+    # to test_distributed and not run_test (this function)
+    if options.run_specified_test_cases:
+        unittest_args.extend(get_test_case_args(test_module, 'pytest' in executable))
+
+    # Can't call `python -m unittest test_*` here because it doesn't run code
+    # in `if __name__ == '__main__': `. So call `python test_*.py` instead.
+    argv = [test_module + '.py'] + unittest_args
 
     command = (launcher_cmd or []) + executable + argv
     print_to_stderr('Executing {} ... [{}]'.format(command, datetime.now()))
@@ -729,8 +766,7 @@ def parse_args():
         default=TESTS,
         metavar='TESTS',
         help='select a set of tests to include (defaults to ALL tests).'
-             ' tests can be specified with module name, module.TestClass'
-             ' or module.TestClass.test_method')
+             ' tests must be a part of the TESTS list defined in run_test.py')
     parser.add_argument(
         '-x',
         '--exclude',
@@ -795,6 +831,14 @@ def parse_args():
         '--exclude-jit-executor',
         action='store_true',
         help='exclude tests that are run for a specific jit config'
+    )
+    parser.add_argument(
+        '--run-specified-test-cases',
+        nargs='?',
+        type=str,
+        const=SPECIFIED_TEST_CASES_FILE,
+        help='runs specified test cases from previous OSS CI stats from a file, format CSV',
+
     )
     return parser.parse_args()
 
@@ -1027,6 +1071,10 @@ def determine_target(target_det_list, test, touched_files, options):
 def run_test_module(test: str, test_directory: str, options) -> Optional[str]:
     test_module = parse_test_module(test)
 
+    if options.run_specified_test_cases and test_module not in SPECIFIED_TEST_CASES_DICT:
+        # Skip any test files not specified in SPECIFIED_TEST_CASES_DICT
+        return None
+
     # Printing the date here can help diagnose which tests are slow
     print_to_stderr('Running {} ... [{}]'.format(test, datetime.now()))
     handler = CUSTOM_HANDLERS.get(test_module, run_test)
@@ -1051,6 +1099,33 @@ def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float])
         job_times_json = get_job_times_json(test_times)
         json.dump(job_times_json, file, indent='    ', separators=(',', ': '))
         file.write('\n')
+
+
+def load_specified_test_cases(filename: str) -> None:
+    if not os.path.exists(filename):
+        print(f'Could not find specified tests file: {filename}. Proceeding with default behavior.')
+        return
+
+    import csv
+    with open(filename, mode='r', encoding="utf-8-sig") as csv_file:
+        csv_reader = csv.DictReader(csv_file)
+        line_count = 0
+        global SPECIFIED_TEST_CASES_DICT
+        for row in csv_reader:
+            line_count += 1
+            if line_count == 1:
+                if 'test_filename' not in row or 'test_case_name' not in row:
+                    print('Data is missing necessary columns for test specification. Proceeding with default behavior.')
+                    return
+            test_filename = row['test_filename']
+            test_case_name = row['test_case_name']
+            if test_filename not in TESTS:
+                print(f'Specified test_filename {test_filename} not found in TESTS. Skipping.')
+                continue
+            if test_filename not in SPECIFIED_TEST_CASES_DICT:
+                SPECIFIED_TEST_CASES_DICT[test_filename] = []
+            SPECIFIED_TEST_CASES_DICT[test_filename].append(test_case_name)
+        print(f'Processed {line_count} test cases.')
 
 
 def query_changed_test_files() -> List[str]:
@@ -1103,6 +1178,11 @@ def main():
         print(f'Exporting past test times from S3 to {test_times_filename}, no tests will be run.')
         export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
+
+    specified_test_cases_filename = options.run_specified_test_cases
+    if specified_test_cases_filename:
+        print(f'Loading specified test cases to run from {specified_test_cases_filename}.')
+        load_specified_test_cases(specified_test_cases_filename)
 
     test_directory = os.path.dirname(os.path.abspath(__file__))
     selected_tests = get_selected_tests(options)

--- a/tools/export_slow_tests.py
+++ b/tools/export_slow_tests.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from tools.stats_utils.s3_stat_parser import get_previous_reports_for_branch, Report, Version2Report
 from typing import cast, DefaultDict, Dict, List
 
-SLOW_TESTS_FILE = '.pytorch-slow-tests'
+SLOW_TESTS_FILE = '.pytorch-slow-tests.json'
 SLOW_TEST_CASE_THRESHOLD_SEC = 60.0
 
 
@@ -56,7 +56,7 @@ def parse_args():
         type=str,
         default=SLOW_TESTS_FILE,
         const=SLOW_TESTS_FILE,
-        help='Specify a file path to dump slow test times from previous S3 stats. Default file path: .pytorch-slow-tests',
+        help='Specify a file path to dump slow test times from previous S3 stats. Default file path: .pytorch-slow-tests.json',
     )
     return parser.parse_args()
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -858,7 +858,7 @@ def check_slow_test_from_stats(test):
     if slow_tests_dict is None:
         if not IS_SANDCASTLE and os.getenv("PYTORCH_RUN_DISABLED_TESTS", "0") != "1":
             url = "https://raw.githubusercontent.com/pytorch/test-infra/master/stats/slow-tests.json"
-            slow_tests_dict = fetch_and_cache(".pytorch-slow-tests", url)
+            slow_tests_dict = fetch_and_cache(".pytorch-slow-tests.json", url)
         else:
             slow_tests_dict = {}
     test_suite = str(test.__class__).split('\'')[1]
@@ -1043,7 +1043,6 @@ class TestCase(expecttest.TestCase):
             result.stop()
 
     def setUp(self):
-
         check_slow_test_from_stats(self)
         if TEST_SKIP_FAST:
             if not getattr(self, self._testMethodName).__dict__.get('slow_test', False):


### PR DESCRIPTION
The run-specified-test-cases option would allow us to specify a list of test cases to run by having a CSV with minimally two columns: test_filename and test_case_name.

This PR also adds .json to some files we use for better clarity.

Usage: 
`python test/run_test.py --run-specified-test-cases <csv_file>` where the csv file can look like:
```
test_filename,test_case_name,test_total_time,windows_only_failure_sha_count,total_sha_count,windows_failure_count,linux_failure_count,windows_total_count,linux_total_count
test_cuda,test_cudnn_multiple_threads_same_device,8068.8409659525,46,3768,53,0,2181,6750
test_utils,test_load_standalone,8308.8062920459,14,4630,65,0,2718,8729
test_ops,test_forward_mode_AD_acosh_cuda_complex128,91.652619369806,11,1971,26,1,1197,3825
test_ops,test_forward_mode_AD_acos_cuda_complex128,91.825633094915,11,1971,26,1,1197,3825
test_profiler,test_source,60.93786725749,9,4656,21,3,2742,8805
test_profiler,test_profiler_tracing,203.09352795241,9,4662,21,3,2737,8807
```

Test plan: 
Without specifying the option, everything should be as they were before.

Running `python test/run_test.py --run-specified-test-cases windows_smoke_tests.csv` resulted in this paste P420276949 (you can see internally). A snippet looks like:
```
(pytorch) janeyx@janeyx-mbp pytorch % python test/run_test.py --run-specified-test-cases windows_smoke_tests.csv         
Loading specified test cases to run from windows_smoke_tests.csv.
Processed 28 test cases.
Running test_cpp_extensions_jit ... [2021-06-04 17:24:41.213644]
Executing ['/Users/janeyx/miniconda3/envs/pytorch/bin/python', 'test_cpp_extensions_jit.py', '-k', 'test_jit_cuda_archflags'] ... [2021-06-04 17:24:41.213781]
s
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK (skipped=1)
...
```
With pytest, an example executable would be:
`Running test_dataloader ... [2021-06-04 17:37:57.643039]
Executing ['/Users/janeyx/miniconda3/envs/pytorch/bin/python', '-m', 'pytest', 'test_dataloader.py', '-v', '-k', 'test_segfault or test_timeout'] ... [2021-06-04 17:37:57.643327]`

