### PR TITLE
[Reland2][DDP] Merge work and future_work in reducer

### DIFF
--- a/torch/lib/c10d/comm.hpp
+++ b/torch/lib/c10d/comm.hpp
@@ -110,7 +110,7 @@ class TORCH_PYTHON_API CppCommHookInterface : public CommHookInterface {
   }
 
  protected:
-  T state_; // Not owned.
+  T state_;
 };
 
 } // namespace c10d

--- a/torch/lib/c10d/default_comm_hooks.cpp
+++ b/torch/lib/c10d/default_comm_hooks.cpp
@@ -1,7 +1,7 @@
 #include <c10d/default_comm_hooks.hpp>
 
-#include <c10d/comm.hpp>
 #include <c10d/ProcessGroup.hpp>
+#include <c10d/comm.hpp>
 #include <torch/torch.h>
 
 namespace c10d {
@@ -10,16 +10,18 @@ c10::intrusive_ptr<c10::ivalue::Future> AllReduceCommHook::runHook(
     GradBucket& bucket) {
   std::vector<at::Tensor> tensors = {bucket.getTensorRef()};
   auto allreduce_fut = state_->allreduce(tensors)->getFuture();
-  auto div_by_process_group_size = [size = state_->getSize()](
-        c10::ivalue::Future& allreduce_fut) {
-    auto result = allreduce_fut.value();
-    TORCH_INTERNAL_ASSERT(result.isTensorList(),
-        "ProcessGroup::allreduce should return TensorList");
-    auto tensor = result.toTensorVector()[0] / size;
-    return c10::IValue(tensor);
-  };
+  auto div_by_process_group_size =
+      [size = state_->getSize()](c10::ivalue::Future& allreduce_fut) {
+        auto result = allreduce_fut.value();
+        TORCH_INTERNAL_ASSERT(
+            result.isTensorList(),
+            "ProcessGroup::allreduce should return TensorList");
+        auto tensor = result.toTensorVector()[0] / size;
+        return c10::IValue(tensor);
+      };
 
-  return allreduce_fut->then(div_by_process_group_size, allreduce_fut->elementType());
+  return allreduce_fut->then(
+      div_by_process_group_size, allreduce_fut->elementType());
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
@@ -31,7 +33,8 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
   auto decompress_and_div_by_process_group_size =
       [size = state_->getSize()](c10::ivalue::Future& allreduce_fut) {
         auto result = allreduce_fut.value();
-        TORCH_INTERNAL_ASSERT(result.isTensorList(),
+        TORCH_INTERNAL_ASSERT(
+            result.isTensorList(),
             "ProcessGroup::allreduce should return TensorList");
         auto reduce_tensor = result.toTensorVector()[0];
         reduce_tensor.copy_(reduce_tensor.to(torch::kFloat) / size);
@@ -40,6 +43,14 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
 
   return allreduce_fut->then(
       decompress_and_div_by_process_group_size, allreduce_fut->elementType());
+}
+
+c10::intrusive_ptr<c10::ivalue::Future> _AllReduceCommHookWithDivFactor::
+    runHook(GradBucket& bucket) {
+  std::vector<at::Tensor> tensors = {bucket.getTensorRef()};
+  // Apply the division first to avoid overflow, especially for FP16.
+  tensors[0] /= state_.div_factor;
+  return state_.pg->allreduce(tensors)->getFuture();
 }
 
 } // namespace c10d

--- a/torch/lib/c10d/default_comm_hooks.hpp
+++ b/torch/lib/c10d/default_comm_hooks.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <c10d/comm.hpp>
 #include <c10d/ProcessGroup.hpp>
+#include <c10d/comm.hpp>
 
 namespace c10d {
 
@@ -15,7 +15,7 @@ class AllReduceCommHook : public CppCommHookInterface<ProcessGroup*> {
   explicit AllReduceCommHook(ProcessGroup* state)
       : CppCommHookInterface<ProcessGroup*>(state) {}
 
-  ~AllReduceCommHook() override {}
+  ~AllReduceCommHook() override = default;
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
 };
@@ -25,7 +25,30 @@ class FP16CompressCommHook : public CppCommHookInterface<ProcessGroup*> {
   explicit FP16CompressCommHook(ProcessGroup* state)
       : CppCommHookInterface<ProcessGroup*>(state) {}
 
-  ~FP16CompressCommHook() override {}
+  ~FP16CompressCommHook() override = default;
+
+  c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
+};
+
+struct _AllReduceCommHookWithDivFactorState {
+  _AllReduceCommHookWithDivFactorState(ProcessGroup* pg, int div_factor)
+      : pg(pg), div_factor(div_factor) {}
+
+  ProcessGroup* pg;
+  // Should be equal to the process group size, with the exception of unevent
+  // input.
+  int div_factor;
+};
+
+// Almost same as AllReduceCommHook, but requires an additional ``div_factor``
+// as the state for handling unevent input. Only used internally and not
+// released as a public built-in communication hook.
+class _AllReduceCommHookWithDivFactor
+    : public CppCommHookInterface<_AllReduceCommHookWithDivFactorState> {
+ public:
+  using CppCommHookInterface::CppCommHookInterface;
+
+  ~_AllReduceCommHookWithDivFactor() override = default;
 
   c10::intrusive_ptr<c10::ivalue::Future> runHook(GradBucket& bucket) override;
 };

--- a/torch/lib/c10d/reducer.hpp
+++ b/torch/lib/c10d/reducer.hpp
@@ -279,11 +279,8 @@ class Reducer {
       Reducer::BucketReplica& replica,
       size_t intra_bucket_index,
       bool global_unused);
-  // Check layout of grad and bucket_view before calling copy_grad_to_bucket
+  // Check layout of grad and bucket_view before copying the grad to bucket.
   void check_grad_layout(const at::Tensor& grad, const at::Tensor& bucket_view);
-  // If gradient_as_bucket_view_ is false, before allreduce buckets,
-  // copy grads to buckets.
-  void copy_grad_to_bucket(const at::Tensor& grad, at::Tensor& bucket_view);
 
   // A bucket holds N bucket replicas (1 per model replica).
   //
@@ -299,10 +296,8 @@ class Reducer {
     // Number of replicas to be marked done before this bucket is ready.
     size_t pending;
 
-    // Keep work handle around when this set of buckets is being reduced.
-    c10::intrusive_ptr<c10d::ProcessGroup::Work> work;
-
-    // Keep future work handle around if DDP comm hook is registered.
+    // Keep future work handle around DDP comm hook.
+    // If no hook is registered, a temporary vanilla allreduce hook will be used.
     c10::intrusive_ptr<torch::jit::Future> future_work;
 
     // If this bucket should expect a single sparse gradient.

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -3315,6 +3315,7 @@ class DistributedTest:
             "Only NCCL and GLOO backend support DistributedDataParallel",
         )
         @skip_if_lt_x_gpu(int(os.environ["WORLD_SIZE"]))
+        @skip_if_rocm
         def test_DistributedDataParallel_non_default_stream(self):
             stream = torch.cuda.Stream(self.rank)
             rank = self.rank


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59523 [DDP] Rename the member divFactor_ as div_factor for naming consistency in reducer
* #59510 [DDP] Remove the duplicate parseHookResult in reducer
* #59576 [Reland][Gradient Compression] Apply division first to avoid overflow
* **#59574 [Reland2][DDP] Merge work and future_work in reducer**

Remove `work` attribute from Reducer class in favor of `future_work`.

Additionally, remove `copy_grad_to_bucket` method since now it's only one-line implementation, and created a new C++ comm hook called `_AllReduceCommHookWithDivFactor` to replace allreduce and also support handling uneven input.

1) Compared with the reverted https://github.com/pytorch/pytorch/pull/58937, updated `_AllReduceCommHookWithDivFactor` in `default_comm_hooks.cpp` to apply division first and hence avoid FP16 overflow.

2) Compared with the reverted https://github.com/pytorch/pytorch/pull/59520, disabled `test_DistributedDataParallel_non_default_stream` on AMD, because now applying division first hurts the gradient averaging accuracy on AMD.
See [07:48:26]:
https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-bionic-rocm4.2-py3.6-test1/1129/console

#Original PR Issue: https://github.com/pytorch/pytorch/issues/41266

Differential Revision: [D28940800](https://our.internmc.facebook.com/intern/diff/D28940800/)