### PR TITLE
[package] add unique_id to StorageImpl and use as storage identifier

### DIFF
--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -5,7 +5,11 @@
 
 #include <c10/util/intrusive_ptr.h>
 
+#include <atomic>
+
 namespace c10 {
+
+static std::atomic<std::uint64_t> next_unique_storage_id{0};
 
 // A storage represents the underlying backing data buffer for a
 // tensor.  This concept was inherited from the original Torch7
@@ -44,7 +48,8 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
         size_bytes_(size_bytes),
         resizable_(resizable),
         received_cuda_(false),
-        allocator_(allocator) {
+        allocator_(allocator),
+        unique_id(next_unique_storage_id++) {
     if (resizable) {
       TORCH_INTERNAL_ASSERT(
           allocator_, "For resizable storage, allocator must be provided");
@@ -194,6 +199,10 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
     return received_cuda_;
   }
 
+  uint64_t get_unique_id() {
+    return unique_id;
+  }
+
  private:
   DataPtr data_ptr_;
   size_t size_bytes_;
@@ -202,5 +211,6 @@ struct C10_API StorageImpl final : public c10::intrusive_ptr_target {
   // local to process cuda memory allocation
   bool received_cuda_;
   Allocator* allocator_;
+  uint64_t unique_id;
 };
 } // namespace c10

--- a/torch/csrc/generic/StorageMethods.cpp
+++ b/torch/csrc/generic/StorageMethods.cpp
@@ -55,6 +55,14 @@ static PyObject * THPStorage_(elementSize)(PyObject *_self, PyObject *noargs)
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPStorage_(getUniqueId)(PyObject *_self, PyObject *noargs)
+{
+  HANDLE_TH_ERRORS
+  auto self = (THPStorage*)_self;
+  return THPUtils_packUInt64(self->cdata->get_unique_id()) ;
+  END_HANDLE_TH_ERRORS
+}
+
 static PyObject * THPStorage_(new)(PyObject *_self, PyObject *noargs)
 {
   HANDLE_TH_ERRORS
@@ -347,6 +355,7 @@ static PyMethodDef THPStorage_(methods)[] = {
   {"copy_", castPyCFunctionWithKeywords(THPStorage_(copy_)),
     METH_VARARGS | METH_KEYWORDS, nullptr},
   {"element_size", THPStorage_(elementSize), METH_NOARGS, nullptr},
+  {"get_unique_id", THPStorage_(getUniqueId), METH_NOARGS, nullptr},
   {"fill_", THPStorage_(fill_), METH_O, nullptr},
   {"new", THPStorage_(new), METH_NOARGS, nullptr},
   {"resize_", THPStorage_(resize_), METH_O, nullptr},

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -85,7 +85,7 @@ class TORCH_API ScriptModuleSerializer {
       const std::string& archive_name,
       const std::string& archive_dir,
       const std::string& tensor_dir,
-      bool tensor_cdata_naming_scheme = false);
+      bool tensor_unique_id_naming_scheme = false);
   void updateSourceRangeTags(const SourceRangeRecords& ranges);
 
   caffe2::serialize::PyTorchStreamWriter& writer_;

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -476,8 +476,8 @@ void ScriptModuleSerializer::writeArchive(
         // returns a string to use in picker.cpp as storage obj key
         if (tensor_cdata_naming_scheme) {
           tensor_names.push_back(
-              std::to_string(reinterpret_cast<std::intptr_t>(
-                  tensor.storage().unsafeGetStorageImpl())) +
+              std::to_string(
+                  tensor.storage().unsafeGetStorageImpl()->get_unique_id()) +
               ".storage");
         } else {
           tensor_names.push_back(std::to_string(tensor_names.size()));

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -436,7 +436,7 @@ void ScriptModuleSerializer::serialize(
         /*archive_name=*/"constants",
         /*archive_dir=*/"",
         /*tensor_dir=*/"constants/",
-        /*tensor_cdata_naming_scheme=*/true);
+        /*tensor_unique_id_naming_scheme=*/true);
 
     writeByteCode(module, save_mobile_debug_info);
     writeMobileMetadata(module, extra_files);
@@ -458,7 +458,7 @@ void ScriptModuleSerializer::writeArchive(
     const std::string& archive_name,
     const std::string& archive_dir,
     const std::string& tensor_dir,
-    bool tensor_cdata_naming_scheme) {
+    bool tensor_unique_id_naming_scheme) {
   std::vector<char> data;
   // Vector to capture the run-time class types during pickling the IValues
   std::vector<c10::ClassTypePtr> memoizedClassTypes;
@@ -474,7 +474,7 @@ void ScriptModuleSerializer::writeArchive(
       &memoizedClassTypes,
       [&](const at::Tensor& tensor) {
         // returns a string to use in picker.cpp as storage obj key
-        if (tensor_cdata_naming_scheme) {
+        if (tensor_unique_id_naming_scheme) {
           tensor_names.push_back(
               std::to_string(
                   tensor.storage().unsafeGetStorageImpl()->get_unique_id()) +
@@ -498,7 +498,7 @@ void ScriptModuleSerializer::writeArchive(
   for (const auto& td : data_pickle.tensorData()) {
     WriteableTensorData writable_td = getWriteableTensorData(td);
     std::string fname = tensor_dir + tensor_names[i++];
-    if (tensor_cdata_naming_scheme &&
+    if (tensor_unique_id_naming_scheme &&
         std::find(
             pre_serialized_files.begin(), pre_serialized_files.end(), fname) !=
             pre_serialized_files.end()) {
@@ -644,7 +644,7 @@ void ScriptModuleSerializer::writeByteCode(
       /*archive_name=*/"bytecode",
       /*archive_dir=*/"",
       /*tensor_dir=*/"constants/",
-      /*tensor_cdata_naming_scheme=*/true);
+      /*tensor_unique_id_naming_scheme=*/true);
 
   auto debug_info_telements = Tup(std::move(debug_info_elements));
 
@@ -754,7 +754,7 @@ void ScriptModuleSerializer::serialize_unified_format(
       "data",
       archive_dir,
       /*tensor_dir=*/".data/",
-      /*tensor_cdata_naming_scheme=*/true);
+      /*tensor_unique_id_naming_scheme=*/true);
   // Then we serialize all code info.
   convertTypes(module.type());
   // The tensor constants from the code are written to a separate archive
@@ -766,7 +766,7 @@ void ScriptModuleSerializer::serialize_unified_format(
       "constants",
       archive_dir,
       /*tensor_dir=*/".data/",
-      /*tensor_cdata_naming_scheme=*/true);
+      /*tensor_unique_id_naming_scheme=*/true);
 
   // Note: writeFiles() call needs to be made in addition to calling this
   // function to have the code actually saved (tensors are saved)

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -700,7 +700,7 @@ node [shape=box];
     def _persistent_id(self, obj):
         if torch.is_storage(obj):
             storage_type = normalize_storage_type(type(obj))
-            obj_key = str(obj._cdata)
+            obj_key = str(obj.get_unique_id()) 
             location = location_tag(obj)
             name = f".data/{obj_key}.storage"
 

--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -700,7 +700,7 @@ node [shape=box];
     def _persistent_id(self, obj):
         if torch.is_storage(obj):
             storage_type = normalize_storage_type(type(obj))
-            obj_key = str(obj.get_unique_id()) 
+            obj_key = str(obj.get_unique_id())
             location = location_tag(obj)
             name = f".data/{obj_key}.storage"
 

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -19,7 +19,7 @@ class _StorageBase(object):
     def cuda(self, device=None, non_blocking=False, **kwargs) -> T: ...  # noqa: E704
     def element_size(self) -> int: ...  # noqa: E704
     def get_device(self) -> int: ...  # noqa: E704
-    def get_unique_id(self) -> int: ... # noqa: E704
+    def get_unique_id(self) -> int: ...  # noqa: E704
 
     # Defined in torch/csrc/generic/StorageSharing.cpp
     def _share_filename_(self): ...  # noqa: E704

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -19,6 +19,7 @@ class _StorageBase(object):
     def cuda(self, device=None, non_blocking=False, **kwargs) -> T: ...  # noqa: E704
     def element_size(self) -> int: ...  # noqa: E704
     def get_device(self) -> int: ...  # noqa: E704
+    def get_unique_id(self) -> int: ... # noqa: E704
 
     # Defined in torch/csrc/generic/StorageSharing.cpp
     def _share_filename_(self): ...  # noqa: E704


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59488 [package] add unique_id to StorageImpl and use as storage identifier**

Changes made:
- Adds unique_id field to `StorageImpl` and added access to the field from Python 
- Changed `torch.package` and mobile's `tensor_cdata_naming_scheme` to `tensor_unique_id_naming_scheme` to use this unique identifier for storages serialization instead of the cptr to the `StorageImpl`

These change are needed to allow for quantization to create/delete tensors during serialization (which leads to the StorageImpl cptrs being reused). The only functional change for the torch.package/mobile code is that now storages have a different naming scheme.

Differential Revision: [D28911924](https://our.internmc.facebook.com/intern/diff/D28911924)