### PR TITLE
[Profiler] Fix memory profiler merge issue

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -385,6 +385,7 @@ void prepareProfiler(
 
   std::set<libkineto::ActivityType> cpuTypes = {
     libkineto::ActivityType::CPU_OP,
+    libkineto::ActivityType::CPU_INSTANT_EVENT,
 #ifdef USE_KINETO_UPDATED
     libkineto::ActivityType::USER_ANNOTATION,
 #endif


### PR DESCRIPTION
Summary: The memory profiler was broken due to a mis-merge during rebase. Add lost line back.

Differential Revision: D29143469

