### PR TITLE
fx quant: remove some dead code in observer insertion (redo)

### DIFF
--- a/torch/quantization/fx/prepare.py
+++ b/torch/quantization/fx/prepare.py
@@ -432,58 +432,43 @@ def maybe_insert_output_observer_for_node(
     root_node, matched_nodes, pattern, qhandler, qconfig = matches.get(
         node.name, (None, None, None, None, None))
 
-    if qhandler is not None:
-        assert qconfig is not None
+    if qhandler is None:
+        return None
 
-        is_standalone_module = qhandler is not None and \
-            isinstance(qhandler, StandaloneModuleQuantizeHandler)
+    assert qconfig is not None
+    assert node.op != 'output', 'observer insertion for outputs is handled elsewhere'
 
-        should_insert_observer = \
-            qhandler.should_insert_observer_for_output(
-                qconfig, model.training)
-        # TODO(future PR): move the following logic to
-        # should_insert_observer_for_output
-        should_insert_observer = should_insert_observer and \
-            activation_is_statically_quantized(qconfig)
+    is_standalone_module = qhandler is not None and \
+        isinstance(qhandler, StandaloneModuleQuantizeHandler)
 
-        # we never insert observers to output of standalone module, we assume
-        # if needed, they are inserted inside the standalone module
-        should_insert_observer = should_insert_observer and \
-            (not is_standalone_module)
+    should_insert_observer = \
+        qhandler.should_insert_observer_for_output(
+            qconfig, model.training)
+    # TODO(future PR): move the following logic to
+    # should_insert_observer_for_output
+    should_insert_observer = should_insert_observer and \
+        activation_is_statically_quantized(qconfig)
 
-        if should_insert_observer:
-            act_post_process_ctr = qconfig.activation
-            if activation_is_int8_quantized(qconfig):
-                act_post_process_ctr = \
-                    get_default_output_activation_post_process_map().get(
-                        matched_pattern,
-                        act_post_process_ctr)
-            observer = act_post_process_ctr()
-            new_obs = insert_observer(node, observer, model, modules, graph)
-            # set the type, so the next node can read it
-            node_name_to_target_dtype[new_obs.name] = \
-                node_name_to_target_dtype[node.name]
-            return new_obs
+    # we never insert observers to output of standalone module, we assume
+    # if needed, they are inserted inside the standalone module
+    should_insert_observer = should_insert_observer and \
+        (not is_standalone_module)
 
-    elif node.op == 'output':
-        prev_node = node.args[0]
-        assert isinstance(prev_node, Node)
-        prev_node_dtype = node_name_to_target_dtype[prev_node.name]
-        node_dtype = node_name_to_target_dtype[node.name]
-        should_insert_observer = (
-            prev_node_dtype == torch.float and
-            node_dtype != torch.float
-        )
-        if should_insert_observer:
-            assert qconfig is not None
-            observer = qconfig.activation()
-            new_obs = insert_observer(
-                prev_node, observer, model, modules, graph)
-            # set the type, so the next node can read it
-            node_name_to_target_dtype[new_obs.name] = node_dtype
-            return new_obs
-
-    return None
+    if should_insert_observer:
+        act_post_process_ctr = qconfig.activation
+        if activation_is_int8_quantized(qconfig):
+            act_post_process_ctr = \
+                get_default_output_activation_post_process_map().get(
+                    matched_pattern,
+                    act_post_process_ctr)
+        observer = act_post_process_ctr()
+        new_obs = insert_observer(node, observer, model, modules, graph)
+        # set the type, so the next node can read it
+        node_name_to_target_dtype[new_obs.name] = \
+            node_name_to_target_dtype[node.name]
+        return new_obs
+    else:
+        return None
 
 def maybe_insert_observers_before_graph_output(
     graph_output_node: Node,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59799 fx quant: remove some dead code in observer insertion (redo)**

Summary:

This is a redo of #58574, easier to create a new PR than to fix rebase
conflicts, as there have been a large number of refactors to the
underlying code.

Removes some code which was incorrectly added by #57519 but never
actually used for anything.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps
```

Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29031955](https://our.internmc.facebook.com/intern/diff/D29031955)