### PR TITLE
[NNC] Add python bindings for loopnest.compress_buffer

### DIFF
--- a/torch/csrc/jit/tensorexpr/expr.h
+++ b/torch/csrc/jit/tensorexpr/expr.h
@@ -251,6 +251,9 @@ class TORCH_API BufHandle : public ExprHandle {
   const Buf* node() const {
     return static_cast<const Buf*>(ExprHandle::node());
   }
+  Buf* node() {
+    return static_cast<Buf*>(ExprHandle::node());
+  }
 
   template <typename... Ts>
   inline ExprHandle load(const Ts&... ts) const;

--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -503,6 +503,12 @@ void initTensorExprBindings(PyObject* module) {
           "vectorize",
           [](const LoopNest& self, For* f) { self.vectorize(f); },
           py::return_value_policy::reference)
+      .def_static(
+          "compress_buffer",
+          [](BufHandle& buf, Stmt* stmt) {
+            return LoopNest::compressBuffer(buf.node(), stmt);
+          },
+          py::return_value_policy::reference)
       .def(
           "cache_accesses",
           [](LoopNest& self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59681 [NNC] Add python bindings for loopnest.compress_buffer**

Differential Revision: [D28981573](https://our.internmc.facebook.com/intern/diff/D28981573)