### PR TITLE
Check native_function's outputs' TensorImpl and StorageImpl 

### DIFF
--- a/aten/src/ATen/ConjugateFallback.cpp
+++ b/aten/src/ATen/ConjugateFallback.cpp
@@ -146,6 +146,7 @@ TORCH_LIBRARY_IMPL(aten, Conjugate, m) {
   m.impl("imag", torch::CppFunction::makeFallthrough());
   m.impl("real", torch::CppFunction::makeFallthrough());
   m.impl("view", torch::CppFunction::makeFallthrough());
+  m.impl("_unsafe_view", torch::CppFunction::makeFallthrough());
   m.impl("reshape", torch::CppFunction::makeFallthrough());
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1887,7 +1887,7 @@ Tensor & squeeze_(Tensor& self, int64_t dim) {
 
 // _unsafe_view() differs from view() in that the returned tensor isn't treated
 // as a view for the purposes of automatic differentiation. (It's not listed in
-// VIEW_FUNCTIONS in gen_autograd.py).  It's only safe to use if the `self` tensor
+// VIEW_FUNCTIONS in gen_inplace_or_view_type.py).  It's only safe to use if the `self` tensor
 // is temporary. For example, the viewed tensor here (a + b) is discarded immediately
 // after viewing:
 //

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1885,6 +1885,7 @@ Tensor & squeeze_(Tensor& self, int64_t dim) {
   return self;
 }
 
+// NOTE [ Unsafe View ]
 // _unsafe_view() differs from view() in that the returned tensor isn't treated
 // as a view for the purposes of automatic differentiation. (It's not listed in
 // VIEW_FUNCTIONS in gen_inplace_or_view_type.py).  It's only safe to use if the `self` tensor

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -28,7 +28,8 @@ Tensor empty_override(IntArrayRef size, c10::optional<ScalarType> dtype, c10::op
 
 Tensor add_override(const Tensor & a, const Tensor & b , const Scalar& c) {
   test_int = 2;
-  return a.clone();
+  // Needs to return a new tensor to pass codegen checks for StorageImpl/TensorImpl use count
+  return empty({5, 5}, at::kMSNPU);
 }
 
 Tensor empty_strided_override(

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -28,7 +28,7 @@ Tensor empty_override(IntArrayRef size, c10::optional<ScalarType> dtype, c10::op
 
 Tensor add_override(const Tensor & a, const Tensor & b , const Scalar& c) {
   test_int = 2;
-  return a;
+  return a.clone();
 }
 
 Tensor empty_strided_override(

--- a/aten/src/ATen/test/extension_backend_test.cpp
+++ b/aten/src/ATen/test/extension_backend_test.cpp
@@ -27,9 +27,9 @@ Tensor empty_override(IntArrayRef size, c10::optional<ScalarType> dtype, c10::op
 }
 
 Tensor add_override(const Tensor & a, const Tensor & b , const Scalar& c) {
+  auto out = empty({5, 5}, at::kMSNPU);  // Don't return self as-is
   test_int = 2;
-  // Needs to return a new tensor to pass codegen checks for StorageImpl/TensorImpl use count
-  return empty({5, 5}, at::kMSNPU);
+  return out;
 }
 
 Tensor empty_strided_override(

--- a/tools/autograd/gen_inplace_or_view_type.py
+++ b/tools/autograd/gen_inplace_or_view_type.py
@@ -74,9 +74,14 @@ RETURNS_VIEWS_OF_INPUT = set(VIEW_FUNCTIONS.keys()).union({
     'tensor_split', 'swapdims', 'swapaxes'
 })
 
-# These are not included above, but shares storage regardless
-OTHER_VIEW_FUNCTIONS = {
-    '_unsafe_view',
+# These are the functions we consider views for the purposes of validating
+# StorageImpl and TensorImpl in gen_variable_type.
+# `_unsafe_view` is not included in VIEW_FUNCTIONS above because it is not a
+# view for the purposes of ADInplaceOrView kernel, we do not want to call as_view
+# See NOTE [Unsafe View] for more info.
+ALL_VIEW_FUNCTIONS = {
+    **VIEW_FUNCTIONS,
+    '_unsafe_view': 'self',
 }
 
 ARRAYREF_TO_VEC = CodeTemplate("""\

--- a/tools/autograd/gen_inplace_or_view_type.py
+++ b/tools/autograd/gen_inplace_or_view_type.py
@@ -74,6 +74,11 @@ RETURNS_VIEWS_OF_INPUT = set(VIEW_FUNCTIONS.keys()).union({
     'tensor_split', 'swapdims', 'swapaxes'
 })
 
+# These are not included above, but shares storage regardless
+OTHER_VIEW_FUNCTIONS = {
+    '_unsafe_view',
+}
+
 ARRAYREF_TO_VEC = CodeTemplate("""\
 auto ${vec} = ${arg}.vec();
 """)
@@ -147,6 +152,9 @@ def is_tensor_list_type(t: Type) -> bool:
 UNPACK_TENSOR = CodeTemplate("""\
 auto${ref} ${arg_name}_ = unpack${suffix}(${arg_name}, "${arg_name}", ${arg_pos});""")
 
+def unpacked_name(arg_name: str) -> str:
+    return arg_name + '_'
+
 @with_native_function
 def unpack_args(f: NativeFunction) -> Tuple[List[str], List[Binding]]:
     body: List[str] = []
@@ -179,7 +187,7 @@ def unpack_args(f: NativeFunction) -> Tuple[List[str], List[Binding]]:
             ref='&' if ref else '',
         ))
         unpacked_bindings.append(Binding(
-            name=binding.name + '_',
+            name=unpacked_name(binding.name),
             nctype=binding.nctype,
             argument=binding.argument,
             default=binding.default,

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -228,7 +228,8 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     'native_layer_norm_backward', 'slow_conv_transpose2d_backward_output_mask',
     'thnn_conv2d_backward_output_mask', 'slow_conv3d_backward_output_mask',
     'slow_conv_transpose2d_backward_output_mask', 'slow_conv_transpose3d_backward_output_mask',
-    '_embedding_bag', '_embedding_bag_forward_only', 'mkldnn_convolution_backward',
+    '_embedding_bag', '_embedding_bag_forward_only',
+    'mkldnn_convolution_backward', 'cudnn_convolution_backward',
     'q_per_channel_scales', 'q_per_channel_zero_points'
 }
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -220,7 +220,7 @@ DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE = {
     # These functions are expected to change impl or storage of input tensors
     'set_', '_cudnn_rnn_flatten_weight',
 }
-DONT_ENFORCE_TENSOR_IMPL_USE_COUNT  = {
+DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # These functions return tensors with use_count > 1
     'native_batch_norm', 'native_batch_norm_backward', '_embedding_bag',
 }
@@ -691,19 +691,19 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
             noref_cpp_type = unpacked_binding.nctype.type.remove_const_ref()
             if noref_cpp_type == BaseCType(tensorListT):
                 stmts_before_call += [SAVE_TENSORLIST_STORAGE.substitute(tensorlist_name=arg),
-                                    SAVE_TENSORLIST_IMPL.substitute(tensorlist_name=arg)]
+                                      SAVE_TENSORLIST_IMPL.substitute(tensorlist_name=arg)]
                 stmts_after_call += [ENFORCE_SAME_TENSORLIST_STORAGE.substitute(tensorlist_name=arg),
-                                            ENFORCE_SAME_TENSORLIST_IMPL.substitute(tensorlist_name=arg)]
+                                     ENFORCE_SAME_TENSORLIST_IMPL.substitute(tensorlist_name=arg)]
             elif noref_cpp_type == ListCType(OptionalCType(BaseCType(tensorT))):
                 stmts_before_call += [SAVE_OPTIONALTENSORLIST_STORAGE.substitute(tensorlist_name=arg),
-                                    SAVE_OPTIONALTENSORLIST_IMPL.substitute(tensorlist_name=arg)]
+                                      SAVE_OPTIONALTENSORLIST_IMPL.substitute(tensorlist_name=arg)]
                 stmts_after_call += [ENFORCE_SAME_OPTIONALTENSORLIST_STORAGE.substitute(tensorlist_name=arg),
-                                            ENFORCE_SAME_OPTIONALTENSORLIST_IMPL.substitute(tensorlist_name=arg)]
+                                     ENFORCE_SAME_OPTIONALTENSORLIST_IMPL.substitute(tensorlist_name=arg)]
             elif noref_cpp_type == BaseCType(tensorT):
                 stmts_before_call += [SAVE_TENSOR_STORAGE.substitute(tensor_name=arg),
-                                    SAVE_TENSOR_IMPL.substitute(tensor_name=arg)]
+                                      SAVE_TENSOR_IMPL.substitute(tensor_name=arg)]
                 stmts_after_call += [ENFORCE_SAME_TENSOR_STORAGE.substitute(tensor_name=arg, out_tensor_name=arg),
-                                            ENFORCE_SAME_TENSOR_IMPL.substitute(tensor_name=arg)]
+                                     ENFORCE_SAME_TENSOR_IMPL.substitute(tensor_name=arg)]
 
         assert (stmts_before_call and stmts_after_call) or (not stmts_before_call and not stmts_after_call)
 
@@ -719,7 +719,7 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                     if aliased_arg_name is not None:
                         assert i == 0, "Expect non-CompositeImplicitAutograd view function {base} to return single output"
                         stmts_after_call += [ENFORCE_SAME_TENSOR_STORAGE.substitute(tensor_name=aliased_arg_name,
-                                                                                            out_tensor_name=ret_name)]
+                                                                                    out_tensor_name=ret_name)]
                     elif base_name not in OTHER_VIEW_FUNCTIONS:
                         stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
 
@@ -729,9 +729,9 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                 # Currently we don't have any functions that return the following types, but
                 # we should update the checks once we do
                 elif noref_cpp_type == ListCType(OptionalCType(BaseCType(tensorT))):
-                    assert False, f"Please add use_count checks for {noref_cpp_type}"
+                    raise AssertionError(f"Please add use_count checks for {noref_cpp_type}")
                 elif noref_cpp_type == BaseCType(tensorListT):
-                    assert False, f"Please add use_count checks for {noref_cpp_type}"
+                    raise AssertionError(f"Please add use_count checks for {noref_cpp_type}")
 
         if stmts_before_call and stmts_after_call:
             call = RUN_ONLY_IN_DEBUG_MODE.substitute(statements=stmts_before_call) + \

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -224,6 +224,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # These functions return tensors with use_count > 1
     # https://github.com/pytorch/pytorch/issues/60426
     'native_batch_norm', 'native_batch_norm_backward', 'native_group_norm_backward',
+    'cudnn_batch_norm',
     'native_layer_norm_backward', 'slow_conv_transpose2d_backward_output_mask',
     'thnn_conv2d_backward_output_mask', 'slow_conv3d_backward_output_mask',
     'slow_conv_transpose2d_backward_output_mask', 'slow_conv_transpose3d_backward_output_mask',
@@ -233,7 +234,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
     # These 'non-view' functions return tensors with storage use_count > 1
     'thnn_conv2d_forward', 'slow_conv3d_forward', 'channel_shuffle',
-    'q_per_channel_zero_points'
+    'q_per_channel_zero_points', 'q_per_channel_scales'
 }
 # END CHECKS FOR [ TensorImpl and Storage Pointer Sanity Checks ]
 

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -731,10 +731,12 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                                                                                     out_tensor_name=ret_name)]
                     else:
                         if type_wrapper_name(f) not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
-                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name, fn_name=type_wrapper_name(f))]
+                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name,
+                                                                                                        fn_name=type_wrapper_name(f))]
 
                     if type_wrapper_name(f) not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
-                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name, fn_name=type_wrapper_name(f))]
+                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name,
+                                                                                                 fn_name=type_wrapper_name(f))]
 
                 # Currently we don't have any functions that return the following types, but
                 # we should update the checks once we do

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -223,7 +223,17 @@ DONT_ENFORCE_SAME_TENSOR_IMPL_OR_STORAGE = {
 DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     # These functions return tensors with use_count > 1
     # https://github.com/pytorch/pytorch/issues/60426
-    'native_batch_norm', 'native_batch_norm_backward', '_embedding_bag',
+    'native_batch_norm', 'native_batch_norm_backward', 'native_group_norm_backward',
+    'native_layer_norm_backward', 'slow_conv_transpose2d_backward_output_mask',
+    'thnn_conv2d_backward_output_mask', 'slow_conv3d_backward_output_mask',
+    'slow_conv_transpose2d_backward_output_mask', 'slow_conv_transpose3d_backward_output_mask',
+    '_embedding_bag', '_embedding_bag_forward_only', 'mkldnn_convolution_backward',
+    'q_per_channel_scales'
+}
+DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
+    # These 'non-view' functions return tensors with storage use_count > 1
+    'thnn_conv2d_forward', 'slow_conv3d_forward', 'channel_shuffle',
+    'q_per_channel_zero_points'
 }
 # END CHECKS FOR [ TensorImpl and Storage Pointer Sanity Checks ]
 
@@ -722,7 +732,8 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                         stmts_after_call += [ENFORCE_SAME_TENSOR_STORAGE.substitute(tensor_name=aliased_arg_name,
                                                                                     out_tensor_name=ret_name)]
                     else:
-                        stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
+                        if base_name not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
+                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
 
                     if base_name not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
                         stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -180,11 +180,11 @@ if (${tensor_name}_impl_saved) AT_ASSERT(${tensor_name}_impl_saved == ${tensor_n
 """)
 
 ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE = CodeTemplate("""\
-AT_ASSERT(${tensor_name}.use_count() == 1);
+AT_ASSERT(${tensor_name}.use_count() == 1, "${fn_name} tensor usecount");
 """)
 
 ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE = CodeTemplate("""\
-if (${tensor_name}.has_storage()) AT_ASSERT(${tensor_name}.storage().use_count() == 1);
+if (${tensor_name}.has_storage()) AT_ASSERT(${tensor_name}.storage().use_count() == 1, "${fn_name} storage usecount");
 """)
 
 SAVE_TENSORLIST_IMPL = CodeTemplate("""\
@@ -228,7 +228,7 @@ DONT_ENFORCE_TENSOR_IMPL_USE_COUNT = {
     'thnn_conv2d_backward_output_mask', 'slow_conv3d_backward_output_mask',
     'slow_conv_transpose2d_backward_output_mask', 'slow_conv_transpose3d_backward_output_mask',
     '_embedding_bag', '_embedding_bag_forward_only', 'mkldnn_convolution_backward',
-    'q_per_channel_scales'
+    'q_per_channel_scales', 'q_per_channel_zero_points'
 }
 DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
     # These 'non-view' functions return tensors with storage use_count > 1
@@ -729,10 +729,10 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                                                                                     out_tensor_name=ret_name)]
                     else:
                         if type_wrapper_name(f) not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
-                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
+                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name, fn_name=type_wrapper_name(f))]
 
                     if type_wrapper_name(f) not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
-                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
+                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name, fn_name=type_wrapper_name(f))]
 
                 # Currently we don't have any functions that return the following types, but
                 # we should update the checks once we do

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -180,11 +180,11 @@ if (${tensor_name}_impl_saved) AT_ASSERT(${tensor_name}_impl_saved == ${tensor_n
 """)
 
 ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE = CodeTemplate("""\
-AT_ASSERT(${tensor_name}.use_count() == 1, "${fn_name} tensor usecount");
+AT_ASSERT(${tensor_name}.use_count() == 1, "function: ${fn_name}");
 """)
 
 ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE = CodeTemplate("""\
-if (${tensor_name}.has_storage()) AT_ASSERT(${tensor_name}.storage().use_count() == 1, "${fn_name} storage usecount");
+if (${tensor_name}.has_storage()) AT_ASSERT(${tensor_name}.storage().use_count() == 1, "function: ${fn_name}");
 """)
 
 SAVE_TENSORLIST_IMPL = CodeTemplate("""\
@@ -731,12 +731,12 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                                                                                     out_tensor_name=ret_name)]
                     else:
                         if type_wrapper_name(f) not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
-                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name,
-                                                                                                        fn_name=type_wrapper_name(f))]
+                            stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(
+                                tensor_name=ret_name, fn_name=type_wrapper_name(f))]
 
                     if type_wrapper_name(f) not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
-                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name,
-                                                                                                 fn_name=type_wrapper_name(f))]
+                        stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(
+                            tensor_name=ret_name, fn_name=type_wrapper_name(f))]
 
                 # Currently we don't have any functions that return the following types, but
                 # we should update the checks once we do

--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -237,10 +237,6 @@ DONT_ENFORCE_STORAGE_IMPL_USE_COUNT = {
 }
 # END CHECKS FOR [ TensorImpl and Storage Pointer Sanity Checks ]
 
-METHOD_DECLARATION = CodeTemplate("""\
-${return_type} ${type_wrapper_name}(${formals}) ;
-""")
-
 DECLARE_GRAD_FN = CodeTemplate("""\
 std::shared_ptr<${op}> grad_fn;
 """)
@@ -732,10 +728,10 @@ def emit_body(fn: NativeFunctionWithDifferentiabilityInfo) -> List[str]:
                         stmts_after_call += [ENFORCE_SAME_TENSOR_STORAGE.substitute(tensor_name=aliased_arg_name,
                                                                                     out_tensor_name=ret_name)]
                     else:
-                        if base_name not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
+                        if type_wrapper_name(f) not in DONT_ENFORCE_STORAGE_IMPL_USE_COUNT:
                             stmts_after_call += [ENFORCE_TENSOR_STORAGE_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
 
-                    if base_name not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
+                    if type_wrapper_name(f) not in DONT_ENFORCE_TENSOR_IMPL_USE_COUNT:
                         stmts_after_call += [ENFORCE_TENSOR_IMPL_USE_COUNT_EQUALS_ONE.substitute(tensor_name=ret_name)]
 
                 # Currently we don't have any functions that return the following types, but


### PR DESCRIPTION
Fixes #25927

Does some checks described in https://github.com/pytorch/pytorch/issues/25927#issuecomment-589354373:
If function does not modify its inputs (non-inplace and has no out arg):
- Check TensorImpl has use_count of 1. (This should make us aware of functions that return self.
- If function is a view function check that StorageImpl is same as that of the aliased input, otherwise, StorageImpl's use_count is 1.

Detected a couple functions that failed the check that returned TensorImpl should have use_count of 1: 'native_batch_norm', 'native_batch_norm_backward', '_embedding_bag'. (Filing issues).

Examples of generated code:
We did not update checks for in-place ops (this includes in-place views).

Example of a view:
- Check that outputs StorageImpl of `result` is the same as that of `self`.
- Check TensorImpl has use_count of 1
```cpp
at::Tensor as_strided(c10::DispatchKeySet ks, const at::Tensor & self, at::IntArrayRef size, at::IntArrayRef stride, c10::optional<int64_t> storage_offset) {
  auto& self_ = unpack(self, "self", 0);
  auto _any_requires_grad = compute_requires_grad( self );
  (void)_any_requires_grad;
  std::shared_ptr<AsStridedBackward> grad_fn;
  if (_any_requires_grad) {
    grad_fn = std::shared_ptr<AsStridedBackward>(new AsStridedBackward(), deleteNode);
    grad_fn->set_next_edges(collect_next_edges( self ));
    grad_fn->self_geometry = TensorGeometry(self);
    grad_fn->size = size.vec();
    grad_fn->stride = stride.vec();
    grad_fn->storage_offset = storage_offset;
  }
  #ifndef NDEBUG
  c10::optional<Storage> self__storage_saved =
    self_.has_storage() ? c10::optional<Storage>(self_.storage()) : c10::nullopt;
  c10::intrusive_ptr<TensorImpl> self__impl_saved;
  if (self_.defined()) self__impl_saved = self_.getIntrusivePtr();
  #endif
  auto _tmp = ([&]() {
    at::AutoDispatchBelowAutograd guard;
    return at::redispatch::as_strided(ks & c10::after_autograd_keyset, self_, size, stride, storage_offset);
  })();
  auto result = std::move(_tmp);
  #ifndef NDEBUG
  if (self__storage_saved.has_value())
    AT_ASSERT(self__storage_saved.value().is_alias_of(self_.storage()));
  if (self__impl_saved) AT_ASSERT(self__impl_saved == self_.getIntrusivePtr());
  if (self__storage_saved.has_value())
    AT_ASSERT(self__storage_saved.value().is_alias_of(result.storage())); <<<<<<<<<<<<<<<<<<<<<<<<
  AT_ASSERT(result.use_count() == 1); <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
  #endif
  if (grad_fn) {
      set_history(flatten_tensor_args( result ), grad_fn);
  }
  TORCH_CHECK_NOT_IMPLEMENTED(!(isFwGradDefined(self)), "Trying to use forward AD with as_strided that does not support it.");
  return result;
}
```
Example of non-view:
- Check that output's StorageImpl has use_count of 1.
- Check that output's TensorImpl has use_count of 1.
```cpp
at::Tensor asin(c10::DispatchKeySet ks, const at::Tensor & self) {
  auto& self_ = unpack(self, "self", 0);
  auto _any_requires_grad = compute_requires_grad( self );
  (void)_any_requires_grad;
  std::shared_ptr<AsinBackward> grad_fn;
  if (_any_requires_grad) {
    grad_fn = std::shared_ptr<AsinBackward>(new AsinBackward(), deleteNode);
    grad_fn->set_next_edges(collect_next_edges( self ));
    grad_fn->self_ = SavedVariable(self, false);
  }
  #ifndef NDEBUG
  c10::optional<Storage> self__storage_saved =
    self_.has_storage() ? c10::optional<Storage>(self_.storage()) : c10::nullopt;
  c10::intrusive_ptr<TensorImpl> self__impl_saved;
  if (self_.defined()) self__impl_saved = self_.getIntrusivePtr();
  #endif
  auto _tmp = ([&]() {
    at::AutoDispatchBelowADInplaceOrView guard;
    return at::redispatch::asin(ks & c10::after_autograd_keyset, self_);
  })();
  auto result = std::move(_tmp);
  #ifndef NDEBUG
  if (self__storage_saved.has_value())
    AT_ASSERT(self__storage_saved.value().is_alias_of(self_.storage())); 
  if (self__impl_saved) AT_ASSERT(self__impl_saved == self_.getIntrusivePtr());
  if (result.has_storage()) AT_ASSERT(result.storage().use_count() == 1); <<<<<<<<<<<<<<<<<<<<<<<<<<
  AT_ASSERT(result.use_count() == 1); <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
  #endif
  if (grad_fn) {
      set_history(flatten_tensor_args( result ), grad_fn);
  }
  if (isFwGradDefined(self)) {
      auto self_t_raw = toNonOptFwGrad(self);
      auto self_t = self_t_raw.defined() ? self_t_raw : at::zeros_like(toNonOptTensor(self));
      auto self_p = toNonOptPrimal(self);
      auto result_new_fw_grad = (self_t.conj() * (-self_p * self_p + 1).rsqrt().conj()).conj();
      if (result_new_fw_grad.defined()) {
        // The hardcoded 0 here will need to be updated once we support multiple levels.
        result._set_fw_grad(result_new_fw_grad, /* level */ 0, /* is_inplace_op */ false);
      }
  }
  return result;
}
```

