### PR TITLE
[Reland][Gradient Compression] Apply division first to avoid overflow

### DIFF
--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -7,16 +7,13 @@ import torch.distributed as dist
 def _allreduce_fut(
     process_group: dist.ProcessGroup, tensor: torch.Tensor
 ) -> torch.futures.Future:
+    "Averages the input gradient tensor by allreduce and returns a future."
     group_to_use = process_group if process_group is not None else dist.group.WORLD
 
-    "Averages the input gradient tensor by allreduce and returns a future."
-    fut = dist.all_reduce(tensor, group=group_to_use, async_op=True).get_future()
+    # Apply the division first to avoid overflow, especially for FP16.
+    tensor.div_(group_to_use.size())
 
-    def div_by_group_size(fut):
-        return [fut.value()[0].div_(group_to_use.size())]
-
-    return fut.then(div_by_group_size)
-
+    return dist.all_reduce(tensor, group=group_to_use, async_op=True).get_future()
 
 def allreduce_hook(
     process_group: dist.ProcessGroup, bucket: dist.GradBucket

--- a/torch/lib/c10d/default_comm_hooks.cpp
+++ b/torch/lib/c10d/default_comm_hooks.cpp
@@ -9,19 +9,9 @@ namespace c10d {
 c10::intrusive_ptr<c10::ivalue::Future> AllReduceCommHook::runHook(
     GradBucket& bucket) {
   std::vector<at::Tensor> tensors = {bucket.getTensorRef()};
-  auto allreduce_fut = state_->allreduce(tensors)->getFuture();
-  auto div_by_process_group_size =
-      [size = state_->getSize()](c10::ivalue::Future& allreduce_fut) {
-        auto result = allreduce_fut.value();
-        TORCH_INTERNAL_ASSERT(
-            result.isTensorList(),
-            "ProcessGroup::allreduce should return TensorList");
-        auto tensor = result.toTensorVector()[0] / size;
-        return c10::IValue(tensor);
-      };
-
-  return allreduce_fut->then(
-      div_by_process_group_size, allreduce_fut->elementType());
+  // Apply the division first to avoid overflow, especially for FP16.
+  tensors[0] /= state_->getSize();
+  return state_->allreduce(tensors)->getFuture();
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
@@ -29,20 +19,21 @@ c10::intrusive_ptr<c10::ivalue::Future> FP16CompressCommHook::runHook(
   auto& tensor = bucket.getTensorRef();
   tensor.copy_(tensor.to(torch::kFloat16));
   std::vector<at::Tensor> tensors = {tensor};
-  auto allreduce_fut = state_->allreduce(tensors)->getFuture();
-  auto decompress_and_div_by_process_group_size =
-      [size = state_->getSize()](c10::ivalue::Future& allreduce_fut) {
-        auto result = allreduce_fut.value();
-        TORCH_INTERNAL_ASSERT(
-            result.isTensorList(),
-            "ProcessGroup::allreduce should return TensorList");
-        auto reduce_tensor = result.toTensorVector()[0];
-        reduce_tensor.copy_(reduce_tensor.to(torch::kFloat) / size);
-        return c10::IValue(reduce_tensor);
-      };
+  // Apply the division first to avoid overflow.
+  tensors[0] /= state_->getSize();
 
-  return allreduce_fut->then(
-      decompress_and_div_by_process_group_size, allreduce_fut->elementType());
+  auto allreduce_fut = state_->allreduce(tensors)->getFuture();
+  auto decompress = [](c10::ivalue::Future& allreduce_fut) {
+    auto result = allreduce_fut.value();
+    TORCH_INTERNAL_ASSERT(
+        result.isTensorList(),
+        "ProcessGroup::allreduce should return TensorList");
+    auto reduce_tensor = result.toTensorVector()[0];
+    reduce_tensor.copy_(reduce_tensor.to(torch::kFloat));
+    return c10::IValue(reduce_tensor);
+  };
+
+  return allreduce_fut->then(decompress, allreduce_fut->elementType());
 }
 
 c10::intrusive_ptr<c10::ivalue::Future> _AllReduceCommHookWithDivFactor::


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59523 [DDP] Rename the member divFactor_ as div_factor for naming consistency in reducer
* #59510 [DDP] Remove the duplicate parseHookResult in reducer
* **#59576 [Reland][Gradient Compression] Apply division first to avoid overflow**
* #59574 [Reland2][DDP] Merge work and future_work in reducer

If the gradients before allreduce are large, then the sum after allreduce may overflow, especially for FP16. Therefore, apply the division before allreduce.

This fix is applied to both C++ and Python comm hooks.

Differential Revision: [D28941327](https://our.internmc.facebook.com/intern/diff/D28941327/)