### PR TITLE
Fix overflow in quantize_val_arm

### DIFF
--- a/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
+++ b/aten/src/ATen/native/quantized/affine_quantizer_base.cpp
@@ -118,10 +118,20 @@ uint8_t quantize_val_arm(
     const float scale,
     const int32_t zero_point,
     const float value) {
-  const int32_t qmin = std::numeric_limits<uint8_t>::min();
-  const int32_t qmax = std::numeric_limits<uint8_t>::max();
+  constexpr int32_t qmin = std::numeric_limits<uint8_t>::min();
+  constexpr int32_t qmax = std::numeric_limits<uint8_t>::max();
   float inv_scale = 1.0f / scale;
+#ifndef _MSC_VER
+  auto r = static_cast<int32_t>(Round(value * inv_scale));
+  // builtin_add_overflow() returns true in case of overflow
+  if (__builtin_add_overflow(zero_point, r, &r)) {
+    // zero_point must be a non-negative value between qmin and qmax,
+    // i.e. only overflow can happen.
+    r = qmax;
+  }
+#else
   auto r = zero_point + static_cast<int32_t>(Round(value * inv_scale));
+#endif
   r = std::max(r, qmin);
   r = std::min(r, qmax);
   return static_cast<uint8_t>(r);
@@ -135,7 +145,7 @@ void quantize_vec(
     T* dst,
     size_t count) {
   checkZeroPoint<typename T::underlying>("quantize_vec", zero_point);
-  for (int64_t i = 0; i < count; ++i) {
+  for (size_t i = 0; i < count; ++i) {
     dst[i] = quantize_val<T>(scale, zero_point, src[i]);
   }
 }

--- a/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
+++ b/aten/src/ATen/native/quantized/cpu/kernels/QuantizedOpKernels.cpp
@@ -32,7 +32,7 @@ void check_tensor_memory_format(const Tensor& ref, const Tensor& other) {
   TORCH_CHECK(
       other.is_contiguous(ref.suggest_memory_format()),
       "Float tensor should be contiguous "
-      "in same memory format as quantizd tensor");
+      "in same memory format as quantized tensor");
 }
 
 // ****************** HEY YOU! YES YOU! Read this! ********************


### PR DESCRIPTION
By using `__builtin_add_overflow` to detect integer overflows when `zero_point` is added to rounded integral value.
Also fix small typo.

After this PR `python3 -c "import torch;print(torch.torch.quantize_per_tensor(torch.ones(10) * 2**32, 0.5, 1, torch.quint8))"` returns same vector of `127` on both x86_64 and aarch64 platforms

This change merely mitigates overflow bug, more proper (and perhaps performance impacting) fix would be to add `zero_point` to floating values both in serial and in vectorized code. Filed https://github.com/pytorch/pytorch/issues/61047 to track this one

Also filed https://github.com/pytorch/pytorch/issues/61046 to clarify intended use of `__ARM_NEON__` define

Fixes #60077
