### PR TITLE
Document debugability features in torch.distributed

### DIFF
--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -581,3 +581,209 @@ For references on how to use it, please refer to `PyTorch example - ImageNet
 implementation <https://github.com/pytorch/examples/tree/master/imagenet>`_
 
 Note that this function requires Python 3.4 or higher.
+
+Debugging ``torch.distributed`` applications
+------------------------------------------------------
+
+Debugging distributed applications can be challenging due to hard to understand hangs, crashes, or inconsistent behavior across ranks. ``torch.distributed`` provides
+a suite of tools to help debug training applications in a self-serve fashion:
+
+As of v1.10, :func:`torch.distributed.monitored_barrier` exists as an alternative to :func:`torch.distributed.barrier` which fails with helpful information about which rank may be faulty
+when crashing, i.e. not all ranks calling into :func:`torch.distributed.monitored_barrier` within the provided timeout. :func:`torch.distributed.monitored_barrier` implements a host-side
+barrier using ``send``/``recv`` communication primitives in a process similar to acknowledgements, allowing rank 0 to report which rank(s) failed to acknowledge
+the barrier in time. As an example, consider the following function where rank 1 fails to call into :func:`torch.distributed.monitored_barrier` (in practice this could be due
+to an application bug or hang in a previous collective):
+
+::
+
+    import os
+    from datetime import timedelta
+
+    import torch
+    import torch.distributed as dist
+    import torch.multiprocessing as mp
+
+
+    def worker(rank):
+        dist.init_process_group("nccl", rank=rank, world_size=2)
+        # monitored barrier requires gloo process group to perform host-side sync.
+        group_gloo = dist.new_group(backend="gloo")
+        if rank not in [1]:
+            dist.monitored_barrier(group=group_gloo, timeout=timedelta(seconds=2))
+
+
+    if __name__ == "__main__":
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29501"
+        mp.spawn(worker, nprocs=2, args=())
+
+The following error message is produced on rank 0, allowing the user to determine which rank(s) may be faulty and investigate further:
+
+::
+
+  RuntimeError: Rank 1 failed to pass monitoredBarrier in 2000 ms
+   Original exception: 
+  [gloo/transport/tcp/pair.cc:598] Connection closed by peer [2401:db00:eef0:1100:3560:0:1c05:25d]:8594
+
+
+Next, the environment variable ``TORCH_DISTRIBUTED_DEBUG``  can be used to trigger additional useful logging and collective synchronization checks to ensure all ranks
+are synchronized appropriately. ``TORCH_DISTRIBUTED_DEBUG`` can be set to either ``OFF`` (default), ``INFO``, or ``DETAIL`` depending on the debugging level
+required. Please note that the most verbose option, ``DETAIL`` may impact the application performance and thus should only be used when debugging issues.
+
+Setting ``TORCH_DISTRIBUTED_DEBUG=INFO`` will result in additional debug logging when models trained with :func:`torch.nn.parallel.DistributedDataParallel` are initialized, and 
+``TORCH_DISTRIBUTED_DEBUG=DETAIL`` will additionally log runtime performance statistics a select number of iterations. These runtime statistics 
+include data such as forward time, backward time, gradient communication time, etc. As an example, given the following application:
+
+::
+
+    import os
+    from datetime import timedelta
+
+    import torch
+    import torch.distributed as dist
+    import torch.multiprocessing as mp
+
+
+    class TwoLinLayerNet(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.a = torch.nn.Linear(10, 10, bias=False)
+            self.b = torch.nn.Linear(10, 1, bias=False)
+
+        def forward(self, x):
+            a = self.a(x)
+            b = self.b(x)
+            return (a, b)
+
+
+    def worker(rank):
+        dist.init_process_group("nccl", rank=rank, world_size=2)
+        torch.cuda.set_device(rank)
+        print("init model")
+        model = TwoLinLayerNet().cuda()
+        print("init ddp")
+        ddp_model = torch.nn.parallel.DistributedDataParallel(model, device_ids=[rank])
+
+        inp = torch.randn(10, 10).cuda()
+        print("train")
+
+        for _ in range(20):
+            output = ddp_model(inp)
+            loss = output[0] + output[1]
+            loss.sum().backward()
+
+
+    if __name__ == "__main__":
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29501"
+        os.environ[
+            "TORCH_DISTRIBUTED_DEBUG"
+        ] = "DETAIL"  # set to DETAIL for runtime logging.
+        mp.spawn(worker, nprocs=2, args=())
+
+The following logs are rendered at initialization time:
+
+::
+
+  I0607 16:10:35.739390 515217 logger.cpp:173] [Rank 0]: DDP Initialized with: 
+  broadcast_buffers: 1
+  bucket_cap_bytes: 26214400
+  find_unused_parameters: 0
+  gradient_as_bucket_view: 0
+  is_multi_device_module: 0
+  iteration: 0
+  num_parameter_tensors: 2
+  output_device: 0
+  rank: 0
+  total_parameter_size_bytes: 440
+  world_size: 2
+  backend_name: nccl
+  bucket_sizes: 440
+  cuda_visible_devices: N/A
+  device_ids: 0
+  dtypes: float
+  master_addr: localhost
+  master_port: 29501
+  module_name: TwoLinLayerNet
+  nccl_async_error_handling: N/A
+  nccl_blocking_wait: N/A
+  nccl_debug: WARN
+  nccl_ib_timeout: N/A
+  nccl_nthreads: N/A
+  nccl_socket_ifname: N/A
+  torch_distributed_debug: INFO
+
+
+The following logs are rendered during runtime (when ``TORCH_DISTRIBUTED_DEBUG=DETAIL`` is set):
+
+::
+
+  I0607 16:18:58.085681 544067 logger.cpp:344] [Rank 1 / 2] Training TwoLinLayerNet unused_parameter_size=0 
+   Avg forward compute time: 40838608 
+   Avg backward compute time: 5983335 
+  Avg backward comm. time: 4326421 
+   Avg backward comm/comp overlap time: 4207652
+  I0607 16:18:58.085693 544066 logger.cpp:344] [Rank 0 / 2] Training TwoLinLayerNet unused_parameter_size=0 
+   Avg forward compute time: 42850427 
+   Avg backward compute time: 3885553 
+  Avg backward comm. time: 2357981 
+   Avg backward comm/comp overlap time: 2234674
+
+
+In addition, ``TORCH_DISTRIBUTED_DEBUG=INFO`` enhances crashes in :func:`torch.nn.parallel.DistributedDataParallel` due to unused parameters in the model. Currently, ``find_unused_parameters=True``
+must be passed into :func:`torch.nn.parallel.DistributedDataParallel` initialization if there are parameters that may be unused in the forward pass, and as of v1.10, all model outputs are required
+to be used in loss computation as :func:`torch.nn.parallel.DistributedDataParallel` does not support unused parameters in the backwards pass. These constraints are challenging especially for larger
+models, thus when crashing with an error, :func:`torch.nn.parallel.DistributedDataParallel` will log the fully qualified name of all parameters that went unused. For example, in the above application,
+if we modify ``loss`` to be instead computed as ``loss = output[1]``, then ``TwoLinLayerNet.a`` does not receive a gradient in the backwards pass, and 
+thus results in ``DDP`` failing. On a crash, the user is passed information about parameters which went unused, which may be challenging to manually find for large models:
+
+
+:: 
+
+  RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing
+   the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by 
+  making sure all `forward` function outputs participate in calculating loss. 
+  If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return va
+  lue of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
+  Parameters which did not receive grad for rank 0: a.weight
+  Parameter indices which did not receive grad for rank 0: 0
+
+
+Setting ``TORCH_DISTRIBUTED_DEBUG=DETAIL`` will trigger additional consistency and synchronization checks on every collective call issued by the user
+either directly or indirectly (such as DDP ``allreduce``). This is done by creating a wrapper process group that wraps all process groups returned by
+:func:`torch.distributed.init_process_group` and :func:`torch.distributed.new_group` APIs. As a result, these APIs will return a wrapper process group that can be used exactly like a regular process
+group, but performs consistency checks before dispatching the collective to an underlying process group. Currently, these checks include a :func:`torch.distributed.monitored_barrier`,
+which ensures all ranks complete their outstanding collective calls and reports ranks which are stuck. Next, the collective itself is checked for consistency by
+ensuring all collective functions match and are called with consistent tensor shapes. If this is not the case, a detailed error report is included when the
+application crashes, rather than a hang or uninformative error message. As an example, consider the following function which has mismatched input shapes into
+:func:`torch.distributed.all_reduce`: 
+
+::
+
+    import torch
+    import torch.distributed as dist
+    import torch.multiprocessing as mp
+
+
+    def worker(rank):
+        dist.init_process_group("nccl", rank=rank, world_size=2)
+        torch.cuda.set_device(rank)
+        tensor = torch.randn(10 if rank == 0 else 20).cuda()
+        dist.all_reduce(tensor)
+        torch.cuda.synchronize(device=rank)
+
+
+    if __name__ == "__main__":
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29501"
+        os.environ["TORCH_DISTRIBUTED_DEBUG"] = "DETAIL"
+        mp.spawn(worker, nprocs=2, args=())
+
+With the ``NCCL`` backend, such an application would likely result in a hang which can be challenging to root-cause in nontrivial scenarios. If the user enables
+``TORCH_DISTRIBUTED_DEBUG=DETAIL`` and reruns the application, the following error message which reveals the root cause:
+
+::
+
+    work = default_pg.allreduce([tensor], opts)
+    RuntimeError: Error when verifying shape tensors for collective ALLREDUCE on rank 0. This likely indicates that input shapes into the collective are mismatched across ranks. Got shapes:  10
+    [ torch.LongTensor{1} ]

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -637,7 +637,6 @@ include data such as forward time, backward time, gradient communication time, e
 ::
 
     import os
