### PR TITLE
[quant] Input-Weight Equalization - convert modifications

### DIFF
--- a/test/quantization/fx/test_equalize_fx.py
+++ b/test/quantization/fx/test_equalize_fx.py
@@ -2,12 +2,13 @@ import torch
 import torch.nn as nn
 from torch.quantization import default_qconfig
 from torch.quantization.observer import MinMaxObserver, PerChannelMinMaxObserver
-from torch.quantization.quantize_fx import prepare_fx
+from torch.quantization.quantize_fx import prepare_fx, convert_fx
 from torch.quantization.fx._equalize import (
     _InputEqualizationObserver,
     _WeightEqualizationObserver,
     calculate_equalization_scale,
     default_equalization_qconfig,
+    _convert_equalization_ref
 )
 
 from torch.testing._internal.common_quantization import NodeSpec as ns
@@ -238,3 +239,62 @@ class TestEqualizeFx(QuantizationTestCase):
             m = M().eval()
             prepared = prepare_fx(m, qconfig_dict, equalization_qconfig_dict=equalization_qconfig_dict)
             self.checkGraphModuleNodes(prepared, expected_node_occurrence=node_occurrence)
+
+    def test_input_weight_equalization_convert(self):
+        """
+        """
+        qconfig_dict = {"": None, 
+                        "object_type": [(nn.Linear, default_qconfig), 
+                                        (nn.functional.linear, default_qconfig)]}
+
+        default_equalization_qconfig_dict = {
+            "": default_qconfig,
+            "object_type": [(nn.Linear, default_equalization_qconfig),
+                            (nn.functional.linear, default_equalization_qconfig)]
+        }
+
+        fp32_equalization_qconfig_dict = {
+            "": None,
+            "object_type": [(nn.Linear, default_equalization_qconfig),
+                            (nn.functional.linear, default_equalization_qconfig)]
+        }
+
+        # Basic test with one linear layer
+        class LinearModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(2, 2)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        # Test with two linear layer with a fp32 operation between
+        class Linear2FP32Module(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = nn.Linear(2, 2)
+                self.linear2 = nn.Linear(2, 2)
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = torch.add(x, torch.tensor([1, 2]))
+                x = self.linear2(x)
+                return x
+
+        tests = [(LinearModule, default_equalization_qconfig_dict), 
+                 (Linear2FP32Module, fp32_equalization_qconfig_dict)]
+        for (M, equalization_qconfig_dict) in tests:
+            m = M().eval()
+            x = torch.tensor([[1.0, 2.0], [2.0, 2.5], [4.5, 6.0]])
+            prepared = prepare_fx(m, qconfig_dict, equalization_qconfig_dict=equalization_qconfig_dict)
+            output = prepared(x)
+
+            convert_ref = _convert_equalization_ref(prepared)
+            convert_ref_output = convert_ref(x)
+
+            m = M().eval()
+            prepared = prepare_fx(m, qconfig_dict, equalization_qconfig_dict=equalization_qconfig_dict)
+            prepared(x)
+            convert_fx(prepared)  # Check if compile?
+
+            self.assertEqual(output, convert_ref_output)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -80,10 +80,7 @@ except ImportError:
     pass
 
 # Equalization for FX mode
-try:
-    from quantization.fx.test_equalize_fx import TestEqualizeFx  # noqa: F401
-except ImportError:
-    pass
+from quantization.fx.test_equalize_fx import TestEqualizeFx  # noqa: F401
 
 # Backward Compatibility. Tests serialization and BC for quantized modules.
 from quantization.bc.test_backward_compatibility import TestSerialization  # noqa: F401

--- a/torch/quantization/fx/_equalize.py
+++ b/torch/quantization/fx/_equalize.py
@@ -1,15 +1,17 @@
 import torch
 import torch.nn as nn
-
+from torch.fx import GraphModule
 from torch.fx.graph import Node
 
 from ..observer import (
     PerChannelMinMaxObserver,
     _with_args, 
+    ObserverBase
 )
 from ..utils import check_min_max_valid
 
 from collections import namedtuple
+from typing import Dict
 import warnings
 
 
@@ -220,3 +222,199 @@ def node_supports_equalization(node: Node, modules) -> bool:
     elif node.op == 'call_function':
         return node.target == nn.functional.linear
     return False
+
+def get_weight_eq_obs(node: Node, model: GraphModule, modules: Dict[str, nn.Module]):
+    """ Gets the following weight equalization observer. There should always
+    exsist a weight equalization observer after an input equalization observer.
+
+    Returns the node containing the weight equalization observer, and the weight
+    equalization observer if it has been newly created
+    """
+
+    # Find the next node that is either a nn.Linear or a functional layer
+    while (node.op not in ('output', 'call_function') and not
+           (node.op == 'call_module' and isinstance(modules[node.target], nn.Linear))):
+        node = node.next
+
+    if node.op == 'call_module':
+        # If the next node is a nn.Linear layer, then it must have a
+        # WeightEqualizationObserver configuration
+
+        assert(model._equalization_qconfig_map.get(node.name, None) is not None)
+
+        weight_eq_obs = model._equalization_qconfig_map.get(node.name, None).weight()
+        assert(isinstance(weight_eq_obs, _WeightEqualizationObserver))
+        # TODO: Maybe we should check that this weight observer comes somewhat
+        # directly after the given InputEqualizationObserver node, but I'm not sure
+        # how to check that
+        return node, weight_eq_obs
+
+    elif node.op == 'call_function':
+        # TODO do something
+        return None, None
+
+    return None, None
+
+def get_next_input_obs(node: Node, modules: Dict[str, nn.Module]):
+    """ Gets the following input observer. We can use this function for both
+    obtaining the next input equalization observer and the next input
+    quantization observer
+
+    Returns the node containing the input observer, and the input observer
+    """
+    node = node.next
+    while node.op not in ('call_module', 'call_function', 'output'):
+        node = node.next
+    if node.op in ('output', 'call_function'):
+        return None, None
+    input_obs = modules[node.target]
+    return node, input_obs
+
+def get_next_equalization_scale(node: Node, modules: Dict[str, nn.Module]) -> torch.tensor:
+    """ If the next next node is an InputEqualizationObserver then we want to
+    return its equalization scale, else we return 1
+
+    This is used in the case where there are two connecting linear layers:
+        linear1 -> LinearOutObs -> InputEqObs -> linear2
+    In this case, the node given is linear1 and we want to locate the InputEqObs.
+    """
+    # TODO: This code seems a little hacky/hard-coded, so any suggestions for
+    # how to improve it would be greatly appreciated!
+    next_node, _ = get_next_input_obs(node, modules)
+    _, next_next_obs = get_next_input_obs(next_node, modules)
+    if isinstance(next_next_obs, _InputEqualizationObserver):
+        return next_next_obs.equalization_scale
+    return torch.tensor(1)
+
+def scale_input_node(node: Node, modules: Dict[str, nn.Module]) -> None:
+    """ Scales the following input quantization observer's min/max values by
+    updating the values with the scaled min/max values calculated by the input
+    equalization observer
+    """
+    input_eq_obs = modules[node.target]
+    assert(isinstance(input_eq_obs, _InputEqualizationObserver))
+    _, input_quant_obs = get_next_input_obs(node, modules)
+
+    if not isinstance(input_quant_obs, ObserverBase):
+        return
+
+    min_input_scaled, max_input_scaled = input_eq_obs.calculate_scaled_minmax()
+    input_quant_obs.min_val = min_input_scaled
+    input_quant_obs.max_val = max_input_scaled
+
+def scale_weight_node(
+    node: Node,
+    model: GraphModule, 
+    modules: Dict[str, nn.Module], 
+    equalization_scale: torch.tensor, 
+    next_equalization_scale: torch.tensor,
+) -> None:
+    """ Scale the weights for input-weight equalization by multiplying the
+    weight by 1/equalization_scale and next_equalization_scale
+
+    Args:
+        node: Current node whose weights we want to scale
+        equalization_scale: Current node's calculated equalization scale
+        next_equalization_scale: Next node's calculated equalization scale if
+           the following node needs to be equalized, 1 otherwise
+    """
+    # Scale the weights for input-weight equalization
+    # If the following layer needs to be equalized then we will multiply its scale
+    scaled_weight = torch.mul(modules[node.target].weight, torch.reciprocal(equalization_scale))
+    scaled_weight = torch.mul(scaled_weight, next_equalization_scale)
+    modules[node.target].weight = nn.Parameter(scaled_weight)
+
+    # TODO: The bias may need to be scaled for connecting linear layers
+    scaled_bias = torch.mul(modules[node.target].bias, next_equalization_scale)
+    modules[node.target].bias = nn.Parameter(scaled_bias)
+
+def update_obs_for_equalization(model: GraphModule, modules: Dict[str, nn.Module]) -> Dict[str, _WeightEqualizationObserver]:
+    """ Update all of the observer's equalization scale. For each
+    InputEqualizationObserver, we will find the location of the next
+    WeightEqualizationObserver, create it, and calculate the equalization scale
+    based on the two observers.
+
+    We will then return a dictionary mapping node names to the newly created
+    WeightEqualizationObserver.
+    """
+    weight_eq_obs_dict = {}
+    for node in model.graph.nodes:
+        if node.op == 'call_module' and isinstance(modules[node.target], _InputEqualizationObserver):
+            input_eq_obs = modules[node.target]
+            next_node, weight_eq_obs = get_weight_eq_obs(node, model, modules)
+
+            weight_eq_obs(modules[next_node.target].weight)
+
+            # Calculate and set the equalization scale values
+            equalization_scale = calculate_equalization_scale(input_eq_obs, weight_eq_obs)
+            input_eq_obs.set_equalization_scale(equalization_scale)
+            weight_eq_obs.set_equalization_scale(equalization_scale)
+
+            weight_eq_obs_dict[next_node.name] = weight_eq_obs
+
+    return weight_eq_obs_dict
+
+def convert_eq_obs(model: GraphModule, modules: Dict[str, nn.Module], weight_eq_obs_dict: Dict[str, _WeightEqualizationObserver]) -> None:
+    """ Removes the input equalization observers and replaces them with mul
+    operators whenever applicable. Updates the input quantization observers with
+    the scaled input min/max values. Scales the weights and runs the weight
+    quantization observers with the scaled weights.
+    """
+    for node in model.graph.nodes:
+        if node.op == 'call_module' and isinstance(modules[node.target], _InputEqualizationObserver):
+            prev_node = node.args[0]
+            # TODO: Possible special handling for connected linear layers
+
+            # Update the following input quantization observer's min/max values
+            scale_input_node(node, modules)
+
+            # Replace the InputEqualizationObserver with a mul operator to scale
+            # all input values
+
+            # Create a node containing the equalization scale
+            with model.graph.inserting_after(prev_node):
+                name = node.name + '_scale'
+                setattr(model, name, modules[node.target].equalization_scale)
+                eq_scale_node = model.graph.create_node('get_attr', name)
+
+            # Create a node multiplying the input with the equalization scale
+            with model.graph.inserting_after(eq_scale_node):
+                inputs = (prev_node, eq_scale_node)
+                mul_node = model.graph.create_node("call_function", torch.mul, inputs)
+
+            # Replace the current node with the new mul node
+            orig_users = list(node.users.keys())
+            for user_node in orig_users:
+                user_node.replace_input_with(node, mul_node)
+
+            # Erase the InputEqualizationObserver node
+            model.graph.erase_node(node)
+
+            # Alternatively, instead of lines 379-390, we could do the following:
+            # inputs = (prev_node, eq_scale_node)
+            # node.op = "call_function"
+            # node.target = torch.mul
+            # node.args = tuple(inputs)
+
+        elif weight_eq_obs_dict.get(node.name, None) is not None:
+            weight_eq_obs = weight_eq_obs_dict.get(node.name)
+
+            equalization_scale = weight_eq_obs.equalization_scale
+
+            # Scales the weights and runs the weight quantization observers
+            next_equalization_scale = get_next_equalization_scale(node, modules)
+            scale_weight_node(node, model, modules, 
+                              equalization_scale, next_equalization_scale)
+
+def _convert_equalization_ref(model: GraphModule):
+    """ Reference function which applies changes needed for equalization, but
+    does not quantize the nodes
+    """
+    modules = dict(model.named_modules(remove_duplicate=False))
+
+    # Calculate the equalization scale, update the observers with the scaled
+    # inputs, and scale the weight
+    weight_eq_obs_dict = update_obs_for_equalization(model, modules)
+    convert_eq_obs(model, modules, weight_eq_obs_dict)
+
+    return GraphModule(model, model.graph)

--- a/torch/quantization/fx/convert.py
+++ b/torch/quantization/fx/convert.py
@@ -23,6 +23,7 @@ from .graph_module import (
 from .quantization_patterns import (
     QuantizeHandler,
 )
+from ._equalize import update_obs_for_equalization, convert_eq_obs
 from .utils import (
     is_get_tensor_info_node,
     node_return_type_is_int,
@@ -178,6 +179,11 @@ def _convert(model: GraphModule, is_reference: bool = False,
         model.graph, modules, patterns,
         qconfig_map,
         custom_module_classes=custom_module_classes)
+
+    # Calculate the equalization scale, update the observers with the scaled
+    # inputs, and scale the weight
+    weight_eq_obs_dict = update_obs_for_equalization(model, modules)
+    convert_eq_obs(model, modules, weight_eq_obs_dict)
 
     quantized_graph = Graph()
     env: Dict[str, Tuple[Node, Optional[torch.dtype]]] = {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59955 [quant] Input-Weight Equalization - support for F.linear
* **#59954 [quant] Input-Weight Equalization - convert modifications**
* #59953 [quant] Equalization Observer modifications
* #59747 [quant] Input Weight Equalization - prepare modifications
* #59739 [quant] EqualizationQConfig to distinguish input/output activations

Summary: When converting, before quantizing the nodes, we call
`update_obs_for_equalization()` and `convert_eq_obs()`.

`update_obs_for_equalization`:
1. For each InputEqualizationObserver, we find the corresponding
WeightEqualizationObserver.
2. For nn.Linear layers, we will create an instance of the
WeightEqualizationObserver, run forward on the observer with the given
weights.
3. Calculate the equalization scale between the
InputEqualizationObserver and WeightEqualizationObserver.

`convert_eq_obs`:
For every InputEqualizationObserver, we will do the following:
1. Create a node (ex. `x0_activation_post_process_scale`) containing the
equalization scale constant.
2. Create another node containing a `mul` operator multiplying the
equalization scale and the input.
3. Remove the current InputEqualizationObserver node, and replace it
with the `mul` node.

For every WeightEqualizationObserver, we will do the following:
1. Get the next equalization scale (we may need this for equalizing
connected linear layers).
2. Scale the weights by multiplying it with the reciprocal of the
current equalization scale and the next equalization scale

Currently, this supports models with `nn.Linear` layers, but does not
support connecting linear layers.

Test Plan: `python test/test_quantization.py
TestEqualizeFx.test_input_weight_equalization_convert`

Original Model:
```
.LinearModule(
  (linear): Linear(in_features=2, out_features=2, bias=True)
)
```

Graph after equalization functions:
```
graph():
    %x : [#users=1] = placeholder[target=x]
    %x_equalization_process_0_scale : [#users=1] = get_attr[target=x_equalization_process_0_scale]
    %mul : [#users=1] = call_function[target=torch.mul](args = (%x, %x_equalization_process_0_scale), kwargs = {})
    %x_equalization_process_0_activation_post_process_0 : [#users=1] = call_module[target=x_equalization_process_0_activation_post_process_0](args = (%mul,), kwargs = {})
    %linear : [#users=1] = call_module[target=linear](args = (%x_equalization_process_0_activation_post_process_0,), kwargs = {})
    %linear_activation_post_process_0 : [#users=1] = call_module[target=linear_activation_post_process_0](args = (%linear,), kwargs = {})
    return linear_activation_post_process_0
```

Graph after `convert_fx`:
```
graph():
    %x : [#users=1] = placeholder[target=x]
    %x_equalization_process_0_scale : [#users=1] = get_attr[target=x_equalization_process_0_scale]
    %mul : [#users=1] = call_function[target=torch.mul](args = (%x, %x_equalization_process_0_scale), kwargs = {})
    %linear_input_scale_0 : [#users=1] = get_attr[target=linear_input_scale_0]
    %linear_input_zero_point_0 : [#users=1] = get_attr[target=linear_input_zero_point_0]
    %quantize_per_tensor : [#users=1] = call_function[target=torch.quantize_per_tensor](args = (%mul, %linear_input_scale_0, %linear_input_zero_point_0, torch.quint8), kwargs = {})
    %linear : [#users=1] = call_module[target=linear](args = (%quantize_per_tensor,), kwargs = {})
    %dequantize : [#users=1] = call_method[target=dequantize](args = (%linear,), kwargs = {})
    return dequantize
```

Reviewers:

Subscribers:

Tasks:

Tags: