### PR TITLE
[BackwardCompatibility] Remove aten::to from allow_list

### DIFF
--- a/test/backward_compatibility/check_backward_compatibility.py
+++ b/test/backward_compatibility/check_backward_compatibility.py
@@ -98,7 +98,6 @@ allow_list = [
     ("aten::segment_reduce_backward", datetime.date(2021, 6, 15)),
     ("aten::segment_reduce", datetime.date(2021, 8, 26)),
     ("aten::_segment_reduce_backward", datetime.date(2021, 8, 26)),
-    ("aten::to", datetime.date(2021, 6, 22)),
 ]
 
 def allow_listed(schema, allow_list):


### PR DESCRIPTION
Summary: Remove aten::to from allow_list now that the aten::to schema change has landed (D29121620 (https://github.com/pytorch/pytorch/commit/eda2ddb5b06dce13bafd2a745e4634802e4640ef)).

Test Plan: CI

Differential Revision: D29187314

