### PR TITLE
enable upload test stats on PR

### DIFF
--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -766,12 +766,12 @@ def send_report_to_s3(head_report: Version2Report) -> None:
     job = os.environ.get('CIRCLE_JOB')
     sha1 = os.environ.get('CIRCLE_SHA1')
     branch = os.environ.get('CIRCLE_BRANCH', '')
-    if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
-        print("S3 upload only enabled on master, nightly and release branches.")
-        print(f"skipping test report on branch: {branch}")
-        return
     now = datetime.datetime.utcnow().isoformat()
-    key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
+    if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
+        pr = os.environ.get('CIRCLE_PR_NUMBER', 'unknown')
+        key = f'test_time/{pr}/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
+    else:
+        key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
     obj = get_S3_object_from_bucket('ossci-metrics', key)
     # use bz2 because the results are smaller than gzip, and the
     # compression time penalty we pay is only about half a second for

--- a/tools/print_test_stats.py
+++ b/tools/print_test_stats.py
@@ -769,7 +769,7 @@ def send_report_to_s3(head_report: Version2Report) -> None:
     now = datetime.datetime.utcnow().isoformat()
     if branch not in ['master', 'nightly'] and not branch.startswith("release/"):
         pr = os.environ.get('CIRCLE_PR_NUMBER', 'unknown')
-        key = f'test_time/{pr}/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
+        key = f'pr_test_time/{pr}/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
     else:
         key = f'test_time/{sha1}/{job}/{now}Z.json.bz2'  # Z meaning UTC
     obj = get_S3_object_from_bucket('ossci-metrics', key)


### PR DESCRIPTION
Enable test stats upload on PR. 

Uses PR number as part of the key so that it can be properly indexed and later parsed if PR has been merged/closed.