### PR TITLE
Simplify parametrizations.SpectralNorm and improve its initialization

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -562,7 +562,7 @@ Tensor multi_dot_impl(TensorList _tensors, c10::optional<Tensor> _out) {
     TORCH_CHECK(
         false,
         "multi_dot(): the last tensor must be 1D or 2D but got ",
-        _tensors[0].dim(),
+        _tensors[n - 1].dim(),
         "D");
   }
 
@@ -573,7 +573,7 @@ Tensor multi_dot_impl(TensorList _tensors, c10::optional<Tensor> _out) {
         "multi_dot(): tensor ",
         i,
         " must be 2D but got ",
-        _tensors[0].dim(),
+        _tensors[i].dim(),
         "D");
     tensors[i] = _tensors[i];
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3822,11 +3822,6 @@ class TestNN(NNTestCase):
                     # run forward again and assert that u and v are updated
                     self.assertNotEqual(u0, spectral_norm_m.u)
                     self.assertNotEqual(v0, spectral_norm_m.v)
-                else:
-                    # The weight has not been updated and u0 and v0 are already the correct
-                    # singular vectors
-                    self.assertEqual(u0, spectral_norm_m.u)
-                    self.assertEqual(v0, spectral_norm_m.v)
 
                 # assert that backprop reaches original weight
                 # can't use gradcheck because the function changes as we

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3730,16 +3730,16 @@ class TestNN(NNTestCase):
         m = torch.nn.utils.parametrizations.spectral_norm(m)
         spectral_norm_m = m.parametrizations.weight[0]
 
-        self.assertEqual(spectral_norm_m.u.size(), torch.Size([m.weight.size(0)]))
+        self.assertEqual(spectral_norm_m._u.size(), torch.Size([m.weight.size(0)]))
 
         # .parametrizations.weight.original should be trainable
         self.assertTrue(hasattr(m.parametrizations.weight, 'original'))
         self.assertTrue('original' in m.parametrizations.weight._parameters)
 
         # u should be just a reused buffer
-        self.assertTrue(hasattr(spectral_norm_m, 'u'))
-        self.assertTrue('u' in spectral_norm_m._buffers)
-        self.assertTrue('v' in spectral_norm_m._buffers)
+        self.assertTrue(hasattr(spectral_norm_m, '_u'))
+        self.assertTrue('_u' in spectral_norm_m._buffers)
+        self.assertTrue('_v' in spectral_norm_m._buffers)
 
         # weight should be a plain attribute, not counted as a buffer or a param
         self.assertIsNotNone(m.weight)
@@ -3804,24 +3804,24 @@ class TestNN(NNTestCase):
 
                 m, wrapped_m, spectral_norm_m = get_modules()
 
-                self.assertTrue(hasattr(spectral_norm_m, 'u'))
-                u0 = spectral_norm_m.u.clone()
-                v0 = spectral_norm_m.v.clone()
+                self.assertTrue(hasattr(spectral_norm_m, '_u'))
+                u0 = spectral_norm_m._u.clone()
+                v0 = spectral_norm_m._v.clone()
 
                 # TEST TRAINING BEHAVIOR
 
                 # We perform GD first to modify the initial matrix
+                opt = torch.optim.SGD(wrapped_m.parameters(), lr=0.1)
+
+                opt.zero_grad()
                 wrapped_m(input).sum().backward()
-                with torch.no_grad():
-                    for p in wrapped_m.parameters():
-                        if p.requires_grad:
-                            p.add_(- p.grad, alpha=0.01)
+                opt.step()
 
                 out = wrapped_m(input)
                 if requires_grad:
                     # run forward again and assert that u and v are updated
-                    self.assertNotEqual(u0, spectral_norm_m.u)
-                    self.assertNotEqual(v0, spectral_norm_m.v)
+                    self.assertNotEqual(u0, spectral_norm_m._u)
+                    self.assertNotEqual(v0, spectral_norm_m._v)
 
                 # assert that backprop reaches original weight
                 # can't use gradcheck because the function changes as we
@@ -3832,12 +3832,12 @@ class TestNN(NNTestCase):
                 # test backward works with multiple forwards
                 # it uses training mode so we need to reset `u` and `v` vectors
                 # to same value at beginning for finite difference test to pass
