### PR TITLE
Fix saved variable unpacking version counter

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -5494,6 +5494,21 @@ for shape in [(1,), ()]:
         # a is left untouched
         self.assertEqual(a, a_orig)
 
+    def test_saved_variable_version_counter(self):
+        a = torch.rand(2, requires_grad=True)
+
+        b = torch.exp(a)
+
+        b_unpacked = b.grad_fn._saved_result
+        self.assertEqual(b, b_unpacked)
+        self.assertEqual(b._version, b_unpacked._version)
+
+        with torch.no_grad():
+            b += 1
+
+        self.assertEqual(b, b_unpacked)
+        self.assertEqual(b._version, b_unpacked._version)
+
 
 def index_perm_variable(shape, max_indices):
     if not isinstance(shape, tuple):

--- a/torch/csrc/autograd/saved_variable.cpp
+++ b/torch/csrc/autograd/saved_variable.cpp
@@ -138,7 +138,7 @@ Variable SavedVariable::unpack(std::shared_ptr<Node> saved_for) const {
   // they still share the same storage. This works only because we never call
   // in-place functions on unpacked variables.
   Variable var = make_variable(data_, Edge(std::move(grad_fn), output_nr_));
-  impl::set_version_counter(var, saved_version_);
+  impl::set_version_counter(var, version_counter_);
 
   // NB: var here is never a view so there is no need to make anything special
   // for the case where the saved Tensor was a view. This whole argument relies


### PR DESCRIPTION
We only set the value and not the actual VC.
This means that in the context of double backward, if that saved tensor is saved again and the original Tensor is modified inplace, we would not detect it.

BC breaking note:
Inplace on the unpacked SavedVariables used to be ignored. They are now properly detected which can lead to errors saying that a variable needed for backward was modified inplace.
This is a valid error and the user should fix this by cloning the unpacked saved variable before using it.