### PR TITLE
[torch][segment_reduce] Support for multi dimension (cpu fwd only)

### DIFF
--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -23,6 +23,19 @@ struct CustomMax {
   }
 };
 
+struct CustomSum {
+  template <typename OutputT>
+  __host__ __device__ __forceinline__ OutputT
+  operator()(const OutputT& a, const OutputT& b) const {
+    if (at::_isnan(a)) {
+      return a;
+    } else if (at::_isnan(b)) {
+      return b;
+    }
+    return a + b;
+  }
+};
+
 Tensor _get_complete_sum(const Tensor& lengths) {
   int64_t segment_count = lengths.numel();
   TORCH_CHECK(segment_count < INT_MAX);
@@ -41,6 +54,27 @@ Tensor _get_complete_sum(const Tensor& lengths) {
   return offsets;
 }
 
+template <typename scalar_t>
+__global__ static void post_sum_div_kernel(
+    scalar_t* output_data,
+    const int64_t* lengths_data,
+    const int64_t segment_count,
+    bool is_initial_set,
+    scalar_t initial) {
+  CUDA_KERNEL_LOOP(index, segment_count) {
+    CUDA_KERNEL_ASSERT(lengths_data[index] >= 0);
+    if (lengths_data[index] == 0) {
+      if (is_initial_set) {
+        output_data[index] = initial;
+      } else {
+        output_data[index] = NAN;
+      }
+    } else if (!at::_isnan(output_data[index])) {
+      output_data[index] = output_data[index] / lengths_data[index];
+    }
+  }
+}
+
 Tensor _segment_reduce_cuda_kernel(
     SegmentReductionType reduction,
     const Tensor& data,
@@ -53,6 +87,11 @@ Tensor _segment_reduce_cuda_kernel(
   auto offsets = _get_complete_sum(lengths);
   auto* offsets_data_ptr = offsets.data_ptr<int64_t>();
 
+  constexpr int threads_per_block = 256;
+  int num_blocks = segment_count / threads_per_block;
+  num_blocks = std::max(num_blocks, 1);
+  auto* lengths_data_ptr = lengths.data_ptr<int64_t>();
+
   AT_DISPATCH_ALL_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
@@ -62,20 +101,44 @@ Tensor _segment_reduce_cuda_kernel(
         auto* data_data_ptr = data.data_ptr<scalar_t>();
         auto* output_data_ptr = output.data_ptr<scalar_t>();
 
-        CustomMax max_op{};
-        scalar_t initial_value = initial.has_value()
-            ? initial.value().to<scalar_t>()
-            : std::numeric_limits<scalar_t>::lowest();
-        CUB_WRAPPER(
-            cub::DeviceSegmentedReduce::Reduce,
-            data_data_ptr,
-            output_data_ptr,
-            segment_count,
-            offsets_data_ptr,
-            offsets_data_ptr + 1,
-            max_op,
-            initial_value,
-            at::cuda::getCurrentCUDAStream());
+        if (reduction == SegmentReductionType::MAX) {
+          CustomMax max_op{};
+          scalar_t initial_value = initial.has_value()
+              ? initial.value().to<scalar_t>()
+              : std::numeric_limits<scalar_t>::lowest();
+          CUB_WRAPPER(
+              cub::DeviceSegmentedReduce::Reduce,
+              data_data_ptr,
+              output_data_ptr,
+              segment_count,
+              offsets_data_ptr,
+              offsets_data_ptr + 1,
+              max_op,
+              initial_value,
+              at::cuda::getCurrentCUDAStream());
+        } else if (reduction == SegmentReductionType::MEAN) {
+          CustomSum sum_op{};
+          scalar_t initial_value = initial.has_value()
+              ? initial.value().to<scalar_t>()
+              : (scalar_t)0;
+          CUB_WRAPPER(
+              cub::DeviceSegmentedReduce::Reduce,
+              data_data_ptr,
+              output_data_ptr,
+              segment_count,
+              offsets_data_ptr,
+              offsets_data_ptr + 1,
+              sum_op,
+              initial_value,
+              at::cuda::getCurrentCUDAStream());
+
+          post_sum_div_kernel<scalar_t>
+              <<<num_blocks,
+                 threads_per_block,
+                 0,
+                 at::cuda::getCurrentCUDAStream()>>>(
+                  output_data_ptr, lengths_data_ptr, segment_count, initial.has_value(), initial_value);
+        }
       });
 
   return output;

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -85,9 +85,6 @@ class TestSegmentReductions(TestCase):
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_simple_1d(self, device, dtype):
         for reduction in ("max", "mean"):
-            # TODO: Remove if once mean reduction for cuda is implemented
-            if reduction == "mean" and device != "cpu":
-                continue
             self._test_simple_1d(reduction, device, dtype, False, 0)
             self._test_simple_1d(reduction, device, dtype, False, -1)
             self._test_simple_1d(reduction, device, dtype, True, 0)

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -1,8 +1,10 @@
+import numpy as np
 import torch
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     dtypes,
     dtypesIfCUDA,
+    onlyCPU,
 )
 from torch.testing._internal.common_utils import (
     TestCase,
@@ -12,29 +14,29 @@ from torch.testing._internal.common_utils import (
 
 
 class TestSegmentReductions(TestCase):
-    def _test_simple_1d(self, reduction, device, dtype, unsafe, axis):
-        lengths = torch.tensor([1, 2, 3, 0], device=device)
+    def _test_common(
+        self,
+        reduction,
+        device,
+        dtype,
+        unsafe,
+        axis,
+        initial_value,
+        data_arr,
+        lengths_arr,
+        expected_arr,
+        expected_grad_arr,
+        check_backward,
+    ):
+        lengths = torch.tensor(lengths_arr, device=device)
         data = torch.tensor(
-            [1, float("nan"), 3, 4, 5, 5],
+            data_arr,
             device=device,
             dtype=dtype,
             requires_grad=True,
         )
-        initial_value = 0
-        if reduction == "max":
-            expected_result = torch.tensor(
-                [1, float("nan"), 5, initial_value], device=device, dtype=dtype
-            )
-            expected_grad = torch.tensor(
-                [1, 1, 0, 0, 0.5, 0.5], device=device, dtype=dtype
-            )
-        elif reduction == "mean":
-            expected_result = torch.tensor(
-                [1, float("nan"), 4.666, initial_value], device=device, dtype=dtype
-            )
-            expected_grad = torch.tensor(
-                [1.0, 0.5, 0.5, 0.333, 0.333, 0.333], device=device, dtype=dtype
-            )
+        expected_result = torch.tensor(expected_arr, device=device, dtype=dtype)
+        expected_grad = torch.tensor(expected_grad_arr, device=device, dtype=dtype)
         actual_result = torch.segment_reduce(
             data=data,
             reduce=reduction,
@@ -47,8 +49,7 @@ class TestSegmentReductions(TestCase):
             expected_result, actual_result, rtol=1e-02, atol=1e-05, equal_nan=True
         )
 
-        # TODO: Remove this check once cuda backward support is implemented
-        if data.is_cuda:
+        if not check_backward:
             return
 
         # Test backward
@@ -60,9 +61,14 @@ class TestSegmentReductions(TestCase):
         # gradcheck does not work well with bfloat16 or fp16 cpu types
         # also there is small numerical difference with fp32
         if dtype not in [torch.half, torch.bfloat16, torch.float]:
-            # gradcheck does not like "nan" input
+            # gradcheck does not like "nan" input, setting to random 10
+            d_non_nan = [
+                10 if is_nan else data_arr[index]
+                for index, is_nan in enumerate(torch.isnan(data))
+            ]
             data = torch.tensor(
-                [1, 10, 3, 4, 5, 5],
+                # [10 if v == float("nan") else v for v in data],
+                d_non_nan,
                 device=device,
                 dtype=dtype,
                 requires_grad=True,
@@ -84,11 +90,130 @@ class TestSegmentReductions(TestCase):
     @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_simple_1d(self, device, dtype):
+        lengths = [1, 2, 3, 0]
+        data = [1, float("nan"), 3, 4, 5, 5]
+        initial_value = 0
+
+        # TODO: Set this to true once cuda backward support is implemented
+        check_backward = device == "cpu"
+
         for reduction in ("max", "mean"):
-            self._test_simple_1d(reduction, device, dtype, False, 0)
-            self._test_simple_1d(reduction, device, dtype, False, -1)
-            self._test_simple_1d(reduction, device, dtype, True, 0)
-            self._test_simple_1d(reduction, device, dtype, True, -1)
+            if reduction == "max":
+                expected_result = [1, float("nan"), 5, initial_value]
+                expected_grad = [1, 1, 0, 0, 0.5, 0.5]
+            elif reduction == "mean":
+                expected_result = [1, float("nan"), 4.666, initial_value]
+                expected_grad = [1.0, 0.5, 0.5, 0.333, 0.333, 0.333]
+            for axis in [0, -1]:
+                for unsafe in [True, False]:
+                    self._test_common(
+                        reduction,
+                        device,
+                        dtype,
+                        unsafe,
+                        axis,
+                        initial_value,
+                        data,
+                        lengths,
+                        expected_result,
+                        expected_grad,
+                        check_backward,
+                    )
+
+    @onlyCPU
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_multi_d_simple(self, device, dtype):
+        initial_value = 0
+        axis = 0
+        lengths = [1, 2, 3, 0]
+        data = [[1, 1], [float("nan"), 1], [3, float("nan")], [4, 1], [5, 1], [5, 1]]
+
+        # TODO: Set this to true once backward is support for multi d
+        check_backward = False
+
+        for reduction in ["max", "mean"]:
+            if reduction == "max":
+                expected_result = [
+                    [1, 1],
+                    [float("nan"), float("nan")],
+                    [5, 1],
+                    [initial_value, initial_value],
+                ]
+                expected_grad = [
+                    [1, 1],
+                    [1, 0],
+                    [0, 1],
+                    [0, 0.333],
+                    [0.5, 0.333],
+                    [0.5, 0.333],
+                ]
+            elif reduction == "mean":
+                expected_result = [
+                    [1, 1],
+                    [float("nan"), float("nan")],
+                    [4.666, 1],
+                    [initial_value, initial_value],
+                ]
+                expected_grad = [
+                    [1.0, 1.0],
+                    [0.5, 0.5],
+                    [0.5, 0.5],
+                    [0.333, 0.333],
+                    [0.333, 0.333],
+                    [0.333, 0.333],
+                ]
+            for unsafe in [True, False]:
+                self._test_common(
+                    reduction,
+                    device,
+                    dtype,
+                    unsafe,
+                    axis,
+                    initial_value,
+                    data,
+                    lengths,
+                    expected_result,
+                    expected_grad,
+                    check_backward,
+                )
+
+    @onlyCPU
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_multi_d(self, device, dtype):
+        initial_value = 0
+        axis = 0
+        lengths = [0, 2]
+        data = np.random.randint(0, 100, size=(2, 2, 5)).tolist()
+        expected_grad = []
+
+        # TODO: Set this to true once backward is support for multi d
+        check_backward = False
+
+        for reduction in ["max", "mean"]:
+            if reduction == "max":
+                expected_result = [
+                    np.full((2, 5), initial_value).tolist(),
+                    np.max(data, axis=0).tolist(),
+                ]
+            elif reduction == "mean":
+                expected_result = [
+                    np.full((2, 5), initial_value).tolist(),
+                    np.mean(data, axis=0).tolist(),
+                ]
+            for unsafe in [True, False]:
+                self._test_common(
+                    reduction,
+                    device,
+                    dtype,
+                    unsafe,
+                    axis,
+                    initial_value,
+                    data,
+                    lengths,
+                    expected_result,
+                    expected_grad,
+                    check_backward,
+                )
 
 
 instantiate_device_type_tests(TestSegmentReductions, globals())


### PR DESCRIPTION
Summary:
Same as title. This is first diff to add support for multi dimension input (though reduction is still on axis=0).

Next steps:
- cpu backward support
- cuda forward/backward support

Test Plan: Added two new unit tests.

Differential Revision: D29051902

