### PR TITLE
OpenMP: Refactor parallel_reduce to share code with parallel_for

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.h
+++ b/aten/src/ATen/ParallelOpenMP.h
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <exception>
 
+#include <c10/util/SmallVector.h>
+
 #ifdef _OPENMP
 #define INTRA_OP_PARALLEL
 
@@ -29,37 +31,11 @@ private:
   int old_id_;
 };
 
-} // namespace detail
-
-template <class F>
-inline void parallel_for(
-    const int64_t begin,
-    const int64_t end,
-    const int64_t grain_size,
-    const F& f) {
-  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(grain_size >= 0);
-  if (begin >= end) {
-    return;
-  }
-
 #ifdef _OPENMP
-  at::internal::lazy_init_num_threads();
-  const auto numiter = end - begin;
-  const bool use_parallel = (
-    numiter > grain_size && numiter > 1 &&
-    omp_get_max_threads() > 1 && !omp_in_parallel());
-  if (!use_parallel) {
-    detail::ThreadIdGuard tid_guard(0);
-    f(begin, end);
-    return;
-  }
-
+template <typename F>
+inline void invoke_parallel(int64_t begin, int64_t end, int64_t grain_size, const F& f) {
   std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
   std::exception_ptr eptr;
-  // Work around memory leak when using 1 thread in nested "omp parallel"
-  // caused by some buggy OpenMP versions and the fact that omp_in_parallel()
-  // returns false when omp_get_max_threads() == 1 inside nested "omp parallel"
-  // See issue gh-32284
 
 #pragma omp parallel
   {
@@ -87,6 +63,36 @@ inline void parallel_for(
   if (eptr) {
     std::rethrow_exception(eptr);
   }
+}
+#endif
+
+} // namespace detail
+
+
+template <class F>
+inline void parallel_for(
+    const int64_t begin,
+    const int64_t end,
+    const int64_t grain_size,
+    const F& f) {
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(grain_size >= 0);
+  if (begin >= end) {
+    return;
+  }
+
+#ifdef _OPENMP
+  at::internal::lazy_init_num_threads();
+  const auto numiter = end - begin;
+  const bool use_parallel = (
+    numiter > grain_size && numiter > 1 &&
+    omp_get_max_threads() > 1 && !omp_in_parallel());
+  if (!use_parallel) {
+    detail::ThreadIdGuard tid_guard(0);
+    f(begin, end);
+    return;
+  }
+
+  detail::invoke_parallel(begin, end, grain_size, f);
 #else
   detail::ThreadIdGuard tid_guard(0);
   f(begin, end);
@@ -102,40 +108,36 @@ inline scalar_t parallel_reduce(
     const F& f,
     const SF& sf) {
   TORCH_CHECK(grain_size >= 0);
-  at::internal::lazy_init_num_threads();
   if (begin >= end) {
     return ident;
-  } else if ((end - begin) <= grain_size || in_parallel_region() ||
-             get_num_threads() == 1) {
+  }
+
+#ifdef _OPENMP
+  at::internal::lazy_init_num_threads();
+  const bool use_parallel = (
+      (end - begin) <= grain_size ||
+      in_parallel_region() ||
+      get_num_threads() == 1);
+  if (!use_parallel) {
     detail::ThreadIdGuard tid_guard(0);
     return f(begin, end, ident);
-  } else {
-    const int64_t num_results = divup((end - begin), grain_size);
-    std::vector<scalar_t> results(num_results);
-    scalar_t* results_data = results.data();
-    std::atomic_flag err_flag = ATOMIC_FLAG_INIT;
-    std::exception_ptr eptr;
-#pragma omp parallel for
-    for (int64_t id = 0; id < num_results; id++) {
-      int64_t i = begin + id * grain_size;
-      try {
-        detail::ThreadIdGuard tid_guard(omp_get_thread_num());
-        results_data[id] = f(i, i + std::min(end - i, grain_size), ident);
-      } catch (...) {
-        if (!err_flag.test_and_set()) {
-          eptr = std::current_exception();
-        }
-      }
-    }
-    if (eptr) {
-      std::rethrow_exception(eptr);
-    }
-    scalar_t result = ident;
-    for (auto partial_result : results) {
-      result = sf(result, partial_result);
-    }
-    return result;
   }
+
+  c10::SmallVector<scalar_t, 64> results(at::get_num_threads(), ident);
+  detail::invoke_parallel(begin, end, grain_size, [&](int64_t begin, int64_t end) {
+    auto tid = at::get_thread_num();
+    results[tid] = f(begin, end, ident);
+  });
+
+  scalar_t result = ident;
+  for (auto partial_result : results) {
+    result = sf(result, partial_result);
+  }
+  return result;
+#else
+  detail::ThreadIdGuard tid_guard(0);
+  return f(begin, end, ident);
+#endif
 }
 
 } // namespace at


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60185 Ensure num_threads is initialized before calling omp_get_max_threads
* **#60184 OpenMP: Refactor parallel_reduce to share code with parallel_for**
* #60183 Ensure thread id is valid in nested parallel regions

Differential Revision: [D29287817](https://our.internmc.facebook.com/intern/diff/D29287817)