### PR TITLE
Fix `get_and_check_clang_format` import in `clang_format_all.py`

### DIFF
--- a/tools/clang_format_all.py
+++ b/tools/clang_format_all.py
@@ -14,7 +14,7 @@ import os
 import sys
 from typing import List, Set
 
-from .clang_format_utils import get_and_check_clang_format, CLANG_FORMAT_PATH
+from clang_format_utils import get_and_check_clang_format, CLANG_FORMAT_PATH
 
 # Allowlist of directories to check. All files that in that directory
 # (recursively) will be checked.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59966 Fix `get_and_check_clang_format` import in `clang_format_all.py`**
* #59244 Move helper structs/methods out of `ir_emitter.cpp`

Differential Revision: [D29108099](https://our.internmc.facebook.com/intern/diff/D29108099)