### PR TITLE
[Profiler] Fix timestamp discrepancy in profiler_kineto.cpp

### DIFF
--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -9,6 +9,7 @@
 
 #ifdef USE_KINETO
 #include <libkineto.h>
+#include <time_since_epoch.h>
 
 #ifndef _MSC_VER
 // TODO: TO be removed, once this properly works from libkineto
@@ -32,8 +33,7 @@ uint64_t next_correlation_id() {
 }
 
 inline int64_t getTimeUs() {
-  using namespace std::chrono;
-  return duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+  return libkineto::timeSinceEpoch(std::chrono::system_clock::now());
 }
 
 std::string shapesToStr(const std::vector<std::vector<int64_t>>& shapes);


### PR DESCRIPTION
Summary:
PyTorch pull request https://github.com/pytorch/pytorch/pull/57333 changed high_resolution_clock to system_clock but missed one location in profiler_kineto.cpp.

On some platforms (e.g. Windows), high_resolution_clock and system_clock do not map to the same underlying clock and therefore we get mixed timestamps on some platforms.

Differential Revision: D29155809

