### PR TITLE
Upgrade Windows CI Python to 3.8

### DIFF
--- a/.circleci/cimodel/data/windows_build_definitions.py
+++ b/.circleci/cimodel/data/windows_build_definitions.py
@@ -40,11 +40,13 @@ class WindowsJob:
 
         target_arch = self.cuda_version.render_dots() if self.cuda_version else "cpu"
 
+        python_version = "3.8"
+
         base_name_parts = [
             "pytorch",
             "windows",
             self.vscode_spec.render(),
-            "py36",
+            "py" + python_version.replace(".", ""),
             target_arch,
         ]
 
@@ -65,7 +67,7 @@ class WindowsJob:
             ["pytorch", "win"]
             + self.vscode_spec.get_elements()
             + arch_env_elements
-            + ["py3"]
+            + ["py" + python_version.split(".")[0]]
         )
 
         is_running_on_cuda = bool(self.cuda_version) and not self.force_on_cpu
@@ -75,7 +77,7 @@ class WindowsJob:
         else:
             props_dict = {
                 "build_environment": build_environment_string,
-                "python_version": miniutils.quote("3.6"),
+                "python_version": miniutils.quote(python_version),
                 "vc_version": miniutils.quote(self.vscode_spec.dotted_version()),
                 "vc_year": miniutils.quote(str(self.vscode_spec.year)),
                 "vc_product": self.vscode_spec.get_product(),

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ pytorch_windows_params: &pytorch_windows_params
       default: "10.1"
     python_version:
       type: string
-      default: "3.6"
+      default: "3.8"
     vc_version:
       type: string
       default: "14.16"
@@ -7631,8 +7631,8 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda10.1_build
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_build
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: ""
@@ -7647,10 +7647,10 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda10.1_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -7666,10 +7666,10 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda10.1_test2
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_test2
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -7684,10 +7684,10 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_on_cpu_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: BuildTools
@@ -7696,8 +7696,8 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.1"
-          name: pytorch_windows_vs2019_py36_cuda11.1_build
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_build
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: ""
@@ -7712,10 +7712,10 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda11.1_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
+            - pytorch_windows_vs2019_py38_cuda11.1_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -7731,10 +7731,10 @@ workflows:
                 - master
                 - /ci-all\/.*/
                 - /release\/.*/
-          name: pytorch_windows_vs2019_py36_cuda11.1_test2
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_test2
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
+            - pytorch_windows_vs2019_py38_cuda11.1_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -9272,8 +9272,8 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
-          name: pytorch_windows_vs2019_py36_cuda10.1_build
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_build
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: ""
@@ -9282,10 +9282,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda10.1_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -9295,10 +9295,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda10.1_test2
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_test2
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -9307,10 +9307,10 @@ workflows:
       - pytorch_windows_test:
           build_environment: pytorch-win-vs2019-cuda10-cudnn7-py3
           cuda_version: "10.1"
-          name: pytorch_windows_vs2019_py36_cuda10.1_on_cpu_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda10.1_on_cpu_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda10.1_build
+            - pytorch_windows_vs2019_py38_cuda10.1_build
           test_name: pytorch-windows-test1
           use_cuda: "0"
           vc_product: BuildTools
@@ -9319,8 +9319,8 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.1"
-          name: pytorch_windows_vs2019_py36_cuda11.1_build
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_build
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: ""
@@ -9329,10 +9329,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.1"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.1_test1
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_test1
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
+            - pytorch_windows_vs2019_py38_cuda11.1_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -9342,10 +9342,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.1"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.1_test2
-          python_version: "3.6"
+          name: pytorch_windows_vs2019_py38_cuda11.1_test2
+          python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.1_build
+            - pytorch_windows_vs2019_py38_cuda11.1_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools
@@ -9495,7 +9495,7 @@ workflows:
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
-          name: pytorch_windows_vs2019_py36_cuda11.3_build
+          name: pytorch_windows_vs2019_py38_cuda11.3_build
           python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
@@ -9510,10 +9510,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.3_test1
+          name: pytorch_windows_vs2019_py38_cuda11.3_test1
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.3_build
+            - pytorch_windows_vs2019_py38_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -9528,10 +9528,10 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.3_test2
+          name: pytorch_windows_vs2019_py38_cuda11.3_test2
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.3_build
+            - pytorch_windows_vs2019_py38_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,7 +715,7 @@ jobs:
         default: "10.1"
       python_version:
         type: string
-        default: "3.6"
+        default: "3.8"
       vc_version:
         type: string
         default: "14.16"
@@ -782,7 +782,7 @@ jobs:
         default: "10.1"
       python_version:
         type: string
-        default: "3.6"
+        default: "3.8"
       vc_version:
         type: string
         default: "14.16"
@@ -9414,7 +9414,7 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           name: periodic_pytorch_windows_cuda11.3_build
-          python_version: "3.6"
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: "14.28.29333"
@@ -9424,7 +9424,7 @@ workflows:
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: periodic_pytorch_windows_cuda11.3_test1
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test1
@@ -9437,7 +9437,7 @@ workflows:
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: periodic_pytorch_windows_cuda11.3_test2
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test2
@@ -9496,7 +9496,7 @@ workflows:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           name: pytorch_windows_vs2019_py36_cuda11.3_build
-          python_version: "3.6"
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: "14.28.29333"
@@ -9511,7 +9511,7 @@ workflows:
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: pytorch_windows_vs2019_py36_cuda11.3_test1
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test1
@@ -9529,7 +9529,7 @@ workflows:
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: pytorch_windows_vs2019_py36_cuda11.3_test2
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test2

--- a/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
+++ b/.circleci/verbatim-sources/build-parameters/pytorch-build-params.yml
@@ -84,7 +84,7 @@ pytorch_windows_params: &pytorch_windows_params
       default: "10.1"
     python_version:
       type: string
-      default: "3.6"
+      default: "3.8"
     vc_version:
       type: string
       default: "14.16"

--- a/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
+++ b/.circleci/verbatim-sources/job-specs/pytorch-job-specs.yml
@@ -253,7 +253,7 @@ jobs:
         default: "10.1"
       python_version:
         type: string
-        default: "3.6"
+        default: "3.8"
       vc_version:
         type: string
         default: "14.16"
@@ -320,7 +320,7 @@ jobs:
         default: "10.1"
       python_version:
         type: string
-        default: "3.6"
+        default: "3.8"
       vc_version:
         type: string
         default: "14.16"

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -116,7 +116,7 @@
       - pytorch_windows_build:
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
-          name: pytorch_windows_vs2019_py36_cuda11.3_build
+          name: pytorch_windows_vs2019_py38_cuda11.3_build
           python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
@@ -131,10 +131,10 @@
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.3_test1
+          name: pytorch_windows_vs2019_py38_cuda11.3_test1
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.3_build
+            - pytorch_windows_vs2019_py38_cuda11.3_build
           test_name: pytorch-windows-test1
           use_cuda: "1"
           vc_product: BuildTools
@@ -149,10 +149,10 @@
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
-          name: pytorch_windows_vs2019_py36_cuda11.3_test2
+          name: pytorch_windows_vs2019_py38_cuda11.3_test2
           python_version: "3.8"
           requires:
-            - pytorch_windows_vs2019_py36_cuda11.3_build
+            - pytorch_windows_vs2019_py38_cuda11.3_build
           test_name: pytorch-windows-test2
           use_cuda: "1"
           vc_product: BuildTools

--- a/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
+++ b/.circleci/verbatim-sources/workflows/workflows-scheduled-ci.yml
@@ -35,7 +35,7 @@
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           name: periodic_pytorch_windows_cuda11.3_build
-          python_version: "3.6"
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: "14.28.29333"
@@ -45,7 +45,7 @@
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: periodic_pytorch_windows_cuda11.3_test1
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test1
@@ -58,7 +58,7 @@
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: periodic_pytorch_windows_cuda11.3_test2
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - periodic_pytorch_windows_cuda11.3_build
           test_name: pytorch-windows-test2
@@ -117,7 +117,7 @@
           build_environment: pytorch-win-vs2019-cuda11-cudnn8-py3
           cuda_version: "11.3"
           name: pytorch_windows_vs2019_py36_cuda11.3_build
-          python_version: "3.6"
+          python_version: "3.8"
           use_cuda: "1"
           vc_product: BuildTools
           vc_version: "14.28.29333"
@@ -132,7 +132,7 @@
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: pytorch_windows_vs2019_py36_cuda11.3_test1
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test1
@@ -150,7 +150,7 @@
           cuda_version: "11.3"
           executor: windows-with-nvidia-gpu
           name: pytorch_windows_vs2019_py36_cuda11.3_test2
-          python_version: "3.6"
+          python_version: "3.8"
           requires:
             - pytorch_windows_vs2019_py36_cuda11.3_build
           test_name: pytorch-windows-test2

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -19,7 +19,7 @@ env:
   IN_CI: 1
   INSTALL_WINDOWS_SDK: 1
   JOB_BASE_NAME: test
-  PYTHON_VERSION: "3.6"
+  PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
   VC_VERSION: ""

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -18,7 +18,7 @@ env:
   IN_CI: 1
   INSTALL_WINDOWS_SDK: 1
   JOB_BASE_NAME: test
-  PYTHON_VERSION: "3.6"
+  PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
   VC_VERSION: ""

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -17,7 +17,7 @@ env:
   IN_CI: 1
   INSTALL_WINDOWS_SDK: 1
   JOB_BASE_NAME: test
-  PYTHON_VERSION: "3.6"
+  PYTHON_VERSION: "3.8"
   SCCACHE_BUCKET: "ossci-compiler-cache"
   VC_PRODUCT: "BuildTools"
   VC_VERSION: ""

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -20,7 +20,6 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
 )
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if NOT "%BUILD_ENVIRONMENT%"=="" (
-    :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
     call conda install -y -q python=3.8 numpy mkl cffi pyyaml boto3 protobuf numba scipy typing_extensions dataclasses libuv
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
     call conda install -y -q -c conda-forge cmake

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -21,7 +21,7 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
-    call conda install -y -q python==3.8 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0 typing_extensions dataclasses libuv
+    call conda install -y -q python=3.8 numpy mkl cffi pyyaml boto3 protobuf numba scipy typing_extensions dataclasses libuv
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
     call conda install -y -q -c conda-forge cmake
     if %errorlevel% neq 0 ( exit /b %errorlevel% )

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -20,9 +20,8 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
 )
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if NOT "%BUILD_ENVIRONMENT%"=="" (
-    :: We have to pin Python version to 3.6.7, until mkl supports Python 3.7
     :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
-    call conda install -y -q python=3.6.7 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0 typing_extensions dataclasses libuv
+    call conda install -y -q python=3.8 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0 typing_extensions dataclasses libuv
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
     call conda install -y -q -c conda-forge cmake
     if %errorlevel% neq 0 ( exit /b %errorlevel% )

--- a/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
+++ b/.jenkins/pytorch/win-test-helpers/setup_pytorch_env.bat
@@ -21,7 +21,7 @@ if NOT "%BUILD_ENVIRONMENT%"=="" (
 call %CONDA_PARENT_DIR%\Miniconda3\Scripts\activate.bat %CONDA_PARENT_DIR%\Miniconda3
 if NOT "%BUILD_ENVIRONMENT%"=="" (
     :: Numba is pinned to 0.44.0 to avoid https://github.com/numba/numba/issues/4352
-    call conda install -y -q python=3.8 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0 typing_extensions dataclasses libuv
+    call conda install -y -q python==3.8 numpy mkl cffi pyyaml boto3 protobuf numba==0.44.0 scipy==1.5.0 typing_extensions dataclasses libuv
     if %errorlevel% neq 0 ( exit /b %errorlevel% )
     call conda install -y -q -c conda-forge cmake
     if %errorlevel% neq 0 ( exit /b %errorlevel% )


### PR DESCRIPTION
Python 3.6 EOL is end of this year--we should use newer Python in CI.