### PR TITLE
Fix `Vectorize<float>::trunc` on ARM platform

### DIFF
--- a/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec256/vec256_float_neon.h
@@ -466,8 +466,8 @@ public:
     return map(std::tanh);
   }
   Vectorized<float> trunc() const {
-    float32x4_t r0 = vcvtq_f32_s32(vcvtq_s32_f32(values.val[0]));
-    float32x4_t r1 = vcvtq_f32_s32(vcvtq_s32_f32(values.val[1]));
+    float32x4_t r0 = vrndq_f32(values.val[0]);
+    float32x4_t r1 = vrndq_f32(values.val[1]);
     return Vectorized<float>(r0, r1);
   }
   Vectorized<float> lgamma() const {


### PR DESCRIPTION
Use `vrndq_f32`, which corresponds to `VRINTZ` instruction, which rounds floating point value towards zero, which matches `std::trunc` behaviour.
This makes trunc implementation correct even for values that fit into float32, but can not be converted to int32, for example `-1.0e+20`, see the following [gist](https://gist.github.com/malfet/c612c9f4b3b5681ca1b2a69930825871):
```
inp= 3.1 2.7 -2.9 -1e+20
old_trunc= 3 2 -2 -2.14748e+09
new_trunc= 3 2 -2 -1e+20
``` 

Fixes `test_reference_numerics_hard_trunc_cpu_float32` on M1