### PR TITLE
Fix aten::to schema to reflect that the output may alias input.

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5251,22 +5251,22 @@
 # to(Device) must not exist because all constructors of Device also works for
 # TensorOptions. Otherwise, an ambiguity error is thrown.
 # See NOTE [ TensorOptions Constructors ].
-- func: to.dtype_layout(Tensor self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype_layout(Tensor(a) self, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
   variants: method
   device_check: NoCheck
   device_guard: False
 
-- func: to.device(Tensor self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.device(Tensor(a) self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
   variants: method
   device_check: NoCheck
   device_guard: False
 
-- func: to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.dtype(Tensor(a) self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
   variants: method
   device_check: NoCheck
   device_guard: False
 
-- func: to.other(Tensor self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor
+- func: to.other(Tensor(a) self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
   variants: method
   device_check: NoCheck
   device_guard: False

--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -97,6 +97,7 @@ allow_list = [
     ("aten::segment_reduce_backward", datetime.date(2021, 6, 15)),
     ("aten::segment_reduce", datetime.date(2021, 8, 26)),
     ("aten::_segment_reduce_backward", datetime.date(2021, 8, 26)),
+    ("aten::to", datetime.date(2021, 6, 22)),
 ]
 
 def allow_listed(schema, allow_list):

--- a/torch/csrc/jit/runtime/static/ops.cpp
+++ b/torch/csrc/jit/runtime/static/ops.cpp
@@ -1234,9 +1234,9 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
     };
   } else if (n->kind() == c10::Symbol::fromQualString("aten::to")) {
     if (!n->matches(torch::schema(
-            "aten::to.other(Tensor self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor")) &&
+            "aten::to.other(Tensor(a) self, Tensor other, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)")) &&
         !n->matches(torch::schema(
-            "aten::to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor"))) {
+            "aten::to.dtype(Tensor(a) self, ScalarType dtype, bool non_blocking=False, bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)"))) {
       LogAndDumpSchema(n);
       return nullptr;
     }
@@ -1246,13 +1246,13 @@ std::function<void(ProcessedNode*)> getNativeOperation(Node* n) {
       const auto in3_i = p_node->Input(3).toBool();
       const auto in4_o = p_node->Input(4).toOptional<at::MemoryFormat>();
       if (p_node->Input(1).isTensor()) {
-        // to.other(Tensor self, Tensor other, bool non_blocking=False, bool
-        // copy=False, MemoryFormat? memory_format=None) -> Tensor
+        // to.other(Tensor(a) self, Tensor other, bool non_blocking=False, bool
+        // copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
         const auto in1_t = p_node->Input(1).toTensor();
         p_node->Output(0) = at::native::to(in0_t, in1_t, in2_i, in3_i, in4_o);
       } else {
-        // to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False, bool
-        // copy=False, MemoryFormat? memory_format=None) -> Tensor
+        // to.dtype(Tensor(a) self, ScalarType dtype, bool non_blocking=False,
+        // bool copy=False, MemoryFormat? memory_format=None) -> Tensor(a)
         const auto in1_i = p_node->Input(1).toScalarType();
         p_node->Output(0) = at::native::to(in0_t, in1_i, in2_i, in3_i, in4_o);
       }


### PR DESCRIPTION
Summary: Fix the aten::to schema to reflect that the output may alias input.

Test Plan: Added new unit tests.

Differential Revision: D29121620

