### PR TITLE
Improved sparse CSR tensor sampling method

### DIFF
--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -12,6 +12,28 @@ from torch.testing._internal.common_device_type import \
 # sharding on sandcastle. This line silences flake warnings
 load_tests = load_tests
 
+
+class TestSparseCSRSampler(TestCase):
+
+    def test_make_crow_indices(self):
+        # Here we test the correctness of the crow_indices algorithm
+        # and testing it on CPU and with int32 dtype will be
+        # sufficient.
+        device = torch.device('cpu')
+        index_dtype = torch.int32
+        for n_rows in range(1, 10):
+            for n_cols in range(1, 10):
+                for nnz in range(0, n_rows * n_cols + 1):
+                    crow_indices = self._make_crow_indices(
+                        n_rows, n_cols, nnz,
+                        device=device, dtype=index_dtype)
+                    self.assertEqual(len(crow_indices), n_rows + 1)
+                    counts = crow_indices[1:] - crow_indices[:-1]
+                    self.assertEqual(counts.sum(), nnz)
+                    self.assertGreaterEqual(counts.min(), 0)
+                    self.assertLessEqual(counts.max(), n_cols)
+
+
 class TestSparseCSR(TestCase):
 
     @onlyCPU

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1106,8 +1106,7 @@ class TestCase(expecttest.TestCase):
         order. Otherwise, the column counts of rows are defined by the
         used sampling method.
 
-        Description of the method:
-          https://pearu.github.io/csr_sampling.html
+        For description of the sampling method, see https://pearu.github.io/csr_sampling.html
         """
         assert 0 <= nnz << n_rows * n_cols
 
@@ -1159,7 +1158,14 @@ class TestCase(expecttest.TestCase):
             q, r = divmod(nnz - n * n_cols - m * (n_rows - n),
                           (n_cols - m) * (n_cols - m + 1) // 2)
             p = 1 + q * (n_cols - m + 1)
-            k = math.isqrt(2 * r)
+            if sys.version_info >= (3, 8):
+                k = math.isqrt(2 * r)
+            else:
+                # math.isqrt(x) is available starting from Python 3.8,
+                # so using int(math.sqrt(x)) as an approximation that
+                # appers to give exaxt result for all x values less
+                # than 2**35, at least, the upper limit of x is TBD.
+                k = int(math.sqrt(2 * r))
             if k * (k + 1) > 2 * r:
                 k -= 1
             corr = r - k * (k + 1) // 2

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1161,10 +1161,11 @@ class TestCase(expecttest.TestCase):
             if sys.version_info >= (3, 8):
                 k = math.isqrt(2 * r)
             else:
-                # math.isqrt(x) is available starting from Python 3.8,
-                # so using int(math.sqrt(x)) as an approximation that
-                # appers to give exaxt result for all x values less
-                # than 2**35, at least, the upper limit of x is TBD.
+                # math.isqrt(x) is available starting from Python 3.8.
+                # Here we use int(math.sqrt(x)) as an approximation
+                # that appers to give exaxt result for all x values
+                # less than 2**35, at least, the upper limit of x is
+                # TBD.
                 k = int(math.sqrt(2 * r))
             if k * (k + 1) > 2 * r:
                 k -= 1
@@ -1195,8 +1196,12 @@ class TestCase(expecttest.TestCase):
 
         def random_sparse_csr(n_rows, n_cols, nnz):
             crow_indices = self._make_crow_indices(n_rows, n_cols, nnz, device=device, dtype=index_dtype)
-            # TODO: check if col_indices are allowed to be unordered within the same row
-            col_indices = torch.randint(0, n_cols, size=[nnz], dtype=index_dtype, device=device)
+            col_indices = torch.zeros(nnz, dtype=index_dtype, device=device)
+            n = 0
+            for i in range(n_rows):
+                count = crow_indices[i + 1] - crow_indices[i]
+                col_indices[n:n + count], _ = torch.sort(torch.randperm(n_cols, dtype=index_dtype, device=device)[:count])
+                n += count
             values = make_tensor([nnz], device=device, dtype=dtype, low=-1, high=1)
             return values, crow_indices, col_indices
 


### PR DESCRIPTION
Fixes #59379 

The improved sparse CSR tensor sampling method is described in https://pearu.github.io/csr_sampling.html that features:
- for specified `nnz`, one gets a CSR sample with the same `nnz`
- variability of the number of specified columns per row is maximized
- `crow_indices` content is randomized
- a given row specific `col_indices` content is sorted and filled with unique values (see also #60277)