### PR TITLE
Link ATEN tests with OpenMP runtime

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1657,6 +1657,11 @@ if(BUILD_TEST)
     get_filename_component(test_name ${test_src} NAME_WE)
     add_executable(${test_name} "${test_src}")
     target_link_libraries(${test_name} torch_library gtest_main)
+    if(USE_OPENMP)
+      # -fopenmp is a compile time flag and as result not guaranteed
+      # to link executable against OpenMP runtime library
+      target_link_libraries(${test_name} ${OpenMP_CXX_LIBRARIES})
+    endif()
     target_include_directories(${test_name} PRIVATE $<INSTALL_INTERFACE:include>)
     target_include_directories(${test_name} PRIVATE $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>)
     target_include_directories(${test_name} PRIVATE ${Caffe2_CPU_INCLUDE})


### PR DESCRIPTION
Even if OpenMP extensions are supported by compiler, OpenMP runtime library is not always implicitly added as dependency by linker
Above fixes linker problems on Apple M1, when libomp.dylib is installed via conda, when tests that directly use OpenMP pragams fail to link with following errors:
```
/Library/Developer/CommandLineTools/usr/bin/c++ -Wno-deprecated -fvisibility-inlines-hidden -Wno-deprecated-declarations -DUSE_PTHREADPOOL -Xpreprocessor -fopenmp -I/Users/nshulga/miniforge3/include -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOCUPTI -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-unused-local-typedefs -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -Wno-invalid-partial-specialization -Wno-typedef-redefinition -Wno-unknown-warning-option -Wno-unused-private-field -Wno-inconsistent-missing-override -Wno-aligned-allocation-unavailable -Wno-c++14-extensions -Wno-constexpr-not-const -Wno-missing-braces -Qunused-arguments -fcolor-diagnostics -fno-math-errno -fno-trapping-math -Werror=format -Werror=cast-function-type -Wno-unused-private-field -Wno-missing-braces -Wno-c++14-extensions -Wno-constexpr-not-const -O3 -DNDEBUG -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk -Wl,-search_paths_first -Wl,-headerpad_max_install_names -rdynamic caffe2/CMakeFiles/test_parallel.dir/__/aten/src/ATen/test/test_parallel.cpp.o -o bin/test_parallel  -Wl,-rpath,/Users/nshulga/git/pytorch/build/lib  lib/libgtest_main.a  lib/libtorch.dylib  lib/libtorch_cpu.dylib  lib/libprotobuf.a  lib/libc10.dylib  lib/libgtest.a && :
Undefined symbols for architecture arm64:
  "___kmpc_fork_call", referenced from:
      TestParallel_NestedParallel_Test::TestBody() in test_parallel.cpp.o
      TestParallel_Exceptions_Test::TestBody() in test_parallel.cpp.o
  "_omp_get_max_threads", referenced from:
      TestParallel_NestedParallel_Test::TestBody() in test_parallel.cpp.o
      TestParallel_Exceptions_Test::TestBody() in test_parallel.cpp.o
  "_omp_get_num_threads", referenced from:
      _.omp_outlined. in test_parallel.cpp.o
      _.omp_outlined..31 in test_parallel.cpp.o
  "_omp_get_thread_num", referenced from:
      _.omp_outlined. in test_parallel.cpp.o
      _.omp_outlined..31 in test_parallel.cpp.o
  "_omp_in_parallel", referenced from:
      TestParallel_NestedParallel_Test::TestBody() in test_parallel.cpp.o
      TestParallel_Exceptions_Test::TestBody() in test_parallel.cpp.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

