### PR TITLE
Improve custom function docs

### DIFF
--- a/docs/source/autograd.rst
+++ b/docs/source/autograd.rst
@@ -189,10 +189,10 @@ When creating a new :class:`Function`, the following methods are available to `c
     :toctree: generated
     :nosignatures:
 
-    function._ContextMethodMixin.mark_dirty
-    function._ContextMethodMixin.mark_non_differentiable
-    function._ContextMethodMixin.save_for_backward
-    function._ContextMethodMixin.set_materialize_grads
+    function.FunctionCtx.mark_dirty
+    function.FunctionCtx.mark_non_differentiable
+    function.FunctionCtx.save_for_backward
+    function.FunctionCtx.set_materialize_grads
 
 .. _grad-check:
 

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -103,7 +103,7 @@ the autograd engine.
   to calling backward, and so your code will need to handle such objects as if they were
   tensors filled with zeros. The default value of this setting is True.
 
-**Step 3:** If your `~Function` does not support double backward
+**Step 3:** If your :class:`~Function` does not support double backward
 you should explicitly declare this by decorating backward with the
 :func:`~function.once_differentiable`. With this decorator, attempts to
 perform double backward through your function will produce an error.

--- a/docs/source/notes/extending.rst
+++ b/docs/source/notes/extending.rst
@@ -12,53 +12,97 @@ Extending :mod:`torch.autograd`
 
 .. currentmodule:: torch.autograd
 
-Adding operations to :mod:`~torch.autograd` requires implementing a new
-:class:`Function` subclass for each operation. Recall that :class:`Function` s
-are what :mod:`~torch.autograd` uses to compute the results and gradients, and
-encode the operation history. Every new function requires you to implement 2 methods:
+Subclassing :class:`autograd.Function` defines a custom autograd function.
 
-- :meth:`~Function.forward` - the code that performs the operation. It can take
-  as many arguments as you want, with some of them being optional, if you
-  specify the default values. All kinds of Python objects are accepted here.
-  :class:`Tensor` arguments that track history (i.e., with
-  ``requires_grad=True``) will be converted to ones that don't track history
-  before the call, and their use will be registered in the graph. Note that this
-  logic won't traverse lists/dicts/any other data structures and will only
-  consider :class:`Tensor` s that are direct arguments to the call. You can
-  return either a single :class:`Tensor` output, or a :class:`tuple` of
-  :class:`Tensor` s if there are multiple outputs. Also, please refer to the
-  docs of :class:`Function` to find descriptions of useful methods that can be
-  called only from :meth:`~Function.forward`.
-- :meth:`~Function.backward` - gradient formula. It will be given
-  as many :class:`Tensor` arguments as there were outputs, with each of them
-  representing gradient w.r.t. that output. It should return as many
-  :class:`Tensor` s as there were inputs, with each of them containing the
-  gradient w.r.t. its corresponding input. If your inputs didn't require
-  gradient (:attr:`~ctx.needs_input_grad` is a tuple of booleans indicating
-  whether each input needs gradient computation), or were non-:class:`Tensor`
-  objects, you can return :class:`python:None`. Also, if you have optional
-  arguments to :meth:`~Function.forward` you can return more gradients than there
-  were inputs, as long as they're all :any:`python:None`.
+When to use
+^^^^^^^^^^^
+In general, implement a custom function if you want to perform computations in your model
+that are not differentiable or rely on non-Pytorch libraries (e.g., NumPy), but
+still wish for your operation to compose with built-in PyTorch operators and
+work with the autograd engine.
 
-.. note::
+In some situations, custom functions can also be used to improve performance and
+memory usage: If you implemented your forward and backward passes using a C++
+extension, you can wrap them in :class:`~Function` to interface with the autograd
+engine. If you'd like to reduce the number of buffers saved for the backward pass,
+custom functions can be used to combine ops together.
 
-  It's the user's responsibility to use the special functions in the forward's `ctx`
-  properly in order to ensure that the new :class:`Function` works properly with
-  the autograd engine.
+When not to use
+^^^^^^^^^^^^^^^
+If you can already write your function in terms of PyTorch's built-in ops, its
+backward graph is (most likely) already able to be recorded by autograd. In this case, you do
+not need to implement the backward function yourself. Consider using a plain
+old Python function.
 
-  - :meth:`~torch.autograd.function._ContextMethodMixin.save_for_backward` must be
-    used when saving input or output of the forward to be used later in the backward.
-  - :meth:`~torch.autograd.function._ContextMethodMixin.mark_dirty` must be used to
-    mark any input that is modified inplace by the forward function.
-  - :meth:`~torch.autograd.function._ContextMethodMixin.mark_non_differentiable` must
-    be used to tell the engine if an output is not differentiable.
-  - :meth:`~torch.autograd.function._ContextMethodMixin.set_materialize_grads` can be
-    used to tell the autograd engine to optimize gradient computations in the cases where
-    the output does not depend on the input by not materializing grad tensors given to backward
-    function. That is, if set to False, None object in python or "undefined tensor" (tensor x for
-    which x.defined() is False) in C++ will not be converted to a tensor filled with zeros prior
-    to calling backward. However, supporting this optimization means your custom autograd function
-    has to handle gradients that are represented in this way and is thus opt-in. Default value is True.
+If you need to maintain state, i.e., trainable parameters, you should (also) use a
+custom Module. See the section below for more information on extending :mod:`torch.nn`.
+
+If you'd like to alter the gradients during the backward pass or perform a side
+effect, consider using function or module hooks.
+
+How to use
+^^^^^^^^^^
+We recommend taking the following steps:
+1. Subclass :class:`~Function` and implement the :meth:`~Function.forward` and
+   :meth:`~Function.backward` methods
+2. Call the proper methods on the `ctx` argument.
+3. Declare whether your function supports double backward
+4. Validate whether your gradients are correct using gradcheck
+
+**Step 1:** After subclassing :class:`Function`, you'll need to define 2 methods:
+
+- :meth:`~Function.forward` is the code that performs the operation. It can take
+as many arguments as you want, with some of them being optional, if you
+specify the default values. All kinds of Python objects are accepted here.
+:class:`Tensor` arguments that track history (i.e., with
+``requires_grad=True``) will be converted to ones that don't track history
+before the call, and their use will be registered in the graph. Note that this
+logic won't traverse lists/dicts/any other data structures and will only
+consider :class:`Tensor`s that are direct arguments to the call. You can
+return either a single :class:`Tensor` output, or a :class:`tuple` of
+:class:`Tensor`s if there are multiple outputs. Also, please refer to the
+docs of :class:`Function` to find descriptions of useful methods that can be
+called only from :meth:`~Function.forward`.
+- :meth:`~Function.backward` defines the gradient formula. It will be given
+as many :class:`Tensor` arguments as there were outputs, with each of them
+representing gradient w.r.t. that output. It should return as many
+:class:`Tensor` s as there were inputs, with each of them containing the
+gradient w.r.t. its corresponding input. If your inputs didn't require
+gradient (:attr:`~ctx.needs_input_grad` is a tuple of booleans indicating
+whether each input needs gradient computation), or were non-:class:`Tensor`
+objects, you can return :class:`python:None`. Also, if you have optional
+arguments to :meth:`~Function.forward` you can return more gradients than there
+were inputs, as long as they're all :any:`python:None`.
+
+**Step 2:** It's the user's responsibility to use the functions in the forward's `ctx`
+properly in order to ensure that the new :class:`Function` works properly with
+the autograd engine.
+
+- :meth:`~torch.autograd.function.ctx.save_for_backward` must be
+  used when saving input or output of the forward to be used later in the backward.
+- :meth:`~torch.autograd.function.ctx.mark_dirty` must be used to
+  mark any input that is modified inplace by the forward function.
+- :meth:`~torch.autograd.function.ctx.mark_non_differentiable` must
+  be used to tell the engine if an output is not differentiable.
+- :meth:`~torch.autograd.function.ctx.set_materialize_grads` can be
+  used to tell the autograd engine to optimize gradient computations in the cases where
+  the output does not depend on the input by not materializing grad tensors given to backward
+  function. That is, if set to False, None object in python or "undefined tensor" (tensor x for
+  which x.defined() is False) in C++ will not be converted to a tensor filled with zeros prior
+  to calling backward. However, supporting this optimization means your custom autograd function
+  has to handle gradients that are represented in this way and is thus opt-in. Default value is True.
+
+**Step 3:** If your `~Function` does not support double backward it is
+recommended that you explicitly declare this by decorating backward with the
+:func:`~function.once_differentiable`. With this decorator, attempts to
+perform double backward through your function will produce an error.
+See our double backward tutorial for more information on double backward.
+
+**Step 4:** It is recommended that you use :func:`torch.autograd.gradcheck`
+to check whether your backward function correctly computes gradients of the
+forward by computing the Jacobian matrix using your backward function and
+comparing the value element-wise with the Jacobian computed numerically using
+finite-differencing.
 
 .. note::
 

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -171,6 +171,9 @@ class FunctionCtx(object):
         """
         self.materialize_grads = value
 
+# DO NOT USE: This is only defined to be able to load old serialized models
+_ContextMethodMixin = FunctionCtx
+
 class _HookMixin(object):
 
     @staticmethod


### PR DESCRIPTION
- Adds some code examples for `ctx` methods and make requirements of arguments more clear
- Type annotations for `save_for_backward`, `mark_dirty`, `mark_non_differentiable`, and `set_materialize_grads` (BC-breaking?)
- Refactor `torch.autograd.Function` doc
