### PR TITLE
[skip ci] export_slow_tests.py - Add option to ignore small differences 

### DIFF
--- a/tools/export_slow_tests.py
+++ b/tools/export_slow_tests.py
@@ -50,9 +50,6 @@ def too_similar(calculated_times: Dict[str, float], other_times: Dict[str, float
         return False
 
     for test_case, test_time in calculated_times.items():
-        if test_case not in other_times:
-            print(test_case)
-            return False
         other_test_time = other_times[test_case]
         relative_difference = abs((other_test_time - test_time) / max(other_test_time, test_time))
         if relative_difference > threshold:

--- a/tools/export_slow_tests.py
+++ b/tools/export_slow_tests.py
@@ -6,11 +6,12 @@ import os
 import statistics
 from collections import defaultdict
 from tools.stats_utils.s3_stat_parser import get_previous_reports_for_branch, Report, Version2Report
-from typing import cast, DefaultDict, Dict, List
+from typing import cast, DefaultDict, Dict, List, Any
+from urllib.request import urlopen
 
 SLOW_TESTS_FILE = '.pytorch-slow-tests.json'
 SLOW_TEST_CASE_THRESHOLD_SEC = 60.0
-
+RELATIVE_DIFFERENCE_THRESHOLD = 0.1
 
 def get_test_case_times() -> Dict[str, float]:
     reports: List[Report] = get_previous_reports_for_branch('origin/viable/strict', "")
@@ -37,11 +38,38 @@ def filter_slow_tests(test_cases_dict: Dict[str, float]) -> Dict[str, float]:
     return {test_case: time for test_case, time in test_cases_dict.items() if time >= SLOW_TEST_CASE_THRESHOLD_SEC}
 
 
-def export_slow_tests(filename: str) -> None:
+def get_test_infra_slow_tests() -> Dict[str, float]:
+    url = "https://raw.githubusercontent.com/pytorch/test-infra/master/stats/slow-tests.json"
+    contents = urlopen(url, timeout=1).read().decode('utf-8')
+    return cast(Dict[str, float], json.loads(contents))
+
+
+def too_similar(calculated_times: Dict[str, float], other_times: Dict[str, float], threshold: float) -> bool:
+    # check that their keys are the same
+    if calculated_times.keys() != other_times.keys():
+        return False
+
+    for test_case, test_time in calculated_times.items():
+        if test_case not in other_times:
+            print(test_case)
+            return False
+        other_test_time = other_times[test_case]
+        relative_difference = abs((other_test_time - test_time) / max(other_test_time, test_time))
+        if relative_difference > threshold:
+            return False
+    return True
+
+
+def export_slow_tests(options: Any) -> None:
+    filename = options.filename
     if os.path.exists(filename):
         print(f'Overwriting existent file: {filename}')
     with open(filename, 'w+') as file:
         slow_test_times: Dict[str, float] = filter_slow_tests(get_test_case_times())
+        if options.ignore_small_diffs:
+            test_infra_slow_tests_dict = get_test_infra_slow_tests()
+            if too_similar(slow_test_times, test_infra_slow_tests_dict, options.ignore_small_diffs):
+                slow_test_times = test_infra_slow_tests_dict
         json.dump(slow_test_times, file, indent='    ', separators=(',', ': '), sort_keys=True)
         file.write('\n')
 
@@ -58,12 +86,22 @@ def parse_args() -> argparse.Namespace:
         const=SLOW_TESTS_FILE,
         help='Specify a file path to dump slow test times from previous S3 stats. Default file path: .pytorch-slow-tests.json',
     )
+    parser.add_argument(
+        '--ignore-small-diffs',
+        nargs='?',
+        type=float,
+        const=RELATIVE_DIFFERENCE_THRESHOLD,
+        help='Compares generated results with stats/slow-tests.json in pytorch/test-infra. If the relative differences '
+             'between test times for each test are smaller than the threshold and the set of test cases have not '
+             'changed, we will export the stats already in stats/slow-tests.json. Else, we will export the calculated '
+             'results. The default threshold is 10%.',
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     options = parse_args()
-    export_slow_tests(options.filename)
+    export_slow_tests(options)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This would lower the number of unnecessary commits to pytorch/test-infra by only exporting a different stats file when the stats are varying enough. This way, if the slow test cases we gather from S3 are the same and their times are trivially different, then we do not bother exporting a different stats file when the --ignore-small-diffs option is enabled.

We instead export the stats already in test-infra, so that when it tries to commit, it realizes it would be an empty commit and not add to the git history.

Test plan:
Run `python tools/export_slow_tests.py --ignore-small-diffs <threshold>`.