### PR TITLE
[fx-acc] Fix wrong device assignment in find_single_partition

### DIFF
--- a/test/test_fx_experimental.py
+++ b/test/test_fx_experimental.py
@@ -166,7 +166,7 @@ class TestFXExperimental(JitTestCase):
         partitioner = Partitioner()
         devices = [
             Device("dev_0", 125, 0),
-            Device("dev_1", 125, 1),
+            Device("dev_1", 150, 1),
             Device("dev_2", 125, 2),
         ]
         partitioner_config = PartitionerConfig(devices)
@@ -174,7 +174,7 @@ class TestFXExperimental(JitTestCase):
         module_with_submodules = ret.module_with_submodules
         dag = ret.dag
         self.assertEqual(traced(a, b), module_with_submodules(a, b))
-        assert dag.nodes[0].logical_device_ids == [0]
+        assert dag.nodes[0].logical_device_ids == [1]
 
     def test_lack_of_devices(self):
         class TestModule(torch.nn.Module):


### PR DESCRIPTION
Summary:
Previously we put the whole graph as a single partition onto a device with maximum memory if possible, but the code assumed that the first logical device always has the maximum memory.

This diff fixes this issue and updates the unittest to reflect such a corner case.

Test Plan:
```
buck test mode/opt //caffe2/test:test_fx_experimental -- --exact 'caffe2/test:test_fx_experimental - test_find_single_partition (test_fx_experimental.TestFXExperimental)'

Started reporting to test run: https://www.internalfb.com/intern/testinfra/testrun/6473924507772744
    ✓ ListingSuccess: caffe2/test:test_fx_experimental - main (1.357)
    ✓ Pass: caffe2/test:test_fx_experimental - test_find_single_partition (test_fx_experimental.TestFXExperimental) (1.206)
Summary
  Pass: 1
  ListingSuccess: 1

```

Reviewed By: gcatron

Differential Revision: D29118715

