### PR TITLE
Enable sharding for Windows GHA CI

### DIFF
--- a/.github/scripts/generate_ci_workflows.py
+++ b/.github/scripts/generate_ci_workflows.py
@@ -81,18 +81,21 @@ WINDOWS_WORKFLOWS = [
         cuda_version="cpu",
         test_runner_type=WINDOWS_CPU_TEST_RUNNER,
         on_pull_request=True,
+        num_test_shards=2,
     ),
     PyTorchWindowsWorkflow(
         build_environment="pytorch-win-vs2019-cuda10-cudnn7-py3",
         cuda_version="10.1",
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
         on_pull_request=True,
-        only_build_on_pull_request=True
+        only_build_on_pull_request=True,
+        num_test_shards=2,
     ),
     PyTorchWindowsWorkflow(
         build_environment="pytorch-win-vs2019-cuda11-cudnn8-py3",
         cuda_version="11.1",
         test_runner_type=WINDOWS_CUDA_TEST_RUNNER,
+        num_test_shards=2,
     )
 ]
 

--- a/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cpu-py3.yml
@@ -73,7 +73,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
     env:
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
@@ -93,7 +93,7 @@ jobs:
     runs-on: windows.4xlarge
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cpu-py3-test
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
       TEST_CONFIG: ${{ matrix.test_config }}
     needs:
       - build

--- a/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda10-cudnn7-py3.yml
@@ -83,7 +83,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' && github.event_name == 'push' }}
     runs-on: ubuntu-18.04
     env:
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
@@ -104,7 +104,7 @@ jobs:
     runs-on: windows.8xlarge.nvidia.gpu
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda10-cudnn7-py3-test
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
       TEST_CONFIG: ${{ matrix.test_config }}
     needs:
       - build

--- a/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
+++ b/.github/workflows/pytorch-win-vs2019-cuda11-cudnn8-py3.yml
@@ -82,7 +82,7 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-18.04
     env:
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
@@ -102,7 +102,7 @@ jobs:
     runs-on: windows.8xlarge.nvidia.gpu
     env:
       JOB_BASE_NAME: pytorch-win-vs2019-cuda11-cudnn8-py3-test
-      NUM_TEST_SHARDS: 1
+      NUM_TEST_SHARDS: 2
       TEST_CONFIG: ${{ matrix.test_config }}
     needs:
       - build

--- a/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
+++ b/.jenkins/pytorch/win-test-helpers/test_python_first_shard.bat
@@ -4,16 +4,6 @@ echo Copying over test times file
 copy /Y "%PYTORCH_FINAL_PACKAGE_DIR_WIN%\.pytorch-test-times.json" "%TEST_DIR_WIN%"
 
 pushd test
-
-echo Some smoke tests
-"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe" /i python.exe +sls
-python %SCRIPT_HELPERS_DIR%\run_python_nn_smoketests.py
-if ERRORLEVEL 1 exit /b 1
-
-"C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\gflags.exe" /i python.exe -sls
-if ERRORLEVEL 1 exit /b 1
-
-echo Run nn tests
 python run_test.py --exclude-jit-executor --shard 1 2 --verbose --determine-from="%1"
 if ERRORLEVEL 1 exit /b 1
 


### PR DESCRIPTION
Enables sharding for Windows on CI. To make that possible, we currently remove the smoke tests tested in shard 1 which don't seem all that important as they are 
1. tested on nightlies
2. seems to be tested anyway by running the test suite