### PR TITLE
Implementation of nn.CrossEntropyLossWithSoftLabels

### DIFF
--- a/aten/src/ATen/core/aten_interned_strings.h
+++ b/aten/src/ATen/core/aten_interned_strings.h
@@ -260,6 +260,7 @@ _(aten, cosine_embedding_loss) \
 _(aten, cosine_similarity) \
 _(aten, count_nonzero) \
 _(aten, cross) \
+_(aten, cross_entropy_loss_with_soft_labels) \
 _(aten, std_mean) \
 _(aten, var_mean) \
 _(aten, ctc_loss) \

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -123,6 +123,21 @@ Tensor kl_div_backward_cpu(const Tensor& grad, const Tensor& input, const Tensor
   return grad_input;
 }
 
+Tensor cross_entropy_loss_with_soft_labels(
+    const Tensor& self,
+    const Tensor& target,
+    int64_t reduction) {
+  TORCH_CHECK(self.dim() == 2, "Expected 2D input; got shape: ", self.sizes());
+  TORCH_CHECK(self.sizes() == target.sizes(), "Expected input and target to be the same shape; got: ",
+      self.sizes(), " and ", target.sizes());
+  return at::kl_div(
+      at::log_softmax(
+          self, 1, optTypeMetaToScalarType(self.options().dtype_opt())),
+      target,
+      reduction,
+      /*log_target=*/ false);
+}
+
 Tensor binary_cross_entropy_cpu(const Tensor& input, const Tensor& target, const c10::optional<Tensor>& weight_opt, int64_t reduction) {
   // See [Note: hacky wrapper removal for optional tensor]
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);

