### PR TITLE
.github: Disable clang-tidy for now

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -266,7 +266,9 @@ jobs:
           fi
 
   clang-tidy:
-    if: github.event_name == 'pull_request'
+    # if: github.event_name == 'pull_request'
+    # TODO: Fix clang-tidy, see https://github.com/pytorch/pytorch/issues/60192
+    if: ${{ false }}
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60219 .github: Disable clang-tidy for now**

See: https://github.com/pytorch/pytorch/issues/60192

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>

Differential Revision: [D29214928](https://our.internmc.facebook.com/intern/diff/D29214928)