### PR TITLE
Remove ci/no-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ parameters:
     default: false
   run_build:
     type: boolean
-    default: false
+    default: true
   run_master_build:
     type: boolean
     default: false

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -13,7 +13,7 @@ parameters:
     default: false
   run_build:
     type: boolean
-    default: false
+    default: true
   run_master_build:
     type: boolean
     default: false

--- a/.github/pytorch-circleci-labels.yml
+++ b/.github/pytorch-circleci-labels.yml
@@ -1,7 +1,5 @@
 # For documentation concerning this configuration please refer to,
 # https://github.com/pytorch/pytorch-probot#trigger-circleci-workflows
-default_params:
-  run_build: true
 labels_to_circle_params:
   ci/binaries:
     parameter: run_binary_tests
@@ -11,15 +9,6 @@ labels_to_circle_params:
         - release/.*
       tags:
         - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-  ci/no-build:
-    default_true_on:
-      branches:
-        - nightly
-        - release/.*
-      tags:
-        - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-    set_to_false:
-      - run_build
   ci/master:
     parameter: run_master_build
   ci/slow-gradcheck:


### PR DESCRIPTION
This reverts #58778, since triggering our primary CircleCI workflow only via pytorch-probot has been causing more problems than it's worth.