-                saved_u = spectral_norm_m.u.clone()
-                saved_v = spectral_norm_m.v.clone()
+                saved_u = spectral_norm_m._u.clone()
+                saved_v = spectral_norm_m._v.clone()
 
                 def fn(input):
-                    spectral_norm_m.u.data.copy_(saved_u)
-                    spectral_norm_m.v.data.copy_(saved_v)
+                    spectral_norm_m._u.data.copy_(saved_u)
+                    spectral_norm_m._v.data.copy_(saved_v)
                     out0 = wrapped_m(input)
                     out1 = wrapped_m(input)
                     return out0 + out1
@@ -3864,8 +3864,8 @@ class TestNN(NNTestCase):
                 m, wrapped_m, spectral_norm_m = get_modules()
                 wrapped_m(input)
                 last_train_out = wrapped_m(input)
-                last_train_u = spectral_norm_m.u.clone()
-                last_train_v = spectral_norm_m.v.clone()
+                last_train_u = spectral_norm_m._u.clone()
+                last_train_v = spectral_norm_m._v.clone()
                 wrapped_m.zero_grad()
                 wrapped_m.eval()
 
@@ -3874,8 +3874,8 @@ class TestNN(NNTestCase):
                 self.assertEqual(eval_out0, last_train_out)
                 # assert doing more iteartion in eval don't change things
                 self.assertEqual(eval_out0, wrapped_m(input))
-                self.assertEqual(last_train_u, spectral_norm_m.u)
-                self.assertEqual(last_train_v, spectral_norm_m.v)
+                self.assertEqual(last_train_u, spectral_norm_m._u)
+                self.assertEqual(last_train_v, spectral_norm_m._v)
 
                 # FIXME: the code below is flaky when executed with DataParallel
                 # see https://github.com/pytorch/pytorch/issues/13818
@@ -3886,12 +3886,12 @@ class TestNN(NNTestCase):
                 # and eval modes
                 # it uses training mode so we need to reset `u` and `v` vectors
                 # to same value at beginning for finite difference test to pass
-                saved_u = spectral_norm_m.u.clone()
-                saved_v = spectral_norm_m.v.clone()
+                saved_u = spectral_norm_m._u.clone()
+                saved_v = spectral_norm_m._v.clone()
 
                 def fn(input):
-                    spectral_norm_m.u.data.copy_(saved_u)
-                    spectral_norm_m.v.data.copy_(saved_v)
+                    spectral_norm_m._u.data.copy_(saved_u)
+                    spectral_norm_m._v.data.copy_(saved_v)
                     wrapped_m.train()
                     out0 = wrapped_m(input)
                     wrapped_m.eval()
@@ -3925,8 +3925,8 @@ class TestNN(NNTestCase):
             self.assertEqual({
                 'parametrizations.weight.original',
                 'bias',
-                'parametrizations.weight.0.v',
-                'parametrizations.weight.0.u'
+                'parametrizations.weight.0._v',
+                'parametrizations.weight.0._u'
             }, set(state_dict.keys()))
 
             # test that non-strict loading works
@@ -3937,9 +3937,9 @@ class TestNN(NNTestCase):
             snm.load_state_dict(non_strict_state_dict, strict=False)
             del non_strict_state_dict['parametrizations.weight.original']
             snm.load_state_dict(non_strict_state_dict, strict=False)
-            del non_strict_state_dict['parametrizations.weight.0.u']
+            del non_strict_state_dict['parametrizations.weight.0._u']
             snm.load_state_dict(non_strict_state_dict, strict=False)
-            del non_strict_state_dict['parametrizations.weight.0.v']
+            del non_strict_state_dict['parametrizations.weight.0._v']
             snm.load_state_dict(non_strict_state_dict, strict=False)
             non_strict_state_dict['weight'] = snm.weight.detach().clone()     # set W as a buffer
             snm.load_state_dict(non_strict_state_dict, strict=False)
@@ -4096,7 +4096,7 @@ class TestNN(NNTestCase):
         # this should not run into incompatible shapes
         x = m(inp)
         # check that u refers to the same dimension