--- a/aten/src/ATen/native/Loss.cpp
+++ b/aten/src/ATen/native/Loss.cpp
@@ -127,12 +127,11 @@ Tensor cross_entropy_loss_with_soft_labels(
     const Tensor& self,
     const Tensor& target,
     int64_t reduction) {
-  TORCH_CHECK(self.dim() == 2, "Expected 2D input; got shape: ", self.sizes());
-  TORCH_CHECK(self.sizes() == target.sizes(), "Expected input and target to be the same shape; got: ",
+  TORCH_CHECK(self.sizes() == target.sizes(),
+      "cross_entropy_loss_with_soft_labels expects input and target to be the same shape; got: ",
       self.sizes(), " and ", target.sizes());
   return at::kl_div(
-      at::log_softmax(
-          self, 1, optTypeMetaToScalarType(self.options().dtype_opt())),
+      at::log_softmax(self, -1),
       target,
       reduction,
       /*log_target=*/ false);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6505,6 +6505,9 @@
 - func: cross_entropy_loss(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, int ignore_index=-100) -> Tensor
   python_module: nn
 
+- func: cross_entropy_loss_with_soft_labels(Tensor self, Tensor target, int reduction=Mean) -> Tensor
+  python_module: nn
+
 - func: lstsq.X(Tensor self, Tensor A, *, Tensor(a!) X, Tensor(b!) qr) -> (Tensor(a!) solution, Tensor(b!) QR)
   dispatch:
     CPU: legacy_lstsq_out

--- a/docs/source/nn.rst
+++ b/docs/source/nn.rst
@@ -283,6 +283,7 @@ Loss Functions
     nn.L1Loss
     nn.MSELoss
     nn.CrossEntropyLoss
+    nn.CrossEntropyLossWithSoftLabels
     nn.CTCLoss
     nn.NLLLoss
     nn.PoissonNLLLoss

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -844,6 +844,20 @@ TEST_F(FunctionalTest, CrossEntropy) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+TEST_F(FunctionalTest, CrossEntropyWithSoftLabels) {
+  auto input = torch::tensor({{3., 3.}, {2., 2.}}, torch::kFloat);
+  auto target = torch::tensor({{1., 0.}, {0., 1.}}, torch::kFloat);
+  auto output = F::cross_entropy_with_soft_labels(
+      input, target, F::CrossEntropyWithSoftLabelsFuncOptions().reduction(torch::kMean));
+  // Using one-hot labels should be equivalent to cross entropy loss except
+  // smaller by a factor of num classes (2 in this case) for the mean reduction.
+  auto expected = torch::tensor(0.6931 / 2., torch::kFloat);
+
+  ASSERT_TRUE(output.allclose(expected, 1e-04));
+  ASSERT_TRUE(F::cross_entropy_with_soft_labels(input, target).allclose(expected, 1e-04));
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 TEST_F(FunctionalTest, MaxUnpool1d) {
   auto x = torch::tensor({{{2, 4, 5}}}, torch::dtype(torch::kFloat).requires_grad(true));
   auto indices = torch::tensor({{{1, 3, 4}}}, torch::kLong);

--- a/test/cpp/api/functional.cpp
+++ b/test/cpp/api/functional.cpp
@@ -851,7 +851,8 @@ TEST_F(FunctionalTest, CrossEntropyWithSoftLabels) {
       input, target, F::CrossEntropyWithSoftLabelsFuncOptions().reduction(torch::kMean));
   // Using one-hot labels should be equivalent to cross entropy loss except
   // smaller by a factor of num classes (2 in this case) for the mean reduction.
-  auto expected = torch::tensor(0.6931 / 2., torch::kFloat);
+  auto ce_target = torch::tensor({0, 1}, torch::kLong);
+  auto expected = F::cross_entropy(input, ce_target, F::CrossEntropyFuncOptions().reduction(torch::kMean)) / 2.;
 
   ASSERT_TRUE(output.allclose(expected, 1e-04));
   ASSERT_TRUE(F::cross_entropy_with_soft_labels(input, target).allclose(expected, 1e-04));

--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -2436,7 +2436,9 @@ TEST_F(ModulesTest, CrossEntropyLossWithSoftLabels) {
   auto output = loss->forward(input, target);
   // Using one-hot labels should be equivalent to cross entropy loss except
   // smaller by a factor of num classes (2 in this case) for the mean reduction.
-  auto expected = torch::tensor(0.6931 / 2., torch::kFloat);
+  CrossEntropyLoss ce_loss;
+  auto ce_target = torch::tensor({0, 1}, torch::kLong);
+  auto expected = ce_loss->forward(input, ce_target) / 2.;
   auto s = output.sum();
   s.backward();
 
@@ -4932,13 +4934,13 @@ TEST_F(ModulesTest, PrettyPrintNLLLoss) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-TEST_F(ModulesTest, PrettyPrinCrossEntropyLoss) {
+TEST_F(ModulesTest, PrettyPrintCrossEntropyLoss) {
   ASSERT_EQ(
       c10::str(CrossEntropyLoss()), "torch::nn::CrossEntropyLoss()");
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-TEST_F(ModulesTest, PrettyPrinCrossEntropyLossWithSoftLabels) {
+TEST_F(ModulesTest, PrettyPrintCrossEntropyLossWithSoftLabels) {
   ASSERT_EQ(
       c10::str(CrossEntropyLossWithSoftLabels()), "torch::nn::CrossEntropyLossWithSoftLabels()");
 }

--- a/test/cpp_api_parity/parity-tracker.md
+++ b/test/cpp_api_parity/parity-tracker.md
@@ -223,6 +223,7 @@ F::binary_cross_entropy_with_logits|Yes|No
 F::poisson_nll_loss|Yes|No
 F::cosine_embedding_loss|Yes|No
 F::cross_entropy|Yes|No
+F::cross_entropy_with_soft_labels|Yes|No
 F::ctc_loss|Yes|No
 F::hinge_embedding_loss|Yes|No
 F::kl_div|Yes|No

--- a/test/cpp_api_parity/parity-tracker.md
+++ b/test/cpp_api_parity/parity-tracker.md
@@ -111,6 +111,7 @@ torch::nn::PairwiseDistance|Yes|No
 torch::nn::L1Loss|Yes|No
 torch::nn::MSELoss|Yes|No
 torch::nn::CrossEntropyLoss|Yes|No
+torch::nn::CrossEntropyLossWithSoftLabels|Yes|No
 torch::nn::CTCLoss|Yes|No
 torch::nn::NLLLoss|Yes|No
 torch::nn::PoissonNLLLoss|Yes|No

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -2789,6 +2789,7 @@ class TestFunctionalTracing(JitTestCase):
         "celu": CONTROL_FLOW,
         "cosine_embedding_loss": CONTROL_FLOW,
         "cross_entropy": CONTROL_FLOW,
+        "cross_entropy_with_soft_labels": CONTROL_FLOW,
         "ctc_loss": CONTROL_FLOW,
         "dropout": CONTROL_FLOW,
         "dropout2d": CONTROL_FLOW,

--- a/test/test_module_init.py
+++ b/test/test_module_init.py
@@ -46,6 +46,7 @@ def build_constructor_arg_db():
         torch.nn.CosineEmbeddingLoss: ((), {}),
         torch.nn.CosineSimilarity: ((), {}),
         torch.nn.CrossEntropyLoss: ((), {}),
+        torch.nn.CrossEntropyLossWithSoftLabels: ((), {}),
         torch.nn.CrossMapLRN2d: ((5,), {}),
         torch.nn.Dropout2d: ((), {}),
         torch.nn.Dropout3d: ((), {}),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16419,7 +16419,7 @@ class TestNNDeviceType(NNTestCase):
     @onlyOnCPUAndCUDA
     def test_cross_entropy_loss_with_soft_labels_input_target_shapes(self, device):
         criterion = nn.CrossEntropyLossWithSoftLabels()
-        shapes = [torch.arange(2, i+3).tolist() for i in range(5)]
+        shapes = [torch.arange(2, i + 3).tolist() for i in range(5)]
         for input_shape, target_shape in itertools.product(shapes, shapes):
             input = torch.randn(input_shape, device=device)
             target = torch.randn(target_shape, device=device)

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -862,6 +862,43 @@ inline Tensor cross_entropy(
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 namespace detail {
+inline Tensor cross_entropy_with_soft_labels(
+    const Tensor& input,
+    const Tensor& target,
+    CrossEntropyWithSoftLabelsFuncOptions::reduction_t reduction) {
+  return torch::cross_entropy_loss_with_soft_labels(
+      input,
+      target,
+      enumtype::reduction_get_enum(reduction));
+}
+} // namespace detail
+#endif /* DOXYGEN_SHOULD_SKIP_THIS */
+
+/// See https://pytorch.org/docs/master/nn.functional.html#torch.nn.functional.cross_entropy_with_soft_labels
+/// about the exact behavior of this functional.
+///
+/// See the documentation for `torch::nn::functional::CrossEntropyWithSoftLabelsFuncOptions` class to learn what
+/// optional arguments are supported for this functional.
+///
+/// Example:
+/// ```
+/// namespace F = torch::nn::functional;
+/// F::cross_entropy_with_soft_labels(input, target, F::CrossEntropyWithSoftLabelsFuncOptions().reduction(torch::kMean));
+/// ```
+inline Tensor cross_entropy_with_soft_labels(
+    const Tensor& input,
+    const Tensor& target,
+    const CrossEntropyWithSoftLabelsFuncOptions& options = {}) {
+  return detail::cross_entropy_with_soft_labels(
+      input,
+      target,
+      options.reduction());
+}
+
+// ============================================================================
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace detail {
 inline Tensor binary_cross_entropy_with_logits(
   const Tensor& input, const Tensor& target, const Tensor& weight,
   BinaryCrossEntropyWithLogitsFuncOptions::reduction_t reduction, const Tensor& pos_weight) {

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -707,8 +707,8 @@ TORCH_MODULE(NLLLoss);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossEntropyLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Creates a criterion that combines :func:`nn.LogSoftmax` and
-/// :func:`nn.NLLLoss` in one single class.
+/// Creates a criterion that combines `torch::nn::LogSoftmax` and
+/// `torch::nn::NLLLoss` in one single class.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLoss to learn
 /// about the exact behavior of this module.
 ///
@@ -749,8 +749,8 @@ TORCH_MODULE(CrossEntropyLoss);
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossEntropyLossWithSoftLabels ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-/// Creates a criterion that combines :func:`nn.LogSoftmax` and
-/// :func:`nn.KLDivLoss` in one single class.
+/// Creates a criterion that combines `torch::nn::LogSoftmax` and
+/// `torch::nn::KLDivLoss` in one single class.
 /// See https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLossWithSoftLabels to learn
 /// about the exact behavior of this module.
 ///

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -747,6 +747,45 @@ struct TORCH_API CrossEntropyLossImpl : public Cloneable<CrossEntropyLossImpl> {
 /// module storage semantics.
 TORCH_MODULE(CrossEntropyLoss);
 
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ CrossEntropyLossWithSoftLabels ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+/// Creates a criterion that combines :func:`nn.LogSoftmax` and
+/// :func:`nn.KLDivLoss` in one single class.
+/// See https://pytorch.org/docs/master/nn.html#torch.nn.CrossEntropyLossWithSoftLabels to learn
+/// about the exact behavior of this module.
+///
+/// See the documentation for `torch::nn::CrossEntropyLossWithSoftLabelsOptions` class to learn what
+/// constructor arguments are supported for this module.
+///
+/// Example:
+/// ```
+/// CrossEntropyLossWithSoftLabels model(CrossEntropyLossWithSoftLabelsOptions().reduction(torch::kMean));
+/// ```
+// NOLINTNEXTLINE(bugprone-exception-escape)
+struct TORCH_API CrossEntropyLossWithSoftLabelsImpl : public Cloneable<CrossEntropyLossWithSoftLabelsImpl> {
+  explicit CrossEntropyLossWithSoftLabelsImpl(
+      const CrossEntropyLossWithSoftLabelsOptions& options_ = {});
+
+  void reset() override;
+
+  /// Pretty prints the `CrossEntropyLossWithSoftLabels` module into the given `stream`.
+  void pretty_print(std::ostream& stream) const override;
+
+  Tensor forward(
+      const Tensor& input,
+      const Tensor& target);
+
+  /// The options with which this `Module` was constructed.
+  CrossEntropyLossWithSoftLabelsOptions options;
+};
+
+/// A `ModuleHolder` subclass for `CrossEntropyLossWithSoftLabelsImpl`.
+/// See the documentation for `CrossEntropyLossWithSoftLabelsImpl` class to learn what methods it
+/// provides, and examples of how to use `CrossEntropyLossWithSoftLabels` with `torch::nn::CrossEntropyLossWithSoftLabelsOptions`.
+/// See the documentation for `ModuleHolder` to learn about PyTorch's
+/// module storage semantics.
+TORCH_MODULE(CrossEntropyLossWithSoftLabels);
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ BCEWithLogitsLoss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// This loss combines a `Sigmoid` layer and the `BCELoss` in one single

--- a/torch/csrc/api/include/torch/nn/options/loss.h
+++ b/torch/csrc/api/include/torch/nn/options/loss.h
@@ -680,6 +680,35 @@ using CrossEntropyFuncOptions = CrossEntropyLossOptions;
 
 // ============================================================================
 
+/// Options for the `CrossEntropyLossWithSoftLabels` module.
+///
+/// Example:
+/// ```
+/// CrossEntropyLossWithSoftLabels model(CrossEntropyLossWithSoftLabelsOptions().reduction(torch::kMean));
+/// ```
+struct TORCH_API CrossEntropyLossWithSoftLabelsOptions {
+  typedef c10::variant<enumtype::kNone, enumtype::kMean, enumtype::kSum> reduction_t;
+
+  /// Specifies the reduction to apply to the output. Default: Mean
+  TORCH_ARG(reduction_t, reduction) = torch::kMean;
+};
+
+namespace functional {
+/// Options for `torch::nn::functional::cross_entropy_with_soft_labels`.
+///
+/// See the documentation for `torch::nn::CrossEntropyLossWithSoftLabelsOptions` class to learn what
+/// arguments are supported.
+///
+/// Example:
+/// ```
+/// namespace F = torch::nn::functional;
+/// F::cross_entropy(input, target, F::CrossEntropyWithSoftLabelsFuncOptions().reduction(torch::kMean));
+/// ```
+using CrossEntropyWithSoftLabelsFuncOptions = CrossEntropyLossWithSoftLabelsOptions;
+} // namespace functional
+
+// ============================================================================
+
 /// Options for the `BCEWithLogitsLoss` module.
 ///
 /// Example:

--- a/torch/csrc/api/src/nn/modules/loss.cpp
+++ b/torch/csrc/api/src/nn/modules/loss.cpp
@@ -383,6 +383,27 @@ Tensor CrossEntropyLossImpl::forward(
 
 // ============================================================================
 
+CrossEntropyLossWithSoftLabelsImpl::CrossEntropyLossWithSoftLabelsImpl(
+    const CrossEntropyLossWithSoftLabelsOptions& options_) // NOLINT(modernize-pass-by-value)
+    : options(options_) {}
+
+void CrossEntropyLossWithSoftLabelsImpl::reset() {}
+
+void CrossEntropyLossWithSoftLabelsImpl::pretty_print(std::ostream& stream) const {
+  stream << "torch::nn::CrossEntropyLossWithSoftLabels()";
+}
+
+Tensor CrossEntropyLossWithSoftLabelsImpl::forward(
+    const Tensor& input,
+    const Tensor& target) {
+  return F::detail::cross_entropy_with_soft_labels(
+    input,
+    target,
+    options.reduction());
+}
+
+// ============================================================================
+
 BCEWithLogitsLossImpl::BCEWithLogitsLossImpl(
   // NOLINTNEXTLINE(modernize-pass-by-value)
   const BCEWithLogitsLossOptions& options_) : options(options_) {

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -2826,6 +2826,41 @@ def cross_entropy(
     return torch._C._nn.cross_entropy_loss(input, target, weight, _Reduction.get_enum(reduction), ignore_index)
 
 
+def cross_entropy_with_soft_labels(
+    input: Tensor,
+    target: Tensor,
+    reduction: str = "mean",
+) -> Tensor:
+    r"""This criterion combines `log_softmax` and `kl_div` in a single function.
+
+    See :class:`~torch.nn.CrossEntropyLossWithSoftLabels` for details.
+
+    Args:
+        input (Tensor) : :math:`(N, C)` where `N = minibatch size` and `C = number of classes`
+        target (Tensor) : :math:`(N, C)`, same shape as the input
+        reduction (string, optional): Specifies the reduction to apply to the output:
+            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
+            ``'mean'``: the sum of the output will be divided by the number of
+            elements in the output, ``'sum'``: the output will be summed. Default: ``'mean'``
+
+    Examples::
+
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randn(3, 5)
+        >>> loss = F.cross_entropy_with_soft_labels(input, target)
+        >>> loss.backward()
+    """
+    if has_torch_function_variadic(input, target):
+        return handle_torch_function(
+            cross_entropy_with_soft_labels,
+            (input, target),
+            input,
+            target,
+            reduction=reduction,
+        )
+    return torch._C._nn.cross_entropy_loss_with_soft_labels(input, target, _Reduction.get_enum(reduction))
+
+
 def binary_cross_entropy(
     input: Tensor,
     target: Tensor,

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -242,6 +242,9 @@ def cross_entropy(input: Tensor, target: Tensor, weight: Optional[Tensor] = ...,
                   ignore_index: int = ..., reduce: Optional[bool] = ..., reduction: str = ...) -> Tensor: ...
 
 
+def cross_entropy_with_soft_labels(input: Tensor, target: Tensor, reduction: str = ...) -> Tensor: ...
+
+
 def binary_cross_entropy(input: Tensor, target: Tensor, weight: Optional[Tensor] = ...,
                          size_average: Optional[bool] = ..., reduce: Optional[bool] = ...,
                          reduction: str = ...) -> Tensor: ...

--- a/torch/nn/modules/__init__.py
+++ b/torch/nn/modules/__init__.py
@@ -10,7 +10,8 @@ from .activation import Threshold, ReLU, Hardtanh, ReLU6, Sigmoid, Tanh, \
 from .loss import L1Loss, NLLLoss, KLDivLoss, MSELoss, BCELoss, BCEWithLogitsLoss, NLLLoss2d, \
     CosineEmbeddingLoss, CTCLoss, HingeEmbeddingLoss, MarginRankingLoss, \
     MultiLabelMarginLoss, MultiLabelSoftMarginLoss, MultiMarginLoss, SmoothL1Loss, HuberLoss, \
-    SoftMarginLoss, CrossEntropyLoss, TripletMarginLoss, TripletMarginWithDistanceLoss, PoissonNLLLoss, GaussianNLLLoss
+    SoftMarginLoss, CrossEntropyLoss, CrossEntropyLossWithSoftLabels, TripletMarginLoss, \
+    TripletMarginWithDistanceLoss, PoissonNLLLoss, GaussianNLLLoss
 from .container import Container, Sequential, ModuleList, ModuleDict, ParameterList, ParameterDict
 from .pooling import AvgPool1d, AvgPool2d, AvgPool3d, MaxPool1d, MaxPool2d, MaxPool3d, \
     MaxUnpool1d, MaxUnpool2d, MaxUnpool3d, FractionalMaxPool2d, FractionalMaxPool3d, LPPool1d, LPPool2d, \
@@ -43,9 +44,9 @@ __all__ = [
     'Tanhshrink', 'RReLU', 'L1Loss', 'NLLLoss', 'KLDivLoss', 'MSELoss', 'BCELoss', 'BCEWithLogitsLoss',
     'NLLLoss2d', 'PoissonNLLLoss', 'CosineEmbeddingLoss', 'CTCLoss', 'HingeEmbeddingLoss', 'MarginRankingLoss',
     'MultiLabelMarginLoss', 'MultiLabelSoftMarginLoss', 'MultiMarginLoss', 'SmoothL1Loss', 'GaussianNLLLoss',
-    'HuberLoss', 'SoftMarginLoss', 'CrossEntropyLoss', 'Container', 'Sequential', 'ModuleList', 'ModuleDict',
-    'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d', 'MaxPool2d',
-    'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d', "FractionalMaxPool3d",
+    'HuberLoss', 'SoftMarginLoss', 'CrossEntropyLoss', 'CrossEntropyLossWithSoftLabels', 'Container', 'Sequential',
+    'ModuleList', 'ModuleDict', 'ParameterList', 'ParameterDict', 'AvgPool1d', 'AvgPool2d', 'AvgPool3d', 'MaxPool1d',
+    'MaxPool2d', 'MaxPool3d', 'MaxUnpool1d', 'MaxUnpool2d', 'MaxUnpool3d', 'FractionalMaxPool2d', "FractionalMaxPool3d",
     'LPPool1d', 'LPPool2d', 'LocalResponseNorm', 'BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d', 'InstanceNorm1d',
     'InstanceNorm2d', 'InstanceNorm3d', 'LayerNorm', 'GroupNorm', 'SyncBatchNorm',
     'Dropout', 'Dropout2d', 'Dropout3d', 'AlphaDropout', 'FeatureAlphaDropout',

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1130,18 +1130,19 @@ class CrossEntropyLossWithSoftLabels(_Loss):
     one single class. It is useful when training a classification problem with `C` classes when
     "soft labels" are required, such as when utilizing label smoothing or blended labels.
 
-    The `input` is expected to contain raw, unnormalized scores for each class and the `target`
+    The ``input`` is expected to contain raw, unnormalized scores for each class and the ``target``
     should match the `input` shape and contain the target distribution over the classes.
 
-    The loss can be described as:
+    With input :math:`x` and target :math:`y`, the unreduced (i.e. with ``reduction`` set
+    to ``none``) loss :math:`L` can be described as:
 
     .. math::
-        L = l_{n,c} = y_{n,c} \cdot \left( \log y_{n,c} - \\
-        \log\left(\frac{\exp(x_{n,c})}{\sum_{i=1}^C \exp(x_{n,i})} \right) \right)
+        L = \{l_1,\dots,l_N\}, \quad
+        l_n = y_n \cdot \left( \log y_n - \log\left(\frac{\exp(x_n)}{\sum_{i} \exp(x_i)} \right) \right)
 
-    where :math:`x_{n,c}` represents each element of ``input``, :math:`y_{n,c}` represents each element of
-    ``target``, and :math:`L` has the same shape as ``input`` and ``target``.  If :attr:`reduction` is not
-    ``'none'`` (default ``'mean'``), then:
+    where the index :math:`N` spans all dimensions of ``input`` and :math:`L` has the same shape as
+    ``input`` and ``target``. If :attr:`reduction` is not ``'none'`` (default ``'mean'``), then the
+    scalar loss output :math:`\ell` is defined as:
 
     .. math::
         \ell(x, y) = \begin{cases}
@@ -1169,9 +1170,10 @@ class CrossEntropyLossWithSoftLabels(_Loss):
             ``'sum'``: the output will be summed. Default: ``'mean'``
 
     Shape:
-        - Input: :math:`(N, C)` where `N = minibatch size` and `C = number of classes`
-        - Target: :math:`(N, C)`, same shape as the input
-        - Output: scalar. If :attr:`reduction` is ``'none'``, then :math:`(N, C)`
+        - Input: :math:`(*, C)` where :math:`*` represents any number of dimensions (including none) and
+          `C = number of classes`
+        - Target: :math:`(*, C)`, same shape as the input
+        - Output: If :attr:`reduction` is ``'none'``, then :math:`(*, C)`, otherwise scalar.
 
     Examples::
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1173,7 +1173,7 @@ class CrossEntropyLossWithSoftLabels(_Loss):
         - Input: :math:`(*, C)` where :math:`*` represents any number of dimensions (including none) and
           `C = number of classes`
         - Target: :math:`(*, C)`, same shape as the input
-        - Output: If :attr:`reduction` is ``'none'``, then :math:`(*, C)`, otherwise scalar.
+        - Output: If :attr:`reduction` is ``'none'``, then :math:`(*, C)`, otherwise scalar
 
     Examples::
 

--- a/torch/nn/modules/loss.py
+++ b/torch/nn/modules/loss.py
@@ -1137,7 +1137,7 @@ class CrossEntropyLossWithSoftLabels(_Loss):
 
     .. math::
         L = l_{n,c} = y_{n,c} \cdot \left( \log y_{n,c} - \\
-        \log\left(\frac{\exp(x_{n,c})}{\sum_{i=1}^C \exp(x_{n,i})} \right)
+        \log\left(\frac{\exp(x_{n,c})}{\sum_{i=1}^C \exp(x_{n,i})} \right) \right)
 
     where :math:`x_{n,c}` represents each element of ``input``, :math:`y_{n,c}` represents each element of
     ``target``, and :math:`L` has the same shape as ``input`` and ``target``.  If :attr:`reduction` is not

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -665,6 +665,7 @@ def get_testing_overrides() -> Dict[Callable, Callable]:
                                                     reduce=None, reduction='mean': -1),
         torch.nn.functional.cross_entropy: (lambda input, target, weight=None, size_average=None, ignore_index=-100,
                                             reduce=None, reduction="mean": -1),
+        torch.nn.functional.cross_entropy_with_soft_labels: (lambda input, target, reduction="mean": -1),
         torch.nn.functional.ctc_loss: (lambda log_probs, targets, input_lengths, target_lengths, blank=0,
                                        reduction='mean', zero_infinity=False: -1),
         torch.nn.functional.dropout: lambda input, p=0.5, training=True, inplace=False: -1,

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -3824,6 +3824,13 @@ def cross_entropy_loss_reference(input, target, weight=None, ignore_index=-100, 
         reduction=reduction)
 
 
+def cross_entropy_loss_with_soft_labels_reference(input, target, reduction='mean'):
+    return kldivloss_reference(
+        torch.log_softmax(input, 1),
+        target,
+        reduction=reduction)
+
+
 def nllloss_reference(input, target, weight=None, ignore_index=-100,
                       reduction='mean'):
 
@@ -4136,7 +4143,8 @@ loss_reference_fns: Dict['str', Callable] = {
     'TripletMarginLoss': tripletmarginloss_reference,
     'MarginRankingLoss': marginrankingloss_reference,
     'CTCLoss': ctcloss_reference,
-    'CrossEntropyLoss': cross_entropy_loss_reference
+    'CrossEntropyLoss': cross_entropy_loss_reference,
+    'CrossEntropyLossWithSoftLabels': cross_entropy_loss_with_soft_labels_reference
 }
 
 
@@ -4257,6 +4265,11 @@ criterion_tests = [
         input_size=(15, 10),
         target_fn=lambda: torch.empty(15).uniform_().mul(10).floor().long(),
         desc='weights',
+    ),
+    dict(
+        module_name='CrossEntropyLossWithSoftLabels',
+        input_size=(15, 10),
+        target_fn=lambda: torch.empty(15, 10).uniform_(),
     ),
     dict(
         module_name='HingeEmbeddingLoss',
@@ -4549,6 +4562,16 @@ criterion_tests = [
             loss_reference_fns['CrossEntropyLoss'](i, t, reduction=get_reduction(m)),
         check_sum_reduction=True,
         desc='dim_is_3',
+        check_bfloat16=False,
+    ),
+    dict(
+        module_name='CrossEntropyLossWithSoftLabels',
+        input_size=(5, 3),
+        target_fn=lambda: torch.rand(5, 3),
+        reference_fn=lambda i, t, m:
+            loss_reference_fns['CrossEntropyLossWithSoftLabels'](i, t, reduction=get_reduction(m)),
+        check_sum_reduction=True,
+        desc='2d',
         check_bfloat16=False,
     ),
     dict(

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -4267,11 +4267,6 @@ criterion_tests = [
         desc='weights',
     ),
     dict(
-        module_name='CrossEntropyLossWithSoftLabels',
-        input_size=(15, 10),
-        target_fn=lambda: torch.empty(15, 10).uniform_(),
-    ),
-    dict(
         module_name='HingeEmbeddingLoss',
         input_size=(10,),
         target_fn=lambda: torch.randn(10).gt(0).double().mul_(2).sub(1),
@@ -4571,7 +4566,6 @@ criterion_tests = [
         reference_fn=lambda i, t, m:
             loss_reference_fns['CrossEntropyLossWithSoftLabels'](i, t, reduction=get_reduction(m)),
         check_sum_reduction=True,
-        desc='2d',
         check_bfloat16=False,
     ),
     dict(


### PR DESCRIPTION
Fixes #11959. The implementation is a combination of `log_softmax` + `kl_div` (see https://github.com/pytorch/pytorch/issues/11959#issuecomment-854076986 for details).

Btw this specific name was chosen for a few reasons:
1. To distinguish the criterion from `SoftMarginLoss`, where "soft" has a different meaning applying to the margin (in contrast to a hard margin)
2. To fit with the "With" naming adopted by `BCELossWithLogits`
3. To fit with the "Labels" naming adopted by `MultiLabelMarginLoss` and `MultiLabelSoftMarginLoss`

This ruled out:
* `SoftCrossEntropyLoss`
* `SoftLabelCrossEntropyLoss`
* `CrossEntropyLossWithSoftTargets`
* `SoftTargetCrossEntropyLoss`
* etc.