### PR TITLE
Ensure thread id is valid in nested parallel regions

### DIFF
--- a/aten/src/ATen/Parallel.h
+++ b/aten/src/ATen/Parallel.h
@@ -36,7 +36,24 @@ inline TORCH_API void lazy_init_num_threads() {
   }
 }
 
-}
+TORCH_API void set_thread_num(int);
+
+class TORCH_API ThreadIdGuard {
+public:
+  ThreadIdGuard(int new_id):
+    old_id_(at::get_thread_num()) {
+    set_thread_num(new_id);
+  }
+
+  ~ThreadIdGuard() {
+    set_thread_num(old_id_);
+  }
+
+private:
+  int old_id_;
+};
+
+}  // namespace internal
 
 /*
 parallel_for

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -37,7 +37,7 @@ void _set_in_parallel_region(bool in_region) {
 }  // namespace (anonymous)
 
 namespace internal {
-void _set_thread_num(size_t thread_num) {
+void set_thread_num(size_t thread_num) {
   thread_num_ = thread_num;
 }
 }
@@ -110,7 +110,7 @@ void _run_with_pool(const std::function<void(int, size_t)>& fn, size_t range) {
 // RAII guard helps to support in_parallel_region() and get_thread_num() API.
 struct ParallelRegionGuard {
   ParallelRegionGuard(int64_t task_id) {
-    _set_thread_num(task_id);
+    internal::set_thread_num(task_id);
     _set_in_parallel_region(true);
   }
 

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -34,10 +34,15 @@ void _set_in_parallel_region(bool in_region) {
   in_parallel_region_ = in_region;
 }
 
+}  // namespace (anonymous)
+
+namespace internal {
 void _set_thread_num(size_t thread_num) {
   thread_num_ = thread_num;
 }
+}
 
+namespace {
 void _unset_thread_num() {
   thread_num_ = 0;
 }

--- a/aten/src/ATen/ParallelNative.cpp
+++ b/aten/src/ATen/ParallelNative.cpp
@@ -28,7 +28,7 @@ thread_local bool in_parallel_region_ = false;
 
 // thread number (task_id) set by parallel primitive
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-thread_local size_t thread_num_ = 0;
+thread_local int thread_num_ = 0;
 
 void _set_in_parallel_region(bool in_region) {
   in_parallel_region_ = in_region;
@@ -37,7 +37,7 @@ void _set_in_parallel_region(bool in_region) {
 }  // namespace (anonymous)
 
 namespace internal {
-void set_thread_num(size_t thread_num) {
+void set_thread_num(int thread_num) {
   thread_num_ = thread_num;
 }
 }
@@ -109,7 +109,7 @@ void _run_with_pool(const std::function<void(int, size_t)>& fn, size_t range) {
 
 // RAII guard helps to support in_parallel_region() and get_thread_num() API.
 struct ParallelRegionGuard {
-  ParallelRegionGuard(int64_t task_id) {
+  ParallelRegionGuard(int task_id) {
     internal::set_thread_num(task_id);
     _set_in_parallel_region(true);
   }

--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -41,7 +41,7 @@ inline void parallel_for(
     return;
   }
   if ((end - begin) < grain_size || in_parallel_region()) {
-    ThreadIdGuard tid_guard(0);
+    internal::ThreadIdGuard tid_guard(0);
     f(begin, end);
     return;
   }
@@ -68,7 +68,7 @@ inline scalar_t parallel_reduce(
     return ident;
   }
   if ((end - begin) < grain_size || in_parallel_region()) {
-    ThreadIdGuard tid_guard(0);
+    internal::ThreadIdGuard tid_guard(0);
     return f(begin, end, ident);
   }
   size_t num_tasks, chunk_size;

--- a/aten/src/ATen/ParallelNative.h
+++ b/aten/src/ATen/ParallelNative.h
@@ -41,6 +41,7 @@ inline void parallel_for(
     return;
   }
   if ((end - begin) < grain_size || in_parallel_region()) {
+    ThreadIdGuard tid_guard(0);
     f(begin, end);
     return;
   }
@@ -67,6 +68,7 @@ inline scalar_t parallel_reduce(
     return ident;
   }
   if ((end - begin) < grain_size || in_parallel_region()) {
+    ThreadIdGuard tid_guard(0);
     return f(begin, end, ident);
   }
   size_t num_tasks, chunk_size;

--- a/aten/src/ATen/ParallelNativeTBB.cpp
+++ b/aten/src/ATen/ParallelNativeTBB.cpp
@@ -23,6 +23,7 @@ namespace at {
 namespace {
 static thread_local tbb::task_scheduler_init tbb_init_(intraop_default_num_threads());
 static thread_local tbb::task_group tg_;
+thread_local thid_thread_id{0};
 
 std::mutex global_thread_mutex_;
 std::shared_ptr<tbb::global_control> global_thread_limit_ = nullptr;
@@ -70,8 +71,13 @@ int get_num_threads() {
 }
 
 int get_thread_num() {
-  auto tid = tbb::this_task_arena::current_thread_index();
-  return std::max(tid, 0);
+  return this_thread_id;
+}
+
+namespace internal {
+void set_thread_num(int id) {
+  this_thread_id = id;
+}
 }
 
 bool in_parallel_region() {

--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -21,6 +21,7 @@ void clear_computation_cache();
 namespace {
 // Number of threads set by the user
 std::atomic<int> num_threads{-1};
+thread_local int this_thread_id{0};
 
 } // namespace
 
@@ -81,11 +82,13 @@ int get_num_threads() {
 }
 
 int get_thread_num() {
-#ifdef _OPENMP
-  return omp_get_thread_num();
-#else
-  return 0;
-#endif
+  return this_thread_id;
+}
+
+namespace detail {
+void set_thread_num(int id) {
+  this_thread_id = id;
+}
 }
 
 bool in_parallel_region() {

--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -85,7 +85,7 @@ int get_thread_num() {
   return this_thread_id;
 }
 
-namespace detail {
+namespace internal {
 void set_thread_num(int id) {
   this_thread_id = id;
 }

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -99,7 +99,9 @@ inline scalar_t parallel_reduce(
     for (int64_t id = 0; id < num_results; id++) {
       int64_t i = begin + id * grain_size;
       try {
+        #ifdef _OPENMP
         internal::ThreadIdGuard tid_guard(omp_get_thread_num());
+        #endif
         results_data[id] = f(i, i + std::min(end - i, grain_size), ident);
       } catch (...) {
         if (!err_flag.test_and_set()) {

--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -10,26 +10,6 @@
 #endif
 
 namespace at {
-namespace detail {
-
-TORCH_API void set_thread_num(int);
-
-class ThreadIdGuard {
-public:
-  ThreadIdGuard(int new_id):
-    old_id_(at::get_thread_num()) {
-    set_thread_num(new_id);
-  }
-
-  ~ThreadIdGuard() {
-    set_thread_num(old_id_);
-  }
-
-private:
-  int old_id_;
-};
-
-} // namespace detail
 
 template <class F>
 inline void parallel_for(
@@ -49,7 +29,7 @@ inline void parallel_for(
     numiter > grain_size && numiter > 1 &&
     omp_get_max_threads() > 1 && !omp_in_parallel());
   if (!use_parallel) {
-    detail::ThreadIdGuard tid_guard(0);
+    internal::ThreadIdGuard tid_guard(0);
     f(begin, end);
     return;
   }
@@ -75,7 +55,7 @@ inline void parallel_for(
     int64_t begin_tid = begin + tid * chunk_size;
     if (begin_tid < end) {
       try {
-        detail::ThreadIdGuard tid_guard(tid);
+        internal::ThreadIdGuard tid_guard(tid);
         f(begin_tid, std::min(end, chunk_size + begin_tid));
       } catch (...) {
         if (!err_flag.test_and_set()) {
@@ -88,7 +68,7 @@ inline void parallel_for(
     std::rethrow_exception(eptr);
   }
 #else
-  detail::ThreadIdGuard tid_guard(0);
+  internal::ThreadIdGuard tid_guard(0);
   f(begin, end);
 #endif
 }
@@ -107,7 +87,7 @@ inline scalar_t parallel_reduce(
     return ident;
   } else if ((end - begin) <= grain_size || in_parallel_region() ||
              get_num_threads() == 1) {
-    detail::ThreadIdGuard tid_guard(0);
+    internal::ThreadIdGuard tid_guard(0);
     return f(begin, end, ident);
   } else {
     const int64_t num_results = divup((end - begin), grain_size);
@@ -119,7 +99,7 @@ inline scalar_t parallel_reduce(
     for (int64_t id = 0; id < num_results; id++) {
       int64_t i = begin + id * grain_size;
       try {
-        detail::ThreadIdGuard tid_guard(omp_get_thread_num());
+        internal::ThreadIdGuard tid_guard(omp_get_thread_num());
         results_data[id] = f(i, i + std::min(end - i, grain_size), ident);
       } catch (...) {
         if (!err_flag.test_and_set()) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60185 Ensure num_threads is initialized before calling omp_get_max_threads
* #60184 OpenMP: Refactor parallel_reduce to share code with parallel_for
* **#60183 Ensure thread id is valid in nested parallel regions**

Fixes https://github.com/pytorch/pytorch/pull/59149#issuecomment-863287331

`parallel_for` will call the function directly if it would have run on only a
single thread anyway. This is great for performance, but causes an issue in
nested parallel regions because `get_thread_num` will reflect the parent
parallel region instead of the current `parallel_for` call.

I fix this by using a `thread_local` variable for the current thread id and
manually setting it before each call to the user-provided function.

Differential Revision: [D29287816](https://our.internmc.facebook.com/intern/diff/D29287816)