### PR TITLE
[quant][eager][fix] Fix a typo in convert function in eager mode quantization

### DIFF
--- a/torch/quantization/quantize.py
+++ b/torch/quantization/quantize.py
@@ -505,7 +505,7 @@ def _convert(
         if not isinstance(mod, _FusedModule) and \
            type(mod) not in custom_module_class_mapping:
             _convert(mod, mapping, True,  # inplace
-                     custom_module_class_mapping)
+                     convert_custom_config_dict)
         reassign[name] = swap_module(mod, mapping, custom_module_class_mapping)
 
     for key, value in reassign.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59571 [quant][eager][fix] Fix a typo in convert function in eager mode quantization**

Summary:

Test Plan:
python test/test_quantization.py TestPostTrainingStatic.test_custom_module_class

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D28938355](https://our.internmc.facebook.com/intern/diff/D28938355)