### PR TITLE
[iOS GPU][MaskRCNN] Force the temporaryImage to become static when doing synchronization

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -118,6 +118,10 @@ void MPSImageWrapper::prepare() {
     TORCH_CHECK(_buffer, "Allocate GPU memory failed!");
   }
   copyToMetalBuffer(_commandBuffer, _buffer, _image);
+  if (_image.isTemporaryImage && _image.readCount != 0) {
+    _image =
+        createStaticImage((MPSTemporaryImage*)_image, _commandBuffer, false);
+  }
 }
 
 void MPSImageWrapper::synchronize() {

--- a/aten/src/ATen/native/metal/ops/MetalReshape.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReshape.mm
@@ -32,18 +32,18 @@ Tensor view(const Tensor& input, IntArrayRef size) {
   MetalTensorImplStorage mt{inferred_size, stride_value};
   mt.texture()->allocateTemporaryStorage(inferred_size, commandBuffer);
   MPSImage* Y = mt.texture()->image();
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
-      specializedPipelineState:"reshape"
-                     Constants:@[
-                       @(Y.height),
-                       @(Y.width),
-                       @(Y.featureChannels),
-                       @(Y.numberOfImages),
-                       @(X.height),
-                       @(X.width),
-                       @(X.featureChannels),
-                       @(X.numberOfImages),
-                     ]];
+  id<MTLComputePipelineState> state =
+      [[MPSCNNContext sharedInstance] specializedPipelineState:"reshape"
+                                                     Constants:@[
+                                                       @(Y.height),
+                                                       @(Y.width),
+                                                       @(Y.featureChannels),
+                                                       @(Y.numberOfImages),
+                                                       @(X.height),
+                                                       @(X.width),
+                                                       @(X.featureChannels),
+                                                       @(X.numberOfImages),
+                                                     ]];
   id<MTLComputeCommandEncoder> encoder =
       [commandBuffer.buffer computeCommandEncoder];
   [encoder setComputePipelineState:state];
@@ -95,7 +95,13 @@ Tensor flatten_using_ints(
   return input.reshape(shape);
 }
 
+Tensor detach(const Tensor& input) {
+  TORCH_CHECK(input.is_metal());
+  return input;
+}
+
 TORCH_LIBRARY_IMPL(aten, Metal, m) {
+  m.impl("detach", TORCH_FN(detach));
   m.impl("view", TORCH_FN(view));
   m.impl("reshape", TORCH_FN(reshape));
   m.impl("flatten.using_ints", TORCH_FN(flatten_using_ints));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

For intermediate tensors, we need to convert them to static images when doing GPU -> CPU synchronization.

Differential Revision: [D29126278](https://our.internmc.facebook.com/intern/diff/D29126278/)