### PR TITLE
[skip ci][wip] Add code coverage based target determination

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,72 @@
+import sys
+import pathlib
+import collections
+import os
+import trace
+import contextlib
+import io
+import json
+
+# content = open(sys.argv[1], "r").read()
+# 
+
+# print(t.results())
+INSTALL_DIR = str(pathlib.Path(__file__).resolve().parent)
+
+# print(INSTALL_DIR)
+# sys.exit(0)
+
+t = trace.Trace()
+
+progname = sys.argv[1]
+arguments = sys.argv[2:]
+
+
+buf = io.StringIO()
+try:
+    sys.argv = [progname, *arguments]
+    sys.path[0] = os.path.dirname(progname)
+
+    with open(progname, 'rb') as fp:
+        code = compile(fp.read(), progname, 'exec')
+    # try to emulate __main__ namespace as much as possible
+    globs = {
+        '__file__': progname,
+        '__name__': '__main__',
+        '__package__': None,
+        '__cached__': None,
+    }
+    with contextlib.redirect_stdout(buf):
+        t.runctx(code, globs, globs)
+except OSError as err:
+    sys.exit("Cannot run file %r because: %s" % (sys.argv[0], err))
+except SystemExit:
+    pass
+
+results = t.results()
+r = results
+c = results.counts
+
+files = collections.defaultdict(list)
+
+def keep_filename(name):
+    if name.startswith("<"):
+        return None
+
+    if name.startswith("/"):
+        if name.startswith(INSTALL_DIR):
+            return name[len(INSTALL_DIR) + 1:]
+        return None
+
+    return name
+
+
+for key_line_tuple, count in results.counts.items():
+    filename, lineno = key_line_tuple
+    filename = keep_filename(filename)
+    if filename:
+        files[filename].append(lineno)
+
+# print(buf.getvalue())
+# print(json.dumps(files))
+# print(json.dumps(files, indent=2))

--- a/go.py
+++ b/go.py
@@ -1,0 +1,8 @@
+import sys
+
+print("hi", sys.argv[1])
+
+if False:
+    print("no!")
+
+print("bye")

