### PR TITLE
Addition of a force argument to Tensor.numpy()

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2405,7 +2405,7 @@ class TestAutograd(TestCase):
 
     def test_numpy_requires_grad(self):
         x = torch.randn(2, 2, requires_grad=True)
-        err_msg_outputs = r"Can't call numpy\(\) on Tensor that requires grad. Use tensor.detach\(\).numpy\(\) instead."
+        err_msg_outputs = r"Can't convert tensor that requires grad to numpy."
         with self.assertRaisesRegex(RuntimeError, err_msg_outputs):
             x.numpy()
 

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -2405,7 +2405,7 @@ class TestAutograd(TestCase):
 
     def test_numpy_requires_grad(self):
         x = torch.randn(2, 2, requires_grad=True)
-        err_msg_outputs = r"Can't convert tensor that requires grad to numpy."
+        err_msg_outputs = r"Can't call numpy\(\) on Tensor that requires grad. Use tensor.detach\(\).numpy\(\) instead."
         with self.assertRaisesRegex(RuntimeError, err_msg_outputs):
             x.numpy()
 

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -173,9 +173,10 @@ class TestNumPyInterop(TestCase):
                             y = x.resolve_conj()
                         expect_error = requires_grad or sparse or conj or not device == 'cpu'
                         if not force and expect_error:
-                            self.assertRaises((RuntimeError, TypeError), lambda: x.numpy())
+                            self.assertRaisesRegex((RuntimeError, TypeError), "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy())
+                            self.assertRaisesRegex((RuntimeError, TypeError), "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy(force=False))
                         elif force and sparse:
-                            self.assertRaises(TypeError, lambda: x.numpy())
+                            self.assertRaisesRegex(TypeError, "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy(force=True))
                         else:
                             self.assertEqual(x.numpy(force=force), y)
 

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -156,24 +156,28 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y.dtype, np.bool_)
         self.assertEqual(x[0], y[0])
 
-    def test_to_numpy_with_force_dense_tensor(self, device) -> None:
-        for requires_grad in [False, True]:
-            x = torch.tensor([[1, 2],[3, 4]], dtype = torch.float, requires_grad = requires_grad, device = device)    	
-            y = x.numpy(force = True)
-            self.assertEqual(x, y)
-            y = x.numpy(True)
-            self.assertEqual(x, y)
-    
-    def test_to_numpy_with_force_sparse_tensor(self, device) -> None:
-        for requires_grad in [False, True]:
-            i = [[0, 1, 1],
-                [2, 0, 2]]
-            v =  [3, 4, 5]
-            x = torch.sparse_coo_tensor(i, v, (2, 3), dtype = torch.float, requires_grad = requires_grad, device = device)
-            y = x.numpy(force = True)
-            self.assertEqual(x, y)
-            y = x.numpy(True)
-            self.assertEqual(x, y)
+    def test_to_numpy_force_argument(self, device) -> None:
+        for force in [False, True]:
+            for requires_grad in [False, True]:
+                for sparse in [False, True]:
+                    for conj in [False, True]:
+                        data = [[1+2j, -2+3j], [-1-2j, 3-2j]]
+                        x = torch.tensor(data, requires_grad = requires_grad, device = device)    	
+                        y = x
+                        if sparse:
+                            if requires_grad:
+                                continue
+                            x = x.to_sparse()
+                        if conj:
+                            x = x.conj()
+                            y = x.resolve_conj()
+                        expect_error = requires_grad or sparse or conj or not device == 'cpu'
+                        if not force and expect_error:
+                            self.assertRaises((RuntimeError, TypeError), lambda: x.numpy())
+                        elif force and sparse:
+                            self.assertRaises(TypeError, lambda: x.numpy())
+                        else:
+                            self.assertEqual(x.numpy(force=force), y)
 
     def test_from_numpy(self, device) -> None:
         dtypes = [

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -171,6 +171,7 @@ class TestNumPyInterop(TestCase):
                         if conj:
                             x = x.conj()
                             y = x.resolve_conj()
+                        expect_error = requires_grad or sparse or conj or not device == 'cpu'
                         error_msg = "Use tensor\..*\.numpy\(\) instead\."
                         if not force and expect_error:
                             self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy())

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -171,12 +171,12 @@ class TestNumPyInterop(TestCase):
                         if conj:
                             x = x.conj()
                             y = x.resolve_conj()
-                        expect_error = requires_grad or sparse or conj or not device == 'cpu'
+                        error_msg = "Use tensor\..*\.numpy\(\) instead\."
                         if not force and expect_error:
-                            self.assertRaisesRegex((RuntimeError, TypeError), "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy())
-                            self.assertRaisesRegex((RuntimeError, TypeError), "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy(force=False))
+                            self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy())
+                            self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy(force=False))
                         elif force and sparse:
-                            self.assertRaisesRegex(TypeError, "Use tensor\..*\.numpy\(\) instead\.", lambda: x.numpy(force=True))
+                            self.assertRaisesRegex(TypeError, error_msg, lambda: x.numpy(force=True))
                         else:
                             self.assertEqual(x.numpy(force=force), y)
 

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -156,6 +156,14 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y.dtype, np.bool_)
         self.assertEqual(x[0], y[0])
 
+    def test_to_numpy_with_force(self, device) -> None:
+        for requires_grad in [False, True]:
+            x = torch.tensor([[1, 2],[3, 4]], dtype = torch.float, requires_grad = requires_grad, device = device)    	
+            y = x.numpy(force = True)
+            self.assertEqual(x, y)
+            y = x.numpy(True)
+            self.assertEqual(x, y)
+
     def test_from_numpy(self, device) -> None:
         dtypes = [
             np.double,

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -172,7 +172,7 @@ class TestNumPyInterop(TestCase):
                             x = x.conj()
                             y = x.resolve_conj()
                         expect_error = requires_grad or sparse or conj or not device == 'cpu'
-                        error_msg = "Use tensor\..*\.numpy\(\) instead\."
+                        error_msg = r"Use tensor\..*\.numpy\(\) instead\."
                         if not force and expect_error:
                             self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy())
                             self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy(force=False))

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -161,8 +161,8 @@ class TestNumPyInterop(TestCase):
             for requires_grad in [False, True]:
                 for sparse in [False, True]:
                     for conj in [False, True]:
