### PR TITLE
[torch][segment_reduce] Add support for multi-dimensional input (cuda)

### DIFF
--- a/aten/src/ATen/native/SegmentReduce.cpp
+++ b/aten/src/ATen/native/SegmentReduce.cpp
@@ -29,52 +29,63 @@ Tensor _segment_reduce_cpu_kernel(
     const Tensor& lengths,
     int64_t axis,
     const c10::optional<Scalar>& initial) {
-  int64_t batch_size = lengths.numel();
-  auto output = at::empty({batch_size}, data.options());
+  int64_t segment_count = lengths.numel();
+  auto output_shape = data.sizes().vec();
+  output_shape[axis] = segment_count;
+  auto output = at::empty(output_shape, data.options());
 
+  int64_t stride_count = data.numel() / data.size(axis);
   const auto* lengths_data = lengths.data_ptr<int64_t>();
 
   AT_DISPATCH_ALL_TYPES_AND2(
       kBFloat16, kHalf, data.scalar_type(), "_segment_reduce_cpu", ([&]() {
         auto* output_data = output.data_ptr<scalar_t>();
         const auto* values_data = data.data_ptr<scalar_t>();
-        int64_t k = 0;
-        for (int64_t i = 0; i < batch_size; ++i) {
-          // ===== step1: initialize starting value
-          scalar_t initial_value;
-          if (initial.has_value()) {
-            initial_value = initial.value().to<scalar_t>();
-          } else if (reduction == SegmentReductionType::MAX) {
-            initial_value = std::numeric_limits<scalar_t>::lowest();
-          } else if (reduction == SegmentReductionType::MEAN) {
-            initial_value = 0;
-          }
-
-          // ===== step2: apply reduction
-          for (int64_t j = 0; j < lengths_data[i]; ++j) {
-            const auto data = values_data[k];
-            // TODO: There is no need to branch with every element
-            if (reduction == SegmentReductionType::MAX) {
-              initial_value = at::_isnan(data)
-                  ? data
-                  : std::max<scalar_t>(initial_value, data);
+        int64_t lengths_cum_sum = 0;
+        for (int64_t i = 0; i < segment_count; ++i) {
+          for (int64_t l = 0; l < stride_count; ++l) {
+            // ===== step1: initialize starting value
+            scalar_t initial_value;
+            if (initial.has_value()) {
+              initial_value = initial.value().to<scalar_t>();
+            } else if (reduction == SegmentReductionType::MAX) {
+              initial_value = std::numeric_limits<scalar_t>::lowest();
             } else if (reduction == SegmentReductionType::MEAN) {
-              initial_value = at::_isnan(data) ? data : (initial_value + data);
+              initial_value = 0;
             }
-            k++;
-          }
 
-          // ===== step3: finalize reduction
-          TORCH_CHECK(lengths_data[i] >= 0);
-          if (lengths_data[i] == 0 && !initial.has_value()) {
-            output_data[i] = static_cast<scalar_t>(NAN);
-            continue;
+            // ===== step2: apply reduction
+            for (int64_t j = 0; j < lengths_data[i]; ++j) {
+              int64_t starting_index =
+                  ((lengths_cum_sum + j) * stride_count) + l;
+              const auto data = values_data[starting_index];
+              // TODO: There is no need to branch with every element
+              if (reduction == SegmentReductionType::MAX) {
+                initial_value = at::_isnan(data)
+                    ? data
+                    : std::max<scalar_t>(initial_value, data);
+              } else if (reduction == SegmentReductionType::MEAN) {
+                initial_value =
+                    at::_isnan(data) ? data : (initial_value + data);
+              }
+            }
+
+            // ===== step3: finalize reduction
+            TORCH_CHECK(lengths_data[i] >= 0);
+            int64_t output_index = (i * stride_count) + l;
+            if (lengths_data[i] == 0 && !initial.has_value()) {
+              output_data[output_index] = static_cast<scalar_t>(NAN);
+            } else {
+              output_data[output_index] = initial_value;
+              if (reduction == SegmentReductionType::MEAN &&
+                  lengths_data[i] > 0 &&
+                  !at::_isnan(output_data[output_index])) {
+                output_data[output_index] =
+                    output_data[output_index] / lengths_data[i];
+              }
+            }
           }
-          output_data[i] = initial_value;
-          if (reduction == SegmentReductionType::MEAN && lengths_data[i] > 0 &&
-              !at::_isnan(output_data[i])) {
-            output_data[i] = output_data[i] / lengths_data[i];
-          }
+          lengths_cum_sum += lengths_data[i];
         }
       }));
 
@@ -86,56 +97,70 @@ Tensor _segment_reduce_cpu_backward_kernel(
     const Tensor& output_contig,
     const Tensor& data_contig,
     SegmentReductionType reduction,
-    const Tensor& lengths_contig) {
+    const Tensor& lengths_contig,
+    int64_t axis) {
+  int64_t segment_count = lengths_contig.numel();
+  auto output_shape = data_contig.sizes().vec();
+  output_shape[axis] = segment_count;
   auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
 
-  int64_t batch_size = lengths_contig.numel();
+  int64_t stride_count = data_contig.numel() / data_contig.size(axis);
   const auto* lengths_data = lengths_contig.data_ptr<int64_t>();
 
+  // TODO: Swtich to TensorIterator for better maintainablility and readability
   AT_DISPATCH_ALL_TYPES_AND2(
       kBFloat16,
       kHalf,
       data_contig.scalar_type(),
       "_segment_reduce_cpu",
       ([&]() {
-        auto* output_data = output_contig.data_ptr<scalar_t>();
-        auto* grad_data = grad_contig.data_ptr<scalar_t>();
-        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
-        const auto* values_data = data_contig.data_ptr<scalar_t>();
-        int64_t k = 0;
-        for (int64_t i = 0; i < batch_size; ++i) {
-          if (lengths_data[i] == 0) {
+    auto* output_data = output_contig.data_ptr<scalar_t>();
+    auto* grad_data = grad_contig.data_ptr<scalar_t>();
+    auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+    const auto* values_data = data_contig.data_ptr<scalar_t>();
+
+    int64_t lengths_cum_sum = 0;
+    for (int64_t i = 0; i < segment_count; ++i) {
+      if (lengths_data[i] == 0) {
+        continue;
+      }
+
+      for (int64_t l = 0; l < stride_count; ++l) {
+        int64_t output_index = (i * stride_count) + l;
+
+        if (reduction == SegmentReductionType::MAX) {
+          int64_t counter = 0;
+          for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            int64_t starting_index = ((lengths_cum_sum + j) * stride_count) + l;
+            if (at::_isnan(values_data[starting_index]) ||
+                values_data[starting_index] == output_data[output_index]) {
+              grad_input_data[starting_index] = grad_data[output_index];
+              counter++;
+            }
+          }
+          // Average gradient based on number of maximum elements in the
+          // segment
+          if (counter < 2) {
             continue;
           }
-          if (reduction == SegmentReductionType::MAX) {
-            int64_t counter = 0;
-            for (int64_t j = 0; j < lengths_data[i]; ++j) {
-              if (at::_isnan(values_data[k]) ||
-                  values_data[k] == output_data[i]) {
-                grad_input_data[k] = grad_data[i];
-                counter++;
-              }
-              k++;
-            }
-            // Average gradient based on number of maximum elements in the
-            // segment
-            if (counter < 2) {
-              continue;
-            }
-            for (int64_t j = 0; j < lengths_data[i]; ++j) {
-              int64_t index = k - j - 1;
-              if (grad_input_data[index] > 0) {
-                grad_input_data[index] = grad_input_data[index] / counter;
-              }
-            }
-          } else if (reduction == SegmentReductionType::MEAN) {
-            auto grad_val = grad_data[i] / lengths_data[i];
-            for (int64_t j = 0; j < lengths_data[i]; ++j) {
-              grad_input_data[k] = grad_val;
-              k++;
+          for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            int64_t starting_index = ((lengths_cum_sum + j) * stride_count) + l;
+            if (grad_input_data[starting_index] > 0) {
+              grad_input_data[starting_index] =
+                  grad_input_data[starting_index] / counter;
             }
           }
+        } else if (reduction == SegmentReductionType::MEAN) {
+          auto grad_val = grad_data[output_index] / lengths_data[i];
+          for (int64_t j = 0; j < lengths_data[i]; ++j) {
+            int64_t starting_index = ((lengths_cum_sum + j) * stride_count) + l;
+            grad_input_data[starting_index] = grad_val;
+          }
         }
+      }
+
+      lengths_cum_sum += lengths_data[i];
+    }
       }));
 
   return grad_input;
@@ -152,8 +177,7 @@ Tensor segment_reduce_kernel(
     bool unsafe,
     const c10::optional<Scalar>& initial) {
   axis = maybe_wrap_dim(axis, data.ndimension());
-  TORCH_CHECK(axis == 0, "Currently only dim=0 is supported!");
-  TORCH_CHECK(data.dim() == 1);
+  TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
   TORCH_CHECK(data.numel() > 0);
 
   // length related checks
@@ -169,7 +193,7 @@ Tensor segment_reduce_kernel(
     auto min_length = lengths_value.min().item<int64_t>();
     TORCH_CHECK((min_length >= 0), "lengths contains negative value!");
     TORCH_CHECK(min_length != 0 || initial.has_value());
-    TORCH_CHECK(lengths_value.sum().item<int64_t>() == data.numel());
+    TORCH_CHECK(lengths_value.sum().item<int64_t>() == data.size(axis));
   }
 
   auto reduction = get_reduction_enum(reduce);
@@ -203,7 +227,10 @@ Tensor _segment_reduce_backward_kernel(
     const Tensor& output,
     const Tensor& data,
     c10::string_view reduce,
-    const c10::optional<Tensor>& lengths) {
+    const c10::optional<Tensor>& lengths,
+    int64_t axis) {
+  axis = maybe_wrap_dim(axis, data.ndimension());
+  TORCH_CHECK(axis == 0, "Currently only dim=0 is supported! ", axis);
   TORCH_CHECK(
       lengths.has_value(),
       "Currently only lengths based reduction is supported!")
@@ -221,7 +248,8 @@ Tensor _segment_reduce_backward_kernel(
       output_contig,
       data_contig,
       reduction,
-      lengths_contig);
+      lengths_contig,
+      axis);
 }
 
 REGISTER_ARCH_DISPATCH(

--- a/aten/src/ATen/native/SegmentReduce.h
+++ b/aten/src/ATen/native/SegmentReduce.h
@@ -22,7 +22,8 @@ using segment_reduce_backward_fn = Tensor (*)(
     const Tensor&,
     const Tensor&,
     SegmentReductionType,
-    const Tensor&);
+    const Tensor&,
+    int64_t);
 DECLARE_DISPATCH(segment_reduce_backward_fn, _segment_reduce_backward_stub);
 
 } // namespace native

--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -10,6 +10,7 @@
 namespace at {
 namespace native {
 
+namespace {
 struct CustomMax {
   template <typename OutputT>
   __host__ __device__ __forceinline__ OutputT
@@ -70,6 +71,169 @@ __global__ static void post_sum_div_kernel(
   }
 }
 
+template <typename scalar_t>
+__global__ static void segment_reduce_forward_kernel(
+    SegmentReductionType reduction,
+    scalar_t* output_data,
+    scalar_t* values_data,
+    const int64_t* lengths_data,
+    const int64_t* lengths_cumsum_data,
+    const int64_t segment_count,
+    const int64_t stride_count,
+    bool is_initial_set,
+    scalar_t initial_value) {
+  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t row_id = idx / stride_count;
+  int64_t lane_id = idx % stride_count;
+  if (idx >= (segment_count * stride_count)) {
+    return;
+  }
+  int64_t offset_start = lengths_cumsum_data[row_id];
+  int64_t offset_end = lengths_cumsum_data[row_id + 1];
+
+  // ===== step2: apply reduction
+  for (int64_t j = offset_start; j < offset_end; ++j) {
+    int64_t starting_index = (j * stride_count) + lane_id;
+    const auto data = values_data[starting_index];
+    // TODO: There is no need to branch with every element
+    if (reduction == SegmentReductionType::MAX) {
+      initial_value =
+          at::_isnan(data) ? data : std::max<scalar_t>(initial_value, data);
+    } else if (reduction == SegmentReductionType::MEAN) {
+      initial_value = initial_value + data;
+    }
+  }
+
+  // ===== step3: finalize reduction
+  CUDA_KERNEL_ASSERT(lengths_data[row_id] >= 0);
+  if (lengths_data[row_id] == 0 && !is_initial_set) {
+    initial_value = static_cast<scalar_t>(NAN);
+  } else if (
+      reduction == SegmentReductionType::MEAN && lengths_data[row_id] > 0 &&
+      !at::_isnan(initial_value)) {
+    initial_value = initial_value / lengths_data[row_id];
+  }
+  int64_t output_index = (row_id * stride_count) + lane_id;
+  output_data[output_index] = initial_value;
+}
+
+template <typename scalar_t>
+__global__ static void segment_reduce_backward_kernel(
+    SegmentReductionType reduction,
+    scalar_t* grad_input_data,
+    scalar_t* grad_data,
+    scalar_t* output_data,
+    const scalar_t* values_data,
+    const int64_t* lengths_data,
+    const int64_t* lengths_cumsum_data,
+    const int64_t segment_count,
+    const int64_t stride_count) {
+  int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t row_id = idx / stride_count;
+  int64_t lane_id = idx % stride_count;
+
+  if (idx >= (segment_count * stride_count)) {
+    return;
+  }
+  if (lengths_data[row_id] == 0) {
+    return;
+  }
+
+  int64_t offset_start = lengths_cumsum_data[row_id];
+  int64_t offset_end = lengths_cumsum_data[row_id + 1];
+
+  int64_t output_index = (row_id * stride_count) + lane_id;
+
+  if (reduction == SegmentReductionType::MAX) {
+    int64_t counter = 0;
+    for (int64_t j = offset_start; j < offset_end; ++j) {
+      int64_t starting_index = (j * stride_count) + lane_id;
+      if (at::_isnan(values_data[starting_index]) ||
+          values_data[starting_index] == output_data[output_index]) {
+        grad_input_data[starting_index] = grad_data[output_index];
+        counter++;
+      }
+    }
+    // Average gradient based on number of maximum elements in the
+    // segment
+    if (counter < 2) {
+      return;
+    }
+    for (int64_t j = offset_start; j < offset_end; ++j) {
+      int64_t starting_index = (j * stride_count) + lane_id;
+      if (grad_input_data[starting_index] > 0) {
+        grad_input_data[starting_index] =
+            grad_input_data[starting_index] / counter;
+      }
+    }
+  } else if (reduction == SegmentReductionType::MEAN) {
+    auto grad_val = grad_data[output_index] / lengths_data[row_id];
+    for (int64_t j = offset_start; j < offset_end; ++j) {
+      int64_t starting_index = (j * stride_count) + lane_id;
+      grad_input_data[starting_index] = grad_val;
+    }
+  }
+}
+
+} // namespace
+
+Tensor _segment_reduce_cuda_backward_kernel(
+    const Tensor& grad_contig,
+    const Tensor& output_contig,
+    const Tensor& data_contig,
+    SegmentReductionType reduction,
+    const Tensor& lengths_contig,
+    int64_t axis) {
+  int64_t segment_count = lengths_contig.numel();
+  auto output_shape = data_contig.sizes().vec();
+  output_shape[axis] = segment_count;
+  auto grad_input = at::zeros({data_contig.sizes()}, grad_contig.options());
+
+  int64_t stride_count = data_contig.numel() / data_contig.size(axis);
+  const auto* lengths_data = lengths_contig.data_ptr<int64_t>();
+
+  auto offsets = _get_complete_sum(lengths_contig);
+  auto* offsets_data = offsets.data_ptr<int64_t>();
+
+  constexpr int threads_per_block = 256;
+  int64_t num_blocks =
+      ((segment_count * stride_count) + threads_per_block - 1) /
+      threads_per_block;
+
+  num_blocks = std::max(num_blocks, (int64_t)1);
+
+  // TODO: Swtich to TensorIterator for better maintainablility and readability
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kBFloat16,
+      kHalf,
+      data_contig.scalar_type(),
+      "_segment_reduce_cpu",
+      ([&]() {
+        auto* output_data = output_contig.data_ptr<scalar_t>();
+        auto* grad_data = grad_contig.data_ptr<scalar_t>();
+        auto* grad_input_data = grad_input.data_ptr<scalar_t>();
+        const auto* values_data = data_contig.data_ptr<scalar_t>();
+
+        segment_reduce_backward_kernel<scalar_t>
+            <<<num_blocks,
+               threads_per_block,
+               0,
+               at::cuda::getCurrentCUDAStream()>>>(
+                reduction,
+                grad_input_data,
+                grad_data,
+                output_data,
+                values_data,
+                lengths_data,
+                offsets_data,
+                segment_count,
+                stride_count);
+        C10_CUDA_KERNEL_LAUNCH_CHECK();
+      }));
+
+  return grad_input;
+}
+
 Tensor _segment_reduce_cuda_kernel(
     SegmentReductionType reduction,
     const Tensor& data,
@@ -77,14 +241,21 @@ Tensor _segment_reduce_cuda_kernel(
     int64_t axis,
     const c10::optional<Scalar>& initial) {
   int64_t segment_count = lengths.numel();
-  auto output = at::empty({segment_count}, data.options());
+  auto output_shape = data.sizes().vec();
+  output_shape[axis] = segment_count;
+  auto output = at::empty(output_shape, data.options());
+
+  int64_t stride_count = data.numel() / data.size(axis);
+  const auto* lengths_data = lengths.data_ptr<int64_t>();
 
   auto offsets = _get_complete_sum(lengths);
   auto* offsets_data_ptr = offsets.data_ptr<int64_t>();
 
   constexpr int threads_per_block = 256;
   int64_t num_blocks =
-      (segment_count + threads_per_block - 1) / threads_per_block;
+      ((segment_count * stride_count) + threads_per_block - 1) /
+      threads_per_block;
+
   num_blocks = std::max(num_blocks, (int64_t)1);
   auto* lengths_data_ptr = lengths.data_ptr<int64_t>();
 
@@ -97,48 +268,70 @@ Tensor _segment_reduce_cuda_kernel(
         auto* data_data_ptr = data.data_ptr<scalar_t>();
         auto* output_data_ptr = output.data_ptr<scalar_t>();
 
-        if (reduction == SegmentReductionType::MAX) {
-          CustomMax max_op{};
-          scalar_t initial_value = initial.has_value()
-              ? initial.value().to<scalar_t>()
-              : std::numeric_limits<scalar_t>::lowest();
-          CUB_WRAPPER(
-              cub::DeviceSegmentedReduce::Reduce,
-              data_data_ptr,
-              output_data_ptr,
-              segment_count,
-              offsets_data_ptr,
-              offsets_data_ptr + 1,
-              max_op,
-              initial_value,
-              at::cuda::getCurrentCUDAStream());
+        // initialize starting value
+        scalar_t initial_value;
+        if (initial.has_value()) {
+          initial_value = initial.value().to<scalar_t>();
+        } else if (reduction == SegmentReductionType::MAX) {
+          initial_value = std::numeric_limits<scalar_t>::lowest();
         } else if (reduction == SegmentReductionType::MEAN) {
-          CustomSum sum_op{};
-          scalar_t initial_value = initial.has_value()
-              ? initial.value().to<scalar_t>()
-              : (scalar_t)0;
-          CUB_WRAPPER(
-              cub::DeviceSegmentedReduce::Reduce,
-              data_data_ptr,
-              output_data_ptr,
-              segment_count,
-              offsets_data_ptr,
-              offsets_data_ptr + 1,
-              sum_op,
-              initial_value,
-              at::cuda::getCurrentCUDAStream());
+          initial_value = 0;
+        }
 
-          post_sum_div_kernel<scalar_t>
+        if (output_shape.size() > 1) {
+          segment_reduce_forward_kernel<scalar_t>
               <<<num_blocks,
                  threads_per_block,
                  0,
                  at::cuda::getCurrentCUDAStream()>>>(
+                  reduction,
                   output_data_ptr,
+                  data_data_ptr,
                   lengths_data_ptr,
+                  offsets_data_ptr,
                   segment_count,
+                  stride_count,
                   initial.has_value(),
                   initial_value);
           C10_CUDA_KERNEL_LAUNCH_CHECK();
+        } else {
+          if (reduction == SegmentReductionType::MAX) {
+            CustomMax max_op{};
+            CUB_WRAPPER(
+                cub::DeviceSegmentedReduce::Reduce,
+                data_data_ptr,
+                output_data_ptr,
+                segment_count,
+                offsets_data_ptr,
+                offsets_data_ptr + 1,
+                max_op,
+                initial_value,
+                at::cuda::getCurrentCUDAStream());
+          } else if (reduction == SegmentReductionType::MEAN) {
+            CustomSum sum_op{};
+            CUB_WRAPPER(
+                cub::DeviceSegmentedReduce::Reduce,
+                data_data_ptr,
+                output_data_ptr,
+                segment_count,
+                offsets_data_ptr,
+                offsets_data_ptr + 1,
+                sum_op,
+                initial_value,
+                at::cuda::getCurrentCUDAStream());
+
+            post_sum_div_kernel<scalar_t>
+                <<<num_blocks,
+                   threads_per_block,
+                   0,
+                   at::cuda::getCurrentCUDAStream()>>>(
+                    output_data_ptr,
+                    lengths_data_ptr,
+                    segment_count,
+                    initial.has_value(),
+                    initial_value);
+            C10_CUDA_KERNEL_LAUNCH_CHECK();
+          }
         }
       });
 
@@ -146,6 +339,9 @@ Tensor _segment_reduce_cuda_kernel(
 }
 
 REGISTER_DISPATCH(_segment_reduce_stub, &_segment_reduce_cuda_kernel);
+REGISTER_DISPATCH(
+    _segment_reduce_backward_stub,
+    &_segment_reduce_cuda_backward_kernel);
 
 } // namespace native
 } // namespace at

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10125,7 +10125,7 @@
   dispatch:
     CPU, CUDA: segment_reduce_kernel
 
-- func: _segment_reduce_backward(Tensor grad, Tensor output, Tensor data, str reduce, *, Tensor? lengths=None) -> Tensor
+- func: _segment_reduce_backward(Tensor grad, Tensor output, Tensor data, str reduce, *, Tensor? lengths=None, int axis=0) -> Tensor
   variants: function
   dispatch:
     CPU, CUDA: _segment_reduce_backward_kernel

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -1,8 +1,10 @@
+import numpy as np
 import torch
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     dtypes,
     dtypesIfCUDA,
+    onlyCPU,
 )
 from torch.testing._internal.common_utils import (
     TestCase,
@@ -12,29 +14,29 @@ from torch.testing._internal.common_utils import (
 
 
 class TestSegmentReductions(TestCase):
-    def _test_simple_1d(self, reduction, device, dtype, unsafe, axis):
-        lengths = torch.tensor([1, 2, 3, 0], device=device)
+    def _test_common(
+        self,
+        reduction,
+        device,
+        dtype,
+        unsafe,
+        axis,
+        initial_value,
+        data_arr,
+        lengths_arr,
+        expected_arr,
+        expected_grad_arr,
+        check_backward,
+    ):
+        lengths = torch.tensor(lengths_arr, device=device)
         data = torch.tensor(
-            [1, float("nan"), 3, 4, 5, 5],
+            data_arr,
             device=device,
             dtype=dtype,
             requires_grad=True,
         )
-        initial_value = 0
-        if reduction == "max":
-            expected_result = torch.tensor(
-                [1, float("nan"), 5, initial_value], device=device, dtype=dtype
-            )
-            expected_grad = torch.tensor(
-                [1, 1, 0, 0, 0.5, 0.5], device=device, dtype=dtype
-            )
-        elif reduction == "mean":
-            expected_result = torch.tensor(
-                [1, float("nan"), 4.666, initial_value], device=device, dtype=dtype
-            )
-            expected_grad = torch.tensor(
-                [1.0, 0.5, 0.5, 0.333, 0.333, 0.333], device=device, dtype=dtype
-            )
+        expected_result = torch.tensor(expected_arr, device=device, dtype=dtype)
+        expected_grad = torch.tensor(expected_grad_arr, device=device, dtype=dtype)
         actual_result = torch.segment_reduce(
             data=data,
             reduce=reduction,
@@ -47,8 +49,7 @@ class TestSegmentReductions(TestCase):
             expected_result, actual_result, rtol=1e-02, atol=1e-05, equal_nan=True
         )
 
-        # TODO: Remove this check once cuda backward support is implemented
-        if data.is_cuda:
+        if not check_backward:
             return
 
         # Test backward
@@ -60,9 +61,11 @@ class TestSegmentReductions(TestCase):
         # gradcheck does not work well with bfloat16 or fp16 cpu types
         # also there is small numerical difference with fp32
         if dtype not in [torch.half, torch.bfloat16, torch.float]:
-            # gradcheck does not like "nan" input
+            # gradcheck does not like "nan" input, setting to random 10
+            d_non_nan = np.nan_to_num(data_arr, nan=10)
             data = torch.tensor(
-                [1, 10, 3, 4, 5, 5],
+                # [10 if v == float("nan") else v for v in data],
+                d_non_nan,
                 device=device,
                 dtype=dtype,
                 requires_grad=True,
@@ -84,11 +87,130 @@ class TestSegmentReductions(TestCase):
     @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_simple_1d(self, device, dtype):
+        lengths = [1, 2, 3, 0]
+        data = [1, float("nan"), 3, 4, 5, 5]
+        initial_value = 0
+
+        # TODO: Set this to true once cuda backward support is implemented
+        check_backward = device == "cpu"
+
         for reduction in ("max", "mean"):
-            self._test_simple_1d(reduction, device, dtype, False, 0)
-            self._test_simple_1d(reduction, device, dtype, False, -1)
-            self._test_simple_1d(reduction, device, dtype, True, 0)
-            self._test_simple_1d(reduction, device, dtype, True, -1)
+            if reduction == "max":
+                expected_result = [1, float("nan"), 5, initial_value]
+                expected_grad = [1, 1, 0, 0, 0.5, 0.5]
+            elif reduction == "mean":
+                expected_result = [1, float("nan"), 4.666, initial_value]
+                expected_grad = [1.0, 0.5, 0.5, 0.333, 0.333, 0.333]
+            for axis in [0, -1]:
+                for unsafe in [True, False]:
+                    self._test_common(
+                        reduction,
+                        device,
+                        dtype,
+                        unsafe,
+                        axis,
+                        initial_value,
+                        data,
+                        lengths,
+                        expected_result,
+                        expected_grad,
+                        check_backward,
+                    )
+
+    @onlyCPU
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_multi_d_simple(self, device, dtype):
+        initial_value = 0
+        axis = 0
+        lengths = [1, 2, 3, 0]
+        data = [[1, 1], [float("nan"), 1], [3, float("nan")], [4, 1], [3, 2], [2, 3]]
+
+        # TODO: Set this to true once cuda backward support is implemented
+        check_backward = device == "cpu"
+
+        for reduction in ["max", "mean"]:
+            if reduction == "max":
+                expected_result = [
+                    [1, 1],
+                    [float("nan"), float("nan")],
+                    [4, 3],
+                    [initial_value, initial_value],
+                ]
+                expected_grad = [
+                    [1, 1],
+                    [1, 0],
+                    [0, 1],
+                    [1, 0],
+                    [0, 0],
+                    [0, 1],
+                ]
+            elif reduction == "mean":
+                expected_result = [
+                    [1, 1],
+                    [float("nan"), float("nan")],
+                    [3, 2],
+                    [initial_value, initial_value],
+                ]
+                expected_grad = [
+                    [1.0, 1.0],
+                    [0.5, 0.5],
+                    [0.5, 0.5],
+                    [0.333, 0.333],
+                    [0.333, 0.333],
+                    [0.333, 0.333],
+                ]
+            for unsafe in [True, False]:
+                self._test_common(
+                    reduction,
+                    device,
+                    dtype,
+                    unsafe,
+                    axis,
+                    initial_value,
+                    data,
+                    lengths,
+                    expected_result,
+                    expected_grad,
+                    check_backward,
+                )
+
+    @onlyCPU
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_multi_d(self, device, dtype):
+        initial_value = 0
+        axis = 0
+        lengths = [0, 2]
+        data = np.arange(20).reshape(2, 2, 5).tolist()
+        expected_grad = []
+
+        # TODO: calculate grad and check correctness
+        check_backward = False
+
+        for reduction in ["max", "mean"]:
+            if reduction == "max":
+                expected_result = [
+                    np.full((2, 5), initial_value).tolist(),
+                    np.max(data, axis=0).tolist(),
+                ]
+            elif reduction == "mean":
+                expected_result = [
+                    np.full((2, 5), initial_value).tolist(),
+                    np.mean(data, axis=0).tolist(),
+                ]
+            for unsafe in [True, False]:
+                self._test_common(
+                    reduction,
+                    device,
+                    dtype,
+                    unsafe,
+                    axis,
+                    initial_value,
+                    data,
+                    lengths,
+                    expected_result,
+                    expected_grad,
+                    check_backward,
+                )
 
 
 instantiate_device_type_tests(TestSegmentReductions, globals())

--- a/test/test_segment_reductions.py
+++ b/test/test_segment_reductions.py
@@ -4,7 +4,6 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     dtypes,
     dtypesIfCUDA,
-    onlyCPU,
 )
 from torch.testing._internal.common_utils import (
     TestCase,
@@ -90,9 +89,7 @@ class TestSegmentReductions(TestCase):
         lengths = [1, 2, 3, 0]
         data = [1, float("nan"), 3, 4, 5, 5]
         initial_value = 0
-
-        # TODO: Set this to true once cuda backward support is implemented
-        check_backward = device == "cpu"
+        check_backward = True
 
         for reduction in ("max", "mean"):
             if reduction == "max":
@@ -117,18 +114,16 @@ class TestSegmentReductions(TestCase):
                         check_backward,
                     )
 
-    @onlyCPU
+    @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_multi_d_simple(self, device, dtype):
         initial_value = 0
+        check_backward = True
         axis = 0
         lengths = [1, 2, 3, 0]
         data = [[1, 1], [float("nan"), 1], [3, float("nan")], [4, 1], [3, 2], [2, 3]]
 
-        # TODO: Set this to true once cuda backward support is implemented
-        check_backward = device == "cpu"
-
-        for reduction in ["max", "mean"]:
+        for reduction in ("max", "mean"):
             if reduction == "max":
                 expected_result = [
                     [1, 1],
@@ -174,7 +169,7 @@ class TestSegmentReductions(TestCase):
                     check_backward,
                 )
 
-    @onlyCPU
+    @dtypesIfCUDA(torch.half, torch.bfloat16, torch.float, torch.double)
     @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
     def test_multi_d(self, device, dtype):
         initial_value = 0


### PR DESCRIPTION
Summary:
Same as title.

Next Steps:
- Add support for multi-d cuda backward
- Add support for sum/min
- More testing and benchmarking
- Cleanup
    - Update default values when length is 0
    - Use TensorIterator
    - Update documentation

Test Plan: Unit test to cover cuda forward path.

Differential Revision: D29135373

