### PR TITLE
Fix some issues after latest merge

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/aten_xla_type.cpp
@@ -836,6 +836,12 @@ at::Tensor permute(const at::Tensor& self, at::IntArrayRef dims) {
       LazyTensor::permute(self_tensor, Helpers::I64List(dims)));
 }
 
+at::Tensor repeat(const at::Tensor& self, at::IntArrayRef repeats) {
+  LTC_FN_COUNTER("xla::");
+  return bridge::AtenFromLtcTensor(LazyTensor::repeat(
+      bridge::GetLtcTensor(self), Helpers::I64List(repeats)));
+}
+
 at::Tensor stack(at::TensorList tensors, int64_t dim) {
   LTC_FN_COUNTER("xla::");
   return bridge::AtenFromLtcTensor(

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -3465,7 +3465,7 @@ TEST_F(AtenLtcTsTensorTest, TestSize) {
   });
 }
 
-TEST_F(AtenLtcTsTensorTest, DISABLED_TestSelect) {
+TEST_F(AtenLtcTsTensorTest, TestSelect) {
   std::vector<int64_t> input_sizes = {14, 24, 8};
   int rank = input_sizes.size();
   for (int dim = -rank; dim < rank; ++dim) {

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -1697,7 +1697,7 @@ TEST_F(AtenLtcTsTensorTest, TestGroupNormBackward) {
   }
 }
 
-TEST_F(AtenLtcTsTensorTest, DISABLED_TestInstanceNorm) {
+TEST_F(AtenLtcTsTensorTest, TestInstanceNorm) {
   int batch = 5;
   int num_channels = 20;
   torch::Tensor input = torch::rand({batch, num_channels, 10, 10},
@@ -3653,7 +3653,7 @@ TEST_F(AtenLtcTsTensorTest, TestUnbind) {
   }
 }
 
-TEST_F(AtenLtcTsTensorTest, DISABLED_TestRepeat) {
+TEST_F(AtenLtcTsTensorTest, TestRepeat) {
   std::vector<std::vector<int64_t>> repeats_list = {{4, 2}, {4, 2, 3}};
   std::vector<std::vector<int64_t>> input_size_list = {{3}, {2, 4}};
   for (const auto& repeats : repeats_list) {

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -36,6 +36,7 @@ supported:
   - max_pool3d_with_indices
   - max_pool3d_with_indices_backward
   - permute
+  - repeat
   - _softmax
   - _softmax_backward_data
   - squeeze_

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -37,6 +37,7 @@ supported:
   - max_pool3d_with_indices_backward
   - permute
   - repeat
+  - select_backward
   - _softmax
   - _softmax_backward_data
   - squeeze_


### PR DESCRIPTION
This fixes two issues:

1. Looks like the `repeat` implementation in core started to rely on `unfold` being a view, which means we'll need a lowering for it. This PR partially fixes it by lowering `repeat` instead, since it's generally useful and used in a few places by higher level operators.
2. The `select` followed by `copy_` pattern broke when selecting on inner dimensions. This pattern is used by `select_backward`, so I'm providing a placeholder for it which converts to eager tensor in its implementation.