### PR TITLE
Make detach return an alias even under inference mode

### DIFF
--- a/aten/src/ATen/native/TensorProperties.cpp
+++ b/aten/src/ATen/native/TensorProperties.cpp
@@ -50,7 +50,7 @@ bool cudnn_is_acceptable(const Tensor& self) {
 Tensor detach(const Tensor& self) {
   // this just exists to give us a hook in VariableType and an entry in Declarations.yaml
   //AT_ERROR("detach is not implemented for Tensor");
-  return self;
+  return self.alias();
 }
 
 Tensor & detach_(Tensor & self) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59633 Make detach return an alias even under inference mode**

Fixes #59614

This fix isn't 100% correct but it appears to stem the bleeding.
A better fix would be understand how to detect when function
implementations don't uphold required invariants, leading to
refcount disaster.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28962183](https://our.internmc.facebook.com/intern/diff/D28962183)