### PR TITLE
Replace ci/no-build with invertible ci/build

### DIFF
--- a/.github/pytorch-circleci-labels.yml
+++ b/.github/pytorch-circleci-labels.yml
@@ -1,7 +1,5 @@
 # For documentation concerning this configuration please refer to,
 # https://github.com/pytorch/pytorch-probot#trigger-circleci-workflows
-default_params:
-  run_build: true
 labels_to_circle_params:
   ci/binaries:
     parameter: run_binary_tests
@@ -11,14 +9,11 @@ labels_to_circle_params:
         - release/.*
       tags:
         - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-  ci/no-build:
+  ci/build:
+    parameter: run_build
     default_true_on:
       branches:
-        - nightly
-        - release/.*
-      tags:
-        - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-    set_to_false:
-      - run_build
+        - master
+      pull_request:
   ci/master:
     parameter: run_master_build


### PR DESCRIPTION
Depends on https://github.com/pytorch/pytorch-probot/pull/27.

Question for reviewers: are there other patterns we want to include under `branches`, besides just `master`?