### PR TITLE
Use more type inference in fbgemm_utils.cpp

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fbgemm_utils.cpp
@@ -368,14 +368,14 @@ Tensor ConvertConvWeightsToChannelLastTensor<3>(
         "quantized", "Conv" + c10::to_string(kSpatialDim) + "dPackedParamsBase")
     .def_pickle(
         [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& params)
-        -> ConvParamsSerializationType { // __getstate__
+        -> typeof(serialize_conv<kSpatialDim>(params)) { // __getstate__
           return serialize_conv<kSpatialDim>(params);
         },
         // __setstate__ takes c10::IValue because we support parsing historical
         // serialization versions.
         [](c10::IValue v)
         -> c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> { // __setstate__
-          ConvParamsSerializationType state = parse_conv_serialized_state<kSpatialDim>(v);
+          auto state = parse_conv_serialized_state<kSpatialDim>(v);
           return deserialize_conv<kSpatialDim>(state);
         })
     .def("weight", [](const c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>>& self) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60242 Swich qconv serialization to format version 3
* #60241 Introduce quantized convolution serialization format 3
* #60240 Fix submodule naming in ONNX quantized test
* **#60239 Use more type inference in fbgemm_utils.cpp**

Summary:
This just makes it possible to change the serialization type in a future
diff without changing this file.

Test Plan:
CI