### PR TITLE
Disable the format library in C10

### DIFF
--- a/c10/util/signal_handler.cpp
+++ b/c10/util/signal_handler.cpp
@@ -1,6 +1,5 @@
 #include <c10/util/Backtrace.h>
 #include <c10/util/signal_handler.h>
-#include <fmt/format.h>
 
 #if defined(C10_SUPPORTS_SIGNAL_HANDLER)
 
@@ -8,6 +7,7 @@
 #include <cxxabi.h>
 #include <dirent.h>
 #include <dlfcn.h>
+#include <fmt/format.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Summary:
Introduction:
We would like to use the minimal implementation of C10 for our our SGX port of pytorch. This would include disabling signal handlers and the fmt library.

Problem :
When C10_SUPPORTS_SIGNAL_HANDLER is disabled there is no reason to have fmt enabled as it is used only in stacktraceSignalHandler. The problem is that fmt/format.h is included regardless whether C10_SUPPORTS_SIGNAL_HANDLER is disabled or not.

Solution :
Move the #include <fmt/format.h> inside the #ifdef section of code where  C10_SUPPORTS_SIGNAL_HANDLER is checked.

Test Plan: Run the pytorch unit tests.

Differential Revision: D29022628

