### PR TITLE
Don't use backend() to compute torch/csrc/utils/tensor_types.cpp

### DIFF
--- a/torch/csrc/utils/tensor_types.cpp
+++ b/torch/csrc/utils/tensor_types.cpp
@@ -28,9 +28,30 @@ static const char* backend_to_string(const at::Backend& backend) {
   }
 }
 
+static const char* options_to_module(const at::TensorOptions& options) {
+  switch(options.layout()) {
+    case at::Layout::Strided:
+      switch(options.device().type()) {
+        case at::Device::CPU: return "torch";
+        case at::Device::CUDA: return "torch.cuda";
+        case at::Device::XPU: return "torch.xpu";
+        case at::Device::QuantizedCPU: return "torch.quantized";
+        default: TORCH_CHECK(false, "Unimplemented backend ", options);
+      }
+    case at::Layout::Sparse:
+      switch(options.device().type()) {
+        case at::Device::CPU: return "torch.sparse";
+        case at::Device::CUDA: return "torch.cuda.sparse";
+        case at::Device::XPU: return "torch.xpu.sparse";
+        default: TORCH_CHECK(false, "Unimplemented backend ", options);
+      }
+    default: TORCH_CHECK(false, "Unimplemented backend ", options);
+  }
+}
+
 std::string options_to_string(const at::TensorOptions options) {
   std::ostringstream ss;
-  ss << backend_to_string(options.backend()) << "." << toString(at::typeMetaToScalarType(options.dtype())) << "Tensor";
+  ss << options_to_module(options) << "." << toString(at::typeMetaToScalarType(options.dtype())) << "Tensor";
   return ss.str();
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59655 Remove some unnecessary functions from CUDAHooks
* **#59654 Don't use backend() to compute torch/csrc/utils/tensor_types.cpp**

Fixes https://github.com/pytorch/pytorch/issues/59645

Signed-off-by: Edward Z. Yang <ezyang@fb.com>