### PR TITLE
[nnc][tests] Tests and benchmarks for computeSum

### DIFF
--- a/benchmarks/cpp/tensorexpr/bench_reduce.cpp
+++ b/benchmarks/cpp/tensorexpr/bench_reduce.cpp
@@ -4,6 +4,7 @@
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/llvm_codegen.h>
 #include <torch/csrc/jit/tensorexpr/tensor.h>
+#include <torch/csrc/jit/tensorexpr/operators/operators.h>
 #include <torch/torch.h>
 
 #include <immintrin.h>
@@ -19,9 +20,11 @@ class Reduce1D : public benchmark::Fixture {
     M = state.range(0);
     A = torch::randn({M});
     B = torch::zeros({});
+    ref = torch::sum(A, {0});
   }
 
   void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-7));
     state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * M * sizeof(float),
                                                  benchmark::Counter::kIsRate);
   }
@@ -29,6 +32,7 @@ class Reduce1D : public benchmark::Fixture {
   int M;
   at::Tensor A;
   at::Tensor B;
+  at::Tensor ref;
 };
 
 }  // namespace
@@ -379,3 +383,220 @@ BENCHMARK_DEFINE_F(Reduce1D, TeRfactorV1)(benchmark::State& state) {
 }
 
 BENCHMARK_REGISTER_F(Reduce1D, TeRfactorV1)->Args({1 << 24});
