### PR TITLE
[quant][fx] Remove extra q-dq for weight bias in normalization ops

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -3272,6 +3272,43 @@ class TestQuantizeFxOps(QuantizationTestCase):
                 quantized_module, torch.ops.quantized.instance_norm,
                 skip_op_arg_for_functional=True)
 
+    def test_norm_weight_bias(self):
+        class Linear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.ones(5, 5)
+                self.b = torch.zeros(5)
+
+            def forward(self, x):
+                return torch.nn.functional.linear(x, self.w, self.b)
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mods1 = Linear()
+                self.scale = torch.randn(5, 5)
+                self.bias = torch.randn(5, 5)
+
+            def forward(self, x):
+                x1 = self.mods1(x)
+                y = F.layer_norm(x1, [5, 5], weight=self.scale, bias=self.bias)
+                return y
+
+        model = M()
+        expected_occurrence = {
+            ns.call_function(torch.quantize_per_tensor): 1,
+            ns.call_function(torch.ops.quantized.linear): 1,
+            ns.call_function(torch.ops.quantized.layer_norm): 1,
+            ns.call_method("dequantize"): 1,
+        }
+
+        self.checkGraphModeFxOp(
+            model,
+            (torch.rand(5, 5),),
+            QuantType.STATIC,
+            expected_node_occurrence=expected_occurrence
+        )
+
     def _test_default_node_quant_handler_ops(
             self, module, functional, qconfig, is_reference=True, node_list=None, additional_quant_pattern_dict=None
     ):

--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -19,6 +19,18 @@ WEIGHT_INDEX_DICT = {
     torch.nn.functional.conv2d : [1],
     torch.nn.functional.conv3d : [1],
     torch.nn.functional.linear : [1],
+    torch.nn.functional.layer_norm : [2],
+    torch.nn.functional.group_norm : [2],
+    torch.nn.functional.instance_norm : [3],
+}
+
+NON_QUANTIZABLE_WEIGHT_OPS = {torch.nn.functional.layer_norm, torch.nn.functional.group_norm, torch.nn.functional.instance_norm}
+
+FUNCTIONAL_OPS_WITH_BIAS = {
+    torch.nn.functional.linear,
+    torch.nn.functional.layer_norm,
+    torch.nn.functional.group_norm,
+    torch.nn.functional.instance_norm
 }
 
 # turn foo.bar -> ['foo', 'bar']


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59882 [quant][fx] Remove extra q-dq for weight bias in normalization ops**

Summary:
Currently for normalization ops, the weight and bias arguments are treated as activationn inputs which require observers.
This results in adding extra quant-dequant ops for the weight and bias inputs.

This PR adds support to skip observing weight/bias inputs of norm operators, thus removing the redundant q-dq ops

Quantized graph with F.layer_norm
Before this PR
```
def forward(self, x):
    _input_scale_0 = self._input_scale_0
    _input_zero_point_0 = self._input_zero_point_0
    quantize_per_tensor = torch.quantize_per_tensor(x, _input_scale_0, _input_zero_point_0, torch.quint8);  x = _input_scale_0 = _input_zero_point_0 = None
    scale = self.scale
    _input_scale_1 = self._input_scale_1
    _input_zero_point_1 = self._input_zero_point_1
    quantize_per_tensor_1 = torch.quantize_per_tensor(scale, _input_scale_1, _input_zero_point_1, torch.quint8);  scale = _input_scale_1 = _input_zero_point_1 = None
    bias = self.bias
    _input_scale_2 = self._input_scale_2
    _input_zero_point_2 = self._input_zero_point_2
    quantize_per_tensor_2 = torch.quantize_per_tensor(bias, _input_scale_2, _input_zero_point_2, torch.quint8);  bias = _input_scale_2 = _input_zero_point_2 = None
    _scale_0 = self._scale_0
    _zero_point_0 = self._zero_point_0
    dequantize = quantize_per_tensor_1.dequantize();  quantize_per_tensor_1 = None
    dequantize_1 = quantize_per_tensor_2.dequantize();  quantize_per_tensor_2 = None
    layer_norm = torch.ops.quantized.layer_norm(quantize_per_tensor, [2, 5, 5], weight = dequantize, bias = dequantize_1, eps = 1e-05, output_scale = _scale_0, output_zero_point = _zero_point_0);  quantize_per_tensor = dequantize = dequantize_1 = _scale_0 = _zero_point_0 = None
    dequantize_2 = layer_norm.dequantize();  layer_norm = None
    return dequantize_2
```
After
```
def forward(self, x):
    _input_scale_0 = self._input_scale_0
    _input_zero_point_0 = self._input_zero_point_0
    quantize_per_tensor = torch.quantize_per_tensor(x, _input_scale_0, _input_zero_point_0, torch.quint8);  x = _input_scale_0 = _input_zero_point_0 = None
    scale = self.scale
    bias = self.bias
    _scale_0 = self._scale_0
    _zero_point_0 = self._zero_point_0
    layer_norm = torch.ops.quantized.layer_norm(quantize_per_tensor, [2, 5, 5], weight = scale, bias = bias, eps = 1e-05, output_scale = _scale_0, output_zero_point = _zero_point_0);  quantize_per_tensor = scale = bias = _scale_0 = _zero_point_0 = None
    dequantize = layer_norm.dequantize();  layer_norm = None
    return dequantize
```

Test Plan:
python test/test_quantization.py TestQuantizeFxOps.test_norm_weight_bias
Reviewers:

Subscribers:

Tasks:

Tags:

Differential Revision: [D29068203](https://our.internmc.facebook.com/intern/diff/D29068203)