### PR TITLE
Test parametrization for instantiated device-specific tests

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -840,15 +840,15 @@ class TestBinaryUfuncs(TestCase):
             self.assertNotEqual(out_uint8_computation, out_int64_computation)
             self.assertEqual(out_uint8_computation.to(dtype=torch.uint8), out_int64_computation.to(dtype=torch.uint8))
 
-    def test_tensor_pow_tensor(self, dev):
+    def test_tensor_pow_tensor(self, device):
         def rotate(l, n):
             return l[-n:] + l[:-n]
 
         def test_tensor_pow_tensor(values, torch_type, numpy_type):
-            vals_tensor = torch.tensor(values, dtype=torch_type, device=dev)
+            vals_tensor = torch.tensor(values, dtype=torch_type, device=device)
             for i in range(len(values)):
                 pows = rotate(values, i)
-                pows_tensor = torch.tensor(pows, dtype=torch_type, device=dev)
+                pows_tensor = torch.tensor(pows, dtype=torch_type, device=device)
                 self._test_pow(vals_tensor, pows_tensor)
 
         ints = [0, 1, 2, 3]

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -57,7 +57,7 @@ class TestCommon(TestCase):
     @skipCUDAIfRocm
     @onlyOnCPUAndCUDA
     @ops(op_db, dtypes=OpDTypes.none)
-    def test_dtypes(self, device, dtype, op):
+    def test_dtypes(self, device, op):
         # dtypes to try to backward in
         allowed_backward_dtypes = floating_and_complex_types_and(torch.bfloat16, torch.float16)
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -738,7 +738,7 @@ class TestSparse(TestCase):
         self.assertEqual(None, x1.grad)
 
     @onlyCUDA
-    def test_cuda_empty(self, _):
+    def test_cuda_empty(self, device):
         def test_tensor(x):
             y = x.cuda(0)
             self.assertEqual(x.sparse_dim(), y.sparse_dim())
@@ -2210,7 +2210,7 @@ class TestSparse(TestCase):
         self.assertFalse(z._indices().numel() != 2 and z.is_coalesced())
 
     @onlyCUDA
-    def test_storage_not_null(self, _):
+    def test_storage_not_null(self, device):
         x = torch.cuda.sparse.FloatTensor(2)
         self.assertNotEqual(x.get_device(), -1)
 
@@ -2219,7 +2219,7 @@ class TestSparse(TestCase):
 
     @onlyCUDA
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
-    def test_same_gpu(self, _):
+    def test_same_gpu(self, device):
         def check_device(x, device_id):
             self.assertEqual(x.get_device(), device_id)
             self.assertEqual(x._values().get_device(), device_id)
@@ -2261,7 +2261,7 @@ class TestSparse(TestCase):
         self.assertEqual(x2.get_device(), device)
 
     @onlyCUDA
-    def test_new_device_single_gpu(self, _):
+    def test_new_device_single_gpu(self, device):
         self._test_new_device((), 0)
         self._test_new_device((30, 20), 0)
         self._test_new_device((30, 20, 10), 0)
@@ -2269,7 +2269,7 @@ class TestSparse(TestCase):
 
     @onlyCUDA
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
-    def test_new_device_multi_gpu(self, _):
+    def test_new_device_multi_gpu(self, device):
         self._test_new_device((), 1)
         self._test_new_device((30, 20), 1)
         self._test_new_device((30, 20, 10), 1)

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -11,7 +11,7 @@ from torch.testing._internal.common_cuda import TEST_CUDA, _get_torch_cuda_versi
 from numbers import Number
 from typing import Dict, Any
 from torch.testing._internal.common_device_type import \
-    (instantiate_device_type_tests, ops, dtypes, dtypesIfCPU, onlyCPU, onlyCUDA)
+    (instantiate_device_type_tests, ops, dtypes, dtypesIfCPU, onlyCPU, onlyCUDA, deviceCountAtLeast)
 from torch.testing._internal.common_methods_invocations import \
     (sparse_unary_ufuncs)
 

--- a/test/test_sparse.py
+++ b/test/test_sparse.py
@@ -738,7 +738,7 @@ class TestSparse(TestCase):
         self.assertEqual(None, x1.grad)
 
     @onlyCUDA
-    def test_cuda_empty(self, device):
+    def test_cuda_empty(self):
         def test_tensor(x):
             y = x.cuda(0)
             self.assertEqual(x.sparse_dim(), y.sparse_dim())
