### PR TITLE
Do not scale atol for fast gradcheck by default

### DIFF
--- a/test/test_mkldnn.py
+++ b/test/test_mkldnn.py
@@ -145,10 +145,10 @@ class TestMkldnn(TestCase):
         # these numbers are just empirical results that seem to work.
         self.assertWarnsRegex(UserWarning,
                               'double precision floating point',
-                              lambda: gradcheck(func, [root], atol=4e-2, rtol=1e-2))
+                              lambda: gradcheck(func, [root], atol=4e-2, rtol=1e-2, fast_mode_scale_atol=True))
         self.assertWarnsRegex(UserWarning,
                               'double precision floating point',
-                              lambda: gradgradcheck(func, [root], atol=4e-2, rtol=1e-2))
+                              lambda: gradgradcheck(func, [root], atol=4e-2, rtol=1e-2, fast_mode_scale_atol=True))
 
     def test_autograd_from_mkldnn(self):
         # MKLDNN only supports float32

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1042,7 +1042,7 @@ def _adjusted_atol(atol, u, v):
     u = u[0] if isinstance(u, tuple) else u
     sum_u = torch.sparse.sum(u) if u.layout == torch.sparse_coo else u.sum()
     sum_v = 1. if v is None else torch.sparse.sum(v) if v.layout == torch.sparse_coo else v.sum()
-    return atol * float(sum_u) * float(sum_v)
+    return atol # * float(sum_u) * float(sum_v)
 
 
 FAST_FAIL_SLOW_OK_MSG = """

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -6712,14 +6712,7 @@ op_db: List[OpInfo] = [
            )),
     OpInfo('renorm',
            dtypes=floating_and_complex_types_and(torch.float16, torch.bfloat16),
-           sample_inputs_func=sample_inputs_renorm,
-           skips=(
-               # https://github.com/pytorch/pytorch/issues/59584
-               SkipInfo('TestGradients', 'test_fn_grad',
-                        device_type='cuda', dtypes=[torch.double, torch.cdouble]),
-               SkipInfo('TestGradients', 'test_inplace_grad',
-                        device_type='cuda', dtypes=[torch.double, torch.cdouble]),
-           )),
+           sample_inputs_func=sample_inputs_renorm),
     ShapeFuncInfo('repeat',
                   op=lambda x, dims: x.repeat(dims),
                   ref=np.tile,


### PR DESCRIPTION
The adjusted atol for fast gradcheck is too lenient for vast majority of cases. In this PR:
 - do not scale atol by default for fast gradcheck
 - add parameter in case user needs to scale atol. This is useful when Jacobian is dense, e.g., for `sum`.
 - fix unrelated issue discovered: when we do `_run_slow_mode_get_error`, it forgets to pass in eps, so it produces different results from actual slow_mode

Context:
 - Currently we scale `atol` for fast gradcheck by `\sum_{i} \sum_{j} u_i * v_j`, but this assumes that every entry in the Jacobian is off by epsilon in the same direction. Since most entries in Jacobian are actually zero, this makes fast_gradcheck H * W times less sensitive than it could be, i.e., if there is an entry in the analytical Jacobian (with width W, and height H), we would actually tolerate an error of sqrt(H * W) * atol.
 - It is tested that removing adjusted atol here would allow fast gradcheck to successfully detect that renorm's grad is wrong.


