### PR TITLE
Re-enable clang-tidy on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -266,13 +266,11 @@ jobs:
           fi
 
   clang-tidy:
-    # if: github.event_name == 'pull_request'
-    # TODO: Fix clang-tidy, see https://github.com/pytorch/pytorch/issues/60192
-    if: ${{ false }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:52a8ad78d49fc9f40241fee7988db48c920499df
+      image: ghcr.io/pytorch/cilint-clang-tidy:32dfb7ff9446785443f2445342a42bb4514e370b
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
This switches clang-tidy to the fresh tag from https://github.com/pytorch/test-infra/runs/2860763986 which has a fix for the missing OMP headers we were seeing. Along with #60225 this should restore clang-tidy to normal functionality and we shouldn't see any spurious warnings.
