### PR TITLE
Add gradcheck tolerance for renorm

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -131,6 +131,7 @@ class TestGradients(TestCase):
                                           check_grad_dtypes=True,
                                           nondet_tol=op.gradcheck_nondet_tol,
                                           fast_mode=op.gradcheck_fast_mode,
+                                          atol=op.gradcheck_atol,
                                           check_forward_ad=check_forward_ad))
             elif check == 'gradgradcheck':
                 self.assertFalse(check_forward_ad, msg="Cannot run forward AD check for gradgradcheck")
@@ -139,12 +140,14 @@ class TestGradients(TestCase):
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
+                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
                 self.assertTrue(gradgradcheck(fn, gradcheck_args,
                                               gen_non_contig_grad_outputs=True,
                                               check_batched_grad=op.check_batched_gradgrad,
                                               check_grad_dtypes=True,
                                               nondet_tol=op.gradcheck_nondet_tol,
+                                              atol=op.gradcheck_atol,
                                               fast_mode=op.gradcheck_fast_mode))
             else:
                 self.assertTrue(False, msg="Unknown check requested!")

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -227,7 +227,7 @@ class OpInfo(object):
                  gradcheck_fast_mode=None,  # Whether to use the fast implmentation for gradcheck/gradgradcheck.
                                             # When set to None, defers to the default value provided by the wrapper
                                             # function around gradcheck (testing._internal.common_utils.gradcheck)
-                 gradcheck_atol=0.0,  # absolute tolerance for gradcheck
+                 gradcheck_atol=1e-5,  # TODO(soulitzer): avoid repeating default value here
                  inplace_variant=_NOTHING,  # explicitly pass the inplace variant of the operator if required
                  method_variant=_NOTHING,  # explicitly pass the method variant of the operator if required
                  test_conjugated_samples=True,

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -227,6 +227,7 @@ class OpInfo(object):
                  gradcheck_fast_mode=None,  # Whether to use the fast implmentation for gradcheck/gradgradcheck.
                                             # When set to None, defers to the default value provided by the wrapper
                                             # function around gradcheck (testing._internal.common_utils.gradcheck)
+                 gradcheck_atol=0.0,  # absolute tolerance for gradcheck
                  inplace_variant=_NOTHING,  # explicitly pass the inplace variant of the operator if required
                  method_variant=_NOTHING,  # explicitly pass the method variant of the operator if required
                  test_conjugated_samples=True,
@@ -292,6 +293,7 @@ class OpInfo(object):
         self.check_batched_gradgrad = check_batched_gradgrad
         self.gradcheck_nondet_tol = gradcheck_nondet_tol
         self.gradcheck_fast_mode = gradcheck_fast_mode
+        self.gradcheck_atol = gradcheck_atol
 
         self.supports_sparse = supports_sparse
 
@@ -6712,7 +6714,9 @@ op_db: List[OpInfo] = [
            )),
     OpInfo('renorm',
            dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-           sample_inputs_func=sample_inputs_renorm),
+           sample_inputs_func=sample_inputs_renorm,
+           gradcheck_atol=4e-3,
+           gradcheck_fast_mode=False),
     ShapeFuncInfo('repeat',
                   op=lambda x, dims: x.repeat(dims),
                   ref=np.tile,


### PR DESCRIPTION
Fix slow gradcheck failure from https://github.com/pytorch/pytorch/pull/59250 by adding some tolerance. Fast gradcheck is likely not failing because the jacobian is relatively sparse - only several values in the jacobian differ between numerical/analytical.

https://app.circleci.com/pipelines/github/pytorch/pytorch/330915/workflows/9e8bbc5d-1670-426f-b8fd-6676b5310e4e/jobs/13895955

It seems that there were already OpInfo tests for renorm before the change, so the new precision issue is probably due to a change in the implmentation, and not because the case was not being tested previously.

This is also the first OpInfo test that requires specifying gradcheck tolerance

