### PR TITLE
[Torch] Cast timestamp type to int

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -84,6 +84,16 @@ class ApiTest(unittest.TestCase):
         self.assertEqual("test error message", pf.message)
         self.assertEqual(10, pf.timestamp)
 
+    def test_process_mast_error_format(self):
+        error_data = {"message": "test error message", "timestamp": "10"}
+        with open(self.test_error_file, "w") as fp:
+            json.dump(error_data, fp)
+        pf = ProcessFailure(
+            local_rank=0, pid=997, exitcode=1, error_file=self.test_error_file
+        )
+        self.assertEqual("test error message", pf.message)
+        self.assertEqual(10, pf.timestamp)
+
     def test_process_failure(self):
         pf = self.failure_with_error_file(exception=SentinelError("foobar"))
         self.assertEqual(0, pf.local_rank)

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -134,7 +134,7 @@ class ProcessFailure:
     def _get_error_data(self, error_file_data: Dict[str, Any]) -> Tuple[str, int]:
         message = error_file_data["message"]
         if isinstance(message, str):
-            timestamp = error_file_data.get("timestamp", 0)
+            timestamp = int(error_file_data.get("timestamp", 0))
         else:
             timestamp = int(message["extraInfo"]["timestamp"])
         return (message, timestamp)


### PR DESCRIPTION
Summary:
When worker process fails in fb due to signal failure, the TerminationHandler writes error reply file. Recently the error reply file was changed for mast jobs. The Json value of ``timestamp`` is string, even though in the thrift struct it is int: https://fburl.com/diffusion/upa228u5

This diff adds support for casting str timestamp to int.

Test Plan: buck test mode/dev-nosan //caffe2/test/distributed/elastic/multiprocessing/errors:api_test

Differential Revision: D28995827

