### PR TITLE
[docs] Add table of contents to torch.package docs

### DIFF
--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -15,6 +15,11 @@ at a later date or on a different machine, and can even be deployed to productio
 This document contains tutorials, how-to guides, explanations, and an API reference that
 will help you learn more about ``torch.package`` and how to use it.
 
+
+.. contents:: :local:
+    :depth: 2
+
+
 Tutorials
 ---------
 Packaging your first model


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59842 [docs] Add table of contents to torch.package docs**
* #59833 [docs] Add explanation section to torch.package docs
* #59503 [docs] Add "how do I" section to torch.package docs
* #59499 [docs] Add tutorials section to torch.package docs
* #59491 [docs] Add torch.package documentation preamble

Test Plan:
Continuous integration.

<img width="544" alt="Captura de Pantalla 2021-06-10 a la(s) 5 13 07 p  m" src="https://user-images.githubusercontent.com/4392003/121612390-2ccec280-ca0f-11eb-87ad-fef632ba05ca.png">

Differential Revision: [D29050627](https://our.internmc.facebook.com/intern/diff/D29050627)