### PR TITLE
Clean Up ZeRO

### DIFF
--- a/test/distributed/optim/test_zero_redundancy_optimizer.py
+++ b/test/distributed/optim/test_zero_redundancy_optimizer.py
@@ -366,7 +366,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
 
         NOTE: The correctness of this test depends on the ZeRO implementation
         using the sorted-greedy partitioning algorithm. For details, see
-        `ZeroRedundancyOptimizer.partition_parameters()` in
+        `ZeroRedundancyOptimizer._partition_parameters()` in
         `zero_redundancy_optimizer.py`.
         """
         self.dist_init(self.rank)
@@ -383,7 +383,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
 
         NOTE: The correctness of this test depends on the ZeRO implementation
         using the sorted-greedy partitioning algorithm. For details, see
-        `ZeroRedundancyOptimizer.partition_parameters()` in
+        `ZeroRedundancyOptimizer._partition_parameters()` in
         `zero_redundancy_optimizer.py`.
         """
         self.dist_init(self.rank)
@@ -476,7 +476,7 @@ class TestZeroRedundancyOptimizerDistributed(TestZeroRedundancyOptimizer):
             optimizer_state_dict,
             src_rank=RECIPIENT_RANK,
             group=dist.group.WORLD,
-            dist_device=self.device,
+            device=self.device,
         )
 
         # Load the optimizer state dict, check that no exception is raised

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -9,16 +9,20 @@ import io
 from itertools import chain
 from typing import Any, Callable, Dict, List, Optional, Type
 
+import logging
 import torch
 import torch.distributed as dist
 from torch.optim import Optimizer
-import logging
 
 __all__ = ["ZeroRedundancyOptimizer"]
 
 
 # Credits:  classy_vision/generic/distributed_util.py
-def _recursive_copy_to_device(value: Any, non_blocking: bool, device: torch.device) -> Any:
+def _recursive_copy_to_device(
+    value: Any,
+    non_blocking: bool,
+    device: torch.device,
+) -> Any:
     r"""
     Recursively searches lists, tuples, dicts and copies tensors to device if
     possible. Non-tensor values are passed as-is in the result.
@@ -27,7 +31,6 @@ def _recursive_copy_to_device(value: Any, non_blocking: bool, device: torch.devi
     the same object, then after this call, there will be two different objects
     referenced on the device.
     """
-
     if isinstance(value, torch.Tensor):
         return value.to(device, non_blocking=non_blocking)
 
