### PR TITLE
add output_process_fn_grad before sum().backward()

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -76,6 +76,8 @@ class TestOpInfo(TestCase):
                 # TODO: handle non-tensor outputs
                 if not isinstance(result, torch.Tensor):
                     self.skipTest("Skipped! Test does not handle non-tensor outputs")
+                if sample.output_process_fn_grad is not None:
+                    result = sample.output_process_fn_grad(result)
                 result.sum().backward()
 
     # Verifies that backward for each supported floating or complex dtype


### PR DESCRIPTION
This should fix `to_sparse` test issue. 

Test Plan:
CI

Also: directly examine the RuntimeError thrown from test_unsupported_backward
- Before: 
```
NotImplementedError: Could not run 'aten::sum' with arguments from the 'SparseCPU' backend.
```
- After: 
```
to_dense() not supported for float16 on CPU
```