-        self.assertEqual(snm.u.shape, m.parametrizations.weight.original[0, :, 0, 0].shape)
+        self.assertEqual(snm._u.shape, m.parametrizations.weight.original[0, :, 0, 0].shape)
 
     def test_spectral_norm_forward(self):
         input = torch.randn(3, 5)
@@ -4121,7 +4121,7 @@ class TestNN(NNTestCase):
         snm = m.parametrizations.weight[0]
         # naive forward
         _weight = m.parametrizations.weight.original
-        _bias, _v = m.bias, snm.v
+        _bias, _v = m.bias, snm._v
         _weight_mat = _weight.view(_weight.size(0), -1)
         _u = torch.mv(_weight_mat, _v)
         _u = F.normalize(_u, dim=0, eps=1e-12)

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -30,10 +30,10 @@ class _SpectralNorm(Module):
             weight_mat = self._reshape_weight_to_matrix(weight)
             h, w = weight_mat.size()
 
-            self.register_buffer('u',
-                F.normalize(weight_mat.new_empty(h).normal_(0, 1), dim=0, eps=self.eps))
-            self.register_buffer('v',
-                F.normalize(weight_mat.new_empty(w).normal_(0, 1), dim=0, eps=self.eps))
+            u = weight_mat.new_empty(h).normal_(0, 1)
+            v = weight_mat.new_empty(w).normal_(0, 1)
+            self.register_buffer('u', F.normalize(u, dim=0, eps=self.eps))
+            self.register_buffer('v', F.normalize(v, dim=0, eps=self.eps))
 
             # Start with u, v initialized to some reasonable values by performing a number
             # of iterations of the power method

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -35,7 +35,13 @@ class _SpectralNorm(Module):
         if self.dim != 0:
             # permute dim to front
             weight = weight.permute(self.dim, *(d for d in range(weight.dim()) if d != self.dim))
-        return weight.flatten(1)
+
+        # TODO for weight of ndim == 1 we can do better as SpectralNorm is just:
+        # F.normalize(x, dim=0, eps=self.eps)
+        if weight.ndim > 1:
+            return weight.flatten(1)
+        else:
+            return weight.unsqueeze(1)
 
     @torch.autograd.no_grad()
     def _update_vectors(self, weight_mat: torch.Tensor, n_power_iterations: int) -> None:

--- a/torch/nn/utils/parametrizations.py
+++ b/torch/nn/utils/parametrizations.py
@@ -14,37 +14,43 @@ class _SpectralNorm(Module):
         eps: float = 1e-12
     ) -> None:
         super().__init__()
-        self.dim = dim
+        ndim = weight.ndim
+        if dim >= ndim or dim < -ndim:
+            raise IndexError("Dimension out of range (expected to be in range of "
+                             f"[-{ndim}, {ndim - 1}] but got {dim})")
+
         if n_power_iterations <= 0:
             raise ValueError('Expected n_power_iterations to be positive, but '
                              'got n_power_iterations={}'.format(n_power_iterations))
-        self.n_power_iterations = n_power_iterations
+        self.dim = dim if dim >= 0 else dim + ndim
         self.eps = eps
-        weight_mat = self._reshape_weight_to_matrix(weight)
-        h, w = weight_mat.size()
+        if ndim > 1:
+            # For ndim == 1 we do not need to approximate anything (see _SpectralNorm.forward)
+            self.n_power_iterations = n_power_iterations
+            weight_mat = self._reshape_weight_to_matrix(weight)
+            h, w = weight_mat.size()
 
-        self.register_buffer('u',
-            F.normalize(weight_mat.new_empty(h).normal_(0, 1), dim=0, eps=self.eps))
-        self.register_buffer('v',
-            F.normalize(weight_mat.new_empty(w).normal_(0, 1), dim=0, eps=self.eps))
+            self.register_buffer('u',
+                F.normalize(weight_mat.new_empty(h).normal_(0, 1), dim=0, eps=self.eps))
+            self.register_buffer('v',
+                F.normalize(weight_mat.new_empty(w).normal_(0, 1), dim=0, eps=self.eps))
 
