### PR TITLE
.jenkins: Ignore exit code of nvidia-smi

### DIFF
--- a/.jenkins/pytorch/win-test.sh
+++ b/.jenkins/pytorch/win-test.sh
@@ -57,7 +57,7 @@ run_tests() {
     # Run nvidia-smi if available
     for path in '/c/Program Files/NVIDIA Corporation/NVSMI/nvidia-smi.exe' /c/Windows/System32/nvidia-smi.exe; do
         if [[ -x "$path" ]]; then
-            "$path";
+            "$path" || echo "true";
             break
         fi
     done


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59826 .jenkins: Ignore exit code of nvidia-smi**

It's only informational and will run on Windows CPU executors as well

Fixes issues found in https://github.com/pytorch/pytorch/runs/2797531966

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29042951](https://our.internmc.facebook.com/intern/diff/D29042951)