### PR TITLE
Allow tools/test_history.py to be piped to head

### DIFF
--- a/tools/test_history.py
+++ b/tools/test_history.py
@@ -4,6 +4,7 @@ import argparse
 import subprocess
 import sys
 from datetime import datetime, timezone
+from signal import SIG_DFL, SIGPIPE, signal
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from tools.stats_utils.s3_stat_parser import (Report, get_cases,
@@ -337,10 +338,11 @@ def run(raw: List[str]) -> Iterator[str]:
 
 def main() -> None:
     for line in run(sys.argv[1:]):
-        print(line)
+        print(line, flush=True)
 
 
 if __name__ == "__main__":
+    signal(SIGPIPE, SIG_DFL)  # https://stackoverflow.com/a/30091579
     try:
         main()
     except KeyboardInterrupt:


### PR DESCRIPTION
**Test plan:**

```
tools/test_history.py --mode=columns --ref=3cf783 --test=test_set_dir --job pytorch_linux_xenial_py3_6_gcc5_4_test --job pytorch_linux_xenial_py3_6_gcc7_test | head -n10
```
Before this PR, the above command seems to just hang. After this PR, it nicely prints the following, line by line, and then exits:
```
2021-02-10 12:18:50Z 3cf78395cbc32fa9c83b585c9ec63f960b32d17f    0.644s    0.312s
2021-02-10 11:13:34Z 594a66d778a660faed0b0fbbe1dd8c2c318707ff    0.360s  errored
2021-02-10 10:13:25Z 9c0caf0384690cb67dcccb7066ece5184f72ca78    0.819s    0.449s
2021-02-10 10:09:14Z 602434bcbebb82c6f3741b2a3d5ebac7ee482268    0.361s    0.454s
2021-02-10 10:09:10Z 2e35fe953553247d8a22fc38b039374e426f13b8
2021-02-10 10:09:07Z ff73be7e45616fe106b9e5040bc091ca5cdbfc7f
2021-02-10 10:05:39Z 74082f0d6f8dfd60f28c0de0fe43bcb97b95ee5a
2021-02-10 07:42:29Z 0620c96fd6a140e68c49d68ed14721b1ee108ecc    0.414s    0.377s (2 job re-runs omitted)
2021-02-10 07:27:53Z 33afb5f19f4e427f099653139ae45b661b8bc596    0.381s    0.294s
2021-02-10 07:05:15Z 5f9fb93c1423814a20007faa506ceb8b4828c8d1    0.461s    0.361s
```