### PR TITLE
Add support for CUDA execution

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/expand.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/expand.cpp
@@ -8,21 +8,25 @@ namespace torch_lazy_tensors {
 namespace ir {
 namespace ops {
 
-Expand::Expand(const Value& input, std::vector<lazy_tensors::int64> size)
+Expand::Expand(const Value& input, std::vector<lazy_tensors::int64> size,
+               bool is_scalar_expand)
     : Node(ir::OpKind(at::aten::expand), {input},
-           /*num_outputs=*/1, lazy_tensors::util::MHash(size)),
-      size_(std::move(size)) {
+           /*num_outputs=*/1,
+           lazy_tensors::util::MHash(size, is_scalar_expand)),
+      size_(std::move(size)),
+      is_scalar_expand_(is_scalar_expand) {
   SetShapeDeferred(
       [&]() { return compiler::NodeLowering::Get()->Infer(this); });
 }
 
 NodePtr Expand::Clone(OpList operands) const {
-  return MakeNode<Expand>(operands.at(0), size_);
+  return MakeNode<Expand>(operands.at(0), size_, is_scalar_expand_);
 }
 
 std::string Expand::ToString() const {
   std::stringstream ss;
-  ss << Node::ToString() << ", size=(" << absl::StrJoin(size_, ", ") << ")";
+  ss << Node::ToString() << ", size=(" << absl::StrJoin(size_, ", ")
+     << "), is_scalar_expand=" << is_scalar_expand_;
   return ss.str();
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/expand.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/expand.h
@@ -10,7 +10,8 @@ namespace ops {
 
 class Expand : public Node {
  public:
-  Expand(const Value& input, std::vector<lazy_tensors::int64> size);
+  Expand(const Value& input, std::vector<lazy_tensors::int64> size,
+         bool is_scalar_expand);
 
   std::string ToString() const override;
 
@@ -18,8 +19,14 @@ class Expand : public Node {
 
   const std::vector<lazy_tensors::int64>& size() const { return size_; };
 
+  bool is_scalar_expand() const { return is_scalar_expand_; }
+
  private:
   std::vector<lazy_tensors::int64> size_;
+  // True iff the input was a scalar and this was generated internally by a
+  // lowering and not by user action. For some backends, this difference can be
+  // material (for example setting strides according to eager semantics).
+  bool is_scalar_expand_;
 };
 
 }  // namespace ops

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/index_ops.cpp
@@ -204,7 +204,8 @@ ir::Value EnsureRank1(const ir::Value& index) {
   LTC_CHECK_LE(index->shape().rank(), 1);
   return index->shape().rank() == 0
              ? ir::MakeNode<ir::ops::Expand>(
-                   index, std::vector<lazy_tensors::int64>{1})
+                   index, std::vector<lazy_tensors::int64>{1},
+                   /*is_scalar_expand=*/false)
              : index;
 }
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.cpp
@@ -757,8 +757,8 @@ ir::Value LazyTensor::GetIrValueForScalar(
   ir::Value ir_value = GetIrValueForScalar(value, type, device);
   if (!dimensions.empty()) {
     ir_value = ir::MakeNode<ir::ops::Expand>(
-        ir_value,
-        lazy_tensors::util::ToVector<lazy_tensors::int64>(dimensions));
+        ir_value, lazy_tensors::util::ToVector<lazy_tensors::int64>(dimensions),
+        /*is_scalar_expand=*/true);
   }
   return ir_value;
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -150,8 +150,10 @@ ir::Value MaybeExpand(const ir::Value& input,
     return input;
   }
   return ir::MakeNode<ir::ops::Expand>(
-      input, lazy_tensors::util::ToVector<lazy_tensors::int64>(
-                 target_shape.dimensions()));
+      input,
+      lazy_tensors::util::ToVector<lazy_tensors::int64>(
+          target_shape.dimensions()),
+      /*is_scalar_expand=*/false);
 }
 
 MinMaxValues GetMinMaxValues(const LazyTensor& tensor,
@@ -1298,7 +1300,8 @@ LazyTensor LazyTensor::expand(const LazyTensor& input,
   auto input_shape = input.shape();
   return input.CreateFrom(ir::MakeNode<ir::ops::Expand>(
       input.GetIrValue(),
-      GetExpandDimensions(input_shape.get(), std::move(size))));
+      GetExpandDimensions(input_shape.get(), std::move(size)),
+      /*is_scalar_expand=*/false));
 }
 
 LazyTensor LazyTensor::expm1(const LazyTensor& input) {

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/backend_impl.cpp
@@ -3,6 +3,7 @@
 #include "lazy_tensor_core/csrc/ts_backend/ts_computation_client.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_lowering_context.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_node_lowering.h"
+#include "lazy_tensors/computation_client/nnc_computation_client.h"
 
 namespace torch_lazy_tensors {
 namespace compiler {
@@ -55,9 +56,11 @@ class TSBackendImpl : public BackendImplInterface {
   lazy_tensors::ComputationClient::DataPtr MakeComputationDataFromTensor(
       const at::Tensor& tensor, const lazy_tensors::Shape& shape,
       const std::string& device) const override {
+    at::TensorOptions options = tensor.options().device(
+        lazy_tensors::NNCComputationClient::HardwareDeviceType());
     return std::make_shared<
         lazy_tensors::compiler::TSComputationClient::TSData>(
-        tensor, lazy_tensors::ToShapeData(shape), device);
+        tensor.to(options), lazy_tensors::ToShapeData(shape), device);
   }
 
   lazy_tensors::StatusOr<std::string> GetComputationBackendText(

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
@@ -3,6 +3,7 @@
 #include "lazy_tensor_core/csrc/tensor_util.h"
 #include "lazy_tensor_core/csrc/ts_backend/ts_lowering_context.h"
 #include "lazy_tensors/computation_client/nnc_computation_client.h"
+#include "torch/csrc/jit/runtime/graph_executor.h"
 
 namespace lazy_tensors {
 namespace {
@@ -47,8 +48,7 @@ std::vector<ComputationClient::DataPtr> TSComputationClient::ExecuteComputation(
           torch_lazy_tensors::compiler::ts_backend::GenericComputationTS*>(
           computation.computation())
           ->graph();
-  torch::jit::Code function(graph, "");
-  torch::jit::InterpreterState interp(function);
+  torch::jit::GraphExecutor interp(graph, "");
   std::vector<torch::jit::IValue> stack;
   for (auto argument : arguments) {
     const auto ts_data =

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/ts_computation_client.cpp
@@ -53,6 +53,9 @@ std::vector<ComputationClient::DataPtr> TSComputationClient::ExecuteComputation(
   for (auto argument : arguments) {
     const auto ts_data =
         std::static_pointer_cast<TSComputationClient::TSData>(argument);
+    LTC_CHECK(lazy_tensors::NNCComputationClient::HardwareDeviceType() !=
+                  at::kCUDA ||
+              ts_data->data_.device().type() == at::kCUDA);
     stack.emplace_back(ts_data->data_);
   }
   interp.run(stack);

--- a/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
+++ b/lazy_tensor_core/test/cpp/test_aten_ltc_ts_tensor.cpp
@@ -10,6 +10,7 @@
 #include "lazy_tensor_core/csrc/ts_backend/backend_impl.h"
 #include "lazy_tensors/computation_client/computation_client.h"
 #include "lazy_tensors/computation_client/metrics.h"
+#include "lazy_tensors/computation_client/nnc_computation_client.h"
 #include "lazy_tensors/permutation_util.h"
 #include "torch_ltc_ts_test.h"
 
@@ -18,6 +19,10 @@ namespace cpp_test {
 namespace {
 
 class AtenLtcTsTensorTest : public AtenLtcTsTensorTestBase {};
+
+bool IsCuda() {
+  return lazy_tensors::NNCComputationClient::HardwareDeviceType() == at::kCUDA;
+}
 
 compiler::BackendRegistrar g_registrar(compiler::GetTSBackendImpl());
 
@@ -4246,6 +4251,9 @@ TEST_F(AtenLtcTsTensorTest, TestOneIndexPut) {
             : torch::randint(100, {3, 5, 6, 7},
                              torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result =
           torch::index_put(params, {indices}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4269,6 +4277,9 @@ TEST_F(AtenLtcTsTensorTest, TestOneIndexPutInPlace) {
     torch::Tensor values =
         torch::ones({3, 5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor params =
             isFloatingType(scalar_type)
@@ -4304,6 +4315,9 @@ TEST_F(AtenLtcTsTensorTest, TestOneIndexPutTransfer) {
     torch::Tensor values =
         torch::ones({3, 5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result =
           torch::index_put(params, {indices}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4333,6 +4347,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPut) {
     torch::Tensor values =
         torch::ones({5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result =
           torch::index_put(params, {indices_0, indices_1}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4365,6 +4382,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPutHeadNull) {
     torch::Tensor values =
         torch::ones({3, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result = torch::index_put(
           params, {indices_null, indices_0, indices_1}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4398,6 +4418,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPutMiddleNull) {
     torch::Tensor values =
         torch::ones({3, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result = torch::index_put(
           params, {indices_0, indices_null, indices_1}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4431,6 +4454,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPutTailNull) {
     torch::Tensor values =
         torch::ones({3, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result = torch::index_put(
           params, {indices_0, indices_1, indices_null}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4463,6 +4489,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPutMiddleBroadcast) {
     torch::Tensor values =
         torch::ones({5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result =
           torch::index_put(params, {indices_0, indices_1}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4494,6 +4523,9 @@ TEST_F(AtenLtcTsTensorTest, TestMultiIndexPutTailBroadcast) {
     torch::Tensor values =
         torch::ones({5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       torch::Tensor result =
           torch::index_put(params, {indices_0, indices_1}, values, accumulate);
       ForEachDevice([&](const torch::Device& device) {
@@ -4545,6 +4577,9 @@ TEST_F(AtenLtcTsTensorTest, TestIndexPutImpl) {
     torch::Tensor values =
         torch::ones({3, 5, 6, 7}, torch::TensorOptions(scalar_type));
     for (bool accumulate : {false, true}) {
+      if (accumulate && IsCuda()) {
+        GTEST_SKIP();
+      }
       ForEachDevice([&](const torch::Device& device) {
         torch::Tensor params =
             isFloatingType(scalar_type)
@@ -4841,6 +4876,9 @@ TEST_F(AtenLtcTsTensorTest, TestIndexCopy) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestIndexCopyInPlace) {
+  if (IsCuda()) {
+    GTEST_SKIP();
+  }
   int index_size = 10;
   int rank = 3;
   for (torch::ScalarType scalar_type :
@@ -8327,6 +8365,9 @@ TEST_F(AtenLtcTsTensorTest, TestAvgPool3DNoBatchBackward) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestAdaptiveAvgPool3DNoBatchBackward) {
+  if (IsCuda()) {
+    GTEST_SKIP();
+  }
   for (int64_t output_size : {7, 4}) {
     auto testfn =
         [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {
@@ -8344,6 +8385,9 @@ TEST_F(AtenLtcTsTensorTest, TestAdaptiveAvgPool3DNoBatchBackward) {
 }
 
 TEST_F(AtenLtcTsTensorTest, TestAdaptiveAvgPool3DBackward) {
+  if (IsCuda()) {
+    GTEST_SKIP();
+  }
   for (int64_t output_size : {7, 4}) {
     auto testfn =
         [&](const std::vector<torch::Tensor>& inputs) -> torch::Tensor {

--- a/lazy_tensor_core/torch_patches/X10-codegen.diff
+++ b/lazy_tensor_core/torch_patches/X10-codegen.diff
@@ -1,8 +1,8 @@
 diff --git a/aten/src/ATen/templates/aten_xla_type_default.cpp b/aten/src/ATen/templates/aten_xla_type_default.cpp
-index 040a752156..fdc5ad8f26 100644
+index 040a752156..e8712d5644 100644
 --- a/aten/src/ATen/templates/aten_xla_type_default.cpp
 +++ b/aten/src/ATen/templates/aten_xla_type_default.cpp
-@@ -1,16 +1,16 @@
+@@ -1,16 +1,17 @@
  // ${generated_comment}
 -#include <torch_xla/csrc/aten_xla_type_default.h>
 +#include <lazy_tensor_core/csrc/ts_backend/aten_xla_type_default.h>
@@ -18,16 +18,72 @@ index 040a752156..fdc5ad8f26 100644
 -#include <torch_xla/csrc/XLANativeFunctions.h>
 -#include <torch_xla/csrc/function_call_tracker.h>
 +#include <lazy_tensors/computation_client/debug_macros.h>
-+#include <lazy_tensors/computation_client/metrics.h>
 +#include <lazy_tensors/computation_client/ltc_logging.h>
++#include <lazy_tensors/computation_client/metrics.h>
++#include <lazy_tensors/computation_client/nnc_computation_client.h>
 +#include <lazy_tensor_core/csrc/aten_ltc_bridge.h>
 +#include <lazy_tensor_core/csrc/ts_backend/XLANativeFunctions.h>
 +#include <lazy_tensor_core/csrc/function_call_tracker.h>
  
  namespace ${cpp_namespace} {
  
+@@ -54,10 +55,25 @@ std::vector<at::Tensor> to_device_opt(const std::vector<at::Tensor>& tensors, c1
+     return output_tensors;
+ }
+ 
++namespace {
++
++std::vector<at::Tensor> _to_eager(at::TensorList tensors) {
++    if (lazy_tensors::NNCComputationClient::HardwareDeviceType() == at::kCUDA) {
++        std::vector<at::Tensor> cuda_tensors;
++        for (const auto& t : tensors) {
++            cuda_tensors.push_back(t.cuda());
++        }
++        return cuda_tensors;
++    }
++    return at::_to_cpu(tensors);
++}
++
++}  // namespace
++
+ // convenience helper for converting tensors to cpu
+ 
+-std::vector<at::Tensor> to_cpu(const at::TensorList& tensors) {
+-    // We can't just call at::to_cpu() on the entire list of Tensors
++std::vector<at::Tensor> to_eager(const at::TensorList& tensors) {
++    // We can't just call at::to_eager() on the entire list of Tensors
+     // Because it will break on undefined tensors. Separate out undefined tensors first.
+     std::vector<at::Tensor> cpu_tensors(tensors.size());
+     std::vector<at::Tensor> valid_tensors;
+@@ -71,7 +87,7 @@ std::vector<at::Tensor> to_cpu(const at::TensorList& tensors) {
+             cpu_tensors[i] = tensor;
+         }
+     }
+-    auto cpu_valid_tensors = at::_to_cpu(valid_tensors);
++    auto cpu_valid_tensors = _to_eager(valid_tensors);
+     for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {
+         if (to_translate[i]) {
+             cpu_tensors[i] = std::move(cpu_valid_tensors[defined_pos++]);
+@@ -80,7 +96,7 @@ std::vector<at::Tensor> to_cpu(const at::TensorList& tensors) {
+   return cpu_tensors;
+ }
+ 
+-std::vector<c10::optional<at::Tensor>> to_cpu(const std::vector<c10::optional<at::Tensor>>& tensors) {
++std::vector<c10::optional<at::Tensor>> to_eager(const std::vector<c10::optional<at::Tensor>>& tensors) {
+     std::vector<c10::optional<at::Tensor>> opt_tensors(tensors.size());
+     std::vector<at::Tensor> materialized_tensors;
+     std::vector<bool> to_translate(tensors.size());
+@@ -91,7 +107,7 @@ std::vector<c10::optional<at::Tensor>> to_cpu(const std::vector<c10::optional<at
+             materialized_tensors.push_back(*tensor);
+         }
+     }
+-    auto aten_materialized_tensors = to_cpu(materialized_tensors);
++    auto aten_materialized_tensors = to_eager(materialized_tensors);
+     for (size_t i = 0, defined_pos = 0; i < tensors.size(); ++i) {
+         if (to_translate[i]) {
+           opt_tensors[i] =
 diff --git a/tools/codegen/dest/gen_external_aten_fallbacks.py b/tools/codegen/dest/gen_external_aten_fallbacks.py
-index 62fdd800b3..f61f4d3128 100644
+index 62fdd800b3..a147184eab 100644
 --- a/tools/codegen/dest/gen_external_aten_fallbacks.py
 +++ b/tools/codegen/dest/gen_external_aten_fallbacks.py
 @@ -30,40 +30,7 @@ _FN_DENYLIST_REGEX = [
@@ -71,6 +127,32 @@ index 62fdd800b3..f61f4d3128 100644
  ]
  
  # See Note [Auto generated composite kernels]
+@@ -190,7 +157,7 @@ class GenExternalAtenFallback:
+ 
+             tensorlist_intermediates_str = ''
+             if len(tensorlist_args) > 0:
+-                tensorlist_intermediates_str = '\n'.join([f'  auto {updated_name} = to_cpu({arg.name});'
++                tensorlist_intermediates_str = '\n'.join([f'  auto {updated_name} = to_eager({arg.name});'
+                                                           for arg, updated_name in tensorlist_args.items()])
+ 
+             opt_tensor_intermediates_str = ''
+@@ -199,14 +166,14 @@ class GenExternalAtenFallback:
+                 opt_tensor_intermediates_str = \
+                     f'\n  std::vector<c10::optional<at::Tensor>> external_tensors_opt_tensors = {{{arg_str}}};'
+                 opt_tensor_intermediates_str += \
+-                    '\n  auto external_tensors_opt = to_cpu(external_tensors_opt_tensors);'
++                    '\n  auto external_tensors_opt = to_eager(external_tensors_opt_tensors);'
+ 
+             intermediates = ''
+             if tensorlist_intermediates_str != '':
+                 intermediates += tensorlist_intermediates_str + '\n'
+             intermediates += \
+                 f"  std::vector<at::Tensor> external_tensors_tensors = {{{', '.join([a.name for a in tensor_args.keys()])}}};"
+-            intermediates += "\n  auto external_tensors = to_cpu(external_tensors_tensors);"
++            intermediates += "\n  auto external_tensors = to_eager(external_tensors_tensors);"
+             if opt_tensor_intermediates_str != '':
+                 intermediates += opt_tensor_intermediates_str
+ 
 @@ -266,9 +233,9 @@ class GenExternalAtenFallback:
  
              return f"""\


### PR DESCRIPTION
Use the graph executor, allow fallback operations to use CUDA interop. Also, fix an issue with how we created constant tensors with expand operations, which surfaced when running end-to-end models on CUDA.

To run on CUDA, set NNC_CUDA to 1. Some tests are disabled for CUDA, but they also fail with regular eager execution, at least for my setup.