### PR TITLE
only reorder tests based on git diff if IN_CI 

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1133,8 +1133,8 @@ def main():
         ]
         sys.path.remove('test')
 
-
-    selected_tests = reorder_tests(selected_tests)
+    if bool(os.environ.get('IN_CI')):
+        selected_tests = reorder_tests(selected_tests)
 
     has_failed = False
     failure_messages = []

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -14,7 +14,7 @@ import tempfile
 
 import torch
 from torch.utils import cpp_extension
-from torch.testing._internal.common_utils import TEST_WITH_ROCM, shell, set_cwd, FILE_SCHEMA
+from torch.testing._internal.common_utils import FILE_SCHEMA, IS_IN_CI, TEST_WITH_ROCM, shell, set_cwd
 from torch.testing._internal.framework_utils import calculate_shards
 import torch.distributed as dist
 from typing import Dict, Optional, Tuple, List, Any
@@ -1133,7 +1133,7 @@ def main():
         ]
         sys.path.remove('test')
 
-    if bool(os.environ.get('IN_CI')):
+    if IS_IN_CI:
         selected_tests = reorder_tests(selected_tests)
 
     has_failed = False

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -63,6 +63,7 @@ FILE_SCHEMA = "file://"
 if sys.platform == 'win32':
     FILE_SCHEMA = "file:///"
 
+IS_IN_CI = bool(os.environ.get('IN_CI'))
 IS_SANDCASTLE = os.getenv('SANDCASTLE') == '1' or os.getenv('TW_JOB_USER') == 'sandcastle'
 IS_FBCODE = os.getenv('PYTORCH_TEST_FBCODE') == '1'
 IS_REMOTE_GPU = os.getenv('PYTORCH_TEST_REMOTE_GPU') == '1'
@@ -158,7 +159,7 @@ parser.add_argument('--repeat', type=int, default=1)
 parser.add_argument('--test_bailouts', action='store_true')
 parser.add_argument('--save-xml', nargs='?', type=str,
                     const=_get_test_report_path(),
-                    default=_get_test_report_path() if bool(os.environ.get('IN_CI')) else None)
+                    default=_get_test_report_path() if IS_IN_CI else None)
 parser.add_argument('--discover-tests', action='store_true')
 parser.add_argument('--log-suffix', type=str, default="")
 parser.add_argument('--run-parallel', type=int, default=1)


### PR DESCRIPTION
Do not reorder tests unless they are in IN_CI, this causes local development test ordering indeterministic. most of use branch out from viable strict not head of master. 


