### PR TITLE
[BE] clean up IS_PYTORCH_CI and IN_CI

### DIFF
--- a/.jenkins/pytorch/common.sh
+++ b/.jenkins/pytorch/common.sh
@@ -29,7 +29,10 @@ fi
 # system; to find out more, grep for this string in ossci-job-dsl.
 echo "ENTERED_USER_LAND"
 
-export IS_PYTORCH_CI=1
+# Previously IN_CI is only set in .circleci/scripts/setup_ci_environment.sh,
+# this means other CI system doesn't actually have this flag properly set.
+# Now we explicitly export IN_CI environment variable here.
+export IN_CI=1
 
 # compositional trap taken from https://stackoverflow.com/a/7287873/23845
 

--- a/test/distributed/elastic/multiprocessing/api_test.py
+++ b/test/distributed/elastic/multiprocessing/api_test.py
@@ -35,7 +35,7 @@ from torch.testing._internal.common_utils import (
     NO_MULTIPROCESSING_SPAWN,
     TEST_WITH_ASAN,
     TEST_WITH_TSAN,
-    IS_PYTORCH_CI,
+    IS_IN_CI,
     IS_WINDOWS,
     IS_MACOS,
 )
@@ -593,7 +593,7 @@ class StartProcessesListTest(StartProcessesTest):
 
 
 @unittest.skipIf(
-    TEST_WITH_ASAN or TEST_WITH_TSAN or IS_WINDOWS or IS_MACOS or IS_PYTORCH_CI,
+    TEST_WITH_ASAN or TEST_WITH_TSAN or IS_WINDOWS or IS_MACOS or IS_IN_CI,
     "tests incompatible with tsan or asan, the redirect functionality does not work on macos or windows",
 )
 class StartProcessesNotCITest(StartProcessesTest):

--- a/test/distributed/rpc/test_faulty_agent.py
+++ b/test/distributed/rpc/test_faulty_agent.py
@@ -9,7 +9,7 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
+from torch.testing._internal.common_utils import IS_IN_CI, run_tests
 from torch.testing._internal.distributed.rpc.faulty_rpc_agent_test_fixture import (
     FaultyRpcAgentTestFixture,
 )
