### PR TITLE
Foreach Binary Test Refactor

### DIFF
--- a/aten/src/ATen/native/BinaryOps.h
+++ b/aten/src/ATen/native/BinaryOps.h
@@ -29,7 +29,7 @@ inline void sub_check(const Tensor& self, const Tensor& other) {
 
 inline void sub_check(const Tensor& self, const Scalar& scalar) {
   TORCH_CHECK(self.scalar_type() != kBool || !scalar.isBoolean(),
-              "Subtraction, the `-` operator, with two bool tensors is not supported."
+              "Subtraction, the `-` operator, with two bool tensors is not supported. "
               "Use the `^` or `logical_xor()` operator instead.")
   TORCH_CHECK(self.scalar_type() != kBool && !scalar.isBoolean(),
               "Subtraction, the `-` operator, with a bool tensor is not supported. "

--- a/aten/src/ATen/native/ForeachUtils.h
+++ b/aten/src/ATen/native/ForeachUtils.h
@@ -65,20 +65,6 @@ void check_foreach_api_restrictions(TensorList tensors1, TensorList tensors2, Te
 // - All tensors must be non-overlapping and dense
 // - Resulting tensor must have the same dtype as the input one
 
-// TODO(mkozuki): Consider whether we really need this function or not.
-// Note that, there is a possibility that foreach fastpath supports type promotion in the future,
-// which might complicate the functionality this function should provides.
-// However, as of now, the check of division op with integer inputs is duplicated.
-// `check_fast_path_restrictions` does the same thing in it before calling this function.
-bool will_promote_tensor(const Tensor& tensor, const Scalar& scalar, bool does_op_promote_integer_inputs_to_float = false) {
-  // In case of division, integer inputs will result in float
-  if (does_op_promote_integer_inputs_to_float &&
-      at::isIntegralType(tensor.scalar_type(), /* includeBool */ true)) {
-    return true;
-  }
-  return tensor.scalar_type() != at::native::result_type(scalar, tensor);
-}
-
 // Please, make sure to call check_foreach_api_restrictions before calling this method.
 // There is a set of preconditions that have to be satisfied.
 bool check_fast_path_restrictions(
@@ -114,29 +100,21 @@ bool check_fast_path_restrictions(
 
     // This function has already checked that `tensorList[j][i]` for all j, i has the same dtype
     // using `is_tensor_okay` function above.
-    // checked by `check_foreach_api_restrictions`).
     // This means we only need to check if {tensorList[0][0], tensorList[0][1], tensorList[0][2], ...}
     // do type promotion with scalarLIst.
     for (const auto i : c10::irange(tensorLists[0].size())) {
+      // For division, integer inputs will result in float.
       if (does_op_promote_integer_inputs_to_float) {
         if (at::isIntegralType(tensorLists[0][i].scalar_type(), /*includeBool*/ true)) {
           return false;
         }
       }
-
-      if (scalarList.size() == 1) {
-        if (will_promote_tensor(tensorLists[0][i], scalarList[0])) {
-          return false;
-        }
-      } else if (scalarList.size() > 1) {
-        // FIXME(mkozuki): Consider specializing `TensorListScalarListMetadata` for complex dtypes
-        // to access the following comment.
-        // Complex scalar list is not supported due to the limit for kernel launch argument (4KB)
-        if (scalarList[i].isComplex()) {
-          return false;
-        }
-
-        if (will_promote_tensor(tensorLists[0][i], scalarList[i])) {
+      if (scalarList.size() > 0) {
+        const auto& scalar = scalarList.size() == 1 ? scalarList[0] : scalarList[i];
+        const auto& tensor = tensorLists[0][i];
+        // note(mkozuki): This check might be responsible for `_foreach_add(bool_tensors, bool_tensors)`
+        // being pushed to slow path.
+        if (tensor.scalar_type() != at::native::result_type(scalar, tensor)) {
           return false;
         }
       }

--- a/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
+++ b/aten/src/ATen/native/cuda/ForeachBinaryOpScalarList.cu
@@ -17,7 +17,7 @@ std::vector<Tensor> foreach_binary_op(TensorList tensors, at::ArrayRef<Scalar> s
     tensor_lists.emplace_back(tensors.vec());
     tensor_lists.emplace_back(vec_res);
 
-    AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBFloat16, kHalf, kBool, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<2, opmath_t>(tensor_lists,
                                         scalars,
@@ -36,7 +36,7 @@ void foreach_binary_op_(TensorList tensors, at::ArrayRef<Scalar> scalars) {
     std::vector<std::vector<at::Tensor>> tensor_lists;
     tensor_lists.emplace_back(tensors.vec());
 
-    AT_DISPATCH_ALL_TYPES_AND3(kBFloat16, kHalf, kBool, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kBFloat16, kHalf, kBool, tensors[0].scalar_type(), "foreach_binary_op_scalarlist_cuda_", [&]() {
         using opmath_t = get_opmath_t<scalar_t>::opmath_t;
         multi_tensor_apply<1, opmath_t>(tensor_lists,
                                         scalars,

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -46,6 +46,9 @@ template<typename scalar_vals_t, int n> struct TensorListScalarListMetadata
   int block_to_chunk[depth_to_max_blocks[n-1]];
 };
 
+// note(mkozuki): `n` of 96 and `scalar_vals_t` of `c10::complex<double>`
+// violates the cuda kernel argument size limitation of 4kb.
+// 80 is a number that does not violate this limitation.
 template<> struct TensorListScalarListMetadata<c10::complex<double>, 1>
 {
   void* addresses[1][80];

--- a/aten/src/ATen/native/cuda/MultiTensorApply.cuh
+++ b/aten/src/ATen/native/cuda/MultiTensorApply.cuh
@@ -46,6 +46,15 @@ template<typename scalar_vals_t, int n> struct TensorListScalarListMetadata
   int block_to_chunk[depth_to_max_blocks[n-1]];
 };
 
+template<> struct TensorListScalarListMetadata<c10::complex<double>, 1>
+{
+  void* addresses[1][80];
+  int numel_for_tensor[80];
+  c10::complex<double> scalar_vals[80];
+  unsigned char block_to_tensor[depth_to_max_blocks[1-1]];
+  int block_to_chunk[depth_to_max_blocks[1-1]];
+};
+
 template<typename T, typename U, typename... ArgTypes>
 C10_LAUNCH_BOUNDS_1(kBlockSize)
 __global__ void

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -572,7 +572,7 @@ class TestForeach(TestCase):
         # different strides
         tensor1 = torch.zeros(10, 10, device=device, dtype=dtype)
         tensor2 = torch.ones(10, 10, device=device, dtype=dtype)
-        inputs = ([tensor1], [tensor2])
+        inputs = ([tensor1], [tensor2.t()])
         self._binary_test(dtype, foreach_op, native_op, inputs, is_fastpath=False, is_inplace=False)
         self._binary_test(dtype, foreach_op_, native_op_, inputs, is_fastpath=False, is_inplace=True)
 

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -486,7 +486,7 @@ class TestForeach(TestCase):
     @skipMeta
     @dtypes(torch.float)
     @ops(foreach_binary_op_db)
-    def test_binary_op_scalar_with_different_tensor_dtypes(self, device, _, op):
+    def test_binary_op_scalar_with_different_tensor_dtypes(self, device, dtype, op):
         foreach_op = op.method_variant
         tensors = [torch.tensor([1.1], dtype=torch.float, device=device),
                    torch.tensor([1], dtype=torch.long, device=device)]

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -587,7 +587,7 @@ class TestForeach(TestCase):
             foreach_op_(tensors1, tensors2)
 
         # different devices
-        if torch.cuda.is_available() and torch.cuda.device_count() > 1:
+        if self.device_type == "cuda" and torch.cuda.device_count() > 1:
             tensor1 = torch.zeros(10, 10, device="cuda:0", dtype=dtype)
             tensor2 = torch.ones(10, 10, device="cuda:1", dtype=dtype)
             if dtype == torch.bool and foreach_op == torch._foreach_sub:

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -128,10 +128,11 @@ class TestForeach(TestCase):
 
     # note(mkozuki): Why ROCm?
     # ROCm is supposed to compile slow path as in
-    # https://github.com/pytorch/pytorch/blob/7e032f18cf1405804c4f787b05ea2de5e08a091e/aten/src/ATen/native/ForeachUtils.h#L148-L164,
-    # Therefore `[torch.add(*args, alpha=alpha) for args in zip(tensors1, tensors2)]` and `torch._foreach_add(tensors1, tensors2, alpha=alpha)`
+    # https://github.com/pytorch/pytorch/blob/7e032f18cf1405804c4f787b05ea2de5e08a091e/aten/src/ATen/native/ForeachUtils.h#L148-L164,  # noqa: E501
+    # Therefore `[torch.add(*args, alpha=alpha) for args in zip(tensors1, tensors2)]` and
+    # `torch._foreach_add(tensors1, tensors2, alpha=alpha)`
     # are expected to return the same outputs, however, the outputs look unstable for torch.bfloat16 and torch.half.
-    # Failure: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-bionic-rocm4.2-py3.6-test1/2741/console
+    # log: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-bionic-rocm4.2-py3.6-test1/2741/console
     @skipCUDAIfRocm
     @skipMeta
     @ops(foreach_binary_op_db)

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -382,7 +382,7 @@ class TestForeach(TestCase):
             self.assertEqual(copied_inputs, inputs)
 
     def _test_unary(self, device, dtype, opinfo, N, is_fastpath):
-        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo)
+        op, ref, inplace_op, inplace_ref = self._get_funcs(opinfo, 1)
         inputs = opinfo.sample_inputs(device, dtype, N, noncontiguous=not is_fastpath),
         # note(mkozuki): Complex inputs for `_foreach_abs` go through slowpath.
         if opinfo.name == "_foreach_abs" and dtype in torch.testing.get_all_complex_dtypes():
@@ -648,7 +648,7 @@ class TestForeach(TestCase):
     def test_unary_op_tensors_on_different_devices(self, device, dtype, op):
         if self.device_type != 'cuda':
             self.skipTest('CUDA is necessary for tests with tensors on different devices')
-        method, ref, inplace_method, ref_inplace = self._get_funcs(op)
+        method, ref, inplace_method, ref_inplace = self._get_funcs(op, 1)
         # tensors: ['cuda', 'cpu]
         tensors = op.sample_inputs(device, dtype, 2)
         tensors[1] = tensors[1].to('cpu')

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -172,7 +172,13 @@ class TestForeach(TestCase):
         self._regular_binary_test(dtype, op, ref, inputs, is_fastpath)
         self._inplace_binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath)
         if opinfo.supports_alpha_param:
-            alpha = 3 if dtype in torch.testing.get_all_int_dtypes() else 3.14
+            alpha = None
+            if dtype in torch.testing.get_all_int_dtypes():
+                alpha = 3
+            elif dtype.is_complex:
+                dtype = complex(3, 3)
+            else:
+                alpha = 3.14
             self._regular_binary_test(dtype, op, ref, inputs, is_fastpath, alpha=alpha)
             self._inplace_binary_test(dtype, inplace_op, inplace_ref, inputs, is_fastpath, alpha=alpha)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -2683,9 +2683,11 @@ class ShapeFuncInfo(OpInfo):
                                             **kwargs)
         self.ref = ref
 
-def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False):
-    tensors = [make_tensor((N - i, N - i), device, dtype, noncontiguous=noncontiguous) for i in range(N)]
-    return tensors
+def sample_inputs_foreach(self, device, dtype, N, *, noncontiguous=False, same_size=False):
+    if same_size:
+        return [make_tensor((N, N), device, dtype, noncontiguous=noncontiguous) for _ in range(N)]
+    else:
+        return [make_tensor((N - i, N - i), device, dtype, noncontiguous=noncontiguous) for i in range(N)]
 
 
 def get_foreach_method_names(name):
@@ -2709,6 +2711,7 @@ class ForeachFuncInfo(OpInfo):
                  dtypesIfCUDA=floating_and_complex_types_and(torch.half),
                  dtypesIfROCM=None,
                  safe_casts_outputs=True,
+                 supports_alpha_param=False,
                  sample_inputs_func=sample_inputs_foreach,
                  **kwargs):
         super().__init__(
@@ -2727,6 +2730,7 @@ class ForeachFuncInfo(OpInfo):
         self.inplace_variant = foreach_method_inplace
         self.ref = torch_ref_method
         self.ref_inplace = torch_ref_inplace
+        self.supports_alpha_param = supports_alpha_param
 
 
 def sample_inputs_linalg_cholesky_inverse(op_info, device, dtype, requires_grad=False):
@@ -4641,6 +4645,31 @@ foreach_unary_op_db: List[OpInfo] = [
         dtypesIfCUDA=all_types_and_complex_and(torch.bfloat16, torch.half, torch.bool),
         safe_casts_outputs=False,
         supports_forward_ad=True,
+    ),
+]
+
+foreach_binary_op_db: List[OpInfo] = [
+    ForeachFuncInfo(
+        "add",
+        dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        supports_alpha_param=True,
+    ),
+    ForeachFuncInfo(
+        "sub",
+        dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        supports_alpha_param=True,
+    ),
+    ForeachFuncInfo(
+        "mul",
+        dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+    ),
+    ForeachFuncInfo(
+        "div",
+        dtypesIfCPU=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
+        dtypesIfCUDA=all_types_and_complex_and(torch.bool, torch.bfloat16, torch.float16),
     ),
 ]
 


### PR DESCRIPTION
Related: https://github.com/pytorch/pytorch/issues/58833

## Changes I'm a bit concerned
- binary ops with one tensorlist and one scalarlist support complex dtypes. To realize this, I added a specialization of [`TensorListScalarListMetadata<c10::complex<double>, 1>` ](https://github.com/pytorch/pytorch/pull/59907/files#diff-131eb9b310905b15b3528da6a23e542a3a3aa952bc88f7423c98a23a8a28cca1R49). This might be out of the scope of this pull request.


cc @ptrblck @ngimel @mcarilli 