### PR TITLE
[caffe2] add SequenceMask op

### DIFF
--- a/caffe2/operators/boolean_mask_ops.cc
+++ b/caffe2/operators/boolean_mask_ops.cc
@@ -557,6 +557,12 @@ REGISTER_CPU_OPERATOR(SequenceMask, SequenceMaskOp<CPUContext>);
 OPERATOR_SCHEMA(SequenceMask)
     .NumInputs(1, 2)
     .NumOutputs(1)
+    .TensorInferenceFunction([](const OperatorDef& def,
+                                const vector<TensorShape>& in) {
+      vector<TensorShape> out(1, in[0]);
+      out[0].set_data_type(in[0].data_type());
+      return out;
+    })
     .SetDoc(R"DOC(
 Mask op designed for use in attention mechanisms for sequence modeling tasks.
 Supports batching: given batch_dim, collapses dims 0 through batch_dim into a


### PR DESCRIPTION
Summary:
This diff
- added SequenceMask op in Dper3 (caffe2 only)
- added shape inference functions for SequenceMask op

Test Plan:
```
buck test dper3/dper3/modules/low_level_modules/tests:single_operators_test -- test_sequence_mask
```

Differential Revision: D29210097

