### PR TITLE
Fix dilated max pooling named tensor warning.

### DIFF
--- a/aten/src/ATen/native/DilatedMaxPool2d.cpp
+++ b/aten/src/ATen/native/DilatedMaxPool2d.cpp
@@ -65,15 +65,16 @@ bool ceil_mode) {
     inputHeight, inputWidth,
     outputHeight, outputWidth, memory_format);
 
+  auto names = input.has_names() ? input.names() : ArrayRef<Dimname>();
   /* resize output and indices */
   if (input.ndimension() == 3) {
-    set_output(0, {nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), input.names());
+    set_output(0, {nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), names);
     /* indices will contain the locations for each output point */
-    set_output(1, {nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), input.names());
+    set_output(1, {nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), names);
   } else {
-    set_output(0, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), input.names());
+    set_output(0, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().memory_format(memory_format), names);
     /* indices will contain the locations for each output point */
-    set_output(1, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), input.names());
+    set_output(1, {nbatch, nInputPlane, outputHeight, outputWidth}, {}, input.options().dtype(kLong), names);
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/60053

I'm not sure this is correct, because I don't see how you can remove propagate_names from https://github.com/pytorch/pytorch/pull/56459 in the case where there are names -- where does the checking happen?

But probably there are no users, so killing the warning is an improvement.