@@ -44,76 +47,96 @@ def _recursive_copy_to_device(value: Any, non_blocking: bool, device: torch.devi
 
 
 def _is_trainable(param: torch.Tensor) -> bool:
+    r"""
+    Returns if a parameter is trainable, where trainability is equivalent to
+    requiring a gradient.
+    """
     return param.requires_grad
 
 
 def _broadcast_object(
-    obj: Any,
-    src_rank: int,
+    obj: Any, src_rank: int,
     group: object = dist.group.WORLD,
-    dist_device: torch.device = torch.device("cpu"),
+    device: torch.device = torch.device("cpu")
 ) -> Any:
     r"""
-    Either broadcast from master to the fleet (default),
-    or use the src setting as the original rank.
-    """
+    Broadcasts an object to the given group, sending the object if called from
+    the source rank and receiving the object otherwise.
 
+    Arguments:
+        obj: object to broadcast; only used if called on the source rank.
+        src_rank (int): source rank.
+        group (``ProcessGroup``, optional): group used for the broadcast
+            (default: ``dist.group.WORLD``).
+        device (``torch.device``, optional): device to send from or receive
+            to (default: ``torch.device("cpu")``).
+
+    Returns:
+        The broadcasted object.
+    """
     if dist.get_rank() == src_rank:
-        # Emit data
+        # Send the object
         buffer = io.BytesIO()
         torch.save(obj, buffer)
         data = bytearray(buffer.getbuffer())
-        length_tensor = torch.LongTensor([len(data)]).to(dist_device)
-        data_send_tensor = torch.ByteTensor(data).to(dist_device)
+        length_tensor = torch.LongTensor([len(data)]).to(device)
+        data_send_tensor = torch.ByteTensor(data).to(device)
         dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
         dist.broadcast(data_send_tensor, src=src_rank, group=group, async_op=False)
     else:
-        # Fetch from the source
-        length_tensor = torch.LongTensor([0]).to(dist_device)
+        # Receive the object
+        length_tensor = torch.LongTensor([0]).to(device)
         dist.broadcast(length_tensor, src=src_rank, group=group, async_op=False)
-        data_recv_tensor = torch.empty([int(length_tensor.item())], dtype=torch.uint8, device=dist_device)
+        data_recv_tensor = torch.empty([int(length_tensor.item())], dtype=torch.uint8, device=device)
         dist.broadcast(data_recv_tensor, src=src_rank, group=group, async_op=False)
         buffer = io.BytesIO(data_recv_tensor.cpu().numpy())
-        obj = torch.load(buffer, map_location=dist_device)
+        obj = torch.load(buffer, map_location=device)
     return obj
 
 
 def _get_global_rank(group: Any, rank: int) -> int:
-    return rank if group is dist.group.WORLD else dist.distributed_c10d._get_global_rank(group, rank)
+    r"""
+    Returns the global rank for the given group and rank.
+    """
+    return (rank if group is dist.group.WORLD
+            else dist.distributed_c10d._get_global_rank(group, rank))
 
 
 class ZeroRedundancyOptimizer(Optimizer):
     r"""
-    This class wraps an arbitrary :class:`optim.Optimizer <torch.optim.Optimizer>`
-    and shards its states across ranks in the group as described by
-    ZeRO_. The optimizer instance in each rank is only responsible for
-    updating ``1 / world_size`` parameters and hence only needs to keep
-    ``1 / world_size`` optimizer states. After parameters are updated locally,
-    each rank will broadcast its parameters to all other peers to keep all
-    model replicas in the same state. ``ZeroRedundancyOptimizer`` can be used
-    in conjunction with :class:`torch.nn.parallel.DistributedDataparallel` to
-    reduce per-rank peak memory consumption.
+    This class wraps an arbitrary :class:`optim.Optimizer
+    <torch.optim.Optimizer>` and shards its states across ranks in the group as
+    described by ZeRO_. The local optimizer instance in each rank is only
+    responsible for updating approximately ``1 / world_size`` parameters and
+    hence only needs to keep ``1 / world_size`` optimizer states. After
+    parameters are updated locally, each rank will broadcast its parameters to
+    all other peers to keep all model replicas in the same state.
+    ``ZeroRedundancyOptimizer`` can be used in conjunction with
+    :class:`torch.nn.parallel.DistributedDataParallel` to reduce per-rank peak
+    memory consumption.
 
-    ``ZeroRedundancyOptimizer`` uses a sorted-greedy algorithm to pack a number of
-    parameters at each rank. Each parameter belongs to a single rank and is not
-    divided among ranks. The partition is arbitrary and might not match the
+    ``ZeroRedundancyOptimizer`` uses a sorted-greedy algorithm to pack a number
+    of parameters at each rank. Each parameter belongs to a single rank and is
+    not divided among ranks. The partition is arbitrary and might not match the
     the parameter registration or usage order.
 
     Arguments:
         params (``Iterable``): an ``Iterable`` of :class:`torch.Tensor` s
+            giving all parameters, which will be sharded across ranks.
 
     Keyword Args:
         optimizer_class (:class:`torch.nn.Optimizer`): the class of the local
             optimizer.
         group (``ProcessGroup``, optional): ``torch.distributed``
-            ``ProcessGroup`` (default: ``group.WORLD`` initialized by
+            ``ProcessGroup`` (default: ``dist.group.WORLD`` initialized by
             :meth:`torch.distributed.init_process_group`).
-        parameters_as_bucket_view (bool): when enabled, parameters will
-            be packed into larger buckets to speed up communication and
-            ``param.data`` fields will point to bucket views at different
-            offsets. When disabled, each individual parameter will be
-            communicated separately, but ``params.data`` will stay intact.
-        **default: all trailing arguments will be forwarded to the given optimizer.
+        parameters_as_bucket_view (bool): when enabled, parameters are packed
+            into larger buckets to speed up communication, and ``param.data``
+            fields point to bucket views at different offsets; when disabled,
+            each individual parameter is communicated separately, but each
+            ``params.data`` stays intact.
+        **defaults: any trailing arguments, which are forwarded to the local
+            optimizer.
 
     Example::
 
@@ -147,44 +170,50 @@ class ZeroRedundancyOptimizer(Optimizer):
         optimizer_class: Type[Optimizer],
         group: Optional[Any] = None,
         parameters_as_bucket_view: bool = False,
-        **default: Any,
+        **defaults: Any,
     ):
         # Perform type and assumption checks on the input parameters
         self._verify_and_init_params(params)
         self._verify_same_param_device()
         self._verify_same_dense_param_type()
-        self._device = self._all_params[0].device
 
-        # Hold all the model params in the root .param_groups
-        # NOTE: the default constructor uses `add_param_group` which is partially overloaded here
-        # we introduce the `initialized` flag for be able to dissociate the behaviour of
-        # `add_param_group` in between super() and ZeroRedundancyOptimizer
+        # NOTE: The parent constructor uses `add_param_group()` which is
+        # partially overloaded in ZeroRedundancyOptimizer, so we use the
+        # `initialized` flag to dissociate the behaviour of `add_param_group()`
+        # between the parent and child.
         self.initialized = False
-        super().__init__(self._all_params, default)
+
+        super().__init__(self._all_params, defaults)
+        # Now, all parameters are held in both `self._all_params` and
+        # `self.param_groups`
 
         # Partition information (evaluated lazily)
         self._param_to_rank_cache: Dict[torch.Tensor, int] = {}
-        self._param_to_index_cache: Dict[int, int] = {}
+        self._param_to_index_cache: Dict[torch.Tensor, int] = {}
         self._partition_parameters_cache: List[List[Dict]] = []
         self._index_to_param_cache: List[torch.Tensor] = []
 
-        # Build the wrapped optimizer, responsible for a shard of the params
+        # Default device for collective communication and buckets
+        self._default_device = self._all_params[0].device
+
         self.group = group if group is not None else dist.group.WORLD
         self.world_size = dist.get_world_size(self.group)
         self.rank = dist.get_rank(self.group)
         self.global_rank = _get_global_rank(self.group, self.rank)
-        self.parameters_as_bucket_view = parameters_as_bucket_view
 
-        self._optim_defaults = default
+        self._optim_defaults = defaults
         self._optim_constructor = optimizer_class
+        self._init_local_optimizer()
 
-        # Optional consolidated optimizer state
-        self._all_states: List[Dict[str, Any]] = []
+        self.parameters_as_bucket_view = parameters_as_bucket_view
+        self._is_trainable_mask = self._get_is_trainable_mask()
+        self._buckets: List[torch.Tensor] = []
+        self._build_param_buckets()
 
-        self._reference_is_trainable_mask = list(map(_is_trainable, self._all_params))
-        self.buckets: List[torch.Tensor] = []
+        # Optional consolidated optimizer state, only populated if this rank
+        # is the target in `consolidate_state_dict()`
+        self._all_state_dicts: List[Dict[str, Any]] = []
 
-        self._update_trainable()
         self.initialized = True
 
     def _clear_cache(self) -> None:
@@ -198,129 +227,125 @@ class ZeroRedundancyOptimizer(Optimizer):
 
     def add_param_group(self, param_group: dict) -> None:
         r"""
-        Add a param group to the :class:`Optimizer` s ``param_groups``.
+        Add a parameter group to the :class:`Optimizer` s ``param_groups``.
 
         This can be useful when fine tuning a pre-trained network, as frozen
         layers can be made trainable and added to the :class:`Optimizer` as
         training progresses.
 
         Arguments:
-            param_group (dict): Specifies what Tensors should be optimized
-                along with group specific optimization options.
+            param_group (dict): specifies the parameters to be optimized and
+                group-specific optimization options.
 
-        .. warning: This method handles updating the shards on all partitions,
-            but needs to be called on all ranks. Calling this on a subset of the
-            ranks will cause the training to hang, because communication
-            primitives are called depending on the managed parameters, and
-            expect all the ranks to participate on the sane set of parameters.
+        .. warning: This method handles updating the shards on all partitions
+            but needs to be called on all ranks. Calling this on a subset of
+            the ranks will cause the training to hang because communication
+            primitives are called depending on the managed parameters and
+            expect all the ranks to participate on the same set of parameters.
         """
-
         super().add_param_group(param_group)
-        if self.initialized:
-            # Force a re-partitioning
-            self._clear_cache()
+        # NOTE: The rest of the function assumes that the call to the parent's
+        # `add_param_group()` appends the new parameter group and preserves
+        # the previous parameter-group ordering
 
-            param_groups = self.partition_parameters()[self.rank]
+        if self.initialized:
+            # Force a re-partitioning of the parameters
+            self._clear_cache()
+            param_groups = self._partition_parameters()[self.rank]
+            # NOTE: All parameters in the old parameter groups should be
+            # assigned to the same ranks so that the local optimizers do not
+            # need to be reinitialized
+
+            # Add the parameters assigned to this rank from the new parameter
+            # group to the local optimizer, if any
             if len(param_groups) == len(self.optim.param_groups) + 1:
                 self.optim.add_param_group(param_groups[-1])
 
             # Update the bucketing strategy accordingly
             if self.parameters_as_bucket_view:
-                self._setup_flat_buffers()
+                self._build_param_buckets()
 
     def consolidate_state_dict(self, to: int = 0) -> None:
         r"""
-        Update the consolidated state_dict list, one per rank.
+        Consolidate a list of ``state_dict`` s (one per rank) on the target
+        rank.
 
         Arguments:
-            to (int): the rank that receives the global states. (default: 0)
+            to (int): the rank that receives the optimizer states (default: 0).
 
-        .. warning: This needs to be called on all replicas
+        .. warning: This needs to be called on all ranks.
         """
-
-        # Sync lr and other attributes in case its been updated
+        # Sync the exposed `param_groups` attributes to the local optimizer in
+        # case they have been updated
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
 
-        empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._device)
+        # Pull the sharded state from all ranks and store them in rank order
+        empty_messenger = torch.tensor([0], dtype=torch.uint8, device=self._default_device)
 
