### PR TITLE
[docs] Add pickle security warning to package docs (#59959)

### DIFF
--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -2,11 +2,6 @@
 
 torch.package
 =============
-
-.. warning::
-
-    This module is experimental and has not yet been publicly released.
-
 ``torch.package`` adds support for creating hermetic packages containing arbitrary
 PyTorch code. These packages can be saved, shared, used to load and execute models
 at a later date or on a different machine, and can even be deployed to production using
@@ -14,6 +9,16 @@ at a later date or on a different machine, and can even be deployed to productio
 
 This document contains tutorials, how-to guides, explanations, and an API reference that
 will help you learn more about ``torch.package`` and how to use it.
+
+
+.. warning::
+
+    This module depends on the ``pickle`` module which is is not secure. Only unpackage data you trust.
+
+    It is possible to construct malicious pickle data which will **execute arbitrary code during unpickling**.
+    Never unpackage data that could have come from an untrusted source, or that could have been tampered with.
+
+    For more information, review the `documentation <https://docs.python.org/3/library/pickle.html>`_ for the ``pickle`` module.
 
 
 .. contents:: :local:


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/59959

**Summary**
This commit replaces the warning on the `torch.package` documentation
page about the module not being publicly released (which will no longer
be true as of 1.9) with one that warns about security issues caused by
the use of the `pickle` module.

**Test Plan**
1) Built the docs locally.
2) Continuous integration.

<img width="877" alt="Captura de Pantalla 2021-06-14 a la(s) 11 22 05 a  m" src="https://user-images.githubusercontent.com/4392003/121940300-c98cab00-cd02-11eb-99dc-08e29632079a.png">

Test Plan: Imported from OSS

Reviewed By: suo

Differential Revision: D29108429

Pulled By: SplitInfinity

fbshipit-source-id: 3a0aeac0dc804a31203bc5071efb1c5bd6ef9725
