### PR TITLE
[WIP] Merge ModuleTest, NewModuleTest, and CriterionTest into one

### DIFF
--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -21,7 +21,7 @@ TorchNNModuleTestParams = namedtuple(
         # Unique identifier for this module config (e.g. "BCELoss_weights_cuda")
         'module_variant_name',
 
-        # An instance of an NN test class (e.g. `CriterionTest`) which stores
+        # An instance of an NN test class (e.g. `ModuleTest`) which stores
         # necessary information (e.g. input / target / extra_args) for running the Python test
         'test_instance',
 
@@ -184,7 +184,7 @@ def move_cpp_tensors_to_device(cpp_tensor_stmts, device):
     return ['{}.to("{}")'.format(tensor_stmt, device) for tensor_stmt in cpp_tensor_stmts]
 
 def is_criterion_test(test_instance):
-    return isinstance(test_instance, common_nn.CriterionTest)
+    return test_instance.is_criterion_test
 
 # This function computes the following:
 # - What variable declaration statements should show up in the C++ parity test function

--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -6,7 +6,6 @@ import shutil
 
 import torch
 import torch.utils.cpp_extension
-import torch.testing._internal.common_nn as common_nn
 from torch.testing._internal.common_cuda import TEST_CUDA
 
 # Note that this namedtuple is for C++ parity test mechanism's internal use.
@@ -183,9 +182,6 @@ def set_cpp_tensors_requires_grad(cpp_tensor_stmts, python_tensors):
 def move_cpp_tensors_to_device(cpp_tensor_stmts, device):
     return ['{}.to("{}")'.format(tensor_stmt, device) for tensor_stmt in cpp_tensor_stmts]
 
-def is_criterion_test(test_instance):
-    return test_instance.is_criterion_test
-
 # This function computes the following:
 # - What variable declaration statements should show up in the C++ parity test function
 # - What arguments should be passed into the C++ module/functional's forward function
@@ -283,7 +279,7 @@ def compute_arg_dict(test_params_dict, test_instance):
             arg_dict[arg_type].append(CppArg(name=arg_type_prefix + str(i), value=arg))
 
     put_args_into_arg_dict('input', 'i', convert_to_list(test_instance._get_input()))
-    if is_criterion_test(test_instance):
+    if test_instance.is_criterion_test:
         put_args_into_arg_dict('target', 't', convert_to_list(test_instance._get_target()))
     if test_instance.extra_args:
         put_args_into_arg_dict('extra_args', 'e', convert_to_list(test_instance.extra_args))

--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -70,7 +70,7 @@ TorchNNFunctionalTestParams = namedtuple(
         # Unique identifier for this functional config (e.g. "BCELoss_no_reduce_cuda")
         'functional_variant_name',
 
-        # An instance of an NN test class (e.g. `NewModuleTest`) which stores
+        # An instance of an NN test class (e.g. `ModuleTest`) which stores
         # necessary information (e.g. input / target / extra_args) for running the Python test
         'test_instance',
 

--- a/test/onnx/export_onnx_tests_generator.py
+++ b/test/onnx/export_onnx_tests_generator.py
@@ -10,7 +10,6 @@ import traceback
 
 import test_onnx_common
 from torch.testing._internal.common_nn import module_tests
-from test_nn import new_module_tests
 
 
 # Take a test case (a dict) as input, return the test name.
@@ -136,5 +135,5 @@ def convert_tests(testcases, sets=1):
     print_stats(FunctionalModule_nums, nn_module)
 
 if __name__ == "__main__":
-    testcases = module_tests + new_module_tests
+    testcases = module_tests
     convert_tests(testcases)

--- a/test/onnx/export_onnx_tests_generator.py
+++ b/test/onnx/export_onnx_tests_generator.py
@@ -9,7 +9,7 @@ import torch
 import traceback
 
 import test_onnx_common
-from torch.testing._internal.common_nn import module_tests
+from torch.testing._internal.common_nn import module_tests, is_criterion_test
 
 
 # Take a test case (a dict) as input, return the test name.
@@ -135,5 +135,7 @@ def convert_tests(testcases, sets=1):
     print_stats(FunctionalModule_nums, nn_module)
 
 if __name__ == "__main__":
-    testcases = module_tests
+    # Note: before the module test / criterion test merge, this test was not run on
+    # criterion tests. For now, this behavior is preserved.
+    testcases = [test for test in module_tests if not is_criterion_test(test)]
     convert_tests(testcases)

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -26,9 +26,9 @@ class TestCppApiParity(common.TestCase):
 expected_test_params_dicts = []
 
 for test_params_dicts, test_instance_class in [
-    (sample_module.module_tests, common_nn.NewModuleTest),
-    (sample_functional.functional_tests, common_nn.NewModuleTest),
-    (common_nn.module_tests, common_nn.NewModuleTest),
+    (sample_module.module_tests, common_nn.ModuleTest),
+    (sample_functional.functional_tests, common_nn.ModuleTest),
+    (common_nn.module_tests, common_nn.ModuleTest),
     (common_nn.criterion_tests, common_nn.CriterionTest),
 ]:
     for test_params_dict in test_params_dicts:

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -29,7 +29,6 @@ for test_params_dicts, test_instance_class in [
     (sample_module.module_tests, common_nn.NewModuleTest),
     (sample_functional.functional_tests, common_nn.NewModuleTest),
     (common_nn.module_tests, common_nn.NewModuleTest),
-    (common_nn.new_module_tests, common_nn.NewModuleTest),
     (common_nn.criterion_tests, common_nn.CriterionTest),
 ]:
     for test_params_dict in test_params_dicts:

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -29,7 +29,7 @@ for test_params_dicts, test_instance_class in [
     (sample_module.module_tests, common_nn.ModuleTest),
     (sample_functional.functional_tests, common_nn.ModuleTest),
     (common_nn.module_tests, common_nn.ModuleTest),
-    (common_nn.criterion_tests, common_nn.CriterionTest),
+    (common_nn.criterion_tests, common_nn.ModuleTest),
 ]:
     for test_params_dict in test_params_dicts:
         if test_params_dict.get('test_cpp_api_parity', True):

--- a/test/test_cpp_api_parity.py
+++ b/test/test_cpp_api_parity.py
@@ -29,7 +29,6 @@ for test_params_dicts, test_instance_class in [
     (sample_module.module_tests, common_nn.ModuleTest),
     (sample_functional.functional_tests, common_nn.ModuleTest),
     (common_nn.module_tests, common_nn.ModuleTest),
-    (common_nn.criterion_tests, common_nn.ModuleTest),
 ]:
     for test_params_dict in test_params_dicts:
         if test_params_dict.get('test_cpp_api_parity', True):

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -29,7 +29,7 @@ import torch.fx.experimental.optimization as optimization
 from torch.fx.experimental import merge_matmul
 from torch.fx.experimental.normalize import NormalizeOperators, NormalizeArgs
 from torch.fx.experimental.schema_type_annotation import AnnotateTypesWithSchema
-from torch.testing._internal.common_nn import module_tests, new_module_tests
+from torch.testing._internal.common_nn import module_tests
 from torch.fx.operator_schemas import (
     _torchscript_type_to_python_type,
     normalize_function,
@@ -866,7 +866,7 @@ terrible spacing
         Exhaustively test `Node.normalized_arguments` on all standard
         torch.nn Module classes
         """
-        for test_params in module_tests + new_module_tests:
+        for test_params in module_tests:
             if 'constructor' not in test_params:
                 constructor = getattr(torch.nn, test_params['module_name'])
             else:

--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -29,7 +29,7 @@ import torch.fx.experimental.optimization as optimization
 from torch.fx.experimental import merge_matmul
 from torch.fx.experimental.normalize import NormalizeOperators, NormalizeArgs
 from torch.fx.experimental.schema_type_annotation import AnnotateTypesWithSchema
-from torch.testing._internal.common_nn import module_tests
+from torch.testing._internal.common_nn import module_tests, is_criterion_test
 from torch.fx.operator_schemas import (
     _torchscript_type_to_python_type,
     normalize_function,
@@ -867,6 +867,11 @@ terrible spacing
         torch.nn Module classes
         """
         for test_params in module_tests:
+            # Note: before the module test / criterion test merge, this test was not run on
+            # criterion tests. For now, this behavior is preserved.
+            if is_criterion_test(test_params):
+                continue
+
             if 'constructor' not in test_params:
                 constructor = getattr(torch.nn, test_params['module_name'])
             else:

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -89,7 +89,7 @@ from torch.testing._internal.jit_metaprogramming_utils import create_script_fn, 
     EXCLUDE_SCRIPT, additional_module_tests, EXCLUDE_SCRIPT_MODULES, \
     get_nn_module_name_from_kwargs, script_method_template
 
-from torch.testing._internal.common_nn import module_tests, criterion_tests
+from torch.testing._internal.common_nn import module_tests, is_criterion_test
 from torch.testing._internal.common_methods_invocations import (
     create_input, unpack_variables)
 
@@ -15824,10 +15824,8 @@ for test in nn_functional_tests:
     add_nn_functional_test(*test)
 
 for test in module_tests + additional_module_tests:
-    add_nn_module_test(**test)
-
-for test in criterion_tests:
-    test['no_grad'] = True
+    if is_criterion_test(test):
+        test['no_grad'] = True
     add_nn_module_test(**test)
 
 if __name__ == '__main__':

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -89,7 +89,7 @@ from torch.testing._internal.jit_metaprogramming_utils import create_script_fn, 
     EXCLUDE_SCRIPT, additional_module_tests, EXCLUDE_SCRIPT_MODULES, \
     get_nn_module_name_from_kwargs, script_method_template
 
-from torch.testing._internal.common_nn import module_tests, new_module_tests, criterion_tests
+from torch.testing._internal.common_nn import module_tests, criterion_tests
 from torch.testing._internal.common_methods_invocations import (
     create_input, unpack_variables)
 
@@ -15823,7 +15823,7 @@ class TestProducerVersion(unittest.TestCase):
 for test in nn_functional_tests:
     add_nn_functional_test(*test)
 
-for test in module_tests + new_module_tests + additional_module_tests:
+for test in module_tests + additional_module_tests:
     add_nn_module_test(**test)
 
 for test in criterion_tests:

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
-from torch.testing._internal.common_nn import NNTestCase, ModuleTest, CriterionTest, \
+from torch.testing._internal.common_nn import NNTestCase, ModuleTest, \
     module_tests, criterion_tests, loss_reference_fns, \
     ctcloss_reference
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
@@ -11263,10 +11263,10 @@ def add_test(test, decorator=None):
     cuda_test_name = test_name + '_cuda'
     # With dtype enable, it's good enough to test against three floating types
     kwargs = {}
-    if 'extra_args' in get_function_arglist(test.test_cuda):
+    if test.is_criterion_test:
         kwargs['extra_args'] = test.extra_args
 
-    if 'dtype' in get_function_arglist(test.test_cuda):
+    if test.is_criterion_test:
         if tf32_is_not_fp32() and test.with_tf32:
 
             def with_tf32_off(self, test=test, kwargs=kwargs):
@@ -11402,7 +11402,7 @@ for test_params in module_tests:
 for test_params in criterion_tests:
     name = test_params.pop('module_name')
     test_params['constructor'] = getattr(nn, name)
-    test = CriterionTest(**test_params)
+    test = ModuleTest(**test_params)
     decorator = test_params.pop('decorator', None)
     add_test(test, decorator)
     if 'check_sum_reduction' in test_params:
@@ -11417,7 +11417,7 @@ for test_params in criterion_tests:
             return sum_reduction_constructor
 
         test_params['constructor'] = gen_sum_reduction_constructor(test_params['constructor'])
-        test = CriterionTest(**test_params)
+        test = ModuleTest(**test_params)
         add_test(test, decorator)
 
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
-from torch.testing._internal.common_nn import NNTestCase, ModuleTest, \
+from torch.testing._internal.common_nn import ModuleTest, \
     module_tests, loss_reference_fns, \
     ctcloss_reference
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
@@ -314,7 +314,7 @@ class TestAvgPool(TestCase):
             self.assertTrue(not torch.isnan(y).any())
 
 
-class TestNN(NNTestCase):
+class TestNN(TestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
@@ -11592,7 +11592,7 @@ def _buildEquivalentAffineTransforms3d(device, input_size, output_size, angle_ra
 # end TestNN.test_affine_* helpers
 
 
-class TestNNDeviceType(NNTestCase):
+class TestNNDeviceType(TestCase):
     def _test_dropout(self, cls, device, input, memory_format=torch.contiguous_format):
         p = 0.2
         input = input.to(device).fill_(1 - p)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -36,11 +36,11 @@ from torch.nn.parallel._functions import Broadcast
 from torch.testing import get_all_fp_dtypes
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_ROCM, download_file, \
-    get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
+    load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, ModuleTest, \
-    module_tests, criterion_tests, loss_reference_fns, \
+    module_tests, loss_reference_fns, \
     ctcloss_reference
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
@@ -11399,15 +11399,15 @@ for test_params in module_tests:
 
         add_test(test, decorator)
 
-for test_params in criterion_tests:
-    name = test_params.pop('module_name')
-    test_params['constructor'] = getattr(nn, name)
-    test = ModuleTest(**test_params)
-    decorator = test_params.pop('decorator', None)
-    add_test(test, decorator)
-    if 'check_sum_reduction' in test_params:
-        desc = test_params.get('desc', None)
-        test_params['desc'] = 'sum_reduction' if desc is None else desc + '_sum_reduction'
+    # Note: Before the module test / criterion test merge, this logic was only
+    # run for criterion tests. For now, this behavior is preserved here.
+    if test.is_criterion_test and 'check_sum_reduction' in test_params:
+        fullname = test_params.get('fullname', None)
+        if fullname:
+            test_params['fullname'] = fullname + '_sum_reduction'
+        else:
+            desc = test_params.get('desc', None)
+            test_params['desc'] = 'sum_reduction' if desc is None else desc + '_sum_reduction'
 
         def gen_sum_reduction_constructor(constructor):
             def sum_reduction_constructor(*args, **kwargs):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -41,7 +41,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, \
-    ctcloss_reference, new_module_tests
+    ctcloss_reference
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
     dtypesIfCUDA, precisionOverride, skipCUDAIfNoCudnn, skipCUDAIfCudnnVersionLessThan, onlyCUDA, onlyCPU, \
     skipCUDAIfRocm, skipCUDAIf, skipCUDAIfNotRocm, onlyOnCPUAndCUDA, \
@@ -11322,7 +11322,7 @@ def add_test(test, decorator=None):
         else:
             add(cuda_test_name, lambda self, test=test, kwargs=kwargs: test.test_cuda(self, **kwargs))
 
-for test_params in module_tests + new_module_tests:
+for test_params in module_tests:
     # TODO: CUDA is not implemented yet
     if 'constructor' not in test_params:
         name = test_params.pop('module_name')

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import freeze_rng_state, run_tests, Te
     get_function_arglist, load_tests, repeat_test_for_types, ALL_TENSORTYPES, \
     ALL_TENSORTYPES2, suppress_warnings, TemporaryFileName, TEST_WITH_UBSAN, IS_PPC
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, TEST_CUDNN_VERSION
-from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
+from torch.testing._internal.common_nn import NNTestCase, ModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, \
     ctcloss_reference
 from torch.testing._internal.common_device_type import instantiate_device_type_tests, dtypes, \
@@ -11328,7 +11328,7 @@ for test_params in module_tests:
         name = test_params.pop('module_name')
         test_params['constructor'] = getattr(nn, name)
     decorator = test_params.pop('decorator', None)
-    test = NewModuleTest(**test_params)
+    test = ModuleTest(**test_params)
     add_test(test, decorator)
     if 'check_eval' in test_params:
         # create a new test that is identical but that sets module.training to False
@@ -11344,7 +11344,7 @@ for test_params in module_tests:
             return eval_constructor
 
         test_params['constructor'] = gen_eval_constructor(test_params['constructor'])
-        test = NewModuleTest(**test_params)
+        test = ModuleTest(**test_params)
         add_test(test, decorator)
     if 'check_with_long_tensor' in test_params:
         fullname = test_params.get('fullname', None)
@@ -11395,7 +11395,7 @@ for test_params in module_tests:
         test_params['check_forward_only'] = True
         # Currently we don't support conv2d/conv3d for LongTensor in CUDA
         test_params['test_cuda'] = False
-        test = NewModuleTest(**test_params)
+        test = ModuleTest(**test_params)
 
         add_test(test, decorator)
 
@@ -11431,19 +11431,19 @@ class UnpoolingNet(nn.Module):
         return self.unpool(*self.pool(input))
 
 
-add_test(NewModuleTest(
+add_test(ModuleTest(
     constructor=lambda: UnpoolingNet(
         nn.MaxPool1d(2, return_indices=True),
         nn.MaxUnpool1d(2)),
     input_size=(1, 1, 4),
     fullname='MaxUnpool1d_net',))
-add_test(NewModuleTest(
+add_test(ModuleTest(
     constructor=lambda: UnpoolingNet(
         nn.MaxPool2d(2, return_indices=True),
         nn.MaxUnpool2d(2)),
     input_size=(1, 1, 2, 4),
     fullname='MaxUnpool2d_net',))
-add_test(NewModuleTest(
+add_test(ModuleTest(
     constructor=lambda: UnpoolingNet(
         nn.MaxPool3d(2, return_indices=True),
         nn.MaxUnpool3d(2)),
@@ -11457,7 +11457,7 @@ class _AdaptiveLogSoftmaxWithLoss(nn.AdaptiveLogSoftmaxWithLoss):
         t = torch.tensor([0, 1, 4, 8]).to(input.device)
         return nn.AdaptiveLogSoftmaxWithLoss.__call__(self, input, t).output
 
-add_test(NewModuleTest(
+add_test(ModuleTest(
     constructor=lambda: _AdaptiveLogSoftmaxWithLoss(16, 10, [2, 6]),
     input_size=(4, 16),
     fullname='AdaptiveLogSoftmax',

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11215,36 +11215,36 @@ def add_test(test, decorator=None):
 
             def with_tf32_off(self, test=test, kwargs=kwargs):
                 with tf32_off():
-                    test.test_cuda(self, dtype=torch.float, **kwargs)
+                    test.test_cpu_gpu_parity(self, dtype=torch.float, **kwargs)
 
             add(cuda_test_name + '_fp32', with_tf32_off)
 
             def with_tf32_on(self, test=test, kwargs=kwargs):
                 with tf32_on(self, test.tf32_precision):
-                    test.test_cuda(self, dtype=torch.float, **kwargs)
+                    test.test_cpu_gpu_parity(self, dtype=torch.float, **kwargs)
 
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
             add(cuda_test_name + '_float', lambda self,
-                test=test, kwargs=kwargs: test.test_cuda(self, dtype=torch.float, **kwargs))
+                test=test, kwargs=kwargs: test.test_cpu_gpu_parity(self, dtype=torch.float, **kwargs))
         add(cuda_test_name + '_double', lambda self,
-            test=test, kwargs=kwargs: test.test_cuda(self, dtype=torch.double, **kwargs))
+            test=test, kwargs=kwargs: test.test_cpu_gpu_parity(self, dtype=torch.double, **kwargs))
 
         def test_half(self, test=test, kwargs=kwargs):
-            test.test_cuda(self, dtype=torch.half, **kwargs)
+            test.test_cpu_gpu_parity(self, dtype=torch.half, **kwargs)
         if getattr(test, 'check_half', True):
             add(cuda_test_name + '_half', test_half)
 
         def test_bfloat16(self, test=test, kwargs=kwargs):
-            test.test_cuda(self, dtype=torch.bfloat16, **kwargs)
+            test.test_cpu_gpu_parity(self, dtype=torch.bfloat16, **kwargs)
         if getattr(test, 'check_bfloat16', True):
             add(cuda_test_name + '_bfloat16', test_bfloat16)
 
         def test_cfloat(self, test=test, kwargs=kwargs):
-            test.test_cuda(self, dtype=torch.cfloat, **kwargs)
+            test.test_cpu_gpu_parity(self, dtype=torch.cfloat, **kwargs)
 
         def test_cdouble(self, test=test, kwargs=kwargs):
-            test.test_cuda(self, dtype=torch.cdouble, **kwargs)
+            test.test_cpu_gpu_parity(self, dtype=torch.cdouble, **kwargs)
         if getattr(test, 'check_complex', False):
             add(cuda_test_name + '_cfloat', test_cfloat)
             add(cuda_test_name + '_cdouble', test_cdouble)
@@ -11254,17 +11254,17 @@ def add_test(test, decorator=None):
 
             def with_tf32_off(self, test=test, kwargs=kwargs):
                 with tf32_off():
-                    test.test_cuda(self, **kwargs)
+                    test.test_cpu_gpu_parity(self, **kwargs)
 
             add(cuda_test_name + '_fp32', with_tf32_off)
 
             def with_tf32_on(self, test=test, kwargs=kwargs):
                 with tf32_on(self, test.tf32_precision):
-                    test.test_cuda(self, **kwargs)
+                    test.test_cpu_gpu_parity(self, **kwargs)
 
             add(cuda_test_name + '_tf32', with_tf32_on)
         else:
-            add(cuda_test_name, lambda self, test=test, kwargs=kwargs: test.test_cuda(self, **kwargs))
+            add(cuda_test_name, lambda self, test=test, kwargs=kwargs: test.test_cpu_gpu_parity(self, **kwargs))
 
 for test_params in module_tests:
     # TODO: CUDA is not implemented yet

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4112,7 +4112,7 @@ loss_reference_fns: Dict['str', Callable] = {
 }
 
 
-criterion_tests = [
+module_tests.extend([
     dict(
         module_name='L1Loss',
         input_size=(2, 3, 4),
@@ -4741,7 +4741,7 @@ criterion_tests = [
         check_gradgrad=False,
         check_half=False,
     ),
-]
+])
 
 
 class NNTestCase(TestCase):
@@ -4867,14 +4867,27 @@ class NNTestCase(TestCase):
             self.assertLessEqual(max(differences), PRECISION)  # type: ignore[type-var]
 
 
+def is_criterion_test(test_params):
+    """
+    Helper function to identify whether or not the test specified by the given test_params is a
+    criterion test.
+
+    Args:
+        test_params (dict): Parameters defining the test
+
+    Returns:
+        True if the given params indicate a criterion test; False otherwise
+    """
+    return any([name in test_params for name in ['target', 'target_fn', 'target_size']])
+
+
 class ModuleTest(object):
     def __init__(self, constructor, desc='', reference_fn=None, fullname=None, **kwargs):
         self.desc = desc
         self.fullname = fullname
         self.constructor = constructor
         self.reference_fn = reference_fn
-        self.is_criterion_test = any(
-            [name in kwargs for name in ['target', 'target_fn', 'target_size']])
+        self.is_criterion_test = is_criterion_test(kwargs)
         self._required_arg_names = {'constructor_args', 'input', 'extra_args'}
         if self.is_criterion_test:
             self._required_arg_names.add('target')

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4938,7 +4938,6 @@ class ModuleTest(object):
             self.check_complex = kwargs.get('check_complex', False)
             self.with_tf32 = kwargs.get('with_tf32', True)
         else:
-            self.jacobian_input = kwargs.get('jacobian_input', True)
             self.should_test_pickle = kwargs.get('pickle', True)
             self.FIXME_no_cuda_gradgrad_comparison = \
                 kwargs.get('FIXME_no_cuda_gradgrad_comparison', False)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5019,10 +5019,9 @@ class ModuleTest(object):
         module = self.constructor(*self.constructor_args)
         input = self._get_input()
 
-        # === Check that these methods don't raise errors. ===
-        if self.is_criterion_test:
-            module.__repr__()
-            str(module)
+        # === Check that the module can be printed. ===
+        module.__repr__()
+        str(module)
 
         # === Check the forward output against the reference function. ===
         if self.reference_fn is not None:
@@ -5040,7 +5039,6 @@ class ModuleTest(object):
                 # TODO(#38095): Replace assertEqualIgnoreType. See issue #38095
                 test_case.assertEqualIgnoreType(out, expected_out)
 
-        # === Possibly only check forward. ===
         if self.check_forward_only:
             return
 
@@ -5060,7 +5058,146 @@ class ModuleTest(object):
 
         # === Do the meat of the module test. ===
         if not self.is_criterion_test:
-            self._do_test(test_case, module, input)
+            num_threads = torch.get_num_threads()
+            torch.set_num_threads(1)
+            input_tuple = input if isinstance(input, tuple) else (input,)
+
+            if self.check_inplace:
+                # check if the inplace variant of the module gives the same result
+                # as the out-of-place
+
+                # check_inplace doesn't support multiple input tensors, since we don't have any modules
+                # that modify the inputs in-place and that accept more than one input
+                assert len(input_tuple) == 1
+                input = input_tuple[0]
+
+                module_ip = self.constructor(*self.constructor_args, inplace=True)
+
+                input_version = input._version
+                with freeze_rng_state():
+                    output = module(input)
+                test_case.assertEqual(input._version, input_version)
+
+                input_ip = deepcopy(input)
+                input_ip_clone = input_ip.clone()
+                with freeze_rng_state():
+                    output_ip = module_ip(input_ip_clone)
+                test_case.assertNotEqual(input_ip_clone._version, input_version)
+                test_case.assertEqual(output, output_ip)
+                grad = output.data.clone().normal_()
+                if input.grad is not None:
+                    with torch.no_grad():
+                        input.grad.zero_()
+                if input_ip.grad is not None:
+                    with torch.no_grad():
+                        input_ip.grad.zero_()
+                output.backward(grad)
+                output_ip.backward(grad)
+                test_case.assertEqual(input.grad, input_ip.grad)
+
+            def assert_module_parameters_are(tensor_type, device_id=None):
+                for p in module.parameters():
+                    test_case.assertIsInstance(p, tensor_type)
+                    if device_id is not None:
+                        test_case.assertEqual(p.get_device(), device_id)
+
+            if all(isinstance(t, torch.LongTensor) for t in input_tuple) and TEST_CUDA:
+                # check that cuda() moves module parameters to correct GPU device,
+                # and that float() casts parameters correctly
+                input_tuple = tuple(t.cuda() for t in input_tuple)
+                module.float().cuda()
+                module(*input_tuple)
+                assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
+
+                if torch.cuda.device_count() > 1:
+                    input_tuple = tuple(t.cuda(1) for t in input_tuple)
+                    module.cuda(1)
+                    with torch.cuda.device(1):
+                        module(*input_tuple)
+                    assert_module_parameters_are(torch.cuda.FloatTensor, 1)  # type: ignore[attr-defined]
+            else:
+                # check that float()/double() casters work correctly
+                def to_type(tensor, real, complex):
+                    if tensor.is_complex():
+                        return tensor.to(complex)
+                    elif tensor.is_floating_point():
+                        return tensor.to(real)
+                    else:
+                        return tensor
+
+                def to_half(x):
+                    # TODO: torch.complex32 when properly supported
+                    return to_type(x, torch.float16, None)
+
+                def to_single(x):
+                    return to_type(x, torch.float32, torch.complex64)
+
+                def to_double(x):
+                    return to_type(x, torch.float64, torch.complex128)
+
+                # to float
+                input_tuple = tuple(to_single(t) for t in input_tuple)
+                module.float()
+                module(*input_tuple)
+                assert_module_parameters_are(torch.FloatTensor)
+
+                # and back to double
+                input_tuple = tuple(to_double(t) for t in input_tuple)
+                module.double()
+                module(*input_tuple)
+                assert_module_parameters_are(torch.DoubleTensor)
+
+                if TEST_CUDA and self.should_test_cuda:
+                    # check that cuda() moves module parameters to correct GPU device,
+                    # and that float() casts parameters correctly
+
+                    # to GPU0
+                    input_tuple = tuple(to_single(t).cuda() for t in input_tuple)
+                    module.float().cuda()
+                    module(*input_tuple)
+                    assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
+
+                    # to CPU
+                    input_tuple = tuple(t.cpu() for t in input_tuple)
+                    module.cpu()
+                    module(*input_tuple)
+                    assert_module_parameters_are(torch.FloatTensor)
+
+                    # back to GPU0
+                    input_tuple = tuple(t.cuda() for t in input_tuple)
+                    module.cuda()
+                    module(*input_tuple)
+                    assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
+
+                    # test that forwards of module runs correctly without cuDNN
+                    if self.cudnn:
+                        with torch.backends.cudnn.flags(enabled=False):
+                            module(*input_tuple)
+                            assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
+
+                    if torch.cuda.device_count() >= 2:
+                        # test cross-GPU transfer works
+                        # to GPU1
+                        input_tuple = tuple(t.cuda(1) for t in input_tuple)
+                        module.cuda(1)
+                        with torch.cuda.device(1):
+                            module(*input_tuple)
+                        assert_module_parameters_are(torch.cuda.FloatTensor, 1)  # type: ignore[attr-defined]
+
+                    if not self.skip_double:
+                        # test double()
+                        input_tuple = tuple(to_double(t).cuda() for t in input_tuple)
+                        module.double().cuda()
+                        module(*input_tuple)
+                        assert_module_parameters_are(torch.cuda.DoubleTensor, 0)  # type: ignore[attr-defined]
+
+                    # test half()
+                    if not self.skip_half:
+                        input_tuple = tuple(to_half(t).cuda() for t in input_tuple)
+                        module.half().cuda()
+                        module(*input_tuple)
+                        assert_module_parameters_are(torch.cuda.HalfTensor, 0)  # type: ignore[attr-defined]
+            torch.set_num_threads(num_threads)
 
         # === Check gradients. ===
         if self.is_criterion_test:
@@ -5080,183 +5217,35 @@ class ModuleTest(object):
 
             if self.check_gradgrad:
                 gradgradcheck(apply_fn, inputs, check_batched_grad=self.check_batched_grad)
+        else:
+            params = tuple(x for x in module.parameters())
+            num_inputs = len(input_tuple)
+
+            def fn_to_gradcheck(*inputs_and_params, **kwargs):
+                assert not kwargs
+                return test_case._forward(module, inputs_and_params[:num_inputs])
+
+            # gradcheck doesn't support operators that take in dense inputs but
+            # return sparse parameters. This only happens in the case of nn.Embedding
+            # and nn.EmbeddingBag. Instead, we call `self.check_jacobian`, which
+            # is a slightly different version of gradcheck that can handle this.
+            if self.has_sparse_gradients:
+                assert num_inputs == 1
+                test_input_jacobian = torch.is_floating_point(input_tuple[0])
+                test_case.check_jacobian(module, input_tuple[0], test_input_jacobian)
+            else:
+                test_case.assertTrue(gradcheck(fn_to_gradcheck, input_tuple + params,
+                                               check_batched_grad=self.check_batched_grad))
+
+            if self.check_gradgrad:
+                test_case.assertTrue(gradgradcheck(fn_to_gradcheck, input_tuple + params,
+                                                   check_batched_grad=self.check_batched_grad))
 
     def test_cuda(self, test_case, dtype=None, extra_args=None):
         if self.is_criterion_test:
             return self._criterion_test_cuda(test_case, dtype, extra_args)
         else:
             return self._module_test_cuda(test_case)
-
-    def _check_gradients(self, test_case, module, input_tuple):
-        params = tuple(x for x in module.parameters())
-        num_inputs = len(input_tuple)
-
-        def fn_to_gradcheck(*inputs_and_params, **kwargs):
-            assert not kwargs
-            return test_case._forward(module, inputs_and_params[:num_inputs])
-
-        # gradcheck doesn't support operators that take in dense inputs but
-        # return sparse parameters. This only happens in the case of nn.Embedding
-        # and nn.EmbeddingBag. Instead, we call `self.check_jacobian`, which
-        # is a slightly different version of gradcheck that can handle this.
-        if self.has_sparse_gradients:
-            assert num_inputs == 1
-            test_input_jacobian = torch.is_floating_point(input_tuple[0])
-            test_case.check_jacobian(module, input_tuple[0], test_input_jacobian)
-        else:
-            test_case.assertTrue(gradcheck(fn_to_gradcheck, input_tuple + params,
-                                           check_batched_grad=self.check_batched_grad))
-
-        if self.check_gradgrad:
-            test_case.assertTrue(gradgradcheck(fn_to_gradcheck, input_tuple + params,
-                                               check_batched_grad=self.check_batched_grad))
-
-    def _do_test(self, test_case, module, input):
-        num_threads = torch.get_num_threads()
-        torch.set_num_threads(1)
-        input_tuple = input if isinstance(input, tuple) else (input,)
-
-        self._check_gradients(test_case, module, input_tuple)
-
-        # check if module can be printed
-        module.__repr__()
-
-        if self.check_inplace:
-            # check if the inplace variant of the module gives the same result
-            # as the out-of-place
-
-            # check_inplace doesn't support multiple input tensors, since we don't have any modules
-            # that modify the inputs in-place and that accept more than one input
-            assert len(input_tuple) == 1
-            input = input_tuple[0]
-
-            module_ip = self.constructor(*self.constructor_args, inplace=True)
-
-            input_version = input._version
-            with freeze_rng_state():
-                output = module(input)
-            test_case.assertEqual(input._version, input_version)
-
-            input_ip = deepcopy(input)
-            input_ip_clone = input_ip.clone()
-            with freeze_rng_state():
-                output_ip = module_ip(input_ip_clone)
-            test_case.assertNotEqual(input_ip_clone._version, input_version)
-            test_case.assertEqual(output, output_ip)
-            grad = output.data.clone().normal_()
-            if input.grad is not None:
-                with torch.no_grad():
-                    input.grad.zero_()
-            if input_ip.grad is not None:
-                with torch.no_grad():
-                    input_ip.grad.zero_()
-            output.backward(grad)
-            output_ip.backward(grad)
-            test_case.assertEqual(input.grad, input_ip.grad)
-
-        def assert_module_parameters_are(tensor_type, device_id=None):
-            for p in module.parameters():
-                test_case.assertIsInstance(p, tensor_type)
-                if device_id is not None:
-                    test_case.assertEqual(p.get_device(), device_id)
-
-        if all(isinstance(t, torch.LongTensor) for t in input_tuple) and TEST_CUDA:
-            # check that cuda() moves module parameters to correct GPU device,
-            # and that float() casts parameters correctly
-            input_tuple = tuple(t.cuda() for t in input_tuple)
-            module.float().cuda()
-            module(*input_tuple)
-            assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
-
-            if torch.cuda.device_count() > 1:
-                input_tuple = tuple(t.cuda(1) for t in input_tuple)
-                module.cuda(1)
-                with torch.cuda.device(1):
-                    module(*input_tuple)
-                assert_module_parameters_are(torch.cuda.FloatTensor, 1)  # type: ignore[attr-defined]
-        else:
-            # check that float()/double() casters work correctly
-            def to_type(tensor, real, complex):
-                if tensor.is_complex():
-                    return tensor.to(complex)
-                elif tensor.is_floating_point():
-                    return tensor.to(real)
-                else:
-                    return tensor
-
-            def to_half(x):
-                # TODO: torch.complex32 when properly supported
-                return to_type(x, torch.float16, None)
-
-            def to_single(x):
-                return to_type(x, torch.float32, torch.complex64)
-
-            def to_double(x):
-                return to_type(x, torch.float64, torch.complex128)
-
-            # to float
-            input_tuple = tuple(to_single(t) for t in input_tuple)
-            module.float()
-            module(*input_tuple)
-            assert_module_parameters_are(torch.FloatTensor)
-
-            # and back to double
-            input_tuple = tuple(to_double(t) for t in input_tuple)
-            module.double()
-            module(*input_tuple)
-            assert_module_parameters_are(torch.DoubleTensor)
-
-            if TEST_CUDA and self.should_test_cuda:
-                # check that cuda() moves module parameters to correct GPU device,
-                # and that float() casts parameters correctly
-
-                # to GPU0
-                input_tuple = tuple(to_single(t).cuda() for t in input_tuple)
-                module.float().cuda()
-                module(*input_tuple)
-                assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
-
-                # to CPU
-                input_tuple = tuple(t.cpu() for t in input_tuple)
-                module.cpu()
-                module(*input_tuple)
-                assert_module_parameters_are(torch.FloatTensor)
-
-                # back to GPU0
-                input_tuple = tuple(t.cuda() for t in input_tuple)
-                module.cuda()
-                module(*input_tuple)
-                assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
-
-                # test that forwards of module runs correctly without cuDNN
-                if self.cudnn:
-                    with torch.backends.cudnn.flags(enabled=False):
-                        module(*input_tuple)
-                        assert_module_parameters_are(torch.cuda.FloatTensor, 0)  # type: ignore[attr-defined]
-
-                if torch.cuda.device_count() >= 2:
-                    # test cross-GPU transfer works
-                    # to GPU1
-                    input_tuple = tuple(t.cuda(1) for t in input_tuple)
-                    module.cuda(1)
-                    with torch.cuda.device(1):
-                        module(*input_tuple)
-                    assert_module_parameters_are(torch.cuda.FloatTensor, 1)  # type: ignore[attr-defined]
-
-                if not self.skip_double:
-                    # test double()
-                    input_tuple = tuple(to_double(t).cuda() for t in input_tuple)
-                    module.double().cuda()
-                    module(*input_tuple)
-                    assert_module_parameters_are(torch.cuda.DoubleTensor, 0)  # type: ignore[attr-defined]
-
-                # test half()
-                if not self.skip_half:
-                    input_tuple = tuple(to_half(t).cuda() for t in input_tuple)
-                    module.half().cuda()
-                    module(*input_tuple)
-                    assert_module_parameters_are(torch.cuda.HalfTensor, 0)  # type: ignore[attr-defined]
-        torch.set_num_threads(num_threads)
 
     def test_noncontig(self, test_case, module, input):
         # check no scalars, can't make non-contig

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5279,7 +5279,7 @@ class ModuleTest(object):
                     module(*input_tuple)
                     assert_module_parameters_are(torch.cuda.HalfTensor, 0)  # type: ignore[attr-defined]
 
-    def test_cuda(self, test_case, dtype=torch.float, extra_args=None):
+    def test_cpu_gpu_parity(self, test_case, dtype=torch.float, extra_args=None):
         if not TEST_CUDA or not self.should_test_cuda:
             raise unittest.SkipTest('Excluded from CUDA tests')
 

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4905,11 +4905,11 @@ class TestBase(object):
 
     @property
     def constructor_args(self):
-        return self._get_arg('constructor_args', True)
+        return self._get_arg('constructor_args', False)
 
     @property
     def extra_args(self):
-        return self._get_arg('extra_args', True)
+        return self._get_arg('extra_args', False)
 
     def _get_arg(self, name, unpack):
         assert name in self._required_arg_names
@@ -5176,10 +5176,6 @@ class ModuleTest(TestBase):  # type: ignore[misc]
     def _get_target(self):
         return self._get_arg('target', False)
 
-    @property
-    def constructor_args(self):
-        return self._get_arg('constructor_args', False)
-
     def noncontiguize(self, obj):
         if isinstance(obj, list):
             return [self.noncontiguize(o) for o in obj]
@@ -5421,11 +5417,3 @@ class CriterionTest(TestBase):  # type: ignore[misc]
 
     def _get_target(self):
         return self._get_arg('target', False)
-
-    @property
-    def constructor_args(self):
-        return self._get_arg('constructor_args', False)
-
-    @property
-    def extra_args(self):
-        return self._get_arg('extra_args', False)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4914,6 +4914,8 @@ class ModuleTest(object):
         self.reference_fn = reference_fn
         self.is_criterion_test = is_criterion_test(kwargs)
         self._required_arg_names = {'constructor_args', 'input', 'extra_args'}
+        if self.is_criterion_test:
+            self._required_arg_names.add('target')
         for name in self._required_arg_names:
             if name not in kwargs and name + '_fn' not in kwargs and name + '_size' not in kwargs:
                 if name in {'constructor_args', 'extra_args'}:
@@ -4931,12 +4933,11 @@ class ModuleTest(object):
         self.tf32_precision = kwargs.get('tf32_precision', 0.001)
         self.check_batched_grad = kwargs.get('check_batched_grad', True)
         self.has_sparse_gradients = kwargs.get('has_sparse_gradients', False)
+        self.with_tf32 = kwargs.get('with_tf32', self.is_criterion_test)
         if self.is_criterion_test:
-            self._required_arg_names.add('target')
             self.check_half = kwargs.get('check_half', True)
             self.check_bfloat16 = kwargs.get('check_bfloat16', False)
             self.check_complex = kwargs.get('check_complex', False)
-            self.with_tf32 = kwargs.get('with_tf32', True)
         else:
             self.should_test_pickle = kwargs.get('pickle', True)
             self.FIXME_no_cuda_gradgrad_comparison = \
@@ -4946,7 +4947,6 @@ class ModuleTest(object):
             self.check_inplace = kwargs.get('check_inplace', False)
             self.skip_double = kwargs.get('skip_double', False)
             self.skip_half = kwargs.get('skip_half', False)
-            self.with_tf32 = kwargs.get('with_tf32', False)
 
     def get_name(self):
         if self.fullname is not None:

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5077,6 +5077,7 @@ class ModuleTest(object):
                 test_case.assertEqualIgnoreType(out, expected_out)
 
         if self.check_forward_only:
+            torch.set_num_threads(num_threads)
             return
 
         # === Check forward with a noncontiguous input. ===

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4977,6 +4977,9 @@ class ModuleTest(TestBase):  # type: ignore[misc]
         self.check_batched_grad = kwargs.get('check_batched_grad', True)
 
     def __call__(self, test_case):
+        return self._module_test_call(test_case)
+
+    def _module_test_call(self, test_case):
         module = self.constructor(*self.constructor_args)
         input = self._get_input()
 
@@ -5231,6 +5234,9 @@ class ModuleTest(TestBase):  # type: ignore[misc]
                 test_case.assertEqual(test_case._get_parameters(module)[1], d_param)
 
     def test_cuda(self, test_case):
+        return self._module_test_cuda(test_case)
+
+    def _module_test_cuda(self, test_case):
         if not TEST_CUDA or not self.should_test_cuda:
             raise unittest.SkipTest('Excluded from CUDA tests')
 
@@ -5330,6 +5336,9 @@ class CriterionTest(TestBase):  # type: ignore[misc]
         self.check_batched_grad = kwargs.get('check_batched_grad', True)
 
     def __call__(self, test_case):
+        return self._criterion_test_call(test_case)
+
+    def _criterion_test_call(self, test_case):
         module = self.constructor(*self.constructor_args)
         input = self._get_input()
 
@@ -5366,6 +5375,9 @@ class CriterionTest(TestBase):  # type: ignore[misc]
             gradgradcheck(apply_fn, inputs, check_batched_grad=self.check_batched_grad)
 
     def test_cuda(self, test_case, dtype, extra_args=None):
+        return self._criterion_test_cuda(test_case, dtype, extra_args)
+
+    def _criterion_test_cuda(self, test_case, dtype, extra_args=None):
         def convert_dtype(obj, dtype, requires_grad=False):
             if isinstance(obj, torch.Tensor):
                 return obj.detach().to(dtype=dtype).requires_grad_(requires_grad)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4938,16 +4938,11 @@ class TestBase(object):
 
         return self._unpack(self._arg_cache[name]) if unpack else self._arg_cache[name]
 
-    def _get_input(self, unpack=True):
-        return self._get_arg('input', unpack)
-
     def __call__(self, test_case):
         raise NotImplementedError
 
-
-class InputVariableMixin(object):
     def _get_input(self):
-        input = TestBase._get_input(self, False)  # type: ignore[arg-type]
+        input = self._get_arg('input', False)  # type: ignore[arg-type]
 
         def map_variables(i):
             if isinstance(i, torch.Tensor):
@@ -4960,7 +4955,7 @@ class InputVariableMixin(object):
         return map_variables(input)
 
 
-class ModuleTest(InputVariableMixin, TestBase):  # type: ignore[misc]
+class ModuleTest(TestBase):  # type: ignore[misc]
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.jacobian_input = kwargs.get('jacobian_input', True)
@@ -5320,7 +5315,7 @@ class ModuleTest(InputVariableMixin, TestBase):  # type: ignore[misc]
         self.test_noncontig(test_case, gpu_module, gpu_input_tuple)
 
 
-class CriterionTest(InputVariableMixin, TestBase):  # type: ignore[misc]
+class CriterionTest(TestBase):  # type: ignore[misc]
     # TODO: check that criterions don't ignore grad_output
 
     _required_arg_names = TestBase._required_arg_names.union({'target'})

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4935,12 +4935,12 @@ class ModuleTest(object):
         self.has_sparse_gradients = kwargs.get('has_sparse_gradients', False)
         self.with_tf32 = kwargs.get('with_tf32', self.is_criterion_test)
         self.check_inplace = kwargs.get('check_inplace', False)
+        self.should_test_pickle = kwargs.get('pickle', not self.is_criterion_test)
         if self.is_criterion_test:
             self.check_half = kwargs.get('check_half', True)
             self.check_bfloat16 = kwargs.get('check_bfloat16', False)
             self.check_complex = kwargs.get('check_complex', False)
         else:
-            self.should_test_pickle = kwargs.get('pickle', True)
             self.FIXME_no_cuda_gradgrad_comparison = \
                 kwargs.get('FIXME_no_cuda_gradgrad_comparison', False)
             self.precision = kwargs.get('precision', 2e-4)
@@ -5046,7 +5046,7 @@ class ModuleTest(object):
             self.test_noncontig(test_case, module, input)
 
         # === Check that the module can be pickled & unpickled.
-        if not self.is_criterion_test and self.should_test_pickle:
+        if self.should_test_pickle:
             # TODO: do this with in-memory files as soon as torch.save will support it
             with tempfile.TemporaryFile() as f:
                 test_case._forward(module, input)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -1248,7 +1248,7 @@ def fractional_max_pool3d_test(test_case):
             fullname='FractionalMaxPool3d_asymsize')
 
 
-new_module_tests = [
+module_tests.extend([
     poissonnllloss_no_reduce_test(),
     bceloss_no_reduce_test(),
     bceloss_weights_no_reduce_test(),
@@ -3698,7 +3698,7 @@ new_module_tests = [
         with_tf32=True,
         tf32_precision=0.01,
     )
-]
+])
 
 # add conv padding mode tests:
 for padding_mode, cpp_padding_mode in zip(
@@ -3717,7 +3717,7 @@ for padding_mode, cpp_padding_mode in zip(
         cpp_padding = '{' + ', '.join(map(str, padding)) + '}'
         input_size = (2, 2) + (4,) * d
         output_size = (2, 3) + tuple(p + 1 for p in padding)  # simplified from `(4 + 2 * p - 3) // 2 + 1`
-        new_module_tests.append(
+        module_tests.append(
             dict(
                 module_name='Conv{}d'.format(d),
                 constructor_args=(2, 3, 3, 2, padding, 1, 1, True, padding_mode),

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -5017,6 +5017,8 @@ class ModuleTest(object):
         module = self.constructor(*self.constructor_args)
         input = self._get_input()
         input_tuple = input if isinstance(input, tuple) else (input,)
+        if self.is_criterion_test:
+            target = self._get_target()
 
         # === Check that the module can be printed. ===
         module.__repr__()
@@ -5025,7 +5027,6 @@ class ModuleTest(object):
         # === Check the forward output against the reference function. ===
         if self.reference_fn is not None:
             if self.is_criterion_test:
-                target = self._get_target()
                 out = test_case._forward_criterion(module, input, target, extra_args=self.extra_args)
                 ref_args = (deepcopy(input), deepcopy(target)) + self.extra_args + (module,)
                 expected_out = self.reference_fn(*ref_args)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4980,14 +4980,13 @@ class ModuleTest(object):
         self.check_inplace = kwargs.get('check_inplace', False)
         self.should_test_pickle = kwargs.get('pickle', not self.is_criterion_test)
         self.precision = kwargs.get('precision', 4e-4 if self.is_criterion_test else 2e-4)
+        self.cudnn = kwargs.get('cudnn', False)
+        self.FIXME_no_cuda_gradgrad_comparison = kwargs.get('FIXME_no_cuda_gradgrad_comparison', False)
         if self.is_criterion_test:
             self.check_half = kwargs.get('check_half', True)
             self.check_bfloat16 = kwargs.get('check_bfloat16', False)
             self.check_complex = kwargs.get('check_complex', False)
         else:
-            self.FIXME_no_cuda_gradgrad_comparison = \
-                kwargs.get('FIXME_no_cuda_gradgrad_comparison', False)
-            self.cudnn = kwargs.get('cudnn', False)
             self.skip_double = kwargs.get('skip_double', False)
             self.skip_half = kwargs.get('skip_half', False)
 

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -8,7 +8,7 @@ import torch.cuda
 import torch.jit
 import torch.jit._logging
 import torch.jit.frontend
-from torch.testing._internal.common_nn import module_tests
+from torch.testing._internal.common_nn import module_tests, is_criterion_test
 from torch.testing._internal.common_utils import is_iterable_of_tensors
 
 from copy import deepcopy
@@ -572,4 +572,7 @@ def try_get_nn_module_compiled_mod_and_inputs(*args, **kwargs):
 
 
 def get_all_nn_module_tests():
-    return module_tests + additional_module_tests
+    # Note: before the module test / criterion test merge, this function did not return
+    # criterion tests. For now, this behavior is preserved.
+    non_criterion_tests = [test for test in module_tests if not is_criterion_test(test)]
+    return non_criterion_tests + additional_module_tests

--- a/torch/testing/_internal/jit_metaprogramming_utils.py
+++ b/torch/testing/_internal/jit_metaprogramming_utils.py
@@ -8,7 +8,7 @@ import torch.cuda
 import torch.jit
 import torch.jit._logging
 import torch.jit.frontend
-from torch.testing._internal.common_nn import module_tests, new_module_tests
+from torch.testing._internal.common_nn import module_tests
 from torch.testing._internal.common_utils import is_iterable_of_tensors
 
 from copy import deepcopy
@@ -572,4 +572,4 @@ def try_get_nn_module_compiled_mod_and_inputs(*args, **kwargs):
 
 
 def get_all_nn_module_tests():
-    return module_tests + new_module_tests + additional_module_tests
+    return module_tests + additional_module_tests


### PR DESCRIPTION
## Background
In preparation for the upcoming `ModuleInfo` work, this PR merges the 3 types of tests defined in `common_nn.py` into a single abstraction and list. That is:
```
ModuleTest + NewModuleTest + CriterionTest -> ModuleTest
module_tests + new_module_tests + criterion_tests -> module_tests
```
(additionally, the now unnecessary `TestBase` and `InputVariableMixin` classes are merged in with `ModuleTest`)

## Incremental Update Process
Because this is tricky to refactor, this PR takes a careful incremental approach split across commits, attempting minimal edits at each step. Following are the step-by-step changes for each of the first 7 commits:
1. Merge `module_tests` + `new_module_tests` -> `module_tests`
2. Merge `ModuleTest` + `NewModuleTest` -> `ModuleTest`
3. Merge `TestBase` + `InputVariableMixin` -> `TestBase`
4. (Prep for next merge: move overridden `constructor_args()` / `extra_args()` implementations into `TestBase`)
5. (Prep for next merge: tweak `__call__()` / `test_cuda()` to simply dispatch to specific names: `_module_test_call()` / `_criterion_test_call()` and `_module_test_cuda()` / `_criterion_test_cuda()`)
6. Merge `ModuleTest` + `CriterionTest` + `TestBase` -> `ModuleTest`
7. Merge `module_tests` + `criterion_tests` -> `module_tests`

After this point, the merging within `ModuleTest` becomes more aggressive (and higher risk). It should be much clearer what is being tested.

## Relevant Test Files
The following test files use at least one of the lists:
* `test/jit/test_complexity.py`
* `test/onnx/export_onnx_tests_generator.py`
* `test/test_cpp_api_parity.py`
* `test/test_fx_experimental.py`
* `test/test_jit.py`
* `test/test_nn.py`
* `torch/testing/_internal/jit_metaprogramming_utils.py`

Only `test_nn.py` actually invokes `__call__()` / `test_cuda()` on the test classes; the rest only use the lists / classes for the metadata to generate their own tests.