### PR TITLE
make --run-specified-test-case use --include

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -394,10 +394,10 @@ JIT_EXECUTOR_TESTS = [
 # options.run_specified_test_cases is enabled.
 # For example:
 # {
-#   "test_nn": ["test_doubletensor_avg_pool3d", "test_share_memory", "test_hook_requires_grad"],
+#   "`test_nn`": ["test_doubletensor_avg_pool3d", "test_share_memory", "test_hook_requires_grad"],
 #   ...
 # }
-# For test_nn.py, we would ONLY run test_doubletensor_avg_pool3d, test_share_memory, and test_hook_requires_grad.
+# then for test_nn.py, we would ONLY run test_doubletensor_avg_pool3d, test_share_memory, and test_hook_requires_grad.
 SPECIFIED_TEST_CASES_DICT: Dict[str, List[str]] = {}
 
 # The file from which the SPECIFIED_TEST_CASES_DICT will be filled, a CSV of test cases that would be run when
@@ -532,10 +532,9 @@ def get_slow_tests_based_on_S3() -> List[str]:
 
 
 def get_test_case_args(test_module, using_pytest) -> List[str]:
-    if test_module not in SPECIFIED_TEST_CASES_DICT:
-        sys.exit(f'Warning! Test module {test_module} is not found in the specified tests dict. This should never'
-                 'happen as we make a check for that before entering this function.')
     args = []
+    if test_module not in SPECIFIED_TEST_CASES_DICT:
+        return args
 
     if using_pytest:
         args.append('-k')
@@ -583,6 +582,7 @@ def run_test(test_module, test_directory, options, launcher_cmd=None, extra_unit
     executable = get_executable_command(options, allow_pytest=not extra_unittest_args,
                                         disable_coverage=disable_coverage)
 
+    # TODO: move this logic into common_utils.py instead of passing in "-k" individually
     # The following logic for running specified tests will only run for non-distributed tests, as those are dispatched
     # to test_distributed and not run_test (this function)
     if options.run_specified_test_cases:
@@ -838,8 +838,18 @@ def parse_args():
         nargs='?',
         type=str,
         const=SPECIFIED_TEST_CASES_FILE,
-        help='runs specified test cases from previous OSS CI stats from a file, format CSV',
-
+        help='load specified test cases file dumped from previous OSS CI stats, format CSV. '
+        'file content is used based on option "--use-specified-test-cases-for".'
+    )
+    parser.add_argument(
+        '--use-specified-test-cases-for',
+        type=str,
+        choices=['include', 'bring-to-front'],
+        default='include',
+        help='used together with option "--run-specified-test-cases". When specified test case '
+        'file is set. This option allow user to control whether to only run the specified test '
+        'modules or to also run the remaining modules. Note: regardless of this option, we '
+        'only run the specified test cases within a test module. ',
     )
     return parser.parse_args()
 
@@ -893,6 +903,11 @@ def exclude_tests(exclude_list, selected_tests, exclude_message=None):
 
 
 def get_selected_tests(options):
+    if options.use_specified_test_cases_for == 'include':
+        options.include = list(SPECIFIED_TEST_CASES_DICT.keys())
+    elif options.use_specified_test_cases_for == 'bring-to-front':
+        options.bring_to_front = list(SPECIFIED_TEST_CASES_DICT.keys())
+
     selected_tests = options.include
 
     if options.bring_to_front:
@@ -910,10 +925,6 @@ def get_selected_tests(options):
 
     if options.exclude_jit_executor:
         options.exclude.extend(JIT_EXECUTOR_TESTS)
-
-    if options.run_specified_test_cases:
-        # Filter out any unspecified test modules.
-        selected_tests = [t for t in selected_tests if t in SPECIFIED_TEST_CASES_DICT]
 
     selected_tests = exclude_tests(options.exclude, selected_tests)
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -536,6 +536,10 @@ def get_test_case_args(test_module, using_pytest) -> List[str]:
     if test_module not in SPECIFIED_TEST_CASES_DICT:
         return args
 
+    # if specified with __all__ then run all tests
+    if '__all__' in SPECIFIED_TEST_CASES_DICT[test_module]:
+        return args
+
     if using_pytest:
         args.append('-k')
         args.append(' or '.join(SPECIFIED_TEST_CASES_DICT[test_module]))
@@ -739,7 +743,8 @@ class TestChoices(list):
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Run the PyTorch unit test suite',
-        epilog='where TESTS is any of: {}'.format(', '.join(TESTS)))
+        epilog='where TESTS is any of: {}'.format(', '.join(TESTS)),
+        formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         '-v',
         '--verbose',
