### PR TITLE
ninja 1.9.0 couldn't be installed, CI might be broken

### DIFF
--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -39,9 +39,10 @@ if not "%USE_CUDA%"=="1" goto cuda_build_end
 set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%
 
 rem version transformer, for example 10.1 to 10_1.
-if x%CUDA_VERSION:.=%==x%CUDA_VERSION%
+if x%CUDA_VERSION:.=%==x%CUDA_VERSION% (
     echo CUDA version %CUDA_VERSION% format isn't correct, which doesn't contain '.'
     exit /b 1
+)
 set VERSION_SUFFIX=%CUDA_VERSION:.=_%
 set CUDA_PATH_V%VERSION_SUFFIX%=%CUDA_PATH%
 

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -22,7 +22,7 @@ call %INSTALLER_DIR%\install_miniconda3.bat
 
 
 :: Install ninja and other deps
-if "%REBUILD%"=="" ( pip install -q "ninja==1.9.0" dataclasses typing_extensions )
+if "%REBUILD%"=="" ( pip install -q "ninja==1.10.0.post1" dataclasses typing_extensions )
 
 :: Override VS env here
 pushd .

--- a/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
+++ b/.jenkins/pytorch/win-test-helpers/build_pytorch.bat
@@ -39,6 +39,9 @@ if not "%USE_CUDA%"=="1" goto cuda_build_end
 set CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v%CUDA_VERSION%
 
 rem version transformer, for example 10.1 to 10_1.
+if x%CUDA_VERSION:.=%==x%CUDA_VERSION%
+    echo CUDA version %CUDA_VERSION% format isn't correct, which doesn't contain '.'
+    exit /b 1
 set VERSION_SUFFIX=%CUDA_VERSION:.=_%
 set CUDA_PATH_V%VERSION_SUFFIX%=%CUDA_PATH%
 

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
@@ -1,4 +1,12 @@
 rem remove dot in cuda_version, fox example 11.1 to 111
+
+if not "%USE_CUDA%"=="1"
+    exit /b 0
+
+if x%CUDA_VERSION:.=%==x%CUDA_VERSION%
+    echo CUDA version %CUDA_VERSION% format isn't correct, which doesn't contain '.' 
+    exit /b 1
+
 set VERSION_SUFFIX=%CUDA_VERSION:.=%
 set CUDA_SUFFIX=cuda%VERSION_SUFFIX%
 

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
@@ -1,14 +1,4 @@
 rem remove dot in cuda_version, fox example 11.1 to 111
-
-if not "%USE_CUDA%"=="1" (
-    exit /b 0
-)
-
-if x%CUDA_VERSION:.=%==x%CUDA_VERSION% (
-    echo CUDA version %CUDA_VERSION% format isn't correct, which doesn't contain '.' 
-    exit /b 1
-)
-
 set VERSION_SUFFIX=%CUDA_VERSION:.=%
 set CUDA_SUFFIX=cuda%VERSION_SUFFIX%
 

--- a/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
+++ b/.jenkins/pytorch/win-test-helpers/installation-helpers/install_magma.bat
@@ -1,11 +1,13 @@
 rem remove dot in cuda_version, fox example 11.1 to 111
 
-if not "%USE_CUDA%"=="1"
+if not "%USE_CUDA%"=="1" (
     exit /b 0
+)
 
-if x%CUDA_VERSION:.=%==x%CUDA_VERSION%
+if x%CUDA_VERSION:.=%==x%CUDA_VERSION% (
     echo CUDA version %CUDA_VERSION% format isn't correct, which doesn't contain '.' 
     exit /b 1
+)
 
 set VERSION_SUFFIX=%CUDA_VERSION:.=%
 set CUDA_SUFFIX=cuda%VERSION_SUFFIX%


### PR DESCRIPTION
I suddenly find that `pip install ninja==1.9.0 ` failed in CI.
And I tested locally and on another colleague's machine. 
It looks it conflicts with cmake installed in conda.


https://app.circleci.com/pipelines/github/pytorch/pytorch/332470/workflows/d8b6ed30-1c7e-4863-898a-7f067c6202e1/jobs/13972409
![image](https://user-images.githubusercontent.com/16190118/121175743-02a1c700-c88e-11eb-9596-97b903b727f9.png)

1.10.0 couldn't be installed either.
![image](https://user-images.githubusercontent.com/16190118/121176606-fbc78400-c88e-11eb-931c-aa65bad080f8.png)