-                        data = [[1+2j, -2+3j], [-1-2j, 3-2j]]
-                        x = torch.tensor(data, requires_grad = requires_grad, device = device)    	
+                        data = [[1 + 2j, -2 + 3j], [-1 - 2j, 3 - 2j]]
+                        x = torch.tensor(data, requires_grad=requires_grad, device=device)
                         y = x
                         if sparse:
                             if requires_grad:

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -156,9 +156,20 @@ class TestNumPyInterop(TestCase):
         self.assertEqual(y.dtype, np.bool_)
         self.assertEqual(x[0], y[0])
 
-    def test_to_numpy_with_force(self, device) -> None:
+    def test_to_numpy_with_force_dense_tensor(self, device) -> None:
         for requires_grad in [False, True]:
             x = torch.tensor([[1, 2],[3, 4]], dtype = torch.float, requires_grad = requires_grad, device = device)    	
+            y = x.numpy(force = True)
+            self.assertEqual(x, y)
+            y = x.numpy(True)
+            self.assertEqual(x, y)
+    
+    def test_to_numpy_with_force_sparse_tensor(self, device) -> None:
+        for requires_grad in [False, True]:
+            i = [[0, 1, 1],
+                [2, 0, 2]]
+            v =  [3, 4, 5]
+            x = torch.sparse_coo_tensor(i, v, (2, 3), dtype = torch.float, requires_grad = requires_grad, device = device)
             y = x.numpy(force = True)
             self.assertEqual(x, y)
             y = x.numpy(True)

--- a/test/test_numpy_interop.py
+++ b/test/test_numpy_interop.py
@@ -172,7 +172,7 @@ class TestNumPyInterop(TestCase):
                             x = x.conj()
                             y = x.resolve_conj()
                         expect_error = requires_grad or sparse or conj or not device == 'cpu'
