### PR TITLE
[DataLoader] Add nesting_level argument to map and filter

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -409,7 +409,7 @@ class TestFunctionalIterDataPipe(TestCase):
             for x, y in zip(map_dp, input_dp):
                 self.assertEqual(len(x), len(y))
                 for a, b in zip(x, y):
-                    print(a,b)
+                    print(a, b)
                     self.assertEqual(a, torch.tensor(b, dtype=torch.float))
 
         with self.assertRaises(Exception):

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -377,6 +377,47 @@ class TestFunctionalIterDataPipe(TestCase):
         for x, y in zip(map_dp_nl, input_dp_nl):
             self.assertEqual(x, torch.tensor(y, dtype=torch.float))
 
+    def test_map_datapipe_nested_level(self):
+
+        input_dp = IDP([list(range(10)) for _ in range(3)])
+
+        def fn(item, dtype=torch.float, *, sum=False):
+            data = torch.tensor(item, dtype=dtype)
+            return data if not sum else data.sum()
+
+        map_dp = input_dp.map(lambda ls: ls * 2, nesting_level=0)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(x, y * 2)
+
+        map_dp = input_dp.map(fn, nesting_level=1)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(len(x), len(y))
+            for a, b in zip(x, y):
+                self.assertEqual(a, torch.tensor(b, dtype=torch.float))
+
+        map_dp = input_dp.map(fn, nesting_level=-1)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(len(x), len(y))
+            for a, b in zip(x, y):
+                self.assertEqual(a, torch.tensor(b, dtype=torch.float))
+
+        with self.assertRaises(Exception):
+            map_dp = input_dp.map(fn, nesting_level=4)
+            for x, y in zip(map_dp, input_dp):
+                self.assertEqual(len(x), len(y))
+                for a, b in zip(x, y):
+                    print(a,b)
+                    self.assertEqual(a, torch.tensor(b, dtype=torch.float))
+
+        with self.assertRaises(Exception):
+            input_dp.map(fn, nesting_level=-2)
+
+        with self.assertRaises(Exception):
+            input_dp.map(fn, nesting_level=-5)
+
     def test_collate_datapipe(self):
         arrs = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         input_dp = IDP(arrs)

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -540,6 +540,39 @@ class TestFunctionalIterDataPipe(TestCase):
         with self.assertRaises(ValueError):
             temp = list(filter_dp)
 
+    def test_filter_datapipe_nested_list(self):
+
+        input_ds = IDP(range(10)).batch(5)
+
+        def _filter_fn(data, val):
+            return data >= val
+
+        filter_dp = input_ds.filter(nesting_level=-1, filter_fn=_filter_fn, fn_kwargs={'val': 5})
+        expected_dp = [[5, 6, 7, 8, 9]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+        filter_dp = input_ds.filter(nesting_level=-1, drop_empty_batches=False, filter_fn=_filter_fn, fn_kwargs={'val': 5})
+        expected_dp = [[], [5, 6, 7, 8, 9]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+        with self.assertRaises(Exception):
+            filter_dp = input_ds.filter(nesting_level=5, filter_fn=_filter_fn, fn_kwargs={'val': 5})
+            temp = list(d for d in filter_dp)
+
+
+        input_ds = IDP(range(10)).batch(3)
+
+        filter_dp = input_ds.filter(lambda ls: len(ls) >= 3)
+        expected_dp = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+
     def test_sampler_datapipe(self):
         input_dp = IDP(range(10))
         # Default SequentialSampler

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -574,13 +574,13 @@ class TestFunctionalIterDataPipe(TestCase):
 
         filter_dp = input_ds.filter(nesting_level=-1, filter_fn=_filter_fn, fn_kwargs={'val': 5})
         expected_dp1 = [[5, 6, 7, 8, 9]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp1))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp1))
         for data, exp in zip(filter_dp, expected_dp1):
             self.assertEqual(data, exp)
 
         filter_dp = input_ds.filter(nesting_level=-1, drop_empty_batches=False, filter_fn=_filter_fn, fn_kwargs={'val': 5})
         expected_dp2: List[List[int]] = [[], [5, 6, 7, 8, 9]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp2))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp2))
         for data, exp in zip(filter_dp, expected_dp2):
             self.assertEqual(data, exp)
 
