### PR TITLE
Fix default DEFAULT_FILE_PATTERN in clang-tidy

### DIFF
--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -39,7 +39,7 @@ Patterns = collections.namedtuple("Patterns", "positive, negative")
 # NOTE: Clang-tidy cannot lint headers directly, because headers are not
 # compiled -- translation units are, of which there is one per implementation
 # (c/cc/cpp) file.
-DEFAULT_FILE_PATTERN = re.compile(r".*\.c(c|pp)?")
+DEFAULT_FILE_PATTERN = re.compile(r"^.*\.c(c|pp)?$")
 
 # Search for:
 #    diff --git ...


### PR DESCRIPTION
Without the change, clang-tidy also checks folders like `.circleci/...`

Example of the clang-tidy that looked into `.circleci` changes
https://github.com/pytorch/pytorch/runs/2844682644?check_suite_focus=true




[skip ci]