-                        error_msg = r"Use tensor\..*\.numpy\(\) instead\."
+                        error_msg = r"Use (t|T)ensor\..*(\.numpy\(\))?"
                         if not force and expect_error:
                             self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy())
                             self.assertRaisesRegex((RuntimeError, TypeError), error_msg, lambda: x.numpy(force=False))

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -791,15 +791,22 @@ static PyObject * THPVariable_element_size(PyObject* self, PyObject* args)
 
 // implemented on the python object bc PyObjects not declarable in native_functions.yaml
 // See: ATen/native/README.md for more context
-static PyObject * THPVariable_numpy(PyObject* self, PyObject* arg)
+static PyObject * THPVariable_numpy(PyObject* self, PyObject* args, PyObject* kwargs)
 {
   HANDLE_TH_ERRORS
-  if (check_has_torch_function(self)) {
-    return handle_torch_function(self, "numpy");
-  }
-  jit::tracer::warn("Converting a tensor to a NumPy array", jit::tracer::WARN_PYTHON_DATAFLOW);
+  static PythonArgParser parser({
+    "numpy(bool force=False)"
+  });
   auto& self_ = THPVariable_Unpack(self);
-  return torch::utils::tensor_to_numpy(self_);
+  ParsedArgs<1> parsed_args;
+  auto r = parser.parse(self, args, kwargs, parsed_args);
+  
+  if (r.has_torch_function()) {
+    return handle_torch_function(r, self, args, kwargs, THPVariableClass, "torch.Tensor");
+  }
+  
+  jit::tracer::warn("Converting a tensor to a NumPy array", jit::tracer::WARN_PYTHON_DATAFLOW);
+  return torch::utils::tensor_to_numpy(self_, r.toBool(0));
   END_HANDLE_TH_ERRORS
 }
 