-    from datetime import timedelta
 
     import torch
     import torch.distributed as dist
@@ -730,7 +729,7 @@ The following logs are rendered during runtime (when ``TORCH_DISTRIBUTED_DEBUG=D
    Avg backward comm/comp overlap time: 2234674
 
 
-In addition, ``TORCH_DISTRIBUTED_DEBUG=INFO`` enhances crashes in :func:`torch.nn.parallel.DistributedDataParallel` due to unused parameters in the model. Currently, ``find_unused_parameters=True``
+In addition, ``TORCH_DISTRIBUTED_DEBUG=INFO`` enhances crash logging in :func:`torch.nn.parallel.DistributedDataParallel` due to unused parameters in the model. Currently, ``find_unused_parameters=True``
 must be passed into :func:`torch.nn.parallel.DistributedDataParallel` initialization if there are parameters that may be unused in the forward pass, and as of v1.10, all model outputs are required
 to be used in loss computation as :func:`torch.nn.parallel.DistributedDataParallel` does not support unused parameters in the backwards pass. These constraints are challenging especially for larger
 models, thus when crashing with an error, :func:`torch.nn.parallel.DistributedDataParallel` will log the fully qualified name of all parameters that went unused. For example, in the above application,

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -622,7 +622,7 @@ The following error message is produced on rank 0, allowing the user to determin
 ::
 
   RuntimeError: Rank 1 failed to pass monitoredBarrier in 2000 ms
-   Original exception: 
+   Original exception:
   [gloo/transport/tcp/pair.cc:598] Connection closed by peer [2401:db00:eef0:1100:3560:0:1c05:25d]:8594
 
 
@@ -630,8 +630,8 @@ Next, the environment variable ``TORCH_DISTRIBUTED_DEBUG``  can be used to trigg
 are synchronized appropriately. ``TORCH_DISTRIBUTED_DEBUG`` can be set to either ``OFF`` (default), ``INFO``, or ``DETAIL`` depending on the debugging level
 required. Please note that the most verbose option, ``DETAIL`` may impact the application performance and thus should only be used when debugging issues.
 
-Setting ``TORCH_DISTRIBUTED_DEBUG=INFO`` will result in additional debug logging when models trained with :func:`torch.nn.parallel.DistributedDataParallel` are initialized, and 
-``TORCH_DISTRIBUTED_DEBUG=DETAIL`` will additionally log runtime performance statistics a select number of iterations. These runtime statistics 
+Setting ``TORCH_DISTRIBUTED_DEBUG=INFO`` will result in additional debug logging when models trained with :func:`torch.nn.parallel.DistributedDataParallel` are initialized, and
+``TORCH_DISTRIBUTED_DEBUG=DETAIL`` will additionally log runtime performance statistics a select number of iterations. These runtime statistics
 include data such as forward time, backward time, gradient communication time, etc. As an example, given the following application:
 
 ::
@@ -685,7 +685,7 @@ The following logs are rendered at initialization time:
 
 ::
 
-  I0607 16:10:35.739390 515217 logger.cpp:173] [Rank 0]: DDP Initialized with: 
+  I0607 16:10:35.739390 515217 logger.cpp:173] [Rank 0]: DDP Initialized with:
   broadcast_buffers: 1
   bucket_cap_bytes: 26214400
   find_unused_parameters: 0
