### PR TITLE
[OSS CI][iOS] Use LibTorch-Lite.h for nightly builds

### DIFF
--- a/.circleci/scripts/binary_ios_upload.sh
+++ b/.circleci/scripts/binary_ios_upload.sh
@@ -24,7 +24,7 @@ do
 done
 lipo -i ${ZIP_DIR}/install/lib/*.a
 # copy the umbrella header and license
-cp ${PROJ_ROOT}/ios/LibTorch.h ${ZIP_DIR}/src/
+cp ${PROJ_ROOT}/ios/LibTorch-Lite.h ${ZIP_DIR}/src/
 cp ${PROJ_ROOT}/LICENSE ${ZIP_DIR}/
 # zip the library
 ZIPFILE=libtorch_ios_nightly_build.zip


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59763 [DO NOT MERGE][iOS] upload binary for lite interpreter
* **#59762 [OSS CI][iOS] Use LibTorch-Lite.h for nightly builds**

Differential Revision: [D29018267](https://our.internmc.facebook.com/intern/diff/D29018267)