### PR TITLE
[DO NOT REVIEW/MERGE] [CUDNN v8 API] cuDNN benchmark

### DIFF
--- a/aten/src/ATen/native/cudnn/Conv_v7.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v7.cpp
@@ -669,8 +669,6 @@ void raw_cudnn_convolution_forward_out(
   split_batch_dim_to_32bit_out(output, input, weight, padding, stride, dilation, groups, benchmark, deterministic, allow_tf32, 1024 * 1024 * 256, raw_cudnn_convolution_forward_out_32bit);
 }
 
-#endif // !HAS_CUDNN_V8()
-
 // ---------------------------------------------------------------------
 //
 // Convolution backward / Transposed convolution forward
@@ -826,6 +824,8 @@ void raw_cudnn_convolution_backward_weight_out(
   // Considering the complexity of this issue, it is better not to use cuDNN for this case
   TORCH_INTERNAL_ASSERT(false, "This case should not be dispatched to cuDNN.");
 }
+
+#endif // !HAS_CUDNN_V8()
 
 void raw_cudnn_convolution_add_relu_out(
     const Tensor& output,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -26,7 +26,7 @@ namespace {
 uint8_t getAlignment(const Tensor &t) {
   // alignment are in bytes
   uint8_t alignment = 1;
-  uint64_t address = reinterpret_cast<uint64_t>(t.data_ptr());
+  uintptr_t address = reinterpret_cast<uintptr_t>(t.data_ptr());
   while (address % alignment == 0 && alignment < 16) alignment *= 2;
   return alignment;
 }

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -182,7 +182,7 @@ void raw_cudnn_convolution_forward_out(
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32)
 {
-  if (y.numel() > 0) {
+  if (output.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR,
       input, output, weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);
@@ -195,7 +195,7 @@ void raw_cudnn_convolution_backward_input_out(
     const at::Tensor& weight,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
-  if (x.numel() > 0) {
+  if (grad_input.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR,
       grad_input, grad_output, weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);
@@ -206,7 +206,7 @@ void raw_cudnn_convolution_backward_weight_out(
     const Tensor& grad_weight, const Tensor& grad_output, const Tensor& input,
     IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,
     bool benchmark, bool deterministic, bool allow_tf32) {
-  if (w.numel() > 0) {
+  if (grad_weight.numel() > 0) {
     run_single_conv(CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR,
       input, grad_output, grad_weight, padding, stride, dilation, groups,
       benchmark, deterministic, allow_tf32);

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -112,7 +112,7 @@ void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const
 }
 
 auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, CacheKey key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {
-   auto op = cudnn_frontend::OperationBuilder(desc)
+  auto op = cudnn_frontend::OperationBuilder(desc)
       .setxDesc(getTensorDescriptor(x, 'x', key.x_alignment))
       .setyDesc(getTensorDescriptor(y, 'y', key.y_alignment))
       .setwDesc(getTensorDescriptor(w, 'w', key.w_alignment))
@@ -123,7 +123,6 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
       .setHandle(handle)
       .setOperationGraph(1, ops.data())
       .build();
-
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   auto variantPack  = cudnn_frontend::VariantPackBuilder().setDataPointers(3, data_ptrs).setUids(3, uids).build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -174,7 +174,7 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
   for (auto& option : options) {
     plans.emplace_back(std::move(option.plan));
   }
-  return plans; 
+  return plans;
 }
 
 auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, const CacheKey& key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -162,8 +162,8 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
   for (auto& option : options) {
     plans.emplace_back(std::move(option.plan));
   }
+  std::cout << "find plans: " << plans.size() << std::endl;
   return plans; 
-  //auto tag = options2.front().plan.getTag();
 }
 
 auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc, const Tensor& x, const Tensor& y, const Tensor& w, CacheKey key, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, bool deterministic, bool allow_tf32) {
@@ -216,7 +216,7 @@ auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_
   std::array<cudnn_frontend::GeneratorSource const, 2> sources = {heurgen_method, fallback_method};
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
   auto plans = generator.cudnnGetPlan(handle, std::move(opGraph), sample_predicate_function);
-  std::cout << plans.size() << std::endl;
+  std::cout << "get plans: " << plans.size() << std::endl;
   return plans;
 }
 

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -234,17 +234,6 @@ void try_plans(cudnn_frontend::executionPlans_t& plans, const CacheKey& key, con
   TORCH_CHECK(false, "Unable to find an engine to execute this computation");
 }
 
-void try_options(cudnn_frontend::executionOptions_t & options, const CacheKey& key, const cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w) {
-  for (auto& option : options) {
-    try {
-      run_conv_plan(handle, x, y, w, option.plan);
-      engine_cache.emplace(key, std::move(option.plan));
-      return;
-    } catch (cudnn_frontend::cudnnException &e) {} catch(CuDNNError &e) {}
-  }
-  TORCH_CHECK(false, "Unable to find an engine to execute this computation");
-}
-
 void run_single_conv(const cudnnBackendDescriptorType_t operation,
   const Tensor& x, const Tensor& y, const Tensor& w,
   IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups,

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -199,7 +199,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   std::for_each(plans.begin(), plans.end(), [&] (cudnn_frontend::ExecutionPlan& plan) {
     size_t curr_workspace_size = plan.getWorkspaceSize();
     if (curr_workspace_size <= max_block_size) {
-      if (curr_workspace_size > max_workspace_size && curr_workspace_size <= max_block_size) {
+      if (curr_workspace_size > max_workspace_size) {
         max_workspace_size = plan.getWorkspaceSize();
       }
       valid_plans.emplace_back(std::move(plan));

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -178,10 +178,6 @@ auto get_plans_from_heuristics(cudnnHandle_t handle, cudnnBackendDescriptorType_
       .setHandle(handle)
       .setOperationGraph(1, ops.data())
       .build();
-  auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
-      .setOperationGraph(opGraph)
-      .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
-      .build();
   void *data_ptrs[] = {x.data_ptr(), y.data_ptr(), w.data_ptr()};
   int64_t uids[] = {'x', 'y', 'w'};
   auto variantPack  = cudnn_frontend::VariantPackBuilder().setDataPointers(3, data_ptrs).setUids(3, uids).build();

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -196,7 +196,7 @@ auto get_plans_from_find(const cudnnHandle_t handle, const cudnnBackendDescripto
   c10::cuda::CUDACachingAllocator::cacheInfo(device, &tmp_bytes, &max_block_size);
   cudnn_frontend::executionPlans_t valid_plans;
 
-  std::for_each(plans.begin(), plans.end(), [&max_workspace_size, &max_block_size, &valid_plans](cudnn_frontend::ExecutionPlan& plan) { 
+  std::for_each(plans.begin(), plans.end(), [&] (cudnn_frontend::ExecutionPlan& plan) {
     size_t curr_workspace_size = plan.getWorkspaceSize();
     if (curr_workspace_size <= max_block_size) {
       if (curr_workspace_size > max_workspace_size && curr_workspace_size <= max_block_size) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -89,7 +89,7 @@ std::unordered_map<CacheKey, cudnn_frontend::ExecutionPlan, ParamsHash<CacheKey>
 
 }
 
-void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, const Tensor& y, const Tensor& x, const Tensor& w, IntArrayRef padding, IntArrayRef stride, IntArrayRef dilation, int64_t groups, bool deterministic, bool allow_tf32) {
+void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, const Tensor& y, const Tensor& x, const Tensor& w, const IntArrayRef padding, const IntArrayRef stride, const IntArrayRef dilation, int64_t groups, bool deterministic, bool allow_tf32) {
    memset(&key, 0, sizeof(key));
    setConvolutionParams(&key.params, x, w, padding, stride, dilation, groups, deterministic, allow_tf32);
    key.operation = operation;
@@ -98,7 +98,7 @@ void get_cachekey(CacheKey& key, const cudnnBackendDescriptorType_t operation, c
    key.w_alignment = getAlignment(w);
 }
 
-void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, cudnn_frontend::ExecutionPlan& plan) {
+void run_conv_plan(cudnnHandle_t handle, const Tensor& x, const Tensor& y, const Tensor& w, const cudnn_frontend::ExecutionPlan& plan) {
     auto workspace_size = plan.getWorkspaceSize();
     Tensor workspace;
     workspace = at::empty({workspace_size}, x.options().dtype(kByte));

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -168,7 +168,7 @@ auto get_plans_from_find(cudnnHandle_t handle, cudnnBackendDescriptorType_t desc
 
   std::array<cudnn_frontend::GeneratorSource const, 2> sources = {heurgen_method, fallback_method};
   cudnn_frontend::EngineConfigGenerator generator(sources.size(), sources.data());
-  auto options = generator.cudnnFindPlan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(opGraph), variantPack, predicate_function); 
+  auto options = generator.cudnnFindPlan<cudnn_frontend::CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE>(handle, std::move(opGraph), variantPack, predicate_function);
 
   cudnn_frontend::executionPlans_t plans;
   for (auto& option : options) {

--- a/aten/src/ATen/native/cudnn/Conv_v8.cpp
+++ b/aten/src/ATen/native/cudnn/Conv_v8.cpp
@@ -159,7 +159,7 @@ const auto get_fallback_method(const cudnn_frontend::OperationGraph &opGraph, co
   auto fallback_method = [&](cudnn_frontend::OperationGraph &opGraph) -> cudnn_frontend::EngineConfigList {
     auto fallback = cudnn_frontend::EngineFallbackListBuilder()
                         .setOperationGraph(opGraph)
-			.setOperation(desc)
+                        .setOperation(desc)
                         .build();
     auto &fallback_list = fallback.getFallbackList();
     cudnn_frontend::EngineConfigList filtered_configs;


### PR DESCRIPTION
#58859, also includes the changes from #58721
We now cache "plans" instead of engine configs.

The current workspace size is a placeholder; it will be updated based on the maximum workspace requirements of the plans or available device memory. 
Includes a fix to properly initialize `CacheKey` in order to make `ParamsHash` work safely.

CC @zasdfgbnm @ptrblck 