-        # Start with u, v initialized to some reasonable values
-        self._update_vectors(weight_mat, 15)
+            # Start with u, v initialized to some reasonable values by performing a number
+            # of iterations of the power method
+            self._power_method(weight_mat, 15)
 
     def _reshape_weight_to_matrix(self, weight: torch.Tensor) -> torch.Tensor:
+        # Precondition
+        assert weight.ndim > 1
+
         if self.dim != 0:
             # permute dim to front
             weight = weight.permute(self.dim, *(d for d in range(weight.dim()) if d != self.dim))
 
-        # TODO for weight of ndim == 1 we can do better as SpectralNorm is just:
-        # F.normalize(x, dim=0, eps=self.eps)
-        if weight.ndim > 1:
-            return weight.flatten(1)
-        else:
-            return weight.unsqueeze(1)
+        return weight.flatten(1)
 
     @torch.autograd.no_grad()
-    def _update_vectors(self, weight_mat: torch.Tensor, n_power_iterations: int) -> None:
+    def _power_method(self, weight_mat: torch.Tensor, n_power_iterations: int) -> None:
         # See original note at torch/nn/utils/spectral_norm.py
         # NB: If `do_power_iteration` is set, the `u` and `v` vectors are
         #     updated in power iteration **in-place**. This is very important
@@ -76,6 +82,8 @@ class _SpectralNorm(Module):
         #    complain that variables needed to do backward for the first forward
         #    (i.e., the `u` and `v` vectors) are changed in the second forward.
 
+        # Precondition
+        assert weight_mat.ndim > 1
         for _ in range(n_power_iterations):
             # Spectral norm of weight equals to `u^T W v`, where `u` and `v`
             # are the first left and right singular vectors.
@@ -89,11 +97,15 @@ class _SpectralNorm(Module):
         self.v = self.v.clone(memory_format=torch.contiguous_format)
 
     def forward(self, weight: torch.Tensor) -> torch.Tensor:
-        weight_mat = self._reshape_weight_to_matrix(weight)
-        if self.training:
-            self._update_vectors(weight_mat, self.n_power_iterations)
-        sigma = torch.dot(self.u, torch.mv(weight_mat, self.v))
-        return weight / sigma
+        if weight.ndim == 1:
+            # Faster and more exact path, no need to approximate anything
+            return F.normalize(weight, dim=0, eps=self.eps)
+        else:
+            weight_mat = self._reshape_weight_to_matrix(weight)
+            if self.training:
+                self._power_method(weight_mat, self.n_power_iterations)
+            sigma = torch.dot(self.u, torch.mv(weight_mat, self.v))
+            return weight / sigma
 
     def right_inverse(self, value: torch.Tensor) -> torch.Tensor:
         # we may want to assert here that the passed value already
@@ -144,6 +156,12 @@ def spectral_norm(module: Module,
         reimplementation of :func:`torch.nn.utils.spectral_norm`.
 
     .. note::
+        When this constraint is registered, the singular vectors associated to the largest
+        singular value are estimated rather than sampled at random. These are then updated
+        performing :attr:`n_power_iterations` of the power method whenever the tensor
+        is accessed with the module on `training` mode.
+
+    .. note::
         If the `_SpectralNorm` module, i.e., `module.parametrization.weight[idx]`,
         is in training mode on removal, it will perform another power iteration.
         If you'd like to avoid this iteration, set the module to eval mode
@@ -161,8 +179,8 @@ def spectral_norm(module: Module,
             )
         )
         )
-        >>> snm.parametrizations.weight[0].u.size()
-        torch.Size([40])
+        >>> torch.linalg.matrix_norm(snm.weight, 2)
+        tensor(1.0000, grad_fn=<CopyBackwards>)
     """
     if not hasattr(module, name):
         raise ValueError(


### PR DESCRIPTION
Implements a number of changes discussed with @soulitzer offline.
In particular:
- Initialise `u`, `v` in `__init__` rather than in `_update_vectors`
- Initialise `u`, `v` to some reasonable vectors by doing 15 power iterations at the start
- Simplify the code of `_reshape_weight_to_matrix` (and make it faster) by using `flatten`