### PR TITLE
Re-enable clang-tidy on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:<need to wait for https://github.com/pytorch/test-infra/pull/43>
+      image: ghcr.io/pytorch/cilint-clang-tidy:7f0b4616100071a4813318bfdbd5b06ae36c5272
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -266,13 +266,11 @@ jobs:
           fi
 
   clang-tidy:
-    # if: github.event_name == 'pull_request'
-    # TODO: Fix clang-tidy, see https://github.com/pytorch/pytorch/issues/60192
-    if: ${{ false }}
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:52a8ad78d49fc9f40241fee7988db48c920499df
+      image: ghcr.io/pytorch/cilint-clang-tidy:32dfb7ff9446785443f2445342a42bb4514e370b
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -270,7 +270,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       # ubuntu18.04-cuda10.2-py3.6-tidy11
-      image: ghcr.io/pytorch/cilint-clang-tidy:32dfb7ff9446785443f2445342a42bb4514e370b
+      image: ghcr.io/pytorch/cilint-clang-tidy:<need to wait for https://github.com/pytorch/test-infra/pull/43>
     steps:
       - name: Checkout PyTorch
         uses: actions/checkout@v2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #60298 [do not merge] Test clang-tidy
* **#60297 Re-enable clang-tidy on PRs**

This switches clang-tidy to the fresh tag from https://github.com/pytorch/test-infra/runs/2862188673 which has a fix for the missing OMP headers we were seeing. Along with #60225 this should restore clang-tidy to normal functionality and we shouldn't see any spurious warnings.

The diff parsing was also broken on diffs that change an entire file (git uses -1 -> +1 as the line range in those diffs for some reason). Rather than deal with these intricacies myself I copied from https://stackoverflow.com/a/39909397 which uses the `unidiff` library, so we need to add that to the image first: https://github.com/pytorch/test-infra/pull/43

Differential Revision: [D29239783](https://our.internmc.facebook.com/intern/diff/D29239783)