### PR TITLE
Convert __constants__ attribute in model to a set to be consistent

### DIFF
--- a/test/jit/test_modules.py
+++ b/test/jit/test_modules.py
@@ -1,0 +1,32 @@
+import torch
+import os
+import sys
+from torch.testing._internal.jit_utils import JitTestCase
+from typing import Final
+
+# Make the helper files in test/ importable
+pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+sys.path.append(pytorch_test_dir)
+
+if __name__ == '__main__':
+    raise RuntimeError("This test file is not meant to be run directly, use:\n\n"
+                       "\tpython test/test_jit.py TESTNAME\n\n"
+                       "instead.")
+
+class TestModules(JitTestCase):
+    def test_script_module_with_constants_list(self):
+        """
+        Test that a module that has __constants__ set to something
+        that is not a set can be scripted.
+        """
+
+        # torch.nn.Linear has a __constants__ attribute defined
+        # and intialized to a list.
+        class Net(torch.nn.Linear):
+            x: Final[int]
+
+            def __init__(self):
+                super().__init__(5, 10)
+                self.x = 0
+
+        self.checkModule(Net(), (torch.randn(5),))

--- a/test/jit/test_modules.py
+++ b/test/jit/test_modules.py
@@ -2,7 +2,6 @@ import torch
 import os
 import sys
 from torch.testing._internal.jit_utils import JitTestCase
-from typing import Final
 
 # Make the helper files in test/ importable
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -23,7 +22,7 @@ class TestModules(JitTestCase):
         # torch.nn.Linear has a __constants__ attribute defined
         # and intialized to a list.
         class Net(torch.nn.Linear):
-            x: Final[int]
+            x: torch.jit.Final[int]
 
             def __init__(self):
                 super().__init__(5, 10)

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -13,6 +13,7 @@ from jit.test_list_dict import TestList, TestDict, TestNamedTuple, TestScriptDic
 from jit.test_async import TestAsync  # noqa: F401
 from jit.test_data_parallel import TestDataParallel  # noqa: F401
 from jit.test_models import TestModels  # noqa: F401
+from jit.test_modules import TestModules  # noqa: F401
 from jit.test_autodiff_subgraph_slicing import TestAutodiffSubgraphSlicing  # noqa: F401
 from jit.test_custom_operators import TestCustomOperators  # noqa: F401
 from jit.test_export_modes import TestExportModes  # noqa: F401

--- a/torch/jit/_recursive.py
+++ b/torch/jit/_recursive.py
@@ -198,7 +198,7 @@ def infer_concrete_type_builder(nn_module, share_types=True):
         added_names.add(name)
 
     # populate constants_set
-    constants_set = getattr(nn_module, "__constants__", set())
+    constants_set = set(getattr(nn_module, "__constants__", ()))
 
     # Constants annotated via `Final[T]` rather than being added to `__constants__`
     for name, ann in class_annotations.items():


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60003 [JIT] Handle modules that already have __constants__**

**Summary**
`infer_concrete_type_builder` in `_recursive.py` assumes `__constants__`
is a `set` if it exists as an attribute on the module being scripted.
Instead, it should create a set out of whatever `__constants__` is.

**Test Plan**
Ran code from the issue.

**Fixes**
This commit fixes #59947.

Differential Revision: [D29174243](https://our.internmc.facebook.com/intern/diff/D29174243)