--- a/py-coverage.py
+++ b/py-coverage.py
@@ -1,0 +1,193 @@
+import argparse
+import json
+import subprocess
+import pathlib
+import tempfile
+import sys
+import xmltodict
+import collections
+import typing
+import asyncio
+import threading
+import random
+import shlex
+import itertools
+import multiprocessing
+
+
+def xml_to_per_file_lines_executed(content):
+    x = xmltodict.parse(content)
+    # json round trip to use standard types
+    x = json.loads(json.dumps(x))
+    data = x["coverage"]["packages"]["package"]
+
+    def get_lines(lines):
+        result = set()
+
+        if isinstance(lines, dict):
+            result.add(int(lines["@number"]))
+        else:
+            for line in lines:
+                result.add(int(line["@number"]))
+
+        return result
+
+    files = collections.defaultdict(set)
+    for item in data:
+        classes = item["classes"]["class"]
+        if isinstance(classes, list):
+            for the_class in classes:
+                name = the_class["@filename"]
+                if the_class["lines"] is None:
+                    # no lines executed in file
+                    continue
+
+                lines = the_class["lines"]["line"]
+                files[name].update(get_lines(lines))
+
+                # if isinstance(lines, dict):
+                #     files[name].add(lines["@number"])
+                # else:
+                #     for line in lines:
+                #         files[name].add(line["@number"])
+        else:
+            name = classes["@filename"]
+            if classes["lines"] is None:
+                # no lines in file
+                continue
+            lines = classes["lines"]["line"]
+            files[name].update(get_lines(lines))
+
+    return dict(files)
+
+
+
+class Test(typing.NamedTuple):
+    file: str
+    classname: str
+    test: str
+
+
+def list_tests(file: str):
+    proc = subprocess.run(["pytest", "--disable-warnings", "-q", "--collect-only", file], stdout=subprocess.PIPE)
+    stdout = proc.stdout.decode()
+
+    tests = []
+    for line in stdout.split("\n"):
+        if "::" not in line:
+            continue
+
+        line = line.strip()
+        file, classname, test = line.split("::")
+
+        tests.append(Test(file=file, classname=classname, test=test))
+
+    return tests
+
+
+async def get_coverage_data(test: Test, try_count=0):
+    test_name = f"{test.file}::{test.classname}::{test.test}"
+    with tempfile.NamedTemporaryFile() as f:
+        cmd = shlex.join([
+            "pytest",
+            "--cov=torch",
+            "--disable-warnings",
+            f"--cov-report=xml:{f.name}",
+            test_name,
+        ])
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.wait()
+        with open(f.name, "r") as f_r:
+            content = f_r.read()
+            if try_count < 2 and content.strip() == "":
+                # retry the test, no coverage data for some reason
+                print(try_count, "failed", cmd)
+                return await get_coverage_data(test, try_count + 1)
+            try:
+                lines = xml_to_per_file_lines_executed(content)
+            except Exception as e:
+                print(cmd)
+                print(content)
+                raise e
+            new_lines = {}
+
+            for filename, lines_set in lines.items():
+                new_lines[filename] = list(ranges(sorted(list(lines_set))))
+            
+            lines = new_lines
+    
+    # print(json.dumps(lines))
+    return lines
+
+
+async def gather_with_concurrency(n, tasks):
+    semaphore = asyncio.Semaphore(n)
+ 
+    async def sem_task(task):
+        async with semaphore:
+            await task
+
+    return await asyncio.gather(*(sem_task(task) for task in tasks), return_exceptions=False)
+
+
+async def main(args):
+    all_results = {}
+
+    finished = 0
+    total = 0
+
+    async def per_test_coverage_task(test):
+        nonlocal finished
+        lines = await get_coverage_data(test)
+
+        if test.file not in all_results:
+            all_results[test.file] = {}
+        if test.classname not in all_results[test.file]:
+            all_results[test.file][test.classname] = {}
+        
+        all_results[test.file][test.classname][test.test] = lines
+
+        finished += 1
+        if finished % 2 == 0:
+            print(f"finished {finished} / {total}")
+
+    tests = list_tests(args.file)
+    tests = tests[:100]
+    coros = [per_test_coverage_task(test) for test in tests]
+    total = len(coros)
+
+    print(f"Running {len(coros)} tests")
+    results = await gather_with_concurrency(multiprocessing.cpu_count(), coros)
+    for index, item in enumerate(results):
+        if item is not None:
+            print(index, tests[index], item)
+
+
+    print("WRITING to", args.out)
+    with open(args.out, "w") as f:
+        json.dump(all_results, f)
+
+
+def ranges(i):
+    for a, b in itertools.groupby(enumerate(i), lambda pair: pair[1] - pair[0]):
+        b = list(b)
+        if b[0][1] == b[-1][1]:
+            yield b[0][1]
+        else:
+            yield [b[0][1], b[-1][1]]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="run pytest-cov on some test")
+    parser.add_argument("--file", help="test file", required=True)
+    parser.add_argument("--out", help="output file", required=True)
+    args = parser.parse_args()
+
+    asyncio.run(main(args))
+
+    # r = list(ranges(x))
+    # print(r)

