### PR TITLE
[iOS GPU][BE][3/n] Give MPSImage objects a label for better debugging experience

### DIFF
--- a/aten/src/ATen/native/metal/mpscnn/MPSCNNClampOp.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSCNNClampOp.mm
@@ -47,8 +47,6 @@
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [_X markRead];
-  [_Y markRead];
 }
 
 @end

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageUtils.h
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageUtils.h
@@ -10,9 +10,7 @@ namespace native {
 namespace metal {
 
 MPSImage* createStaticImage(IntArrayRef sizes);
-MPSImage* createStaticImage(
-    const float* src,
-    const IntArrayRef sizes);
+MPSImage* createStaticImage(const float* src, const IntArrayRef sizes);
 MPSImage* createStaticImage(
     MPSTemporaryImage* image,
     MetalCommandBuffer* buffer,
@@ -29,8 +27,12 @@ MPSTemporaryImage* createTemporaryImage(
     MetalCommandBuffer* buffer,
     MPSImage* image);
 
-void copyToHost(float* dst, MPSImage* image);
-void copyToMetalBuffer(MetalCommandBuffer* buffer, id<MTLBuffer> dst, MPSImage* image);
+void copyImageToFloatBuffer(float* dst, MPSImage* image);
+
+void copyImageToMetalBuffer(
+    MetalCommandBuffer* buffer,
+    id<MTLBuffer> dst,
+    MPSImage* image);
 
 static inline MPSImage* imageFromTensor(const Tensor& tensor) {
   TORCH_CHECK(tensor.is_metal());
@@ -57,7 +59,7 @@ static inline std::vector<int64_t> computeImageSize(IntArrayRef sizes) {
   int64_t batch = 1;
   for (int64_t i = sizes.size() - 1; i >= 0; i--) {
     if (index != 0) {
-        imageSize[index] = sizes[i];
+      imageSize[index] = sizes[i];
       index--;
       continue;
     }

--- a/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
+++ b/aten/src/ATen/native/metal/mpscnn/MPSImageWrapper.mm
@@ -117,7 +117,7 @@ void MPSImageWrapper::prepare() {
                     options:MTLResourceCPUCacheModeWriteCombined];
     TORCH_CHECK(_buffer, "Allocate GPU memory failed!");
   }
-  copyToMetalBuffer(_commandBuffer, _buffer, _image);
+  copyImageToMetalBuffer(_commandBuffer, _buffer, _image);
   if (_image.isTemporaryImage && _image.readCount != 0) {
     _image =
         createStaticImage((MPSTemporaryImage*)_image, _commandBuffer, false);

--- a/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
+++ b/aten/src/ATen/native/metal/mpscnn/tests/MPSCNNTests.mm
@@ -115,7 +115,7 @@ bool test_copy_nchw_to_metal() {
         createTemporaryImage(cb, t1.sizes().vec(), t1.data_ptr<float>());
     MPSImage* img2 = createStaticImage(img1, cb, true);
     auto t2 = at::zeros(size);
-    copyToHost(t2.data_ptr<float>(), img2);
+    copyImageToFloatBuffer(t2.data_ptr<float>(), img2);
     return almostEqual(t1, t2);
   });
 }

--- a/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
+++ b/aten/src/ATen/native/metal/ops/MetalBinaryElementwise.mm
@@ -94,8 +94,6 @@ Tensor binaryElementwiseShaderKernel(
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X1 markRead];
-  [X2 markRead];
   auto output = makeTensor(std::move(mt), input1.options());
   return output;
 }
@@ -134,8 +132,6 @@ Tensor& binaryElementwiseShaderKernel_(
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X1 markRead];
-  [X2 markRead];
   MetalTensorImpl* impl = (MetalTensorImpl*)input1.unsafeGetTensorImpl();
   MetalTensorImplStorage& implStorage = impl->unsafe_opaque_handle();
   implStorage.texture()->setImage(Y);

--- a/aten/src/ATen/native/metal/ops/MetalChunk.mm
+++ b/aten/src/ATen/native/metal/ops/MetalChunk.mm
@@ -54,9 +54,6 @@ std::vector<Tensor> chunk(const Tensor& input, int64_t chunks, int64_t dim) {
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X markRead];
-  [Y1 markRead];
-  [Y2 markRead];
   auto output1 = makeTensor(std::move(mt1), input.options());
   auto output2 = makeTensor(std::move(mt2), input.options());
   return {output1, output2};

--- a/aten/src/ATen/native/metal/ops/MetalConcat.mm
+++ b/aten/src/ATen/native/metal/ops/MetalConcat.mm
@@ -49,7 +49,6 @@ Tensor cat_batch(const TensorList tensors, MetalTensorImplStorage& mt) {
     [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
             threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
     [encoder endEncoding];
-    [X markRead];
     cat_dim4_pointer += t.size(0) * ((t.size(1) + 3) / 4);
   }
   auto output = makeTensor(std::move(mt), tensor.options());
@@ -111,7 +110,6 @@ Tensor cat_feature(const TensorList tensors, MetalTensorImplStorage& mt) {
     [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
             threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
     [encoder endEncoding];
-    [X markRead];
     channel_offset += X.featureChannels;
   }
   auto output = makeTensor(std::move(mt), tensor.options());

--- a/aten/src/ATen/native/metal/ops/MetalCopy.mm
+++ b/aten/src/ATen/native/metal/ops/MetalCopy.mm
@@ -46,7 +46,6 @@ Tensor copy_to_host(const Tensor& input) {
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X markRead];
   auto output = makeTensor(std::move(mt), input.options());
   return output;
 }

--- a/aten/src/ATen/native/metal/ops/MetalHardswish.mm
+++ b/aten/src/ATen/native/metal/ops/MetalHardswish.mm
@@ -41,7 +41,6 @@ Tensor& hardswish_(Tensor& input) {
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X markRead];
   MetalTensorImpl* impl = (MetalTensorImpl*)input.unsafeGetTensorImpl();
   MetalTensorImplStorage& implStorage = impl->unsafe_opaque_handle();
   implStorage.texture()->setImage(Y);

--- a/aten/src/ATen/native/metal/ops/MetalPadding.mm
+++ b/aten/src/ATen/native/metal/ops/MetalPadding.mm
@@ -81,7 +81,6 @@ Tensor reflection_pad2d(const Tensor& input, IntArrayRef padding) {
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X markRead];
   auto output = makeTensor(std::move(mt), input.options());
   return output;
 }

--- a/aten/src/ATen/native/metal/ops/MetalReshape.mm
+++ b/aten/src/ATen/native/metal/ops/MetalReshape.mm
@@ -57,8 +57,6 @@ Tensor view(const Tensor& input, IntArrayRef size) {
   [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
           threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
   [encoder endEncoding];
-  [X markRead];
-  [Y markRead];
   auto output = makeTensor(std::move(mt), input.options());
   return output;
 }

--- a/aten/src/ATen/native/metal/ops/MetalTranspose.mm
+++ b/aten/src/ATen/native/metal/ops/MetalTranspose.mm
@@ -82,9 +82,6 @@ Tensor transpose(const Tensor& input, int64_t dim0, int64_t dim1) {
     [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
             threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
     [encoder endEncoding];
-    [X markRead];
-    [Y markRead];
-
     auto output = makeTensor(std::move(mt), input.options());
     return output;
   }

--- a/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
+++ b/aten/src/ATen/native/metal/ops/MetalUpsamplingNearest.mm
@@ -81,8 +81,6 @@ Tensor upsample_nearest2d_vec(
     [encoder dispatchThreadgroups:launchParams.threadgroupsPerGrid
             threadsPerThreadgroup:launchParams.threadsPerThreadgroup];
     [encoder endEncoding];
-    [X markRead];
-    [Y markRead];
   }
   auto output = makeTensor(std::move(mt), input.options());
   return output;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#60282 [iOS GPU][BE][3/n] Give MPSImage objects a label for better debugging experience**
* #60281 [iOS GPU][BE][2/n] Remove unused APIs
* #60280 [iOS GPU][BE][1/n] Rename MPSCNNContext to MetalContext

1. Adds a label to the MPSImage objects. The label describes the size of the image.
2. Remove `[image markRead]`.
3. Rename two APIs for better naming convention.

Differential Revision: [D29232975](https://our.internmc.facebook.com/intern/diff/D29232975/)

**NOTE FOR REVIEWERS**: This PR has internal Facebook specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D29232975/)!