### PR TITLE
Fix `CosineAnnealingLR` on restart

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1330,6 +1330,18 @@ class TestLRScheduler(TestCase):
         closed_form_scheduler = CosineAnnealingLR(self.opt, T_max=T_max, eta_min=eta_min)
         self._test_against_closed_form(scheduler, closed_form_scheduler, epochs)
 
+    def test_cos_anneal_lr_continue(self):
+        eta_min = 0.1
+        T_max = 5
+        scheduler = CosineAnnealingLR(self.opt, T_max=T_max, eta_min=eta_min)
+        self.opt.step()
+        scheduler.step()
+        original_lrs = scheduler._last_lr
+        new_scheduler = CosineAnnealingLR(
+            self.opt, T_max=T_max, eta_min=eta_min, last_epoch=0)
+        new_lrs = new_scheduler._last_lr
+        torch.testing.assert_allclose(original_lrs, new_lrs, rtol=1e-4, atol=1e-5)
+
     def test_reduce_lr_on_plateau1(self):
         epochs = 10
         for param_group in self.opt.param_groups:

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -721,6 +721,7 @@ class CosineAnnealingLR(_LRScheduler):
     def __init__(self, optimizer, T_max, eta_min=0, last_epoch=-1, verbose=False):
         self.T_max = T_max
         self.eta_min = eta_min
+        self._is_recreated = last_epoch != -1
         super(CosineAnnealingLR, self).__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
@@ -730,6 +731,11 @@ class CosineAnnealingLR(_LRScheduler):
 
         if self.last_epoch == 0:
             return [group['lr'] for group in self.optimizer.param_groups]
+        elif self._is_recreated:
+            return [self.eta_min + (base_lr - self.eta_min) *
+                    (1 + math.cos((self.last_epoch) * math.pi / self.T_max)) / 2
+                    for base_lr, group in
+                    zip(self.base_lrs, self.optimizer.param_groups)]
         elif (self.last_epoch - 1 - self.T_max) % (2 * self.T_max) == 0:
             return [group['lr'] + (base_lr - self.eta_min) *
                     (1 - math.cos(math.pi / self.T_max)) / 2

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -721,7 +721,6 @@ class CosineAnnealingLR(_LRScheduler):
     def __init__(self, optimizer, T_max, eta_min=0, last_epoch=-1, verbose=False):
         self.T_max = T_max
         self.eta_min = eta_min
-        self._is_recreated = last_epoch != -1
         super(CosineAnnealingLR, self).__init__(optimizer, last_epoch, verbose)
 
     def get_lr(self):
@@ -731,7 +730,7 @@ class CosineAnnealingLR(_LRScheduler):
 
         if self.last_epoch == 0:
             return [group['lr'] for group in self.optimizer.param_groups]
-        elif self._is_recreated:
+        elif self._step_count == 1 and self.last_epoch > 0:
             return [self.eta_min + (base_lr - self.eta_min) *
                     (1 + math.cos((self.last_epoch) * math.pi / self.T_max)) / 2
                     for base_lr, group in


### PR DESCRIPTION
Fixes #60265

The initial LR for this scheduler is not consistent when a new instance is created with `last_epoch != -1`

Maybe we can refactor the testing code to test `last_epoch != -1` in schedulers that can recreate their state from the current epoch?
