### PR TITLE
[iOS GPU][BE][1/n] Rename MPSCNNContext to MetalContext

### DIFF
--- a/aten/src/ATen/native/metal/MetalAten.mm
+++ b/aten/src/ATen/native/metal/MetalAten.mm
@@ -1,6 +1,6 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/MetalUtils.h>
 #include <ATen/metal/Context.h>
 #include <torch/script.h>
@@ -114,7 +114,7 @@ TORCH_LIBRARY_IMPL(aten, Metal, m) {
 struct MetalImpl : public at::metal::MetalInterface {
   bool is_metal_available() const override {
 #if defined(USE_PYTORCH_METAL)
-    return [[MPSCNNContext sharedInstance] available];
+    return [[MetalContext sharedInstance] available];
 #else
     return false;
 #endif

--- a/aten/src/ATen/native/metal/MetalCommandBuffer.mm
+++ b/aten/src/ATen/native/metal/MetalCommandBuffer.mm
@@ -1,5 +1,5 @@
 #import <ATen/native/metal/MetalCommandBuffer.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 
 NSString* thread_local_storage_key = @"PTMetalCommandBuffer";
@@ -10,7 +10,7 @@ NSString* thread_local_storage_key = @"PTMetalCommandBuffer";
 
 + (MetalCommandBuffer*)newBuffer {
   MetalCommandBuffer* cb = [MetalCommandBuffer new];
-  cb->_buffer = [[MPSCNNContext sharedInstance].commandQueue commandBuffer];
+  cb->_buffer = [[MetalContext sharedInstance].commandQueue commandBuffer];
   cb->_images = [NSMutableArray new];
   cb->_delegates = [NSMutableSet new];
   return cb;

--- a/aten/src/ATen/native/metal/MetalContext.h
+++ b/aten/src/ATen/native/metal/MetalContext.h
@@ -5,7 +5,7 @@
 
 API_AVAILABLE(ios(10.0), macos(10.13))
 // TODO[T79947194]: Convert this class to C++
-@interface MPSCNNContext : NSObject
+@interface MetalContext : NSObject
 @property(nonatomic, strong, readonly) id<MTLDevice> device;
 @property(nonatomic, strong, readonly) id<MTLCommandQueue> commandQueue;
 @property(nonatomic, strong, readonly) id<MTLLibrary> library;

--- a/aten/src/ATen/native/metal/MetalContext.mm
+++ b/aten/src/ATen/native/metal/MetalContext.mm
@@ -1,6 +1,6 @@
 #import <ATen/native/metal/MetalDevice.h>
 #import <ATen/native/metal/MetalShaders.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 
 #include <c10/util/Exception.h>
 
@@ -14,7 +14,7 @@
 #endif
 
 using namespace at::native::metal;
-@implementation MPSCNNContext {
+@implementation MetalContext {
   std::mutex _pipelineCacheMutex;
   MetalDeviceInfo _deviceInfo;
   std::unordered_map<std::string, id<MTLComputePipelineState>> _pipelineCache;
@@ -22,9 +22,9 @@ using namespace at::native::metal;
 
 + (instancetype)sharedInstance {
   static dispatch_once_t onceToken;
-  static MPSCNNContext* instance = nil;
+  static MetalContext* instance = nil;
   dispatch_once(&onceToken, ^{
-    instance = [[MPSCNNContext alloc] init];
+    instance = [[MetalContext alloc] init];
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
     instance->_device = device;
     instance->_deviceInfo = createDeviceInfo(device);

--- a/aten/src/ATen/native/metal/MetalUtils.h
+++ b/aten/src/ATen/native/metal/MetalUtils.h
@@ -1,5 +1,5 @@
 #include <ATen/Tensor.h>
-#include <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#include <ATen/native/metal/MetalContext.h>
 #include <ATen/native/metal/MetalCommandBuffer.h>
 #include <ATen/native/metal/MetalTensorImpl.h>
 #include <ATen/native/metal/MetalTensorImplStorage.h>
@@ -78,7 +78,7 @@ static inline MetalCommandBuffer* getCommandBufferFromTensor(
 
 template<typename T>
 id<MTLBuffer>makeMTLBuffer(const std::vector<T>& src) {
-    id<MTLBuffer> buffer = [[MPSCNNContext sharedInstance].device
+    id<MTLBuffer> buffer = [[MetalContext sharedInstance].device
           newBufferWithLength:src.size() * sizeof(T)
                       options:MTLResourceOptionCPUCacheModeWriteCombined];
     memcpy(buffer.contents, src.data(), src.size() * sizeof(T));
@@ -86,7 +86,7 @@ id<MTLBuffer>makeMTLBuffer(const std::vector<T>& src) {
 }
 
 static inline id<MTLBuffer>makeMTLBuffer(int64_t bytes) {
-    id<MTLBuffer> buffer = [[MPSCNNContext sharedInstance].device
+    id<MTLBuffer> buffer = [[MetalContext sharedInstance].device
           newBufferWithLength:bytes
                       options:MTLResourceOptionCPUCacheModeWriteCombined];
     return buffer;

--- a/aten/src/ATen/native/metal/MetalUtils.mm
+++ b/aten/src/ATen/native/metal/MetalUtils.mm
@@ -1,5 +1,5 @@
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <Accelerate/Accelerate.h>
 
 namespace at {

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNClampOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNClampOp.mm
@@ -1,7 +1,7 @@
 #import <ATen/native/metal/MetalUtils.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSCNNClampOp.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 
 @implementation MPSCNNClampOp {
@@ -28,14 +28,14 @@
   have to use `clamp(vector<half4>, half4, half4)` instead.
   */
   id<MTLComputeCommandEncoder> encoder = [cb computeCommandEncoder];
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       pipelineState:at::native::metal::mpscnn::kernelFor(
                         _X, "clamp_half4", "clamp_half4_nonarray")];
 
   [encoder setComputePipelineState:state];
   [encoder setTexture:[_X texture] atIndex:0];
   [encoder setTexture:[_Y texture] atIndex:1];
-  id<MTLBuffer> clampBuffer = [[MPSCNNContext sharedInstance].device
+  id<MTLBuffer> clampBuffer = [[MetalContext sharedInstance].device
       newBufferWithLength:2 * sizeof(fp16_t)
                   options:MTLResourceOptionCPUCacheModeWriteCombined];
   fp16_t* clampBufferPtr = (fp16_t*)[clampBuffer contents];

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNConvOp.mm
@@ -1,5 +1,5 @@
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNConvOp.h>
 #import <ATen/native/metal/mpscnn/MPSCNNNeuronOp.h>
 
@@ -120,14 +120,14 @@
   MPSCNNConvolution* conv = nil;
   if (@available(iOS 11.0, *)) {
     conv = [[MPSCNNConvolution alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device
+        initWithDevice:[MetalContext sharedInstance].device
                weights:dataSource];
 
   } else {
 #if TARGET_OS_IPHONE
     // Fallback on earlier versions
     conv = [[MPSCNNConvolution alloc]
-               initWithDevice:[MPSCNNContext sharedInstance].device
+               initWithDevice:[MetalContext sharedInstance].device
         convolutionDescriptor:desc
                 kernelWeights:w
                     biasTerms:b

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.mm
@@ -1,4 +1,4 @@
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h>
 #import <ATen/native/metal/mpscnn/MPSCNNNeuronOp.h>
 
@@ -28,12 +28,12 @@
                                                  Bias:(float*)b
                                                  Desc:desc];
     fc = [[MPSCNNFullyConnected alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device
+        initWithDevice:[MetalContext sharedInstance].device
                weights:ds];
   } else {
 #if TARGET_OS_IPHONE
     fc = [[MPSCNNFullyConnected alloc]
-               initWithDevice:[MPSCNNContext sharedInstance].device
+               initWithDevice:[MetalContext sharedInstance].device
         convolutionDescriptor:desc
                 kernelWeights:w
                     biasTerms:b

--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNNeuronOp.mm
@@ -1,4 +1,4 @@
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNNeuronOp.h>
 
 @implementation MPSCNNNeuronOp
@@ -8,7 +8,7 @@
   static MPSCNNNeuronHardSigmoid* neuron = nil;
   dispatch_once(&onceToken, ^{
     neuron = [[MPSCNNNeuronHardSigmoid alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device
+        initWithDevice:[MetalContext sharedInstance].device
                      a:1.0 / 6.0
                      b:0.5];
   });
@@ -20,7 +20,7 @@
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     relu = [[MPSCNNNeuronReLU alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device
+        initWithDevice:[MetalContext sharedInstance].device
                      a:0];
   });
   return relu;
@@ -31,7 +31,7 @@
   static MPSCNNNeuronSigmoid* sigmoid = nil;
   dispatch_once(&onceToken, ^{
     sigmoid = [[MPSCNNNeuronSigmoid alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device];
+        initWithDevice:[MetalContext sharedInstance].device];
   });
   return sigmoid;
 }
@@ -41,7 +41,7 @@
   static MPSCNNNeuronTanH* tanh = nil;
   dispatch_once(&onceToken, ^{
     tanh = [[MPSCNNNeuronTanH alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device
+        initWithDevice:[MetalContext sharedInstance].device
                      a:1
                      b:1];
   });

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -1,6 +1,6 @@
 #import <ATen/native/metal/MetalCommandBuffer.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -112,7 +112,7 @@ void MPSImageWrapper::setImage(MPSImage* image) {
 void MPSImageWrapper::prepare() {
   if (!_buffer) {
     int64_t size_bytes = c10::multiply_integers([_image sizes]) * sizeof(float);
-    _buffer = [[MPSCNNContext sharedInstance].device
+    _buffer = [[MetalContext sharedInstance].device
         newBufferWithLength:size_bytes
                     options:MTLResourceCPUCacheModeWriteCombined];
     TORCH_CHECK(_buffer, "Allocate GPU memory failed!");

--- a/aten/src/ATen/native/metal/ops/MetalAddmm.mm
+++ b/aten/src/ATen/native/metal/ops/MetalAddmm.mm
@@ -5,7 +5,7 @@
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
 #import <ATen/native/metal/mpscnn/MPSCNNClampOp.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNFullyConnectedOp.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>

--- a/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
+++ b/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalTensorUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -82,7 +82,7 @@ Tensor binaryElementwiseShaderKernel(
       [cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   mt.texture()->allocateTemporaryStorage(outputSize, cb1);
   MPSImage* Y = mt.texture()->image();
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       pipelineState:mpscnn::kernelFor(X1, arrayKernel, nonarrayKernel)];
   id<MTLComputeCommandEncoder> encoder = [cb1.buffer computeCommandEncoder];
   [encoder setComputePipelineState:state];
@@ -122,7 +122,7 @@ Tensor& binaryElementwiseShaderKernel_(
   TORCH_CHECK(
       [cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   MPSImage* Y = createTemporaryImage(cb1, outputSize.vec());
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       pipelineState:mpscnn::kernelFor(X1, arrayKernel, nonarrayKernel)];
   id<MTLComputeCommandEncoder> encoder = [cb1.buffer computeCommandEncoder];
   [encoder setComputePipelineState:state];
@@ -165,7 +165,7 @@ Tensor binaryElementwiseMPSCNNKernel(
       [cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   mt.texture()->allocateTemporaryStorage(outputSize, cb1);
   MPSImage* Y = mt.texture()->image();
-  T* kernel = [[T alloc] initWithDevice:[MPSCNNContext sharedInstance].device];
+  T* kernel = [[T alloc] initWithDevice:[MetalContext sharedInstance].device];
   kernel.primaryStrideInPixelsY = X1.height == 1 ? 0 : 1;
   kernel.primaryStrideInPixelsX = X1.width == 1 ? 0 : 1;
   kernel.secondaryStrideInPixelsY = X2.height == 1 ? 0 : 1;
@@ -197,7 +197,7 @@ Tensor& binaryElementwiseMPSCNNKernel_(Tensor& input1, const Tensor& input2) {
   TORCH_CHECK(
       [cb1 isEqual:cb2], @"inputs have different Metal command buffers");
   MPSImage* Y = createTemporaryImage(cb1, outputSize.vec());
-  T* kernel = [[T alloc] initWithDevice:[MPSCNNContext sharedInstance].device];
+  T* kernel = [[T alloc] initWithDevice:[MetalContext sharedInstance].device];
   kernel.primaryStrideInPixelsY = X1.height == 1 ? 0 : 1;
   kernel.primaryStrideInPixelsX = X1.width == 1 ? 0 : 1;
   kernel.secondaryStrideInPixelsY = X2.height == 1 ? 0 : 1;

--- a/aten/src/ATen/native/metal/ops/MetalChunk.mm
+++ b/aten/src/ATen/native/metal/ops/MetalChunk.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -37,7 +37,7 @@ std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
   mt2.texture()->allocateTemporaryStorage(outputSize2, commandBuffer);
   MPSImage* Y1 = mt1.texture()->image();
   MPSImage* Y2 = mt2.texture()->image();
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       specializedPipelineState:"split_channels"
                      Constants:@[
                          @(X.featureChannels),

--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -30,10 +30,10 @@ Tensor cat_batch(const TensorList tensors, MetalTensorImplStorage& mt) {
         @"inputs have different Metal command buffers");
     id<MTLComputeCommandEncoder> encoder =
         [commandBuffer.buffer computeCommandEncoder];
-    id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+    id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
         pipelineState:mpscnn::kernelFor(
                           X, "copy_offset", "copy_offset_nonarray")];
-    id<MTLBuffer> offsetBuffer = [[MPSCNNContext sharedInstance].device
+    id<MTLBuffer> offsetBuffer = [[MetalContext sharedInstance].device
         newBufferWithLength:1 * sizeof(ushort)
                     options:MTLResourceOptionCPUCacheModeWriteCombined];
     ushort* offsetBufferPtr = (ushort*)[offsetBuffer contents];
@@ -85,8 +85,8 @@ Tensor cat_feature(const TensorList tensors, MetalTensorImplStorage& mt) {
     }
 
     id<MTLComputePipelineState> state =
-        [[MPSCNNContext sharedInstance] pipelineState:kernelString];
-    id<MTLBuffer> offsetBuffer = [[MPSCNNContext sharedInstance].device
+        [[MetalContext sharedInstance] pipelineState:kernelString];
+    id<MTLBuffer> offsetBuffer = [[MetalContext sharedInstance].device
         newBufferWithLength:5 * sizeof(ushort)
                     options:MTLResourceOptionCPUCacheModeWriteCombined];
     ushort* offsetBufferPtr = (ushort*)[offsetBuffer contents];

--- a/aten/src/ATen/native/metal/ops/MetalCopy.mm
+++ b/aten/src/ATen/native/metal/ops/MetalCopy.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -28,7 +28,7 @@ Tensor copy_to_host(const Tensor& input) {
 
   id<MTLComputeCommandEncoder> encoder =
       [commandBuffer.buffer computeCommandEncoder];
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       specializedPipelineState:metal::mpscnn::kernelFor(
                                    X, "copy", "copy_nonarray")
                      Constants:@[

--- a/aten/src/ATen/native/metal/ops/MetalHardswish.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardswish.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -23,7 +23,7 @@ Tensor& hardswish_(Tensor& input) {
   MPSImage* Y = createTemporaryImage(commandBuffer, imageSize);
   id<MTLComputeCommandEncoder> encoder =
       [commandBuffer.buffer computeCommandEncoder];
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       specializedPipelineState:mpscnn::kernelFor(
                                    X, "hardswish", "hardswish_nonarray")
                      Constants:@[

--- a/aten/src/ATen/native/metal/ops/MetalNeurons.mm
+++ b/aten/src/ATen/native/metal/ops/MetalNeurons.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNNeuronOp.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>

--- a/aten/src/ATen/native/metal/ops/MetalPadding.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPadding.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -55,7 +55,7 @@ Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
 
   id<MTLComputeCommandEncoder> encoder =
       [commandBuffer.buffer computeCommandEncoder];
-  id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+  id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
       specializedPipelineState:"reflection_pad2d"
                      Constants:@[
                        @(Y.height),

--- a/aten/src/ATen/native/metal/ops/MetalPooling.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPooling.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -49,7 +49,7 @@ Tensor max_pool2d(
   }
   MPSImage* X = imageFromTensor(input);
   MPSCNNPoolingMax* pool = [[MPSCNNPoolingMax alloc]
-       initWithDevice:[MPSCNNContext sharedInstance].device
+       initWithDevice:[MetalContext sharedInstance].device
           kernelWidth:kernel_size[0]
          kernelHeight:kernel_size[1]
       strideInPixelsX:stride[0]
@@ -82,7 +82,7 @@ Tensor adaptive_avg_pool2d(const Tensor& input, IntArrayRef output_size) {
   }
   MPSImage* X = imageFromTensor(input);
   MPSCNNPoolingAverage* pool = [[MPSCNNPoolingAverage alloc]
-       initWithDevice:[MPSCNNContext sharedInstance].device
+       initWithDevice:[MetalContext sharedInstance].device
           kernelWidth:X.width
          kernelHeight:X.height
       strideInPixelsX:X.width

--- a/aten/src/ATen/native/metal/ops/MetalReduce.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReduce.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 
@@ -17,7 +17,7 @@ namespace metal {
 
 API_AVAILABLE(ios(11.3), macos(10.13))
 static inline MPSNNReduceUnary* kernelForReducedDim(int dim) {
-  id<MTLDevice> device = [MPSCNNContext sharedInstance].device;
+  id<MTLDevice> device = [MetalContext sharedInstance].device;
   if (dim == 3) {
     return [[MPSNNReduceRowMean alloc] initWithDevice:device];
   } else if (dim == 2) {

--- a/aten/src/ATen/native/metal/ops/MetalReshape.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReshape.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -36,7 +36,7 @@ Tensor view(const Tensor& input, IntArrayRef size) {
   mt.texture()->allocateTemporaryStorage(inferred_size, commandBuffer);
   MPSImage* Y = mt.texture()->image();
   id<MTLComputePipelineState> state =
-      [[MPSCNNContext sharedInstance] specializedPipelineState:"reshape"
+      [[MetalContext sharedInstance] specializedPipelineState:"reshape"
                                                      Constants:@[
                                                        @(Y.height),
                                                        @(Y.width),

--- a/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
+++ b/aten/src/ATen/native/metal/ops/MetalSoftmax.mm
@@ -3,7 +3,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
 
@@ -37,7 +37,7 @@ Tensor mpscnn_softmax(
   MPSImage* X = imageFromTensor(input_);
   // MPSCNNSoftmax kernels operate on feature channels
   // https://developer.apple.com/documentation/metalperformanceshaders/mpscnnsoftmax?changes=_1&language=objc
-  T* softmax = [[T alloc] initWithDevice:[MPSCNNContext sharedInstance].device];
+  T* softmax = [[T alloc] initWithDevice:[MetalContext sharedInstance].device];
   MetalTensorImplStorage mt{newSize};
   MetalCommandBuffer* commandBuffer = getCommandBufferFromTensor(input_);
   mt.texture()->allocateTemporaryStorage(newSize, commandBuffer);

--- a/aten/src/ATen/native/metal/ops/MetalTranspose.mm
+++ b/aten/src/ATen/native/metal/ops/MetalTranspose.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -33,7 +33,7 @@ Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
     mt.texture()->allocateTemporaryStorage(outputSizes, commandBuffer);
     MPSImage* Y = mt.texture()->image();
     MPSImageTranspose* transpose = [[MPSImageTranspose alloc]
-        initWithDevice:[MPSCNNContext sharedInstance].device];
+        initWithDevice:[MetalContext sharedInstance].device];
     [transpose encodeToCommandBuffer:commandBuffer.buffer
                          sourceImage:X
                     destinationImage:Y];
@@ -50,7 +50,7 @@ Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
     id<MTLComputeCommandEncoder> encoder =
         [commandBuffer.buffer computeCommandEncoder];
     id<MTLComputePipelineState> state =
-        [[MPSCNNContext sharedInstance] specializedPipelineState:"transpose"
+        [[MetalContext sharedInstance] specializedPipelineState:"transpose"
                                                        Constants:@[
                                                          @(dim0),
                                                          @(dim1),

--- a/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
+++ b/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
@@ -2,7 +2,7 @@
 #import <ATen/native/metal/MetalTensorImpl.h>
 #import <ATen/native/metal/MetalTensorImplStorage.h>
 #import <ATen/native/metal/MetalUtils.h>
-#import <ATen/native/metal/mpscnn/MPSCNNContext.h>
+#import <ATen/native/metal/MetalContext.h>
 #import <ATen/native/metal/mpscnn/MPSCNNUtils.h>
 #import <ATen/native/metal/mpscnn/MPSImage+Tensor.h>
 #import <ATen/native/metal/mpscnn/MPSImageUtils.h>
@@ -51,7 +51,7 @@ Tensor upsample_nearest2d_vec(
   MPSImage* Y = mt.texture()->image();
   if (@available(iOS 11.0, *)) {
     MPSCNNUpsamplingNearest* kernel = [[MPSCNNUpsamplingNearest alloc]
-             initWithDevice:[MPSCNNContext sharedInstance].device
+             initWithDevice:[MetalContext sharedInstance].device
         integerScaleFactorX:(NSUInteger)scale_w.value()
         integerScaleFactorY:(NSUInteger)scale_h.value()];
     [kernel encodeToCommandBuffer:commandBuffer.buffer
@@ -60,7 +60,7 @@ Tensor upsample_nearest2d_vec(
   } else {
     NSUInteger sh = scale_h.value() * 10000;
     NSUInteger sw = scale_w.value() * 10000;
-    id<MTLComputePipelineState> state = [[MPSCNNContext sharedInstance]
+    id<MTLComputePipelineState> state = [[MetalContext sharedInstance]
         specializedPipelineState:mpscnn::kernelFor(
                                      Y,
                                      "resize_nearest",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60282 [iOS GPU][BE][3/n] Give MPSImage objects a label for better debugging experience
* #60281 [iOS GPU][BE][2/n] Remove unused APIs
* **#60280 [iOS GPU][BE][1/n] Rename MPSCNNContext to MetalContext**

No significant changes besides renaming the class. In the future, we'll convert this objc class to c++.

Differential Revision: [D29231824](https://our.internmc.facebook.com/intern/diff/D29231824/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29231824/)!