### PR TITLE
[PyTorch][Edge] Adding tests for lite quantized models

### DIFF
--- a/test/mobile/test_lite_script_module.py
+++ b/test/mobile/test_lite_script_module.py
@@ -1,12 +1,26 @@
 import torch
 import torch.utils.bundled_inputs
 import io
-from typing import Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple, Type
 from collections import namedtuple
 import inspect
 
 from torch.jit.mobile import _load_for_lite_interpreter, _export_operator_list
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_quantized import (
+    override_quantized_engine,
+)
+from torch.testing._internal.common_quantization import (
+    AnnotatedSingleLayerLinearModel,
+    TwoLayerLinearModel,
+    AnnotatedNestedModel
+)
+from torch.quantization import (
+    quantize,
+    # prepare,
+    # convert,
+)
+from torch.testing._internal.common_quantization import QuantizationTestCase, test_only_eval_fn
 
 class TestLiteScriptModule(TestCase):
 
@@ -430,6 +444,99 @@ class TestLiteScriptModule(TestCase):
             error_message = f"{e}"
         self.assertTrue('test_lite_script_module.py\", line {}'.format(lineno + 8) in error_message)
         self.assertTrue('top(FooTest5)' in error_message)
+
+
+class TestLiteScriptQuantizedModule(QuantizationTestCase):
+
+    def _compare_script_and_mobile(self,
+                                   model_class: Type[torch.nn.Module],
+                                   input: torch.Tensor,
+                                   **kwargs):
+        qengine = "qnnpack"
+        with override_quantized_engine(qengine):
+            qconfig = torch.quantization.get_default_qconfig(qengine)
+            model = model_class(**kwargs)
+            # model.qconfig = qconfig
+            # model = prepare(model)
+
+            # test_only_eval_fn(model, self.calib_data)
+            # model = convert(model)
+            model = quantize(model, test_only_eval_fn, [self.calib_data])
+
+            script_module = torch.jit.script(model)
+            script_module_result = script_module(input)
+
+            buffer = io.BytesIO(script_module._save_to_buffer_for_lite_interpreter())
+            buffer.seek(0)
+            mobile_module = _load_for_lite_interpreter(buffer)
+
+            mobile_module_result = mobile_module(input)
+
+            torch.testing.assert_allclose(script_module_result, mobile_module_result)
+            mobile_module_forward_result = mobile_module.forward(input)
+            torch.testing.assert_allclose(script_module_result, mobile_module_forward_result)
+
+            mobile_module_run_method_result = mobile_module.run_method("forward", input)
+            torch.testing.assert_allclose(script_module_result, mobile_module_run_method_result)
+
+
+    def test_single_layer(self):
+        input = torch.rand(2, 5, dtype=torch.float)
+        self._compare_script_and_mobile(model_class=AnnotatedSingleLayerLinearModel, input=input, qengine="qnnpack")
+
+    def test_two_layer(self):
+        input = torch.rand(2, 5, dtype=torch.float)
+        self._compare_script_and_mobile(model_class=TwoLayerLinearModel, input=input)
+
+    def test_annotated_nested(self):
+        input = torch.rand(2, 5, dtype=torch.float)
+        self._compare_script_and_mobile(model_class=AnnotatedNestedModel, input=input, qengine="qnnpack")
+
+    def test_quantization_example(self):
+
+        # From the example in Static Quantization section of https://pytorch.org/docs/stable/quantization.html
+        class M(torch.nn.Module):
+            def __init__(self):
+                super(M, self).__init__()
+                self.quant = torch.quantization.QuantStub()
+                self.conv = torch.nn.Conv2d(1, 1, 1)
+                self.relu = torch.nn.ReLU()
+                self.dequant = torch.quantization.DeQuantStub()
+
+            def forward(self, x):
+                x = self.quant(x)
+                x = self.conv(x)
+                x = self.relu(x)
+                x = self.dequant(x)
+                return x
+
+        model_fp32 = M()
+
+        model_fp32.eval()
+        model_fp32.qconfig = torch.quantization.get_default_qconfig('qnnpack')
+        model_fp32_fused = torch.quantization.fuse_modules(model_fp32, [['conv', 'relu']])
+        model_fp32_prepared = torch.quantization.prepare(model_fp32_fused)
+        input_fp32 = torch.randn(4, 1, 4, 4)
+        model_fp32_prepared(input_fp32)
+        model_int8 = torch.quantization.convert(model_fp32_prepared)
+
+        input = torch.randn(4, 1, 4, 4)
+        script_module = torch.jit.script(model_int8)
+        script_module_result = script_module(input)
+
+        buffer = io.BytesIO(script_module._save_to_buffer_for_lite_interpreter())
+        buffer.seek(0)
+        mobile_module = _load_for_lite_interpreter(buffer)
+
+        mobile_module_result = mobile_module(input)
+
+        torch.testing.assert_allclose(script_module_result, mobile_module_result)
+        mobile_module_forward_result = mobile_module.forward(input)
+        torch.testing.assert_allclose(script_module_result, mobile_module_forward_result)
+
+        mobile_module_run_method_result = mobile_module.run_method("forward", input)
+        torch.testing.assert_allclose(script_module_result, mobile_module_run_method_result)
+
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
# Context
Read this posts for details about why we need a test bench for quantized lite modules
https://fb.workplace.com/groups/2322282031156145/permalink/4289792691071726/

In lite interpreter unit tests (both C++ and Python), quantization are not covered well. We are looking for ideas on testing quantized models from both eager mode and torchscript. The tests are expected to be
Small. Probably a module with simple operators like the existing ones in the link above.
end-to-end coverage. It covers conversion, serialization, deserialization and run at host and target sides.
Representative. The quantization flow is what mobile users are using, or representing future usage.

# This Diff
Adds test cases for Quantized Lite modules

Differential Revision: [D29212232](https://our.internmc.facebook.com/intern/diff/D29212232/)

[ghstack-poisoned]

Fixes [T92871037](https://www.internalfb.com/tasks/?t=92871037)
