### PR TITLE
[nnc] Move batchnorm to operators library

### DIFF
--- a/tools/build_variables.bzl
+++ b/tools/build_variables.bzl
@@ -292,6 +292,7 @@ core_sources_full_mobile = [
     "torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp",
     "torch/csrc/jit/tensorexpr/operators/conv2d.cpp",
     "torch/csrc/jit/tensorexpr/operators/matmul.cpp",
+    "torch/csrc/jit/tensorexpr/operators/norm.cpp",
     "torch/csrc/jit/tensorexpr/operators/reduction.cpp",
     "torch/csrc/jit/tensorexpr/operators/softmax.cpp",
     "torch/csrc/jit/tensorexpr/reduction.cpp",

--- a/torch/csrc/jit/tensorexpr/kernel.h
+++ b/torch/csrc/jit/tensorexpr/kernel.h
@@ -23,6 +23,17 @@ inline std::vector<int64_t> bufferSizes(const T& t) {
   }
   return sizes;
 }
+
+enum ElementType {
+  kAllTypes = 0,
+  kIntegralTypes = 1 << 0,
+  kFloatingPointTypes = 1 << 1,
+  kBoolType = 1 << 2,
+  kComplexTypes = 1 << 3,
+  kQintTypes = 1 << 4,
+  kNonComplexOrQintTypes = kIntegralTypes | kBoolType | kFloatingPointTypes,
+};
+
 using ArgNone = c10::monostate;
 using BufList = std::vector<tensorexpr::BufHandle>;
 using IntList = std::vector<int64_t>;
@@ -54,6 +65,14 @@ ExprHandle constant(const ArgValue& v);
 std::vector<ExprHandle> computeIndicesToBroadcast(
     const std::vector<ExprHandle>& outputAxes,
     const std::vector<ExprHandle>& inputSizes);
+
+void promoteInputs(
+    std::vector<ExprHandle>& inputs,
+    const int typeConstraints = kAllTypes);
+
+ExprHandle demoteOutput(
+    const ExprHandle& e,
+    const c10::optional<ScalarType> type);
 
 inline std::string getArgValueName(const ArgValue& a) {
   if (c10::get_if<tensorexpr::BufHandle>(&a)) {
@@ -96,16 +115,6 @@ std::vector<T> convertVecArgValue(const std::vector<ArgValue>& v) {
 struct TensorInfo {
   std::vector<int64_t> dims;
   c10::ScalarType dtype;
-};
-
-enum ElementType {
-  kAllTypes = 0,
-  kIntegralTypes = 1 << 0,
-  kFloatingPointTypes = 1 << 1,
-  kBoolType = 1 << 2,
-  kComplexTypes = 1 << 3,
-  kQintTypes = 1 << 4,
-  kNonComplexOrQintTypes = kIntegralTypes | kBoolType | kFloatingPointTypes,
 };
 
 TORCH_API Tensor* computeOperandValue(

--- a/torch/csrc/jit/tensorexpr/operators/norm.cpp
+++ b/torch/csrc/jit/tensorexpr/operators/norm.cpp
@@ -1,0 +1,75 @@
+#include <torch/csrc/jit/tensorexpr/operators/norm.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+Tensor* computeBatchNorm(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType) {
+  bool hasWeight = true;
+  bool hasBias = true;
+
+  if (c10::get_if<ArgNone>(&inputs[1])) {
+    hasWeight = false;
+  }
+
+  if (c10::get_if<ArgNone>(&inputs[2])) {
+    hasBias = false;
+  }
+
+  return Compute(
+      "aten_batch_norm",
+      c10::fmap<DimArg>(outputShape),
+      [&](const std::vector<VarHandle>& axes) {
+        TORCH_INTERNAL_ASSERT(axes.size() >= 2);
+        // axes: N, C, H, W
+        std::vector<ExprHandle> indices(axes.begin(), axes.end());
+        ExprHandle c = indices[1];
+
+        // Parameter list:
+        // input, weight, bias, mean, var, training, momentum, eps,
+        // cudnn_enabled
+        std::vector<ExprHandle> exprInputs = {
+            tensorOrConstant(inputs[0], indices), // input
+            tensorOrConstant(inputs[3], {c}), // mean
+            tensorOrConstant(inputs[4], {c}), // var
+            constant(inputs[7]) // eps
+        };
+
+        if (hasWeight) {
+          exprInputs.push_back(tensorOrConstant(inputs[1], {c}));
+        }
+        if (hasBias) {
+          exprInputs.push_back(tensorOrConstant(inputs[2], {c}));
+        }
+        promoteInputs(exprInputs);
+
+        ExprHandle input = exprInputs[0];
+        ExprHandle mean = exprInputs[1];
+        ExprHandle var = exprInputs[2];
+        ExprHandle eps = exprInputs[3];
+        ExprHandle weight = FloatImm::make(1);
+        ExprHandle bias = FloatImm::make(0);
+
+        if (hasWeight) {
+          weight = exprInputs[4];
+        }
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+        if (hasBias) {
+          bias = exprInputs[5];
+        }
+
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+        auto inv_var = rsqrt(var + eps);
+        auto alpha = inv_var * weight;
+        auto beta = bias - mean * alpha;
+        auto output = input * alpha + beta;
+        return demoteOutput(output, outputType);
+      });
+}
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/operators/norm.h
+++ b/torch/csrc/jit/tensorexpr/operators/norm.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <torch/csrc/jit/tensorexpr/kernel.h>
+
+namespace torch {
+namespace jit {
+namespace tensorexpr {
+
+Tensor* computeBatchNorm(
+    const std::vector<ArgValue>& inputs,
+    const std::vector<ExprHandle>& outputShape,
+    const c10::optional<ScalarType>& outputType);
+
+} // namespace tensorexpr
+} // namespace jit
+} // namespace torch

--- a/torch/csrc/jit/tensorexpr/operators/operators.h
+++ b/torch/csrc/jit/tensorexpr/operators/operators.h
@@ -2,5 +2,6 @@
 
 #include <torch/csrc/jit/tensorexpr/operators/conv2d.h>
 #include <torch/csrc/jit/tensorexpr/operators/matmul.h>
+#include <torch/csrc/jit/tensorexpr/operators/norm.h>
 #include <torch/csrc/jit/tensorexpr/operators/reduction.h>
 #include <torch/csrc/jit/tensorexpr/operators/softmax.h>


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#59992 [nnc] Move batchnorm to operators library**
* #59988 [nnc] Move operator implementations into a subdirectory

Wrapped batch norm in function `computeBatchNorm`.

Differential Revision: [D29116661](https://our.internmc.facebook.com/intern/diff/D29116661/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29116661/)!