@@ -2210,7 +2210,7 @@ class TestSparse(TestCase):
         self.assertFalse(z._indices().numel() != 2 and z.is_coalesced())
 
     @onlyCUDA
-    def test_storage_not_null(self, device):
+    def test_storage_not_null(self):
         x = torch.cuda.sparse.FloatTensor(2)
         self.assertNotEqual(x.get_device(), -1)
 
@@ -2219,7 +2219,7 @@ class TestSparse(TestCase):
 
     @onlyCUDA
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
-    def test_same_gpu(self, device):
+    def test_same_gpu(self):
         def check_device(x, device_id):
             self.assertEqual(x.get_device(), device_id)
             self.assertEqual(x._values().get_device(), device_id)
@@ -2261,7 +2261,7 @@ class TestSparse(TestCase):
         self.assertEqual(x2.get_device(), device)
 
     @onlyCUDA
-    def test_new_device_single_gpu(self, device):
+    def test_new_device_single_gpu(self):
         self._test_new_device((), 0)
         self._test_new_device((30, 20), 0)
         self._test_new_device((30, 20, 10), 0)
@@ -2269,7 +2269,7 @@ class TestSparse(TestCase):
 
     @onlyCUDA
     @unittest.skipIf(torch.cuda.device_count() < 2, "only one GPU detected")
-    def test_new_device_multi_gpu(self, device):
+    def test_new_device_multi_gpu(self):
         self._test_new_device((), 1)
         self._test_new_device((30, 20), 1)
         self._test_new_device((30, 20, 10), 1)

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -15,7 +15,7 @@ load_tests = load_tests
 class TestSparseCSR(TestCase):
 
     @onlyCPU
-    def test_csr_layout(self, device):
+    def test_csr_layout(self):
         self.assertEqual(str(torch.sparse_csr), 'torch.sparse_csr')
         self.assertEqual(type(torch.sparse_csr), torch.layout)
 

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -15,7 +15,7 @@ load_tests = load_tests
 class TestSparseCSR(TestCase):
 
     @onlyCPU
-    def test_csr_layout(self, _):
+    def test_csr_layout(self, device):
         self.assertEqual(str(torch.sparse_csr), 'torch.sparse_csr')
         self.assertEqual(type(torch.sparse_csr), torch.layout)
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -353,11 +353,14 @@ class DeviceTypeTestBase(TestCase):
             # Constructs the test
             @wraps(test)
             def instantiated_test(self, param_kwargs=param_kwargs):
+                # Add the device param kwarg if the test needs device or devices.
                 param_kwargs = {} if param_kwargs is None else param_kwargs
-                device_arg: str = cls.get_primary_device()
-                if hasattr(test, 'num_required_devices'):
-                    device_arg = cls.get_all_devices()
-                _update_param_kwargs(param_kwargs, 'device', device_arg)
+                test_sig_params = inspect.signature(test).parameters
+                if 'device' in test_sig_params or 'devices' in test_sig_params:
+                    device_arg: str = cls.get_primary_device()
+                    if hasattr(test, 'num_required_devices'):
+                        device_arg = cls.get_all_devices()
+                    _update_param_kwargs(param_kwargs, 'device', device_arg)
 
                 # Sets precision and runs test
                 # Note: precision is reset after the test is run

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -797,12 +797,12 @@ class skipIf(object):
     def __call__(self, fn):
 
         @wraps(fn)
-        def dep_fn(slf, device, *args, **kwargs):
+        def dep_fn(slf, *args, **kwargs):
             if self.device_type is None or self.device_type == slf.device_type:
                 if (isinstance(self.dep, str) and getattr(slf, self.dep, True)) or (isinstance(self.dep, bool) and self.dep):
                     raise unittest.SkipTest(self.reason)
 
-            return fn(slf, device, *args, **kwargs)
+            return fn(slf, *args, **kwargs)
         return dep_fn
 
 
@@ -888,16 +888,16 @@ class expectedFailure(object):
     def __call__(self, fn):
 
         @wraps(fn)
-        def efail_fn(slf, device, *args, **kwargs):
+        def efail_fn(slf, *args, **kwargs):
             if self.device_type is None or self.device_type == slf.device_type:
                 try:
-                    fn(slf, device, *args, **kwargs)
+                    fn(slf, *args, **kwargs)
                 except Exception:
                     return
                 else:
                     slf.fail('expected test to fail, but it passed')
 
