### PR TITLE
Deprecate old quanzation / dequantization util functions.

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_prepack.cpp
@@ -222,7 +222,7 @@ Tensor qembeddingbag_byte_prepack(const Tensor& weight) {
   at::parallel_for(
       0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
         for (int64_t row = start_idx; row < end_idx; ++row) {
-          fbgemm::FloatToFused8BitRowwiseQuantizedSBFloat(
+          fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
             weight_data + row * embedding_cols, 1,
               embedding_cols, output_data + row * output_columns);
         }
@@ -302,7 +302,7 @@ Tensor _qembeddingbag_nbit_prepack_helper(
     at::parallel_for(
       0, embedding_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
         for (int64_t row = start_idx; row < end_idx; ++row) {
-          fbgemm::FloatToFusedNBitRowwiseQuantizedSBHalf(
+          fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
             bit_width, weight_data + row * embedding_cols, 1,
             embedding_cols, output_data + row * output_shape[1]);
         }

--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag_unpack.cpp
@@ -128,7 +128,7 @@ Tensor qembeddingbag_byte_unpack(const Tensor& packed_weight) {
     at::parallel_for(
       0, input_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
         for (int64_t row = start_idx; row < end_idx; ++row) {
-          fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloat(
+          fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float>(
             input_data + row * input_columns,
             1,
             input_columns,
@@ -175,7 +175,7 @@ Tensor _qembeddingbag_nbit_unpack_helper(
     at::parallel_for(
       0, input_rows, 1, [&](int32_t start_idx, int32_t end_idx) {
         for (int64_t row = start_idx; row < end_idx; ++row) {
-          fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat(BIT_RATE,
+          fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<float>(BIT_RATE,
             input_data + row * input_columns,
             1,
             input_columns,

--- a/caffe2/perfkernels/fused_nbit_rowwise_conversion.cc
+++ b/caffe2/perfkernels/fused_nbit_rowwise_conversion.cc
@@ -75,7 +75,7 @@ void FloatToFused8BitRowwiseQuantized(
     int input_columns,
     std::uint8_t* output) {
 #ifdef USE_FBGEMM
-  fbgemm::FloatToFused8BitRowwiseQuantizedSBFloat(
+  fbgemm::FloatOrHalfToFused8BitRowwiseQuantizedSBFloat<float>(
       input, input_rows, input_columns, output);
 #else
   FloatToFused8BitRowwiseQuantized__base(
@@ -89,7 +89,7 @@ void Fused8BitRowwiseQuantizedToFloat(
     int input_columns,
     float* output) {
 #ifdef USE_FBGEMM
-  fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloat(
+  fbgemm::Fused8BitRowwiseQuantizedSBFloatToFloatOrHalf<float>(
       input, input_rows, input_columns, output);
 #else
   Fused8BitRowwiseQuantizedToFloat__base(
@@ -196,7 +196,7 @@ void FloatToFusedNBitRowwiseQuantizedSBHalf(
     int input_columns,
     std::uint8_t* output) {
 #ifdef USE_FBGEMM
-  fbgemm::FloatToFusedNBitRowwiseQuantizedSBHalf(
+  fbgemm::FloatOrHalfToFusedNBitRowwiseQuantizedSBHalf<float>(
       bit_rate, input, input_rows, input_columns, output);
 #else
   FloatToFusedNBitRowwiseQuantizedSBHalf__base(
@@ -211,7 +211,7 @@ void FusedNBitRowwiseQuantizedSBHalfToFloat(
     int input_columns,
     float* output) {
 #ifdef USE_FBGEMM
-  fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloat(
+  fbgemm::FusedNBitRowwiseQuantizedSBHalfToFloatOrHalf<float>(
       bit_rate, input, input_rows, input_columns, output);
 #else
   FusedNBitRowwiseQuantizedSBHalfToFloat__base(


### PR DESCRIPTION
Summary: Deprecate FloatToFusedNBitRowwiseQuantizedSBHalf, FusedNBitRowwiseQuantizedSBHalfToFloat, FloatToFused8BitRowwiseQuantizedSBFloat, and Fused8BitRowwiseQuantizedSBFloatToFloat.

Test Plan: Presubmit tests.

Differential Revision: D28918581

