### PR TITLE
Avoid complex-to-real cast warning in CopyBackward

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -8354,6 +8354,18 @@ class TestAutogradDeviceType(TestCase):
         _tensor_tensor_helper(x, x)
         _tensor_tensor_helper(y, y)
 
+    def test_copy_r_to_c(self, device):
+        out_c = torch.empty(3, 2, dtype=torch.cdouble, device=device)
+        inp_r = torch.randn(3, 2, dtype=torch.double, device=device,
+                            requires_grad=True)
+
+        def do_test():
+            out_c.copy_(inp_r)
+            out_c.sum().backward()
+            self.assertEqual(inp_r.grad, torch.ones_like(inp_r))
+
+        self.assertNotWarn(do_test)
+
 
 class TestAutogradInferenceMode(TestCase):
     def _is_inference_tensor(self, tensor):

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -35,9 +35,9 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
       // This code is kind of weirdly asymmetric.
       const bool copy = (grad->is_cuda() && grad->device() != src_device);
       grad_inputs[1] = grad->to(
-        src_options,
-        /*non_blocking=*/false,
-        /*copy=*/copy);
+          src_options,
+          /*non_blocking=*/false,
+          /*copy=*/copy);
     }
   }
   return grad_inputs;

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -17,24 +17,27 @@ namespace torch { namespace autograd {
 
 auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
   check_input_variables("CopyBackwards", grads, 1, -1, true);
-  auto& grad = grads[0];
+  auto grad = c10::MaybeOwned<at::Tensor>::borrowed(grads[0]);
   variable_list grad_inputs(2);
-  if (grad.defined()) {
+  if (grad->defined()) {
     if (should_compute_output(0)) {
-      grad_inputs[0] = at::zeros_like(grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
+      grad_inputs[0] = at::zeros_like(*grad, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
     }
     if (should_compute_output(1)) {
+      // Handle R->C copies without raising a warning
+      const auto src_type = src_options.dtype().toScalarType();
+      if (!c10::isComplexType(src_type) && grad->is_complex()) {
+        grad = c10::MaybeOwned<at::Tensor>::owned(at::real(grads[0]));
+      }
+
       at::DeviceGuard device_guard(src_device);
       // TODO: What if !grad.is_cuda(), but src_device is CUDA?
       // This code is kind of weirdly asymmetric.
-      if (grad.is_cuda() && grad.device() != src_device) {
-        grad_inputs[1] = grad.to(
-            src_options,
-            /*non_blocking=*/false,
-            /*copy=*/true);
-      } else {
-        grad_inputs[1] = grad.to(src_options);
-      }
+      const bool copy = (grad->is_cuda() && grad->device() != src_device);
+      grad_inputs[1] = grad->to(
+        src_options,
+        /*non_blocking=*/false,
+        /*copy=*/copy);
     }
   }
   return grad_inputs;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60025 CopyBackward: Remove redundant src_device and unnecessary copy=True
* **#60021 Avoid complex-to-real cast warning in CopyBackward**
* #60020 Set TORCH_WARN_ONCE to always warn inside of assertNotWarn

Dropping the imaginary component is expected and gives the correct gradient
formula, so silencing the warning is appropriate.

Differential Revision: [D29589371](https://our.internmc.facebook.com/intern/diff/D29589371)