-            return fn(slf, device, *args, **kwargs)
+            return fn(slf, *args, **kwargs)
         return efail_fn
 
 
@@ -909,12 +909,12 @@ class onlyOn(object):
     def __call__(self, fn):
 
         @wraps(fn)
-        def only_fn(slf, device, *args, **kwargs):
+        def only_fn(slf, *args, **kwargs):
             if self.device_type != slf.device_type:
                 reason = "Only runs on {0}".format(self.device_type)
                 raise unittest.SkipTest(reason)
 
-            return fn(slf, device, *args, **kwargs)
+            return fn(slf, *args, **kwargs)
 
         return only_fn
 
@@ -933,24 +933,24 @@ class deviceCountAtLeast(object):
         fn.num_required_devices = self.num_required_devices
 
         @wraps(fn)
-        def multi_fn(slf, devices, *args, **kwargs):
+        def multi_fn(slf, *args, **kwargs):
             if len(devices) < self.num_required_devices:
                 reason = "fewer than {0} devices detected".format(self.num_required_devices)
                 raise unittest.SkipTest(reason)
 
-            return fn(slf, devices, *args, **kwargs)
+            return fn(slf, *args, **kwargs)
 
         return multi_fn
 
 # Only runs the test on the CPU and CUDA (the native device types)
 def onlyOnCPUAndCUDA(fn):
     @wraps(fn)
-    def only_fn(self, device, *args, **kwargs):
+    def only_fn(self, *args, **kwargs):
         if self.device_type != 'cpu' and self.device_type != 'cuda':
             reason = "onlyOnCPUAndCUDA: doesn't run on {0}".format(self.device_type)
             raise unittest.SkipTest(reason)
 
-        return fn(self, device, *args, **kwargs)
+        return fn(self, *args, **kwargs)
 
     return only_fn
 
@@ -1187,7 +1187,7 @@ def skipCUDAIfCudnnVersionLessThan(version=0):
 
     def dec_fn(fn):
         @wraps(fn)
-        def wrap_fn(self, device, *args, **kwargs):
+        def wrap_fn(self, *args, **kwargs):
             if self.device_type == 'cuda':
                 if self.no_cudnn:
                     reason = "cuDNN not available"
@@ -1196,7 +1196,7 @@ def skipCUDAIfCudnnVersionLessThan(version=0):
                     reason = "cuDNN version {0} is available but {1} required".format(self.cudnn_version, version)
                     raise unittest.SkipTest(reason)
 
-            return fn(self, device, *args, **kwargs)
+            return fn(self, *args, **kwargs)
 
         return wrap_fn
     return dec_fn

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -933,12 +933,12 @@ class deviceCountAtLeast(object):
         fn.num_required_devices = self.num_required_devices
 
         @wraps(fn)
-        def multi_fn(slf, *args, **kwargs):
+        def multi_fn(slf, devices, *args, **kwargs):
             if len(devices) < self.num_required_devices:
                 reason = "fewer than {0} devices detected".format(self.num_required_devices)
                 raise unittest.SkipTest(reason)
 
-            return fn(slf, *args, **kwargs)
+            return fn(slf, devices, *args, **kwargs)
 
         return multi_fn
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -272,10 +272,12 @@ def _dtype_test_suffix(dtypes):
 def _update_param_kwargs(param_kwargs, name, value):
     """ Adds a kwarg with the specified name and value to the param_kwargs dict. """
     if isinstance(value, list) or isinstance(value, tuple):
-        # Make name plural
+        # Make name plural (e.g. devices / dtypes) if the value is composite.
         param_kwargs['{}s'.format(name)] = value
     elif value:
         param_kwargs[name] = value
+
+    # Leave param_kwargs as-is when value is None.
 
 
 class DeviceTypeTestBase(TestCase):