--- a/should_run_test.py
+++ b/should_run_test.py
@@ -1,0 +1,127 @@
+import argparse
+import json
+import subprocess
+import pathlib
+import tempfile
+import sys
+import xmltodict
+import collections
+import typing
+import asyncio
+import threading
+import random
+import shlex
+import itertools
+import multiprocessing
+import re
+from typing import List, Dict, Any, Tuple, Union
+
+
+CHUNK_HEADER_RE = r"diff --git .*?\nindex.*?\n---.*?\n\+\+\+ b/(.*?)\n@@ -(\d+,\d+) \+(\d+,\d+) @@"
+
+
+class Test(typing.NamedTuple):
+    file: str
+    classname: str
+    test: str
+
+
+def list_tests(file: str):
+    proc = subprocess.run(["pytest", "--disable-warnings", "-q", "--collect-only", file], stdout=subprocess.PIPE)
+    stdout = proc.stdout.decode()
+
+    tests = []
+    for line in stdout.split("\n"):
+        if "::" not in line:
+            continue
+
+        line = line.strip()
+        file, classname, test = line.split("::")
+
+        tests.append(Test(file=file, classname=classname, test=test))
+
+    return tests
+
+
+def find_changed_lines(diff: str) -> Dict[str, List[Tuple[int, int]]]:
+    files = collections.defaultdict(list)
+
+    matches = re.findall(CHUNK_HEADER_RE, diff, re.MULTILINE)
+    for file, start, end in matches:
+        start_line, _ = start.split(",")
+        end_line, _ = end.split(",")
+
+        files[file].append((int(start_line), int(end_line)))
+
+    return dict(files)
+
+
+def match(test_lines: Dict[str, Union[int, List[int]]], pr_lines: Dict[str, List[Tuple[int, int]]]):
+    tl = test_lines
+
+    # tl is a dict of files -> lines touched
+    # file names are rooted in the torch/ dir
+
+    # pr_lines is a list of test filename -> changed lines
+    # file names are rooted at the repo root
+    # for 
+
+    def match_ranges(coverage_lines, changed_lines):
+        return True
+
+    # algo is: loop over diff files (since it's way smaller), check test lines to see
+    # if any of them are present (check for file name, then line ranges). if not, skip
+    # the test.
+    def clean_filename(name):
+        if name.startswith("torch/"):
+            return name[len("torch/"):]
+
+    # for k in test_lines.keys():
+    #     print(k)
+
+    should_skip = True
+    for pr_filename, changed_lines in pr_lines.items():
+        # changed_lines is a list of line ranges ((int, int) tuples)
+        cleaned = clean_filename(pr_filename)
+        
+        # print(cleaned)
+        if cleaned in test_lines:
+            coverage_lines = test_lines[cleaned]
+            if match_ranges(coverage_lines, changed_lines):
+                should_skip = False
+
+    return should_skip
+
+
+def main(args):
+    with open(args.coverage, "r") as f:
+        coverage = json.load(f)
+
+    with open(args.diff, "r") as f:
+        changes_lines = find_changed_lines(f.read())
+    
+    skip_tests = []
+    not_skipped = []
+
+    for test_file, file_data in coverage.items():
+        for test_class, class_data in file_data.items():
+            for test_name, test_data in class_data.items():
+                if match(test_data, changes_lines):
+                    skip_tests.append(Test(file=test_file, classname=test_class, test=test_name))
+                else:
+                    not_skipped.append(Test(file=test_file, classname=test_class, test=test_name))
+
+    for skip in skip_tests:
+        print(f"Skipped {skip.classname}.{skip.test}")
+
+    for not_skip in not_skipped:
+        print(f"NOT Skipped {not_skip.classname}.{not_skip.test}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="output skipped tests")
+    parser.add_argument("--coverage", help="coverage json", required=True)
+    parser.add_argument("--diff", help="patch file to use for checking line numbers", required=True)
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
py-coverage.py: run the tests for a specific file and save out all the lines of code that each test touches. The resulting dict looks like `test file name` -> `test class name` -> `test name` -> `code file` -> `line ranges`.
should_run_test.py: take the output from py-coverage.py and a test file and output which tests to skip and which to not skip.

This works with pytest-cov which itself relies on `coverage`.

TODO:
* pytest doesn't work sometimes and also has crazy long startup times for a single test (> 10s)

```bash
python py-coverage.py --file test/test_jit.py --out jitcoverage.json

curl somepr.diff > diffs/py-only.diff

python should_run_test.py --coverage jit.json --diff diffs/py-only.diff
```

