### PR TITLE
Fix typo in checkpoint docs

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -184,7 +184,7 @@ def checkpoint(function, *args, **kwargs):
         gradient in the model. To circumvent this, detach the tensors outside of
         the `checkpoint` function.
 
-    .. warning:
+    .. warning::
         At least one of the inputs needs to have :code:`requires_grad=True` if
         grads are needed for model inputs, otherwise the checkpointed part of the
         model won't have gradients. At least one of the outputs needs to have


### PR DESCRIPTION
This small typo causing this valuable piece of information to be excluded from the docs.

<img width="876" alt="image" src="https://user-images.githubusercontent.com/8812459/121240517-47f2d400-c84f-11eb-9288-23c551c1591a.png">

The last "warning" is missing a second ":", so it doesn't render in the docs 👇

<img width="875" alt="image" src="https://user-images.githubusercontent.com/8812459/121240467-39a4b800-c84f-11eb-9dd6-ec26754c43d3.png">