@@ -718,15 +718,15 @@ The following logs are rendered during runtime (when ``TORCH_DISTRIBUTED_DEBUG=D
 
 ::
 
-  I0607 16:18:58.085681 544067 logger.cpp:344] [Rank 1 / 2] Training TwoLinLayerNet unused_parameter_size=0 
-   Avg forward compute time: 40838608 
-   Avg backward compute time: 5983335 
-  Avg backward comm. time: 4326421 
+  I0607 16:18:58.085681 544067 logger.cpp:344] [Rank 1 / 2] Training TwoLinLayerNet unused_parameter_size=0
+   Avg forward compute time: 40838608
+   Avg backward compute time: 5983335
+  Avg backward comm. time: 4326421
    Avg backward comm/comp overlap time: 4207652
-  I0607 16:18:58.085693 544066 logger.cpp:344] [Rank 0 / 2] Training TwoLinLayerNet unused_parameter_size=0 
-   Avg forward compute time: 42850427 
-   Avg backward compute time: 3885553 
-  Avg backward comm. time: 2357981 
+  I0607 16:18:58.085693 544066 logger.cpp:344] [Rank 0 / 2] Training TwoLinLayerNet unused_parameter_size=0
+   Avg forward compute time: 42850427
+   Avg backward compute time: 3885553
+  Avg backward comm. time: 2357981
    Avg backward comm/comp overlap time: 2234674
 
 
