### PR TITLE
support parsing of PR stats in run_test.py

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -1194,6 +1194,7 @@ def reorder_tests(tests: List[str]) -> List[str]:
             s3_reports: List[Tuple["Report", str]] = get_previous_reports_for_pr(
                 pr_number, ci_job_prefix)
             prioritized_tests = query_failure_test_module(s3_reports)
+            print("Prioritized test from previous CI info.")
 
     # Using file changes priority if no stats found from previous PR.
     if len(prioritized_tests) == 0:
@@ -1207,6 +1208,7 @@ def reorder_tests(tests: List[str]) -> List[str]:
         prioritized_tests = [f for f in changed_files if f.startswith(prefix) and f.endswith(".py")]
         prioritized_tests = [f[len(prefix):] for f in prioritized_tests]
         prioritized_tests = [f[:-len(".py")] for f in prioritized_tests]
+        print("Prioritized test from test file changes.")
 
     bring_to_front = []
     the_rest = []
@@ -1217,12 +1219,12 @@ def reorder_tests(tests: List[str]) -> List[str]:
         else:
             the_rest.append(test)
     if len(tests) == len(bring_to_front) + len(the_rest):
-        print(f"reordering tests based on CI:\n"
-            f"prioritized: {bring_to_front}\n the rest: {the_rest}\n")
+        print(f"reordering tests for PR:\n"
+              f"prioritized: {bring_to_front}\nthe rest: {the_rest}\n")
         return bring_to_front + the_rest
     else:
         print(f"Something went wrong in CI reordering, expecting total of {len(tests)}:\n"
-            f"prioritized: {bring_to_front}\nthe rest: {the_rest}\n")
+              f"but found prioritized: {len(bring_to_front)}\nthe rest: {len(the_rest)}\n")
         return tests
 
 

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -216,8 +216,8 @@ def get_previous_reports_for_branch(branch: str, ci_job_prefix: str = "") -> Lis
     return reports
 
 
-def get_previous_reports_for_pr(pr: str, ci_job_prefix: str = "") -> List[Report]:
-    reports: List[Tuple[str, Report]] = []
+def get_previous_reports_for_pr(pr: str, ci_job_prefix: str = "") -> List[Tuple[Report, str]]:
+    reports: List[Tuple[Report, str]] = []
     logger.info(f'Grabbing reports from PR: {[pr]}')
     summaries = get_test_stats_summaries_for_pr(pr=pr, job_prefix=ci_job_prefix)
     for _, summary in summaries.items():

--- a/tools/stats_utils/s3_stat_parser.py
+++ b/tools/stats_utils/s3_stat_parser.py
@@ -4,7 +4,7 @@ import logging
 import subprocess
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union, Any, cast
+from typing import Dict, List, Optional, Tuple, Union, Any, cast
 from typing_extensions import Literal, TypedDict
 
 try:
@@ -143,9 +143,10 @@ def get_cases(
     return cases
 
 
-def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Report]]:
+def _parse_master_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Report]]:
     summary_dict = defaultdict(list)
     for summary in summaries:
+        # master summary format: "test_time/{sha}/{job}/file"
         summary_job = summary.key.split('/')[2]
         if summary_job in jobs or len(jobs) == 0:
             binary = summary.get()["Body"].read()
@@ -153,19 +154,37 @@ def _parse_s3_summaries(summaries: Any, jobs: List[str]) -> Dict[str, List[Repor
             summary_dict[summary_job].append(json.loads(string))
     return summary_dict
 
+def _parse_pr_summaries(summaries: Any, job_prefix: str) -> Dict[str, List[Tuple[Report, str]]]:
+    summary_dict = defaultdict(list)
+    for summary in summaries:
+        # PR summary format: "pr_test_time/{pr}/{sha}/{job}/file"
+        summary_job = summary.key.split('/')[3]
+        summary_timestamp = summary.key.split('/')[4][:len("YYYY-MM-ddTHH:mm:ss")]
+        if not job_prefix or len(job_prefix) == 0 or summary_job.startswith(job_prefix):
+            binary = summary.get()["Body"].read()
+            string = bz2.decompress(binary).decode("utf-8")
+            summary_dict[summary_job].append((json.loads(string), summary_timestamp))
+    return summary_dict
+
+
 # Collect and decompress S3 test stats summaries into JSON.
 # data stored on S3 buckets are pathed by {sha}/{job} so we also allow
 # optional jobs filter
 def get_test_stats_summaries(*, sha: str, jobs: Optional[List[str]] = None) -> Dict[str, List[Report]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
     summaries = bucket.objects.filter(Prefix=f"test_time/{sha}")
-    return _parse_s3_summaries(summaries, jobs=list(jobs or []))
+    return _parse_master_summaries(summaries, jobs=list(jobs or []))
 
 
 def get_test_stats_summaries_for_job(*, sha: str, job_prefix: str) -> Dict[str, List[Report]]:
     bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
     summaries = bucket.objects.filter(Prefix=f"test_time/{sha}/{job_prefix}")
-    return _parse_s3_summaries(summaries, jobs=list())
+    return _parse_master_summaries(summaries, jobs=list())
+
+def get_test_stats_summaries_for_pr(*, pr: str, job_prefix: str) -> Dict[str, List[Tuple[Report, str]]]:
+    bucket = get_S3_bucket_readonly(OSSCI_METRICS_BUCKET)
+    summaries = bucket.objects.filter(Prefix=f"pr_test_time/{pr}/")
+    return _parse_pr_summaries(summaries, job_prefix=job_prefix)
 
 
 # This function returns a list of S3 test time reports. This function can run into errors if HAVE_BOTO3 = False
@@ -194,4 +213,15 @@ def get_previous_reports_for_branch(branch: str, ci_job_prefix: str = "") -> Lis
             if len(summary) > 1:
                 logger.warning(f'WARNING: Multiple summary objects found for {commit}/{job_name}')
         commit_index += 1
+    return reports
+
+
+def get_previous_reports_for_pr(pr: str, ci_job_prefix: str = "") -> List[Report]:
+    reports: List[Tuple[str, Report]] = []
+    logger.info(f'Grabbing reports from PR: {[pr]}')
+    summaries = get_test_stats_summaries_for_pr(pr=pr, job_prefix=ci_job_prefix)
+    for _, summary in summaries.items():
+        reports.extend(summary)
+    # sort by summary_timestamp
+    reports.sort(reverse=True, key=lambda s: s[1])
     return reports


### PR DESCRIPTION
Currently S3 test stats doesn't support PR stats parisng.

Changes to s3_stats_parser:
1. they are uploaded to `test_times/{sha1}/{job}` and `pr_test_times/{pr}/{sha1}/{job}` separately. Thus we need parsing logics for both 
2. need to attach time for PR stats parsing for ordering since PR commits can be force-pushed

Changes to run_test.py
1. Reordering based on previous PR stats if available
2. Falling back to file change option if not enabled.

Test Plan
- CI. 
- local repro: plz run:
```
CIRCLE_JOB="pytorch_linux_bionic_py3_6_clang9_noarch_test" CIRCLE_PR_NUMBER=60057 IN_CI=1 ENABLE_PR_HISTORY_REORDERING=1 python test/run_test.py
```