### PR TITLE
Implement a generic Distribution.expand() and use it in a few places

### DIFF
--- a/torch/distributions/binomial.py
+++ b/torch/distributions/binomial.py
@@ -50,19 +50,9 @@ class Binomial(Distribution):
         batch_shape = self._param.size()
         super(Binomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Binomial, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.total_count = self.total_count.expand(batch_shape)
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(batch_shape)
-            new._param = new.probs
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
-        super(Binomial, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+    @property
+    def _param(self):
+        return self.__dict__.get("probs", self.__dict__.get("logits"))
 
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)

--- a/torch/distributions/cauchy.py
+++ b/torch/distributions/cauchy.py
@@ -36,15 +36,6 @@ class Cauchy(Distribution):
             batch_shape = self.loc.size()
         super(Cauchy, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Cauchy, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.loc = self.loc.expand(batch_shape)
-        new.scale = self.scale.expand(batch_shape)
-        super(Cauchy, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     @property
     def mean(self):
         return torch.full(self._extended_shape(), nan, dtype=self.loc.dtype, device=self.loc.device)

--- a/torch/distributions/chi2.py
+++ b/torch/distributions/chi2.py
@@ -21,6 +21,7 @@ class Chi2(Gamma):
     def __init__(self, df, validate_args=None):
         super(Chi2, self).__init__(0.5 * df, 0.5, validate_args=validate_args)
 
+    # FIXME
     def expand(self, batch_shape, _instance=None):
         new = self._get_checked_instance(Chi2, _instance)
         return super(Chi2, self).expand(batch_shape, new)

--- a/torch/distributions/continuous_bernoulli.py
+++ b/torch/distributions/continuous_bernoulli.py
@@ -62,19 +62,9 @@ class ContinuousBernoulli(ExponentialFamily):
         self._lims = lims
         super(ContinuousBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(ContinuousBernoulli, _instance)
-        new._lims = self._lims
-        batch_shape = torch.Size(batch_shape)
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(batch_shape)
-            new._param = new.probs
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
-        super(ContinuousBernoulli, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+    @property
+    def _param(self):
+        return self.__dict__.get("probs", self.__dict__.get("logits"))
 
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)

--- a/torch/distributions/dirichlet.py
+++ b/torch/distributions/dirichlet.py
@@ -51,14 +51,6 @@ class Dirichlet(ExponentialFamily):
         batch_shape, event_shape = concentration.shape[:-1], concentration.shape[-1:]
         super(Dirichlet, self).__init__(batch_shape, event_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Dirichlet, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.concentration = self.concentration.expand(batch_shape + self.event_shape)
-        super(Dirichlet, new).__init__(batch_shape, self.event_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def rsample(self, sample_shape=()):
         shape = self._extended_shape(sample_shape)
         concentration = self.concentration.expand(shape)

--- a/torch/distributions/distribution.py
+++ b/torch/distributions/distribution.py
@@ -85,7 +85,7 @@ class Distribution(object):
                 event_shape = old_param.shape[:old_param.dim() - constraint.event_dim]
                 new_param = old_param.expand(batch_shape + event_shape)
                 setattr(new, name, new_param)
-        Distribution.__init__(batch_shape, self.event_shape, validate_args=False)
+        Distribution.__init__(new, batch_shape, self.event_shape, validate_args=False)
         new._validate_args = self._validate_args
         return new
 

--- a/torch/distributions/exponential.py
+++ b/torch/distributions/exponential.py
@@ -41,14 +41,6 @@ class Exponential(ExponentialFamily):
         batch_shape = torch.Size() if isinstance(rate, Number) else self.rate.size()
         super(Exponential, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Exponential, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.rate = self.rate.expand(batch_shape)
-        super(Exponential, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         if torch._C._get_tracing_state():

--- a/torch/distributions/gamma.py
+++ b/torch/distributions/gamma.py
@@ -47,15 +47,6 @@ class Gamma(ExponentialFamily):
             batch_shape = self.concentration.size()
         super(Gamma, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Gamma, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.concentration = self.concentration.expand(batch_shape)
-        new.rate = self.rate.expand(batch_shape)
-        super(Gamma, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         value = _standard_gamma(self.concentration.expand(shape)) / self.rate.expand(shape)

--- a/torch/distributions/half_cauchy.py
+++ b/torch/distributions/half_cauchy.py
@@ -33,10 +33,6 @@ class HalfCauchy(TransformedDistribution):
         super(HalfCauchy, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(HalfCauchy, _instance)
-        return super(HalfCauchy, self).expand(batch_shape, _instance=new)
-
     @property
     def scale(self):
         return self.base_dist.scale

--- a/torch/distributions/half_normal.py
+++ b/torch/distributions/half_normal.py
@@ -32,10 +32,6 @@ class HalfNormal(TransformedDistribution):
         super(HalfNormal, self).__init__(base_dist, AbsTransform(),
                                          validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(HalfNormal, _instance)
-        return super(HalfNormal, self).expand(batch_shape, _instance=new)
-
     @property
     def scale(self):
         return self.base_dist.scale

--- a/torch/distributions/laplace.py
+++ b/torch/distributions/laplace.py
@@ -43,15 +43,6 @@ class Laplace(Distribution):
             batch_shape = self.loc.size()
         super(Laplace, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Laplace, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.loc = self.loc.expand(batch_shape)
-        new.scale = self.scale.expand(batch_shape)
-        super(Laplace, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def rsample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         finfo = torch.finfo(self.loc.dtype)

--- a/torch/distributions/lkj_cholesky.py
+++ b/torch/distributions/lkj_cholesky.py
@@ -69,6 +69,7 @@ class LKJCholesky(Distribution):
         super(LKJCholesky, self).__init__(batch_shape, event_shape, validate_args)
 
     def expand(self, batch_shape, _instance=None):
+        # This needs a custom .expand() because the dim arg is not in arg_constraints.
         new = self._get_checked_instance(LKJCholesky, _instance)
         batch_shape = torch.Size(batch_shape)
         new.dim = self.dim

--- a/torch/distributions/log_normal.py
+++ b/torch/distributions/log_normal.py
@@ -30,10 +30,6 @@ class LogNormal(TransformedDistribution):
         base_dist = Normal(loc, scale, validate_args=validate_args)
         super(LogNormal, self).__init__(base_dist, ExpTransform(), validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(LogNormal, _instance)
-        return super(LogNormal, self).expand(batch_shape, _instance=new)
-
     @property
     def loc(self):
         return self.base_dist.loc

--- a/torch/distributions/logistic_normal.py
+++ b/torch/distributions/logistic_normal.py
@@ -38,10 +38,6 @@ class LogisticNormal(TransformedDistribution):
                                              StickBreakingTransform(),
                                              validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(LogisticNormal, _instance)
-        return super(LogisticNormal, self).expand(batch_shape, _instance=new)
-
     @property
     def loc(self):
         return self.base_dist.base_dist.loc

--- a/torch/distributions/negative_binomial.py
+++ b/torch/distributions/negative_binomial.py
@@ -38,19 +38,9 @@ class NegativeBinomial(Distribution):
         batch_shape = self._param.size()
         super(NegativeBinomial, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(NegativeBinomial, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.total_count = self.total_count.expand(batch_shape)
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(batch_shape)
-            new._param = new.probs
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
-        super(NegativeBinomial, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+    @property
+    def _param(self):
+        return self.__dict__.get("probs", self.__dict__.get("logits"))
 
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)

--- a/torch/distributions/normal.py
+++ b/torch/distributions/normal.py
@@ -49,15 +49,6 @@ class Normal(ExponentialFamily):
             batch_shape = self.loc.size()
         super(Normal, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Normal, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.loc = self.loc.expand(batch_shape)
-        new.scale = self.scale.expand(batch_shape)
-        super(Normal, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():

--- a/torch/distributions/poisson.py
+++ b/torch/distributions/poisson.py
@@ -43,14 +43,6 @@ class Poisson(ExponentialFamily):
             batch_shape = self.rate.size()
         super(Poisson, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Poisson, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.rate = self.rate.expand(batch_shape)
-        super(Poisson, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     def sample(self, sample_shape=torch.Size()):
         shape = self._extended_shape(sample_shape)
         with torch.no_grad():

--- a/torch/distributions/relaxed_bernoulli.py
+++ b/torch/distributions/relaxed_bernoulli.py
@@ -47,19 +47,9 @@ class LogitRelaxedBernoulli(Distribution):
             batch_shape = self._param.size()
         super(LogitRelaxedBernoulli, self).__init__(batch_shape, validate_args=validate_args)
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(LogitRelaxedBernoulli, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.temperature = self.temperature
-        if 'probs' in self.__dict__:
-            new.probs = self.probs.expand(batch_shape)
-            new._param = new.probs
-        if 'logits' in self.__dict__:
-            new.logits = self.logits.expand(batch_shape)
-            new._param = new.logits
-        super(LogitRelaxedBernoulli, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
+    @property
+    def _param(self):
+        return self.__dict__.get("probs", self.__dict__.get("logits"))
 
     def _new(self, *args, **kwargs):
         return self._param.new(*args, **kwargs)
@@ -119,10 +109,6 @@ class RelaxedBernoulli(TransformedDistribution):
         super(RelaxedBernoulli, self).__init__(base_dist,
                                                SigmoidTransform(),
                                                validate_args=validate_args)
-
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(RelaxedBernoulli, _instance)
-        return super(RelaxedBernoulli, self).expand(batch_shape, _instance=new)
 
     @property
     def temperature(self):

--- a/torch/distributions/uniform.py
+++ b/torch/distributions/uniform.py
@@ -50,15 +50,6 @@ class Uniform(Distribution):
         if self._validate_args and not torch.lt(self.low, self.high).all():
             raise ValueError("Uniform is not defined when low>= high")
 
-    def expand(self, batch_shape, _instance=None):
-        new = self._get_checked_instance(Uniform, _instance)
-        batch_shape = torch.Size(batch_shape)
-        new.low = self.low.expand(batch_shape)
-        new.high = self.high.expand(batch_shape)
-        super(Uniform, new).__init__(batch_shape, validate_args=False)
-        new._validate_args = self._validate_args
-        return new
-
     @constraints.dependent_property(is_discrete=False, event_dim=0)
     def support(self):
         return constraints.interval(self.low, self.high)


### PR DESCRIPTION
This aims to make it easier to implement new distributions by providing a best-effort default implementation of `Distribution.expand()`, which is possible with the new `Constraint.event_dim` metadata provided by #50581 and #51369.  While this simple default implementation does not work in all cases, this PR aims to support the following common cases of new distributions (only some of which currently work; discussion needed):
- [x] All the distribution's data is stored as instance attributes described by `.arg_constraints` (e.g. Normal, Cauchy, Poisson);
- [ ] The distribution `.__init__()` simply constructs a `base_dist` and `tansforms` and passes those to `TransformedDistribution.__init__()`;
- [ ] The distribution inherits from another distribution and the `.__init__()` method simply changes parameters (e.g. Chi2)

To make this work, I've refactored some instance attributes such as `._param` and `._event_ndim` to be properties or lazy properties.

## Questions for reviewers
- [ ] Should we weaken the check in [Distribution._get_checked_instance()](https://github.com/pytorch/pytorch/blob/68d690ffbd64d0fb697dc3da1635216366649787/torch/distributions/distribution.py#L279)?
- [ ] How should we document and check whether the default `.expand()` works correctly?

cc @neerajprad @fehiepsi 