+
+BENCHMARK_DEFINE_F(Reduce1D, Op)(benchmark::State& state) {
+  te::KernelScope ks;
+  const int M = A.numel();
+  const int kChunkSize = 8;
+
+  te::Placeholder a("A", te::kFloat, {M});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({0}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto loops = nest.getLoopStmtsFor(b);
+  te::For *mi, *mo;
+  te::Buf *rf;
+  nest.splitWithMask(loops[0], kChunkSize, &mi);
+  loops = nest.reorder({loops[0], mi}, {1, 0});
+  nest.rfactor(nest.getLoopBodyFor(b), loops[0], &rf);
+  nest.reorderAxis(loops[0], loops[1]);
+  for (auto const& loop : nest.getAllInnermostLoopsWritingToBuf(rf)) {
+    nest.vectorize(loop);
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce1D, Op)->Args({1 << 24});
+
+class Reduce2DCol : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    at::set_num_threads(1);
+    torch::manual_seed(0x12345678);
+    M = state.range(0);
+    N = state.range(1);
+    A = torch::randn({M, N});
+    ref = torch::sum(A, {0});
+    B = torch::zeros_like(ref);
+  }
+
+  void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-5));
+    state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * (A.nbytes() + B.nbytes()),
+                                                 benchmark::Counter::kIsRate);
+  }
+
+  int M;
+  int N;
+  at::Tensor A;
+  at::Tensor B;
+  at::Tensor ref;
+};
+
+BENCHMARK_DEFINE_F(Reduce2DCol, Torch)(benchmark::State& state) {
+  for (auto _ : state) {
+    B = torch::sum(A, {0});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DCol, Torch)
+->Args({1 << 3, 1 << 21})
+->Args({1 << 6, 1 << 18})
+->Args({1 << 12, 1 << 12});
+
+BENCHMARK_DEFINE_F(Reduce2DCol, OpSchedule)(benchmark::State& state) {
+  te::KernelScope ks;
+  constexpr int kCacheSize = 1 << 12;
+  te::Placeholder a("A", te::kFloat, {M, N});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({0}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto sch = state.range(2);
+  if (sch == 0) {
+  } else if (sch == 1) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[0], loops[1]);
+  } else if (sch == 2) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithTail(loops[0], kCacheSize);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[1], loops[2]);
+  } else if (sch == 3) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithTail(loops[1], 8);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[0], loops[1]);
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DCol, OpSchedule)->Apply(//CustomArgs);
+    [](benchmark::internal::Benchmark* b) {
+      for (auto sch : {0, 1, 2, 3}) {
+        for (auto rows : {3, 6, 12}) {
+          auto cols = 24 - rows;
+          b->Args({1 << rows, 1 << cols, sch});
+        }
+      }
+    });
+
+class Reduce2DRow : public benchmark::Fixture {
+ public:
+  void SetUp(const benchmark::State& state) override {
+    at::set_num_threads(1);
+    torch::manual_seed(0x12345678);
+    M = state.range(0);
+    N = state.range(1);
+    A = torch::randn({M, N});
+    ref = torch::sum(A, {1});
+    B = torch::zeros_like(ref);
+  }
+
+  void TearDown(benchmark::State& state) override {
+    TORCH_CHECK(at::allclose(B, ref, std::sqrt(A.numel()) * 1e-4));
+    state.counters["BYTES"] = benchmark::Counter(uint64_t(state.iterations()) * (A.nbytes() + B.nbytes()),
+                                                 benchmark::Counter::kIsRate);
+  }
+
+  int M;
+  int N;
+  at::Tensor A;
+  at::Tensor B;
+  at::Tensor ref;
+};
+
+BENCHMARK_DEFINE_F(Reduce2DRow, Torch)(benchmark::State& state) {
+  for (auto _ : state) {
+    B = torch::sum(A, {1});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, Torch)
+->Args({1 << 3, 1 << 21})
+->Args({1 << 6, 1 << 18})
+->Args({1 << 12, 1 << 12})
+->Args({1 << 18, 1 << 6});
+
+BENCHMARK_DEFINE_F(Reduce2DRow, Hand)(benchmark::State& state) {
+  auto a = A.data_ptr<float>();
+  auto b = B.data_ptr<float>();
+  constexpr int Mb = 4;
+  constexpr int Nb = 4;
+  auto fn = [&] {
+    for (int m_outer = 0; m_outer < M; m_outer += Mb) {
+      float bregs[Mb][Nb] = {0.0f};
+      for (int n_outer = 0; n_outer < N; n_outer += Nb) {
+        for (int m_inner = 0; m_inner < Mb; m_inner++) {
+          for (int n_inner = 0; n_inner < Nb; n_inner++) {
+            bregs[m_inner][n_inner] += a[(m_outer + m_inner) * N + n_outer + n_inner];
+          }
+        }
+      }
+      for (int m_inner = 0; m_inner < Mb; m_inner++) {
+        b[m_outer + m_inner] = 0.f;
+        for (int n_inner = 0; n_inner < Nb; n_inner++) {
+          b[m_outer + m_inner] += bregs[m_inner][n_inner];
+        }
+      }
+    }
+  };
+  for (auto _ : state) {
+    fn();
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, Hand)
+->Args({1 << 18, 1 << 6});
+
+BENCHMARK_DEFINE_F(Reduce2DRow, OpSchedule)(benchmark::State& state) {
+  te::KernelScope ks;
+  constexpr int kChunkSize = 8;
+  te::Placeholder a("A", te::kFloat, {M, N});
+  te::Tensor* b = te::computeSum({a.handle(), te::IntList({1}), false}, at::kFloat);
+  te::LoopNest nest({b});
+
+  auto sch = state.range(2);
+  if (sch == 1) {
+    auto loops = nest.getLoopStmtsFor(b);
+    te::For *mi, *mo;
+    te::Buf *rf;
+    nest.splitWithMask(loops[1], kChunkSize, &mi);
+    loops = nest.reorder({loops[1], mi}, {1, 0});
+    TORCH_CHECK(nest.rfactor(nest.getLoopBodyFor(b), loops[0], &rf));
+    nest.reorderAxis(loops[0], loops[1]);
+    for (auto const& loop : nest.getAllInnermostLoopsWritingToBuf(rf)) {
+      nest.vectorize(loop);
+    }
+  } else if (sch == 2) {
+    auto loops = nest.getLoopStmtsFor(b);
+    nest.splitWithMask(loops[1], 8);
+    nest.splitWithMask(loops[0], 4);
+    loops = nest.getLoopStmtsFor(b);
+    nest.reorderAxis(loops[1], loops[2]);
+  }
+
+  nest.prepareForCodegen();
+  nest.simplify();
+  te::LLVMCodeGen cg(nest.root_stmt(), {a, b});
+
+  for (auto _ : state) {
+    cg.call({A.data_ptr<float>(), B.data_ptr<float>()});
+  }
+}
+BENCHMARK_REGISTER_F(Reduce2DRow, OpSchedule)->Apply(//CustomArgs);
+    [](benchmark::internal::Benchmark* b) {
+      for (auto sch : {0, 1, 2}) {
+        for (auto rows : {3, 6, 12, 18}) {
+          auto cols = 24 - rows;
+          b->Args({1 << rows, 1 << cols, sch});
+        }
+      }
+    });

--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,8 +1,8 @@
-#include <torch/torch.h>
+#include <gtest/gtest.h>
 #include <torch/csrc/jit/tensorexpr/eval.h>
 #include <torch/csrc/jit/tensorexpr/loopnest.h>
 #include <torch/csrc/jit/tensorexpr/operators/operators.h>
-#include <gtest/gtest.h>
+#include <torch/torch.h>
 
 using namespace torch::jit::tensorexpr;
 

--- a/test/cpp/tensorexpr/test_ops.cpp
+++ b/test/cpp/tensorexpr/test_ops.cpp
@@ -1,0 +1,40 @@
+#include <torch/torch.h>
+#include <torch/csrc/jit/tensorexpr/eval.h>
+#include <torch/csrc/jit/tensorexpr/loopnest.h>
+#include <torch/csrc/jit/tensorexpr/operators/operators.h>
+#include <gtest/gtest.h>
+
+using namespace torch::jit::tensorexpr;
+
+using Tensors = std::vector<Tensor*>;
+using Args = std::vector<CodeGen::BufferArg>;
+SimpleIREvaluator compile(const Args& inputs, const Tensors& outputs) {
+  LoopNest nest({outputs});
+  nest.prepareForCodegen();
+  nest.simplify();
+  auto join = inputs;
+  join.insert(join.end(), outputs.begin(), outputs.end());
+  return SimpleIREvaluator{nest.root_stmt(), join};
+}
+
+TEST(Ops, Sum) {
+  KernelScope ks;
+
+  std::vector<IntList> testDims = {{0}, {1}, {0, 1}};
+  for (auto const& dims : testDims) {
+    constexpr int M = 8;
+    constexpr int N = 16;
+
+    Placeholder a("a", kFloat, {M, N});
+    Tensor* b = computeSum({a.handle(), dims, false}, c10::kFloat);
+    auto cg = compile({a}, {b});
+
+    auto at = at::arange(M * N, at::kFloat).view({M, N});
+    auto ref = at::sum(at, dims);
+    auto bt = at::empty_like(ref);
+
+    cg.call({at.data_ptr<float>(), bt.data_ptr<float>()});
+
+    ASSERT_TRUE(at::allclose(bt, ref));
+  }
+}

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -2093,10 +2093,6 @@ bool LoopNest::flatten(const std::vector<For*>& loops) {
 }
 
 void LoopNest::compressBuffer(Buf* buf, Stmt* stmt) {
-  if (buf->initializer()) {
-    throw malformed_input("Can't compress buffer whose initializer is set");
-  }
-
   // Loop iterations in NNC IR do not follow sequential semantics by default.
   // In other words, the iterations of the loops could be executed in any
   // random order without affecting correctness. This constraint in turn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60160 [nnc][tests] Tests and benchmarks for computeSum**



Adds a few simple tests and benchmarks for the `computeSum` op
(equivalent to `at::sum`).

The benchmarks test 1D reduction and 2D row and column reduction.  Performance
is in the ballpark of aten (14-15 GB/s) on my skylake devserver for all cases,
and occasionally better (e.g. 256k * 64 row reduction goes from 9 GB/s to 13).

Results (on my skylake-avx512, with turbo disabled):
```
------------------------------------------------------------------------------------------
Benchmark                                   Time           CPU Iterations UserCounters...
------------------------------------------------------------------------------------------
Reduce1D/Torch/16777216               4746995 ns    4746722 ns        150 BYTES=14.1379G/s
Reduce1D/Naive/16777216              34063215 ns   34061388 ns         21 BYTES=1.97023G/s
Reduce1D/NativeRfactor/16777216       5057175 ns    5057167 ns        139 BYTES=13.2701G/s
Reduce1D/TeNaive/16777216            33868945 ns   33868851 ns         21 BYTES=1.98143G/s
Reduce1D/TeSplitTail/16777216        33902786 ns   33900436 ns         21 BYTES=1.97959G/s
Reduce1D/TeSplitMask/16777216        33922509 ns   33920604 ns         21 BYTES=1.97841G/s
Reduce1D/TeRfactorV1/16777216         5141150 ns    5141002 ns        135 BYTES=13.0537G/s
Reduce1D/Op/16777216                  5140390 ns    5140091 ns        135 BYTES=13.056G/s
Reduce2DCol/Torch/8/2097152          12824403 ns   12823563 ns         55 BYTES=5.8874G/s
Reduce2DCol/Torch/64/262144           8306873 ns    8306743 ns         83 BYTES=8.20507G/s
Reduce2DCol/Torch/4096/4096           7992364 ns    7992239 ns         87 BYTES=8.3988G/s
Reduce2DCol/OpSchedule/8/2097152/0    4866144 ns    4865766 ns        138 BYTES=15.5161G/s
Reduce2DCol/OpSchedule/64/262144/0   36668978 ns   36666415 ns         19 BYTES=1.85885G/s
Reduce2DCol/OpSchedule/4096/4096/0  155862459 ns  155801266 ns          4 BYTES=430.839M/s
Reduce2DCol/OpSchedule/8/2097152/1    8067683 ns    8061117 ns         85 BYTES=9.36563G/s
Reduce2DCol/OpSchedule/64/262144/1    7496686 ns    7496562 ns         93 BYTES=9.09183G/s
Reduce2DCol/OpSchedule/4096/4096/1    5262821 ns    5262186 ns        131 BYTES=12.7562G/s
Reduce2DCol/OpSchedule/8/2097152/2    6237899 ns    6237210 ns        109 BYTES=12.1044G/s
Reduce2DCol/OpSchedule/64/262144/2    5258012 ns    5257655 ns        127 BYTES=12.9635G/s
Reduce2DCol/OpSchedule/4096/4096/2    5231686 ns    5228241 ns        132 BYTES=12.839G/s
Reduce2DCol/OpSchedule/8/2097152/3   11088573 ns   11087557 ns         62 BYTES=6.80921G/s
Reduce2DCol/OpSchedule/64/262144/3    5338843 ns    5338326 ns        127 BYTES=12.7676G/s
Reduce2DCol/OpSchedule/4096/4096/3    4311617 ns    4308102 ns        162 BYTES=15.5812G/s
Reduce2DRow/Torch/8/2097152           4642244 ns    4641794 ns        151 BYTES=14.4575G/s
Reduce2DRow/Torch/64/262144           4628311 ns    4628245 ns        151 BYTES=14.4999G/s
Reduce2DRow/Torch/4096/4096           4894012 ns    4893316 ns        143 BYTES=13.7177G/s
Reduce2DRow/Torch/262144/64          10469098 ns   10468027 ns         68 BYTES=6.51101G/s
Reduce2DRow/Hand/262144/64            5554380 ns    5554059 ns        126 BYTES=12.2716G/s
Reduce2DRow/OpSchedule/8/2097152/0   33890363 ns   33888931 ns         21 BYTES=1.98026G/s
Reduce2DRow/OpSchedule/64/262144/0   33901317 ns   33899436 ns         21 BYTES=1.97965G/s
Reduce2DRow/OpSchedule/4096/4096/0   33500358 ns   33498815 ns         21 BYTES=2.00381G/s
Reduce2DRow/OpSchedule/262144/64/0   13132231 ns   13131049 ns         53 BYTES=5.19056G/s
Reduce2DRow/OpSchedule/8/2097152/1    5200423 ns    5200025 ns        134 BYTES=12.9055G/s
Reduce2DRow/OpSchedule/64/262144/1    5204428 ns    5204327 ns        133 BYTES=12.8949G/s
Reduce2DRow/OpSchedule/4096/4096/1    8724355 ns    8723370 ns         80 BYTES=7.69488G/s
Reduce2DRow/OpSchedule/262144/64/1 1811861280 ns 1811352083 ns          1 BYTES=37.6279M/s
Reduce2DRow/OpSchedule/8/2097152/2    9169829 ns    9168946 ns         76 BYTES=7.31915G/s
Reduce2DRow/OpSchedule/64/262144/2    9159901 ns    9158560 ns         76 BYTES=7.32747G/s
Reduce2DRow/OpSchedule/4096/4096/2    9217398 ns    9215557 ns         76 BYTES=7.28391G/s
Reduce2DRow/OpSchedule/262144/64/2   10820450 ns   10818998 ns         66 BYTES=6.29979G/s
Reduce2DRow/OpSchedule/8/2097152/3    5227921 ns    5226544 ns        133 BYTES=12.84G/s
Reduce2DRow/OpSchedule/64/262144/3    5194362 ns    5194082 ns        133 BYTES=12.9203G/s
Reduce2DRow/OpSchedule/4096/4096/3    5196080 ns    5195349 ns        134 BYTES=12.9203G/s
Reduce2DRow/OpSchedule/262144/64/3    5235189 ns    5234728 ns        133 BYTES=13.0202G/s
```


Differential Revision: [D29190420](https://our.internmc.facebook.com/intern/diff/D29190420/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29190420/)!

Differential Revision: [D29190420](https://our.internmc.facebook.com/intern/diff/D29190420)