### PR TITLE
[Static Runtime] Add schema check to several aten ops

### DIFF
--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -274,9 +274,12 @@ REGISTER_OPERATOR_FUNCTOR(
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::mul.Tensor(Tensor self, Tensor other) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
+
   return [](ProcessedNode* p_node) {
     const auto& in0_t = p_node->Input(0).toTensor();
     const auto& in1_t = p_node->Input(1).toTensor();
@@ -291,7 +294,9 @@ REGISTER_OPERATOR_FUNCTOR(aten::mul, aten_mul, [](Node* n) -> SROperator {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::addmm, aten_addmm, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 5) {
+  if (!n->matches(torch::schema(
+          "aten::addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -309,13 +314,16 @@ REGISTER_OPERATOR_FUNCTOR(aten::addmm, aten_addmm, [](Node* n) -> SROperator {
   };
 });
 
-// clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor
-// clamp.Tensor(Tensor self, Tensor? min=None, Tensor? max=None) -> Tensor
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::clamp, aten_clamp, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 3) {
+  if (!n->matches(torch::schema(
+          "aten::clamp(Tensor self, Scalar? min=None, Scalar? max=None) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::clamp.Tensor(Tensor self, Tensor? min=None, Tensor? max=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
+
   return [](ProcessedNode* p_node) {
     const auto& in0_t = p_node->Input(0).toTensor();
 
@@ -339,7 +347,9 @@ REGISTER_OPERATOR_FUNCTOR(aten::clamp, aten_clamp, [](Node* n) -> SROperator {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::bmm, aten_bmm, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(
+          torch::schema("aten::bmm(Tensor self, Tensor mat2) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -355,29 +365,30 @@ REGISTER_OPERATOR_FUNCTOR(aten::bmm, aten_bmm, [](Node* n) -> SROperator {
 });
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    aten::nan_to_num,
-    aten_nan_to_num,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 4) {
-        return nullptr;
-      }
-      return [](ProcessedNode* p_node) {
-        const auto& in0_t = p_node->Input(0).toTensor();
-        const auto in1_d = p_node->Input(1).toOptional<double>();
-        const auto in2_d = p_node->Input(2).toOptional<double>();
-        const auto in3_d = p_node->Input(3).toOptional<double>();
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = create_empty_from(in0_t);
-        }
-        auto& out_t = p_node->Output(0).toTensor();
-        fastResizeToZero(out_t);
-        at::native::nan_to_num_out(in0_t, in1_d, in2_d, in3_d, out_t);
-      };
-    });
+REGISTER_OPERATOR_FUNCTOR(aten::nan_to_num, aten_nan_to_num, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  return [](ProcessedNode* p_node) {
+    const auto& in0_t = p_node->Input(0).toTensor();
+    const auto in1_d = p_node->Input(1).toOptional<double>();
+    const auto in2_d = p_node->Input(2).toOptional<double>();
+    const auto in3_d = p_node->Input(3).toOptional<double>();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    fastResizeToZero(out_t);
+    at::native::nan_to_num_out(in0_t, in1_d, in2_d, in3_d, out_t);
+  };
+});
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(
+          torch::schema("aten::cat(Tensor[] tensors, int dim=0) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -394,7 +405,9 @@ REGISTER_OPERATOR_FUNCTOR(aten::cat, aten_cat, [](Node* n) -> SROperator {
 
 // Split out into a function to appease MSVC's pre-processor
 SROperator aten_stack(Node* n) {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::stack(Tensor[] tensors, int dim=0) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -413,23 +426,22 @@ SROperator aten_stack(Node* n) {
 REGISTER_OPERATOR_FUNCTOR(aten::stack, aten_stack, aten_stack);
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    aten::leaky_relu,
-    aten_leaky_relu,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 2) {
-        return nullptr;
-      }
-      return [](ProcessedNode* p_node) {
-        const auto& in0_t = p_node->Input(0).toTensor();
-        const auto in1_s = p_node->Input(1).toScalar();
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = create_empty_from(in0_t);
-        }
-        auto& out_t = p_node->Output(0).toTensor();
-        at::cpu::leaky_relu_out(out_t, in0_t, in1_s);
-      };
-    });
+REGISTER_OPERATOR_FUNCTOR(aten::leaky_relu, aten_leaky_relu, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::leaky_relu(Tensor self, Scalar negative_slope=0.01) -> Tensor"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  return [](ProcessedNode* p_node) {
+    const auto& in0_t = p_node->Input(0).toTensor();
+    const auto in1_s = p_node->Input(1).toScalar();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(in0_t);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    at::cpu::leaky_relu_out(out_t, in0_t, in1_s);
+  };
+});
 
 namespace {
 
@@ -584,7 +596,8 @@ std::shared_ptr<TEWrapper> createSigmoid() {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::relu, aten_relu, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 1) {
+  if (!n->matches(torch::schema("aten::relu(Tensor self) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   auto te = createRelu();
@@ -607,7 +620,8 @@ REGISTER_OPERATOR_FUNCTOR(aten::relu, aten_relu, [](Node* n) -> SROperator {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::tanh, aten_tanh, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 1) {
+  if (!n->matches(torch::schema("aten::tanh(Tensor self) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   auto te = createTanh();
@@ -633,7 +647,8 @@ REGISTER_OPERATOR_FUNCTOR(
     aten::sigmoid,
     aten_sigmoid,
     [](Node* n) -> SROperator {
-      if (n->inputs().size() != 1) {
+      if (!n->matches(torch::schema("aten::sigmoid(Tensor self) -> Tensor"))) {
+        LogAndDumpSchema(n);
         return nullptr;
       }
       auto te = createSigmoid();
@@ -656,7 +671,9 @@ REGISTER_OPERATOR_FUNCTOR(
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::logit(Tensor self, float? eps=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   c10::optional<float> clamp = c10::nullopt;
@@ -686,10 +703,11 @@ REGISTER_OPERATOR_FUNCTOR(aten::logit, aten_logit, [](Node* n) -> SROperator {
   };
 });
 
-// clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::clone, aten_clone, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -721,7 +739,9 @@ REGISTER_OPERATOR_FUNCTOR(
     quantized::embedding_bag_byte_rowwise_offsets,
     quantized_embedding_bag_byte_rowwise_offsets,
     [](Node* n) -> SROperator {
-      if (n->inputs().size() != 9) {
+      if (!n->matches(torch::schema(
+              "quantized::embedding_bag_byte_rowwise_offsets(Tensor weight, Tensor indices, Tensor? offsets=None, bool scale_grad_by_freq=False, int mode=0, bool pruned_weights=False, Tensor? per_sample_weights=None, Tensor? compressed_indices_mapping=None, bool include_last_offset=False) -> Tensor"))) {
+        LogAndDumpSchema(n);
         return nullptr;
       }
       return [](ProcessedNode* p_node) {
@@ -757,7 +777,9 @@ REGISTER_OPERATOR_FUNCTOR(
     quantized::embedding_bag_4bit_rowwise_offsets,
     embedding_bag_4bit_rowwise_offsets,
     [](Node* n) -> SROperator {
-      if (n->inputs().size() != 9) {
+      if (!n->matches(torch::schema(
+              "quantized::embedding_bag_4bit_rowwise_offsets(Tensor weight, Tensor indices, Tensor? offsets=None, bool scale_grad_by_freq=False, int mode=0, bool pruned_weights=False, Tensor? per_sample_weights=None, Tensor? compressed_indices_mapping=None, bool include_last_offset=False) -> Tensor"))) {
+        LogAndDumpSchema(n);
         return nullptr;
       }
       return [](ProcessedNode* p_node) {
@@ -791,36 +813,37 @@ REGISTER_OPERATOR_FUNCTOR(
 
 // The out variant takes precedence over native
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    aten::narrow_copy,
-    aten_narrow_copy,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 4) {
-        return nullptr;
-      }
-      return [](ProcessedNode* p_node) {
-        const auto& self = p_node->Input(0).toTensor(); // self
-        const auto dim = p_node->Input(1).toInt(); // dim
-        int64_t start = 0;
-        if (p_node->Input(2).isScalar()) {
-          start = p_node->Input(2).toInt();
-        } else {
-          auto& t = p_node->Input(2).toTensor();
-          start = t.item<int64_t>();
-        }
-        auto length = p_node->Input(3).toInt(); // length
+REGISTER_OPERATOR_FUNCTOR(aten::narrow_copy, aten_narrow_copy, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::narrow_copy(Tensor self, int dim, int start, int length) -> Tensor"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  return [](ProcessedNode* p_node) {
+    const auto& self = p_node->Input(0).toTensor(); // self
+    const auto dim = p_node->Input(1).toInt(); // dim
+    int64_t start = 0;
+    if (p_node->Input(2).isScalar()) {
+      start = p_node->Input(2).toInt();
+    } else {
+      auto& t = p_node->Input(2).toTensor();
+      start = t.item<int64_t>();
+    }
+    auto length = p_node->Input(3).toInt(); // length
 
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = create_empty_from(self);
-        }
-        auto& output = p_node->Output(0).toTensor();
-        fastResizeToZero(output);
-        at::native::narrow_copy_dense_cpu_out(self, dim, start, length, output);
-      };
-    });
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = create_empty_from(self);
+    }
+    auto& output = p_node->Output(0).toTensor();
+    fastResizeToZero(output);
+    at::native::narrow_copy_dense_cpu_out(self, dim, start, length, output);
+  };
+});
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::index, aten_index, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::index.Tensor(Tensor self, Tensor?[] indices) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -837,7 +860,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::index, aten_index, [](Node* n) -> SROperator {
 });
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::pow, aten_pow, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::pow.Scalar(Scalar self, Tensor exponent) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::pow.Tensor_Scalar(Tensor self, Scalar exponent) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -980,6 +1009,13 @@ REGISTER_OPERATOR_FUNCTOR(aten::sum, aten_sum, [](Node* n) -> SROperator {
   if (n->inputs().size() != 2 && n->inputs().size() != 4) {
     return nullptr;
   }
+  if (!n->matches(torch::schema(
+          "aten::sum(Tensor self, *, ScalarType? dtype=None) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::sum.dim_IntList(Tensor self, int[1] dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
   return [](ProcessedNode* p_node) {
     const at::Tensor& self = p_node->Input(0).toTensor();
 
@@ -1010,7 +1046,9 @@ REGISTER_OPERATOR_FUNCTOR(aten::sum, aten_sum, [](Node* n) -> SROperator {
 
 std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
   if (n->kind() == c10::Symbol::fromQualString("aten::transpose")) {
-    if (n->inputs().size() != 3) {
+    if (!n->matches(torch::schema(
+            "aten::transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1020,7 +1058,9 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       p_node->Output(0) = at::native::transpose(in0_t, in1_i, in2_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::flatten")) {
-    if (n->inputs().size() != 3) {
+    if (!n->matches(torch::schema(
+            "aten::flatten.using_ints(Tensor(a) self, int start_dim=0, int end_dim=-1) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1119,7 +1159,9 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       }
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::permute")) {
-    if (n->inputs().size() != 2) {
+    if (!n->matches(torch::schema(
+            "aten::permute(Tensor(a) self, int[] dims) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1128,7 +1170,9 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       p_node->Output(0) = at::native::permute(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::reshape")) {
-    if (n->inputs().size() != 2) {
+    if (!n->matches(torch::schema(
+            "aten::reshape(Tensor(a) self, int[] shape) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1137,7 +1181,9 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       p_node->Output(0) = at::native::reshape(in0_t, in1_iv);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::slice")) {
-    if (n->inputs().size() != 5) {
+    if (!n->matches(torch::schema(
+            "aten::slice.Tensor(Tensor(a) self, int dim=0, int? start=0, int? end=9223372036854775807, int step=1) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1149,7 +1195,11 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       p_node->Output(0) = at::native::slice(in0_t, in1_i, in2_i, in3_i, in4_i);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::narrow")) {
-    if (n->inputs().size() != 4) {
+    if (!n->matches(torch::schema(
+            "aten::narrow(Tensor(a) self, int dim, int start, int length) -> Tensor(a)")) &&
+        !n->matches(torch::schema(
+            "aten::narrow.Tensor(Tensor(a) self, int dim, Tensor start, int length) -> Tensor(a)"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1183,7 +1233,11 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
           at::native::slice(self, dim, start, start + length, 1);
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::to")) {
-    if (n->inputs().size() != 5) {
+    if (!n->matches(torch::schema(
+            "aten::to.other(Tensor self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor")) &&
+        !n->matches(torch::schema(
+            "aten::to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor"))) {
+      LogAndDumpSchema(n);
       return nullptr;
     }
     return [](ProcessedNode* p_node) {
@@ -1208,111 +1262,112 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    aten::embedding_bag,
-    aten_embedding_bag,
-    [](Node* n) -> SROperator {
-      // TODO: Support only 9 args once the old signature has been removed.
-      if (n->inputs().size() != 8 && n->inputs().size() != 9) {
-        return nullptr;
+REGISTER_OPERATOR_FUNCTOR(aten::embedding_bag, aten_embedding_bag, [](Node* n) -> SROperator {
+  // TODO: Support only 9 args once the old signature has been removed.
+  if (!n->matches(torch::schema(
+          "aten::embedding_bag(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq=False, int mode=0, bool sparse=False, Tensor? per_sample_weights=None, bool include_last_offset=False) -> (Tensor, Tensor, Tensor, Tensor)")) &&
+      !n->matches(torch::schema(
+          "aten::embedding_bag.padding_idx(Tensor weight, Tensor indices, Tensor offsets, bool scale_grad_by_freq, int mode, bool sparse, Tensor? per_sample_weights, bool include_last_offset, int? padding_idx) -> (Tensor, Tensor, Tensor, Tensor)"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  return [](ProcessedNode* p_node) {
+    const auto& weight = p_node->Input(0).toTensor();
+    const auto& indices = p_node->Input(1).toTensor();
+    const auto& offsets = p_node->Input(2).toTensor();
+    auto scale_grad_by_freq = p_node->Input(3).toBool();
+    auto mode = p_node->Input(4).to<int64_t>();
+    auto sparse = p_node->Input(5).toBool();
+    auto per_sample_weights = p_node->Input(6).toOptional<at::Tensor>();
+    auto include_last_offset = p_node->Input(7).toBool();
+    c10::optional<int64_t> padding_idx;
+    if (p_node->inputs().size() == 9) {
+      if (p_node->Input(8).isNone()) {
+        padding_idx = c10::nullopt;
+      } else {
+        padding_idx = p_node->Input(8).toInt();
       }
-      return [](ProcessedNode* p_node) {
-        const auto& weight = p_node->Input(0).toTensor();
-        const auto& indices = p_node->Input(1).toTensor();
-        const auto& offsets = p_node->Input(2).toTensor();
-        auto scale_grad_by_freq = p_node->Input(3).toBool();
-        auto mode = p_node->Input(4).to<int64_t>();
-        auto sparse = p_node->Input(5).toBool();
-        auto per_sample_weights = p_node->Input(6).toOptional<at::Tensor>();
-        auto include_last_offset = p_node->Input(7).toBool();
-        c10::optional<int64_t> padding_idx;
-        if (p_node->inputs().size() == 9) {
-          if (p_node->Input(8).isNone()) {
-            padding_idx = c10::nullopt;
-          } else {
-            padding_idx = p_node->Input(8).toInt();
-          }
-        }
+    }
 
-        at::native::check_arguments(
-            weight,
-            indices,
-            offsets,
-            mode,
-            per_sample_weights,
-            include_last_offset);
+    at::native::check_arguments(
+        weight,
+        indices,
+        offsets,
+        mode,
+        per_sample_weights,
+        include_last_offset);
 
-        std::ignore = scale_grad_by_freq;
-        std::ignore = sparse;
+    std::ignore = scale_grad_by_freq;
+    std::ignore = sparse;
 
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = at::empty(
-              {include_last_offset ? offsets.sizes()[0] - 1
-                                   : offsets.sizes()[0],
-               weight.sizes()[1]},
-              weight.options());
-        } else {
-          at::native::resize_(
-              p_node->Output(0).toTensor(),
-              {include_last_offset ? offsets.sizes()[0] - 1
-                                   : offsets.sizes()[0],
-               weight.sizes()[1]},
-              c10::nullopt);
-        }
-        at::Tensor& output = p_node->Output(0).toTensor();
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = at::empty(
+          {include_last_offset ? offsets.sizes()[0] - 1 : offsets.sizes()[0],
+           weight.sizes()[1]},
+          weight.options());
+    } else {
+      at::native::resize_(
+          p_node->Output(0).toTensor(),
+          {include_last_offset ? offsets.sizes()[0] - 1 : offsets.sizes()[0],
+           weight.sizes()[1]},
+          c10::nullopt);
+    }
+    at::Tensor& output = p_node->Output(0).toTensor();
 
-        if (p_node->Output(1).isNone()) {
-          p_node->Output(1) = at::empty({0}, offsets.options());
-        }
-        at::Tensor& offset2bag = p_node->Output(1).toTensor();
-        at::native::make_offset2bag_out(
-            offset2bag,
-            output,
-            weight,
-            indices,
-            offsets,
-            mode,
-            per_sample_weights,
-            padding_idx.value_or(-1));
+    if (p_node->Output(1).isNone()) {
+      p_node->Output(1) = at::empty({0}, offsets.options());
+    }
+    at::Tensor& offset2bag = p_node->Output(1).toTensor();
+    at::native::make_offset2bag_out(
+        offset2bag,
+        output,
+        weight,
+        indices,
+        offsets,
+        mode,
+        per_sample_weights,
+        padding_idx.value_or(-1));
 
-        if (p_node->Output(2).isNone()) {
-          p_node->Output(2) = at::empty(offsets.sizes(), offsets.options());
-        }
-        at::Tensor& bag_size = p_node->Output(2).toTensor();
-        at::native::make_bag_size_out(
-            bag_size, offsets, indices, mode, include_last_offset, false);
+    if (p_node->Output(2).isNone()) {
+      p_node->Output(2) = at::empty(offsets.sizes(), offsets.options());
+    }
+    at::Tensor& bag_size = p_node->Output(2).toTensor();
+    at::native::make_bag_size_out(
+        bag_size, offsets, indices, mode, include_last_offset, false);
 
-        if (p_node->Output(3).isNone()) {
-          p_node->Output(3) = at::empty(bag_size.sizes(), offsets.options());
-        }
-        at::Tensor& max_indices = p_node->Output(3).toTensor();
-        at::native::make_max_indices_out(
-            max_indices,
-            weight,
-            indices,
-            offsets,
-            bag_size,
-            mode,
-            include_last_offset);
+    if (p_node->Output(3).isNone()) {
+      p_node->Output(3) = at::empty(bag_size.sizes(), offsets.options());
+    }
+    at::Tensor& max_indices = p_node->Output(3).toTensor();
+    at::native::make_max_indices_out(
+        max_indices,
+        weight,
+        indices,
+        offsets,
+        bag_size,
+        mode,
+        include_last_offset);
 
-        at::native::_embedding_bag_cpu_impl_out(
-            output,
-            offset2bag,
-            bag_size,
-            max_indices,
-            weight,
-            indices,
-            offsets,
-            mode,
-            per_sample_weights,
-            include_last_offset,
-            padding_idx.value_or(-1));
-      };
-    });
+    at::native::_embedding_bag_cpu_impl_out(
+        output,
+        offset2bag,
+        bag_size,
+        max_indices,
+        weight,
+        indices,
+        offsets,
+        mode,
+        per_sample_weights,
+        include_last_offset,
+        padding_idx.value_or(-1));
+  };
+});
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::repeat, aten_repeat, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(torch::schema(
+          "aten::repeat(Tensor self, int[] repeats) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -1328,7 +1383,15 @@ REGISTER_OPERATOR_FUNCTOR(aten::repeat, aten_repeat, [](Node* n) -> SROperator {
 });
 
 REGISTER_OPERATOR_FUNCTOR(aten::div, aten_div, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2 && n->inputs().size() != 3) {
+  if (!n->matches(torch::schema(
+          "aten::div.Tensor(Tensor self, Tensor other) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::div.Scalar(Tensor self, Scalar other) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::div.Scalar_mode(Tensor self, Scalar other, *, str? rounding_mode) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -1353,7 +1416,11 @@ REGISTER_OPERATOR_FUNCTOR(aten::div, aten_div, [](Node* n) -> SROperator {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::sub, aten_sub, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 3) {
+  if (!n->matches(torch::schema(
+          "aten::sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::sub.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -1373,12 +1440,15 @@ REGISTER_OPERATOR_FUNCTOR(aten::sub, aten_sub, [](Node* n) -> SROperator {
   };
 });
 
+// TODO: support clamp_min.Tensor(Tensor self, Tensor min) -> Tensor
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(
     aten::clamp_min,
     aten_clamp_min,
     [](Node* n) -> SROperator {
-      if (n->inputs().size() != 2) {
+      if (!n->matches(torch::schema(
+              "aten::clamp_min(Tensor self, Scalar min) -> Tensor"))) {
+        LogAndDumpSchema(n);
         return nullptr;
       }
       return [](ProcessedNode* p_node) {
@@ -1395,7 +1465,9 @@ REGISTER_OPERATOR_FUNCTOR(
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::argmin, aten_argmin, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 3) {
+  if (!n->matches(torch::schema(
+          "aten::argmin(Tensor self, int? dim=None, bool keepdim=False) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -1411,83 +1483,64 @@ REGISTER_OPERATOR_FUNCTOR(aten::argmin, aten_argmin, [](Node* n) -> SROperator {
   };
 });
 
-REGISTER_OPERATOR_FUNCTOR(
-    aten::layer_norm,
-    aten_layer_norm,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 6) {
-        return nullptr;
-      }
-      return [](ProcessedNode* p_node) {
-        // ignore Input(5): `bool cudnn_enable=True`
-        const auto& input = p_node->Input(0).toTensor();
-        const auto normalized_shape = p_node->Input(1).toIntVector();
-        auto weight_opt = p_node->Input(2).toOptional<at::Tensor>();
-        auto bias_opt = p_node->Input(3).toOptional<at::Tensor>();
-        float eps = p_node->Input(4).toDouble();
-
-        c10::MaybeOwned<at::Tensor> weight_maybe_owned =
-            at::borrow_from_optional_tensor(weight_opt);
-        const at::Tensor& weight = *weight_maybe_owned;
-        c10::MaybeOwned<at::Tensor> bias_maybe_owned =
-            at::borrow_from_optional_tensor(bias_opt);
-        const at::Tensor& bias = *bias_maybe_owned;
-
-        auto M_N = at::native::_check_layer_norm_inputs(
-            input, normalized_shape, weight, bias);
-        auto M = M_N.first;
-        auto N = M_N.second;
-        auto X = input.expect_contiguous();
-        auto gamma = weight.expect_contiguous();
-        auto beta = bias.expect_contiguous();
-
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = at::native::empty_like(
-              *X,
-              c10::nullopt /* dtype */,
-              c10::nullopt /* layout */,
-              c10::nullopt /* device */,
-              c10::nullopt /* pin_memory */,
-              at::MemoryFormat::Contiguous);
-        } else {
-          at::native::resize_(
-              p_node->Output(0).toTensor(), X->sizes(), c10::nullopt);
-        }
-        at::Tensor& output = p_node->Output(0).toTensor();
-        at::Tensor mean = create_empty_from({M}, *X);
-        at::Tensor rstd = create_empty_from({M}, *X);
-
-        at::native::layer_norm_cpu_out(
-            output,
-            mean,
-            rstd,
-            input,
-            normalized_shape,
-            *gamma,
-            *beta,
-            eps,
-            M,
-            N);
-      };
-    });
-
-/* Support the following signatures of norm:
- * norm.ScalarOpt_dtype(Tensor self, Scalar? p, *, ScalarType dtype)
- * norm.ScalarOpt_dim_dtype(Tensor self, Scalar? p, int[1] dim, bool keepdim, *,
- *                          ScalarType dtype)
- * norm.ScalarOpt_dim(Tensor self, Scalar? p, int[1] dim, bool keepdim=False)
- */
-REGISTER_OPERATOR_FUNCTOR(aten::norm, aten_norm, [](Node* n) -> SROperator {
-  if (n->inputs().size() <= 2) {
-    LOG(ERROR)
-        << "Please implement static runtime support for aten::norm 2-arg version";
+REGISTER_OPERATOR_FUNCTOR(aten::layer_norm, aten_layer_norm, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::layer_norm(Tensor input, int[] normalized_shape, Tensor? weight=None, Tensor? bias=None, float eps=1e-05, bool cudnn_enable=True) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
-  // check that the third arg is scalar or int[]
-  auto val_2 = toIValue(n->inputs()[2]);
-  if (val_2 && !(val_2->isIntList() || val_2->isInt())) {
-    LOG(ERROR)
-        << "Please implement static runtime support for aten::norm w/ DimnameList";
+  return [](ProcessedNode* p_node) {
+    // ignore Input(5): `bool cudnn_enable=True`
+    const auto& input = p_node->Input(0).toTensor();
+    const auto normalized_shape = p_node->Input(1).toIntVector();
+    auto weight_opt = p_node->Input(2).toOptional<at::Tensor>();
+    auto bias_opt = p_node->Input(3).toOptional<at::Tensor>();
+    float eps = p_node->Input(4).toDouble();
+
+    c10::MaybeOwned<at::Tensor> weight_maybe_owned =
+        at::borrow_from_optional_tensor(weight_opt);
+    const at::Tensor& weight = *weight_maybe_owned;
+    c10::MaybeOwned<at::Tensor> bias_maybe_owned =
+        at::borrow_from_optional_tensor(bias_opt);
+    const at::Tensor& bias = *bias_maybe_owned;
+
+    auto M_N = at::native::_check_layer_norm_inputs(
+        input, normalized_shape, weight, bias);
+    auto M = M_N.first;
+    auto N = M_N.second;
+    auto X = input.expect_contiguous();
+    auto gamma = weight.expect_contiguous();
+    auto beta = bias.expect_contiguous();
+
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = at::native::empty_like(
+          *X,
+          c10::nullopt /* dtype */,
+          c10::nullopt /* layout */,
+          c10::nullopt /* device */,
+          c10::nullopt /* pin_memory */,
+          at::MemoryFormat::Contiguous);
+    } else {
+      at::native::resize_(
+          p_node->Output(0).toTensor(), X->sizes(), c10::nullopt);
+    }
+    at::Tensor& output = p_node->Output(0).toTensor();
+    at::Tensor mean = create_empty_from({M}, *X);
+    at::Tensor rstd = create_empty_from({M}, *X);
+
+    at::native::layer_norm_cpu_out(
+        output, mean, rstd, input, normalized_shape, *gamma, *beta, eps, M, N);
+  };
+});
+
+REGISTER_OPERATOR_FUNCTOR(aten::norm, aten_norm, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::norm.ScalarOpt_dtype(Tensor self, Scalar? p, *, ScalarType dtype) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::norm.ScalarOpt_dim_dtype(Tensor self, Scalar? p, int[1] dim, bool keepdim, *, ScalarType dtype) -> Tensor")) &&
+      !n->matches(torch::schema(
+          "aten::norm.ScalarOpt_dim(Tensor self, Scalar? p, int[1] dim, bool keepdim=False) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
 
@@ -1534,7 +1587,9 @@ REGISTER_OPERATOR_FUNCTOR(aten::norm, aten_norm, [](Node* n) -> SROperator {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 REGISTER_OPERATOR_FUNCTOR(aten::matmul, aten_matmul, [](Node* n) -> SROperator {
-  if (n->inputs().size() != 2) {
+  if (!n->matches(
+          torch::schema("aten::matmul(Tensor self, Tensor other) -> Tensor"))) {
+    LogAndDumpSchema(n);
     return nullptr;
   }
   return [](ProcessedNode* p_node) {
@@ -1551,76 +1606,73 @@ REGISTER_OPERATOR_FUNCTOR(aten::matmul, aten_matmul, [](Node* n) -> SROperator {
 });
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    quantized::linear,
-    quantized_linear,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 4) {
-        return nullptr;
-      }
-      const auto w = toIValue(n->inputs()[1]);
-      c10::intrusive_ptr<LinearPackedParamsBase> packed_weight;
-      if (w) {
-        packed_weight = w->toCustomClass<LinearPackedParamsBase>();
-      }
-      return [packed_weight](ProcessedNode* p_node) {
-        const auto& input = p_node->Input(0).toTensor();
-        const auto output_scale = p_node->Input(2).toDouble();
-        const auto output_zero_point = p_node->Input(3).toInt();
+REGISTER_OPERATOR_FUNCTOR(quantized::linear, quantized_linear, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "quantized::linear(Tensor X, __torch__.torch.classes.quantized.LinearPackedParamsBase W_prepack, float Y_scale_i, int Y_zero_point_i) -> Tensor Y"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  const auto w = toIValue(n->inputs()[1]);
+  c10::intrusive_ptr<LinearPackedParamsBase> packed_weight;
+  if (w) {
+    packed_weight = w->toCustomClass<LinearPackedParamsBase>();
+  }
+  return [packed_weight](ProcessedNode* p_node) {
+    const auto& input = p_node->Input(0).toTensor();
+    const auto output_scale = p_node->Input(2).toDouble();
+    const auto output_zero_point = p_node->Input(3).toInt();
 
-        if (p_node->Output(0).isNone()) {
-          p_node->Output(0) = at::native::empty_affine_quantized(
-              {0},
-              c10::kQUInt8,
-              c10::nullopt,
-              c10::kCPU,
-              false,
-              output_scale,
-              output_zero_point,
-              c10::nullopt);
-        }
-        auto& out_t = p_node->Output(0).toTensor();
-        fastResizeToZero(out_t);
+    if (p_node->Output(0).isNone()) {
+      p_node->Output(0) = at::native::empty_affine_quantized(
+          {0},
+          c10::kQUInt8,
+          c10::nullopt,
+          c10::kCPU,
+          false,
+          output_scale,
+          output_zero_point,
+          c10::nullopt);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    fastResizeToZero(out_t);
 
-        if (packed_weight) {
-          packed_weight->apply_out(
-              input, output_scale, output_zero_point, out_t);
-        } else {
-          // Weights could be quantized on the fly
-          auto packed_weight_tmp =
-              p_node->Input(1).toCustomClass<LinearPackedParamsBase>();
-          packed_weight_tmp->apply_out(
-              input, output_scale, output_zero_point, out_t);
-        }
-      };
-    });
+    if (packed_weight) {
+      packed_weight->apply_out(input, output_scale, output_zero_point, out_t);
+    } else {
+      // Weights could be quantized on the fly
+      auto packed_weight_tmp =
+          p_node->Input(1).toCustomClass<LinearPackedParamsBase>();
+      packed_weight_tmp->apply_out(
+          input, output_scale, output_zero_point, out_t);
+    }
+  };
+});
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-REGISTER_OPERATOR_FUNCTOR(
-    aten::full_like,
-    aten_full_like,
-    [](Node* n) -> SROperator {
-      if (n->inputs().size() != 7) {
-        return nullptr;
-      }
-      return [](ProcessedNode* p_node) {
-        const auto in1_s = p_node->Input(1).toScalar();
-        if (p_node->Output(0).isNone()) {
-          const auto& in0_t = p_node->Input(0).toTensor();
-          const auto dtype = p_node->Input(2).toOptional<c10::ScalarType>();
-          const auto layout = p_node->Input(3).toOptional<c10::Layout>();
-          const auto device = p_node->Input(4).toOptional<c10::Device>();
-          const auto pin_memory = p_node->Input(5).toOptional<bool>();
-          const auto memory_format =
-              p_node->Input(6).toOptional<c10::MemoryFormat>();
+REGISTER_OPERATOR_FUNCTOR(aten::full_like, aten_full_like, [](Node* n) -> SROperator {
+  if (!n->matches(torch::schema(
+          "aten::full_like(Tensor self, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor"))) {
+    LogAndDumpSchema(n);
+    return nullptr;
+  }
+  return [](ProcessedNode* p_node) {
+    const auto in1_s = p_node->Input(1).toScalar();
+    if (p_node->Output(0).isNone()) {
+      const auto& in0_t = p_node->Input(0).toTensor();
+      const auto dtype = p_node->Input(2).toOptional<c10::ScalarType>();
+      const auto layout = p_node->Input(3).toOptional<c10::Layout>();
+      const auto device = p_node->Input(4).toOptional<c10::Device>();
+      const auto pin_memory = p_node->Input(5).toOptional<bool>();
+      const auto memory_format =
+          p_node->Input(6).toOptional<c10::MemoryFormat>();
 
-          p_node->Output(0) = at::native::empty_like(
-              in0_t, dtype, layout, device, pin_memory, memory_format);
-        }
-        auto& out_t = p_node->Output(0).toTensor();
-        at::native::fill_out(out_t, in1_s);
-      };
-    });
+      p_node->Output(0) = at::native::empty_like(
+          in0_t, dtype, layout, device, pin_memory, memory_format);
+    }
+    auto& out_t = p_node->Output(0).toTensor();
+    at::native::fill_out(out_t, in1_s);
+  };
+});
 
 } // namespace jit
 } // namespace torch

--- a/torch/csrc/jit/runtime/static/ops.h
+++ b/torch/csrc/jit/runtime/static/ops.h
@@ -133,5 +133,10 @@ inline std::string PrintNode(const Node* node) {
   return ss.str();
 }
 
+inline void LogAndDumpSchema(const Node* node) {
+  VLOG(1) << "Found schema mismatch";
+  node->schema().dump();
+}
+
 } // namespace jit
 } // namespace torch


### PR DESCRIPTION
Summary:
D28698997 (https://github.com/pytorch/pytorch/commit/10345010f761e961b3f6785a874374f7dc2be1c2) was reverted because I forgot to replace the
```
  VLOG(1) << "Found schema mismatch";
  n->schema().dump();
```
block in `aten::clamp_min` with `LogAndDumpSchema(n)` and that led to the bazel build to fail. I don't know why it makes the bazel build though.

Test Plan: OSS CI.

Differential Revision: D28950177

