### PR TITLE
Add .github/stale.yaml for torch.distributed issues.

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,63 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 14
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+# Only enable for distributed for now.
+onlyLabels: ["oncall: distributed"]
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+#exemptLabels:
+#  - pinned
+#  - security
+#  - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: Stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions. If you feel this issue needs further assistance, 
+  please tag the appropriate owners on the issue.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+   This issue has been automatically closed since it was stale.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -33,7 +33,7 @@ staleLabel: Stale
 markComment: >
   This issue has been automatically marked as stale because it has not had
   recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions. If you feel this issue needs further assistance, 
+  for your contributions. If you feel this issue needs further assistance,
   please tag the appropriate owners on the issue.
 
 # Comment to post when removing the stale label.

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -42,7 +42,8 @@ markComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-   This issue has been automatically closed since it was stale.
+   This issue has been automatically closed since it was stale. If you feel
+   the issue has not been resolved, feel free to re-open the issue.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 14
+daysUntilStale: 30
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60038 Add .github/stale.yaml for torch.distributed issues.**

Followed the instructions in  https://github.com/probot/stale to
enable the probot-stale github bot to automatically purge stale issues.

Enabled it only for the label "oncall: distributed" for now.

The goal is to automatically mark and purge stale issues which is a good forcing function for users and developers to follow up on an issue or close it out because it is not actionable.

Differential Revision: [D29144396](https://our.internmc.facebook.com/intern/diff/D29144396/)