### PR TITLE
.circleci: Disable pytorch_windows_test_multigpu

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -153,7 +153,9 @@ WORKFLOW_DATA = [
     WindowsJob(None, _VC2019, CudaVersion(11, 1)),
     WindowsJob(1, _VC2019, CudaVersion(11, 1), master_only=True),
     WindowsJob(2, _VC2019, CudaVersion(11, 1), master_only=True),
-    WindowsJob('_azure_multi_gpu', _VC2019, CudaVersion(11, 1), multi_gpu=True, master_and_nightly=True),
+
+    # TODO: This test is disabled due to https://github.com/pytorch/pytorch/issues/59724
+    # WindowsJob('_azure_multi_gpu', _VC2019, CudaVersion(11, 1), multi_gpu=True, master_and_nightly=True),
 ]
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1896,6 +1896,10 @@ jobs:
   pytorch_windows_test_multigpu:
     machine:
       image: ubuntu-2004:202104-01
+    # TODO: Remove this when statement when multi-gpu tests are working
+    #       see: https://github.com/pytorch/pytorch/issues/59724
+    when: false
+    # TODO: delete block
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1896,10 +1896,6 @@ jobs:
   pytorch_windows_test_multigpu:
     machine:
       image: ubuntu-2004:202104-01
-    # TODO: Remove this when statement when multi-gpu tests are working
-    #       see: https://github.com/pytorch/pytorch/issues/59724
-    when: false
-    # TODO: delete block
     steps:
       - checkout
       - run:
@@ -7741,19 +7737,6 @@ workflows:
           vc_product: BuildTools
           vc_version: ""
           vc_year: "2019"
-      - pytorch_windows_test_multigpu:
-          filters:
-            branches:
-              only:
-                - master
-                - /ci-all\/.*/
-                - /release\/.*/
-                - nightly
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*-rc[0-9]+/
-          name: pytorch_windows_vs2019_py36_cuda11.1_test_azure_multi_gpu
-          requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
       - update_s3_htmls:
           context: org-member
           filters:
@@ -9365,10 +9348,6 @@ workflows:
           vc_product: BuildTools
           vc_version: ""
           vc_year: "2019"
-      - pytorch_windows_test_multigpu:
-          name: pytorch_windows_vs2019_py36_cuda11.1_test_azure_multi_gpu
-          requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
     when: << pipeline.parameters.run_master_build >>
   scheduled-ci:
     triggers:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -657,10 +657,6 @@
   pytorch_windows_test_multigpu:
     machine:
       image: ubuntu-2004:202104-01
-    # TODO: Remove this when statement when multi-gpu tests are working
-    #       see: https://github.com/pytorch/pytorch/issues/59724
-    when: false
-    # TODO: delete block
     steps:
       - checkout
       - run:

--- a/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
+++ b/.circleci/verbatim-sources/job-specs/job-specs-custom.yml
@@ -657,6 +657,10 @@
   pytorch_windows_test_multigpu:
     machine:
       image: ubuntu-2004:202104-01
+    # TODO: Remove this when statement when multi-gpu tests are working
+    #       see: https://github.com/pytorch/pytorch/issues/59724
+    when: false
+    # TODO: delete block
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59725 .circleci: Disable pytorch_windows_test_multigpu**

These are failing on CircleCI with no apparent debug messages, see https://github.com/pytorch/pytorch/issues/59724

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29001353](https://our.internmc.facebook.com/intern/diff/D29001353)