### PR TITLE
Avoid un-necessary unwrapping of Tensor in SavedVariable

### DIFF
--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -12,6 +12,8 @@
 #include <memory>
 #include <sstream>
 
+#include <iostream>
+
 namespace torch { namespace autograd {
 
 SavedVariable::SavedVariable(const Variable& variable, bool is_output, bool is_inplace_view) {
@@ -36,29 +38,44 @@ SavedVariable::SavedVariable(const Variable& variable, bool is_output, bool is_i
       "Inference tensors cannot be saved for backward. To work around "
       "you can make a clone to get a normal tensor and use it in autograd.")
 
+    version_counter_ = impl::version_counter(variable);
+    saved_version_ = version_counter_.current_version();
+
     was_default_constructed_ = false;
     output_nr_ = variable.output_nr();
     requires_grad_ = variable.requires_grad();
     has_grad_fn_ = !variable.is_leaf();
     is_inplace_view_ = is_inplace_view;
+
     // These copies are all shared_ptr copies, so slightly more expensive.
     // Do them here instead of in the init list in case data is undefined.
-    data_ = variable.tensor_data();
     // TODO(albanD) This needs to be updated when moving to multiple levels
     const auto& fw_grad = variable._fw_grad(/* level */ 0);
     if (fw_grad.defined()) {
       fw_grad_ = std::make_shared<ForwardGrad>();
       fw_grad_->set_value(fw_grad, /* level */ 0);
     }
-    if (variable.is_leaf()) {
-      grad_accumulator_ = impl::grad_accumulator(variable);
-    } else if (!is_output) {
-      grad_fn_ = variable.grad_fn();
-    } else if (is_inplace_view) {
+
+    // If the variable is a leaf or not an output, we can safely save the
+    // original variable without running the risk of reference cycles.
+    // Why? The cycle we have to be careful about is from the SavedVariable
+    // to its var_, to its grad_fn, if that grad_fn is the Node that created
+    // the SavedVariable
+    // 1. For leaves, there are no grad_fn
+    // 2. If the variable is not an output, its grad_fn has already been fully
+    // created and in particular will be a different Node than the one
+    // we are currently constructing (the one that owns the current SavedVariable)
+    if (variable.is_leaf() || !is_output) {
+      saved_original = true;
+      // std::cout << "Saving variable" << variable.toString() << " " << variable.sizes() << "\n";
+      var_ = variable;
+      return;
+    }
+    var_ = variable.tensor_data();
+
+    if (is_inplace_view) {
       weak_grad_fn_ = variable.grad_fn();
     }
-    version_counter_ = impl::version_counter(variable);
-    saved_version_ = version_counter_.current_version();
   }
 }
 
@@ -66,28 +83,20 @@ SavedVariable::SavedVariable(const c10::optional<Variable>& variable, bool is_ou
   : SavedVariable(variable.has_value() ? *variable : Variable(), is_output, is_inplace_view) {}
 
 Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
-  if (!data_.defined()) {
+  if (!var_.defined()) {
     if (!was_default_constructed_) {
-      throw std::runtime_error(ERR_BACKWARD_TWICE);
+      TORCH_CHECK(false, ERR_BACKWARD_TWICE);
     }
     return Variable();
   }
 
-  auto grad_fn = is_inplace_view_ ? weak_grad_fn_.lock() : grad_fn_;
-  if (has_grad_fn_ && !grad_fn) {
-    if (!saved_for) {
-      // If saving the grad_fn would create a circular reference, then it must
-      // be passed in to the unpack function.
-      throw std::runtime_error("No grad_fn for non-leaf saved variable");
-    }
-    grad_fn = std::move(saved_for);
-  }
+  auto grad_fn = is_inplace_view_ ? weak_grad_fn_.lock() : nullptr;
 
   if (saved_version_ != version_counter_.current_version()) {
     std::stringstream message;
     message << "one of the variables needed for gradient computation has been "
-        "modified by an inplace operation: [" << data_.toString() << " "
-        << data_.sizes() << "]";
+        "modified by an inplace operation: [" << var_.toString() << " "
+        << var_.sizes() << "]";
     if (grad_fn) {
         message << ", which is output " << output_nr_
             << " of " << grad_fn->name() << ",";
@@ -104,7 +113,22 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
             "that failed to compute its gradient. The variable in question "
             "was changed in there or anywhere later. Good luck!";
     }
-    throw std::runtime_error(message.str());
+    TORCH_CHECK(false, message.str());
+  }
+
+  if (saved_original) {
+    return var_;
+  }
+
+  TORCH_CHECK(has_grad_fn_, "The original variable for a leaf was not saved");
+
+  if (!grad_fn) {
+    if (!saved_for) {
+      // If saving the grad_fn would create a circular reference, then it must
+      // be passed in to the unpack function.
+      TORCH_CHECK(false, "No grad_fn for non-leaf saved variable");
+    }
+    grad_fn = std::move(saved_for);
   }
 
   // NB: saved views are unpacked as normal Variables (not views) even though
@@ -112,19 +136,12 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
   // in-place functions on unpacked variables.
   Variable var;
   if (grad_fn) {
-    var = make_variable(data_, Edge(std::move(grad_fn), output_nr_));
+    var = make_variable(var_, Edge(std::move(grad_fn), output_nr_));
   } else {
-    var = make_variable(data_, requires_grad_);
+    // var = make_variable(var_, requires_grad_);
+    TORCH_CHECK(false, "The original variable for a leaf was not saved");
   }
   impl::set_version_counter(var, saved_version_);
-
-  // If a Variable is a leaf (no grad_fn saved), and it requires_grad, then we
-  // should have saved the grad accumulator. Even if the Variable no longer
-  // alive, the accumulator should be kept alive by the references in the
-  // graph).
-  if (requires_grad_ && !var.grad_fn() && grad_accumulator_.expired())
-    throw std::logic_error("No grad accumulator for a saved leaf!");
-  impl::set_grad_accumulator(var, grad_accumulator_);
 
   // NB: var here is never a view so there is no need to make anything special
   // for the case where the saved Tensor was a view. This whole argument relies


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59772 Avoid un-necessary unwrapping of Tensor in SavedVariable**

Summary: Fixes #58500

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: