### PR TITLE
.github: Ensure cleaner windows workspace

### DIFF
--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -20,9 +20,11 @@ else
 fi
 
 cudnn_installer_link="https://ossci-windows.s3.amazonaws.com/${cudnn_installer_name}.zip"
+cudnn_install_folder="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA_VERSION}/"
 
-curl --retry 3 -O $cudnn_installer_link
-7z x ${cudnn_installer_name}.zip -ocudnn
-cp -r cudnn/cuda/* "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA_VERSION}/"
+curl --retry 3 -O "$cudnn_installer_link"
+7z x "${cudnn_installer_name}.zip" -ocudnn
+rm -rf "${cudnn_install_folder}"
+cp -r cudnn/cuda/* "${cudnn_install_folder}"
 rm -rf cudnn
-rm -f ${cudnn_installer_name}.zip
+rm -f "${cudnn_installer_name}.zip"

--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -24,7 +24,6 @@ cudnn_install_folder="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA
 
 curl --retry 3 -O "$cudnn_installer_link"
 7z x "${cudnn_installer_name}.zip" -ocudnn
-rm -rf "${cudnn_install_folder}"
-cp -r cudnn/cuda/* "${cudnn_install_folder}"
+cp -rf cudnn/cuda/* "${cudnn_install_folder}"
 rm -rf cudnn
 rm -f "${cudnn_installer_name}.zip"

--- a/.circleci/scripts/windows_cudnn_install.sh
+++ b/.circleci/scripts/windows_cudnn_install.sh
@@ -24,6 +24,9 @@ cudnn_install_folder="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v${CUDA
 
 curl --retry 3 -O "$cudnn_installer_link"
 7z x "${cudnn_installer_name}.zip" -ocudnn
+# shellcheck recommends to use '${var:?}/*' to avoid potentially expanding to '/*'
+# Remove all of the directories before attempting to copy files
+rm -rf "${cudnn_install_folder:?}/*"
 cp -rf cudnn/cuda/* "${cudnn_install_folder}"
 rm -rf cudnn
 rm -f "${cudnn_installer_name}.zip"

--- a/.github/templates/windows_ci_workflow.yml.j2
+++ b/.github/templates/windows_ci_workflow.yml.j2
@@ -38,6 +38,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Clean workspace (including things in .gitignore)
+        shell: bash
+        run: |
+          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -77,6 +81,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Clean workspace (including things in .gitignore)
+        shell: bash
+        run: |
+          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Clean workspace (including things in .gitignore)
+        shell: bash
+        run: |
+          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |
@@ -76,6 +80,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Clean workspace (including things in .gitignore)
+        shell: bash
+        run: |
+          git clean -xdf
       - name: Install Visual Studio 2019 toolchain
         shell: powershell
         run: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59751 .github: Enable Windows GPU on PRs
* #59752 [reland] .github: Add Windows GPU workflow (#58782)
* **#59742 .github: Ensure cleaner windows workspace**

It looks like Windows workers were failing out due to some leftovers
from previous builds, this should hopefully remedy some of those errors

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29009076](https://our.internmc.facebook.com/intern/diff/D29009076)