### PR TITLE
updated launch bounds for trilinear 3d

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleTrilinear3d.cu
@@ -27,7 +27,7 @@ idx_3d(const size_t nc,
 }
 
 template <typename scalar_t, typename accscalar_t>
-C10_LAUNCH_BOUNDS_1(1024)
+C10_LAUNCH_BOUNDS_1(512)
 __global__ void upsample_trilinear3d_out_frame(
     const int n,
     const accscalar_t rdepth,
@@ -111,7 +111,7 @@ __global__ void upsample_trilinear3d_out_frame(
 
 // Backward (adjoint) operation 1 <- 2 (accumulates)
 template <typename scalar_t, typename accscalar_t>
-C10_LAUNCH_BOUNDS_1(1024)
+C10_LAUNCH_BOUNDS_1(256)
 __global__ void upsample_trilinear3d_backward_out_frame(
     const int num_kernels,
     const accscalar_t rdepth,
@@ -254,7 +254,7 @@ static void upsample_trilinear3d_out_cuda_template(
 
   const int num_kernels = output_depth * output_height * output_width;
   const int num_threads = std::min(
-      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
+      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 512);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -322,7 +322,7 @@ static void upsample_trilinear3d_backward_out_cuda_template(
 
   const int num_kernels = output_depth * output_height * output_width;
   const int num_threads = std::min(
-      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 1024);
+      at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock, 256);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(


### PR DESCRIPTION
Updates launch bounds for upsample_trilinear_3d forward and backward kernel to remove register spilling into local memory. Improves runtime for forward pass by 3-4x factor, backward pass has same runtime (probably different bottleneck). 

Timing data: (Using Nvidia Titan-V GPU)
![TrilinearTimingData](https://user-images.githubusercontent.com/22803332/121979658-72f19200-cd3f-11eb-9363-c00e2c4eea6d.PNG)