@@ -22,7 +22,7 @@ from torch.testing._internal.distributed.rpc_utils import (
 
 # On CircleCI these tests are already run on CPU jobs, thus to save resources do
 # not run them on GPU jobs, since thet wouldn't provide additional test signal.
-if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+if not (IS_IN_CI and torch.cuda.is_available()):
     globals().update(
         generate_tests(
             "Faulty",

--- a/test/distributed/rpc/test_process_group_agent.py
+++ b/test/distributed/rpc/test_process_group_agent.py
@@ -9,7 +9,7 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
+from torch.testing._internal.common_utils import IS_IN_CI, run_tests
 from torch.testing._internal.distributed.rpc.process_group_agent_test_fixture import (
     ProcessGroupRpcAgentTestFixture,
 )
@@ -23,7 +23,7 @@ from torch.testing._internal.distributed.rpc_utils import (
 
 # On CircleCI these tests are already run on CPU jobs, thus to save resources do
 # not run them on GPU jobs, since thet wouldn't provide additional test signal.
-if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+if not (IS_IN_CI and torch.cuda.is_available()):
     globals().update(
         generate_tests(
             "ProcessGroup",

--- a/test/distributed/rpc/test_tensorpipe_agent.py
+++ b/test/distributed/rpc/test_tensorpipe_agent.py
@@ -9,7 +9,7 @@ if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
     sys.exit(0)
 
-from torch.testing._internal.common_utils import IS_PYTORCH_CI, run_tests
+from torch.testing._internal.common_utils import IS_IN_CI, run_tests
 from torch.testing._internal.distributed.rpc.tensorpipe_rpc_agent_test_fixture import (
     TensorPipeRpcAgentTestFixture,
 )
@@ -23,7 +23,7 @@ from torch.testing._internal.distributed.rpc_utils import (
 
 # On CircleCI these tests are already run on CPU jobs, thus to save resources do
 # not run them on GPU jobs, since thet wouldn't provide additional test signal.
-if not (IS_PYTORCH_CI and torch.cuda.is_available()):
+if not (IS_IN_CI and torch.cuda.is_available()):
     globals().update(
         generate_tests(
             "TensorPipe",

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -18,7 +18,7 @@ from torch.utils.data._utils import MP_STATUS_CHECK_INTERVAL
 from torch.utils.data.dataset import random_split
 from torch._utils import ExceptionWrapper
 from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS,
-                                                  IS_PYTORCH_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
+                                                  IS_IN_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
                                                   load_tests, TEST_WITH_TSAN, IS_SANDCASTLE)
 
 try:
@@ -28,7 +28,7 @@ except ImportError:
     HAS_PSUTIL = False
     err_msg = ("psutil not found. Some critical data loader tests relying on it "
                "(e.g., TestDataLoader.test_proper_exit) will not run.")
-    if IS_PYTORCH_CI:
+    if IS_IN_CI:
         raise ImportError(err_msg) from None
     else:
         warnings.warn(err_msg)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -8,7 +8,7 @@ from torch.testing import \
     (FileCheck, floating_and_complex_types_and, get_all_dtypes)
 from torch.testing._internal.common_utils import \
     (TestCase, is_iterable_of_tensors, run_tests, IS_SANDCASTLE, clone_input_helper, make_tensor,
-     gradcheck, gradgradcheck, IS_PYTORCH_CI)
+     gradcheck, gradgradcheck, IS_IN_CI)
 from torch.testing._internal.common_methods_invocations import \
     (op_db,)
 from torch.testing._internal.common_device_type import \
@@ -35,7 +35,7 @@ class TestCommon(TestCase):
     def tearDownClass(cls):
         super().tearDownClass()
 
-        if IS_PYTORCH_CI:
+        if IS_IN_CI:
             err_msg = ("The operator(s) below is(are) using dynamic_dtypes in the OpInfo entries."
                        "This is OK for testing, but be sure to set the dtypes manually before landing your PR!")
             # Assure no opinfo entry has dynamic_dtypes

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -63,6 +63,7 @@ FILE_SCHEMA = "file://"
 if sys.platform == 'win32':
     FILE_SCHEMA = "file:///"
 
+# Environment variable `IN_CI` is set in `.jenkins/common.sh`.
 IS_IN_CI = os.getenv('IN_CI') == '1'
 IS_SANDCASTLE = os.getenv('SANDCASTLE') == '1' or os.getenv('TW_JOB_USER') == 'sandcastle'
 IS_FBCODE = os.getenv('PYTORCH_TEST_FBCODE') == '1'
@@ -234,9 +235,6 @@ def repeat_test_for_types(dtypes):
 
         return call_helper
     return repeat_helper
-
-# Environment variable `IS_PYTORCH_CI` is set in `.jenkins/common.sh`.
-IS_PYTORCH_CI = bool(os.environ.get('IS_PYTORCH_CI'))
 
 
 def discover_test_cases_recursively(suite_or_case):
@@ -832,7 +830,7 @@ try:
             verbosity=hypothesis.Verbosity.verbose))
 
     hypothesis.settings.load_profile(
-        "pytorch_ci" if IS_PYTORCH_CI else os.getenv('PYTORCH_HYPOTHESIS_PROFILE',
+        "pytorch_ci" if IS_IN_CI else os.getenv('PYTORCH_HYPOTHESIS_PROFILE',
                                                      'dev')
     )
 except ImportError:

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -830,8 +830,7 @@ try:
             verbosity=hypothesis.Verbosity.verbose))
 
     hypothesis.settings.load_profile(
-        "pytorch_ci" if IS_IN_CI else os.getenv('PYTORCH_HYPOTHESIS_PROFILE',
-                                                     'dev')
+        "pytorch_ci" if IS_IN_CI else os.getenv('PYTORCH_HYPOTHESIS_PROFILE', 'dev')
     )
 except ImportError:
     print('Fail to import hypothesis in common_utils, tests are not derandomized')


### PR DESCRIPTION
`IS_PYTORCH_CI` and `IN_CI` are used randomly, however in some cases IN_CI is not currently set because it only exist in 
- .circleci/scripts/setup_ci_environment.sh for circle
- .github/templates/* for GHA
- 
This cleans up the 2 flags and only use IN_CI

Test Plan:
CI

