### PR TITLE
[fbgemm] fix gconv + acc16

### DIFF
--- a/caffe2/quantization/server/conv_dnnlowp_op.cc
+++ b/caffe2/quantization/server/conv_dnnlowp_op.cc
@@ -167,7 +167,7 @@ bool ConvDNNLowPOp<T, ReluFused>::TakeGConvFastPath_() {
   const Tensor& X = InputTensorCPU_(INPUT);
   if (this->order_ != StorageOrder::NHWC || !is_same<T, uint8_t>::value ||
       !X.template IsType<T>() ||
-      (this->kernel_.size() != 2 && this->kernel_.size() != 3)) {
+      (this->kernel_.size() != 2 && this->kernel_.size() != 3) || Acc16()) {
     return false;
   }
 


### PR DESCRIPTION
Summary:
Fixing 2 issues.
1) conv 16-bit accumulation doesn't support fast gconv path, so TakeGConvFastPath_ should honor it
2) packed_index_ generates indices up to (G/GTogether_) F R S OC_per_G GTogether_ paddedICPerG which can exceed G kernel_prod OC_per_G paddedICPerG allocated in PackWeightMatrixForGConv (kernel_prod = F R S): e.g., when G=3, GTogether_=2, we allocate 3 F R S OC_per_G paddedICPerG but we access up to 2 F R S OC_per_G 2 paddedICPerG

Test Plan:
In a BDW machine,
buck test //caffe2/caffe2/quantization/server:conv_groupwise_dnnlowp_acc16_op_test -- --run-disabled

Differential Revision: D28927214

