### PR TITLE
Fix leak

### DIFF
--- a/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.cpp
@@ -2314,10 +2314,12 @@ Block* TermExpander::fuseConditions(Block* v) {
 
     // avoid unflattening this Cond if we can.
     if (true_block->empty()) {
+      delete true_block;
       true_block = nullptr;
     }
 
     if (false_block->empty()) {
+      delete false_block;
       false_block = nullptr;
     }
 


### PR DESCRIPTION
jit/tensorexpr uses raw pointers everywhere. It's hard to avoid memory leaks....
