### PR TITLE
Fix ignoring Tensor properties in torch.overrides

### DIFF
--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -1377,8 +1377,14 @@ def get_overridable_functions() -> Dict[Any, List[Callable]]:
                 continue
 
             if not callable(func) and hasattr(func, "__get__"):
-                overridable_funcs[func].append(func.__get__)
-                continue
+                if func.__get__ in get_ignored_functions():
+                    msg = ("{}.{} is in the tuple returned by torch._overrides.get_ignored_functions "
+                           "but still has an explicit override")
+                    assert func.__get__ not in get_testing_overrides(), msg.format(namespace, func.__name__)
+                    continue
+                else:
+                    overridable_funcs[func].append(func.__get__)
+                    continue
 
             if not callable(func):
                 continue


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #59760 Dispatch to Python via __torch_dispatch__
* **#60050 Fix ignoring Tensor properties in torch.overrides**
* #60044 Fix Python 3.8 expecttest machinery again, this time for good.

It doesn't work to put torch.Tensor.prop.__get__ in the ignored
list.  Now it does.  (Not exercised here, see next diff in stack).

Signed-off-by: Edward Z. Yang <ezyang@fb.com>

Differential Revision: [D29171464](https://our.internmc.facebook.com/intern/diff/D29171464)