### PR TITLE
__BYTE_ORDER is can not be redefined

### DIFF
--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -127,12 +127,12 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
     #endif
 #elif defined(__ARMEB__)
   #define __BYTE_ORDER __BIG_ENDIAN
-#elif defined(__BYTE_ORDER__)
-  #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-      #define __BYTE_ORDER __BIG_ENDIAN
-  #else
-      #define __BYTE_ORDER __LITTLE_ENDIAN
-  #endif
+#elif (defined(__BYTE_ORDER__) and !defined(__BYTE_ORDER))
+    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        #define __BYTE_ORDER __BIG_ENDIAN
+    #else
+        #define __BYTE_ORDER __LITTLE_ENDIAN
+    #endif
 #else
   // defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
   #include <sys/param.h>


### PR DESCRIPTION
Summary:
Introduction:
In order to support the Intel SGX platform, we have to avoid redefining __BYTE_ORDER.
Solution:
Check if the platform is SGX and avoid the redefinition.

Test Plan: Run the PyTorch tests.

Differential Revision: D29022626

