### PR TITLE
Use a world size of 2 for test_zero_redundancy_optimizer

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -205,7 +205,7 @@ class TestZeroRedundancyOptimizerSingleRank(TestZeroRedundancyOptimizer):
 class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
     @property
     def world_size(self):
-        return min(4, max(2, torch.cuda.device_count()))
+        return 2
 
     @common_distributed.skip_if_rocm
     def test_step(self):


### PR DESCRIPTION
This is the only working configuration for those tests at the moment.

Fixes #59548

See https://github.com/pytorch/pytorch/commit/787854ce413e7b73614fac60f9af767ea6dac3be which already limits it to 2-4 but https://github.com/pytorch/pytorch/issues/53322#issuecomment-821551901 reported that it also fails with 3, which I can confirm (see #59548). At least 1 test also fails with 4 GPUs, hence use 2 here which always works.
