### PR TITLE
CopyBackward: Remove redundant src_device and unnecessary copy=True

### DIFF
--- a/torch/csrc/autograd/VariableTypeManual.cpp
+++ b/torch/csrc/autograd/VariableTypeManual.cpp
@@ -123,7 +123,6 @@ Tensor & copy_(c10::DispatchKeySet ks, Tensor & self, const Tensor & src, bool n
     grad_fn = std::make_shared<CopyBackwards>();
     grad_fn->set_next_edges(collect_next_edges(self, src));
     grad_fn->src_options = src.options();
-    grad_fn->src_device = src.device();
   }
   {
     at::AutoDispatchBelowAutograd mode;

--- a/torch/csrc/autograd/functions/tensor.cpp
+++ b/torch/csrc/autograd/functions/tensor.cpp
@@ -30,14 +30,8 @@ auto CopyBackwards::apply(variable_list&& grads) -> variable_list {
         grad = c10::MaybeOwned<at::Tensor>::owned(at::real(grads[0]));
       }
 
-      at::DeviceGuard device_guard(src_device);
-      // TODO: What if !grad.is_cuda(), but src_device is CUDA?
-      // This code is kind of weirdly asymmetric.
-      const bool copy = (grad->is_cuda() && grad->device() != src_device);
-      grad_inputs[1] = grad->to(
-          src_options,
-          /*non_blocking=*/false,
-          /*copy=*/copy);
+      at::DeviceGuard device_guard(src_options.device());
+      grad_inputs[1] = grad->to(src_options);
     }
   }
   return grad_inputs;

--- a/torch/csrc/autograd/functions/tensor.h
+++ b/torch/csrc/autograd/functions/tensor.h
@@ -17,7 +17,6 @@ struct TORCH_API CopyBackwards : public Node {
   variable_list apply(variable_list&& grads) override;
 
   at::TensorOptions src_options;
-  at::Device src_device = at::kCPU;
 };
 
 // Note [View + Inplace update for base tensor]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60025 CopyBackward: Remove redundant src_device and unnecessary copy=True**
* #60021 Avoid complex-to-real cast warning in CopyBackward
* #60020 Set TORCH_WARN_ONCE to always warn inside of assertNotWarn

`to` already copies unconditionally if `src.device() != options.device()` so
specifying the copy argument is unnecessary.

`src.device()` is also completely equivalent to `src.options().device()` so
storing both is redundant.

Differential Revision: [D29698627](https://our.internmc.facebook.com/intern/diff/D29698627)