@@ -1271,7 +1278,7 @@ PyMethodDef variable_methods[] = {
   {"new_tensor", castPyCFunctionWithKeywords(THPVariable_new_tensor), METH_VARARGS | METH_KEYWORDS, NULL},
   {"nonzero", castPyCFunctionWithKeywords(THPVariable_nonzero), METH_VARARGS | METH_KEYWORDS, NULL},
   {"numel", THPVariable_numel, METH_NOARGS, NULL},
-  {"numpy", THPVariable_numpy, METH_NOARGS, NULL},
+  {"numpy", castPyCFunctionWithKeywords(THPVariable_numpy), METH_VARARGS | METH_KEYWORDS, NULL},
   {"requires_grad_", castPyCFunctionWithKeywords(THPVariable_requires_grad_), METH_VARARGS | METH_KEYWORDS, NULL},
   {"set_", castPyCFunctionWithKeywords(THPVariable_set_), METH_VARARGS | METH_KEYWORDS, NULL},
   {"short", castPyCFunctionWithKeywords(THPVariable_short), METH_VARARGS | METH_KEYWORDS, NULL},

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -795,7 +795,7 @@ static PyObject * THPVariable_numpy(PyObject* self, PyObject* args, PyObject* kw
 {
   HANDLE_TH_ERRORS
   static PythonArgParser parser({
-    "numpy(bool force=False)"
+    "numpy(*, bool force=False)"
   });
   auto& self_ = THPVariable_Unpack(self);
   ParsedArgs<1> parsed_args;

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -800,11 +800,11 @@ static PyObject * THPVariable_numpy(PyObject* self, PyObject* args, PyObject* kw
   auto& self_ = THPVariable_Unpack(self);
   ParsedArgs<1> parsed_args;
   auto r = parser.parse(self, args, kwargs, parsed_args);
-  
+
   if (r.has_torch_function()) {
     return handle_torch_function(r, self, args, kwargs, THPVariableClass, "torch.Tensor");
   }
-  
+
   jit::tracer::warn("Converting a tensor to a NumPy array", jit::tracer::WARN_PYTHON_DATAFLOW);
   return torch::utils::tensor_to_numpy(self_, r.toBool(0));
   END_HANDLE_TH_ERRORS

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -638,7 +638,7 @@ def gen_pyi(
             "cuda": [
                 "def cuda(self, device: Optional[Union[_device, _int, str]]=None, non_blocking: _bool=False) -> Tensor: ..."
             ],
-            "numpy": ["def numpy(self) -> Any: ..."],
+            "numpy": ["def numpy(self, *, force: _bool=False) -> Any: ..."],
             "apply_": ["def apply_(self, callable: Callable) -> Tensor: ..."],
             "map_": [
                 "def map_(self, tensor: Tensor, callable: Callable) -> Tensor: ..."

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2852,7 +2852,7 @@ If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and
 :attr:`GradMode` is ``True``, or tensor is sparse, or :attr:`is_conj()`
 is ``True``, it throws exception.
 
-If :attr:`force` is ``True``, it tries to resolve issues, that would otherwise throw an exception.
+If :attr:`force` is ``True`` it tries to resolve issues that would otherwise throw an exception.
 It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and :func:`torch.Tensor.resolve_conj`.
 If tensor is sparse, it still throws an exception. Since it makes a copy in some scenarios,
 tensor :attr:`self` and the returned :class:`ndarray` can have separate

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2841,11 +2841,26 @@ See :func:`torch.numel`
 
 add_docstr_all('numpy',
                r"""
-numpy() -> numpy.ndarray
+numpy(force=False) -> numpy.ndarray
 
-Returns :attr:`self` tensor as a NumPy :class:`ndarray`. This tensor and the
+Returns :attr:`self` tensor as a NumPy :class:`ndarray`.
+
+If :attr:`force` is ``False``, tensor :attr:`self` and the
 returned :class:`ndarray` share the same underlying storage. Changes to
 :attr:`self` tensor will be reflected in the :class:`ndarray` and vice versa.
+If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and 
+:attr:`GradMode` is ``True``, or tensor is sprase, or :attr:`is_conj()` 
+is ``True``, it throws exception.
+
+If :attr:`force` is ``True`` it tries to resolve issues, that would throw exception.
+It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and if :attr:`is_conj()` 
+is ``True`` it calls :func:`torch.Tensor.resolve_conj`.
+Therefore tensor :attr:`self` and the returned :class:`ndarray` can have separate
+underlying storage and changes to :attr:`self` may not be reflected 
+in the :class:`ndarray` and vice versa.
+
+Args:
+    force (bool): whether to copy/change :attr:`self` or throw exception
 """)
 
 add_docstr_all('orgqr',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2848,15 +2848,15 @@ Returns :attr:`self` tensor as a NumPy :class:`ndarray`.
 If :attr:`force` is ``False``, tensor :attr:`self` and the
 returned :class:`ndarray` share the same underlying storage. Changes to
 :attr:`self` tensor will be reflected in the :class:`ndarray` and vice versa.
-If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and 
-:attr:`GradMode` is ``True``, or tensor is sprase, or :attr:`is_conj()` 
+If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and
+:attr:`GradMode` is ``True``, or tensor is sprase, or :attr:`is_conj()`
 is ``True``, it throws exception.
 
 If :attr:`force` is ``True`` it tries to resolve issues, that would throw exception.
-It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and if :attr:`is_conj()` 
+It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and if :attr:`is_conj()`
 is ``True`` it calls :func:`torch.Tensor.resolve_conj`.
 Therefore tensor :attr:`self` and the returned :class:`ndarray` can have separate
-underlying storage and changes to :attr:`self` may not be reflected 
+underlying storage and changes to :attr:`self` may not be reflected
 in the :class:`ndarray` and vice versa.
 
 Args:

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2843,24 +2843,23 @@ add_docstr_all('numpy',
                r"""
 numpy(*, force=False) -> numpy.ndarray
 
-Returns :attr:`self` tensor as a NumPy :class:`ndarray`.
+Returns the tensor as a NumPy :class:`ndarray`.
 
-If :attr:`force` is ``False``, tensor :attr:`self` and the
-returned :class:`ndarray` share the same underlying storage. Changes to
-:attr:`self` tensor will be reflected in the :class:`ndarray` and vice versa.
-If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and
-:attr:`GradMode` is ``True``, or tensor is sparse, or :attr:`is_conj()`
-is ``True``, it throws exception.
+If :attr:`force` is ``False`` (the default), the conversion
+is performed only if the tensor is on the CPU, does not require grad,
+does not have its conjugate bit set, and is a dtype and layout that
+NumPy supports. The returned ndarray and the tensor will share their
+storage, so changes to the tensor will be reflected in the ndarray
+and vice versa.
 
-If :attr:`force` is ``True`` it tries to resolve issues that would otherwise throw an exception.
-It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and :func:`torch.Tensor.resolve_conj`.
-If tensor is sparse, it still throws an exception. Since it makes a copy in some scenarios,
-tensor :attr:`self` and the returned :class:`ndarray` can have separate
-underlying storage and changes to :attr:`self` may not be reflected
-in the :class:`ndarray` and vice versa.
+If :attr:`force` is ``True`` this is equivalent to
+calling ``t.detach().cpu().resolve_conj().numpy()``. If the tensor
+isn't on the CPU or its conjugate bit is set, the tensor won't share
+its storage with the returned ndarray. Setting :attr:`force` to
+``True`` can be a useful shorthand.
 
 Args:
-    force (bool): whether to copy/change :attr:`self` or throw exception
+    force (bool): if ``True``, it allows the ndarray to be a copy of the tensor instead of always sharing its memory, defaults to ``False``.
 """)
 
 add_docstr_all('orgqr',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2852,7 +2852,7 @@ If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and
 :attr:`GradMode` is ``True``, or tensor is sparse, or :attr:`is_conj()`
 is ``True``, it throws exception.
 
-If :attr:`force` is ``True`` it tries to resolve issues, that would throw an exception.
+If :attr:`force` is ``True``, it tries to resolve issues, that would otherwise throw an exception.
 It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and :func:`torch.Tensor.resolve_conj`.
 If tensor is sparse, it still throws an exception. Since it makes a copy in some scenarios,
 tensor :attr:`self` and the returned :class:`ndarray` can have separate

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2841,7 +2841,7 @@ See :func:`torch.numel`
 
 add_docstr_all('numpy',
                r"""
-numpy(force=False) -> numpy.ndarray
+numpy(*, force=False) -> numpy.ndarray
 
 Returns :attr:`self` tensor as a NumPy :class:`ndarray`.
 
@@ -2849,13 +2849,13 @@ If :attr:`force` is ``False``, tensor :attr:`self` and the
 returned :class:`ndarray` share the same underlying storage. Changes to
 :attr:`self` tensor will be reflected in the :class:`ndarray` and vice versa.
 If tensors storage is not CPU, or if :attr:`requires_grad` is ``True`` and
-:attr:`GradMode` is ``True``, or tensor is sprase, or :attr:`is_conj()`
+:attr:`GradMode` is ``True``, or tensor is sparse, or :attr:`is_conj()`
 is ``True``, it throws exception.
 
-If :attr:`force` is ``True`` it tries to resolve issues, that would throw exception.
-It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and if :attr:`is_conj()`
-is ``True`` it calls :func:`torch.Tensor.resolve_conj`.
-Therefore tensor :attr:`self` and the returned :class:`ndarray` can have separate
+If :attr:`force` is ``True`` it tries to resolve issues, that would throw an exception.
+It calls :func:`torch.Tensor.detach`, :func:`torch.Tensor.cpu` and :func:`torch.Tensor.resolve_conj`.
+If tensor is sparse, it still throws an exception. Since it makes a copy in some scenarios,
+tensor :attr:`self` and the returned :class:`ndarray` can have separate
 underlying storage and changes to :attr:`self` may not be reflected
 in the :class:`ndarray` and vice versa.
 

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2859,7 +2859,8 @@ the tensor won't share its storage with the returned ndarray.
 Setting :attr:`force` to ``True`` can be a useful shorthand.
 
 Args:
-    force (bool): if ``True``, it allows the ndarray to be a copy of the tensor instead of always sharing its memory, defaults to ``False``.
+    force (bool): if ``True``, the ndarray may be a copy of the tensor
+               instead of always sharing memory, defaults to ``False``.
 """)
 
 add_docstr_all('orgqr',

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -2853,10 +2853,10 @@ storage, so changes to the tensor will be reflected in the ndarray
 and vice versa.
 
 If :attr:`force` is ``True`` this is equivalent to
-calling ``t.detach().cpu().resolve_conj().numpy()``. If the tensor
-isn't on the CPU or its conjugate bit is set, the tensor won't share
-its storage with the returned ndarray. Setting :attr:`force` to
-``True`` can be a useful shorthand.
+calling ``t.detach().cpu().resolve_conj().resolve_neg().numpy()``.
+If the tensor isn't on the CPU or the conjugate or negative bit is set,
+the tensor won't share its storage with the returned ndarray.
+Setting :attr:`force` to ``True`` can be a useful shorthand.
 
 Args:
     force (bool): if ``True``, it allows the ndarray to be a copy of the tensor instead of always sharing its memory, defaults to ``False``.

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -135,9 +135,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force/*=false*/) {
                 "Use tensor.resolve_neg().numpy() instead.");
   }
 
-  auto prepared_tensor = tensor.is_conj() ? tensor.resolve_conj() : tensor;
-  prepared_tensor = prepared_tensor.is_neg() ? prepared_tensor.resolve_neg() : prepared_tensor;
-  prepared_tensor = prepared_tensor.cpu().detach();
+  auto prepared_tensor = prepared_tensor.detach().cpu().resolve_conj().resolve_neg();
 
   auto dtype = aten_to_numpy_dtype(prepared_tensor.scalar_type());
   auto sizes = to_numpy_shape(prepared_tensor.sizes());

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -105,49 +105,61 @@ static std::vector<int64_t> seq_to_aten_shape(PyObject *py_seq) {
   return result;
 }
 
-PyObject* tensor_to_numpy(const at::Tensor& tensor) {
+PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force/*=false*/) {
   TORCH_CHECK(is_numpy_available(), "Numpy is not available");
+  TORCH_CHECK(!tensor.unsafeGetTensorImpl()->is_python_dispatch(),
+              ".numpy() is not supported for tensor subclasses.");
 
-  TORCH_CHECK_TYPE(tensor.device().type() == DeviceType::CPU,
+  bool is_on_cpu = tensor.device().type() == DeviceType::CPU;
+  TORCH_CHECK_TYPE(is_on_cpu && force == false,
       "can't convert ", tensor.device().str().c_str(),
       " device type tensor to numpy. Use Tensor.cpu() to ",
       "copy the tensor to host memory first.");
+  auto tensor_on_cpu = (requires_grad && force == true)? tensor.cpu() : tensor;
 
-  TORCH_CHECK_TYPE(tensor.layout() == Layout::Strided,
+  bool is_dense = tensor_on_cpu.layout() == Layout::Strided;
+  TORCH_CHECK_TYPE(is_sparse && force == false,
       "can't convert ", c10::str(tensor.layout()).c_str(),
       " layout tensor to numpy.",
-      "convert the tensor to a strided layout first.");
+                   "convert the tensor to a strided layout first.");
+  auto dense_cpu_tensor = (is_dense && force == true)? tensor_on_cpu.to_dense() : tensor_on_cpu;
 
-  TORCH_CHECK(!(at::GradMode::is_enabled() && tensor.requires_grad()),
+  bool requires_grad = (at::GradMode::is_enabled() && dense_cpu_tensor.requires_grad());
+  TORCH_CHECK(!(requires_grad) && force == false,
       "Can't call numpy() on Tensor that requires grad. "
       "Use tensor.detach().numpy() instead.");
+  auto detatched_cpu_tensor = (requires_grad && force == true)? dense_cpu_tensor.detach() : dense_cpu_tensor;
 
-  TORCH_CHECK(!tensor.is_conj(),
+  bool is_conj = detatched_cpu_tensor.is_conj();
+  TORCH_CHECK(!is_conj && force == false,
       "Can't call numpy() on Tensor that has conjugate bit set. ",
       "Use tensor.resolve_conj().numpy() instead.");
+  auto not_conj_cpu_detatched_dense_tensor = (is_conj && force == true)? detatched_cpu_tensor.resolve_conj() : detatched_cpu_tensor;
 
-  TORCH_CHECK(!tensor.is_neg(),
+  bool is_neg = not_conj_cpu_detatched_dense_tensor.is_neg();
+  TORCH_CHECK(!is_neg && force == false,
       "Can't call numpy() on Tensor that has negative bit set. "
       "Use tensor.resolve_neg().numpy() instead.");
+  auto prepared_tensor = (is_neg && force == true)? not_conj_cpu_detatched_dense_tensor.resolve_neg() : not_conj_cpu_detatched_dense_tensor;
 
-  TORCH_CHECK(!tensor.unsafeGetTensorImpl()->is_python_dispatch(), ".numpy() is not supported for tensor subclasses.");
 
-  auto dtype = aten_to_numpy_dtype(tensor.scalar_type());
-  auto sizes = to_numpy_shape(tensor.sizes());
-  auto strides = to_numpy_shape(tensor.strides());
+  auto dtype = aten_to_numpy_dtype(prepared_tensor.scalar_type());
+  auto sizes = to_numpy_shape(prepared_tensor.sizes());
+  auto strides = to_numpy_shape(prepared_tensor.strides());
+
   // NumPy strides use bytes. Torch strides use element counts.
-  auto element_size_in_bytes = tensor.element_size();
+  auto element_size_in_bytes = prepared_tensor.element_size();
   for (auto& stride : strides) {
     stride *= element_size_in_bytes;
   }
 
   auto array = THPObjectPtr(PyArray_New(
       &PyArray_Type,
-      tensor.dim(),
+      prepared_tensor.dim(),
       sizes.data(),
       dtype,
       strides.data(),
-      tensor.data_ptr(),
+      prepared_tensor.data_ptr(),
       0,
       NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE,
       nullptr));
@@ -157,13 +169,13 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor) {
   // object of the ndarray to the tensor and disabling resizes on the storage.
   // This is not sufficient. For example, the tensor's storage may be changed
   // via Tensor.set_, which can free the underlying memory.
-  PyObject* py_tensor = THPVariable_Wrap(tensor);
+  PyObject* py_tensor = THPVariable_Wrap(prepared_tensor);
   if (!py_tensor) throw python_error();
   if (PyArray_SetBaseObject((PyArrayObject*)array.get(), py_tensor) == -1) {
     return nullptr;
   }
   // Use the private storage API
-  tensor.storage().unsafeGetStorageImpl()->set_resizable(false);
+  prepared_tensor.storage().unsafeGetStorageImpl()->set_resizable(false);
 
   return array.release();
 }

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -113,8 +113,8 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force/*=false*/) {
 
   TORCH_CHECK_TYPE(tensor.layout() == Layout::Strided,
       "can't convert ", c10::str(tensor.layout()).c_str(),
-      " layout tensor to numpy.",
-                   "convert the tensor to a strided layout first.");
+      " layout tensor to numpy. ",
+      "Use Tensor.dense() first.");
 
   if (!force){
     TORCH_CHECK_TYPE(tensor.device().type() == DeviceType::CPU,

--- a/torch/csrc/utils/tensor_numpy.cpp
+++ b/torch/csrc/utils/tensor_numpy.cpp
@@ -135,7 +135,7 @@ PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force/*=false*/) {
                 "Use tensor.resolve_neg().numpy() instead.");
   }
 
-  auto prepared_tensor = prepared_tensor.detach().cpu().resolve_conj().resolve_neg();
+  auto prepared_tensor = tensor.detach().cpu().resolve_conj().resolve_neg();
 
   auto dtype = aten_to_numpy_dtype(prepared_tensor.scalar_type());
   auto sizes = to_numpy_shape(prepared_tensor.sizes());

--- a/torch/csrc/utils/tensor_numpy.h
+++ b/torch/csrc/utils/tensor_numpy.h
@@ -5,7 +5,7 @@
 
 namespace torch { namespace utils {
 
-PyObject* tensor_to_numpy(const at::Tensor& tensor);
+PyObject* tensor_to_numpy(const at::Tensor& tensor, bool force=false);
 at::Tensor tensor_from_numpy(PyObject* obj, bool warn_if_not_writeable=true);
 
 int aten_to_numpy_dtype(const at::ScalarType scalar_type);


### PR DESCRIPTION
solving issues:
- #20778
- #59945

In this PR i have added force argument to Tensor.numpy(). It is set to False by default. If it's set to True then it:
1. detatches Tensor, if requires_grad == True
2. moves to cpu, if it's not on cpu already
3. uses .resolve_conj() if .is_conj() == True
4. [updated] uses .resolve_neg() if .is_neg() == True