### PR TITLE
mkl_scsrmm needs to be disabled when MKL is not used

### DIFF
--- a/caffe2/experiments/operators/fully_connected_op_sparse.h
+++ b/caffe2/experiments/operators/fully_connected_op_sparse.h
@@ -83,9 +83,16 @@ void Sparse_mm<float, CPUContext>(
     const float* b,
     float* c,
     CPUContext* /*context*/) {
+
+  #ifdef CAFFE2_USE_MKL
+
   float alpha = 1.0, beta = 0.;
   mkl_scsrmm("N", &m, &n, &k, &alpha, "GLNC",
              acsr, ja, ia, ia+1, b, &n, &beta, c, &n);
+
+  #else
+  throw std::runtime_error("Not compiled with MKL");
+  #endif
 }
 
 }


### PR DESCRIPTION
Summary:
Introduction:
We want to minimize the number of dependencies for the SGX port. Therefore we need the ability to disable MKL when it is not used.

Problem :
There is a call to mkl_scsrmm that is enabled when CAFFE2_USE_MKL is not defined. This causes a compile error.

Solution :
Surround the call with preprocessor checks to CAFFE2_USE_MKL

Test Plan: Run the pytorch tests.

Differential Revision: D29022635

