### PR TITLE
Add device runtime API for the plug-in to register platform python module into torch

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -827,7 +827,7 @@ class TestStandaloneCPPJIT(TestCase):
 
 class DummyXPUModule(object):
     @staticmethod
-    def is_avaliable():
+    def is_available():
         return True
 
 
@@ -842,11 +842,11 @@ class TestExtensionUtils(TestCase):
             torch._register_device_module('dummmy', DummyXPUModule)
 
         with self.assertRaises(AttributeError):
-            torch.xpu.is_avaliable()  # type: ignore[attr-defined]
+            torch.xpu.is_available()  # type: ignore[attr-defined]
 
         torch._register_device_module('xpu', DummyXPUModule)
 
-        torch.xpu.is_avaliable()  # type: ignore[attr-defined]
+        torch.xpu.is_available()  # type: ignore[attr-defined]
 
         # No supporting for override
         with self.assertRaisesRegex(RuntimeError, "The runtime module of"):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -825,5 +825,33 @@ class TestStandaloneCPPJIT(TestCase):
             shutil.rmtree(build_dir)
 
 
+class DummyXPUModule(object):
+    @staticmethod
+    def is_avaliable():
+        return True
+
+
+class TestExtensionUtils(TestCase):
+    def test_external_module_register(self):
+        # Built-in module
+        with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
+            torch._register_device_module('cuda', torch.cuda)
+
+        # Wrong device type
+        with self.assertRaisesRegex(RuntimeError, "Expected one of cpu"):
+            torch._register_device_module('dummmy', DummyXPUModule)
+
+        with self.assertRaises(AttributeError):
+            torch.xpu.is_avaliable()  # type: ignore[attr-defined]
+
+        torch._register_device_module('xpu', DummyXPUModule)
+
+        torch.xpu.is_avaliable()  # type: ignore[attr-defined]
+
+        # No supporting for override
+        with self.assertRaisesRegex(RuntimeError, "The runtime module of"):
+            torch._register_device_module('xpu', DummyXPUModule)
+
+
 if __name__ == '__main__':
     run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -752,3 +752,19 @@ from ._vmap_internals import vmap as vmap
 # class usage. We add these lines here to preserve backward compatibility.
 quantized_lstm = torch.ops.aten.quantized_lstm
 quantized_gru = torch.ops.aten.quantized_gru
+
+
+def _register_device_module(device_type, module):
+    r"""Register an external runtime module of the specific :attr:`device_type`
+    supported by torch.
+
+    After the :attr:`module` is registered correctly, the user can refer
+    the external runtime module as part of torch with attribute torch.xxx.
+    """
+    # Make sure the device_type represent a supported device type for torch.
+    device_type = torch.device(device_type).type
+    m = sys.modules[__name__]
+    if hasattr(m, device_type):
+        raise RuntimeError("The runtime module of '{}' has already "
+                           "been registered with '{}'".format(device_type, getattr(m, device_type)))
+    setattr(m, device_type, module)


### PR DESCRIPTION
## Motivation
Allow the out-of-tree Pytorch plug-in, for the device type other than CUDA, to add the runtime interface to the `torch` module. The runtime interface of the device can be referred with the device type name in the `torch` module. I.E., `torch.cuda` or `torch.xpu`.


## Solution
- Add a register interface for the plug-in to add the platform python module into `torch` module with the device type name. I.E., The `torch.xpu` can be used to refer the XPU runtime interface after the XPU runtime module is registered with `torch._register_device_module('xpu', xpu_module)` in Intel's XPU plug-in.


## Additional Context
More details about runtime has been discussed in #53707. 
