### PR TITLE
changed launch bound to fix col2im kernel

### DIFF
--- a/aten/src/ATen/cuda/detail/KernelUtils.h
+++ b/aten/src/ATen/cuda/detail/KernelUtils.h
@@ -25,12 +25,12 @@ namespace at { namespace cuda { namespace detail {
 constexpr int CUDA_NUM_THREADS = 1024;
 
 // CUDA: number of blocks for threads.
-inline int GET_BLOCKS(const int64_t N) {
+inline int GET_BLOCKS(const int64_t N, const int64_t max_threads_per_block=CUDA_NUM_THREADS) {
   TORCH_INTERNAL_ASSERT(N > 0, "CUDA kernel launch blocks must be positive, but got N=", N);
   constexpr int64_t max_int = std::numeric_limits<int>::max();
 
   // Round up division for positive number that cannot cause integer overflow
-  auto block_num = (N - 1) / CUDA_NUM_THREADS + 1;
+  auto block_num = (N - 1) / max_threads_per_block + 1;
   TORCH_INTERNAL_ASSERT(block_num <= max_int, "Can't schedule too many blocks on CUDA device");
 
   return static_cast<int>(block_num);

--- a/aten/src/ATen/native/cuda/im2col.cuh
+++ b/aten/src/ATen/native/cuda/im2col.cuh
@@ -112,7 +112,7 @@ void im2col(
 }
 
 template <typename dt, typename accT>
-C10_LAUNCH_BOUNDS_1(1024)
+C10_LAUNCH_BOUNDS_1(512)
 __global__ void col2im_kernel(
     const int64_t n,
     const dt* data_col,
@@ -191,7 +191,7 @@ void col2im(
   // bottom dimension, and then in the kernel add up the top dimensions.
   // CUDA_NUM_THREADS = 1024
   col2im_kernel<dt, accT>
-      <<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, stream>>>(
+      <<<GET_BLOCKS(num_kernels, 512), 512, 0, stream>>>(
           num_kernels,
           data_col,
           height,


### PR DESCRIPTION
Changed launch bound for col2im kernel from 1024 to 512 to fix register spilling into local memory.

Perf comparison (using Nvidia Titan-V): 

![Col2ImTimingData](https://user-images.githubusercontent.com/22803332/122627527-e0b1fc80-d064-11eb-83df-f2a1165cefcc.PNG)
