### PR TITLE
Add the specific Intel XPU stubs and the pluggable XPU hooks.

### DIFF
--- a/aten/src/ATen/Utils.cpp
+++ b/aten/src/ATen/Utils.cpp
@@ -41,7 +41,12 @@ Tensor empty_cpu(
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
   c10::Allocator* allocator;
   if (pin_memory) {
-    allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
+    deviceExclusiveCheck();
+    if (hasCUDA()) {
+      allocator = detail::getCUDAHooks().getPinnedMemoryAllocator();
+    } else if (hasXPU()) {
+      allocator = detail::getXPUHooks().getPinnedMemoryAllocator();
+    }
   } else {
     allocator = at::getCPUAllocator();
   }

--- a/aten/src/ATen/Version.cpp
+++ b/aten/src/ATen/Version.cpp
@@ -184,6 +184,10 @@ std::string show_config() {
     ss << detail::getCUDAHooks().showConfig();
   }
 
+  if (hasXPU()) {
+    ss << detail::getXPUHooks().showConfig();
+  }
+
   ss << "  - Build settings: ";
   for (const auto& pair : caffe2::GetBuildOptions()) {
     if (!pair.second.empty()) {

--- a/aten/src/ATen/detail/XPUHooksInterface.cpp
+++ b/aten/src/ATen/detail/XPUHooksInterface.cpp
@@ -1,0 +1,29 @@
+#include <ATen/detail/XPUHooksInterface.h>
+
+#include <c10/util/Exception.h>
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+
+namespace at {
+namespace detail {
+
+static XPUHooksInterface *xpu_hooks = nullptr;
+
+const XPUHooksInterface &getXPUHooks() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    xpu_hooks =
+        XPUHooksRegistry()->Create("XPUHooks", XPUHooksArgs{}).release();
+    if (!xpu_hooks) {
+      xpu_hooks = new XPUHooksInterface();
+    }
+  });
+  return *xpu_hooks;
+}
+} // namespace detail
+
+C10_DEFINE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs)
+
+} // namespace at

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <ATen/core/Generator.h>
+#include <c10/core/Allocator.h>
+#include <c10/util/Exception.h>
+
+#include <c10/util/Registry.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+
+namespace at {
+class Context;
+}
+
+namespace at {
+
+constexpr const char* XPU_HELP =
+  "PyTorch splits its backend into two shared libraries: a CPU library "
+  "and a XPU library; this error has occurred because you are trying "
+  "to use some XPU functionality, but the XPU library has not been "
+  "loaded by the dynamic linker for some reason.  The XPU library MUST "
+  "be loaded, EVEN IF you don't directly use any symbols from the XPU library!";
+
+struct TORCH_API XPUHooksInterface {
+  virtual ~XPUHooksInterface() {}
+
+  virtual void initXPU() const {
+    TORCH_CHECK(false, "Cannot initialize XPU without XPU library.", XPU_HELP);
+  }
+
+  virtual bool hasXPU() const {
+    return false;
+  }
+
+  virtual bool hasOneMKL() const {
+    return false;
+  }
+
+  virtual bool hasOneDNN() const {
+    return false;
+  }
+
+  virtual std::string showConfig() const {
+    TORCH_CHECK(false, "Cannot query detailed XPU version without XPU library. ", XPU_HELP);
+  }
+
+  virtual int64_t getCurrentDevice() const {
+    return -1;
+  }
+
+  virtual int getDeviceCount() const {
+    return 0;
+  }
+
+  virtual Device getDeviceFromPtr(void* data) const {
+    TORCH_CHECK(false, "Cannot get device of pointer on XPU without XPU library.", XPU_HELP);
+  }
+
+  virtual bool isPinnedPtr(void* data) const {
+    return false;
+  }
+
+  virtual Allocator* getPinnedMemoryAllocator() const {
+    TORCH_CHECK(false, "Pinned Memory requires XPU library support", XPU_HELP);
+  }
+
+  virtual const Generator& getDefaultXPUGenerator(DeviceIndex device_index = -1) const {
+    TORCH_CHECK(false, "Cannot get default XPU generator without XPU library.", XPU_HELP);
+  }
+};
+
+struct TORCH_API XPUHooksArgs {};
+
+C10_DECLARE_REGISTRY(XPUHooksRegistry, XPUHooksInterface, XPUHooksArgs);
+#define REGISTER_XPU_HOOKS(clsname) \
+  C10_REGISTER_CLASS(XPUHooksRegistry, clsname, clsname)
+
+namespace detail {
+TORCH_API const XPUHooksInterface& getXPUHooks();
+} // namespace detail
+} // namespace at


### PR DESCRIPTION
## Motivation
Add XPU runtime specific stubs for default generator and pinned memory. And dispatch to the pluggable XPU hooks if the XPU extension is loaded.


## Solution
- Add pluggable hooks for XPU backend.
- Add XPU stubs in `at::Context` for the API `defaultGenerator`, `getDeviceFromPtr` and `isPinnedPtr`.
- Add XPU stubs when creating the pinned tensor for XPU.


## Additional Context
More details about XPU hooks has been discussed in #53707. 