@@ -592,28 +592,28 @@ class TestFunctionalIterDataPipe(TestCase):
 
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3)
         expected_dp3: List[List[int]] = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp3))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp3))
         for data, exp in zip(filter_dp, expected_dp3):
             self.assertEqual(data, exp)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 3, nesting_level=-1)
         expected_dp4 = [[[4, 5]], [[6, 7, 8]]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp4))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp4))
         for data2, exp2 in zip(filter_dp, expected_dp4):
             self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 7, nesting_level=-1)
         expected_dp5 = [[[8]]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp5))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp5))
         for data2, exp2 in zip(filter_dp, expected_dp5):
             self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1], [3, 4]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3, nesting_level=1)
         expected_dp6 = [[[6, 7, 8], [1, 2, 3]]]
-        self.assertEqual(len([d for d in filter_dp]), len(expected_dp6))
+        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp6))
         for data2, exp2 in zip(filter_dp, expected_dp6):
             self.assertEqual(data2, exp2)
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -574,46 +574,46 @@ class TestFunctionalIterDataPipe(TestCase):
 
         filter_dp = input_ds.filter(nesting_level=-1, filter_fn=_filter_fn, fn_kwargs={'val': 5})
         expected_dp1 = [[5, 6, 7, 8, 9]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp1))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp1))
         for data, exp in zip(filter_dp, expected_dp1):
             self.assertEqual(data, exp)
 
         filter_dp = input_ds.filter(nesting_level=-1, drop_empty_batches=False, filter_fn=_filter_fn, fn_kwargs={'val': 5})
         expected_dp2: List[List[int]] = [[], [5, 6, 7, 8, 9]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp2))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp2))
         for data, exp in zip(filter_dp, expected_dp2):
             self.assertEqual(data, exp)
 
         with self.assertRaises(IndexError):
             filter_dp = input_ds.filter(nesting_level=5, filter_fn=_filter_fn, fn_kwargs={'val': 5})
-            temp = list(d for d in filter_dp)
+            temp = list(filter_dp)
 
         input_ds = IDP(range(10)).batch(3)
 
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3)
         expected_dp3: List[List[int]] = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp3))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp3))
         for data, exp in zip(filter_dp, expected_dp3):
             self.assertEqual(data, exp)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 3, nesting_level=-1)
         expected_dp4 = [[[4, 5]], [[6, 7, 8]]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp4))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp4))
         for data2, exp2 in zip(filter_dp, expected_dp4):
             self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 7, nesting_level=-1)
         expected_dp5 = [[[8]]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp5))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp5))
         for data2, exp2 in zip(filter_dp, expected_dp5):
             self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1], [3, 4]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3, nesting_level=1)
         expected_dp6 = [[[6, 7, 8], [1, 2, 3]]]
-        self.assertEqual(len(list(d for d in filter_dp)), len(expected_dp6))
+        self.assertEqual(len(list(filter_dp)), len(expected_dp6))
         for data2, exp2 in zip(filter_dp, expected_dp6):
             self.assertEqual(data2, exp2)
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -415,8 +415,33 @@ class TestFunctionalIterDataPipe(TestCase):
         with self.assertRaises(Exception):
             input_dp.map(fn, nesting_level=-2)
 
-        with self.assertRaises(Exception):
-            input_dp.map(fn, nesting_level=-5)
+        def addition(item, amount=1.0):
+            return item + amount
+
+        map_dp = input_dp.map(addition, nesting_level=-1)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(len(x), len(y))
+            for a, b in zip(x, y):
+                self.assertEqual(a, b + 1.0)
+
+        map_dp = input_dp.map(addition, fn_kwargs={'amount': 2.0}, nesting_level=-1)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(len(x), len(y))
+            for a, b in zip(x, y):
+                self.assertEqual(a, b + 2.0)
+
+        def subtraction(item, amount):
+            return item - amount
+
+        map_dp = input_dp.map(subtraction, fn_args=(1.0, ), nesting_level=-1)
+        self.assertEqual(len(input_dp), len(map_dp))
+        for x, y in zip(map_dp, input_dp):
+            self.assertEqual(len(x), len(y))
+            for a, b in zip(x, y):
+                self.assertEqual(a, b - 1.0)
+
 
     def test_collate_datapipe(self):
         arrs = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -563,12 +588,29 @@ class TestFunctionalIterDataPipe(TestCase):
             filter_dp = input_ds.filter(nesting_level=5, filter_fn=_filter_fn, fn_kwargs={'val': 5})
             temp = list(d for d in filter_dp)
 
-
         input_ds = IDP(range(10)).batch(3)
 
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3)
         expected_dp = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
         self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+        input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
+        filter_dp = input_ds.filter(lambda x: x > 3, nesting_level=-1)
+        expected_dp = [[[4, 5]], [[6, 7, 8]]]
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+        input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
+        filter_dp = input_ds.filter(lambda x: x > 7, nesting_level=-1)
+        expected_dp = [[[8]]]
+        for data, exp in zip(filter_dp, expected_dp):
+            self.assertEqual(data, exp)
+
+        input_ds = IDP([[[0, 1], [3, 4]], [[6, 7, 8], [1, 2, 3]]])
+        filter_dp = input_ds.filter(lambda ls: len(ls) >= 3, nesting_level=1)
+        expected_dp = [[[6, 7, 8], [1, 2, 3]]]
         for data, exp in zip(filter_dp, expected_dp):
             self.assertEqual(data, exp)
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -573,15 +573,15 @@ class TestFunctionalIterDataPipe(TestCase):
             return data >= val
 
         filter_dp = input_ds.filter(nesting_level=-1, filter_fn=_filter_fn, fn_kwargs={'val': 5})
-        expected_dp = [[5, 6, 7, 8, 9]]
-        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
-        for data, exp in zip(filter_dp, expected_dp):
+        expected_dp1 = [[5, 6, 7, 8, 9]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp1))), len(expected_dp1))
+        for data, exp in zip(filter_dp, expected_dp1):
             self.assertEqual(data, exp)
 
         filter_dp = input_ds.filter(nesting_level=-1, drop_empty_batches=False, filter_fn=_filter_fn, fn_kwargs={'val': 5})
-        expected_dp = [[], [5, 6, 7, 8, 9]]
-        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
-        for data, exp in zip(filter_dp, expected_dp):
+        expected_dp2: List[List[int]] = [[], [5, 6, 7, 8, 9]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp2))), len(expected_dp2))
+        for data, exp in zip(filter_dp, expected_dp2):
             self.assertEqual(data, exp)
 
         with self.assertRaises(Exception):
@@ -591,28 +591,28 @@ class TestFunctionalIterDataPipe(TestCase):
         input_ds = IDP(range(10)).batch(3)
 
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3)
-        expected_dp = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
-        self.assertEqual(len(list(zip(filter_dp, expected_dp))), len(expected_dp))
-        for data, exp in zip(filter_dp, expected_dp):
+        expected_dp3: List[List[int]] = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        self.assertEqual(len(list(zip(filter_dp, expected_dp3))), len(expected_dp3))
+        for data, exp in zip(filter_dp, expected_dp3):
             self.assertEqual(data, exp)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 3, nesting_level=-1)
-        expected_dp = [[[4, 5]], [[6, 7, 8]]]
-        for data, exp in zip(filter_dp, expected_dp):
-            self.assertEqual(data, exp)
+        expected_dp4 = [[[4, 5]], [[6, 7, 8]]]
+        for data2, exp2 in zip(filter_dp, expected_dp4):
+            self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda x: x > 7, nesting_level=-1)
-        expected_dp = [[[8]]]
-        for data, exp in zip(filter_dp, expected_dp):
-            self.assertEqual(data, exp)
+        expected_dp5 = [[[8]]]
+        for data2, exp2 in zip(filter_dp, expected_dp5):
+            self.assertEqual(data2, exp2)
 
         input_ds = IDP([[[0, 1], [3, 4]], [[6, 7, 8], [1, 2, 3]]])
         filter_dp = input_ds.filter(lambda ls: len(ls) >= 3, nesting_level=1)
-        expected_dp = [[[6, 7, 8], [1, 2, 3]]]
-        for data, exp in zip(filter_dp, expected_dp):
-            self.assertEqual(data, exp)
+        expected_dp6 = [[[6, 7, 8], [1, 2, 3]]]
+        for data2, exp2 in zip(filter_dp, expected_dp6):
+            self.assertEqual(data2, exp2)
 
 
     def test_sampler_datapipe(self):

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -150,7 +150,7 @@ class CollateIterDataPipe(MapIterDataPipe):
         super().__init__(datapipe, fn=collate_fn, fn_args=fn_args, fn_kwargs=fn_kwargs)
 
 
