### PR TITLE
[torch][segment_reduce] Add support for mean reduction (cpu)

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -7,15 +7,22 @@
 namespace at {
 namespace native {
 
+enum SegmentReductionType { MAX, MEAN };
+
 using segment_reduce_fn = Tensor (*)(
+    SegmentReductionType,
     const Tensor&,
     const Tensor&,
     int64_t,
     const c10::optional<Scalar>&);
 DECLARE_DISPATCH(segment_reduce_fn, _segment_reduce_stub);
 
-using segment_reduce_backward_fn =
-    Tensor (*)(const Tensor&, const Tensor&, const Tensor&, const Tensor&);
+using segment_reduce_backward_fn = Tensor (*)(
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    SegmentReductionType,
+    const Tensor&);
 DECLARE_DISPATCH(segment_reduce_backward_fn, _segment_reduce_backward_stub);
 
 } // namespace native

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -42,6 +42,7 @@ Tensor _get_complete_sum(const Tensor& lengths) {
 }
 
 Tensor _segment_reduce_cuda_kernel(
+    SegmentReductionType reduction,
     const Tensor& data,
     const Tensor& lengths,
     int64_t axis,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10078,10 +10078,10 @@
   dispatch:
     CPU, CUDA: segment_reduce_kernel
 
-- func: segment_reduce_backward(Tensor grad, Tensor output, Tensor data, *, Tensor? lengths=None) -> Tensor
+- func: _segment_reduce_backward(Tensor grad, Tensor output, Tensor data, str reduce, *, Tensor? lengths=None) -> Tensor
   variants: function
   dispatch:
-    CPU, CUDA: segment_reduce_backward_kernel
+    CPU, CUDA: _segment_reduce_backward_kernel
 
 - func: pad_sequence(Tensor[] sequences, bool batch_first=False, float padding_value=0.0) -> Tensor
   python_module: nn

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -94,6 +94,9 @@ allow_list = [
     ("aten::conj", datetime.date(2021, 8, 1)),
     ("aten::_conj", datetime.date(2021, 8, 1)),
     ("aten::conj.out", datetime.date(2021, 8, 1)),
+    ("aten::segment_reduce_backward", datetime.date(2021, 6, 15)),
+    ("aten::segment_reduce", datetime.date(2021, 8, 26)),
+    ("aten::_segment_reduce_backward", datetime.date(2021, 8, 26)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -12,7 +12,7 @@ from torch.testing._internal.common_utils import (
 
 
 class TestSegmentReductions(TestCase):
-    def _test_max_simple_1d(self, device, dtype, unsafe, axis):
+    def _test_simple_1d(self, reduction, device, dtype, unsafe, axis):
         lengths = torch.tensor([1, 2, 3, 0], device=device)
         data = torch.tensor(
             [1, float("nan"), 3, 4, 5, 5],
@@ -21,30 +21,40 @@ class TestSegmentReductions(TestCase):
             requires_grad=True,
         )
         initial_value = 0
-        expected_result = torch.tensor(
-            [1, float("nan"), 5, initial_value], device=device, dtype=dtype
-        )
+        if reduction == "max":
+            expected_result = torch.tensor(
+                [1, float("nan"), 5, initial_value], device=device, dtype=dtype
+            )
+            expected_grad = torch.tensor(
+                [1, 1, 0, 0, 0.5, 0.5], device=device, dtype=dtype
+            )
+        elif reduction == "mean":
+            expected_result = torch.tensor(
+                [1, float("nan"), 4.666, initial_value], device=device, dtype=dtype
+            )
+            expected_grad = torch.tensor(
+                [1.0, 0.5, 0.5, 0.333, 0.333, 0.333], device=device, dtype=dtype
+            )
         actual_result = torch.segment_reduce(
             data=data,
-            reduce="max",
+            reduce=reduction,
             lengths=lengths,
             axis=axis,
             unsafe=unsafe,
             initial=initial_value,
         )
         self.assertEqual(
-            expected_result, actual_result, rtol=1e-03, atol=1e-05, equal_nan=True
+            expected_result, actual_result, rtol=1e-02, atol=1e-05, equal_nan=True
         )
 
-        # Backward is only supported for cpu tensors for now. Return early if cuda
+        # TODO: Remove this check once cuda backward support is implemented
         if data.is_cuda:
             return
 
         # Test backward
-        expected_grad = torch.tensor([1, 1, 0, 0, 0.5, 0.5], device=device, dtype=dtype)
         actual_result.sum().backward()
         self.assertEqual(
-            expected_grad, data.grad, rtol=1e-03, atol=1e-05, equal_nan=True
+            expected_grad, data.grad, rtol=1e-02, atol=1e-05, equal_nan=True
         )
 
         # gradcheck does not work well with bfloat16 or fp16 cpu types
@@ -61,7 +71,7 @@ class TestSegmentReductions(TestCase):
                 gradcheck(
                     lambda x: torch.segment_reduce(
                         data=x,
-                        reduce="max",
+                        reduce=reduction,
                         lengths=lengths,
                         axis=axis,
                         unsafe=unsafe,
@@ -73,11 +83,15 @@ class TestSegmentReductions(TestCase):
 
     @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
-    def test_max_simple_1d(self, device, dtype):
-        self._test_max_simple_1d(device, dtype, False, 0)
-        self._test_max_simple_1d(device, dtype, False, -1)
-        self._test_max_simple_1d(device, dtype, True, 0)
-        self._test_max_simple_1d(device, dtype, True, -1)
+    def test_simple_1d(self, device, dtype):
+        for reduction in ("max", "mean"):
+            # TODO: Remove if once mean reduction for cuda is implemented
+            if reduction == "mean" and device != "cpu":
+                continue
+            self._test_simple_1d(reduction, device, dtype, False, 0)
+            self._test_simple_1d(reduction, device, dtype, False, -1)
+            self._test_simple_1d(reduction, device, dtype, True, 0)
+            self._test_simple_1d(reduction, device, dtype, True, -1)
 
 
 instantiate_device_type_tests(TestSegmentReductions, globals())

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2118,4 +2118,4 @@
   output_differentiability: [False]
 
 - name: segment_reduce(Tensor data, str reduce, *, Tensor? lengths=None, Tensor? indices=None, int axis=0, bool unsafe=False, Scalar? initial=None) -> Tensor
-  data: segment_reduce_backward(grad, result, data, lengths)
+  data: _segment_reduce_backward(grad, result, data, reduce, lengths)


### PR DESCRIPTION
Summary:
This diff is adding support for mean reduction for CPU (fwd + bckwd).

Will add cuda implementation in subsequent PR. We are using "cub::DeviceSegmentedReduce" for other aggregation, trying to see how to support mean or will write custom kernel for it.

Next Steps:
- cuda support for mean
- 2d data input support
- more testing
- benchmarking

Test Plan: updated unit test. Still relying on manual data for ease of debugging. Will add more tests that covers edge cases once major features are complete.

Differential Revision: D28922547

