### PR TITLE
[torch][segment_reduce] Add missing cuda kernel launch check

### DIFF
--- a/aten/src/ATen/native/cuda/SegmentReduce.cu
+++ b/aten/src/ATen/native/cuda/SegmentReduce.cu
@@ -138,6 +138,7 @@ Tensor _segment_reduce_cuda_kernel(
                   segment_count,
                   initial.has_value(),
                   initial_value);
+          C10_CUDA_KERNEL_LAUNCH_CHECK();
         }
       });
 


### PR DESCRIPTION
Summary: Same as title.

Test Plan: Unit test (test_kernel_launch_checks.py) is passing.

Differential Revision: D29169538

