### PR TITLE
fx quant: failing test case for quant op after expand

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -2396,6 +2396,25 @@ class TestQuantizeFx(QuantizationTestCase):
         mc = convert_fx(mp)
         # if the above code does not crash, the test is successful
 
+    def test_quant_op_after_expand_as(self):
+        # TODO(before land): make the test pass
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(1, 1, 1)
+
+            def forward(self, x):
+                x = self.conv(x)
+                x1 = x.expand_as(x)
+                x2 = torch.add(x, x1)
+                return x2
+
+        m = M().eval()
+        mp = prepare_fx(m, {"": default_qconfig})
+        print(mp)
+        mc = convert_fx(mp)
+        # if the above code does not crash, the test is successful
+
 
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59895 fx quant: failing test case for quant op after expand**
* #59894 fx quant: fix bug with quant op after ndim

Summary:

Currently this crashes in convert because
* the input to expand is fp32, so a dequant is inserted
* the inserted dequant overrides the name of the original node in `env`
* if the next op is quantized, there is a crash of dtype mismatch

Fixes could be:
* key env by (node.name, dtype)
* move to modifying the graph inplace instead of copying over with env

Test Plan:

TODO

Reviewers:

Subscribers:

Tasks:

Tags: