### PR TITLE
fx quant: fix bug with quant op after ndim

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2379,6 +2379,23 @@ class TestQuantizeFx(QuantizationTestCase):
         }
         self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
 
+    def test_quant_op_after_ndim(self):
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(1, 1, 1)
+
+            def forward(self, x):
+                x = self.conv(x)
+                d = x.ndim
+                x = torch.add(x, d)
+                return x, d
+
+        m = M().eval()
+        mp = prepare_fx(m, {"": default_qconfig})
+        mc = convert_fx(mp)
+        # if the above code does not crash, the test is successful
+
 
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):

--- a/torch/quantization/fx/utils.py
+++ b/torch/quantization/fx/utils.py
@@ -466,6 +466,11 @@ def is_get_tensor_info_node(node: Node) -> bool:
     """ Returns True if this node is a node that takes a Tensor as input and output some
     meta information about the Tensor, e.g. shape, size etc.
     """
-    result: bool = \
-        node.op == "call_function" and node.target == getattr and node.args[1] == "shape"  # type: ignore[assignment]
-    return result
+    if (
+        node.op == "call_function" and
+        node.target == getattr and
+        node.args[1] in ("shape", "ndim")  # type: ignore[assignment]
+    ):
+        return True
+    else:
+        return False


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59895 fx quant: failing test case for quant op after expand
* **#59894 fx quant: fix bug with quant op after ndim**

Summary:

Before this PR, calling `x.ndim` would insert a dequant
befor the `ndim`. This caused a crash in convert if there
was a quantized op using the output of `x`.

After this PR, `x.ndim` can happen without dequantizing x.

Test Plan:

```
python test/test_quantization.py TestQuantizeFx.test_quant_op_after_ndim
```

Reviewers:

Subscribers:

Tasks:

Tags: