### PR TITLE
[reland] Pass RequestCallback to FaultyPG RPC agent

### DIFF
--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.cpp
@@ -1,4 +1,3 @@
-#include <torch/csrc/distributed/rpc/request_callback_impl.h>
 #include <torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h>
 #include <torch/csrc/distributed/rpc/utils.h>
 
@@ -16,6 +15,7 @@ FaultyProcessGroupAgent::FaultyProcessGroupAgent(
     c10::intrusive_ptr<::c10d::ProcessGroup> pg,
     int numSendRecvThreads,
     std::chrono::milliseconds rpcTimeout,
+    std::unique_ptr<RequestCallback> cb,
     const std::vector<std::string>& messagesToFail,
     const std::unordered_map<std::string, float>& messageTypesToDelay,
     int failNumSends)
@@ -25,7 +25,7 @@ FaultyProcessGroupAgent::FaultyProcessGroupAgent(
           std::move(pg),
           numSendRecvThreads,
           rpcTimeout,
-          std::make_unique<RequestCallbackImpl>()),
+          std::move(cb)),
       failNumSends_(failNumSends),
       messageTypesToFail_(parseMessagesToFailInput(messagesToFail)),
       messageTypesToDelay_(parseMessagesToDelay(messageTypesToDelay)) {}

--- a/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
+++ b/torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h
@@ -39,6 +39,7 @@ class FaultyProcessGroupAgent : public ProcessGroupAgent {
       c10::intrusive_ptr<c10d::ProcessGroup> pg,
       int numSendRecvThreads,
       std::chrono::milliseconds rpcTimeout,
+      std::unique_ptr<RequestCallback> cb,
       const std::vector<std::string>& messagesToFail,
       const std::unordered_map<std::string, float>& messageTypesToDelay,
       int failNumSends = 0);

--- a/torch/csrc/distributed/rpc/testing/init.cpp
+++ b/torch/csrc/distributed/rpc/testing/init.cpp
@@ -1,6 +1,7 @@
 #include <torch/csrc/python_headers.h>
 
 #include <torch/csrc/distributed/rpc/process_group_agent.h>
+#include <torch/csrc/distributed/rpc/request_callback_impl.h>
 #include <torch/csrc/distributed/rpc/rpc_agent.h>
 #include <torch/csrc/distributed/rpc/testing/faulty_process_group_agent.h>
 #include <torch/csrc/utils/pybind.h>
@@ -82,6 +83,7 @@ PyObject* faulty_agent_init(PyObject* _unused, PyObject* noargs) {
                     process_group,
                     num_send_recv_threads,
                     rpc_timeout,
+                    std::make_unique<RequestCallbackImpl>(),
                     messages_to_fail,
                     messages_to_delay,
                     failNumSends),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60169 [reland] Add some TORCH_API annotations to RPC
* **#60168 [reland] Pass RequestCallback to FaultyPG RPC agent**

Reland of #59939.

Differential Revision: [D29193235](https://our.internmc.facebook.com/intern/diff/D29193235/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29193235/)!