### PR TITLE
[TODO] for test entrypoint restructure

### DIFF
--- a/.circleci/scripts/upload_binary_size_to_scuba.py
+++ b/.circleci/scripts/upload_binary_size_to_scuba.py
@@ -1,3 +1,5 @@
+# TODO: move to tools/ folder
+
 import glob
 import json
 import logging

--- a/.jenkins/pytorch/test.sh
+++ b/.jenkins/pytorch/test.sh
@@ -435,6 +435,14 @@ test_torch_deploy() {
   assert_git_not_dirty
 }
 
+
+# TODO: download S3 stats based on BUILD_ENVIRONMENT
+# TODO: download github stats based on BUILD_ENVIRONMENT
+# TODO invoke tools/stats/stats_downloader
+
+
+# Launching different test entrypoints or python test/run_test.py with different arguments
+# based on BUILD_ENVIRONMENT
 if ! [[ "${BUILD_ENVIRONMENT}" == *libtorch* || "${BUILD_ENVIRONMENT}" == *-bazel-* ]]; then
   (cd test && python -c "import torch; print(torch.__config__.show())")
   (cd test && python -c "import torch; print(torch.__config__.parallel_info())")

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1124,7 +1124,6 @@ def export_S3_test_times(test_times_filename: str, test_times: Dict[str, float])
         json.dump(job_times_json, file, indent='    ', separators=(',', ': '))
         file.write('\n')
 
-
 def load_specified_test_cases(filename: str) -> None:
     if not os.path.exists(filename):
         print(f'Could not find specified tests file: {filename}. Proceeding with default behavior.')
@@ -1203,6 +1202,7 @@ def main():
         export_S3_test_times(test_times_filename, pull_job_times_from_S3())
         return
 
+    # TODO: Downloading of this file should move to tools/stats_downloader.py
     specified_test_cases_filename = options.run_specified_test_cases
     if specified_test_cases_filename:
         print(f'Loading specified test cases to run from {specified_test_cases_filename}.')

--- a/tools/stats_utils/github_stats_parser.py
+++ b/tools/stats_utils/github_stats_parser.py
@@ -1,0 +1,2 @@
+# TODO Downloading status from github including githubcontent URLs or github APIs
+# stats might not be the best name here

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -153,6 +153,8 @@ def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Repor
             summary_dict[summary_job].append(json.loads(string))
     return summary_dict
 
+# TODO: the following 2 functions should be move to stats_downloader.py as they are entrypoint currently called by run_test.py
+
 # Collect and decompress S3 test stats summaries into JSON.
 # data stored on S3 buckets are pathed by {sha}/{job} so we also allow
 # optional jobs filter

--- a/tools/stats_utils/stats_downloader.py
+++ b/tools/stats_utils/stats_downloader.py
@@ -1,0 +1,7 @@
+# TODO: download entrypoint for all STATS
+
+from s3_stats_parser import *
+from github_stats_parser import *
+
+
+

--- a/tools/test_selection/test_selection.py
+++ b/tools/test_selection/test_selection.py
@@ -1,0 +1,15 @@
+# TODO provide function to select test-modules or test-cases within a test module / test case
+# It basically loads files downloaded from tools/stats_downloader.py and convert into 
+#    1. list of test_modules in test/run_test.py: TESTS 
+#    2. list of test cases used for torch/testing/_internal/common_utils.py: discover_test_cases_recursively
+#    3. list of test case name pattern used by unittest.main: -k argument
+
+from typing import Dict, List
+
+# Return list of test modules to be run
+def determine_test_module(**kwargs) -> Dict[str, List[str]]:
+    pass
+
+# Return list of test cases to be run
+def determine_test_case(**kwargs) -> List[str]:
+    pass

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -867,6 +867,7 @@ def fetch_and_cache(name: str, url: str):
 
 
 slow_tests_dict: Optional[Dict[str, float]] = None
+# TODO: the following should move to tools/stats_downloader
 def check_slow_test_from_stats(test):
     global slow_tests_dict
     if slow_tests_dict is None:
@@ -883,7 +884,7 @@ def check_slow_test_from_stats(test):
         if not TEST_WITH_SLOW:
             raise unittest.SkipTest("test is slow; run with PYTORCH_TEST_WITH_SLOW to enable test")
 
-
+# TODO: the following should move to tools/stats_downloader
 disabled_test_from_issues: Optional[Dict[str, Any]] = None
 def check_disabled(test_name):
     global disabled_test_from_issues
@@ -891,6 +892,7 @@ def check_disabled(test_name):
         _disabled_test_from_issues: Dict = {}
 
         def read_and_process():
+            # TODO: the following should move to tools/github_stats_parser.py
             url = 'https://raw.githubusercontent.com/pytorch/test-infra/master/stats/disabled-tests.json'
             contents = urlopen(url, timeout=1).read().decode('utf-8')
             the_response = fetch_and_cache(".pytorch-disabled-tests", url)

--- a/torch/testing/_internal/framework_utils.py
+++ b/torch/testing/_internal/framework_utils.py
@@ -1,3 +1,4 @@
+# TODO move this to tools/
 from typing import Dict, Tuple, List
 
 def calculate_shards(num_shards: int, tests: List[str], job_times: Dict[str, float]) -> List[Tuple[float, List[str]]]:


### PR DESCRIPTION
Some example TODO comments for test entrypoint restructuring. 
- .jenkins/pytorch/test.sh should also invoke download logic 
- tools
  - tools/stats_utils/* should consist of s3_stats_parser.py github_stats_parser.py (and any additional stats file access)
  - tools/stats_utils/stats_downloader.py is entrypoint called by test.sh
  - tools/test_selection/* consist of file parser / converter that converts raw stats into test module or test case lists (based on whether to do slow_test / sharding / disabled / config-based selection (e.g. only run cuda_mem_check on cuda11) / build environment based selection (only run smoke test on windows for PR) ...
- torch/testing/_internal/* shouldn't have any http access
- test/run_test converts any CI-related arguments into common_utils arguments