### PR TITLE
[ONNX] Support aten:normal op.

### DIFF
--- a/docs/source/onnx.rst
+++ b/docs/source/onnx.rst
@@ -435,6 +435,101 @@ The example below shows how you can access ``requires_grad`` via the ``Node`` ob
     from torch.onnx import register_custom_op_symbolic
     register_custom_op_symbolic("::prim_PythonOp", symbolic_pythonop, 1)
 
+Autograd Function
+~~~~~~~~~~~~~~~~~
+
+Autograd functions can be used to compute operation results and gradients and save the history.
+More information on extending the torch.autograd engine can be found on this `page <https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function>`_.
+There are two ways to export a subclass of the torch.autograd.function.
+
+Symbolic Static Method
+^^^^^^^^^^^^^^^^^^^^^^
+
+You can add a symbolic static method to your function class. The symbolic method should contain a set
+of ONNX operators that represent operator's behavior in ONNX. Here's an example for adding symbolic to
+the your autograd function: ::
+
+
+    class MyRelu(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, input):
+            ctx.save_for_backward(input)
+            return input.clamp(min=0)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            input, = ctx.saved_tensors
+            grad_input = grad_output.clone()
+            grad_input[input < 0] = 0
+            return grad_input
+
+        @staticmethod
+        def symbolic(g, self):
+            return g.op("Clip", self, g.op('Constant', value_t=torch.tensor(0, dtype=torch.float)))
+
+    class MyModel(torch.nn.Module):
+        def forward(self, x):
+            my_relu = MyRelu.apply
+            return my_relu(x)
+
+    input_tensor = torch.randn(2, 3, 224, 224, requires_grad=True)
+    torch.onnx.export(MyModel(), input_tensor, 'test.onnx', opset_version=12)
+
+Export as Custom Operator
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Alternatively, you can register a custom symbolic function to export the autograd function as custom operator.
+This is designed for more advanced usage, because it gives you access to more info on the export symbolic side.
+Autograd functions are emitted in the IR graph as ``prim::PythonOp`` nodes. The attribute ``name`` identifies the
+original module name. The ``prim::PythonOp`` node object can be accessed by argument ``n``. The example below shows
+how you can access ``requires_grad`` info of the inputs and outputs of the autograd function. ::
+
+    class MyClip(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, input, scalar):
+            ctx.save_for_backward(input)
+            return input.clamp(min=scalar)
+
+    class MyRelu(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, input):
+            ctx.save_for_backward(input)
+            return input.clamp(min=0)
+
+    class MyModule(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.clip = MyClip.apply
+            self.relu = MyRelu.apply
+
+        def forward(self, x):
+            h = self.clip(x, 2)
+            h = self.relu(h)
+            return h
+
+    def symbolic_pythonop(g, n, *args, **kwargs):
+        # print information
+        print('original node: ', n)
+        for i, out in enumerate(n.outputs()):
+            print('original output {}: {}, requires grad: {}'.format(i, out, out.requiresGrad()))
+        import torch.onnx.symbolic_helper as sym_helper
+        for i, arg in enumerate(args):
+            print('arg {}: {}, requires grad: {}'.format(i, arg, arg.requiresGrad() if sym_helper._is_value(arg) else False))
+
+        name = kwargs['name']
+        if name == "MyClip":
+            return g.op("Clip", args[0], min_f=args[1])
+        elif name == "MyRelu":
+            return g.op("Relu", args[0])
+        else:
+            return _unimplemented("prim::PythonOp", "unknown node kind: " + name)
+
+    from torch.onnx import register_custom_op_symbolic
+    register_custom_op_symbolic('::prim_PythonOp', symbolic_pythonop, 1)
+
+    input_tensor = torch.randn(2, 3, 224, 224, requires_grad=True)
+    torch.onnx.export(MyModule(), input_tensor, 'test.onnx', opset_version=12)
+
 Custom operators
 ^^^^^^^^^^^^^^^^
 

--- a/test/onnx/test_pytorch_onnx_onnxruntime.py
+++ b/test/onnx/test_pytorch_onnx_onnxruntime.py
@@ -9246,6 +9246,7 @@ class TestONNXRuntime(unittest.TestCase):
         x = torch.ones(0)
         self.run_test(M(), (x,))
 
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_broad_cast_tensors(self):
         class M(torch.nn.Module):
             def forward(self, x, y):
@@ -9268,6 +9269,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(M(), (x, y))
 
     @disableScriptTest()
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_dist_normal(self):
         class M(torch.nn.Module):
             def forward(self, x, y):
@@ -9279,6 +9281,7 @@ class TestONNXRuntime(unittest.TestCase):
         self.run_test(M(), (torch.tensor([[[0.0], [10.0]], [[2.0], [8.0]], [[2.0], [8.0]]]), torch.tensor([[1.0], [3.0]])))
 
     @disableScriptTest()
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_dist_normal_correctness(self):
         class M(torch.nn.Module):
             def forward(self, x, y):
@@ -9305,13 +9308,14 @@ class TestONNXRuntime(unittest.TestCase):
                "the gap of variance between ort outputs and expected one is unacceptable."
 
     @disableScriptTest()
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_dist_uniform(self):
         class M(torch.nn.Module):
             def forward(self, x, y):
                 return torch.distributions.Uniform(x, y).sample().size(0), x , y
 
-
     @disableScriptTest()
+    @skipIfUnsupportedMinOpsetVersion(11)
     def test_dist_uniform_correctness(self):
         class M(torch.nn.Module):
             def forward(self, x, y):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,7 +1,4 @@
-# EDITING THIS FILE? READ THIS FIRST!
-# see Note [Edit Symbolic Files] in symbolic_helper.py
-
-# This file exports ONNX ops for opset 11
+#!/usr/bin/env python3
 
 from sys import maxsize
 
@@ -14,6 +11,13 @@ from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_li
 from torch.onnx.symbolic_opset9 import expand, expand_as, mul, sqrt, unused, zeros_like
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
+
+
+# EDITING THIS FILE? READ THIS FIRST!
+# see Note [Edit Symbolic Files] in symbolic_helper.py
+
+# This file exports ONNX ops for opset 11
+
 
 @parse_args("v", "f", "f")
 def hardtanh(g, self, min_val, max_val):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# encoding: utf-8
 
 from sys import maxsize
 

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,6 +1,5 @@
 
 from sys import maxsize
-from numpy.core.fromnumeric import shape
 
 import torch
 import torch.onnx.symbolic_helper as sym_help
@@ -8,7 +7,7 @@ import warnings
 import numpy
 
 from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_list
-from torch.onnx.symbolic_opset9 import expand, unused, zeros_like
+from torch.onnx.symbolic_opset9 import expand, expand_as, mul, sqrt, unused, zeros_like
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
 
@@ -996,32 +995,7 @@ def repeat_interleave(g, self, repeats, dim=None, output_size=None):
     loop_out = g.op("Transpose", loop_out, perm_i=perm_i)
     return reshape(g, loop_out, g.op("Constant", value_t=torch.LongTensor(output_sizes)))
 
-# For example:
-#   x = torch.randint(5, (4, 2, 1, 4))
-#   y = torch.randint(5, (2, 1, 1))
-# Steps:
-# 1. Unpack the tensor list.
-# 2. Find out the max rank.
-# 3. Find out the shape of each tensor.
-# 4. unsqueeze 0 of each tensor so that all of them have the same rank.
-# 5. Slice the tensor with dim=1.
-# 6. Leverage Unique to make sure each slice is qualified for broad cast.
-# 7. Along with dim=1, find out the max value of each slice to construct a new shape.
-# 8. Expand each tensor in self to the new shape.
-
-# Solution 2:
-# Go to ORT, expose an operator for broadcast directly.
-
-# Solution 3:
-# Leverage Add/Sum:
-#     1. Construct a constant zero_like tensor.
-#     2. Add all tensors into above tensor.
-#     3. Get the final shape.
-#     4. Exapnd each tensors in self list to final shape.
-
 def broadcast_tensors(g, self):
-    from torch.onnx.symbolic_opset9 import expand_as
-
     all_tensors = sym_help._unpack_list(self)
     final_result = zeros_like(g, all_tensors[0])
 
@@ -1034,15 +1008,14 @@ def broadcast_tensors(g, self):
 
     return outputs
 
-@parse_args("f", "f", "v")
-def normal(g, loc, scale, shape):
-    print('access normal', loc, scale, shape)
-    # result = g.op("RandomNormal", dtype_i=1, mean_f=0.0, scale_f=1.0, shape_i=[1])
-    result = g.op("RandomNormal", loc, scale)
-    return result
-
-def uniform(g, low, high, shape):
-    print('access uniform', low, high, shape)
-    # result = g.op("RandomNormal", dtype_i=1, mean_f=0.0, scale_f=1.0, shape_i=[1])
-    result = g.op("RandomNormal", low, high)
-    return result
+def normal(g, loc, scale, seed):
+    # If you can sample from a given distribution with mean 0 and variance 1, then you can easily sample from a
+    # scale-location transformation of that distribution, which has mean μ and variance, σ's square. If x is a sample
+    # from a mean 0 and variance 1 distribution then
+    #       σx+μ
+    # is a sample with mean μ and variance σ's square.
+    result = zeros_like(g, loc)
+    normal_base = add(g, result, g.op("RandomNormal", shape_i=[1]))
+    result = sqrt(g, scale)
+    result = mul(g, result, normal_base)
+    return add(g, result, loc)

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 
 from sys import maxsize
 
@@ -12,7 +12,6 @@ from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_li
 from torch.onnx.symbolic_opset9 import expand, expand_as, mul, sqrt, unused, zeros_like
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
-
 
 # EDITING THIS FILE? READ THIS FIRST!
 # see Note [Edit Symbolic Files] in symbolic_helper.py

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,3 +1,8 @@
+# EDITING THIS FILE? READ THIS FIRST!
+# see Note [Edit Symbolic Files] in symbolic_helper.py
+
+# This file exports ONNX ops for opset 11
+
 from sys import maxsize
 
 import torch
@@ -9,12 +14,6 @@ from torch.onnx.symbolic_helper import parse_args, _unimplemented, _is_tensor_li
 from torch.onnx.symbolic_opset9 import expand, expand_as, mul, sqrt, unused, zeros_like
 from torch.nn.modules.utils import _single, _pair, _triple
 from torch.onnx.utils import _add_block, _add_input_to_block, _add_output_to_block
-
-# EDITING THIS FILE? READ THIS FIRST!
-# see Note [Edit Symbolic Files] in symbolic_helper.py
-
-# This file exports ONNX ops for opset 11
-
 
 @parse_args("v", "f", "f")
 def hardtanh(g, self, min_val, max_val):

--- a/torch/onnx/symbolic_opset11.py
+++ b/torch/onnx/symbolic_opset11.py
@@ -1,4 +1,3 @@
-
 from sys import maxsize
 
 import torch

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -149,7 +149,7 @@ def _reduce_op_symbolic(onnx_op_name):
             # all-reduce path
             return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
-            keepdim = sym_help._get_const(keepdim, "i", "keepdim")
+            keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic
 

--- a/torch/onnx/symbolic_opset13.py
+++ b/torch/onnx/symbolic_opset13.py
@@ -149,7 +149,7 @@ def _reduce_op_symbolic(onnx_op_name):
             # all-reduce path
             return sym_help._handle_reduce_dim_none(g, self, onnx_op_name)
         else:
-            keepdim = sym_help._get_const(keepdim, 'i', 'keepdim')
+            keepdim = sym_help._get_const(keepdim, "i", "keepdim")
             return g.op(onnx_op_name, self, dim, keepdims_i=keepdim)
     return symbolic
 

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3217,32 +3217,3 @@ def roll(g, self, shifts, dims):
         result = g.op("Concat", *shapes, axis_i=dims[i])
 
     return result
-
-
-def broadcast_tensors(g, self):
-    print('=== Type:', sym_help._is_tensor_list(self))
-    all_tensors = sym_help._unpack_list(self)
-    print('=== Tensors:', all_tensors)
-
-    # self_dim_rank = sym_help._get_tensor_rank(self)
-    # other_dim_rank = sym_help._get_tensor_rank(other)
-
-    # # Construct a new shape. It's almost as same as self except the size of the 'dim'
-    # # dimension is 1, so that we can expand other dimensions as expected.
-    # new_shape_axes = list(range(self_dim_rank))
-    # new_shape_starts = [0 for i in range(self_dim_rank)]
-    # new_shape_ends = [maxsize
-    #                   if (i != dim)
-    #                   else
-    #                   1
-    #                   for i in range(self_dim_rank)]
-
-    # new_shape = sym_help._slice_helper(g,
-    #                                    self,
-    #                                    axes=new_shape_axes,
-    #                                    starts=new_shape_starts,
-    #                                    ends=new_shape_ends)
-    # other = expand_as(g, other, new_shape)
-
-    return self
-

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2435,7 +2435,7 @@ def bernoulli(g, input, generator=None, out=None):
     return g.op("Cast", output, to_i=sym_help.cast_pytorch_to_onnx[dtype])
 
 
-@parse_args("v")
+@parse_args('v')
 def log_sigmoid(g, input):
     p = g.op("Sigmoid", input)
     return g.op("Log", p)

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2435,7 +2435,7 @@ def bernoulli(g, input, generator=None, out=None):
     return g.op("Cast", output, to_i=sym_help.cast_pytorch_to_onnx[dtype])
 
 
-@parse_args('v')
+@parse_args("v")
 def log_sigmoid(g, input):
     p = g.op("Sigmoid", input)
     return g.op("Log", p)
@@ -2607,7 +2607,7 @@ def prim_tolist(g, input, dim_val, elem_ty_val):
     return input
 
 
-@parse_args('v', 'i')
+@parse_args("v", "i")
 def one_hot(g, self, num_classes):
     values = g.op("Constant", value_t=torch.LongTensor([0, 1]))
     depth = g.op("Constant", value_t=torch.LongTensor([num_classes]))

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -3217,3 +3217,32 @@ def roll(g, self, shifts, dims):
         result = g.op("Concat", *shapes, axis_i=dims[i])
 
     return result
+
+
+def broadcast_tensors(g, self):
+    print('=== Type:', sym_help._is_tensor_list(self))
+    all_tensors = sym_help._unpack_list(self)
+    print('=== Tensors:', all_tensors)
+
+    # self_dim_rank = sym_help._get_tensor_rank(self)
+    # other_dim_rank = sym_help._get_tensor_rank(other)
+
+    # # Construct a new shape. It's almost as same as self except the size of the 'dim'
+    # # dimension is 1, so that we can expand other dimensions as expected.
+    # new_shape_axes = list(range(self_dim_rank))
+    # new_shape_starts = [0 for i in range(self_dim_rank)]
+    # new_shape_ends = [maxsize
+    #                   if (i != dim)
+    #                   else
+    #                   1
+    #                   for i in range(self_dim_rank)]
+
+    # new_shape = sym_help._slice_helper(g,
+    #                                    self,
+    #                                    axes=new_shape_axes,
+    #                                    starts=new_shape_starts,
+    #                                    ends=new_shape_ends)
+    # other = expand_as(g, other, new_shape)
+
+    return self
+

--- a/torch/onnx/symbolic_opset9.py
+++ b/torch/onnx/symbolic_opset9.py
@@ -2435,7 +2435,7 @@ def bernoulli(g, input, generator=None, out=None):
     return g.op("Cast", output, to_i=sym_help.cast_pytorch_to_onnx[dtype])
 
 
-@parse_args('v')
+@parse_args("v")
 def log_sigmoid(g, input):
     p = g.op("Sigmoid", input)
     return g.op("Log", p)


### PR DESCRIPTION
1. Add a new symbolic function broadcast_tensors() to support exporting torch.broadcast_tensors() function. This is required by exporting torch.distribution.normal() function.
2. Add a new symbolic function normal() to support exporting torch.distribution.normal() function.
3. Add relative tests as well.
