### PR TITLE
[TensorExpr] Add error checking in mem_arena

### DIFF
--- a/test/test_tensorexpr_pybind.py
+++ b/test/test_tensorexpr_pybind.py
@@ -304,6 +304,9 @@ graph(%a : Float(1, 3, 1, strides=[3, 1, 1], requires_grad=0, device=cpu)):
         np.testing.assert_allclose(res1.numpy(), correct.numpy(), atol=2e-3)
         np.testing.assert_allclose(res2.numpy(), correct.numpy(), atol=2e-3)
 
+    def test_forgot_kernel_arena(self):
+        self.assertRaises(RuntimeError, lambda: torch._C._te.VarHandle("n", torch._C._te.Dtype.Int))
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/csrc/jit/tensorexpr/mem_arena.h
+++ b/torch/csrc/jit/tensorexpr/mem_arena.h
@@ -36,10 +36,10 @@ class KernelScope {
   KernelScope& operator=(const KernelScope&) = delete;
 
  private:
-  KernelArena* old_kernel_arena_ =
-      nullptr; // previous arena, will be restored in destructor
-  bool owning_ = false; // determines whether the arena will be freed along with
-                        // the scope object
+  KernelArena* kernel_arena_; // maybe owned
+  KernelArena* old_kernel_arena_; // previous arena, restored in destructor
+  bool owning_; // determines whether the arena will be freed along with
+                // the scope object
 };
 
 // The base object managed by the Kernel.


### PR DESCRIPTION
Gives an error message (rather than a segfault) if you forget `KernelScope()`.