@@ -612,13 +614,17 @@ def instantiate_device_type_tests(generic_test_class, scope, except_for=None, on
 # Category of dtypes to run an OpInfo-based test for
 # Example use: @ops(dtype=OpDTypes.supported)
 #
-# There are 3 categories: supported, unsupported and basic.
+# There are 6 categories:
 # - basic: The dtypes the operator wants to be tested on by default. This will be
 #          a subset of the types supported by the operator.
 # - supported: Every dtype supported by the operator. Use for exhaustive
 #              testing of all dtypes.
 # - unsupported: Run tests on dtypes not supported by the operator. e.g. for
 #                testing the operator raises an error and doesn't crash.
+# - supported_backward: Every dtype supported by the operator's backward pass.
+# - unsupported_backward: Run tests on dtypes not supported by the operator's backward pass.
+# - none: Useful for tests that are not dtype-specific. No dtype will be passed to the test
+#         when this is selected.
 class OpDTypes(Enum):
     basic = 0  # Test the basic set of dtypes (default)
     supported = 1  # Test all supported dtypes

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -380,7 +380,7 @@ class DeviceTypeTestBase(TestCase):
             assert not hasattr(cls, test_name), "Redefinition of test {0}".format(test_name)
             setattr(cls, test_name, instantiated_test)
 
-        # Handles tests that need parameterization (e.g. those that run across a set of
+        # Handles tests that need parametrization (e.g. those that run across a set of
         # ops / modules using the @ops or @modules decorators).
         if hasattr(test, 'parametrize_fn'):
             for (test, test_name, param_kwargs) in test.parametrize_fn(test, generic_cls, cls):
@@ -627,9 +627,9 @@ class OpDTypes(Enum):
 
 class _TestParametrizer(object):
     """
-    Decorator class for parameterizing a test function, yielding a set of new tests spawned
+    Decorator class for parametrizing a test function, yielding a set of new tests spawned
     from the original generic test, each specialized for a specific set of test inputs. For
-    example, parameterizing a test across the set of ops will result in a test function per op.
+    example, parametrizing a test across the set of ops will result in a test function per op.
 
     The decision of how to parametrize / what to parametrize over is intended to be implemented
     by each derived class.
@@ -640,7 +640,7 @@ class _TestParametrizer(object):
     """
     def _parametrize_test(self, test, generic_cls, device_cls):
         """
-        Parameterizes the given test function across whatever dimension is specified by the derived class.
+        Parametrizes the given test function across whatever dimension is specified by the derived class.
         Tests can be parametrized over any arbitrary dimension or combination of dimensions, such as all
         ops, all modules, or all ops + their associated dtypes.
 
@@ -651,8 +651,8 @@ class _TestParametrizer(object):
 
         Returns:
             Generator object returning 3-tuples of:
-                test (fn): Parameterized test function; must support a device arg and args for any params
-                test_name (str): Parameterized name of the test (e.g. test_bar_opname_int64)
+                test (fn): Parametrized test function; must support a device arg and args for any params
+                test_name (str): Parametrized name of the test (e.g. test_bar_opname_int64)
                 param_kwargs (dict): Param kwargs to pass to the test (e.g. {'op': 'add', 'dtype': torch.int64})
         """
         raise NotImplementedError


### PR DESCRIPTION
The `@ops` decorator provides a way to parameterize a test across a given list of ops. This would be useful for modules as well (e.g. a `@modules` decorator), but the mechanism by which this is accomplished is specific to ops. In the details, the `@ops` decorator tags a test function with the metadata needed (list of ops, `dtypes`) and the actual tests are generated according to this metadata during the call to `instantiate_device_type_tests()`.

This PR makes this mechanism more generic, allowing for test parameterization across arbitrary dimensions. This makes a `@modules` decorator (or any similar type of decorator) straightforward to implement without changes to the device-specific test instantiation logic.

One caveat is that, since this is implemented where the old `@ops` decorator was (within `instantiate_device_type_tests()`), this only works for tests instantiated using the device-specific instantiation logic. Longer term, even device-specific test instantiation could be treated as an optional parameterization across device types, but this PR takes a low-risk approach for now. In practice, this just means that a `device` kwarg is required for all test signatures used with the mechanism.

The `@ops` decorator has been refactored to use the generic mechanism and works the same as before, with one difference: when `OpDTypes.none` is specified, the test signature no longer needs an unused `dtype` kwarg. This is a nice bonus that demonstrates the added flexibility of a generic parameterization mechanism. The refactored form also has the bonus that all op-specific test generation logic is contained within the `@ops` decorator class, improving readability.

Behind the scenes, the generic mechanism is a base decorator class (`_TestParameterizer`) from which `@ops` derives. The core functionality is in the `_parameterize_test()` method, which takes in a test function and returns a generator that produces parameterized tests, including names and parameter kwargs to pass to them. Using the `@ops` decorator results in a set of op-specific tests from a given generic test.