### PR TITLE
[DO NOT MERGE] do cuda mem check on a per class level

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -736,6 +736,7 @@ BAD_EXAMPLES = [
 
 class TestDistributions(TestCase):
     _do_cuda_memory_leak_check = True
+    _do_cuda_memory_leak_check_per_method = True
     _do_cuda_non_default_stream = True
 
     def _gradcheck_log_prob(self, dist_ctor, ctor_params):

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -92,6 +92,7 @@ def get_cycles_per_ms():
 
 class TestCuda(TestCase):
     _do_cuda_memory_leak_check = True
+    _do_cuda_memory_leak_check_per_method = True
     _do_cuda_non_default_stream = True
     FIFTY_MIL_CYCLES = 50000000
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -392,6 +392,7 @@ class CUDATestBase(DeviceTypeTestBase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # has_magma shows up after cuda is initialized
         t = torch.ones(1).cuda()
         cls.no_magma = not torch.cuda.has_magma


### PR DESCRIPTION
This is a follow up of #59805. 

But in addition it does a class level mem leak check before/after the TestCase class.