### PR TITLE
Use own linux runner for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quick-checks:
-    runs-on: ubuntu-18.04
+    runs-on: linux.2xlarge
     steps:
       - name: Setup Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Seeing many issues from the lint.yml that I'm guessing if we run lint on our own runners, things may improve.

- https://github.com/pytorch/pytorch/pull/59760/checks?check_run_id=2788684303
- https://github.com/pytorch/pytorch/pull/59760/checks?check_run_id=2788683792
