### PR TITLE
Support fused_dropout with XPU backend

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -22,7 +22,7 @@ Tensor make_feature_noise(const Tensor& input) {
 }
 
 bool is_fused_kernel_acceptable(const Tensor& input, double p) {
-  return input.is_cuda() && p > 0 && p < 1 && input.numel() > 0;
+  return (input.is_cuda() || input.is_xpu()) && p > 0 && p < 1 && input.numel() > 0;
 }
 
 // NB: sure, we could have used different overloads here, but I would feel insecure


### PR DESCRIPTION
## Motivation
Enable the fused dropout optimization on XPU devices.

## Solution
Add XPU device in the fused dropout acceptable checking.
