### PR TITLE
add BFloat16 support for topk on CPU

### DIFF
--- a/aten/src/ATen/native/SortingUtils.h
+++ b/aten/src/ATen/native/SortingUtils.h
@@ -87,7 +87,7 @@ inline namespace DEFAULT {
 #endif
 
 // Core topk loop, shared between CPU and QuantizedCPU
-template <typename scalar_t>
+template <typename scalar_t, typename accscalar_t>
 void topk_impl_loop(
     const int64_t mode_values_stride,
     const int64_t mode_indices_stride,
@@ -111,7 +111,7 @@ void topk_impl_loop(
     auto n = dim_size;
     auto use_partial_sort = k * 64 <= n;
 
-    using elem_t = std::pair<scalar_t, int64_t>;
+    using elem_t = std::pair<accscalar_t, int64_t>;
     std::vector<elem_t> queue(n);
     for (int64_t j = 0; j < n; j++) {
       queue[j].first = tmp_values[j];
@@ -123,35 +123,35 @@ void topk_impl_loop(
       if (largest) {
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
           });
       } else {
         std::partial_sort(queue.begin(), queue.begin() + k, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
           });
       }
     } else {
       if (largest) {
         std::nth_element(queue.begin(), queue.begin() + k - 1, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+            return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
           });
         if (sorted) {
           std::sort(queue.begin(), queue.begin() + k - 1,
             [](const elem_t& x, const elem_t& y) -> bool {
-              return ((_isnan<scalar_t>(x.first) && !_isnan<scalar_t>(y.first)) || (x.first > y.first));
+              return ((_isnan<accscalar_t>(x.first) && !_isnan<accscalar_t>(y.first)) || (x.first > y.first));
             });
         }
       } else {
         std::nth_element(queue.begin(), queue.begin() + k -1, queue.end(),
           [](const elem_t& x, const elem_t& y) -> bool {
-            return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+            return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
           });
         if (sorted) {
           std::sort(queue.begin(), queue.begin() + k -1,
             [](const elem_t& x, const elem_t& y) -> bool {
-              return ((!_isnan<scalar_t>(x.first) && _isnan<scalar_t>(y.first)) || (x.first < y.first));
+              return ((!_isnan<accscalar_t>(x.first) && _isnan<accscalar_t>(y.first)) || (x.first < y.first));
             });
         }
       }

--- a/aten/src/ATen/native/cpu/SortingKernel.cpp
+++ b/aten/src/ATen/native/cpu/SortingKernel.cpp
@@ -162,11 +162,17 @@ static void topk_kernel(
   auto mode_indices_stride = indices.strides()[dim];
   auto tmp_values_stride = self.strides()[dim];
 
-  AT_DISPATCH_ALL_TYPES(self.scalar_type(), "topk_cpu", [&] {
+  AT_DISPATCH_ALL_TYPES_AND(ScalarType::BFloat16, self.scalar_type(), "topk_cpu", [&] {
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
-      return topk_impl_loop<scalar_t>(
-          mode_values_stride, mode_indices_stride, tmp_values_stride,
-          k, sizes[dim], largest, sorted, data, strides, n);
+      if (self.scalar_type() == ScalarType::BFloat16) {
+        return topk_impl_loop<scalar_t, float>(
+            mode_values_stride, mode_indices_stride, tmp_values_stride,
+            k, sizes[dim], largest, sorted, data, strides, n);
+      } else {
+        return topk_impl_loop<scalar_t, scalar_t>(
+            mode_values_stride, mode_indices_stride, tmp_values_stride,
+            k, sizes[dim], largest, sorted, data, strides, n);
+      }
     };
 
     int64_t grain_size = internal::GRAIN_SIZE / std::max(int64_t{1}, sizes[dim]);

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -1925,7 +1925,7 @@ void qtopk_kernel(Tensor& values,
     auto loop = [&](char** data, const int64_t* strides, int64_t n) {
       using underlying_t = typename scalar_t::underlying;
       static_assert(sizeof(scalar_t) == sizeof(underlying_t), "");
-      return topk_impl_loop<underlying_t>(
+      return topk_impl_loop<underlying_t, underlying_t>(
           mode_values_stride, mode_indices_stride, tmp_values_stride,
           k, sizes[dim], largest, sorted, data, strides, n);
     };

--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -612,7 +612,7 @@ class TestSortAndSelect(TestCase):
             self._test_topk_dtype(device, dtype, False, curr_size)
 
     @dtypesIfCUDA(*torch.testing.get_all_fp_dtypes())
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.float, torch.double, torch.bfloat16)
     def test_topk_nonfinite(self, device, dtype):
         if TEST_WITH_ROCM and dtype == torch.bfloat16:
             return

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6307,6 +6307,7 @@ op_db: List[OpInfo] = [
     ),
     OpInfo('topk',
            dtypes=all_types(),
+           dtypesIfCPU=all_types_and(torch.bfloat16),
            dtypesIfCUDA=all_types_and(torch.bfloat16, torch.float16),
            sample_inputs_func=sample_inputs_topk,
            skips=(


### PR DESCRIPTION
Added BFloat16 support for topk on CPU, and collected the benchmark data of topk for BFloat16 and Float32 data type by using the operator_benchmark tool of PyTorch on the platform of Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz 


Input: 512x512, 512x1024, 1024x512, 1024x1024 
K: 5 
Number of cores: 1 core, 28 cores(1 socket) 
 


For 1 core: 

 ----------------------------------------
 PyTorch/Caffe2 Operator Micro-benchmarks
 ----------------------------------------
 Tag : all

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W512_k5_dtypetorch.float32_cpu
 Input: H: 512, W: 512, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 911.401

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W512_k5_dtypetorch.bfloat16_cpu
 Input: H: 512, W: 512, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 911.700

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W1024_k5_dtypetorch.float32_cpu
 Input: H: 512, W: 1024, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 1506.927

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W1024_k5_dtypetorch.bfloat16_cpu
 Input: H: 512, W: 1024, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 1492.036

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W512_k5_dtypetorch.float32_cpu
 Input: H: 1024, W: 512, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 1825.634

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W512_k5_dtypetorch.bfloat16_cpu
 Input: H: 1024, W: 512, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 1819.872

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W1024_k5_dtypetorch.float32_cpu
 Input: H: 1024, W: 1024, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 3001.459

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W1024_k5_dtypetorch.bfloat16_cpu
 Input: H: 1024, W: 1024, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 2970.718

 

For 28 cores(1 socket): 

 ----------------------------------------
 PyTorch/Caffe2 Operator Micro-benchmarks
 ----------------------------------------
 Tag : all

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W512_k5_dtypetorch.float32_cpu
 Input: H: 512, W: 512, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 146.995

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W512_k5_dtypetorch.bfloat16_cpu
 Input: H: 512, W: 512, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 123.423

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W1024_k5_dtypetorch.float32_cpu
 Input: H: 512, W: 1024, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 105.967

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H512_W1024_k5_dtypetorch.bfloat16_cpu
 Input: H: 512, W: 1024, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 101.498

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W512_k5_dtypetorch.float32_cpu
 Input: H: 1024, W: 512, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 128.023

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W512_k5_dtypetorch.bfloat16_cpu
 Input: H: 1024, W: 512, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 125.172

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W1024_k5_dtypetorch.float32_cpu
 Input: H: 1024, W: 1024, k: 5, dtype: torch.float32, device: cpu
Forward Execution Time (us) : 129.855

 Benchmarking PyTorch: topk
 Mode: Eager
 Name: topk_H1024_W1024_k5_dtypetorch.bfloat16_cpu
 Input: H: 1024, W: 1024, k: 5, dtype: torch.bfloat16, device: cpu
Forward Execution Time (us) : 124.556

