### PR TITLE
Use GitHub's diff directly in clang-tidy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -312,11 +312,13 @@ jobs:
           fi
       - name: Run clang-tidy
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           cd "${GITHUB_WORKSPACE}"
           set -eux
+
+          wget -O pr.diff "https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/$PR_NUMBER.diff"
 
           # Run Clang-Tidy
           # The negative filters below are to exclude files that include onnx_pb.h or
@@ -326,27 +328,28 @@ jobs:
           # /torch/csrc/generic/*.cpp is excluded because those files aren't actually built.
           # deploy/interpreter files are excluded due to using macros and other techniquies
           # that are not easily converted to accepted c++
-          python3 tools/clang_tidy.py                               \
-            --verbose                                              \
-            --paths torch/csrc/                                    \
-            --diff "$BASE_SHA"                                   \
-            -g"-torch/csrc/jit/passes/onnx/helper.cpp"             \
-            -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp"\
-            -g"-torch/csrc/jit/serialization/onnx.cpp"             \
-            -g"-torch/csrc/jit/serialization/export.cpp"           \
-            -g"-torch/csrc/jit/serialization/import.cpp"           \
-            -g"-torch/csrc/jit/serialization/import_legacy.cpp"    \
-            -g"-torch/csrc/onnx/init.cpp"                          \
-            -g"-torch/csrc/cuda/nccl.*"                            \
-            -g"-torch/csrc/cuda/python_nccl.cpp"                   \
-            -g"-torch/csrc/autograd/FunctionsManual.cpp"           \
-            -g"-torch/csrc/generic/*.cpp"                          \
-            -g"-torch/csrc/jit/codegen/cuda/runtime/*"             \
-            -g"-torch/csrc/deploy/interpreter/interpreter.cpp"     \
-            -g"-torch/csrc/deploy/interpreter/interpreter.h"  \
-            -g"-torch/csrc/deploy/interpreter/interpreter_impl.h"  \
-            -g"-torch/csrc/deploy/interpreter/test_main.cpp"  \
-            "$@" > "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+          python3 tools/clang_tidy.py \
+            --verbose \
+            --paths torch/csrc/ \
+            --diff-file pr.diff \
+            -g"-torch/csrc/jit/passes/onnx/helper.cpp" \
+            -g"-torch/csrc/jit/passes/onnx/shape_type_inference.cpp" \
+            -g"-torch/csrc/jit/serialization/onnx.cpp" \
+            -g"-torch/csrc/jit/serialization/export.cpp" \
+            -g"-torch/csrc/jit/serialization/import.cpp" \
+            -g"-torch/csrc/jit/serialization/import_legacy.cpp" \
+            -g"-torch/csrc/onnx/init.cpp" \
+            -g"-torch/csrc/cuda/nccl.*" \
+            -g"-torch/csrc/cuda/python_nccl.cpp" \
+            -g"-torch/csrc/autograd/FunctionsManual.cpp" \
+            -g"-torch/csrc/generic/*.cpp" \
+            -g"-torch/csrc/jit/codegen/cuda/runtime/*" \
+            -g"-torch/csrc/deploy/interpreter/interpreter.cpp" \
+            -g"-torch/csrc/deploy/interpreter/interpreter.h" \
+            -g"-torch/csrc/deploy/interpreter/interpreter_impl.h" \
+            -g"-torch/csrc/deploy/interpreter/test_main.cpp" \
+            "$@" >"${GITHUB_WORKSPACE}"/clang-tidy-output.txt
+
 
           cat "${GITHUB_WORKSPACE}"/clang-tidy-output.txt
 

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     from pipes import quote
 
-from typing import Any, Dict, Iterable, List, Set, Union
+from typing import Any, Dict, Iterable, List, Set, Union, IO, Tuple
 
 Patterns = collections.namedtuple("Patterns", "positive, negative")
 
@@ -44,6 +44,7 @@ DEFAULT_FILE_PATTERN = re.compile(r".*\.c(c|pp)?")
 
 # @@ -start,count +start,count @@
 CHUNK_PATTERN = r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@"
+CHUNK_HEADER_RE = r"diff --git .*?\nindex.*?\n---.*?\n\+\+\+ b/(.*?)\n@@ -(\d+,\d+) \+(\d+,\d+) @@"
 CLANG_WARNING_PATTERN = re.compile(r"([^:]+):(\d+):\d+:\s+warning:.*\[([^\]]+)\]")
 
 
@@ -125,35 +126,26 @@ def filter_files(files: Iterable[str], file_patterns: Patterns) -> Iterable[str]
             print("{} omitted due to file filters".format(file))
 
 
-def get_changed_files(revision: str, paths: List[str]) -> List[str]:
-    """Runs git diff to get the paths of all changed files."""
-    # --diff-filter AMU gets us files that are (A)dded, (M)odified or (U)nmerged (in the working copy).
-    # --name-only makes git diff return only the file paths, without any of the source changes.
-    command = "git diff-index --diff-filter=AMU --ignore-all-space --name-only"
-    output = run_shell_command(shlex.split(command) + [revision] + paths)
-    return output.split("\n")
-
-
 def get_all_files(paths: List[str]) -> List[str]:
     """Returns all files that are tracked by git in the given paths."""
     output = run_shell_command(["git", "ls-files"] + paths)
     return output.split("\n")
 
 
-def get_changed_lines(revision: str, filename: str) -> Dict[str, Union[str, List[List[int]]]]:
-    """Runs git diff to get the line ranges of all file changes."""
-    command = shlex.split("git diff-index --unified=0") + [revision, filename]
-    output = run_shell_command(command)
-    changed_lines = []
-    for chunk in re.finditer(CHUNK_PATTERN, output, re.MULTILINE):
-        start = int(chunk.group(1))
-        count = int(chunk.group(2) or 1)
-        # If count == 0, a chunk was removed and can be ignored.
-        if count == 0:
-            continue
-        changed_lines.append([start, start + count])
+def find_changed_lines_from_diff(f: IO) -> Dict[str, List[Tuple[int, int]]]:
+    content = f.read()
+    files = collections.defaultdict(list)
 
-    return {"name": filename, "lines": changed_lines}
+    matches = re.findall(CHUNK_HEADER_RE, content, re.MULTILINE)
+    for file, start, end in matches:
+        start_line, _ = start.split(",")
+        end_line, _ = end.split(",")
+        print(file, start_line, end_line)
+
+        files[file].append((start_line, end_line))
+
+    return dict(files)
+
 
 ninja_template = """
 rule do_cmd
@@ -180,7 +172,7 @@ def run_shell_commands_in_parallel(commands: Iterable[List[str]]) -> str:
         return run_shell_command(['ninja', '-f', f.name])
 
 
-def run_clang_tidy(options: Any, line_filters: Any, files: Iterable[str]) -> str:
+def run_clang_tidy(options: Any, line_filters: Dict[str, List[Tuple[int, int]]], files: Iterable[str]) -> str:
     """Executes the actual clang-tidy command in the shell."""
     command = [options.clang_tidy_exe, "-p", options.compile_commands_dir]
     if not options.config_file and os.path.exists(".clang-tidy"):
@@ -283,7 +275,7 @@ def parse_options() -> Any:
         help="Path to the folder containing compile_commands.json",
     )
     parser.add_argument(
-        "-d", "--diff", help="Git revision to diff against to get changes"
+        "--diff-file", help="File containing diff to use for determining files to lint and line filters"
     )
     parser.add_argument(
         "-p",
@@ -333,8 +325,10 @@ def main() -> None:
 
     # Normalize the paths first.
     paths = [path.rstrip("/") for path in options.paths]
-    if options.diff:
-        files = get_changed_files(options.diff, paths)
+    if options.diff_file:
+        with open(options.diff_file, "r") as f:
+            line_filters = find_changed_lines_from_diff(f)
+            files = list(line_filters.keys())
     else:
         files = get_all_files(paths)
     file_patterns = get_file_patterns(options.glob, options.regex)
@@ -344,10 +338,6 @@ def main() -> None:
     if not files:
         print("No files detected.")
         sys.exit()
-
-    line_filters = []
-    if options.diff:
-        line_filters = [get_changed_lines(options.diff, f) for f in files]
 
     clang_tidy_output = run_clang_tidy(options, line_filters, files)
     if options.suppress_diagnostics:


### PR DESCRIPTION
This changes clang-tidy in lint.yml to pull the raw diff from GitHub and parse that rather than use the PRs base revision. The base revision can cause the spurious inclusion of files not changed in the PR as in https://github.com/pytorch/pytorch/pull/59967/checks?check_run_id=2832565901. We could be smarter about how we query git, but this approach ends up being simpler since we just need to search for the diff headers in the .diff file.
