### PR TITLE
[vulkan] Do not use memcmp to compare structs

### DIFF
--- a/aten/src/ATen/native/vulkan/api/Pipeline.h
+++ b/aten/src/ATen/native/vulkan/api/Pipeline.h
@@ -196,11 +196,8 @@ inline Pipeline::Barrier::operator bool() const {
 inline bool operator==(
     const Pipeline::Layout::Descriptor& _1,
     const Pipeline::Layout::Descriptor& _2) {
-  static_assert(
-      std::is_trivially_copyable<Pipeline::Layout::Descriptor>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(Pipeline::Layout::Descriptor)));
+  return (_1.descriptor_set_layout == _2.descriptor_set_layout);
 }
 
 inline size_t Pipeline::Layout::Factory::Hasher::operator()(
@@ -211,11 +208,10 @@ inline size_t Pipeline::Layout::Factory::Hasher::operator()(
 inline bool operator==(
     const Pipeline::Descriptor& _1,
     const Pipeline::Descriptor& _2) {
-  static_assert(
-      std::is_trivially_copyable<Pipeline::Descriptor>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(Pipeline::Descriptor)));
+  return (_1.pipeline_layout == _2.pipeline_layout && \
+          _1.shader_module == _2.shader_module && \
+          _1.local_work_group == _2.local_work_group);
 }
 
 inline size_t Pipeline::Factory::Hasher::operator()(

--- a/aten/src/ATen/native/vulkan/api/Resource.h
+++ b/aten/src/ATen/native/vulkan/api/Resource.h
@@ -396,11 +396,11 @@ inline Resource::Buffer::operator bool() const {
 inline bool operator==(
     const Resource::Image::Sampler::Descriptor& _1,
     const Resource::Image::Sampler::Descriptor& _2) {
-    static_assert(
-      std::is_trivially_copyable<Resource::Image::Sampler::Descriptor>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(Resource::Image::Sampler::Descriptor)));
+  return (_1.filter == _2.filter && \
+          _1.mipmap_mode == _2.mipmap_mode && \
+          _1.address_mode == _2.address_mode && \
+          _1.border == _2.border);
 }
 
 inline size_t Resource::Image::Sampler::Factory::Hasher::operator()(

--- a/aten/src/ATen/native/vulkan/api/Shader.h
+++ b/aten/src/ATen/native/vulkan/api/Shader.h
@@ -221,11 +221,8 @@ inline Shader::Layout::Object Shader::Layout::Cache::retrieve(
 inline bool operator==(
     const Shader::WorkGroup& _1,
     const Shader::WorkGroup& _2) {
-  static_assert(
-      std::is_trivially_copyable<Shader::WorkGroup>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(Shader::WorkGroup)));
+  return (_1.data[0u] == _2.data[0u] && _1.data[1u] == _2.data[1u] && _1.data[2u] == _2.data[2u]);
 }
 
 inline Shader::Descriptor::Descriptor(const char* const glsl)
@@ -259,11 +256,17 @@ inline Shader::Descriptor::Descriptor(
 inline bool operator==(
     const Shader::Descriptor& _1,
     const Shader::Descriptor& _2) {
-  static_assert(
-      std::is_trivially_copyable<Shader::Descriptor>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(Shader::Descriptor)));
+  if (_1.type != _2.type)
+    return false;
+
+  if (_1.type == Shader::Descriptor::Type::Binary) {
+    return (_1.shader.binary.spirv == _2.shader.binary.spirv && \
+            _1.shader.binary.size == _2.shader.binary.size);
+  }
+  else {
+    return (_1.shader.source.glsl == _2.shader.source.glsl);
+  }
 }
 
 inline size_t Shader::Factory::Hasher::operator()(
@@ -286,11 +289,12 @@ inline size_t Shader::Factory::Hasher::operator()(
 inline bool operator==(
     const VkDescriptorSetLayoutBinding& _1,
     const VkDescriptorSetLayoutBinding& _2) {
-  static_assert(
-      std::is_trivially_copyable<VkDescriptorSetLayoutBinding>::value,
-      "This implementation is no longer valid!");
 
-  return (0 == memcmp(&_1, &_2, sizeof(VkDescriptorSetLayoutBinding)));
+  return (_1.binding == _2.binding && \
+          _1.descriptorType == _2.descriptorType && \
+          _1.descriptorCount == _2.descriptorCount && \
+          _1.stageFlags == _2.stageFlags && \
+          _1.pImmutableSamplers == _2.pImmutableSamplers);
 }
 
 #endif /* USE_VULKAN_API */


### PR DESCRIPTION
Summary:
It isn't safe to use `memcmp` to determine the equality of structs due to potential random padding between fields of the struct. This can cause overloaded equality operators to return false when comparing structs with equivalent fields.

This bug appears to be responsible for the Vulkan backend crashing on WorkVC release builds.

Test Plan:
Run Vulkan unit tests:

```
cd ~/fbsource
buck build -c ndk.custom_libcxx=false -c pt.enable_qpl=0 //xplat/caffe2:pt_vulkan_api_test_binAndroid\#android-arm64 --show-output
adb push buck-out/gen/xplat/caffe2/pt_vulkan_api_test_binAndroid\#android-arm64 /data/local/tmp/vulkan_api_test
adb shell "/data/local/tmp/vulkan_api_test"
cd -
```

Test on workvc rdk build, first ensure you are receiving the Vulkan models.
```
buck install fbsource//fbandroid/mode/opt fbsource//fbandroid/mode/aloha_build_rdk fbsource//fbandroid/mode/no_obfuscation fbandroid/buck-configs/buckconfig.caffe2_pkg_snpe_libs_android aloha_workvc_rdk --deep --show-full-output
```

Reviewed By: IvanKobzarev

Differential Revision: D29203177

