### PR TITLE
Fix compile failure on CUDA92

### DIFF
--- a/c10/macros/Macros.h
+++ b/c10/macros/Macros.h
@@ -409,6 +409,12 @@ __host__ __device__
 #define C10_HOST_CONSTEXPR_VAR constexpr
 #endif
 
+#if defined(__CUDA_ARCH__) && defined(CUDA_VERSION) && CUDA_VERSION <= 9200
+#define C10_CONSTEXPR_EXCEPT_CUDA92
+#else
+#define C10_CONSTEXPR_EXCEPT_CUDA92 constexpr
+#endif
+
 #if !defined(__clang__) && !defined(_MSC_VER) && defined(__GNUC__) && \
     __GNUC__ < 6
 #define CONSTEXPR_EXCEPT_GCC5

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -72,14 +72,12 @@ class ArrayRef final {
   constexpr ArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
 
   /// Construct an ArrayRef from a pointer and length.
-  ArrayRef(const T* data, size_t length)
-      : Data(data), Length(length) {
+  ArrayRef(const T* data, size_t length) : Data(data), Length(length) {
     debugCheckNullptrInvariant();
   }
 
   /// Construct an ArrayRef from a range.
-  ArrayRef(const T* begin, const T* end)
-      : Data(begin), Length(end - begin) {
+  ArrayRef(const T* begin, const T* end) : Data(begin), Length(end - begin) {
     debugCheckNullptrInvariant();
   }
 

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -72,13 +72,13 @@ class ArrayRef final {
   constexpr ArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
 
   /// Construct an ArrayRef from a pointer and length.
-  constexpr ArrayRef(const T* data, size_t length)
+  ArrayRef(const T* data, size_t length)
       : Data(data), Length(length) {
     debugCheckNullptrInvariant();
   }
 
   /// Construct an ArrayRef from a range.
-  constexpr ArrayRef(const T* begin, const T* end)
+  ArrayRef(const T* begin, const T* end)
       : Data(begin), Length(end - begin) {
     debugCheckNullptrInvariant();
   }

--- a/c10/util/ArrayRef.h
+++ b/c10/util/ArrayRef.h
@@ -72,12 +72,16 @@ class ArrayRef final {
   constexpr ArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
 
   /// Construct an ArrayRef from a pointer and length.
-  ArrayRef(const T* data, size_t length) : Data(data), Length(length) {
+  /// CUDA 9.2 fails to compile constexpr that throws exception
+  C10_CONSTEXPR_EXCEPT_CUDA92 ArrayRef(const T* data, size_t length)
+      : Data(data), Length(length) {
     debugCheckNullptrInvariant();
   }
 
   /// Construct an ArrayRef from a range.
-  ArrayRef(const T* begin, const T* end) : Data(begin), Length(end - begin) {
+  /// CUDA 9.2 fails to compile constexpr that throws exception
+  C10_CONSTEXPR_EXCEPT_CUDA92 ArrayRef(const T* begin, const T* end)
+      : Data(begin), Length(end - begin) {
     debugCheckNullptrInvariant();
   }
 

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -530,9 +530,10 @@ using OptionalBase = std::conditional_t<
     detail_::is_arrayref<T>::value,
     arrayref_optional_base<T>,
     std::conditional_t<
-      std::is_trivially_destructible<T>::value, // if possible
-      constexpr_optional_base<std::remove_const_t<T>>, // use base with trivial destructor
-      optional_base<std::remove_const_t<T>>>>;
+        std::is_trivially_destructible<T>::value, // if possible
+        constexpr_optional_base<std::remove_const_t<T>>, // use base with
+                                                         // trivial destructor
+        optional_base<std::remove_const_t<T>>>>;
 #endif
 
 template <class T>
@@ -570,9 +571,10 @@ class optional : private OptionalBase<T> {
       detail_::is_arrayref<U>::value,
       arrayref_optional_base<U>,
       std::conditional_t<
-        std::is_trivially_destructible<U>::value, // if possible
-        constexpr_optional_base<std::remove_const_t<U>>, // use base with trivial destructor
-        optional_base<std::remove_const_t<U>>>>;
+          std::is_trivially_destructible<U>::value, // if possible
+          constexpr_optional_base<std::remove_const_t<U>>, // use base with
+                                                           // trivial destructor
+          optional_base<std::remove_const_t<U>>>>;
 #endif
 
   static_assert(

--- a/c10/util/Optional.h
+++ b/c10/util/Optional.h
@@ -526,11 +526,13 @@ using OptionalBase = std::conditional_t<
             optional_base<std::remove_const_t<T>>>>>;
 #else
 template <class T>
-using OptionalBase = typename std::conditional<
-    std::is_trivially_destructible<T>::value, // if possible
-    constexpr_optional_base<typename std::remove_const<
-        T>::type>, // use base with trivial destructor
-    optional_base<typename std::remove_const<T>::type>>::type;
+using OptionalBase = std::conditional_t<
+    detail_::is_arrayref<T>::value,
+    arrayref_optional_base<T>,
+    std::conditional_t<
+      std::is_trivially_destructible<T>::value, // if possible
+      constexpr_optional_base<std::remove_const_t<T>>, // use base with trivial destructor
+      optional_base<std::remove_const_t<T>>>>;
 #endif
 
 template <class T>
@@ -564,11 +566,13 @@ class optional : private OptionalBase<T> {
               optional_base<std::remove_const_t<U>>>>>;
 #else
   template <class U>
-  using OptionalBase = typename std::conditional<
-      std::is_trivially_destructible<U>::value, // if possible
-      constexpr_optional_base<typename std::remove_const<
-          U>::type>, // use base with trivial destructor
-      optional_base<typename std::remove_const<U>::type>>::type;
+  using OptionalBase = std::conditional_t<
+      detail_::is_arrayref<U>::value,
+      arrayref_optional_base<U>,
+      std::conditional_t<
+        std::is_trivially_destructible<U>::value, // if possible
+        constexpr_optional_base<std::remove_const_t<U>>, // use base with trivial destructor
+        optional_base<std::remove_const_t<U>>>>;
 #endif
 
   static_assert(
@@ -638,7 +642,7 @@ class optional : private OptionalBase<T> {
       std::is_nothrow_move_constructible<T>::value) {
     if (rhs.initialized()) {
       ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
-      setInitialized(true);
+      OptionalBase<T>::setInitialized(true);
     }
   }
 #endif


### PR DESCRIPTION
Fixes #60016

For CUDA 92
- OptionalBase was not check if `is_arrayref`
- constexpr seems not expect to raise Exception for cuda 92

