### PR TITLE
[package] Add docstring for PackageExporter.intern

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -614,7 +614,21 @@ node [shape=box];
         exclude: "GlobPattern" = (),
         allow_empty: bool = True,
     ):
-        """TODO DOC"""
+        """Specify modules that should be packaged. A module must match some ``intern`` pattern in order to be
+        included in the package and have its dependencies processed recursively.
+
+        Args:
+            include (Union[List[str], str]): A string e.g. "my_package.my_subpackage", or list of strings
+                for the names of the modules to be externed. This can also be a glob-style pattern, as described in :meth:`mock`.
+
+            exclude (Union[List[str], str]): An optional pattern that excludes some patterns that match the include string.
+
+            allow_empty (bool): An optional flag that specifies whether the intern modules specified by this call
+                to the ``intern`` method must be matched to some module during packaging. If an ``intern`` module glob
+                pattern is added with ``allow_empty=False``, and ``close`` is called (either explicitly or via ``__exit__``)
+                before any modules match that pattern, an exception is thrown. If ``allow_empty=True``, no such exception is thrown.
+
+        """
         self.patterns[GlobGroup(include, exclude=exclude)] = _PatternInfo(
             _ModuleProviderAction.INTERN, allow_empty
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59602 [package] Add docstring for PackageExporter.intern**

**Summary**
This commit adds a docstring for `PackageExporter.intern`.

**Test Plan**
Continuous integration.

Differential Revision: [D28972939](https://our.internmc.facebook.com/intern/diff/D28972939)