### PR TITLE
[DO NOT MERGE] disable cuda mem check per test method

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -736,6 +736,7 @@ BAD_EXAMPLES = [
 
 class TestDistributions(TestCase):
     _do_cuda_memory_leak_check = True
+    _do_cuda_memory_leak_check_per_method = True
     _do_cuda_non_default_stream = True
 
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -92,6 +92,7 @@ def get_cycles_per_ms():
 
 class TestCuda(TestCase):
     _do_cuda_memory_leak_check = True
+    _do_cuda_memory_leak_check_per_method = True
     _do_cuda_non_default_stream = True
     FIFTY_MIL_CYCLES = 50000000
 


### PR DESCRIPTION
- Disabling mem check per method unless explicit specified in method attr