### PR TITLE
adding zero_point checks for cuda quantization functions

### DIFF
--- a/aten/src/ATen/native/quantized/affine_quantizer.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer.cpp
@@ -158,7 +158,7 @@ Tensor& quantize_tensor_per_channel_affine(
     checkQuantizedTensor<scalar_t>(fn_name, qtensor);
     if(qtensor.device().type() != c10::DeviceType::CUDA){
       checkZeroPoints<underlying_t>(fn_name, zero_points);
-    }
+    }  // for cuda, this check will occur in the actual cuda function
   });
 
   TORCH_CHECK(
@@ -262,7 +262,7 @@ Tensor& dequantize_tensor_per_channel_affine(
     checkQuantizedTensor<scalar_t>(fn_name, qtensor);
     if(qtensor.device().type() != c10::DeviceType::CUDA){
       checkZeroPoints<underlying_t>(fn_name, zero_points);
-    }
+    }  // for cuda, this check will occur in the actual cuda function
   });
 
   TORCH_CHECK(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59702 adding zero_point checks for cuda quantization functions**
* #59701 update internal function names that apply to both cpu and cuda
* #58245 Cuda quantized tensors, support for quantize per channel
* #59700 Cuda quantized tensors, support for quantize per tensor

Summary: we bypass the checks for zero_point for affine_quantizer.cpp since it could no support quantized tensors, this adds those checks to the cuda ops

Test Plan: python test/test_quantization.py TestQuantizedTensor

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29018269](https://our.internmc.facebook.com/intern/diff/D29018269)