### PR TITLE
displays graph node's info

### DIFF
--- a/torch/csrc/jit/runtime/static/impl.h
+++ b/torch/csrc/jit/runtime/static/impl.h
@@ -188,6 +188,8 @@ class TORCH_API StaticRuntime {
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs);
 
+  void display_nodes(const std::vector<c10::IValue>& args);
+
   void benchmark(
       const std::vector<c10::IValue>& args,
       const std::unordered_map<std::string, c10::IValue>& kwargs,


### PR DESCRIPTION
Summary: Displays info about graph's nodes

Test Plan:
Expected view:

%wide_offset.1 : Tensor = aten::add(%wide.1, %self._mu, %4)
	i0: Tensor CPUFloatType {32, 50}
	i1: Tensor CPUFloatType {1, 50}
	i2: int {1}
	o0: Tensor CPUFloatType {32, 50}
%wide_normalized.1 : Tensor = aten::mul(%wide_offset.1, %self._sigma)
	i0: Tensor CPUFloatType {32, 50}
	i1: Tensor CPUFloatType {1, 50}
	o0: Tensor CPUFloatType {32, 50}
%wide_preproc.1 : Tensor = aten::clamp(%wide_normalized.1, %5, %6)
	i0: Tensor CPUFloatType {32, 50}
	i1: double {0}
	i2: double {10}
	o0: Tensor CPUFloatType {32, 50}
%user_emb_t.1 : Tensor = aten::transpose(%user_emb.1, %4, %7)
	i0: Tensor CPUFloatType {32, 1, 32}
	i1: int {1}
	i2: int {2}
	o0: Tensor CPUFloatType {32, 32, 1}
%dp_unflatten.1 : Tensor = aten::bmm(%ad_emb_packed.1, %user_emb_t.1)
	i0: Tensor CPUFloatType {32, 1, 32}
	i1: Tensor CPUFloatType {32, 32, 1}
	o0: Tensor CPUFloatType {32, 1, 1}
%31 : Tensor = static_runtime::flatten_copy(%dp_unflatten.1, %4, %8)
	i0: Tensor CPUFloatType {32, 1, 1}
	i1: int {1}
	i2: int {-1}
	o0: Tensor CPUFloatType {32, 1}
%19 : Tensor[] = prim::ListConstruct(%31, %wide_preproc.1)
	i0: Tensor CPUFloatType {32, 1}
	i1: Tensor CPUFloatType {32, 50}
	o0: TensorList {2}
%input.1 : Tensor = aten::cat(%19, %4)
	i0: TensorList {2}
	i1: int {1}
	o0: Tensor CPUFloatType {32, 51}
%fc1.1 : Tensor = aten::addmm(%self._fc_b, %input.1, %29, %4, %4)
	i0: Tensor CPUFloatType {1}
	i1: Tensor CPUFloatType {32, 51}
	i2: Tensor CPUFloatType {51, 1}
	i3: int {1}
	i4: int {1}
	o0: Tensor CPUFloatType {32, 1}
%23 : Tensor = aten::sigmoid(%fc1.1)
	i0: Tensor CPUFloatType {32, 1}
	o0: Tensor CPUFloatType {32, 1}
%24 : (Tensor) = prim::TupleConstruct(%23)
	i0: Tensor CPUFloatType {32, 1}
	o0: Tuple {1}

Reviewed By: hlu1

Differential Revision: D28592852

