### PR TITLE
Fix clang-tidy path filtering

### DIFF
--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -142,7 +142,6 @@ def find_changed_lines(diff: str) -> Dict[str, List[Tuple[int, int]]]:
     for file, start, end in matches:
         start_line, _ = start.split(",")
         end_line, _ = end.split(",")
-        print(file, start_line, end_line)
 
         files[file].append((start_line, end_line))
 
@@ -330,6 +329,11 @@ def main() -> None:
     if options.diff_file:
         with open(options.diff_file, "r") as f:
             changed_files = find_changed_lines(f.read())
+            changed_files = {
+                filename: v
+                for filename, v in changed_files.items()
+                if any(filename.startswith(path) for path in options.paths)
+            }
             line_filters = [
                 {"name": name, "lines": lines} for name, lines, in changed_files.items()
             ]


### PR DESCRIPTION
PR #60048 neglected to include the `--paths` option for file filtering, so it ended up passing every changed file in the diff to clang-tidy (cpp files outside `torch/csrc/`, yaml/sh files, etc.). This adds that back in to make the filtering work properly again.

Tested it manually by printing out the files to lint and running

```bash
curl -L https://github.com/pytorch/pytorch/pull/60018.diff > diff
python tools/clang_tidy.py --diff-file diff --paths torch/csrc/

curl -L https://github.com/pytorch/pytorch/pull/60222.diff > diff
python tools/clang_tidy.py --diff-file diff --paths torch/csrc/
```

Should fix #60192 and fix #60193, the files tripping errors there shouldn't have been passed to clang-tidy in the first place (supporting aten/ for clang-tidy is a separate task)