### PR TITLE
Enable docker layer cache for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,18 +26,21 @@ executors:
     machine:
       resource_class: windows.gpu.nvidia.medium
       image: windows-server-2019-nvidia:previous
+      docker_layer_caching: true
       shell: bash.exe
 
   windows-xlarge-cpu-with-nvidia-cuda:
     machine:
       resource_class: windows.xlarge
       image: windows-server-2019-vs2019:stable
+      docker_layer_caching: true
       shell: bash.exe
 
   windows-medium-cpu-with-nvidia-cuda:
     machine:
       resource_class: windows.medium
       image: windows-server-2019-vs2019:stable
+      docker_layer_caching: true
       shell: bash.exe
 commands:
 
@@ -2018,119 +2021,122 @@ jobs:
 #    <<: *binary_linux_test
 #
   docker_build_job:
-      parameters:
-        image_name:
-          type: string
-          default: ""
-      machine:
-        image: ubuntu-2004:202104-01
-      resource_class: large
-      environment:
-        IMAGE_NAME: << parameters.image_name >>
-        # Enable 'docker manifest'
-        DOCKER_CLI_EXPERIMENTAL: "enabled"
-        DOCKER_BUILDKIT: 1
-      steps:
-        - checkout
-        - calculate_docker_image_tag
-        - run:
-            name: Check if image should be built
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-              export AWS_REGION=us-east-1
-              aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
-                       --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-              set -x
-              # Check if image already exists, if it does then skip building it
-              if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
-                circleci-agent step halt
-                # circleci-agent step halt doesn't actually halt the step so we need to
-                # explicitly exit the step here ourselves before it causes too much trouble
-                exit 0
-              fi
-              # Covers the case where a previous tag doesn't exist for the tree
-              # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
-              if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
-                echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
-                exit 1
-              fi
-              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
-              # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
-                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                echo "       contact the PyTorch team to restore the original images"
-                exit 1
-              fi
-        - run:
-            name: build_docker_image_<< parameters.image_name >>
-            no_output_timeout: "1h"
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              set -x
-              cd .circleci/docker && ./build_docker.sh
-  docker_for_ecr_gc_build_job:
-      machine:
-        image: ubuntu-2004:202104-01
-      steps:
-        - checkout
-        - run:
-            name: build_docker_image_for_ecr_gc
-            no_output_timeout: "1h"
-            command: |
-              cd .circleci/ecr_gc_docker
-              docker build . -t 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-              export AWS_REGION=us-east-1
-              aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
-                       --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-              set -x
-              docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/gc/ecr
-  ecr_gc_job:
-      parameters:
-        project:
-          type: string
-          default: "pytorch"
-        tags_to_keep:  # comma separate values
-          type: string
-      environment:
-        PROJECT: << parameters.project >>
-        # TODO: Remove legacy image tags once we feel comfortable with new docker image tags
-        IMAGE_TAG: << parameters.tags_to_keep >>
-      docker:
-        - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
-          aws_auth:
-            aws_access_key_id: ${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-            aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+    parameters:
+      image_name:
+        type: string
+        default: ""
+    machine:
+      image: ubuntu-2004:202104-01
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      IMAGE_NAME: << parameters.image_name >>
+      # Enable 'docker manifest'
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - calculate_docker_image_tag
+      - run:
+          name: Check if image should be built
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+            export AWS_REGION=us-east-1
+            aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
+                     --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            set -x
+            # Check if image already exists, if it does then skip building it
+            if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
+              circleci-agent step halt
+              # circleci-agent step halt doesn't actually halt the step so we need to
+              # explicitly exit the step here ourselves before it causes too much trouble
+              exit 0
+            fi
+            # Covers the case where a previous tag doesn't exist for the tree
+            # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
+            if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
+              echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
+              exit 1
+            fi
+            PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+            # If no image exists but the hash is the same as the previous hash then we should error out here
+            if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
+              echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+              echo "       contact the PyTorch team to restore the original images"
+              exit 1
+            fi
+      - run:
+          name: build_docker_image_<< parameters.image_name >>
+          no_output_timeout: "1h"
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            set -x
+            cd .circleci/docker && ./build_docker.sh
 
-      steps:
-        - checkout
-        - run:
-            # NOTE: see 'docker_build_job' for how these tags actually get built
-            name: dynamically generate tags to keep
-            no_output_timeout: "1h"
-            command: |
-              GENERATED_IMAGE_TAG=$(\
-                git log --oneline --pretty='%H' .circleci/docker \
-                  | xargs -I '{}' git rev-parse '{}:.circleci/docker' \
-                  | paste -sd "," -)
-              echo "export GENERATED_IMAGE_TAG='${GENERATED_IMAGE_TAG}'" >> ${BASH_ENV}
-        - run:
-            name: garbage collecting for ecr images
-            no_output_timeout: "1h"
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              set -x
-              /usr/bin/gc.py --filter-prefix ${PROJECT}  --ignore-tags "${IMAGE_TAG},${GENERATED_IMAGE_TAG}"
+  docker_for_ecr_gc_build_job:
+    machine:
+      image: ubuntu-2004:202104-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: build_docker_image_for_ecr_gc
+          no_output_timeout: "1h"
+          command: |
+            cd .circleci/ecr_gc_docker
+            docker build . -t 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+            export AWS_REGION=us-east-1
+            aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
+                     --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            set -x
+            docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/gc/ecr
+
+  ecr_gc_job:
+    parameters:
+      project:
+        type: string
+        default: "pytorch"
+      tags_to_keep:  # comma separate values
+        type: string
+    environment:
+      PROJECT: << parameters.project >>
+      # TODO: Remove legacy image tags once we feel comfortable with new docker image tags
+      IMAGE_TAG: << parameters.tags_to_keep >>
+    docker:
+      - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
+        aws_auth:
+          aws_access_key_id: ${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+          aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+    steps:
+      - checkout
+      - run:
+          # NOTE: see 'docker_build_job' for how these tags actually get built
+          name: dynamically generate tags to keep
+          no_output_timeout: "1h"
+          command: |
+            GENERATED_IMAGE_TAG=$(\
+              git log --oneline --pretty='%H' .circleci/docker \
+                | xargs -I '{}' git rev-parse '{}:.circleci/docker' \
+                | paste -sd "," -)
+            echo "export GENERATED_IMAGE_TAG='${GENERATED_IMAGE_TAG}'" >> ${BASH_ENV}
+      - run:
+          name: garbage collecting for ecr images
+          no_output_timeout: "1h"
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            set -x
+            /usr/bin/gc.py --filter-prefix ${PROJECT}  --ignore-tags "${IMAGE_TAG},${GENERATED_IMAGE_TAG}"
 ##############################################################################
 # Workflows
 ##############################################################################

--- a/.circleci/docker/build.sh
+++ b/.circleci/docker/build.sh
@@ -326,7 +326,6 @@ tmp_tag="tmp-$(cat /dev/urandom | tr -dc 'a-z' | head -c 32)"
 # TODO: build-arg THRIFT is not turned on for any image, remove it once we confirm
 # it's no longer needed.
 docker build \
-       --no-cache \
        --progress=plain \
        --build-arg "TRAVIS_DL_URL_PREFIX=${TRAVIS_DL_URL_PREFIX}" \
        --build-arg "BUILD_ENVIRONMENT=${image}" \

--- a/.circleci/verbatim-sources/header-section.yml
+++ b/.circleci/verbatim-sources/header-section.yml
@@ -26,16 +26,19 @@ executors:
     machine:
       resource_class: windows.gpu.nvidia.medium
       image: windows-server-2019-nvidia:previous
+      docker_layer_caching: true
       shell: bash.exe
 
   windows-xlarge-cpu-with-nvidia-cuda:
     machine:
       resource_class: windows.xlarge
       image: windows-server-2019-vs2019:stable
+      docker_layer_caching: true
       shell: bash.exe
 
   windows-medium-cpu-with-nvidia-cuda:
     machine:
       resource_class: windows.medium
       image: windows-server-2019-vs2019:stable
+      docker_layer_caching: true
       shell: bash.exe

--- a/.circleci/verbatim-sources/job-specs/docker_jobs.yml
+++ b/.circleci/verbatim-sources/job-specs/docker_jobs.yml
@@ -1,114 +1,117 @@
   docker_build_job:
-      parameters:
-        image_name:
-          type: string
-          default: ""
-      machine:
-        image: ubuntu-2004:202104-01
-      resource_class: large
-      environment:
-        IMAGE_NAME: << parameters.image_name >>
-        # Enable 'docker manifest'
-        DOCKER_CLI_EXPERIMENTAL: "enabled"
-        DOCKER_BUILDKIT: 1
-      steps:
-        - checkout
-        - calculate_docker_image_tag
-        - run:
-            name: Check if image should be built
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-              export AWS_REGION=us-east-1
-              aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
-                       --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-              set -x
-              # Check if image already exists, if it does then skip building it
-              if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
-                circleci-agent step halt
-                # circleci-agent step halt doesn't actually halt the step so we need to
-                # explicitly exit the step here ourselves before it causes too much trouble
-                exit 0
-              fi
-              # Covers the case where a previous tag doesn't exist for the tree
-              # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
-              if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
-                echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
-                exit 1
-              fi
-              PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
-              # If no image exists but the hash is the same as the previous hash then we should error out here
-              if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
-                echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
-                echo "       contact the PyTorch team to restore the original images"
-                exit 1
-              fi
-        - run:
-            name: build_docker_image_<< parameters.image_name >>
-            no_output_timeout: "1h"
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              set -x
-              cd .circleci/docker && ./build_docker.sh
-  docker_for_ecr_gc_build_job:
-      machine:
-        image: ubuntu-2004:202104-01
-      steps:
-        - checkout
-        - run:
-            name: build_docker_image_for_ecr_gc
-            no_output_timeout: "1h"
-            command: |
-              cd .circleci/ecr_gc_docker
-              docker build . -t 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
-              export AWS_REGION=us-east-1
-              aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
-                       --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
-              set -x
-              docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/gc/ecr
-  ecr_gc_job:
-      parameters:
-        project:
-          type: string
-          default: "pytorch"
-        tags_to_keep:  # comma separate values
-          type: string
-      environment:
-        PROJECT: << parameters.project >>
-        # TODO: Remove legacy image tags once we feel comfortable with new docker image tags
-        IMAGE_TAG: << parameters.tags_to_keep >>
-      docker:
-        - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
-          aws_auth:
-            aws_access_key_id: ${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-            aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+    parameters:
+      image_name:
+        type: string
+        default: ""
+    machine:
+      image: ubuntu-2004:202104-01
+      docker_layer_caching: true
+    resource_class: large
+    environment:
+      IMAGE_NAME: << parameters.image_name >>
+      # Enable 'docker manifest'
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - calculate_docker_image_tag
+      - run:
+          name: Check if image should be built
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+            export AWS_REGION=us-east-1
+            aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
+                     --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            set -x
+            # Check if image already exists, if it does then skip building it
+            if docker manifest inspect "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${IMAGE_NAME}:${DOCKER_TAG}"; then
+              circleci-agent step halt
+              # circleci-agent step halt doesn't actually halt the step so we need to
+              # explicitly exit the step here ourselves before it causes too much trouble
+              exit 0
+            fi
+            # Covers the case where a previous tag doesn't exist for the tree
+            # this is only really applicable on trees that don't have `.circleci/docker` at its merge base, i.e. nightly
+            if ! git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker"; then
+              echo "Directory '.circleci/docker' not found in tree << pipeline.git.base_revision >>, you should probably rebase onto a more recent commit"
+              exit 1
+            fi
+            PREVIOUS_DOCKER_TAG=$(git rev-parse "$(git merge-base HEAD << pipeline.git.base_revision >>):.circleci/docker")
+            # If no image exists but the hash is the same as the previous hash then we should error out here
+            if [[ "${PREVIOUS_DOCKER_TAG}" = "${DOCKER_TAG}" ]]; then
+              echo "ERROR: Something has gone wrong and the previous image isn't available for the merge-base of your branch"
+              echo "       contact the PyTorch team to restore the original images"
+              exit 1
+            fi
+      - run:
+          name: build_docker_image_<< parameters.image_name >>
+          no_output_timeout: "1h"
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            set -x
+            cd .circleci/docker && ./build_docker.sh
 
-      steps:
-        - checkout
-        - run:
-            # NOTE: see 'docker_build_job' for how these tags actually get built
-            name: dynamically generate tags to keep
-            no_output_timeout: "1h"
-            command: |
-              GENERATED_IMAGE_TAG=$(\
-                git log --oneline --pretty='%H' .circleci/docker \
-                  | xargs -I '{}' git rev-parse '{}:.circleci/docker' \
-                  | paste -sd "," -)
-              echo "export GENERATED_IMAGE_TAG='${GENERATED_IMAGE_TAG}'" >> ${BASH_ENV}
-        - run:
-            name: garbage collecting for ecr images
-            no_output_timeout: "1h"
-            command: |
-              set +x
-              export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
-              export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
-              set -x
-              /usr/bin/gc.py --filter-prefix ${PROJECT}  --ignore-tags "${IMAGE_TAG},${GENERATED_IMAGE_TAG}"
+  docker_for_ecr_gc_build_job:
+    machine:
+      image: ubuntu-2004:202104-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: build_docker_image_for_ecr_gc
+          no_output_timeout: "1h"
+          command: |
+            cd .circleci/ecr_gc_docker
+            docker build . -t 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_ACCOUNT_ID=$(aws sts get-caller-identity|grep Account|cut -f4 -d\")
+            export AWS_REGION=us-east-1
+            aws ecr get-login-password --region $AWS_REGION|docker login --username AWS \
+                     --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            set -x
+            docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/gc/ecr
+
+  ecr_gc_job:
+    parameters:
+      project:
+        type: string
+        default: "pytorch"
+      tags_to_keep:  # comma separate values
+        type: string
+    environment:
+      PROJECT: << parameters.project >>
+      # TODO: Remove legacy image tags once we feel comfortable with new docker image tags
+      IMAGE_TAG: << parameters.tags_to_keep >>
+    docker:
+      - image: 308535385114.dkr.ecr.us-east-1.amazonaws.com/gc/ecr
+        aws_auth:
+          aws_access_key_id: ${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+          aws_secret_access_key: ${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+    steps:
+      - checkout
+      - run:
+          # NOTE: see 'docker_build_job' for how these tags actually get built
+          name: dynamically generate tags to keep
+          no_output_timeout: "1h"
+          command: |
+            GENERATED_IMAGE_TAG=$(\
+              git log --oneline --pretty='%H' .circleci/docker \
+                | xargs -I '{}' git rev-parse '{}:.circleci/docker' \
+                | paste -sd "," -)
+            echo "export GENERATED_IMAGE_TAG='${GENERATED_IMAGE_TAG}'" >> ${BASH_ENV}
+      - run:
+          name: garbage collecting for ecr images
+          no_output_timeout: "1h"
+          command: |
+            set +x
+            export AWS_ACCESS_KEY_ID=${CIRCLECI_AWS_ACCESS_KEY_FOR_DOCKER_BUILDER_V1}
+            export AWS_SECRET_ACCESS_KEY=${CIRCLECI_AWS_SECRET_KEY_FOR_DOCKER_BUILDER_V1}
+            set -x
+            /usr/bin/gc.py --filter-prefix ${PROJECT}  --ignore-tags "${IMAGE_TAG},${GENERATED_IMAGE_TAG}"

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -39,7 +39,7 @@ Patterns = collections.namedtuple("Patterns", "positive, negative")
 # NOTE: Clang-tidy cannot lint headers directly, because headers are not
 # compiled -- translation units are, of which there is one per implementation
 # (c/cc/cpp) file.
-DEFAULT_FILE_PATTERN = re.compile(r".*\.c(c|pp)?")
+DEFAULT_FILE_PATTERN = re.compile(r"^.*\.c(c|pp)?$")
 
 # Search for:
 #    diff --git ...


### PR DESCRIPTION
I think leveraging https://circleci.com/docs/2.0/docker-layer-caching/#configyml is a good idea to speed up all the docker related builds, especially for those PRs that didn't change layers that much.

Places that I searched

- `docker build`
- `machine within .circleci` 