-@functional_datapipe('legacy_transforms')
+@functional_datapipe('transforms')
 class TransformsIterDataPipe(MapIterDataPipe):
     r""" :class:`TransformsIterDataPipe`.
 

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -147,7 +147,7 @@ class CollateIterDataPipe(MapIterDataPipe):
                  fn_args: Optional[Tuple] = None,
                  fn_kwargs: Optional[Dict] = None,
                  ) -> None:
-        super().__init__(datapipe, fn=collate_fn, fn_args=fn_args, fn_kwargs=fn_kwargs, batch_level=True)
+        super().__init__(datapipe, fn=collate_fn, fn_args=fn_args, fn_kwargs=fn_kwargs)
 
 
 @functional_datapipe('legacy_transforms')

--- a/torch/utils/data/datapipes/iter/callable.py
+++ b/torch/utils/data/datapipes/iter/callable.py
@@ -67,7 +67,7 @@ class MapIterDataPipe(IterDataPipe[T_co]):
             return self.fn(data, *self.args, **self.kwargs)
         elif nesting_level > 0:
             if not isinstance(data, list):
-                raise IndexError(f"nesting_level {nesting_level} out of range (exceeds data pipe depth)")
+                raise IndexError(f"nesting_level {self.nesting_level} out of range (exceeds data pipe depth)")
             result = [self._apply(i, nesting_level - 1) for i in data]
             return result
         else:

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -38,6 +38,9 @@ class FilterIterDataPipe(MapIterDataPipe):
                 if len(t) > 0 or not self.drop_empty_batches:
                     result.append(t)
             else:
+                if not isinstance(b, bool):
+                    raise ValueError("Boolean output is required for "
+                                     "`filter_fn` of FilterIterDataPipe")
                 if b:
                     result.append(i)
         return result
@@ -45,9 +48,7 @@ class FilterIterDataPipe(MapIterDataPipe):
     def __iter__(self) -> Iterator[T_co]:
         res: bool
         for data in self.datapipe:
-            if self.nesting_level > 0 and not isinstance(data, list):
-                raise IndexError(f"nesting_level {self.nesting_level} out of range (exceeds data pipe depth)")
-            elif self.nesting_level == 0 or not isinstance(data, list):
+            if self.nesting_level == 0:
                 res = self.fn(data, *self.args, **self.kwargs)
                 if not isinstance(res, bool):
                     raise ValueError("Boolean output is required for "

--- a/torch/utils/data/datapipes/iter/selecting.py
+++ b/torch/utils/data/datapipes/iter/selecting.py
@@ -16,24 +16,47 @@ class FilterIterDataPipe(MapIterDataPipe):
         filter_fn: Customized function mapping an element to a boolean.
         fn_args: Positional arguments for `filter_fn`
         fn_kwargs: Keyword arguments for `filter_fn`
+        drop_empty_batches:
+        nesting_level:
     """
     def __init__(self,
                  datapipe: IterDataPipe[T_co],
                  filter_fn: Callable[..., bool],
                  fn_args: Optional[Tuple] = None,
                  fn_kwargs: Optional[Dict] = None,
+                 drop_empty_batches: bool = True,
+                 nesting_level: int = 0,
                  ) -> None:
-        super().__init__(datapipe, fn=filter_fn, fn_args=fn_args, fn_kwargs=fn_kwargs)
+        self.drop_empty_batches = drop_empty_batches
+        super().__init__(datapipe, fn=filter_fn, fn_args=fn_args, fn_kwargs=fn_kwargs, nesting_level=nesting_level)
+
+    def _merge(self, data, mask):
+        result = []
+        for i, b in zip(data, mask):
+            if isinstance(b, list):
+                t = self._merge(i, b)
+                if len(t) > 0 or not self.drop_empty_batches:
+                    result.append(t)
+            else:
+                if b:
+                    result.append(i)
+        return result
 
     def __iter__(self) -> Iterator[T_co]:
         res: bool
         for data in self.datapipe:
-            res = self.fn(data, *self.args, **self.kwargs)
-            if not isinstance(res, bool):
-                raise ValueError("Boolean output is required for "
-                                 "`filter_fn` of FilterIterDataPipe")
-            if res:
-                yield data
+            if self.nesting_level == 0 or not isinstance(data, list):
+                res = self.fn(data, *self.args, **self.kwargs)
+                if not isinstance(res, bool):
+                    raise ValueError("Boolean output is required for "
+                                     "`filter_fn` of FilterIterDataPipe")
+                if res:
+                    yield data
+            else:
+                mask = self._apply(data, self.nesting_level, self.fn, self.args, self.kwargs)
+                merged = self._merge(data, mask)
+                if len(merged) > 0 or not self.drop_empty_batches:
+                    yield merged
 
     def __len__(self):
         raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))


### PR DESCRIPTION
This PR implements the .map and .filter APIs for IterDataPipe.

[DataPipes] Make .map of DataPipe sensitive to nested_level argument #58145
[DataPipes] Make .filter of DataPipe sensitive to nested_level argument #58147

cc @VitalyFedyunin @ejguan