### PR TITLE
Add .isort.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+include_trailing_comma=True
+multi_line_output=3
+skip=third_party
+skip_gitignore=True
+use_parentheses=True


### PR DESCRIPTION
This adds the `.isort.cfg` file from #55928, but doesn't try to enforce it in CI because as that PR showed, that is currently difficult to do. We could use this to gradually sort the codebase according to this configuration (enforcing bits and pieces in CI) but I don't do that here.

The advantage of including this file (even if we don't enforce it) is that it affects how certain tools work, thus encouraging a specific import style for people who happen to use those tools.

**Test plan:**

Open `test/run_test.py` in VS Code and run the **Python Refactor: Sort Imports** command. Compare with and without this PR.