-        # Pull the sharded state from all the other replicas
-        # Store all the states in order, rank by rank
-
-        # NOTE: In practice, `broadcast` is used, which is wasteful (gather would have been appropriate)
-        # compatibility issues with some backends make the use of broadcast mandatory for now.
-        # a possible follow up would be to move all sharded state management to RPC RRef
-
-        self._all_states = []
+        # NOTE: We wastefully use `broadcast()` (e.g. instead of `gather()`)
+        # due to compatibility issues with NCCL backend; a possible follow-up
+        # is to move all sharded state management to RPC RRef
+        self._all_state_dicts = []
         for rank in range(self.world_size):
             global_rank = _get_global_rank(self.group, rank)
-
-            # This rank collects the whole state
             if self.rank == to:
+                # Consolidate all local `state_dict`s on this rank, storing on
+                # CPU to save GPU memory
                 if rank == self.rank:
-                    self._all_states.append(
-                        _recursive_copy_to_device(
-                            self.local_state_dict(),
-                            non_blocking=True,
-                            device=torch.device("cpu"),
-                        )
+                    # Directly append own optimizer state
+                    self._all_state_dicts.append(
+                        _recursive_copy_to_device(self.optim.state_dict(), non_blocking=True, device=torch.device("cpu"),)
                     )
                 else:
-                    # Fetch the optim state from the other replicas
-                    replica_state = _broadcast_object(
+                    # Receive the optimizer state from the source rank
+                    local_state_dict = _broadcast_object(
                         empty_messenger,
                         src_rank=global_rank,
                         group=self.group,
-                        dist_device=self._device,
+                        device=self._default_device,
                     )
-
-                    self._all_states.append(
-                        _recursive_copy_to_device(replica_state, non_blocking=True, device=torch.device("cpu"))
+                    self._all_state_dicts.append(
+                        _recursive_copy_to_device(local_state_dict, non_blocking=True, device=torch.device("cpu"))
                     )
             else:
-                # Acknowledge broadcasts, and send this rank's shard when needed
-                # Default to CPU space to gain some memory headroom
                 if rank == self.rank:
-                    # Send the state to the reference replica
+                    # Send the optimizer state to the target rank
                     _ = _broadcast_object(
-                        self.local_state_dict(),
+                        self.optim.state_dict(),
                         src_rank=self.global_rank,
                         group=self.group,
-                        dist_device=self._device,
+                        device=self._default_device,
                     )
-
                 elif rank != to:
-                    # Discard this tensor/rank, broadcast was being use for compatibility reasons
+                    # Discard the received object; `broadcast()` is used for
+                    # compatibility reasons
                     _ = _broadcast_object(
                         empty_messenger,
                         src_rank=global_rank,
                         group=self.group,
-                        dist_device=self._device,
+                        device=self._default_device,
                     )
 
-    def partition_parameters(self) -> List[List[Dict]]:
+    def _partition_parameters(self) -> List[List[Dict]]:
         r"""
         Partitions parameters across distributed data parallel ranks.
 
         Returns:
-            a list of ``param_groups`` (which is a list of dict) where each
-            element of the list contains the param_groups for a rank. Element 0
-            corresponds to rank 0, etc. We need all the ranks for the broadcast
-            inside ``step()``.
-
-        NOTE: `test_sharding()` and `test_add_param_group()` rely on this
-        function using the sorted-greedy algorithm for partitioning. If the
-        algorithm is changed, please re-examine those two tests in
-        `test_zero_redundancy_optimizer.py` accordingly.
+            A :class:`list` of ``param_groups`` (which is a :class:`list` of
+            :class:`dict`) where each element of the list contains the
+            ``param_groups`` for a rank. Element 0 corresponds to rank 0, etc.
+            Each rank stores the ``param_groups`` for all of the ranks for the
+            collective communication in :meth:`step`.
         """
         if len(self._partition_parameters_cache) == 0:
             self._partition_parameters_cache = [list() for _ in range(self.world_size)]
             sizes = [0] * self.world_size
             for param_group in self.param_groups:
-                param_lists: List[List] = [list() for _ in range(self.world_size)]
-                # Sort the params by size (largest first)
+                param_lists = [list() for _ in range(self.world_size)]
+                # Sort the parameters by size (largest first)
                 params_sorted = sorted(param_group["params"], key=lambda t: t.size()[0], reverse=True)
                 for param in params_sorted:
-                    # Add this param to rank with smallest size.
+                    # Greedily add the parameter to rank with smallest size so far
                     rank = sizes.index(min(sizes))
                     param_lists[rank].append(param)
                     sizes[rank] += param.numel()
@@ -339,21 +364,24 @@ class ZeroRedundancyOptimizer(Optimizer):
         the partition.
         """
         if len(self._param_to_rank_cache) == 0:
-            for rank, param_groups in enumerate(self.partition_parameters()):
+            for rank, param_groups in enumerate(self._partition_parameters()):
                 for param_group in param_groups:
                     for param in param_group["params"]:
                         self._param_to_rank_cache[param] = rank
         return self._param_to_rank_cache
 
     @property
-    def _param_to_index(self) -> Dict[int, int]:
+    def _param_to_index(self) -> Dict[torch.Tensor, int]:
         r"""
         Hash table mapping parameters to their indices in the global optimizer
-        scheme.
+        state.
+
+        NOTE: This assumes that the global optimizer state's indexing (in
+        ``state_dict``) follows a linear ordering over the parameter groups.
         """
         if len(self._param_to_index_cache) == 0:
             self._param_to_index_cache = {
-                id(p): i for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
+                p: i for i, p in enumerate(chain(*(g["params"] for g in self.param_groups)))
             }
         return self._param_to_index_cache
 
@@ -367,49 +395,53 @@ class ZeroRedundancyOptimizer(Optimizer):
             self._index_to_param_cache = list(chain(*(g["params"] for g in self.param_groups)))
         return self._index_to_param_cache
 
-    def step(self, closure: Optional[Callable[[], float]] = None, **kwargs: Any) -> Optional[float]:
+    def step(
+        self,
+        closure: Optional[Callable[[], float]] = None,
+        **kwargs: Any,
+    ) -> Optional[float]:
         r"""
         Performs a single optimization step (parameter update).
 
         Arguments:
-            closure (callable): A closure that reevaluates the model and
-                returns the loss. Optional for most optimizers.
+            closure (callable): a closure that re-evaluates the model and
+                returns the loss; optional for most optimizers.
         Returns:
-            optional loss, depends on the underlying optimizer
+            Optional loss depending on the underlying local optimizer.
 
-        .. note: Any extra parameter is passed to the base optimizer as-is
+        .. note: Any extra parameters are passed to the base optimizer as-is.
         """
-
-        # Check whether the model trainability graph changed
-        trainable_mask = list(map(_is_trainable, self._all_params))
-        if trainable_mask != self._reference_is_trainable_mask:
+        # Check if the model trainability has changed
+        is_trainable_mask = self._get_is_trainable_mask()
+        if is_trainable_mask != self._is_trainable_mask:
             logging.warning(
                 "ZeroRedundancyOptimizer detected that the trainable params "
                 "changed, updating the partitioning"
             )
-            self._update_trainable()
-            self._reference_is_trainable_mask = trainable_mask
+            self._build_param_buckets()
+            self._is_trainable_mask = is_trainable_mask
 
-        # Sync oss param_groups attributes in case they've been updated by a scheduler.
+        # Sync the exposed `param_groups` attributes to the local optimizer in
+        # case they have been updated
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
 
-        # Run the optimizer step on this shard only:
+        # Run the optimizer step on this shard only
         if closure is not None:
             loss = self.optim.step(closure=closure, **kwargs)  # type: ignore[call-arg]
         else:
             loss = self.optim.step(**kwargs)
 
-        # Sync all the updated shards in between the ranks
+        # Sync all of the updated parameter shards across the ranks
         handles = []
         if self.parameters_as_bucket_view:
-            for rank, bucket in enumerate(self.buckets):
+            for rank, bucket in enumerate(self._buckets):
                 global_rank = _get_global_rank(self.group, rank)
                 handles.append(
                     dist.broadcast(tensor=bucket, src=global_rank,
                                    group=self.group, async_op=True)
                 )
         else:
-            for rank, param_groups in enumerate(self.partition_parameters()):
+            for rank, param_groups in enumerate(self._partition_parameters()):
                 global_rank = _get_global_rank(self.group, rank)
                 for param_group in param_groups:
                     for param in param_group["params"]:
@@ -419,172 +451,165 @@ class ZeroRedundancyOptimizer(Optimizer):
                         )
         _ = list(map(lambda x: x.wait(), handles))
 
-        # Sync hypothethical new results from the wrapped optimizer to the exposed param_groups
+        # Sync any updated attributes in the local optimizer to the exposed
+        # `param_groups`
         self._sync_param_groups(self.optim.param_groups, self.param_groups)
 
         return loss
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         r"""
-        Restore the global parameter groups as well as the shard.
+        Load the state pertaining to the given rank from the input
+        ``state_dict``, updating the local optimizer as needed.
 
         Arguments:
-            state_dict (dict): optimizer state. Should be an object returned
-                from a call to :meth:`state_dict`
+            state_dict (dict): optimizer state; should be an object returned
+                from a call to :meth:`state_dict`.
         """
-
-        for key, value in state_dict["state"].items():
-            param = self._index_to_param[key]
-
-            # Populate the sharded optimizer state on the fly
+        for index, value in state_dict["state"].items():
+            param = self._index_to_param[index]
             if self._param_to_rank[param] != self.rank:
-                state_dict["state"][key] = None
+                # Clear any state irrelevant to this rank
+                state_dict["state"][index] = None
             else:
+                # Load the parameter state to the local optimizer
                 self.optim.state[param] = _recursive_copy_to_device(value, non_blocking=True, device=param.device)
 
         super().load_state_dict(state_dict)
 
-        # Sync with the optimizer param groups
+        # Sync the input state with the exposed and local optimizer states
         self._sync_param_groups(state_dict["param_groups"], self.param_groups)
         self._sync_param_groups(self.param_groups, self.optim.param_groups)
 
-    def local_state_dict(self) -> Dict:
-        r"""
-        Gets this rank's ``state_dict``.
-
-        Returns:
-            The state of the optimizer as a :class:`dict`.
-            It contains two entries:
-
-            * state - a dict holding current optimization state. Its content
-                differs between optimizer classes.
-            * param_groups - a dict containing all parameter groups
-        """
-        return self.optim.state_dict()
-
     def state_dict(self) -> Dict[str, Any]:
         r"""
-        Returns:
-            the last known global optimizer state, which consist of a list of
-            the shards.
+        Returns the last global optimizer state known to this rank.
 
         .. warning:
-            If the state has not been consolidated, this returns a shard's worth,
-            not the global state.
-
-        .. warning:
-            Returning the global state is limited to the replica which was
-            responsible for the consolidation. The state may also not be up to
-            date, depending on when :meth:`consolidate_state_dict` was last called.
+            If the state has not been consolidated to this rank, this raises a
+            runtime error, and even if it has, the state may not be up-to-date,
+            depending on when :meth:`consolidate_state_dict` was last called.
         """
 
-        if len(self._all_states) == 0:
+        if len(self._all_state_dicts) == 0:
             raise RuntimeError(
-                "Optimizer state has not been consolidated on this rank. \
-                Please call `consolidate_state_dict()` on all ranks beforehand if you meant to save the global state"
+                "Optimizer state has not been consolidated on this rank. "
+                f"Please call `consolidate_state_dict(to={self.rank})` on "
+                "all ranks beforehand if you meant to save the global state."
             )
 
-        # Unify the shard states and the state that pytorch would expect, given the model.
-        # Indexation needs several redirections, since each shard only knows a limited scope of the model
-        # - get the pytorch compliant parameter indexing
+        # Get the possibly-stale global optimizer state that uses global
+        # parameter indexing
         state_dict = super().state_dict()
 
-        # - go through the per-shard states, which are all indexed locally
-        for rank, s in enumerate(self._all_states):
-            # -- match the local indexing and the global partition, update the corresponding saved state globally
-            for local_pg, global_pg in zip(s["param_groups"], self.partition_parameters()[rank]):
-                local_index_to_param_id = {
-                    i_param: id(global_pg["params"][i]) for i, i_param in enumerate(local_pg["params"])
-                }
+        # Update the global optimizer state with local state information,
+        # factoring in the translation from local to global indexing
+        for rank, local_state_dict in enumerate(self._all_state_dicts):
+            local_param_groups = local_state_dict["param_groups"]
+            global_param_groups = self._partition_parameters()[rank]
+            assert len(local_param_groups) == len(global_param_groups), \
+                "Mismatch between number of local and global parameter groups"
 
-                for local_param_index in local_pg["params"]:
-                    # Update the state, if any
-                    if local_param_index in s["state"].keys():
-                        global_id = self._param_to_index[local_index_to_param_id[local_param_index]]
-                        state_dict["state"][global_id] = s["state"][local_param_index]
+            for local_param_group, global_param_group in zip(local_param_groups, global_param_groups):
+                # `local_param_group` stores local indices, while
+                # `global_param_group` stores the tensors directly
+                local_param_indices = local_param_group["params"]
+                global_params = global_param_group["params"]
 
-        # Make sure that the parameters are sorted in the state, as expected
+                assert len(local_param_indices) == len(global_params), \
+                    "Mismatch between number of local and global parameters in parameter group"
+                for local_param_index, global_param in zip(local_param_indices, global_params):
+                    # Update the global parameter state, if any
+                    if local_param_index in local_state_dict["state"]:
+                        global_param_index = self._param_to_index[global_param]
+                        state_dict["state"][global_param_index] = local_state_dict["state"][local_param_index]
+
+        # Sort the parameters in the state
         state_dict["state"] = dict(sorted(state_dict["state"].items()))
         return state_dict
 
     @staticmethod
-    def rank_local_state_dict(rank: int, state_dict: dict) -> dict:
+    def _sync_param_groups(
+        src_param_groups: List[Dict[Any, Any]],
+        dst_param_groups: List[Dict[Any, Any]],
+    ) -> None:
         r"""
-        Returns the local_state_dict for a given rank.
+        Syncs the attributes from the source parameter groups to the
+        destination parameter groups.
+
+        Example attributes include learning rate or scheduler attributes. The
+        two parameter groups should have the same length (i.e. same number of
+        parameter groups).
 
         Arguments:
-            rank (int): rank to get ``local_state_dict`` for
-            state_dict (dict): global ``state_dict``
+            src_param_groups (list[dict]): parameter groups giving the
+                attribute settings to copy.
+            dst_param_groups (list[dict]): parameter groups giving the
+                attribute settings to set.
         """
-        param_groups = state_dict["param_groups"][state_dict["partition"][rank][0] : state_dict["partition"][rank][1]]
-        return {"state": state_dict["state"][rank], "param_groups": param_groups}
+        assert len(src_param_groups) == len(dst_param_groups), \
+            "Mismatch between number of source and destination parameter groups"
+        for src_param_group, dst_param_group in zip(src_param_groups, dst_param_groups):
+            # Sync all attributes except the parameters
+            for attr in filter(lambda x: x != "params", src_param_group.keys()):
+                dst_param_group[attr] = src_param_group[attr]
 
-    @staticmethod
-    def _sync_param_groups(source: List[Dict[Any, Any]], destination: List[Dict[Any, Any]]) -> None:
-        r"""Sync learning rate and other optimizer attributes (needed to support schedulers)."""
-
-        for source_group, destination_group in zip(source, destination):
-            # Sync everything but the parameters
-            for k in filter(lambda x: x != "params", source_group.keys()):
-                destination_group[k] = source_group[k]
-
-    def _setup_flat_buffers(self) -> None:
+    def _build_param_buckets(self) -> None:
         r"""
-        Make all params which are on the same device and tied to the same rank
-        views of a single buffer. This is used at construction time, and
-        anytime parameter trainability is changed (frozen or unfrozen) and
-        ``_update_trainable`` is called.
+        Builds parameter buckets so that for each device that stores this
+        rank's parameters, there is a bucket (represented as a tensor)
+        containing all of the parameters on that device that are assigned to a
+        given rank, if ``parameters_as_bucket_view`` is enabled.
+
+        This function is called in the constructor and any time parameter
+        trainability is changed.
+
+        NOTE: The current implementation assumes that each rank stores all of
+        its parameters (i.e. ``self._all_params``) on a single device. This
+        means that there should be exactly ``world_size``-many buckets.
+
+        NOTE: The current implementation assumes that all of the parameters in
+        a bucket are of the same dense type when allocating the bucket's
+        tensor.
         """
-        for rank, param_groups in enumerate(self.partition_parameters()):
-            # Clone the non-trainable params, find the buffer size and dtype
-            # for the trainable params' bucket, and compile a list of the
-            # trainable params
-            buffer_size = 0
+        if not self.parameters_as_bucket_view:
+            return
+        for rank, param_groups in enumerate(self._partition_parameters()):
+            # Find the bucket size and dtype, compile the trainable
+            # parameters, and clone the non-trainable parameters
+            bucket_size = 0
             dtype = None
             trainable_params = []
             for param_group in param_groups:
                 for param in param_group["params"]:
                     if not _is_trainable(param):
+                        # Clone in case the parameter was previously part of
+                        # a bucket to avoid the data from being destroyed
                         param.data = param.data.detach().clone()
                     else:
-                        buffer_size += param.numel()
+                        bucket_size += param.numel()
                         trainable_params.append(param)
-                    dtype = param.dtype  # assumes all dense and same dtype
+                    dtype = param.dtype  # assumes all same dtype
+            device = self._default_device  # assumes all on single device
 
-            # Create a dummy bucket if there are no params
-            if buffer_size == 0:
-                self.buckets.append(torch.zeros(1, device=self._device))
-                continue
-
-            # Otherwise, construct the bucket
-            bucket = torch.empty(buffer_size, dtype=dtype, device=self._device)
-            offset = 0
-            for param in trainable_params:
-                offset_next = offset + param.numel()
-                bucket[offset:offset_next].copy_(param.data.flatten())
-                param.data = bucket[offset:offset_next].view_as(param.data)
-                offset = offset_next
+            if bucket_size == 0:
+                # Create a dummy bucket if there are no parameters
+                bucket = torch.zeros(1, device=device)
+            else:
+                # Construct the bucket (assuming all dense and same dtype)
+                bucket = torch.empty(bucket_size, dtype=dtype, device=device)
+                offset = 0
+                for param in trainable_params:
+                    offset_next = offset + param.numel()
+                    bucket[offset:offset_next].copy_(param.data.flatten())
+                    param.data = bucket[offset:offset_next].view_as(param.data)
+                    offset = offset_next
 
             # Either replace the existing bucket or create it
-            if len(self.buckets) != rank:
-                self.buckets[rank] = bucket
+            if len(self._buckets) != rank:
+                self._buckets[rank] = bucket
             else:
-                self.buckets.append(bucket)
-
-    def _update_trainable(self) -> None:
-        r"""
-        Updates the partitioning and communication patterns if the trainability
-        (``requires_grad``) of some parameters changed.
-        """
-
-        # Create the optim which will work on the param shard
-        if not hasattr(self, "optim"):
-            self._clear_cache()
-            self.optim = self._optim_constructor(self.partition_parameters()[self.rank], **self._optim_defaults)
-            self._sync_param_groups(self.optim.param_groups, self.param_groups)
-
-        if self.parameters_as_bucket_view:
-            self._setup_flat_buffers()
+                self._buckets.append(bucket)
 
     def _verify_and_init_params(self, params: Any) -> None:
         r"""
@@ -667,3 +692,22 @@ class ZeroRedundancyOptimizer(Optimizer):
                                  "using the same dense type for all "
                                  f"parameters but got both {typename} and "
                                  f"{other_typename}")
+
+    def _init_local_optimizer(self) -> None:
+        r"""
+        Initializes this rank's local optimizer, responsible for its subset of
+        the parameters.
+
+        The local optimizer is saved in ``self.optim``.
+        """
+        assert self._optim_constructor is not None
+        self._clear_cache()
+        self.optim = self._optim_constructor(self._partition_parameters()[self.rank], **self._optim_defaults)
+        self._sync_param_groups(self.optim.param_groups, self.param_groups)
+
+    def _get_is_trainable_mask(self) -> List[bool]:
+        r"""
+        Returns a boolean mask indicating if each parameter is trainable
+        (``requires_grad``) or not.
+        """
+        return list(map(_is_trainable, self._all_params))


### PR DESCRIPTION
**Overview:**
Being relatively new to PyTorch and ZeRO, I found parts of the code slightly hard to follow. This change strives to clean up the `ZeroRedundancyOptimizer` code in `zero_redundancy_optimizer.py` by reorganizing some computations, making variable names more explicit and consistent, and unifying terminology in the documentation. The goal is for the code to be easier to extend afterwards.

**Changes:**
1) `state_dict()`: The [logic](https://github.com/pytorch/pytorch/blob/85517a2b700a5abc0b38f53ce8c99404cd67db79/torch/distributed/optim/zero_redundancy_optimizer.py#L510) for updating the global `state_dict` with each rank's local `state_dict` is simplified and made more explicit. Notably, the `dict` [`local_index_to_param_id`](https://github.com/pytorch/pytorch/blob/85517a2b700a5abc0b38f53ce8c99404cd67db79/torch/distributed/optim/zero_redundancy_optimizer.py#L513) is unneeded. It maps `local_pg["params"][i]` to `id(global_pg["params"][i])`, so it is equivalent to make a single pass over both lists in tandem, effectively iterating over `i`, without a need for the explicit `dict`.
2) `_update_trainable()`: The function [initializes](https://github.com/pytorch/pytorch/blob/85517a2b700a5abc0b38f53ce8c99404cd67db79/torch/distributed/optim/zero_redundancy_optimizer.py#L597) the local optimizer if it does not exist. I am unaware of any reason for the local optimizer to be destroyed after initialization, so I moved that logic to its own function `_init_local_optimizer()`, which is called once in the constructor. 
After [discussion](https://github.com/pytorch/pytorch/pull/60285#discussion_r654706728), I removed the function `_update_trainable()` itself in favor of adding a check for `parameters_as_bucket_view` in `build_param_buckets()` directly. 
3) `rank_local_state_dict()`: This [function](https://github.com/pytorch/pytorch/blob/85517a2b700a5abc0b38f53ce8c99404cd67db79/torch/distributed/optim/zero_redundancy_optimizer.py#L528) is currently broken. It appears to be legacy and relies on the input `state_dict` to have the key `"partitions"`. For now, I have removed it and added an [issue](https://github.com/pytorch/pytorch/issues/60284). Is it a notable use case to want to access another rank's `state_dict` in particular (as opposed to consolidating the entire state and then accessing)? 
4) `local_state_dict():` After [discussion](https://github.com/pytorch/pytorch/pull/60285#discussion_r655571043), I removed the function. 
5) `partition_parameters()`: After [discussion](https://github.com/pytorch/pytorch/pull/60285#discussion_r654708183), I renamed the function to `_partition_parameters()` to mark it as private.
6) `_param_to_index`: After [discussion](https://github.com/pytorch/pytorch/pull/60285#discussion_r654828100), I changed the key to be the parameter itself rather than its integer ID.
7) `buckets`: I renamed the data structure to `_buckets` to mark it as private.
8) Terminology: I tried to reduce the set of terms being used instead of juggling a number of synonyms. In particular, I made an effort to distinguish between "local" and "global" and to make names more indicative of typing.
9) Style: Per the [PyTorch contributing guide](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#writing-documentation), I made all docstrings abide by the 80 character limit, except for the one [line](https://github.com/andwgu/pytorch/blob/554891f6faa764c76dec4afb1107cb5aa88ef589/torch/distributed/optim/zero_redundancy_optimizer.py#L142) showing the example ZeRO usage. Some code lines violate the limit for readability. Also, I unified some of the minor stylistic usages out of habit.

**Test Plan:**
The test suite passes as expected (on the AI AWS cluster):
```
gpurun python test/distributed/optim/test_zero_redundancy_optimizer.py
```
I visually inspected the generated HTML doc (as generated following [this](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md#writing-documentation)). 