@@ -839,6 +844,11 @@ def parse_args():
         type=str,
         const=SPECIFIED_TEST_CASES_FILE,
         help='load specified test cases file dumped from previous OSS CI stats, format CSV. '
+        ' If all test cases should run for a <test_module> please add a single row: \n'
+        ' test_filename,test_case_name\n'
+        ' ...\n'
+        ' <test_module>,__all__\n'
+        ' ...\n'
         'file content is used based on option "--use-specified-test-cases-for".'
     )
     parser.add_argument(
@@ -849,7 +859,7 @@ def parse_args():
         help='used together with option "--run-specified-test-cases". When specified test case '
         'file is set. This option allow user to control whether to only run the specified test '
         'modules or to also run the remaining modules. Note: regardless of this option, we '
-        'only run the specified test cases within a test module. ',
+        'only run the specified test cases within a test module.',
     )
     return parser.parse_args()
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -533,11 +533,8 @@ def get_slow_tests_based_on_S3() -> List[str]:
 
 def get_test_case_args(test_module, using_pytest) -> List[str]:
     args = []
-    if test_module not in SPECIFIED_TEST_CASES_DICT:
-        return args
-
-    # if specified with __all__ then run all tests
-    if '__all__' in SPECIFIED_TEST_CASES_DICT[test_module]:
+    # if test_module not specified or specified with '__all__' then run all tests
+    if test_module not in SPECIFIED_TEST_CASES_DICT or '__all__' in SPECIFIED_TEST_CASES_DICT[test_module]:
         return args
 
     if using_pytest:
@@ -849,17 +846,19 @@ def parse_args():
         ' ...\n'
         ' <test_module>,__all__\n'
         ' ...\n'
-        'file content is used based on option "--use-specified-test-cases-for".'
+        'how we use the stats will be based on option "--use-specified-test-cases-by".'
     )
     parser.add_argument(
-        '--use-specified-test-cases-for',
+        '--use-specified-test-cases-by',
         type=str,
         choices=['include', 'bring-to-front'],
         default='include',
         help='used together with option "--run-specified-test-cases". When specified test case '
-        'file is set. This option allow user to control whether to only run the specified test '
-        'modules or to also run the remaining modules. Note: regardless of this option, we '
-        'only run the specified test cases within a test module.',
+        'file is set, this option allows the user to control whether to only run the specified test '
+        'modules or to simply bring the specified modules to front and also run the remaining '
+        'modules. Note: regardless of this option, we will only run the specified test cases '
+        ' within a specified test module. For unspecified test modules with the bring-to-front '
+        'option, all test cases will be run, as one may expect.',
     )
     return parser.parse_args()
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -903,10 +903,11 @@ def exclude_tests(exclude_list, selected_tests, exclude_message=None):
 
 
 def get_selected_tests(options):
-    if options.use_specified_test_cases_for == 'include':
-        options.include = list(SPECIFIED_TEST_CASES_DICT.keys())
-    elif options.use_specified_test_cases_for == 'bring-to-front':
-        options.bring_to_front = list(SPECIFIED_TEST_CASES_DICT.keys())
+    if options.run_specified_test_cases:
+        if options.use_specified_test_cases_for == 'include':
+            options.include = list(SPECIFIED_TEST_CASES_DICT.keys())
+        elif options.use_specified_test_cases_for == 'bring-to-front':
+            options.bring_to_front = list(SPECIFIED_TEST_CASES_DICT.keys())
 
     selected_tests = options.include
 

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -394,7 +394,7 @@ JIT_EXECUTOR_TESTS = [
 # options.run_specified_test_cases is enabled.
 # For example:
 # {
-#   "`test_nn`": ["test_doubletensor_avg_pool3d", "test_share_memory", "test_hook_requires_grad"],
+#   "test_nn": ["test_doubletensor_avg_pool3d", "test_share_memory", "test_hook_requires_grad"],
 #   ...
 # }
 # then for test_nn.py, we would ONLY run test_doubletensor_avg_pool3d, test_share_memory, and test_hook_requires_grad.


### PR DESCRIPTION
instead of having specific logic to handle run-specific-test-case, we provide the flag to override include or bring-to-front with the SPECIFIED_TEST_CASES_FILE. 
