### PR TITLE
[package] fix tutorial link (#60113)

### DIFF
--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -30,7 +30,7 @@ Tutorials
 Packaging your first model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 A tutorial that guides you through packaging and unpackaging a simple model is available
-`on Colab <https://colab.research.google.com/drive/1dWATcDir22kgRQqBg2X_Lsh5UPfC7UTK?usp=sharing>`_.
+`on Colab <https://colab.research.google.com/drive/1lFZkLyViGfXxB-m3jqlyTQuYToo3XLo->`_.
 After completing this exercise, you will be familiar with the basic API for creating and using
 Torch packages.
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/60113

The tutorial link in the docs was to an fb-only colab.

Test Plan: Imported from OSS

Reviewed By: SplitInfinity

Differential Revision: D29169818

Pulled By: suo

fbshipit-source-id: 374807c234a185bd515b8ffe1300e6cf8d821636

Fixes #{issue number}
