### PR TITLE
[TensorExpr] Python binding improvements

### DIFF
--- a/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
+++ b/torch/csrc/jit/tensorexpr/tensorexpr_init.cpp
@@ -47,6 +47,7 @@ ArgValue convertPyToArgValue(py::handle inp) {
     throw std::runtime_error("nyi");
   }
 }
+
 void initTensorExprBindings(PyObject* module) {
   auto m = py::handle(module).cast<py::module>();
 
@@ -653,13 +654,29 @@ void initTensorExprBindings(PyObject* module) {
   py::class_<CodeGen>(te, "CodeGen")
       .def(
           "call",
-          [](CodeGen& self, const std::vector<at::Tensor>& values) {
+          [](CodeGen& self, const py::sequence& values) {
             std::vector<CodeGen::CallArg> value_ptrs;
-            value_ptrs.reserve(values.size());
+            value_ptrs.reserve(py::len(values));
             for (const auto& value : values) {
-              value_ptrs.emplace_back(CodeGen::CallArg(value.data_ptr()));
+              if (py::isinstance<py::int_>(value)) {
+                value_ptrs.emplace_back(value.cast<int64_t>());
+              } else {
+                value_ptrs.emplace_back(value.cast<at::Tensor>().data_ptr());
+              }
             }
             self.call(value_ptrs);
+          })
+      .def(
+          "call_raw",
+          [](CodeGen& self, const py::sequence& values) {
+            std::vector<void*> value_ptrs;
+            value_ptrs.reserve(py::len(values));
+            for (const auto& value : values) {
+              // Tensor.data_ptr() returns an int in python
+              value_ptrs.emplace_back(
+                  reinterpret_cast<void*>(value.cast<intptr_t>()));
+            }
+            self.call_raw(value_ptrs);
           })
       .def(
           "get_code_text",
@@ -677,6 +694,11 @@ void initTensorExprBindings(PyObject* module) {
       .def(py::init<Tensor*>())
       .def(py::init<const VarHandle&>())
       .def(py::init<const BufHandle&>());
+
+  py::implicitly_convertible<Placeholder, CodeGen::BufferArg>();
+  py::implicitly_convertible<Tensor*, CodeGen::BufferArg>();
+  py::implicitly_convertible<VarHandle, CodeGen::BufferArg>();
+  py::implicitly_convertible<BufHandle, CodeGen::BufferArg>();
 
   te.def(
       "construct_codegen",
@@ -696,8 +718,11 @@ void initTensorExprBindings(PyObject* module) {
 #else
           throw std::runtime_error("PyTorch not compiled with CUDA support!");
 #endif
-        } else {
+        } else if (name == "ir_eval") {
           cg = new SimpleIREvaluator(stmt, args);
+        } else {
+          throw std::runtime_error(
+              "construct_codegen() expects 'llvm', 'cuda', or 'ir_eval'");
         }
         return cg;
       });


### PR DESCRIPTION
Some minor quality of life improvements for the NNC python bindings:
- expose `call_raw()`
- support passing integers to `call()` (for dynamic shapes)
- implicit conversions to cleanup `[BufferArg(x) for x in [A, B, C]]` into just `[A, B, C]`
- don't silently default to "ir_eval" for unknown mode (e.g. "LLVM")