### PR TITLE
[package] fix tutorial link

### DIFF
--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -30,7 +30,7 @@ Tutorials
 Packaging your first model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 A tutorial that guides you through packaging and unpackaging a simple model is available
-`on Colab <https://colab.research.google.com/drive/1dWATcDir22kgRQqBg2X_Lsh5UPfC7UTK?usp=sharing>`_.
+`on Colab <https://colab.research.google.com/drive/1lFZkLyViGfXxB-m3jqlyTQuYToo3XLo->`_.
 After completing this exercise, you will be familiar with the basic API for creating and using
 Torch packages.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60113 [package] fix tutorial link**

The tutorial link in the docs was to an fb-only colab.

Differential Revision: [D29169818](https://our.internmc.facebook.com/intern/diff/D29169818)