### PR TITLE
SGX can not read from /dev/urandom

### DIFF
--- a/c10/core/GeneratorImpl.cpp
+++ b/c10/core/GeneratorImpl.cpp
@@ -2,6 +2,10 @@
 #include <chrono>
 #include <random>
 
+#if defined(__SGX_ENABLED__)
+#include <sgx_trts.h>
+#endif
+
 #ifndef _WIN32
 #include <fcntl.h>
 #include <unistd.h>
@@ -57,7 +61,9 @@ static uint64_t readURandomLong() {
 /**
  * Gets a non deterministic random number number from either the
  * /dev/urandom or the current time. For CUDA, gets random from
- * std::random_device and adds a transformation on it.
+ * std::random_device and adds a transformation on it. For Intel SGX
+ * platform use sgx_read_rand as reading from /dev/urandom is
+ * prohibited on that platfrom.
  *
  * FIXME: The behavior in this function is from legacy code
  * (THRandom_seed/THCRandom_seed) and is probably not the right thing to do,
@@ -76,6 +82,10 @@ uint64_t getNonDeterministicRandom(bool is_cuda) {
     s = (uint64_t)std::chrono::high_resolution_clock::now()
             .time_since_epoch()
             .count();
+#elif defined(__SGX_ENABLED__)
+    TORCH_CHECK(
+        sgx_read_rand(reinterpret_cast<uint8_t*>(&s), sizeof(s)) == SGX_SUCCESS,
+        "Could not generate random number with sgx_read_rand.");
 #else
     s = readURandomLong();
 #endif

--- a/caffe2/serialize/crc_alt.h
+++ b/caffe2/serialize/crc_alt.h
@@ -127,12 +127,12 @@ uint32_t crc32_16bytes_prefetch(const void* data, size_t length, uint32_t previo
     #endif
 #elif defined(__ARMEB__)
   #define __BYTE_ORDER __BIG_ENDIAN
-#elif defined(__BYTE_ORDER__)
-  #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-      #define __BYTE_ORDER __BIG_ENDIAN
-  #else
-      #define __BYTE_ORDER __LITTLE_ENDIAN
-  #endif
+#elif (defined(__BYTE_ORDER__) and !defined(__BYTE_ORDER))
+    #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        #define __BYTE_ORDER __BIG_ENDIAN
+    #else
+        #define __BYTE_ORDER __LITTLE_ENDIAN
+    #endif
 #else
   // defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
   #include <sys/param.h>


### PR DESCRIPTION
Summary:
Problem:
The SGX secure enclave does not support reading from /dev/urandom as it is isolated from the OS for greater security. The SGX api provides a way to generate random numbers as a replacment.
Solution:
Conditionally enable SGX api for random number generation when building for it.

Test Plan: Run the PyTorch tests

Differential Revision: D29022616

