### PR TITLE
[add/sub] Cast `alpha` to `acc_type` 

### DIFF
--- a/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
+++ b/aten/src/ATen/native/cuda/BinaryAddSubKernel.cu
@@ -1,3 +1,4 @@
+#include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/DispatchStub.h>
 #include <ATen/native/cuda/Loops.cuh>
@@ -8,19 +9,20 @@
 
 namespace at { namespace native {
 
-template<typename scalar_t>
+template<typename scalar_t, typename accscalar_t>
 struct AddFunctor {
-  AddFunctor(scalar_t a): alpha(a) {}
+  AddFunctor(accscalar_t a): alpha(a) {}
   __device__ __forceinline__ scalar_t operator() (const scalar_t a, const scalar_t b) const {
     return a + alpha * b;
   }
   private:
-    scalar_t alpha;
+    accscalar_t alpha;
 };
 
 void add_kernel_cuda(TensorIteratorBase& iter, const Scalar& alpha_scalar) {
   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND3(kHalf, kBool, kBFloat16, iter.common_dtype(), "add_cuda/sub_cuda", [&]() {
-    AddFunctor<scalar_t> f(alpha_scalar.to<scalar_t>());
+    using accscalar_t = at::acc_type<scalar_t, true>;
+    AddFunctor<scalar_t, accscalar_t> f(alpha_scalar.to<accscalar_t>());
     gpu_kernel_with_scalars(iter, f);
   });
 }

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2355,6 +2355,12 @@ class TestBinaryUfuncs(TestCase):
         self.assertRaisesRegex(RuntimeError, r"result type ComplexFloat can't be cast to the desired output type Double",
                                lambda: torch.add(m1, m1, out=m2))
 
+    @onlyCUDA
+    def test_add_half_tensor_with_alpha(self, device):
+        x = torch.tensor([6000.0], dtype=torch.half, device=device)
+        y = torch.tensor([-6000.0], dtype=torch.half, device=device)
+        actual = torch.add(x, y, alpha=2)
+        self.assertTrue(not (actual.isnan() or actual.isinf()))
 
     def test_sub_typing(self, device):
         m1 = torch.tensor([True, False, False, True, False, False], dtype=torch.bool, device=device)

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -2357,8 +2357,8 @@ class TestBinaryUfuncs(TestCase):
 
     @onlyCUDA
     def test_add_half_tensor_with_alpha(self, device):
-        x = torch.tensor([6000.0], dtype=torch.half, device=device)
-        y = torch.tensor([-6000.0], dtype=torch.half, device=device)
+        x = torch.tensor([60000.0], dtype=torch.half, device=device)
+        y = torch.tensor([-60000.0], dtype=torch.half, device=device)
         actual = torch.add(x, y, alpha=2)
         self.assertTrue(not (actual.isnan() or actual.isinf()))
 


### PR DESCRIPTION
This PR lets `torch.add` & `torch.sub` CUDA kernels cast `alpha` to `acc_type`, not `scalar_t`.
I do not remove `cast`s from `test/test_foreach.py` because I'll do this in #59907 or follow-up for it.

Current upstream `torch._foreach_add` & `torch._foreach_sub` upcast `alpha` parameter to `acc_type<scalar_t>` while `torch.add` & `torch.sub` not. This is kind of problematic because outputs of `torch.add` and `torch.sub` are different from `torch._foreach_add` and `torch._foreach_sub`, respectively if the dtype of input tensors is either `torch.half` or `torch.bfloat16`. The discrepancy is proportional-ish to `abs(alpha)` except when `alpha` is representable with 16 bits.

ref:
- `torch._foreach_add` & `torch._foreach_sub` cast `alpha`: https://github.com/pytorch/pytorch/blob/6d0fb85a623f5ef3f3f1a2afc3660cb71fa70511/aten/src/ATen/native/cuda/ForeachBinaryOpList.cu#L21-L28, `BinaryOpListAlphaFunctor` is defined here: https://github.com/pytorch/pytorch/blob/6d0fb85a623f5ef3f3f1a2afc3660cb71fa70511/aten/src/ATen/native/cuda/ForeachFunctors.cuh#L202

related: https://github.com/pytorch/pytorch/issues/58833, https://github.com/pytorch/pytorch/pull/59907

cc @ngimel @ptrblck @mcarilli 