### PR TITLE
[quant] Input-Weight Equalization - support for F.linear

### DIFF
--- a/test/quantization/fx/test_equalize_fx.py
+++ b/test/quantization/fx/test_equalize_fx.py
@@ -281,8 +281,55 @@ class TestEqualizeFx(QuantizationTestCase):
                 x = self.linear2(x)
                 return x
 
+        # Test with two connected linear layers
+        class Linear2Module(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = nn.Linear(2, 2)
+                self.linear2 = nn.Linear(2, 2)
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = self.linear2(x)
+                return x
+
+        class Linear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.rand(2, 2)
+                self.b = torch.zeros(2)
+
+            def forward(self, x):
+                return nn.functional.linear(x, self.w, self.b)
+
+        # Test where we have one functional linear layer
+        class FunctionalLinearModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = Linear()
+
+            def forward(self, x):
+                x = self.linear1(x)
+                return x
+
+        # Test where we have two functional linear layers with fp32 operation between
+        class FunctionalLinear2FP32Module(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = Linear()
+                self.linear2 = Linear()
+
+            def forward(self, x):
+                x = self.linear1(x)
+                x = torch.add(x, torch.tensor([1, 2]))
+                x = self.linear2(x)
+                return x
+
         tests = [(LinearModule, default_equalization_qconfig_dict), 
-                 (Linear2FP32Module, fp32_equalization_qconfig_dict)]
+                 (Linear2FP32Module, fp32_equalization_qconfig_dict),
+                 (FunctionalLinearModule, default_equalization_qconfig_dict),
+                 (FunctionalLinear2FP32Module, fp32_equalization_qconfig_dict)]
+
         for (M, equalization_qconfig_dict) in tests:
             m = M().eval()
             x = torch.tensor([[1.0, 2.0], [2.0, 2.5], [4.5, 6.0]])

--- a/torch/quantization/fx/_equalize.py
+++ b/torch/quantization/fx/_equalize.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 from torch.fx import GraphModule
 from torch.fx.graph import Node
 
+from .utils import collect_producer_nodes
 from ..observer import (
     PerChannelMinMaxObserver,
     _with_args, 
@@ -250,8 +251,14 @@ def get_weight_eq_obs(node: Node, model: GraphModule, modules: Dict[str, nn.Modu
         return node, weight_eq_obs
 
     elif node.op == 'call_function':
-        # TODO do something
-        return None, None
+        # If the next node is a functional layer, then the weight observer node
+        # has already been created, so we want to traverse the weight observer
+        # nodes to find the WeightEqualizationObserver node
+        weight_observer_nodes = collect_producer_nodes(node.args[1])
+        for weight_obs_node in weight_observer_nodes:
+            if isinstance(modules[weight_obs_node.target], _WeightEqualizationObserver):
+                # We return None for the weight_eq_obs because it already exists
+                return weight_obs_node, None
 
     return None, None
 
@@ -328,6 +335,32 @@ def scale_weight_node(
     scaled_bias = torch.mul(modules[node.target].bias, next_equalization_scale)
     modules[node.target].bias = nn.Parameter(scaled_bias)
 
+def scale_weight_functional(node: Node, model: GraphModule, equalization_scale: torch.tensor):
+    """ Scales the weight value for functional layers
+    """
+
+    # Find the next functional node so that we can construct the weight observer nodes
+    while node.op != 'output' and node.op != 'call_function':
+        node = node.next
+
+    if node.op == 'output':
+        return
+
+    weight_observer_nodes = collect_producer_nodes(node.args[1])
+    for weight_node in weight_observer_nodes:
+        # Find the node containing the weight values
+        if weight_node.op == 'get_attr':
+            weight = model.get_buffer(weight_node.target)
+
+            # Scale the weights for input-weight equalization
+            # If the following layer needs to be equalized then we will multiply its scale
+            scaled_weight = torch.mul(weight, torch.reciprocal(equalization_scale))
+            # TODO: connecting functional layers?
+            # scaled_weight = torch.mul(scaled_weight, next_equalization_scale)
+
+            # Set the weight with the newly scaled weight in the original model
+            setattr(getattr(model, weight_node.target[:-2]), "w", scaled_weight)
+
 def update_obs_for_equalization(model: GraphModule, modules: Dict[str, nn.Module]) -> Dict[str, _WeightEqualizationObserver]:
     """ Update all of the observer's equalization scale. For each
     InputEqualizationObserver, we will find the location of the next
@@ -343,7 +376,12 @@ def update_obs_for_equalization(model: GraphModule, modules: Dict[str, nn.Module
             input_eq_obs = modules[node.target]
             next_node, weight_eq_obs = get_weight_eq_obs(node, model, modules)
 
-            weight_eq_obs(modules[next_node.target].weight)
+            if weight_eq_obs is None:
+                # If the equalization observer has already been created, then we
+                # can extract the observer from the node itself
+                weight_eq_obs = modules[next_node.target]
+            else:
+                weight_eq_obs(modules[next_node.target].weight)
 
             # Calculate and set the equalization scale values
             equalization_scale = calculate_equalization_scale(input_eq_obs, weight_eq_obs)
@@ -364,6 +402,16 @@ def convert_eq_obs(model: GraphModule, modules: Dict[str, nn.Module], weight_eq_
         if node.op == 'call_module' and isinstance(modules[node.target], _InputEqualizationObserver):
             prev_node = node.args[0]
             # TODO: Possible special handling for connected linear layers
+            # We might need to replace the InputEqualizationObserver with another mul operator...
+            # if prev_node.op == 'call_module' and modules[prev_node.target].dtype != torch.float32:
+            # If this is a connecting linear layer, we want to remove the InputEqualizationObserver
+            #     # Replace the current node with the previous node
+            #     orig_users = list(node.users.keys())
+            #     for user_node in orig_users:
+            #         user_node.replace_input_with(node, prev_node)
+            #     # Erase the node
+            #     model.graph.erase_node(node)
+            #     continue
 
             # Update the following input quantization observer's min/max values
             scale_input_node(node, modules)
@@ -398,6 +446,14 @@ def convert_eq_obs(model: GraphModule, modules: Dict[str, nn.Module], weight_eq_
 
         elif weight_eq_obs_dict.get(node.name, None) is not None:
             weight_eq_obs = weight_eq_obs_dict.get(node.name)
+
+            if (modules[node.target] == weight_eq_obs):
+                # If the WeightEqualizationObserver is already in the node
+                # itself, this implies we are using functional layers(?) so we
+                # need to scale the weights differently
+                equalization_scale = weight_eq_obs.equalization_scale
+                scale_weight_functional(node, model, equalization_scale)
+                return
 
             equalization_scale = weight_eq_obs.equalization_scale
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59955 [quant] Input-Weight Equalization - support for F.linear**
* #59954 [quant] Input-Weight Equalization - convert modifications
* #59953 [quant] Equalization Observer modifications
* #59747 [quant] Input Weight Equalization - prepare modifications
* #59739 [quant] EqualizationQConfig to distinguish input/output activations

Summary:

Test Plan: `python test/test_quantization.py
TestEqualizeFx.test_input_weight_equalization_convert`

Original model:
```
FunctionalLinearModule(
  (linear1): Linear()
)
```

Graph after equalization functions:
```
graph():
    %x : [#users=1] = placeholder[target=x]
    %x_equalization_process_0_scale : [#users=1] = get_attr[target=x_equalization_process_0_scale]
    %mul : [#users=1] = call_function[target=torch.mul](args = (%x, %x_equalization_process_0_scale), kwargs = {})
    %x_equalization_process_0_activation_post_process_0 : [#users=1] = call_module[target=x_equalization_process_0_activation_post_process_0](args = (%mul,), kwargs = {})
    %linear1_w : [#users=1] = get_attr[target=linear1.w]
    %linear1_w_equalization_process_0 : [#users=1] = call_module[target=linear1_w_equalization_process_0](args = (%linear1_w,), kwargs = {})
    %linear1_w_equalization_process_0_activation_post_process_0 : [#users=1] = call_module[target=linear1_w_equalization_process_0_activation_post_process_0](args = (%linear1_w_equalization_process_0,), kwargs = {})
    %linear1_b : [#users=1] = get_attr[target=linear1.b]
    %linear : [#users=1] = call_function[target=torch.nn.functional.linear](args = (%x_equalization_process_0_activation_post_process_0, %linear1_w_equalization_process_0_activation_post_process_0), kwargs = {bias: %linear1_b})
    %linear_activation_post_process_0 : [#users=1] = call_module[target=linear_activation_post_process_0](args = (%linear,), kwargs = {})
    return linear_activation_post_process_0
```

Graph after `convert_fx`:
```
graph():
    %x : [#users=1] = placeholder[target=x]
    %x_equalization_process_0_scale : [#users=1] = get_attr[target=x_equalization_process_0_scale]
    %mul : [#users=1] = call_function[target=torch.mul](args = (%x, %x_equalization_process_0_scale), kwargs = {})
    %linear1_input_scale_0 : [#users=1] = get_attr[target=linear1_input_scale_0]
    %linear1_input_zero_point_0 : [#users=1] = get_attr[target=linear1_input_zero_point_0]
    %quantize_per_tensor : [#users=1] = call_function[target=torch.quantize_per_tensor](args = (%mul, %linear1_input_scale_0, %linear1_input_zero_point_0, torch.quint8), kwargs = {})
    %linear1_packed_weight_0 : [#users=1] = get_attr[target=linear1_packed_weight_0]
    %linear1_scale_0 : [#users=1] = get_attr[target=linear1_scale_0]
    %linear1_zero_point_0 : [#users=1] = get_attr[target=linear1_zero_point_0]
    %linear : [#users=1] = call_function[target=torch.ops.quantized.linear](args = (%quantize_per_tensor, %linear1_packed_weight_0, %linear1_scale_0, %linear1_zero_point_0), kwargs = {})
    %dequantize : [#users=1] = call_method[target=dequantize](args = (%linear,), kwargs = {})
    return dequantize
```

Reviewers:

Subscribers:

Tasks:

Tags: