### PR TITLE
[nnc] SEGV bug in LoopNest::getLoopAt

### DIFF
--- a/test/jit/segv_test.py
+++ b/test/jit/segv_test.py
@@ -1,0 +1,32 @@
+import torch
+
+class kernel_arena_scope(object):
+    def __enter__(self):
+        self.scope = torch._C._te.KernelScope()
+
+    def __exit__(self, typ, val, traceback):
+        self.scope = None
+
+with kernel_arena_scope():
+    f32 = torch._C._te.Dtype.Float
+    i32 = torch._C._te.Dtype.Int
+
+    X, Y, M, N = 64, 72, 56, 56
+    Xte, Yte, Mte, Nte = [torch._C._te.ExprHandle.int(x) for x in [X, Y, M, N]]
+    A = torch._C._te.Placeholder('A', f32, [Xte, Yte, Mte, Nte])
+
+    dim_args = [torch._C._te.DimArg(*args) for args in [(Xte, 'n'), (Yte, 'c'), (Mte, 'h'), (Nte, 'w')]]
+
+    def compute(x, y, m, n):
+        return A.load([x, y, m, n])
+    B = torch._C._te.Compute('B', dim_args, compute)
+    loopnest = torch._C._te.LoopNest([B])
+    loopnest.simplify()
+
+    n, c, h, w = loopnest.get_loops_for(B)
+    xtail = loopnest.tile(c, h, 16, 16)
+    print("loopnest:", loopnest)
+    ho = loopnest.get_loop_at(c, [0])
+    print("ho:", ho)
+    htail = loopnest.get_loop_at(c, [1])
+    print("htail:", htail)

--- a/torch/csrc/jit/tensorexpr/loopnest.cpp
+++ b/torch/csrc/jit/tensorexpr/loopnest.cpp
@@ -1924,7 +1924,7 @@ For* LoopNest::getLoopAt(For* root, const std::vector<int>& indicies) const {
       if (i<0 || curr->body()->nstmts()<=i){
           return nullptr;
       }
-      std::list<Stmt*>::iterator stmtp = curr->body()->begin();
+      std::list<Stmt*>::iterator stmtp = curr->body()->stmts().begin();
       std::advance(stmtp, i);
       curr = dynamic_cast<For*>(*stmtp);
       if (curr == nullptr){


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60222 [nnc] SEGV bug in LoopNest::getLoopAt**
* #60218 [nnc] Add LoopNest::getLoopAt to retrieve a specified inner For-stmt
* #57758 [NNC] Add tile transformation in loopnest (fixed #52785)

Differential Revision: [D29215245](https://our.internmc.facebook.com/intern/diff/D29215245)