### PR TITLE
Ensure num_threads is initialized before calling omp_get_max_threads

### DIFF
--- a/aten/src/ATen/ParallelOpenMP.cpp
+++ b/aten/src/ATen/ParallelOpenMP.cpp
@@ -75,6 +75,7 @@ void set_num_threads(int nthreads) {
 // consistent size of parallel region in different threads
 int get_num_threads() {
 #ifdef _OPENMP
+  at::internal::lazy_init_num_threads();
   return omp_get_max_threads();
 #else
   return 1;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60185 Ensure num_threads is initialized before calling omp_get_max_threads**
* #60184 OpenMP: Refactor parallel_reduce to share code with parallel_for
* #60183 Ensure thread id is valid in nested parallel regions

`get_num_threads` is usually called before `parallel_for` so there's no
guaruntee we've initialized `num_threads` properly.

Differential Revision: [D29287814](https://our.internmc.facebook.com/intern/diff/D29287814)