@@ -734,15 +734,15 @@ In addition, ``TORCH_DISTRIBUTED_DEBUG=INFO`` enhances crashes in :func:`torch.n
 must be passed into :func:`torch.nn.parallel.DistributedDataParallel` initialization if there are parameters that may be unused in the forward pass, and as of v1.10, all model outputs are required
 to be used in loss computation as :func:`torch.nn.parallel.DistributedDataParallel` does not support unused parameters in the backwards pass. These constraints are challenging especially for larger
 models, thus when crashing with an error, :func:`torch.nn.parallel.DistributedDataParallel` will log the fully qualified name of all parameters that went unused. For example, in the above application,
-if we modify ``loss`` to be instead computed as ``loss = output[1]``, then ``TwoLinLayerNet.a`` does not receive a gradient in the backwards pass, and 
+if we modify ``loss`` to be instead computed as ``loss = output[1]``, then ``TwoLinLayerNet.a`` does not receive a gradient in the backwards pass, and
 thus results in ``DDP`` failing. On a crash, the user is passed information about parameters which went unused, which may be challenging to manually find for large models:
 
 
-:: 
+::
 
   RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing
-   the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by 
-  making sure all `forward` function outputs participate in calculating loss. 
+   the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by
+  making sure all `forward` function outputs participate in calculating loss.
   If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return va
   lue of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
   Parameters which did not receive grad for rank 0: a.weight
@@ -756,7 +756,7 @@ group, but performs consistency checks before dispatching the collective to an u
 which ensures all ranks complete their outstanding collective calls and reports ranks which are stuck. Next, the collective itself is checked for consistency by
 ensuring all collective functions match and are called with consistent tensor shapes. If this is not the case, a detailed error report is included when the
 application crashes, rather than a hang or uninformative error message. As an example, consider the following function which has mismatched input shapes into
-:func:`torch.distributed.all_reduce`: 
+:func:`torch.distributed.all_reduce`:
 
 ::
 

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -779,10 +779,12 @@ application crashes, rather than a hang or uninformative error message. As an ex
         mp.spawn(worker, nprocs=2, args=())
 
 With the ``NCCL`` backend, such an application would likely result in a hang which can be challenging to root-cause in nontrivial scenarios. If the user enables
-``TORCH_DISTRIBUTED_DEBUG=DETAIL`` and reruns the application, the following error message which reveals the root cause:
+``TORCH_DISTRIBUTED_DEBUG=DETAIL`` and reruns the application, the following error message reveals the root cause:
 
 ::
 
     work = default_pg.allreduce([tensor], opts)
     RuntimeError: Error when verifying shape tensors for collective ALLREDUCE on rank 0. This likely indicates that input shapes into the collective are mismatched across ranks. Got shapes:  10
     [ torch.LongTensor{1} ]
+
+In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected.

--- a/docs/source/distributed.rst
+++ b/docs/source/distributed.rst
@@ -787,4 +787,6 @@ With the ``NCCL`` backend, such an application would likely result in a hang whi
     RuntimeError: Error when verifying shape tensors for collective ALLREDUCE on rank 0. This likely indicates that input shapes into the collective are mismatched across ranks. Got shapes:  10
     [ torch.LongTensor{1} ]
 
-In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected.
+In addition, `TORCH_DISTRIBUTED_DEBUG=DETAIL` can be used in conjunction with `TORCH_SHOW_CPP_STACKTRACES=1` to log the entire callstack when a collective desynchronization is detected. These
+collective desynchronization checks will work for all applications that use ``c10d`` collective calls backed by process groups created with the
+ :func:`torch.distributed.init_process_group` and :func:`torch.distributed.new_group` APIs.


### PR DESCRIPTION
Adds comprehensive documentation around debugability features added to `torch.distributed` recently, including the `monitored_barrier` and TORCH_DISTRIBUTED_DEBUG env variable.

![dist_one](https://user-images.githubusercontent.com/8039770/121102672-0f052180-c7b3-11eb-974c-81dbbe102cb6.png)
![dist_two](https://user-images.githubusercontent.com/8039770/121102734-39ef7580-c7b3-11eb-94f7-c75469351440.png)
