### PR TITLE
Include full Python version in collect_env.py output

### DIFF
--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -318,10 +318,12 @@ def get_env_info():
         version_str = debug_mode_str = cuda_available_str = cuda_version_str = 'N/A'
         hip_compiled_version = hip_runtime_version = miopen_runtime_version = 'N/A'
 
+    sys_version = sys.version.replace("\n", " ")
+
     return SystemEnv(
         torch_version=version_str,
         is_debug_build=debug_mode_str,
-        python_version='{}.{} ({}-bit runtime)'.format(sys.version_info[0], sys.version_info[1], sys.maxsize.bit_length() + 1),
+        python_version=f'{sys_version} ({sys.maxsize.bit_length() + 1}-bit runtime)',
         python_platform=get_python_platform(),
         is_cuda_available=cuda_available_str,
         cuda_compiled_version=cuda_version_str,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59633 Make detach return an alias even under inference mode
* **#59632 Include full Python version in collect_env.py output**

Before:

```
Python version: 3.7 (64-bit runtime)
```

After:

```
Python version: 3.7.7 (default, Mar 23 2020, 17:31:31)  [Clang 4.0.1 (tags/RELEASE_401/final)] (64-bit runtime)
```

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28961500](https://our.internmc.facebook.com/intern/diff/D28961500)