### PR TITLE
[FX] Specifies a default value when possible for placeholders created from concrete_args

### DIFF
--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -425,7 +425,7 @@ class Tracer(TracerBase):
                     nonlocal cnt
                     cnt += 1
                     param = sig.parameters[name]
-                    default = () if param.default is inspect.Parameter.empty else (x if x != PH else param.default,)
+                    default = () if param.default is inspect.Parameter.empty else (param.default,)
                     out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', default, {})
                     if x == PH:
                         return out

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -424,7 +424,9 @@ class Tracer(TracerBase):
                 def replace_ph(x):
                     nonlocal cnt
                     cnt += 1
-                    out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', (), {})
+                    param = sig.parameters[name]
+                    default = () if param.default is inspect.Parameter.empty else (x if x != PH else param.default,)
+                    out = self.create_proxy('placeholder', f'{name}_{str(cnt)}', default, {})
                     if x == PH:
                         return out
                     # Union[int, bool] == bool in Python <= 3.6


### PR DESCRIPTION

```python
class Foo(torch.nn.Module):
    def __init__(self):
        super().__init__()

    def forward(self, a=None, b=None):
        res = a
        if b is not None:
            res = res + b
        return res

concrete_args = {'b': torch.tensor(5)}
traced = fx.symbolic_trace(Foo(), concrete_args=concrete_args)
```

Gives the following error:

```
  File "<eval_with_key_9>", line 2
    def forward(self, a = None, b_1):
                ^
SyntaxError: non-default argument follows default argument
```

Since #55888, placeholders are also created for concrete arguments. But these placeholders do not have default values even when  it was provided for the argument in question, causing the error above. 

To solve this, I add a default value when it is available during placeholder creation for concrete arguments. 

I also tried to set the default value to the value specified in concrete_args (since it many cases it will actually use this value anyway), but ran into an error because the default value is never defined:

```
def forward(self, a = None, b_1 = _tensor_constant0):
    _tensor_constant0 = self._tensor_constant0
    _tensor_constant1 = self._tensor_constant1
    add = a + _tensor_constant1;  a = _tensor_constant1 = None

NameError: name '_tensor_constant0' is not defined
```