### PR TITLE
Fix bad change in a CUDACachingAllocator loop

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1195,7 +1195,7 @@ class THCCachingAllocator {
     const auto size = static_cast<int64_t>(device_allocator.size());
     if (size < device_count) {
       device_allocator.resize(device_count);
-      for (const auto i : c10::irange(device_count)) {
+      for (const auto i : c10::irange(size, device_count)) {
         device_allocator[i] = std::unique_ptr<DeviceCachingAllocator>(
             new DeviceCachingAllocator());
       }


### PR DESCRIPTION
Summary: D29034650 (https://github.com/pytorch/pytorch/commit/cf0c4ac25811cf93e51b4be6eb58bbdb95963b3b) probably breaks something because it changes a for loop from `[size,max)` to `[0,max)`. This fixes that

Test Plan: Sandcastle

Differential Revision: D29081688

