### PR TITLE
Bump the bytecode reading version kMaxSupportedBytecodeVersion to 6

### DIFF
--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -67,6 +67,10 @@ constexpr uint64_t kProducedFileFormatVersion = 0x3L;
 //  0x3L: (Comment missing)
 //  0x4L: (Comment missing)
 //  0x4L: (update) Added schema to function tuple. Forward-compatible change.
+//  0x5L: (update) Update bytecode is sharing constant tensor files from torchscript, and only serialize
+//  0x6L: Implicit opereator versioning using number of specified argument.
+//  Refer to the summary of https://github.com/pytorch/pytorch/pull/56845
+//  for details.
 constexpr uint64_t kProducedBytecodeVersion = 0x4L;
 
 static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,

--- a/caffe2/serialize/versions.h
+++ b/caffe2/serialize/versions.h
@@ -78,7 +78,7 @@ static_assert(kProducedBytecodeVersion >= kProducedFileFormatVersion,
 // we should support this model_version. For example, we provide a wrapper to
 // handle an updated operator.
 constexpr uint64_t kMinSupportedBytecodeVersion = 0x3L;
-constexpr uint64_t kMaxSupportedBytecodeVersion = 0x5L;
+constexpr uint64_t kMaxSupportedBytecodeVersion = 0x6L;
 
 } // namespace serialize
 } // namespace caffe2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59714 Bump the bytecode reading version kMaxSupportedBytecodeVersion to 6**
Bytecode v6 is on implicit operator versioning through number of specified arguments. Both the read and write codes are available. This PR is to enable reading v6 models. The default writing format is not changed yet and will be bumped in a later PR.

Test: CI.
Local: change the writing version to 6 temporally and run the unit tests in LiteInterpreterTest. There are a number of end-to-end tests to write v6 bytecode, read and run it.

Differential Revision: [D29007538](https://our.internmc.facebook.com/intern/diff/D29007538)