### PR TITLE
Remove composite definition for new_empty_strided

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1758,6 +1758,8 @@
 
 - func: new_empty_strided(Tensor self, int[] size, int[] stride, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   variants: method
+  dispatch:
+    CPU, CUDA, QuantizedCPU, QuantizedCUDA, MkldnnCPU, Meta: new_empty_strided
 
 - func: new_full(Tensor self, int[] size, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor
   variants: method


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59708 Remove composite definition for new_empty_strided**

This function internally uses options() to construct the new
tensor, which means it only works for the fixed set of types
that options() understands.  This was getting in the way of #59049

I'm not entirely sure this is the correct fix, but it makes my
local tests work.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D28994614](https://our.internmc.facebook.com/intern/diff/D28994614)